### PR TITLE
Remove support for restoring old backup formats

### DIFF
--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -239,6 +239,14 @@ func (d *DistributedBackupDescriptor) GetStatus() Status {
 	return d.Status
 }
 
+func (d *DistributedBackupDescriptor) GetVersion() string {
+	return d.Version
+}
+
+func (d *DistributedBackupDescriptor) GetServerVersion() string {
+	return d.ServerVersion
+}
+
 func (d *DistributedBackupDescriptor) GetCompressionType() CompressionType {
 	return d.CompressionType
 }
@@ -508,6 +516,14 @@ func (d *BackupDescriptor) GetCompressionType() CompressionType {
 
 func (d *BackupDescriptor) GetStatus() Status {
 	return d.Status
+}
+
+func (d *BackupDescriptor) GetVersion() string {
+	return d.Version
+}
+
+func (d *BackupDescriptor) GetServerVersion() string {
+	return d.ServerVersion
 }
 
 // List all existing classes in d

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -596,38 +596,10 @@ func (d *BackupDescriptor) GetClassDescriptor(className string) *ClassDescriptor
 	return nil
 }
 
-// ValidateV1 validates d
-func (d *BackupDescriptor) validateV1() error {
-	for _, c := range d.Classes {
-		if c.Name == "" || len(c.Schema) == 0 || len(c.ShardingState) == 0 {
-			return fmt.Errorf("invalid class %q: [name schema sharding]", c.Name)
-		}
-		for _, s := range c.Shards {
-			n := len(s.Files)
-			if s.Name == "" || s.Node == "" || s.DocIDCounterPath == "" ||
-				s.ShardVersionPath == "" || s.PropLengthTrackerPath == "" ||
-				(n > 0 && (len(s.DocIDCounter) == 0 ||
-					len(s.PropLengthTracker) == 0 ||
-					len(s.Version) == 0)) {
-				return fmt.Errorf("invalid shard %q.%q", c.Name, s.Name)
-			}
-			for i, fpath := range s.Files {
-				if fpath == "" {
-					return fmt.Errorf("invalid shard %q.%q: file number %d", c.Name, s.Name, i)
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func (d *BackupDescriptor) Validate(newSchema bool) error {
+func (d *BackupDescriptor) Validate() error {
 	if d.StartedAt.IsZero() || d.ID == "" ||
 		d.Version == "" || d.ServerVersion == "" || d.Error != "" {
 		return fmt.Errorf("attribute mismatch: [id versions time error]")
-	}
-	if !newSchema {
-		return d.validateV1()
 	}
 	for _, c := range d.Classes {
 		if c.Name == "" || len(c.Schema) == 0 || len(c.ShardingState) == 0 {

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -641,27 +641,3 @@ func (d *BackupDescriptor) Validate(newSchema bool) error {
 	}
 	return nil
 }
-
-// ToDistributed is used just for backward compatibility with the old version.
-func (d *BackupDescriptor) ToDistributed() *DistributedBackupDescriptor {
-	node, cs := "", d.List()
-	for _, xs := range d.Classes {
-		for _, s := range xs.Shards {
-			node = s.Node
-		}
-	}
-	result := &DistributedBackupDescriptor{
-		StartedAt:               d.StartedAt,
-		CompletedAt:             d.CompletedAt,
-		ID:                      d.ID,
-		Status:                  Status(d.Status),
-		Version:                 d.Version,
-		ServerVersion:           d.ServerVersion,
-		Error:                   d.Error,
-		PreCompressionSizeBytes: d.PreCompressionSizeBytes, // Copy pre-compression size
-	}
-	if node != "" && len(cs) > 0 {
-		result.Nodes = map[string]*NodeDescriptor{node: {Classes: cs}}
-	}
-	return result
-}

--- a/entities/backup/descriptor_test.go
+++ b/entities/backup/descriptor_test.go
@@ -198,45 +198,6 @@ func TestValidateBackup(t *testing.T) {
 	}
 }
 
-func TestBackwardCompatibility(t *testing.T) {
-	timept := time.Now().UTC()
-	tests := []struct {
-		desc    BackupDescriptor
-		success bool
-	}{
-		// first level check
-		{desc: BackupDescriptor{}},
-		{desc: BackupDescriptor{ID: "1"}},
-		{desc: BackupDescriptor{ID: "1", Version: "1"}},
-		{desc: BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1"}},
-		{desc: BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept}},
-		{desc: BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept, Error: "err"}},
-		{desc: BackupDescriptor{
-			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
-			Classes: []ClassDescriptor{{
-				Name:   "n",
-				Shards: []*ShardDescriptor{{Name: "n", Node: ""}},
-			}},
-		}},
-		{desc: BackupDescriptor{
-			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
-			Classes: []ClassDescriptor{{
-				Name: "n",
-				Shards: []*ShardDescriptor{{
-					Name: "n", Node: "n",
-				}},
-			}},
-		}, success: true},
-	}
-	for i, tc := range tests {
-		desc := tc.desc.ToDistributed()
-		err := desc.Validate()
-		if got := err == nil; got != tc.success {
-			t.Errorf("%d. validate(%+v): want=%v got=%v err=%v", i, tc.desc, tc.success, got, err)
-		}
-	}
-}
-
 func TestDistributedBackup(t *testing.T) {
 	d := DistributedBackupDescriptor{
 		Nodes: map[string]*NodeDescriptor{

--- a/entities/backup/descriptor_test.go
+++ b/entities/backup/descriptor_test.go
@@ -80,9 +80,8 @@ func TestValidateBackup(t *testing.T) {
 	timept := time.Now().UTC()
 	bytes := []byte("hello")
 	tests := []struct {
-		desc      BackupDescriptor
-		successV1 bool
-		successV2 bool
+		desc    BackupDescriptor
+		success bool
 	}{
 		// first level check
 		{desc: BackupDescriptor{}},
@@ -90,8 +89,8 @@ func TestValidateBackup(t *testing.T) {
 		{desc: BackupDescriptor{ID: "1", Version: "1"}},
 		{desc: BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1"}},
 		{
-			desc:      BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept},
-			successV1: true, successV2: true,
+			desc:    BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept},
+			success: true,
 		},
 		{desc: BackupDescriptor{ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept, Error: "err"}},
 		{desc: BackupDescriptor{
@@ -109,7 +108,7 @@ func TestValidateBackup(t *testing.T) {
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{Name: "n", Schema: bytes, ShardingState: bytes}},
-		}, successV1: true, successV2: true},
+		}, success: true},
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{
@@ -130,7 +129,7 @@ func TestValidateBackup(t *testing.T) {
 				Name: "n", Schema: bytes, ShardingState: bytes,
 				Shards: []*ShardDescriptor{{Name: "n", Node: "n"}},
 			}},
-		}, successV2: true},
+		}, success: true},
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{
@@ -140,7 +139,7 @@ func TestValidateBackup(t *testing.T) {
 					PropLengthTrackerPath: "n", DocIDCounterPath: "n", ShardVersionPath: "n",
 				}},
 			}},
-		}, successV1: true, successV2: true},
+		}, success: true},
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{
@@ -151,7 +150,7 @@ func TestValidateBackup(t *testing.T) {
 					Files: []string{"file"},
 				}},
 			}},
-		}, successV2: true},
+		}, success: true},
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{
@@ -162,7 +161,7 @@ func TestValidateBackup(t *testing.T) {
 					DocIDCounter: bytes, Files: []string{"file"},
 				}},
 			}},
-		}, successV2: true},
+		}, success: true},
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{
@@ -173,7 +172,7 @@ func TestValidateBackup(t *testing.T) {
 					DocIDCounter: bytes, Version: bytes, PropLengthTracker: bytes, Files: []string{""},
 				}},
 			}},
-		}, successV2: true},
+		}, success: true},
 		{desc: BackupDescriptor{
 			ID: "1", Version: "1", ServerVersion: "1", StartedAt: timept,
 			Classes: []ClassDescriptor{{
@@ -184,16 +183,12 @@ func TestValidateBackup(t *testing.T) {
 					DocIDCounter: bytes, Version: bytes, PropLengthTracker: bytes, Files: []string{"file"},
 				}},
 			}},
-		}, successV1: true, successV2: true},
+		}, success: true},
 	}
 	for i, tc := range tests {
-		err := tc.desc.Validate(false)
-		if got := err == nil; got != tc.successV1 {
-			t.Errorf("%d. validate(%+v): want=%v got=%v err=%v", i, tc.desc, tc.successV1, got, err)
-		}
-		err = tc.desc.Validate(true)
-		if got := err == nil; got != tc.successV2 {
-			t.Errorf("%d. validate(%+v): want=%v got=%v err=%v", i, tc.desc, tc.successV1, got, err)
+		err := tc.desc.Validate()
+		if got := err == nil; got != tc.success {
+			t.Errorf("%d. validate(%+v): want=%v got=%v err=%v", i, tc.desc, tc.success, got, err)
 		}
 	}
 }

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -128,23 +128,25 @@ func (s *objectStore) meta(ctx context.Context, key, overrideBucket, overridePat
 	return nil
 }
 
+// hasMeta reports whether a parseable metadata file exists at key.
+func (s *objectStore) hasMeta(ctx context.Context, key, overrideBucket, overridePath string) bool {
+	var desc backup.BackupDescriptor
+	return s.meta(ctx, key, overrideBucket, overridePath, &desc) == nil
+}
+
 type nodeStore struct {
 	objectStore
 }
 
-// Meta gets meta data using standard path or deprecated old path
-//
-// adjustBasePath: sets the base path to the old path if the backup has been created prior to v1.17.
-func (s *nodeStore) Meta(ctx context.Context, backupID, overrideBucket, overridePath string, adjustBasePath bool) (*backup.BackupDescriptor, error) {
+// Meta gets the node's metadata. A backup carrying metadata only at the top-level base path
+// is refused as errLegacySingleNode.
+func (s *nodeStore) Meta(ctx context.Context, backupID, overrideBucket, overridePath string) (*backup.BackupDescriptor, error) {
 	var result backup.BackupDescriptor
 	err := s.meta(ctx, BackupFile, overrideBucket, overridePath, &result)
 	if err != nil {
-		cs := &objectStore{s.backend, backupID, overrideBucket, overridePath, ""} // for backward compatibility
-		if err := cs.meta(ctx, BackupFile, overrideBucket, overridePath, &result); err == nil {
-			if adjustBasePath {
-				s.objectStore.backupId = backupID
-			}
-			return &result, nil
+		base := &objectStore{s.backend, backupID, overrideBucket, overridePath, ""}
+		if base.hasMeta(ctx, BackupFile, overrideBucket, overridePath) {
+			return &result, errLegacySingleNode
 		}
 	}
 
@@ -178,15 +180,14 @@ func (s *coordStore) PutMeta(ctx context.Context, filename string, desc *backup.
 	return s.putMeta(ctx, filename, overrideBucket, overridePath, desc)
 }
 
-// Meta gets coordinator's global metadata from object store
+// Meta gets coordinator's global metadata from object store. A backup carrying only the
+// top-level per-node metadata is refused as errLegacySingleNode.
 func (s *coordStore) Meta(ctx context.Context, filename, overrideBucket, overridePath string) (*backup.DistributedBackupDescriptor, error) {
 	var result backup.DistributedBackupDescriptor
 	err := s.meta(ctx, filename, overrideBucket, overridePath, &result)
-	if err != nil && filename == GlobalBackupFile {
-		var oldBackup backup.BackupDescriptor
-		if err := s.meta(ctx, BackupFile, overrideBucket, overridePath, &oldBackup); err == nil {
-			return oldBackup.ToDistributed(), nil
-		}
+	if err != nil && filename == GlobalBackupFile &&
+		s.hasMeta(ctx, BackupFile, overrideBucket, overridePath) {
+		return &result, errLegacySingleNode
 	}
 	return &result, err
 }

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -725,14 +725,13 @@ type fileWriter struct {
 	tempDir    string
 	destDir    string
 	movedFiles []string // files successfully moved to destination folder
-	compressed bool
 	GoPoolSize int
 	migrator   func(classPath string) error
 	logger     logrus.FieldLogger
 }
 
 func newFileWriter(sourcer Sourcer, backend nodeStore,
-	compressed bool, logger logrus.FieldLogger,
+	logger logrus.FieldLogger,
 ) *fileWriter {
 	destDir := backend.SourceDataPath()
 	return &fileWriter{
@@ -741,7 +740,6 @@ func newFileWriter(sourcer Sourcer, backend nodeStore,
 		destDir:    destDir,
 		tempDir:    path.Join(destDir, TempDirectory),
 		movedFiles: make([]string, 0, 64),
-		compressed: compressed,
 		GoPoolSize: routinePoolSize(50),
 		logger:     logger,
 	}
@@ -787,22 +785,7 @@ func (fw *fileWriter) writeTempFiles(ctx context.Context, classTempDir, override
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// no compression processed as before
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(fw.logger, ctx)
-	if !fw.compressed {
-		eg.SetLimit(2 * numCPU())
-		for _, shard := range desc.Shards {
-			// Check for cancellation before processing each shard
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-			shard := shard
-			eg.Go(func() error { return fw.writeTempShard(ctx, shard, classTempDir, overrideBucket, overridePath) }, shard.Name)
-		}
-		return eg.Wait()
-	}
-
-	// source files are compressed
 	eg.SetLimit(fw.GoPoolSize)
 	for k := range desc.Chunks {
 		// Check for cancellation before processing each chunk
@@ -836,36 +819,6 @@ func (fw *fileWriter) writeTempFiles(ctx context.Context, classTempDir, override
 		}
 	}
 	return eg.Wait()
-}
-
-func (fw *fileWriter) writeTempShard(ctx context.Context, sd *backup.ShardDescriptor, classTempDir, overrideBucket, overridePath string) error {
-	for _, key := range sd.Files {
-		// Check for cancellation before processing each file
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		destPath := path.Join(classTempDir, key)
-		destDir := path.Dir(destPath)
-		if err := os.MkdirAll(destDir, os.ModePerm); err != nil {
-			return fmt.Errorf("create folder %s: %w", destDir, err)
-		}
-		if err := fw.backend.WriteToFile(ctx, key, destPath, overrideBucket, overridePath); err != nil {
-			return fmt.Errorf("write file %s: %w", destPath, err)
-		}
-	}
-	destPath := path.Join(classTempDir, sd.DocIDCounterPath)
-	if err := os.WriteFile(destPath, sd.DocIDCounter, os.ModePerm); err != nil {
-		return fmt.Errorf("write counter file %s: %w", destPath, err)
-	}
-	destPath = path.Join(classTempDir, sd.PropLengthTrackerPath)
-	if err := os.WriteFile(destPath, sd.PropLengthTracker, os.ModePerm); err != nil {
-		return fmt.Errorf("write prop file %s: %w", destPath, err)
-	}
-	destPath = path.Join(classTempDir, sd.ShardVersionPath)
-	if err := os.WriteFile(destPath, sd.Version, os.ModePerm); err != nil {
-		return fmt.Errorf("write version file %s: %w", destPath, err)
-	}
-	return nil
 }
 
 // readAndUnzipChunk downloads a chunk via readFn and unzips it into classTempDir.

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -726,7 +726,6 @@ type fileWriter struct {
 	destDir    string
 	movedFiles []string // files successfully moved to destination folder
 	GoPoolSize int
-	migrator   func(classPath string) error
 	logger     logrus.FieldLogger
 }
 
@@ -750,8 +749,6 @@ func (fw *fileWriter) WithPoolPercentage(p int) *fileWriter {
 	return fw
 }
 
-func (fw *fileWriter) setMigrator(m func(classPath string) error) { fw.migrator = m }
-
 // Write downloads files and put them in the destination directory
 func (fw *fileWriter) Write(ctx context.Context, desc *backup.ClassDescriptor, overrideBucket, overridePath string, compressionType backup.CompressionType) (err error) {
 	if len(desc.Shards) == 0 { // nothing to copy
@@ -761,12 +758,6 @@ func (fw *fileWriter) Write(ctx context.Context, desc *backup.ClassDescriptor, o
 
 	if err := fw.writeTempFiles(ctx, classTempDir, overrideBucket, overridePath, desc, compressionType); err != nil {
 		return fmt.Errorf("get files: %w", err)
-	}
-
-	if fw.migrator != nil {
-		if err := fw.migrator(classTempDir); err != nil {
-			return fmt.Errorf("migrate from pre 1.23: %w", err)
-		}
 	}
 
 	return nil

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -1412,3 +1412,98 @@ func TestIncrementalBackupChainWithManySplitFiles(t *testing.T) {
 		env.verify(restoredDir, allFiles[i])
 	}
 }
+
+func TestCoordStoreMeta(t *testing.T) {
+	var (
+		ctx      = context.Background()
+		backupID = "1234"
+		global   = marshalCoordinatorMeta(backup.DistributedBackupDescriptor{ID: backupID})
+		single   = marshalMeta(backup.BackupDescriptor{ID: backupID})
+	)
+	tests := []struct {
+		name       string
+		filename   string
+		globalMeta []byte
+		singleMeta []byte
+		wantErr    error
+	}{
+		{name: "current layout", filename: GlobalBackupFile, globalMeta: global},
+		{
+			name: "single-node layout only", filename: GlobalBackupFile,
+			singleMeta: single, wantErr: errLegacySingleNode,
+		},
+		{name: "no metadata at all", filename: GlobalBackupFile, wantErr: backup.ErrNotFound{}},
+		{
+			// Only a backup read probes for the single-node layout; a restore-status read
+			// of a legacy backup reports the missing file rather than the legacy reject.
+			name: "restore status read never rejects", filename: GlobalRestoreFile,
+			singleMeta: single, wantErr: backup.ErrNotFound{},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockBackend := newFakeBackend()
+			returnOrNotFound(mockBackend, ctx, backupID, tc.filename, tc.globalMeta)
+			returnOrNotFound(mockBackend, ctx, backupID, BackupFile, tc.singleMeta)
+
+			store := coordStore{objectStore{backend: mockBackend, backupId: backupID}}
+			got, err := store.Meta(ctx, tc.filename, "", "")
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				assert.Equal(t, backupID, got.ID)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestNodeStoreMeta(t *testing.T) {
+	var (
+		ctx      = context.Background()
+		backupID = "1234"
+		node     = "Node-1"
+		nodeHome = backupID + "/" + node
+		meta     = marshalMeta(backup.BackupDescriptor{ID: backupID})
+		baseMeta = marshalMeta(backup.BackupDescriptor{ID: "from-base-path"})
+	)
+	tests := []struct {
+		name     string
+		nodeMeta []byte
+		baseMeta []byte
+		wantErr  error
+	}{
+		{name: "current layout", nodeMeta: meta},
+		{name: "single-node layout only", baseMeta: baseMeta, wantErr: errLegacySingleNode},
+		{name: "no metadata at all", wantErr: backup.ErrNotFound{}},
+		{name: "both layouts present", nodeMeta: meta, baseMeta: baseMeta},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockBackend := newFakeBackend()
+			returnOrNotFound(mockBackend, ctx, nodeHome, BackupFile, tc.nodeMeta)
+			returnOrNotFound(mockBackend, ctx, backupID, BackupFile, tc.baseMeta)
+
+			store := nodeStore{objectStore{backend: mockBackend, backupId: nodeHome, node: node}}
+			got, err := store.Meta(ctx, backupID, "", "")
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				assert.Equal(t, backupID, got.ID)
+				return
+			}
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+// returnOrNotFound mocks a metadata read that succeeds with body, or reports the object
+// missing when body is nil.
+func returnOrNotFound(fb *fakeBackend, ctx context.Context, backupID, key string, body []byte) {
+	if body == nil {
+		fb.On("GetObject", ctx, backupID, key).Return(nil, backup.ErrNotFound{})
+		return
+	}
+	fb.On("GetObject", ctx, backupID, key).Return(body, nil)
+}

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -961,7 +961,6 @@ func (e *incrementalTestEnv) restore(backupID string, desc *backup.ClassDescript
 		},
 		destDir:    restoreDir,
 		tempDir:    filepath.Join(restoreDir, TempDirectory),
-		compressed: true,
 		GoPoolSize: 4,
 		logger:     logrus.New(),
 	}

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -64,7 +64,7 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqState,
 		return reqState{}, fmt.Errorf("no backup provider %q, did you enable the right module?", req.Backend)
 	}
 
-	meta, err := store.Meta(ctx, req.ID, store.bucket, store.path, false)
+	meta, err := store.Meta(ctx, req.ID, store.bucket, store.path)
 	if err != nil {
 		path := fmt.Sprintf("%s/%s", req.ID, BackupFile)
 		return reqState{}, fmt.Errorf("cannot get status while backing up: %w: %q: %w", errMetaNotFound, path, err)

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -165,6 +165,8 @@ type ChainDescriptor interface {
 	GetBaseBackupID() string
 	GetCompressionType() backup.CompressionType
 	GetStatus() backup.Status
+	GetVersion() string
+	GetServerVersion() string
 }
 
 // resolveBaseBackupChain follows the chain of base backups and validates them.
@@ -175,6 +177,7 @@ type ChainDescriptor interface {
 // - All backups in the chain exist
 // - All backups have compression type set
 // - All backups have the same compression type as requested
+// - All backups are in a format this build can restore
 func resolveBaseBackupChain[T ChainDescriptor](
 	ctx context.Context,
 	baseBackupID string,
@@ -209,6 +212,11 @@ func resolveBaseBackupChain[T ChainDescriptor](
 
 		if baseDescr.GetStatus() != backup.Success {
 			return nil, fmt.Errorf("backup %q has status %q, expected %q", nextID, baseDescr.GetStatus(), backup.Success)
+		}
+
+		// An unrestorable base makes the whole chain unrestorable, so refuse it at creation.
+		if err := checkRestorableVersion(baseDescr.GetVersion(), baseDescr.GetServerVersion()); err != nil {
+			return nil, fmt.Errorf("base backup %q: %w", nextID, err)
 		}
 
 		baseDescrs = append(baseDescrs, baseDescr)

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -561,6 +561,51 @@ func TestResolveBaseBackupChain(t *testing.T) {
 			errorContains: []string{"backup \"backup-1\" has compression type", "expected"},
 		},
 		{
+			name:            "LegacyBaseByStructureVersion",
+			baseBackupID:    "backup-1",
+			compressionType: gzipCompression,
+			setupFetchMeta: func() fetchMetaFunc {
+				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
+					return &backup.BackupDescriptor{
+						ID:              "backup-1",
+						CompressionType: &gzipCompression,
+						Version:         "1.0",
+						ServerVersion:   "1.23",
+						Status:          backup.Success,
+					}, nil
+				}
+			},
+			errorContains: []string{"base backup \"backup-1\"", "older than v1.21"},
+		},
+		{
+			name:            "LegacyBaseDeeperInChain",
+			baseBackupID:    "backup-2",
+			compressionType: gzipCompression,
+			setupFetchMeta: func() fetchMetaFunc {
+				descriptors := map[string]*backup.BackupDescriptor{
+					"backup-1": {
+						ID:              "backup-1",
+						CompressionType: &gzipCompression,
+						Version:         Version,
+						ServerVersion:   "1.22",
+						Status:          backup.Success,
+					},
+					"backup-2": {
+						ID:              "backup-2",
+						CompressionType: &gzipCompression,
+						Version:         Version,
+						ServerVersion:   "1.23",
+						BaseBackupID:    "backup-1",
+						Status:          backup.Success,
+					},
+				}
+				return func(ctx context.Context, backupID, bucket, path string) (*backup.BackupDescriptor, error) {
+					return descriptors[backupID], nil
+				}
+			},
+			errorContains: []string{"base backup \"backup-1\"", "older than v1.23"},
+		},
+		{
 			name:            "FailedBackupStatus",
 			baseBackupID:    "backup-1",
 			compressionType: gzipCompression,

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -653,7 +653,7 @@ func (c *coordinator) commit(ctx context.Context,
 						},
 					}
 
-					if meta, err := nodeStore.Meta(ctx, req.ID, req.Bucket, req.Path, false); err == nil {
+					if meta, err := nodeStore.Meta(ctx, req.ID, req.Bucket, req.Path); err == nil {
 						st.PreCompressionSizeBytes = meta.PreCompressionSizeBytes
 						totalPreCompressionSize += meta.PreCompressionSizeBytes
 						c.log.WithFields(logrus.Fields{

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -42,6 +42,8 @@ var (
 	errLegacySingleNode = legacyRestoreErr("by Weaviate older than v1.17, which stored a single " +
 		"top-level backup.json instead of per-node metadata")
 	errLegacyUncompressed = legacyRestoreErr("by Weaviate older than v1.21, which stored files uncompressed")
+	errLegacyFlatFS       = legacyRestoreErr("by Weaviate older than v1.23, which stored shard files " +
+		"in a flat directory instead of one directory per shard")
 )
 
 // legacyRestoreErr builds the refusal for a backup format this build no longer restores.
@@ -60,6 +62,9 @@ func checkRestorableVersion(version, serverVersion string) error {
 	// An empty version means a corrupt descriptor rather than an old one; Validate reports it.
 	if version != "" && version <= version1 {
 		return errLegacyUncompressed
+	}
+	if serverVersionOlderThan(serverVersion, 1, 23) {
+		return errLegacyFlatFS
 	}
 	if major, _, ok := parseVersion(version); ok && major > maxMajorVersion {
 		return fmt.Errorf("%s: %s > %s", errMsgHigherVersion, version, Version)

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -13,6 +13,7 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -38,6 +39,10 @@ const (
 	// version1 store plain files without compression
 	version1 = "1.0"
 )
+
+var errLegacySingleNode = errors.New("backup was created by Weaviate older than v1.17, which stored " +
+	"a single top-level backup.json instead of per-node metadata, and can no longer be restored: " +
+	"restore it on a release that still supports it and create a new backup")
 
 // serverVersionOlderThan reports whether serverVersion, formatted "major.minor[.patch]",
 // is older than major.minor. An unparseable version is not treated as older.

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -53,7 +53,7 @@ func legacyRestoreErr(origin string) error {
 }
 
 // maxMajorVersion is the newest backup-structure major version this build restores.
-var maxMajorVersion, _, _ = parseVersion(Version)
+var maxMajorVersion, _ = parseMajor(Version)
 
 // checkRestorableVersion refuses backups this build cannot restore, either because their
 // format is too old or because a later Weaviate produced them. version is the
@@ -66,10 +66,18 @@ func checkRestorableVersion(version, serverVersion string) error {
 	if serverVersionOlderThan(serverVersion, 1, 23) {
 		return errLegacyFlatFS
 	}
-	if major, _, ok := parseVersion(version); ok && major > maxMajorVersion {
+	// A structure version may omit the minor, so compare majors only.
+	if major, ok := parseMajor(version); ok && major > maxMajorVersion {
 		return fmt.Errorf("%s: %s > %s", errMsgHigherVersion, version, Version)
 	}
 	return nil
+}
+
+// parseMajor reads the leading number of a "major[.minor[.patch]]" version. ok is false
+// when it is missing or unparseable.
+func parseMajor(version string) (major int, ok bool) {
+	major, err := strconv.Atoi(strings.Split(version, ".")[0])
+	return major, err == nil
 }
 
 // parseVersion splits a "major.minor[.patch]" version. ok is false when either number is
@@ -79,11 +87,11 @@ func parseVersion(version string) (major, minor int, ok bool) {
 	if len(parts) < 2 {
 		return 0, 0, false
 	}
-	major, err := strconv.Atoi(parts[0])
-	if err != nil {
+	major, ok = parseMajor(version)
+	if !ok {
 		return 0, 0, false
 	}
-	minor, err = strconv.Atoi(parts[1])
+	minor, err := strconv.Atoi(parts[1])
 	if err != nil {
 		return 0, 0, false
 	}

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -15,6 +15,8 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -36,6 +38,27 @@ const (
 	// version1 store plain files without compression
 	version1 = "1.0"
 )
+
+// serverVersionOlderThan reports whether serverVersion, formatted "major.minor[.patch]",
+// is older than major.minor. An unparseable version is not treated as older.
+func serverVersionOlderThan(serverVersion string, major, minor int) bool {
+	parts := strings.Split(serverVersion, ".")
+	if len(parts) < 2 {
+		return false
+	}
+	gotMajor, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return false
+	}
+	gotMinor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	if gotMajor != major {
+		return gotMajor < major
+	}
+	return gotMinor < minor
+}
 
 // TODO error handling need to be implemented properly.
 // Current error handling is not idiomatic and relays on string comparisons which makes testing very brittle.

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -13,7 +13,6 @@ package backup
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -31,32 +30,66 @@ import (
 
 // Version of backup structure
 const (
-	// Version > version1 support compression
 	// "2.1" support restore on 2 phases
 	Version = "2.1"
 	// "2.0" support compression
 	// Version = "2.0"
-	// version1 store plain files without compression
+	// version1 is the newest structure version that is no longer restorable
 	version1 = "1.0"
 )
 
-var errLegacySingleNode = errors.New("backup was created by Weaviate older than v1.17, which stored " +
-	"a single top-level backup.json instead of per-node metadata, and can no longer be restored: " +
-	"restore it on a release that still supports it and create a new backup")
+var (
+	errLegacySingleNode = legacyRestoreErr("by Weaviate older than v1.17, which stored a single " +
+		"top-level backup.json instead of per-node metadata")
+	errLegacyUncompressed = legacyRestoreErr("by Weaviate older than v1.21, which stored files uncompressed")
+)
+
+// legacyRestoreErr builds the refusal for a backup format this build no longer restores.
+func legacyRestoreErr(origin string) error {
+	return fmt.Errorf("backup was created %s, and can no longer be restored: restore it on a "+
+		"release that still supports it and create a new backup", origin)
+}
+
+// maxMajorVersion is the newest backup-structure major version this build restores.
+var maxMajorVersion, _, _ = parseVersion(Version)
+
+// checkRestorableVersion refuses backups this build cannot restore, either because their
+// format is too old or because a later Weaviate produced them. version is the
+// backup-structure version; serverVersion is the Weaviate version that wrote it.
+func checkRestorableVersion(version, serverVersion string) error {
+	// An empty version means a corrupt descriptor rather than an old one; Validate reports it.
+	if version != "" && version <= version1 {
+		return errLegacyUncompressed
+	}
+	if major, _, ok := parseVersion(version); ok && major > maxMajorVersion {
+		return fmt.Errorf("%s: %s > %s", errMsgHigherVersion, version, Version)
+	}
+	return nil
+}
+
+// parseVersion splits a "major.minor[.patch]" version. ok is false when either number is
+// missing or unparseable.
+func parseVersion(version string) (major, minor int, ok bool) {
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
+}
 
 // serverVersionOlderThan reports whether serverVersion, formatted "major.minor[.patch]",
 // is older than major.minor. An unparseable version is not treated as older.
 func serverVersionOlderThan(serverVersion string, major, minor int) bool {
-	parts := strings.Split(serverVersion, ".")
-	if len(parts) < 2 {
-		return false
-	}
-	gotMajor, err := strconv.Atoi(parts[0])
-	if err != nil {
-		return false
-	}
-	gotMinor, err := strconv.Atoi(parts[1])
-	if err != nil {
+	gotMajor, gotMinor, ok := parseVersion(serverVersion)
+	if !ok {
 		return false
 	}
 	if gotMajor != major {

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -99,6 +99,9 @@ func TestCheckRestorableVersion(t *testing.T) {
 		{version: "2.1", serverVersion: current},
 		{version: "2.9", serverVersion: current},
 		{version: "3.0", serverVersion: current, wantMsg: errMsgHigherVersion},
+		// A structure version may omit the minor; the major still decides.
+		{version: "3", serverVersion: current, wantMsg: errMsgHigherVersion},
+		{version: "10", serverVersion: current, wantMsg: errMsgHigherVersion},
 		// A byte compare read this as older than "2.1" and wrongly accepted it.
 		{version: "10.0", serverVersion: current, wantMsg: errMsgHigherVersion},
 		// A corrupt descriptor is reported by Validate, not refused as an old format.

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -13,6 +13,7 @@ package backup
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -53,6 +54,32 @@ func TestFilterClasses(t *testing.T) {
 	for _, tc := range tests {
 		got := filterClasses(tc.in, tc.xs)
 		assert.ElementsMatch(t, tc.out, got)
+	}
+}
+
+func TestServerVersionOlderThan(t *testing.T) {
+	tests := []struct {
+		serverVersion string
+		want          bool
+	}{
+		{serverVersion: "1.9", want: true},
+		{serverVersion: "1.100", want: false},
+		{serverVersion: "1.22.3", want: true},
+		{serverVersion: "1.23", want: false},
+		{serverVersion: "1.23.0", want: false},
+		{serverVersion: "1.16", want: true},
+		{serverVersion: "2.0", want: false},
+		{serverVersion: "0.9", want: true},
+		{serverVersion: "", want: false},
+		{serverVersion: "garbage", want: false},
+		{serverVersion: "1", want: false},
+		{serverVersion: "1.x", want: false},
+		{serverVersion: "v1.22", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.serverVersion), func(t *testing.T) {
+			assert.Equal(t, tc.want, serverVersionOlderThan(tc.serverVersion, 1, 23))
+		})
 	}
 }
 

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/backup"
 )
@@ -79,6 +80,41 @@ func TestServerVersionOlderThan(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("%q", tc.serverVersion), func(t *testing.T) {
 			assert.Equal(t, tc.want, serverVersionOlderThan(tc.serverVersion, 1, 23))
+		})
+	}
+}
+
+func TestCheckRestorableVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		wantErr error
+		wantMsg string
+	}{
+		{version: "1.0", wantErr: errLegacyUncompressed},
+		{version: "1", wantErr: errLegacyUncompressed},
+		{version: "0.9", wantErr: errLegacyUncompressed},
+		{version: "2.0"},
+		{version: "2.1"},
+		{version: "2.9"},
+		{version: "3.0", wantMsg: errMsgHigherVersion},
+		// A byte compare read this as older than "2.1" and wrongly accepted it.
+		{version: "10.0", wantMsg: errMsgHigherVersion},
+		// A corrupt descriptor is reported by Validate, not refused as an old format.
+		{version: ""},
+		// The version this build writes must stay restorable by it.
+		{version: Version},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("%q", tc.version), func(t *testing.T) {
+			err := checkRestorableVersion(tc.version, "1.23")
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+			case tc.wantMsg != "":
+				require.ErrorContains(t, err, tc.wantMsg)
+			default:
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/usecases/backup/handler_test.go
+++ b/usecases/backup/handler_test.go
@@ -85,28 +85,41 @@ func TestServerVersionOlderThan(t *testing.T) {
 }
 
 func TestCheckRestorableVersion(t *testing.T) {
+	const current = "1.23"
 	tests := []struct {
-		version string
-		wantErr error
-		wantMsg string
+		version       string
+		serverVersion string
+		wantErr       error
+		wantMsg       string
 	}{
-		{version: "1.0", wantErr: errLegacyUncompressed},
-		{version: "1", wantErr: errLegacyUncompressed},
-		{version: "0.9", wantErr: errLegacyUncompressed},
-		{version: "2.0"},
-		{version: "2.1"},
-		{version: "2.9"},
-		{version: "3.0", wantMsg: errMsgHigherVersion},
+		{version: "1.0", serverVersion: current, wantErr: errLegacyUncompressed},
+		{version: "1", serverVersion: current, wantErr: errLegacyUncompressed},
+		{version: "0.9", serverVersion: current, wantErr: errLegacyUncompressed},
+		{version: "2.0", serverVersion: current},
+		{version: "2.1", serverVersion: current},
+		{version: "2.9", serverVersion: current},
+		{version: "3.0", serverVersion: current, wantMsg: errMsgHigherVersion},
 		// A byte compare read this as older than "2.1" and wrongly accepted it.
-		{version: "10.0", wantMsg: errMsgHigherVersion},
+		{version: "10.0", serverVersion: current, wantMsg: errMsgHigherVersion},
 		// A corrupt descriptor is reported by Validate, not refused as an old format.
-		{version: ""},
+		{version: "", serverVersion: current},
 		// The version this build writes must stay restorable by it.
-		{version: Version},
+		{version: Version, serverVersion: current},
+
+		{version: Version, serverVersion: "1.22", wantErr: errLegacyFlatFS},
+		{version: Version, serverVersion: "1.16", wantErr: errLegacyFlatFS},
+		// A lexical compare read "1.100" as older than "1.23" and would have refused it.
+		{version: Version, serverVersion: "1.100"},
+		{version: Version, serverVersion: "2.0"},
+		// An unreadable server version is never classified as an old format.
+		{version: Version, serverVersion: ""},
+		{version: Version, serverVersion: "garbage"},
+		// Both clauses match; the format the version names is reported first.
+		{version: "1.0", serverVersion: "1.16", wantErr: errLegacyUncompressed},
 	}
 	for _, tc := range tests {
-		t.Run(fmt.Sprintf("%q", tc.version), func(t *testing.T) {
-			err := checkRestorableVersion(tc.version, "1.23")
+		t.Run(fmt.Sprintf("%q/%q", tc.version, tc.serverVersion), func(t *testing.T) {
+			err := checkRestorableVersion(tc.version, tc.serverVersion)
 			switch {
 			case tc.wantErr != nil:
 				require.ErrorIs(t, err, tc.wantErr)

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -233,7 +233,7 @@ func (r *restorer) restoreOne(ctx context.Context,
 		WithPoolPercentage(cpuPercentage)
 
 	// Pre-v1.23 versions store files in a flat format
-	if serverVersion < "1.23" {
+	if serverVersionOlderThan(serverVersion, 1, 23) {
 		f, err := hfsMigrator(desc, r.node, serverVersion)
 		if err != nil {
 			return fmt.Errorf("migrate to pre 1.23: %w", err)
@@ -327,7 +327,7 @@ func (s oneClassSchema) ReadOnlySchema() models.Schema {
 
 // hfsMigrator builds and return a class migrator ready for use
 func hfsMigrator(desc *backup.ClassDescriptor, nodeName string, serverVersion string) (func(classDir string) error, error) {
-	if serverVersion >= "1.23" {
+	if !serverVersionOlderThan(serverVersion, 1, 23) {
 		return func(string) error { return nil }, nil
 	}
 	var ss sharding.State

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -13,7 +13,6 @@ package backup
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -27,8 +26,6 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/monitoring"
-	migratefs "github.com/weaviate/weaviate/usecases/schema/migrate/fs"
-	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 type restorer struct {
@@ -190,7 +187,7 @@ func (r *restorer) restoreAll(ctx context.Context,
 			r.lastOp.set(backup.Cancelled)
 			return fmt.Errorf("restore cancelled: %w", err)
 		}
-		if err := r.restoreOne(ctx, &cdesc, desc.ServerVersion, compressionType, cpuPercentage, store, overrideBucket, overridePath); err != nil {
+		if err := r.restoreOne(ctx, &cdesc, compressionType, cpuPercentage, store, overrideBucket, overridePath); err != nil {
 			if errors.Is(err, context.Canceled) {
 				r.lastOp.set(backup.Cancelled)
 				return fmt.Errorf("restore cancelled: %w", err)
@@ -214,7 +211,7 @@ func getType(myvar interface{}) string {
 }
 
 func (r *restorer) restoreOne(ctx context.Context,
-	desc *backup.ClassDescriptor, serverVersion string, compressionType backup.CompressionType,
+	desc *backup.ClassDescriptor, compressionType backup.CompressionType,
 	cpuPercentage int, store nodeStore,
 	overrideBucket, overridePath string,
 ) (err error) {
@@ -230,15 +227,6 @@ func (r *restorer) restoreOne(ctx context.Context,
 
 	fw := newFileWriter(r.sourcer, store, r.logger).
 		WithPoolPercentage(cpuPercentage)
-
-	// Pre-v1.23 versions store files in a flat format
-	if serverVersionOlderThan(serverVersion, 1, 23) {
-		f, err := hfsMigrator(desc, r.node, serverVersion)
-		if err != nil {
-			return fmt.Errorf("migrate to pre 1.23: %w", err)
-		}
-		fw.setMigrator(f)
-	}
 
 	if err := fw.Write(ctx, desc, overrideBucket, overridePath, compressionType); err != nil {
 		return fmt.Errorf("write files: %w", err)
@@ -297,54 +285,4 @@ func (r *restorer) validate(ctx context.Context, store *nodeStore, req *Request)
 	}
 
 	return meta, cs, nil
-}
-
-// oneClassSchema allows for creating schema with one class
-// This is required when migrating to hierarchical file structure from pre-v1.23
-type oneClassSchema struct {
-	cls *models.Class
-	ss  *sharding.State
-}
-
-func (s oneClassSchema) Read(_ string, reader func(*models.Class, *sharding.State) error) error {
-	return reader(s.cls, s.ss)
-}
-
-func (s oneClassSchema) Shards(_ string) ([]string, error) {
-	return s.ss.AllPhysicalShards(), nil
-}
-
-func (s oneClassSchema) LocalShards() ([]string, error) {
-	return s.ss.AllLocalPhysicalShards(), nil
-}
-
-func (s oneClassSchema) ReadOnlySchema() models.Schema {
-	return models.Schema{
-		Classes: []*models.Class{s.cls},
-	}
-}
-
-// hfsMigrator builds and return a class migrator ready for use
-func hfsMigrator(desc *backup.ClassDescriptor, nodeName string, serverVersion string) (func(classDir string) error, error) {
-	if !serverVersionOlderThan(serverVersion, 1, 23) {
-		return func(string) error { return nil }, nil
-	}
-	var ss sharding.State
-	if desc.ShardingState != nil {
-		err := json.Unmarshal(desc.ShardingState, &ss)
-		if err != nil {
-			return nil, fmt.Errorf("marshal sharding state: %w", err)
-		}
-	}
-	ss.SetLocalName(nodeName)
-
-	// get schema and sharding state
-	class := &models.Class{}
-	if err := json.Unmarshal(desc.Schema, &class); err != nil {
-		return nil, fmt.Errorf("marshal class schema: %w", err)
-	}
-
-	return func(classDir string) error {
-		return migratefs.MigrateToHierarchicalFS(classDir, oneClassSchema{class, &ss})
-	}, nil
 }

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -154,7 +154,6 @@ func (r *restorer) restoreAll(ctx context.Context,
 	store nodeStore, overrideBucket, overridePath, rbacRestoreOption, usersRestoreOption string,
 ) error {
 	compressionType := desc.GetCompressionType()
-	compressed := desc.Version > version1
 	r.lastOp.set(backup.Transferring)
 
 	// Check for cancellation before starting restore operations
@@ -191,7 +190,7 @@ func (r *restorer) restoreAll(ctx context.Context,
 			r.lastOp.set(backup.Cancelled)
 			return fmt.Errorf("restore cancelled: %w", err)
 		}
-		if err := r.restoreOne(ctx, &cdesc, desc.ServerVersion, compressionType, compressed, cpuPercentage, store, overrideBucket, overridePath); err != nil {
+		if err := r.restoreOne(ctx, &cdesc, desc.ServerVersion, compressionType, cpuPercentage, store, overrideBucket, overridePath); err != nil {
 			if errors.Is(err, context.Canceled) {
 				r.lastOp.set(backup.Cancelled)
 				return fmt.Errorf("restore cancelled: %w", err)
@@ -216,7 +215,7 @@ func getType(myvar interface{}) string {
 
 func (r *restorer) restoreOne(ctx context.Context,
 	desc *backup.ClassDescriptor, serverVersion string, compressionType backup.CompressionType,
-	compressed bool, cpuPercentage int, store nodeStore,
+	cpuPercentage int, store nodeStore,
 	overrideBucket, overridePath string,
 ) (err error) {
 	classLabel := desc.Name
@@ -229,7 +228,7 @@ func (r *restorer) restoreOne(ctx context.Context,
 		defer timer.ObserveDuration()
 	}
 
-	fw := newFileWriter(r.sourcer, store, compressed, r.logger).
+	fw := newFileWriter(r.sourcer, store, r.logger).
 		WithPoolPercentage(cpuPercentage)
 
 	// Pre-v1.23 versions store files in a flat format
@@ -282,11 +281,11 @@ func (r *restorer) validate(ctx context.Context, store *nodeStore, req *Request)
 		err = fmt.Errorf("invalid backup in restorer %s status: %s", destPath, meta.Status)
 		return nil, nil, err
 	}
-	if err := meta.Validate(meta.Version > version1); err != nil {
-		return nil, nil, fmt.Errorf("corrupted backup file: %w", err)
+	if err := checkRestorableVersion(meta.Version, meta.ServerVersion); err != nil {
+		return nil, nil, err
 	}
-	if v := meta.Version; v[0] > Version[0] {
-		return nil, nil, fmt.Errorf("%s: %s > %s", errMsgHigherVersion, v, Version)
+	if err := meta.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("corrupted backup file: %w", err)
 	}
 	cs := meta.List()
 	if len(req.Classes) > 0 {

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -267,7 +267,7 @@ func (r *restorer) status(backend, ID string) (Status, error) {
 
 func (r *restorer) validate(ctx context.Context, store *nodeStore, req *Request) (*backup.BackupDescriptor, []string, error) {
 	destPath := store.HomeDir(req.Bucket, req.Path)
-	meta, err := store.Meta(ctx, req.ID, req.Bucket, req.Path, true)
+	meta, err := store.Meta(ctx, req.ID, req.Bucket, req.Path)
 	if err != nil {
 		nerr := backup.ErrNotFound{}
 		if errors.As(err, &nerr) {

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -126,7 +126,7 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		ID:            backupID,
 		StartedAt:     timept,
 		Version:       Version,
-		ServerVersion: "1.22",
+		ServerVersion: "1.23",
 		Status:        backup.Success,
 		Classes: []backup.ClassDescriptor{{
 			Name:          cls,
@@ -170,17 +170,28 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		assert.Equal(t, time.Duration(0), resp.Timeout)
 	})
 
-	t.Run("RejectUncompressedBackup", func(t *testing.T) {
-		for _, version := range []string{"1.0", "1"} {
-			t.Run(version, func(t *testing.T) {
+	t.Run("RejectLegacyBackup", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			version       string
+			serverVersion string
+			wantErr       error
+		}{
+			{name: "uncompressed 1.0", version: "1.0", serverVersion: metadata.ServerVersion, wantErr: errLegacyUncompressed},
+			{name: "uncompressed 1", version: "1", serverVersion: metadata.ServerVersion, wantErr: errLegacyUncompressed},
+			{name: "flat file structure", version: metadata.Version, serverVersion: "1.22", wantErr: errLegacyFlatFS},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
 				legacy := metadata
-				legacy.Version = version
+				legacy.Version = tc.version
+				legacy.ServerVersion = tc.serverVersion
 				backend := newFakeBackend()
 				backend.On("GetObject", ctx, nodeHome, BackupFile).Return(marshalMeta(legacy), nil)
 				backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 				bm := createManager(nil, nil, backend, nil)
 				resp := bm.OnCanCommit(ctx, &req)
-				assert.Contains(t, resp.Err, errLegacyUncompressed.Error())
+				assert.Contains(t, resp.Err, tc.wantErr.Error())
 				assert.Equal(t, time.Duration(0), resp.Timeout)
 			})
 		}
@@ -321,7 +332,7 @@ func TestRestoreAllCancellation(t *testing.T) {
 
 		desc := &backup.BackupDescriptor{
 			ID:            backupID,
-			ServerVersion: "1.23", // Use version >= 1.23 to skip migration
+			ServerVersion: "1.23",
 			Version:       "1",
 			StartedAt:     time.Now().UTC(),
 			Classes: []backup.ClassDescriptor{

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -97,12 +97,13 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		backendName = "gcs"
 		rawbytes    = []byte("hello")
 		timept      = time.Now().UTC()
-		cls         = "Class-A"
-		backupID    = "2"
-		ctx         = context.Background()
-		nodeHome    = backupID + "/" + nodeName
-		path        = "bucket/backups/" + nodeHome
-		req         = Request{
+		// Article matches the chunk fixture registered in fakes_test.go.
+		cls      = "Article"
+		backupID = "2"
+		ctx      = context.Background()
+		nodeHome = backupID + "/" + nodeName
+		path     = "bucket/backups/" + nodeHome
+		req      = Request{
 			Method:   OpRestore,
 			ID:       backupID,
 			Classes:  []string{cls},
@@ -124,13 +125,14 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 	metadata := backup.BackupDescriptor{
 		ID:            backupID,
 		StartedAt:     timept,
-		Version:       "1",
+		Version:       Version,
 		ServerVersion: "1.22",
 		Status:        backup.Success,
 		Classes: []backup.ClassDescriptor{{
 			Name:          cls,
 			Schema:        rawClassBytes,
 			ShardingState: rawShardingStateBytes,
+			Chunks:        map[int32][]string{1: {"dir1/file1", "dir2/file2"}},
 			Shards: []*backup.ShardDescriptor{
 				{
 					Name: "Shard1", Node: "Node-1",
@@ -168,6 +170,22 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		assert.Equal(t, time.Duration(0), resp.Timeout)
 	})
 
+	t.Run("RejectUncompressedBackup", func(t *testing.T) {
+		for _, version := range []string{"1.0", "1"} {
+			t.Run(version, func(t *testing.T) {
+				legacy := metadata
+				legacy.Version = version
+				backend := newFakeBackend()
+				backend.On("GetObject", ctx, nodeHome, BackupFile).Return(marshalMeta(legacy), nil)
+				backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+				bm := createManager(nil, nil, backend, nil)
+				resp := bm.OnCanCommit(ctx, &req)
+				assert.Contains(t, resp.Err, errLegacyUncompressed.Error())
+				assert.Equal(t, time.Duration(0), resp.Timeout)
+			})
+		}
+	})
+
 	t.Run("AnotherBackupIsInProgress", func(t *testing.T) {
 		backend := newFakeBackend()
 		sourcer := &fakeSourcer{}
@@ -193,7 +211,7 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(bytes, nil)
 		backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		backend.On("SourceDataPath").Return(t.TempDir())
-		backend.On("WriteToFile", any, nodeHome, mock.Anything, mock.Anything).Return(nil)
+		backend.On("Read", any, nodeHome, chunkKey(cls, 1), mock.Anything).Return(int64(0), nil)
 		m := createManager(sourcer, nil, backend, nil)
 		resp1 := m.OnCanCommit(ctx, &req)
 		want1 := &CanCommitResponse{
@@ -218,7 +236,7 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(bytes, nil)
 		backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		backend.On("SourceDataPath").Return(t.TempDir())
-		backend.On("WriteToFile", any, nodeHome, mock.Anything, mock.Anything).Return(nil)
+		backend.On("Read", any, nodeHome, chunkKey(cls, 1), mock.Anything).Return(int64(0), nil)
 		m := createManager(sourcer, nil, backend, nil)
 		resp1 := m.OnCanCommit(ctx, &req)
 		want1 := &CanCommitResponse{

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -125,7 +125,7 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		ID:            backupID,
 		StartedAt:     timept,
 		Version:       "1",
-		ServerVersion: "1",
+		ServerVersion: "1.22",
 		Status:        backup.Success,
 		Classes: []backup.ClassDescriptor{{
 			Name:          cls,

--- a/usecases/backup/restorer_test.go
+++ b/usecases/backup/restorer_test.go
@@ -157,6 +157,17 @@ func TestManagerCoordinatedRestore(t *testing.T) {
 		assert.Equal(t, resp.Timeout, time.Duration(0))
 	})
 
+	t.Run("RejectSingleNodeBackup", func(t *testing.T) {
+		backend := newFakeBackend()
+		backend.On("GetObject", ctx, nodeHome, BackupFile).Return(nil, backup.ErrNotFound{})
+		backend.On("GetObject", ctx, backupID, BackupFile).Return(marshalMeta(metadata), nil)
+		backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		bm := createManager(nil, nil, backend, nil)
+		resp := bm.OnCanCommit(ctx, &req)
+		assert.Contains(t, resp.Err, errLegacySingleNode.Error())
+		assert.Equal(t, time.Duration(0), resp.Timeout)
+	})
+
 	t.Run("AnotherBackupIsInProgress", func(t *testing.T) {
 		backend := newFakeBackend()
 		sourcer := &fakeSourcer{}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -758,7 +758,7 @@ func (s *Scheduler) fetchSchema(
 		if err != nil {
 			return nil, err
 		}
-		meta, err := store.Meta(ctx, req.ID, store.bucket, store.path, true)
+		meta, err := store.Meta(ctx, req.ID, store.bucket, store.path)
 		if err != nil {
 			return nil, err
 		}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -711,11 +711,11 @@ func (s *Scheduler) validateRestoreRequest(ctx context.Context, store coordStore
 	if meta.Status != backup.Success {
 		return nil, fmt.Errorf("invalid backup in scheduler %s status: %s", destPath, meta.Status)
 	}
+	if err := checkRestorableVersion(meta.Version, meta.ServerVersion); err != nil {
+		return nil, err
+	}
 	if err := meta.Validate(); err != nil {
 		return nil, fmt.Errorf("corrupted backup file: %w", err)
-	}
-	if v := meta.Version; v[0] > Version[0] {
-		return nil, fmt.Errorf("%s: %s > %s", errMsgHigherVersion, v, Version)
 	}
 	cs := meta.Classes()
 

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -542,8 +542,8 @@ func TestSchedulerRestoration(t *testing.T) {
 	meta := backup.DistributedBackupDescriptor{
 		ID:            backupID,
 		StartedAt:     timePt,
-		Version:       "1",
-		ServerVersion: "1",
+		Version:       Version,
+		ServerVersion: "1.23",
 		Status:        backup.Success,
 		Nodes: map[string]*backup.NodeDescriptor{
 			nodeA: {Classes: []string{cls}},
@@ -698,8 +698,8 @@ func TestSchedulerRestoration(t *testing.T) {
 		metaWithOldNodes := backup.DistributedBackupDescriptor{
 			ID:            backupID,
 			StartedAt:     timePt,
-			Version:       "1",
-			ServerVersion: "1",
+			Version:       Version,
+			ServerVersion: "1.23",
 			Status:        backup.Success,
 			Nodes: map[string]*backup.NodeDescriptor{
 				oldNodeA: {Classes: []string{cls}},
@@ -796,8 +796,8 @@ func TestSchedulerRestoreRequestValidation(t *testing.T) {
 	meta := backup.DistributedBackupDescriptor{
 		ID:            id,
 		StartedAt:     timePt,
-		Version:       "1",
-		ServerVersion: "1",
+		Version:       Version,
+		ServerVersion: "1.23",
 		Status:        backup.Success,
 		Nodes: map[string]*backup.NodeDescriptor{
 			nodeName: {Classes: []string{cls}},
@@ -871,6 +871,21 @@ func TestSchedulerRestoreRequestValidation(t *testing.T) {
 		// backup.ErrUnprocessable has no Unwrap, so match on the surfaced message.
 		_, err := fs.scheduler().Restore(ctx, nil, req, false)
 		require.ErrorContains(t, err, errLegacySingleNode.Error())
+	})
+
+	t.Run("RejectUncompressedBackup", func(t *testing.T) {
+		for _, version := range []string{"1.0", "1"} {
+			t.Run(version, func(t *testing.T) {
+				legacy := meta
+				legacy.Version = version
+				fs := newFakeScheduler(nil)
+				fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(marshalCoordinatorMeta(legacy), nil)
+				fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+
+				_, err := fs.scheduler().Restore(ctx, nil, req, false)
+				require.ErrorContains(t, err, errLegacyUncompressed.Error())
+			})
+		}
 	})
 
 	t.Run("FailedBackup", func(t *testing.T) {

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
@@ -276,28 +277,21 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("ReadFromOldMetadata", func(t *testing.T) {
+	t.Run("RejectSingleNodeMetadata", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		completedAt := starTime.Add(time.Hour)
 		bytes := marshalMeta(
 			backup.BackupDescriptor{
 				StartedAt:   starTime,
-				CompletedAt: completedAt,
+				CompletedAt: starTime.Add(time.Hour),
 				Status:      backup.Success,
-				// 1.5Gb
-				PreCompressionSizeBytes: 1610612736,
 			},
 		)
-		want := want
-		want.CompletedAt = completedAt
-		want.Status = backup.Success
-		want.Size = 1.5
 		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
 		fs.backend.On("GetObject", ctx, id, BackupFile).Return(bytes, nil)
 		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		got, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
-		assert.Nil(t, err)
-		assert.Equal(t, want, got)
+		require.ErrorIs(t, err, errLegacySingleNode)
+		assert.Nil(t, got)
 	})
 }
 
@@ -867,6 +861,18 @@ func TestSchedulerRestoreRequestValidation(t *testing.T) {
 		}
 	})
 
+	t.Run("RejectSingleNodeBackup", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		bytes := marshalMeta(backup.BackupDescriptor{ID: id, Status: backup.Success})
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", ctx, id, BackupFile).Return(bytes, nil)
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+
+		// backup.ErrUnprocessable has no Unwrap, so match on the surfaced message.
+		_, err := fs.scheduler().Restore(ctx, nil, req, false)
+		require.ErrorContains(t, err, errLegacySingleNode.Error())
+	})
+
 	t.Run("FailedBackup", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
 		bytes := marshalMeta(backup.BackupDescriptor{ID: id, Status: backup.Failed})
@@ -1209,8 +1215,8 @@ func TestCancellingBackup(t *testing.T) {
 		// classes instead of a wildcard DELETE that a scoped caller would fail.
 		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).Return([]byte("{"), nil).Once()
 		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).Return(b, nil)
-		// The partial GlobalBackupFile read triggers the old-format fallback; deny it
-		// so the json.SyntaxError surfaces and the read is retried.
+		// The partial GlobalBackupFile read makes coordStore.Meta probe for single-node
+		// metadata; deny it so the json.SyntaxError surfaces and the read is retried.
 		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
 		fakeScheduler.backend.On("Initialize", mock.Anything, mock.Anything).Return(nil)
 

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -873,17 +873,28 @@ func TestSchedulerRestoreRequestValidation(t *testing.T) {
 		require.ErrorContains(t, err, errLegacySingleNode.Error())
 	})
 
-	t.Run("RejectUncompressedBackup", func(t *testing.T) {
-		for _, version := range []string{"1.0", "1"} {
-			t.Run(version, func(t *testing.T) {
+	t.Run("RejectLegacyBackup", func(t *testing.T) {
+		tests := []struct {
+			name          string
+			version       string
+			serverVersion string
+			wantErr       error
+		}{
+			{name: "uncompressed 1.0", version: "1.0", serverVersion: meta.ServerVersion, wantErr: errLegacyUncompressed},
+			{name: "uncompressed 1", version: "1", serverVersion: meta.ServerVersion, wantErr: errLegacyUncompressed},
+			{name: "flat file structure", version: meta.Version, serverVersion: "1.22", wantErr: errLegacyFlatFS},
+		}
+		for _, tc := range tests {
+			t.Run(tc.name, func(t *testing.T) {
 				legacy := meta
-				legacy.Version = version
+				legacy.Version = tc.version
+				legacy.ServerVersion = tc.serverVersion
 				fs := newFakeScheduler(nil)
 				fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(marshalCoordinatorMeta(legacy), nil)
 				fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 
 				_, err := fs.scheduler().Restore(ctx, nil, req, false)
-				require.ErrorContains(t, err, errLegacyUncompressed.Error())
+				require.ErrorContains(t, err, tc.wantErr.Error())
 			})
 		}
 	})


### PR DESCRIPTION
### What's being changed:

This PR drops the 3 legacy backup formats that we supported in the past:
1. Legacy format: Single-node backup (top-level backup.json instead of distributed backup_config.json),  Stopped writing it: #2277, 2022-10-10 (~v1.16/1.17)
2. Uncompressed "1.0" (plain files, no compression) Stopped writing it: #3327, 2023-08-08 (~v1.21)
3. Pre-v1.23 flat file structure, Stopped writing it: #4457, 2024-03-14 (v1.23)

Nothing could create these formats since over two years

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
