### PR TITLE
tokenizer: fix KagomeJa custom-dict throttle release without acquire

### DIFF
--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -155,18 +155,26 @@ func init_gse_ch() error {
 	return nil
 }
 
+// TokenizeForClass tokenizes like [Tokenize], except that the kagome
+// tokenizations consult the class's custom user-dictionary tokenizer first.
+// Only those two tokenizations pay the customTokenizers lookup; every other
+// tokenization dispatches straight to Tokenize.
 func TokenizeForClass(tokenization string, in string, class string) []string {
-	tokenizer, ok := customTokenizers.Load(class)
-	if tokenization == models.PropertyTokenizationKagomeKr && ok && tokenizer.(*KagomeTokenizers).Korean != nil {
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-		return tokenizeKagome(tokenizer.(*KagomeTokenizers).Korean, kagomeTokenizer.Normal, models.PropertyTokenizationKagomeKr, in)
-	} else if tokenization == models.PropertyTokenizationKagomeJa && ok && tokenizer.(*KagomeTokenizers).Japanese != nil {
-		defer func() { <-ApacTokenizerThrottle }()
-		return tokenizeKagome(tokenizer.(*KagomeTokenizers).Japanese, kagomeTokenizer.Search, models.PropertyTokenizationKagomeJa, in)
-	} else {
-		return Tokenize(tokenization, in)
+	switch tokenization {
+	case models.PropertyTokenizationKagomeKr:
+		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Korean != nil {
+			ApacTokenizerThrottle <- struct{}{}
+			defer func() { <-ApacTokenizerThrottle }()
+			return tokenizeKagome(custom.(*KagomeTokenizers).Korean, kagomeTokenizer.Normal, models.PropertyTokenizationKagomeKr, in)
+		}
+	case models.PropertyTokenizationKagomeJa:
+		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Japanese != nil {
+			ApacTokenizerThrottle <- struct{}{}
+			defer func() { <-ApacTokenizerThrottle }()
+			return tokenizeKagome(custom.(*KagomeTokenizers).Japanese, kagomeTokenizer.Search, models.PropertyTokenizationKagomeJa, in)
+		}
 	}
+	return Tokenize(tokenization, in)
 }
 
 func Tokenize(tokenization string, in string) []string {

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -64,17 +64,32 @@ var Tokenizations []string = []string{
 }
 
 func init() {
-	numParallel := runtime.GOMAXPROCS(0)
-	numParallelStr := os.Getenv("TOKENIZER_CONCURRENCY_COUNT")
-	if numParallelStr != "" {
-		x, err := strconv.Atoi(numParallelStr)
-		if err == nil {
-			numParallel = x
-		}
-	}
-	ApacTokenizerThrottle = make(chan struct{}, numParallel)
+	ApacTokenizerThrottle = make(chan struct{}, throttleCapacity(os.Getenv("TOKENIZER_CONCURRENCY_COUNT")))
 	InitOptionalTokenizers()
 	customTokenizers = sync.Map{}
+}
+
+// throttleCapacity computes the ApacTokenizerThrottle capacity from the
+// TOKENIZER_CONCURRENCY_COUNT env value. Non-numeric values and values below
+// 1 are rejected with a warning and fall back to runtime.GOMAXPROCS(0), like
+// an unset variable: a capacity-0 channel would deadlock the first
+// tokenization (an acquire with no holder to ever release it), and make
+// panics on a negative capacity.
+func throttleCapacity(envValue string) int {
+	fallback := runtime.GOMAXPROCS(0)
+	if envValue == "" {
+		return fallback
+	}
+	x, err := strconv.Atoi(envValue)
+	if err != nil {
+		logrus.StandardLogger().Warnf("invalid TOKENIZER_CONCURRENCY_COUNT %q, using default %d: %v", envValue, fallback, err)
+		return fallback
+	}
+	if x < 1 {
+		logrus.StandardLogger().Warnf("invalid TOKENIZER_CONCURRENCY_COUNT %d, must be at least 1, using default %d", x, fallback)
+		return fallback
+	}
+	return x
 }
 
 func InitOptionalTokenizers() {
@@ -157,8 +172,6 @@ func init_gse_ch() error {
 
 // TokenizeForClass tokenizes like [Tokenize], except that the kagome
 // tokenizations consult the class's custom user-dictionary tokenizer first.
-// Only those two tokenizations pay the customTokenizers lookup; every other
-// tokenization dispatches straight to Tokenize.
 func TokenizeForClass(tokenization string, in string, class string) []string {
 	switch tokenization {
 	case models.PropertyTokenizationKagomeKr:

--- a/entities/tokenizer/tokenizer_test.go
+++ b/entities/tokenizer/tokenizer_test.go
@@ -12,12 +12,37 @@
 package tokenizer
 
 import (
+	"runtime"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+// TestThrottleCapacity pins the throttle sizing against bad
+// TOKENIZER_CONCURRENCY_COUNT values: 0 would make the first tokenization
+// deadlock on a capacity-0 channel and make panics on a negative value, so
+// both must fall back like an unset variable.
+func TestThrottleCapacity(t *testing.T) {
+	fallback := runtime.GOMAXPROCS(0)
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{"unset", "", fallback},
+		{"valid positive", "3", 3},
+		{"zero", "0", fallback},
+		{"negative", "-2", fallback},
+		{"non-numeric", "many", fallback},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, throttleCapacity(tt.env))
+		})
+	}
+}
 
 func TestTokenizeParallel(t *testing.T) {
 	t.Setenv("USE_GSE", "true")

--- a/entities/tokenizer/tokenizer_userdict_test.go
+++ b/entities/tokenizer/tokenizer_userdict_test.go
@@ -13,8 +13,10 @@ package tokenizer
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -72,6 +74,46 @@ func TestKagomeUserTokenizerForClass(t *testing.T) {
 
 	tokens = TokenizeForClass(models.PropertyTokenizationKagomeKr, "We", className)
 	assert.Equal(t, []string{"W", "e"}, tokens)
+}
+
+// TestKagomeJaUserTokenizerForClassBalancesThrottle pins the throttle
+// acquire/release pairing of the KagomeJa custom-dictionary branch in
+// TokenizeForClass. A release without a matching acquire blocks the calling
+// goroutine forever on an empty throttle channel (or steals another holder's
+// release), so the call is made from a guarded goroutine: a hang is reported
+// as a test failure instead of a suite timeout.
+func TestKagomeJaUserTokenizerForClassBalancesThrottle(t *testing.T) {
+	ptr := func(s string) *string { return &s }
+	className := "TestClassJaThrottle"
+	err := AddCustomDict(className, []*models.TokenizerUserDictConfig{{
+		Tokenizer: models.PropertyTokenizationKagomeJa,
+		Replacements: []*models.TokenizerUserDictConfigReplacementsItems0{
+			{
+				Source: ptr("Weaviate"),
+				Target: ptr("We Aviate"),
+			},
+		},
+	}})
+	require.Nil(t, err)
+	defer func() {
+		require.Nil(t, AddCustomDict(className, nil))
+	}()
+
+	require.Zero(t, len(ApacTokenizerThrottle), "throttle must be empty before the call")
+
+	done := make(chan []string, 1)
+	go func() {
+		done <- TokenizeForClass(models.PropertyTokenizationKagomeJa, "Weaviate Semi Technologies", className)
+	}()
+
+	select {
+	case tokens := <-done:
+		assert.Equal(t, []string{"We", "Aviate", "Semi", "Technologies"}, tokens)
+	case <-time.After(30 * time.Second):
+		t.Fatal("TokenizeForClass(KagomeJa, custom dict) hung: throttle released without a matching acquire")
+	}
+
+	assert.Zero(t, len(ApacTokenizerThrottle), "throttle must be balanced (empty) after the call")
 }
 
 func TestKagomeUserTokenizerForClassValidate(t *testing.T) {

--- a/entities/tokenizer/tokenizer_userdict_test.go
+++ b/entities/tokenizer/tokenizer_userdict_test.go
@@ -20,8 +20,9 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
+func ptr(s string) *string { return &s }
+
 func generateReplacementModel() *models.TokenizerUserDictConfig {
-	ptr := func(s string) *string { return &s }
 	return &models.TokenizerUserDictConfig{
 		Tokenizer: models.PropertyTokenizationKagomeKr,
 		Replacements: []*models.TokenizerUserDictConfigReplacementsItems0{
@@ -76,16 +77,14 @@ func TestKagomeUserTokenizerForClass(t *testing.T) {
 	assert.Equal(t, []string{"W", "e"}, tokens)
 }
 
-// TestKagomeJaUserTokenizerForClassBalancesThrottle pins the throttle
-// acquire/release pairing of the KagomeJa custom-dictionary branch in
-// TokenizeForClass. A release without a matching acquire blocks the calling
-// goroutine forever on an empty throttle channel (or steals another holder's
-// release), so the call is made from a guarded goroutine: a hang is reported
-// as a test failure instead of a suite timeout.
-func TestKagomeJaUserTokenizerForClassBalancesThrottle(t *testing.T) {
-	ptr := func(s string) *string { return &s }
-	className := "TestClassJaThrottle"
-	err := AddCustomDict(className, []*models.TokenizerUserDictConfig{{
+// TestKagomeUserTokenizerForClassBalancesThrottle pins the throttle
+// acquire/release pairing of the kagome custom-dictionary branches in
+// TokenizeForClass, including the fallthrough to the global tokenizer when
+// the class's dict has no tokenizer for the requested language. Each call is
+// made from a guarded goroutine so an unbalanced throttle surfaces as a test
+// failure instead of a suite timeout.
+func TestKagomeUserTokenizerForClassBalancesThrottle(t *testing.T) {
+	jaDict := &models.TokenizerUserDictConfig{
 		Tokenizer: models.PropertyTokenizationKagomeJa,
 		Replacements: []*models.TokenizerUserDictConfigReplacementsItems0{
 			{
@@ -93,33 +92,78 @@ func TestKagomeJaUserTokenizerForClassBalancesThrottle(t *testing.T) {
 				Target: ptr("We Aviate"),
 			},
 		},
-	}})
-	require.Nil(t, err)
-	defer func() {
-		require.Nil(t, AddCustomDict(className, nil))
-	}()
-
-	require.Zero(t, len(ApacTokenizerThrottle), "throttle must be empty before the call")
-
-	done := make(chan []string, 1)
-	go func() {
-		done <- TokenizeForClass(models.PropertyTokenizationKagomeJa, "Weaviate Semi Technologies", className)
-	}()
-
-	select {
-	case tokens := <-done:
-		assert.Equal(t, []string{"We", "Aviate", "Semi", "Technologies"}, tokens)
-	case <-time.After(30 * time.Second):
-		t.Fatal("TokenizeForClass(KagomeJa, custom dict) hung: throttle released without a matching acquire")
 	}
 
-	assert.Zero(t, len(ApacTokenizerThrottle), "throttle must be balanced (empty) after the call")
+	tests := []struct {
+		name         string
+		tokenization string
+		dict         *models.TokenizerUserDictConfig
+		// nil means: expect the output of the global Tokenize for the same
+		// input (the custom-dict fallthrough)
+		want []string
+	}{
+		{
+			name:         "KagomeJa with custom JA dict",
+			tokenization: models.PropertyTokenizationKagomeJa,
+			dict:         jaDict,
+			want:         []string{"We", "Aviate", "Semi", "Technologies"},
+		},
+		{
+			name:         "KagomeKr with custom KR dict",
+			tokenization: models.PropertyTokenizationKagomeKr,
+			dict:         generateReplacementModel(),
+			want:         []string{"We", "Aviate", "SemiTechnologies"},
+		},
+		{
+			name:         "KagomeJa against KR-only dict falls through to global tokenizer",
+			tokenization: models.PropertyTokenizationKagomeJa,
+			dict:         generateReplacementModel(),
+			want:         nil,
+		},
+		{
+			name:         "KagomeKr against JA-only dict falls through to global tokenizer",
+			tokenization: models.PropertyTokenizationKagomeKr,
+			dict:         jaDict,
+			want:         nil,
+		},
+	}
+
+	const input = "Weaviate Semi Technologies"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			className := "TestClassThrottle"
+			require.NoError(t, AddCustomDict(className, []*models.TokenizerUserDictConfig{tt.dict}))
+			defer func() {
+				require.NoError(t, AddCustomDict(className, nil))
+			}()
+
+			want := tt.want
+			if want == nil {
+				want = Tokenize(tt.tokenization, input)
+			}
+
+			require.Zero(t, len(ApacTokenizerThrottle), "throttle must be empty before the call")
+
+			done := make(chan []string, 1)
+			go func() {
+				done <- TokenizeForClass(tt.tokenization, input, className)
+			}()
+
+			select {
+			case tokens := <-done:
+				assert.Equal(t, want, tokens)
+			case <-time.After(30 * time.Second):
+				t.Fatal("TokenizeForClass hung: throttle released without a matching acquire")
+			}
+
+			assert.Zero(t, len(ApacTokenizerThrottle), "throttle must be balanced (empty) after the call")
+		})
+	}
 }
 
 func TestKagomeUserTokenizerForClassValidate(t *testing.T) {
 	t.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
 	InitOptionalTokenizers()
-	ptr := func(s string) *string { return &s }
 	className := "TestClass"
 	format := generateReplacementModel()
 	format.Replacements[2].Source = nil // invalid


### PR DESCRIPTION
## Motivation

`TokenizeForClass`'s KagomeJa custom-dictionary branch deferred a receive from `ApacTokenizerThrottle` without ever performing the matching acquire send that its KagomeKr sibling (and every site in `Tokenize`) performs. Any KagomeJa query against a class with a user dictionary therefore either hung its goroutine forever on the empty throttle channel, or stole another tokenizer's release token and hung *that* goroutine later — a silent, hard-to-attribute stall.

While fixing this, an adjacent bug surfaced in throttle sizing: `TOKENIZER_CONCURRENCY_COUNT=0` built a capacity-0 channel, so the *first* gse/kagome tokenization blocked forever with no log line, and a negative value panicked `make` during package init.

## Approach

- `TokenizeForClass` is restructured to switch on the tokenization *before* consulting `customTokenizers`: only KagomeKr/KagomeJa can ever use a custom class tokenizer, so every other tokenization skips the `sync.Map` lookup and dispatches straight to `Tokenize`. The two kagome branches are now structurally identical, so the acquire/release asymmetry cannot quietly reappear.
- Throttle sizing is extracted into `throttleCapacity`, which rejects non-numeric values and values below 1 with a warning and falls back to `runtime.GOMAXPROCS(0)` — the same behavior as an unset variable. Extracting it also makes the sizing directly unit-testable without process-restart gymnastics around `init()`.

## Key areas for review

- `entities/tokenizer/tokenizer.go:TokenizeForClass` — the core fix; verify both kagome branches pair acquire and release, and that the fallthrough to `Tokenize` covers every non-matching case
- `entities/tokenizer/tokenizer.go:throttleCapacity` — the env-value clamp and fallback semantics

## Risks and mitigations

- **Behavioral change for `TOKENIZER_CONCURRENCY_COUNT<=0`**: previously deadlock (0) or init panic (negative); now falls back to `GOMAXPROCS` with a warning. Both prior behaviors were unusable, so no working configuration changes.
- **Regression of the throttle pairing**: pinned by `TestKagomeUserTokenizerForClassBalancesThrottle`, which runs each call in a guarded goroutine so an unbalanced throttle fails the test (30s guard) instead of timing out the suite.

## Testing

- `TestKagomeUserTokenizerForClassBalancesThrottle` — table-driven over all four custom-dict paths: KagomeJa with a JA dict (red on the old code — 30s hang guard — green with the fix), KagomeKr with a KR dict, and both cross-language fallthroughs (requested language absent from the dict), asserted against the global tokenizer's own output. Asserts the throttle is empty before and after every call.
- `TestThrottleCapacity` — table-driven over unset, valid, zero, negative, and non-numeric env values.