### PR TITLE
tokenizer: add AnalyzeBatch with resolve-once dispatch and metrics at dispatch

### DIFF
--- a/entities/tokenizer/analyze.go
+++ b/entities/tokenizer/analyze.go
@@ -85,19 +85,7 @@ func Analyze(
 	prepared *PreparedAnalyzer,
 	stopwords StopwordDetector,
 ) AnalyzeResult {
-	fn, throttled := resolveTokenizer(tokenization, className)
-	if fn == nil {
-		return AnalyzeResult{Indexed: []string{}, Query: []string{}}
-	}
-	if throttled {
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-	}
-
-	text = prepared.foldText(text)
-	// the empty (zero-byte, non-nil) seed keeps Indexed non-nil even when no
-	// tokens are appended
-	indexed := timed(tokenization, text, []string{}, fn)
+	indexed := TokenizeForClass(tokenization, prepared.foldText(text), className)
 	query := filterStopwords(make([]string, 0, len(indexed)), indexed, stopwords)
 	return AnalyzeResult{
 		Indexed: indexed,
@@ -107,9 +95,9 @@ func Analyze(
 
 // AnalyzedBatch holds the per-value query tokens produced by AnalyzeBatch.
 // It is backed by two flat arrays — every token in value order plus one end
-// offset per value — so the batch costs a constant number of allocations
-// regardless of how many values it holds; per-value views are computed on
-// access, never stored.
+// offset per value — so a large batch avoids the per-value result allocation
+// of calling Analyze in a loop (the shared backing buffers grow amortized);
+// per-value views are computed on access, never stored.
 //
 // All views returned by Tokens and All alias the shared backing array and
 // must be treated as read-only.
@@ -158,7 +146,13 @@ func (b *AnalyzedBatch) All() iter.Seq2[int, []string] {
 // tokenizer metrics once for the whole batch (one duration observation, the
 // summed pre-stopword token count) and reuses buffers across values, so the
 // per-value cost is the tokenization itself rather than metric and
-// allocation scaffolding.
+// allocation scaffolding. The whole batch counts as a single
+// TokenCountPerRequest observation with the summed token count, where the
+// per-value path observes once per value.
+//
+// Offsets are uint32: a single batch must stay under 4B tokens, which any
+// request-bounded caller does by orders of magnitude; exceeding it silently
+// corrupts per-value views.
 //
 // Per-value Indexed is intentionally not exposed: materializing it would
 // force a per-value allocation, defeating the batch — callers needing
@@ -225,11 +219,8 @@ func AnalyzeBatch(
 
 	// One record for the whole batch, under the same label the per-value path
 	// uses. As in Analyze, the token count is the indexed (pre-stopword)
-	// count; the duration covers the batch's full analysis loop.
-	m := metricsFor(tokenization)
-	m.duration.Observe(busy.Seconds())
-	m.tokenCount.Add(float64(totalTokens))
-	m.tokensPerRequest.Observe(float64(totalTokens))
+	// count; the duration is the summed in-slot analysis time.
+	metricsFor(tokenization).record(busy, totalTokens)
 	return batch
 }
 

--- a/entities/tokenizer/analyze.go
+++ b/entities/tokenizer/analyze.go
@@ -12,6 +12,9 @@
 package tokenizer
 
 import (
+	"iter"
+	"time"
+
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -56,6 +59,20 @@ func (p *PreparedAnalyzer) foldText(text string) string {
 	return FoldASCII(text, p.ignoreSet)
 }
 
+// filterStopwords appends the tokens that are not stopwords to dst; a nil
+// detector keeps every token. It is the one stopword-filter implementation —
+// Analyze and AnalyzeBatch both run fold → tokenize → filterStopwords,
+// differing only in buffer strategy.
+func filterStopwords(dst []string, tokens []string, stopwords StopwordDetector) []string {
+	for _, token := range tokens {
+		if stopwords != nil && stopwords.IsStopword(token) {
+			continue
+		}
+		dst = append(dst, token)
+	}
+	return dst
+}
+
 // Analyze runs the full text-analysis pipeline: ASCII-fold → tokenize →
 // stopword removal (query only).
 //
@@ -68,22 +85,133 @@ func Analyze(
 	prepared *PreparedAnalyzer,
 	stopwords StopwordDetector,
 ) AnalyzeResult {
-	text = prepared.foldText(text)
-
-	indexed := TokenizeForClass(tokenization, text, className)
-
-	query := make([]string, 0, len(indexed))
-	for _, token := range indexed {
-		if stopwords != nil && stopwords.IsStopword(token) {
-			continue
-		}
-		query = append(query, token)
+	fn, throttled := resolveTokenizer(tokenization, className)
+	if fn == nil {
+		return AnalyzeResult{Indexed: []string{}, Query: []string{}}
+	}
+	if throttled {
+		ApacTokenizerThrottle <- struct{}{}
+		defer func() { <-ApacTokenizerThrottle }()
 	}
 
+	text = prepared.foldText(text)
+	// the empty (zero-byte, non-nil) seed keeps Indexed non-nil even when no
+	// tokens are appended
+	indexed := timed(tokenization, text, []string{}, fn)
+	query := filterStopwords(make([]string, 0, len(indexed)), indexed, stopwords)
 	return AnalyzeResult{
 		Indexed: indexed,
 		Query:   query,
 	}
+}
+
+// AnalyzedBatch holds the per-value query tokens produced by AnalyzeBatch.
+// It is backed by two flat arrays — every token in value order plus one end
+// offset per value — so the batch costs a constant number of allocations
+// regardless of how many values it holds; per-value views are computed on
+// access, never stored.
+//
+// All views returned by Tokens and All alias the shared backing array and
+// must be treated as read-only.
+type AnalyzedBatch struct {
+	flat []string
+	// ends[i] is the end offset of value i's tokens in flat (value i's
+	// tokens are flat[ends[i-1]:ends[i]]). uint32 caps a batch at 4B tokens,
+	// far beyond any request size.
+	ends []uint32
+}
+
+// Len returns the number of values in the batch.
+func (b *AnalyzedBatch) Len() int {
+	return len(b.ends)
+}
+
+// Tokens returns value i's query tokens; the result is empty when value i
+// was entirely stopword-filtered (or the tokenization was unknown).
+func (b *AnalyzedBatch) Tokens(i int) []string {
+	start := uint32(0)
+	if i > 0 {
+		start = b.ends[i-1]
+	}
+	end := b.ends[i]
+	// full slice expression: a caller appending to one value's view cannot
+	// clobber its neighbor's tokens in the shared backing array
+	return b.flat[start:end:end]
+}
+
+// All iterates the batch in value order, yielding each value's index and
+// query tokens: for i, tokens := range batch.All() { ... }.
+func (b *AnalyzedBatch) All() iter.Seq2[int, []string] {
+	return func(yield func(int, []string) bool) {
+		start := uint32(0)
+		for i, end := range b.ends {
+			if !yield(i, b.flat[start:end:end]) {
+				return
+			}
+			start = end
+		}
+	}
+}
+
+// AnalyzeBatch analyzes each value independently — the batch equivalent of
+// calling Analyze per value and collecting each result's Query — but records
+// tokenizer metrics once for the whole batch (one duration observation, the
+// summed pre-stopword token count) and reuses buffers across values, so the
+// per-value cost is the tokenization itself rather than metric and
+// allocation scaffolding.
+//
+// Per-value Indexed is intentionally not exposed: materializing it would
+// force a per-value allocation, defeating the batch — callers needing
+// Indexed should use Analyze.
+func AnalyzeBatch(
+	values []string,
+	tokenization string,
+	className string,
+	prepared *PreparedAnalyzer,
+	stopwords StopwordDetector,
+) *AnalyzedBatch {
+	batch := &AnalyzedBatch{ends: make([]uint32, len(values))}
+	if len(values) == 0 {
+		return batch
+	}
+
+	// dispatch once for the whole batch; fn == nil (unknown tokenization or
+	// unavailable tokenizer) leaves every value's tokens empty (all end
+	// offsets zero) and records no metrics, matching the per-value path's
+	// guard early-outs
+	fn, throttled := resolveTokenizer(tokenization, className)
+	if fn == nil {
+		return batch
+	}
+
+	if throttled {
+		// held across the batch: one acquire instead of one per value, and
+		// panic-safe via defer (a per-value acquire would need a
+		// non-deferred release inside the loop)
+		ApacTokenizerThrottle <- struct{}{}
+		defer func() { <-ApacTokenizerThrottle }()
+	}
+
+	start := time.Now()
+	totalTokens := 0
+	flat := make([]string, 0, len(values))
+	var scratch []string // one value's raw tokens, reused across the batch
+	for i, v := range values {
+		scratch = fn(prepared.foldText(v), scratch[:0])
+		totalTokens += len(scratch)
+		flat = filterStopwords(flat, scratch, stopwords)
+		batch.ends[i] = uint32(len(flat))
+	}
+	batch.flat = flat
+
+	// One record for the whole batch, under the same label the per-value path
+	// uses. As in Analyze, the token count is the indexed (pre-stopword)
+	// count; the duration covers the batch's full analysis loop.
+	m := metricsFor(tokenization)
+	m.duration.Observe(time.Since(start).Seconds())
+	m.tokenCount.Add(float64(totalTokens))
+	m.tokensPerRequest.Observe(float64(totalTokens))
+	return batch
 }
 
 // AnalyzeAndCountDuplicates is like Analyze but also deduplicates tokens and

--- a/entities/tokenizer/analyze.go
+++ b/entities/tokenizer/analyze.go
@@ -184,23 +184,42 @@ func AnalyzeBatch(
 		return batch
 	}
 
-	if throttled {
-		// held across the batch: one acquire instead of one per value, and
-		// panic-safe via defer (a per-value acquire would need a
-		// non-deferred release inside the loop)
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-	}
-
-	start := time.Now()
 	totalTokens := 0
 	flat := make([]string, 0, len(values))
 	var scratch []string // one value's raw tokens, reused across the batch
-	for i, v := range values {
-		scratch = fn(prepared.foldText(v), scratch[:0])
-		totalTokens += len(scratch)
-		flat = filterStopwords(flat, scratch, stopwords)
-		batch.ends[i] = uint32(len(flat))
+	// busy is the in-slot analysis time, excluding waits on re-acquiring the
+	// throttle between chunks — the same semantics as the per-value path,
+	// which acquires before its duration window starts.
+	var busy time.Duration
+
+	// processChunk analyzes values[from:to] under one throttle acquisition
+	// (when the tokenization is throttled at all), released panic-safe via
+	// defer.
+	processChunk := func(from, to int) {
+		if throttled {
+			ApacTokenizerThrottle <- struct{}{}
+			defer func() { <-ApacTokenizerThrottle }()
+		}
+		chunkStart := time.Now()
+		defer func() { busy += time.Since(chunkStart) }()
+		for i := from; i < to; i++ {
+			scratch = fn(prepared.foldText(values[i]), scratch[:0])
+			totalTokens += len(scratch)
+			flat = filterStopwords(flat, scratch, stopwords)
+			batch.ends[i] = uint32(len(flat))
+		}
+	}
+
+	// An unthrottled batch runs as a single chunk. A throttled one yields its
+	// slot every throttledBatchChunk values, so concurrent large batches
+	// cannot hold every throttle slot for their whole duration and starve
+	// single-value tokenizations — waiters get in between chunks.
+	chunk := len(values)
+	if throttled {
+		chunk = throttledBatchChunk
+	}
+	for from := 0; from < len(values); from += chunk {
+		processChunk(from, min(from+chunk, len(values)))
 	}
 	batch.flat = flat
 
@@ -208,11 +227,18 @@ func AnalyzeBatch(
 	// uses. As in Analyze, the token count is the indexed (pre-stopword)
 	// count; the duration covers the batch's full analysis loop.
 	m := metricsFor(tokenization)
-	m.duration.Observe(time.Since(start).Seconds())
+	m.duration.Observe(busy.Seconds())
 	m.tokenCount.Add(float64(totalTokens))
 	m.tokensPerRequest.Observe(float64(totalTokens))
 	return batch
 }
+
+// throttledBatchChunk bounds how many values a batch analyzes per
+// ApacTokenizerThrottle acquisition. Throttled kernels cost roughly 0.1-1ms
+// per value, so 16 keeps the worst-case slot hold in the low milliseconds
+// for waiting single-value tokenizations, while the ~µs acquire/release cost
+// per chunk stays negligible.
+const throttledBatchChunk = 16
 
 // AnalyzeAndCountDuplicates is like Analyze but also deduplicates tokens and
 // returns per-token counts (boost factors). Used by BM25 scoring.

--- a/entities/tokenizer/analyze.go
+++ b/entities/tokenizer/analyze.go
@@ -12,7 +12,9 @@
 package tokenizer
 
 import (
+	"fmt"
 	"iter"
+	"math"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/models"
@@ -60,9 +62,7 @@ func (p *PreparedAnalyzer) foldText(text string) string {
 }
 
 // filterStopwords appends the tokens that are not stopwords to dst; a nil
-// detector keeps every token. It is the one stopword-filter implementation —
-// Analyze and AnalyzeBatch both run fold → tokenize → filterStopwords,
-// differing only in buffer strategy.
+// detector keeps every token.
 func filterStopwords(dst []string, tokens []string, stopwords StopwordDetector) []string {
 	for _, token := range tokens {
 		if stopwords != nil && stopwords.IsStopword(token) {
@@ -93,19 +93,14 @@ func Analyze(
 	}
 }
 
-// AnalyzedBatch holds the per-value query tokens produced by AnalyzeBatch.
-// It is backed by two flat arrays — every token in value order plus one end
-// offset per value — so a large batch avoids the per-value result allocation
-// of calling Analyze in a loop (the shared backing buffers grow amortized);
-// per-value views are computed on access, never stored.
-//
-// All views returned by Tokens and All alias the shared backing array and
-// must be treated as read-only.
+// AnalyzedBatch holds the per-value query tokens produced by AnalyzeBatch,
+// backed by two flat arrays: every token in value order plus one end offset
+// per value. All views returned by Tokens and All alias the shared backing
+// array and must be treated as read-only.
 type AnalyzedBatch struct {
 	flat []string
 	// ends[i] is the end offset of value i's tokens in flat (value i's
-	// tokens are flat[ends[i-1]:ends[i]]). uint32 caps a batch at 4B tokens,
-	// far beyond any request size.
+	// tokens are flat[ends[i-1]:ends[i]]).
 	ends []uint32
 }
 
@@ -115,15 +110,15 @@ func (b *AnalyzedBatch) Len() int {
 }
 
 // Tokens returns value i's query tokens; the result is empty when value i
-// was entirely stopword-filtered (or the tokenization was unknown).
+// was entirely stopword-filtered (or the tokenization was unknown). Tokens
+// panics if i is not in [0, Len()).
 func (b *AnalyzedBatch) Tokens(i int) []string {
 	start := uint32(0)
 	if i > 0 {
 		start = b.ends[i-1]
 	}
 	end := b.ends[i]
-	// full slice expression: a caller appending to one value's view cannot
-	// clobber its neighbor's tokens in the shared backing array
+	// three-index slice: appending to a view cannot clobber the next value's tokens
 	return b.flat[start:end:end]
 }
 
@@ -142,57 +137,42 @@ func (b *AnalyzedBatch) All() iter.Seq2[int, []string] {
 }
 
 // AnalyzeBatch analyzes each value independently — the batch equivalent of
-// calling Analyze per value and collecting each result's Query — but records
-// tokenizer metrics once for the whole batch (one duration observation, the
-// summed pre-stopword token count) and reuses buffers across values, so the
-// per-value cost is the tokenization itself rather than metric and
-// allocation scaffolding. The whole batch counts as a single
-// TokenCountPerRequest observation with the summed token count, where the
-// per-value path observes once per value.
-//
-// Offsets are uint32: a single batch must stay under 4B tokens, which any
-// request-bounded caller does by orders of magnitude; exceeding it silently
-// corrupts per-value views.
-//
-// Per-value Indexed is intentionally not exposed: materializing it would
-// force a per-value allocation, defeating the batch — callers needing
-// Indexed should use Analyze.
+// calling Analyze per value and collecting each result's Query — but reuses
+// buffers across values and records tokenizer metrics once for the whole
+// batch (one duration observation, one TokenCountPerRequest observation with
+// the summed pre-stopword count). Offsets are uint32: a batch producing more
+// than math.MaxUint32 tokens fails with an error. Per-value Indexed is not
+// exposed; callers needing it should use Analyze.
 func AnalyzeBatch(
 	values []string,
 	tokenization string,
 	className string,
 	prepared *PreparedAnalyzer,
 	stopwords StopwordDetector,
-) *AnalyzedBatch {
+) (*AnalyzedBatch, error) {
 	batch := &AnalyzedBatch{ends: make([]uint32, len(values))}
 	if len(values) == 0 {
-		return batch
+		return batch, nil
 	}
 
-	// dispatch once for the whole batch; fn == nil (unknown tokenization or
-	// unavailable tokenizer) leaves every value's tokens empty (all end
-	// offsets zero) and records no metrics, matching the per-value path's
-	// guard early-outs
+	// fn == nil (unknown tokenization or unavailable tokenizer) leaves every
+	// value's tokens empty and records no metrics, like the per-value path
 	fn, throttled := resolveTokenizer(tokenization, className)
 	if fn == nil {
-		return batch
+		return batch, nil
 	}
 
 	totalTokens := 0
 	flat := make([]string, 0, len(values))
 	var scratch []string // one value's raw tokens, reused across the batch
-	// busy is the in-slot analysis time, excluding waits on re-acquiring the
-	// throttle between chunks — the same semantics as the per-value path,
-	// which acquires before its duration window starts.
+	// in-slot analysis time only, excluding waits on re-acquiring the throttle
+	// between chunks — matching what the per-value path measures
 	var busy time.Duration
 
-	// processChunk analyzes values[from:to] under one throttle acquisition
-	// (when the tokenization is throttled at all), released panic-safe via
-	// defer.
-	processChunk := func(from, to int) {
+	// processChunk analyzes values[from:to] under one throttle acquisition.
+	processChunk := func(from, to int) error {
 		if throttled {
-			ApacTokenizerThrottle <- struct{}{}
-			defer func() { <-ApacTokenizerThrottle }()
+			defer acquireThrottleSlot()()
 		}
 		chunkStart := time.Now()
 		defer func() { busy += time.Since(chunkStart) }()
@@ -202,33 +182,33 @@ func AnalyzeBatch(
 			flat = filterStopwords(flat, scratch, stopwords)
 			batch.ends[i] = uint32(len(flat))
 		}
+		if uint64(len(flat)) > math.MaxUint32 {
+			return fmt.Errorf("batch produced %d tokens, above the uint32 offset limit %d", len(flat), uint32(math.MaxUint32))
+		}
+		return nil
 	}
 
-	// An unthrottled batch runs as a single chunk. A throttled one yields its
-	// slot every throttledBatchChunk values, so concurrent large batches
-	// cannot hold every throttle slot for their whole duration and starve
-	// single-value tokenizations — waiters get in between chunks.
+	// a throttled batch yields its slot every throttledBatchChunk values so it
+	// cannot starve concurrent single-value tokenizations; unthrottled runs whole
 	chunk := len(values)
 	if throttled {
 		chunk = throttledBatchChunk
 	}
 	for from := 0; from < len(values); from += chunk {
-		processChunk(from, min(from+chunk, len(values)))
+		if err := processChunk(from, min(from+chunk, len(values))); err != nil {
+			return nil, err
+		}
 	}
 	batch.flat = flat
 
-	// One record for the whole batch, under the same label the per-value path
-	// uses. As in Analyze, the token count is the indexed (pre-stopword)
-	// count; the duration is the summed in-slot analysis time.
+	// one record for the whole batch, under the same label the per-value path uses
 	metricsFor(tokenization).record(busy, totalTokens)
-	return batch
+	return batch, nil
 }
 
 // throttledBatchChunk bounds how many values a batch analyzes per
-// ApacTokenizerThrottle acquisition. Throttled kernels cost roughly 0.1-1ms
-// per value, so 16 keeps the worst-case slot hold in the low milliseconds
-// for waiting single-value tokenizations, while the ~µs acquire/release cost
-// per chunk stays negligible.
+// ApacTokenizerThrottle acquisition: throttled tokenizers cost ~0.1-1ms per
+// value, so 16 keeps the worst-case slot hold in the low milliseconds.
 const throttledBatchChunk = 16
 
 // AnalyzeAndCountDuplicates is like Analyze but also deduplicates tokens and

--- a/entities/tokenizer/analyze_batch_test.go
+++ b/entities/tokenizer/analyze_batch_test.go
@@ -1,0 +1,202 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+type fakeStopwords map[string]struct{}
+
+func (f fakeStopwords) IsStopword(word string) bool {
+	_, ok := f[word]
+	return ok
+}
+
+// TestAnalyzeBatchEquivalence is the drift guard for AnalyzeBatch: for every
+// tokenization × stopword × folding combination, the batch result must equal
+// Analyze called per value. A pipeline change applied to one entry point but
+// not the other turns this red.
+func TestAnalyzeBatchEquivalence(t *testing.T) {
+	className := "EquivClass"
+	// deliberately awkward inputs: plain multiword, mixed case + punctuation,
+	// leading/trailing unicode whitespace, empty, whitespace-only,
+	// stopword-only, foldable accents
+	values := []string{
+		"hello world",
+		"Hello, World-Wide!",
+		" \t padded value  ",
+		"",
+		"   ",
+		"the",
+		"café crème",
+	}
+
+	tokenizations := []string{
+		models.PropertyTokenizationField,
+		models.PropertyTokenizationWhitespace,
+		models.PropertyTokenizationLowercase,
+		models.PropertyTokenizationWord,
+		models.PropertyTokenizationTrigram,
+	}
+
+	stopwordVariants := map[string]StopwordDetector{
+		"no-stopwords": nil,
+		"stopwords":    fakeStopwords{"the": {}, "world": {}},
+	}
+
+	analyzerVariants := map[string]*PreparedAnalyzer{
+		"no-fold": nil,
+		"fold":    NewPreparedAnalyzer(&models.TextAnalyzerConfig{ASCIIFold: true}),
+	}
+
+	for _, tok := range tokenizations {
+		for swName, sw := range stopwordVariants {
+			for prepName, prepared := range analyzerVariants {
+				t.Run(fmt.Sprintf("%s/%s/%s", tok, swName, prepName), func(t *testing.T) {
+					got := AnalyzeBatch(values, tok, className, prepared, sw)
+					require.Equal(t, len(values), got.Len())
+					for i, v := range values {
+						want := Analyze(v, tok, className, prepared, sw).Query
+						assert.Equal(t, want, append([]string{}, got.Tokens(i)...),
+							"value %d (%q)", i, v)
+					}
+				})
+			}
+		}
+	}
+}
+
+// TestAnalyzeBatchEquivalenceCustomKagome covers the TokenizeForClass custom
+// user-dictionary branch, which AnalyzeBatch reaches through the same
+// unrecorded dispatch.
+func TestAnalyzeBatchEquivalenceCustomKagome(t *testing.T) {
+	className := "EquivClassKagome"
+	err := AddCustomDict(className, []*models.TokenizerUserDictConfig{generateReplacementModel()})
+	require.Nil(t, err)
+	defer func() {
+		require.Nil(t, AddCustomDict(className, nil))
+	}()
+
+	values := []string{"Weaviate Semi Technologies", "We Aviate", ""}
+	got := AnalyzeBatch(values, models.PropertyTokenizationKagomeKr, className, nil, nil)
+	require.Equal(t, len(values), got.Len())
+	for i, v := range values {
+		want := Analyze(v, models.PropertyTokenizationKagomeKr, className, nil, nil).Query
+		assert.Equal(t, want, append([]string{}, got.Tokens(i)...), "value %d (%q)", i, v)
+	}
+}
+
+// TestAnalyzeBatchMetricsOncePerBatch pins the batch metric contract: one
+// batch of N values adds exactly the summed token count under the
+// tokenization's label — not one observation per value, and nothing under
+// any other label.
+func TestAnalyzeBatchMetricsOncePerBatch(t *testing.T) {
+	countFor := func(label string) float64 {
+		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
+	}
+
+	fieldBefore := countFor(models.PropertyTokenizationField)
+	out := AnalyzeBatch([]string{" a ", "b", " c "}, models.PropertyTokenizationField, "C", nil, nil)
+	require.Equal(t, 3, out.Len())
+	require.Equal(t, fieldBefore+3, countFor(models.PropertyTokenizationField),
+		"batch of 3 FIELD values must add exactly 3 tokens under field")
+
+	wordBefore := countFor(models.PropertyTokenizationWord)
+	AnalyzeBatch([]string{"one two", "three"}, models.PropertyTokenizationWord, "C", nil, nil)
+	require.Equal(t, wordBefore+3, countFor(models.PropertyTokenizationWord),
+		"batch token count is the summed indexed count")
+
+	// empty batch records nothing
+	fieldBefore = countFor(models.PropertyTokenizationField)
+	out = AnalyzeBatch(nil, models.PropertyTokenizationField, "C", nil, nil)
+	require.Zero(t, out.Len())
+	require.Equal(t, fieldBefore, countFor(models.PropertyTokenizationField))
+}
+
+// TestAnalyzeBatchUnknownTokenization pins guard parity with the per-value
+// path: an unknown tokenization yields empty results for every value and
+// records nothing (no metric series under a bogus label).
+func TestAnalyzeBatchUnknownTokenization(t *testing.T) {
+	out := AnalyzeBatch([]string{"a", "b"}, "no-such-tokenization", "C", nil, nil)
+	require.Equal(t, 2, out.Len())
+	assert.Empty(t, out.Tokens(0))
+	assert.Empty(t, out.Tokens(1))
+	for _, v := range []string{"a", "b"} {
+		assert.Empty(t, Analyze(v, "no-such-tokenization", "C", nil, nil).Query)
+	}
+	count := testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues("no-such-tokenization"))
+	assert.Zero(t, count, "unknown tokenization must not record metrics")
+}
+
+// TestAnalyzeBatchStopwordFilteredValue pins the shape contract the searcher
+// relies on: a fully stopword-filtered value yields an EMPTY result at its
+// index (not a shifted or missing entry).
+func TestAnalyzeBatchStopwordFilteredValue(t *testing.T) {
+	sw := fakeStopwords{"the": {}}
+	out := AnalyzeBatch([]string{"keep", "the", "also-keep"},
+		models.PropertyTokenizationField, "C", nil, sw)
+	require.Equal(t, 3, out.Len())
+	assert.Equal(t, []string{"keep"}, append([]string{}, out.Tokens(0)...))
+	assert.Empty(t, out.Tokens(1))
+	assert.Equal(t, []string{"also-keep"}, append([]string{}, out.Tokens(2)...))
+}
+
+// TestAnalyzedBatchAccessors pins the AnalyzedBatch API contract: All yields
+// every value's index and tokens in order, each identical to Tokens(i);
+// breaking out of All stops the iteration; views cannot clobber their
+// neighbors through the shared backing array.
+func TestAnalyzedBatchAccessors(t *testing.T) {
+	out := AnalyzeBatch([]string{"one two", "", "three four five"},
+		models.PropertyTokenizationWhitespace, "C", nil, nil)
+	require.Equal(t, 3, out.Len())
+
+	t.Run("All matches Tokens, in order", func(t *testing.T) {
+		var seen []int
+		for i, tokens := range out.All() {
+			assert.Equal(t, out.Tokens(i), tokens)
+			seen = append(seen, i)
+		}
+		assert.Equal(t, []int{0, 1, 2}, seen)
+	})
+
+	t.Run("Tokens per value", func(t *testing.T) {
+		assert.Equal(t, []string{"one", "two"}, out.Tokens(0))
+		assert.Empty(t, out.Tokens(1))
+		assert.Equal(t, []string{"three", "four", "five"}, out.Tokens(2))
+	})
+
+	t.Run("break stops All early", func(t *testing.T) {
+		var seen []int
+		for i := range out.All() {
+			seen = append(seen, i)
+			if i == 1 {
+				break
+			}
+		}
+		assert.Equal(t, []int{0, 1}, seen)
+	})
+
+	t.Run("appending to one view cannot clobber the next value", func(t *testing.T) {
+		grown := append(out.Tokens(0), "INJECTED")
+		require.Equal(t, []string{"one", "two", "INJECTED"}, grown)
+		assert.Equal(t, []string{"three", "four", "five"}, out.Tokens(2),
+			"full-slice-capped views must force append to reallocate")
+	})
+}

--- a/entities/tokenizer/analyze_batch_test.go
+++ b/entities/tokenizer/analyze_batch_test.go
@@ -103,6 +103,32 @@ func TestAnalyzeBatchEquivalenceCustomKagome(t *testing.T) {
 	}
 }
 
+// TestAnalyzeBatchEquivalenceThrottledGseCh covers the throttled batch path:
+// the batch acquires the ApacTokenizerThrottle in throttledBatchChunk-sized
+// chunks, so the test spans several chunks and pins per-value equivalence
+// with Analyze plus a balanced throttle afterwards.
+func TestAnalyzeBatchEquivalenceThrottledGseCh(t *testing.T) {
+	t.Setenv("ENABLE_TOKENIZER_GSE_CH", "true")
+	InitOptionalTokenizers()
+
+	phrases := []string{"你好世界", "微维数据库", "向量搜索引擎", ""}
+	values := make([]string, 3*throttledBatchChunk+1)
+	for i := range values {
+		values[i] = phrases[i%len(phrases)]
+	}
+
+	require.Zero(t, len(ApacTokenizerThrottle), "throttle must be empty before the batch")
+
+	got := AnalyzeBatch(values, models.PropertyTokenizationGseCh, "C", nil, nil)
+	require.Equal(t, len(values), got.Len())
+	for i, v := range values {
+		want := Analyze(v, models.PropertyTokenizationGseCh, "C", nil, nil).Query
+		assert.Equal(t, want, append([]string{}, got.Tokens(i)...), "value %d (%q)", i, v)
+	}
+
+	require.Zero(t, len(ApacTokenizerThrottle), "batch must release its throttle slot")
+}
+
 // TestAnalyzeBatchMetricsOncePerBatch pins the batch metric contract: one
 // batch of N values adds exactly the summed token count under the
 // tokenization's label — not one observation per value, and nothing under

--- a/entities/tokenizer/analyze_batch_test.go
+++ b/entities/tokenizer/analyze_batch_test.go
@@ -29,6 +29,19 @@ func (f fakeStopwords) IsStopword(word string) bool {
 	return ok
 }
 
+// assertBatchMatchesPerValue asserts that every value's tokens in the batch
+// equal the Query result of a per-value Analyze call with the same inputs.
+func assertBatchMatchesPerValue(t *testing.T, got *AnalyzedBatch, values []string,
+	tokenization, className string, prepared *PreparedAnalyzer, stopwords StopwordDetector,
+) {
+	t.Helper()
+	require.Equal(t, len(values), got.Len())
+	for i, v := range values {
+		want := Analyze(v, tokenization, className, prepared, stopwords).Query
+		assert.Equal(t, want, append([]string{}, got.Tokens(i)...), "value %d (%q)", i, v)
+	}
+}
+
 // TestAnalyzeBatchEquivalence is the drift guard for AnalyzeBatch: for every
 // tokenization × stopword × folding combination, the batch result must equal
 // Analyze called per value. A pipeline change applied to one entry point but
@@ -71,35 +84,46 @@ func TestAnalyzeBatchEquivalence(t *testing.T) {
 			for prepName, prepared := range analyzerVariants {
 				t.Run(fmt.Sprintf("%s/%s/%s", tok, swName, prepName), func(t *testing.T) {
 					got := AnalyzeBatch(values, tok, className, prepared, sw)
-					require.Equal(t, len(values), got.Len())
-					for i, v := range values {
-						want := Analyze(v, tok, className, prepared, sw).Query
-						assert.Equal(t, want, append([]string{}, got.Tokens(i)...),
-							"value %d (%q)", i, v)
-					}
+					assertBatchMatchesPerValue(t, got, values, tok, className, prepared, sw)
 				})
 			}
 		}
 	}
 }
 
-// TestAnalyzeBatchEquivalenceCustomKagome covers the TokenizeForClass custom
-// user-dictionary branch, which AnalyzeBatch reaches through the same
-// unrecorded dispatch.
+// TestAnalyzeBatchEquivalenceCustomKagome covers both kagome custom
+// user-dictionary branches, which AnalyzeBatch reaches through the same
+// unrecorded dispatch, and pins that the batch's own throttle acquire is
+// balanced.
+//
+// Named coverage gap: of the throttled global tokenizers, only gse_ch is
+// exercised through the batch path (TestAnalyzeBatchEquivalenceThrottledGseCh
+// below); gse and the env-enabled global kagome tokenizers are not.
 func TestAnalyzeBatchEquivalenceCustomKagome(t *testing.T) {
-	className := "EquivClassKagome"
-	err := AddCustomDict(className, []*models.TokenizerUserDictConfig{generateReplacementModel()})
-	require.Nil(t, err)
-	defer func() {
-		require.Nil(t, AddCustomDict(className, nil))
-	}()
+	tests := []struct {
+		name         string
+		tokenization string
+		dict         *models.TokenizerUserDictConfig
+	}{
+		{"custom KR dict", models.PropertyTokenizationKagomeKr, generateReplacementModel()},
+		{"custom JA dict", models.PropertyTokenizationKagomeJa, jaCustomDict()},
+	}
 
-	values := []string{"Weaviate Semi Technologies", "We Aviate", ""}
-	got := AnalyzeBatch(values, models.PropertyTokenizationKagomeKr, className, nil, nil)
-	require.Equal(t, len(values), got.Len())
-	for i, v := range values {
-		want := Analyze(v, models.PropertyTokenizationKagomeKr, className, nil, nil).Query
-		assert.Equal(t, want, append([]string{}, got.Tokens(i)...), "value %d (%q)", i, v)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			className := "EquivClassKagome"
+			require.NoError(t, AddCustomDict(className, []*models.TokenizerUserDictConfig{tt.dict}))
+			defer func() {
+				require.NoError(t, AddCustomDict(className, nil))
+			}()
+
+			values := []string{"Weaviate Semi Technologies", "We Aviate", ""}
+			got := AnalyzeBatch(values, tt.tokenization, className, nil, nil)
+			assertBatchMatchesPerValue(t, got, values, tt.tokenization, className, nil, nil)
+
+			require.Zero(t, len(ApacTokenizerThrottle),
+				"batch must release its throttle slot")
+		})
 	}
 }
 
@@ -107,6 +131,11 @@ func TestAnalyzeBatchEquivalenceCustomKagome(t *testing.T) {
 // the batch acquires the ApacTokenizerThrottle in throttledBatchChunk-sized
 // chunks, so the test spans several chunks and pins per-value equivalence
 // with Analyze plus a balanced throttle afterwards.
+//
+// The inter-chunk slot yielding itself — a competing acquire getting in
+// while the batch is mid-flight — is deliberately untested: asserting it
+// races the batch's final release, so such a test could pass with a
+// whole-batch hold.
 func TestAnalyzeBatchEquivalenceThrottledGseCh(t *testing.T) {
 	t.Setenv("ENABLE_TOKENIZER_GSE_CH", "true")
 	InitOptionalTokenizers()
@@ -120,11 +149,7 @@ func TestAnalyzeBatchEquivalenceThrottledGseCh(t *testing.T) {
 	require.Zero(t, len(ApacTokenizerThrottle), "throttle must be empty before the batch")
 
 	got := AnalyzeBatch(values, models.PropertyTokenizationGseCh, "C", nil, nil)
-	require.Equal(t, len(values), got.Len())
-	for i, v := range values {
-		want := Analyze(v, models.PropertyTokenizationGseCh, "C", nil, nil).Query
-		assert.Equal(t, want, append([]string{}, got.Tokens(i)...), "value %d (%q)", i, v)
-	}
+	assertBatchMatchesPerValue(t, got, values, models.PropertyTokenizationGseCh, "C", nil, nil)
 
 	require.Zero(t, len(ApacTokenizerThrottle), "batch must release its throttle slot")
 }

--- a/entities/tokenizer/analyze_batch_test.go
+++ b/entities/tokenizer/analyze_batch_test.go
@@ -15,11 +15,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 type fakeStopwords map[string]struct{}
@@ -46,6 +44,10 @@ func assertBatchMatchesPerValue(t *testing.T, got *AnalyzedBatch, values []strin
 // tokenization × stopword × folding combination, the batch result must equal
 // Analyze called per value. A pipeline change applied to one entry point but
 // not the other turns this red.
+//
+// Named coverage gap: AnalyzeBatch's uint32 offset-overflow error is
+// untested — triggering it takes a batch of over 4B tokens, and making the
+// limit injectable would add a test-only seam to production code.
 func TestAnalyzeBatchEquivalence(t *testing.T) {
 	className := "EquivClass"
 	// deliberately awkward inputs: plain multiword, mixed case + punctuation,
@@ -83,7 +85,8 @@ func TestAnalyzeBatchEquivalence(t *testing.T) {
 		for swName, sw := range stopwordVariants {
 			for prepName, prepared := range analyzerVariants {
 				t.Run(fmt.Sprintf("%s/%s/%s", tok, swName, prepName), func(t *testing.T) {
-					got := AnalyzeBatch(values, tok, className, prepared, sw)
+					got, err := AnalyzeBatch(values, tok, className, prepared, sw)
+					require.NoError(t, err)
 					assertBatchMatchesPerValue(t, got, values, tok, className, prepared, sw)
 				})
 			}
@@ -118,7 +121,8 @@ func TestAnalyzeBatchEquivalenceCustomKagome(t *testing.T) {
 			}()
 
 			values := []string{"Weaviate Semi Technologies", "We Aviate", ""}
-			got := AnalyzeBatch(values, tt.tokenization, className, nil, nil)
+			got, err := AnalyzeBatch(values, tt.tokenization, className, nil, nil)
+			require.NoError(t, err)
 			assertBatchMatchesPerValue(t, got, values, tt.tokenization, className, nil, nil)
 
 			require.Zero(t, len(ApacTokenizerThrottle),
@@ -148,7 +152,8 @@ func TestAnalyzeBatchEquivalenceThrottledGseCh(t *testing.T) {
 
 	require.Zero(t, len(ApacTokenizerThrottle), "throttle must be empty before the batch")
 
-	got := AnalyzeBatch(values, models.PropertyTokenizationGseCh, "C", nil, nil)
+	got, err := AnalyzeBatch(values, models.PropertyTokenizationGseCh, "C", nil, nil)
+	require.NoError(t, err)
 	assertBatchMatchesPerValue(t, got, values, models.PropertyTokenizationGseCh, "C", nil, nil)
 
 	require.Zero(t, len(ApacTokenizerThrottle), "batch must release its throttle slot")
@@ -159,41 +164,46 @@ func TestAnalyzeBatchEquivalenceThrottledGseCh(t *testing.T) {
 // tokenization's label — not one observation per value, and nothing under
 // any other label.
 func TestAnalyzeBatchMetricsOncePerBatch(t *testing.T) {
-	countFor := func(label string) float64 {
-		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
-	}
-
-	fieldBefore := countFor(models.PropertyTokenizationField)
-	out := AnalyzeBatch([]string{" a ", "b", " c "}, models.PropertyTokenizationField, "C", nil, nil)
+	fieldBefore := tokenCount(models.PropertyTokenizationField)
+	fieldObsBefore := tokensPerRequestObservations(t, models.PropertyTokenizationField)
+	out, err := AnalyzeBatch([]string{" a ", "b", " c "}, models.PropertyTokenizationField, "C", nil, nil)
+	require.NoError(t, err)
 	require.Equal(t, 3, out.Len())
-	require.Equal(t, fieldBefore+3, countFor(models.PropertyTokenizationField),
+	require.Equal(t, fieldBefore+3, tokenCount(models.PropertyTokenizationField),
 		"batch of 3 FIELD values must add exactly 3 tokens under field")
+	require.Equal(t, fieldObsBefore+1, tokensPerRequestObservations(t, models.PropertyTokenizationField),
+		"batch of 3 values must add exactly one TokenCountPerRequest observation, not one per value")
 
-	wordBefore := countFor(models.PropertyTokenizationWord)
-	AnalyzeBatch([]string{"one two", "three"}, models.PropertyTokenizationWord, "C", nil, nil)
-	require.Equal(t, wordBefore+3, countFor(models.PropertyTokenizationWord),
+	wordBefore := tokenCount(models.PropertyTokenizationWord)
+	_, err = AnalyzeBatch([]string{"one two", "three"}, models.PropertyTokenizationWord, "C", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, wordBefore+3, tokenCount(models.PropertyTokenizationWord),
 		"batch token count is the summed indexed count")
 
 	// empty batch records nothing
-	fieldBefore = countFor(models.PropertyTokenizationField)
-	out = AnalyzeBatch(nil, models.PropertyTokenizationField, "C", nil, nil)
+	fieldBefore = tokenCount(models.PropertyTokenizationField)
+	fieldObsBefore = tokensPerRequestObservations(t, models.PropertyTokenizationField)
+	out, err = AnalyzeBatch(nil, models.PropertyTokenizationField, "C", nil, nil)
+	require.NoError(t, err)
 	require.Zero(t, out.Len())
-	require.Equal(t, fieldBefore, countFor(models.PropertyTokenizationField))
+	require.Equal(t, fieldBefore, tokenCount(models.PropertyTokenizationField))
+	require.Equal(t, fieldObsBefore, tokensPerRequestObservations(t, models.PropertyTokenizationField))
 }
 
 // TestAnalyzeBatchUnknownTokenization pins guard parity with the per-value
 // path: an unknown tokenization yields empty results for every value and
 // records nothing (no metric series under a bogus label).
 func TestAnalyzeBatchUnknownTokenization(t *testing.T) {
-	out := AnalyzeBatch([]string{"a", "b"}, "no-such-tokenization", "C", nil, nil)
+	out, err := AnalyzeBatch([]string{"a", "b"}, "no-such-tokenization", "C", nil, nil)
+	require.NoError(t, err)
 	require.Equal(t, 2, out.Len())
 	assert.Empty(t, out.Tokens(0))
 	assert.Empty(t, out.Tokens(1))
 	for _, v := range []string{"a", "b"} {
 		assert.Empty(t, Analyze(v, "no-such-tokenization", "C", nil, nil).Query)
 	}
-	count := testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues("no-such-tokenization"))
-	assert.Zero(t, count, "unknown tokenization must not record metrics")
+	assert.Zero(t, tokenCount("no-such-tokenization"),
+		"unknown tokenization must not record metrics")
 }
 
 // TestAnalyzeBatchStopwordFilteredValue pins the shape contract the searcher
@@ -201,8 +211,9 @@ func TestAnalyzeBatchUnknownTokenization(t *testing.T) {
 // index (not a shifted or missing entry).
 func TestAnalyzeBatchStopwordFilteredValue(t *testing.T) {
 	sw := fakeStopwords{"the": {}}
-	out := AnalyzeBatch([]string{"keep", "the", "also-keep"},
+	out, err := AnalyzeBatch([]string{"keep", "the", "also-keep"},
 		models.PropertyTokenizationField, "C", nil, sw)
+	require.NoError(t, err)
 	require.Equal(t, 3, out.Len())
 	assert.Equal(t, []string{"keep"}, append([]string{}, out.Tokens(0)...))
 	assert.Empty(t, out.Tokens(1))
@@ -214,8 +225,9 @@ func TestAnalyzeBatchStopwordFilteredValue(t *testing.T) {
 // breaking out of All stops the iteration; views cannot clobber their
 // neighbors through the shared backing array.
 func TestAnalyzedBatchAccessors(t *testing.T) {
-	out := AnalyzeBatch([]string{"one two", "", "three four five"},
+	out, err := AnalyzeBatch([]string{"one two", "", "three four five"},
 		models.PropertyTokenizationWhitespace, "C", nil, nil)
+	require.NoError(t, err)
 	require.Equal(t, 3, out.Len())
 
 	t.Run("All matches Tokens, in order", func(t *testing.T) {

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -181,6 +181,15 @@ type boundTokenizerMetrics struct {
 	tokensPerRequest prometheus.Observer
 }
 
+// record writes one tokenization's worth of metrics: n tokens produced over
+// dur. The single home for the metric triplet, shared by the per-value and
+// batch recorders.
+func (m *boundTokenizerMetrics) record(dur time.Duration, n int) {
+	m.duration.Observe(dur.Seconds())
+	m.tokenCount.Add(float64(n))
+	m.tokensPerRequest.Observe(float64(n))
+}
+
 var boundMetricsByLabel sync.Map // tokenization label → *boundTokenizerMetrics
 
 func metricsFor(label string) *boundTokenizerMetrics {
@@ -207,15 +216,11 @@ func metricsFor(label string) *boundTokenizerMetrics {
 // logic. The recorded count is the appended delta, so it stays correct for
 // any dst. Callers that bypass a tokenizer's dispatch guard (disabled
 // tokenizer, nil kagome instance) must return before timed so early-outs
-// stay unrecorded, as they always were.
+// stay unrecorded.
 func timed(label string, in string, dst []string, tokenize func(string, []string) []string) []string {
 	start := time.Now()
 	ret := tokenize(in, dst)
-	n := len(ret) - len(dst)
-	m := metricsFor(label)
-	m.duration.Observe(time.Since(start).Seconds())
-	m.tokenCount.Add(float64(n))
-	m.tokensPerRequest.Observe(float64(n))
+	metricsFor(label).record(time.Since(start), len(ret)-len(dst))
 	return ret
 }
 
@@ -227,8 +232,8 @@ func timed(label string, in string, dst []string, tokenize func(string, []string
 //
 // fn == nil means the tokenization is unknown or its tokenizer is
 // unavailable (disabled gse, uninitialized kagome); callers emit empty
-// results, exactly as the per-value dispatch always did. throttled reports
-// that ApacTokenizerThrottle must be held around kernel invocations.
+// results. throttled reports that ApacTokenizerThrottle must be held around
+// kernel invocations.
 func resolveTokenizer(tokenization string, class string) (fn func(string, []string) []string, throttled bool) {
 	switch tokenization {
 	case models.PropertyTokenizationWord:
@@ -316,9 +321,8 @@ func TokenizeWithWildcardsForClass(tokenization string, in string, class string)
 	}
 }
 
-// appendNonEmpty appends terms to dst, dropping empty and single-space
-// entries — the append-style form of the historical removeEmptyStrings
-// filter the gse and kagome tokenizers apply to their library output.
+// appendNonEmpty appends terms to dst, dropping the empty and single-space
+// entries the gse and kagome tokenizers produce in their library output.
 func appendNonEmpty(dst []string, terms []string) []string {
 	for _, term := range terms {
 		if term == "" || term == " " {
@@ -333,8 +337,10 @@ func appendNonEmpty(dst []string, terms []string) []string {
 // func(in string, dst []string) []string: tokens are appended to dst and the
 // grown slice returned. Batch callers reuse one buffer across many values so
 // per-value token materialization costs nothing; single-value callers seed
-// dst with an empty slice (a zero-byte allocation) and get the historical
-// freshly-allocated, never-nil result.
+// dst with an empty slice (a zero-byte allocation) and get a freshly
+// allocated, never-nil result. Kernels whose splitter already
+// produces a ready-made slice return it directly when dst has no capacity,
+// sparing single-value callers the extra append copy.
 
 // tokenizeField trims white spaces; the whole trimmed input is the one and
 // only token (former DataTypeString/Field)
@@ -345,7 +351,11 @@ func tokenizeField(in string, dst []string) []string {
 // tokenizeWhitespace splits on white spaces, does not alter casing
 // (former DataTypeString/Word)
 func tokenizeWhitespace(in string, dst []string) []string {
-	return append(dst, strings.FieldsFunc(in, unicode.IsSpace)...)
+	fields := strings.FieldsFunc(in, unicode.IsSpace)
+	if cap(dst) == 0 {
+		return fields
+	}
+	return append(dst, fields...)
 }
 
 // tokenizeLowercase splits on white spaces and lowercases the words
@@ -359,10 +369,15 @@ func tokenizeLowercase(in string, dst []string) []string {
 // tokenizeWord splits on any non-alphanumerical and lowercases the words
 // (former DataTypeText/Word)
 func tokenizeWord(in string, dst []string) []string {
-	prev := len(dst)
-	dst = append(dst, strings.FieldsFunc(in, func(r rune) bool {
+	fields := strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	})...)
+	})
+	if cap(dst) == 0 {
+		lowercase(fields)
+		return fields
+	}
+	prev := len(dst)
+	dst = append(dst, fields...)
 	lowercase(dst[prev:])
 	return dst
 }
@@ -463,10 +478,15 @@ func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.T
 // tokenizeWordWithWildcards splits on any non-alphanumerical except wildcard-symbols and
 // lowercases the words
 func tokenizeWordWithWildcards(in string, dst []string) []string {
-	prev := len(dst)
-	dst = append(dst, strings.FieldsFunc(in, func(r rune) bool {
+	fields := strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '?' && r != '*'
-	})...)
+	})
+	if cap(dst) == 0 {
+		lowercase(fields)
+		return fields
+	}
+	prev := len(dst)
+	dst = append(dst, fields...)
 	lowercase(dst[prev:])
 	return dst
 }

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -21,6 +21,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	entcfg "github.com/weaviate/weaviate/entities/config"
@@ -170,6 +171,51 @@ func init_gse_ch() error {
 	return nil
 }
 
+// boundTokenizerMetrics holds the prometheus handles for one tokenization
+// label, resolved once. WithLabelValues performs a registry lookup (label
+// hashing plus a locked map access) on every call; hot paths tokenize once
+// per value, so the handles are bound once per label and cached instead.
+type boundTokenizerMetrics struct {
+	duration         prometheus.Observer
+	tokenCount       prometheus.Counter
+	tokensPerRequest prometheus.Observer
+}
+
+var boundMetricsByLabel sync.Map // tokenization label → *boundTokenizerMetrics
+
+func metricsFor(label string) *boundTokenizerMetrics {
+	if m, ok := boundMetricsByLabel.Load(label); ok {
+		return m.(*boundTokenizerMetrics)
+	}
+	// Cold path: first call for this label (or a concurrent first-call race).
+	// LoadOrStore evaluates its value argument eagerly, so a losing racer
+	// builds a second struct — harmless: WithLabelValues is idempotent (both
+	// structs wrap the identical prometheus children), the loser is garbage,
+	// and this runs at most a handful of times per process.
+	mon := monitoring.GetMetrics()
+	m, _ := boundMetricsByLabel.LoadOrStore(label, &boundTokenizerMetrics{
+		duration:         mon.TokenizerDuration.WithLabelValues(label),
+		tokenCount:       mon.TokenCount.WithLabelValues(label),
+		tokensPerRequest: mon.TokenCountPerRequest.WithLabelValues(label),
+	})
+	return m.(*boundTokenizerMetrics)
+}
+
+// timed runs tokenize on in and records duration and token counts under
+// label. All tokenization metrics are recorded here, at the dispatch level —
+// the tokenizeXxx functions contain pure logic. Callers that bypass a
+// tokenizer's dispatch guard (disabled tokenizer, nil kagome instance) must
+// return before timed so early-outs stay unrecorded, as they always were.
+func timed(label string, in string, tokenize func(string) []string) []string {
+	start := time.Now()
+	ret := tokenize(in)
+	m := metricsFor(label)
+	m.duration.Observe(time.Since(start).Seconds())
+	m.tokenCount.Add(float64(len(ret)))
+	m.tokensPerRequest.Observe(float64(len(ret)))
+	return ret
+}
+
 // TokenizeForClass tokenizes like [Tokenize], except that the kagome
 // tokenizations consult the class's custom user-dictionary tokenizer first.
 func TokenizeForClass(tokenization string, in string, class string) []string {
@@ -178,13 +224,17 @@ func TokenizeForClass(tokenization string, in string, class string) []string {
 		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Korean != nil {
 			ApacTokenizerThrottle <- struct{}{}
 			defer func() { <-ApacTokenizerThrottle }()
-			return tokenizeKagome(custom.(*KagomeTokenizers).Korean, kagomeTokenizer.Normal, models.PropertyTokenizationKagomeKr, in)
+			return timed(tokenization, in, func(in string) []string {
+				return tokenizeKagome(custom.(*KagomeTokenizers).Korean, kagomeTokenizer.Normal, in)
+			})
 		}
 	case models.PropertyTokenizationKagomeJa:
 		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Japanese != nil {
 			ApacTokenizerThrottle <- struct{}{}
 			defer func() { <-ApacTokenizerThrottle }()
-			return tokenizeKagome(custom.(*KagomeTokenizers).Japanese, kagomeTokenizer.Search, models.PropertyTokenizationKagomeJa, in)
+			return timed(tokenization, in, func(in string) []string {
+				return tokenizeKagome(custom.(*KagomeTokenizers).Japanese, kagomeTokenizer.Search, in)
+			})
 		}
 	}
 	return Tokenize(tokenization, in)
@@ -193,31 +243,47 @@ func TokenizeForClass(tokenization string, in string, class string) []string {
 func Tokenize(tokenization string, in string) []string {
 	switch tokenization {
 	case models.PropertyTokenizationWord:
-		return tokenizeWord(in)
+		return timed(tokenization, in, tokenizeWord)
 	case models.PropertyTokenizationLowercase:
-		return tokenizeLowercase(in)
+		return timed(tokenization, in, tokenizeLowercase)
 	case models.PropertyTokenizationWhitespace:
-		return tokenizeWhitespace(in)
+		return timed(tokenization, in, tokenizeWhitespace)
 	case models.PropertyTokenizationField:
-		return tokenizeField(in)
+		return timed(tokenization, in, tokenizeField)
 	case models.PropertyTokenizationTrigram:
-		return tokenizetrigram(in)
+		return timed(tokenization, in, tokenizetrigram)
 	case models.PropertyTokenizationGse:
+		if !UseGse {
+			return []string{}
+		}
 		ApacTokenizerThrottle <- struct{}{}
 		defer func() { <-ApacTokenizerThrottle }()
-		return tokenizeGSE(in)
+		return timed(tokenization, in, tokenizeGSE)
 	case models.PropertyTokenizationGseCh:
+		if !UseGseCh {
+			return []string{}
+		}
 		ApacTokenizerThrottle <- struct{}{}
 		defer func() { <-ApacTokenizerThrottle }()
-		return tokenizeGseCh(in)
+		return timed(tokenization, in, tokenizeGseCh)
 	case models.PropertyTokenizationKagomeKr:
+		if tokenizers.Korean == nil {
+			return []string{}
+		}
 		ApacTokenizerThrottle <- struct{}{}
 		defer func() { <-ApacTokenizerThrottle }()
-		return tokenizeKagome(tokenizers.Korean, kagomeTokenizer.Normal, models.PropertyTokenizationKagomeKr, in)
+		return timed(tokenization, in, func(in string) []string {
+			return tokenizeKagome(tokenizers.Korean, kagomeTokenizer.Normal, in)
+		})
 	case models.PropertyTokenizationKagomeJa:
+		if tokenizers.Japanese == nil {
+			return []string{}
+		}
 		ApacTokenizerThrottle <- struct{}{}
 		defer func() { <-ApacTokenizerThrottle }()
-		return tokenizeKagome(tokenizers.Japanese, kagomeTokenizer.Search, models.PropertyTokenizationKagomeJa, in)
+		return timed(tokenization, in, func(in string) []string {
+			return tokenizeKagome(tokenizers.Japanese, kagomeTokenizer.Search, in)
+		})
 	default:
 		return []string{}
 	}
@@ -226,9 +292,9 @@ func Tokenize(tokenization string, in string) []string {
 func TokenizeWithWildcardsForClass(tokenization string, in string, class string) []string {
 	switch tokenization {
 	case models.PropertyTokenizationWord:
-		return tokenizeWordWithWildcards(in)
+		return timed("word_with_wildcards", in, tokenizeWordWithWildcards)
 	case models.PropertyTokenizationTrigram:
-		return tokenizetrigramWithWildcards(in)
+		return timed("trigram_with_wildcards", in, tokenizetrigramWithWildcards)
 	default:
 		return TokenizeForClass(tokenization, in, class)
 	}
@@ -247,51 +313,31 @@ func removeEmptyStrings(terms []string) []string {
 // tokenizeField trims white spaces
 // (former DataTypeString/Field)
 func tokenizeField(in string) []string {
-	startTime := time.Now()
-	ret := []string{strings.TrimFunc(in, unicode.IsSpace)}
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("field").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("field").Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("field").Observe(float64(len(ret)))
-	return ret
+	return []string{strings.TrimFunc(in, unicode.IsSpace)}
 }
 
 // tokenizeWhitespace splits on white spaces, does not alter casing
 // (former DataTypeString/Word)
 func tokenizeWhitespace(in string) []string {
-	startTime := time.Now()
-	ret := strings.FieldsFunc(in, unicode.IsSpace)
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("whitespace").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("whitespace").Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("whitespace").Observe(float64(len(ret)))
-	return ret
+	return strings.FieldsFunc(in, unicode.IsSpace)
 }
 
 // tokenizeLowercase splits on white spaces and lowercases the words
 func tokenizeLowercase(in string) []string {
-	startTime := time.Now()
-	terms := tokenizeWhitespace(in)
-	ret := lowercase(terms)
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("lowercase").Observe(float64(time.Since(startTime).Seconds()))
-	return ret
+	return lowercase(tokenizeWhitespace(in))
 }
 
 // tokenizeWord splits on any non-alphanumerical and lowercases the words
 // (former DataTypeText/Word)
 func tokenizeWord(in string) []string {
-	startTime := time.Now()
 	terms := strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
 	})
-	ret := lowercase(terms)
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("word").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("word").Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("word").Observe(float64(len(ret)))
-	return ret
+	return lowercase(terms)
 }
 
 // tokenizetrigram splits on any non-alphanumerical and lowercases the words, joins them together, then groups them into trigrams
 func tokenizetrigram(in string) []string {
-	startTime := time.Now()
 	// Strip whitespace and punctuation from the input string
 	inputString := strings.ToLower(strings.Join(strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
@@ -306,9 +352,6 @@ func tokenizetrigram(in string) []string {
 	for _, trirune := range trirunes {
 		trigrams = append(trigrams, string(trirune))
 	}
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("trigram").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("trigram").Add(float64(len(trigrams)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("trigram").Observe(float64(len(trigrams)))
 	return trigrams
 }
 
@@ -317,34 +360,19 @@ func tokenizeGSE(in string) []string {
 	if !UseGse {
 		return []string{}
 	}
-	startTime := time.Now()
 	gseLock.Lock()
 	defer gseLock.Unlock()
-	terms := gseTokenizer.CutAll(in)
-
-	ret := removeEmptyStrings(terms)
-
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("gse").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("gse").Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("gse").Observe(float64(len(ret)))
-	return ret
+	return removeEmptyStrings(gseTokenizer.CutAll(in))
 }
 
-// tokenizeGSE uses the gse tokenizer to tokenize Chinese
+// tokenizeGseCh uses the gse tokenizer to tokenize Chinese
 func tokenizeGseCh(in string) []string {
 	if !UseGseCh {
 		return []string{}
 	}
 	gseLock.Lock()
 	defer gseLock.Unlock()
-	startTime := time.Now()
-	terms := gseTokenizerCh.CutAll(in)
-	ret := removeEmptyStrings(terms)
-
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("gse").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("gse").Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("gse").Observe(float64(len(ret)))
-	return ret
+	return removeEmptyStrings(gseTokenizerCh.CutAll(in))
 }
 
 func initializeKagomeTokenizerKr(userDict *models.TokenizerUserDictConfig) (*kagomeTokenizer.Tokenizer, error) {
@@ -392,14 +420,10 @@ func initializeKagomeTokenizer(dictInstance *dict.Dict, userDict *models.Tokeniz
 	return tokenizer, nil
 }
 
-func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.TokenizeMode, label string, in string) []string {
-	if label == models.PropertyTokenizationKagomeJa && tokenizer == nil {
+func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.TokenizeMode, in string) []string {
+	if tokenizer == nil {
 		return []string{}
 	}
-	if label == models.PropertyTokenizationKagomeKr && tokenizer == nil {
-		return []string{}
-	}
-	startTime := time.Now()
 	kagomeTokens := tokenizer.Analyze(in, mode)
 	var terms []string
 	for _, token := range kagomeTokens {
@@ -410,40 +434,27 @@ func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.T
 		}
 	}
 
-	ret := removeEmptyStrings(terms)
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues(label).Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues(label).Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues(label).Observe(float64(len(ret)))
-	return ret
+	return removeEmptyStrings(terms)
 }
 
 // tokenizeWordWithWildcards splits on any non-alphanumerical except wildcard-symbols and
 // lowercases the words
 func tokenizeWordWithWildcards(in string) []string {
-	startTime := time.Now()
 	terms := strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '?' && r != '*'
 	})
-	ret := lowercase(terms)
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("word_with_wildcards").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("word_with_wildcards").Add(float64(len(ret)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("word_with_wildcards").Observe(float64(len(ret)))
-	return ret
+	return lowercase(terms)
 }
 
 // tokenizetrigramWithWildcards splits on any non-alphanumerical and lowercases the words, applies any wildcards, then joins them together, then groups them into trigrams
 // this is unlikely to be useful, but is included for completeness
 func tokenizetrigramWithWildcards(in string) []string {
-	startTime := time.Now()
 	terms := tokenizeWordWithWildcards(in)
 	inputString := strings.Join(terms, "")
 	var trigrams []string
 	for i := 0; i < len(inputString)-2; i++ {
 		trigrams = append(trigrams, inputString[i:i+3])
 	}
-	monitoring.GetMetrics().TokenizerDuration.WithLabelValues("trigram_with_wildcards").Observe(float64(time.Since(startTime).Seconds()))
-	monitoring.GetMetrics().TokenCount.WithLabelValues("trigram_with_wildcards").Add(float64(len(trigrams)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("trigram_with_wildcards").Observe(float64(len(trigrams)))
 	return trigrams
 }
 
@@ -451,8 +462,6 @@ func lowercase(terms []string) []string {
 	for i := range terms {
 		terms[i] = strings.ToLower(terms[i])
 	}
-	monitoring.GetMetrics().TokenCount.WithLabelValues("lowercase").Add(float64(len(terms)))
-	monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues("lowercase").Observe(float64(len(terms)))
 	return terms
 }
 

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -201,178 +201,203 @@ func metricsFor(label string) *boundTokenizerMetrics {
 	return m.(*boundTokenizerMetrics)
 }
 
-// timed runs tokenize on in and records duration and token counts under
-// label. All tokenization metrics are recorded here, at the dispatch level —
-// the tokenizeXxx functions contain pure logic. Callers that bypass a
-// tokenizer's dispatch guard (disabled tokenizer, nil kagome instance) must
-// return before timed so early-outs stay unrecorded, as they always were.
-func timed(label string, in string, tokenize func(string) []string) []string {
+// timed runs tokenize on in (appending to dst) and records duration and
+// token counts under label. All tokenization metrics are recorded here or at
+// a batch's per-batch equivalent — the tokenizeXxx kernels contain pure
+// logic. The recorded count is the appended delta, so it stays correct for
+// any dst. Callers that bypass a tokenizer's dispatch guard (disabled
+// tokenizer, nil kagome instance) must return before timed so early-outs
+// stay unrecorded, as they always were.
+func timed(label string, in string, dst []string, tokenize func(string, []string) []string) []string {
 	start := time.Now()
-	ret := tokenize(in)
+	ret := tokenize(in, dst)
+	n := len(ret) - len(dst)
 	m := metricsFor(label)
 	m.duration.Observe(time.Since(start).Seconds())
-	m.tokenCount.Add(float64(len(ret)))
-	m.tokensPerRequest.Observe(float64(len(ret)))
+	m.tokenCount.Add(float64(n))
+	m.tokensPerRequest.Observe(float64(n))
 	return ret
+}
+
+// resolveTokenizer performs tokenization dispatch once: it maps a
+// tokenization (and, for the kagome tokenizations, the class's custom
+// user-dictionary tokenizer) to its append-style kernel, so batch callers
+// pay the switch, guard checks, and custom-tokenizer lookup once instead of
+// per value.
+//
+// fn == nil means the tokenization is unknown or its tokenizer is
+// unavailable (disabled gse, uninitialized kagome); callers emit empty
+// results, exactly as the per-value dispatch always did. throttled reports
+// that ApacTokenizerThrottle must be held around kernel invocations.
+func resolveTokenizer(tokenization string, class string) (fn func(string, []string) []string, throttled bool) {
+	switch tokenization {
+	case models.PropertyTokenizationWord:
+		return tokenizeWord, false
+	case models.PropertyTokenizationLowercase:
+		return tokenizeLowercase, false
+	case models.PropertyTokenizationWhitespace:
+		return tokenizeWhitespace, false
+	case models.PropertyTokenizationField:
+		return tokenizeField, false
+	case models.PropertyTokenizationTrigram:
+		return tokenizetrigram, false
+	case models.PropertyTokenizationGse:
+		if !UseGse {
+			return nil, false
+		}
+		return tokenizeGSE, true
+	case models.PropertyTokenizationGseCh:
+		if !UseGseCh {
+			return nil, false
+		}
+		return tokenizeGseCh, true
+	case models.PropertyTokenizationKagomeKr:
+		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Korean != nil {
+			return func(in string, dst []string) []string {
+				return tokenizeKagome(custom.(*KagomeTokenizers).Korean, kagomeTokenizer.Normal, in, dst)
+			}, true
+		}
+		if tokenizers.Korean == nil {
+			return nil, false
+		}
+		return func(in string, dst []string) []string {
+			return tokenizeKagome(tokenizers.Korean, kagomeTokenizer.Normal, in, dst)
+		}, true
+	case models.PropertyTokenizationKagomeJa:
+		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Japanese != nil {
+			return func(in string, dst []string) []string {
+				return tokenizeKagome(custom.(*KagomeTokenizers).Japanese, kagomeTokenizer.Search, in, dst)
+			}, true
+		}
+		if tokenizers.Japanese == nil {
+			return nil, false
+		}
+		return func(in string, dst []string) []string {
+			return tokenizeKagome(tokenizers.Japanese, kagomeTokenizer.Search, in, dst)
+		}, true
+	default:
+		return nil, false
+	}
 }
 
 // TokenizeForClass tokenizes like [Tokenize], except that the kagome
 // tokenizations consult the class's custom user-dictionary tokenizer first.
 func TokenizeForClass(tokenization string, in string, class string) []string {
-	switch tokenization {
-	case models.PropertyTokenizationKagomeKr:
-		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Korean != nil {
-			ApacTokenizerThrottle <- struct{}{}
-			defer func() { <-ApacTokenizerThrottle }()
-			return timed(tokenization, in, func(in string) []string {
-				return tokenizeKagome(custom.(*KagomeTokenizers).Korean, kagomeTokenizer.Normal, in)
-			})
-		}
-	case models.PropertyTokenizationKagomeJa:
-		if custom, ok := customTokenizers.Load(class); ok && custom.(*KagomeTokenizers).Japanese != nil {
-			ApacTokenizerThrottle <- struct{}{}
-			defer func() { <-ApacTokenizerThrottle }()
-			return timed(tokenization, in, func(in string) []string {
-				return tokenizeKagome(custom.(*KagomeTokenizers).Japanese, kagomeTokenizer.Search, in)
-			})
-		}
-	}
-	return Tokenize(tokenization, in)
+	return tokenizeWithClass(tokenization, in, class)
 }
 
 func Tokenize(tokenization string, in string) []string {
-	switch tokenization {
-	case models.PropertyTokenizationWord:
-		return timed(tokenization, in, tokenizeWord)
-	case models.PropertyTokenizationLowercase:
-		return timed(tokenization, in, tokenizeLowercase)
-	case models.PropertyTokenizationWhitespace:
-		return timed(tokenization, in, tokenizeWhitespace)
-	case models.PropertyTokenizationField:
-		return timed(tokenization, in, tokenizeField)
-	case models.PropertyTokenizationTrigram:
-		return timed(tokenization, in, tokenizetrigram)
-	case models.PropertyTokenizationGse:
-		if !UseGse {
-			return []string{}
-		}
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-		return timed(tokenization, in, tokenizeGSE)
-	case models.PropertyTokenizationGseCh:
-		if !UseGseCh {
-			return []string{}
-		}
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-		return timed(tokenization, in, tokenizeGseCh)
-	case models.PropertyTokenizationKagomeKr:
-		if tokenizers.Korean == nil {
-			return []string{}
-		}
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-		return timed(tokenization, in, func(in string) []string {
-			return tokenizeKagome(tokenizers.Korean, kagomeTokenizer.Normal, in)
-		})
-	case models.PropertyTokenizationKagomeJa:
-		if tokenizers.Japanese == nil {
-			return []string{}
-		}
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
-		return timed(tokenization, in, func(in string) []string {
-			return tokenizeKagome(tokenizers.Japanese, kagomeTokenizer.Search, in)
-		})
-	default:
+	// no class: kagome resolves to the globally initialized tokenizers
+	return tokenizeWithClass(tokenization, in, "")
+}
+
+func tokenizeWithClass(tokenization string, in string, class string) []string {
+	fn, throttled := resolveTokenizer(tokenization, class)
+	if fn == nil {
 		return []string{}
 	}
+	if throttled {
+		ApacTokenizerThrottle <- struct{}{}
+		defer func() { <-ApacTokenizerThrottle }()
+	}
+	// seeding dst with an empty (zero-byte, non-nil) slice keeps the public
+	// contract of a non-nil result even when no tokens are appended
+	return timed(tokenization, in, []string{}, fn)
 }
 
 func TokenizeWithWildcardsForClass(tokenization string, in string, class string) []string {
 	switch tokenization {
 	case models.PropertyTokenizationWord:
-		return timed("word_with_wildcards", in, tokenizeWordWithWildcards)
+		return timed("word_with_wildcards", in, []string{}, tokenizeWordWithWildcards)
 	case models.PropertyTokenizationTrigram:
-		return timed("trigram_with_wildcards", in, tokenizetrigramWithWildcards)
+		return timed("trigram_with_wildcards", in, []string{}, tokenizetrigramWithWildcards)
 	default:
 		return TokenizeForClass(tokenization, in, class)
 	}
 }
 
-func removeEmptyStrings(terms []string) []string {
-	for i := 0; i < len(terms); i++ {
-		if terms[i] == "" || terms[i] == " " {
-			terms = append(terms[:i], terms[i+1:]...)
-			i--
+// appendNonEmpty appends terms to dst, dropping empty and single-space
+// entries — the append-style form of the historical removeEmptyStrings
+// filter the gse and kagome tokenizers apply to their library output.
+func appendNonEmpty(dst []string, terms []string) []string {
+	for _, term := range terms {
+		if term == "" || term == " " {
+			continue
 		}
+		dst = append(dst, term)
 	}
-	return terms
+	return dst
 }
 
-// tokenizeField trims white spaces
-// (former DataTypeString/Field)
-func tokenizeField(in string) []string {
-	return []string{strings.TrimFunc(in, unicode.IsSpace)}
+// Tokenizer kernels share one append-style signature,
+// func(in string, dst []string) []string: tokens are appended to dst and the
+// grown slice returned. Batch callers reuse one buffer across many values so
+// per-value token materialization costs nothing; single-value callers seed
+// dst with an empty slice (a zero-byte allocation) and get the historical
+// freshly-allocated, never-nil result.
+
+// tokenizeField trims white spaces; the whole trimmed input is the one and
+// only token (former DataTypeString/Field)
+func tokenizeField(in string, dst []string) []string {
+	return append(dst, strings.TrimFunc(in, unicode.IsSpace))
 }
 
 // tokenizeWhitespace splits on white spaces, does not alter casing
 // (former DataTypeString/Word)
-func tokenizeWhitespace(in string) []string {
-	return strings.FieldsFunc(in, unicode.IsSpace)
+func tokenizeWhitespace(in string, dst []string) []string {
+	return append(dst, strings.FieldsFunc(in, unicode.IsSpace)...)
 }
 
 // tokenizeLowercase splits on white spaces and lowercases the words
-func tokenizeLowercase(in string) []string {
-	return lowercase(tokenizeWhitespace(in))
+func tokenizeLowercase(in string, dst []string) []string {
+	prev := len(dst)
+	dst = tokenizeWhitespace(in, dst)
+	lowercase(dst[prev:])
+	return dst
 }
 
 // tokenizeWord splits on any non-alphanumerical and lowercases the words
 // (former DataTypeText/Word)
-func tokenizeWord(in string) []string {
-	terms := strings.FieldsFunc(in, func(r rune) bool {
+func tokenizeWord(in string, dst []string) []string {
+	prev := len(dst)
+	dst = append(dst, strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	})
-	return lowercase(terms)
+	})...)
+	lowercase(dst[prev:])
+	return dst
 }
 
 // tokenizetrigram splits on any non-alphanumerical and lowercases the words, joins them together, then groups them into trigrams
-func tokenizetrigram(in string) []string {
+func tokenizetrigram(in string, dst []string) []string {
 	// Strip whitespace and punctuation from the input string
 	inputString := strings.ToLower(strings.Join(strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
 	}), ""))
 	runes := []rune(inputString)
-	var trirunes [][]rune
 	for i := 0; i < len(runes)-2; i++ {
-		trirunes = append(trirunes, runes[i:i+3])
+		dst = append(dst, string(runes[i:i+3]))
 	}
-
-	var trigrams []string
-	for _, trirune := range trirunes {
-		trigrams = append(trigrams, string(trirune))
-	}
-	return trigrams
+	return dst
 }
 
 // tokenizeGSE uses the gse tokenizer to tokenize Japanese
-func tokenizeGSE(in string) []string {
+func tokenizeGSE(in string, dst []string) []string {
 	if !UseGse {
-		return []string{}
+		return dst
 	}
 	gseLock.Lock()
 	defer gseLock.Unlock()
-	return removeEmptyStrings(gseTokenizer.CutAll(in))
+	return appendNonEmpty(dst, gseTokenizer.CutAll(in))
 }
 
 // tokenizeGseCh uses the gse tokenizer to tokenize Chinese
-func tokenizeGseCh(in string) []string {
+func tokenizeGseCh(in string, dst []string) []string {
 	if !UseGseCh {
-		return []string{}
+		return dst
 	}
 	gseLock.Lock()
 	defer gseLock.Unlock()
-	return removeEmptyStrings(gseTokenizerCh.CutAll(in))
+	return appendNonEmpty(dst, gseTokenizerCh.CutAll(in))
 }
 
 func initializeKagomeTokenizerKr(userDict *models.TokenizerUserDictConfig) (*kagomeTokenizer.Tokenizer, error) {
@@ -420,42 +445,40 @@ func initializeKagomeTokenizer(dictInstance *dict.Dict, userDict *models.Tokeniz
 	return tokenizer, nil
 }
 
-func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.TokenizeMode, in string) []string {
+func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.TokenizeMode, in string, dst []string) []string {
 	if tokenizer == nil {
-		return []string{}
+		return dst
 	}
 	kagomeTokens := tokenizer.Analyze(in, mode)
-	var terms []string
 	for _, token := range kagomeTokens {
 		if extra := token.UserExtra(); extra != nil {
-			terms = append(terms, extra.Tokens...)
-		} else {
-			terms = append(terms, token.Surface)
+			dst = appendNonEmpty(dst, extra.Tokens)
+		} else if token.Surface != "" && token.Surface != " " {
+			dst = append(dst, token.Surface)
 		}
 	}
-
-	return removeEmptyStrings(terms)
+	return dst
 }
 
 // tokenizeWordWithWildcards splits on any non-alphanumerical except wildcard-symbols and
 // lowercases the words
-func tokenizeWordWithWildcards(in string) []string {
-	terms := strings.FieldsFunc(in, func(r rune) bool {
+func tokenizeWordWithWildcards(in string, dst []string) []string {
+	prev := len(dst)
+	dst = append(dst, strings.FieldsFunc(in, func(r rune) bool {
 		return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '?' && r != '*'
-	})
-	return lowercase(terms)
+	})...)
+	lowercase(dst[prev:])
+	return dst
 }
 
 // tokenizetrigramWithWildcards splits on any non-alphanumerical and lowercases the words, applies any wildcards, then joins them together, then groups them into trigrams
 // this is unlikely to be useful, but is included for completeness
-func tokenizetrigramWithWildcards(in string) []string {
-	terms := tokenizeWordWithWildcards(in)
-	inputString := strings.Join(terms, "")
-	var trigrams []string
+func tokenizetrigramWithWildcards(in string, dst []string) []string {
+	inputString := strings.Join(tokenizeWordWithWildcards(in, nil), "")
 	for i := 0; i < len(inputString)-2; i++ {
-		trigrams = append(trigrams, inputString[i:i+3])
+		dst = append(dst, inputString[i:i+3])
 	}
-	return trigrams
+	return dst
 }
 
 func lowercase(terms []string) []string {

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -70,12 +70,16 @@ func init() {
 	customTokenizers = sync.Map{}
 }
 
+// acquireThrottleSlot blocks for an ApacTokenizerThrottle slot and returns
+// its release: defer acquireThrottleSlot()().
+func acquireThrottleSlot() func() {
+	ApacTokenizerThrottle <- struct{}{}
+	return func() { <-ApacTokenizerThrottle }
+}
+
 // throttleCapacity computes the ApacTokenizerThrottle capacity from the
-// TOKENIZER_CONCURRENCY_COUNT env value. Non-numeric values and values below
-// 1 are rejected with a warning and fall back to runtime.GOMAXPROCS(0), like
-// an unset variable: a capacity-0 channel would deadlock the first
-// tokenization (an acquire with no holder to ever release it), and make
-// panics on a negative capacity.
+// TOKENIZER_CONCURRENCY_COUNT env value. Values below 1 or non-numeric fall
+// back to GOMAXPROCS with a warning (capacity 0 would deadlock, negative panics).
 func throttleCapacity(envValue string) int {
 	fallback := runtime.GOMAXPROCS(0)
 	if envValue == "" {
@@ -171,19 +175,15 @@ func init_gse_ch() error {
 	return nil
 }
 
-// boundTokenizerMetrics holds the prometheus handles for one tokenization
-// label, resolved once. WithLabelValues performs a registry lookup (label
-// hashing plus a locked map access) on every call; hot paths tokenize once
-// per value, so the handles are bound once per label and cached instead.
+// boundTokenizerMetrics caches one tokenization label's prometheus handles:
+// WithLabelValues does a registry lookup per call, too costly per value.
 type boundTokenizerMetrics struct {
 	duration         prometheus.Observer
 	tokenCount       prometheus.Counter
 	tokensPerRequest prometheus.Observer
 }
 
-// record writes one tokenization's worth of metrics: n tokens produced over
-// dur. The single home for the metric triplet, shared by the per-value and
-// batch recorders.
+// record writes one tokenization's worth of metrics: n tokens produced over dur.
 func (m *boundTokenizerMetrics) record(dur time.Duration, n int) {
 	m.duration.Observe(dur.Seconds())
 	m.tokenCount.Add(float64(n))
@@ -196,11 +196,8 @@ func metricsFor(label string) *boundTokenizerMetrics {
 	if m, ok := boundMetricsByLabel.Load(label); ok {
 		return m.(*boundTokenizerMetrics)
 	}
-	// Cold path: first call for this label (or a concurrent first-call race).
-	// LoadOrStore evaluates its value argument eagerly, so a losing racer
-	// builds a second struct — harmless: WithLabelValues is idempotent (both
-	// structs wrap the identical prometheus children), the loser is garbage,
-	// and this runs at most a handful of times per process.
+	// LoadOrStore evaluates eagerly, so a losing racer builds a second struct —
+	// harmless, both wrap the identical prometheus children
 	mon := monitoring.GetMetrics()
 	m, _ := boundMetricsByLabel.LoadOrStore(label, &boundTokenizerMetrics{
 		duration:         mon.TokenizerDuration.WithLabelValues(label),
@@ -211,12 +208,9 @@ func metricsFor(label string) *boundTokenizerMetrics {
 }
 
 // timed runs tokenize on in (appending to dst) and records duration and
-// token counts under label. All tokenization metrics are recorded here or at
-// a batch's per-batch equivalent — the tokenizeXxx kernels contain pure
-// logic. The recorded count is the appended delta, so it stays correct for
-// any dst. Callers that bypass a tokenizer's dispatch guard (disabled
-// tokenizer, nil kagome instance) must return before timed so early-outs
-// stay unrecorded.
+// token counts under label — the tokenize functions themselves record
+// nothing. The count is the appended delta. Guard early-outs must return
+// before timed to stay unrecorded.
 func timed(label string, in string, dst []string, tokenize func(string, []string) []string) []string {
 	start := time.Now()
 	ret := tokenize(in, dst)
@@ -224,16 +218,10 @@ func timed(label string, in string, dst []string, tokenize func(string, []string
 	return ret
 }
 
-// resolveTokenizer performs tokenization dispatch once: it maps a
-// tokenization (and, for the kagome tokenizations, the class's custom
-// user-dictionary tokenizer) to its append-style kernel, so batch callers
-// pay the switch, guard checks, and custom-tokenizer lookup once instead of
-// per value.
-//
-// fn == nil means the tokenization is unknown or its tokenizer is
-// unavailable (disabled gse, uninitialized kagome); callers emit empty
-// results. throttled reports that ApacTokenizerThrottle must be held around
-// kernel invocations.
+// resolveTokenizer maps a tokenization (and, for kagome, the class's custom
+// user-dictionary tokenizer) to its append-style tokenize function, so batch callers pay
+// dispatch once. fn == nil means unknown tokenization or unavailable tokenizer;
+// throttled reports that ApacTokenizerThrottle must be held around calls.
 func resolveTokenizer(tokenization string, class string) (fn func(string, []string) []string, throttled bool) {
 	switch tokenization {
 	case models.PropertyTokenizationWord:
@@ -302,11 +290,9 @@ func tokenizeWithClass(tokenization string, in string, class string) []string {
 		return []string{}
 	}
 	if throttled {
-		ApacTokenizerThrottle <- struct{}{}
-		defer func() { <-ApacTokenizerThrottle }()
+		defer acquireThrottleSlot()()
 	}
-	// seeding dst with an empty (zero-byte, non-nil) slice keeps the public
-	// contract of a non-nil result even when no tokens are appended
+	// empty non-nil seed keeps the public contract of a non-nil result
 	return timed(tokenization, in, []string{}, fn)
 }
 
@@ -333,14 +319,11 @@ func appendNonEmpty(dst []string, terms []string) []string {
 	return dst
 }
 
-// Tokenizer kernels share one append-style signature,
-// func(in string, dst []string) []string: tokens are appended to dst and the
-// grown slice returned. Batch callers reuse one buffer across many values so
-// per-value token materialization costs nothing; single-value callers seed
-// dst with an empty slice (a zero-byte allocation) and get a freshly
-// allocated, never-nil result. Kernels whose splitter already
-// produces a ready-made slice return it directly when dst has no capacity,
-// sparing single-value callers the extra append copy.
+// The tokenize functions share one append-style signature: tokens are
+// appended to dst and the grown slice returned. Batch callers reuse one
+// buffer across values; single-value callers seed dst with an empty slice
+// and get a never-nil result. When dst has no capacity, the split-based
+// functions return the splitter's slice directly to spare the append copy.
 
 // tokenizeField trims white spaces; the whole trimmed input is the one and
 // only token (former DataTypeString/Field)
@@ -397,9 +380,6 @@ func tokenizetrigram(in string, dst []string) []string {
 
 // tokenizeGSE uses the gse tokenizer to tokenize Japanese
 func tokenizeGSE(in string, dst []string) []string {
-	if !UseGse {
-		return dst
-	}
 	gseLock.Lock()
 	defer gseLock.Unlock()
 	return appendNonEmpty(dst, gseTokenizer.CutAll(in))
@@ -407,9 +387,6 @@ func tokenizeGSE(in string, dst []string) []string {
 
 // tokenizeGseCh uses the gse tokenizer to tokenize Chinese
 func tokenizeGseCh(in string, dst []string) []string {
-	if !UseGseCh {
-		return dst
-	}
 	gseLock.Lock()
 	defer gseLock.Unlock()
 	return appendNonEmpty(dst, gseTokenizerCh.CutAll(in))
@@ -501,11 +478,10 @@ func tokenizetrigramWithWildcards(in string, dst []string) []string {
 	return dst
 }
 
-func lowercase(terms []string) []string {
+func lowercase(terms []string) {
 	for i := range terms {
 		terms[i] = strings.ToLower(terms[i])
 	}
-	return terms
 }
 
 func TokenizeAndCountDuplicatesForClass(tokenization string, in string, class string) ([]string, []int) {

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -331,14 +332,46 @@ func tokenizeField(in string, dst []string) []string {
 	return append(dst, strings.TrimFunc(in, unicode.IsSpace))
 }
 
+// appendFieldsFunc is strings.FieldsFunc with an append-style tail: fields are
+// appended to dst instead of a freshly allocated slice, so a batch caller
+// reusing one buffer splits without allocating per value. The span pass is
+// stdlib's — recording indices before materializing substrings measures
+// faster than emitting them inline — with the final make replaced by one Grow.
+func appendFieldsFunc(dst []string, in string, isSep func(rune) bool) []string {
+	type span struct{ start, end int }
+	var spanBuf [32]span
+	spans := spanBuf[:0]
+
+	start := -1
+	for end, r := range in {
+		if isSep(r) {
+			if start >= 0 {
+				spans = append(spans, span{start, end})
+				start = -1
+			}
+		} else if start < 0 {
+			start = end
+		}
+	}
+	if start >= 0 {
+		spans = append(spans, span{start, len(in)})
+	}
+
+	dst = slices.Grow(dst, len(spans))
+	for _, s := range spans {
+		dst = append(dst, in[s.start:s.end])
+	}
+	return dst
+}
+
+func isNotAlphanumeric(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+}
+
 // tokenizeWhitespace splits on white spaces, does not alter casing
 // (former DataTypeString/Word)
 func tokenizeWhitespace(in string, dst []string) []string {
-	fields := strings.FieldsFunc(in, unicode.IsSpace)
-	if cap(dst) == 0 {
-		return fields
-	}
-	return append(dst, fields...)
+	return appendFieldsFunc(dst, in, unicode.IsSpace)
 }
 
 // tokenizeLowercase splits on white spaces and lowercases the words
@@ -352,15 +385,8 @@ func tokenizeLowercase(in string, dst []string) []string {
 // tokenizeWord splits on any non-alphanumerical and lowercases the words
 // (former DataTypeText/Word)
 func tokenizeWord(in string, dst []string) []string {
-	fields := strings.FieldsFunc(in, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	})
-	if cap(dst) == 0 {
-		lowercase(fields)
-		return fields
-	}
 	prev := len(dst)
-	dst = append(dst, fields...)
+	dst = appendFieldsFunc(dst, in, isNotAlphanumeric)
 	lowercase(dst[prev:])
 	return dst
 }
@@ -368,12 +394,18 @@ func tokenizeWord(in string, dst []string) []string {
 // tokenizetrigram splits on any non-alphanumerical and lowercases the words, joins them together, then groups them into trigrams
 func tokenizetrigram(in string, dst []string) []string {
 	// Strip whitespace and punctuation from the input string
-	inputString := strings.ToLower(strings.Join(strings.FieldsFunc(in, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	}), ""))
-	runes := []rune(inputString)
-	for i := 0; i < len(runes)-2; i++ {
-		dst = append(dst, string(runes[i:i+3]))
+	inputString := strings.ToLower(strings.Join(strings.FieldsFunc(in, isNotAlphanumeric), ""))
+	// Byte offset of each rune start, plus a terminator, so a trigram is the
+	// substring inputString[off[i]:off[i+3]] — sliced, not copied, which is
+	// what keeps a trigram batch from allocating once per emitted trigram.
+	var offBuf [128]int
+	offs := offBuf[:0]
+	for i := range inputString {
+		offs = append(offs, i)
+	}
+	offs = append(offs, len(inputString))
+	for i := 0; i+3 < len(offs); i++ {
+		dst = append(dst, inputString[offs[i]:offs[i+3]])
 	}
 	return dst
 }
@@ -455,15 +487,10 @@ func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.T
 // tokenizeWordWithWildcards splits on any non-alphanumerical except wildcard-symbols and
 // lowercases the words
 func tokenizeWordWithWildcards(in string, dst []string) []string {
-	fields := strings.FieldsFunc(in, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '?' && r != '*'
-	})
-	if cap(dst) == 0 {
-		lowercase(fields)
-		return fields
-	}
 	prev := len(dst)
-	dst = append(dst, fields...)
+	dst = appendFieldsFunc(dst, in, func(r rune) bool {
+		return isNotAlphanumeric(r) && r != '?' && r != '*'
+	})
 	lowercase(dst[prev:])
 	return dst
 }

--- a/entities/tokenizer/tokenizer_bench_test.go
+++ b/entities/tokenizer/tokenizer_bench_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+var benchTokenizations = []string{
+	models.PropertyTokenizationField,
+	models.PropertyTokenizationWord,
+	models.PropertyTokenizationWhitespace,
+	models.PropertyTokenizationLowercase,
+	models.PropertyTokenizationTrigram,
+}
+
+// BenchmarkAnalyze guards the single-value allocation profile: the append-style
+// kernels must not cost more than materializing a fresh slice per call did.
+func BenchmarkAnalyze(b *testing.B) {
+	for _, tokenization := range benchTokenizations {
+		b.Run(tokenization, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = Analyze("some value number 42 here", tokenization, "C", nil, nil)
+			}
+		})
+	}
+}
+
+// BenchmarkAnalyzeBatch is the reason the kernels are append-style: allocations
+// per batch should stay flat in the number of values rather than scaling with
+// it. Compare against BenchmarkAnalyzeBatchPerValueLoop.
+func BenchmarkAnalyzeBatch(b *testing.B) {
+	values := benchValues(1000)
+	for _, tokenization := range benchTokenizations {
+		b.Run(tokenization, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, _ = AnalyzeBatch(values, tokenization, "C", nil, nil)
+			}
+		})
+	}
+}
+
+// BenchmarkAnalyzeBatchPerValueLoop is the baseline AnalyzeBatch replaces:
+// calling Analyze per value and keeping each result.
+func BenchmarkAnalyzeBatchPerValueLoop(b *testing.B) {
+	values := benchValues(1000)
+	for _, tokenization := range benchTokenizations {
+		b.Run(tokenization, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out := make([][]string, len(values))
+				for j, v := range values {
+					out[j] = Analyze(v, tokenization, "C", nil, nil).Query
+				}
+			}
+		})
+	}
+}
+
+func benchValues(n int) []string {
+	values := make([]string, n)
+	for i := range values {
+		values[i] = fmt.Sprintf("some value number %d here", i)
+	}
+	return values
+}

--- a/entities/tokenizer/tokenizer_metrics_test.go
+++ b/entities/tokenizer/tokenizer_metrics_test.go
@@ -60,3 +60,48 @@ func TestTokenizeMetricsRecordedAtDispatch(t *testing.T) {
 	require.Equal(t, lowercaseBefore, countFor(models.PropertyTokenizationLowercase),
 		"word tokenization must not count its lowercasing under the lowercase label")
 }
+
+// TestTrigramWithWildcardsMetricsAndOutput pins that a trigram-with-wildcards
+// call records only under trigram_with_wildcards: its internal
+// word-with-wildcards split must not count under word_with_wildcards (the
+// historical double record). Doubles as the only output assertion for the
+// trigram-wildcards path.
+func TestTrigramWithWildcardsMetricsAndOutput(t *testing.T) {
+	countFor := func(label string) float64 {
+		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
+	}
+
+	wordBefore := countFor("word_with_wildcards")
+	trigramBefore := countFor("trigram_with_wildcards")
+
+	tokens := TokenizeWithWildcardsForClass(models.PropertyTokenizationTrigram, "Hello W?rld*", "")
+	require.Equal(t, []string{"hel", "ell", "llo", "low", "ow?", "w?r", "?rl", "rld", "ld*"}, tokens)
+
+	require.Equal(t, trigramBefore+float64(len(tokens)), countFor("trigram_with_wildcards"),
+		"trigram wildcards must record its token count under its own label")
+	require.Equal(t, wordBefore, countFor("word_with_wildcards"),
+		"trigram wildcards must not count its internal word split under word_with_wildcards")
+}
+
+// TestGseChRecordsUnderOwnLabel pins the gse_ch relabel: Chinese tokenization
+// records under its own "gse_ch" label, not under "gse" (the historical
+// copy-paste), so operators can tell the two tokenizers' volume apart.
+func TestGseChRecordsUnderOwnLabel(t *testing.T) {
+	t.Setenv("ENABLE_TOKENIZER_GSE_CH", "true")
+	InitOptionalTokenizers()
+
+	countFor := func(label string) float64 {
+		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
+	}
+
+	gseBefore := countFor(models.PropertyTokenizationGse)
+	gseChBefore := countFor(models.PropertyTokenizationGseCh)
+
+	tokens := Tokenize(models.PropertyTokenizationGseCh, "你好世界")
+	require.NotEmpty(t, tokens)
+
+	require.Equal(t, gseChBefore+float64(len(tokens)), countFor(models.PropertyTokenizationGseCh),
+		"gse_ch tokenization must record under gse_ch")
+	require.Equal(t, gseBefore, countFor(models.PropertyTokenizationGse),
+		"gse_ch tokenization must not record under gse")
+}

--- a/entities/tokenizer/tokenizer_metrics_test.go
+++ b/entities/tokenizer/tokenizer_metrics_test.go
@@ -1,0 +1,62 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// TestTokenizeMetricsRecordedAtDispatch pins that tokenization metrics are
+// recorded once, under the dispatched tokenization's own label. Regression
+// coverage for the historical double-count: tokenizeLowercase delegated to
+// tokenizeWhitespace, which ALSO recorded its own metrics, so one lowercase
+// call inflated the "whitespace" token count (and "lowercase" itself never
+// recorded any token count at all, only a duration).
+func TestTokenizeMetricsRecordedAtDispatch(t *testing.T) {
+	countFor := func(label string) float64 {
+		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
+	}
+
+	lowercaseBefore := countFor(models.PropertyTokenizationLowercase)
+	whitespaceBefore := countFor(models.PropertyTokenizationWhitespace)
+
+	tokens := Tokenize(models.PropertyTokenizationLowercase, "Hello World")
+	require.Equal(t, []string{"hello", "world"}, tokens)
+
+	require.Equal(t, lowercaseBefore+2, countFor(models.PropertyTokenizationLowercase),
+		"lowercase must record its own token count")
+	require.Equal(t, whitespaceBefore, countFor(models.PropertyTokenizationWhitespace),
+		"lowercase must not count its internal whitespace delegation under the whitespace label")
+
+	whitespaceBefore = countFor(models.PropertyTokenizationWhitespace)
+	tokens = Tokenize(models.PropertyTokenizationWhitespace, "Hello World")
+	require.Equal(t, []string{"Hello", "World"}, tokens)
+	require.Equal(t, whitespaceBefore+2, countFor(models.PropertyTokenizationWhitespace),
+		"direct whitespace tokenization still records under whitespace")
+
+	// The lowercase() helper is shared by the word (and wildcard) tokenizers;
+	// it must not record anything itself, or word tokenization pollutes the
+	// "lowercase" label (the historical behavior).
+	lowercaseBefore = countFor(models.PropertyTokenizationLowercase)
+	wordBefore := countFor(models.PropertyTokenizationWord)
+	tokens = Tokenize(models.PropertyTokenizationWord, "Hello World")
+	require.Equal(t, []string{"hello", "world"}, tokens)
+	require.Equal(t, wordBefore+2, countFor(models.PropertyTokenizationWord),
+		"word tokenization records under word")
+	require.Equal(t, lowercaseBefore, countFor(models.PropertyTokenizationLowercase),
+		"word tokenization must not count its lowercasing under the lowercase label")
+}

--- a/entities/tokenizer/tokenizer_metrics_test.go
+++ b/entities/tokenizer/tokenizer_metrics_test.go
@@ -14,94 +14,96 @@ package tokenizer
 import (
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-// TestTokenizeMetricsRecordedAtDispatch pins that tokenization metrics are
-// recorded once, under the dispatched tokenization's own label. Regression
-// coverage for the historical double-count: tokenizeLowercase delegated to
-// tokenizeWhitespace, which ALSO recorded its own metrics, so one lowercase
-// call inflated the "whitespace" token count (and "lowercase" itself never
-// recorded any token count at all, only a duration).
-func TestTokenizeMetricsRecordedAtDispatch(t *testing.T) {
-	countFor := func(label string) float64 {
-		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
-	}
+// tokenCount reads the TokenCount counter for label.
+func tokenCount(label string) float64 {
+	return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
+}
 
-	lowercaseBefore := countFor(models.PropertyTokenizationLowercase)
-	whitespaceBefore := countFor(models.PropertyTokenizationWhitespace)
+// tokensPerRequestObservations reads the number of TokenCountPerRequest
+// histogram observations recorded for label.
+func tokensPerRequestObservations(t *testing.T, label string) uint64 {
+	t.Helper()
+	var m dto.Metric
+	observer := monitoring.GetMetrics().TokenCountPerRequest.WithLabelValues(label)
+	require.NoError(t, observer.(prometheus.Metric).Write(&m))
+	return m.GetHistogram().GetSampleCount()
+}
+
+// TestTokenizeMetricsRecordedAtDispatch pins that tokenization metrics are
+// recorded once, under the dispatched tokenization's own label: a lowercase
+// call must not also add to the whitespace count, even though lowercase
+// tokenization delegates to the whitespace splitter internally.
+func TestTokenizeMetricsRecordedAtDispatch(t *testing.T) {
+	lowercaseBefore := tokenCount(models.PropertyTokenizationLowercase)
+	whitespaceBefore := tokenCount(models.PropertyTokenizationWhitespace)
 
 	tokens := Tokenize(models.PropertyTokenizationLowercase, "Hello World")
 	require.Equal(t, []string{"hello", "world"}, tokens)
 
-	require.Equal(t, lowercaseBefore+2, countFor(models.PropertyTokenizationLowercase),
+	require.Equal(t, lowercaseBefore+2, tokenCount(models.PropertyTokenizationLowercase),
 		"lowercase must record its own token count")
-	require.Equal(t, whitespaceBefore, countFor(models.PropertyTokenizationWhitespace),
+	require.Equal(t, whitespaceBefore, tokenCount(models.PropertyTokenizationWhitespace),
 		"lowercase must not count its internal whitespace delegation under the whitespace label")
 
-	whitespaceBefore = countFor(models.PropertyTokenizationWhitespace)
+	whitespaceBefore = tokenCount(models.PropertyTokenizationWhitespace)
 	tokens = Tokenize(models.PropertyTokenizationWhitespace, "Hello World")
 	require.Equal(t, []string{"Hello", "World"}, tokens)
-	require.Equal(t, whitespaceBefore+2, countFor(models.PropertyTokenizationWhitespace),
+	require.Equal(t, whitespaceBefore+2, tokenCount(models.PropertyTokenizationWhitespace),
 		"direct whitespace tokenization still records under whitespace")
 
 	// The lowercase() helper is shared by the word (and wildcard) tokenizers;
 	// it must not record anything itself, or word tokenization pollutes the
-	// "lowercase" label (the historical behavior).
-	lowercaseBefore = countFor(models.PropertyTokenizationLowercase)
-	wordBefore := countFor(models.PropertyTokenizationWord)
+	// "lowercase" label.
+	lowercaseBefore = tokenCount(models.PropertyTokenizationLowercase)
+	wordBefore := tokenCount(models.PropertyTokenizationWord)
 	tokens = Tokenize(models.PropertyTokenizationWord, "Hello World")
 	require.Equal(t, []string{"hello", "world"}, tokens)
-	require.Equal(t, wordBefore+2, countFor(models.PropertyTokenizationWord),
+	require.Equal(t, wordBefore+2, tokenCount(models.PropertyTokenizationWord),
 		"word tokenization records under word")
-	require.Equal(t, lowercaseBefore, countFor(models.PropertyTokenizationLowercase),
+	require.Equal(t, lowercaseBefore, tokenCount(models.PropertyTokenizationLowercase),
 		"word tokenization must not count its lowercasing under the lowercase label")
 }
 
 // TestTrigramWithWildcardsMetricsAndOutput pins that a trigram-with-wildcards
 // call records only under trigram_with_wildcards: its internal
-// word-with-wildcards split must not count under word_with_wildcards (the
-// historical double record). Doubles as the only output assertion for the
-// trigram-wildcards path.
+// word-with-wildcards split must not also count under word_with_wildcards.
+// Doubles as the only output assertion for the trigram-wildcards path.
 func TestTrigramWithWildcardsMetricsAndOutput(t *testing.T) {
-	countFor := func(label string) float64 {
-		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
-	}
-
-	wordBefore := countFor("word_with_wildcards")
-	trigramBefore := countFor("trigram_with_wildcards")
+	wordBefore := tokenCount("word_with_wildcards")
+	trigramBefore := tokenCount("trigram_with_wildcards")
 
 	tokens := TokenizeWithWildcardsForClass(models.PropertyTokenizationTrigram, "Hello W?rld*", "")
 	require.Equal(t, []string{"hel", "ell", "llo", "low", "ow?", "w?r", "?rl", "rld", "ld*"}, tokens)
 
-	require.Equal(t, trigramBefore+float64(len(tokens)), countFor("trigram_with_wildcards"),
+	require.Equal(t, trigramBefore+float64(len(tokens)), tokenCount("trigram_with_wildcards"),
 		"trigram wildcards must record its token count under its own label")
-	require.Equal(t, wordBefore, countFor("word_with_wildcards"),
+	require.Equal(t, wordBefore, tokenCount("word_with_wildcards"),
 		"trigram wildcards must not count its internal word split under word_with_wildcards")
 }
 
-// TestGseChRecordsUnderOwnLabel pins the gse_ch relabel: Chinese tokenization
-// records under its own "gse_ch" label, not under "gse" (the historical
-// copy-paste), so operators can tell the two tokenizers' volume apart.
+// TestGseChRecordsUnderOwnLabel pins that Chinese tokenization records under
+// its own "gse_ch" label, not under "gse", so operators can tell the two
+// tokenizers' volume apart.
 func TestGseChRecordsUnderOwnLabel(t *testing.T) {
 	t.Setenv("ENABLE_TOKENIZER_GSE_CH", "true")
 	InitOptionalTokenizers()
 
-	countFor := func(label string) float64 {
-		return testutil.ToFloat64(monitoring.GetMetrics().TokenCount.WithLabelValues(label))
-	}
-
-	gseBefore := countFor(models.PropertyTokenizationGse)
-	gseChBefore := countFor(models.PropertyTokenizationGseCh)
+	gseBefore := tokenCount(models.PropertyTokenizationGse)
+	gseChBefore := tokenCount(models.PropertyTokenizationGseCh)
 
 	tokens := Tokenize(models.PropertyTokenizationGseCh, "你好世界")
 	require.NotEmpty(t, tokens)
 
-	require.Equal(t, gseChBefore+float64(len(tokens)), countFor(models.PropertyTokenizationGseCh),
+	require.Equal(t, gseChBefore+float64(len(tokens)), tokenCount(models.PropertyTokenizationGseCh),
 		"gse_ch tokenization must record under gse_ch")
-	require.Equal(t, gseBefore, countFor(models.PropertyTokenizationGse),
+	require.Equal(t, gseBefore, tokenCount(models.PropertyTokenizationGse),
 		"gse_ch tokenization must not record under gse")
 }

--- a/entities/tokenizer/tokenizer_split_test.go
+++ b/entities/tokenizer/tokenizer_split_test.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+)
+
+// randomInputs builds inputs from an alphabet mixing separators, ASCII,
+// wildcards and multi-byte runes, so span boundaries land mid-rune as often
+// as the tokenizers will see in practice.
+func randomInputs(seed int64, n int, alphabet string) []string {
+	runes := []rune(alphabet)
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]string, n)
+	for i := range out {
+		var sb strings.Builder
+		for j := rng.Intn(40); j > 0; j-- {
+			sb.WriteRune(runes[rng.Intn(len(runes))])
+		}
+		out[i] = sb.String()
+	}
+	return out
+}
+
+// TestAppendFieldsFuncMatchesStdlib is the drift guard for the append-style
+// splitter: it must produce exactly what strings.FieldsFunc produces, for
+// every separator predicate the tokenizers use, both into a fresh buffer and
+// appended after existing tokens.
+func TestAppendFieldsFuncMatchesStdlib(t *testing.T) {
+	tests := []struct {
+		name  string
+		isSep func(rune) bool
+	}{
+		{"whitespace", unicode.IsSpace},
+		{"alphanumeric", isNotAlphanumeric},
+		{"alphanumeric with wildcards", func(r rune) bool {
+			return isNotAlphanumeric(r) && r != '?' && r != '*'
+		}},
+	}
+
+	inputs := append([]string{"", " ", "\t\n", "a", "abc", "a b", "  a  b  "},
+		randomInputs(1, 20000, " \t\n abcXY01_-.?*é日本語한글")...)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, in := range inputs {
+				want := strings.FieldsFunc(in, tt.isSep)
+
+				got := appendFieldsFunc(nil, in, tt.isSep)
+				require.Len(t, got, len(want), "input %q", in)
+				if len(want) > 0 {
+					require.Equal(t, want, got, "input %q", in)
+				}
+
+				// appending after existing tokens must leave them untouched
+				prefix := []string{"KEEP_0", "KEEP_1"}
+				appended := appendFieldsFunc(append([]string{}, prefix...), in, tt.isSep)
+				require.Equal(t, prefix, appended[:len(prefix)], "input %q", in)
+				require.Len(t, appended[len(prefix):], len(want), "input %q", in)
+				if len(want) > 0 {
+					require.Equal(t, want, appended[len(prefix):], "input %q", in)
+				}
+			}
+		})
+	}
+}
+
+// referenceTrigram is the straightforward rune-slicing implementation, kept as
+// the oracle for the offset-based one, which emits trigrams as substrings of
+// the stripped input instead of copying each one.
+func referenceTrigram(in string) []string {
+	stripped := strings.ToLower(strings.Join(strings.FieldsFunc(in, isNotAlphanumeric), ""))
+	runes := []rune(stripped)
+	var out []string
+	for i := 0; i < len(runes)-2; i++ {
+		out = append(out, string(runes[i:i+3]))
+	}
+	return out
+}
+
+func TestTokenizeTrigramMatchesReference(t *testing.T) {
+	inputs := append([]string{"", "a", "ab", "abc", "abcd", "日本語です", "a-b-c"},
+		randomInputs(2, 50000, " \t abcXY01_-.é日本語한글🎉")...)
+
+	for _, in := range inputs {
+		want := referenceTrigram(in)
+		got := tokenizetrigram(in, nil)
+		require.Len(t, got, len(want), "input %q", in)
+		if len(want) > 0 {
+			require.Equal(t, want, got, "input %q", in)
+		}
+	}
+}

--- a/entities/tokenizer/tokenizer_userdict_test.go
+++ b/entities/tokenizer/tokenizer_userdict_test.go
@@ -22,6 +22,20 @@ import (
 
 func ptr(s string) *string { return &s }
 
+// jaCustomDict returns a Japanese-only user-dictionary config (the KR
+// counterpart is generateReplacementModel).
+func jaCustomDict() *models.TokenizerUserDictConfig {
+	return &models.TokenizerUserDictConfig{
+		Tokenizer: models.PropertyTokenizationKagomeJa,
+		Replacements: []*models.TokenizerUserDictConfigReplacementsItems0{
+			{
+				Source: ptr("Weaviate"),
+				Target: ptr("We Aviate"),
+			},
+		},
+	}
+}
+
 func generateReplacementModel() *models.TokenizerUserDictConfig {
 	return &models.TokenizerUserDictConfig{
 		Tokenizer: models.PropertyTokenizationKagomeKr,
@@ -84,15 +98,7 @@ func TestKagomeUserTokenizerForClass(t *testing.T) {
 // made from a guarded goroutine so an unbalanced throttle surfaces as a test
 // failure instead of a suite timeout.
 func TestKagomeUserTokenizerForClassBalancesThrottle(t *testing.T) {
-	jaDict := &models.TokenizerUserDictConfig{
-		Tokenizer: models.PropertyTokenizationKagomeJa,
-		Replacements: []*models.TokenizerUserDictConfigReplacementsItems0{
-			{
-				Source: ptr("Weaviate"),
-				Target: ptr("We Aviate"),
-			},
-		},
-	}
+	jaDict := jaCustomDict()
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Motivation

Second PR in the stacked series toward batched `ContainsAny`/`ContainsAll` filter resolution (#12242). A filter with 100K values tokenizes each value individually, paying per value: three prometheus registry lookups + two wall-clock reads, a fresh result slice, and full tokenizer dispatch. This PR removes that scaffolding at the tokenizer layer.

**`AnalyzeBatch` has no callers yet** — it is wired up by the next PR in the series.

## Approach

- **Metrics once at dispatch, kernels pure**: exactly one wrapper (`timed`) records duration + token counts via per-label prometheus handles bound once and cached (`metricsFor`). Also fixes three metric-misaccounting bugs — see Breaking changes.
- **Append-style kernels, resolve-once dispatch**: all kernels share `func(in string, dst []string) []string`; `resolveTokenizer` resolves the switch, guards, and custom-kagome lookup once per call/batch. The single-value path keeps its previous allocation profile (verified by benchmark); the batch path reuses one scratch buffer.
- **`AnalyzeBatch` → `AnalyzedBatch`**: equivalent to per-value `Analyze`, but returns one flat `[]string` + a `uint32` offset table (two allocations per batch instead of one slice per value). Views alias the shared array, read-only, append-safe via full slice expressions.
- **Chunked throttle acquisition** (`throttledBatchChunk = 16`): a throttled batch (gse/gse_ch/global kagome) re-acquires its `ApacTokenizerThrottle` slot every 16 values instead of holding it for the whole run, so concurrent large batches cannot starve single-value tokenizations. Per-chunk deferred release is panic-safe; recorded duration counts in-slot time only. Unthrottled batches (everything the Contains wiring routes) run as one chunk.

## Key areas for review

- `resolveTokenizer` — guard early-outs (disabled gse, nil kagome, custom-dict fallthrough) must match the old per-call behavior, including recording no metrics
- `AnalyzeBatch` — chunk loop and offset table; the `uint32` cap (4B tokens/batch) is a documented caller obligation, no runtime guard

## Breaking changes (metrics only — release note)

- **gse_ch relabel**: gse_ch tokenization previously recorded under label `"gse"`; now under `"gse_ch"`. Dashboards tracking `gse` will see Chinese traffic move to its own series.
- `"lowercase"` no longer inflated by word/wildcard tokenization; `trigram_with_wildcards` no longer double-records under `"word_with_wildcards"`.
- With the upcoming batch caller, one batch = one `TokenCountPerRequest` observation (summed count).

## Testing

- Batch/per-value equivalence across all tokenizations, custom KR/JA kagome dicts, throttled gse_ch spanning several chunks, stopword-filtered values; throttle balance asserted after every batch.
- The three metric fixes pinned red/green in `tokenizer_metrics_test.go`.
- Single-value allocation profile benchmarked back to pre-refactor numbers (word 248B/9 allocs per value).