### PR TITLE
lsmkv/roaringset: cut per-read allocations on the roaringset read path

### DIFF
--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -32,7 +32,7 @@ func requireBitmapValid(t *testing.T, bm *sroar.Bitmap) {
 
 func newTrackingOps(t *testing.T) *BitmapOps {
 	t.Helper()
-	pool := roaringset.NewBitmapBufPoolTracking()
+	pool := roaringset.NewBitmapBufPoolTrackingForTests()
 	t.Cleanup(func() {
 		if n := pool.Outstanding(); n != 0 {
 			t.Errorf("pool: %d bitmap buffer(s) not released", n)

--- a/adapters/repos/db/inverted/searcher_nested_test_helpers_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test_helpers_test.go
@@ -50,12 +50,12 @@ func writeIdx(t *testing.T, bucket *lsmkv.Bucket, path string, elemIdx int, posi
 	require.NoError(t, bucket.RoaringSetAddList(invnested.IdxKey(path, elemIdx), positions))
 }
 
-// newTrackingPool returns a BitmapBufPoolTracking that asserts at test cleanup
+// newTrackingPool returns a BitmapBufPoolTrackingForTests that asserts at test cleanup
 // time that every leased buffer has been returned. Detects pool-buffer leaks
 // in the recursive executor.
-func newTrackingPool(t *testing.T) *roaringset.BitmapBufPoolTracking {
+func newTrackingPool(t *testing.T) *roaringset.BitmapBufPoolTrackingForTests {
 	t.Helper()
-	pool := roaringset.NewBitmapBufPoolTracking()
+	pool := roaringset.NewBitmapBufPoolTrackingForTests()
 	t.Cleanup(func() {
 		if n := pool.Outstanding(); n != 0 {
 			t.Errorf("pool: %d bitmap buffer(s) not released", n)

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
@@ -133,7 +134,7 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 ) (bm *sroar.Bitmap, release func(), err error) {
 	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
-	layers, diskRelease, err := b.disk.roaringSetGet(key, view.Disk, maxConc)
+	diskLayer, diskRelease, err := b.disk.roaringSetGet(key, view.Disk, maxConc)
 	if err != nil {
 		return nil, noopRelease, err
 	}
@@ -146,6 +147,12 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 		}
 	}()
 
+	// Fold the disk-flattened layer with the flushing and active memtable layers
+	// one at a time, chronologically oldest first, instead of materializing a
+	// []BitmapLayer. diskLayer.Additions is the pooled base (with headroom), so
+	// the memtable layers merge into it in place.
+	merger := roaringset.NewLayerMerger(diskLayer.Additions, false, maxConc)
+
 	if view.Flushing != nil {
 		flushing, flushErr := view.Flushing.roaringSetGet(key)
 		if flushErr != nil {
@@ -154,7 +161,7 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 				return nil, noopRelease, err
 			}
 		} else {
-			layers = append(layers, flushing)
+			merger.Add(flushing)
 		}
 	}
 
@@ -165,8 +172,8 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 			return nil, noopRelease, err
 		}
 	} else {
-		layers = append(layers, activeBM)
+		merger.Add(activeBM)
 	}
 
-	return layers.Flatten(false, maxConc), diskRelease, nil
+	return merger.Result(), diskRelease, nil
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -147,10 +147,10 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 		}
 	}()
 
-	// Fold the disk-flattened layer with the flushing and active memtable layers
-	// one at a time, chronologically oldest first, instead of materializing a
-	// []BitmapLayer. diskLayer.Additions is the pooled base (with headroom), so
-	// the memtable layers merge into it in place.
+	// Fold the disk, flushing and active layers one at a time, oldest first,
+	// without materializing a []BitmapLayer. diskLayer.Additions is the pooled
+	// base (with headroom); on a disk miss it is nil and the merger adopts the
+	// first memtable layer's clone instead of copying it.
 	merger := roaringset.NewLayerMerger(diskLayer.Additions, false, maxConc)
 
 	if view.Flushing != nil {

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -289,6 +289,142 @@ func TestBucket_RoaringSet_DeleteThenReaddAcrossSegments(t *testing.T) {
 	requireRoaringSetElements(t, ctx, b, clean, []uint64{100, 101, 102, 103})
 }
 
+// TestBucket_RoaringSet_DeletionsOnlyOldestSegment pins the empty-additions
+// base across multiple disk segments: the oldest segment holding a key
+// becomes the mutable accumulator base of the disk fold, so the segment read
+// must substitute a non-nil additions bitmap when the node stores only
+// deletions — the newer segment's merge runs AndNot/Or directly on it.
+// Covers both segment read modes, whose branches both return nil additions
+// for the empty region.
+func TestBucket_RoaringSet_DeletionsOnlyOldestSegment(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []BucketOption
+	}{
+		{"mmap", nil},
+		{"pread", []BucketOption{WithPread(true)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger, _ := test.NewNullLogger()
+
+			opts := append([]BucketOption{
+				WithStrategy(StrategyRoaringSet),
+				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
+			}, tt.opts...)
+			b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+			b.SetMemtableThreshold(1e9) // flush explicitly so writes span several segments
+
+			key := []byte("key")
+
+			// segment 1 (oldest): deletions only -> empty additions region
+			require.NoError(t, b.RoaringSetRemoveOne(key, 7))
+			require.NoError(t, b.FlushAndSwitch())
+
+			// segment 2: additions merged into the substituted base (the Or arm)
+			require.NoError(t, b.RoaringSetAddList(key, []uint64{1, 2, 3}))
+			require.NoError(t, b.FlushAndSwitch())
+
+			// segment 3: deletes 2, added by segment 2, so the AndNot arm's
+			// effect on the accumulated base is visible in the result
+			require.NoError(t, b.RoaringSetRemoveOne(key, 2))
+			require.NoError(t, b.FlushAndSwitch())
+
+			requireRoaringSetElements(t, ctx, b, key, []uint64{1, 3})
+		})
+	}
+}
+
+// TestBucket_RoaringSet_ReleasesAllPooledBuffers pins combineReleases: the
+// buffers a node's read pools must all be freed by the single returned
+// release, in either read mode. The region shapes of the oldest segment
+// steer which combineReleases arm the read takes (and the arms differ per
+// mode — a pread read always pools the whole node buffer), so together the
+// scenarios cover every arm in both modes.
+func TestBucket_RoaringSet_ReleasesAllPooledBuffers(t *testing.T) {
+	modes := []struct {
+		name string
+		opts []BucketOption
+	}{
+		{"mmap", nil},
+		{"pread", []BucketOption{WithPread(true)}},
+	}
+
+	// The oldest segment's shape is what matters, because only the oldest
+	// segment holding the key is read through segment.roaringSetGet (and so
+	// through combineReleases) — newer segments are folded via
+	// roaringSetMergeWith, which pools nothing through it.
+	scenarios := []struct {
+		name     string
+		seg1     func(t *testing.T, b *Bucket, key []byte)
+		expected []uint64
+	}{
+		{
+			name: "oldest segment has additions and deletions",
+			seg1: func(t *testing.T, b *Bucket, key []byte) {
+				require.NoError(t, b.RoaringSetAddList(key, []uint64{2}))
+				require.NoError(t, b.RoaringSetRemoveOne(key, 5))
+			},
+			expected: []uint64{1, 2, 3},
+		},
+		{
+			name: "oldest segment has additions only",
+			seg1: func(t *testing.T, b *Bucket, key []byte) {
+				require.NoError(t, b.RoaringSetAddList(key, []uint64{2}))
+			},
+			expected: []uint64{1, 2, 3},
+		},
+		{
+			name: "oldest segment has deletions only",
+			seg1: func(t *testing.T, b *Bucket, key []byte) {
+				require.NoError(t, b.RoaringSetRemoveOne(key, 5))
+			},
+			expected: []uint64{1, 3},
+		},
+	}
+
+	for _, mode := range modes {
+		for _, scenario := range scenarios {
+			t.Run(mode.name+"/"+scenario.name, func(t *testing.T) {
+				ctx := context.Background()
+				logger, _ := test.NewNullLogger()
+				pool := roaringset.NewBitmapBufPoolTrackingForTests()
+
+				opts := append([]BucketOption{
+					WithStrategy(StrategyRoaringSet),
+					WithBitmapBufPool(pool),
+				}, mode.opts...)
+				b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+				b.SetMemtableThreshold(1e9)
+
+				key := []byte("key")
+				scenario.seg1(t, b, key)
+				require.NoError(t, b.FlushAndSwitch())
+
+				require.NoError(t, b.RoaringSetAddList(key, []uint64{1, 3}))
+				require.NoError(t, b.FlushAndSwitch())
+
+				bm, release, err := b.RoaringSetGet(ctx, key)
+				require.NoError(t, err)
+				require.ElementsMatch(t, scenario.expected, bm.ToArray())
+				release()
+
+				require.Zero(t, pool.Outstanding(), "single release must free every pooled buffer")
+			})
+		}
+	}
+}
+
 func requireRoaringSetElements(t *testing.T, ctx context.Context, b *Bucket, key []byte, want []uint64) {
 	t.Helper()
 	bm, release, err := b.RoaringSetGet(ctx, key)

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -241,3 +241,58 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 		return nil
 	})
 }
+
+// TestBucket_RoaringSet_DeleteThenReaddAcrossSegments is a read-path regression
+// test for roaringset reads with tombstones spread across multiple disk segments
+// plus the active memtable, including a doc deleted in one segment and re-added
+// in a later layer. The first (oldest) segment carries no tombstones, so it
+// takes the empty-deletions path in segment.roaringSetGet; the test pins that
+// the full add / delete / re-add fold still resolves correctly. (Note: Flatten
+// ignores the base layer's Deletions, so this exercises the surrounding fold
+// rather than the base layer's deletions bitmap directly.)
+func TestBucket_RoaringSet_DeleteThenReaddAcrossSegments(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	b.SetMemtableThreshold(1e9) // flush explicitly so writes span several segments
+
+	tombstoned := []byte("tombstoned")
+	clean := []byte("clean")
+
+	// segment 1 (oldest): additions only -> empty deletions -> shared empty path
+	require.NoError(t, b.RoaringSetAddList(tombstoned, []uint64{1, 2, 3, 4, 5}))
+	require.NoError(t, b.RoaringSetAddList(clean, []uint64{100, 101}))
+	require.NoError(t, b.FlushAndSwitch())
+
+	// segment 2: real deletions of 2 and 4, plus addition 6
+	require.NoError(t, b.RoaringSetRemoveOne(tombstoned, 2))
+	require.NoError(t, b.RoaringSetRemoveOne(tombstoned, 4))
+	require.NoError(t, b.RoaringSetAddList(tombstoned, []uint64{6}))
+	require.NoError(t, b.RoaringSetAddList(clean, []uint64{102}))
+	require.NoError(t, b.FlushAndSwitch())
+
+	// active memtable (unflushed): re-add 2 (deleted in segment 2) and add 7
+	require.NoError(t, b.RoaringSetAddList(tombstoned, []uint64{2, 7}))
+	require.NoError(t, b.RoaringSetAddList(clean, []uint64{103}))
+
+	// {1,2,3,4,5} -(del 2,4)-> {1,3,5} +6 -> {1,3,5,6}; re-add {2,7} -> {1,2,3,5,6,7}
+	// (doc 2, deleted in segment 2, must survive because it is re-added later)
+	requireRoaringSetElements(t, ctx, b, tombstoned, []uint64{1, 2, 3, 5, 6, 7})
+	// pure additions across every layer -> every layer takes the empty path
+	requireRoaringSetElements(t, ctx, b, clean, []uint64{100, 101, 102, 103})
+}
+
+func requireRoaringSetElements(t *testing.T, ctx context.Context, b *Bucket, key []byte, want []uint64) {
+	t.Helper()
+	bm, release, err := b.RoaringSetGet(ctx, key)
+	require.NoError(t, err)
+	defer release()
+	require.ElementsMatch(t, want, bm.ToArray())
+}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -1178,7 +1178,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 
 	// the original memtable was flushed to disk
 	v, release, err := b.disk.roaringSetGet([]byte("key1"), view3.Disk, concurrency.SROAR_MERGE)
-	assert.Equal(t, []uint64{1, 2}, v.Flatten(true, concurrency.SROAR_MERGE).ToArray())
+	assert.Equal(t, []uint64{1, 2}, roaringset.BitmapLayers{v}.Flatten(true, concurrency.SROAR_MERGE).ToArray())
 	require.NoError(t, err)
 	release()
 }
@@ -1248,7 +1248,7 @@ func TestBucketRoaringSetStrategyWriteVsFlush(t *testing.T) {
 
 	bm, release, err := b.disk.roaringSetGet([]byte("key1"), view.Disk, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
-	assert.Equal(t, []uint64{1, 2, 3}, bm.Flatten(true, concurrency.SROAR_MERGE).ToArray())
+	assert.Equal(t, []uint64{1, 2, 3}, roaringset.BitmapLayers{bm}.Flatten(true, concurrency.SROAR_MERGE).ToArray())
 	release()
 }
 

--- a/adapters/repos/db/lsmkv/commitlogger_parser_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/commitlogger_parser_roaring_set_test.go
@@ -1,0 +1,65 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+// TestCommitlogParserRoaringSetLegacyNode pins WAL replay of legacy
+// CommitTypeRoaringSet records against SegmentNode's nil-bitmap accessor
+// contract: a record whose additions or deletions region is empty
+// (zero-length, e.g. a deletions-only write) decodes to a nil bitmap, and
+// replay must consume it as empty rather than fail.
+func TestCommitlogParserRoaringSetLegacyNode(t *testing.T) {
+	tests := []struct {
+		name      string
+		additions []uint64
+		deletions []uint64
+	}{
+		{name: "deletions only", deletions: []uint64{7, 8}},
+		{name: "additions only", additions: []uint64{1, 2, 3}},
+		{name: "additions and deletions", additions: []uint64{1, 2}, deletions: []uint64{3}},
+		{name: "both empty"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := []byte("k1")
+			sn, err := roaringset.NewSegmentNode(key,
+				roaringset.NewBitmap(tt.additions...),
+				roaringset.NewBitmap(tt.deletions...))
+			require.NoError(t, err)
+
+			var gotKey []byte
+			var gotAdditions, gotDeletions []uint64
+			prs := &commitlogParserRoaringSet{
+				consume: func(key []byte, additions, deletions []uint64) error {
+					gotKey = key
+					gotAdditions = additions
+					gotDeletions = deletions
+					return nil
+				},
+			}
+
+			require.NoError(t, prs.parseNode(bytes.NewReader(sn.ToBuffer())))
+			assert.Equal(t, key, gotKey)
+			assert.Equal(t, tt.additions, gotAdditions)
+			assert.Equal(t, tt.deletions, gotDeletions)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -149,6 +149,11 @@ type diskIndex interface {
 	// Get return lsmkv.NotFound in case no node can be found
 	Get(key []byte) (segmentindex.Node, error)
 
+	// GetOffsets returns only the payload position (start, end) of the matching
+	// node without materializing its key. Prefer it on hot read paths that only
+	// need the offsets and never read Node.Key.
+	GetOffsets(key []byte) (start, end uint64, err error)
+
 	// Seek returns lsmkv.NotFound in case the seek value is larger than
 	// the highest value in the collection, otherwise it returns the next highest
 	// value (or the exact value if present)

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -149,9 +149,8 @@ type diskIndex interface {
 	// Get return lsmkv.NotFound in case no node can be found
 	Get(key []byte) (segmentindex.Node, error)
 
-	// GetOffsets returns only the payload position (start, end) of the matching
-	// node without materializing its key. Prefer it on hot read paths that only
-	// need the offsets and never read Node.Key.
+	// GetOffsets returns only the payload position (start, end) of the
+	// matching node; prefer it on hot paths that never read Node.Key.
 	GetOffsets(key []byte) (start, end uint64, err error)
 
 	// Seek returns lsmkv.NotFound in case the seek value is larger than

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -40,6 +40,13 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
+// baseLayerHeadroomFactor sizes the first (base) layer's pooled buffer with
+// 25% headroom, so the in-place merges of the following segments' layers can
+// usually grow the bitmap without leaving the pooled buffer. Too little
+// headroom forces off-pool reallocation, defeating the pooling; more wastes
+// pooled memory.
+const baseLayerHeadroomFactor = 1.25
+
 type SegmentGroup struct {
 	segments []Segment
 
@@ -98,11 +105,11 @@ type SegmentGroup struct {
 
 	roaringSetRangeSegmentInMemory *roaringsetrange.SegmentInMemory
 	bitmapBufPool                  roaringset.BitmapBufPool
-	// bitmapBufPoolFactored wraps bitmapBufPool with a size factor so the first
-	// layer of a multi-segment roaringSetGet gets a buffer with headroom for the
-	// in-place merges of the following layers. Built once at construction rather
-	// than per read (the wrapper is otherwise allocated on every roaringSetGet).
-	bitmapBufPoolFactored        roaringset.BitmapBufPool
+	// bitmapBufPoolWithHeadroom wraps bitmapBufPool with
+	// baseLayerHeadroomFactor so the first layer of a multi-segment
+	// roaringSetGet gets a buffer with headroom for the in-place merges of
+	// the following layers. Built once at construction.
+	bitmapBufPoolWithHeadroom    roaringset.BitmapBufPool
 	bm25config                   *schema.BM25Config
 	lazyPropertyLengths          *configRuntime.DynamicValue[bool]
 	writeSegmentInfoIntoFileName bool
@@ -180,7 +187,7 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		sequentialAccess:             cfg.sequentialAccess,
 		lazyPropertyLengths:          cfg.lazyPropertyLengths,
 		bitmapBufPool:                b.bitmapBufPool,
-		bitmapBufPoolFactored:        roaringset.NewBitmapBufPoolFactorWrapper(b.bitmapBufPool, 1.25),
+		bitmapBufPoolWithHeadroom:    roaringset.NewBitmapBufPoolFactorWrapper(b.bitmapBufPool, baseLayerHeadroomFactor),
 		keepLevelCompaction:          cfg.keepLevelCompaction,
 		shouldSkipKey:                cfg.shouldSkipKey,
 		deleteMarkerCounter:          deleteMarkerCounter,
@@ -950,6 +957,10 @@ func (sg *SegmentGroup) getCollectionAndSegments(ctx context.Context, key []byte
 // If no segment has the key, a zero BitmapLayer (nil bitmaps) and a noop release
 // are returned. Callers fold this base together with the memtable layers using
 // roaringset.LayerMerger.
+//
+// Only Additions is fully folded; Deletions is the first found segment's
+// deletions, retained solely so its buffer gets released, and must not be
+// read as the flattened deletions.
 func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc int) (out roaringset.BitmapLayer, release func(), err error) {
 	ln := len(segments)
 	if ln == 0 {
@@ -963,9 +974,7 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc in
 
 	i := 0
 	for ; i < ln; i++ {
-		// bitmapBufPoolFactored gives the first layer a buffer with headroom for
-		// the in-place merges of the following layers (see field decl).
-		layer, layerRelease, getErr := segments[i].roaringSetGet(key, sg.bitmapBufPoolFactored)
+		layer, layerRelease, getErr := segments[i].roaringSetGet(key, sg.bitmapBufPoolWithHeadroom)
 		if getErr == nil {
 			out = layer
 			acquired = layerRelease

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -943,10 +943,17 @@ func (sg *SegmentGroup) getCollectionAndSegments(ctx context.Context, key []byte
 	return out[:i], outSegments[:i], nil
 }
 
-func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc int) (out roaringset.BitmapLayers, release func(), err error) {
+// roaringSetGet folds all disk segments holding key into a single BitmapLayer.
+// The first segment that has the key becomes the base (its additions are cloned
+// into a pooled buffer with headroom); every later segment is merged in place
+// into that base via roaringSetMergeWith, so no per-layer slice is materialized.
+// If no segment has the key, a zero BitmapLayer (nil bitmaps) and a noop release
+// are returned. Callers fold this base together with the memtable layers using
+// roaringset.LayerMerger.
+func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc int) (out roaringset.BitmapLayer, release func(), err error) {
 	ln := len(segments)
 	if ln == 0 {
-		return nil, noopRelease, nil
+		return out, noopRelease, nil
 	}
 
 	// acquired (not the named return, which error paths overwrite with
@@ -960,13 +967,13 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc in
 		// the in-place merges of the following layers (see field decl).
 		layer, layerRelease, getErr := segments[i].roaringSetGet(key, sg.bitmapBufPoolFactored)
 		if getErr == nil {
-			out = append(out, layer)
+			out = layer
 			acquired = layerRelease
 			i++
 			break
 		}
 		if !errors.Is(getErr, lsmkv.NotFound) {
-			return nil, noopRelease, getErr
+			return roaringset.BitmapLayer{}, noopRelease, getErr
 		}
 	}
 	defer func() {
@@ -976,9 +983,9 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc in
 	}()
 
 	for ; i < ln; i++ {
-		if mergeErr := segments[i].roaringSetMergeWith(key, out[0], sg.bitmapBufPool, maxConc); mergeErr != nil {
+		if mergeErr := segments[i].roaringSetMergeWith(key, out, sg.bitmapBufPool, maxConc); mergeErr != nil {
 			err = mergeErr
-			return nil, noopRelease, err
+			return roaringset.BitmapLayer{}, noopRelease, err
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -98,11 +98,16 @@ type SegmentGroup struct {
 
 	roaringSetRangeSegmentInMemory *roaringsetrange.SegmentInMemory
 	bitmapBufPool                  roaringset.BitmapBufPool
-	bm25config                     *schema.BM25Config
-	lazyPropertyLengths            *configRuntime.DynamicValue[bool]
-	writeSegmentInfoIntoFileName   bool
-	writeMetadata                  bool
-	sequentialAccess               bool // hint kernel for sequential read-ahead (export snapshots)
+	// bitmapBufPoolFactored wraps bitmapBufPool with a size factor so the first
+	// layer of a multi-segment roaringSetGet gets a buffer with headroom for the
+	// in-place merges of the following layers. Built once at construction rather
+	// than per read (the wrapper is otherwise allocated on every roaringSetGet).
+	bitmapBufPoolFactored        roaringset.BitmapBufPool
+	bm25config                   *schema.BM25Config
+	lazyPropertyLengths          *configRuntime.DynamicValue[bool]
+	writeSegmentInfoIntoFileName bool
+	writeMetadata                bool
+	sequentialAccess             bool // hint kernel for sequential read-ahead (export snapshots)
 
 	shouldSkipKey func(key []byte, ctx context.Context) (bool, error)
 	// averagePropLength caches the live-set property-length sum and count for BM25
@@ -175,6 +180,7 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		sequentialAccess:             cfg.sequentialAccess,
 		lazyPropertyLengths:          cfg.lazyPropertyLengths,
 		bitmapBufPool:                b.bitmapBufPool,
+		bitmapBufPoolFactored:        roaringset.NewBitmapBufPoolFactorWrapper(b.bitmapBufPool, 1.25),
 		keepLevelCompaction:          cfg.keepLevelCompaction,
 		shouldSkipKey:                cfg.shouldSkipKey,
 		deleteMarkerCounter:          deleteMarkerCounter,
@@ -947,13 +953,12 @@ func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc in
 	// noopRelease) is what the defer frees, so a mid-merge disk read error
 	// can't leak the first layer's pooled buffer.
 	acquired := noopRelease
-	// use bigger buffer for first layer, to make space for further merges
-	// with following layers
-	bitmapBufPool := roaringset.NewBitmapBufPoolFactorWrapper(sg.bitmapBufPool, 1.25)
 
 	i := 0
 	for ; i < ln; i++ {
-		layer, layerRelease, getErr := segments[i].roaringSetGet(key, bitmapBufPool)
+		// bitmapBufPoolFactored gives the first layer a buffer with headroom for
+		// the in-place merges of the following layers (see field decl).
+		layer, layerRelease, getErr := segments[i].roaringSetGet(key, sg.bitmapBufPoolFactored)
 		if getErr == nil {
 			out = append(out, layer)
 			acquired = layerRelease

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -40,11 +40,9 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
-// baseLayerHeadroomFactor sizes the first (base) layer's pooled buffer with
-// 25% headroom, so the in-place merges of the following segments' layers can
-// usually grow the bitmap without leaving the pooled buffer. Too little
-// headroom forces off-pool reallocation, defeating the pooling; more wastes
-// pooled memory.
+// baseLayerHeadroomFactor sizes the base layer's pooled buffer with 25%
+// headroom so the in-place merges of later layers usually fit without
+// reallocating off-pool.
 const baseLayerHeadroomFactor = 1.25
 
 type SegmentGroup struct {
@@ -105,10 +103,8 @@ type SegmentGroup struct {
 
 	roaringSetRangeSegmentInMemory *roaringsetrange.SegmentInMemory
 	bitmapBufPool                  roaringset.BitmapBufPool
-	// bitmapBufPoolWithHeadroom wraps bitmapBufPool with
-	// baseLayerHeadroomFactor so the first layer of a multi-segment
-	// roaringSetGet gets a buffer with headroom for the in-place merges of
-	// the following layers. Built once at construction.
+	// bitmapBufPool wrapped with baseLayerHeadroomFactor for roaringSetGet's
+	// base layer; built once at construction
 	bitmapBufPoolWithHeadroom    roaringset.BitmapBufPool
 	bm25config                   *schema.BM25Config
 	lazyPropertyLengths          *configRuntime.DynamicValue[bool]
@@ -950,17 +946,12 @@ func (sg *SegmentGroup) getCollectionAndSegments(ctx context.Context, key []byte
 	return out[:i], outSegments[:i], nil
 }
 
-// roaringSetGet folds all disk segments holding key into a single BitmapLayer.
-// The first segment that has the key becomes the base (its additions are cloned
-// into a pooled buffer with headroom); every later segment is merged in place
-// into that base via roaringSetMergeWith, so no per-layer slice is materialized.
-// If no segment has the key, a zero BitmapLayer (nil bitmaps) and a noop release
-// are returned. Callers fold this base together with the memtable layers using
-// roaringset.LayerMerger.
-//
-// Only Additions is fully folded; Deletions is the first found segment's
-// deletions, retained solely so its buffer gets released, and must not be
-// read as the flattened deletions.
+// roaringSetGet folds all disk segments holding key into a single BitmapLayer:
+// the first segment with the key becomes the base (additions cloned into a
+// pooled buffer with headroom), every later segment merges into it in place.
+// If no segment has the key, a zero BitmapLayer and noop release are returned.
+// Only Additions is fully folded; Deletions is the first segment's deletions,
+// retained solely so its buffer gets released — not the flattened deletions.
 func (sg *SegmentGroup) roaringSetGet(key []byte, segments []Segment, maxConc int) (out roaringset.BitmapLayer, release func(), err error) {
 	ln := len(segments)
 	if ln == 0 {

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -142,7 +142,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	v, _, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	expected := []uint64{1}
-	require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v on initial state")
+	require.Equal(t, expected, roaringset.BitmapLayers{v}.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v on initial state")
 
 	// append new segment
 	segment2Data := map[string]*sroar.Bitmap{
@@ -154,7 +154,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	v, _, err = sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	expected = []uint64{1}
-	require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v after segment addition on old view")
+	require.Equal(t, expected, roaringset.BitmapLayers{v}.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v after segment addition on old view")
 
 	// prove that new readers will see the most recent view
 	segments, release = sg.getConsistentViewOfSegments()
@@ -162,7 +162,7 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentAddition(t *testing.
 	v, _, err = sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	expected = []uint64{1, 2}
-	require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v on new view after segment addition")
+	require.Equal(t, expected, roaringset.BitmapLayers{v}.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "k==v on new view after segment addition")
 }
 
 func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T) {
@@ -190,12 +190,12 @@ func TestSegmentGroup_RoaringSet_ConsistentViewAcrossSegmentSwitch(t *testing.T)
 		v, _, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 		require.NoError(t, err)
 		expected := []uint64{1}
-		require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "key1 on initial state")
+		require.Equal(t, expected, roaringset.BitmapLayers{v}.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "key1 on initial state")
 
 		v, _, err = sg.roaringSetGet([]byte("key2"), segments, concurrency.SROAR_MERGE)
 		require.NoError(t, err)
 		expected = []uint64{2}
-		require.Equal(t, expected, v.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "key2 on initial state")
+		require.Equal(t, expected, roaringset.BitmapLayers{v}.Flatten(true, concurrency.SROAR_MERGE).ToArray(), "key2 on initial state")
 	}
 	validateView(t, segments)
 
@@ -244,7 +244,7 @@ func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
 
 		out, release, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 		require.ErrorIs(t, err, mergeErr)
-		require.Nil(t, out)
+		require.Nil(t, out.Additions)
 		require.NotNil(t, release)
 
 		require.Equal(t, 1, seg0.roaringSetReleases,
@@ -268,7 +268,7 @@ func TestSegmentGroup_RoaringSet_ReleasesFirstLayerOnMergeError(t *testing.T) {
 
 		out, release, err := sg.roaringSetGet([]byte("key1"), segments, concurrency.SROAR_MERGE)
 		require.NoError(t, err)
-		require.NotNil(t, out)
+		require.NotNil(t, out.Additions)
 
 		require.Equal(t, 0, seg0.roaringSetReleases,
 			"success path must not release before the caller does")

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -19,22 +19,54 @@ import (
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
-// emptyDeletions is a shared, immutable empty deletions bitmap returned instead
-// of cloning an empty deletions set on every roaringset read. Downstream every
-// consumer only reads a layer's Deletions (as an AndNot operand — see
-// BitmapLayers.Flatten and layer merge), so sharing one instance is safe. Never
-// mutate it.
-var emptyDeletions = sroar.NewBitmap()
-
-// cloneDeletionsToBuf clones del into a pooled buffer, unless del is empty — in
-// which case it returns the shared empty bitmap and a noop release, avoiding a
-// per-read clone (its pooled buffer + bitmap struct) for the common
-// no-tombstone case.
+// cloneDeletionsToBuf clones del into a pooled buffer, or returns nil when del
+// is empty (including nil — which is what SegmentNode.Deletions returns for an
+// empty region). Deletions are only ever consumed as an AndNot operand (see
+// BitmapLayers.Flatten, where the base layer's deletions are unused and every
+// other layer's deletions feed AndNotConc), and that operand treats nil as
+// empty, so no empty bitmap needs to be materialized for the common
+// no-tombstone case. Using IsEmpty rather than a nil check keeps this correct
+// regardless of how an empty del is represented. The release is nil (not a
+// shared noop) when nothing was pooled, so combineReleases can drop it without
+// allocating a wrapper closure.
 func cloneDeletionsToBuf(bitmapBufPool roaringset.BitmapBufPool, del *sroar.Bitmap) (*sroar.Bitmap, func()) {
 	if del.IsEmpty() {
-		return emptyDeletions, noopRelease
+		return nil, nil
 	}
 	return bitmapBufPool.CloneToBuf(del)
+}
+
+// cloneAdditionsToBuf clones add into a pooled buffer, unless add is empty — in
+// which case it returns a fresh empty bitmap and a nil release. add may be nil
+// (SegmentNode.Additions returns nil for an empty region). Unlike deletions,
+// additions become the mutable accumulator base when layers are flattened, so a
+// non-nil (and non-shared, as it is mutated) bitmap must be returned. The
+// release is nil (not a shared noop) when nothing was pooled, so
+// combineReleases can drop it without allocating a wrapper closure.
+func cloneAdditionsToBuf(bitmapBufPool roaringset.BitmapBufPool, add *sroar.Bitmap) (*sroar.Bitmap, func()) {
+	if add.IsEmpty() {
+		return sroar.NewBitmap(), nil
+	}
+	return bitmapBufPool.CloneToBuf(add)
+}
+
+// combineReleases folds the additions and deletions release funcs into the
+// single release the caller expects. Either may be nil (empty region, nothing
+// pooled). A wrapper closure — which escapes and thus heap-allocates — is only
+// built when both are non-nil; in the common no-tombstone case (deletions
+// empty) the additions release is returned directly, and if neither pooled
+// anything the shared noop is reused.
+func combineReleases(releaseAdd, releaseDel func()) func() {
+	switch {
+	case releaseAdd == nil && releaseDel == nil:
+		return noopRelease
+	case releaseDel == nil:
+		return releaseAdd
+	case releaseAdd == nil:
+		return releaseDel
+	default:
+		return func() { releaseAdd(); releaseDel() }
+	}
 }
 
 // returned bitmaps are cloned and safe to mutate
@@ -62,7 +94,7 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 			return out, noopRelease, err
 		}
 		out.Deletions, releaseDel = cloneDeletionsToBuf(bitmapBufPool, sn.Deletions())
-		out.Additions, releaseAdd = bitmapBufPool.CloneToBuf(sn.Additions())
+		out.Additions, releaseAdd = cloneAdditionsToBuf(bitmapBufPool, sn.Additions())
 	} else {
 		sn, release, err := s.segmentNodeFromBufferPread(offset, bitmapBufPool)
 		if err != nil {
@@ -75,7 +107,7 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 		out.Additions, releaseAdd = sn.AdditionsUnlimited(), release
 	}
 
-	return out, func() { releaseAdd(); releaseDel() }, nil
+	return out, combineReleases(releaseAdd, releaseDel), nil
 }
 
 func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int,

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -23,7 +23,7 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 ) (l roaringset.BitmapLayer, release func(), err error) {
 	out := roaringset.BitmapLayer{}
 
-	if err := segmentindex.CheckExpectedStrategy(s.strategy, segmentindex.StrategyRoaringSet); err != nil {
+	if err := segmentindex.CheckStrategyRoaringSet(s.strategy); err != nil {
 		return out, noopRelease, err
 	}
 
@@ -61,7 +61,7 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 
 func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, bitmapBufPool roaringset.BitmapBufPool, maxConc int,
 ) error {
-	if err := segmentindex.CheckExpectedStrategy(s.strategy, segmentindex.StrategyRoaringSet); err != nil {
+	if err := segmentindex.CheckStrategyRoaringSet(s.strategy); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -13,10 +13,29 @@ package lsmkv
 
 import (
 	"github.com/pkg/errors"
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
+
+// emptyDeletions is a shared, immutable empty deletions bitmap returned instead
+// of cloning an empty deletions set on every roaringset read. Downstream every
+// consumer only reads a layer's Deletions (as an AndNot operand — see
+// BitmapLayers.Flatten and layer merge), so sharing one instance is safe. Never
+// mutate it.
+var emptyDeletions = sroar.NewBitmap()
+
+// cloneDeletionsToBuf clones del into a pooled buffer, unless del is empty — in
+// which case it returns the shared empty bitmap and a noop release, avoiding a
+// per-read clone (its pooled buffer + bitmap struct) for the common
+// no-tombstone case.
+func cloneDeletionsToBuf(bitmapBufPool roaringset.BitmapBufPool, del *sroar.Bitmap) (*sroar.Bitmap, func()) {
+	if del.IsEmpty() {
+		return emptyDeletions, noopRelease
+	}
+	return bitmapBufPool.CloneToBuf(del)
+}
 
 // returned bitmaps are cloned and safe to mutate
 func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPool,
@@ -42,14 +61,14 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 		if err != nil {
 			return out, noopRelease, err
 		}
-		out.Deletions, releaseDel = bitmapBufPool.CloneToBuf(sn.Deletions())
+		out.Deletions, releaseDel = cloneDeletionsToBuf(bitmapBufPool, sn.Deletions())
 		out.Additions, releaseAdd = bitmapBufPool.CloneToBuf(sn.Additions())
 	} else {
 		sn, release, err := s.segmentNodeFromBufferPread(offset, bitmapBufPool)
 		if err != nil {
 			return out, noopRelease, err
 		}
-		out.Deletions, releaseDel = bitmapBufPool.CloneToBuf(sn.Deletions())
+		out.Deletions, releaseDel = cloneDeletionsToBuf(bitmapBufPool, sn.Deletions())
 		// reuse buffer of entire segment node.
 		// node's data might get overwritten by changes of underlying additions bitmap.
 		// overwrites should be safe, as other data is not used later on

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -64,12 +64,6 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 		}
 		out.Deletions, releaseDel = sn.DeletionsCloneToBuf(bitmapBufPool)
 		out.Additions, releaseAdd = sn.AdditionsCloneToBuf(bitmapBufPool)
-		if out.Additions == nil {
-			// additions become the mutable accumulator base when layers are
-			// flattened, so a non-nil (and non-shared, as it is mutated) bitmap
-			// is needed even when the node holds none
-			out.Additions = sroar.NewBitmap()
-		}
 	} else {
 		sn, release, err := s.segmentNodeFromBufferPread(offset, bitmapBufPool)
 		if err != nil {
@@ -80,6 +74,14 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 		// node's data might get overwritten by changes of underlying additions bitmap.
 		// overwrites should be safe, as other data is not used later on
 		out.Additions, releaseAdd = sn.AdditionsUnlimited(), release
+	}
+
+	if out.Additions == nil {
+		// deletions-only node (both read branches return nil additions for an
+		// empty region): additions become the mutable accumulator base when
+		// layers are folded, so a non-nil (and non-shared, as it is mutated)
+		// bitmap is needed even when the node holds none
+		out.Additions = sroar.NewBitmap()
 	}
 
 	return out, combineReleases(releaseAdd, releaseDel), nil

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -30,13 +30,13 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return out, noopRelease, lsmkv.NotFound
 	}
-	node, err := s.index.Get(key)
+	start, end, err := s.index.GetOffsets(key)
 	if err != nil {
 		return out, noopRelease, err
 	}
 
 	var releaseAdd, releaseDel func()
-	offset := nodeOffset{node.Start, node.End}
+	offset := nodeOffset{start, end}
 	if s.readFromMemory {
 		sn, err := s.segmentNodeFromBufferMmap(offset)
 		if err != nil {
@@ -68,7 +68,7 @@ func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, 
 	if s.useBloomFilter && !s.bloomFilter.Test(key) {
 		return nil
 	}
-	node, err := s.index.Get(key)
+	start, end, err := s.index.GetOffsets(key)
 	if err != nil {
 		if errors.Is(err, lsmkv.NotFound) {
 			return nil
@@ -77,7 +77,7 @@ func (s *segment) roaringSetMergeWith(key []byte, input roaringset.BitmapLayer, 
 	}
 
 	var sn *roaringset.SegmentNode
-	offset := nodeOffset{node.Start, node.End}
+	offset := nodeOffset{start, end}
 	if s.readFromMemory {
 		sn, err = s.segmentNodeFromBufferMmap(offset)
 	} else {

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -21,10 +21,8 @@ import (
 
 // combineReleases folds the additions and deletions release funcs into the
 // single release the caller expects. Either may be nil (empty region, nothing
-// pooled). A wrapper closure — which escapes and thus heap-allocates — is only
-// built when both are non-nil; in the common no-tombstone case (deletions
-// empty) the additions release is returned directly, and if neither pooled
-// anything the shared noop is reused.
+// pooled). A wrapper closure — which escapes and thus heap-allocates — is
+// only built when both are non-nil.
 func combineReleases(releaseAdd, releaseDel func()) func() {
 	switch {
 	case releaseAdd == nil && releaseDel == nil:

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -19,37 +19,6 @@ import (
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
-// cloneDeletionsToBuf clones del into a pooled buffer, or returns nil when del
-// is empty (including nil — which is what SegmentNode.Deletions returns for an
-// empty region). Deletions are only ever consumed as an AndNot operand (see
-// BitmapLayers.Flatten, where the base layer's deletions are unused and every
-// other layer's deletions feed AndNotConc), and that operand treats nil as
-// empty, so no empty bitmap needs to be materialized for the common
-// no-tombstone case. Using IsEmpty rather than a nil check keeps this correct
-// regardless of how an empty del is represented. The release is nil (not a
-// shared noop) when nothing was pooled, so combineReleases can drop it without
-// allocating a wrapper closure.
-func cloneDeletionsToBuf(bitmapBufPool roaringset.BitmapBufPool, del *sroar.Bitmap) (*sroar.Bitmap, func()) {
-	if del.IsEmpty() {
-		return nil, nil
-	}
-	return bitmapBufPool.CloneToBuf(del)
-}
-
-// cloneAdditionsToBuf clones add into a pooled buffer, unless add is empty — in
-// which case it returns a fresh empty bitmap and a nil release. add may be nil
-// (SegmentNode.Additions returns nil for an empty region). Unlike deletions,
-// additions become the mutable accumulator base when layers are flattened, so a
-// non-nil (and non-shared, as it is mutated) bitmap must be returned. The
-// release is nil (not a shared noop) when nothing was pooled, so
-// combineReleases can drop it without allocating a wrapper closure.
-func cloneAdditionsToBuf(bitmapBufPool roaringset.BitmapBufPool, add *sroar.Bitmap) (*sroar.Bitmap, func()) {
-	if add.IsEmpty() {
-		return sroar.NewBitmap(), nil
-	}
-	return bitmapBufPool.CloneToBuf(add)
-}
-
 // combineReleases folds the additions and deletions release funcs into the
 // single release the caller expects. Either may be nil (empty region, nothing
 // pooled). A wrapper closure — which escapes and thus heap-allocates — is only
@@ -93,14 +62,20 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 		if err != nil {
 			return out, noopRelease, err
 		}
-		out.Deletions, releaseDel = cloneDeletionsToBuf(bitmapBufPool, sn.Deletions())
-		out.Additions, releaseAdd = cloneAdditionsToBuf(bitmapBufPool, sn.Additions())
+		out.Deletions, releaseDel = sn.DeletionsCloneToBuf(bitmapBufPool)
+		out.Additions, releaseAdd = sn.AdditionsCloneToBuf(bitmapBufPool)
+		if out.Additions == nil {
+			// additions become the mutable accumulator base when layers are
+			// flattened, so a non-nil (and non-shared, as it is mutated) bitmap
+			// is needed even when the node holds none
+			out.Additions = sroar.NewBitmap()
+		}
 	} else {
 		sn, release, err := s.segmentNodeFromBufferPread(offset, bitmapBufPool)
 		if err != nil {
 			return out, noopRelease, err
 		}
-		out.Deletions, releaseDel = cloneDeletionsToBuf(bitmapBufPool, sn.Deletions())
+		out.Deletions, releaseDel = sn.DeletionsCloneToBuf(bitmapBufPool)
 		// reuse buffer of entire segment node.
 		// node's data might get overwritten by changes of underlying additions bitmap.
 		// overwrites should be safe, as other data is not used later on

--- a/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_roaring_set_strategy.go
@@ -19,9 +19,8 @@ import (
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
-// combineReleases folds the additions and deletions release funcs into the
-// single release the caller expects. Either may be nil (empty region, nothing
-// pooled). A wrapper closure — which escapes and thus heap-allocates — is
+// combineReleases folds the additions and deletions releases into one. Either
+// may be nil (empty region); the wrapper closure — which heap-allocates — is
 // only built when both are non-nil.
 func combineReleases(releaseAdd, releaseDel func()) func() {
 	switch {
@@ -75,10 +74,9 @@ func (s *segment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapBufPo
 	}
 
 	if out.Additions == nil {
-		// deletions-only node (both read branches return nil additions for an
-		// empty region): additions become the mutable accumulator base when
-		// layers are folded, so a non-nil (and non-shared, as it is mutated)
-		// bitmap is needed even when the node holds none
+		// deletions-only node: additions become the mutable accumulator base
+		// when layers are folded, so a non-nil, unshared bitmap is needed
+		// even when the node holds none
 		out.Additions = sroar.NewBitmap()
 	}
 

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -46,43 +46,43 @@ func NewDiskTree(data []byte) *DiskTree {
 	}
 }
 
-func (t *DiskTree) Get(key []byte) (Node, error) {
+// GetOffsets walks the tree for key and returns the payload position
+// (start, end) of the matching node, or lsmkv.NotFound. It allocates nothing:
+// node keys are compared in place against the tree data and no key is
+// materialized. Prefer it on hot read paths that only need the payload offsets
+// and never read Node.Key.
+//
+// pos can be an arbitrary child offset read from possibly corrupt data, so
+// every read is bounds-checked against dataLen-pos (never pos+n, which would
+// wrap). Truncated or corrupt data yields NotFound or an error, never a panic.
+func (t *DiskTree) GetOffsets(key []byte) (start, end uint64, err error) {
 	if len(t.data) == 0 {
-		return Node{}, lsmkv.NotFound
+		return 0, 0, lsmkv.NotFound
 	}
-	var out Node
 	data := t.data
 	dataLen := uint64(len(data))
 	pos := uint64(0)
 	steps := 0
 	maxSteps := maxDescentSteps(len(data))
 
-	// jump through the buffer until the node with _key_ is found or return a
-	// NotFound error. Node keys are compared in place against the tree data, so
-	// the descent allocates nothing; only the matched node's key is materialized
-	// (callers may keep it beyond the underlying segment's lifetime).
-	//
-	// pos can be an arbitrary child offset read from possibly corrupt data, so
-	// every read is bounds-checked against dataLen-pos (never pos+n, which would
-	// wrap). Truncated or corrupt data yields NotFound or an error, never a panic.
 	for {
 		// A child pointer leading back to an already visited node would keep the
 		// descent going forever. No descent visits a node twice, so it cannot take
 		// more steps than the buffer can hold nodes.
 		steps++
 		if steps > maxSteps {
-			return out, errors.New("cyclic child pointers in segment index")
+			return 0, 0, errors.New("cyclic child pointers in segment index")
 		}
 
 		// node layout: [keyLen:4][key:keyLen][start:8][end:8][left:8][right:8].
 		if pos+4 > dataLen || pos+4 < 4 {
-			return out, lsmkv.NotFound
+			return 0, 0, lsmkv.NotFound
 		}
 
 		keyLen := uint64(binary.LittleEndian.Uint32(data[pos:]))
 		pos += 4
 		if keyLen > dataLen-pos {
-			return out, fmt.Errorf("node key at %d len %d out of range", pos, keyLen)
+			return 0, 0, fmt.Errorf("node key at %d len %d out of range", pos, keyLen)
 		}
 
 		keyEqual := bytes.Compare(key, data[pos:pos+keyLen])
@@ -90,20 +90,18 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 		avail := dataLen - pos
 		if keyEqual == 0 {
 			if avail < 16 { // start + end
-				return out, fmt.Errorf("node value at %d out of range", pos)
+				return 0, 0, fmt.Errorf("node value at %d out of range", pos)
 			}
-			out.Key = bytes.Clone(data[pos-keyLen : pos])
-			out.Start = binary.LittleEndian.Uint64(data[pos:])
-			out.End = binary.LittleEndian.Uint64(data[pos+8:])
-			return out, nil
+			return binary.LittleEndian.Uint64(data[pos:]),
+				binary.LittleEndian.Uint64(data[pos+8:]), nil
 		} else if keyEqual < 0 {
 			if avail < 24 { // start + end + left child
-				return out, fmt.Errorf("node left child at %d out of range", pos)
+				return 0, 0, fmt.Errorf("node left child at %d out of range", pos)
 			}
 			pos = binary.LittleEndian.Uint64(data[pos+16:]) // skip start+end, read left child
 		} else {
 			if avail < 32 { // start + end + left + right child
-				return out, fmt.Errorf("node right child at %d out of range", pos)
+				return 0, 0, fmt.Errorf("node right child at %d out of range", pos)
 			}
 			pos = binary.LittleEndian.Uint64(data[pos+24:]) // skip start+end+left, read right child
 		}
@@ -115,6 +113,19 @@ func (t *DiskTree) Get(key []byte) (Node, error) {
 // reaches. It is what makes a cyclic pointer terminate.
 func maxDescentSteps(dataLen int) int {
 	return dataLen/TREE_KEY_STORE_OVERHEAD + 1
+}
+
+// Get returns the matching node with an owned copy of its key, safe to keep
+// beyond the underlying segment's lifetime. A match requires exact key equality,
+// so the matched node's key is byte-identical to the argument key — Get clones
+// the caller's key rather than the (equal) in-tree bytes, which keeps the whole
+// allocation-free descent in GetOffsets.
+func (t *DiskTree) Get(key []byte) (Node, error) {
+	start, end, err := t.GetOffsets(key)
+	if err != nil {
+		return Node{}, err
+	}
+	return Node{Key: bytes.Clone(key), Start: start, End: end}, nil
 }
 
 func (t *DiskTree) readNodeAt(offset int64) (dtNode, error) {

--- a/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
+++ b/adapters/repos/db/lsmkv/segmentindex/disk_tree.go
@@ -46,15 +46,12 @@ func NewDiskTree(data []byte) *DiskTree {
 	}
 }
 
-// GetOffsets walks the tree for key and returns the payload position
-// (start, end) of the matching node, or lsmkv.NotFound. It allocates nothing:
-// node keys are compared in place against the tree data and no key is
-// materialized. Prefer it on hot read paths that only need the payload offsets
-// and never read Node.Key.
-//
-// pos can be an arbitrary child offset read from possibly corrupt data, so
-// every read is bounds-checked against dataLen-pos (never pos+n, which would
-// wrap). Truncated or corrupt data yields NotFound or an error, never a panic.
+// GetOffsets walks the tree for key and returns the payload position (start,
+// end) of the matching node, or lsmkv.NotFound. It allocates nothing: keys
+// are compared in place against the tree data. pos can be an arbitrary child
+// offset read from possibly corrupt data, so every read is bounds-checked
+// against dataLen-pos (never pos+n, which would wrap) — corrupt or truncated
+// data yields NotFound or an error, never a panic.
 func (t *DiskTree) GetOffsets(key []byte) (start, end uint64, err error) {
 	if len(t.data) == 0 {
 		return 0, 0, lsmkv.NotFound
@@ -116,10 +113,9 @@ func maxDescentSteps(dataLen int) int {
 }
 
 // Get returns the matching node with an owned copy of its key, safe to keep
-// beyond the underlying segment's lifetime. A match requires exact key equality,
-// so the matched node's key is byte-identical to the argument key — Get clones
-// the caller's key rather than the (equal) in-tree bytes, which keeps the whole
-// allocation-free descent in GetOffsets.
+// beyond the segment's lifetime. A match means the in-tree key equals the
+// argument, so Get clones the caller's key, keeping the descent in
+// GetOffsets allocation-free.
 func (t *DiskTree) Get(key []byte) (Node, error) {
 	start, end, err := t.GetOffsets(key)
 	if err != nil {

--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -79,3 +79,14 @@ func MustBeExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) {
 		panic(err)
 	}
 }
+
+// strategiesRoaringSet is spread into CheckExpectedStrategy with `...` so the
+// check does not heap-allocate a []Strategy on every call. The variadic literal
+// form (CheckExpectedStrategy(strategy, StrategyRoaringSet)) packs a fresh slice
+// per call, which is wasteful on hot read paths that check the strategy once per
+// operation. Read-only; never mutate.
+var strategiesRoaringSet = []Strategy{StrategyRoaringSet}
+
+func CheckStrategyRoaringSet(strategy Strategy) error {
+	return CheckExpectedStrategy(strategy, strategiesRoaringSet...)
+}

--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -80,11 +80,8 @@ func MustBeExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) {
 	}
 }
 
-// strategiesRoaringSet is spread into CheckExpectedStrategy with `...` so the
-// check does not heap-allocate a []Strategy on every call. The variadic literal
-// form (CheckExpectedStrategy(strategy, StrategyRoaringSet)) packs a fresh slice
-// per call, which is wasteful on hot read paths that check the strategy once per
-// operation. Read-only; never mutate.
+// Pre-built (and never mutated) so the RoaringSet check doesn't allocate a
+// []Strategy per call.
 var strategiesRoaringSet = []Strategy{StrategyRoaringSet}
 
 func CheckStrategyRoaringSet(strategy Strategy) error {

--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -80,8 +80,7 @@ func MustBeExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) {
 	}
 }
 
-// Pre-built (and never mutated) so the RoaringSet check doesn't allocate a
-// []Strategy per call.
+// pre-built and never mutated, so the RoaringSet check doesn't allocate per call
 var strategiesRoaringSet = []Strategy{StrategyRoaringSet}
 
 func CheckStrategyRoaringSet(strategy Strategy) error {

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -82,12 +82,22 @@ func MustBeExpectedStrategy(strategy string, expectedStrategies ...string) {
 	}
 }
 
+// Predefined single-strategy argument slices, spread into CheckExpectedStrategy
+// with `...` so the check does not heap-allocate a []string on every call. The
+// variadic literal form (CheckExpectedStrategy(strategy, StrategyRoaringSet))
+// packs a fresh slice per call, which is wasteful on hot read paths that check
+// the strategy once per operation. Read-only; never mutate.
+var (
+	strategiesRoaringSet      = []string{StrategyRoaringSet}
+	strategiesRoaringSetRange = []string{StrategyRoaringSetRange}
+)
+
 func CheckStrategyRoaringSet(strategy string) error {
-	return CheckExpectedStrategy(strategy, StrategyRoaringSet)
+	return CheckExpectedStrategy(strategy, strategiesRoaringSet...)
 }
 
 func CheckStrategyRoaringSetRange(strategy string) error {
-	return CheckExpectedStrategy(strategy, StrategyRoaringSetRange)
+	return CheckExpectedStrategy(strategy, strategiesRoaringSetRange...)
 }
 
 func DefaultSearchableStrategy(useInvertedSearchable bool) string {

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -82,11 +82,8 @@ func MustBeExpectedStrategy(strategy string, expectedStrategies ...string) {
 	}
 }
 
-// Predefined single-strategy argument slices, spread into CheckExpectedStrategy
-// with `...` so the check does not heap-allocate a []string on every call. The
-// variadic literal form (CheckExpectedStrategy(strategy, StrategyRoaringSet))
-// packs a fresh slice per call, which is wasteful on hot read paths that check
-// the strategy once per operation. Read-only; never mutate.
+// Pre-built (and never mutated) so the strategy checks don't allocate a
+// []string per call.
 var (
 	strategiesRoaringSet      = []string{StrategyRoaringSet}
 	strategiesRoaringSetRange = []string{StrategyRoaringSetRange}

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -82,8 +82,7 @@ func MustBeExpectedStrategy(strategy string, expectedStrategies ...string) {
 	}
 }
 
-// Pre-built (and never mutated) so the strategy checks don't allocate a
-// []string per call.
+// pre-built and never mutated, so the strategy checks don't allocate per call
 var (
 	strategiesRoaringSet      = []string{StrategyRoaringSet}
 	strategiesRoaringSetRange = []string{StrategyRoaringSetRange}

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -31,11 +31,25 @@ import (
 type BitmapBufPool interface {
 	Get(minCap int) (buf []byte, put func())
 	CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func())
+	// CloneBytesToBuf clones an already-serialized bitmap (e.g. a segment
+	// node's additions/deletions region) into a pooled buffer, without
+	// materializing an intermediate bitmap over src first. src must be a
+	// valid, non-empty sroar serialization. The returned bitmap owns the
+	// pooled buffer's full capacity, so it can grow in place (same contract
+	// as CloneToBuf).
+	CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func())
 }
 
 func cloneToBuf(pool BitmapBufPool, bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
 	buf, put := pool.Get(bm.LenInBytes())
 	return bm.CloneToBuf(buf), put
+}
+
+func cloneBytesToBuf(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
+	buf, put := pool.Get(len(src))
+	buf = buf[:len(src)]
+	copy(buf, src)
+	return sroar.FromBufferUnlimited(buf), put
 }
 
 func NewBitmapBufPoolDefault(logger logrus.FieldLogger, metrics *monitoring.PrometheusMetrics,
@@ -84,6 +98,10 @@ func (p *bitmapBufPoolNoop) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, 
 	return cloneToBuf(p, bm)
 }
 
+func (p *bitmapBufPoolNoop) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBuf(p, src)
+}
+
 // -----------------------------------------------------------------------------
 
 // BitmapBufPoolTracking is a pool for use in tests. It tracks outstanding
@@ -115,6 +133,10 @@ func (p *BitmapBufPoolTracking) Get(minCap int) (buf []byte, put func()) {
 
 func (p *BitmapBufPoolTracking) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
 	return cloneToBuf(p, bm)
+}
+
+func (p *BitmapBufPoolTracking) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBuf(p, src)
 }
 
 // Outstanding returns the number of buffers that have been allocated but not
@@ -199,6 +221,10 @@ func (p *bitmapBufPoolRanged) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap
 	return cloneToBuf(p, bm)
 }
 
+func (p *bitmapBufPoolRanged) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBuf(p, src)
+}
+
 func (p *bitmapBufPoolRanged) cleanup(n int) map[int]int {
 	cleaned := map[int]int{}
 	for i := p.firstInMemoRngIdx; i < len(p.ranges); i++ {
@@ -244,6 +270,10 @@ func (p *bitmapBufPoolFactorWrapper) Get(minCap int) (buf []byte, put func()) {
 
 func (p *bitmapBufPoolFactorWrapper) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
 	return cloneToBuf(p, bm)
+}
+
+func (p *bitmapBufPoolFactorWrapper) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBuf(p, src)
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -241,10 +241,9 @@ type BufPoolFixedSync struct {
 	pool *sync.Pool
 }
 
-// pooledBuf holds a reusable buffer together with a release closure bound to it
-// once, at creation. Get can then return that pre-bound closure instead of
-// allocating a fresh one per call — the closure is amortized across the
-// buffer's whole pool lifetime rather than paid on every Get.
+// pooledBuf holds a reusable buffer together with a release closure bound to
+// it once, at creation, so Get returns the pre-bound closure instead of
+// allocating a fresh one per call.
 type pooledBuf struct {
 	buf []byte
 	put func()

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -17,7 +17,6 @@ import (
 	"math/bits"
 	"slices"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -45,6 +44,9 @@ func cloneToBuf(pool BitmapBufPool, bm *sroar.Bitmap) (cloned *sroar.Bitmap, put
 	return bm.CloneToBuf(buf), put
 }
 
+// src must be a valid, non-empty sroar serialization (even length, >= 8
+// bytes): shorter input yields a bitmap not backed by the pooled buffer, and
+// odd-length input panics inside sroar.
 func cloneBytesToBuf(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
 	buf, put := pool.Get(len(src))
 	buf = buf[:len(src)]
@@ -100,49 +102,6 @@ func (p *bitmapBufPoolNoop) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, 
 
 func (p *bitmapBufPoolNoop) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
 	return cloneBytesToBuf(p, src)
-}
-
-// -----------------------------------------------------------------------------
-
-// BitmapBufPoolTracking is a pool for use in tests. It tracks outstanding
-// allocations and zeroes the backing buffer on release, so that any bitmap
-// read after its release returns zeros — making premature releases visible as
-// wrong values in test assertions. Double-release panics immediately.
-//
-// Call Outstanding() in a t.Cleanup to assert all buffers were released.
-type BitmapBufPoolTracking struct {
-	outstanding atomic.Int64
-}
-
-func NewBitmapBufPoolTracking() *BitmapBufPoolTracking {
-	return &BitmapBufPoolTracking{}
-}
-
-func (p *BitmapBufPoolTracking) Get(minCap int) (buf []byte, put func()) {
-	p.outstanding.Add(1)
-	buf = make([]byte, 0, max(minCap, 0))
-	var released atomic.Bool
-	return buf, func() {
-		if !released.CompareAndSwap(false, true) {
-			panic("bitmap buffer released twice")
-		}
-		clear(buf[:cap(buf)])
-		p.outstanding.Add(-1)
-	}
-}
-
-func (p *BitmapBufPoolTracking) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
-	return cloneToBuf(p, bm)
-}
-
-func (p *BitmapBufPoolTracking) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
-	return cloneBytesToBuf(p, src)
-}
-
-// Outstanding returns the number of buffers that have been allocated but not
-// yet released. A non-zero value at the end of a test indicates a leak.
-func (p *BitmapBufPoolTracking) Outstanding() int64 {
-	return p.outstanding.Load()
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -252,20 +252,30 @@ type BufPoolFixedSync struct {
 	pool *sync.Pool
 }
 
+// pooledBuf holds a reusable buffer together with a release closure bound to it
+// once, at creation. Get can then return that pre-bound closure instead of
+// allocating a fresh one per call — the closure is amortized across the
+// buffer's whole pool lifetime rather than paid on every Get.
+type pooledBuf struct {
+	buf []byte
+	put func()
+}
+
 func NewBufPoolFixedSync(cap int) *BufPoolFixedSync {
-	return &BufPoolFixedSync{
-		pool: &sync.Pool{
-			New: func() any {
-				buf := make([]byte, 0, cap)
-				return &buf
-			},
+	p := &BufPoolFixedSync{}
+	p.pool = &sync.Pool{
+		New: func() any {
+			pb := &pooledBuf{buf: make([]byte, 0, cap)}
+			pb.put = func() { p.pool.Put(pb) }
+			return pb
 		},
 	}
+	return p
 }
 
 func (p *BufPoolFixedSync) Get() (buf []byte, put func()) {
-	ptr := p.pool.Get().(*[]byte)
-	return *ptr, func() { p.pool.Put(ptr) }
+	pb := p.pool.Get().(*pooledBuf)
+	return pb.buf, pb.put
 }
 
 // -----------------------------------------------------------------------------
@@ -273,7 +283,7 @@ func (p *BufPoolFixedSync) Get() (buf []byte, put func()) {
 type BufPoolFixedInMemory struct {
 	cap     int
 	limit   int
-	bufsCh  chan *[]byte
+	bufsCh  chan *pooledBuf
 	metrics bufPoolInMemoMetrics
 }
 
@@ -281,28 +291,29 @@ func NewBufPoolFixedInMemory(metrics bufPoolInMemoMetrics, cap int, limit int) *
 	return &BufPoolFixedInMemory{
 		cap:     cap,
 		limit:   limit,
-		bufsCh:  make(chan *[]byte, limit),
+		bufsCh:  make(chan *pooledBuf, limit),
 		metrics: metrics,
 	}
 }
 
 func (p *BufPoolFixedInMemory) Get() (buf []byte, put func()) {
-	var ptr *[]byte
+	var pb *pooledBuf
 	select {
-	case ptr = <-p.bufsCh:
-		buf = *ptr
+	case pb = <-p.bufsCh:
 		p.metrics.bufGot()
 	default:
-		buf = make([]byte, 0, p.cap)
-		ptr = &buf
+		// New buffers bind their release closure once here; reused buffers keep
+		// it, so Get never allocates a fresh closure on the reuse path.
+		pb = &pooledBuf{buf: make([]byte, 0, p.cap)}
+		pb.put = func() { p.put(pb) }
 		p.metrics.bufCreated()
 	}
-	return buf, func() { p.put(ptr) }
+	return pb.buf, pb.put
 }
 
-func (p *BufPoolFixedInMemory) put(ptr *[]byte) bool {
+func (p *BufPoolFixedInMemory) put(pb *pooledBuf) bool {
 	select {
-	case p.bufsCh <- ptr:
+	case p.bufsCh <- pb:
 		p.metrics.bufPut()
 		// successfully returned
 		return true

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -30,12 +30,10 @@ import (
 type BitmapBufPool interface {
 	Get(minCap int) (buf []byte, put func())
 	CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func())
-	// CloneBytesToBuf clones an already-serialized bitmap (e.g. a segment
-	// node's additions/deletions region) into a pooled buffer, without
-	// materializing an intermediate bitmap over src first. src must be a
-	// valid, non-empty sroar serialization. The returned bitmap owns the
-	// pooled buffer's full capacity, so it can grow in place (same contract
-	// as CloneToBuf).
+	// CloneBytesToBuf clones an already-serialized bitmap into a pooled
+	// buffer without materializing an intermediate bitmap over src. src must
+	// be a valid, non-empty sroar serialization. Like CloneToBuf, the clone
+	// owns the buffer's full capacity and can grow in place.
 	CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func())
 }
 
@@ -241,9 +239,8 @@ type BufPoolFixedSync struct {
 	pool *sync.Pool
 }
 
-// pooledBuf holds a reusable buffer together with a release closure bound to
-// it once, at creation, so Get returns the pre-bound closure instead of
-// allocating a fresh one per call.
+// pooledBuf pairs a reusable buffer with its release closure, bound once at
+// creation so Get doesn't allocate a closure per call.
 type pooledBuf struct {
 	buf []byte
 	put func()
@@ -290,8 +287,7 @@ func (p *BufPoolFixedInMemory) Get() (buf []byte, put func()) {
 	case pb = <-p.bufsCh:
 		p.metrics.bufGot()
 	default:
-		// New buffers bind their release closure once here; reused buffers keep
-		// it, so Get never allocates a fresh closure on the reuse path.
+		// bind the release closure once; reused buffers keep theirs
 		pb = &pooledBuf{buf: make([]byte, 0, p.cap)}
 		pb.put = func() { p.put(pb) }
 		p.metrics.bufCreated()

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -850,9 +850,9 @@ func TestValidateBufferRanges(t *testing.T) {
 	}
 }
 
-func TestBitmapBufPoolTracking_Get(t *testing.T) {
+func TestBitmapBufPoolTrackingForTests_Get(t *testing.T) {
 	t.Run("outstanding increments on Get and decrements on release", func(t *testing.T) {
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 		assert.Equal(t, int64(0), pool.Outstanding())
 
 		_, rel1 := pool.Get(64)
@@ -869,7 +869,7 @@ func TestBitmapBufPoolTracking_Get(t *testing.T) {
 	})
 
 	t.Run("release zeroes backing buffer", func(t *testing.T) {
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 		buf, release := pool.Get(64)
 		// Write into the backing array through the cap slice.
 		full := buf[:cap(buf)]
@@ -887,16 +887,16 @@ func TestBitmapBufPoolTracking_Get(t *testing.T) {
 	})
 
 	t.Run("double release panics", func(t *testing.T) {
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 		_, release := pool.Get(64)
 		release()
 		assert.Panics(t, release)
 	})
 }
 
-func TestBitmapBufPoolTracking_CloneToBuf(t *testing.T) {
+func TestBitmapBufPoolTrackingForTests_CloneToBuf(t *testing.T) {
 	t.Run("outstanding increments on CloneToBuf and decrements on release", func(t *testing.T) {
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 
 		bm := sroar.NewBitmap()
 		bm.SetMany([]uint64{1, 2, 3})
@@ -910,7 +910,7 @@ func TestBitmapBufPoolTracking_CloneToBuf(t *testing.T) {
 	})
 
 	t.Run("release zeroes cloned bitmap backing buffer", func(t *testing.T) {
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 
 		bm := sroar.NewBitmap()
 		bm.SetMany([]uint64{10, 20, 30})

--- a/adapters/repos/db/roaringset/buf_pool_testonly.go
+++ b/adapters/repos/db/roaringset/buf_pool_testonly.go
@@ -1,0 +1,62 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringset
+
+import (
+	"sync/atomic"
+
+	"github.com/weaviate/sroar"
+)
+
+// BitmapBufPoolTrackingForTests is a pool for use in tests. It tracks outstanding
+// allocations and zeroes the backing buffer on release, so that any bitmap
+// read after its release returns zeros — making premature releases visible as
+// wrong values in test assertions. Double-release panics immediately.
+//
+// It lives in a non-test file because tests of several packages consume it;
+// nothing in production code may use it.
+//
+// Call Outstanding() in a t.Cleanup to assert all buffers were released.
+type BitmapBufPoolTrackingForTests struct {
+	outstanding atomic.Int64
+}
+
+func NewBitmapBufPoolTrackingForTests() *BitmapBufPoolTrackingForTests {
+	return &BitmapBufPoolTrackingForTests{}
+}
+
+func (p *BitmapBufPoolTrackingForTests) Get(minCap int) (buf []byte, put func()) {
+	p.outstanding.Add(1)
+	buf = make([]byte, 0, max(minCap, 0))
+	var released atomic.Bool
+	return buf, func() {
+		if !released.CompareAndSwap(false, true) {
+			panic("bitmap buffer released twice")
+		}
+		clear(buf[:cap(buf)])
+		p.outstanding.Add(-1)
+	}
+}
+
+func (p *BitmapBufPoolTrackingForTests) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
+	return cloneToBuf(p, bm)
+}
+
+func (p *BitmapBufPoolTrackingForTests) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBuf(p, src)
+}
+
+// Outstanding returns the number of buffers that have been allocated but not
+// yet released. A non-zero value at the end of a test indicates a leak.
+func (p *BitmapBufPoolTrackingForTests) Outstanding() int64 {
+	return p.outstanding.Load()
+}

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -104,6 +104,46 @@ func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 	return merged
 }
 
+// LayerMerger performs the same left-fold as [BitmapLayers.Flatten], but one
+// layer at a time, so callers that produce layers incrementally (e.g. disk →
+// flushing → active on a read) need not materialize a []BitmapLayer. Seed it
+// with the chronologically-first layer's additions, Add each subsequent layer
+// in order, then read Result.
+//
+// As in Flatten, the base layer's own deletions are irrelevant — only its
+// additions survive as the initial state. Feeding layers in the same order
+// Flatten would iterate them yields a byte-identical result.
+type LayerMerger struct {
+	merged  *sroar.Bitmap
+	maxConc int
+}
+
+// NewLayerMerger starts a fold from base, which becomes the accumulator and is
+// mutated in place by Add. If base is nil an empty bitmap is used. Pass
+// clone=true when base must not be mutated.
+func NewLayerMerger(base *sroar.Bitmap, clone bool, maxConc int) LayerMerger {
+	switch {
+	case base == nil:
+		base = sroar.NewBitmap()
+	case clone:
+		base = base.Clone()
+	}
+	return LayerMerger{merged: base, maxConc: maxConc}
+}
+
+// Add folds one subsequent layer into the accumulator: its deletions remove
+// existing elements, then its additions are unioned in — identical to one
+// iteration of Flatten's loop. A nil Additions/Deletions is treated as empty.
+func (m *LayerMerger) Add(layer BitmapLayer) {
+	m.merged.AndNotConc(layer.Deletions, m.maxConc)
+	m.merged.OrConc(layer.Additions, m.maxConc)
+}
+
+// Result returns the flattened bitmap accumulated so far.
+func (m LayerMerger) Result() *sroar.Bitmap {
+	return m.merged
+}
+
 // Merge turns two successive layers into one. It does not flatten the segment,
 // but keeps additions and deletions separate. This is because there are no
 // guarantees that the first segment was the root segment. A merge could run on

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -113,6 +113,9 @@ func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 // As in Flatten, the base layer's own deletions are irrelevant — only its
 // additions survive as the initial state. Feeding layers in the same order
 // Flatten would iterate them yields a byte-identical result.
+//
+// Result returns the accumulator itself, and copies of a LayerMerger share
+// it: do not Add after reading Result, and do not copy a merger.
 type LayerMerger struct {
 	merged  *sroar.Bitmap
 	maxConc int

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -104,46 +104,49 @@ func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 	return merged
 }
 
-// LayerMerger performs the same left-fold as [BitmapLayers.Flatten], but one
-// layer at a time, so callers that produce layers incrementally (e.g. disk →
+// LayerMerger performs the same left-fold as [BitmapLayers.Flatten], one
+// layer at a time, so callers that produce layers incrementally (disk →
 // flushing → active on a read) need not materialize a []BitmapLayer. Seed it
-// with the chronologically-first layer's additions, Add each subsequent layer
-// in order, then read Result.
-//
-// As in Flatten, the base layer's own deletions are irrelevant — only its
-// additions survive as the initial state. Feeding layers in the same order
-// Flatten would iterate them yields a byte-identical result.
-//
-// Result returns the accumulator itself, and copies of a LayerMerger share
-// it: do not Add after reading Result, and do not copy a merger.
+// with the chronologically-first layer's additions (or nil when there is
+// none yet), Add each later layer in order, then read Result. Result returns
+// the accumulator itself: do not Add after reading Result, and do not copy a
+// merger.
 type LayerMerger struct {
 	merged  *sroar.Bitmap
 	maxConc int
 }
 
-// NewLayerMerger starts a fold from base, which becomes the accumulator and is
-// mutated in place by Add. If base is nil an empty bitmap is used. Pass
-// clone=true when base must not be mutated.
+// NewLayerMerger starts a fold from base, which becomes the accumulator and
+// is mutated in place by Add; pass clone=true when base must not be mutated.
+// A nil base means no layer yet: the first Add'd layer's additions are
+// adopted as the accumulator without a copy, as in Flatten.
 func NewLayerMerger(base *sroar.Bitmap, clone bool, maxConc int) LayerMerger {
-	switch {
-	case base == nil:
-		base = sroar.NewBitmap()
-	case clone:
+	if clone && base != nil {
 		base = base.Clone()
 	}
 	return LayerMerger{merged: base, maxConc: maxConc}
 }
 
-// Add folds one subsequent layer into the accumulator: its deletions remove
-// existing elements, then its additions are unioned in — identical to one
-// iteration of Flatten's loop. A nil Additions/Deletions is treated as empty.
+// Add folds one layer into the accumulator: deletions remove existing
+// elements, then additions are unioned in — one iteration of Flatten's loop.
+// With no accumulator yet, the layer's additions are adopted (and mutated by
+// later Adds); its deletions would delete from nothing and are dropped, as
+// Flatten drops the base layer's. A nil Additions/Deletions is treated as
+// empty.
 func (m *LayerMerger) Add(layer BitmapLayer) {
+	if m.merged == nil {
+		m.merged = layer.Additions
+		return
+	}
 	m.merged.AndNotConc(layer.Deletions, m.maxConc)
 	m.merged.OrConc(layer.Additions, m.maxConc)
 }
 
-// Result returns the flattened bitmap accumulated so far.
+// Result returns the flattened bitmap accumulated so far, never nil.
 func (m LayerMerger) Result() *sroar.Bitmap {
+	if m.merged == nil {
+		return sroar.NewBitmap()
+	}
 	return m.merged
 }
 

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -128,6 +128,75 @@ func Test_BitmapLayers_Flatten(t *testing.T) {
 	}
 }
 
+func Test_LayerMerger_MatchesFlatten(t *testing.T) {
+	// A left-fold via LayerMerger (base = first layer's additions, Add the rest
+	// in order) must produce the exact same set as BitmapLayers.Flatten over the
+	// same layers. Reuses Flatten's own cases as the oracle.
+	type inputSegment struct {
+		additions []uint64
+		deletions []uint64
+	}
+
+	tests := []struct {
+		name   string
+		inputs []inputSegment
+	}{
+		{name: "no inputs", inputs: nil},
+		{name: "single segment", inputs: []inputSegment{{additions: []uint64{4, 5}}}},
+		{name: "three segments, only additions", inputs: []inputSegment{
+			{additions: []uint64{4, 5}}, {additions: []uint64{5, 6}}, {additions: []uint64{6, 7, 8}},
+		}},
+		{name: "two segments, including a delete", inputs: []inputSegment{
+			{additions: []uint64{4, 5}}, {additions: []uint64{5, 6}, deletions: []uint64{4}},
+		}},
+		{name: "three segments, delete and re-add", inputs: []inputSegment{
+			{additions: []uint64{3, 4, 5}}, {additions: []uint64{6}, deletions: []uint64{4, 5}}, {additions: []uint64{5}},
+		}},
+	}
+
+	maxConcs := []int{1, 2, concurrency.SROAR_MERGE}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for _, maxConc := range maxConcs {
+				t.Run(fmt.Sprintf("maxConc=%d", maxConc), func(t *testing.T) {
+					layers := make(BitmapLayers, len(test.inputs))
+					for i, inp := range test.inputs {
+						layers[i].Additions = NewBitmap(inp.additions...)
+						layers[i].Deletions = NewBitmap(inp.deletions...)
+					}
+
+					// oracle: Flatten (clone so it doesn't mutate the layers we
+					// reuse for the merger below)
+					want := layers.Flatten(true, maxConc).ToArray()
+
+					// LayerMerger: seed with base additions, Add the rest
+					var got []uint64
+					if len(layers) == 0 {
+						got = NewLayerMerger(nil, false, maxConc).Result().ToArray()
+					} else {
+						m := NewLayerMerger(layers[0].Additions, true, maxConc)
+						for i := 1; i < len(layers); i++ {
+							m.Add(layers[i])
+						}
+						got = m.Result().ToArray()
+					}
+
+					assert.Equal(t, want, got)
+				})
+			}
+		})
+	}
+}
+
+func Test_LayerMerger_NilBase(t *testing.T) {
+	// nil base (disk miss) folds the memtable layers into a fresh empty bitmap.
+	m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
+	m.Add(BitmapLayer{Additions: NewBitmap(1, 2), Deletions: NewBitmap()})
+	m.Add(BitmapLayer{Additions: NewBitmap(3), Deletions: NewBitmap(1)})
+	assert.Equal(t, []uint64{2, 3}, m.Result().ToArray())
+}
+
 func Test_BitmapLayers_Merge(t *testing.T) {
 	type inputSegment struct {
 		additions []uint64

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -183,6 +183,21 @@ func Test_LayerMerger_MatchesFlatten(t *testing.T) {
 					}
 
 					assert.Equal(t, want, got)
+
+					// nil base: the merger adopts the first Add'd layer, so
+					// folding every layer through Add must equal Flatten too;
+					// fresh layers because the adopted bitmap is mutated in
+					// place
+					layers = make(BitmapLayers, len(test.inputs))
+					for i, inp := range test.inputs {
+						layers[i].Additions = NewBitmap(inp.additions...)
+						layers[i].Deletions = NewBitmap(inp.deletions...)
+					}
+					m := NewLayerMerger(nil, false, maxConc)
+					for _, layer := range layers {
+						m.Add(layer)
+					}
+					assert.Equal(t, want, m.Result().ToArray())
 				})
 			}
 		})
@@ -190,11 +205,43 @@ func Test_LayerMerger_MatchesFlatten(t *testing.T) {
 }
 
 func Test_LayerMerger_NilBase(t *testing.T) {
-	// nil base (disk miss) folds the memtable layers into a fresh empty bitmap.
-	m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
-	m.Add(BitmapLayer{Additions: NewBitmap(1, 2), Deletions: NewBitmap()})
-	m.Add(BitmapLayer{Additions: NewBitmap(3), Deletions: NewBitmap(1)})
-	assert.Equal(t, []uint64{2, 3}, m.Result().ToArray())
+	t.Run("layers fold like Flatten", func(t *testing.T) {
+		m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
+		m.Add(BitmapLayer{Additions: NewBitmap(1, 2), Deletions: NewBitmap()})
+		m.Add(BitmapLayer{Additions: NewBitmap(3), Deletions: NewBitmap(1)})
+		assert.Equal(t, []uint64{2, 3}, m.Result().ToArray())
+	})
+
+	t.Run("no layers yield an empty, non-nil result", func(t *testing.T) {
+		m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
+		require.NotNil(t, m.Result())
+		assert.Empty(t, m.Result().ToArray())
+	})
+
+	t.Run("first layer's additions are adopted, not copied", func(t *testing.T) {
+		first := NewBitmap(1, 2)
+		m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
+		m.Add(BitmapLayer{Additions: first, Deletions: NewBitmap()})
+		assert.Same(t, first, m.Result())
+		m.Add(BitmapLayer{Additions: NewBitmap(3), Deletions: NewBitmap(1)})
+		assert.Same(t, first, m.Result())
+		assert.Equal(t, []uint64{2, 3}, m.Result().ToArray())
+	})
+
+	t.Run("adopted layer's own deletions are dropped", func(t *testing.T) {
+		// the first layer's deletions delete from older state, of which there
+		// is none — Flatten drops the base layer's deletions the same way
+		m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
+		m.Add(BitmapLayer{Additions: NewBitmap(1, 2), Deletions: NewBitmap(1)})
+		assert.Equal(t, []uint64{1, 2}, m.Result().ToArray())
+	})
+
+	t.Run("nil-additions layer defers adoption to the next layer", func(t *testing.T) {
+		m := NewLayerMerger(nil, false, concurrency.SROAR_MERGE)
+		m.Add(BitmapLayer{Additions: nil, Deletions: NewBitmap(1)})
+		m.Add(BitmapLayer{Additions: NewBitmap(2, 3), Deletions: NewBitmap(2)})
+		assert.Equal(t, []uint64{2, 3}, m.Result().ToArray())
+	})
 }
 
 func Test_BitmapLayers_Merge(t *testing.T) {

--- a/adapters/repos/db/roaringset/segment_cursor.go
+++ b/adapters/repos/db/roaringset/segment_cursor.go
@@ -12,6 +12,7 @@
 package roaringset
 
 import (
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 )
 
@@ -53,9 +54,20 @@ func (c *segmentCursor) Next() ([]byte, BitmapLayer, error) {
 
 	sn := NewSegmentNodeFromBuffer(c.data[c.nextOffset:])
 	c.nextOffset += sn.Len()
+	// Additions/Deletions return nil for empty regions. Cursor consumers
+	// (compaction, sorting, aggregation, ...) expect non-nil layers, so
+	// materialize an empty bitmap here — matching the pre-nil behavior.
+	additions := sn.Additions()
+	if additions == nil {
+		additions = sroar.NewBitmap()
+	}
+	deletions := sn.Deletions()
+	if deletions == nil {
+		deletions = sroar.NewBitmap()
+	}
 	layer := BitmapLayer{
-		Additions: sn.Additions(),
-		Deletions: sn.Deletions(),
+		Additions: additions,
+		Deletions: deletions,
 	}
 	return sn.PrimaryKey(), layer, nil
 }

--- a/adapters/repos/db/roaringset/segment_cursor.go
+++ b/adapters/repos/db/roaringset/segment_cursor.go
@@ -54,9 +54,9 @@ func (c *segmentCursor) Next() ([]byte, BitmapLayer, error) {
 
 	sn := NewSegmentNodeFromBuffer(c.data[c.nextOffset:])
 	c.nextOffset += sn.Len()
-	// Additions/Deletions return nil for empty regions. Cursor consumers
-	// (compaction, sorting, aggregation, ...) expect non-nil layers, so
-	// materialize an empty bitmap here — matching the pre-nil behavior.
+	// Additions/Deletions return nil for empty regions, but cursor consumers
+	// (compaction, sorting, aggregation, ...) require non-nil layers, so
+	// substitute an empty bitmap here.
 	additions := sn.Additions()
 	if additions == nil {
 		additions = sroar.NewBitmap()

--- a/adapters/repos/db/roaringset/segment_cursor.go
+++ b/adapters/repos/db/roaringset/segment_cursor.go
@@ -54,9 +54,8 @@ func (c *segmentCursor) Next() ([]byte, BitmapLayer, error) {
 
 	sn := NewSegmentNodeFromBuffer(c.data[c.nextOffset:])
 	c.nextOffset += sn.Len()
-	// Additions/Deletions return nil for empty regions, but cursor consumers
-	// (compaction, sorting, aggregation, ...) require non-nil layers, so
-	// substitute an empty bitmap here.
+	// cursor consumers (compaction, sorting, aggregation) require non-nil
+	// layers; substitute empties for the accessors' nil returns
 	additions := sn.Additions()
 	if additions == nil {
 		additions = sroar.NewBitmap()

--- a/adapters/repos/db/roaringset/segment_cursor_test.go
+++ b/adapters/repos/db/roaringset/segment_cursor_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 )
 
@@ -78,6 +79,38 @@ func TestSegmentCursor(t *testing.T) {
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "seek and fail")
 	})
+}
+
+func TestSegmentCursor_EmptyRegionsSubstitutedWithNonNilLayer(t *testing.T) {
+	// SegmentNode.Additions/Deletions return nil for empty regions, but cursor
+	// consumers (compaction, sorting, ...) expect non-nil layer bitmaps. The
+	// cursor must materialize an empty bitmap instead of exposing nil.
+	build := func(t *testing.T, add, del *sroar.Bitmap) []byte {
+		sn, err := NewSegmentNode([]byte("00000"), add, del)
+		require.Nil(t, err)
+		return sn.ToBuffer()
+	}
+
+	cases := []struct {
+		name string
+		add  *sroar.Bitmap
+		del  *sroar.Bitmap
+	}{
+		{"both empty", NewBitmap(), NewBitmap()},
+		{"additions empty", NewBitmap(), NewBitmap(2, 3)},
+		{"deletions empty", NewBitmap(0, 1), NewBitmap()},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			seg := build(t, tc.add, tc.del)
+			c := NewSegmentCursor(seg, nil)
+			_, layer, err := c.First()
+			require.Nil(t, err)
+			require.NotNil(t, layer.Additions)
+			require.NotNil(t, layer.Deletions)
+		})
+	}
 }
 
 func createDummySegment(t *testing.T, count uint64) ([]byte, []uint64) {

--- a/adapters/repos/db/roaringset/serialization.go
+++ b/adapters/repos/db/roaringset/serialization.go
@@ -70,10 +70,19 @@ func (sn *SegmentNode) Len() uint64 {
 // this method if you can guarantee that you will only use it while holding a
 // maintenance lock or can otherwise be sure that no compaction can occur. If
 // you can't guarantee that, instead use [*SegmentNode.AdditionsWithCopy].
+//
+// It returns nil when the node holds no additions (length indicator 0),
+// avoiding the allocation of an empty bitmap. Callers that need a non-nil
+// bitmap must substitute an empty one; sroar's bitmap operations already treat
+// a nil operand as empty.
 func (sn *SegmentNode) Additions() *sroar.Bitmap {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
-	return sroar.FromBuffer(rw.ReadBytesFromBufferWithUint64LengthIndicator())
+	buf := rw.ReadBytesFromBufferWithUint64LengthIndicator()
+	if len(buf) == 0 {
+		return nil
+	}
+	return sroar.FromBuffer(buf)
 }
 
 // AdditionsWithCopy returns the additions roaring bitmap without sharing state. It
@@ -104,11 +113,20 @@ func (sn *SegmentNode) AdditionsUnlimited() *sroar.Bitmap {
 // this method if you can guarantee that you will only use it while holding a
 // maintenance lock or can otherwise be sure that no compaction can occur. If
 // you can't guarantee that, instead use [*SegmentNode.DeletionsWithCopy].
+//
+// It returns nil when the node holds no deletions (length indicator 0),
+// avoiding the allocation of an empty bitmap. Callers that need a non-nil
+// bitmap must substitute an empty one; sroar's bitmap operations already treat
+// a nil operand as empty.
 func (sn *SegmentNode) Deletions() *sroar.Bitmap {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
 	rw.DiscardBytesFromBufferWithUint64LengthIndicator()
-	return sroar.FromBuffer(rw.ReadBytesFromBufferWithUint64LengthIndicator())
+	buf := rw.ReadBytesFromBufferWithUint64LengthIndicator()
+	if len(buf) == 0 {
+		return nil
+	}
+	return sroar.FromBuffer(buf)
 }
 
 // DeletionsWithCopy returns the deletions roaring bitmap without sharing state. It

--- a/adapters/repos/db/roaringset/serialization.go
+++ b/adapters/repos/db/roaringset/serialization.go
@@ -121,10 +121,17 @@ func (sn *SegmentNode) AdditionsWithCopy() *sroar.Bitmap {
 // you can't guarantee that, instead use [*SegmentNode.AdditionsWithCopy].
 // CAUTION: bitmap uses entire capacity of underlying buffer. By expanding it may overwrite
 // node's data after additions bitmap
+//
+// It returns nil when the node holds no additions (length indicator 0), the
+// same contract as [*SegmentNode.Additions].
 func (sn *SegmentNode) AdditionsUnlimited() *sroar.Bitmap {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
-	return sroar.FromBufferUnlimited(rw.ReadBytesFromBufferWithUint64LengthIndicator())
+	buf := rw.ReadBytesFromBufferWithUint64LengthIndicator()
+	if len(buf) == 0 {
+		return nil
+	}
+	return sroar.FromBufferUnlimited(buf)
 }
 
 // Deletions returns the deletions roaring bitmap with shared state. Only use

--- a/adapters/repos/db/roaringset/serialization.go
+++ b/adapters/repos/db/roaringset/serialization.go
@@ -85,6 +85,24 @@ func (sn *SegmentNode) Additions() *sroar.Bitmap {
 	return sroar.FromBuffer(buf)
 }
 
+// AdditionsCloneToBuf clones the node's additions bitmap into a buffer taken
+// from pool, without materializing an intermediate bitmap over the node's
+// memory first (one bitmap allocation and one container-table parse instead
+// of two). The clone is safe to use and mutate beyond the node's lifetime, up
+// to the pooled buffer's capacity.
+//
+// It returns (nil, nil) when the node holds no additions (length indicator
+// 0) — the release is non-nil exactly when the bitmap is.
+func (sn *SegmentNode) AdditionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, func()) {
+	rw := byteops.NewReadWriter(sn.data)
+	rw.MoveBufferToAbsolutePosition(8)
+	buf := rw.ReadBytesFromBufferWithUint64LengthIndicator()
+	if len(buf) == 0 {
+		return nil, nil
+	}
+	return pool.CloneBytesToBuf(buf)
+}
+
 // AdditionsWithCopy returns the additions roaring bitmap without sharing state. It
 // creates a copy of the underlying buffer. This is safe to use indefinitely,
 // but much slower than [*SegmentNode.Additions] as it requires copying all the
@@ -127,6 +145,21 @@ func (sn *SegmentNode) Deletions() *sroar.Bitmap {
 		return nil
 	}
 	return sroar.FromBuffer(buf)
+}
+
+// DeletionsCloneToBuf clones the node's deletions bitmap into a buffer taken
+// from pool; the deletions counterpart of [*SegmentNode.AdditionsCloneToBuf],
+// with the identical contract: (nil, nil) when the node holds no deletions,
+// otherwise the clone and its release, never one without the other.
+func (sn *SegmentNode) DeletionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, func()) {
+	rw := byteops.NewReadWriter(sn.data)
+	rw.MoveBufferToAbsolutePosition(8)
+	rw.DiscardBytesFromBufferWithUint64LengthIndicator()
+	buf := rw.ReadBytesFromBufferWithUint64LengthIndicator()
+	if len(buf) == 0 {
+		return nil, nil
+	}
+	return pool.CloneBytesToBuf(buf)
 }
 
 // DeletionsWithCopy returns the deletions roaring bitmap without sharing state. It

--- a/adapters/repos/db/roaringset/serialization.go
+++ b/adapters/repos/db/roaringset/serialization.go
@@ -71,10 +71,8 @@ func (sn *SegmentNode) Len() uint64 {
 // maintenance lock or can otherwise be sure that no compaction can occur. If
 // you can't guarantee that, instead use [*SegmentNode.AdditionsWithCopy].
 //
-// It returns nil when the node holds no additions (length indicator 0),
-// avoiding the allocation of an empty bitmap. Callers that need a non-nil
-// bitmap must substitute an empty one; sroar's bitmap operations already treat
-// a nil operand as empty.
+// It returns nil when the node holds no additions (length indicator 0);
+// callers needing a non-nil bitmap must substitute an empty one.
 func (sn *SegmentNode) Additions() *sroar.Bitmap {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
@@ -85,14 +83,11 @@ func (sn *SegmentNode) Additions() *sroar.Bitmap {
 	return sroar.FromBuffer(buf)
 }
 
-// AdditionsCloneToBuf clones the node's additions bitmap into a buffer taken
-// from pool, without materializing an intermediate bitmap over the node's
-// memory first (one bitmap allocation and one container-table parse instead
-// of two). The clone is safe to use and mutate beyond the node's lifetime, up
-// to the pooled buffer's capacity.
-//
-// It returns (nil, nil) when the node holds no additions (length indicator
-// 0) — the release is non-nil exactly when the bitmap is.
+// AdditionsCloneToBuf clones the node's additions bitmap straight into a
+// buffer taken from pool, skipping the intermediate bitmap over the node's
+// memory. The clone is safe to use and mutate beyond the node's lifetime, up
+// to the pooled buffer's capacity. It returns (nil, nil) when the node holds
+// no additions — the release is non-nil exactly when the bitmap is.
 func (sn *SegmentNode) AdditionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, func()) {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
@@ -139,10 +134,8 @@ func (sn *SegmentNode) AdditionsUnlimited() *sroar.Bitmap {
 // maintenance lock or can otherwise be sure that no compaction can occur. If
 // you can't guarantee that, instead use [*SegmentNode.DeletionsWithCopy].
 //
-// It returns nil when the node holds no deletions (length indicator 0),
-// avoiding the allocation of an empty bitmap. Callers that need a non-nil
-// bitmap must substitute an empty one; sroar's bitmap operations already treat
-// a nil operand as empty.
+// It returns nil when the node holds no deletions (length indicator 0);
+// callers needing a non-nil bitmap must substitute an empty one.
 func (sn *SegmentNode) Deletions() *sroar.Bitmap {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
@@ -154,10 +147,8 @@ func (sn *SegmentNode) Deletions() *sroar.Bitmap {
 	return sroar.FromBuffer(buf)
 }
 
-// DeletionsCloneToBuf clones the node's deletions bitmap into a buffer taken
-// from pool; the deletions counterpart of [*SegmentNode.AdditionsCloneToBuf],
-// with the identical contract: (nil, nil) when the node holds no deletions,
-// otherwise the clone and its release, never one without the other.
+// DeletionsCloneToBuf is the deletions counterpart of
+// [*SegmentNode.AdditionsCloneToBuf], with the identical contract.
 func (sn *SegmentNode) DeletionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, func()) {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)

--- a/adapters/repos/db/roaringset/serialization_test.go
+++ b/adapters/repos/db/roaringset/serialization_test.go
@@ -99,7 +99,7 @@ func TestSerialization_CloneToBuf(t *testing.T) {
 		require.Nil(t, err)
 		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
 
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 		addClone, addRelease := newSN.AdditionsCloneToBuf(pool)
 		delClone, delRelease := newSN.DeletionsCloneToBuf(pool)
 		require.NotNil(t, addClone)
@@ -128,7 +128,7 @@ func TestSerialization_CloneToBuf(t *testing.T) {
 
 		// factor wrapper hands out a buffer with headroom, mirroring the first
 		// disk layer's pool in SegmentGroup.roaringSetGet
-		pool := NewBitmapBufPoolFactorWrapper(NewBitmapBufPoolTracking(), 2)
+		pool := NewBitmapBufPoolFactorWrapper(NewBitmapBufPoolTrackingForTests(), 2)
 		addClone, addRelease := newSN.AdditionsCloneToBuf(pool)
 		require.NotNil(t, addClone)
 		defer addRelease()
@@ -144,7 +144,7 @@ func TestSerialization_CloneToBuf(t *testing.T) {
 		require.Nil(t, err)
 		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
 
-		pool := NewBitmapBufPoolTracking()
+		pool := NewBitmapBufPoolTrackingForTests()
 		addClone, addRelease := newSN.AdditionsCloneToBuf(pool)
 		delClone, delRelease := newSN.DeletionsCloneToBuf(pool)
 		assert.Nil(t, addClone)

--- a/adapters/repos/db/roaringset/serialization_test.go
+++ b/adapters/repos/db/roaringset/serialization_test.go
@@ -52,6 +52,43 @@ func TestSerialization_HappyPath(t *testing.T) {
 	assert.True(t, newDeletions.Contains(5))
 }
 
+func TestSerialization_EmptyBitmapsReturnNil(t *testing.T) {
+	// A node holding no additions/deletions writes a length indicator of 0 for
+	// the empty region(s). Additions()/Deletions() return nil in that case
+	// rather than allocating an empty bitmap.
+	key := []byte("my-key")
+
+	t.Run("both empty", func(t *testing.T) {
+		sn, err := NewSegmentNode(key, NewBitmap(), NewBitmap())
+		require.Nil(t, err)
+
+		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
+		assert.Nil(t, newSN.Additions())
+		assert.Nil(t, newSN.Deletions())
+		assert.Equal(t, key, newSN.PrimaryKey())
+	})
+
+	t.Run("additions present, deletions empty", func(t *testing.T) {
+		sn, err := NewSegmentNode(key, NewBitmap(1, 2, 3), NewBitmap())
+		require.Nil(t, err)
+
+		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
+		require.NotNil(t, newSN.Additions())
+		assert.True(t, newSN.Additions().Contains(2))
+		assert.Nil(t, newSN.Deletions())
+	})
+
+	t.Run("additions empty, deletions present", func(t *testing.T) {
+		sn, err := NewSegmentNode(key, NewBitmap(), NewBitmap(5, 7))
+		require.Nil(t, err)
+
+		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
+		assert.Nil(t, newSN.Additions())
+		require.NotNil(t, newSN.Deletions())
+		assert.True(t, newSN.Deletions().Contains(5))
+	})
+}
+
 func TestSerialization_InitializingFromBufferTooLarge(t *testing.T) {
 	additions := NewBitmap(1, 2, 3, 4, 6)
 	deletions := NewBitmap(5, 7)

--- a/adapters/repos/db/roaringset/serialization_test.go
+++ b/adapters/repos/db/roaringset/serialization_test.go
@@ -89,6 +89,72 @@ func TestSerialization_EmptyBitmapsReturnNil(t *testing.T) {
 	})
 }
 
+func TestSerialization_CloneToBuf(t *testing.T) {
+	key := []byte("my-key")
+
+	t.Run("clones match the plain accessors and are independent of the node", func(t *testing.T) {
+		additions := NewBitmap(1, 2, 3, 4, 6)
+		deletions := NewBitmap(5, 7)
+		sn, err := NewSegmentNode(key, additions, deletions)
+		require.Nil(t, err)
+		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
+
+		pool := NewBitmapBufPoolTracking()
+		addClone, addRelease := newSN.AdditionsCloneToBuf(pool)
+		delClone, delRelease := newSN.DeletionsCloneToBuf(pool)
+		require.NotNil(t, addClone)
+		require.NotNil(t, addRelease)
+		require.NotNil(t, delClone)
+		require.NotNil(t, delRelease)
+
+		assert.Equal(t, additions.ToArray(), addClone.ToArray())
+		assert.Equal(t, deletions.ToArray(), delClone.ToArray())
+
+		// mutating the clones must not touch the node's memory
+		addClone.Set(100)
+		delClone.Set(200)
+		assert.Equal(t, additions.ToArray(), newSN.Additions().ToArray())
+		assert.Equal(t, deletions.ToArray(), newSN.Deletions().ToArray())
+
+		addRelease()
+		delRelease()
+		assert.Equal(t, int64(0), pool.Outstanding())
+	})
+
+	t.Run("clone can grow in place within the pooled buffer's capacity", func(t *testing.T) {
+		sn, err := NewSegmentNode(key, NewBitmap(1), NewBitmap())
+		require.Nil(t, err)
+		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
+
+		// factor wrapper hands out a buffer with headroom, mirroring the first
+		// disk layer's pool in SegmentGroup.roaringSetGet
+		pool := NewBitmapBufPoolFactorWrapper(NewBitmapBufPoolTracking(), 2)
+		addClone, addRelease := newSN.AdditionsCloneToBuf(pool)
+		require.NotNil(t, addClone)
+		defer addRelease()
+
+		for i := uint64(2); i < 100; i++ {
+			addClone.Set(i)
+		}
+		assert.Equal(t, 99, addClone.GetCardinality())
+	})
+
+	t.Run("empty regions return nil bitmap and nil release", func(t *testing.T) {
+		sn, err := NewSegmentNode(key, NewBitmap(), NewBitmap())
+		require.Nil(t, err)
+		newSN := NewSegmentNodeFromBuffer(sn.ToBuffer())
+
+		pool := NewBitmapBufPoolTracking()
+		addClone, addRelease := newSN.AdditionsCloneToBuf(pool)
+		delClone, delRelease := newSN.DeletionsCloneToBuf(pool)
+		assert.Nil(t, addClone)
+		assert.Nil(t, addRelease)
+		assert.Nil(t, delClone)
+		assert.Nil(t, delRelease)
+		assert.Equal(t, int64(0), pool.Outstanding())
+	})
+}
+
 func TestSerialization_InitializingFromBufferTooLarge(t *testing.T) {
 	additions := NewBitmap(1, 2, 3, 4, 6)
 	deletions := NewBitmap(5, 7)

--- a/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
@@ -611,6 +611,13 @@ func (p *bitmapBufPoolWithCounter) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.B
 	return cloned, put
 }
 
+func (p *bitmapBufPoolWithCounter) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
+	buf, put := p.Get(len(src))
+	buf = buf[:len(src)]
+	copy(buf, src)
+	return sroar.FromBufferUnlimited(buf), put
+}
+
 func (p *bitmapBufPoolWithCounter) InUseCounter() int {
 	return p.inUseCounter
 }

--- a/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_in_memory_test.go
@@ -419,7 +419,7 @@ func TestSegmentInMemoryReaderBufPool(t *testing.T) {
 
 	waitUntilMemtablesMerged(t, seg)
 
-	bufPool := newBitmapBufPoolWithCounter()
+	bufPool := roaringset.NewBitmapBufPoolTrackingForTests()
 	readers, release := seg.Readers(bufPool)
 	defer release()
 
@@ -509,9 +509,9 @@ func TestSegmentInMemoryReaderBufPool(t *testing.T) {
 				_, release, err := reader.Read(context.Background(), tc.value, tc.operator)
 				require.NoError(t, err)
 
-				assert.GreaterOrEqual(t, 1, bufPool.InUseCounter())
+				assert.GreaterOrEqual(t, int64(1), bufPool.Outstanding())
 				release()
-				assert.Equal(t, 0, bufPool.InUseCounter())
+				assert.Zero(t, bufPool.Outstanding())
 			})
 		}
 	})
@@ -590,34 +590,4 @@ func assertElemsByBit(t *testing.T, s *SegmentInMemory, expectedElemsByBit map[i
 func waitUntilMemtablesMerged(t *testing.T, s *SegmentInMemory) {
 	t.Helper()
 	require.Eventually(t, func() bool { return s.countPendingMemtables() == 0 }, time.Second, 10*time.Millisecond)
-}
-
-type bitmapBufPoolWithCounter struct {
-	inUseCounter int
-}
-
-func newBitmapBufPoolWithCounter() *bitmapBufPoolWithCounter {
-	return &bitmapBufPoolWithCounter{inUseCounter: 0}
-}
-
-func (p *bitmapBufPoolWithCounter) Get(minCap int) (buf []byte, put func()) {
-	p.inUseCounter++
-	return make([]byte, 0, minCap), func() { p.inUseCounter-- }
-}
-
-func (p *bitmapBufPoolWithCounter) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
-	buf, put := p.Get(bm.LenInBytes())
-	cloned = bm.CloneToBuf(buf)
-	return cloned, put
-}
-
-func (p *bitmapBufPoolWithCounter) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
-	buf, put := p.Get(len(src))
-	buf = buf[:len(src)]
-	copy(buf, src)
-	return sroar.FromBufferUnlimited(buf), put
-}
-
-func (p *bitmapBufPoolWithCounter) InUseCounter() int {
-	return p.inUseCounter
 }


### PR DESCRIPTION
## Motivation

Part 3 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242). A `ContainsAny` over N values performs N roaringset point reads, each paying a fixed allocation tax: a variadic slice per strategy check, a pool-wrapper struct and release closure per read, a cloned index key that is never read, empty bitmaps materialized just to say "no deletions", a `[]BitmapLayer` that never holds more than one disk element, and a bitmap parsed once only to be copied and reparsed.

This PR removes that tax. 

## Approach

- **Hoist per-read allocations to construction**: pre-built strategy-check slices; the 1.25-headroom pool wrapper built once per segment group (`bitmapBufPoolWithHeadroom`, named const `baseLayerHeadroomFactor`); pool entries pre-bind their release closure.
- **Represent "nothing" as nil instead of allocating it**: `DiskTree.GetOffsets` returns payload offsets without the matched-key clone (`Get` keeps its owned-key contract by cloning the caller's byte-identical key); re-done on top of stable's van Emde Boas rewrite, preserving the fuzzer-era cycle guard and bounds checks. `SegmentNode.Additions/Deletions` return nil for empty regions; empty deletions are never cloned. Consumers needing non-nil substitute at their call site (segment cursor; the fold's accumulator base — established in exactly one place for both mmap and pread).
- **Fold instead of materialize**: `roaringset.LayerMerger` performs `Flatten`'s left-fold one layer at a time, so the point read builds no `[]BitmapLayer`; `Flatten` stays on the cursor/compaction path, which genuinely has N layers. `CloneBytesToBuf` clones a serialized region straight into a pooled buffer (one parse instead of parse-copy-reparse).
- Cleanup: roaringsetrange's duplicated counter test double replaced by the renamed, explicitly test-only `BitmapBufPoolTrackingForTests`.

## Key areas for review

- `segment_roaring_set_strategy.go:roaringSetGet` — the invariant knot: nil deletions are legal (AndNot operand only), nil additions are not (mutable fold base, substituted once after the mmap/pread branch); `combineReleases` must free every pooled buffer in all four nil/non-nil arms.
- `roaringset/layers.go:LayerMerger` — faithful left-fold of `Flatten` (parity test asserts byte-identical output); `Result` returns the accumulator itself — no `Add` after `Result`.
- `segmentindex/disk_tree.go:GetOffsets` — the safety properties survived the split: bounds checks as `dataLen-pos`, descent step cap against cyclic child pointers.

## Risks and mitigations

- **Nil escaping to a dereferencing consumer**: nil flows only where sroar treats nil as empty; cursor consumers get a substituted empty bitmap; the fold's non-nil base is pinned by a regression test that panics without the substitution (deletions-only oldest segment, mmap + pread).
- **Pooled-buffer leaks/double-release**: `combineReleases` arms asserted via the tracking pool's `Outstanding()` across region shapes in both read modes; the pool zeroes on release and panics on double-release.
- **LayerMerger/Flatten drift**: parity test over Flatten's full case table.

## Testing

Bucket-level regression tests (deletions-only oldest segment, delete-then-readd across segments, leak assertions; mmap + pread), LayerMerger/Flatten parity, serialization and cursor nil-contract tests, `go test -race` across lsmkv/roaringset/roaringsetrange/inverted.

No breaking changes; on-disk format and public read semantics unchanged.