### PR TITLE
fix(drop-vector-index): decouple tenant lifecycle from cleanups, with a shard-close/edit-ops interlock preventing stripped-data resurrection

### DIFF
--- a/adapters/repos/db/drop_vector_index_conflict.go
+++ b/adapters/repos/db/drop_vector_index_conflict.go
@@ -108,30 +108,17 @@ func (p *DropVectorIndexProvider) CheckClassMutation(className string, existingT
 	return nil
 }
 
-// CheckTenantMutation blocks tenant mutations that would make a tenant's shards
-// locally unavailable while a drop-vector task on the class is in flight.
-// Conservative: any in-flight drop on the class blocks every tenant mutation on
-// it (the payload is class-scoped, not per-tenant).
+// CheckTenantMutation is deliberately permissive: tenant lifecycle is not
+// coupled to in-flight drop-vector cleanups. Deactivating (or deleting) a
+// tenant mid-strip makes its unit unfinishable — the drain loop loses the
+// shard, fails the unit after its bounded poll retries, and the round ends
+// FAILED — and reconciliation then re-enqueues for the remaining active
+// shards: already-stripped shards re-drain instantly (their pending sets are
+// empty), and the deactivated tenant is picked up by the cold-tenant deferral
+// once it activates again. The schema marker stays the source of truth
+// throughout, so no path here can lose data; blocking would only trade tenant
+// availability for one round's bookkeeping. Always returns nil.
 func (p *DropVectorIndexProvider) CheckTenantMutation(className string, tenants []string, existingTasks []*distributedtask.Task) error {
-	for _, task := range existingTasks {
-		if !task.Status.IsActive() {
-			continue
-		}
-		existP, err := decodeDropVectorIndexPayload(task.Payload)
-		if err != nil {
-			// Skip a corrupt payload rather than block every tenant mutation
-			// cluster-wide on one bad task. Deterministic across nodes.
-			p.logger.WithField("task", task.ID).
-				Warnf("drop-vector: skipping active task with unparseable payload in tenant-mutation check: %v", err)
-			continue
-		}
-		if !strings.EqualFold(existP.Collection, className) {
-			continue
-		}
-		return fmt.Errorf(
-			"drop-vector task %q is in flight on %s (status=%s); wait for it to complete before mutating tenants %v",
-			task.ID, existP.Collection, task.Status, tenants)
-	}
 	return nil
 }
 

--- a/adapters/repos/db/drop_vector_index_provider.go
+++ b/adapters/repos/db/drop_vector_index_provider.go
@@ -311,11 +311,23 @@ func (p *DropVectorIndexProvider) drainUnit(
 	ctx context.Context, task *distributedtask.Task,
 	payload *DropVectorIndexTaskPayload, unitID string, bucket editOpBucket,
 ) {
-	if err := p.pollUntilEmpty(ctx, bucket, task, unitID, payload.OpID); err != nil {
+	shardGone := func() bool {
+		return !p.shardLocallyLoaded(payload.Collection, payload.UnitToShard[unitID])
+	}
+	if err := p.pollUntilEmpty(ctx, bucket, task, unitID, payload.OpID, shardGone); err != nil {
 		if ctx.Err() != nil {
 			return // shutdown: resume after restart, do not mark failed
 		}
-		p.failUnit(ctx, task, unitID, "drain pending segments: "+err.Error())
+		msg := "drain pending segments: " + err.Error()
+		// Tenant lifecycle is decoupled from cleanups (see CheckTenantMutation):
+		// a mid-strip deactivation surfaces here as persistent read errors on
+		// the closed sidecar. Name the real cause — this failure is an expected
+		// hand-off to the next reconcile round, not a fault.
+		if shard := payload.UnitToShard[unitID]; !p.shardLocallyLoaded(payload.Collection, shard) {
+			msg += " (shard no longer locally available — tenant deactivated, offloaded, or deleted; " +
+				"reconciliation re-covers the remaining shards and the tenant on reactivation)"
+		}
+		p.failUnit(ctx, task, unitID, msg)
 		return
 	}
 
@@ -332,7 +344,7 @@ func (p *DropVectorIndexProvider) drainUnit(
 // unstripped, so empty pending with a quarantine row is not success.
 func (p *DropVectorIndexProvider) pollUntilEmpty(
 	ctx context.Context, bucket editOpBucket, task *distributedtask.Task,
-	unitID, opID string,
+	unitID, opID string, shardGone func() bool,
 ) error {
 	ticker := time.NewTicker(p.pollInterval)
 	defer ticker.Stop()
@@ -351,6 +363,14 @@ func (p *DropVectorIndexProvider) pollUntilEmpty(
 		}
 		switch {
 		case err != nil:
+			// A read error on a shard that is no longer locally loaded is not a
+			// blip — the tenant deactivated/offloaded/deleted mid-drain (tenant
+			// lifecycle is decoupled from cleanups). Fail the unit NOW instead
+			// of burning the blip tolerance: the round ends and reconciliation
+			// re-covers the surviving shards without multi-tick delay.
+			if shardGone() {
+				return fmt.Errorf("shard no longer locally loaded: %w", err)
+			}
 			// Tolerate a few consecutive blips (incl. the first read); only
 			// persistent errors fail the unit.
 			consecutiveErrors++
@@ -385,6 +405,18 @@ func (p *DropVectorIndexProvider) pollUntilEmpty(
 		case <-ticker.C:
 		}
 	}
+}
+
+// shardLocallyLoaded reports whether the shard is currently loaded on this
+// node. Diagnostic only (enriches a unit-failure reason); errors read as
+// "loaded" so a listing blip cannot mislabel a real drain failure.
+func (p *DropVectorIndexProvider) shardLocallyLoaded(collection, shardName string) bool {
+	buckets, err := p.shards.EditOpBucketsForLoadedShards(collection, []string{shardName})
+	if err != nil {
+		return true
+	}
+	_, ok := buckets[shardName]
+	return ok
 }
 
 func (p *DropVectorIndexProvider) failUnit(

--- a/adapters/repos/db/drop_vector_index_provider_test.go
+++ b/adapters/repos/db/drop_vector_index_provider_test.go
@@ -1414,11 +1414,15 @@ func TestCheckVectorConfigRemoval_GatesOnFinished(t *testing.T) {
 	})
 }
 
-func TestCheckTenantMutation_BlocksDuringDrop(t *testing.T) {
+// TestCheckTenantMutation_NeverBlocks pins the decoupling contract: tenant
+// lifecycle is independent of in-flight drop cleanups. A mid-strip
+// deactivation fails that unit and the next reconcile round re-covers the
+// surviving shards; the marker (not the task) is the source of truth.
+func TestCheckTenantMutation_NeverBlocks(t *testing.T) {
 	p := newTestDropProvider(&fakeShards{}, &fakeFinalizer{}, newFakeRecorder())
-	require.Error(t, p.CheckTenantMutation("C", []string{"tenant1"}, []*distributedtask.Task{activeDropTask("t1", "C", "v1")}))
-	require.NoError(t, p.CheckTenantMutation("Other", []string{"tenant1"}, []*distributedtask.Task{activeDropTask("t1", "C", "v1")}),
-		"a drop on another collection must not block this one's tenant mutations")
+	require.NoError(t, p.CheckTenantMutation("C", []string{"tenant1"},
+		[]*distributedtask.Task{activeDropTask("t1", "C", "v1")}),
+		"deactivating a tenant must succeed even while its collection's drop is stripping")
 }
 
 func TestCheckPropertyUpdate_NeverConflicts(t *testing.T) {
@@ -1465,18 +1469,6 @@ func TestCheckConflict_SkipsCorruptActiveTask(t *testing.T) {
 		Status:    distributedtask.TaskStatusStarted,
 	}
 	require.NoError(t, p.CheckConflict(newPayload, []*distributedtask.Task{corrupt}))
-}
-
-// TestCheckTenantMutation_SkipsCorruptActiveTask: likewise a corrupt task must not
-// block every tenant mutation cluster-wide.
-func TestCheckTenantMutation_SkipsCorruptActiveTask(t *testing.T) {
-	p := newTestDropProvider(&fakeShards{}, &fakeFinalizer{}, newFakeRecorder())
-	corrupt := &distributedtask.Task{
-		Namespace: DropVectorIndexNamespace,
-		Payload:   []byte("not json"),
-		Status:    distributedtask.TaskStatusStarted,
-	}
-	require.NoError(t, p.CheckTenantMutation("C", []string{"t1"}, []*distributedtask.Task{corrupt}))
 }
 
 func TestExtractDropVectorIndexTaskCollection(t *testing.T) {

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -246,6 +246,12 @@ type Bucket struct {
 	// observing true is guaranteed a populated rep.
 	rangeableRepRebuilt atomic.Bool
 
+	// shuttingDown flips at Shutdown entry and never resets: registering a
+	// NEW edit op on a closing bucket must hard-fail (see RegisterEditOp) —
+	// the snapshot would race the dismantling and could record "nothing to
+	// clean" for a bucket full of data.
+	shuttingDown atomic.Bool
+
 	// Dedup for the rangeable diagnostic log lines, once per bucket-open.
 	rangeableDeferredLogOnce  sync.Once
 	rangeableFallbackWarnOnce sync.Once
@@ -436,6 +442,13 @@ func (b *Bucket) HasEditOps() bool {
 func (b *Bucket) RegisterEditOp(opID string, desc OpDescriptor) error {
 	if !b.HasEditOps() {
 		return fmt.Errorf("edit ops not enabled for this bucket")
+	}
+	if b.shuttingDown.Load() {
+		// Arming against a closing bucket is unsound: the flush + segment
+		// snapshot race the dismantling, and an empty or partial snapshot
+		// would let the drop record completion without stripping. Fail the
+		// unit instead; a later round re-arms on a live instance.
+		return fmt.Errorf("bucket is shutting down; refusing to register edit op %q", opID)
 	}
 	snapshotted, err := b.disk.editOps.HasPendingSnapshot(opID)
 	if err != nil {
@@ -1744,6 +1757,7 @@ func (b *Bucket) existsOnDiskAndPreviousMemtable(previous *countStats, key []byt
 }
 
 func (b *Bucket) Shutdown(ctx context.Context) (err error) {
+	b.shuttingDown.Store(true)
 	// Drain all in-flight read pins first (see the lifetimeLock doc); the
 	// heartbeat makes a wedged drain diagnosable.
 	drained := make(chan struct{})
@@ -1763,7 +1777,6 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 	b.lifetimeLock.Lock()
 	close(drained)
 	defer b.lifetimeLock.Unlock()
-
 	defer GlobalBucketRegistry.Remove(b.GetDir())
 
 	start := time.Now()

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -94,6 +94,22 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 
 	recovered := false
 
+	// Data in these WALs predates any strip progress the edit-ops sidecar has
+	// recorded: keeping the last WAL's memtable as the live one would hold
+	// pre-strip bytes OUTSIDE the pending-segment bookkeeping, and a drop that
+	// already recorded those bytes as stripped would see them resurrect — with
+	// nothing left to re-clean them once its op is gone. With ops present,
+	// flush EVERY recovered WAL into a segment; the sidecar recovery that runs
+	// after this (see newSegmentGroup) then re-pends them all.
+	sidecarHasOps := false
+	if sg.editOps != nil {
+		ops, opsErr := sg.editOps.LoadOps()
+		if opsErr != nil {
+			return errors.Wrap(opsErr, "probe edit-ops sidecar before WAL recovery")
+		}
+		sidecarHasOps = len(ops) > 0
+	}
+
 	// recover from each log
 	for i, fname := range walFileNames {
 		if err := func() error {
@@ -145,7 +161,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 
 			// immediately flush the .wal file if there have been any damages during recovery. This means that the file is
 			// damaged and cannot be used for new writes.
-			if walForActiveMemtable && errRecovery == nil {
+			if walForActiveMemtable && errRecovery == nil && !sidecarHasOps {
 				_, err = cl.file.Seek(0, io.SeekEnd)
 				if err != nil {
 					return err

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	bolterrors "go.etcd.io/bbolt/errors"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/editops"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
@@ -485,6 +486,16 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		sg.strategy = StrategyInverted
 	}
 
+	// Construct the edit-ops sidecar BEFORE WAL recovery: the recovery must
+	// know whether ops exist — a last-WAL memtable kept live under a pending
+	// drop would hold pre-strip bytes outside the pending-segment bookkeeping
+	// (see mayRecoverFromCommitLogs). Recovery of the sidecar itself runs
+	// after the WALs, over the final segment set.
+	if cfg.className != "" && cfg.strategy == StrategyReplace {
+		sg.editOps = newSegmentEditOps(cfg.dir, cfg.className)
+		sg.editOps.logger = sg.logger
+	}
+
 	if err := b.mayRecoverFromCommitLogs(ctx, sg, files); err != nil {
 		return nil, err
 	}
@@ -493,23 +504,26 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		sg.metrics.ObjectCount(sg.count())
 	}
 
-	// Construct the sidecar before the cleaner (newSegmentCleaner consults
-	// sg.editOps to enable the edit-ops-only drain when the heuristic cleanup is
-	// disabled) and before the compaction cycle registers, so sg.editOps is
-	// published before any pass can read it (happens-before). The bolt file itself
-	// is opened lazily on the first registered op (see newSegmentEditOps), so an
-	// objects bucket that never sees a drop carries no sidecar. Closed in shutdown.
-	//
-	// A non-empty className means the objects bucket (the only WithClassName caller);
-	// edit ops only apply to its replace-strategy store. Transformers are resolved
-	// per op type from the global registry; the persisted ops drive what runs.
-	if cfg.className != "" && cfg.strategy == StrategyReplace {
-		sg.editOps = newSegmentEditOps(cfg.dir, cfg.className)
-		sg.editOps.logger = sg.logger
+	// Recover the sidecar AFTER WAL recovery so the re-snapshot covers every
+	// segment the WALs flushed (construction happened above, before recovery —
+	// still ahead of the cleaner, which consults sg.editOps, and of the
+	// compaction cycle registration: published before any pass reads it). The
+	// bolt file opens lazily on the first registered op, so an objects bucket
+	// that never sees a drop carries no sidecar. Closed in shutdown.
+	if sg.editOps != nil {
 		if err := sg.recoverEditOps(ctx); err != nil {
-			// Not fatal: bricking the shard over drop-progress bookkeeping (e.g. a
-			// torn sidecar copy) would trade data availability for cleanup state.
-			// The drop stalls and every cleanup pass logs until repaired.
+			if errors.Is(err, bolterrors.ErrTimeout) {
+				// The sidecar's bolt file is still locked — a previous instance of
+				// this shard has not finished closing. Running blind here is how a
+				// completed drop's stripped data got resurrected (WAL replay with
+				// no healing re-pend possible); fail the load so the shard
+				// lifecycle retries once the old instance is gone.
+				return nil, fmt.Errorf("segment edit ops sidecar still locked by a previous instance: %w", err)
+			}
+			// Other failures are not fatal: bricking the shard over drop-progress
+			// bookkeeping (e.g. a torn sidecar copy) would trade data availability
+			// for cleanup state. The drop stalls and every cleanup pass logs until
+			// repaired.
 			sg.logger.WithField("path", cfg.dir).
 				Errorf("recover segment edit ops failed; drop-vector cleanup on this shard is stalled: %v", err)
 		}

--- a/adapters/repos/db/lsmkv/segment_group_interlock_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_interlock_test.go
@@ -1,0 +1,100 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func newInterlockTestBucket(t *testing.T, dir string) (*Bucket, error) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	return NewBucketCreator().NewBucket(context.Background(), dir, dir, logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSegmentsCleanupInterval(time.Hour),
+		WithClassName("TestClass"))
+}
+
+// TestRegisterEditOp_RefusedOnClosingBucket pins the arm-time interlock: once
+// a bucket's shutdown began, registering a NEW edit op must hard-fail — the
+// flush + segment snapshot would race the dismantling and could record
+// "nothing to clean" for a bucket full of data.
+func TestRegisterEditOp_RefusedOnClosingBucket(t *testing.T) {
+	bucket, _ := newReplaceBucketWithEditOps(t, prefixTransformer)
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+
+	bucket.shuttingDown.Store(true)
+	err := bucket.RegisterEditOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "shutting down")
+}
+
+// TestWALRecovery_FlushesLastWALUnderLiveOps pins the resurrection fix: data
+// recovered from the last WAL used to become the live memtable — pre-strip
+// bytes OUTSIDE the pending-segment bookkeeping, resurrecting a completed
+// drop's data with nothing left to re-clean it. With ops in the sidecar,
+// recovery must flush every WAL into segments so the sidecar re-snapshot
+// covers them.
+func TestWALRecovery_FlushesLastWALUnderLiveOps(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	b1, err := newInterlockTestBucket(t, dir)
+	require.NoError(t, err)
+	// Small enough for Shutdown's flushWAL path, which KEEPS the WAL on disk —
+	// the exact shape an interrupted close leaves behind.
+	require.NoError(t, b1.Put([]byte("k1"), []byte("v1")))
+
+	// Register the op through a separate sidecar handle: going through the
+	// bucket would FlushAndSwitch and drain the very WAL this test needs to
+	// survive the close.
+	ext := newSegmentEditOps(dir, "TestClass")
+	require.NoError(t, ext.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	require.NoError(t, ext.Close())
+	require.NoError(t, b1.Shutdown(ctx))
+
+	b2, err := newInterlockTestBucket(t, dir)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, b2.Shutdown(ctx)) }()
+
+	require.NotNil(t, b2.disk.editOps)
+	pending, err := b2.disk.editOps.Pending("op1")
+	require.NoError(t, err)
+	require.NotEmpty(t, pending,
+		"WAL-recovered data must land in segments re-pended under the surviving op, not in the live memtable")
+
+	v, err := b2.Get([]byte("k1"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), v, "recovered data must still be readable after the flush")
+}
+
+// TestNewBucket_FailsWhenSidecarLocked pins the reload fence: a sidecar still
+// flocked by a previous instance means that instance has not finished closing
+// — loading blind here (the old soft-skip logged "cleanup stalled") is how a
+// completed drop lost its healing re-pend. The load must fail retryably.
+func TestNewBucket_FailsWhenSidecarLocked(t *testing.T) {
+	dir := t.TempDir()
+
+	ext := newSegmentEditOps(dir, "TestClass")
+	require.NoError(t, ext.RegisterOp("op1", OpDescriptor{Type: OpTypeRemoveTargetVectors, CreatedAt: 1}))
+	defer ext.Close() // holds the bolt flock for the duration of the test
+
+	_, err := newInterlockTestBucket(t, dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "still locked by a previous instance")
+}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -715,10 +715,21 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 					if errors.Is(err, errAlreadyShutdown) {
 						m.logger.WithField("shard", shard.Name()).Debug("already shut down or dropped")
 					} else {
+						// Lifecycle fence: a shard whose shutdown failed (typically
+						// "still in use" — performShutdown refuses before marking the
+						// shard shut) is fully alive. Leaving it out of the map would
+						// orphan the running instance, and a later reactivation would
+						// build a SECOND instance over the same directory (double-open
+						// corruption; observed as sidecar flock timeouts). Restore it
+						// under the still-held shardCreateLock: the tenant stays
+						// loaded locally and the failed transition is retryable.
+						if shardStillAlive(shard) {
+							idx.shards.Store(name, shard)
+						}
 						idx.logger.
 							WithField("action", "shard_shutdown").
 							WithField("shard", shard.ID()).
-							Error(err)
+							Errorf("shutdown failed; live shard restored to the active map to prevent a duplicate instance: %v", err)
 						ec.Add(err)
 					}
 				}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -23,6 +23,27 @@ import (
 	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
+// shardStillAlive reports whether a shard instance remains operational after a
+// failed Shutdown. performShutdown refuses BEFORE marking the shard shut when
+// it is still in use, so a failed close usually leaves a fully live instance —
+// the caller must then restore it to the shard map rather than orphan it (an
+// orphaned live instance lets a reactivation double-open the same directory).
+func shardStillAlive(s ShardLike) bool {
+	switch sh := s.(type) {
+	case *Shard:
+		return !sh.shut.Load()
+	case *LazyLoadShard:
+		sh.mutex.Lock()
+		defer sh.mutex.Unlock()
+		return sh.loaded && !sh.shard.shut.Load()
+	default:
+		// Unknown wrapper: restoring a live shard is the safe direction — a
+		// dead map entry fails requests loudly, an orphaned live instance
+		// corrupts silently.
+		return true
+	}
+}
+
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.shutdownRequested.Store(true)
 	return backoff.Retry(func() error {

--- a/test/acceptance/drop_vector_index/helpers_test.go
+++ b/test/acceptance/drop_vector_index/helpers_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/distributed_tasks"
 	clobjects "github.com/weaviate/weaviate/client/objects"
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -211,8 +212,34 @@ func listTenantObjectsWithVectors(t *testing.T, className, tenant string) []*mod
 	return listObjectsWithVectors(t, className, tenant, 100)
 }
 
-// setTenantStatusEventually retries a tenant status change: the tenant-mutation
-// guard rejects changes while a cleanup task is momentarily active.
+// waitForNoActiveDropTask waits until no drop-vector cleanup task is active.
+// A tenant's coverage is recorded only when its cleaning ROUND completes:
+// deactivating it while the round still runs — possible even after its
+// objects already read as stripped, since unit completion lags by up to a
+// poll tick — aborts the round and loses the coverage until the tenant's
+// next activation. Tests that re-cool a tenant and expect its coverage to
+// survive must pass this barrier first.
+func waitForNoActiveDropTask(t *testing.T) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		resp, err := helper.Client(nil).DistributedTasks.DistributedTasksGet(
+			distributed_tasks.NewDistributedTasksGetParams(), nil)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		for _, task := range resp.Payload["drop-vector-index"] {
+			switch task.Status {
+			case "FINISHED", "FAILED", "CANCELLED":
+			default:
+				assert.Failf(collect, "drop task still active", "task %s status %s", task.ID, task.Status)
+			}
+		}
+	}, time.Minute, 500*time.Millisecond)
+}
+
+// setTenantStatusEventually retries a tenant status change through transient
+// rejections (leadership changes, other guards). Drop-vector cleanups no
+// longer block tenant mutations, so for them a plain update works too.
 func setTenantStatusEventually(t *testing.T, className, tenant, status string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {

--- a/test/acceptance/drop_vector_index/partially_cold_tenants_test.go
+++ b/test/acceptance/drop_vector_index/partially_cold_tenants_test.go
@@ -109,6 +109,13 @@ func testPartiallyColdTenants() func(t *testing.T) {
 		})
 
 		t.Run("4 deactivate the cleaned tenant again", func(t *testing.T) {
+			// Coverage exists only once the cleaning round COMPLETED. Tenant
+			// lifecycle no longer waits for cleanups, so re-cooling during the
+			// round (stripped objects notwithstanding) would abort it and lose
+			// this tenant's coverage until its next activation — a different
+			// journey; this one pins "re-cooling a COVERED tenant does not
+			// block finalize".
+			waitForNoActiveDropTask(t)
 			setTenantStatusEventually(t, className, tenants[2], models.TenantActivityStatusCOLD)
 		})
 

--- a/test/acceptance/drop_vector_index/tenant_mutation_test.go
+++ b/test/acceptance/drop_vector_index/tenant_mutation_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-// testTenantMutationDuringDrop pins the tenant-mutation guard: deactivating a
-// tenant while a drop is in flight is rejected (its shard's cleanup unit would
-// lose its data), and the same mutation succeeds once the drop finalized.
+// testTenantMutationDuringDrop pins the decoupling of tenant lifecycle from
+// drop cleanups: deactivating a tenant mid-strip succeeds immediately, the
+// round's unit for that tenant fails and reconciliation re-covers the
+// remaining active tenants, the marker stays until every tenant is covered,
+// and reactivating the tenant lets the drop complete fully.
 func testTenantMutationDuringDrop() func(t *testing.T) {
 	return func(t *testing.T) {
 		const (
@@ -77,30 +79,44 @@ func testTenantMutationDuringDrop() func(t *testing.T) {
 			time.Sleep(3 * time.Second) // past the 1s dirty-flush
 		})
 
-		t.Run("deactivating a tenant mid-drop is rejected", func(t *testing.T) {
+		t.Run("deactivating a tenant mid-drop succeeds immediately", func(t *testing.T) {
 			dropTargetVector(t, className, dropped)
 
 			// Guaranteed still in flight: the first poll tick is 30s away.
 			err := helper.UpdateTenantsReturnError(t, className, []*models.Tenant{
 				{Name: tenant2, ActivityStatus: models.TenantActivityStatusCOLD},
 			})
-			require.Error(t, err, "tenant deactivation must be blocked while the drop is in flight")
-			require.Contains(t, errorResponseText(err), "wait for it to complete")
+			require.NoError(t, err, "tenant lifecycle must not be coupled to an in-flight drop")
 		})
 
-		t.Run("deactivation succeeds after the drop finalized", func(t *testing.T) {
-			eventuallyTargetVectorRemoved(t, className, dropped)
+		t.Run("the remaining active tenant is stripped; the marker defers on the cold one", func(t *testing.T) {
+			// tenant2's unit fails once its shard closed (bounded poll retries),
+			// the round ends FAILED, and reconciliation re-enqueues for tenant1
+			// alone — so tenant1 strips despite the aborted first round.
+			requireTenantStripped(t, className, tenant1, dropped, 10)
+			got, err := getClassErr(className)
+			require.NoError(t, err)
+			cfg, present := got.VectorConfig[dropped]
+			require.True(t, present, "the marker must stay while a tenant is uncovered")
+			require.Equal(t, "none", cfg.VectorIndexType)
+		})
+
+		t.Run("reactivating the tenant completes the drop", func(t *testing.T) {
 			helper.UpdateTenants(t, className, []*models.Tenant{
-				{Name: tenant2, ActivityStatus: models.TenantActivityStatusCOLD},
+				{Name: tenant2, ActivityStatus: models.TenantActivityStatusHOT},
 			})
+			eventuallyTargetVectorRemoved(t, className, dropped)
 		})
 
-		t.Run("active tenant is stripped with sibling intact", func(t *testing.T) {
-			objs := listTenantObjectsWithVectors(t, className, tenant1)
-			require.Len(t, objs, 10)
-			for _, obj := range objs {
-				require.NotContains(t, obj.Vectors, dropped)
-				require.Equal(t, dim, vecDim(t, obj.Vectors[sibling]))
+		t.Run("both tenants stripped with sibling intact", func(t *testing.T) {
+			for _, tenant := range []string{tenant1, tenant2} {
+				objs := listTenantObjectsWithVectors(t, className, tenant)
+				require.Len(t, objs, 10)
+				for _, obj := range objs {
+					require.NotContains(t, obj.Vectors, dropped)
+					require.Equal(t, dim, vecDim(t, obj.Vectors[sibling]))
+				}
+				require.Equal(t, 3, nearVectorTenantResults(t, className, tenant, sibling, randVec(dim, 5), 3))
 			}
 		})
 	}


### PR DESCRIPTION
## What

Tenant lifecycle is no longer coupled to in-flight drop-vector cleanups: tenants can be deactivated (COLD/FROZEN/OFFLOADED) or deleted at any moment, including mid-strip. Getting there safely surfaced that the old tenant-mutation guard was load-bearing for **shard-local** integrity, not just task liveness — removing it exposed real interleavings between the edit-ops machinery and an in-process shard close, two of which are pre-existing bugs reachable on `main`. This PR removes the guard **and** builds the interlock that makes the removal sound.

Based on `drop-vector-s20` (#12295); merges after it.

### The decoupling contract

- Deactivating a tenant mid-strip **succeeds immediately** (`CheckTenantMutation` for the drop namespace is now deliberately permissive; the interface method stays — the marker-removal gate dispatches over the same detector registry).
- The deactivated tenant's unit fails fast — the drain loop detects "read error + shard no longer locally loaded" on the first errored poll and fails the unit with a named reason instead of burning the 3×30s blip tolerance.
- The round ends FAILED; reconciliation re-enqueues for the surviving active shards. Already-stripped shards re-drain instantly (their pending sets are empty), so only bookkeeping is redone.
- The reactivated tenant is picked up by the existing cold-tenant deferral; the marker leaves the schema only when a single round covers every tenant. The schema marker stays the source of truth throughout.
- Nuance: "cleaned" in the coverage chain means *covered by a completed round*. Deactivating in the window after objects read as stripped but before the round completes (≤ one 30s poll tick) discards that round's coverage — harmless, but the tenant must activate once more before the drop can finalize.

### The interlock (why the guard could be removed)

Chasing a 1-in-10 e2e flake produced full forensics (raft apply log + per-second task snapshots + node logs) of a **finalize-over-unstripped-data** sequence: a mid-strip deactivation wedged the shard close, reactivation raced the wedged close into a second live instance over the same directory, WAL recovery resurrected pre-strip object bytes outside the pending-segment bookkeeping, and the sidecar recovery that would have healed it soft-skipped on a flock timeout. Four layers close this:

1. **Lifecycle fence** (`migrator.go`, `shard_shutdown.go`): a shard whose `Shutdown` fails (typically "still in use" — refused before the shard is marked shut) is restored to the shard map under the still-held `shardCreateLock`. No orphaned live instance ⇒ no reactivation double-open. *Pre-existing bug on `main`* — any shutdown failure could orphan a live shard.
2. **Fast-fail drain** (`drop_vector_index_provider.go`): a poll error on a shard that is no longer locally loaded fails the unit immediately. No preemption hook was needed: the drain holds no shard pins, so drop work never blocks a close.
3. **Arm guard** (`bucket.go`): `Bucket.Shutdown` sets a `shuttingDown` flag at entry; `RegisterEditOp` hard-fails on a closing bucket — an arm can never snapshot "nothing to clean" against a dismantling segment list.
4. **WAL/recovery soundness** (`segment_group.go`, `bucket_recover_from_wal.go`): the edit-ops sidecar is constructed *before* WAL recovery; when it carries ops, **every** recovered WAL — including the last one that used to become the live memtable — is flushed into segments, so the post-recovery re-snapshot covers all recovered bytes. *Closes a pre-existing `main` hole*: WAL-recovered data escaped edit-op coverage entirely. And a sidecar still flocked by a previous instance (`bbolt` `ErrTimeout`) now **fails the shard load retryably** instead of soft-skipping into "cleanup stalled" with healing disabled.

Since 1 and 4 fix bugs that exist on `main` independently of the decoupling, they are separate commits and can be cherry-picked into their own PR if preferred.

## Tests

- **E2e** — `tenant_mutation_test.go` reworked to pin the new journey end-to-end: deactivate mid-strip succeeds immediately → survivor stripped next round while the marker defers → reactivate → full finalize, both tenants stripped, sibling intact and searchable. `partially_cold_tenants` now crosses an explicit `waitForNoActiveDropTask` barrier (GET /v1/tasks) before re-cooling, pinning the covered-tenant contract rather than the race.
- **Unit pins** (red-verified against the pre-fix code): `TestRegisterEditOp_RefusedOnClosingBucket`, `TestWALRecovery_FlushesLastWALUnderLiveOps`, `TestNewBucket_FailsWhenSidecarLocked`; plus `TestCheckTenantMutation_NeverBlocks` for the contract. The timing-window interleavings are pinned here because no e2e can hit them deterministically. Known gap: the lifecycle fence (layer 1) has no unit pin yet — it needs an Index-level harness and is currently covered behaviorally by the e2e suite.

## Verification

- Full `drop_vector_index` e2e package green (919s, `-race`).
- The previously 1-in-10-flaky deactivate-mid-strip journey: **10/10 consecutive runs green** on this build (the same loop caught both bugs pre-fix).
- `lsmkv` + `db` unit suites green with `-race`; `golangci-lint` + goroutine linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
