### PR TITLE
fix(usage): stop the shard usage calculation from measuring its own writes

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -397,6 +397,18 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 	lsmPath := shardPathLSM(i.path(), shardName)
 
+	// Opening the dimensions bucket materialises files (a bloom filter) inside the
+	// tree the sizes below are taken from, so it has to happen first. Otherwise the
+	// first report for a shard is smaller than every later one by that amount.
+	targetVectors := make([]string, 0, len(vectorConfigs))
+	for targetVector := range vectorConfigs {
+		targetVectors = append(targetVectors, targetVector)
+	}
+	dimensionalitiesAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors)
+	if err != nil {
+		return nil, err
+	}
+
 	_, directories, err := diskio.GetFileWithSizes(lsmPath)
 	if err != nil {
 		return nil, err
@@ -424,16 +436,6 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 
 	// Get named vector data for cold shards from schema configuration
-	targetVectors := make([]string, 0, len(vectorConfigs))
-	for targetVector := range vectorConfigs {
-		targetVectors = append(targetVectors, targetVector)
-	}
-	// open the dimensions bucket once for all target vectors
-	dimensionalitiesAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, targetVectors)
-	if err != nil {
-		return nil, err
-	}
-
 	var namedVectors types.VectorsUsage
 	uncompressedVectorSize := uint64(0) // calculate total uncompressed vector size for all vectors
 	for targetVector, vectorConfig := range vectorConfigs {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -397,9 +397,8 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 	lsmPath := shardPathLSM(i.path(), shardName)
 
-	// Opening the dimensions bucket materialises files (a bloom filter) inside the
-	// tree the sizes below are taken from, so it has to happen first. Otherwise the
-	// first report for a shard is smaller than every later one by that amount.
+	// Opening the dimensions bucket materialises a bloom filter inside the tree
+	// measured below, so it has to happen before the sizes are taken.
 	targetVectors := make([]string, 0, len(vectorConfigs))
 	for targetVector := range vectorConfigs {
 		targetVectors = append(targetVectors, targetVector)

--- a/adapters/repos/db/index_usage_idempotency_test.go
+++ b/adapters/repos/db/index_usage_idempotency_test.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/weaviate/weaviate/entities/models"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestIndex_UsageForCollection_IsIdempotent pins an observer effect: calculating
+// a cold shard's usage wrote files into the very directories it measures, so a
+// second calculation of unchanged data reported a bigger shard than the first.
+// Two sources, both counted:
+//
+//   - the usage cache the calculation itself saves into the shard root
+//   - the bloom filter materialised when the dimensions bucket is opened
+//
+// The inflated figure is then saved back into the cache and served from there
+// on every later report, so a single recalculation permanently overstated the
+// shard. This surfaced as `acceptance large (python)` failures in
+// test_usage.py, where hot and cold reports differed by exactly the size of the
+// cache file.
+func TestIndex_UsageForCollection_IsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	tenantName := "test-tenant"
+
+	index := setupPopulatedLazyIndex(ctx, t)
+	t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+	// drop the shard from the in-memory map so usage takes the cold path
+	index.shards.LoadAndDelete(tenantName)
+
+	vectorConfigs := map[string]models.VectorConfig{
+		"": {
+			VectorIndexType:   "hnsw",
+			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+		},
+	}
+
+	first, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+	require.NoError(t, err)
+	require.Len(t, first.Shards, 1)
+
+	// A cache hit would trivially return the same numbers and hide the effect.
+	// Make the second call recompute, which is what a concurrent report or a
+	// cache left behind by an older UsageDiskVersion does.
+	cachePath := filepath.Join(index.path(), tenantName, "usage.json.tmp")
+	stale, err := os.ReadFile(cachePath)
+	require.NoError(t, err, "cold usage calculation must have written its cache")
+	require.NoError(t, os.WriteFile(cachePath, make([]byte, len(stale)), 0o600))
+
+	second, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+	require.NoError(t, err)
+	require.Len(t, second.Shards, 1)
+
+	assert.Equal(t, first.Shards[0].ObjectsStorageBytes, second.Shards[0].ObjectsStorageBytes)
+	assert.Equal(t, first.Shards[0].VectorStorageBytes, second.Shards[0].VectorStorageBytes)
+	assert.Equal(t, first.Shards[0].IndexStorageBytes, second.Shards[0].IndexStorageBytes)
+	assert.Equal(t, first.Shards[0].FullShardStorageBytes, second.Shards[0].FullShardStorageBytes,
+		"recalculating an unchanged shard must report the same size")
+}

--- a/adapters/repos/db/index_usage_idempotency_test.go
+++ b/adapters/repos/db/index_usage_idempotency_test.go
@@ -25,19 +25,9 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// TestIndex_UsageForCollection_IsIdempotent pins an observer effect: calculating
-// a cold shard's usage wrote files into the very directories it measures, so a
-// second calculation of unchanged data reported a bigger shard than the first.
-// Two sources, both counted:
-//
-//   - the usage cache the calculation itself saves into the shard root
-//   - the bloom filter materialised when the dimensions bucket is opened
-//
-// The inflated figure is then saved back into the cache and served from there
-// on every later report, so a single recalculation permanently overstated the
-// shard. This surfaced as `acceptance large (python)` failures in
-// test_usage.py, where hot and cold reports differed by exactly the size of the
-// cache file.
+// TestIndex_UsageForCollection_IsIdempotent pins an observer effect: the cold usage
+// calculation wrote files into the directories it measures (its own cache, and the
+// bloom filter from opening the dimensions bucket), inflating every recalculation.
 func TestIndex_UsageForCollection_IsIdempotent(t *testing.T) {
 	ctx := context.Background()
 	tenantName := "test-tenant"
@@ -45,7 +35,7 @@ func TestIndex_UsageForCollection_IsIdempotent(t *testing.T) {
 	index := setupPopulatedLazyIndex(ctx, t)
 	t.Cleanup(func() { _ = index.Shutdown(ctx) })
 
-	// drop the shard from the in-memory map so usage takes the cold path
+	// force the cold path
 	index.shards.LoadAndDelete(tenantName)
 
 	vectorConfigs := map[string]models.VectorConfig{
@@ -59,9 +49,8 @@ func TestIndex_UsageForCollection_IsIdempotent(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, first.Shards, 1)
 
-	// A cache hit would trivially return the same numbers and hide the effect.
-	// Make the second call recompute, which is what a concurrent report or a
-	// cache left behind by an older UsageDiskVersion does.
+	// A cache hit would hide the effect; recomputing is what a concurrent report or
+	// a cache from an older UsageDiskVersion hits in production.
 	cachePath := filepath.Join(index.path(), tenantName, "usage.json.tmp")
 	stale, err := os.ReadFile(cachePath)
 	require.NoError(t, err, "cold usage calculation must have written its cache")

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -44,9 +44,8 @@ func shardPathDimensionsLSM(indexPath, shardName string) string {
 	return path.Join(shardPathLSM(indexPath, shardName), helpers.DimensionsBucketLSM)
 }
 
-// usageFileName lives in the shard root, which is also the directory whose
-// files CalculateNonLSMStorage adds up. It must therefore be excluded there,
-// otherwise the reported size depends on whether a usage calculation ran before.
+// usageFileName lives in the shard root that CalculateNonLSMStorage sums, so it
+// must be excluded there or the reported size grows once usage has been calculated.
 const usageFileName = "usage.json.tmp"
 
 func usageTmpFilePath(indexPath, shardName string) string {

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -293,7 +293,7 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 		return 0, 0, err
 	}
 
-	// Add sizes of all files in the shard root directory
+	// Add sizes of the shard root's files, skipping our own usage cache
 	for name, size := range files {
 		if name == usageFileName {
 			continue

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -44,8 +44,13 @@ func shardPathDimensionsLSM(indexPath, shardName string) string {
 	return path.Join(shardPathLSM(indexPath, shardName), helpers.DimensionsBucketLSM)
 }
 
+// usageFileName lives in the shard root, which is also the directory whose
+// files CalculateNonLSMStorage adds up. It must therefore be excluded there,
+// otherwise the reported size depends on whether a usage calculation ran before.
+const usageFileName = "usage.json.tmp"
+
 func usageTmpFilePath(indexPath, shardName string) string {
-	return path.Join(indexPath, shardName, "usage.json.tmp")
+	return path.Join(indexPath, shardName, usageFileName)
 }
 
 // ComputedUsageDataExists checks if pre-calculated shard usage data file exists
@@ -290,7 +295,10 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 	}
 
 	// Add sizes of all files in the shard root directory
-	for _, size := range files {
+	for name, size := range files {
+		if name == usageFileName {
+			continue
+		}
 		otherNonLSMFoldersStorageSize += uint64(size)
 	}
 	for _, dir := range dirs {

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -434,6 +434,44 @@ func TestCalculateNonLSMStorage_HFreshOneLevelDeep(t *testing.T) {
 	assert.Equal(t, uint64(0), otherNonLSMFoldersStorageSize, "no other storage expected")
 }
 
+// TestCalculateNonLSMStorage_ExcludesUsageCacheFile pins a self-reference that made
+// cold shard usage non-idempotent: SaveComputedUsageData writes its cache into the
+// shard root, and CalculateNonLSMStorage adds up every file it finds there. The same
+// shard with the same data therefore reported a larger size once a usage calculation
+// had run before, which surfaced as hot and cold reports disagreeing by exactly the
+// size of the cache file.
+func TestCalculateNonLSMStorage_ExcludesUsageCacheFile(t *testing.T) {
+	dirName := t.TempDir()
+	shardPath := filepath.Join(dirName, "shard1")
+	require.NoError(t, os.MkdirAll(shardPath, 0o777))
+
+	// files a real shard root holds next to lsm/ and the commitlog directories
+	rootFiles := map[string]int{"proplengths": 169, "indexcount": 8, "version": 2}
+	expected := uint64(0)
+	for name, size := range rootFiles {
+		require.NoError(t, os.WriteFile(filepath.Join(shardPath, name), make([]byte, size), 0o644))
+		expected += uint64(size)
+	}
+
+	_, before, err := CalculateNonLSMStorage(dirName, "shard1")
+	require.NoError(t, err)
+	assert.Equal(t, expected, before)
+
+	require.NoError(t, SaveComputedUsageData(dirName, "shard1", &types.ShardUsage{
+		Name:                  "shard1",
+		ObjectsCount:          100,
+		FullShardStorageBytes: before,
+	}))
+
+	cacheSize, err := os.Stat(usageTmpFilePath(dirName, "shard1"))
+	require.NoError(t, err)
+	require.Positive(t, cacheSize.Size())
+
+	_, after, err := CalculateNonLSMStorage(dirName, "shard1")
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "calculating usage must not change the size it reports")
+}
+
 // TestCalculateUnloadedDimensionsUsage_Concurrent pins the "bucket already registered" error:
 // concurrent usage reports (overlapping periodic collections, /debug/usage) used to open the
 // same unloaded dimensions bucket at once, which lsmkv's GlobalBucketRegistry rejects.

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -434,18 +434,14 @@ func TestCalculateNonLSMStorage_HFreshOneLevelDeep(t *testing.T) {
 	assert.Equal(t, uint64(0), otherNonLSMFoldersStorageSize, "no other storage expected")
 }
 
-// TestCalculateNonLSMStorage_ExcludesUsageCacheFile pins a self-reference that made
-// cold shard usage non-idempotent: SaveComputedUsageData writes its cache into the
-// shard root, and CalculateNonLSMStorage adds up every file it finds there. The same
-// shard with the same data therefore reported a larger size once a usage calculation
-// had run before, which surfaced as hot and cold reports disagreeing by exactly the
-// size of the cache file.
+// TestCalculateNonLSMStorage_ExcludesUsageCacheFile pins a self-reference: SaveComputedUsageData
+// writes its cache into the shard root that CalculateNonLSMStorage sums, so the same unchanged
+// shard reported a larger size once a usage calculation had run.
 func TestCalculateNonLSMStorage_ExcludesUsageCacheFile(t *testing.T) {
 	dirName := t.TempDir()
 	shardPath := filepath.Join(dirName, "shard1")
 	require.NoError(t, os.MkdirAll(shardPath, 0o777))
 
-	// files a real shard root holds next to lsm/ and the commitlog directories
 	rootFiles := map[string]int{"proplengths": 169, "indexcount": 8, "version": 2}
 	expected := uint64(0)
 	for name, size := range rootFiles {


### PR DESCRIPTION
SuperClaude here.

## Motivation

Calculating a cold shard's usage wrote files into the very directories it was measuring, so calculating the usage of unchanged data a second time reported a bigger shard than the first time.

Two sources, both counted into `full_shard_storage_bytes`:

| # | What is written | Where | Counted by |
|---|---|---|---|
| 1 | `usage.json.tmp`, the usage cache `SaveComputedUsageData` saves at the end of the calculation | shard root | `CalculateNonLSMStorage`, which sums **every** file in the shard root |
| 2 | a bloom filter materialised when the dimensions bucket is opened | `lsm/dimensions/` | `CalculateUnloadedIndicesSize`, which had already run by then |

This is not transient noise. `calculateUnloadedShardUsage` ends by saving its result, so an inflated figure is written back into the cache and served from there on every later report, until the shard is loaded again (the only thing that removes the cache). Measured on a stock `docker-compose-test.yml` node:

```
true value             : 43954
after one cache miss   : 44334   (+380)
two further reads      : 44334, 44334   <- error persists
```

A cache miss is not exotic. `LoadComputedUsageData` rejects a cache written by a different `types.UsageDiskVersion`, so the first report after any upgrade that bumps that version recomputes for every cold shard, with the stale cache file sitting on disk being counted. Concurrent reports race the same way: `ComputedUsageDataExists` and `CalculateNonLSMStorage` are separated by the whole calculation, so a report can check "no cache" and then measure a directory another report has meanwhile written its cache into.

## Who reads this number

`full_shard_storage_bytes` is not debug-only:

- `usecases/modulecomponents/usage/base_module.go` collects it on a ticker and `UploadUsageData`s the report — that is the `usage-gcs` / `usage-s3` metering path.
- `DB.totalShardSizeBytes` (`adapters/repos/db/init.go`) reads the same cached value to decide lazy-shard loading against a size threshold.
- `/debug/usage`.

## How it surfaced

`acceptance large (python)` going red on unrelated branches, in `test/acceptance_with_python/test_usage.py`:

- `test_object_storage`: `assert 151921 == 151537` — a +384 difference between the hot and the cold report.
- `test_usage_with_caching`: two back-to-back reports of the same *inactive* shard differing by 603 bytes, with `objects_storage_bytes`, `vector_storage_bytes` and `index_storage_bytes` all identical.

384 bytes is exactly the size of `usage.json.tmp` for that shard. The suite runs `pytest -n auto`, every worker's `get_debug_usage()` walks all collections on the node, so several full usage scans are in flight at once and race over the same cache files.

## Measurement

Reproduced on an **unmodified** `stable/v1.37` image (no other branch's code involved), with 8 concurrent `/debug/usage` pollers standing in for the xdist workers, running the `test_object_storage` sequence repeatedly:

| Image | Rounds failing hot == cold | Observed delta |
|---|---|---|
| `stable/v1.37`, unmodified | 2 / 20 | +384 |
| this branch | 0 / 30 | — |

The failing rounds print `cold_full=151921 hot_full=151537`, the same two numbers as CI. Forcing the cache miss deterministically instead of racing for it:

| | `objects` | `vector` | `index` | `full` |
|---|---|---|---|---|
| before | +0 | +0 | **+36** | **+36** |
| after | +0 | +0 | +0 | +0 |

`test_usage.py` passes 16/16 on three consecutive runs against the fixed image.

## Design decisions

- **Exclude the cache from the sum rather than move the file.** Moving `usage.json.tmp` out of the shard directory would orphan it on shard drop and on the offload/onload paths. The file belongs with the shard; it just is not shard data.
- **Reorder rather than re-measure.** Opening the dimensions bucket now happens before any size is taken, so a report describes the tree as it stands once the calculation is finished. Measuring twice and taking the second reading would cost a second walk of every bucket directory for the same result.
- **No test assertion was weakened.** `test_object_storage` asserts hot and cold agree byte for byte. That assertion was right and the product was wrong; it holds in 30/30 repro rounds and 3 full suite runs once the observer effect is gone.

## Risks

The reordering changes when the dimensions bucket is opened relative to the object/vector/index measurements. Cold-path only. If the bucket fails to open, the report now fails before measuring rather than after — same error, earlier.

Reported sizes for cold shards will drop by a few hundred bytes per shard wherever a stale inflated value was cached. That is a correction, not a regression, but it is a visible change in the uploaded reports.

## What to look at hardest

`calculateUnloadedShardUsage` in `adapters/repos/db/index_usage.go` — whether moving `CalculateUnloadedDimensionsUsageAll` above the measurement block has any ordering dependency I missed. `dimensionalitiesAll` is only consumed further down when building `namedVectors`, and `uncompressedVectorSize` is still derived there, so the move should be inert, but that is the load-bearing part of the change.

Also worth a second opinion: `TestIndex_UsageForCollection_IsIdempotent` corrupts the cache to force recomputation. That models the version-mismatch and torn-read paths; it does not model the TOCTOU race between two concurrent reports, which stays unpinned.

## Not fixed here

The same shape exists elsewhere and is deliberately left alone, because I did not measure it:

- LSM compaction and memtable flush write `*.db.tmp` alongside the segment being rewritten, and every bucket-directory sum counts both. That transiently double counts a segment mid-compaction on the hot path. Cold shards do not compact, so it does not affect the cold path in steady state.
- `JsonShardMetaData.lockFreeFlush` writes `proplengths.tmp` then renames, so a shard-root walk landing inside that window counts `proplengths` twice.

Unlike `usage.json.tmp`, those files are duplicates of real data genuinely occupying disk at that instant, so counting them is at least defensible.



Fixes [weaviate/0-weaviate-issues#314](https://github.com/weaviate/0-weaviate-issues/issues/314).

— SuperClaude

