### PR TITLE
fix(replica): make read repair converge and stop older tombstones destroying newer objects

### DIFF
--- a/adapters/repos/db/replication_nonadvancing_delete_integration_test.go
+++ b/adapters/repos/db/replication_nonadvancing_delete_integration_test.go
@@ -1,0 +1,95 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// Read repair in usecases/replica/repairer.go repairs a replica that is still live at the
+// winning tombstone's own time by sending a delete whose stale time and deletion time are
+// both that same time. Should the receiver ever start requiring a delete to advance the
+// update time, that repair would be refused on every read and repeat forever instead of
+// converging, so the acceptance below is load-bearing for it.
+func TestOverwriteObjectsAcceptsNonAdvancingDelete(t *testing.T) {
+	ctx := testCtx()
+
+	class := &models.Class{
+		Class:               "NonAdvancingDelete",
+		InvertedIndexConfig: invertedConfig(),
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
+		},
+	}
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false, func(i *Index) {
+			i.Config.DeletionStrategy = models.ReplicationConfigDeletionStrategyTimeBasedResolution
+		})
+
+	id := strfmt.UUID("981c09f9-67f3-4e6e-a988-c53eaefbd58e")
+
+	// T is both the live object's update time and the incoming delete's time.
+	const T = int64(1785156684275)
+
+	require.NoError(t, shd.PutObject(ctx, &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:                 id,
+			Class:              class.Class,
+			CreationTimeUnix:   T,
+			LastUpdateTimeUnix: T,
+			Properties:         map[string]interface{}{"name": "still live"},
+		},
+		Vector: []float32{1, 2, 3},
+	}))
+
+	digest, err := shd.ObjectDigestErrDeleted(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, T, digest.UpdateTime, "fixture must hold a live object at T")
+
+	res, err := idx.OverwriteObjects(ctx, shd.Name(), []*objects.VObject{
+		{
+			ID:                      id,
+			Deleted:                 true,
+			LastUpdateTimeUnixMilli: T,
+			StaleUpdateTime:         T,
+		},
+	})
+	require.NoError(t, err)
+	require.Empty(t, res, "a delete that does not advance the update time must not be refused")
+
+	deleted, deletionTime, err := shd.WasDeleted(ctx, id)
+	require.NoError(t, err)
+	require.True(t, deleted, "object must be gone at rest")
+	require.Equal(t, T, deletionTime.UnixMilli())
+
+	found, err := shd.ObjectByID(ctx, id, nil, additional.Properties{})
+	require.NoError(t, err)
+	require.Nil(t, found)
+}

--- a/adapters/repos/db/replication_nonadvancing_delete_integration_test.go
+++ b/adapters/repos/db/replication_nonadvancing_delete_integration_test.go
@@ -27,11 +27,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-// Read repair in usecases/replica/repairer.go repairs a replica that is still live at the
-// winning tombstone's own time by sending a delete whose stale time and deletion time are
-// both that same time. Should the receiver ever start requiring a delete to advance the
-// update time, that repair would be refused on every read and repeat forever instead of
-// converging, so the acceptance below is load-bearing for it.
+// Pins that OverwriteObjects accepts a delete whose time does not advance the
+// update time: read repair (usecases/replica/repairer.go) sends exactly that
+// when healing a replica still live at the tombstone's own time, and refusing
+// it would leave that repair looping on every read instead of converging.
 func TestOverwriteObjectsAcceptsNonAdvancingDelete(t *testing.T) {
 	ctx := testCtx()
 

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -303,3 +303,8 @@ type BatchReply struct {
 func (r BatchReply) UpdateTimeAt(idx int) int64 {
 	return r.DigestData[idx].UpdateTime
 }
+
+// DeletedAt reports whether this replica holds a tombstone for the object at idx
+func (r BatchReply) DeletedAt(idx int) bool {
+	return r.DigestData[idx].Deleted
+}

--- a/usecases/replica/finder_stream_consistency_internal_test.go
+++ b/usecases/replica/finder_stream_consistency_internal_test.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// Pins weaviate/0-weaviate-issues#385: an object must not be reported consistent
+// while a replica still holds a tombstone the strategy refuses to overrule.
+func TestReadBatchPartIsConsistentThreeTier(t *testing.T) {
+	const (
+		shard = "S1"
+		node  = "A"
+
+		tContent   = int64(100)
+		tTombstone = int64(200)
+		tWinner    = int64(300)
+	)
+
+	id := strfmt.UUID("00000000-0000-0000-0000-0000000000aa")
+	ids := []strfmt.UUID{id}
+
+	for _, order := range [][]string{{"A", "B", "C"}, {"A", "C", "B"}} {
+		t.Run(fmt.Sprintf("digest order %v", order), func(t *testing.T) {
+			ctx := context.Background()
+			c := newFakeReplicas(models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+				[]string{"A", "B", "C"})
+			c.put("A", id, tContent, false)
+			c.put("B", id, tTombstone, true)
+			c.put("C", id, tWinner, false)
+
+			logger, _ := test.NewNullLogger()
+			f := &finderStream{repairer: *c.newRepairer(t), log: logger}
+
+			data := []*storobj.Object{{
+				MarshallerVersion: 1,
+				Object:            models.Object{ID: id, LastUpdateTimeUnix: tContent},
+				BelongsToNode:     node,
+				BelongsToShard:    shard,
+			}}
+			batch := ShardPart{Shard: shard, Node: node, Data: data, Index: []int{0}}
+
+			votes := c.votes(order, ids)
+			ch := make(chan Result[BatchReply], len(votes))
+			for _, v := range votes {
+				ch <- Result[BatchReply]{Value: v.BatchReply}
+			}
+			close(ch)
+
+			require.NoError(t, <-f.readBatchPart(ctx, batch, ids, ch, len(votes)))
+
+			t.Logf("isConsistent=%v; A=%+v B=%+v C=%+v",
+				data[0].IsConsistent, c.get("A", id), c.get("B", id), c.get("C", id))
+
+			assert.False(t, data[0].IsConsistent,
+				"object reported consistent while a replica still holds an unresolved tombstone")
+		})
+	}
+}

--- a/usecases/replica/finder_stream_consistency_internal_test.go
+++ b/usecases/replica/finder_stream_consistency_internal_test.go
@@ -25,8 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-// Pins weaviate/0-weaviate-issues#385: an object must not be reported consistent
-// while a replica still holds a tombstone the strategy refuses to overrule.
+// Pins weaviate/0-weaviate-issues#385: don't report consistent while a replica still holds an unresolved tombstone.
 func TestReadBatchPartIsConsistentThreeTier(t *testing.T) {
 	const (
 		shard = "S1"

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -400,12 +400,14 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 	for i, vote := range votes {
 		if i != contentIdx {
 			for j, x := range vote.DigestData {
+				// Deleted must describe the winning version: OR-ing it across
+				// replies would make it depend on digest RPC completion order.
 				if curTime := lastTimes[j].T; x.UpdateTime > curTime {
 					// input object is not up to date
-					lastTimes[j] = iTuple{S: i, O: j, T: x.UpdateTime}
+					lastTimes[j] = iTuple{S: i, O: j, T: x.UpdateTime, Deleted: x.Deleted}
+				} else if x.UpdateTime == curTime {
+					lastTimes[j].Deleted = lastTimes[j].Deleted || x.Deleted
 				}
-
-				lastTimes[j].Deleted = lastTimes[j].Deleted || x.Deleted
 
 				if x.Deleted && x.UpdateTime > lastDeletionTimes[j] {
 					lastDeletionTimes[j] = x.UpdateTime
@@ -417,10 +419,16 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 	}
 
 	// An object needs content only if some replica disagrees with the winner and
-	// will therefore be written to. Same condition the repair loop below applies.
+	// will therefore be written to. Same condition the repair loop below applies,
+	// including its skip of a replica whose tombstone the strategy will not
+	// overrule: that replica disagrees on every read, and counting it here would
+	// fetch content no write ever consumes.
 	needsContent := make([]bool, len(ids))
 	for _, vote := range votes {
 		for j := range ids {
+			if vote.DeletedAt(j) && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
+				continue
+			}
 			if vote.UpdateTimeAt(j) != lastTimes[j].T {
 				needsContent[j] = true
 			}
@@ -537,9 +545,7 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 			deleted := x.Deleted && lastDeletionTimes[j] == x.T
 
 			if x.Deleted && deletionStrategy == models.ReplicationConfigDeletionStrategyDeleteOnConflict {
-				alreadyDeleted := vote.DigestData[j].Deleted
-
-				if alreadyDeleted && lastDeletionTimes[j] == vote.UpdateTimeAt(j) {
+				if vote.DeletedAt(j) && lastDeletionTimes[j] == vote.UpdateTimeAt(j) {
 					continue
 				}
 
@@ -560,6 +566,15 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 				continue
 			}
 
+			// Overwriting is refused with "conflict" here, so skip only this replica:
+			// the merely stale ones stay repairable and the round converges instead of
+			// repeating on every read. The vote is withdrawn because that refusal used
+			// to be what kept the object from counting as consistent.
+			if vote.DeletedAt(j) && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
+				votes[rid].Count[j]--
+				continue
+			}
+
 			if !deleted && result[j] == nil {
 				// only a write carrying content needs the winning object, and it
 				// could not be fetched
@@ -568,7 +583,13 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 
 			cTime := vote.UpdateTimeAt(j)
 
-			if x.T != cTime && vote.Count[j] == nVotes {
+			// Matching update times are not enough when the tie was broken in
+			// favour of the tombstone: a replica still holding the live version
+			// differs from the winner, and no later round can tell, because the
+			// times keep matching.
+			outdated := x.T != cTime || (deleted && !vote.DeletedAt(j))
+
+			if outdated && vote.Count[j] == nVotes {
 				var latestObject *models.Object
 				var vector []float32
 				var vectors map[string][]float32

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -419,10 +419,9 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 	}
 
 	// An object needs content only if some replica disagrees with the winner and
-	// will therefore be written to. Same condition the repair loop below applies,
-	// including its skip of a replica whose tombstone the strategy will not
-	// overrule: that replica disagrees on every read, and counting it here would
-	// fetch content no write ever consumes.
+	// will therefore be written to (same condition as the repair loop below).
+	// This also skips a replica whose tombstone won't be overruled: it always
+	// disagrees, so counting it would fetch content no write ever consumes.
 	needsContent := make([]bool, len(ids))
 	for _, vote := range votes {
 		for j := range ids {

--- a/usecases/replica/repairer_convergence_internal_test.go
+++ b/usecases/replica/repairer_convergence_internal_test.go
@@ -425,8 +425,32 @@ func TestRepairBatchPartNewestTombstoneIsNotResurrected(t *testing.T) {
 				c.put("B", id, tTombstone, true)
 				c.put("C", id, tc.cLive, false)
 
+				vs := c.votes(order, ids)
+
+				// The tie rows are the only ones that reach the "live at the
+				// winning tombstone's own time" half of the repair condition.
+				// Replica times are set directly above rather than produced by a
+				// write, so nothing about when an object write advances its
+				// timestamp can quietly dissolve the tie; assert it anyway, because
+				// a row that stops tying still passes on final state alone.
+				if tc.cLive == tTombstone {
+					var tombstone, liveAtTie bool
+					for _, v := range vs {
+						if v.UpdateTimeAt(0) != tTombstone {
+							continue
+						}
+						if v.DeletedAt(0) {
+							tombstone = true
+						} else {
+							liveAtTie = true
+						}
+					}
+					require.True(t, tombstone && liveAtTie,
+						"fixture no longer ties a live replica with the winning tombstone, so the condition under test is unreachable")
+				}
+
 				r := c.newRepairer(t)
-				_, err := r.repairBatchPart(ctx, shard, ids, c.votes(order, ids), 0)
+				_, err := r.repairBatchPart(ctx, shard, ids, vs, 0)
 				require.NoError(t, err)
 
 				got := map[string]replicaObj{}

--- a/usecases/replica/repairer_convergence_internal_test.go
+++ b/usecases/replica/repairer_convergence_internal_test.go
@@ -1,0 +1,443 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+type replicaObj struct {
+	updateTime int64
+	deleted    bool
+}
+
+// fakeReplicas is stateful so a second repair round observes what the first one
+// did, which a per-call mock cannot express. Overwrite mirrors
+// (*Index).OverwriteObjects in adapters/repos/db/replication.go; locked because
+// repairBatchPart fans out one goroutine per replica.
+type fakeReplicas struct {
+	strategy string
+
+	mu                sync.Mutex
+	state             map[string]map[strfmt.UUID]replicaObj
+	fetchedObjects    int
+	overwriteAttempts int
+	overwritesApplied int
+}
+
+func newFakeReplicas(strategy string, nodes []string) *fakeReplicas {
+	c := &fakeReplicas{strategy: strategy, state: map[string]map[strfmt.UUID]replicaObj{}}
+	for _, n := range nodes {
+		c.state[n] = map[strfmt.UUID]replicaObj{}
+	}
+	return c
+}
+
+func (c *fakeReplicas) put(node string, id strfmt.UUID, updateTime int64, deleted bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.state[node][id] = replicaObj{updateTime: updateTime, deleted: deleted}
+}
+
+func (c *fakeReplicas) get(node string, id strfmt.UUID) replicaObj {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.state[node][id]
+}
+
+func (c *fakeReplicas) counters() (fetched, attempted, applied int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fetchedObjects, c.overwriteAttempts, c.overwritesApplied
+}
+
+func (c *fakeReplicas) replica(node string, id strfmt.UUID) Replica {
+	x := c.get(node, id)
+	if x.deleted || x.updateTime == 0 {
+		return Replica{ID: id, Deleted: x.deleted, LastUpdateTimeUnixMilli: x.updateTime}
+	}
+	return Replica{ID: id, Object: &storobj.Object{
+		MarshallerVersion: 1,
+		Object:            models.Object{ID: id, LastUpdateTimeUnix: x.updateTime},
+	}}
+}
+
+func (c *fakeReplicas) fetch(node string, ids []strfmt.UUID) []Replica {
+	c.mu.Lock()
+	c.fetchedObjects += len(ids)
+	c.mu.Unlock()
+
+	rs := make([]Replica, len(ids))
+	for i, id := range ids {
+		rs[i] = c.replica(node, id)
+	}
+	return rs
+}
+
+func (c *fakeReplicas) overwrite(node string, ups []*objects.VObject) []types.RepairResponse {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	timeBased := c.strategy == models.ReplicationConfigDeletionStrategyTimeBasedResolution
+	var out []types.RepairResponse
+	for _, u := range ups {
+		c.overwriteAttempts++
+
+		id := u.ID
+		if id == "" && u.LatestObject != nil {
+			id = u.LatestObject.ID
+		}
+		cur := c.state[node][id]
+		conflict := types.RepairResponse{
+			ID: id.String(), Deleted: cur.deleted, UpdateTime: cur.updateTime, Err: "conflict",
+		}
+
+		if cur.updateTime != u.StaleUpdateTime {
+			if cur.updateTime == u.LastUpdateTimeUnixMilli {
+				continue // already at the target version
+			}
+			if !cur.deleted || !timeBased || cur.updateTime > u.LastUpdateTimeUnixMilli {
+				out = append(out, conflict)
+				continue
+			}
+		}
+		if !u.Deleted && cur.deleted && (!timeBased || cur.updateTime > u.LastUpdateTimeUnixMilli) {
+			out = append(out, conflict)
+			continue
+		}
+
+		c.state[node][id] = replicaObj{updateTime: u.LastUpdateTimeUnixMilli, deleted: u.Deleted}
+		c.overwritesApplied++
+	}
+	return out
+}
+
+// votes builds one round of replica replies. order[0] is the caller's own copy,
+// the rest are digest reads in RPC completion order: coordinator.Pull appends
+// them in exactly that order, so arrival order is an input to repair, not a
+// constant.
+func (c *fakeReplicas) votes(order []string, ids []strfmt.UUID) []Vote {
+	vs := make([]Vote, 0, len(order))
+	for i, node := range order {
+		local := i == 0
+		digest := make([]types.RepairResponse, len(ids))
+		for j, id := range ids {
+			x := c.get(node, id)
+			d := types.RepairResponse{ID: id.String(), UpdateTime: x.updateTime, Deleted: x.deleted}
+			if local {
+				// ShardPart.Digests never reports Deleted: the caller's copy is a
+				// search result, so it is always live.
+				d.Deleted = false
+			}
+			digest[j] = d
+		}
+		vs = append(vs, Vote{
+			BatchReply: BatchReply{Sender: node, IsLocal: local, DigestData: digest},
+			Count:      make([]int, len(ids)),
+		})
+	}
+	return vs
+}
+
+func (c *fakeReplicas) newRepairer(t *testing.T) *repairer {
+	t.Helper()
+	rc := NewMockRClient(t)
+	rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, host, _, _ string, ids []strfmt.UUID) ([]Replica, error) {
+			return c.fetch(host, ids), nil
+		}).Maybe()
+	rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, host, _, _ string, ups []*objects.VObject) ([]types.RepairResponse, error) {
+			return c.overwrite(host, ups), nil
+		}).Maybe()
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	return &repairer{
+		class:               "C1",
+		getDeletionStrategy: func() string { return c.strategy },
+		client:              NewFinderClient(rc, logger),
+		metrics:             metrics,
+		logger:              logger,
+	}
+}
+
+// Pins weaviate/0-weaviate-issues#385: repeated read repair over an unchanging
+// three-tier divergence (stale live content, tombstone, newer live winner) must
+// terminate rather than re-fetch the same objects on every read.
+func TestRepairBatchPartConverges(t *testing.T) {
+	const (
+		shard      = "S1"
+		numObjects = 5
+		numReads   = 10
+
+		tContent   = int64(100)
+		tTombstone = int64(200)
+		tWinner    = int64(300)
+	)
+
+	ids := make([]strfmt.UUID, numObjects)
+	for i := range ids {
+		ids[i] = strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000000%02d", i))
+	}
+
+	cases := []struct {
+		name     string
+		order    []string // [content, digest…] in RPC completion order
+		strategy string
+		// Replicas a single repair round has to write. Bounds the write axis the
+		// way numObjects bounds the fetch axis.
+		staleReplicas int
+	}{
+		{
+			name:     "tombstone digest arrives before the winner",
+			order:    []string{"A", "B", "C"},
+			strategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			// Only the content replica: writing to the tombstone is refused.
+			staleReplicas: 1,
+		},
+		{
+			name:          "tombstone digest arrives after the winner",
+			order:         []string{"A", "C", "B"},
+			strategy:      models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			staleReplicas: 1,
+		},
+		{
+			name:     "tombstone digest arrives after the winner, time based",
+			order:    []string{"A", "C", "B"},
+			strategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+			// The tombstone loses to the newer write, so it is repairable too.
+			staleReplicas: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			c := newFakeReplicas(tc.strategy, []string{"A", "B", "C"})
+			for _, id := range ids {
+				c.put("A", id, tContent, false)
+				c.put("B", id, tTombstone, true)
+				c.put("C", id, tWinner, false)
+			}
+			r := c.newRepairer(t)
+
+			fetchesPerRead := make([]int, 0, numReads)
+			for read := 0; read < numReads; read++ {
+				// A read only sees objects the content replica still serves.
+				live := make([]strfmt.UUID, 0, len(ids))
+				for _, id := range ids {
+					if x := c.get("A", id); !x.deleted && x.updateTime != 0 {
+						live = append(live, id)
+					}
+				}
+				if len(live) == 0 {
+					break
+				}
+				before, _, _ := c.counters()
+				_, err := r.repairBatchPart(ctx, shard, live, c.votes(tc.order, live), 0)
+				require.NoError(t, err)
+				after, _, _ := c.counters()
+				fetchesPerRead = append(fetchesPerRead, after-before)
+			}
+
+			fetched, attempted, applied := c.counters()
+			t.Logf("fetches per read: %v (total %d), overwrites attempted %d applied %d",
+				fetchesPerRead, fetched, attempted, applied)
+
+			// Anti-vacuity: without a fetch, every bound below holds trivially.
+			require.NotEmpty(t, fetchesPerRead, "no read was performed")
+			require.Positive(t, fetched, "fixture never reached the fetch path")
+
+			assert.Positive(t, attempted,
+				"repair transferred object content but never attempted a write")
+			assert.LessOrEqual(t, attempted, tc.staleReplicas*numObjects,
+				"unbounded write amplification: total overwrite attempts exceed one repair round")
+			assert.Zero(t, fetchesPerRead[len(fetchesPerRead)-1],
+				"repair has not converged: still re-fetching content on the last read")
+			assert.LessOrEqual(t, fetched, numObjects,
+				"unbounded read amplification: total object fetches exceed one repair round")
+		})
+	}
+}
+
+// Pins the data-loss half of weaviate/0-weaviate-issues#385: under
+// DeleteOnConflict a tombstone that lost the race to a newer write must not be
+// propagated, or the winner is destroyed everywhere with no copy to heal from.
+func TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject(t *testing.T) {
+	const (
+		shard = "S1"
+
+		tContent   = int64(100)
+		tTombstone = int64(200)
+		tWinner    = int64(300)
+	)
+
+	id := strfmt.UUID("00000000-0000-0000-0000-0000000000ff")
+	ids := []strfmt.UUID{id}
+
+	for _, order := range [][]string{{"A", "B", "C"}, {"A", "C", "B"}} {
+		t.Run(fmt.Sprintf("digest order %v", order), func(t *testing.T) {
+			ctx := context.Background()
+			c := newFakeReplicas(models.ReplicationConfigDeletionStrategyDeleteOnConflict,
+				[]string{"A", "B", "C"})
+			c.put("A", id, tContent, false)
+			c.put("B", id, tTombstone, true)
+			c.put("C", id, tWinner, false)
+
+			r := c.newRepairer(t)
+			_, err := r.repairBatchPart(ctx, shard, ids, c.votes(order, ids), 0)
+			require.NoError(t, err)
+
+			t.Logf("after repair: A=%+v B=%+v C=%+v", c.get("A", id), c.get("B", id), c.get("C", id))
+
+			assert.Equal(t, replicaObj{updateTime: tWinner}, c.get("C", id),
+				"the winning live version was destroyed by an older tombstone")
+			assert.False(t, c.get("A", id).deleted,
+				"an older tombstone was propagated to the content replica")
+		})
+	}
+}
+
+// Pins the mirror image of TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject:
+// when the tombstone is the newest version, no strategy may resurrect the object
+// from an older live replica, and the outcome must not depend on digest arrival
+// order. Update times are millisecond resolution, so the tie row (a delete and a
+// write in the same millisecond) is an ordinary event, and it is the only place
+// where the fold has to break the tie in favour of the tombstone.
+func TestRepairBatchPartNewestTombstoneIsNotResurrected(t *testing.T) {
+	const (
+		shard = "S1"
+
+		tContent   = int64(100)
+		tLoser     = int64(200)
+		tTombstone = int64(300)
+	)
+
+	id := strfmt.UUID("00000000-0000-0000-0000-0000000000ab")
+	ids := []strfmt.UUID{id}
+
+	// A is the content replica and always holds a stale live version; B always
+	// holds the winning tombstone. cLive is the live version C votes with.
+	cases := []struct {
+		name     string
+		strategy string
+		cLive    int64
+		want     map[string]replicaObj
+	}{
+		{
+			// Refusing to resolve leaves the replicas divergent by design, so the
+			// live versions are expected to survive here. What must hold is that
+			// the tombstone is not overwritten by one of them.
+			name:     "tombstone newest, no automated resolution",
+			strategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			cLive:    tLoser,
+			want: map[string]replicaObj{
+				"A": {updateTime: tContent},
+				"B": {updateTime: tTombstone, deleted: true},
+				"C": {updateTime: tLoser},
+			},
+		},
+		{
+			name:     "tombstone newest, delete on conflict",
+			strategy: models.ReplicationConfigDeletionStrategyDeleteOnConflict,
+			cLive:    tLoser,
+			want: map[string]replicaObj{
+				"A": {updateTime: tTombstone, deleted: true},
+				"B": {updateTime: tTombstone, deleted: true},
+				"C": {updateTime: tTombstone, deleted: true},
+			},
+		},
+		{
+			name:     "tombstone newest, time based",
+			strategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+			cLive:    tLoser,
+			want: map[string]replicaObj{
+				"A": {updateTime: tTombstone, deleted: true},
+				"B": {updateTime: tTombstone, deleted: true},
+				"C": {updateTime: tTombstone, deleted: true},
+			},
+		},
+		{
+			name:     "tombstone ties with the newest write, no automated resolution",
+			strategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			cLive:    tTombstone,
+			want: map[string]replicaObj{
+				"A": {updateTime: tContent},
+				"B": {updateTime: tTombstone, deleted: true},
+				"C": {updateTime: tTombstone},
+			},
+		},
+		{
+			name:     "tombstone ties with the newest write, delete on conflict",
+			strategy: models.ReplicationConfigDeletionStrategyDeleteOnConflict,
+			cLive:    tTombstone,
+			want: map[string]replicaObj{
+				"A": {updateTime: tTombstone, deleted: true},
+				"B": {updateTime: tTombstone, deleted: true},
+				"C": {updateTime: tTombstone, deleted: true},
+			},
+		},
+		{
+			name:     "tombstone ties with the newest write, time based",
+			strategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+			cLive:    tTombstone,
+			want: map[string]replicaObj{
+				"A": {updateTime: tTombstone, deleted: true},
+				"B": {updateTime: tTombstone, deleted: true},
+				"C": {updateTime: tTombstone, deleted: true},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		for _, order := range [][]string{{"A", "B", "C"}, {"A", "C", "B"}} {
+			t.Run(fmt.Sprintf("%s/digest order %v", tc.name, order), func(t *testing.T) {
+				ctx := context.Background()
+				c := newFakeReplicas(tc.strategy, []string{"A", "B", "C"})
+				c.put("A", id, tContent, false)
+				c.put("B", id, tTombstone, true)
+				c.put("C", id, tc.cLive, false)
+
+				r := c.newRepairer(t)
+				_, err := r.repairBatchPart(ctx, shard, ids, c.votes(order, ids), 0)
+				require.NoError(t, err)
+
+				got := map[string]replicaObj{}
+				for _, node := range []string{"A", "B", "C"} {
+					got[node] = c.get(node, id)
+				}
+				t.Logf("after repair: %+v", got)
+
+				assert.Equal(t, tc.want, got,
+					"repair outcome depends on digest arrival order or resurrects a deleted object")
+			})
+		}
+	}
+}

--- a/usecases/replica/repairer_convergence_internal_test.go
+++ b/usecases/replica/repairer_convergence_internal_test.go
@@ -188,9 +188,8 @@ func (c *fakeReplicas) newRepairer(t *testing.T) *repairer {
 	}
 }
 
-// Pins weaviate/0-weaviate-issues#385: repeated read repair over an unchanging
-// three-tier divergence (stale live content, tombstone, newer live winner) must
-// terminate rather than re-fetch the same objects on every read.
+// Pins weaviate/0-weaviate-issues#385: repeated repair over an unchanging
+// three-tier divergence must converge, not re-fetch content every read.
 func TestRepairBatchPartConverges(t *testing.T) {
 	const (
 		shard      = "S1"
@@ -287,9 +286,8 @@ func TestRepairBatchPartConverges(t *testing.T) {
 	}
 }
 
-// Pins the data-loss half of weaviate/0-weaviate-issues#385: under
-// DeleteOnConflict a tombstone that lost the race to a newer write must not be
-// propagated, or the winner is destroyed everywhere with no copy to heal from.
+// Pins the data-loss half of weaviate/0-weaviate-issues#385: DeleteOnConflict
+// must not let an older tombstone destroy a newer live winner with no copy left to heal from.
 func TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject(t *testing.T) {
 	const (
 		shard = "S1"
@@ -325,12 +323,10 @@ func TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject(t *testing.T) {
 	}
 }
 
-// Pins the mirror image of TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject:
-// when the tombstone is the newest version, no strategy may resurrect the object
-// from an older live replica, and the outcome must not depend on digest arrival
-// order. Update times are millisecond resolution, so the tie row (a delete and a
-// write in the same millisecond) is an ordinary event, and it is the only place
-// where the fold has to break the tie in favour of the tombstone.
+// Mirror of TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject: the
+// newest tombstone must never be resurrected, for any strategy or digest
+// arrival order. Millisecond resolution makes update-time ties ordinary,
+// so this also covers the row where the tie favours the tombstone.
 func TestRepairBatchPartNewestTombstoneIsNotResurrected(t *testing.T) {
 	const (
 		shard = "S1"

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -76,19 +76,22 @@ func TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch(t *testing.T) {
 
 // TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch pins that a delete,
 // which carries no content, is propagated even when the content fetch fails.
-// Under DeleteOnConflict a replica's older tombstone deletes a live winner, so
-// the only pending write is a delete and no object read can be a precondition
-// for it.
+// The batch holds two objects: one C is stale on, whose winning content has to
+// be read from A, and one B's newer tombstone deletes. Only the read can fail,
+// and the delete must not be gated on it.
 func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 	const (
 		class = "C1"
 		shard = "S1"
-		// caller A holds the live winner, replica B an older tombstone
+		// A and C hold the live copy that B's newer tombstone deletes
 		liveTime = int64(100)
-		delTime  = int64(80)
+		delTime  = int64(150)
+		// C is stale on the read object, which is what forces the fetch
+		staleTime = int64(50)
 	)
-	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
-	ids := []strfmt.UUID{id}
+	readID := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+	delID := strfmt.UUID("00000000-0000-0000-0000-000000000def")
+	ids := []strfmt.UUID{readID, delID}
 
 	tests := []struct {
 		name       string
@@ -100,18 +103,25 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var fetches atomic.Int32
 			rc := NewMockRClient(t)
 			if tt.fetchFails {
 				rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(nil, errors.New("fetch failed")).Maybe()
+					RunAndReturn(func(context.Context, string, string, string, []strfmt.UUID) ([]Replica, error) {
+						fetches.Add(1)
+						return nil, errors.New("fetch failed")
+					}).Maybe()
 			} else {
 				rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return([]Replica{{
-						ID: id,
-						Object: &storobj.Object{Object: models.Object{
-							ID: id, Class: class, LastUpdateTimeUnix: liveTime,
-						}},
-					}}, nil).Maybe()
+					RunAndReturn(func(context.Context, string, string, string, []strfmt.UUID) ([]Replica, error) {
+						fetches.Add(1)
+						return []Replica{{
+							ID: readID,
+							Object: &storobj.Object{Object: models.Object{
+								ID: readID, Class: class, LastUpdateTimeUnix: liveTime,
+							}},
+						}}, nil
+					}).Maybe()
 			}
 
 			var (
@@ -140,15 +150,24 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 
 			votes := []Vote{
 				{BatchReply: BatchReply{Sender: "A", IsLocal: true, DigestData: []types.RepairResponse{
-					{ID: id.String(), UpdateTime: liveTime},
+					{ID: readID.String(), UpdateTime: liveTime},
+					{ID: delID.String(), UpdateTime: liveTime},
 				}}, Count: make([]int, len(ids))},
 				{BatchReply: BatchReply{Sender: "B", DigestData: []types.RepairResponse{
-					{ID: id.String(), UpdateTime: delTime, Deleted: true},
+					{ID: readID.String(), UpdateTime: liveTime},
+					{ID: delID.String(), UpdateTime: delTime, Deleted: true},
+				}}, Count: make([]int, len(ids))},
+				{BatchReply: BatchReply{Sender: "C", DigestData: []types.RepairResponse{
+					{ID: readID.String(), UpdateTime: staleTime},
+					{ID: delID.String(), UpdateTime: liveTime},
 				}}, Count: make([]int, len(ids))},
 			}
 
 			_, err = r.repairBatchPart(context.Background(), shard, ids, votes, 0)
 			_ = err // a failed fetch is reported, but it must not suppress the delete
+
+			require.NotZero(t, fetches.Load(),
+				"the read object must actually be fetched, otherwise this case tests nothing")
 
 			mu.Lock()
 			defer mu.Unlock()
@@ -157,6 +176,7 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 			require.Empty(t, captured["B"], "B already holds the winning tombstone")
 
 			got := captured["A"][0]
+			require.Equal(t, delID, got.ID)
 			require.True(t, got.Deleted)
 			require.Nil(t, got.LatestObject, "a delete carries no content")
 			require.Equal(t, delTime, got.LastUpdateTimeUnixMilli)

--- a/usecases/replica/repairer_stale_position_internal_test.go
+++ b/usecases/replica/repairer_stale_position_internal_test.go
@@ -1,0 +1,217 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// staleAt says where the replica that is behind sits relative to the reply
+// carrying the caller's copy.
+type staleAt int
+
+const (
+	// staleServesRead puts the replica that is behind at contentIdx: the node
+	// answering the read is the one holding the outdated version.
+	staleServesRead staleAt = iota
+	// stalePeer answers the read from a replica that already holds the winning
+	// version, leaving a peer behind.
+	stalePeer
+)
+
+// Read repair has to close the same divergence whether the replica that is
+// behind is the one serving the read or a peer. contentIdx marks the reply for
+// the copy the caller already holds, and it is the only reply lastTimes is
+// seeded from, so where the stale replica sits relative to it is an axis of its
+// own, independent of digest arrival order.
+//
+// Convergence here is both halves: the rounds stop doing work, and the replica
+// that was behind reached the winning version. A round that writes nothing also
+// stops doing work while leaving the replicas divergent forever, so the first
+// half alone is satisfied by repair doing nothing at all.
+func TestRepairBatchPartConvergesWhereverTheStaleReplicaSits(t *testing.T) {
+	const (
+		shard      = "S1"
+		numObjects = 5
+		numReads   = 10
+
+		tStale     = int64(100)
+		tTombstone = int64(200)
+		tWinner    = int64(300)
+	)
+
+	ids := make([]strfmt.UUID, numObjects)
+	for i := range ids {
+		ids[i] = strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000000%02d", i))
+	}
+
+	cases := []struct {
+		name     string
+		order    []string // order[0] serves the read, the rest in RPC completion order
+		position staleAt
+		strategy string
+		// Replicas a single repair round has to write. Bounds the write axis the
+		// way numObjects bounds the fetch axis.
+		staleReplicas int
+	}{
+		{
+			name:          "stale replica serves the read, tombstone digest first",
+			order:         []string{"A", "B", "C"},
+			position:      staleServesRead,
+			strategy:      models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			staleReplicas: 1,
+		},
+		{
+			name:          "stale replica serves the read, winner digest first",
+			order:         []string{"A", "C", "B"},
+			position:      staleServesRead,
+			strategy:      models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			staleReplicas: 1,
+		},
+		{
+			name:          "winner serves the read, tombstone digest first",
+			order:         []string{"C", "B", "A"},
+			position:      stalePeer,
+			strategy:      models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			staleReplicas: 1,
+		},
+		{
+			name:          "winner serves the read, stale digest first",
+			order:         []string{"C", "A", "B"},
+			position:      stalePeer,
+			strategy:      models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			staleReplicas: 1,
+		},
+		{
+			name:     "winner serves the read, time based",
+			order:    []string{"C", "A", "B"},
+			position: stalePeer,
+			strategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+			// The tombstone loses to the newer write, so it is repairable too.
+			staleReplicas: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			c := newFakeReplicas(tc.strategy, []string{"A", "B", "C"})
+			for _, id := range ids {
+				c.put("A", id, tStale, false)
+				c.put("B", id, tTombstone, true)
+				c.put("C", id, tWinner, false)
+			}
+			r := c.newRepairer(t)
+
+			reader := tc.order[0]
+			fetchesPerRead := make([]int, 0, numReads)
+			writesPerRead := make([]int, 0, numReads)
+
+			for read := 0; read < numReads; read++ {
+				// A read only sees objects the replica answering it still serves.
+				live := make([]strfmt.UUID, 0, len(ids))
+				for _, id := range ids {
+					if x := c.get(reader, id); !x.deleted && x.updateTime != 0 {
+						live = append(live, id)
+					}
+				}
+				if len(live) == 0 {
+					break
+				}
+
+				vs := c.votes(tc.order, live)
+				if read == 0 {
+					requireStalePosition(t, vs, tc.position)
+				}
+
+				f0, w0, _ := c.counters()
+				_, err := r.repairBatchPart(ctx, shard, live, vs, 0)
+				require.NoError(t, err)
+				f1, w1, _ := c.counters()
+				fetchesPerRead = append(fetchesPerRead, f1-f0)
+				writesPerRead = append(writesPerRead, w1-w0)
+			}
+
+			fetched, attempted, applied := c.counters()
+			t.Logf("fetches per read: %v, writes per read: %v (total fetched %d, attempted %d, applied %d)",
+				fetchesPerRead, writesPerRead, fetched, attempted, applied)
+
+			require.NotEmpty(t, fetchesPerRead, "no read was performed")
+
+			// Asserted before the bounds below, which a repair that never wrote
+			// anything satisfies while leaving the replicas divergent.
+			for _, id := range ids {
+				require.Equal(t, replicaObj{updateTime: tWinner}, c.get("A", id),
+					"the replica that was behind never reached the winning version")
+			}
+
+			// Anti-vacuity: without a fetch, every bound below holds trivially.
+			require.Positive(t, fetched, "fixture never reached the fetch path")
+
+			last := len(fetchesPerRead) - 1
+			assert.Zero(t, fetchesPerRead[last],
+				"repair has not converged: still re-fetching content on the last read")
+			assert.Zero(t, writesPerRead[last],
+				"repair has not converged: still writing on the last read")
+
+			assert.LessOrEqual(t, attempted, tc.staleReplicas*numObjects,
+				"unbounded write amplification: total overwrite attempts exceed one repair round")
+			assert.LessOrEqual(t, fetched, numObjects,
+				"unbounded read amplification: total object fetches exceed one repair round")
+			assert.Equal(t, attempted, applied,
+				"a repair write was refused, so the round spent an RPC that changed nothing")
+		})
+	}
+}
+
+// requireStalePosition asserts the fixture still builds the divergence its case
+// names. A fixture that stopped placing the stale replica where the case says
+// would still satisfy every convergence bound, because it would be exercising
+// the other arm twice.
+func requireStalePosition(t *testing.T, vs []Vote, position staleAt) {
+	t.Helper()
+
+	require.True(t, vs[0].IsLocal,
+		"vote 0 does not carry the caller's copy, so contentIdx no longer marks the replica serving the read")
+
+	var winning int64
+	for _, v := range vs {
+		if x := v.UpdateTimeAt(0); x > winning {
+			winning = x
+		}
+	}
+
+	behind := 0
+	for _, v := range vs {
+		if v.UpdateTimeAt(0) < winning {
+			behind++
+		}
+	}
+	require.Positive(t, behind,
+		"fixture no longer holds a replica behind the winner, so there is nothing to repair")
+
+	if position == staleServesRead {
+		require.Less(t, vs[0].UpdateTimeAt(0), winning,
+			"fixture no longer serves the read from the stale replica, so the condition under test is unreachable")
+		return
+	}
+	require.Equal(t, winning, vs[0].UpdateTimeAt(0),
+		"fixture no longer serves the read from a replica holding the winner, so the condition under test is unreachable")
+}

--- a/usecases/replica/repairer_stale_position_internal_test.go
+++ b/usecases/replica/repairer_stale_position_internal_test.go
@@ -36,16 +36,14 @@ const (
 	stalePeer
 )
 
-// Read repair has to close the same divergence whether the replica that is
-// behind is the one serving the read or a peer. contentIdx marks the reply for
-// the copy the caller already holds, and it is the only reply lastTimes is
-// seeded from, so where the stale replica sits relative to it is an axis of its
-// own, independent of digest arrival order.
+// Read repair must close the same divergence whether the stale replica serves
+// the read or is a peer: lastTimes seeds only from contentIdx's reply, so the
+// stale replica's position is an axis of its own, independent of digest order.
 //
-// Convergence here is both halves: the rounds stop doing work, and the replica
-// that was behind reached the winning version. A round that writes nothing also
-// stops doing work while leaving the replicas divergent forever, so the first
-// half alone is satisfied by repair doing nothing at all.
+// Both halves of convergence are asserted: the rounds stop doing work, and the
+// replica that was behind reached the winner. A round that writes nothing also
+// stops doing work, so on the write axis alone a repair that leaves the
+// replicas divergent forever is indistinguishable from one that succeeded.
 func TestRepairBatchPartConvergesWhereverTheStaleReplicaSits(t *testing.T) {
 	const (
 		shard      = "S1"


### PR DESCRIPTION
SuperClaude here.

Read repair can spin forever without converging, and an older tombstone can destroy a newer live object cluster-wide. Both are decided by the order two concurrent digest RPCs happen to complete in.

**Retargeted from `stable/v1.36` to `stable/v1.37`, rebased, and re-measured on the new base.** Fixes weaviate/0-weaviate-issues#385.

> ✅ **Resolved: the branch is green.** An earlier revision of this description called `TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch` (from [weaviate/weaviate#12355](https://github.com/weaviate/weaviate/issues/12355)) a semantics conflict needing a product decision. **That was a misreading and it is withdrawn.** Its doc comment shows the older-tombstone-beats-live-winner behaviour was the *scaffolding* used to construct a delete-only write, not the property under test. The test was re-scaffolded at `04048f16d` onto a two-object fixture; it now asserts exactly what its name claims, and no longer rests on a property this PR removes.

## Why `stable/v1.37`

The earlier plan was to backport 12355 to `stable/v1.36` and land here on top of it. That is now moot: v1.39 is being released, so v1.36 drops out of support shortly and **`stable/v1.37` is the fix base**.

Retargeting also dissolves the blocker that held this PR. The concern was that on v1.36, which lacks 12355's projection guard, this PR makes read repair *write* where it previously wrote nothing, turning a stale-but-intact replica into one overwritten with a projected search result. **`stable/v1.37` carries 12355** (`5caf508568`), so `BatchReply` no longer holds object content at all and that hazard cannot arise.

There is a second reason the retarget is the right direction, raised on this PR before the decision was made. This fix was going to be validated on v1.36 and then merged forward into lines with a **different input distribution** (see blast radius below). Landing it on v1.37 means it is validated on the line it ships to.

## The mechanism

The fixture is three replicas disagreeing in three tiers: a stale live content replica at `t=100`, a tombstone at `t=200`, and a strictly newer live winner at `t=300`. That is what a delete racing a later write leaves behind in a cluster that is already slightly behind.

`repairBatchPart` folds each digest reply into `lastTimes[j]`. The winner-replacement builds a fresh `iTuple` whose `Deleted` field defaults to `false`, and the OR on the next line runs *after* it. So `lastTimes[j].Deleted` does not mean "some replica holds a tombstone" — it means **"some replica *after the last replacement* said deleted"**. Which replicas fall after the last replacement is the completion order of the concurrent `DigestReads`, which `coordinator.Pull` appends to `replyCh` as they land.

Measured on `stable/v1.37`, three-tier fixture, 5 objects over 10 consecutive reads, `NoAutomatedResolution`:

| digest arrival order | object fetches per read | writes | outcome |
|---|---|---|---|
| tombstone **after** winner | `[0 0 0 0 0 0 0 0 0 0]` | 0 attempted | 🔴 stale replica never repaired, no round ever does anything |
| tombstone **before** winner | `[5 0 0 …]` | 10 attempted / 5 applied | 🔴 5 futile writes to the tombstone replica, refused as `conflict` |

The first row is the non-termination in its purest form: the condition that is true on entry is still true on exit, and no work in between advances it. That condition is

> **`contentReplica.UpdateTime(j) < max over replicas of UpdateTime(j)`**

Closing that gap is read repair's entire job. In this arrival order it declines to, forever.

The second row is louder on v1.37 than it was on v1.36, because 12355 now surfaces the refusal instead of dropping it: `B rejected the repair of [...]: source object changed during repair`.

## The fix

**Derive `Deleted` from the winning version** rather than OR-ing it across all replies, OR-ing only across replies that tie at the winning time. `Deleted` then holds *exactly* when `lastDeletionTimes[j] == lastTimes[j].T`, so the fetch gate and the write skip become the same predicate.

**Make the write skip per replica rather than per object.** A replica holding a tombstone the strategy will not overrule refuses the overwrite with `conflict`, so there is no point spending an RPC on it, but a merely stale replica alongside it stays repairable. `votes[rid].Count[j]--` withdraws that replica's vote, which is what the refusal used to do, so the object is still not reported consistent.

**Teach the `needsContent` pass the same skip.** This hunk is **new in the rebase and it is required**, not tidying. `needsContent` is 12355's; it decides which objects to fetch content for by asking whether any replica disagrees with the winner, and its comment claims it applies "the same condition the repair loop below applies". Once the repair loop grows a per-replica skip that is no longer true: a replica whose tombstone will not be overruled disagrees on every read forever. Without this hunk the fix transplants onto v1.37 and **does not converge**, see the table under Testing.

**Widen the outdated test.** Matching update times are not sufficient on their own: when the tie at the winning time was broken in favour of the tombstone, a replica still holding the live version differs from the winner while their times agree, and no later round can tell.

Measured after the fix, same fixture and both arrival orders:

| arm | fetches per read | writes |
|---|---|---|
| tombstone after winner | `[5 0 0 0 0 0 0 0 0 0]` | 5 attempted / 5 applied |
| tombstone before winner | `[5 0 0 0 0 0 0 0 0 0]` | 5 attempted / 5 applied |

Identical. The arrival-order dependence is gone rather than resolved in one direction.

## Resolved: the apparent `DeleteOnConflict` conflict was a fixture, not a disagreement

An earlier revision raised this as a product decision. It is not one, and the evidence is the conflicting test's own doc comment:

> *"pins that a delete, which carries no content, is propagated even when the content fetch fails. Under DeleteOnConflict a replica's older tombstone deletes a live winner, **so** the only pending write is a delete…"*

The subject is **delete propagation under a failed fetch**. The tombstone-beats-live-winner behaviour appears after a *"so"* — it is how the author reached a state where the only pending write was a delete. `liveTime=100, delTime=80` was chosen to get there, not asserted as desired semantics.

At `04048f16d` that test is re-scaffolded onto two objects and three replicas: one object whose winning content must be read from A (so the fetch that fails is real), and one that B's **newer** tombstone deletes. Every original assertion survives verbatim, plus `require.NotZero(fetches)` so the arm cannot silently go dead. The naive repair — simply making the tombstone newer on the single existing object — was tried and **rejected**: it yields `fetches=0`, collapsing both table rows into the same scenario and killing the `fetchFails` dimension entirely.

**What genuinely changes, and is the intended fix rather than an open question:** after this PR an older tombstone no longer destroys a newer live object under `DeleteOnConflict`. That is the [weaviate/0-weaviate-issues#385](https://github.com/weaviate/0-weaviate-issues/issues/385) data-loss fix. A tombstone at `t=100` against a live object at `t=300` is not a *conflict* — it is a clear happens-before, deleted then recreated. A tie-break strategy should decide cases with no ordering.

**And 12355's guard is not made redundant.** Moving its content guard back to its pre-12355 position still turns `TestRepairBatchSkipsContentTheStrategyDiscards` red — because this PR inserted the vote withdrawal at `repairer.go:573` into that same window. The *reason* for the guard changed; the guard stays.

## Blast radius

**The v1.34→main "`repairer.go` is byte-identical" argument from the previous revision of this description has been withdrawn.** It was true and it was not sufficient: a commit in a *different* file changes the distribution of inputs that reach this code, and byte-identical code over a different input distribution is a different experiment. No claim here is sourced from weaviate/0-weaviate-issues#375's version table, which was retracted in full.

The widened outdated test fires only on a timestamp tie between a live replica and the winning tombstone. [weaviate/weaviate#11866](https://github.com/weaviate/weaviate/issues/11866) (`0320ecdd0`, *"persist advanced update time when object content is unchanged"*) governs how often that tie arises, and its ancestry is not uniform:

| line | carries `0320ecdd0` | how ties arise |
|---|---|---|
| `stable/v1.36` | 🔴 no | an unchanged re-write leaves the timestamp alone, so that whole family of histories produces ties |
| `stable/v1.37` — **this base** | ✅ yes | that route is closed; ties come from a genuine same-millisecond delete and write |
| `stable/v1.38`, `main` | ✅ yes | as v1.37 |

So this branch is now validated on a line whose tie provenance matches every line it merges forward into. Everything claimed above is from execution on `stable/v1.37`.

The non-termination and data-loss mechanisms themselves do not depend on 11866, and both are **verified by execution on `stable/v1.37`** by reverting this diff and running the tests.

## Behaviour changes, release-note material

- **`DeleteOnConflict` stops deleting in this shape.** Where an older tombstone previously destroyed a newer live object on every replica, the newer object now survives and the tombstone stays put on its own replica. This is the intended fix and it is a real change in what the database does with existing data. The apparent conflict with 12355's test over this was a fixture problem, resolved above.
- **Stale-but-live replicas next to an unrelated tombstone now repair on the first read.** Previously they repaired on whatever fraction of reads landed in the winning arrival order, and never at all under systematic latency skew. Not a *new* behaviour, since the winning order already did this; the change removes the coin flip.

Under `NoAutomatedResolution` the delete/write conflict itself is still left unresolved. That is the strategy's contract and is unchanged.

## Known follow-up, not fixed here

`repairOne` computes `deleted` as "any replica holds a tombstone", so a single-object read at CL >= QUORUM in this shape still returns `ErrConflictExistOrDeleted` while the batch path now repairs and returns the object. That divergence exists today; this change slightly widens it. Left alone deliberately to keep the diff reviewable.

## Testing

Four tests kept, one dropped. Every kept test was proven to **fail without the fix and pass with it** by reverting the production files to pristine `stable/v1.37` and re-running.

| test | verdict | what proves it still bites on v1.37 |
|---|---|---|
| `TestRepairBatchPartConverges` | ✅ kept | red on both non-control arms: `after` fails `require.Positive(fetched)` at 0 fetches and 0 writes; `before` fails `require.NoError` on the surfaced `conflict` refusal. The time-based arm is the control and passes at red, by design. |
| `TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject` | ✅ kept | red both orders; `[A C B]` reproduces the destruction verbatim, all three replicas at `{200, deleted:true}` |
| `TestRepairBatchPartNewestTombstoneIsNotResurrected` | ✅ kept | red on exactly the two `ties + time based` rows, which is the only strategy that reaches the widened branch |
| `TestReadBatchPartIsConsistentThreeTier` | ✅ kept, **does not bite the baseline** | passes at red, because 12355's `resolved[i]` gating already makes the flag false. It is not vacuous: deleting `votes[rid].Count[j]--` flips it to `isConsistent=true` and the test fails. It guards this PR's own new hazard rather than the pre-existing bug. Stated rather than left for a reader to discover. |
| `TestRepairBatchPartLiveWinnerFailedRefetchNoPanic` | ❌ **dropped** | superseded. 12355 brought `TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch` with a byte-identical fixture and strictly stronger assertions, since it also pins the surfaced error and `resolved`. Keeping this one would have required inverting its `require.NoError`, at which point it is the 12355 test rewritten. |

**The `needsContent` hunk is load-bearing, measured not argued.** Removing only that hunk and keeping everything else:

| | fetches per read | writes |
|---|---|---|
| full fix | `[5 0 0 0 0 0 0 0 0 0]` | 5 attempted / 5 applied |
| without the `needsContent` skip | 🔴 `[5 5 5 5 5 5 5 5 5 5]`, 50 total | 5 attempted / 5 applied |

The write axis converges and the read axis does not. Transplanting the v1.36 fix verbatim would have produced a green-looking branch that still re-fetches on every read forever.

**Tie fixtures assert their own precondition.** Because 11866 makes tie provenance line-dependent, the tie rows now assert that a live replica and the winning tombstone actually share a timestamp before asserting on the outcome. These fixtures set replica times directly rather than deriving them from a write, so they are not exposed to 11866, but a row that stopped tying would otherwise still pass on final state alone. Verified by dissolving the tie by one millisecond and watching the precondition fail rather than the test quietly passing.

Checks on `303d30b24`, against `stable/v1.37`:

⚠️ `go test ./adapters/repos/db/ -race` **alone silently skips** this PR's integration test — it sits behind `//go:build integrationTest`. The tagged run is the only one that exercises it, so a green from the untagged command is not coverage.

| check | result |
|---|---|
| `go build ./...` | ✅ |
| `go test -race -timeout 30m ./adapters/repos/db/...` | ✅ |
| `go test -tags integrationTest -race -run TestOverwriteObjectsAcceptsNonAdvancingDelete` | ✅ |
| `go test -race -timeout 30m ./usecases/replica/...` | ✅ ok 254s, 403 tests, 0 data races |
| `tools/linter_error_groups.sh`, `linter_go_routines.sh`, `linter_waitgroups_done.sh` | ✅ all rc 0 |
| `gofumpt -l`, `goimports -l` | ✅ clean |

That package needs an explicit `-timeout`: it exceeds Go's default 10m under `-race` and panics with a stack trace that reads like a hang. Filed separately as weaviate/0-weaviate-issues#383.

**`go test ./adapters/repos/db/ -race` alone silently skips `TestOverwriteObjectsAcceptsNonAdvancingDelete`.** That test sits behind `//go:build integrationTest`, so an untagged run never compiles it, reports `ok` for the package, and gives you a green that contains no coverage of it at all. The `-tags integrationTest` row above is the only run that exercises it.

— SuperClaude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZEgmfbefao1Zz1EJCKuev


