### PR TITLE
Release shard references exactly once per acquire

### DIFF
--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -946,7 +946,7 @@ func TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks(t *testing.T
 	idx := newDescriptorTestIndex(t, rootDir, className, shardState)
 
 	mockShard := NewMockShardLike(t)
-	mockShard.EXPECT().preventShutdown().Return(nil, errors.New("shard is shutting down"))
+	mockShard.EXPECT().preventShutdown().Return(func() {}, errors.New("shard is shutting down"))
 	idx.shards.Store(shardName, mockShard)
 
 	_, err := idx.backupShardWithHardlinks(ctx, shardName, nil, t.TempDir())

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1202,7 +1202,8 @@ const (
 // getShardForDirectLocalOperation is used to try to get a shard for a local read/write operation.
 // It will return the shard if it is found, and a release function to release the shard.
 // The shard will be nil if the shard is not found, or if the local shard should not be used.
-// The caller should always call the release function.
+// The release function is never nil, including on error, so defer it immediately
+// after the call: an error can be returned after a reference was already taken.
 func (i *Index) getShardForDirectLocalOperation(
 	ctx context.Context,
 	tenantName, shardName string,
@@ -1261,10 +1262,13 @@ func (i *Index) getShardForWrite(
 	if shard == nil {
 		// this to handle MT auto enable and RF=1 case
 		ensureInit := i.Config.AutoTenantActivation || !i.replicationEnabled()
-		shard, release, err = i.getOptInitLocalShard(ctx, shardName, ensureInit)
+		initShard, initRelease, err := i.getOptInitLocalShard(ctx, shardName, ensureInit)
+		// the reference we were handed is not returned to the caller, release it
+		release()
 		if err != nil {
-			return nil, release, err
+			return nil, initRelease, err
 		}
+		return initShard, initRelease, nil
 	}
 
 	return shard, release, nil
@@ -1298,10 +1302,13 @@ func (i *Index) getShardForRead(
 	if shard == nil {
 		// this to handle MT auto enable and RF=1 case
 		ensureInit := i.Config.AutoTenantActivation || !i.replicationEnabled()
-		shard, release, err = i.getOptInitLocalShard(ctx, shardName, ensureInit)
+		initShard, initRelease, err := i.getOptInitLocalShard(ctx, shardName, ensureInit)
+		// the reference we were handed is not returned to the caller, release it
+		release()
 		if err != nil {
-			return nil, release, err
+			return nil, initRelease, err
 		}
+		return initShard, initRelease, nil
 	}
 
 	return shard, release, nil
@@ -1526,7 +1533,6 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 					func() {
 						i.backupLock.RLock(shardName)
 						defer i.backupLock.RUnlock(shardName)
-						defer release()
 						errs = shard.PutObjectBatch(ctx, group.objects)
 					}()
 				} else {
@@ -1635,19 +1641,20 @@ func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchRefere
 		if i.shardHasMultipleReplicasWrite(tenantName, shardName) {
 			errs = i.replicator.AddReferences(ctx, shardName, group.refs, routerTypes.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
 		} else {
-			shard, release, err := i.getShardForDirectLocalOperation(ctx, tenantName, shardName, localShardOperationWrite, schemaVersion)
-			if err != nil {
-				errs = duplicateErr(err, len(group.refs))
-			} else if shard != nil {
-				func() {
+			// anonymous func is here to ensure release is executed after each loop iteration
+			func() {
+				shard, release, err := i.getShardForDirectLocalOperation(ctx, tenantName, shardName, localShardOperationWrite, schemaVersion)
+				defer release()
+				if err != nil {
+					errs = duplicateErr(err, len(group.refs))
+				} else if shard != nil {
 					i.backupLock.RLock(shardName)
 					defer i.backupLock.RUnlock(shardName)
-					defer release()
 					errs = shard.AddReferencesBatch(ctx, group.refs)
-				}()
-			} else {
-				errs = i.remote.BatchAddReferences(ctx, shardName, group.refs, schemaVersion)
-			}
+				} else {
+					errs = i.remote.BatchAddReferences(ctx, shardName, group.refs, schemaVersion)
+				}
+			}()
 		}
 
 		for i, err := range errs {
@@ -1705,10 +1712,10 @@ func (i *Index) objectByID(ctx context.Context, id strfmt.UUID,
 	}
 
 	shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, shardName, localShardOperationRead, 0)
+	defer release()
 	if err != nil {
 		return obj, err
 	}
-	defer release()
 
 	if shard != nil {
 		if obj, err = shard.ObjectByID(ctx, id, props, addl); err != nil {
@@ -1796,26 +1803,29 @@ func (i *Index) multiObjectByID(ctx context.Context,
 
 	for shardName, group := range byShard {
 		var objects []*storobj.Object
-		var err error
-		shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, shardName, localShardOperationRead, 0)
-		if err != nil {
-			return nil, err
-		} else if shard != nil {
-			func() {
-				defer release()
+
+		// anonymous func is here to ensure release is executed after each loop iteration
+		err := func() error {
+			shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, shardName, localShardOperationRead, 0)
+			defer release()
+			if err != nil {
+				return err
+			}
+			if shard != nil {
 				objects, err = shard.MultiObjectByID(ctx, group.ids)
 				if err != nil {
-					err = errors.Wrapf(err, "local shard %s", shardId(i.ID(), shardName))
+					return errors.Wrapf(err, "local shard %s", shardId(i.ID(), shardName))
 				}
-			}()
-			if err != nil {
-				return nil, err
+				return nil
 			}
-		} else {
 			objects, err = i.remote.MultiGetObjects(ctx, shardName, extractIDsFromMulti(group.ids))
 			if err != nil {
-				return nil, errors.Wrapf(err, "remote shard %s", shardName)
+				return errors.Wrapf(err, "remote shard %s", shardName)
 			}
+			return nil
+		}()
+		if err != nil {
+			return nil, err
 		}
 
 		for i, obj := range objects {
@@ -2323,10 +2333,10 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 
 	if len(readPlan.Shards()) == 1 && !i.Config.ForceFullReplicasSearch {
 		shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, readPlan.Shards()[0], localShardOperationRead, 0)
+		defer release()
 		if err != nil {
 			return nil, nil, err
 		}
-		defer release()
 		if shard != nil {
 			return i.singleLocalShardObjectVectorSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters,
 				sort, groupBy, additionalProps, shard, targetCombination, properties, selection)
@@ -2691,10 +2701,10 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 	}
 
 	shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, shardName, localShardOperationWrite, schemaVersion)
+	defer release()
 	if err != nil {
 		return err
 	}
-	defer release()
 
 	// no replication, remote shard (or local not yet inited)
 	if shard == nil {
@@ -2835,6 +2845,7 @@ func (i *Index) getOrInitShard(ctx context.Context, shardName string) (
 // It is ensured that the returned instance is a fully loaded shard if ensureInit is set to true.
 // The returned shard may be a lazy shard instance or nil if the shard hasn't yet been initialized.
 // The returned shard cannot be closed until release is called.
+// release is never nil, including on error, so defer it immediately after the call.
 func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensureInit bool) (
 	shard ShardLike, release func(), err error,
 ) {
@@ -2923,10 +2934,10 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 	}
 
 	shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, shardName, localShardOperationWrite, schemaVersion)
+	defer release()
 	if err != nil {
 		return err
 	}
-	defer release()
 
 	// no replication, remote shard (or local not yet inited)
 	if shard == nil {
@@ -3594,7 +3605,6 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 					func() {
 						i.backupLock.RLock(shardName)
 						defer i.backupLock.RUnlock(shardName)
-						defer release()
 						objs = shard.DeleteObjectBatch(ctx, uuids, deletionTime, dryRun)
 					}()
 				} else {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -119,6 +119,7 @@ type ShardLike interface {
 	ConvertQueue(targetVector string) error
 	FillQueue(targetVector string, from uint64) error
 	Shutdown(context.Context) error // Shutdown the shard
+	// preventShutdown blocks shutdown until release is called; release is never nil, including on error.
 	preventShutdown() (release func(), err error)
 
 	// TODO tests only

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -706,7 +706,7 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 
 func (l *LazyLoadShard) preventShutdown() (release func(), err error) {
 	if err := l.Load(context.Background()); err != nil {
-		return nil, fmt.Errorf("LazyLoadShard::preventShutdown: %w", err)
+		return func() {}, fmt.Errorf("LazyLoadShard::preventShutdown: %w", err)
 	}
 	return l.shard.preventShutdown()
 }

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -294,6 +294,40 @@ func TestAddProperty_ColdShardLoadFailureDoesNotPanic(t *testing.T) {
 	}
 }
 
+// preventShutdown must return a callable release even when the load it triggers
+// fails, so a caller can defer the release before checking the error.
+func TestLazyLoadShard_PreventShutdownAlwaysReturnsRelease(t *testing.T) {
+	cases := []struct {
+		name      string
+		loadFails bool
+	}{
+		{name: "load succeeds"},
+		{name: "load fails", loadFails: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAddPropertyLazyFixture(t, "PreventShutdownRelease", singleShardState())
+
+			for name, shard := range f.coldShards(t) {
+				if tc.loadFails {
+					shard.memMonitor = failingAllocChecker{}
+				}
+
+				release, err := shard.preventShutdown()
+				require.NotNil(t, release, "release for shard %q must never be nil", name)
+				if tc.loadFails {
+					require.Error(t, err)
+					require.False(t, shard.isLoaded(), "shard %q must remain unloaded", name)
+				} else {
+					require.NoError(t, err)
+				}
+				release()
+			}
+		})
+	}
+}
+
 // Resuming maintenance cycles after a backup must not force-load cold shards:
 // an unloaded shard has no running cycles to resume.
 func TestResumeMaintenanceCycles_DoesNotForceLoadColdShards(t *testing.T) {

--- a/adapters/repos/db/shard_refcount_test.go
+++ b/adapters/repos/db/shard_refcount_test.go
@@ -1,0 +1,444 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/multi"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/objects"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// refCountTestIndex returns a single-shard index plus its only shard. The shard
+// carries a real vector index so the search paths can run, and the node resolver
+// never resolves a host, so remote forwards fail without touching the network.
+func refCountTestIndex(t *testing.T, className string) (*Index, *Shard) {
+	t.Helper()
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	nodeResolver.EXPECT().NodeHostname(mock.Anything).Return("", false).Maybe()
+
+	shard, idx := testShardWithSettings(t, t.Context(), &models.Class{Class: className},
+		enthnsw.NewDefaultUserConfig(), false, false, false, func(i *Index) {
+			i.shardResolver = resolver.NewShardResolver(className, false, i.getSchema)
+			i.remote = sharding.NewRemoteIndex(className, i.getSchema,
+				nodeResolver, &FakeRemoteClient{})
+		})
+
+	localShard := underlyingShard(t, shard)
+	router, ok := idx.router.(*types.MockRouter)
+	require.True(t, ok, "the test index must carry a mock router to extend")
+	expectReadRoutingPlan(router, localShard.name, "node1", "127.0.0.1")
+
+	return idx, localShard
+}
+
+// expectReadRoutingPlan answers the routing plan the search paths build before
+// they look a shard up, routing every read to the given node's replica.
+func expectReadRoutingPlan(router *types.MockRouter, shardName, nodeName, hostAddr string) {
+	router.EXPECT().BuildReadRoutingPlan(mock.Anything).Return(
+		types.ReadRoutingPlan{
+			ReplicaSet: types.ReadReplicaSet{
+				Replicas: []types.Replica{{NodeName: nodeName, ShardName: shardName, HostAddr: hostAddr}},
+			},
+		}, nil,
+	).Maybe()
+}
+
+// releaseMisuseHook captures what the index logs, so a test can assert on the
+// release misuse reported by preventShutdown.
+func releaseMisuseHook(t *testing.T, idx *Index) *logrustest.Hook {
+	t.Helper()
+
+	logger, ok := idx.logger.(*logrus.Logger)
+	require.True(t, ok, "the test index must carry a concrete logger to hook")
+	return logrustest.NewLocal(logger)
+}
+
+// releaseMisuse returns the release misuse captured so far. The logger is shared
+// with the index's background work, so unrelated entries are ignored.
+func releaseMisuse(hook *logrustest.Hook) []*logrus.Entry {
+	var out []*logrus.Entry
+	for _, entry := range hook.AllEntries() {
+		if strings.Contains(entry.Message, msgReleasedMoreThanOnce) {
+			out = append(out, entry)
+		}
+	}
+	return out
+}
+
+// forwardToRemote points the router at a peer node so the local shard lookup
+// yields a nil shard and the operation is forwarded instead.
+func forwardToRemote(t *testing.T, idx *Index, className, shardName string) {
+	t.Helper()
+
+	router := types.NewMockRouter(t)
+	router.EXPECT().GetWriteReplicasLocation(className, mock.Anything, mock.Anything).Return(
+		types.WriteReplicaSet{
+			Replicas: []types.Replica{{NodeName: "node2", ShardName: shardName, HostAddr: "127.0.0.2"}},
+		}, nil,
+	).Maybe()
+	router.EXPECT().GetReadReplicasLocation(className, mock.Anything, mock.Anything).Return(
+		types.ReadReplicaSet{
+			Replicas: []types.Replica{{NodeName: "node2", ShardName: shardName, HostAddr: "127.0.0.2"}},
+		}, nil,
+	).Maybe()
+	expectReadRoutingPlan(router, shardName, "node2", "127.0.0.2")
+	idx.router = router
+}
+
+// batchDeleteErr collapses the per-object errors of a delete batch, which the
+// call reports inside the result rather than as its own error.
+func batchDeleteErr(objs objects.BatchSimpleObjects, err error) error {
+	if err != nil {
+		return err
+	}
+	errs := make([]error, 0, len(objs))
+	for _, obj := range objs {
+		errs = append(errs, obj.Err)
+	}
+	return errors.Join(errs...)
+}
+
+// TestShardRefCountArity asserts that every data-path operation releases the
+// shard exactly as often as it acquired it, locally and forwarded to a peer. A
+// positive counter blocks unloading; an extra release shows up as logged misuse.
+func TestShardRefCountArity(t *testing.T) {
+	className := "RefCountArity"
+
+	tests := []struct {
+		name   string
+		remote bool
+		// wantErr is set where the exercised branch cannot succeed, which also
+		// pins that the operation took the intended branch.
+		wantErr bool
+		// wantErrContains is set where both branches fail, so only the error text
+		// tells them apart.
+		wantErrContains string
+		run             func(t *testing.T, idx *Index, shardName string) error
+	}{
+		{
+			name: "putObjectBatch local",
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				return errors.Join(idx.putObjectBatch(t.Context(),
+					[]*storobj.Object{testObject(className)}, nil, 0)...)
+			},
+		},
+		{
+			name: "putObjectBatch forwarded", remote: true, wantErr: true,
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				return errors.Join(idx.putObjectBatch(t.Context(),
+					[]*storobj.Object{testObject(className)}, nil, 0)...)
+			},
+		},
+		{
+			name: "batchDeleteObjects local",
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				return batchDeleteErr(idx.batchDeleteObjects(t.Context(),
+					map[string][]strfmt.UUID{shardName: {strfmt.UUID(uuid.NewString())}},
+					time.Now(), false, nil, 0, ""))
+			},
+		},
+		{
+			name: "batchDeleteObjects forwarded", remote: true, wantErr: true,
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				return batchDeleteErr(idx.batchDeleteObjects(t.Context(),
+					map[string][]strfmt.UUID{shardName: {strfmt.UUID(uuid.NewString())}},
+					time.Now(), false, nil, 0, ""))
+			},
+		},
+		{
+			// the referenced source object does not exist, so the shard rejects the write
+			name: "AddReferencesBatch local", wantErr: true, wantErrContains: "ref batch",
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				return errors.Join(idx.AddReferencesBatch(t.Context(), objects.BatchReferences{{
+					From: &crossref.RefSource{TargetID: strfmt.UUID(uuid.NewString())},
+					To:   &crossref.Ref{TargetID: strfmt.UUID(uuid.NewString())},
+				}}, nil, 0)...)
+			},
+		},
+		{
+			name: "AddReferencesBatch forwarded", remote: true, wantErr: true,
+			wantErrContains: "resolve node name",
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				return errors.Join(idx.AddReferencesBatch(t.Context(), objects.BatchReferences{{
+					From: &crossref.RefSource{TargetID: strfmt.UUID(uuid.NewString())},
+					To:   &crossref.Ref{TargetID: strfmt.UUID(uuid.NewString())},
+				}}, nil, 0)...)
+			},
+		},
+		{
+			name: "objectVectorSearch local",
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				_, _, err := idx.objectVectorSearch(t.Context(), []models.Vector{[]float32{1, 2, 3}},
+					[]string{""}, 0, 10, nil, nil, nil, additional.Properties{}, nil, "", nil, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "objectVectorSearch forwarded", remote: true, wantErr: true,
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				_, _, err := idx.objectVectorSearch(t.Context(), []models.Vector{[]float32{1, 2, 3}},
+					[]string{""}, 0, 10, nil, nil, nil, additional.Properties{}, nil, "", nil, nil, nil)
+				return err
+			},
+		},
+		{
+			name: "multiObjectByID local",
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				_, err := idx.multiObjectByID(t.Context(),
+					[]multi.Identifier{{ID: uuid.NewString(), ClassName: className}}, "")
+				return err
+			},
+		},
+		{
+			name: "multiObjectByID forwarded", remote: true, wantErr: true,
+			run: func(t *testing.T, idx *Index, shardName string) error {
+				_, err := idx.multiObjectByID(t.Context(),
+					[]multi.Identifier{{ID: uuid.NewString(), ClassName: className}}, "")
+				return err
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idx, shard := refCountTestIndex(t, className)
+			hook := releaseMisuseHook(t, idx)
+			if test.remote {
+				forwardToRemote(t, idx, className, shard.name)
+			}
+
+			for i := 0; i < 3; i++ {
+				err := test.run(t, idx, shard.name)
+				if test.wantErr {
+					require.Error(t, err, "the exercised branch must be the one under test")
+				} else {
+					require.NoError(t, err)
+				}
+				if test.wantErrContains != "" {
+					require.ErrorContains(t, err, test.wantErrContains,
+						"the failure must be the one the exercised branch produces")
+				}
+				require.Equalf(t, int64(0), shard.inUseCounter.Load(),
+					"after %d operation(s) every acquire must have exactly one release", i+1)
+				require.Emptyf(t, releaseMisuse(hook),
+					"after %d operation(s) no call site may release twice", i+1)
+			}
+		})
+	}
+}
+
+// TestShardRefCountSchemaWaitFailure covers the write paths that wait for the
+// schema version a second time inside getShardForDirectLocalOperation, which by
+// then already holds a reference: a failed wait still has to release it.
+func TestShardRefCountSchemaWaitFailure(t *testing.T) {
+	className := "RefCountSchemaWait"
+	const schemaVersion = uint64(7)
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, idx *Index, id strfmt.UUID) error
+	}{
+		{
+			name: "deleteObject",
+			run: func(t *testing.T, idx *Index, id strfmt.UUID) error {
+				return idx.deleteObject(t.Context(), id, time.Now(), nil, "", schemaVersion)
+			},
+		},
+		{
+			name: "mergeObject",
+			run: func(t *testing.T, idx *Index, id strfmt.UUID) error {
+				return idx.mergeObject(t.Context(),
+					objects.MergeDocument{Class: className, ID: id}, nil, "", schemaVersion)
+			},
+		},
+		{
+			name: "AddReferencesBatch",
+			run: func(t *testing.T, idx *Index, id strfmt.UUID) error {
+				return errors.Join(idx.AddReferencesBatch(t.Context(), objects.BatchReferences{{
+					From: &crossref.RefSource{TargetID: id},
+					To:   &crossref.Ref{TargetID: strfmt.UUID(uuid.NewString())},
+				}}, nil, schemaVersion)...)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idx, shard := refCountTestIndex(t, className)
+
+			// the caller's own wait succeeds, the one inside the shard lookup does not
+			schemaReader := idx.schemaReader.(*schemaUC.MockSchemaReader)
+			schemaReader.EXPECT().WaitForUpdate(mock.Anything, schemaVersion).Return(nil).Once()
+			schemaReader.EXPECT().WaitForUpdate(mock.Anything, schemaVersion).
+				Return(context.Canceled).Once()
+
+			require.Error(t, test.run(t, idx, strfmt.UUID(uuid.NewString())))
+			require.Equal(t, int64(0), shard.inUseCounter.Load(),
+				"a failed schema wait must still release the shard")
+		})
+	}
+}
+
+// TestBatchDeleteReleasesShardOnPartialGroupFailure asserts that a batch split
+// over several shards releases the reference of the group that acquired one and
+// reports the failure of the group that could not be looked up.
+func TestBatchDeleteReleasesShardOnPartialGroupFailure(t *testing.T) {
+	const blockedShard = "blocked-shard"
+
+	idx, shard := refCountTestIndex(t, "RefCountPartialBatch")
+	hook := releaseMisuseHook(t, idx)
+
+	// the shard is not loaded and may not be initialized, so its group fails the lookup
+	idx.backupProtectedShards.Store(blockedShard, struct{}{})
+
+	objs, err := idx.batchDeleteObjects(t.Context(), map[string][]strfmt.UUID{
+		shard.name:   {strfmt.UUID(uuid.NewString())},
+		blockedShard: {strfmt.UUID(uuid.NewString())},
+	}, time.Now(), false, nil, 0, "")
+	require.NoError(t, err)
+
+	failed := 0
+	for _, obj := range objs {
+		if obj.Err != nil {
+			failed++
+		}
+	}
+	require.Equal(t, 1, failed, "only the blocked group may fail, and its failure must be reported")
+	require.Equal(t, int64(0), shard.inUseCounter.Load(),
+		"the group that acquired the shard must release it")
+	require.Empty(t, releaseMisuse(hook), "no group may release twice")
+}
+
+// TestShardLookupReleasesReplacedReference asserts that getShardForWrite and
+// getShardForRead release the reference they were handed whenever they hand back
+// a different one; the caller only defers the returned release.
+func TestShardLookupReleasesReplacedReference(t *testing.T) {
+	className := "RefCountReplacedReference"
+
+	tests := []struct {
+		name string
+		// blockInit exercises the branch where the shard cannot be initialized,
+		// which still has to release the reference it was handed
+		blockInit bool
+		run       func(ctx context.Context, idx *Index, shardName string, release func()) (ShardLike, func(), error)
+	}{
+		{
+			name: "write",
+			run: func(ctx context.Context, idx *Index, shardName string, release func()) (ShardLike, func(), error) {
+				return idx.getShardForWrite(ctx, className, "", shardName, nil, release)
+			},
+		},
+		{
+			name: "read",
+			run: func(ctx context.Context, idx *Index, shardName string, release func()) (ShardLike, func(), error) {
+				return idx.getShardForRead(ctx, className, "", shardName, nil, release)
+			},
+		},
+		{
+			name: "write with failing init", blockInit: true,
+			run: func(ctx context.Context, idx *Index, shardName string, release func()) (ShardLike, func(), error) {
+				return idx.getShardForWrite(ctx, className, "", shardName, nil, release)
+			},
+		},
+		{
+			name: "read with failing init", blockInit: true,
+			run: func(ctx context.Context, idx *Index, shardName string, release func()) (ShardLike, func(), error) {
+				return idx.getShardForRead(ctx, className, "", shardName, nil, release)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idx, shard := refCountTestIndex(t, className)
+			hook := releaseMisuseHook(t, idx)
+
+			// the reference handed over along with the nil shard that makes the
+			// lookup initialize one
+			release, err := shard.preventShutdown()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), shard.inUseCounter.Load())
+
+			wantInUse := int64(1)
+			if test.blockInit {
+				idx.shards.LoadAndDelete(shard.name)
+				idx.backupProtectedShards.Store(shard.name, struct{}{})
+				wantInUse = 0
+			}
+
+			got, gotRelease, err := test.run(t.Context(), idx, shard.name, release)
+			require.NotNil(t, gotRelease, "the returned release is what the caller defers")
+			if test.blockInit {
+				require.Error(t, err)
+				require.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, got, "the shard must be initialized")
+			}
+			require.Equal(t, wantInUse, shard.inUseCounter.Load(),
+				"the reference that is not handed back must be released")
+
+			gotRelease()
+			require.Equal(t, int64(0), shard.inUseCounter.Load())
+			require.Empty(t, releaseMisuse(hook), "no reference may be released twice")
+		})
+	}
+}
+
+// TestPreventShutdownReleaseIsIdempotent asserts that a caller releasing more
+// than once per acquire cannot drive the counter negative, which would disable
+// the in-use guard, and that the misuse is reported rather than silently
+// absorbed.
+func TestPreventShutdownReleaseIsIdempotent(t *testing.T) {
+	idx, shard := refCountTestIndex(t, "RefCountIdempotent")
+	hook := releaseMisuseHook(t, idx)
+
+	release, err := shard.preventShutdown()
+	require.NoError(t, err)
+	require.Equal(t, int64(1), shard.inUseCounter.Load())
+
+	release()
+	require.Empty(t, releaseMisuse(hook), "one release per acquire is not a misuse")
+
+	release()
+	release()
+
+	require.Equal(t, int64(0), shard.inUseCounter.Load())
+	entries := releaseMisuse(hook)
+	require.Len(t, entries, 2, "each extra release must be reported")
+	for _, entry := range entries {
+		require.Equal(t, logrus.ErrorLevel, entry.Level)
+	}
+}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -183,6 +184,8 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	return ec.ToError()
 }
 
+const msgReleasedMoreThanOnce = "shard reference released more than once per acquire"
+
 func (s *Shard) preventShutdown() (release func(), err error) {
 	if s.shutdownRequested.Load() {
 		return func() {}, errShutdownInProgress
@@ -195,17 +198,31 @@ func (s *Shard) preventShutdown() (release func(), err error) {
 	}
 
 	s.refCountAdd()
-	return func() { s.refCountSub() }, nil
+	// Releasing more than once per acquire would drive the counter negative and
+	// disable the in-use guard in performShutdown, so absorb it and report it.
+	var released atomic.Bool
+	return func() {
+		if !released.CompareAndSwap(false, true) {
+			s.index.logger.
+				WithField("action", "shard_ref_count").
+				WithField("shard", s.name).
+				Error(msgReleasedMoreThanOnce)
+			return
+		}
+		s.refCountSub()
+	}, nil
 }
 
 func (s *Shard) refCountAdd() {
 	s.inUseCounter.Add(1)
 }
 
+// refCountSub, and hence preventShutdown's release func, must not be called
+// while holding s.shutdownLock: performShutdown takes the write lock.
 func (s *Shard) refCountSub() {
-	s.inUseCounter.Add(-1)
-	// if the counter is 0, we can shutdown
-	if s.inUseCounter.Load() == 0 && s.shutdownRequested.Load() {
+	// a shutdown requested while the shard was in use runs once the last
+	// reference drops
+	if s.inUseCounter.Add(-1) == 0 && s.shutdownRequested.Load() {
 		s.performShutdown(context.TODO())
 	}
 }


### PR DESCRIPTION
### What's being changed:

This fixes a double free of shard counter which results in a negative counter => the shard-usage gate which prevents a premature shutdown will not fire.

This only happens on clusters with rf=1 or rf != nodecount 

Note: I will refactor the release/aquire in a follow up PR to make this kind of bug in the future, but the diff got to large

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
