### PR TITLE
tokenizer: append-style field splitting so batch allocations stay flat

### DIFF
--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -348,14 +349,46 @@ func tokenizeField(in string, dst []string) []string {
 	return append(dst, strings.TrimFunc(in, unicode.IsSpace))
 }
 
+// appendFieldsFunc is strings.FieldsFunc with an append-style tail: fields are
+// appended to dst instead of a freshly allocated slice, so a batch caller
+// reusing one buffer splits without allocating per value. The span pass is
+// stdlib's — recording indices before materializing substrings measures
+// faster than emitting them inline — with the final make replaced by one Grow.
+func appendFieldsFunc(dst []string, in string, isSep func(rune) bool) []string {
+	type span struct{ start, end int }
+	var spanBuf [32]span
+	spans := spanBuf[:0]
+
+	start := -1
+	for end, r := range in {
+		if isSep(r) {
+			if start >= 0 {
+				spans = append(spans, span{start, end})
+				start = -1
+			}
+		} else if start < 0 {
+			start = end
+		}
+	}
+	if start >= 0 {
+		spans = append(spans, span{start, len(in)})
+	}
+
+	dst = slices.Grow(dst, len(spans))
+	for _, s := range spans {
+		dst = append(dst, in[s.start:s.end])
+	}
+	return dst
+}
+
+func isNotAlphanumeric(r rune) bool {
+	return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+}
+
 // tokenizeWhitespace splits on white spaces, does not alter casing
 // (former DataTypeString/Word)
 func tokenizeWhitespace(in string, dst []string) []string {
-	fields := strings.FieldsFunc(in, unicode.IsSpace)
-	if cap(dst) == 0 {
-		return fields
-	}
-	return append(dst, fields...)
+	return appendFieldsFunc(dst, in, unicode.IsSpace)
 }
 
 // tokenizeLowercase splits on white spaces and lowercases the words
@@ -369,15 +402,8 @@ func tokenizeLowercase(in string, dst []string) []string {
 // tokenizeWord splits on any non-alphanumerical and lowercases the words
 // (former DataTypeText/Word)
 func tokenizeWord(in string, dst []string) []string {
-	fields := strings.FieldsFunc(in, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	})
-	if cap(dst) == 0 {
-		lowercase(fields)
-		return fields
-	}
 	prev := len(dst)
-	dst = append(dst, fields...)
+	dst = appendFieldsFunc(dst, in, isNotAlphanumeric)
 	lowercase(dst[prev:])
 	return dst
 }
@@ -385,12 +411,18 @@ func tokenizeWord(in string, dst []string) []string {
 // tokenizetrigram splits on any non-alphanumerical and lowercases the words, joins them together, then groups them into trigrams
 func tokenizetrigram(in string, dst []string) []string {
 	// Strip whitespace and punctuation from the input string
-	inputString := strings.ToLower(strings.Join(strings.FieldsFunc(in, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r)
-	}), ""))
-	runes := []rune(inputString)
-	for i := 0; i < len(runes)-2; i++ {
-		dst = append(dst, string(runes[i:i+3]))
+	inputString := strings.ToLower(strings.Join(strings.FieldsFunc(in, isNotAlphanumeric), ""))
+	// Byte offset of each rune start, plus a terminator, so a trigram is the
+	// substring inputString[off[i]:off[i+3]] — sliced, not copied, which is
+	// what keeps a trigram batch from allocating once per emitted trigram.
+	var offBuf [128]int
+	offs := offBuf[:0]
+	for i := range inputString {
+		offs = append(offs, i)
+	}
+	offs = append(offs, len(inputString))
+	for i := 0; i+3 < len(offs); i++ {
+		dst = append(dst, inputString[offs[i]:offs[i+3]])
 	}
 	return dst
 }
@@ -478,15 +510,10 @@ func tokenizeKagome(tokenizer *kagomeTokenizer.Tokenizer, mode kagomeTokenizer.T
 // tokenizeWordWithWildcards splits on any non-alphanumerical except wildcard-symbols and
 // lowercases the words
 func tokenizeWordWithWildcards(in string, dst []string) []string {
-	fields := strings.FieldsFunc(in, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsNumber(r) && r != '?' && r != '*'
-	})
-	if cap(dst) == 0 {
-		lowercase(fields)
-		return fields
-	}
 	prev := len(dst)
-	dst = append(dst, fields...)
+	dst = appendFieldsFunc(dst, in, func(r rune) bool {
+		return isNotAlphanumeric(r) && r != '?' && r != '*'
+	})
 	lowercase(dst[prev:])
 	return dst
 }

--- a/entities/tokenizer/tokenizer_bench_test.go
+++ b/entities/tokenizer/tokenizer_bench_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+var benchTokenizations = []string{
+	models.PropertyTokenizationField,
+	models.PropertyTokenizationWord,
+	models.PropertyTokenizationWhitespace,
+	models.PropertyTokenizationLowercase,
+	models.PropertyTokenizationTrigram,
+}
+
+// BenchmarkAnalyze guards the single-value allocation profile: the append-style
+// kernels must not cost more than materializing a fresh slice per call did.
+func BenchmarkAnalyze(b *testing.B) {
+	for _, tokenization := range benchTokenizations {
+		b.Run(tokenization, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = Analyze("some value number 42 here", tokenization, "C", nil, nil)
+			}
+		})
+	}
+}
+
+// BenchmarkAnalyzeBatch is the reason the kernels are append-style: allocations
+// per batch should stay flat in the number of values rather than scaling with
+// it. Compare against BenchmarkAnalyzeBatchPerValueLoop.
+func BenchmarkAnalyzeBatch(b *testing.B) {
+	values := benchValues(1000)
+	for _, tokenization := range benchTokenizations {
+		b.Run(tokenization, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = AnalyzeBatch(values, tokenization, "C", nil, nil)
+			}
+		})
+	}
+}
+
+// BenchmarkAnalyzeBatchPerValueLoop is the baseline AnalyzeBatch replaces:
+// calling Analyze per value and keeping each result.
+func BenchmarkAnalyzeBatchPerValueLoop(b *testing.B) {
+	values := benchValues(1000)
+	for _, tokenization := range benchTokenizations {
+		b.Run(tokenization, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				out := make([][]string, len(values))
+				for j, v := range values {
+					out[j] = Analyze(v, tokenization, "C", nil, nil).Query
+				}
+			}
+		})
+	}
+}
+
+func benchValues(n int) []string {
+	values := make([]string, n)
+	for i := range values {
+		values[i] = fmt.Sprintf("some value number %d here", i)
+	}
+	return values
+}

--- a/entities/tokenizer/tokenizer_split_test.go
+++ b/entities/tokenizer/tokenizer_split_test.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+)
+
+// randomInputs builds inputs from an alphabet mixing separators, ASCII,
+// wildcards and multi-byte runes, so span boundaries land mid-rune as often
+// as the tokenizers will see in practice.
+func randomInputs(seed int64, n int, alphabet string) []string {
+	runes := []rune(alphabet)
+	rng := rand.New(rand.NewSource(seed))
+	out := make([]string, n)
+	for i := range out {
+		var sb strings.Builder
+		for j := rng.Intn(40); j > 0; j-- {
+			sb.WriteRune(runes[rng.Intn(len(runes))])
+		}
+		out[i] = sb.String()
+	}
+	return out
+}
+
+// TestAppendFieldsFuncMatchesStdlib is the drift guard for the append-style
+// splitter: it must produce exactly what strings.FieldsFunc produces, for
+// every separator predicate the tokenizers use, both into a fresh buffer and
+// appended after existing tokens.
+func TestAppendFieldsFuncMatchesStdlib(t *testing.T) {
+	tests := []struct {
+		name  string
+		isSep func(rune) bool
+	}{
+		{"whitespace", unicode.IsSpace},
+		{"alphanumeric", isNotAlphanumeric},
+		{"alphanumeric with wildcards", func(r rune) bool {
+			return isNotAlphanumeric(r) && r != '?' && r != '*'
+		}},
+	}
+
+	inputs := append([]string{"", " ", "\t\n", "a", "abc", "a b", "  a  b  "},
+		randomInputs(1, 20000, " \t\n abcXY01_-.?*é日本語한글")...)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, in := range inputs {
+				want := strings.FieldsFunc(in, tt.isSep)
+
+				got := appendFieldsFunc(nil, in, tt.isSep)
+				require.Len(t, got, len(want), "input %q", in)
+				if len(want) > 0 {
+					require.Equal(t, want, got, "input %q", in)
+				}
+
+				// appending after existing tokens must leave them untouched
+				prefix := []string{"KEEP_0", "KEEP_1"}
+				appended := appendFieldsFunc(append([]string{}, prefix...), in, tt.isSep)
+				require.Equal(t, prefix, appended[:len(prefix)], "input %q", in)
+				require.Len(t, appended[len(prefix):], len(want), "input %q", in)
+				if len(want) > 0 {
+					require.Equal(t, want, appended[len(prefix):], "input %q", in)
+				}
+			}
+		})
+	}
+}
+
+// referenceTrigram is the straightforward rune-slicing implementation, kept as
+// the oracle for the offset-based one, which emits trigrams as substrings of
+// the stripped input instead of copying each one.
+func referenceTrigram(in string) []string {
+	stripped := strings.ToLower(strings.Join(strings.FieldsFunc(in, isNotAlphanumeric), ""))
+	runes := []rune(stripped)
+	var out []string
+	for i := 0; i < len(runes)-2; i++ {
+		out = append(out, string(runes[i:i+3]))
+	}
+	return out
+}
+
+func TestTokenizeTrigramMatchesReference(t *testing.T) {
+	inputs := append([]string{"", "a", "ab", "abc", "abcd", "日本語です", "a-b-c"},
+		randomInputs(2, 50000, " \t abcXY01_-.é日本語한글🎉")...)
+
+	for _, in := range inputs {
+		want := referenceTrigram(in)
+		got := tokenizetrigram(in, nil)
+		require.Len(t, got, len(want), "input %q", in)
+		if len(want) > 0 {
+			require.Equal(t, want, got, "input %q", in)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

Follow-up to #12342, which makes the tokenizer kernels append-style so a batch can reuse one buffer. That works for `field`, gse and kagome, but not for the split-based tokenizations — `word`, `whitespace` and `lowercase` still allocated once per value inside a batch, `word` being the most common tokenizer in practice.

The cause is `strings.FieldsFunc`: it allocates a fresh `[]string` on every call regardless of the destination, so the `cap(dst) == 0` fast path in #12342 could only ever help the single-value seed. In a batch, every value after the first paid a `FieldsFunc` allocation *plus* a copy into the scratch buffer — measurably more bytes than the per-value loop it replaces.

## Approach

**`appendFieldsFunc`** keeps stdlib's two-pass span algorithm — recording field indices before materializing substrings measures faster than emitting them inline — but replaces the final `make` with one `slices.Grow` into `dst`. `tokenizeWhitespace`, `tokenizeWord` and `tokenizeWordWithWildcards` become one-liners over it, and the `cap(dst) == 0` special case disappears: every kernel is now uniformly append-style.

**`tokenizetrigram`** had the same shape of problem, allocating per emitted trigram via `string(runes[i:i+3])`. Precomputing rune start offsets lets each trigram be a substring of the already-stripped input. Side benefit: trigrams now pin that input once rather than copying it three times over.

## Results

Batch of 1000 values (M3 Max, `-count 3`), #12342 → this PR:

| tokenization | ns/op | allocs/op | B/op |
|---|---|---|---|
| word | 174µs → **148µs** | 1007 → **8** | 305KB → **225KB** |
| whitespace | 134µs → **112µs** | 1007 → **8** | 305KB → **225KB** |
| lowercase | 166µs → **143µs** | 1007 → **8** | 305KB → **225KB** |
| trigram | 785µs → **488µs** | 21907 → **2017** | 1816KB → **1657KB** |
| field | 13.8µs → 12.7µs | 4 → 4 | unchanged |

Against the per-value loop `AnalyzeBatch` replaces, `word` is now 257µs/2001 allocs → 148µs/8 allocs. Bytes stay ~1.2x the loop because `flat` regrows geometrically from `cap = len(values)`, but that is three large short-lived allocations instead of two thousand small ones.

**Single-value is not regressed**: `word`/`whitespace`/`lowercase` stay at exactly 2 allocs / 160 B with the same ns/op; `trigram` improves on its own (26 → 7 allocs, 1078 → 579 ns), which also benefits the query and wildcards paths.

## Testing

Token output is unchanged — no behavioural delta, including nil-vs-empty:

- Differential corpus against #12342: 29 inputs (empty, whitespace-only, punctuation-only, CJK, accented, wildcards) × 9 tokenizations × `Tokenize`/`TokenizeForClass`/`TokenizeWithWildcardsForClass`/`Analyze` × folding on and off — byte-identical.
- `TestAppendFieldsFuncMatchesStdlib`: 20k random inputs per separator predicate (whitespace, alphanumeric, wildcard-preserving), into both a fresh buffer and one with existing tokens, asserted equal to `strings.FieldsFunc`.
- `TestTokenizeTrigramMatchesReference`: 50k random inputs against the rune-slicing implementation, kept in the test as the oracle.
- `BenchmarkAnalyze` / `BenchmarkAnalyzeBatch` / `BenchmarkAnalyzeBatchPerValueLoop` commit the allocation profile the kernels exist to deliver, so a future refactor regressing it shows up.

`go test -race` on the package, `golangci-lint` and the goroutine linter all pass, as do the downstream `adapters/repos/db/inverted/...` and `adapters/handlers/rest` suites.

## Notes for review

- `appendFieldsFunc` uses a 32-span stack buffer; values with more than 32 fields spill to the heap — the same threshold as stdlib's `make([]span, 0, 32)`.
- Trigrams now alias the stripped input instead of owning their own storage. Strictly less memory than before (1x pinned vs 3x copied), but it is a retention-shape change worth being aware of.

Stacked on #12342 — review that one first; this targets `opt/contains-pr2-tokenizer-batch`.
