### PR TITLE
test(replica): cover multi-object repair batches and pin a tombstone order dependence

### DIFF
--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -229,7 +229,8 @@ func (f *Finder) CheckConsistency(ctx context.Context,
 		}
 		return nil
 	}
-	// check shard consistency concurrently
+	// One group over every shard of the request, so the first shard to report an
+	// error cancels the context the others are still reading and repairing on.
 	gr, ctx := enterrors.NewErrorGroupWithContextWrapper(f.logger, ctx)
 	for _, part := range clusterObjectByShard(createBatch(xs)) {
 		part := part

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -258,8 +258,10 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 		}
 		resolved, err := f.repairBatchPart(ctx, batch.Shard, ids, votes, contentIdx)
 		if err != nil {
-			// Returning this cancels the error group context shared with the
-			// request's other shards, aborting their repairs mid-flight.
+			// Logged, not propagated: a repair failure is per object and has
+			// already decremented that object's vote count, which is what
+			// withholds IsConsistent below. Reporting it here would fail the
+			// whole request and cancel the shards still repairing.
 			f.log.WithField("op", "repair_batch").WithField("class", f.class).
 				WithField("shard", batch.Shard).WithField("uuids", ids).Error(err)
 		}

--- a/usecases/replica/fullreads_adversarial_test.go
+++ b/usecases/replica/fullreads_adversarial_test.go
@@ -1,0 +1,350 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// fullReadFetcher implements only FetchObjects; the embedded nil RClient makes
+// any other call panic rather than silently return a zero value.
+type fullReadFetcher struct {
+	RClient
+	fn    func(ids []strfmt.UUID) ([]Replica, error)
+	calls atomic.Int32
+	// maxInFlight tracks observed concurrency
+	inFlight    atomic.Int32
+	maxInFlight atomic.Int32
+}
+
+func (f *fullReadFetcher) FetchObjects(_ context.Context, _, _, _ string,
+	ids []strfmt.UUID,
+) ([]Replica, error) {
+	f.calls.Add(1)
+	cur := f.inFlight.Add(1)
+	for {
+		old := f.maxInFlight.Load()
+		if cur <= old || f.maxInFlight.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+	defer f.inFlight.Add(-1)
+	return f.fn(ids)
+}
+
+// seqID builds a UUID that encodes i, so a misattribution names the position it
+// came from.
+func seqID(i int) strfmt.UUID {
+	return strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012d", i))
+}
+
+func seqIDs(n int) []strfmt.UUID {
+	ids := make([]strfmt.UUID, n)
+	for i := range ids {
+		ids[i] = seqID(i)
+	}
+	return ids
+}
+
+// replicaFor builds an honest response element: both the envelope ID and the
+// carried object's own ID are the requested id.
+func replicaFor(id strfmt.UUID) Replica {
+	return Replica{
+		ID: id,
+		Object: &storobj.Object{Object: models.Object{
+			ID: id, Class: "C1", LastUpdateTimeUnix: 42,
+		}},
+		LastUpdateTimeUnixMilli: 42,
+	}
+}
+
+func newFullReadClient(t *testing.T, f *fullReadFetcher) FinderClient {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	return NewFinderClient(f, logger)
+}
+
+// TestFullReadsIdentityAtEveryPosition pins that the object at each position is
+// the one requested at that position, across the chunk boundaries. Asserting
+// only the length passes while every object is misattributed, so identity is
+// checked at each index on both the envelope and the carried payload.
+func TestFullReadsIdentityAtEveryPosition(t *testing.T) {
+	sizes := []int{0, 1, 2, 15, 16, 17, 255, 256, 257, 511, 512, 513, 4096, 4097}
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			ids := seqIDs(n)
+			f := &fullReadFetcher{fn: func(chunk []strfmt.UUID) ([]Replica, error) {
+				// honest server, but with jitter so chunks complete out of order
+				time.Sleep(time.Duration(rand.Intn(400)) * time.Microsecond)
+				out := make([]Replica, len(chunk))
+				for i, id := range chunk {
+					out[i] = replicaFor(id)
+				}
+				return out, nil
+			}}
+			rs, err := newFullReadClient(t, f).FullReads(context.Background(), "h", "C1", "S1", ids)
+			require.NoError(t, err)
+			require.Len(t, rs, n)
+			for i := range ids {
+				require.Equal(t, ids[i], rs[i].ID,
+					"envelope id at position %d does not match requested id", i)
+				require.NotNil(t, rs[i].Object, "object missing at position %d", i)
+				require.Equal(t, ids[i], rs[i].Object.ID(),
+					"OBJECT CONTENT at position %d belongs to a different id", i)
+			}
+			// fan-out bound must hold
+			require.LessOrEqual(t, int(f.maxInFlight.Load()), MaxConcurrentFullReadRequests,
+				"observed in-flight requests exceeded the bound")
+		})
+	}
+}
+
+// TestFullReadsRejectsMalformedChunks covers the response shapes a buggy peer
+// can return. Each must produce an error and a nil result: a partial result
+// that reads as complete is what lets the repairer write the wrong content.
+func TestFullReadsRejectsMalformedChunks(t *testing.T) {
+	tests := []struct {
+		name    string
+		n       int
+		badMuts func(chunk []strfmt.UUID, out []Replica) []Replica
+		// which chunk index to corrupt; -1 = all
+		badChunk int
+	}{
+		{
+			name: "chunk returns fewer objects than requested",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				return out[:len(out)-1]
+			},
+			badChunk: 1,
+		},
+		{
+			name: "chunk returns empty slice",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				return nil
+			},
+			badChunk: 1,
+		},
+		{
+			name: "chunk returns MORE objects than requested",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				return append(out, replicaFor(seqID(99999)))
+			},
+			badChunk: 2,
+		},
+		{
+			name: "chunk shuffles objects internally",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				if len(out) >= 2 {
+					out[0], out[len(out)-1] = out[len(out)-1], out[0]
+				}
+				return out
+			},
+			badChunk: 1,
+		},
+		{
+			name: "first chunk shuffled",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				if len(out) >= 2 {
+					out[0], out[1] = out[1], out[0]
+				}
+				return out
+			},
+			badChunk: 0,
+		},
+		{
+			name: "last chunk shuffled",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				if len(out) >= 2 {
+					out[0], out[len(out)-1] = out[len(out)-1], out[0]
+				}
+				return out
+			},
+			badChunk: 2,
+		},
+		{
+			name: "single-chunk path shuffled (no concurrency)",
+			n:    200,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				out[0], out[1] = out[1], out[0]
+				return out
+			},
+			badChunk: 0,
+		},
+		{
+			// envelope ids stay in request order while the carried objects are
+			// swapped. The envelope is not what the repairer writes, so checking
+			// only the envelope would accept this and file content under the
+			// wrong id.
+			name: "chunk keeps envelope ids but swaps the carried payloads",
+			n:    600,
+			badMuts: func(_ []strfmt.UUID, out []Replica) []Replica {
+				out[0].Object, out[len(out)-1].Object = out[len(out)-1].Object, out[0].Object
+				return out
+			},
+			badChunk: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := seqIDs(tt.n)
+			var seen atomic.Int32
+			f := &fullReadFetcher{}
+			f.fn = func(chunk []strfmt.UUID) ([]Replica, error) {
+				out := make([]Replica, len(chunk))
+				for i, id := range chunk {
+					out[i] = replicaFor(id)
+				}
+				// identify chunk by its first id's encoded index
+				idx := -1
+				for k := 0; k < tt.n; k += MaxFullReadIDsPerRequest {
+					if chunk[0] == ids[k] {
+						idx = k / MaxFullReadIDsPerRequest
+						break
+					}
+				}
+				if idx == tt.badChunk {
+					seen.Add(1)
+					return tt.badMuts(chunk, out), nil
+				}
+				return out, nil
+			}
+			rs, err := newFullReadClient(t, f).FullReads(context.Background(), "h", "C1", "S1", ids)
+			require.Equal(t, int32(1), seen.Load(), "the corrupted chunk was never requested")
+			if err == nil {
+				// the ONLY acceptable no-error outcome is a fully correct result
+				for i := range ids {
+					require.Equal(t, ids[i], rs[i].ID, "envelope mispair at %d WITHOUT an error", i)
+					require.NotNil(t, rs[i].Object, "nil object at %d WITHOUT an error", i)
+					require.Equal(t, ids[i], rs[i].Object.ID(),
+						"CONTENT MISATTRIBUTION at position %d and FullReads returned no error", i)
+				}
+				t.Fatalf("malformed response accepted without error (result was internally consistent, but the corruption was silently absorbed)")
+			}
+			require.Nil(t, rs, "a failed FullReads must not return a partial result")
+		})
+	}
+}
+
+// TestFullReadsPropagatesChunkFailure makes chunk k fail while all others
+// succeed, for k at the start, middle and end. The error must surface and the
+// result must be nil, never a partial slice that reads as complete.
+func TestFullReadsPropagatesChunkFailure(t *testing.T) {
+	const n = 2000 // 8 chunks at 256
+	nChunks := (n + MaxFullReadIDsPerRequest - 1) / MaxFullReadIDsPerRequest
+	for _, k := range []int{0, nChunks / 2, nChunks - 1} {
+		t.Run(fmt.Sprintf("failing_chunk=%d_of_%d", k, nChunks), func(t *testing.T) {
+			ids := seqIDs(n)
+			sentinel := errors.New("qa-sentinel-chunk-failure")
+			f := &fullReadFetcher{}
+			f.fn = func(chunk []strfmt.UUID) ([]Replica, error) {
+				idx := -1
+				for c := 0; c < n; c += MaxFullReadIDsPerRequest {
+					if chunk[0] == ids[c] {
+						idx = c / MaxFullReadIDsPerRequest
+						break
+					}
+				}
+				if idx == k {
+					return nil, sentinel
+				}
+				out := make([]Replica, len(chunk))
+				for i, id := range chunk {
+					out[i] = replicaFor(id)
+				}
+				return out, nil
+			}
+			rs, err := newFullReadClient(t, f).FullReads(context.Background(), "h", "C1", "S1", ids)
+			require.Error(t, err, "a failed chunk must fail the whole read")
+			require.ErrorIs(t, err, sentinel, "the underlying error must reach the caller")
+			require.Nil(t, rs, "a failed FullReads must return nil, not a partial result")
+		})
+	}
+}
+
+// TestFullReadsLeavesNoZeroValueGaps pins that reassembly never leaves a hole.
+// A gap surfaces as a zero-value Replica (nil Object, empty ID) that reads as a
+// real entry, and the repairer indexes the result positionally.
+func TestFullReadsLeavesNoZeroValueGaps(t *testing.T) {
+	for _, n := range []int{257, 600, 1024, 4096} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			ids := seqIDs(n)
+			f := &fullReadFetcher{fn: func(chunk []strfmt.UUID) ([]Replica, error) {
+				out := make([]Replica, len(chunk))
+				for i, id := range chunk {
+					out[i] = replicaFor(id)
+				}
+				return out, nil
+			}}
+			rs, err := newFullReadClient(t, f).FullReads(context.Background(), "h", "C1", "S1", ids)
+			require.NoError(t, err)
+			for i := range rs {
+				require.NotEmpty(t, rs[i].ID, "ZERO-VALUE HOLE at index %d", i)
+				require.NotNil(t, rs[i].Object, "ZERO-VALUE HOLE (nil object) at index %d", i)
+			}
+		})
+	}
+}
+
+// TestFullReadsSharedResultSliceStress drives the shared result slice from many
+// concurrent reads so -race can see an overlapping range write.
+func TestFullReadsSharedResultSliceStress(t *testing.T) {
+	ids := seqIDs(8192)
+	var wg sync.WaitGroup
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			f := &fullReadFetcher{fn: func(chunk []strfmt.UUID) ([]Replica, error) {
+				time.Sleep(time.Duration(rand.Intn(200)) * time.Microsecond)
+				out := make([]Replica, len(chunk))
+				for i, id := range chunk {
+					out[i] = replicaFor(id)
+				}
+				return out, nil
+			}}
+			logger, _ := test.NewNullLogger()
+			rs, err := NewFinderClient(f, logger).FullReads(context.Background(), "h", "C1", "S1", ids)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			for i := range ids {
+				if rs[i].ID != ids[i] || rs[i].Object == nil || rs[i].Object.ID() != ids[i] {
+					t.Errorf("misattribution at %d", i)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/usecases/replica/repairer_fetch_failure_test.go
+++ b/usecases/replica/repairer_fetch_failure_test.go
@@ -262,12 +262,22 @@ func TestFullReadsChunksIDs(t *testing.T) {
 	}
 }
 
-// TestFullReadsFetchesChunksConcurrently pins the bounded fan-out: the barrier
-// releases only once the full in-flight cap of requests is simultaneously in
-// flight, so a serial implementation times out here and an unbounded one
-// overshoots the peak.
+// TestFullReadsFetchesChunksConcurrently pins the bounded fan-out in both
+// directions: the barrier releases only once the full in-flight cap is
+// simultaneously in flight, so a serial implementation times out here, and the
+// cap-th arrival then holds the barrier open for a settling window so a request
+// the bound should have prevented has time to arrive and be counted.
+//
+// Releasing the instant the cap is reached is not enough to see a missing
+// bound: the first requests drain as the extra ones start, so the peak never
+// observes them and an unbounded implementation passes.
 func TestFullReadsFetchesChunksConcurrently(t *testing.T) {
-	const inFlightCap = replica.MaxConcurrentFullReadRequests
+	const (
+		inFlightCap = replica.MaxConcurrentFullReadRequests
+		// long enough for the goroutines an absent bound would have started to
+		// arrive, short enough not to matter when the bound holds
+		settle = 250 * time.Millisecond
+	)
 	ids := fullReadIDs((inFlightCap + 4) * replica.MaxFullReadIDsPerRequest)
 
 	var (
@@ -289,6 +299,7 @@ func TestFullReadsFetchesChunksConcurrently(t *testing.T) {
 				}
 			}
 			if arrivals.Add(1) == inFlightCap {
+				time.Sleep(settle)
 				close(release)
 			}
 			select {
@@ -339,9 +350,15 @@ func TestFullReadsFailedChunkFailsTheRead(t *testing.T) {
 
 // TestFullReadsRejectsMisalignedLaterChunk pins that the ID alignment check
 // reports absolute indices for chunks past the first.
+//
+// The corrupted chunk is full sized and in the middle of the batch, which is
+// the shape a real repair batch produces. Corrupting a short trailing chunk
+// instead would leave a guard that only inspects undersized chunks unexercised.
 func TestFullReadsRejectsMisalignedLaterChunk(t *testing.T) {
-	ids := fullReadIDs(replica.MaxFullReadIDsPerRequest + 1)
+	const chunkSize = replica.MaxFullReadIDsPerRequest
+	ids := fullReadIDs(3 * chunkSize) // three full chunks, none of them short
 	other := strfmt.UUID("99999999-9999-4999-8999-999999999999")
+	badAt := 2*chunkSize - 1 // the last id of the middle chunk
 
 	rc := replica.NewMockRClient(t)
 	rc.EXPECT().FetchObjects(anyVal, "B", "C1", "S1", anyVal).
@@ -350,16 +367,15 @@ func TestFullReadsRejectsMisalignedLaterChunk(t *testing.T) {
 			for i, id := range chunk {
 				rs[i] = repl(id, 1, false)
 			}
-			if len(chunk) == 1 { // the second chunk, holding the one trailing id
-				rs[0] = repl(other, 1, false)
+			if chunk[0] == ids[chunkSize] { // the middle chunk
+				rs[len(rs)-1] = repl(other, 1, false)
 			}
 			return rs, nil
 		})
 
 	logger, _ := test.NewNullLogger()
 	rs, err := replica.NewFinderClient(rc, logger).FullReads(context.Background(), "B", "C1", "S1", ids)
-	require.ErrorContains(t, err,
-		fmt.Sprintf("object %d is %q", replica.MaxFullReadIDsPerRequest, other))
+	require.ErrorContains(t, err, fmt.Sprintf("object %d is %q", badAt, other))
 	require.Nil(t, rs)
 }
 

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -107,15 +107,16 @@ func describeWrites(xs []*objects.VObject) string {
 // the only pending write is a delete and no object read can be a precondition
 // for it.
 //
-// The last row is expected to FAIL. It pins a pre-existing order dependence
-// that this test does not fix: a tombstone only wins when no replica after it
-// holds a newer live version. See the row comment.
+// Whether an older tombstone should beat a newer live copy at all is decided by
+// TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject in
+// https://github.com/weaviate/weaviate/pull/12361, which covers this shape in
+// both digest arrival orders. Both rows here use the two-replica fixture, where
+// no such ordering question arises.
 func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 	const (
 		class    = "C1"
 		shard    = "S1"
 		liveTime = int64(100)
-		newTime  = int64(150)
 		delTime  = int64(80)
 	)
 	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
@@ -147,23 +148,6 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 			},
 			fetchFails: true,
 			wantDelete: []string{"A"},
-			wantQuiet:  []string{"B"},
-		},
-		{
-			// RED, and pre-existing: identical to the rows above except that C
-			// holds a newer live copy after B's tombstone. Folding the digests
-			// resets the accumulated Deleted bit whenever a later replica raises
-			// the winning time, so a tombstone is only seen when no replica after
-			// it is newer. Move C's live@150 to index 1 and the same multiset
-			// deletes on every replica. Rewritten by
-			// https://github.com/weaviate/weaviate/pull/12361.
-			name: "tombstone ahead of the newest live copy",
-			digests: []nodeDigest{
-				{sender: "A", utime: liveTime},
-				{sender: "B", utime: delTime, deleted: true},
-				{sender: "C", utime: newTime},
-			},
-			wantDelete: []string{"A", "C"},
 			wantQuiet:  []string{"B"},
 		},
 	}

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -14,6 +14,8 @@ package replica
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -74,17 +76,46 @@ func TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch(t *testing.T) {
 	require.Equal(t, []bool{false}, resolved)
 }
 
+// nodeDigest is one replica's digest for the single object under test. The
+// first entry of a fixture is the caller's copy.
+type nodeDigest struct {
+	sender  string
+	utime   int64
+	deleted bool
+}
+
+// describeWrites renders repair payloads so a failure names what was written
+// rather than printing pointers.
+func describeWrites(xs []*objects.VObject) string {
+	if len(xs) == 0 {
+		return "no writes"
+	}
+	parts := make([]string, len(xs))
+	for i, x := range xs {
+		kind := "live"
+		if x.Deleted {
+			kind = "delete"
+		}
+		parts[i] = fmt.Sprintf("%s@%d over @%d", kind, x.LastUpdateTimeUnixMilli, x.StaleUpdateTime)
+	}
+	return strings.Join(parts, ", ")
+}
+
 // TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch pins that a delete,
 // which carries no content, is propagated even when the content fetch fails.
 // Under DeleteOnConflict a replica's older tombstone deletes a live winner, so
 // the only pending write is a delete and no object read can be a precondition
 // for it.
+//
+// The last row is expected to FAIL. It pins a pre-existing order dependence
+// that this test does not fix: a tombstone only wins when no replica after it
+// holds a newer live version. See the row comment.
 func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 	const (
-		class = "C1"
-		shard = "S1"
-		// caller A holds the live winner, replica B an older tombstone
+		class    = "C1"
+		shard    = "S1"
 		liveTime = int64(100)
+		newTime  = int64(150)
 		delTime  = int64(80)
 	)
 	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
@@ -92,14 +123,62 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 
 	tests := []struct {
 		name       string
+		digests    []nodeDigest
 		fetchFails bool
+		wantDelete []string // replicas that must receive the tombstone
+		wantQuiet  []string // replicas that must be left untouched
+		wantErr    string
 	}{
-		{name: "content fetch succeeds", fetchFails: false},
-		{name: "content fetch fails", fetchFails: true},
+		{
+			// caller A holds the live winner, replica B an older tombstone
+			name: "content fetch succeeds",
+			digests: []nodeDigest{
+				{sender: "A", utime: liveTime},
+				{sender: "B", utime: delTime, deleted: true},
+			},
+			wantDelete: []string{"A"},
+			wantQuiet:  []string{"B"},
+		},
+		{
+			name: "content fetch fails",
+			digests: []nodeDigest{
+				{sender: "A", utime: liveTime},
+				{sender: "B", utime: delTime, deleted: true},
+			},
+			fetchFails: true,
+			wantDelete: []string{"A"},
+			wantQuiet:  []string{"B"},
+		},
+		{
+			// RED, and pre-existing: identical to the rows above except that C
+			// holds a newer live copy after B's tombstone. Folding the digests
+			// resets the accumulated Deleted bit whenever a later replica raises
+			// the winning time, so a tombstone is only seen when no replica after
+			// it is newer. Move C's live@150 to index 1 and the same multiset
+			// deletes on every replica. Rewritten by
+			// https://github.com/weaviate/weaviate/pull/12361.
+			name: "tombstone ahead of the newest live copy",
+			digests: []nodeDigest{
+				{sender: "A", utime: liveTime},
+				{sender: "B", utime: delTime, deleted: true},
+				{sender: "C", utime: newTime},
+			},
+			wantDelete: []string{"A", "C"},
+			wantQuiet:  []string{"B"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// the newest version any replica claims, so a fetch that the winner
+			// has not moved past returns content the repairer accepts
+			maxTime := int64(0)
+			for _, d := range tt.digests {
+				if d.utime > maxTime {
+					maxTime = d.utime
+				}
+			}
+
 			rc := NewMockRClient(t)
 			if tt.fetchFails {
 				rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
@@ -109,7 +188,7 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 					Return([]Replica{{
 						ID: id,
 						Object: &storobj.Object{Object: models.Object{
-							ID: id, Class: class, LastUpdateTimeUnix: liveTime,
+							ID: id, Class: class, LastUpdateTimeUnix: maxTime,
 						}},
 					}}, nil).Maybe()
 			}
@@ -138,29 +217,45 @@ func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
 				logger:              logger,
 			}
 
-			votes := []Vote{
-				{BatchReply: BatchReply{Sender: "A", IsLocal: true, DigestData: []types.RepairResponse{
-					{ID: id.String(), UpdateTime: liveTime},
-				}}, Count: make([]int, len(ids))},
-				{BatchReply: BatchReply{Sender: "B", DigestData: []types.RepairResponse{
-					{ID: id.String(), UpdateTime: delTime, Deleted: true},
-				}}, Count: make([]int, len(ids))},
+			votes := make([]Vote, len(tt.digests))
+			for i, d := range tt.digests {
+				votes[i] = Vote{
+					BatchReply: BatchReply{Sender: d.sender, IsLocal: i == 0, DigestData: []types.RepairResponse{
+						{ID: id.String(), UpdateTime: d.utime, Deleted: d.deleted},
+					}},
+					Count: make([]int, len(ids)),
+				}
 			}
 
 			_, err = r.repairBatchPart(context.Background(), shard, ids, votes, 0)
-			_ = err // a failed fetch is reported, but it must not suppress the delete
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+
+			staleOn := map[string]int64{}
+			for _, d := range tt.digests {
+				staleOn[d.sender] = d.utime
+			}
 
 			mu.Lock()
 			defer mu.Unlock()
-			require.Len(t, captured["A"], 1,
-				"the live copy on A must be deleted: B holds a tombstone and the strategy is delete-on-conflict")
-			require.Empty(t, captured["B"], "B already holds the winning tombstone")
+			for _, node := range tt.wantQuiet {
+				require.Empty(t, captured[node],
+					"%s already holds the winning tombstone and must not be written, got %s",
+					node, describeWrites(captured[node]))
+			}
+			for _, node := range tt.wantDelete {
+				require.Len(t, captured[node], 1,
+					"the live copy on %s must be deleted: a replica holds a tombstone and the strategy is delete-on-conflict", node)
 
-			got := captured["A"][0]
-			require.True(t, got.Deleted)
-			require.Nil(t, got.LatestObject, "a delete carries no content")
-			require.Equal(t, delTime, got.LastUpdateTimeUnixMilli)
-			require.Equal(t, liveTime, got.StaleUpdateTime)
+				got := captured[node][0]
+				require.True(t, got.Deleted)
+				require.Nil(t, got.LatestObject, "a delete carries no content")
+				require.Equal(t, delTime, got.LastUpdateTimeUnixMilli)
+				require.Equal(t, staleOn[node], got.StaleUpdateTime)
+			}
 		})
 	}
 }
@@ -206,6 +301,197 @@ func TestRepairBatchPartDeleteOnConflictSkipsContentFetch(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []bool{true}, resolved, "the winning outcome is a delete, known from the digests alone")
 	require.Zero(t, fetches.Load(), "a delete carries no content, so nothing needs reading")
+}
+
+// batchObj is one object of a mixed batch, seen from three replicas A, B and C.
+// Exactly one field is set: winnerNode names the replica holding the newer live
+// version the repair fetches, tombstoneNode the replica holding the older
+// tombstone that deletes the object under delete-on-conflict. Every other
+// replica holds the same baseline live version.
+type batchObj struct {
+	winnerNode    int // -1 when the repair is a delete
+	tombstoneNode int // -1 when the repair carries content
+}
+
+func fetchFrom(node int) batchObj { return batchObj{winnerNode: node, tombstoneNode: -1} }
+
+func deleteFrom(node int) batchObj { return batchObj{winnerNode: -1, tombstoneNode: node} }
+
+// TestRepairBatchPartMixedBatch pins that a batch mixing objects repaired from
+// fetched content with objects repaired by a delete files every fetched object
+// under the id it was requested for.
+//
+// An object whose repair is a delete carries no content and is dropped before
+// the fetch is partitioned by replica, so a fetched object no longer sits at
+// the batch position of its id and the response has to be mapped back through
+// the partition. Every winning version shares one update time, which keeps the
+// staleness check from masking a mismatch that only the content reveals.
+func TestRepairBatchPartMixedBatch(t *testing.T) {
+	const (
+		class     = "C1"
+		shard     = "S1"
+		baseTime  = int64(100) // the version every replica starts from
+		winTime   = int64(200) // the newer live version to fetch
+		deleteTim = int64(80)  // an older tombstone
+	)
+	nodes := []string{"A", "B", "C"}
+
+	tests := []struct {
+		name string
+		objs []batchObj
+	}{
+		{
+			// deletes sit between the fetches on both replicas
+			name: "deletes interleaved between two fetch partitions",
+			objs: []batchObj{
+				fetchFrom(1), deleteFrom(2), fetchFrom(2),
+				deleteFrom(1), fetchFrom(1), fetchFrom(2),
+			},
+		},
+		{
+			// a delete first and last, so both partition edges shift
+			name: "deletes at both ends of the batch",
+			objs: []batchObj{
+				deleteFrom(2), fetchFrom(1), deleteFrom(1),
+				fetchFrom(2), fetchFrom(1), deleteFrom(2), fetchFrom(2),
+			},
+		},
+		{
+			// one partition holding every fetch, its members non contiguous
+			name: "single fetch partition with gaps",
+			objs: []batchObj{
+				fetchFrom(1), deleteFrom(2), fetchFrom(1),
+				deleteFrom(2), fetchFrom(1),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ids := make([]strfmt.UUID, len(tt.objs))
+			for j := range ids {
+				ids[j] = strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000000%02d", j))
+			}
+			// a per id property, so content landing under a foreign id is visible
+			// even when both objects carry the same update time
+			tagOf := func(j int) string { return "content-of-" + ids[j].String() }
+			winner := func(j int) *storobj.Object {
+				return &storobj.Object{Object: models.Object{
+					ID:                 ids[j],
+					Class:              class,
+					LastUpdateTimeUnix: winTime,
+					Properties:         map[string]interface{}{"tag": tagOf(j)},
+				}}
+			}
+			byID := map[strfmt.UUID]*storobj.Object{}
+			for j := range tt.objs {
+				byID[ids[j]] = winner(j)
+			}
+
+			votes := make([]Vote, len(nodes))
+			for n, node := range nodes {
+				digests := make([]types.RepairResponse, len(tt.objs))
+				for j, o := range tt.objs {
+					switch n {
+					case o.winnerNode:
+						digests[j] = types.RepairResponse{ID: ids[j].String(), UpdateTime: winTime}
+					case o.tombstoneNode:
+						digests[j] = types.RepairResponse{ID: ids[j].String(), UpdateTime: deleteTim, Deleted: true}
+					default:
+						digests[j] = types.RepairResponse{ID: ids[j].String(), UpdateTime: baseTime}
+					}
+				}
+				votes[n] = Vote{
+					BatchReply: BatchReply{Sender: node, IsLocal: n == 0, DigestData: digests},
+					Count:      make([]int, len(tt.objs)),
+				}
+			}
+
+			rc := NewMockRClient(t)
+			rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, class, shard, mock.Anything).
+				RunAndReturn(func(_ context.Context, host, _, _ string, query []strfmt.UUID) ([]Replica, error) {
+					rs := make([]Replica, len(query))
+					for i, id := range query {
+						obj, ok := byID[id]
+						require.True(t, ok, "%s was asked for an id that is not in the batch: %s", host, id)
+						rs[i] = Replica{ID: id, Object: obj}
+					}
+					return rs, nil
+				})
+
+			var (
+				mu       sync.Mutex
+				captured = map[string][]*objects.VObject{}
+			)
+			rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, class, shard, mock.Anything).
+				RunAndReturn(func(_ context.Context, host, _, _ string, xs []*objects.VObject) ([]types.RepairResponse, error) {
+					mu.Lock()
+					defer mu.Unlock()
+					captured[host] = append(captured[host], xs...)
+					return nil, nil
+				}).Maybe()
+
+			metrics, err := NewMetrics(monitoring.GetMetrics())
+			require.NoError(t, err)
+			logger, _ := test.NewNullLogger()
+
+			r := &repairer{
+				class:               class,
+				getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyDeleteOnConflict },
+				client:              NewFinderClient(rc, logger),
+				metrics:             metrics,
+				logger:              logger,
+			}
+
+			resolved, err := r.repairBatchPart(context.Background(), shard, ids, votes, 0)
+			require.NoError(t, err)
+			require.Equal(t, len(tt.objs), len(resolved))
+			for j := range resolved {
+				require.True(t, resolved[j], "object %d (%s) was left unresolved", j, ids[j])
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			for n, node := range nodes {
+				written := map[strfmt.UUID]*objects.VObject{}
+				for _, up := range captured[node] {
+					_, dup := written[up.ID]
+					require.False(t, dup, "%s was written %s twice", node, up.ID)
+					written[up.ID] = up
+				}
+
+				want := 0
+				for j, o := range tt.objs {
+					if n == o.winnerNode || n == o.tombstoneNode {
+						require.NotContains(t, written, ids[j],
+							"%s already holds the winning version of object %d", node, j)
+						continue
+					}
+					want++
+
+					up := written[ids[j]]
+					require.NotNil(t, up, "%s was not repaired for object %d (%s)", node, j, ids[j])
+					require.Equal(t, baseTime, up.StaleUpdateTime)
+
+					if o.tombstoneNode >= 0 {
+						require.True(t, up.Deleted, "object %d must be repaired by a delete", j)
+						require.Nil(t, up.LatestObject, "a delete carries no content")
+						require.Equal(t, deleteTim, up.LastUpdateTimeUnixMilli)
+						continue
+					}
+
+					require.False(t, up.Deleted)
+					require.Equal(t, winTime, up.LastUpdateTimeUnixMilli)
+					require.NotNil(t, up.LatestObject, "object %d must be repaired with content", j)
+					require.Equal(t, ids[j], up.LatestObject.ID,
+						"%s received another object's content under %s", node, ids[j])
+					require.Equal(t, map[string]interface{}{"tag": tagOf(j)}, up.LatestObject.Properties,
+						"%s received the content of a different object under %s", node, ids[j])
+				}
+				require.Len(t, captured[node], want, "unexpected number of repairs on %s", node)
+			}
+		})
+	}
 }
 
 // TestRepairBatchPartWithoutCallerCopy pins that a missing caller copy is

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -374,6 +374,12 @@ func (fc FinderClient) fullReadChunk(ctx context.Context,
 			return nil, fmt.Errorf("malformed full read response: object %d is %q, expected %q",
 				offset+i, part[i].ID, chunk[i])
 		}
+		// The envelope id is not what gets written: the repairer takes the
+		// carried object. A tombstone carries none, hence the nil check.
+		if part[i].Object != nil && part[i].Object.ID() != chunk[i] {
+			return nil, fmt.Errorf("malformed full read response: object %d carries content for %q, expected %q",
+				offset+i, part[i].Object.ID(), chunk[i])
+		}
 	}
 	return part, nil
 }


### PR DESCRIPTION
Follow-up to [weaviate/weaviate#12355](https://github.com/weaviate/weaviate/pull/12355), which merged before four review gaps were closed. **No live bug was found**: every behaviour investigated here — the multi-object index arithmetic, the fan-out bound, the chunk alignment guard — is correct as shipped. This PR is additive test coverage, three tests whose coverage did not reach what their names claimed, one factually wrong comment, and one dropped error assertion.

✅ **The branch is green.** An earlier revision committed one table row red on the claim that [#12361](https://github.com/weaviate/weaviate/pull/12361) would turn it green. **That claim was wrong and the row is removed at `e5188cb35`** — no merge order could ever have satisfied it. Section 2 has the measurement.

The single production change is one defensive line in `fullReadChunk` (section 6), which cannot fire against any current peer.

## 1. Multi-object batch coverage — investigated, shipped behaviour is correct ✅

Every fixture in #12355 used `len(ids) == 1`. That left the riskiest arithmetic in `repairBatchPart` untested: the delete-only branch drops objects from `ms` *before* the fetch is partitioned by replica, so a fetched object no longer sits at the batch position of its id, and the response has to be mapped back through `ms[start-n+i].O`. A positional error there writes one object's content under another object's id — the same data-destruction class #12355 exists to close.

**Result: the shipped mapping is correct.** `TestRepairBatchPartMixedBatch` passes against unmodified `stable/v1.37`.

Three rows, three replicas, delete-on-conflict, batches of 5–7 ids mixing delete-only objects with objects needing content, interleaved so a delete is never merely first or last:

| row | shape |
|---|---|
| `deletes interleaved between two fetch partitions` | 6 ids, deletes at 1 and 3, fetches split across two replicas |
| `deletes at both ends of the batch` | 7 ids, deletes at 0, 2 and 5, so both partition edges shift |
| `single fetch partition with gaps` | 5 ids, all fetches on one replica at non-contiguous positions |

### Evidence that the coverage is real and not decorative

A passing test proves nothing unless it can fail for the right reason. Two independent off-by-one injections at `usecases/replica/repairer.go:502`, each red on all three rows, then reverted (`git diff --exit-code` clean):

**A — drop the `.O` indirection** (`idx := ms[start-n+i].O` → `idx := start - n + i`), which is exactly what goes wrong if the delete-only entries removed from `ms` are forgotten:

```
B no longer holds the agreed version of [00000000-0000-0000-0000-000000000004]: source object changed during repair
C no longer holds the agreed version of [00000000-0000-0000-0000-000000000005]: source object changed during repair
```

**B — rotate one slot inside the partition** (`idx := ms[start-n+((i+1)%n)].O`). Every winning version in the fixture deliberately shares one update time, so the staleness guard is blind to this swap and **only** the content assertion can catch it:

```
A received another object's content under 00000000-0000-0000-0000-000000000000
expected: "00000000-0000-0000-0000-000000000000"
actual  : "00000000-0000-0000-0000-000000000004"
```

Injection B is the one that matters: it demonstrates the fixture catches a *pure positional swap*, the actual data-destruction shape, rather than merely being sensitive to some unrelated invariant. Each object carries a per-id property so foreign content is visible even when update times match.

## 2. ✅ The order dependence this PR found, and the row that could never pin it

An earlier revision committed one row of `TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch` red — `tombstone ahead of the newest live copy` — on the claim that [#12361](https://github.com/weaviate/weaviate/pull/12361) would turn it green. **That claim was wrong. The row is removed at `e5188cb35`.**

The order dependence itself is real. Folding the digests in `repairBatchPart` resets the accumulated `Deleted` bit whenever a later replica raises the winning time:

```go
lastTimes[j] = iTuple{S: i, O: j, T: x.UpdateTime} // Deleted defaults to false
lastTimes[j].Deleted = lastTimes[j].Deleted || x.Deleted
```

So a tombstone only survives the fold when no replica *after* it holds a newer live version. Two identical multisets, differing only in which host holds which:

| fixture | outcome |
|---|---|
| `A=live@100  B=DEL@80  C=live@150` | live@150 everywhere |
| `A=live@100  B=live@150  C=DEL@80` | DEL@80 everywhere |

**The removed row asserted the wrong side of it.** It required `DEL@80` to win on every replica: an older tombstone destroying a newer live object. That is the data-loss half of [weaviate/0-weaviate-issues#385](https://github.com/weaviate/0-weaviate-issues/issues/385), and removing it is exactly what #12361 exists to do. #12361 resolves the same dependence in the **opposite** direction — newest live wins, in both arrival orders.

Measured, not argued. Applying #12361's production diff (`repairer.go` + `finder_stream.go`) on top of this branch and re-running:

| row | before | with #12361 applied |
|---|---|---|
| `content fetch succeeds` | ✅ | 🔴 `"[]" should have 1 item(s), but has 0` |
| `content fetch fails` | ✅ | 🔴 `"[]" should have 1 item(s), but has 0` |
| `tombstone ahead of the newest live copy` | 🔴 at `require.Empty` | 🔴 at `require.True(t, got.Deleted)` |

The red row does not go green; it fails at a *different* assertion, and it takes the other two rows down with it, because those rest on the same older-tombstone-wins behaviour. **No merge order makes it green.** #12361 handles this by re-scaffolding the whole function onto a two-object fixture with a *newer* tombstone, which is the right answer and which this PR should not duplicate.

**The reproduction is not lost.** #12361 carries `TestRepairBatchPartDeleteOnConflictKeepsNewerLiveObject`, covering this three-tier shape in **both** digest arrival orders and asserting the outcome that PR establishes as correct. Reverting only #12361's `repairer.go` turns it red on the `[A C B]` order with `expected {300,false}, actual {200,true}` — *"the winning live version was destroyed by an older tombstone"*. It is a genuine pin, and it owns these semantics. The doc comment here now points at it.

⚠️ **Merge note:** both PRs edit `TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch` in `repairer_internal_test.go` and will conflict. **#12361's version must win** — this PR's two remaining rows rest on behaviour #12361 removes.

## 3. A factually wrong comment in `finder_stream.go`

The comment claimed the code returns the repair error and that doing so cancels the shared context. The code logs and continues — it never propagates a repair error, and always ends with `resultCh <- nil`. Rewritten to state what the code does and why: the failure has already decremented that object's vote count, which is what withholds `IsConsistent` further down.

The invariant the old comment described is real, just located elsewhere — `CheckConsistency` runs one group over every shard of the request, so a returned error would cancel the shards still repairing. That is now stated at `finder.go`, where it is true.

## 4. An error assertion that was being dropped — and what it was hiding

`TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch` did `_ = err`, now asserted through a `wantErr` table field.

**This is the most instructive thing in the diff.** The discarded error was hiding that the row named `content fetch fails` **never reaches a fetch**. For the two-replica delete-only fixture the repairer issues no fetch at all, so the failing-fetch mock it installs is never called and the row could not have observed a fetch failure. `_ = err` is what let a well-named, green test claim coverage it did not have.

The row still earns its place — it demonstrates the delete path never consults the fetch, which is exactly the contract #12355 established — but it is now asserted (`NoError`) rather than assumed, and it says so.

The same illusion is the theme of section 5.

## 5. Three tests whose coverage pointed away from the risk

Found by mutating the concurrency path shipped in `d18e7eee46`. All three mutations **survived** the tests as merged. Each is now killed; every kill below was verified by applying the mutation and observing the failure, then reverting.

**The fan-out bound was not actually pinned.** `TestFullReadsFetchesChunksConcurrently` asserts `peak` never exceeds `MaxConcurrentFullReadRequests`, but deleting `SetLimit(16)` outright left it green **10/10 under `-race`**. The barrier released the moment the 16th request arrived, so the first chunks drained before any extra one started and `peak` never observed the excess. The cap-th arrival now holds the barrier open for a settling window first, giving the goroutines an absent bound would have started time to arrive and be counted.

The same mutation now fails **10/10 under `-race`** with `in-flight requests must reach and never exceed the cap`, `expected: int(16), actual: int64(20)` — the peak sees every one of the 20 chunks. The unmutated test passes 10/10 under `-race`, so the settling window adds no flakiness.

**The alignment guard was only ever exercised on a 1-element chunk.** `TestFullReadsRejectsMisalignedLaterChunk` used 257 ids and selected its target with `len(chunk) == 1`, so a guard mutated to fire only for undersized chunks survived — while real repair batches produce full-size chunks. It now uses three full chunks and corrupts the last id of the **middle** one, selected by its first id rather than its length. Verified against the shipped code with the section 6 line removed, so the kill is the test's, not the hardening's: the mutation fails with `An error is expected but got nil`.

**Removing the length guard produced silent holes.** With `len(part) != len(chunk)` deleted, a short chunk makes `copy(rs[start:end], part)` leave zero-value `Replica` entries (nil `Object`, empty `ID`) mid-slice while `FullReads` returns success — and the repairer indexes that positionally. No chunked test covered a short response. Now killed with `envelope mispair at 511 WITHOUT an error`.

New file `usecases/replica/fullreads_adversarial_test.go` adds an identity oracle at every position across boundary counts (0, 1, 2, 15, 16, 17, 255, 256, 257, 511, 512, 513, 4096, 4097), a malformed-response table, per-chunk failure propagation at the first/middle/last chunk, a no-zero-value-gaps check, and a shared-slice stress run for `-race`.

## 6. One defensive line, not a fix

`fullReadChunk` validated `part[i].ID` — the envelope — but the repairer consumes `part[i].Object`. Checking a field the caller does not use leaves correct envelopes carrying swapped payloads acceptable. One line, guarded on a non-nil payload since a tombstone carries none:

```go
if part[i].Object != nil && part[i].Object.ID() != chunk[i] {
```

**Not a live bug and not reachable through any current peer**: the only server-side producer builds the envelope from the payload (`ID: obj.ID()` in `adapters/repos/db/replication.go`), so the two cannot diverge. Included because it is one line on precisely the axis this PR exists to defend, and because it cannot reject anything a correct peer sends. Covered by `chunk keeps envelope ids but swaps the carried payloads`; removing the line fails with `CONTENT MISATTRIBUTION at position 256 and FullReads returned no error`. Say the word and I will drop it if you would rather this PR stay strictly test-only.

## What a reviewer should look at hardest

- **The settling window in `TestFullReadsFetchesChunksConcurrently`.** It is the difference between pinning the bound and pinning only the fan-out. If it is too short on a loaded CI box the test weakens silently rather than failing — worth deciding whether 250ms is right.
- Whether the shared winning update time in `TestRepairBatchPartMixedBatch` is understood as load-bearing: raise it per object and injection B stops being catchable, because the staleness guard would mask the swap.
- Whether the section 6 line belongs on a release branch at all.
- Whether section 2's merge note is handled when #12361 lands: this PR's two remaining rows go red under it.

## Verification

| gate | result |
|---|---|
| `go build ./...` | ✅ rc=0 |
| `gofumpt -l` / `goimports -l` | ✅ no files listed |
| `golangci-lint run ./usecases/replica/...` | ✅ rc=0 **and** literal `0 issues.` |
| `tools/linter_go_routines.sh` | ✅ rc=0 |
| `tools/linter_error_groups.sh` | ✅ rc=0 |
| `tools/linter_hidden_unicode.sh` | ✅ rc=0 |
| `tools/linter_waitgroups_done.sh` | ✅ rc=0 |
| `go test -race -count 1 -timeout 30m ./usecases/replica/...` | ✅ completed in 254s — **0 data races**, all tests pass |

`go vet` reports one pre-existing finding at `usecases/replica/coordinator.go:269` (untouched here, carries an explicit `//nolint:govet`, last modified in `035716f5ac`). `golangci-lint` honours the directive and is clean.

