### PR TITLE
fix(replication): unify the loading-shard readiness check and fix FetchObjects 

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1144,6 +1144,17 @@ func (i *Index) replicationEnabled() bool {
 	return i.Config.ReplicationFactor > 1
 }
 
+// ensureShardLocallyReady rejects reads of a loading shard so the caller retries
+// on a replica. With replication off there is none, so the shard is used as it is
+// rather than failing a read that would otherwise only be slow.
+func (i *Index) ensureShardLocallyReady(shard ShardLike) error {
+	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
+		return enterrors.NewErrUnprocessable(
+			fmt.Errorf("local %s shard is not ready", shard.Name()))
+	}
+	return nil
+}
+
 func (i *Index) shardHasMultipleReplicasWrite(tenantName, shardName string) bool {
 	// if replication is enabled, we always have multiple replicas
 	if i.replicationEnabled() {
@@ -1744,8 +1755,8 @@ func (i *Index) IncomingGetObject(ctx context.Context, shardName string,
 		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, err
 	}
 
 	return shard.ObjectByID(ctx, id, props, additional)
@@ -1764,8 +1775,8 @@ func (i *Index) IncomingMultiGetObjects(ctx context.Context, shardName string,
 		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, err
 	}
 
 	return shard.MultiObjectByID(ctx, wrapIDsInMulti(ids))
@@ -1916,8 +1927,8 @@ func (i *Index) IncomingExists(ctx context.Context, shardName string,
 		return false, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return false, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return false, err
 	}
 
 	return shard.Exists(ctx, id)
@@ -2213,8 +2224,8 @@ func (i *Index) singleLocalShardObjectVectorSearch(ctx context.Context, searchVe
 ) ([]*storobj.Object, []float32, error) {
 	ctx = helpers.InitSlowQueryDetails(ctx)
 	helpers.AnnotateSlowQueryLog(ctx, "is_coordinator", true)
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shard.Name()))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, nil, err
 	}
 	var shardStart time.Time
 	if additional.QueryProfile {
@@ -2622,8 +2633,8 @@ func (i *Index) IncomingSearch(ctx context.Context, shardName string,
 		return nil, nil, nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, nil, nil, err
 	}
 
 	ctx = helpers.InitSlowQueryDetails(ctx)
@@ -3053,8 +3064,8 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, err
 	}
 
 	return shard.Aggregate(ctx, params, mods.(*modules.Provider))
@@ -3378,8 +3389,8 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 		return 0, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return 0, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return 0, err
 	}
 	var size int64
 	_ = shard.ForEachVectorQueue(func(_ string, queue *VectorIndexQueue) error {
@@ -3441,8 +3452,8 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 		return "", fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return "", enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return "", err
 	}
 	return shard.GetStatus().String(), nil
 }
@@ -3555,8 +3566,8 @@ func (i *Index) IncomingFindUUIDs(ctx context.Context, shardName string,
 		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, err
 	}
 
 	return shard.FindUUIDs(ctx, filters, limit)

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -34,7 +34,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/file"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -686,8 +685,8 @@ func (idx *Index) OverwriteObjects(ctx context.Context,
 		return nil, fmt.Errorf("shard %q not found locally", shard)
 	}
 
-	if s.GetStatus() == storagestate.StatusLoading && idx.replicationEnabled() {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shard))
+	if err := idx.ensureShardLocallyReady(s); err != nil {
+		return nil, err
 	}
 
 	var result []types.RepairResponse
@@ -861,8 +860,8 @@ func (i *Index) DigestObjects(ctx context.Context,
 		return nil, fmt.Errorf("shard %q not found locally", shardName)
 	}
 
-	if s.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(s); err != nil {
+		return nil, err
 	}
 
 	multiIDs := make([]multi.Identifier, len(ids))
@@ -1027,8 +1026,8 @@ func (i *Index) FetchObject(ctx context.Context,
 		return replica.Replica{}, fmt.Errorf("shard %q does not exist locally", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return replica.Replica{}, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return replica.Replica{}, err
 	}
 
 	obj, err := shard.ObjectByID(ctx, id, nil, additional.Properties{})
@@ -1073,8 +1072,8 @@ func (i *Index) FetchObjects(ctx context.Context,
 		return nil, fmt.Errorf("shard %q does not exist locally", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
+	if err := i.ensureShardLocallyReady(shard); err != nil {
+		return nil, err
 	}
 
 	objs, err := shard.MultiObjectByID(ctx, wrapIDsInMulti(ids))

--- a/adapters/repos/db/shard_loading_guard_test.go
+++ b/adapters/repos/db/shard_loading_guard_test.go
@@ -1,0 +1,166 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/entities/storobj"
+	esync "github.com/weaviate/weaviate/entities/sync"
+)
+
+const (
+	loadingGuardClass = "C1"
+	loadingGuardShard = "S1"
+)
+
+func newLoadingGuardIndex(shard ShardLike, replicationFactor int64) *Index {
+	idx := &Index{
+		Config: IndexConfig{
+			ClassName:         schema.ClassName(loadingGuardClass),
+			ReplicationFactor: replicationFactor,
+		},
+		shardCreateLocks: esync.NewKeyRWLocker(),
+	}
+	idx.shards.Store(loadingGuardShard, shard)
+	return idx
+}
+
+func TestEnsureShardLocallyReady(t *testing.T) {
+	tests := []struct {
+		name              string
+		status            storagestate.Status
+		replicationFactor int64
+		wantRejected      bool
+	}{
+		{
+			name:              "loading shard is rejected so the read retries on a replica",
+			status:            storagestate.StatusLoading,
+			replicationFactor: 3,
+			wantRejected:      true,
+		},
+		{
+			name:              "loading shard is used as is when there is no replica to retry on",
+			status:            storagestate.StatusLoading,
+			replicationFactor: 1,
+		},
+		{
+			name:              "ready shard is used, replicated",
+			status:            storagestate.StatusReady,
+			replicationFactor: 3,
+		},
+		{
+			name:              "ready shard is used, unreplicated",
+			status:            storagestate.StatusReady,
+			replicationFactor: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shard := NewMockShardLike(t)
+			shard.EXPECT().GetStatus().Return(tt.status).Once()
+			shard.EXPECT().Name().Return(loadingGuardShard).Maybe()
+
+			err := newLoadingGuardIndex(shard, tt.replicationFactor).
+				ensureShardLocallyReady(shard)
+
+			if !tt.wantRejected {
+				require.NoError(t, err)
+				return
+			}
+
+			var unprocessable enterrors.ErrUnprocessable
+			require.True(t, errors.As(err, &unprocessable),
+				"a loading shard must be reported as unprocessable, got %T: %v", err, err)
+			require.ErrorContains(t, err, "shard is not ready")
+		})
+	}
+}
+
+func TestFetchObjectsAppliesReadinessCheck(t *testing.T) {
+	ids := []strfmt.UUID{
+		"00000000-0000-0000-0000-00000000000a",
+		"00000000-0000-0000-0000-00000000000b",
+	}
+
+	object := func(id strfmt.UUID, updateTime int64) *storobj.Object {
+		return &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 id,
+				Class:              loadingGuardClass,
+				LastUpdateTimeUnix: updateTime,
+			},
+		}
+	}
+
+	t.Run("loading shard is refused while replicated", func(t *testing.T) {
+		shard := NewMockShardLike(t)
+		shard.EXPECT().GetStatus().Return(storagestate.StatusLoading).Once()
+		shard.EXPECT().Name().Return(loadingGuardShard).Once()
+		shard.EXPECT().preventShutdown().Return(func() {}, nil).Once()
+		idx := newLoadingGuardIndex(shard, 3)
+
+		_, err := idx.FetchObjects(context.Background(), loadingGuardShard, ids)
+
+		var unprocessable enterrors.ErrUnprocessable
+		require.True(t, errors.As(err, &unprocessable), "got %T: %v", err, err)
+		shard.AssertNotCalled(t, "MultiObjectByID")
+	})
+
+	t.Run("loading shard is served when unreplicated", func(t *testing.T) {
+		shard := NewMockShardLike(t)
+		shard.EXPECT().GetStatus().Return(storagestate.StatusLoading).Once()
+		shard.EXPECT().preventShutdown().Return(func() {}, nil).Once()
+		shard.EXPECT().MultiObjectByID(mock.Anything, wrapIDsInMulti(ids)).
+			Return([]*storobj.Object{object(ids[0], 100), object(ids[1], 200)}, nil).Once()
+		idx := newLoadingGuardIndex(shard, 1)
+
+		got, err := idx.FetchObjects(context.Background(), loadingGuardShard, ids)
+
+		require.NoError(t, err)
+		require.Len(t, got, len(ids))
+		require.Equal(t, ids[0], got[0].ID)
+		require.Equal(t, ids[1], got[1].ID)
+		require.Equal(t, int64(100), got[0].LastUpdateTimeUnixMilli)
+		require.Equal(t, int64(200), got[1].LastUpdateTimeUnixMilli)
+		require.NotNil(t, got[0].Object)
+		require.NotNil(t, got[1].Object)
+	})
+
+	t.Run("singular FetchObject agrees", func(t *testing.T) {
+		shard := NewMockShardLike(t)
+		shard.EXPECT().GetStatus().Return(storagestate.StatusLoading).Once()
+		shard.EXPECT().preventShutdown().Return(func() {}, nil).Once()
+		shard.EXPECT().ObjectByID(mock.Anything, ids[0], mock.Anything, mock.Anything).
+			Return(object(ids[0], 100), nil).Once()
+		idx := newLoadingGuardIndex(shard, 1)
+
+		got, err := idx.FetchObject(context.Background(), loadingGuardShard, ids[0])
+
+		require.NoError(t, err)
+		require.Equal(t, ids[0], got.ID)
+		require.Equal(t, int64(100), got.LastUpdateTimeUnixMilli)
+		require.NotNil(t, got.Object)
+	})
+}


### PR DESCRIPTION
### What's being changed:
`Index.FetchObjects()` rejected every read of a loading shard, while the singular `Index.FetchObject()` rejected only when replication is enabled. The guard exists so a replicated read can be retried against a peer with replication off there is no peer, so rejecting only turns a slow read into a failed one.

this PR fixes this and adds unit test to verify other methods 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
