### PR TITLE
backport(v1.36): never use a search result as a read-repair payload (#12355)

### DIFF
--- a/test/acceptance/replication/read_repair/read_repair_projection_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_projection_test.go
@@ -88,8 +88,11 @@ func (suite *ReplicationTestSuite) TestReadRepairPreservesProjectedAwayContent()
 	// projected copy is the caller's copy the repair path sees.
 	readerURI := func() string { return compose.ContainerURI(1) }
 	laggingURI := func() string { return compose.ContainerURI(3) }
-	laggingNode := docker.Weaviate2
-	t.Logf("reader node (stays up): %s at %s", docker.Weaviate0, readerURI())
+	// ?node_name= wants the cluster node name, which is not the container name:
+	// CLUSTER_HOSTNAME is node1..node3 while the containers are weaviate,
+	// weaviate2 and weaviate3.
+	laggingNode := "node3"
+	t.Logf("reader node (stays up): %s at %s", "node1", readerURI())
 	t.Logf("lagging node (stopped during rewrite): %s at %s", laggingNode, laggingURI())
 
 	helper.SetupClient(readerURI())
@@ -126,7 +129,7 @@ func (suite *ReplicationTestSuite) TestReadRepairPreservesProjectedAwayContent()
 		common.CreateObjectsCL(t, readerURI(), batch, types.ConsistencyLevelAll)
 
 		// Confirm full replication before treating later state as a divergence.
-		for _, nodeName := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
+		for _, nodeName := range []string{"node1", "node2", "node3"} {
 			for i, id := range projectionRepairIDs {
 				require.EventuallyWithT(t, func(ct *assert.CollectT) {
 					obj, err := common.GetObjectFromNodeWithVector(t, readerURI(), className, id, nodeName)
@@ -232,8 +235,8 @@ func (suite *ReplicationTestSuite) TestReadRepairPreservesProjectedAwayContent()
 			uri  string
 			name string
 		}{
-			{compose.ContainerURI(1), docker.Weaviate0},
-			{compose.ContainerURI(2), docker.Weaviate1},
+			{compose.ContainerURI(1), "node1"},
+			{compose.ContainerURI(2), "node2"},
 		} {
 			for i := 0; i < rewrittenCount; i++ {
 				obj, err := common.GetObjectFromNodeWithVector(t, node.uri, className,

--- a/test/acceptance/replication/read_repair/read_repair_projection_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_projection_test.go
@@ -1,0 +1,261 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+var projectionRepairIDs = []strfmt.UUID{
+	strfmt.UUID("6ad5b7dc-5b0e-4d64-9d5b-3f4a3f5f9c01"),
+	strfmt.UUID("2c1d1c9f-9d0e-4a9d-9a1a-6c1e2d3f4a02"),
+	strfmt.UUID("f0a1b2c3-d4e5-4f60-8a7b-9c0d1e2f3a03"),
+	strfmt.UUID("11223344-5566-4778-899a-bbccddeeff04"),
+	strfmt.UUID("55667788-99aa-4bcc-8dee-ff0011223305"),
+	strfmt.UUID("99aabbcc-ddee-4f00-9112-233445566706"),
+}
+
+// The first rewrittenCount objects get rewritten while the replica is down;
+// the rest stay untouched so the triggering filter matches a strict subset.
+const rewrittenCount = 3
+
+func projectionContents(i int, rewritten bool) string {
+	if rewritten {
+		return fmt.Sprintf("rewritten%d", i)
+	}
+	return fmt.Sprintf("original%d", i)
+}
+
+func projectionTitle(i int) string { return fmt.Sprintf("title%d", i) }
+
+func projectionVector(i int) []float32 {
+	return []float32{float32(i) + 0.25, float32(i) + 0.5, float32(i) + 0.75, 1}
+}
+
+// TestReadRepairPreservesProjectedAwayContent pins the regression where read
+// repair overwrote a lagging replica with a search result's projection,
+// destroying properties and the vector outside the query's selection.
+//
+// Filter, narrow selection and CL above ONE are all load-bearing: an unfiltered
+// read carries a complete object, a wide selection leaves nothing to destroy,
+// and ONE short-circuits the repair path before it runs.
+func (suite *ReplicationTestSuite) TestReadRepairPreservesProjectedAwayContent() {
+	t := suite.T()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		With3NodeCluster().
+		// Vectors are explicit; contextionary only keeps container indices
+		// aligned with the rest of the package (slot 0).
+		WithText2VecContextionary().
+		// Keeps the lagging replica's divergence from healing via async replication.
+		// Only on|enabled|1|true engage it; "disabled" would silently do nothing.
+		WithWeaviateEnv("ASYNC_REPLICATION_DISABLED", "true").
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	// Funcs, not vars: restarting a container remaps its published port. Only
+	// the lagging node is stopped; the reader coordinates every request, so its
+	// projected copy is the caller's copy the repair path sees.
+	readerURI := func() string { return compose.ContainerURI(1) }
+	laggingURI := func() string { return compose.ContainerURI(3) }
+	laggingNode := docker.Weaviate2
+	t.Logf("reader node (stays up): %s at %s", docker.Weaviate0, readerURI())
+	t.Logf("lagging node (stopped during rewrite): %s at %s", laggingNode, laggingURI())
+
+	helper.SetupClient(readerURI())
+	paragraphClass := articles.ParagraphsClass()
+	className := paragraphClass.Class
+
+	t.Run("CreateSchema", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
+			Factor:           3,
+			AsyncEnabled:     false,
+			DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+		}
+		helper.CreateClass(t, paragraphClass)
+
+		got := helper.GetClass(t, className)
+		require.EqualValues(t, 3, got.ReplicationConfig.Factor)
+		require.False(t, got.ReplicationConfig.AsyncEnabled,
+			"async replication must stay off, it would converge the lagging replica and delete the precondition")
+	})
+
+	t.Run("InsertOnAllReplicas", func(t *testing.T) {
+		batch := make([]*models.Object, len(projectionRepairIDs))
+		for i, id := range projectionRepairIDs {
+			batch[i] = &models.Object{
+				Class: className,
+				ID:    id,
+				Properties: map[string]interface{}{
+					"contents": projectionContents(i, false),
+					"title":    projectionTitle(i),
+				},
+				Vector: projectionVector(i),
+			}
+		}
+		common.CreateObjectsCL(t, readerURI(), batch, types.ConsistencyLevelAll)
+
+		// Confirm full replication before treating later state as a divergence.
+		for _, nodeName := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
+			for i, id := range projectionRepairIDs {
+				require.EventuallyWithT(t, func(ct *assert.CollectT) {
+					obj, err := common.GetObjectFromNodeWithVector(t, readerURI(), className, id, nodeName)
+					if !assert.NoError(ct, err) {
+						return
+					}
+					assertProjectionObject(ct, obj, i, false, nodeName)
+				}, 60*time.Second, 500*time.Millisecond,
+					"object %s never fully replicated to %s", id, nodeName)
+			}
+		}
+	})
+
+	t.Run("StopLaggingNode", func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("RewriteSubsetAtQuorum", func(t *testing.T) {
+		for i := 0; i < rewrittenCount; i++ {
+			obj := &models.Object{
+				Class: className,
+				ID:    projectionRepairIDs[i],
+				Properties: map[string]interface{}{
+					"contents": projectionContents(i, true),
+					"title":    projectionTitle(i),
+				},
+				Vector: projectionVector(i),
+			}
+			require.NoError(t, common.UpdateObjectCL(t, readerURI(), obj, types.ConsistencyLevelQuorum))
+		}
+	})
+
+	t.Run("RestartLaggingNode", func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, 3)
+		// The last id was never rewritten, so probing it cannot repair anything.
+		common.WaitForNodeReadyForClass(t, laggingURI(), className,
+			projectionRepairIDs[len(projectionRepairIDs)-1])
+	})
+
+	t.Run("PreconditionLaggingReplicaIsStale", func(t *testing.T) {
+		for i := 0; i < rewrittenCount; i++ {
+			obj, err := common.GetObjectFromNodeWithVector(t, laggingURI(), className,
+				projectionRepairIDs[i], laggingNode)
+			require.NoError(t, err)
+			require.Equal(t, projectionContents(i, false), projectionProps(t, obj)["contents"],
+				"invalid fixture: %s already holds the rewritten value for %s, so there is no divergence left to repair",
+				laggingNode, projectionRepairIDs[i])
+		}
+	})
+
+	t.Run("TriggerRepairWithFilteredNarrowQuery", func(t *testing.T) {
+		helper.SetupClient(readerURI())
+		// Where clause + selection omitting `title`/vector: the exact projection
+		// that used to get written back over the replica.
+		q := fmt.Sprintf(`{Get {%s(where: {path: ["contents"], operator: Like, valueText: "rewritten*"}, `+
+			`consistencyLevel: ALL, limit: 100) {contents _additional {id isConsistent}}}}`, className)
+		resp := common.GQLDo(t, className, q)
+		require.Len(t, resp, rewrittenCount,
+			"invalid fixture: the triggering query matched %d objects instead of %d, "+
+				"so it did not reach the repair path for the rewritten subset", len(resp), rewrittenCount)
+	})
+
+	t.Run("RepairedReplicaKeepsUnselectedContent", func(t *testing.T) {
+		for i := 0; i < rewrittenCount; i++ {
+			id := projectionRepairIDs[i]
+
+			// Confirms repair actually wrote to the lagging replica; async
+			// replication is off, so nothing else could have moved this value.
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				obj, err := common.GetObjectFromNodeWithVector(t, laggingURI(), className, id, laggingNode)
+				if !assert.NoError(ct, err) {
+					return
+				}
+				assert.Equal(ct, projectionContents(i, true), projectionProps(t, obj)["contents"])
+			}, 30*time.Second, 250*time.Millisecond,
+				"invalid fixture: read repair never wrote %s on %s, the assertions below would be vacuous",
+				id, laggingNode)
+
+			obj, err := common.GetObjectFromNodeWithVector(t, laggingURI(), className, id, laggingNode)
+			require.NoError(t, err)
+			props := projectionProps(t, obj)
+
+			// assert, not require: report property and vector loss together.
+			assert.Equal(t, projectionTitle(i), props["title"],
+				"read repair destroyed property %q on %s for object %s: the triggering query "+
+					"did not select it, and the projected search result was written back over the full object. "+
+					"properties on the repaired replica: %v", "title", laggingNode, id, props)
+			assert.EqualValues(t, projectionVector(i), obj.Vector,
+				"read repair destroyed the vector on %s for object %s: the triggering query "+
+					"did not request it, and the projected search result was written back over the full object",
+				laggingNode, id)
+		}
+	})
+
+	t.Run("UntouchedObjectsAndHealthyReplicasIntact", func(t *testing.T) {
+		for i := rewrittenCount; i < len(projectionRepairIDs); i++ {
+			obj, err := common.GetObjectFromNodeWithVector(t, laggingURI(), className,
+				projectionRepairIDs[i], laggingNode)
+			require.NoError(t, err)
+			assertProjectionObject(t, obj, i, false, laggingNode)
+		}
+		for _, node := range []struct {
+			uri  string
+			name string
+		}{
+			{compose.ContainerURI(1), docker.Weaviate0},
+			{compose.ContainerURI(2), docker.Weaviate1},
+		} {
+			for i := 0; i < rewrittenCount; i++ {
+				obj, err := common.GetObjectFromNodeWithVector(t, node.uri, className,
+					projectionRepairIDs[i], node.name)
+				require.NoError(t, err)
+				assertProjectionObject(t, obj, i, true, node.name)
+			}
+		}
+	})
+}
+
+func projectionProps(t assert.TestingT, obj *models.Object) map[string]interface{} {
+	props, ok := obj.Properties.(map[string]interface{})
+	if !assert.True(t, ok, "unexpected properties payload %T", obj.Properties) {
+		return map[string]interface{}{}
+	}
+	return props
+}
+
+func assertProjectionObject(t assert.TestingT, obj *models.Object, i int, rewritten bool, nodeName string) {
+	props := projectionProps(t, obj)
+	assert.Equal(t, projectionContents(i, rewritten), props["contents"], "contents on %s", nodeName)
+	assert.Equal(t, projectionTitle(i), props["title"], "title on %s", nodeName)
+	assert.EqualValues(t, projectionVector(i), obj.Vector, "vector on %s", nodeName)
+}

--- a/usecases/replica/batch.go
+++ b/usecases/replica/batch.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 
+	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
@@ -86,14 +87,17 @@ func (b *ShardPart) ObjectIDs() []strfmt.UUID {
 	return xs
 }
 
-func (b *ShardPart) Extract() ([]Replica, []strfmt.UUID) {
-	xs := make([]Replica, len(b.Index))
+// Digests returns update times and ids for the caller's own copies, in Index
+// order. These are search results that may lack projected-away properties or
+// a requested vector, so they can never serve as repair content.
+func (b *ShardPart) Digests() ([]types.RepairResponse, []strfmt.UUID) {
+	xs := make([]types.RepairResponse, len(b.Index))
 	ys := make([]strfmt.UUID, len(b.Index))
 
 	for i, idx := range b.Index {
 		p := b.Data[idx]
-		xs[i] = Replica{ID: p.ID(), Deleted: false, Object: p}
 		ys[i] = p.ID()
+		xs[i] = types.RepairResponse{ID: ys[i].String(), UpdateTime: p.LastUpdateTimeUnix()}
 	}
 	return xs, ys
 }

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -79,7 +79,7 @@ func NewFinder(className string,
 	l logrus.FieldLogger,
 	getDeletionStrategy func() string,
 ) *Finder {
-	cl := FinderClient{client}
+	cl := FinderClient{cl: client, log: l}
 	return &Finder{
 		router:       router,
 		nodeResolver: nodeResolver,
@@ -229,7 +229,7 @@ func (f *Finder) CheckConsistency(ctx context.Context,
 	for _, part := range clusterObjectByShard(createBatch(xs)) {
 		part := part
 		gr.Go(func() error {
-			_, err := f.checkShardConsistency(ctx, l, part)
+			err := f.checkShardConsistency(ctx, l, part)
 			if err != nil {
 				f.log.WithField("op", "check_shard_consistency").
 					WithField("shard", part.Shard).Error(err)
@@ -287,31 +287,28 @@ func (f *Finder) NodeObject(ctx context.Context,
 }
 
 // checkShardConsistency checks consistency for a set of objects belonging to a shard
-// It returns the most recent objects or and error
 func (f *Finder) checkShardConsistency(ctx context.Context,
 	l types.ConsistencyLevel,
 	batch ShardPart,
-) ([]*storobj.Object, error) {
+) error {
 	var (
-		c         = NewReadCoordinator[BatchReply](f.router, f.metrics, f.class, batch.Shard, f.getDeletionStrategy(), f.log)
-		shard     = batch.Shard
-		data, ids = batch.Extract() // extract from current content
+		c            = NewReadCoordinator[BatchReply](f.router, f.metrics, f.class, batch.Shard, f.getDeletionStrategy(), f.log)
+		shard        = batch.Shard
+		digests, ids = batch.Digests()
 	)
-	op := func(ctx context.Context, host string, fullRead bool) (BatchReply, error) {
-		if fullRead { // we already have the content
-			return BatchReply{Sender: host, IsDigest: false, FullData: data}, nil
-		} else {
-			xs, err := f.client.DigestReads(ctx, host, f.class, shard, ids, 0)
-			return BatchReply{Sender: host, IsDigest: true, DigestData: xs}, err
+	op := func(ctx context.Context, host string, isCallerCopy bool) (BatchReply, error) {
+		if isCallerCopy { // we already know the update times of this copy
+			return BatchReply{Sender: host, IsLocal: true, DigestData: digests}, nil
 		}
+		xs, err := f.client.DigestReads(ctx, host, f.class, shard, ids, 0)
+		return BatchReply{Sender: host, DigestData: xs}, err
 	}
 
 	replyCh, state, err := c.Pull(ctx, l, op, batch.Node, 20*time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("pull shard: %w", ErrReplicas)
+		return fmt.Errorf("pull shard: %w", ErrReplicas)
 	}
-	result := <-f.readBatchPart(ctx, batch, ids, replyCh, state)
-	return result.Value, result.Err
+	return <-f.readBatchPart(ctx, batch, ids, replyCh, state)
 }
 
 type ShardDifferenceReader struct {

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -122,16 +122,12 @@ func (f *finderStream) readOne(ctx context.Context,
 	return resultCh
 }
 
-type (
-	batchResult Result[[]*storobj.Object]
-
-	// Vote represents objects received from a specific replica and the number of votes per object.
-	Vote struct {
-		BatchReply       // reply from a replica
-		Count      []int // number of votes per object
-		Err        error
-	}
-)
+// Vote represents objects received from a specific replica and the number of votes per object.
+type Vote struct {
+	BatchReply       // reply from a replica
+	Count      []int // number of votes per object
+	Err        error
+}
 
 type BoolTuple tuple[types.RepairResponse]
 
@@ -207,8 +203,8 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 	ids []strfmt.UUID,
 	ch <-chan Result[BatchReply],
 	level int,
-) <-chan batchResult {
-	resultCh := make(chan batchResult, 1)
+) <-chan error {
+	resultCh := make(chan error, 1)
 
 	g := func() {
 		defer close(resultCh)
@@ -216,7 +212,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 			N = len(ids) // number of requested objects
 			// votes counts number of votes per object for each node
 			votes      = make([]Vote, 0, level)
-			contentIdx = -1 // index of full read reply
+			contentIdx = -1 // index of the reply describing the caller's copy
 		)
 
 		for r := range ch { // len(ch) == level
@@ -224,10 +220,10 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 			if r.Err != nil { // at least one node is not responding
 				f.log.WithField("op", "read_batch.get").WithField("replica", r.Value.Sender).
 					WithField("class", f.class).WithField("shard", batch.Shard).Error(r.Err)
-				resultCh <- batchResult{nil, ErrRead}
+				resultCh <- ErrRead
 				return
 			}
-			if !resp.IsDigest {
+			if resp.IsLocal {
 				contentIdx = len(votes)
 			}
 
@@ -256,16 +252,16 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 				for _, idx := range batch.Index {
 					batch.Data[idx].IsConsistent = true
 				}
-				resultCh <- batchResult{fromReplicas(votes[contentIdx].FullData), nil}
+				resultCh <- nil
 				return
 			}
 		}
-		res, err := f.repairBatchPart(ctx, batch.Shard, ids, votes, contentIdx)
+		resolved, err := f.repairBatchPart(ctx, batch.Shard, ids, votes, contentIdx)
 		if err != nil {
-			resultCh <- batchResult{nil, ErrRepair}
+			// Returning this cancels the error group context shared with the
+			// request's other shards, aborting their repairs mid-flight.
 			f.log.WithField("op", "repair_batch").WithField("class", f.class).
 				WithField("shard", batch.Shard).WithField("uuids", ids).Error(err)
-			return
 		}
 		// count total number of votes
 		maxCount := len(votes) * len(votes)
@@ -275,49 +271,35 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 				sum[i] += n
 			}
 		}
-		// set consistency flag
+		// The caller's object is never replaced with the repaired version: the
+		// newer object may not satisfy the filter criteria used to retrieve it.
+		// Read repair has already propagated it to stale replicas.
 		for i, n := range sum {
-			if n == maxCount { // if consistent
-				x := res[i]
-
-				if x == nil {
-					// object was fetched but deleted during repair phase
-					batch.Data[batch.Index[i]].IsConsistent = false
-					continue
-				}
-
-				// Do not replace the original object with the repaired version:
-				// the newer object may not satisfy the filter criteria used
-				// to retrieve the original objects. Read-repair has already
-				// propagated the latest version to stale replicas above.
+			if n == maxCount && resolved[i] {
 				batch.Data[batch.Index[i]].IsConsistent = true
 			}
 		}
 
-		resultCh <- batchResult{res, nil}
+		resultCh <- nil
 	}
 	enterrors.GoWrapper(g, f.logger)
 
 	return resultCh
 }
 
-// BatchReply is a container of the batch received from a replica
-// The returned data may result from a full or digest read request
+// BatchReply carries only digests, never object content: repair always
+// fetches content fresh from the winning replica, so a projected search
+// result can never become a repair payload.
 type BatchReply struct {
 	// Sender hostname of the Sender
 	Sender string
-	// IsDigest is this reply from a digest read?
-	IsDigest bool
-	// FullData returned from a full read request
-	FullData []Replica
-	// DigestData returned from a digest read request
+	// IsLocal marks the reply for the copy the caller already holds (exactly one per batch).
+	IsLocal bool
+	// DigestData holds one digest per requested object, in request order
 	DigestData []types.RepairResponse
 }
 
 // UpdateTimeAt gets update time from reply
 func (r BatchReply) UpdateTimeAt(idx int) int64 {
-	if len(r.DigestData) != 0 {
-		return r.DigestData[idx].UpdateTime
-	}
-	return r.FullData[idx].UpdateTime()
+	return r.DigestData[idx].UpdateTime
 }

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -344,13 +344,26 @@ func (r *repairer) repairExist(ctx context.Context,
 	return !resp.Deleted, gr.Wait()
 }
 
-// repairAll repairs objects when reading them ((use in combination with Finder::GetAll)
+// repairBatchPart brings the replicas that disagree about any of ids up to the
+// most recent version. Repair content is fetched from the replica holding that
+// version; the caller's copy contributes only its update times, because it may
+// be a projected search result. A write carrying no content, such as a delete,
+// is never held up by a fetch.
+//
+// contentIdx must index the vote carrying the caller's copy, and every vote must
+// hold one digest and one count per id, in ids order.
+//
+// resolved[i] reports that the winning version of ids[i] is known, whether it
+// was fetched, already agreed on by every replica, or a delete needing no
+// content. It does not report that the repair writes landed: an object left in
+// doubt is marked instead by decrementing its Count entry on one of the votes.
+// The returned error names the replicas and objects left stale.
 func (r *repairer) repairBatchPart(ctx context.Context,
 	shard string,
 	ids []strfmt.UUID,
 	votes []Vote,
 	contentIdx int,
-) (_ []*storobj.Object, err error) {
+) (_ []bool, err error) {
 	r.metrics.IncReadRepairCount()
 
 	defer func(start time.Time) {
@@ -361,23 +374,25 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 	}(time.Now())
 
 	var (
-		result            = make([]*storobj.Object, len(ids)) // final result
+		result            = make([]*storobj.Object, len(ids)) // content to write
+		resolved          = make([]bool, len(ids))            // per object outcome
 		lastTimes         = make([]iTuple, len(ids))          // most recent times
 		lastDeletionTimes = make([]int64, len(ids))           // most recent deletion times
-		ms                = make([]iTuple, 0, len(ids))       // mismatches
+		ms                = make([]iTuple, 0, len(ids))       // objects whose content is needed
 		cl                = r.client
 		nVotes            = len(votes)
-		// The input objects cannot be used for repair because
-		// their attributes might have been filtered out
-		reFetchSet       = make(map[int]struct{})
-		deletionStrategy = r.getDeletionStrategy()
+		deletionStrategy  = r.getDeletionStrategy()
 	)
 
+	if contentIdx < 0 || contentIdx >= len(votes) {
+		return resolved, fmt.Errorf("no reply identified as the caller's copy among %d replies", len(votes))
+	}
+
 	// find most recent objects
-	for i, x := range votes[contentIdx].FullData {
-		lastTimes[i] = iTuple{S: contentIdx, O: i, T: x.UpdateTime(), Deleted: x.Deleted}
+	for i, x := range votes[contentIdx].DigestData {
+		lastTimes[i] = iTuple{S: contentIdx, O: i, T: x.UpdateTime, Deleted: x.Deleted}
 		if x.Deleted {
-			lastDeletionTimes[i] = x.UpdateTime()
+			lastDeletionTimes[i] = x.UpdateTime
 		}
 		votes[contentIdx].Count[i] = nVotes // reuse Count[] to check consistency
 	}
@@ -388,7 +403,6 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 				if curTime := lastTimes[j].T; x.UpdateTime > curTime {
 					// input object is not up to date
 					lastTimes[j] = iTuple{S: i, O: j, T: x.UpdateTime}
-					reFetchSet[j] = struct{}{} // we need to fetch this object again
 				}
 
 				lastTimes[j].Deleted = lastTimes[j].Deleted || x.Deleted
@@ -402,18 +416,47 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 		}
 	}
 
-	// find missing content (diff)
-	for i, p := range votes[contentIdx].FullData {
+	// An object needs content only if some replica disagrees with the winner and
+	// will therefore be written to. Same condition the repair loop below applies.
+	needsContent := make([]bool, len(ids))
+	for _, vote := range votes {
+		for j := range ids {
+			if vote.UpdateTimeAt(j) != lastTimes[j].T {
+				needsContent[j] = true
+			}
+		}
+	}
+
+	for i := range ids {
 		if lastTimes[i].Deleted && lastDeletionTimes[i] == lastTimes[i].T {
+			// the winner is a tombstone, there is no content to propagate
 			continue
 		}
 
-		if _, ok := reFetchSet[i]; ok {
-			ms = append(ms, lastTimes[i])
-		} else {
-			result[i] = p.Object
+		if !needsContent[i] {
+			// every replica already holds the winning version
+			resolved[i] = true
+			continue
 		}
+
+		if lastTimes[i].Deleted {
+			if deletionStrategy == models.ReplicationConfigDeletionStrategyDeleteOnConflict {
+				// a tombstone anywhere deletes the live winner, so the pending
+				// write is a delete and the winning outcome is already known
+				resolved[i] = true
+				continue
+			}
+			if deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
+				// the conflict is not resolved, so nothing is written
+				continue
+			}
+		}
+
+		ms = append(ms, lastTimes[i])
 	}
+
+	// Collected here since nothing else records why an object stayed stale.
+	var fetchErrs []error
 
 	if len(ms) > 0 { // fetch most recent objects
 		// partition by hostname
@@ -428,10 +471,13 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 		}
 		partitions = append(partitions, len(ms))
 
+		// One slot per partition: a failure on one replica must not hide others.
+		fetchErrs = make([]error, len(partitions))
+
 		// concurrent fetches
 		gr, ctx := enterrors.NewErrorGroupWithContextWrapper(r.logger, ctx)
 		start := 0
-		for _, end := range partitions { // fetch diffs
+		for p, end := range partitions { // fetch diffs
 			rid := ms[start].S
 			receiver := votes[rid].Sender
 			query := make([]strfmt.UUID, end-start)
@@ -441,45 +487,57 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 			}
 			start := start
 			gr.Go(func() error {
+				n := len(query)
 				resp, err := cl.FullReads(ctx, receiver, r.class, shard, query)
-				for i, n := 0, len(query); i < n; i++ {
-					idx := ms[start-n+i].O
-					if err != nil || lastTimes[idx].T != resp[i].UpdateTime() {
-						votes[rid].Count[idx]--
-					} else {
-						result[idx] = resp[i].Object
+				if err != nil {
+					for i := 0; i < n; i++ {
+						votes[rid].Count[ms[start-n+i].O]--
 					}
+					fetchErrs[p] = fmt.Errorf("read %d object(s) from %s: %w", n, receiver, err)
+					return nil
+				}
+
+				var changed []strfmt.UUID
+				for i := 0; i < n; i++ {
+					idx := ms[start-n+i].O
+					if lastTimes[idx].T != resp[i].UpdateTime() {
+						// the winner moved on between casting its vote and this read
+						votes[rid].Count[idx]--
+						changed = append(changed, query[i])
+						continue
+					}
+					result[idx] = resp[i].Object
+					resolved[idx] = result[idx] != nil
+					if result[idx] == nil {
+						changed = append(changed, query[i])
+					}
+				}
+				if len(changed) > 0 {
+					fetchErrs[p] = fmt.Errorf("%s no longer holds the agreed version of %v: %w",
+						receiver, changed, ErrConflictObjectChanged)
 				}
 				return nil
 			})
 
 		}
 		if err := gr.Wait(); err != nil {
-			return nil, err
+			return resolved, err
 		}
 	}
 
 	// concurrent repairs
 	gr, ctx := enterrors.NewErrorGroupWithContextWrapper(r.logger, ctx)
+	writeErrs := make([]error, len(votes))
 
 	for rid, vote := range votes {
 		query := make([]*objects.VObject, 0, len(ids)/2)
 		m := make(map[string]int, len(ids)/2) //
 
 		for j, x := range lastTimes {
-			if !x.Deleted && result[j] == nil {
-				// latest object could not be fetched
-				continue
-			}
+			deleted := x.Deleted && lastDeletionTimes[j] == x.T
 
 			if x.Deleted && deletionStrategy == models.ReplicationConfigDeletionStrategyDeleteOnConflict {
-				alreadyDeleted := false
-
-				if rid == contentIdx {
-					alreadyDeleted = vote.BatchReply.FullData[j].Deleted
-				} else {
-					alreadyDeleted = vote.BatchReply.DigestData[j].Deleted
-				}
+				alreadyDeleted := vote.DigestData[j].Deleted
 
 				if alreadyDeleted && lastDeletionTimes[j] == vote.UpdateTimeAt(j) {
 					continue
@@ -502,6 +560,12 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 				continue
 			}
 
+			if !deleted && result[j] == nil {
+				// only a write carrying content needs the winning object, and it
+				// could not be fetched
+				continue
+			}
+
 			cTime := vote.UpdateTimeAt(j)
 
 			if x.T != cTime && vote.Count[j] == nVotes {
@@ -509,8 +573,6 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 				var vector []float32
 				var vectors map[string][]float32
 				var multiVectors map[string][][]float32
-
-				deleted := x.Deleted && lastDeletionTimes[j] == x.T
 
 				if !deleted {
 					latestObject = &result[j].Object
@@ -557,18 +619,28 @@ func (r *repairer) repairBatchPart(ctx context.Context,
 				for _, idx := range m {
 					votes[rid].Count[idx]--
 				}
+				writeErrs[rid] = fmt.Errorf("repair %d object(s) on %s: %w", len(query), receiver, err)
 				return nil
 			}
+			var rejected []string
 			for _, r := range rs {
 				if r.Err != "" {
 					if idx, ok := m[r.ID]; ok {
 						votes[rid].Count[idx]--
+						rejected = append(rejected, r.ID)
 					}
 				}
+			}
+			if len(rejected) > 0 {
+				writeErrs[rid] = fmt.Errorf("%s rejected the repair of %v: %w",
+					receiver, rejected, ErrConflictObjectChanged)
 			}
 			return nil
 		})
 	}
 
-	return result, gr.Wait()
+	if err := gr.Wait(); err != nil {
+		return resolved, err
+	}
+	return resolved, errors.Join(errors.Join(fetchErrs...), errors.Join(writeErrs...))
 }

--- a/usecases/replica/repairer_fetch_failure_test.go
+++ b/usecases/replica/repairer_fetch_failure_test.go
@@ -1,0 +1,533 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/replica"
+)
+
+const (
+	metricRepairCount   = "weaviate_replication_read_repair_count"
+	metricRepairFailure = "weaviate_replication_read_repair_failure"
+)
+
+// repairProbe is a Finder whose read repair metrics land in a registry the test
+// owns, so an assertion can read the counters rather than infer them.
+type repairProbe struct {
+	*replica.Finder
+	reg *prometheus.Registry
+	f   *fakeFactory
+}
+
+func newRepairProbe(t *testing.T, f *fakeFactory, thisNode, deletionStrategy string) *repairProbe {
+	t.Helper()
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	for _, n := range f.Nodes {
+		nodeResolver.EXPECT().NodeHostname(n).Return(n, true).Maybe()
+	}
+
+	reg := prometheus.NewPedanticRegistry()
+	metrics, err := replica.NewMetrics(&monitoring.PrometheusMetrics{Registerer: reg})
+	require.NoError(t, err)
+
+	return &repairProbe{
+		Finder: replica.NewFinder(f.CLS, f.newRouter(thisNode), nodeResolver, thisNode,
+			f.RClient, metrics, f.log, func() string { return deletionStrategy }),
+		reg: reg,
+		f:   f,
+	}
+}
+
+func (p *repairProbe) counter(t *testing.T, name string) float64 {
+	t.Helper()
+	families, err := p.reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() == name {
+			require.Len(t, fam.GetMetric(), 1)
+			return fam.GetMetric()[0].GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+// repairBatchLogs returns the messages the batch repair path logged. The log
+// write happens before CheckConsistency returns, so no polling is needed.
+func (p *repairProbe) repairBatchLogs(t *testing.T) []string {
+	t.Helper()
+	var msgs []string
+	for _, e := range p.f.hook.AllEntries() {
+		if op, _ := e.Data["op"].(string); op == "repair_batch" {
+			msgs = append(msgs, e.Message)
+		}
+	}
+	return msgs
+}
+
+// writeRecorder accepts any OverwriteObjects call and remembers the payloads,
+// so a test can assert on what was written, including that nothing was.
+type writeRecorder struct {
+	mu       sync.Mutex
+	byNode   map[string][]*objects.VObject
+	numCalls int
+}
+
+func recordWrites(f *fakeFactory, nodes ...string) *writeRecorder {
+	w := &writeRecorder{byNode: map[string][]*objects.VObject{}}
+	for _, node := range nodes {
+		f.RClient.EXPECT().OverwriteObjects(anyVal, node, anyVal, anyVal, anyVal).
+			Return([]types.RepairResponse{}, nil).
+			Maybe().
+			RunFn = func(a mock.Arguments) {
+			w.mu.Lock()
+			defer w.mu.Unlock()
+			w.numCalls++
+			w.byNode[a[1].(string)] = append(w.byNode[a[1].(string)], a[4].([]*objects.VObject)...)
+		}
+	}
+	return w
+}
+
+func (w *writeRecorder) calls() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.numCalls
+}
+
+func (w *writeRecorder) written(node string) []*objects.VObject {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.byNode[node]
+}
+
+// TestRepairBatchFetchFromWinnerFails pins that unusable winner fetches are
+// logged, counted, and leave the object inconsistent.
+func TestRepairBatchFetchFromWinnerFails(t *testing.T) {
+	var (
+		cls    = "C1"
+		shard  = "S1"
+		nodes  = []string{"A", "B"}
+		id     = strfmt.UUID("11111111-1111-1111-1111-111111111111")
+		otherI = strfmt.UUID("22222222-2222-2222-2222-222222222222")
+	)
+
+	tests := []struct {
+		name    string
+		fetched []replica.Replica
+		err     error
+		wantLog string
+	}{
+		{
+			name:    "transport error",
+			err:     errAny,
+			wantLog: "read 1 object(s) from B",
+		},
+		{
+			name:    "response carries another uuid",
+			fetched: []replica.Replica{repl(otherI, 2, false)},
+			wantLog: `malformed full read response: object 0 is "22222222-2222-2222-2222-222222222222"`,
+		},
+		{
+			name:    "response is shorter than the request",
+			fetched: []replica.Replica{},
+			wantLog: "malformed full read response: length expected 1 got 0",
+		},
+		{
+			name:    "winner moved on after voting",
+			fetched: []replica.Replica{repl(id, 3, false)},
+			wantLog: "no longer holds the agreed version",
+		},
+		{
+			name:    "winner was deleted mid flight",
+			fetched: []replica.Replica{{ID: id, LastUpdateTimeUnixMilli: 2}},
+			wantLog: "no longer holds the agreed version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				ctx   = context.Background()
+				f     = newFakeFactory(t, cls, shard, nodes, false)
+				probe = newRepairProbe(t, f, "A", models.ReplicationConfigDeletionStrategyNoAutomatedResolution)
+				xs    = []*storobj.Object{objectEx(id, 1, shard, "A")}
+			)
+
+			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, []strfmt.UUID{id}, anyVal).
+				Return([]types.RepairResponse{{ID: id.String(), UpdateTime: 2}}, nil)
+			f.RClient.EXPECT().FetchObjects(anyVal, nodes[1], cls, shard, []strfmt.UUID{id}).
+				Return(tt.fetched, tt.err).
+				Once()
+			writes := recordWrites(f, nodes...)
+
+			require.NoError(t, probe.CheckConsistency(ctx, types.ConsistencyLevelAll, xs))
+
+			require.Zero(t, writes.calls(), "content was unusable, nothing may be written")
+			require.Equal(t, []*storobj.Object{objectEx(id, 1, shard, "A")}, xs)
+			require.False(t, xs[0].IsConsistent)
+			require.Equal(t, float64(1), probe.counter(t, metricRepairCount))
+			require.Equal(t, float64(1), probe.counter(t, metricRepairFailure))
+			require.Contains(t, strings.Join(probe.repairBatchLogs(t), "\n"), tt.wantLog)
+		})
+	}
+}
+
+// fullReadIDs returns n deterministic uuids for driving FullReads.
+func fullReadIDs(n int) []strfmt.UUID {
+	ids := make([]strfmt.UUID, n)
+	for i := range ids {
+		ids[i] = strfmt.UUID(uuid.NewSHA1(uuid.Nil, []byte(strconv.Itoa(i))).String())
+	}
+	return ids
+}
+
+// TestFullReadsChunksIDs pins that FullReads splits large id lists into
+// bounded chunks instead of one unbounded request.
+func TestFullReadsChunksIDs(t *testing.T) {
+	const chunkSize = replica.MaxFullReadIDsPerRequest
+	tests := []struct {
+		total      int
+		wantChunks []int
+	}{
+		{total: 1, wantChunks: []int{1}},
+		{total: chunkSize, wantChunks: []int{chunkSize}},
+		{total: chunkSize + 1, wantChunks: []int{chunkSize, 1}},
+		{total: 3*chunkSize + 8, wantChunks: []int{chunkSize, chunkSize, chunkSize, 8}},
+	}
+
+	for _, tt := range tests {
+		t.Run(strconv.Itoa(tt.total), func(t *testing.T) {
+			ids := fullReadIDs(tt.total)
+
+			rc := replica.NewMockRClient(t)
+			var (
+				mu  sync.Mutex
+				got []int
+			)
+			rc.EXPECT().FetchObjects(anyVal, "B", "C1", "S1", anyVal).
+				RunAndReturn(func(_ context.Context, _, _, _ string, chunk []strfmt.UUID) ([]replica.Replica, error) {
+					mu.Lock()
+					got = append(got, len(chunk))
+					mu.Unlock()
+					rs := make([]replica.Replica, len(chunk))
+					for i, id := range chunk {
+						rs[i] = repl(id, 1, false)
+					}
+					return rs, nil
+				})
+
+			logger, _ := test.NewNullLogger()
+			rs, err := replica.NewFinderClient(rc, logger).FullReads(context.Background(), "B", "C1", "S1", ids)
+			require.NoError(t, err)
+			// chunks are fetched concurrently, so only the multiset is deterministic
+			require.ElementsMatch(t, tt.wantChunks, got)
+
+			require.Len(t, rs, tt.total)
+			for i := range rs {
+				require.Equal(t, ids[i], rs[i].ID, "responses must stay in request order across chunks")
+			}
+		})
+	}
+}
+
+// TestFullReadsFetchesChunksConcurrently pins the bounded fan-out: the barrier
+// releases only once the full in-flight cap of requests is simultaneously in
+// flight, so a serial implementation times out here and an unbounded one
+// overshoots the peak.
+func TestFullReadsFetchesChunksConcurrently(t *testing.T) {
+	const inFlightCap = replica.MaxConcurrentFullReadRequests
+	ids := fullReadIDs((inFlightCap + 4) * replica.MaxFullReadIDsPerRequest)
+
+	var (
+		inFlight atomic.Int64
+		peak     atomic.Int64
+		arrivals atomic.Int64
+		release  = make(chan struct{})
+	)
+
+	rc := replica.NewMockRClient(t)
+	rc.EXPECT().FetchObjects(anyVal, "B", "C1", "S1", anyVal).
+		RunAndReturn(func(_ context.Context, _, _, _ string, chunk []strfmt.UUID) ([]replica.Replica, error) {
+			n := inFlight.Add(1)
+			defer inFlight.Add(-1)
+			for {
+				p := peak.Load()
+				if n <= p || peak.CompareAndSwap(p, n) {
+					break
+				}
+			}
+			if arrivals.Add(1) == inFlightCap {
+				close(release)
+			}
+			select {
+			case <-release:
+			case <-time.After(10 * time.Second):
+				return nil, fmt.Errorf("never saw %d requests in flight: chunks are being fetched serially", inFlightCap)
+			}
+			rs := make([]replica.Replica, len(chunk))
+			for i, id := range chunk {
+				rs[i] = repl(id, 1, false)
+			}
+			return rs, nil
+		})
+
+	logger, _ := test.NewNullLogger()
+	rs, err := replica.NewFinderClient(rc, logger).FullReads(context.Background(), "B", "C1", "S1", ids)
+	require.NoError(t, err)
+	require.EqualValues(t, inFlightCap, peak.Load(), "in-flight requests must reach and never exceed the cap")
+	require.Len(t, rs, len(ids))
+	for i := range rs {
+		require.Equal(t, ids[i], rs[i].ID, "responses must stay in request order across concurrent chunks")
+	}
+}
+
+// TestFullReadsFailedChunkFailsTheRead pins that one failed chunk fails the
+// whole read instead of returning a partial result the repairer would trust.
+func TestFullReadsFailedChunkFailsTheRead(t *testing.T) {
+	ids := fullReadIDs(2 * replica.MaxFullReadIDsPerRequest)
+
+	rc := replica.NewMockRClient(t)
+	rc.EXPECT().FetchObjects(anyVal, "B", "C1", "S1", anyVal).
+		RunAndReturn(func(_ context.Context, _, _, _ string, chunk []strfmt.UUID) ([]replica.Replica, error) {
+			if chunk[0] == ids[replica.MaxFullReadIDsPerRequest] {
+				return nil, errAny
+			}
+			rs := make([]replica.Replica, len(chunk))
+			for i, id := range chunk {
+				rs[i] = repl(id, 1, false)
+			}
+			return rs, nil
+		})
+
+	logger, _ := test.NewNullLogger()
+	rs, err := replica.NewFinderClient(rc, logger).FullReads(context.Background(), "B", "C1", "S1", ids)
+	require.ErrorIs(t, err, errAny)
+	require.Nil(t, rs)
+}
+
+// TestFullReadsRejectsMisalignedLaterChunk pins that the ID alignment check
+// reports absolute indices for chunks past the first.
+func TestFullReadsRejectsMisalignedLaterChunk(t *testing.T) {
+	ids := fullReadIDs(replica.MaxFullReadIDsPerRequest + 1)
+	other := strfmt.UUID("99999999-9999-4999-8999-999999999999")
+
+	rc := replica.NewMockRClient(t)
+	rc.EXPECT().FetchObjects(anyVal, "B", "C1", "S1", anyVal).
+		RunAndReturn(func(_ context.Context, _, _, _ string, chunk []strfmt.UUID) ([]replica.Replica, error) {
+			rs := make([]replica.Replica, len(chunk))
+			for i, id := range chunk {
+				rs[i] = repl(id, 1, false)
+			}
+			if len(chunk) == 1 { // the second chunk, holding the one trailing id
+				rs[0] = repl(other, 1, false)
+			}
+			return rs, nil
+		})
+
+	logger, _ := test.NewNullLogger()
+	rs, err := replica.NewFinderClient(rc, logger).FullReads(context.Background(), "B", "C1", "S1", ids)
+	require.ErrorContains(t, err,
+		fmt.Sprintf("object %d is %q", replica.MaxFullReadIDsPerRequest, other))
+	require.Nil(t, rs)
+}
+
+// TestRepairBatchThreeDistinctWinners pins that per-replica fetch
+// partitioning maps each response back onto the correct object slot.
+func TestRepairBatchThreeDistinctWinners(t *testing.T) {
+	var (
+		ctx   = context.Background()
+		cls   = "C1"
+		shard = "S1"
+		nodes = []string{"A", "B", "C"}
+		ids   = []strfmt.UUID{
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222",
+			"33333333-3333-3333-3333-333333333333",
+		}
+		f     = newFakeFactory(t, cls, shard, nodes, false)
+		probe = newRepairProbe(t, f, "A", models.ReplicationConfigDeletionStrategyNoAutomatedResolution)
+	)
+
+	// one winner per replica: A owns ids[0], B owns ids[1], C owns ids[2]
+	xs := []*storobj.Object{
+		objectEx(ids[0], 3, shard, "A"),
+		objectEx(ids[1], 1, shard, "A"),
+		objectEx(ids[2], 1, shard, "A"),
+	}
+	digest := func(times ...int64) []types.RepairResponse {
+		rs := make([]types.RepairResponse, len(times))
+		for i, ts := range times {
+			rs[i] = types.RepairResponse{ID: ids[i].String(), UpdateTime: ts}
+		}
+		return rs
+	}
+	f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).
+		Return(digest(1, 3, 1), nil)
+	f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, ids, anyVal).
+		Return(digest(1, 1, 3), nil)
+
+	for i, node := range nodes {
+		f.RClient.EXPECT().FetchObjects(anyVal, node, cls, shard, []strfmt.UUID{ids[i]}).
+			Return([]replica.Replica{repl(ids[i], 3, false)}, nil).
+			Once()
+	}
+	writes := recordWrites(f, nodes...)
+
+	require.NoError(t, probe.CheckConsistency(ctx, types.ConsistencyLevelAll, xs))
+	require.Zero(t, probe.counter(t, metricRepairFailure))
+
+	// each replica gets the two objects it lacks, filed under the correct id
+	for _, node := range nodes {
+		written := writes.written(node)
+		require.Len(t, written, 2, "node %s", node)
+		for _, up := range written {
+			require.NotNil(t, up.LatestObject, "node %s object %s", node, up.ID)
+			require.Equal(t, up.ID, up.LatestObject.ID, "content filed under the wrong uuid")
+			require.Equal(t, int64(3), up.LastUpdateTimeUnixMilli)
+			require.Equal(t, int64(1), up.StaleUpdateTime)
+		}
+	}
+	for i := range xs {
+		require.True(t, xs[i].IsConsistent, "object %d", i)
+	}
+}
+
+// TestRepairBatchCarriesVectorShapes pins that fetched winner content,
+// including multi-vectors, reaches the stale replica intact.
+func TestRepairBatchCarriesVectorShapes(t *testing.T) {
+	var (
+		cls   = "C1"
+		shard = "S1"
+		nodes = []string{"A", "B"}
+		id    = strfmt.UUID("11111111-1111-1111-1111-111111111111")
+	)
+
+	tests := []struct {
+		name             string
+		vectors          map[string][]float32
+		multiVectors     map[string][][]float32
+		wantVectors      map[string][]float32
+		wantMultiVectors map[string][][]float32
+	}{
+		{
+			name:             "multi vectors",
+			multiVectors:     map[string][][]float32{"colbert": {{1, 2}, {3, 4}}},
+			wantMultiVectors: map[string][][]float32{"colbert": {{1, 2}, {3, 4}}},
+		},
+		{
+			name:             "named and multi vectors together",
+			vectors:          map[string][]float32{"title": {5, 6}},
+			multiVectors:     map[string][][]float32{"colbert": {{1, 2}}},
+			wantVectors:      map[string][]float32{"title": {5, 6}},
+			wantMultiVectors: map[string][][]float32{"colbert": {{1, 2}}},
+		},
+		{
+			// the copy is guarded on != nil rather than on length, so an empty
+			// map survives as an empty map instead of collapsing to nil
+			name:             "empty but non nil maps",
+			vectors:          map[string][]float32{},
+			multiVectors:     map[string][][]float32{},
+			wantVectors:      map[string][]float32{},
+			wantMultiVectors: map[string][][]float32{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				ctx   = context.Background()
+				f     = newFakeFactory(t, cls, shard, nodes, false)
+				probe = newRepairProbe(t, f, "A", models.ReplicationConfigDeletionStrategyNoAutomatedResolution)
+				xs    = []*storobj.Object{objectEx(id, 1, shard, "A")}
+			)
+
+			winner := &storobj.Object{
+				Object:       models.Object{ID: id, LastUpdateTimeUnix: 2},
+				Vector:       []float32{7, 8},
+				Vectors:      tt.vectors,
+				MultiVectors: tt.multiVectors,
+			}
+
+			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, []strfmt.UUID{id}, anyVal).
+				Return([]types.RepairResponse{{ID: id.String(), UpdateTime: 2}}, nil)
+			f.RClient.EXPECT().FetchObjects(anyVal, nodes[1], cls, shard, []strfmt.UUID{id}).
+				Return([]replica.Replica{{ID: id, Object: winner}}, nil).
+				Once()
+			writes := recordWrites(f, nodes...)
+
+			require.NoError(t, probe.CheckConsistency(ctx, types.ConsistencyLevelAll, xs))
+			require.Zero(t, probe.counter(t, metricRepairFailure))
+
+			written := writes.written(nodes[0])
+			require.Len(t, written, 1)
+			require.Equal(t, []float32{7, 8}, written[0].Vector)
+			require.Equal(t, tt.wantVectors, written[0].Vectors)
+			require.Equal(t, tt.wantMultiVectors, written[0].MultiVectors)
+			require.True(t, xs[0].IsConsistent)
+		})
+	}
+}
+
+// TestRepairBatchSkipsContentTheStrategyDiscards pins that
+// NoAutomatedResolution skips the fetch and reports the object inconsistent.
+func TestRepairBatchSkipsContentTheStrategyDiscards(t *testing.T) {
+	var (
+		ctx   = context.Background()
+		cls   = "C1"
+		shard = "S1"
+		nodes = []string{"A", "B"}
+		id    = strfmt.UUID("11111111-1111-1111-1111-111111111111")
+		f     = newFakeFactory(t, cls, shard, nodes, false)
+		probe = newRepairProbe(t, f, "A", models.ReplicationConfigDeletionStrategyNoAutomatedResolution)
+		xs    = []*storobj.Object{objectEx(id, 5, shard, "A")}
+	)
+
+	// the caller's copy is the newest, but B holds an older tombstone
+	f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, []strfmt.UUID{id}, anyVal).
+		Return([]types.RepairResponse{{ID: id.String(), UpdateTime: 3, Deleted: true}}, nil)
+	var fetches atomic.Int64
+	f.RClient.EXPECT().FetchObjects(anyVal, anyVal, anyVal, anyVal, anyVal).
+		Return(nil, nil).
+		Maybe().
+		RunFn = func(mock.Arguments) { fetches.Add(1) }
+	writes := recordWrites(f, nodes...)
+
+	require.NoError(t, probe.CheckConsistency(ctx, types.ConsistencyLevelAll, xs))
+
+	require.Zero(t, fetches.Load(), "no write is possible, so no content may be fetched")
+	require.Zero(t, writes.calls())
+	require.False(t, xs[0].IsConsistent, "the replicas still disagree")
+	require.Zero(t, probe.counter(t, metricRepairFailure), "declining to resolve is not a failure")
+}

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -1,0 +1,239 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch pins that a live winner whose refetch fails does not nil-deref under TimeBasedResolution (regression for the repairBatchPart guard).
+func TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch(t *testing.T) {
+	ctx := context.Background()
+	const (
+		class = "C1"
+		shard = "S1"
+	)
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+	ids := []strfmt.UUID{id}
+
+	rc := NewMockRClient(t)
+	// Winner refetch fails so result stays nil (repairer.go err branch after FullReads).
+	rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, errors.New("refetch failed")).Maybe()
+	rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).Maybe()
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	r := &repairer{
+		class:               class,
+		getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyTimeBasedResolution },
+		client:              NewFinderClient(rc, logger),
+		metrics:             metrics,
+		logger:              logger,
+	}
+
+	// caller's copy live@100, digest B live@150 (winner, refetch fails → result nil), digest C deleted@80 (older delete OR'd in).
+	votes := []Vote{
+		{BatchReply: BatchReply{Sender: "A", IsLocal: true, DigestData: []types.RepairResponse{{ID: id.String(), UpdateTime: 100}}}, Count: make([]int, len(ids))},
+		{BatchReply: BatchReply{Sender: "B", DigestData: []types.RepairResponse{{ID: id.String(), UpdateTime: 150}}}, Count: make([]int, len(ids))},
+		{BatchReply: BatchReply{Sender: "C", DigestData: []types.RepairResponse{{ID: id.String(), UpdateTime: 80, Deleted: true}}}, Count: make([]int, len(ids))},
+	}
+
+	var resolved []bool
+	require.NotPanics(t, func() {
+		resolved, err = r.repairBatchPart(ctx, shard, ids, votes, 0)
+	})
+	require.ErrorContains(t, err, "read 1 object(s) from B")
+	require.Equal(t, []bool{false}, resolved)
+}
+
+// TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch pins that a delete,
+// which carries no content, is propagated even when the content fetch fails.
+// Under DeleteOnConflict a replica's older tombstone deletes a live winner, so
+// the only pending write is a delete and no object read can be a precondition
+// for it.
+func TestRepairBatchPartDeleteOnConflictSurvivesFailedFetch(t *testing.T) {
+	const (
+		class = "C1"
+		shard = "S1"
+		// caller A holds the live winner, replica B an older tombstone
+		liveTime = int64(100)
+		delTime  = int64(80)
+	)
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+	ids := []strfmt.UUID{id}
+
+	tests := []struct {
+		name       string
+		fetchFails bool
+	}{
+		{name: "content fetch succeeds", fetchFails: false},
+		{name: "content fetch fails", fetchFails: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := NewMockRClient(t)
+			if tt.fetchFails {
+				rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, errors.New("fetch failed")).Maybe()
+			} else {
+				rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return([]Replica{{
+						ID: id,
+						Object: &storobj.Object{Object: models.Object{
+							ID: id, Class: class, LastUpdateTimeUnix: liveTime,
+						}},
+					}}, nil).Maybe()
+			}
+
+			var (
+				mu       sync.Mutex
+				captured = map[string][]*objects.VObject{}
+			)
+			rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				RunAndReturn(func(_ context.Context, host, _, _ string, xs []*objects.VObject) ([]types.RepairResponse, error) {
+					mu.Lock()
+					defer mu.Unlock()
+					captured[host] = append(captured[host], xs...)
+					return nil, nil
+				}).Maybe()
+
+			metrics, err := NewMetrics(monitoring.GetMetrics())
+			require.NoError(t, err)
+			logger, _ := test.NewNullLogger()
+
+			r := &repairer{
+				class:               class,
+				getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyDeleteOnConflict },
+				client:              NewFinderClient(rc, logger),
+				metrics:             metrics,
+				logger:              logger,
+			}
+
+			votes := []Vote{
+				{BatchReply: BatchReply{Sender: "A", IsLocal: true, DigestData: []types.RepairResponse{
+					{ID: id.String(), UpdateTime: liveTime},
+				}}, Count: make([]int, len(ids))},
+				{BatchReply: BatchReply{Sender: "B", DigestData: []types.RepairResponse{
+					{ID: id.String(), UpdateTime: delTime, Deleted: true},
+				}}, Count: make([]int, len(ids))},
+			}
+
+			_, err = r.repairBatchPart(context.Background(), shard, ids, votes, 0)
+			_ = err // a failed fetch is reported, but it must not suppress the delete
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Len(t, captured["A"], 1,
+				"the live copy on A must be deleted: B holds a tombstone and the strategy is delete-on-conflict")
+			require.Empty(t, captured["B"], "B already holds the winning tombstone")
+
+			got := captured["A"][0]
+			require.True(t, got.Deleted)
+			require.Nil(t, got.LatestObject, "a delete carries no content")
+			require.Equal(t, delTime, got.LastUpdateTimeUnixMilli)
+			require.Equal(t, liveTime, got.StaleUpdateTime)
+		})
+	}
+}
+
+// TestRepairBatchPartDeleteOnConflictSkipsContentFetch pins that an object
+// whose only pending write is a delete is not read from any replica first.
+func TestRepairBatchPartDeleteOnConflictSkipsContentFetch(t *testing.T) {
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+	ids := []strfmt.UUID{id}
+
+	var fetches atomic.Int32
+	rc := NewMockRClient(t)
+	rc.EXPECT().FetchObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(context.Context, string, string, string, []strfmt.UUID) ([]Replica, error) {
+			fetches.Add(1)
+			return nil, nil
+		}).Maybe()
+	rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(nil, nil).Maybe()
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	r := &repairer{
+		class:               "C1",
+		getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyDeleteOnConflict },
+		client:              NewFinderClient(rc, logger),
+		metrics:             metrics,
+		logger:              logger,
+	}
+
+	votes := []Vote{
+		{BatchReply: BatchReply{Sender: "A", IsLocal: true, DigestData: []types.RepairResponse{
+			{ID: id.String(), UpdateTime: 100},
+		}}, Count: make([]int, len(ids))},
+		{BatchReply: BatchReply{Sender: "B", DigestData: []types.RepairResponse{
+			{ID: id.String(), UpdateTime: 80, Deleted: true},
+		}}, Count: make([]int, len(ids))},
+	}
+
+	resolved, err := r.repairBatchPart(context.Background(), "S1", ids, votes, 0)
+	require.NoError(t, err)
+	require.Equal(t, []bool{true}, resolved, "the winning outcome is a delete, known from the digests alone")
+	require.Zero(t, fetches.Load(), "a delete carries no content, so nothing needs reading")
+}
+
+// TestRepairBatchPartWithoutCallerCopy pins that a missing caller copy is
+// reported instead of indexing votes[-1].
+func TestRepairBatchPartWithoutCallerCopy(t *testing.T) {
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+	ids := []strfmt.UUID{id}
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	r := &repairer{
+		class:               "C1",
+		getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyNoAutomatedResolution },
+		client:              NewFinderClient(NewMockRClient(t), logger),
+		metrics:             metrics,
+		logger:              logger,
+	}
+
+	votes := []Vote{
+		{BatchReply: BatchReply{Sender: "A", DigestData: []types.RepairResponse{{ID: id.String(), UpdateTime: 100}}}, Count: make([]int, len(ids))},
+	}
+
+	var resolved []bool
+	require.NotPanics(t, func() {
+		resolved, err = r.repairBatchPart(context.Background(), "S1", ids, votes, -1)
+	})
+	require.ErrorContains(t, err, "no reply identified as the caller's copy")
+	require.Equal(t, []bool{false}, resolved)
+}

--- a/usecases/replica/repairer_test.go
+++ b/usecases/replica/repairer_test.go
@@ -14,19 +14,49 @@ package replica_test
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
 )
+
+// replicasOf builds the FetchObjects response for the current versions of xs.
+func replicasOf(xs ...*storobj.Object) []replica.Replica {
+	rs := make([]replica.Replica, len(xs))
+	for i, x := range xs {
+		rs[i] = repl(x.ID(), x.LastUpdateTimeUnix(), false)
+	}
+	return rs
+}
+
+// expectFetch mocks node's one FetchObjects call for exactly ids, returning xs.
+func expectFetch(f *fakeFactory, node, cls, shard string, ids []strfmt.UUID, xs []replica.Replica) {
+	f.RClient.EXPECT().FetchObjects(anyVal, node, cls, shard, ids).
+		Return(xs, nil).
+		Once()
+}
+
+// expectFetchAnyOrder is like expectFetch but asserts the ids in any order:
+// read repair batches ids per replica without guaranteeing their order.
+func expectFetchAnyOrder(t *testing.T, f *fakeFactory, node, cls, shard string, want []strfmt.UUID, xs []replica.Replica) {
+	f.RClient.EXPECT().FetchObjects(anyVal, node, cls, shard, anyVal).
+		Return(xs, nil).
+		Once().
+		RunFn = func(a mock.Arguments) {
+		require.ElementsMatch(t, want, a[4].([]strfmt.UUID))
+	}
+}
 
 func TestRepairerOneWithALL(t *testing.T) {
 	var (
@@ -800,7 +830,8 @@ func TestRepairerCheckConsistencyAll(t *testing.T) {
 
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).Return(digestR2, nil)
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, ids, anyVal).Return(digestR3, nil)
-			// Note: FetchObjects is NOT called on nodes[0] (local node) - it already has full data
+			// the caller's own replica wins all three, so it serves the content
+			expectFetch(f, nodes[0], cls, shard, ids, replicasOf(directR...))
 			// Repair stale replicas
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, anyVal).
 				Return(digestR2, nil).
@@ -889,6 +920,9 @@ func TestRepairerCheckConsistencyAll(t *testing.T) {
 					repl(ids[0], 2, false),
 					repl(ids[1], 2, false),
 				}
+				directR1 = []replica.Replica{
+					repl(ids[3], 4, false),
+				}
 				directR3 = []replica.Replica{
 					repl(ids[2], 3, false),
 					repl(ids[4], 3, false),
@@ -901,19 +935,11 @@ func TestRepairerCheckConsistencyAll(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).Return(digestR2, nil)
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, ids, anyVal).Return(digestR3, nil)
 
-			// fetch most recent objects from nodes that have higher UpdateTime
-			f.RClient.EXPECT().FetchObjects(anyVal, nodes[1], cls, shard, anyVal).Return(directR2, nil).
-				Once().
-				RunFn = func(a mock.Arguments) {
-				got := a[4].([]strfmt.UUID)
-				require.ElementsMatch(t, ids[:2], got)
-			}
-			f.RClient.EXPECT().FetchObjects(anyVal, nodes[2], cls, shard, anyVal).Return(directR3, nil).
-				Once().
-				RunFn = func(a mock.Arguments) {
-				got := a[4].([]strfmt.UUID)
-				require.ElementsMatch(t, []strfmt.UUID{ids[2], ids[4]}, got)
-			}
+			// fetch the winning version of every object that has to be written,
+			// from whichever replica won it
+			expectFetchAnyOrder(t, f, nodes[0], cls, shard, []strfmt.UUID{ids[3]}, directR1)
+			expectFetchAnyOrder(t, f, nodes[1], cls, shard, ids[:2], directR2)
+			expectFetchAnyOrder(t, f, nodes[2], cls, shard, []strfmt.UUID{ids[2], ids[4]}, directR3)
 
 			// repair
 			var (
@@ -1060,7 +1086,8 @@ func TestRepairerCheckConsistencyAll(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).Return(digestR2, nil)
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, ids, anyVal).Return(digestR3, nil)
 
-			// Note: FetchObjects is NOT called on nodes[0] (local node) - it already has full data
+			// the caller's own replica wins all three, so it serves the content
+			expectFetch(f, nodes[0], cls, shard, ids, replicasOf(xs...))
 			// Repair stale replicas
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, anyVal).
 				Return(directR2, nil).
@@ -1160,9 +1187,9 @@ func TestRepairerCheckConsistencyAll(t *testing.T) {
 				Return(digestR3, nil).
 				Once()
 
-			// fetch most recent objects from nodes that have higher UpdateTime
-			// nodes[2] has ids[2] with UpdateTime 4 (higher than local's 1)
-			// nodes[1] has ids[1] with UpdateTime 3 (same as local's 3, so no fetch needed)
+			// fetch the winning version of every object that has to be written.
+			// nodes[1] holds ids[1] at the winning time already, so it is not asked.
+			expectFetchAnyOrder(t, f, nodes[0], cls, shard, ids[:2], replicasOf(xs[:2]...))
 			f.RClient.EXPECT().FetchObjects(anyVal, nodes[2], cls, shard, anyVal).
 				Return(directR3, nil).
 				Once()
@@ -1343,14 +1370,9 @@ func TestRepairerCheckConsistencyAll(t *testing.T) {
 				Return(digestR3, nil).
 				Once()
 
-			// fetch most recent objects from nodes that have higher UpdateTime
-			// nodes[1] has ids[1] with UpdateTime 3 (same as local's 3, so no fetch needed)
-			// nodes[2] has ids[2] with UpdateTime 4 (deleted, higher than local's 1)
-			// However, for deleted objects, if lastDeletionTimes[i] == lastTimes[i].T, FetchObjects is skipped (line 407-408)
-			// Since ids[2] is deleted with UpdateTime 4, and that's the latest, FetchObjects might not be called
-			// But the test failure suggests it should be called. Let me check the test data again.
-			// Actually, the test expects FetchObjects on nodes[1] for ids[1], but that's wrong since UpdateTime is the same.
-			// Let me remove that expectation.
+			// caller's replica wins ids[0]/ids[1] and serves them; ids[2]'s winner is
+			// a tombstone, so no content is fetched for it.
+			expectFetchAnyOrder(t, f, nodes[0], cls, shard, ids[:2], replicasOf(xs[:2]...))
 			var (
 				repairR2 = []types.RepairResponse{
 					{ID: ids[1].String(), UpdateTime: 1},
@@ -1418,11 +1440,10 @@ func TestRepairerCheckConsistencyQuorum(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).Return(digestR2, errAny)
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, ids, anyVal).Return(digestR3, nil)
 
-			// Note: FetchObjects is NOT called on nodes[0] (local node) - it already has full data
-			// For ConsistencyLevelQuorum, we only need 2 out of 3 nodes to agree
-			// Local has: ids[0]=4, ids[1]=5, ids[2]=6 (all latest)
-			// nodes[1] has error, nodes[2] has: ids[0]=1, ids[1]=5, ids[2]=3
-			// So we need to repair nodes[2] for ids[0] and ids[2]
+			// Quorum (2 of 3) tolerates nodes[1] erroring: nodes[2] is repaired for
+			// ids[0] and ids[2], served from the caller's own replica.
+			expectFetchAnyOrder(t, f, nodes[0], cls, shard, []strfmt.UUID{ids[0], ids[2]},
+				replicasOf(xs[0], xs[2]))
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[2], cls, shard, anyVal).
 				Return(digestR2, nil).
 				Once().
@@ -1451,5 +1472,335 @@ func TestRepairerCheckConsistencyQuorum(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, want, xs)
 		})
+	}
+}
+
+// Pins that repair writes the stored object, never the caller's projected search result.
+func TestRepairerCheckConsistencyRepairPayloadIsRefetched(t *testing.T) {
+	var (
+		id    = strfmt.UUID("10")
+		cls   = "C1"
+		shard = "SH1"
+		nodes = []string{"A", "B"}
+		ids   = []strfmt.UUID{id}
+		ctx   = context.Background()
+
+		// update time of the copy held by the coordinator (node A)
+		localTime = int64(2)
+
+		// what the object actually looks like on disk on every replica
+		storedProps = map[string]interface{}{
+			"num":    float64(1),
+			"bucket": "b1",
+			"tag":    "t1",
+			"body":   "lorem ipsum",
+		}
+		storedVector = []float32{0.1, 0.2, 0.3}
+
+		// what a Get selecting only "num" materialises
+		projectedProps = map[string]interface{}{"num": float64(1)}
+	)
+
+	newObject := func(updateTime int64, props map[string]interface{}, vector []float32) *storobj.Object {
+		return &storobj.Object{
+			Object: models.Object{
+				ID:                 id,
+				Class:              cls,
+				LastUpdateTimeUnix: updateTime,
+				Properties:         props,
+				Vector:             vector,
+			},
+			BelongsToShard: shard,
+			BelongsToNode:  nodes[0],
+			Vector:         vector,
+		}
+	}
+
+	tests := []struct {
+		name string
+		// inputProps/inputVector describe the object handed to CheckConsistency,
+		// i.e. what the local search actually materialised
+		inputProps  map[string]interface{}
+		inputVector []float32
+		// remoteTime is the update time reported by the other replica's digest
+		remoteTime int64
+		// repairedNode is the replica expected to receive the repair payload
+		repairedNode string
+	}{
+		{
+			name:         "projected properties reach the lagging replica",
+			inputProps:   projectedProps,
+			inputVector:  storedVector,
+			remoteTime:   localTime - 1,
+			repairedNode: nodes[1],
+		},
+		{
+			name:         "unprojected properties reach the lagging replica",
+			inputProps:   storedProps,
+			inputVector:  storedVector,
+			remoteTime:   localTime - 1,
+			repairedNode: nodes[1],
+		},
+		{
+			name:         "vector reaches the lagging replica",
+			inputProps:   storedProps,
+			inputVector:  nil,
+			remoteTime:   localTime - 1,
+			repairedNode: nodes[1],
+		},
+		{
+			name:         "newer remote is refetched before repairing the local replica",
+			inputProps:   projectedProps,
+			inputVector:  nil,
+			remoteTime:   localTime + 1,
+			repairedNode: nodes[0],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				f        = newFakeFactory(t, cls, shard, nodes, false)
+				finder   = f.newFinder(nodes[0])
+				xs       = []*storobj.Object{newObject(localTime, tt.inputProps, tt.inputVector)}
+				digestR  = []types.RepairResponse{{ID: id.String(), UpdateTime: tt.remoteTime}}
+				mu       sync.Mutex
+				captured []*objects.VObject
+			)
+
+			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).
+				Return(digestR, nil)
+
+			// content is always fetched, even when the caller's own node wins
+			winner, winnerTime := nodes[0], localTime
+			if tt.remoteTime > localTime {
+				winner, winnerTime = nodes[1], tt.remoteTime
+			}
+			full := []replica.Replica{{
+				ID:     id,
+				Object: newObject(winnerTime, storedProps, storedVector),
+			}}
+			f.RClient.EXPECT().FetchObjects(anyVal, winner, cls, shard, ids).Return(full, nil).Once()
+
+			f.RClient.EXPECT().OverwriteObjects(anyVal, tt.repairedNode, cls, shard, anyVal).
+				Return([]types.RepairResponse{}, nil).
+				Once().
+				RunFn = func(a mock.Arguments) {
+				mu.Lock()
+				defer mu.Unlock()
+				captured = append(captured, a[4].([]*objects.VObject)...)
+			}
+
+			require.NoError(t, finder.CheckConsistency(ctx, types.ConsistencyLevelQuorum, xs))
+
+			mu.Lock()
+			defer mu.Unlock()
+			require.Len(t, captured, 1, "expected a single repair payload for node %q", tt.repairedNode)
+			payload := captured[0]
+			require.NotNil(t, payload.LatestObject, "repair payload carries no object")
+
+			gotProps, _ := payload.LatestObject.Properties.(map[string]interface{})
+			assert.Equal(t, storedProps, gotProps,
+				"this is the payload read repair sends to node %q as the winning version of the object, "+
+					"stamped with the winning update time. Any property missing here is missing from that "+
+					"write, and no later digest comparison can notice, because digests only compare "+
+					"update times.", tt.repairedNode)
+
+			assert.Equal(t, storedVector, payload.Vector,
+				"this is the payload read repair sends to node %q as the winning version of the object, "+
+					"stamped with the winning update time. A missing vector here is missing from that "+
+					"write, and no later digest comparison can notice, because digests only compare "+
+					"update times.", tt.repairedNode)
+		})
+	}
+}
+
+// MMR strips a vector after ranking with it, so the result looks like an
+// object that never had it; that must not become repair content either.
+func TestRepairerCheckConsistencyMMRStrippedVectorIsRefetched(t *testing.T) {
+	var (
+		id    = strfmt.UUID("10")
+		cls   = "C1"
+		shard = "SH1"
+		nodes = []string{"A", "B"}
+		ids   = []strfmt.UUID{id}
+		ctx   = context.Background()
+
+		localTime = int64(2)
+		props     = map[string]interface{}{"num": float64(1)}
+
+		storedVectors = map[string][]float32{
+			"text":  {0.1, 0.2},
+			"image": {0.3, 0.4},
+		}
+		// left after MMR ranks on "image", which the caller never asked for
+		strippedVectors = map[string][]float32{"text": {0.1, 0.2}}
+
+		f        = newFakeFactory(t, cls, shard, nodes, false)
+		finder   = f.newFinder(nodes[0])
+		digestR  = []types.RepairResponse{{ID: id.String(), UpdateTime: localTime - 1}}
+		mu       sync.Mutex
+		captured []*objects.VObject
+	)
+
+	newObject := func(vectors map[string][]float32) *storobj.Object {
+		named := make(models.Vectors, len(vectors))
+		for target, v := range vectors {
+			named[target] = v
+		}
+		return &storobj.Object{
+			Object: models.Object{
+				ID:                 id,
+				Class:              cls,
+				LastUpdateTimeUnix: localTime,
+				Properties:         props,
+				Vectors:            named,
+			},
+			BelongsToShard: shard,
+			BelongsToNode:  nodes[0],
+			Vectors:        vectors,
+		}
+	}
+
+	f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).Return(digestR, nil)
+	f.RClient.EXPECT().FetchObjects(anyVal, nodes[0], cls, shard, ids).
+		Return([]replica.Replica{{ID: id, Object: newObject(storedVectors)}}, nil).Once()
+	f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, anyVal).
+		Return([]types.RepairResponse{}, nil).
+		Once().
+		RunFn = func(a mock.Arguments) {
+		mu.Lock()
+		defer mu.Unlock()
+		captured = append(captured, a[4].([]*objects.VObject)...)
+	}
+
+	xs := []*storobj.Object{newObject(strippedVectors)}
+	require.NoError(t, finder.CheckConsistency(ctx, types.ConsistencyLevelQuorum, xs))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, captured, 1)
+	assert.Equal(t, storedVectors, captured[0].Vectors,
+		"a named vector stripped after MMR must not be dropped from the repair payload")
+}
+
+// Every object in a repaired batch takes its content from whichever replica won,
+// in one fetch per replica, and objects no replica disagrees on are not fetched.
+func TestRepairerCheckConsistencyBatchMixedWinners(t *testing.T) {
+	var (
+		cls   = "C1"
+		shard = "SH1"
+		nodes = []string{"A", "B"}
+		ctx   = context.Background()
+
+		// agreed, local wins, local wins, remote wins
+		ids        = []strfmt.UUID{"01", "02", "03", "04"}
+		localTimes = []int64{5, 5, 5, 3}
+		digestR    = []types.RepairResponse{
+			{ID: "01", UpdateTime: 5},
+			{ID: "02", UpdateTime: 3},
+			{ID: "03", UpdateTime: 3},
+			{ID: "04", UpdateTime: 7},
+		}
+
+		f      = newFakeFactory(t, cls, shard, nodes, false)
+		finder = f.newFinder(nodes[0])
+
+		mu        sync.Mutex
+		fetched   = map[string][]strfmt.UUID{}
+		overwrote = map[string][]*objects.VObject{}
+	)
+
+	// the stored object always carries a property the caller's copy does not
+	stored := func(id strfmt.UUID, updateTime int64) *storobj.Object {
+		return &storobj.Object{
+			Object: models.Object{
+				ID:                 id,
+				Class:              cls,
+				LastUpdateTimeUnix: updateTime,
+				Properties:         map[string]interface{}{"body": "stored " + id.String()},
+			},
+			BelongsToShard: shard,
+			BelongsToNode:  nodes[0],
+		}
+	}
+
+	xs := make([]*storobj.Object, len(ids))
+	for i, id := range ids {
+		xs[i] = &storobj.Object{
+			Object: models.Object{
+				ID:                 id,
+				Class:              cls,
+				LastUpdateTimeUnix: localTimes[i],
+				Properties:         map[string]interface{}{},
+			},
+			BelongsToShard: shard,
+			BelongsToNode:  nodes[0],
+		}
+	}
+
+	f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, ids, anyVal).Return(digestR, nil)
+
+	fetchReply := func(node string) func(mock.Arguments) {
+		return func(a mock.Arguments) {
+			mu.Lock()
+			defer mu.Unlock()
+			fetched[node] = append(fetched[node], a[4].([]strfmt.UUID)...)
+		}
+	}
+	f.RClient.EXPECT().FetchObjects(anyVal, nodes[0], cls, shard, []strfmt.UUID{ids[1], ids[2]}).
+		Return([]replica.Replica{
+			{ID: ids[1], Object: stored(ids[1], 5)},
+			{ID: ids[2], Object: stored(ids[2], 5)},
+		}, nil).
+		Once().
+		RunFn = fetchReply(nodes[0])
+	f.RClient.EXPECT().FetchObjects(anyVal, nodes[1], cls, shard, []strfmt.UUID{ids[3]}).
+		Return([]replica.Replica{{ID: ids[3], Object: stored(ids[3], 7)}}, nil).
+		Once().
+		RunFn = fetchReply(nodes[1])
+
+	overwriteReply := func(node string) func(mock.Arguments) {
+		return func(a mock.Arguments) {
+			mu.Lock()
+			defer mu.Unlock()
+			overwrote[node] = append(overwrote[node], a[4].([]*objects.VObject)...)
+		}
+	}
+	for _, node := range nodes {
+		f.RClient.EXPECT().OverwriteObjects(anyVal, node, cls, shard, anyVal).
+			Return([]types.RepairResponse{}, nil).
+			Once().
+			RunFn = overwriteReply(node)
+	}
+
+	require.NoError(t, finder.CheckConsistency(ctx, types.ConsistencyLevelAll, xs))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.ElementsMatch(t, []strfmt.UUID{ids[1], ids[2]}, fetched[nodes[0]],
+		"the objects the caller's replica wins are fetched from it in one batched read")
+	assert.ElementsMatch(t, []strfmt.UUID{ids[3]}, fetched[nodes[1]],
+		"the object the remote replica wins is fetched from the remote replica")
+
+	got := map[strfmt.UUID]*objects.VObject{}
+	for node, payloads := range overwrote {
+		for _, p := range payloads {
+			got[p.ID] = p
+			assert.NotNil(t, p.LatestObject, "payload for %s on %s carries no object", p.ID, node)
+		}
+	}
+	require.Len(t, got, 3, "ids[0] agrees everywhere and must not be repaired")
+
+	for id, wantTime := range map[strfmt.UUID]int64{ids[1]: 5, ids[2]: 5, ids[3]: 7} {
+		require.Contains(t, got, id)
+		assert.Equal(t, "stored "+id.String(), got[id].LatestObject.Properties.(map[string]interface{})["body"],
+			"the payload for %s must come from the winning replica, not from the caller's search result", id)
+		assert.Equal(t, wantTime, got[id].LastUpdateTimeUnixMilli)
+	}
+
+	for i := range xs {
+		assert.True(t, xs[i].IsConsistent, "object %s should be reported consistent", ids[i])
 	}
 }

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -17,8 +17,11 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -162,14 +165,6 @@ func (r *DeleteBatchResponse) FirstError() error {
 	return nil
 }
 
-func fromReplicas(xs []Replica) []*storobj.Object {
-	rs := make([]*storobj.Object, len(xs))
-	for i := range xs {
-		rs[i] = xs[i].Object
-	}
-	return rs
-}
-
 type DigestObjectsInRangeReq struct {
 	InitialUUID strfmt.UUID `json:"initialUUID,omitempty"`
 	FinalUUID   strfmt.UUID `json:"finalUUID,omitempty"`
@@ -232,11 +227,12 @@ type RClient interface {
 
 // FinderClient extends RClient with consistency checks
 type FinderClient struct {
-	cl RClient
+	cl  RClient
+	log logrus.FieldLogger
 }
 
-func NewFinderClient(cl RClient) FinderClient {
-	return FinderClient{cl: cl}
+func NewFinderClient(cl RClient, log logrus.FieldLogger) FinderClient {
+	return FinderClient{cl: cl, log: log}
 }
 
 // FullRead reads full object
@@ -276,17 +272,78 @@ func (fc FinderClient) DigestObjectsInRange(ctx context.Context,
 	return fc.cl.DigestObjectsInRange(ctx, host, index, shard, initialUUID, finalUUID, limit)
 }
 
-// FullReads read full objects
+// MaxFullReadIDsPerRequest bounds ids per FetchObjects request. The REST
+// transport base64-encodes them into the URL query string at ~53 bytes per id,
+// so 256 ids is ~14 KB: well inside the receiving server's 1 MiB header cap
+// (MaxHeaderBytes is unset) and the 60 KiB a service-mesh sidecar (Envoy
+// default) allows on node-to-node traffic. An unbounded list would overflow
+// those caps with a 414 that is not retried. The chunk also caps how many
+// whole objects one response holds in memory.
+const MaxFullReadIDsPerRequest = 256
+
+// MaxConcurrentFullReadRequests bounds how many chunked FetchObjects requests
+// are in flight at once against the single winning host, capping peak response
+// memory at MaxConcurrentFullReadRequests * MaxFullReadIDsPerRequest whole
+// objects per FullReads call. The repairer runs one FullReads per winning
+// replica concurrently, so the ceiling per repaired batch is that product
+// times the number of winning replicas (at most the replication factor).
+const MaxConcurrentFullReadRequests = 16
+
+// FullReads reads the current version of each id from host, one entry per
+// requested id in request order. Ids are fetched in bounded chunks, chunks
+// concurrently; any failed chunk fails the whole read. A response that does
+// not line up with its request is rejected rather than returned: callers
+// index the result positionally, so a mispair would repair the wrong object.
 func (fc FinderClient) FullReads(ctx context.Context,
 	host, index, shard string,
 	ids []strfmt.UUID,
 ) ([]Replica, error) {
-	n := len(ids)
-	rs, err := fc.cl.FetchObjects(ctx, host, index, shard, ids)
-	if m := len(rs); err == nil && n != m {
-		err = fmt.Errorf("malformed full read response: length expected %d got %d", n, m)
+	if len(ids) <= MaxFullReadIDsPerRequest {
+		return fc.fullReadChunk(ctx, host, index, shard, ids, 0)
 	}
-	return rs, err
+
+	rs := make([]Replica, len(ids))
+	gr, ctx := enterrors.NewErrorGroupWithContextWrapper(fc.log, ctx)
+	gr.SetLimit(MaxConcurrentFullReadRequests)
+	for start := 0; start < len(ids); start += MaxFullReadIDsPerRequest {
+		start, end := start, min(start+MaxFullReadIDsPerRequest, len(ids))
+		gr.Go(func() error {
+			part, err := fc.fullReadChunk(ctx, host, index, shard, ids[start:end], start)
+			if err != nil {
+				return err
+			}
+			copy(rs[start:end], part)
+			return nil
+		})
+	}
+	if err := gr.Wait(); err != nil {
+		return nil, err
+	}
+	return rs, nil
+}
+
+// fullReadChunk performs one FetchObjects request and validates that the
+// response carries exactly the requested ids in request order. offset is the
+// chunk's position in the whole id list, so errors name absolute indices.
+func (fc FinderClient) fullReadChunk(ctx context.Context,
+	host, index, shard string,
+	chunk []strfmt.UUID, offset int,
+) ([]Replica, error) {
+	part, err := fc.cl.FetchObjects(ctx, host, index, shard, chunk)
+	if err != nil {
+		return nil, err
+	}
+	if len(part) != len(chunk) {
+		return nil, fmt.Errorf("malformed full read response: length expected %d got %d",
+			len(chunk), len(part))
+	}
+	for i := range part {
+		if part[i].ID != chunk[i] {
+			return nil, fmt.Errorf("malformed full read response: object %d is %q, expected %q",
+				offset+i, part[i].ID, chunk[i])
+		}
+	}
+	return part, nil
 }
 
 // Overwrite specified object with most recent contents


### PR DESCRIPTION
Backport of [weaviate/weaviate#12355](https://github.com/weaviate/weaviate/issues/12355) to `stable/v1.36`, as a cherry-pick of the merge commit `e4e2a3822c` plus one adaptation commit for this branch's test harness.

The argument for the change itself is in #12355 and is not repeated here.

## Why this branch needs it

`stable/v1.36` still carries the destructive read-repair path. On a batch read that triggers repair, the coordinator's own copy of an object is a **projected search result**: only the properties the query selected, and not necessarily the vector. The pre-fix code hands that copy to the repairer as the repair payload:

```go
result[i] = p.Object   // p comes from BatchReply.FullData, i.e. the search result
```

The repairer then overwrites the stale replica's *complete* object with it. Unselected properties and the vector are gone, the request returns `HTTP 200`, and no later repair restores them: the replica now agrees on update time, so nothing marks it as needing repair again.

Verified at the branch tips rather than inferred:

| branch | `result[i] = p.Object` | `FullData` refs | contains `e4e2a3822c` |
|---|---|---|---|
| `stable/v1.36` | 1 | 3 | 🔴 no |
| `stable/v1.37` | 0 | 0 | ✅ yes |
| `stable/v1.38` | 0 | 0 | ✅ yes |

Forward merges run `v1.36 → v1.37 → v1.38 → main`, so a fix that landed on `v1.37` can never reach `v1.36`. This branch needs an explicit backport and did not have one. (`stable/v1.36` is not an ancestor of `stable/v1.37`: merge-base `0c737d407c`, v1.36 ahead 6, v1.37 ahead 1206. Merging v1.37 back was never an option.)

## Prerequisite for #12361

This is not parallel cleanup. It is a prerequisite for [weaviate/weaviate#12361](https://github.com/weaviate/weaviate/issues/12361), which also targets `stable/v1.36` and rewrites the same function.

12361 makes read repair *write* in a case where it previously wrote nothing. On a branch lacking the projection guard, that converts "stale but intact" into "overwritten with a deficient object". Measured on the rig in [this comment](https://github.com/weaviate/weaviate/issues/12361#issuecomment-5092174172), identical fixture and skew, only the binary differing:

| | pre-12361 | with 12361 |
|---|---|---|
| replica the repair wrote | `PRESENT_INTACT`, damaged **0** | `PRESENT_DAMAGED` ×60, damaged **1500** |

A stale-but-intact replica can still be repaired later; an overwritten one has lost data permanently. With this backport first, the write 12361 introduces carries a complete object.

## What changed

The fix is structural rather than a guard on the destructive branch. `BatchReply.FullData` is removed outright, so the projected copy cannot reach the repairer at all. The caller's copy contributes only update times (`DigestData` + `IsLocal`), and repair content is always fetched from the winning replica. `repairBatchPart` returns `[]bool` instead of `[]*storobj.Object`.

Also carried over from the merged PR: read-repair fetch failures are surfaced instead of dropped, a delete-only repair no longer waits on a content fetch, and `FullReads` fetches in bounded concurrent chunks.

## How it was ported

`git cherry-pick -m 1 -x e4e2a3822c`, the actual merge commit, not hand-restored hunks. Three conflicts, all `v1.36`-vs-`v1.37` drift:

| file | conflict | resolution |
|---|---|---|
| `repairer.go` | `deleted :=` hoist not yet on v1.36 | took 12355's side |
| `finder.go` | v1.36 lacks the `%w: %w` error wrap | kept v1.36's message text, adopted 12355's single-value return |
| `transport.go` | v1.36's `FinderClient` has no `CompareDigests`/`CompareHashTreeRoots` | added only 12355's new consts and doc, did not pull in the two v1.37-line methods |

`repairer_internal_test.go` does not exist on `v1.36` (added on the v1.37 line), so it came across whole.

**Fidelity check.** After the port these are byte-identical to `stable/v1.37`: `repairer.go`, `batch.go`, `finder_stream.go`, `repairer_internal_test.go`, `repairer_fetch_failure_test.go`, `repairer_test.go`, and `read_repair_projection_test.go` before the naming commit below.

```
diff <(git show origin/stable/v1.37:usecases/replica/repairer.go) usecases/replica/repairer.go   # empty
```

`finder.go` and `transport.go` stay different from v1.37. The residual delta is pre-existing branch divergence outside the hunks 12355 touches, and every 12355 hunk in both landed.

### The `deleted :=` hoist carries a second fix

v1.36 guards with `if !x.Deleted && result[j] == nil` and computes `deleted` later, inside the write branch. When a replica holds a tombstone that is not the newest version, the guard does not fire, `deleted` is false, and `&result[j].Object` nil-derefs on a failed refetch. Taking v1.37's file closes that, and `repairer_internal_test.go` brings `TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch`, which pins it. Worth knowing when reading the diff, because that hunk is not explained by the projection fix.

### Cluster node naming (`8af9e58`)

The backported acceptance test asked for objects from `docker.Weaviate0..2`, which do not exist here. The substitution is not mechanical:

| | container name | cluster node name (`?node_name=`) |
|---|---|---|
| `v1.37` | `weaviate-0` | `weaviate-0`, same string |
| `v1.36` | `weaviate` | `node1`, **different** |

`GetObjectFromNodeWithVector` passes its argument to `?node_name=`, so mapping onto v1.36's `docker.Weaviate1..3` compiles and then queries a node name matching nothing. The test now uses `node1`/`node2`/`node3`, as every other replication test on this branch already does. Containers are still addressed by index via `StopNodeAt`/`ContainerURI`.

## Testing

| check | `-race` | result |
|---|---|---|
| `go build ./usecases/replica/...` | n/a | 🟢 clean |
| `go vet ./usecases/replica/...` | n/a | 🟢 only v1.36's pre-existing `coordinator.go:263` lostcancel, present on the untouched branch |
| `go vet ./test/acceptance/replication/read_repair/...` | n/a | 🟢 clean |
| `gofmt -l` on both touched packages | n/a | 🟢 clean |
| `go test -timeout 30m ./usecases/replica/...` | **no** | 🟢 `ok 368.9s` |
| `go test -race -timeout 30m ./usecases/replica/...` | **yes** | 🟢 `ok 370.0s`, no data races |
| `go test -race -timeout 30m ./adapters/repos/db/...` | **yes** | 🟢 37 packages ok, no data races |
| `test/acceptance/replication/read_repair` (3-node docker) | n/a | ⚪ **not executed**: compiles and vets, but needs a built image and a 3-node cluster |

No unit test expectations were changed relative to #12355.

## Risks

**Behavioural change, same as the original.** `BatchReply` is digest-only, so content is fetched from the winner wherever any replica disagrees, including a round trip from the coordinator to itself. `FullReads` chunks at 256 ids with 16 requests in flight. Cost analysis is in #12355 and applies unchanged.

**Forward-merge cost, measured.** Merging `stable/v1.36` into `stable/v1.37` today conflicts in **2** files (`usecases/backup/backupper.go`, `scheduler.go`, both unrelated to this change). With this branch it conflicts in **5**: those two plus `usecases/replica/finder.go`, `transport.go`, and the acceptance test as add/add. In all three added cases v1.37's side wins, taking care to preserve the v1.36-only symbols in `transport.go`. Better to see that cost here than to meet it at merge-forward time.

**The acceptance test has not run on this branch.** It should go through the pipelines before this leaves draft.

## Note for #12361's rebase

Checked against `repair385-repair-convergence` at `9d1dae1e4b`.

12361's fixtures build `BatchReply` with `FullData` and `IsDigest`, both deleted here (`IsDigest` is replaced by the **inverted-sense** `IsLocal`). Its tests therefore **do not compile** on top of this, 8 errors, and its `DeletedAt` helper reads `FullData` in production code, so that needs rewriting too. The break is loud and safe.

The risk is what happens during the fixture rewrite. Porting the fixtures to the digest-only shape and running them **without** 12361's production fix:

| 12361 test | on plain v1.36 | on v1.36 + this backport, 12361's fix absent |
|---|---|---|
| `TestReadBatchPartIsConsistentThreeTier/[A_C_B]` | 🔴 fails | 🟢 **passes**, this PR's `resolved[i]` gate fixes the inverted flag on its own |
| `…LiveWinnerFailedRefetchNoPanic` | 🔴 nil-deref panic | `NotPanics` **passes**, red only on `require.NoError` |
| `…Converges/before_the_winner` | 🔴 write amplification 10>5 | 🔴 but trips on `require.NoError`, convergence assertions never reached |
| `…Converges/after_the_winner` | 🔴 read amplification 50>5 | 🔴 **"fixture never reached the fetch path"**, 0 fetches, was 50 |

Two of 12361's red tests go green without its production change, and a third stops exercising its path.

**The nil-deref coverage changes owner rather than disappearing.** This PR brings `TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch`, which pins the same shape. 12361 may therefore drop `…LiveWinnerFailedRefetchNoPanic`, but must **not** drop its two convergence tests: nothing else covers those, and they need their red state re-derived against the new shape rather than merely made to compile.
