### PR TITLE
fix disposable_created size label off-by-one

### DIFF
--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -437,13 +437,13 @@ func newPromBufDisposableMetrics(metrics *monitoring.PrometheusMetrics) *promBuf
 }
 
 func (m *promBufDisposableMetrics) bufCreated(sizeInBytes int) {
-	s := uint64(sizeInBytes)
-	ceil := uint64(1 << bits.Len64(s))
-	if s^ceil != 0 {
-		ceil *= 2
+	// smallest power of two >= sizeInBytes, so the label names the same size
+	// class the pooled tiers use
+	ceil := uint64(1)
+	if sizeInBytes > 1 {
+		ceil = 1 << bits.Len64(uint64(sizeInBytes)-1)
 	}
-	size := humanize.IBytes(ceil)
-	m.usageCounter.WithLabelValues(size, "disposable_created").Inc()
+	m.usageCounter.WithLabelValues(humanize.IBytes(ceil), "disposable_created").Inc()
 }
 
 type bufDisposableNoopMetrics struct{}

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -14,10 +14,13 @@ package roaringset
 import (
 	"encoding/binary"
 	"fmt"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -847,4 +850,84 @@ func TestValidateBufferRanges(t *testing.T) {
 			require.Equal(t, tc.expectedRanges, ranges)
 		})
 	}
+}
+
+// mirrors the real LSMBitmapBuffersUsage definition, but unregistered so each
+// test observes only its own increments.
+func newTestBitmapBuffersUsage() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "lsm_bitmap_buffers_usage",
+		Help: "Number of bitmap buffers used by size",
+	}, []string{"size", "operation"})
+}
+
+func expectedDisposableCreated(sizeLabel string) string {
+	return fmt.Sprintf(`
+# HELP lsm_bitmap_buffers_usage Number of bitmap buffers used by size
+# TYPE lsm_bitmap_buffers_usage counter
+lsm_bitmap_buffers_usage{operation="disposable_created",size="%s"} 1
+`, sizeLabel)
+}
+
+func TestPromBufDisposableMetricsSizeLabel(t *testing.T) {
+	tests := []struct {
+		name        string
+		sizeInBytes int
+		sizeLabel   string
+	}{
+		{
+			name:        "exactly a power of two",
+			sizeInBytes: 32 << 20,
+			sizeLabel:   "32 MiB",
+		},
+		{
+			name:        "one byte above a power of two",
+			sizeInBytes: 32<<20 + 1,
+			sizeLabel:   "64 MiB",
+		},
+		{
+			name:        "one byte below a power of two",
+			sizeInBytes: 64<<20 - 1,
+			sizeLabel:   "64 MiB",
+		},
+		{
+			name:        "between two powers of two",
+			sizeInBytes: 100_000_000,
+			sizeLabel:   "128 MiB",
+		},
+		{
+			name:        "smallest buffer",
+			sizeInBytes: 1,
+			sizeLabel:   "1 B",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			counter := newTestBitmapBuffersUsage()
+			metrics := newPromBufDisposableMetrics(&monitoring.PrometheusMetrics{
+				LSMBitmapBuffersUsage: counter,
+			})
+
+			metrics.bufCreated(test.sizeInBytes)
+
+			require.NoError(t, testutil.CollectAndCompare(counter,
+				strings.NewReader(expectedDisposableCreated(test.sizeLabel))))
+		})
+	}
+}
+
+func TestBitmapBufPoolRangedDisposableMetrics(t *testing.T) {
+	// 2048 is above the largest range, so it is served by an unpooled buffer
+	// and labelled with the size class it would have needed.
+	counter := newTestBitmapBuffersUsage()
+	pool := NewBitmapBufPoolRanged(&monitoring.PrometheusMetrics{
+		LSMBitmapBuffersUsage: counter,
+	}, 1024, nil, 512, 1024)
+
+	_, put := pool.Get(2048)
+	put()
+
+	require.NoError(t, testutil.CollectAndCompare(counter,
+		strings.NewReader(expectedDisposableCreated("2.0 KiB"))))
 }


### PR DESCRIPTION
The `size` label on `lsm_bitmap_buffers_usage{operation="disposable_created"}` named the wrong size class.

The class was derived with `1 << bits.Len64(s)`. That is already the next power of two *strictly above* `s`, so the `s^ceil != 0` guard that follows it (meant to detect "s was not already a power of two") could never be false and doubled the result a second time.

| request | label before | label now |
|---|---|---|
| 32 MiB (exact power of two) | 128 MiB | 32 MiB |
| 32 MiB + 1 B | 128 MiB | 64 MiB |
| ~95 MiB | 256 MiB | 128 MiB |

Every size class was affected: one class too high for a normal request, two classes too high when the request was exactly a power of two. Only the `disposable_created` label was wrong; the pooled `inmemo_*` labels take their size straight from the pool's range and were always correct. This is metrics-only, no behaviour change.

The disposable path is reached for requests above the largest pooled class, so with the shipped `QUERY_BITMAP_BUFS_MAX_BUF_SIZE=32MiB` it is buffers over 32 MiB that were mislabelled.

Tests assert the emitted label through `testutil.CollectAndCompare`, both directly and via `bitmapBufPoolRanged.Get`. All six cases fail on `stable/v1.37` before the fix.

Salvaged from weaviate/weaviate#12353, which is being closed rather than merged; this fix is base-branch behaviour and unrelated to the range features that branch composed, so it lands standalone.
