### PR TITLE
Add retry to module base client

### DIFF
--- a/usecases/modulecomponents/base_client.go
+++ b/usecases/modulecomponents/base_client.go
@@ -20,8 +20,8 @@ import (
 )
 
 // NewBaseHttpClient creates an http.Client that does not follow redirects and
-// resends a request whose connection broke before a response arrived, so an
-// origin may see the same request more than once. The timeout lives in the
+// resends a request whose pooled connection broke before a response arrived, so
+// an origin may see the same request more than once. The timeout lives in the
 // transport, not http.Client.Timeout, so replacing Transport also removes it.
 // When MODULES_VALIDATE_BASE_URL is enabled it also installs a dial guard
 // rejecting internal addresses — the network-layer SSRF backstop covering every

--- a/usecases/modulecomponents/base_client.go
+++ b/usecases/modulecomponents/base_client.go
@@ -19,17 +19,15 @@ import (
 	"time"
 )
 
-// NewBaseHttpClient creates an http.Client with the given timeout that does not
-// follow redirects. When MODULES_VALIDATE_BASE_URL is enabled it also installs
-// a dial guard rejecting internal addresses — the network-layer SSRF backstop
-// covering every client and baseURL source (config, headers, redirects).
+// NewBaseHttpClient creates an http.Client that does not follow redirects and
+// resends a request whose connection broke before a response arrived, so an
+// origin may see the same request more than once. The timeout lives in the
+// transport, not http.Client.Timeout, so replacing Transport also removes it.
+// When MODULES_VALIDATE_BASE_URL is enabled it also installs a dial guard
+// rejecting internal addresses — the network-layer SSRF backstop covering every
+// client and baseURL source (config, headers, redirects).
 func NewBaseHttpClient(timeout time.Duration) *http.Client {
-	client := &http.Client{
-		Timeout: timeout,
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
+	transport := http.DefaultTransport
 
 	if BaseURLValidationEnabled() {
 		// DefaultTransport's dialer settings plus a Control hook that runs
@@ -39,12 +37,17 @@ func NewBaseHttpClient(timeout time.Duration) *http.Client {
 			KeepAlive: 30 * time.Second,
 			Control:   ssrfDialGuard,
 		}
-		transport := http.DefaultTransport.(*http.Transport).Clone()
-		transport.DialContext = dialer.DialContext
-		client.Transport = transport
+		guarded := http.DefaultTransport.(*http.Transport).Clone()
+		guarded.DialContext = dialer.DialContext
+		transport = guarded
 	}
 
-	return client
+	return &http.Client{
+		Transport: &retryTransport{base: transport, timeout: timeout},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 }
 
 // ssrfDialGuard blocks connections to internal addresses. address is the

--- a/usecases/modulecomponents/base_client_test.go
+++ b/usecases/modulecomponents/base_client_test.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBaseHttpClient(t *testing.T) {
+	post := func(t *testing.T, client *http.Client, url string) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url,
+			bytes.NewReader([]byte(`{"text":"hello"}`)))
+		require.NoError(t, err)
+		return client.Do(req)
+	}
+
+	// dropConn ends the request without responding, which is what the client sees
+	// when an inference service closes a connection it considers idle.
+	dropConn := func(t *testing.T, w http.ResponseWriter, r *http.Request) {
+		io.Copy(io.Discard, r.Body)
+		conn, _, err := w.(http.Hijacker).Hijack()
+		require.NoError(t, err)
+		conn.Close()
+	}
+
+	t.Run("retries a dropped connection", func(t *testing.T) {
+		var requests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if requests.Add(1) == 1 {
+				dropConn(t, w, r)
+				return
+			}
+			w.Write([]byte("second attempt"))
+		}))
+		defer server.Close()
+
+		res, err := post(t, NewBaseHttpClient(30*time.Second), server.URL)
+
+		require.NoError(t, err)
+		defer res.Body.Close()
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "second attempt", string(body))
+		assert.Equal(t, int32(2), requests.Load())
+	})
+
+	t.Run("gives up once the retry budget is spent", func(t *testing.T) {
+		var requests atomic.Int32
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requests.Add(1)
+			dropConn(t, w, r)
+		}))
+		defer server.Close()
+
+		res, err := post(t, NewBaseHttpClient(30*time.Second), server.URL)
+		if res != nil {
+			defer res.Body.Close()
+		}
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "EOF")
+		assert.Equal(t, int32(3), requests.Load())
+	})
+
+	// blockingServer never finishes its response, so only the client's own
+	// timeout can end the request. The release channel closes before
+	// server.Close, which would otherwise block on the handler.
+	blockingServer := func(t *testing.T, respond func(w http.ResponseWriter)) *httptest.Server {
+		release := make(chan struct{})
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if respond != nil {
+				respond(w)
+			}
+			<-release
+		}))
+		t.Cleanup(server.Close)
+		t.Cleanup(func() { close(release) })
+		return server
+	}
+
+	t.Run("reports the timeout as a deadline", func(t *testing.T) {
+		server := blockingServer(t, nil)
+		client := NewBaseHttpClient(200 * time.Millisecond)
+
+		// On http.Client the timeout would report a cancellation, not a deadline.
+		require.Zero(t, client.Timeout)
+
+		res, err := post(t, client, server.URL)
+		if res != nil {
+			defer res.Body.Close()
+		}
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "context deadline exceeded")
+		assert.NotContains(t, err.Error(), "request canceled")
+	})
+
+	t.Run("keeps the dial guard in place", func(t *testing.T) {
+		t.Setenv("MODULES_VALIDATE_BASE_URL", "true")
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		defer server.Close()
+
+		res, err := post(t, NewBaseHttpClient(30*time.Second), server.URL)
+		if res != nil {
+			defer res.Body.Close()
+		}
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "refusing to dial internal address")
+	})
+
+	t.Run("keeps the timeout in force while the body is read", func(t *testing.T) {
+		server := blockingServer(t, func(w http.ResponseWriter) {
+			w.Write([]byte("partial"))
+			w.(http.Flusher).Flush()
+		})
+
+		res, err := post(t, NewBaseHttpClient(200*time.Millisecond), server.URL)
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		_, err = io.ReadAll(res.Body)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "context deadline exceeded")
+		assert.NotContains(t, err.Error(), "request canceled")
+	})
+}

--- a/usecases/modulecomponents/base_client_test.go
+++ b/usecases/modulecomponents/base_client_test.go
@@ -42,36 +42,54 @@ func TestNewBaseHttpClient(t *testing.T) {
 		conn.Close()
 	}
 
+	// poolConn leaves a connection to the server in the client's idle pool, which
+	// the next request reuses. Only a request sent on a pooled connection is
+	// resent.
+	poolConn := func(t *testing.T, client *http.Client, url string) {
+		res, err := post(t, client, url)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		_, err = io.Copy(io.Discard, res.Body)
+		require.NoError(t, err)
+	}
+
 	t.Run("retries a dropped connection", func(t *testing.T) {
 		var requests atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if requests.Add(1) == 1 {
+			if requests.Add(1) == 2 {
 				dropConn(t, w, r)
 				return
 			}
 			w.Write([]byte("second attempt"))
 		}))
 		defer server.Close()
+		client := NewBaseHttpClient(30 * time.Second)
+		poolConn(t, client, server.URL)
 
-		res, err := post(t, NewBaseHttpClient(30*time.Second), server.URL)
+		res, err := post(t, client, server.URL)
 
 		require.NoError(t, err)
 		defer res.Body.Close()
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		assert.Equal(t, "second attempt", string(body))
-		assert.Equal(t, int32(2), requests.Load())
+		assert.Equal(t, int32(3), requests.Load())
 	})
 
-	t.Run("gives up once the retry budget is spent", func(t *testing.T) {
+	t.Run("stops resending once the connection is freshly dialed", func(t *testing.T) {
 		var requests atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requests.Add(1)
+			if requests.Add(1) == 1 {
+				w.Write([]byte("pooling the connection"))
+				return
+			}
 			dropConn(t, w, r)
 		}))
 		defer server.Close()
+		client := NewBaseHttpClient(30 * time.Second)
+		poolConn(t, client, server.URL)
 
-		res, err := post(t, NewBaseHttpClient(30*time.Second), server.URL)
+		res, err := post(t, client, server.URL)
 		if res != nil {
 			defer res.Body.Close()
 		}

--- a/usecases/modulecomponents/retry_transport.go
+++ b/usecases/modulecomponents/retry_transport.go
@@ -16,20 +16,24 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
+	"net/http/httptrace"
+	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-// retryDelays holds the pause before each retry, so its length is the number of
-// retries. The first retry runs immediately: the broken connection is already
-// out of the pool.
-var retryDelays = []time.Duration{0, 100 * time.Millisecond}
+// retryDelays holds the base pause before each retry, so its length is the
+// number of retries.
+var retryDelays = []time.Duration{50 * time.Millisecond, 250 * time.Millisecond}
 
-// retryTransport resends a request whose connection broke before any response
-// arrived. net/http resends a POST only when none of its bytes reached the wire,
-// so a server closing a pooled connection mid-request fails the call. A resent
-// request may be processed twice by the origin.
+// retryTransport resends a request whose pooled connection broke before any
+// response arrived. net/http resends a POST only when none of its bytes reached
+// the wire, so a server closing a pooled connection mid-request fails the call.
+// A resent request may be processed twice by the origin.
 //
 // timeout covers all attempts and the response body read. http.Client.Timeout
 // cannot be used: with a wrapped transport it cancels through Request.Cancel, so
@@ -59,9 +63,20 @@ func (t *retryTransport) roundTripWithRetries(req *http.Request) (*http.Response
 
 	attempt := req
 	for i := 0; ; i++ {
-		res, err := t.base.RoundTrip(attempt)
-		if err == nil || !canResend || !isBrokenConnError(err) {
-			return res, err
+		if i > 0 {
+			monitoring.GetMetrics().ModuleExternalRequestResends.Inc()
+		}
+
+		var reusedConn atomic.Bool
+		res, err := t.base.RoundTrip(withConnReuseTrace(attempt, &reusedConn))
+		if err == nil {
+			return res, nil
+		}
+		// Only a request sent on a pooled connection is resent: a server closing
+		// a connection it considered idle cannot have processed it, while a break
+		// on a freshly dialed one may mean the origin already took the request.
+		if !canResend || !reusedConn.Load() || !isBrokenConnError(err) {
+			return nil, err
 		}
 		if i >= len(retryDelays) {
 			// Without the count a caller cannot tell the request was resent.
@@ -70,7 +85,7 @@ func (t *retryTransport) roundTripWithRetries(req *http.Request) (*http.Response
 
 		// A deadline landing in the pause is what ended the call, not the
 		// connection error before it.
-		if waitErr := waitBeforeRetry(req.Context(), retryDelays[i]); waitErr != nil {
+		if waitErr := waitBeforeRetry(req.Context(), jittered(retryDelays[i])); waitErr != nil {
 			return nil, waitErr
 		}
 
@@ -86,6 +101,23 @@ func (t *retryTransport) roundTripWithRetries(req *http.Request) (*http.Response
 	}
 }
 
+// withConnReuseTrace returns req set up to record whether it goes out on a
+// pooled connection. GotConn does not fire when no connection could be
+// obtained, leaving reused false.
+func withConnReuseTrace(req *http.Request, reused *atomic.Bool) *http.Request {
+	trace := &httptrace.ClientTrace{
+		GotConn: func(info httptrace.GotConnInfo) { reused.Store(info.Reused) },
+	}
+	return req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
+}
+
+// jittered spreads out resends of connections that broke at the same moment, as
+// an inference service being restarted closes all of its pooled connections at
+// once.
+func jittered(delay time.Duration) time.Duration {
+	return delay + rand.N(delay)
+}
+
 // isBrokenConnError reports whether the connection died before a response could
 // be read. net/http wraps these, hence errors.Is.
 func isBrokenConnError(err error) bool {
@@ -98,9 +130,6 @@ func isBrokenConnError(err error) bool {
 func waitBeforeRetry(ctx context.Context, delay time.Duration) error {
 	if err := ctx.Err(); err != nil {
 		return err
-	}
-	if delay == 0 {
-		return nil
 	}
 
 	timer := time.NewTimer(delay)

--- a/usecases/modulecomponents/retry_transport.go
+++ b/usecases/modulecomponents/retry_transport.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"syscall"
+	"time"
+)
+
+// retryDelays holds the pause before each retry, so its length is the number of
+// retries. The first retry runs immediately: the broken connection is already
+// out of the pool.
+var retryDelays = []time.Duration{0, 100 * time.Millisecond}
+
+// retryTransport resends a request whose connection broke before any response
+// arrived. net/http resends a POST only when none of its bytes reached the wire,
+// so a server closing a pooled connection mid-request fails the call. A resent
+// request may be processed twice by the origin.
+//
+// timeout covers all attempts and the response body read. http.Client.Timeout
+// cannot be used: with a wrapped transport it cancels through Request.Cancel, so
+// a timed-out call can report "request canceled" instead of the deadline.
+type retryTransport struct {
+	base    http.RoundTripper
+	timeout time.Duration
+}
+
+func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.timeout <= 0 {
+		return t.roundTripWithRetries(req)
+	}
+
+	ctx, cancel := context.WithTimeout(req.Context(), t.timeout)
+	res, err := t.roundTripWithRetries(req.WithContext(ctx))
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	res.Body = &cancelOnClose{ReadCloser: res.Body, cancel: cancel}
+	return res, nil
+}
+
+func (t *retryTransport) roundTripWithRetries(req *http.Request) (*http.Response, error) {
+	canResend := req.Body == nil || req.GetBody != nil
+
+	attempt := req
+	for i := 0; ; i++ {
+		res, err := t.base.RoundTrip(attempt)
+		if err == nil || !canResend || !isBrokenConnError(err) {
+			return res, err
+		}
+		if i >= len(retryDelays) {
+			// Without the count a caller cannot tell the request was resent.
+			return nil, fmt.Errorf("after %d attempts: %w", i+1, err)
+		}
+
+		// A deadline landing in the pause is what ended the call, not the
+		// connection error before it.
+		if waitErr := waitBeforeRetry(req.Context(), retryDelays[i]); waitErr != nil {
+			return nil, waitErr
+		}
+
+		// The previous attempt consumed and closed the body, so take a fresh one.
+		attempt = req.Clone(req.Context())
+		if req.GetBody != nil {
+			body, bodyErr := req.GetBody()
+			if bodyErr != nil {
+				return nil, bodyErr
+			}
+			attempt.Body = body
+		}
+	}
+}
+
+// isBrokenConnError reports whether the connection died before a response could
+// be read. net/http wraps these, hence errors.Is.
+func isBrokenConnError(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE)
+}
+
+func waitBeforeRetry(ctx context.Context, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if delay == 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// cancelOnClose keeps the timeout in force until the caller closes the body.
+type cancelOnClose struct {
+	io.ReadCloser
+	cancel context.CancelFunc
+}
+
+func (b *cancelOnClose) Close() error {
+	err := b.ReadCloser.Close()
+	b.cancel()
+	return err
+}

--- a/usecases/modulecomponents/retry_transport_test.go
+++ b/usecases/modulecomponents/retry_transport_test.go
@@ -18,11 +18,16 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptrace"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func TestRetryTransport(t *testing.T) {
@@ -33,7 +38,10 @@ func TestRetryTransport(t *testing.T) {
 		name string
 		// errs[i] is returned for attempt i+1; a nil entry (or running past
 		// the end of the slice) responds 200.
-		errs             []error
+		errs []error
+		// reusedConns[i] tells attempt i+1 whether its connection came out of
+		// the pool; attempts past the end of the slice use a pooled one.
+		reusedConns      []bool
 		body             io.Reader
 		bodyCannotResend bool
 		cancelCtx        bool
@@ -95,6 +103,22 @@ func TestRetryTransport(t *testing.T) {
 			wantErr:      certErr,
 		},
 		{
+			name:         "does not retry a connection that did not come out of the pool",
+			errs:         []error{io.EOF},
+			reusedConns:  []bool{false},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 1,
+			wantErr:      io.EOF,
+		},
+		{
+			name:         "stops once a resend dials a fresh connection",
+			errs:         []error{io.EOF, io.EOF},
+			reusedConns:  []bool{true, false},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 2,
+			wantErr:      io.EOF,
+		},
+		{
 			name:             "does not retry a body it cannot resend",
 			errs:             []error{io.EOF},
 			body:             bytes.NewReader([]byte(`{"text":"hello"}`)),
@@ -114,7 +138,8 @@ func TestRetryTransport(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			base := &fakeRoundTripper{errs: test.errs}
+			base := &fakeRoundTripper{errs: test.errs, reusedConns: test.reusedConns}
+			resends := testutil.ToFloat64(monitoring.GetMetrics().ModuleExternalRequestResends)
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			if test.cancelCtx {
@@ -141,6 +166,8 @@ func TestRetryTransport(t *testing.T) {
 				assert.Equal(t, http.StatusOK, res.StatusCode)
 			}
 			assert.Equal(t, test.wantAttempts, base.attempts)
+			assert.Equal(t, float64(test.wantAttempts-1),
+				testutil.ToFloat64(monitoring.GetMetrics().ModuleExternalRequestResends)-resends)
 
 			// A retried attempt must not send different input than the caller passed.
 			if test.body != nil {
@@ -154,13 +181,17 @@ func TestRetryTransport(t *testing.T) {
 }
 
 type fakeRoundTripper struct {
-	errs     []error
-	attempts int
-	bodies   []string
+	errs        []error
+	reusedConns []bool
+	attempts    int
+	bodies      []string
 }
 
 func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	f.attempts++
+	if trace := httptrace.ContextClientTrace(req.Context()); trace != nil {
+		trace.GotConn(httptrace.GotConnInfo{Reused: f.connReused()})
+	}
 	if req.Body != nil {
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
@@ -174,4 +205,27 @@ func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 		return nil, f.errs[i]
 	}
 	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}
+
+func (f *fakeRoundTripper) connReused() bool {
+	if i := f.attempts - 1; i < len(f.reusedConns) {
+		return f.reusedConns[i]
+	}
+	return true
+}
+
+func TestJittered(t *testing.T) {
+	const delay = 100 * time.Millisecond
+
+	seen := map[time.Duration]bool{}
+	for range 100 {
+		got := jittered(delay)
+		require.GreaterOrEqual(t, got, delay)
+		require.Less(t, got, 2*delay)
+		seen[got] = true
+	}
+
+	// Without a spread every connection dropped at the same moment is resent
+	// at the same moment.
+	assert.Greater(t, len(seen), 1)
 }

--- a/usecases/modulecomponents/retry_transport_test.go
+++ b/usecases/modulecomponents/retry_transport_test.go
@@ -1,0 +1,177 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryTransport(t *testing.T) {
+	connReset := &net.OpError{Op: "read", Err: syscall.ECONNRESET}
+	certErr := errors.New("x509: certificate signed by unknown authority")
+
+	tests := []struct {
+		name string
+		// errs[i] is returned for attempt i+1; a nil entry (or running past
+		// the end of the slice) responds 200.
+		errs             []error
+		body             io.Reader
+		bodyCannotResend bool
+		cancelCtx        bool
+		wantAttempts     int
+		wantErr          error
+	}{
+		{
+			name:         "no retry when the first attempt succeeds",
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 1,
+		},
+		{
+			name:         "retries a bare EOF",
+			errs:         []error{io.EOF},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 2,
+		},
+		{
+			name:         "retries an unexpected EOF",
+			errs:         []error{io.ErrUnexpectedEOF},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 2,
+		},
+		{
+			name:         "retries a connection reset",
+			errs:         []error{connReset},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 2,
+		},
+		{
+			name:         "retries a broken pipe",
+			errs:         []error{syscall.EPIPE},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 2,
+		},
+		{
+			name:         "retries a request without a body",
+			errs:         []error{io.EOF},
+			wantAttempts: 2,
+		},
+		{
+			name:         "retries twice before giving up",
+			errs:         []error{io.EOF, connReset, io.EOF},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 3,
+			wantErr:      io.EOF,
+		},
+		{
+			name:         "recovers on the last retry",
+			errs:         []error{io.EOF, io.EOF},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 3,
+		},
+		{
+			name:         "does not retry an error unrelated to the connection",
+			errs:         []error{certErr},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			wantAttempts: 1,
+			wantErr:      certErr,
+		},
+		{
+			name:             "does not retry a body it cannot resend",
+			errs:             []error{io.EOF},
+			body:             bytes.NewReader([]byte(`{"text":"hello"}`)),
+			bodyCannotResend: true,
+			wantAttempts:     1,
+			wantErr:          io.EOF,
+		},
+		{
+			name:         "does not retry a cancelled request",
+			errs:         []error{io.EOF},
+			body:         bytes.NewReader([]byte(`{"text":"hello"}`)),
+			cancelCtx:    true,
+			wantAttempts: 1,
+			wantErr:      context.Canceled,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			base := &fakeRoundTripper{errs: test.errs}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if test.cancelCtx {
+				cancel()
+			}
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://localhost/vectors", test.body)
+			require.NoError(t, err)
+			if test.bodyCannotResend {
+				req.GetBody = nil
+			}
+
+			res, err := (&retryTransport{base: base}).RoundTrip(req)
+			if res != nil {
+				defer res.Body.Close()
+			}
+
+			if test.wantErr != nil {
+				require.ErrorIs(t, err, test.wantErr)
+				assert.Nil(t, res)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				assert.Equal(t, http.StatusOK, res.StatusCode)
+			}
+			assert.Equal(t, test.wantAttempts, base.attempts)
+
+			// A retried attempt must not send different input than the caller passed.
+			if test.body != nil {
+				require.Len(t, base.bodies, test.wantAttempts)
+				for _, body := range base.bodies {
+					assert.Equal(t, `{"text":"hello"}`, body)
+				}
+			}
+		})
+	}
+}
+
+type fakeRoundTripper struct {
+	errs     []error
+	attempts int
+	bodies   []string
+}
+
+func (f *fakeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.attempts++
+	if req.Body != nil {
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		req.Body.Close()
+		f.bodies = append(f.bodies, string(body))
+	}
+
+	if i := f.attempts - 1; i < len(f.errs) && f.errs[i] != nil {
+		return nil, f.errs[i]
+	}
+	return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -182,6 +182,8 @@ type PrometheusMetrics struct {
 	ModuleCallError                  *prometheus.CounterVec
 	ModuleBatchError                 *prometheus.CounterVec
 
+	ModuleExternalRequestResends prometheus.Counter
+
 	// Checksum metrics
 	ChecksumValidationDuration prometheus.Summary
 	ChecksumBytesRead          prometheus.Summary
@@ -941,6 +943,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "weaviate_module_batch_error_total",
 			Help: "Number of batch errors",
 		}, []string{"operation", "class_name"}),
+		ModuleExternalRequestResends: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "weaviate_module_request_resends_total",
+			Help: "Number of module requests to external APIs sent again after their connection broke",
+		}),
 
 		// Checksum metrics
 		ChecksumValidationDuration: promauto.NewSummary(prometheus.SummaryOpts{


### PR DESCRIPTION
### What's being changed:

Inference services routinely close connections they consider idle. When that close races a request we just sent on that pooled connection, net/http gives up — it only resends a POST when none of its bytes reached the wire — and the vectorizer call fails with `EOF` or `connection reset`, even though the origin never saw the request.

`NewBaseHttpClient` now wraps its transport in a `retryTransport` that resends such a request up to twice, with jittered backoff (50ms, 250ms). Resending is deliberately narrow: only on a connection that came *out of the pool* (`httptrace.GotConn.Reused`), only for connection-death errors (`EOF`, `ErrUnexpectedEOF`, `ECONNRESET`, `EPIPE`), and only when the body can be replayed. A break on a freshly dialed connection may mean the origin already took the request, so it is not retried.

Two things worth a look:

- **The timeout moved out of `http.Client.Timeout` into the transport.** With a wrapped transport, `Client.Timeout` cancels via `Request.Cancel` and surfaces as `request canceled` rather than the deadline. The transport-level context covers all attempts *and* the body read; the response body carries the `cancel` so the deadline stays in force until it is closed.
- **A resent request may be processed twice by the origin.** That is the tradeoff for surviving pool churn; the reused-connection check keeps it to cases where processing is very unlikely. `weaviate_module_request_resends_total` makes the rate visible.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
