### PR TITLE
fix(ci): stop two custom linters exiting 1 with no output, and pin that all four still fire

### DIFF
--- a/.github/actions/security-lint/action.yml
+++ b/.github/actions/security-lint/action.yml
@@ -14,8 +14,8 @@ inputs:
 runs:
   using: composite
   steps:
-    # The scan below reports success identically whether the diff is clean or
-    # the scanner has stopped matching. This proves it still fires first.
+    # A green scan below doesn't prove it's working: it exits 0 the same way on
+    # a clean diff and on a scanner that stopped matching. This checks the latter.
     - name: Positive control for the hidden Unicode scanner
       shell: bash
       run: bash "$GITHUB_ACTION_PATH/selfcheck.sh"

--- a/.github/actions/security-lint/action.yml
+++ b/.github/actions/security-lint/action.yml
@@ -14,6 +14,12 @@ inputs:
 runs:
   using: composite
   steps:
+    # The scan below reports success identically whether the diff is clean or
+    # the scanner has stopped matching. This proves it still fires first.
+    - name: Positive control for the hidden Unicode scanner
+      shell: bash
+      run: bash "$GITHUB_ACTION_PATH/selfcheck.sh"
+
     - name: Check PR diff for hidden Unicode
       shell: bash
       # Inputs are passed through env vars — never interpolated into the

--- a/.github/actions/security-lint/selfcheck.sh
+++ b/.github/actions/security-lint/selfcheck.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Positive control for linter_hidden_unicode.sh.
+#
+# The linter prints "No hidden Unicode characters detected." and exits 0 both
+# when a diff is genuinely clean and when the scanner has stopped matching
+# altogether, so a green PR Security Lint proves nothing on its own. This feeds
+# the linter a known-bad diff and fails unless it fires and names the character.
+#
+# It runs as the first step of the composite action so every consumer of that
+# action, including the client repos that pin it by SHA and have no Go
+# toolchain, re-proves the scanner on every run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LINTER="$SCRIPT_DIR/linter_hidden_unicode.sh"
+
+fail() {
+    echo "POSITIVE CONTROL FAILED: $LINTER $1" >&2
+    echo "  The hidden Unicode scanner no longer detects trojan-source characters." >&2
+    echo "  Until this is fixed, PR Security Lint passes every pull request." >&2
+    exit 1
+}
+
+# Written as UTF-8 bytes rather than a literal character: a tracked file
+# containing a real U+200B would be flagged by this very linter when it scans
+# the pull request that adds the file.
+zwsp=$(printf '\xe2\x80\x8b')
+
+if bad_out=$(printf '+++ b/fixture.go\n@@ -0,0 +1 @@\n+var x = "%s"\n' "$zwsp" \
+    | bash "$LINTER" --stdin 2>&1); then
+    fail "exited 0 on a known-bad diff containing U+200B ZERO WIDTH SPACE. Output: $bad_out"
+fi
+
+case "$bad_out" in
+    *"U+200B ZERO WIDTH SPACE"*) ;;
+    *) fail "exited non-zero on the known-bad diff but never named U+200B ZERO WIDTH SPACE. Output: $bad_out" ;;
+esac
+
+# Without this the control would also pass against a linter hardwired to fail.
+if ! clean_out=$(printf '+++ b/fixture.go\n@@ -0,0 +1 @@\n+var x = "safe"\n' \
+    | bash "$LINTER" --stdin 2>&1); then
+    fail "rejected a clean diff, so its failure on the known-bad diff proves nothing. Output: $clean_out"
+fi
+
+echo "Positive control passed: hidden Unicode scanner fires on U+200B and passes a clean diff."

--- a/.github/actions/security-lint/selfcheck.sh
+++ b/.github/actions/security-lint/selfcheck.sh
@@ -1,14 +1,8 @@
 #!/usr/bin/env bash
-# Positive control for linter_hidden_unicode.sh.
-#
-# The linter prints "No hidden Unicode characters detected." and exits 0 both
-# when a diff is genuinely clean and when the scanner has stopped matching
-# altogether, so a green PR Security Lint proves nothing on its own. This feeds
-# the linter a known-bad diff and fails unless it fires and names the character.
-#
-# It runs as the first step of the composite action so every consumer of that
-# action, including the client repos that pin it by SHA and have no Go
-# toolchain, re-proves the scanner on every run.
+# Positive control for linter_hidden_unicode.sh: it exits 0 both on a clean
+# diff and when the scanner has stopped matching, so a green PR Security Lint
+# proves nothing on its own. Shell, not Go, so client repos that pin this
+# action by SHA and have no Go toolchain still re-run it.
 
 set -euo pipefail
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -35,7 +35,16 @@ jobs:
     name: custom checks
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version: '1.26'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Each linter below is silent and exits 0 when it finds nothing, so those
+      # steps going green does not distinguish a clean tree from a linter that
+      # has stopped matching. This proves each one still fires on a known-bad
+      # fixture before we trust the steps that follow.
+      - name: linter positive controls
+        run: go test ./tools/lintercheck/...
       - name: Error groups checks
         run: ./tools/linter_error_groups.sh
       - name: goroutine checks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -39,10 +39,8 @@ jobs:
         with:
           go-version: '1.26'
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      # Each linter below is silent and exits 0 when it finds nothing, so those
-      # steps going green does not distinguish a clean tree from a linter that
-      # has stopped matching. This proves each one still fires on a known-bad
-      # fixture before we trust the steps that follow.
+      # Each linter below exits 0 silently on no match, so green alone doesn't
+      # prove it still works. This checks each one still fires.
       - name: linter positive controls
         run: go test ./tools/lintercheck/...
       - name: Error groups checks

--- a/tools/linter_error_groups.sh
+++ b/tools/linter_error_groups.sh
@@ -6,13 +6,15 @@ set -euo pipefail
 all_files=$(git ls-files | grep -E '\.go$' | grep -vE 'test')
 
 # Get all files with 'errgroup' in them. The only place where direct usage is allowed is in error_group_wrapper.go
-files=$(grep -l 'errgroup' ${all_files})
+# `|| true` because grep exits 1 when nothing matches, which under `set -e` would
+# abort here and exit 1 with no output — indistinguishable from a real violation.
+files=$(grep -l 'errgroup' ${all_files} || true)
 
 found_error=false
 
 for file in $files; do
     # Check if the file is not one of the permitted usages
-    if [ "$file" != "entities/errors/error_group_wrapper.go" ] && [ "$file" != "tools/linter_error_groups.sh" ]; then
+    if [ "$file" != "entities/errors/error_group_wrapper.go" ]; then
         echo "Error: $file directly uses error groups. Please use entities/errors/error_group_wrapper.go instead."
         found_error=true
     fi

--- a/tools/linter_go_routines.sh
+++ b/tools/linter_go_routines.sh
@@ -5,7 +5,9 @@ set -euo pipefail
 all_files=$(git ls-files | grep -E '\.go$' | grep -vE '_test\.go$')
 
 # Get all files with 'go ' in them, ignoring lines that start with a comment
-files=$(grep -E -l '^[[:space:]]*[^/]*go ' ${all_files})
+# `|| true` because grep exits 1 when nothing matches, which under `set -e` would
+# abort here and exit 1 with no output — indistinguishable from a real violation.
+files=$(grep -E -l '^[[:space:]]*[^/]*go ' ${all_files} || true)
 
 found_error=false
 

--- a/tools/lintercheck/lintercheck_test.go
+++ b/tools/lintercheck/lintercheck_test.go
@@ -1,0 +1,193 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package lintercheck holds positive controls for the repo's custom linters.
+//
+// Every custom linter is silent and exits 0 when it finds nothing, so a green
+// "custom checks" job is indistinguishable from a linter that has quietly
+// stopped matching. These tests assert on every CI run that each linter still
+// fires on a known-bad input, and still passes a known-good one.
+package lintercheck
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestTreeWalkingLintersFireOnKnownViolations(t *testing.T) {
+	root := repoRoot(t)
+
+	cases := []struct {
+		name           string
+		script         string
+		violationClass string
+		badFixture     string
+		badPath        string
+		cleanFixture   string
+		cleanPath      string
+		wantOutput     string
+	}{
+		{
+			name:           "error groups",
+			script:         "tools/linter_error_groups.sh",
+			violationClass: "direct errgroup use outside entities/errors/error_group_wrapper.go",
+			badFixture:     "errgroup_violation.go.txt",
+			// This linter drops every path containing "test", so its fixture
+			// cannot be staged under a testdata/ directory.
+			badPath:      "pkg/errgroup_violation.go",
+			cleanFixture: "errgroup_clean.go.txt",
+			cleanPath:    "entities/errors/error_group_wrapper.go",
+			wantOutput:   "directly uses error groups",
+		},
+		{
+			name:           "goroutines",
+			script:         "tools/linter_go_routines.sh",
+			violationClass: "bare go statements instead of the entities/errors wrapper",
+			badFixture:     "goroutine_violation.go.txt",
+			badPath:        "pkg/goroutine_violation.go",
+			cleanFixture:   "goroutine_clean.go.txt",
+			cleanPath:      "pkg/goroutine_clean.go",
+			wantOutput:     "uses direct goroutines",
+		},
+		{
+			name:           "waitgroups",
+			script:         "tools/linter_waitgroups_done.sh",
+			violationClass: "wg.Done() that is not deferred",
+			badFixture:     "waitgroup_violation.go.txt",
+			// This linter skips tools/ and test/ wholesale.
+			badPath:      "pkg/waitgroup_violation.go",
+			cleanFixture: "waitgroup_clean.go.txt",
+			cleanPath:    "pkg/waitgroup_clean.go",
+			// This linter's whole diagnostic is file:line: line, so naming the
+			// file is the assertion; a line number would break on fixture edits.
+			wantOutput: "waitgroup_violation.go:",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			script := filepath.Join(root, filepath.FromSlash(tc.script))
+
+			code, out := runLinter(t, stageFixture(t, tc.badFixture, tc.badPath), script)
+			if code == 0 {
+				t.Fatalf("POSITIVE CONTROL FAILED: %s exited 0 on known-bad fixture "+
+					"tools/lintercheck/testdata/%s (staged as %s).\n"+
+					"It no longer detects %s, so CI is blind to that violation class.\n"+
+					"Linter output:\n%s", tc.script, tc.badFixture, tc.badPath, tc.violationClass, out)
+			}
+			if !strings.Contains(out, tc.wantOutput) {
+				t.Fatalf("POSITIVE CONTROL FAILED: %s exited %d on known-bad fixture "+
+					"tools/lintercheck/testdata/%s (staged as %s) but never mentioned %q.\n"+
+					"Either its diagnostic changed, or it failed for an unrelated reason and "+
+					"is no longer detecting %s.\nLinter output:\n%s",
+					tc.script, code, tc.badFixture, tc.badPath, tc.wantOutput, tc.violationClass, out)
+			}
+
+			// Without this a linter hardwired to fail would satisfy the check above.
+			if code, out := runLinter(t, stageFixture(t, tc.cleanFixture, tc.cleanPath), script); code != 0 {
+				t.Fatalf("POSITIVE CONTROL FAILED: %s exited %d on known-good fixture "+
+					"tools/lintercheck/testdata/%s (staged as %s).\n"+
+					"It rejects clean input, so its failure on the known-bad fixture proves nothing.\n"+
+					"Linter output:\n%s", tc.script, code, tc.cleanFixture, tc.cleanPath, out)
+			}
+		})
+	}
+}
+
+func TestHiddenUnicodeLinterFiresOnKnownViolation(t *testing.T) {
+	// The control itself is shell rather than Go so the security-lint composite
+	// action can run it for the client repos that pin the action by SHA and have
+	// no Go toolchain. This keeps it wired into the Go suite as well.
+	script := filepath.Join(repoRoot(t), ".github", "actions", "security-lint", "selfcheck.sh")
+	if code, out := runLinter(t, t.TempDir(), script); code != 0 {
+		t.Fatalf("POSITIVE CONTROL FAILED: %s exited %d.\n%s", script, code, out)
+	}
+}
+
+// stageFixture copies a fixture into a throwaway git repo and returns its root.
+//
+// The tree-walking linters enumerate files with `git ls-files`, so they cannot
+// be pointed at a fixture path: they scan whatever git repo the working
+// directory belongs to. Staging in a throwaway repo is what keeps the
+// known-bad files from tripping the real lint pass over this repo.
+func stageFixture(t *testing.T, fixture, stagedPath string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join("testdata", fixture))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", fixture, err)
+	}
+
+	dir := t.TempDir()
+	dst := filepath.Join(dir, filepath.FromSlash(stagedPath))
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		t.Fatalf("create fixture dir for %s: %v", stagedPath, err)
+	}
+	if err := os.WriteFile(dst, content, 0o644); err != nil {
+		t.Fatalf("write fixture %s: %v", stagedPath, err)
+	}
+
+	runGit(t, dir, "init", "-q")
+	// -f because a developer's global gitignore could otherwise keep the fixture
+	// out of `git ls-files` and silently make this control vacuous.
+	runGit(t, dir, "add", "-f", stagedPath)
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = hermeticEnv()
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s in %s: %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+}
+
+func runLinter(t *testing.T, dir, script string) (int, string) {
+	t.Helper()
+	cmd := exec.Command("bash", script)
+	cmd.Dir = dir
+	cmd.Env = hermeticEnv()
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		t.Fatalf("run %s: %v\n%s", script, err, out)
+	}
+	return cmd.ProcessState.ExitCode(), string(out)
+}
+
+// hermeticEnv drops the developer's and the runner's git config, which can
+// otherwise change which files `git ls-files` reports and make the throwaway
+// repo behave differently on a laptop than in CI.
+func hermeticEnv() []string {
+	return append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+}
+
+// repoRoot resolves from this file's own path rather than the working
+// directory, which the subtests hand to the linters.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve this test file's path")
+	}
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolved repo root %s has no go.mod; did this package move? %v", root, err)
+	}
+	return root
+}

--- a/tools/lintercheck/lintercheck_test.go
+++ b/tools/lintercheck/lintercheck_test.go
@@ -113,9 +113,10 @@ func TestHiddenUnicodeLinterFiresOnKnownViolation(t *testing.T) {
 	}
 }
 
-// stageFixture stages a fixture in a throwaway git repo. The linters run
-// `git ls-files` on whatever repo they're invoked from, so testdata/ fixtures
-// would otherwise also trip the real lint pass over this repo.
+// stageFixture stages a fixture in a throwaway git repo, because the linters
+// enumerate files with `git ls-files` and cannot be pointed at a path. Keeping
+// them out of the real lint pass is a separate mechanism: the fixtures carry a
+// .go.txt extension, which every linter's .go filter skips.
 func stageFixture(t *testing.T, fixture, stagedPath string) string {
 	t.Helper()
 

--- a/tools/lintercheck/lintercheck_test.go
+++ b/tools/lintercheck/lintercheck_test.go
@@ -9,12 +9,9 @@
 //  CONTACT: hello@weaviate.io
 //
 
-// Package lintercheck holds positive controls for the repo's custom linters.
-//
-// Every custom linter is silent and exits 0 when it finds nothing, so a green
-// "custom checks" job is indistinguishable from a linter that has quietly
-// stopped matching. These tests assert on every CI run that each linter still
-// fires on a known-bad input, and still passes a known-good one.
+// Package lintercheck holds positive controls for the repo's custom linters:
+// each one exits 0 silently on no match, so these tests assert it still fires
+// on known-bad input and still passes known-good input.
 package lintercheck
 
 import (
@@ -71,8 +68,8 @@ func TestTreeWalkingLintersFireOnKnownViolations(t *testing.T) {
 			badPath:      "pkg/waitgroup_violation.go",
 			cleanFixture: "waitgroup_clean.go.txt",
 			cleanPath:    "pkg/waitgroup_clean.go",
-			// This linter's whole diagnostic is file:line: line, so naming the
-			// file is the assertion; a line number would break on fixture edits.
+			// Diagnostic is file:line; asserting just the filename avoids breaking
+			// when the fixture's line numbers shift.
 			wantOutput: "waitgroup_violation.go:",
 		},
 	}
@@ -108,21 +105,17 @@ func TestTreeWalkingLintersFireOnKnownViolations(t *testing.T) {
 }
 
 func TestHiddenUnicodeLinterFiresOnKnownViolation(t *testing.T) {
-	// The control itself is shell rather than Go so the security-lint composite
-	// action can run it for the client repos that pin the action by SHA and have
-	// no Go toolchain. This keeps it wired into the Go suite as well.
+	// Shell, not Go, so the security-lint composite action can also run it for
+	// client repos that pin it by SHA and have no Go toolchain.
 	script := filepath.Join(repoRoot(t), ".github", "actions", "security-lint", "selfcheck.sh")
 	if code, out := runLinter(t, t.TempDir(), script); code != 0 {
 		t.Fatalf("POSITIVE CONTROL FAILED: %s exited %d.\n%s", script, code, out)
 	}
 }
 
-// stageFixture copies a fixture into a throwaway git repo and returns its root.
-//
-// The tree-walking linters enumerate files with `git ls-files`, so they cannot
-// be pointed at a fixture path: they scan whatever git repo the working
-// directory belongs to. Staging in a throwaway repo is what keeps the
-// known-bad files from tripping the real lint pass over this repo.
+// stageFixture stages a fixture in a throwaway git repo. The linters run
+// `git ls-files` on whatever repo they're invoked from, so testdata/ fixtures
+// would otherwise also trip the real lint pass over this repo.
 func stageFixture(t *testing.T, fixture, stagedPath string) string {
 	t.Helper()
 
@@ -170,9 +163,8 @@ func runLinter(t *testing.T, dir, script string) (int, string) {
 	return cmd.ProcessState.ExitCode(), string(out)
 }
 
-// hermeticEnv drops the developer's and the runner's git config, which can
-// otherwise change which files `git ls-files` reports and make the throwaway
-// repo behave differently on a laptop than in CI.
+// hermeticEnv drops the developer's and runner's git config so `git ls-files`
+// behaves the same in the throwaway repo on a laptop as it does in CI.
 func hermeticEnv() []string {
 	return append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 }

--- a/tools/lintercheck/testdata/errgroup_clean.go.txt
+++ b/tools/lintercheck/testdata/errgroup_clean.go.txt
@@ -1,0 +1,9 @@
+package errors
+
+import "golang.org/x/sync/errgroup"
+
+// Staged at the one allow-listed path, so this exercises the allow-list rather
+// than merely the absence of any errgroup mention.
+func NewErrorGroupWrapper() *errgroup.Group {
+	return &errgroup.Group{}
+}

--- a/tools/lintercheck/testdata/errgroup_clean.go.txt
+++ b/tools/lintercheck/testdata/errgroup_clean.go.txt
@@ -2,8 +2,8 @@ package errors
 
 import "golang.org/x/sync/errgroup"
 
-// Staged at the one allow-listed path, so this exercises the allow-list rather
-// than merely the absence of any errgroup mention.
+// Staged at the allow-listed path, exercising the allow-list itself rather
+// than just the absence of an errgroup mention.
 func NewErrorGroupWrapper() *errgroup.Group {
 	return &errgroup.Group{}
 }

--- a/tools/lintercheck/testdata/errgroup_violation.go.txt
+++ b/tools/lintercheck/testdata/errgroup_violation.go.txt
@@ -2,8 +2,7 @@ package pkg
 
 import "golang.org/x/sync/errgroup"
 
-// Known-bad input for tools/linter_error_groups.sh: a direct errgroup use
-// outside the one allow-listed wrapper file.
+// Known-bad: direct errgroup use outside the allow-listed wrapper file.
 func Violation() error {
 	var g errgroup.Group
 	g.Go(func() error { return nil })

--- a/tools/lintercheck/testdata/errgroup_violation.go.txt
+++ b/tools/lintercheck/testdata/errgroup_violation.go.txt
@@ -1,0 +1,11 @@
+package pkg
+
+import "golang.org/x/sync/errgroup"
+
+// Known-bad input for tools/linter_error_groups.sh: a direct errgroup use
+// outside the one allow-listed wrapper file.
+func Violation() error {
+	var g errgroup.Group
+	g.Go(func() error { return nil })
+	return g.Wait()
+}

--- a/tools/lintercheck/testdata/goroutine_clean.go.txt
+++ b/tools/lintercheck/testdata/goroutine_clean.go.txt
@@ -1,0 +1,9 @@
+package pkg
+
+import enterrors "github.com/weaviate/weaviate/entities/errors"
+
+func Clean() {
+	enterrors.GoWrapper(func() { doWork() }, nil)
+}
+
+func doWork() {}

--- a/tools/lintercheck/testdata/goroutine_violation.go.txt
+++ b/tools/lintercheck/testdata/goroutine_violation.go.txt
@@ -1,7 +1,6 @@
 package pkg
 
-// Known-bad input for tools/linter_go_routines.sh: a bare go statement instead
-// of the entities/errors wrapper.
+// Known-bad: bare go statement instead of the entities/errors wrapper.
 func Violation() {
 	go doWork()
 }

--- a/tools/lintercheck/testdata/goroutine_violation.go.txt
+++ b/tools/lintercheck/testdata/goroutine_violation.go.txt
@@ -1,0 +1,9 @@
+package pkg
+
+// Known-bad input for tools/linter_go_routines.sh: a bare go statement instead
+// of the entities/errors wrapper.
+func Violation() {
+	go doWork()
+}
+
+func doWork() {}

--- a/tools/lintercheck/testdata/waitgroup_clean.go.txt
+++ b/tools/lintercheck/testdata/waitgroup_clean.go.txt
@@ -1,0 +1,14 @@
+package pkg
+
+import "sync"
+
+// The deferred form still matches the raw pattern the linter greps for, so this
+// exercises its defer exclusion rather than merely the absence of a match.
+func Clean() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+	}()
+	wg.Wait()
+}

--- a/tools/lintercheck/testdata/waitgroup_clean.go.txt
+++ b/tools/lintercheck/testdata/waitgroup_clean.go.txt
@@ -2,8 +2,8 @@ package pkg
 
 import "sync"
 
-// The deferred form still matches the raw pattern the linter greps for, so this
-// exercises its defer exclusion rather than merely the absence of a match.
+// Deferred Done() still matches the linter's raw grep pattern, exercising its
+// defer exclusion rather than just the absence of a match.
 func Clean() {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/tools/lintercheck/testdata/waitgroup_violation.go.txt
+++ b/tools/lintercheck/testdata/waitgroup_violation.go.txt
@@ -1,0 +1,18 @@
+package pkg
+
+import "sync"
+
+// Known-bad input for tools/linter_waitgroups_done.sh: the counter is
+// decremented inline, so an early return or panic strands the Wait below.
+//
+// Do not spell the flagged call in a comment here; the linter only excludes
+// comment text made of letters, spaces and dots, so a mention would be flagged
+// too and this fixture would stop pinpointing one line.
+func Violation() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		wg.Done()
+	}()
+	wg.Wait()
+}

--- a/tools/lintercheck/testdata/waitgroup_violation.go.txt
+++ b/tools/lintercheck/testdata/waitgroup_violation.go.txt
@@ -2,12 +2,9 @@ package pkg
 
 import "sync"
 
-// Known-bad input for tools/linter_waitgroups_done.sh: the counter is
-// decremented inline, so an early return or panic strands the Wait below.
-//
-// Do not spell the flagged call in a comment here; the linter only excludes
-// comment text made of letters, spaces and dots, so a mention would be flagged
-// too and this fixture would stop pinpointing one line.
+// Known-bad: an early return or panic here would strand Wait below. Don't
+// spell the flagged call in this comment either: the linter matches comment
+// text too, excluding only letters, spaces, and dots.
 func Violation() {
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
SuperClaude here.

Two of the repo's four custom linters fail in a way that prints nothing and looks exactly like a real violation. This fixes both, and adds the fixtures that keep all four honest.

## The bugs

`tools/linter_error_groups.sh:9` and `tools/linter_go_routines.sh:8` both built their match list like this, under `set -euo pipefail`:

```sh
files=$(grep -l 'errgroup' ${all_files})                    # linter_error_groups.sh
files=$(grep -E -l '^[[:space:]]*[^/]*go ' ${all_files})    # linter_go_routines.sh
```

When `grep` matches nothing it exits 1, `set -e` aborts, and the linter exits **1 with no output at all**. The `custom checks` job goes red and says nothing about why — indistinguishable from a real violation, with no diagnostic to chase.

The trigger is *no matches*, so this becomes more likely the more compliant the repo gets, not less. Right now only the incidental presence of unrelated `errgroup` and `go ` hits is keeping it from firing.

`tools/linter_waitgroups_done.sh:28` already guards its `grep` with `|| true`; these two never got it. Both now do the same, and the known-good fixtures below pin the behaviour so it cannot regress silently.

Also removed: one line of dead code in the errgroup linter, a `"$file" != "tools/linter_error_groups.sh"` guard that can never be true, since `all_files` is pre-filtered to `.go` paths.

## Why nothing caught them

Every custom linter exits 0 and prints nothing when it finds nothing. A green `custom checks` job is therefore indistinguishable from a linter that has silently stopped matching. Nothing in CI has ever asserted that these linters can still fail, which is how two of them carried a no-output failure mode without anyone noticing.

That is not hypothetical. Here is the `custom checks` job on this repo today, with the errgroup linter's ruleset pointed at a token that never occurs:

```
$ ./tools/linter_error_groups.sh; echo "exit: $?"
exit: 0  -> CI GREEN
```

And the security linter, with its codepoint class shrunk to one that never occurs, fed a real bidi-override payload:

```
$ printf '+++ b/foo.go\n@@ -0,0 +1 @@\n+var x = "<U+202E> admin"\n' | bash linter_hidden_unicode.sh --stdin
No hidden Unicode characters detected.
exit: 0  -> CI GREEN on a trojan-source payload
```

## Inventory

There are **four** custom linters, not three:

| Linter | Violation class | Invoked from |
|---|---|---|
| `tools/linter_error_groups.sh` | direct `errgroup` use outside the wrapper | `linter.yml` → `custom checks`, `.pre-commit-config.yaml` |
| `tools/linter_go_routines.sh` | bare `go` statements | `linter.yml` → `custom checks`, `.pre-commit-config.yaml` |
| `tools/linter_waitgroups_done.sh` | `wg.Done()` that is not deferred | `linter.yml` → `custom checks`, `.pre-commit-config.yaml` |
| `.github/actions/security-lint/linter_hidden_unicode.sh` | hidden/trojan-source Unicode | `pr-security-lint.yaml` via the composite action (`tools/linter_hidden_unicode.sh` is a dev forwarder) |

The two fixes above cover the first two. The fixtures cover all four.

## The guarantee

`tools/lintercheck/` holds a known-bad and a known-good fixture per linter, plus the harness that points each linter at them. Every run of `custom checks` now proves each linter still fires before trusting it, rather than inferring it from a green exit code.

The placement needed care. The three tree-walking linters enumerate files with `git ls-files`, so they walk the tree themselves and **do not honour Go's `testdata/` build exclusion** — a `testdata/foo.go` fixture is invisible to the compiler but fully visible to the goroutine linter, and would break the real lint pass on every PR. Two mechanisms keep that from happening, and they are deliberately separate:

- Fixtures carry a **`.go.txt`** extension, which every linter's `.go` filter skips. This is what keeps them out of the real lint pass.
- The harness stages each fixture in a **throwaway `git init` repo** and runs the linter with that as its working directory. This is what lets a linter be pointed at a fixture at all, given it takes no path argument.

The errgroup linter additionally drops every path containing the substring `test`, so its fixture cannot live under a `testdata/` directory even by name.

Each linter is also run against a **known-good** fixture. Without that, a linter hardwired to fail would satisfy "fires on bad input". The errgroup and waitgroup good-path fixtures exercise the allow-list and the defer exclusion rather than an empty match — and the good-path fixtures are what pin the two `|| true` fixes above.

Failures name the linter, the fixture, and the violation class that just went unguarded:

```
POSITIVE CONTROL FAILED: tools/linter_go_routines.sh exited 0 on known-bad fixture
tools/lintercheck/testdata/goroutine_violation.go.txt (staged as pkg/goroutine_violation.go).
It no longer detects bare go statements instead of the entities/errors wrapper,
so CI is blind to that violation class.
```

## Vacuity proof

A fixture that passes green against a no-op linter is the original defect one level up, so each linter was deliberately broken and the fixture re-run. Full verbatim output is in the PR thread's companion report; the result matrix:

| Linter | working, no fixture | working, fixture | **broken, no fixture** | **broken, fixture** |
|---|---|---|---|---|
| error groups | green | green | 🟢 **green (the defect)** | 🔴 **red** |
| goroutines | green | green | 🟢 **green (the defect)** | 🔴 **red** |
| waitgroups | green | green | 🟢 **green (the defect)** | 🔴 **red** |
| hidden unicode | green | green | 🟢 **green (the defect)** | 🔴 **red** |

Plus a fifth cell the two-by-two does not name: a linter hardwired to *always* fail is caught by the known-good fixture, not the known-bad one.

Each linter was restored after its cell and `git status --porcelain` verified empty.

## Wiring

- `linter.yml` `custom checks` gains a `go test ./tools/lintercheck/...` step ahead of the three linters it guards. The job needed a `setup-go` step, which it did not previously have.
- The hidden-Unicode control is shell (`selfcheck.sh`) rather than Go, and runs as the first step of the security-lint composite action. Client repos pin that action by SHA and have no Go toolchain, so a Go-only control would have left them uninstrumented. This adds a step to the composite, not a job to the `pull_request_target` workflow, and touches neither its permissions nor its secrets.

Its known-bad U+200B is written as UTF-8 escape bytes rather than a literal character. A tracked file containing a real one would be flagged by this very linter when it scans the PR that adds it.

## Found, not fixed

The waitgroup linter's comment exclusion is `(defer|//)[[:space:].a-zA-Z]*wg[^[:space:]]*\.Done\(\)`. It only tolerates letters, spaces and dots between `//` and the match, so any comment mentioning the call with a hyphen, colon, underscore or slash before it is flagged as a violation. It caught this PR's own fixture comment. Widening the exclusion is a behaviour change that risks letting real violations through, which is the opposite of what this PR is for, so it is left alone and the fixture comment avoids spelling the call. Worth its own PR.

## Base

Targets `stable/v1.37` so it forward-merges into v1.38 and main.

— SuperClaude
