### PR TITLE
Shard loading/closing bugfixes

### DIFF
--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -204,13 +204,16 @@ func (h *batchObjectHandlers) objectsDeleteResponse(input *objects.BatchDeleteRe
 		var errorResponse *models.ErrorResponse
 
 		status := models.BatchDeleteResponseResultsObjectsItems0StatusSUCCESS
-		if input.DryRun {
-			status = models.BatchDeleteResponseResultsObjectsItems0StatusDRYRUN
-		} else if obj.Err != nil {
+		// a failed dry run would otherwise report no failures and, with output "minimal",
+		// drop the affected ids
+		switch {
+		case obj.Err != nil:
 			status = models.BatchDeleteResponseResultsObjectsItems0StatusFAILED
 			errorResponse = errPayloadFromSingleErr(obj.Err)
 			failed += 1
-		} else {
+		case input.DryRun:
+			status = models.BatchDeleteResponseResultsObjectsItems0StatusDRYRUN
+		default:
 			successful += 1
 		}
 

--- a/adapters/handlers/rest/handlers_batch_objects_test.go
+++ b/adapters/handlers/rest/handlers_batch_objects_test.go
@@ -1,0 +1,152 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	uco "github.com/weaviate/weaviate/usecases/objects"
+)
+
+func TestObjectsDeleteResponse(t *testing.T) {
+	const (
+		idA = strfmt.UUID("f8a8a1b6-2b6a-4a3b-9c8d-0f0e1d2c3b4a")
+		idB = strfmt.UUID("2c1e6a3d-5b47-4e2a-8f31-6d9c0a7b4e15")
+	)
+	shardErr := stderrors.New("shard lookup failed")
+
+	type wantObject struct {
+		id       strfmt.UUID
+		status   string
+		errorMsg string
+	}
+
+	tests := []struct {
+		name           string
+		dryRun         bool
+		output         string
+		objects        uco.BatchSimpleObjects
+		wantSuccessful int64
+		wantFailed     int64
+		wantObjects    []wantObject
+	}{
+		{
+			name:           "verbose deletion",
+			output:         verbosity.OutputVerbose,
+			objects:        uco.BatchSimpleObjects{{UUID: idA}},
+			wantSuccessful: 1,
+			wantObjects:    []wantObject{{id: idA, status: models.BatchDeleteResponseResultsObjectsItems0StatusSUCCESS}},
+		},
+		{
+			name:           "minimal deletion omits the id",
+			output:         verbosity.OutputMinimal,
+			objects:        uco.BatchSimpleObjects{{UUID: idA}},
+			wantSuccessful: 1,
+		},
+		{
+			name:        "verbose deletion failure",
+			output:      verbosity.OutputVerbose,
+			objects:     uco.BatchSimpleObjects{{UUID: idA, Err: shardErr}},
+			wantFailed:  1,
+			wantObjects: []wantObject{{id: idA, status: models.BatchDeleteResponseResultsObjectsItems0StatusFAILED, errorMsg: shardErr.Error()}},
+		},
+		{
+			name:        "minimal deletion failure keeps the id",
+			output:      verbosity.OutputMinimal,
+			objects:     uco.BatchSimpleObjects{{UUID: idA, Err: shardErr}},
+			wantFailed:  1,
+			wantObjects: []wantObject{{id: idA, status: models.BatchDeleteResponseResultsObjectsItems0StatusFAILED, errorMsg: shardErr.Error()}},
+		},
+		{
+			name:        "verbose dry run",
+			dryRun:      true,
+			output:      verbosity.OutputVerbose,
+			objects:     uco.BatchSimpleObjects{{UUID: idA}},
+			wantObjects: []wantObject{{id: idA, status: models.BatchDeleteResponseResultsObjectsItems0StatusDRYRUN}},
+		},
+		{
+			name:    "minimal dry run omits the id",
+			dryRun:  true,
+			output:  verbosity.OutputMinimal,
+			objects: uco.BatchSimpleObjects{{UUID: idA}},
+		},
+		{
+			name:        "verbose dry run failure",
+			dryRun:      true,
+			output:      verbosity.OutputVerbose,
+			objects:     uco.BatchSimpleObjects{{UUID: idA, Err: shardErr}},
+			wantFailed:  1,
+			wantObjects: []wantObject{{id: idA, status: models.BatchDeleteResponseResultsObjectsItems0StatusFAILED, errorMsg: shardErr.Error()}},
+		},
+		{
+			name:        "minimal dry run failure keeps the id",
+			dryRun:      true,
+			output:      verbosity.OutputMinimal,
+			objects:     uco.BatchSimpleObjects{{UUID: idA, Err: shardErr}},
+			wantFailed:  1,
+			wantObjects: []wantObject{{id: idA, status: models.BatchDeleteResponseResultsObjectsItems0StatusFAILED, errorMsg: shardErr.Error()}},
+		},
+		{
+			name:        "dry run with one of two ids failing",
+			dryRun:      true,
+			output:      verbosity.OutputMinimal,
+			objects:     uco.BatchSimpleObjects{{UUID: idA}, {UUID: idB, Err: shardErr}},
+			wantFailed:  1,
+			wantObjects: []wantObject{{id: idB, status: models.BatchDeleteResponseResultsObjectsItems0StatusFAILED, errorMsg: shardErr.Error()}},
+		},
+		{
+			name:    "no matches",
+			dryRun:  true,
+			output:  verbosity.OutputMinimal,
+			objects: uco.BatchSimpleObjects{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			h := &batchObjectHandlers{}
+
+			res := h.objectsDeleteResponse(&uco.BatchDeleteResponse{
+				Match:  &models.BatchDeleteMatch{Class: "Foo"},
+				DryRun: test.dryRun,
+				Output: test.output,
+				Result: uco.BatchDeleteResult{Objects: test.objects},
+			})
+
+			assert.Equal(t, test.dryRun, *res.DryRun)
+			assert.Equal(t, test.wantSuccessful, res.Results.Successful)
+			assert.Equal(t, test.wantFailed, res.Results.Failed)
+
+			require.Len(t, res.Results.Objects, len(test.wantObjects))
+			for i, want := range test.wantObjects {
+				got := res.Results.Objects[i]
+				assert.Equal(t, want.id, got.ID)
+				require.NotNil(t, got.Status)
+				assert.Equal(t, want.status, *got.Status)
+				if want.errorMsg == "" {
+					assert.Nil(t, got.Errors)
+					continue
+				}
+				require.NotNil(t, got.Errors)
+				require.Len(t, got.Errors.Error, 1)
+				assert.Equal(t, want.errorMsg, got.Errors.Error[0].Message)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2847,6 +2847,8 @@ func (i *Index) getOrInitShard(ctx context.Context, shardName string) (
 // The returned shard may be a lazy shard instance or nil if the shard hasn't yet been initialized.
 // The returned shard cannot be closed until release is called.
 // release is never nil, including on error, so defer it immediately after the call.
+// The lookup holds shardCreateLocks until the reference is taken, so an unload of
+// the same shard waits for it — for a cold lazy shard that includes loading it.
 func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensureInit bool) (
 	shard ShardLike, release func(), err error,
 ) {
@@ -2857,15 +2859,14 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 		return nil, func() {}, fmt.Errorf("local shard %q: %w", shardName, errAlreadyShutdown)
 	}
 
-	// make sure same shard is not inited in parallel. In case it is not loaded yet, switch to a RW lock and initialize
-	// the shard
-	func() {
-		i.shardCreateLocks.RLock(shardName)
-		defer i.shardCreateLocks.RUnlock(shardName)
-		shard = i.shards.Load(shardName)
-	}()
+	// make sure same shard is not inited in parallel
+	i.shardCreateLocks.RLock(shardName)
+	shard = i.shards.Load(shardName)
 
 	if shard == nil {
+		// the read lock cannot be upgraded, so release it before taking the write lock
+		i.shardCreateLocks.RUnlock(shardName)
+
 		if !ensureInit {
 			return nil, func() {}, nil
 		}
@@ -2891,10 +2892,13 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 			}
 			i.shards.Store(shardName, shard)
 		}
+	} else {
+		// keep the read lock until the reference is taken: UnloadLocalShard shuts the
+		// shard down while holding the same lock for write
+		defer i.shardCreateLocks.RUnlock(shardName)
 	}
 
-	// If ensureInit is true, ensure the shard is loaded. For lazy shards, preventShutdown()
-	// will call Load() internally
+	// for lazy shards this loads the shard, whether or not ensureInit was set
 	release, err = shard.preventShutdown()
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("get/init local shard %q, no shutdown: %w", shardName, err)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3747,6 +3747,19 @@ func convertToVectorIndexConfigs(configs map[string]models.VectorConfig) map[str
 	return nil
 }
 
+// runInBackground runs f in a goroutine, taking over the shard reference the
+// caller took for it and releasing it once f is done. Errors are logged as
+// failureMsg.
+func (i *Index) runInBackground(shardName, failureMsg string, release func(), f func() error) {
+	enterrors.GoWrapper(func() {
+		defer release()
+
+		if err := f(); err != nil {
+			i.logger.WithField("shard", shardName).Errorf("%s: %v", failureMsg, err)
+		}
+	}, i.logger)
+}
+
 // IMPORTANT:
 // DebugResetVectorIndex is intended to be used for debugging purposes only.
 // It drops the selected vector index, creates a new one, then reindexes it in the background.
@@ -3772,6 +3785,20 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 		return errors.New("vector index is not hnsw")
 	}
 
+	// taken before the reset, otherwise the shard can end up with an emptied
+	// vector index and no reindex to refill it
+	reindexRelease, err := shard.preventShutdown()
+	if err != nil {
+		return err
+	}
+	// without this the reference leaks if the reset fails
+	reindexStarted := false
+	defer func() {
+		if !reindexStarted {
+			reindexRelease()
+		}
+	}()
+
 	// Reset the vector index
 	err = shard.DebugResetVectorIndex(ctx, targetVector)
 	if err != nil {
@@ -3779,13 +3806,10 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 	}
 
 	// Reindex in the background
-	enterrors.GoWrapper(func() {
-		err = shard.FillQueue(targetVector, 0)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to reindex vector index")
-			return
-		}
-	}, i.logger)
+	reindexStarted = true
+	i.runInBackground(shardName, "failed to reindex vector index", reindexRelease, func() error {
+		return shard.FillQueue(targetVector, 0)
+	})
 
 	return nil
 }
@@ -3800,14 +3824,15 @@ func (i *Index) DebugRepairIndex(ctx context.Context, shardName, targetVector st
 		return errors.New("shard not found")
 	}
 
+	repairRelease, err := shard.preventShutdown()
+	if err != nil {
+		return err
+	}
+
 	// Repair in the background
-	enterrors.GoWrapper(func() {
-		err := shard.RepairIndex(context.Background(), targetVector)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to repair vector index")
-			return
-		}
-	}, i.logger)
+	i.runInBackground(shardName, "failed to repair vector index", repairRelease, func() error {
+		return shard.RepairIndex(i.closingCtx, targetVector)
+	})
 
 	return nil
 }
@@ -3847,14 +3872,15 @@ func (i *Index) DebugRequantizeIndex(ctx context.Context, shardName, targetVecto
 		return errors.New("shard not found")
 	}
 
-	// Repair in the background
-	enterrors.GoWrapper(func() {
-		err := shard.RequantizeIndex(context.Background(), targetVector)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to requantize vector index")
-			return
-		}
-	}, i.logger)
+	requantizeRelease, err := shard.preventShutdown()
+	if err != nil {
+		return err
+	}
+
+	// Requantize in the background
+	i.runInBackground(shardName, "failed to requantize vector index", requantizeRelease, func() error {
+		return shard.RequantizeIndex(i.closingCtx, targetVector)
+	})
 
 	return nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3722,6 +3722,19 @@ func convertToVectorIndexConfigs(configs map[string]models.VectorConfig) map[str
 	return nil
 }
 
+// runInBackground runs f in a goroutine, taking over the shard reference the
+// caller took for it and releasing it once f is done. Errors are logged as
+// failureMsg.
+func (i *Index) runInBackground(shardName, failureMsg string, release func(), f func() error) {
+	enterrors.GoWrapper(func() {
+		defer release()
+
+		if err := f(); err != nil {
+			i.logger.WithField("shard", shardName).Errorf("%s: %v", failureMsg, err)
+		}
+	}, i.logger)
+}
+
 // IMPORTANT:
 // DebugResetVectorIndex is intended to be used for debugging purposes only.
 // It drops the selected vector index, creates a new one, then reindexes it in the background.
@@ -3747,6 +3760,20 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 		return errors.New("vector index is not hnsw")
 	}
 
+	// taken before the reset, otherwise the shard can end up with an emptied
+	// vector index and no reindex to refill it
+	reindexRelease, err := shard.preventShutdown()
+	if err != nil {
+		return err
+	}
+	// without this the reference leaks if the reset fails
+	reindexStarted := false
+	defer func() {
+		if !reindexStarted {
+			reindexRelease()
+		}
+	}()
+
 	// Reset the vector index
 	err = shard.DebugResetVectorIndex(ctx, targetVector)
 	if err != nil {
@@ -3754,13 +3781,10 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 	}
 
 	// Reindex in the background
-	enterrors.GoWrapper(func() {
-		err = shard.FillQueue(targetVector, 0)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to reindex vector index")
-			return
-		}
-	}, i.logger)
+	reindexStarted = true
+	i.runInBackground(shardName, "failed to reindex vector index", reindexRelease, func() error {
+		return shard.FillQueue(targetVector, 0)
+	})
 
 	return nil
 }
@@ -3775,14 +3799,15 @@ func (i *Index) DebugRepairIndex(ctx context.Context, shardName, targetVector st
 		return errors.New("shard not found")
 	}
 
+	repairRelease, err := shard.preventShutdown()
+	if err != nil {
+		return err
+	}
+
 	// Repair in the background
-	enterrors.GoWrapper(func() {
-		err := shard.RepairIndex(context.Background(), targetVector)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to repair vector index")
-			return
-		}
-	}, i.logger)
+	i.runInBackground(shardName, "failed to repair vector index", repairRelease, func() error {
+		return shard.RepairIndex(i.closingCtx, targetVector)
+	})
 
 	return nil
 }
@@ -3822,14 +3847,15 @@ func (i *Index) DebugRequantizeIndex(ctx context.Context, shardName, targetVecto
 		return errors.New("shard not found")
 	}
 
-	// Repair in the background
-	enterrors.GoWrapper(func() {
-		err := shard.RequantizeIndex(context.Background(), targetVector)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to requantize vector index")
-			return
-		}
-	}, i.logger)
+	requantizeRelease, err := shard.preventShutdown()
+	if err != nil {
+		return err
+	}
+
+	// Requantize in the background
+	i.runInBackground(shardName, "failed to requantize vector index", requantizeRelease, func() error {
+		return shard.RequantizeIndex(i.closingCtx, targetVector)
+	})
 
 	return nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3562,6 +3562,15 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 		f := func() {
 			defer wg.Done()
 
+			// Without this the panic skips the send below, and the caller reads the
+			// remaining shards' deletions as the complete result.
+			defer func() {
+				if r := recover(); r != nil {
+					ch <- result{failedDeletes(uuids, fmt.Errorf("an unexpected error occurred: %v", r))}
+					panic(r) // re-panic so GoWrapper still logs the full stack
+				}
+			}()
+
 			var objs objects.BatchSimpleObjects
 			if i.shardHasMultipleReplicasWrite(tenant, shardName) {
 				objs = i.replicator.DeleteObjects(ctx, shardName, uuids, deletionTime,
@@ -3579,9 +3588,7 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 						return nil
 					})
 				if err != nil {
-					objs = objects.BatchSimpleObjects{
-						objects.BatchSimpleObject{Err: err},
-					}
+					objs = failedDeletes(uuids, err)
 				}
 			}
 
@@ -3599,6 +3606,17 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 	}
 
 	return out, nil
+}
+
+// failedDeletes reports err for every id of a shard group, so a group that could
+// not run is reported with as many results as one that did. A result without an
+// id is counted as a single failure and cannot be encoded into a gRPC reply.
+func failedDeletes(ids []strfmt.UUID, err error) objects.BatchSimpleObjects {
+	out := make(objects.BatchSimpleObjects, len(ids))
+	for i, id := range ids {
+		out[i] = objects.BatchSimpleObject{UUID: id, Err: err}
+	}
+	return out
 }
 
 func (i *Index) IncomingDeleteObjectBatch(ctx context.Context, shardName string,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3591,6 +3591,15 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 		f := func() {
 			defer wg.Done()
 
+			// Without this the panic skips the send below, and the caller reads the
+			// remaining shards' deletions as the complete result.
+			defer func() {
+				if r := recover(); r != nil {
+					ch <- result{failedDeletes(uuids, fmt.Errorf("an unexpected error occurred: %v", r))}
+					panic(r) // re-panic so GoWrapper still logs the full stack
+				}
+			}()
+
 			var objs objects.BatchSimpleObjects
 			if i.shardHasMultipleReplicasWrite(tenant, shardName) {
 				objs = i.replicator.DeleteObjects(ctx, shardName, uuids, deletionTime,
@@ -3608,9 +3617,7 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 						return nil
 					})
 				if err != nil {
-					objs = objects.BatchSimpleObjects{
-						objects.BatchSimpleObject{Err: err},
-					}
+					objs = failedDeletes(uuids, err)
 				}
 			}
 
@@ -3628,6 +3635,17 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 	}
 
 	return out, nil
+}
+
+// failedDeletes reports err for every id of a shard group, so a group that could
+// not run is reported with as many results as one that did. A result without an
+// id is counted as a single failure and cannot be encoded into a gRPC reply.
+func failedDeletes(ids []strfmt.UUID, err error) objects.BatchSimpleObjects {
+	out := make(objects.BatchSimpleObjects, len(ids))
+	for i, id := range ids {
+		out[i] = objects.BatchSimpleObject{UUID: id, Err: err}
+	}
+	return out
 }
 
 func (i *Index) IncomingDeleteObjectBatch(ctx context.Context, shardName string,

--- a/adapters/repos/db/index_batch_delete_objects_test.go
+++ b/adapters/repos/db/index_batch_delete_objects_test.go
@@ -1,0 +1,113 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+)
+
+// TestBatchDeleteObjectsReportsEveryID asserts that every id handed to the call
+// comes back, whether its shard group ran or panicked. An id left out reaches
+// the client as a successful delete of fewer objects than were matched, and an
+// id reported without its own value cannot be encoded into a gRPC reply.
+func TestBatchDeleteObjectsReportsEveryID(t *testing.T) {
+	className := "BatchDeleteEveryID"
+	const panickingShardA, panickingShardB = "panicking-shard-a", "panicking-shard-b"
+
+	tests := []struct {
+		name string
+		// panickingShards are groups whose write replica lookup panics
+		panickingShards []string
+		// withHealthyShard adds the index's own shard as a group that runs
+		withHealthyShard bool
+	}{
+		{
+			name:             "a panicking group beside one that runs",
+			panickingShards:  []string{panickingShardA},
+			withHealthyShard: true,
+		},
+		{
+			name:            "every group panics",
+			panickingShards: []string{panickingShardA, panickingShardB},
+		},
+		{
+			name:            "the only group panics",
+			panickingShards: []string{panickingShardA},
+		},
+		{
+			name: "no groups",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// the integration suite exports this, which would let the panic kill the test
+			t.Setenv("DISABLE_RECOVERY_ON_PANIC", "false")
+
+			idx, shard := refCountTestIndex(t, className)
+
+			router := types.NewMockRouter(t)
+			groups := map[string][]strfmt.UUID{}
+			var wantFailed, wantDeleted []string
+
+			for _, shardName := range test.panickingShards {
+				router.EXPECT().GetWriteReplicasLocation(className, mock.Anything, shardName).
+					RunAndReturn(func(string, string, string) (types.WriteReplicaSet, error) {
+						panic("write replicas lookup panicked")
+					})
+				// more than one id, so a group reported as a single failure fails the test
+				for range 2 {
+					id := strfmt.UUID(uuid.NewString())
+					groups[shardName] = append(groups[shardName], id)
+					wantFailed = append(wantFailed, id.String())
+				}
+			}
+
+			if test.withHealthyShard {
+				router.EXPECT().GetWriteReplicasLocation(className, mock.Anything, shard.name).Return(
+					types.WriteReplicaSet{
+						Replicas: []types.Replica{{NodeName: "node1", ShardName: shard.name, HostAddr: "127.0.0.1"}},
+					}, nil,
+				)
+				id := strfmt.UUID(uuid.NewString())
+				groups[shard.name] = []strfmt.UUID{id}
+				wantDeleted = append(wantDeleted, id.String())
+			}
+			idx.router = router
+
+			objs, err := idx.batchDeleteObjects(t.Context(), groups, time.Now(), false, nil, 0, "")
+			require.NoError(t, err)
+
+			var failed, deleted []string
+			for _, obj := range objs {
+				if obj.Err != nil {
+					require.ErrorContains(t, obj.Err, "an unexpected error occurred")
+					failed = append(failed, obj.UUID.String())
+					continue
+				}
+				deleted = append(deleted, obj.UUID.String())
+			}
+			require.ElementsMatch(t, wantFailed, failed,
+				"every id of a panicking group must be reported as failed, under its own id")
+			require.ElementsMatch(t, wantDeleted, deleted,
+				"a group that ran must report its own deletions")
+		})
+	}
+}

--- a/adapters/repos/db/shard_refcount_test.go
+++ b/adapters/repos/db/shard_refcount_test.go
@@ -611,3 +611,89 @@ func TestPreventShutdownReleaseIsIdempotent(t *testing.T) {
 		require.Equal(t, logrus.ErrorLevel, entry.Level)
 	}
 }
+
+// TestGetOptInitLocalShardAcquiresUnderShardCreateLock asserts that the lookup
+// takes the reference under the same shardCreateLocks it read the shard map
+// under. UnloadLocalShard shuts the shard down while holding that lock for
+// write, so a gap between the two hands the caller a shard that is already gone.
+func TestGetOptInitLocalShardAcquiresUnderShardCreateLock(t *testing.T) {
+	className := "RefCountAcquireUnderLock"
+	shardName := "shard-1"
+
+	tests := []struct {
+		name            string
+		loaded          bool
+		ensureInit      bool
+		acquireErr      error
+		wantErrContains string
+	}{
+		{name: "loaded shard", loaded: true},
+		{
+			name: "reference cannot be taken", loaded: true,
+			acquireErr: errAlreadyShutdown, wantErrContains: "no shutdown",
+		},
+		// the arm that releases the read lock by hand to take the write lock
+		{name: "shard not loaded", ensureInit: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			shardState := NewMultiTenantShardingStateBuilder().
+				AddTenant(shardName, models.TenantActivityStatusHOT).
+				WithReplicationFactor(1).
+				Build()
+			idx := newDescriptorTestIndex(t, t.TempDir(), className, shardState)
+
+			acquiring := make(chan struct{})
+			unloaded := make(chan struct{})
+			var unloadedWhileAcquiring bool
+
+			var want ShardLike
+			if test.loaded {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().Shutdown(mock.Anything).Return(nil).Maybe()
+				shard.EXPECT().preventShutdown().RunAndReturn(func() (func(), error) {
+					close(acquiring)
+					select {
+					case <-unloaded:
+						unloadedWhileAcquiring = true
+					case <-time.After(time.Second):
+					}
+					return func() {}, test.acquireErr
+				})
+				idx.shards.Store(shardName, shard)
+				want = shard
+			} else {
+				// no reference is taken here, so the unload only checks that the
+				// lookup released the read lock before returning
+				close(acquiring)
+			}
+
+			unloadErr := make(chan error, 1)
+			go func() {
+				<-acquiring
+				unloadErr <- idx.UnloadLocalShard(t.Context(), shardName)
+				close(unloaded)
+			}()
+
+			got, release, err := idx.getOptInitLocalShard(t.Context(), shardName, test.ensureInit)
+			defer release()
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+				require.Nil(t, got)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, want, got)
+			}
+			require.False(t, unloadedWhileAcquiring,
+				"the unload must wait for the reference to be taken")
+
+			select {
+			case err := <-unloadErr:
+				require.NoError(t, err, "the lock must be released once the lookup returns")
+			case <-time.After(5 * time.Second):
+				t.Fatal("UnloadLocalShard still blocked: the lookup did not release shardCreateLocks")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Fixes a few bugs connected with shard closing/unloading
1. Report every id when a batch-delete shard group fails. Before some objects looked like a success
2. Batch delete dry-run would eat some errors and not return
3. ~~Small race in shard loading. getOptInitLocalShard took `shardCreateLocks` for read, read the map — and then released it before calling shard.preventShutdown(), which is what actually takes the reference. Was introduced in #10199~~
4. Add shard references to some debug endpoints, so shards are not shutdown while they are operating on it

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
