### PR TITLE
fix: return the gRPC query profile when a query matches no objects

### DIFF
--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -106,9 +106,8 @@ func (r *Replier) Search(ctx context.Context, res []interface{}, start time.Time
 	return out, nil
 }
 
-// extractQueryProfile builds the [pb.QueryProfile] for the reply. It reads the profile
-// from ctx rather than from the returned objects because the profile describes the query,
-// not any object: a query that matched nothing still profiled every shard it visited.
+// extractQueryProfile reads from ctx, not the returned objects: a query that matched
+// nothing still profiled every shard it visited.
 func (r *Replier) extractQueryProfile(ctx context.Context) *pb.QueryProfile {
 	queryProfiles := helpers.ExtractQueryProfiles(ctx)
 	if len(queryProfiles) == 0 {

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -12,6 +12,7 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"strings"
@@ -71,7 +72,7 @@ func NewReplier(
 	}
 }
 
-func (r *Replier) Search(res []interface{}, start time.Time, searchParams dto.GetParams, resolver *schemaResolver) (*pb.SearchReply, error) {
+func (r *Replier) Search(ctx context.Context, res []interface{}, start time.Time, searchParams dto.GetParams, resolver *schemaResolver) (*pb.SearchReply, error) {
 	tookSeconds := float64(time.Since(start)) / float64(time.Second)
 	out := &pb.SearchReply{
 		Took:                    float32(tookSeconds),
@@ -100,34 +101,17 @@ func (r *Replier) Search(res []interface{}, start time.Time, searchParams dto.Ge
 		out.Results = objects
 	}
 	if searchParams.AdditionalProperties.QueryProfile {
-		out.QueryProfile = r.extractQueryProfile(res)
+		out.QueryProfile = r.extractQueryProfile(ctx)
 	}
 	return out, nil
 }
 
-// extractQueryProfile converts the raw profile data from the first search result's
-// additional properties into a [pb.QueryProfile] for the gRPC response.
-func (r *Replier) extractQueryProfile(res []interface{}) *pb.QueryProfile {
-	if len(res) == 0 {
-		return nil
-	}
-	asMap, ok := res[0].(map[string]interface{})
-	if !ok {
-		return nil
-	}
-	add, ok := asMap["_additional"]
-	if !ok {
-		return nil
-	}
-	additional, ok := add.(models.AdditionalProperties)
-	if !ok {
-		additional, ok = add.(map[string]interface{})
-	}
-	if !ok {
-		return nil
-	}
-	queryProfiles, ok := additional["queryProfileRaw"].([]helpers.ShardQueryProfile)
-	if !ok {
+// extractQueryProfile builds the [pb.QueryProfile] for the reply. It reads the profile
+// from ctx rather than from the returned objects because the profile describes the query,
+// not any object: a query that matched nothing still profiled every shard it visited.
+func (r *Replier) extractQueryProfile(ctx context.Context) *pb.QueryProfile {
+	queryProfiles := helpers.ExtractQueryProfiles(ctx)
+	if len(queryProfiles) == 0 {
 		return nil
 	}
 	shards := make([]*pb.QueryProfile_ShardProfile, len(queryProfiles))

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -12,6 +12,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/binary"
 	"math"
 	"math/big"
@@ -20,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/usecases/byteops"
 
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
@@ -1330,7 +1332,7 @@ func TestGRPCReply(t *testing.T) {
 		replier := NewReplier(false, fakeGenerativeParams{}, nil)
 		t.Run(tt.name, func(t *testing.T) {
 			getClass := func(className string) (*models.Class, error) { return scheme.GetClass(className), nil }
-			out, err := replier.Search(tt.res, time.Now(), tt.searchParams, newSchemaResolver(getClass))
+			out, err := replier.Search(context.Background(), tt.res, time.Now(), tt.searchParams, newSchemaResolver(getClass))
 			if tt.hasError {
 				require.NotNil(t, err)
 			} else {
@@ -1348,6 +1350,84 @@ func TestGRPCReply(t *testing.T) {
 				}
 				require.Equal(t, tt.outGenerative, *out.GenerativeGroupedResult)
 			}
+		})
+	}
+}
+
+func TestGRPCReplyQueryProfile(t *testing.T) {
+	className := "className"
+	scheme := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class:      className,
+					Properties: []*models.Property{{Name: "word", DataType: schema.DataTypeText.PropString()}},
+				},
+			},
+		},
+	}
+
+	profiledCtx := func() context.Context {
+		ctx := helpers.InitQueryProfileCollector(context.Background())
+		helpers.AddShardQueryProfile(ctx, "shard-1", "node-1", "vector", 10*time.Millisecond,
+			map[string]any{"vector_search_took": 5 * time.Millisecond})
+		return ctx
+	}
+	object := map[string]interface{}{"_additional": map[string]interface{}{"vector": []float32{1}}}
+
+	tests := []struct {
+		name           string
+		ctx            context.Context
+		res            []interface{}
+		groupBy        *searchparams.GroupBy
+		requestProfile bool
+		wantProfile    bool
+	}{
+		{
+			name: "no object matched", ctx: profiledCtx(), res: []interface{}{},
+			requestProfile: true, wantProfile: true,
+		},
+		{
+			name: "no group matched", ctx: profiledCtx(), res: []interface{}{},
+			groupBy:        &searchparams.GroupBy{Property: "word", Groups: 1, ObjectsPerGroup: 1},
+			requestProfile: true, wantProfile: true,
+		},
+		{
+			name: "objects matched", ctx: profiledCtx(), res: []interface{}{object},
+			requestProfile: true, wantProfile: true,
+		},
+		{
+			name: "profile not requested", ctx: profiledCtx(), res: []interface{}{},
+			requestProfile: false, wantProfile: false,
+		},
+		{
+			name: "nothing collected", ctx: context.Background(), res: []interface{}{},
+			requestProfile: true, wantProfile: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			searchParams := dto.GetParams{
+				ClassName:            className,
+				GroupBy:              tt.groupBy,
+				AdditionalProperties: additional.Properties{Vector: true, QueryProfile: tt.requestProfile},
+			}
+			getClass := func(name string) (*models.Class, error) { return scheme.GetClass(name), nil }
+			replier := NewReplier(false, fakeGenerativeParams{}, nil)
+
+			out, err := replier.Search(tt.ctx, tt.res, time.Now(), searchParams, newSchemaResolver(getClass))
+			require.Nil(t, err)
+
+			if !tt.wantProfile {
+				require.Nil(t, out.QueryProfile)
+				return
+			}
+			require.NotNil(t, out.QueryProfile)
+			require.Len(t, out.QueryProfile.Shards, 1)
+			require.Equal(t, "shard-1", out.QueryProfile.Shards[0].Name)
+			require.Equal(t, "node-1", out.QueryProfile.Shards[0].Node)
+			require.Equal(t, "5ms", out.QueryProfile.Shards[0].Searches["vector"].Details["vector_search_took"])
 		})
 	}
 }

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/grpc/v1/batch"
 	restCtx "github.com/weaviate/weaviate/adapters/handlers/rest/context"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/weaviate/weaviate/usecases/config"
@@ -308,12 +309,18 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 		return nil, err
 	}
 
+	// Own the collector here so the profile outlives the result set: the deeper inits
+	// are idempotent and will write into this one.
+	if searchParams.AdditionalProperties.QueryProfile {
+		ctx = helpers.InitQueryProfileCollector(ctx)
+	}
+
 	res, err := s.traverser.GetClass(restCtx.AddPrincipalToContext(ctx, principal), principal, searchParams)
 	if err != nil {
 		return nil, err
 	}
 
-	return replier.Search(res, before, searchParams, newSchemaResolver(getClass))
+	return replier.Search(ctx, res, before, searchParams, newSchemaResolver(getClass))
 }
 
 func (s *Service) validateClassAndProperty(getClass classGetterWithAuthzFunc, searchParams dto.GetParams) error {

--- a/adapters/repos/db/helpers/profile_collector.go
+++ b/adapters/repos/db/helpers/profile_collector.go
@@ -171,11 +171,10 @@ func AddRemoteQueryProfiles(ctx context.Context, queryProfiles []ShardQueryProfi
 	}()
 }
 
-// AttachQueryProfileToResults serves GraphQL only, whose "queryProfile" field lives on the
-// per-object _additional map; results[0] is picked because the profile is per-query and
-// would otherwise be repeated on every object. GraphQL has no query-level slot, so a query
-// that matched nothing reports no profile there. gRPC does not go through this path: it
-// reads the profile from the context, which survives an empty result set.
+// AttachQueryProfileToResults serves GraphQL only: "queryProfile" lives on the per-object
+// _additional map, so results[0] carries it rather than repeating it on every object.
+// GraphQL has no query-level slot, so an empty result set legitimately reports no profile
+// here (gRPC reads it from the context instead, unaffected by an empty result set).
 func AttachQueryProfileToResults(ctx context.Context, results search.Results) search.Results {
 	queryProfiles := ExtractQueryProfiles(ctx)
 	if len(queryProfiles) == 0 || len(results) == 0 {

--- a/adapters/repos/db/helpers/profile_collector.go
+++ b/adapters/repos/db/helpers/profile_collector.go
@@ -171,25 +171,24 @@ func AddRemoteQueryProfiles(ctx context.Context, queryProfiles []ShardQueryProfi
 	}()
 }
 
-// AttachQueryProfileToResults calls [ExtractQueryProfiles] and attaches the collected
-// [ShardQueryProfile] entries to the first search result's AdditionalProperties.
-// Profile data is per-query (not per-object), so it is only attached to results[0].
-// The data is stored in two formats: "queryProfileRaw" ([][ShardQueryProfile] for gRPC)
-// and "queryProfile" (JSON string for GraphQL).
+// AttachQueryProfileToResults serves GraphQL only, whose "queryProfile" field lives on the
+// per-object _additional map; results[0] is picked because the profile is per-query and
+// would otherwise be repeated on every object. GraphQL has no query-level slot, so a query
+// that matched nothing reports no profile there. gRPC does not go through this path: it
+// reads the profile from the context, which survives an empty result set.
 func AttachQueryProfileToResults(ctx context.Context, results search.Results) search.Results {
 	queryProfiles := ExtractQueryProfiles(ctx)
 	if len(queryProfiles) == 0 || len(results) == 0 {
 		return results
 	}
+	b, err := json.Marshal(queryProfiles)
+	if err != nil {
+		return results
+	}
 	if results[0].AdditionalProperties == nil {
 		results[0].AdditionalProperties = make(models.AdditionalProperties)
 	}
-	// Store raw query profiles for gRPC consumption.
-	results[0].AdditionalProperties["queryProfileRaw"] = queryProfiles
-	// Store JSON string for GraphQL consumption.
-	if b, err := json.Marshal(queryProfiles); err == nil {
-		results[0].AdditionalProperties["queryProfile"] = string(b)
-	}
+	results[0].AdditionalProperties["queryProfile"] = string(b)
 	return results
 }
 

--- a/adapters/repos/db/helpers/profile_collector_test.go
+++ b/adapters/repos/db/helpers/profile_collector_test.go
@@ -13,6 +13,7 @@ package helpers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -286,15 +287,11 @@ func TestAttachQueryProfileToResults(t *testing.T) {
 	results = AttachQueryProfileToResults(ctx, results)
 
 	require.NotNil(t, results[0].AdditionalProperties)
-	// GraphQL: JSON string
 	profileStr, ok := results[0].AdditionalProperties["queryProfile"].(string)
 	require.True(t, ok)
-	assert.Contains(t, profileStr, "shard-1")
-	assert.Contains(t, profileStr, "vector")
 
-	// gRPC: raw queryProfiles
-	queryProfiles, ok := results[0].AdditionalProperties["queryProfileRaw"].([]ShardQueryProfile)
-	require.True(t, ok)
+	var queryProfiles []ShardQueryProfile
+	require.NoError(t, json.Unmarshal([]byte(profileStr), &queryProfiles))
 	require.Len(t, queryProfiles, 1)
 	assert.Equal(t, "shard-1", queryProfiles[0].Name)
 	assert.NotNil(t, queryProfiles[0].Searches["vector"])
@@ -336,8 +333,11 @@ func TestAttachQueryProfileToResults_ExistingAdditionalProperties(t *testing.T) 
 
 	results = AttachQueryProfileToResults(ctx, results)
 	assert.Equal(t, "value", results[0].AdditionalProperties["existing"])
-	queryProfiles, ok := results[0].AdditionalProperties["queryProfileRaw"].([]ShardQueryProfile)
+	profileStr, ok := results[0].AdditionalProperties["queryProfile"].(string)
 	require.True(t, ok)
+
+	var queryProfiles []ShardQueryProfile
+	require.NoError(t, json.Unmarshal([]byte(profileStr), &queryProfiles))
 	require.Len(t, queryProfiles, 1)
 }
 

--- a/test/acceptance/profiling/query_profiling_test.go
+++ b/test/acceptance/profiling/query_profiling_test.go
@@ -355,4 +355,87 @@ func TestQueryProfiling(t *testing.T) {
 				"filtered search should include filter timing for shard %s", shard.Name)
 		}
 	})
+
+	// A query that matches nothing still visited every shard, so it still has a profile
+	// worth reading — that is usually exactly the query you are trying to explain.
+	t.Run("profile survives an empty result set", func(t *testing.T) {
+		// No object has num > 1000; objects are numbered 0..29.
+		matchNothing := &pb.Filters{
+			Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+			TestValue: &pb.Filters_ValueInt{ValueInt: 1000},
+			Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "num"}},
+		}
+		nearVector := &pb.NearVector{
+			Vectors: []*pb.Vectors{{
+				VectorBytes: vecBytes,
+				Type:        pb.Vectors_VECTOR_TYPE_SINGLE_FP32,
+			}},
+		}
+
+		tests := []struct {
+			name    string
+			request *pb.SearchRequest
+		}{
+			{
+				name: "vector",
+				request: &pb.SearchRequest{
+					NearVector: nearVector,
+					Filters:    matchNothing,
+				},
+			},
+			{
+				name: "keyword",
+				request: &pb.SearchRequest{
+					Bm25Search: &pb.BM25{Query: "hello world document", Properties: []string{"text"}},
+					Filters:    matchNothing,
+				},
+			},
+			{
+				name: "hybrid",
+				request: &pb.SearchRequest{
+					HybridSearch: &pb.Hybrid{
+						Query:      "hello world document",
+						Alpha:      0.5,
+						Properties: []string{"text"},
+						NearVector: nearVector,
+					},
+					Filters: matchNothing,
+				},
+			},
+			{
+				name: "groupBy",
+				request: &pb.SearchRequest{
+					NearVector: nearVector,
+					Filters:    matchNothing,
+					GroupBy:    &pb.GroupBy{Path: []string{"category"}, NumberOfGroups: 3, ObjectsPerGroup: 2},
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				req := tt.request
+				req.Collection = className
+				req.Metadata = &pb.MetadataRequest{Uuid: true, QueryProfile: true}
+				req.Uses_127Api = true
+
+				resp, err := grpcClient.Search(ctx, req)
+				require.NoError(t, err)
+				require.Empty(t, resp.Results, "filter should match nothing")
+				require.Empty(t, resp.GroupByResults, "filter should match nothing")
+
+				require.NotNil(t, resp.QueryProfile,
+					"profile must survive a query that matched no objects")
+				require.NotEmpty(t, resp.QueryProfile.Shards)
+				for _, shard := range resp.QueryProfile.Shards {
+					assert.NotEmpty(t, shard.Name)
+					assert.NotEmpty(t, shard.Node)
+					for searchType, sp := range shard.Searches {
+						assert.NotEmpty(t, sp.Details["total_took"],
+							"shard %s search %s should report timing", shard.Name, searchType)
+					}
+				}
+			})
+		}
+	})
 }

--- a/test/acceptance/profiling/query_profiling_test.go
+++ b/test/acceptance/profiling/query_profiling_test.go
@@ -356,8 +356,7 @@ func TestQueryProfiling(t *testing.T) {
 		}
 	})
 
-	// A query that matches nothing still visited every shard, so it still has a profile
-	// worth reading — that is usually exactly the query you are trying to explain.
+	// A query that matches nothing still visited every shard, so its profile is still worth reading.
 	t.Run("profile survives an empty result set", func(t *testing.T) {
 		// No object has num > 1000; objects are numbered 0..29.
 		matchNothing := &pb.Filters{

--- a/usecases/traverser/hybrid_group_by.go
+++ b/usecases/traverser/hybrid_group_by.go
@@ -22,9 +22,9 @@ import (
 )
 
 func (e *Explorer) groupSearchResults(ctx context.Context, sr search.Results, groupBy *searchparams.GroupBy) (search.Results, error) {
-	var queryProfileRaw, queryProfile interface{}
+	// Grouping rebuilds the result list, so carry the profile over from the old results[0].
+	var queryProfile interface{}
 	if len(sr) > 0 && sr[0].AdditionalProperties != nil {
-		queryProfileRaw = sr[0].AdditionalProperties["queryProfileRaw"]
 		queryProfile = sr[0].AdditionalProperties["queryProfile"]
 	}
 
@@ -121,16 +121,11 @@ func (e *Explorer) groupSearchResults(ctx context.Context, sr search.Results, gr
 		out = append(out, first)
 	}
 
-	if len(out) > 0 && (queryProfileRaw != nil || queryProfile != nil) {
+	if len(out) > 0 && queryProfile != nil {
 		if out[0].AdditionalProperties == nil {
 			out[0].AdditionalProperties = make(models.AdditionalProperties)
 		}
-		if queryProfileRaw != nil {
-			out[0].AdditionalProperties["queryProfileRaw"] = queryProfileRaw
-		}
-		if queryProfile != nil {
-			out[0].AdditionalProperties["queryProfile"] = queryProfile
-		}
+		out[0].AdditionalProperties["queryProfile"] = queryProfile
 	}
 
 	return out, nil


### PR DESCRIPTION
SuperClaude here.

Follow-up to the query-profiling verification campaign on #12352. QA hit this while reading per-row profiles: 4 of 552 rows matched nothing, and those rows carried **no profile at all** in every arm. They had to fall back to the slow-query log to recover the data.

## What was wrong

`AttachQueryProfileToResults` attached the profile to `results[0].AdditionalProperties`, so a query that matched nothing had nowhere to put it:

```go
if len(queryProfiles) == 0 || len(results) == 0 {
    return results   // profile already computed, now discarded
}
```

The profile was **computed and then thrown away**, not skipped. Every layer below the last hop already treats it as result-count-independent:

- `AddShardQueryProfile` is called regardless of how many objects a shard returned (`index.go:2098, 2225, 2257, 2646, 2662`).
- The cluster wire format gates the profile block on `len(queryProfiles) > 0`, **not** `len(objs) > 0` (`indices_payloads.go` `MarshalWithAdditional`). A remote shard returning zero objects ships its profile home correctly, and the coordinator merges it.

So the data made it all the way to the coordinator and died at the final `results[0]` hop.

## Product defect or test gap?

**Product defect on the gRPC path. Not a defect on the GraphQL path.** What settled it:

| | Where the profile lives in the response | Empty result set |
|---|---|---|
| 🔴 gRPC | `SearchReply.query_profile` — a **top-level reply field** (`search_get.proto:122`) | Has a well-defined slot, and we were leaving it nil |
| 🟢 GraphQL | `_additional.queryProfile` — a field on the **per-object** `_additional` object (`class_builder.go:190`) | No object, so structurally nowhere to put it |

The gRPC contract already models the profile as per-query. The code even says so — `profile_collector.go` carried the comment *"Profile data is per-query (not per-object), so it is only attached to results[0]"*. A per-query artifact was being smuggled through a per-object carrier, which is exactly why it vanished when the carrier was empty.

GraphQL is the opposite case: there the profile genuinely is a per-object field, and returning it for an empty result set would need a **schema change** (a new query-level field), not a bug fix. I deliberately did not force one — that is an API design decision, and not something to land on a stable branch.

## The fix

The gRPC handler now owns the collector, and `Replier.Search` reads the profile from the context instead of from `results[0]`:

- `service.go` calls `helpers.InitQueryProfileCollector(ctx)` before the traverser when `QueryProfile` was requested. The deeper inits in `db.Search` / `db.VectorSearch` / `Explorer.Hybrid` are idempotent, so they write into this collector rather than creating their own.
- `extractQueryProfile` takes `ctx` and calls `helpers.ExtractQueryProfiles(ctx)`. It no longer digs through `res[0]["_additional"]`.

Two follow-on cleanups fall out of that: with gRPC off the `results[0]` carrier, the `queryProfileRaw` key had **no reader left**, so it and its group-by carry-forward in `hybrid_group_by.go` are removed. `AttachQueryProfileToResults` now serves GraphQL only.

This also fixes a second, quieter drop: `hybrid_group_by.go` gated the carry-forward on `len(out) > 0`, so a groupBy that produced zero groups lost the profile too, even when the underlying search had matched objects.

## Consumer inventory

Everyone who reads the profile, checked before deciding:

| Consumer | Path | Effect of this change |
|---|---|---|
| `prepare_reply.go` → `SearchReply.QueryProfile` | gRPC | 🟢 Now sourced from ctx; survives an empty result set |
| `_additional.queryProfile` (JSON string) | GraphQL | ⚪ Unchanged |
| `hybrid_group_by.go` carry-forward | both | 🟢 `queryProfileRaw` carry removed; gRPC no longer depends on it |
| Slow-query log | server log | ⚪ Unchanged — independent mechanism, gated on a 5s threshold plus 1% sampling, and already result-count-independent |
| Prometheus / metrics | — | ⚪ No metrics consumer exists |

## Proving the tests can go red

Both new tests were run against reverted production code.

**Unit** (`TestGRPCReplyQueryProfile`), with only the inert `ctx` parameter kept so it compiles:

```
--- FAIL: TestGRPCReplyQueryProfile (0.00s)
    --- FAIL: TestGRPCReplyQueryProfile/no_object_matched (0.00s)
    --- FAIL: TestGRPCReplyQueryProfile/no_group_matched (0.00s)
    --- FAIL: TestGRPCReplyQueryProfile/objects_matched (0.00s)
    --- PASS: TestGRPCReplyQueryProfile/profile_not_requested (0.00s)
    --- PASS: TestGRPCReplyQueryProfile/nothing_collected (0.00s)
```

`objects_matched` fails too, and should: the unit test never stuffs `queryProfileRaw` into `res[0]`, which proves the reply no longer depends on the object carrier. The two negative cases stay green, so the test is not just asserting "non-nil always".

**Acceptance** (`profile survives an empty result set`), against a real 3-node cluster built from the base commit `5787a513e` with production reverted (the acceptance test drives the gRPC client, so it compiles against unmodified production code — this is a clean revert, no plumbing kept):

```
    query_profiling_test.go:426:
        	Error:      	Expected value not to be nil.
        	Test:       	TestQueryProfiling/profile_survives_an_empty_result_set/hybrid
        	Messages:   	profile must survive a query that matched no objects
--- FAIL: TestQueryProfiling (27.28s)
    --- FAIL: TestQueryProfiling/profile_survives_an_empty_result_set (0.14s)
        --- FAIL: TestQueryProfiling/profile_survives_an_empty_result_set/vector (0.13s)
        --- FAIL: TestQueryProfiling/profile_survives_an_empty_result_set/keyword (0.00s)
        --- FAIL: TestQueryProfiling/profile_survives_an_empty_result_set/hybrid (0.00s)
        --- FAIL: TestQueryProfiling/profile_survives_an_empty_result_set/groupBy (0.00s)
FAIL	github.com/weaviate/weaviate/test/acceptance/profiling	27.441s
```

With the fix, the whole suite is green including the pre-existing subtests:

```
--- PASS: TestQueryProfiling (26.37s)
    ...
    --- PASS: TestQueryProfiling/profile_survives_an_empty_result_set (0.01s)
        --- PASS: TestQueryProfiling/profile_survives_an_empty_result_set/vector (0.00s)
        --- PASS: TestQueryProfiling/profile_survives_an_empty_result_set/keyword (0.00s)
        --- PASS: TestQueryProfiling/profile_survives_an_empty_result_set/hybrid (0.00s)
        --- PASS: TestQueryProfiling/profile_survives_an_empty_result_set/groupBy (0.00s)
ok  	github.com/weaviate/weaviate/test/acceptance/profiling	26.485s
```

## Test coverage added

- `TestGRPCReplyQueryProfile` — table-driven over: no object matched, no group matched, objects matched, profile not requested, nothing collected.
- `TestQueryProfiling/profile_survives_an_empty_result_set` — real 3-node cluster, gRPC, table-driven over vector / keyword / hybrid / groupBy with a filter (`num > 1000`) that matches none of the 30 fixtures.

## Risk

Behavioural change is confined to the gRPC reply when `query_profile` was explicitly requested. A client that did not ask for profiling sees no change; a client that did asked for it and previously got `nil` on an empty result set now gets the profile it asked for. No proto change, so no client regeneration.

— SuperClaude
