### PR TITLE
fix(queue): fix data race in TestPartialChunkRecovery

### DIFF
--- a/adapters/repos/db/queue/queue_test.go
+++ b/adapters/repos/db/queue/queue_test.go
@@ -470,13 +470,15 @@ func TestPartialChunkRecovery(t *testing.T) {
 			// open the queue again
 			// this should not return an error
 			q = makeQueueWith(t, s, e, 500, tmpDir)
+
+			err = q.Pause(t.Context())
 			require.NoError(t, err)
 
-			s.RegisterQueue(q)
-			q.Pause(t.Context())
-
-			// manually promote a partial chunk to a full chunk
+			// manually promote a partial chunk to a full chunk, holding the
+			// queue lock like every production caller of Promote does
+			q.m.Lock()
 			err = q.w.Promote()
+			q.m.Unlock()
 			require.NoError(t, err)
 
 			batch, err := q.DequeueBatch()


### PR DESCRIPTION
### What's being changed:

Fixes a rare data race in `TestPartialChunkRecovery` that the race detector caught in CI (e.g. [this run](https://github.com/weaviate/weaviate/actions/runs/30341599801/job/90218209733) on an unrelated PR).

The test registered its queue with the scheduler twice: `makeQueueWith` already registers it, and the test called `s.RegisterQueue(q)` again. `RegisterQueue` unconditionally replaces the scheduler's `queueState`, so `Pause` set the paused flag and waited on the **fresh** state while a dispatch could still be in flight on the **old** one. That in-flight `DequeueBatch → checkIfStale` then read the chunk writer's fields concurrently with the test's manual `q.w.Promote()`, which was called without the queue lock.

Changes:
- Drop the duplicate `s.RegisterQueue(q)` so `Pause` correctly waits for any in-flight dispatch
- Check the previously ignored `Pause` error
- Hold `q.m` around the manual `Promote()`, like every production caller does

Verification:
- `go test -race -count 200 -run TestPartialChunkRecovery ./adapters/repos/db/queue/` — 1200 subtest runs pass
- Full queue package with `-race`, `golangci-lint`, and the goroutine linter pass

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
