### PR TITLE
Reduce HNSW snapshot allocations

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -1272,6 +1272,14 @@ func (l *hnswCommitLogger) legacyReadSnapshotBody(filename string, f common.File
 	return nil
 }
 
+// snapshotBlockBufferPool holds readSnapshotBody's block-sized read buffers. Each
+// shard re-reads its previous snapshot every time it writes a new one, so a fresh
+// multi-megabyte buffer per worker per read is a large share of allocation churn.
+// *[]byte so Put won't allocate.
+var snapshotBlockBufferPool = sync.Pool{
+	New: func() any { return new([]byte) },
+}
+
 // readSnapshotBody reads the snapshot body from the file for snapshot versions >= 3.
 func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationResult) error {
 	var mu sync.Mutex
@@ -1304,7 +1312,14 @@ func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationR
 	// blocks costs a block-sized buffer each and reads nothing
 	for i := 0; i < min(snapshotConcurrency, blockCount); i++ {
 		eg.Go(func() error {
-			buf := make([]byte, snapshotBlockSize)
+			bufPtr := snapshotBlockBufferPool.Get().(*[]byte)
+			defer snapshotBlockBufferPool.Put(bufPtr)
+			// New cannot see the block size, so a pool miss comes back empty
+			if cap(*bufPtr) < snapshotBlockSize {
+				*bufPtr = make([]byte, snapshotBlockSize)
+			}
+			buf := (*bufPtr)[:snapshotBlockSize]
+
 			var b [8]byte
 
 			for {

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -1293,13 +1293,16 @@ func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationR
 	if bodySize <= 0 || bodySize%snapshotBlockSize != 0 {
 		return fmt.Errorf("snapshot body of %d bytes is not a whole number of %d byte blocks", bodySize, snapshotBlockSize)
 	}
+	blockCount := bodySize / snapshotBlockSize
 
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(l.logger, context.Background())
 	eg.SetLimit(snapshotConcurrency)
 
 	ch := make(chan int, snapshotConcurrency)
 
-	for i := 0; i < snapshotConcurrency; i++ {
+	// every worker holds a whole block, so starting more workers than there are
+	// blocks costs a block-sized buffer each and reads nothing
+	for i := 0; i < min(snapshotConcurrency, blockCount); i++ {
 		eg.Go(func() error {
 			buf := make([]byte, snapshotBlockSize)
 			var b [8]byte

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -1275,6 +1275,7 @@ func (l *hnswCommitLogger) legacyReadSnapshotBody(filename string, f common.File
 // readSnapshotBody reads the snapshot body from the file for snapshot versions >= 3.
 func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationResult) error {
 	var mu sync.Mutex
+	var lastNodeID uint64 // highest node slot any block reached, guarded by mu
 
 	finfo, err := f.Stat()
 	if err != nil {
@@ -1285,7 +1286,13 @@ func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationR
 	if err != nil {
 		return err
 	}
+	snapshotBlockSize := int(l.snapshotBlockSize)
 	bodySize := int(fsize - seek)
+	// the writer always pads to whole blocks, so a body that is not one was truncated.
+	// an empty body would otherwise read back as an all-nil node set with no error
+	if bodySize <= 0 || bodySize%snapshotBlockSize != 0 {
+		return fmt.Errorf("snapshot body of %d bytes is not a whole number of %d byte blocks", bodySize, snapshotBlockSize)
+	}
 
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(l.logger, context.Background())
 	eg.SetLimit(snapshotConcurrency)
@@ -1294,7 +1301,7 @@ func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationR
 
 	for i := 0; i < snapshotConcurrency; i++ {
 		eg.Go(func() error {
-			buf := make([]byte, l.snapshotBlockSize)
+			buf := make([]byte, snapshotBlockSize)
 			var b [8]byte
 
 			for {
@@ -1311,8 +1318,8 @@ func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationR
 					if err != nil {
 						return err
 					}
-					if n != int(l.snapshotBlockSize) {
-						return fmt.Errorf("read %d bytes, expected %d bytes at offset %d", n, l.snapshotBlockSize, seek+int64(offset))
+					if n != snapshotBlockSize {
+						return fmt.Errorf("read %d bytes, expected %d bytes at offset %d", n, snapshotBlockSize, seek+int64(offset))
 					}
 
 					hasher := crc32.NewIEEE()
@@ -1387,13 +1394,17 @@ func (l *hnswCommitLogger) readSnapshotBody(f common.File, res *DeserializationR
 						mu.Unlock()
 						currNodeID++
 					}
+
+					mu.Lock()
+					lastNodeID = max(lastNodeID, currNodeID)
+					mu.Unlock()
 				}
 			}
 		})
 	}
 
 LOOP:
-	for i := 0; i < bodySize; i += int(l.snapshotBlockSize) {
+	for i := 0; i < bodySize; i += snapshotBlockSize {
 		select {
 		case <-ctx.Done():
 			break LOOP
@@ -1402,7 +1413,18 @@ LOOP:
 	}
 	close(ch)
 
-	return eg.Wait()
+	if err := eg.Wait(); err != nil {
+		return err
+	}
+
+	// the writer emits one slot per node, so a complete body ends at the node count
+	// the metadata records. a shorter one means whole blocks are missing, which the
+	// per-block checksums cannot see
+	if lastNodeID != uint64(len(res.Nodes)) {
+		return fmt.Errorf("snapshot body ends at node %d, metadata declares %d nodes", lastNodeID, len(res.Nodes))
+	}
+
+	return nil
 }
 
 func (l *hnswCommitLogger) readMetadata(f common.File, res *DeserializationResult) (int, error) {

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -16,12 +16,14 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
@@ -1535,35 +1537,122 @@ func snapshotStateWithNodes(t *testing.T, size, levelOffset int) *Deserializatio
 	return state
 }
 
-// TestReadSnapshotBufferAllocation pins that a snapshot read allocates a block
-// buffer for each block it actually reads, not one per reader goroutine.
+// TestReadSnapshotBufferAllocation pins both halves of how a snapshot read gets
+// its block buffers: one per block actually read rather than one per reader
+// goroutine, and taken from the pool once it holds any.
 func TestReadSnapshotBufferAllocation(t *testing.T) {
 	const size = 10
 
-	dir := t.TempDir()
-	id := "test"
-	cl := createTestCommitLoggerForSnapshots(t, dir, id)
-	cl.snapshotBlockSize = blockSize // production size, so this small state is one block
-
-	snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
-	require.NoError(t, cl.writeSnapshot(snapshotStateWithNodes(t, size, 0), snapshotPath))
-
-	var before, after runtime.MemStats
-	runtime.ReadMemStats(&before)
-	restored, err := cl.readStateFrom(snapshotPath)
-	runtime.ReadMemStats(&after)
-	require.NoError(t, err)
-
-	for i := 0; i < size; i++ {
-		require.NotNilf(t, restored.Nodes[i], "node %d must survive the round-trip", i)
+	tests := []struct {
+		name string
+		// reads above 1 leave the pool filled from the read before, so the
+		// cheapest of them is the one that reuses a buffer
+		reads        int
+		maxAllocated uint64
+	}{
+		{
+			// one block, so one buffer; the bound is two because TotalAlloc also
+			// counts whatever else the process allocates
+			name:         "empty pool allocates per block, not per reader goroutine",
+			reads:        1,
+			maxAllocated: 2 * blockSize,
+		},
+		{
+			name:         "filled pool hands the buffer back",
+			reads:        5,
+			maxAllocated: blockSize / 2,
+		},
 	}
 
-	// one block, so one buffer; the bound is two because TotalAlloc also counts
-	// whatever else the process allocates
-	allocated := after.TotalAlloc - before.TotalAlloc
-	require.Lessf(t, allocated, uint64(2*blockSize),
-		"reading a single-block snapshot allocated %d bytes; one buffer per reader goroutine would be %d",
-		allocated, snapshotConcurrency*blockSize)
+	// a GC empties the pool, so hold it off to keep reuse observable
+	defer debug.SetGCPercent(debug.SetGCPercent(-1))
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			id := "test"
+			cl := createTestCommitLoggerForSnapshots(t, dir, id)
+			cl.snapshotBlockSize = blockSize // production size, so this small state is one block
+
+			snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+			require.NoError(t, cl.writeSnapshot(snapshotStateWithNodes(t, size, 0), snapshotPath))
+
+			// TotalAlloc counts the whole process, and that noise only ever adds,
+			// so the cheapest read is the honest measurement
+			var lowest uint64
+			var restored *DeserializationResult
+			for i := 0; i < test.reads; i++ {
+				var before, after runtime.MemStats
+				var err error
+
+				runtime.ReadMemStats(&before)
+				restored, err = cl.readStateFrom(snapshotPath)
+				runtime.ReadMemStats(&after)
+				require.NoError(t, err)
+
+				if allocated := after.TotalAlloc - before.TotalAlloc; i == 0 || allocated < lowest {
+					lowest = allocated
+				}
+			}
+
+			for i := 0; i < size; i++ {
+				require.NotNilf(t, restored.Nodes[i], "node %d must survive the round-trip", i)
+			}
+
+			require.Lessf(t, lowest, test.maxAllocated,
+				"reading a single-block snapshot allocated %d bytes; one buffer per reader goroutine would be %d",
+				lowest, snapshotConcurrency*blockSize)
+		})
+	}
+}
+
+// TestReadSnapshotConcurrent pins that snapshots read at the same time keep
+// their own content, since the readers share their block buffers.
+func TestReadSnapshotConcurrent(t *testing.T) {
+	const shards = 4
+	const readsPerShard = 5
+
+	dir := t.TempDir()
+
+	paths := make([]string, shards)
+	loggers := make([]*hnswCommitLogger, shards)
+	sizes := make([]int, shards)
+
+	for s := 0; s < shards; s++ {
+		id := fmt.Sprintf("shard-%d", s)
+		sizes[s] = 100 * (s + 1)
+		loggers[s] = createTestCommitLoggerForSnapshots(t, dir, id)
+		paths[s] = filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+		require.NoError(t, loggers[s].writeSnapshot(snapshotStateWithNodes(t, sizes[s], s), paths[s]))
+	}
+
+	var wg sync.WaitGroup
+	for s := 0; s < shards; s++ {
+		for range readsPerShard {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				// assert rather than require: require stops the calling goroutine,
+				// which here is not the one running the test
+				restored, err := loggers[s].readStateFrom(paths[s])
+				if !assert.NoError(t, err) || !assert.Len(t, restored.Nodes, sizes[s]) {
+					return
+				}
+
+				for i := 0; i < sizes[s]; i++ {
+					node := restored.Nodes[i]
+					if !assert.NotNilf(t, node, "shard %d node %d missing", s, i) {
+						return
+					}
+					if !assert.Equalf(t, (i+s)%6, node.level, "shard %d node %d holds another shard's data", s, i) {
+						return
+					}
+				}
+			}()
+		}
+	}
+	wg.Wait()
 }
 
 // TestReadSnapshotRejectsTruncatedBody pins that a truncated body fails instead

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1419,26 +1419,9 @@ func TestMetadataWriteAndRestore(t *testing.T) {
 func TestSnapshotMultiBlockNodeLossRepro(t *testing.T) {
 	const size = 2000
 
-	c, err := packedconn.NewWithMaxLayer(2)
-	require.Nil(t, err)
-	c.ReplaceLayer(0, connsSlice1)
-
-	state := &DeserializationResult{
-		Entrypoint: 1,
-		Level:      6,
-		Compressed: false,
-		Nodes:      make([]*vertex, size),
-		Tombstones: make(map[uint64]struct{}),
-	}
 	// every slot is a live node — no nil slots, no tombstones — so the ONLY
 	// way a node can go missing on round-trip is the block-boundary bug.
-	for i := 0; i < size; i++ {
-		state.Nodes[i] = &vertex{
-			id:          uint64(i),
-			level:       i % 6,
-			connections: c,
-		}
-	}
+	state := snapshotStateWithNodes(t, size, 0)
 
 	dir := t.TempDir()
 	id := "test"
@@ -1529,6 +1512,75 @@ func TestSnapshotCleanedTombstoneKeepsSlotAlignment(t *testing.T) {
 		}
 		require.NotNilf(t, restored.Nodes[i], "node %d must survive", i)
 		require.Equalf(t, i, restored.Nodes[i].level, "node %d shifted id/level", i)
+	}
+}
+
+func snapshotStateWithNodes(t *testing.T, size, levelOffset int) *DeserializationResult {
+	t.Helper()
+
+	c, err := packedconn.NewWithMaxLayer(2)
+	require.NoError(t, err)
+	c.ReplaceLayer(0, connsSlice1)
+
+	state := &DeserializationResult{
+		Entrypoint: 1,
+		Level:      6,
+		Nodes:      make([]*vertex, size),
+		Tombstones: make(map[uint64]struct{}),
+	}
+	for i := 0; i < size; i++ {
+		state.Nodes[i] = &vertex{id: uint64(i), level: (i + levelOffset) % 6, connections: c}
+	}
+	return state
+}
+
+// TestReadSnapshotRejectsTruncatedBody pins that a truncated body fails instead
+// of reporting success with the nodes that happened to survive.
+func TestReadSnapshotRejectsTruncatedBody(t *testing.T) {
+	const size = 200
+
+	tests := []struct {
+		name string
+		// truncateTo returns the size the snapshot file is truncated to
+		truncateTo func(fileSize, blockSize int64) int64
+		wantErr    string
+	}{
+		{
+			name:       "last block cut in half",
+			truncateTo: func(fileSize, blockSize int64) int64 { return fileSize - blockSize/2 },
+			wantErr:    "is not a whole number of",
+		},
+		{
+			// the body is a whole number of blocks, so the remainder is the metadata
+			name:       "body missing entirely",
+			truncateTo: func(fileSize, blockSize int64) int64 { return fileSize % blockSize },
+			wantErr:    "is not a whole number of",
+		},
+		{
+			// whole blocks still pass their own checksum, so only the node count
+			// recorded in the metadata catches this
+			name:       "last block removed",
+			truncateTo: func(fileSize, blockSize int64) int64 { return fileSize - blockSize },
+			wantErr:    "metadata declares",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			id := "test"
+			cl := createTestCommitLoggerForSnapshots(t, dir, id)
+
+			snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+			require.NoError(t, cl.writeSnapshot(snapshotStateWithNodes(t, size, 0), snapshotPath))
+
+			info, err := os.Stat(snapshotPath)
+			require.NoError(t, err)
+			require.NoError(t, os.Truncate(snapshotPath, test.truncateTo(info.Size(), cl.snapshotBlockSize)))
+
+			_, err = cl.readStateFrom(snapshotPath)
+			require.ErrorContains(t, err, test.wantErr)
+		})
 	}
 }
 

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -1532,6 +1533,37 @@ func snapshotStateWithNodes(t *testing.T, size, levelOffset int) *Deserializatio
 		state.Nodes[i] = &vertex{id: uint64(i), level: (i + levelOffset) % 6, connections: c}
 	}
 	return state
+}
+
+// TestReadSnapshotBufferAllocation pins that a snapshot read allocates a block
+// buffer for each block it actually reads, not one per reader goroutine.
+func TestReadSnapshotBufferAllocation(t *testing.T) {
+	const size = 10
+
+	dir := t.TempDir()
+	id := "test"
+	cl := createTestCommitLoggerForSnapshots(t, dir, id)
+	cl.snapshotBlockSize = blockSize // production size, so this small state is one block
+
+	snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+	require.NoError(t, cl.writeSnapshot(snapshotStateWithNodes(t, size, 0), snapshotPath))
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	restored, err := cl.readStateFrom(snapshotPath)
+	runtime.ReadMemStats(&after)
+	require.NoError(t, err)
+
+	for i := 0; i < size; i++ {
+		require.NotNilf(t, restored.Nodes[i], "node %d must survive the round-trip", i)
+	}
+
+	// one block, so one buffer; the bound is two because TotalAlloc also counts
+	// whatever else the process allocates
+	allocated := after.TotalAlloc - before.TotalAlloc
+	require.Lessf(t, allocated, uint64(2*blockSize),
+		"reading a single-block snapshot allocated %d bytes; one buffer per reader goroutine would be %d",
+		allocated, snapshotConcurrency*blockSize)
 }
 
 // TestReadSnapshotRejectsTruncatedBody pins that a truncated body fails instead


### PR DESCRIPTION
### What's being changed:

This contains one safeguard and two allocation improvements
1. reject a truncated snapshot body instead of loading it partially
2. don't start more snapshot readers than there are blocks. Each worker allocates a full block-sized buffer, so surplus workers cost a multi-MB
3. pool the block buffers

  | Snapshot | Variant | B/op | allocs/op | ns/op |
  | --- | --- | ---: | ---: | ---: |
  | 68 MiB body, 17 blocks | base | 109.5 MB | 16,501 | 10.6 ms |
  | 68 MiB body, 17 blocks | HEAD | 87.7 MB | 16,499 | 5.0 ms |
  | 68 MiB body, 17 blocks | **delta** | **−21.8 MB (−20%)** | −2 | **−53%** |
  | 4 MiB body, 1 block | base | 33.8 MB | 4,096 | 1.32 ms |
  | 4 MiB body, 1 block | HEAD | 0.48 MB | 4,044 | 0.95 ms |
  | 4 MiB body, 1 block | **delta** | **−33.4 MB (−70×)** | −52 | **−28%** |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

