### PR TITLE
lsmkv/roaringset: storage-side support for batched Contains resolution

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -129,6 +129,24 @@ func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitma
 	return b.roaringSetGetFromConsistentView(ctx, view, key)
 }
 
+// RoaringSetGetFromView reads key using a caller-held BucketConsistentView,
+// skipping the per-call GetConsistentView()/ReleaseView() pair (RLock +
+// disk-segment pinning) that RoaringSetGet performs on every invocation.
+// Intended for callers that read many keys from the same bucket in one
+// logical operation: call GetConsistentView() once, pass the result to every
+// RoaringSetGetFromView call, then call view.ReleaseView() exactly once when
+// done. The view must come from this bucket's GetConsistentView: a view of
+// another bucket is not detected and would silently read that bucket's data.
+func (b *Bucket) RoaringSetGetFromView(
+	ctx context.Context, view BucketConsistentView, key []byte,
+) (bm *sroar.Bitmap, release func(), err error) {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
+		return nil, noopRelease, err
+	}
+
+	return b.roaringSetGetFromConsistentView(ctx, view, key)
+}
+
 func (b *Bucket) roaringSetGetFromConsistentView(
 	ctx context.Context, view BucketConsistentView, key []byte,
 ) (bm *sroar.Bitmap, release func(), err error) {

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -242,6 +242,102 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	})
 }
 
+// TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet proves the new
+// batched-read primitive returns byte-identical results to the per-key
+// RoaringSetGet entry point, whether the key is present across several
+// on-disk segments plus the active memtable, or absent entirely, and that a
+// single GetConsistentView() call serves every RoaringSetGetFromView read.
+func TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	tmpDir := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	// never auto-flush; flush explicitly so the key spans several disk
+	// segments plus a final write left in the active memtable
+	b.SetMemtableThreshold(1e9)
+
+	keyA := []byte("key-a")
+	keyB := []byte("key-b")
+	keyMissing := []byte("key-missing")
+
+	require.NoError(t, b.RoaringSetAddList(keyA, []uint64{1, 2, 3}))
+	require.NoError(t, b.RoaringSetAddList(keyB, []uint64{10, 20}))
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.NoError(t, b.RoaringSetAddList(keyA, []uint64{4, 5}))
+	require.NoError(t, b.FlushAndSwitch())
+
+	// left in the active memtable, unflushed
+	require.NoError(t, b.RoaringSetAddList(keyA, []uint64{6}))
+
+	wantA, releaseWantA, err := b.RoaringSetGet(ctx, keyA)
+	require.NoError(t, err)
+	arrWantA := append([]uint64(nil), wantA.ToArray()...)
+	releaseWantA()
+
+	wantB, releaseWantB, err := b.RoaringSetGet(ctx, keyB)
+	require.NoError(t, err)
+	arrWantB := append([]uint64(nil), wantB.ToArray()...)
+	releaseWantB()
+
+	wantMissing, releaseWantMissing, err := b.RoaringSetGet(ctx, keyMissing)
+	require.NoError(t, err)
+	arrWantMissing := append([]uint64(nil), wantMissing.ToArray()...)
+	releaseWantMissing()
+	require.Empty(t, arrWantMissing, "absent key must resolve to an empty, non-nil bitmap")
+
+	// one shared view serves all three RoaringSetGetFromView reads below
+	view := b.GetConsistentView()
+
+	gotA, releaseA, err := b.RoaringSetGetFromView(ctx, view, keyA)
+	require.NoError(t, err)
+	require.Equal(t, arrWantA, gotA.ToArray())
+	releaseA()
+
+	gotB, releaseB, err := b.RoaringSetGetFromView(ctx, view, keyB)
+	require.NoError(t, err)
+	require.Equal(t, arrWantB, gotB.ToArray())
+	releaseB()
+
+	gotMissing, releaseMissing, err := b.RoaringSetGetFromView(ctx, view, keyMissing)
+	require.NoError(t, err)
+	require.NotNil(t, gotMissing)
+	require.Empty(t, gotMissing.ToArray())
+	releaseMissing()
+
+	view.ReleaseView()
+}
+
+// TestBucket_RoaringSetGetFromView_WrongStrategy pins the strategy guard: a
+// view read on a non-roaringset bucket must error before touching the view
+// at all (a zero view makes that observable — reaching the memtable read
+// would nil-panic), and the returned release must be safe to call. The
+// deeper layers reject the wrong strategy too, so without the guard the
+// error would only surface after the disk descent.
+func TestBucket_RoaringSetGetFromView_WrongStrategy(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	bm, release, err := b.RoaringSetGetFromView(ctx, BucketConsistentView{}, []byte("key"))
+	require.Error(t, err)
+	require.Nil(t, bm)
+	require.NotNil(t, release)
+	release()
+}
+
 // TestBucket_RoaringSet_DeleteThenReaddAcrossSegments is a read-path regression
 // test for roaringset reads with tombstones spread across multiple disk segments
 // plus the active memtable, including a doc deleted in one segment and re-added

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -315,6 +315,64 @@ func TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet(t *testing.T) {
 	view.ReleaseView()
 }
 
+// TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch pins the view
+// stability that justifies the caller-held-view API: reads through a view
+// taken before a FlushAndSwitch must keep resolving without error (the
+// flushed-away memtable stays readable through the held reference) and keep
+// returning the pre-switch state — writes landing in the new active memtable
+// must stay invisible. A fresh RoaringSetGet sees the post-switch write,
+// proving the view pinned state rather than the two paths coincidentally
+// agreeing.
+// (A view is not a write snapshot: writes before the switch go to the old
+// active memtable the view references, so only post-switch invisibility is
+// asserted.)
+func TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	b.SetMemtableThreshold(1e9) // flush only via the explicit switch below
+
+	key := []byte("key")
+
+	// one disk segment plus unflushed state in the active memtable, so the
+	// view references both layer kinds when taken
+	require.NoError(t, b.RoaringSetAddList(key, []uint64{1, 2, 3}))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetAddList(key, []uint64{4}))
+
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+
+	before, releaseBefore, err := b.RoaringSetGetFromView(ctx, view, key)
+	require.NoError(t, err)
+	arrBefore := append([]uint64(nil), before.ToArray()...)
+	releaseBefore()
+	require.Equal(t, []uint64{1, 2, 3, 4}, arrBefore)
+
+	// flush the memtable the view references, then write past the view
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.RoaringSetAddList(key, []uint64{5}))
+
+	after, releaseAfter, err := b.RoaringSetGetFromView(ctx, view, key)
+	require.NoError(t, err)
+	require.Equal(t, arrBefore, after.ToArray(),
+		"view read must keep returning the pre-switch state")
+	releaseAfter()
+
+	fresh, releaseFresh, err := b.RoaringSetGet(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2, 3, 4, 5}, fresh.ToArray(),
+		"a fresh read must see the post-switch write the view cannot")
+	releaseFresh()
+}
+
 // TestBucket_RoaringSetGetFromView_WrongStrategy pins the strategy guard: a
 // view read on a non-roaringset bucket must error before touching the view
 // at all (a zero view makes that observable — reaching the memtable read

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -29,6 +29,12 @@ import (
 
 type BitmapBufPool interface {
 	Get(minCap int) (buf []byte, put func())
+	// getWithBitmap additionally returns a result Bitmap struct for the
+	// buffer. Pooling implementations return the entry's embedded struct —
+	// re-initialized by the caller over buf, so cloning allocates nothing —
+	// while non-pooling ones return a fresh struct. bm shares buf's
+	// lifetime: neither may be used after put.
+	getWithBitmap(minCap int) (buf []byte, bm *sroar.Bitmap, put func())
 	CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func())
 	// CloneBytesToBuf clones an already-serialized bitmap into a pooled
 	// buffer without materializing an intermediate bitmap over src. src must
@@ -37,19 +43,21 @@ type BitmapBufPool interface {
 	CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func())
 }
 
-func cloneToBuf(pool BitmapBufPool, bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
-	buf, put := pool.Get(bm.LenInBytes())
-	return bm.CloneToBuf(buf), put
+func cloneToBuf(pool BitmapBufPool, src *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
+	buf, bm, put := pool.getWithBitmap(src.LenInBytes())
+	src.InitCloneToBuf(bm, buf)
+	return bm, put
 }
 
 // src must be a valid, non-empty sroar serialization (even length, >= 8
 // bytes): shorter input yields a bitmap not backed by the pooled buffer, and
 // odd-length input panics inside sroar.
 func cloneBytesToBuf(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
-	buf, put := pool.Get(len(src))
+	buf, bm, put := pool.getWithBitmap(len(src))
 	buf = buf[:len(src)]
 	copy(buf, src)
-	return sroar.FromBufferUnlimited(buf), put
+	sroar.InitFromBufferUnlimited(bm, buf)
+	return bm, put
 }
 
 func NewBitmapBufPoolDefault(logger logrus.FieldLogger, metrics *monitoring.PrometheusMetrics,
@@ -92,6 +100,10 @@ func NewBitmapBufPoolNoop() *bitmapBufPoolNoop {
 
 func (p *bitmapBufPoolNoop) Get(minCap int) (buf []byte, put func()) {
 	return make([]byte, 0, minCap), func() {}
+}
+
+func (p *bitmapBufPoolNoop) getWithBitmap(minCap int) (buf []byte, bm *sroar.Bitmap, put func()) {
+	return make([]byte, 0, minCap), &sroar.Bitmap{}, func() {}
 }
 
 func (p *bitmapBufPoolNoop) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
@@ -160,18 +172,27 @@ func NewBitmapBufPoolRanged(metrics *monitoring.PrometheusMetrics,
 }
 
 func (p *bitmapBufPoolRanged) Get(minCap int) (buf []byte, put func()) {
+	buf, _, put = p.getWithBitmap(minCap)
+	return buf, put
+}
+
+func (p *bitmapBufPoolRanged) getWithBitmap(minCap int) (buf []byte, bm *sroar.Bitmap, put func()) {
 	for i := 0; i < p.firstInMemoRngIdx; i++ {
 		if minCap <= p.ranges[i] {
-			return p.poolsSync[i].Get()
+			pb := p.poolsSync[i].getEntry()
+			return pb.buf, &pb.bm, pb.put
 		}
 	}
 	for i := p.firstInMemoRngIdx; i < len(p.ranges); i++ {
 		if minCap <= p.ranges[i] {
-			return p.poolsInMemo[i-p.firstInMemoRngIdx].Get()
+			pb := p.poolsInMemo[i-p.firstInMemoRngIdx].getEntry()
+			return pb.buf, &pb.bm, pb.put
 		}
 	}
+	// Oversized buffers are not pooled; their Bitmap struct is a one-off for
+	// the same reason.
 	p.disposableMetrics.bufCreated(minCap)
-	return make([]byte, 0, minCap), func() {}
+	return make([]byte, 0, minCap), &sroar.Bitmap{}, func() {}
 }
 
 func (p *bitmapBufPoolRanged) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
@@ -221,8 +242,13 @@ func NewBitmapBufPoolFactorWrapper(pool BitmapBufPool, factor float64) *bitmapBu
 }
 
 func (p *bitmapBufPoolFactorWrapper) Get(minCap int) (buf []byte, put func()) {
+	buf, _, put = p.getWithBitmap(minCap)
+	return buf, put
+}
+
+func (p *bitmapBufPoolFactorWrapper) getWithBitmap(minCap int) (buf []byte, bm *sroar.Bitmap, put func()) {
 	newMinCap := int(math.Ceil(float64(minCap) * p.factor))
-	return p.pool.Get(newMinCap)
+	return p.pool.getWithBitmap(newMinCap)
 }
 
 func (p *bitmapBufPoolFactorWrapper) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
@@ -241,8 +267,14 @@ type BufPoolFixedSync struct {
 
 // pooledBuf pairs a reusable buffer with its release closure, bound once at
 // creation so Get doesn't allocate a closure per call.
+//
+// bm is the reusable result view for the clone paths: it shares the buffer's
+// exact lifetime, so getWithBitmap hands it out to be re-initialized over buf
+// and the clone allocates nothing. put resets it so a parked entry cannot pin
+// heap memory that a mutated bitmap may have migrated its data to.
 type pooledBuf struct {
 	buf []byte
+	bm  sroar.Bitmap
 	put func()
 }
 
@@ -251,7 +283,10 @@ func NewBufPoolFixedSync(cap int) *BufPoolFixedSync {
 	p.pool = &sync.Pool{
 		New: func() any {
 			pb := &pooledBuf{buf: make([]byte, 0, cap)}
-			pb.put = func() { p.pool.Put(pb) }
+			pb.put = func() {
+				pb.bm = sroar.Bitmap{}
+				p.pool.Put(pb)
+			}
 			return pb
 		},
 	}
@@ -259,8 +294,12 @@ func NewBufPoolFixedSync(cap int) *BufPoolFixedSync {
 }
 
 func (p *BufPoolFixedSync) Get() (buf []byte, put func()) {
-	pb := p.pool.Get().(*pooledBuf)
+	pb := p.getEntry()
 	return pb.buf, pb.put
+}
+
+func (p *BufPoolFixedSync) getEntry() *pooledBuf {
+	return p.pool.Get().(*pooledBuf)
 }
 
 // -----------------------------------------------------------------------------
@@ -282,6 +321,11 @@ func NewBufPoolFixedInMemory(metrics bufPoolInMemoMetrics, cap int, limit int) *
 }
 
 func (p *BufPoolFixedInMemory) Get() (buf []byte, put func()) {
+	pb := p.getEntry()
+	return pb.buf, pb.put
+}
+
+func (p *BufPoolFixedInMemory) getEntry() *pooledBuf {
 	var pb *pooledBuf
 	select {
 	case pb = <-p.bufsCh:
@@ -292,10 +336,11 @@ func (p *BufPoolFixedInMemory) Get() (buf []byte, put func()) {
 		pb.put = func() { p.put(pb) }
 		p.metrics.bufCreated()
 	}
-	return pb.buf, pb.put
+	return pb
 }
 
 func (p *BufPoolFixedInMemory) put(pb *pooledBuf) bool {
+	pb.bm = sroar.Bitmap{}
 	select {
 	case p.bufsCh <- pb:
 		p.metrics.bufPut()

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -41,6 +41,12 @@ type BitmapBufPool interface {
 	// be a valid, non-empty sroar serialization. Like CloneToBuf, the clone
 	// owns the buffer's full capacity and can grow in place.
 	CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func())
+	// CloneBytesToBufBounded is CloneBytesToBuf with the decode window
+	// clamped to len(src): the clone cannot grow in place, and a corrupt
+	// serialization panics at the region boundary instead of silently
+	// decoding recycled buffer bytes. Use for bitmaps never mutated after
+	// cloning (e.g. a segment node's deletions).
+	CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func())
 }
 
 func cloneToBuf(pool BitmapBufPool, src *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
@@ -55,6 +61,17 @@ func cloneToBuf(pool BitmapBufPool, src *sroar.Bitmap) (cloned *sroar.Bitmap, pu
 func cloneBytesToBuf(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
 	buf, bm, put := pool.getWithBitmap(len(src))
 	buf = buf[:len(src)]
+	copy(buf, src)
+	sroar.InitFromBufferUnlimited(bm, buf)
+	return bm, put
+}
+
+// cloneBytesToBufBounded is cloneBytesToBuf with the buffer's capacity
+// clamped to len(src), so the "unlimited" init cannot reach the pooled
+// buffer's recycled tail.
+func cloneBytesToBufBounded(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
+	buf, bm, put := pool.getWithBitmap(len(src))
+	buf = buf[:len(src):len(src)]
 	copy(buf, src)
 	sroar.InitFromBufferUnlimited(bm, buf)
 	return bm, put
@@ -112,6 +129,10 @@ func (p *bitmapBufPoolNoop) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, 
 
 func (p *bitmapBufPoolNoop) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
 	return cloneBytesToBuf(p, src)
+}
+
+func (p *bitmapBufPoolNoop) CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBufBounded(p, src)
 }
 
 // -----------------------------------------------------------------------------
@@ -203,6 +224,10 @@ func (p *bitmapBufPoolRanged) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap,
 	return cloneBytesToBuf(p, src)
 }
 
+func (p *bitmapBufPoolRanged) CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBufBounded(p, src)
+}
+
 func (p *bitmapBufPoolRanged) cleanup(n int) map[int]int {
 	cleaned := map[int]int{}
 	for i := p.firstInMemoRngIdx; i < len(p.ranges); i++ {
@@ -257,6 +282,10 @@ func (p *bitmapBufPoolFactorWrapper) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar
 
 func (p *bitmapBufPoolFactorWrapper) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, put func()) {
 	return cloneBytesToBuf(p, src)
+}
+
+func (p *bitmapBufPoolFactorWrapper) CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBufBounded(p, src)
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -47,6 +47,12 @@ type BitmapBufPool interface {
 	// decoding recycled buffer bytes. Use for bitmaps never mutated after
 	// cloning (e.g. a segment node's deletions).
 	CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func())
+	// AccumulatorToBuf materializes the accumulator's union into a pooled
+	// buffer, so a warm accumulator building into pooled memory allocates
+	// nothing. The returned bitmap owns the buffer's full capacity: it can
+	// grow in place and migrates to the heap past that (same contract as
+	// CloneToBuf). Release via put; the accumulator stays reusable.
+	AccumulatorToBuf(acc *sroar.Accumulator) (bm *sroar.Bitmap, put func())
 }
 
 func cloneToBuf(pool BitmapBufPool, src *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
@@ -74,6 +80,15 @@ func cloneBytesToBufBounded(pool BitmapBufPool, src []byte) (cloned *sroar.Bitma
 	buf = buf[:len(src):len(src)]
 	copy(buf, src)
 	sroar.InitFromBufferUnlimited(bm, buf)
+	return bm, put
+}
+
+func accumulatorToBuf(pool BitmapBufPool, acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
+	bm = acc.InitBitmapToBuf(func(sizeBytes int) (*sroar.Bitmap, []byte) {
+		buf, dst, p := pool.getWithBitmap(sizeBytes)
+		put = p
+		return dst, buf
+	})
 	return bm, put
 }
 
@@ -133,6 +148,10 @@ func (p *bitmapBufPoolNoop) CloneBytesToBuf(src []byte) (cloned *sroar.Bitmap, p
 
 func (p *bitmapBufPoolNoop) CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func()) {
 	return cloneBytesToBufBounded(p, src)
+}
+
+func (p *bitmapBufPoolNoop) AccumulatorToBuf(acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
+	return accumulatorToBuf(p, acc)
 }
 
 // -----------------------------------------------------------------------------
@@ -228,6 +247,10 @@ func (p *bitmapBufPoolRanged) CloneBytesToBufBounded(src []byte) (cloned *sroar.
 	return cloneBytesToBufBounded(p, src)
 }
 
+func (p *bitmapBufPoolRanged) AccumulatorToBuf(acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
+	return accumulatorToBuf(p, acc)
+}
+
 func (p *bitmapBufPoolRanged) cleanup(n int) map[int]int {
 	cleaned := map[int]int{}
 	for i := p.firstInMemoRngIdx; i < len(p.ranges); i++ {
@@ -286,6 +309,10 @@ func (p *bitmapBufPoolFactorWrapper) CloneBytesToBuf(src []byte) (cloned *sroar.
 
 func (p *bitmapBufPoolFactorWrapper) CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func()) {
 	return cloneBytesToBufBounded(p, src)
+}
+
+func (p *bitmapBufPoolFactorWrapper) AccumulatorToBuf(acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
+	return accumulatorToBuf(p, acc)
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -98,6 +98,9 @@ func requireEvenLength(src []byte) {
 }
 
 func accumulatorToBuf(pool BitmapBufPool, acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
+	// noop default so put stays callable even if a future sroar version
+	// short-circuits without invoking the allocation callback
+	put = func() {}
 	bm = acc.InitBitmapToBuf(func(sizeBytes int) (*sroar.Bitmap, []byte) {
 		buf, dst, p := pool.getWithBitmap(sizeBytes)
 		put = p

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -13,6 +13,7 @@ package roaringset
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/bits"
 	"slices"
@@ -51,7 +52,8 @@ type BitmapBufPool interface {
 	// buffer, so a warm accumulator building into pooled memory allocates
 	// nothing. The returned bitmap owns the buffer's full capacity: it can
 	// grow in place and migrates to the heap past that (same contract as
-	// CloneToBuf). Release via put; the accumulator stays reusable.
+	// CloneToBuf). Release via put; the accumulator stays reusable. acc must
+	// be non-nil (unlike CloneToBuf's nil tolerance, it panics).
 	AccumulatorToBuf(acc *sroar.Accumulator) (bm *sroar.Bitmap, put func())
 }
 
@@ -63,8 +65,9 @@ func cloneToBuf(pool BitmapBufPool, src *sroar.Bitmap) (cloned *sroar.Bitmap, pu
 
 // src must be a valid, non-empty sroar serialization (even length, >= 8
 // bytes): shorter input yields a bitmap not backed by the pooled buffer, and
-// odd-length input panics inside sroar.
+// odd-length input — always corruption, the format is []uint16-based — panics.
 func cloneBytesToBuf(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
+	requireEvenLength(src)
 	buf, bm, put := pool.getWithBitmap(len(src))
 	buf = buf[:len(src)]
 	copy(buf, src)
@@ -76,11 +79,22 @@ func cloneBytesToBuf(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put 
 // clamped to len(src), so the "unlimited" init cannot reach the pooled
 // buffer's recycled tail.
 func cloneBytesToBufBounded(pool BitmapBufPool, src []byte) (cloned *sroar.Bitmap, put func()) {
+	requireEvenLength(src)
 	buf, bm, put := pool.getWithBitmap(len(src))
 	buf = buf[:len(src):len(src)]
 	copy(buf, src)
 	sroar.InitFromBufferUnlimited(bm, buf)
 	return bm, put
+}
+
+// requireEvenLength rejects odd-length serializations — always corruption,
+// since sroar serializes []uint16 — with a recoverable panic. Reaching
+// sroar's own even-length assert instead would log.Fatal the whole process
+// on one corrupt segment region.
+func requireEvenLength(src []byte) {
+	if len(src)%2 != 0 {
+		panic(fmt.Sprintf("roaringset: corrupt serialized bitmap: odd length %d", len(src)))
+	}
 }
 
 func accumulatorToBuf(pool BitmapBufPool, acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
@@ -230,7 +244,8 @@ func (p *bitmapBufPoolRanged) getWithBitmap(minCap int) (buf []byte, bm *sroar.B
 		}
 	}
 	// Oversized buffers are not pooled; their Bitmap struct is a one-off for
-	// the same reason.
+	// the same reason (wasted on plain Get, but negligible next to the
+	// oversized buffer itself).
 	p.disposableMetrics.bufCreated(minCap)
 	return make([]byte, 0, minCap), &sroar.Bitmap{}, func() {}
 }

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -1076,6 +1076,11 @@ func TestAccumulatorToBuf(t *testing.T) {
 		require.True(t, bm.IsEmpty())
 	})
 
+	t.Run("nil accumulator panics, as documented", func(t *testing.T) {
+		pool := NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
+		require.Panics(t, func() { pool.AccumulatorToBuf(nil) })
+	})
+
 	t.Run("reuses the pooled entry's struct, allocates nothing warm", func(t *testing.T) {
 		pool := NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
 		acc := newAcc()
@@ -1106,4 +1111,29 @@ func TestAccumulatorToBuf(t *testing.T) {
 		require.Equal(t, ids, bm2.ToArray(),
 			"reused entry must reflect only the fresh union, not the grown bitmap")
 	})
+}
+
+// TestCloneBytesToBuf_OddLengthPanics pins the corrupt-input guard: an
+// odd-length src — always corruption, sroar serializations are []uint16-based
+// — must fail with a recoverable panic naming the length. Without the guard
+// the input reaches sroar's even-length assert, a log.Fatal that kills the
+// whole process over one corrupt segment region.
+func TestCloneBytesToBuf_OddLengthPanics(t *testing.T) {
+	pool := NewBitmapBufPoolNoop()
+
+	methods := []struct {
+		name  string
+		clone func(src []byte) (*sroar.Bitmap, func())
+	}{
+		{"CloneBytesToBuf", pool.CloneBytesToBuf},
+		{"CloneBytesToBufBounded", pool.CloneBytesToBufBounded},
+	}
+
+	for _, m := range methods {
+		t.Run(m.name, func(t *testing.T) {
+			require.PanicsWithValue(t,
+				"roaringset: corrupt serialized bitmap: odd length 9",
+				func() { m.clone(make([]byte, 9)) })
+		})
+	}
 }

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -1038,3 +1038,72 @@ func TestPooledBitmapStructReuse(t *testing.T) {
 		assert.Zero(t, allocs, "pooled clone must reuse both buffer and Bitmap struct")
 	})
 }
+
+func TestAccumulatorToBuf(t *testing.T) {
+	ids := []uint64{1, 2, 3, 70_000, 200_000}
+	newAcc := func() *sroar.Accumulator {
+		acc := sroar.NewAccumulator()
+		bm := sroar.NewBitmap()
+		bm.SetMany(ids)
+		acc.Or(bm)
+		return acc
+	}
+
+	pools := []struct {
+		name string
+		pool BitmapBufPool
+	}{
+		{"noop", NewBitmapBufPoolNoop()},
+		{"ranged channel-backed", NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)},
+		{"ranged sync.Pool-backed", NewBitmapBufPoolRanged(nil, 1<<20, nil, 512, 1024)},
+		{"factor wrapper", NewBitmapBufPoolFactorWrapper(NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024), 1.5)},
+		{"tracking", NewBitmapBufPoolTrackingForTests()},
+	}
+	for _, tc := range pools {
+		t.Run(tc.name, func(t *testing.T) {
+			acc := newAcc()
+			bm, put := tc.pool.AccumulatorToBuf(acc)
+			require.Equal(t, acc.Bitmap().ToArray(), bm.ToArray())
+			put()
+		})
+	}
+
+	t.Run("empty accumulator yields an empty bitmap", func(t *testing.T) {
+		pool := NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
+		bm, put := pool.AccumulatorToBuf(sroar.NewAccumulator())
+		defer put()
+		require.NotNil(t, bm)
+		require.True(t, bm.IsEmpty())
+	})
+
+	t.Run("reuses the pooled entry's struct, allocates nothing warm", func(t *testing.T) {
+		pool := NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
+		acc := newAcc()
+		bm1, put1 := pool.AccumulatorToBuf(acc)
+		put1()
+		bm2, put2 := pool.AccumulatorToBuf(acc)
+		assert.Same(t, bm1, bm2, "the pooled entry's embedded Bitmap must be reused, not reallocated")
+		put2()
+
+		allocs := testing.AllocsPerRun(100, func() {
+			bm, put := pool.AccumulatorToBuf(acc)
+			_ = bm.GetCardinality()
+			put()
+		})
+		assert.Zero(t, allocs, "warm materialization must reuse both buffer and Bitmap struct")
+	})
+
+	t.Run("growth past the buffer cannot corrupt the next checkout", func(t *testing.T) {
+		pool := NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
+		acc := newAcc()
+		bm1, put1 := pool.AccumulatorToBuf(acc)
+		for i := uint64(0); i < 100_000; i += 7 {
+			bm1.Set(i)
+		}
+		put1()
+		bm2, put2 := pool.AccumulatorToBuf(acc)
+		defer put2()
+		require.Equal(t, ids, bm2.ToArray(),
+			"reused entry must reflect only the fresh union, not the grown bitmap")
+	})
+}

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -1063,6 +1063,7 @@ func TestAccumulatorToBuf(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			acc := newAcc()
 			bm, put := tc.pool.AccumulatorToBuf(acc)
+			require.NotNil(t, put, "put must always be callable")
 			require.Equal(t, acc.Bitmap().ToArray(), bm.ToArray())
 			put()
 		})
@@ -1071,6 +1072,7 @@ func TestAccumulatorToBuf(t *testing.T) {
 	t.Run("empty accumulator yields an empty bitmap", func(t *testing.T) {
 		pool := NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
 		bm, put := pool.AccumulatorToBuf(sroar.NewAccumulator())
+		require.NotNil(t, put, "put must always be callable")
 		defer put()
 		require.NotNil(t, bm)
 		require.True(t, bm.IsEmpty())

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -931,3 +931,110 @@ func TestBitmapBufPoolTrackingForTests_CloneToBuf(t *testing.T) {
 		}
 	})
 }
+
+// TestPooledBitmapStructReuse pins the pooled-entry Bitmap contract: the
+// clone paths hand out the entry's embedded struct (re-initialized per
+// checkout, not allocated), the struct cycles with its buffer, and a bitmap
+// that grew past its buffer cannot leak state into the next checkout.
+func TestPooledBitmapStructReuse(t *testing.T) {
+	// syncMaxBufSize 0 puts every range on the channel-backed in-memory
+	// pools, which reuse entries deterministically — sync.Pool guarantees no
+	// steady-state allocation but NOT entry identity across cycles (and the
+	// race detector deliberately randomizes it), so the pointer-identity
+	// assertions below need the channel pools.
+	newRanged := func() *bitmapBufPoolRanged {
+		return NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)
+	}
+
+	src := sroar.NewBitmap()
+	src.SetMany([]uint64{1, 2, 3, 100_000})
+	serialized := src.ToBufferWithCopy()
+
+	t.Run("same struct across checkout cycles", func(t *testing.T) {
+		pool := newRanged()
+		bm1, put1 := pool.CloneBytesToBuf(serialized)
+		require.Equal(t, src.ToArray(), bm1.ToArray())
+		put1()
+		bm2, put2 := pool.CloneBytesToBuf(serialized)
+		defer put2()
+		require.Equal(t, src.ToArray(), bm2.ToArray())
+		assert.Same(t, bm1, bm2, "the pooled entry's embedded Bitmap must be reused, not reallocated")
+	})
+
+	t.Run("CloneToBuf uses the embedded struct too", func(t *testing.T) {
+		pool := newRanged()
+		bm1, put1 := pool.CloneToBuf(src)
+		require.Equal(t, src.ToArray(), bm1.ToArray())
+		put1()
+		bm2, put2 := pool.CloneToBuf(src)
+		defer put2()
+		assert.Same(t, bm1, bm2)
+	})
+
+	t.Run("factor wrapper preserves entry reuse", func(t *testing.T) {
+		pool := NewBitmapBufPoolFactorWrapper(newRanged(), 1.5)
+		bm1, put1 := pool.CloneBytesToBuf(serialized)
+		put1()
+		bm2, put2 := pool.CloneBytesToBuf(serialized)
+		defer put2()
+		assert.Same(t, bm1, bm2)
+	})
+
+	t.Run("growth past the buffer cannot corrupt the next checkout", func(t *testing.T) {
+		pool := newRanged()
+		bm1, put1 := pool.CloneBytesToBuf(serialized)
+		// Force the bitmap to outgrow the pooled buffer: sroar migrates its
+		// data to the heap internally.
+		for i := uint64(0); i < 100_000; i += 7 {
+			bm1.Set(i)
+		}
+		put1()
+		bm2, put2 := pool.CloneBytesToBuf(serialized)
+		defer put2()
+		require.Equal(t, src.ToArray(), bm2.ToArray(),
+			"reused entry must reflect only the new clone, not the grown bitmap")
+	})
+
+	t.Run("release resets the embedded struct", func(t *testing.T) {
+		// The reset is invisible to functional assertions (every checkout
+		// re-initializes the struct before use); its job is retention: a
+		// grown bitmap migrates its data to the heap, and a parked entry
+		// whose struct still points there would pin that heap for as long
+		// as the entry sits in the pool. The zeroed fields ARE the dropped
+		// references, so observing them observes the fix.
+		pools := []struct {
+			name string
+			pool BitmapBufPool
+		}{
+			{"channel-backed", NewBitmapBufPoolRanged(nil, 0, nil, 512, 1024)},
+			{"sync.Pool-backed", NewBitmapBufPoolRanged(nil, 1<<20, nil, 512, 1024)},
+		}
+		for _, tc := range pools {
+			t.Run(tc.name, func(t *testing.T) {
+				bm, put := tc.pool.CloneBytesToBuf(serialized)
+				// Outgrow the pooled buffer so the bitmap's data migrates to
+				// a fresh heap allocation the entry must not keep alive.
+				for i := uint64(0); i < 100_000; i += 7 {
+					bm.Set(i)
+				}
+				require.NotZero(t, bm.GetCardinality())
+				put()
+				assert.Equal(t, sroar.Bitmap{}, *bm,
+					"released entry must not retain the grown bitmap's heap")
+			})
+		}
+	})
+
+	t.Run("clone allocates nothing steady-state", func(t *testing.T) {
+		pool := newRanged()
+		// warm the pool entry
+		_, put := pool.CloneBytesToBuf(serialized)
+		put()
+		allocs := testing.AllocsPerRun(100, func() {
+			bm, put := pool.CloneBytesToBuf(serialized)
+			_ = bm.GetCardinality()
+			put()
+		})
+		assert.Zero(t, allocs, "pooled clone must reuse both buffer and Bitmap struct")
+	})
+}

--- a/adapters/repos/db/roaringset/buf_pool_testonly.go
+++ b/adapters/repos/db/roaringset/buf_pool_testonly.go
@@ -47,6 +47,14 @@ func (p *BitmapBufPoolTrackingForTests) Get(minCap int) (buf []byte, put func())
 	}
 }
 
+// getWithBitmap returns a fresh struct rather than a pooled one, so a bitmap
+// used after its release keeps reading the zeroed buffer (visible as wrong
+// values) instead of silently aliasing a reused struct.
+func (p *BitmapBufPoolTrackingForTests) getWithBitmap(minCap int) (buf []byte, bm *sroar.Bitmap, put func()) {
+	buf, put = p.Get(minCap)
+	return buf, &sroar.Bitmap{}, put
+}
+
 func (p *BitmapBufPoolTrackingForTests) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
 	return cloneToBuf(p, bm)
 }

--- a/adapters/repos/db/roaringset/buf_pool_testonly.go
+++ b/adapters/repos/db/roaringset/buf_pool_testonly.go
@@ -63,6 +63,10 @@ func (p *BitmapBufPoolTrackingForTests) CloneBytesToBuf(src []byte) (cloned *sro
 	return cloneBytesToBuf(p, src)
 }
 
+func (p *BitmapBufPoolTrackingForTests) CloneBytesToBufBounded(src []byte) (cloned *sroar.Bitmap, put func()) {
+	return cloneBytesToBufBounded(p, src)
+}
+
 // Outstanding returns the number of buffers that have been allocated but not
 // yet released. A non-zero value at the end of a test indicates a leak.
 func (p *BitmapBufPoolTrackingForTests) Outstanding() int64 {

--- a/adapters/repos/db/roaringset/buf_pool_testonly.go
+++ b/adapters/repos/db/roaringset/buf_pool_testonly.go
@@ -67,6 +67,10 @@ func (p *BitmapBufPoolTrackingForTests) CloneBytesToBufBounded(src []byte) (clon
 	return cloneBytesToBufBounded(p, src)
 }
 
+func (p *BitmapBufPoolTrackingForTests) AccumulatorToBuf(acc *sroar.Accumulator) (bm *sroar.Bitmap, put func()) {
+	return accumulatorToBuf(p, acc)
+}
+
 // Outstanding returns the number of buffers that have been allocated but not
 // yet released. A non-zero value at the end of a test indicates a leak.
 func (p *BitmapBufPoolTrackingForTests) Outstanding() int64 {

--- a/adapters/repos/db/roaringset/serialization.go
+++ b/adapters/repos/db/roaringset/serialization.go
@@ -149,6 +149,10 @@ func (sn *SegmentNode) Deletions() *sroar.Bitmap {
 
 // DeletionsCloneToBuf is the deletions counterpart of
 // [*SegmentNode.AdditionsCloneToBuf], with the identical contract.
+//
+// The clone is bounded to the region length: deletions never grow (they are
+// only ever an AndNot operand), and a corrupt header then panics at the
+// region boundary instead of silently decoding recycled buffer bytes.
 func (sn *SegmentNode) DeletionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, func()) {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)
@@ -157,7 +161,7 @@ func (sn *SegmentNode) DeletionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, f
 	if len(buf) == 0 {
 		return nil, nil
 	}
-	return pool.CloneBytesToBuf(buf)
+	return pool.CloneBytesToBufBounded(buf)
 }
 
 // DeletionsWithCopy returns the deletions roaring bitmap without sharing state. It

--- a/adapters/repos/db/roaringset/serialization.go
+++ b/adapters/repos/db/roaringset/serialization.go
@@ -147,12 +147,12 @@ func (sn *SegmentNode) Deletions() *sroar.Bitmap {
 	return sroar.FromBuffer(buf)
 }
 
-// DeletionsCloneToBuf is the deletions counterpart of
-// [*SegmentNode.AdditionsCloneToBuf], with the identical contract.
-//
-// The clone is bounded to the region length: deletions never grow (they are
-// only ever an AndNot operand), and a corrupt header then panics at the
-// region boundary instead of silently decoding recycled buffer bytes.
+// DeletionsCloneToBuf clones the node's deletions bitmap straight into a
+// buffer taken from pool. The clone is safe to use beyond the node's
+// lifetime, but bounded to the region length and cannot grow in place —
+// fine, since deletions are only ever an AndNot operand; a corrupt header
+// panics at the region boundary. It returns (nil, nil) when the node holds
+// no deletions — the release is non-nil exactly when the bitmap is.
 func (sn *SegmentNode) DeletionsCloneToBuf(pool BitmapBufPool) (*sroar.Bitmap, func()) {
 	rw := byteops.NewReadWriter(sn.data)
 	rw.MoveBufferToAbsolutePosition(8)

--- a/adapters/repos/db/roaringset/serialization_test.go
+++ b/adapters/repos/db/roaringset/serialization_test.go
@@ -13,6 +13,7 @@ package roaringset
 
 import (
 	"bytes"
+	"encoding/binary"
 	"math"
 	"testing"
 
@@ -215,4 +216,45 @@ func TestSerialization_KeyIndexAndWriteTo(t *testing.T) {
 	assert.False(t, newDeletions.Contains(4))
 	assert.True(t, newDeletions.Contains(5))
 	assert.Equal(t, []byte("my-key"), newSN.PrimaryKey())
+}
+
+// TestDeletionsCloneToBuf_CorruptHeaderStopsAtRegion pins the bounded decode
+// window of the deletions clone: a region whose length indicator is shrunk
+// below what the serialization's own header describes must fail loudly at
+// the region boundary, not silently decode recycled pooled-buffer bytes.
+// Cloning and releasing the intact deletions first primes the recycled
+// buffer's tail with exactly the "missing" bytes, so an unbounded decode
+// would silently reconstruct them.
+func TestDeletionsCloneToBuf_CorruptHeaderStopsAtRegion(t *testing.T) {
+	values := make([]uint64, 64)
+	for i := range values {
+		values[i] = uint64(i * 7)
+	}
+	additions := NewBitmap(1)
+	deletions := NewBitmap(values...)
+
+	sn, err := NewSegmentNode([]byte("key"), additions, deletions)
+	require.NoError(t, err)
+
+	pool := NewBitmapBufPoolRanged(nil, 1<<20, nil, 512, 1024, 4096)
+
+	// positive control + adversarial priming (see godoc)
+	intact, release := sn.DeletionsCloneToBuf(pool)
+	require.NotNil(t, intact)
+	require.Equal(t, deletions.ToArray(), intact.ToArray())
+	release()
+
+	// shrink the deletions region's length indicator (it sits right after
+	// the additions region; see the SegmentNode layout godoc)
+	addLen := binary.LittleEndian.Uint64(sn.data[8:16])
+	delLenOff := 16 + addLen
+	delLen := binary.LittleEndian.Uint64(sn.data[delLenOff : delLenOff+8])
+	require.Greater(t, delLen, uint64(24), "fixture deletions region too small to truncate")
+	binary.LittleEndian.PutUint64(sn.data[delLenOff:delLenOff+8], delLen-16)
+
+	require.Panics(t, func() {
+		bm, release := sn.DeletionsCloneToBuf(pool)
+		defer release()
+		bm.ToArray()
+	}, "a corrupt deletions header must fail at the region boundary, not silently decode recycled buffer bytes")
 }

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/weaviate/fgprof v0.0.1
 	github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.15
+	github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b
 	github.com/weaviate/tiktoken-go v0.0.3
 	github.com/zeebo/xxh3 v1.1.0
 	go.etcd.io/bbolt v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -695,10 +695,6 @@ github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2 h1:lJpPgu+7Vx9K2
 github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2/go.mod h1:6cErcTSXUX3sGQEY+FQlxBztdlzVPoArKdMRNq6XKlE=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
-github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
-github.com/weaviate/sroar v0.0.16-0.20260724154935-40ed44a3b74f h1:X3TscqkX4ucJvRfmW6zW1g2o8lYU7FnKfnVUPSH+NXw=
-github.com/weaviate/sroar v0.0.16-0.20260724154935-40ed44a3b74f/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b h1:DMWSAV5e8QCQ1JTm4W4m7/sv5VA73AqCrA+hy4UAsRk=
 github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=

--- a/go.sum
+++ b/go.sum
@@ -697,6 +697,10 @@ github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
 github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
 github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.16-0.20260724154935-40ed44a3b74f h1:X3TscqkX4ucJvRfmW6zW1g2o8lYU7FnKfnVUPSH+NXw=
+github.com/weaviate/sroar v0.0.16-0.20260724154935-40ed44a3b74f/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b h1:DMWSAV5e8QCQ1JTm4W4m7/sv5VA73AqCrA+hy4UAsRk=
+github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
## Motivation

Part 4 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242). The batched fold landing in the next PR needs three storage primitives: reading many roaringset keys under **one** consistent view (instead of RLock + segment-pinning per key), an N-way union that avoids repeated `union2by2` churn (`sroar.Accumulator`), and pooled materialization so warm reads and the union result don't allocate.

Two changes benefit every roaringset read today (struct reuse, bounded deletions clone). The other two (`RoaringSetGetFromView`, `AccumulatorToBuf`) have **no callers in this PR** — the fold adopts them next.

## Approach

- **`RoaringSetGetFromView`**: same read as `RoaringSetGet` against a caller-held `BucketConsistentView` — acquire once, read N keys, release once. Foreign-view requirement is a documented contract, not a runtime guard (existing view-family convention).
- **sroar bump** (`bd6aaff5bb3b`): brings `Accumulator` and the in-place `Init*` initializers. Pseudo-version for now; tagging before merge is an open item.
- **Pooled `Bitmap` struct reuse**: pool entries embed the ~80-byte view struct and clones re-init it in place, so a warm clone allocates nothing; `put` zeroes the struct. At `ContainsAny` N=100K: **200K → 100K allocs/op, 16.1 → 6.1 MB/op**.
- **Bounded deletions clone** (safety fix): pooled buffers gave the decoder capacity beyond the region length, so a corrupt header could silently decode a previous user's recycled bytes. `CloneBytesToBufBounded` clamps to `len(src)`, restoring the pre-pooling panic. Deletions only — they never grow (`AndNot` operand only).
- **`AccumulatorToBuf`**: materializes the union straight into a pooled entry — zero allocs warm.
- Review hardening: odd-length regions hit a recoverable `panic` before sroar's process-killing assert.

## Risks and testing

- Struct aliasing across checkouts: `TestPooledBitmapStructReuse` pins reuse, zeroing on release, zero-alloc steady state, growth isolation — both pool variants.
- Bounded clone rejecting valid data: bound equals what the pre-pooling decoder saw; primed-buffer corrupt-header regression, red-checked against the unbounded clone.
- View misuse: contract documented; test pins reads across `FlushAndSwitch` (segment snapshot, not a write snapshot).

Plus wrong-strategy guard and `TestAccumulatorToBuf` across pool shapes; `go test -race` on lsmkv/roaringset/inverted; both linters clean. No breaking changes: on-disk format untouched, downgrade-safe.