### PR TITLE
perf(hnsw): async/muvera parallel prefill + targeted object reads

### DIFF
--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -36,6 +36,7 @@ type Cache[T any] interface {
 	CountVectors() int64
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vec []T)
+	PreloadIfAbsent(id uint64, vec []T) bool
 	PreloadNoLock(id uint64, vec []T)
 	SetSizeAndGrowNoLock(id uint64)
 	Prefetch(id uint64)

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -224,10 +224,11 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 		return nil, err
 	}
 
-	atomic.AddInt64(&s.count, 1)
-
 	if vec != nil {
 		s.shardedLocks.Lock(id)
+		if s.cache[id] == nil {
+			atomic.AddInt64(&s.count, 1)
+		}
 		s.cache[id] = vec
 		s.shardedLocks.Unlock(id)
 	}
@@ -340,8 +341,12 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 		// it here keeps the common case as cheap as before the cache became
 		// lazy: one stripe lock, no maintenanceLock traffic.
 		if int(id) < len(s.cache) {
+			// count tracks occupied slots, not calls; replaceIfFull wipes the
+			// cache when count reaches maxSize, so overwrites must not inflate it.
+			if s.cache[id] == nil {
+				atomic.AddInt64(&s.count, 1)
+			}
 			s.cache[id] = vec
-			atomic.AddInt64(&s.count, 1)
 			s.shardedLocks.Unlock(id)
 			return
 		}
@@ -350,6 +355,27 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 		// slow path: the cache doesn't cover id yet — preloaders (e.g. the
 		// HNSW insert path) don't grow the cache themselves. Grow guarantees
 		// coverage of id, so the next iteration stores.
+		s.Grow(id)
+	}
+}
+
+// PreloadIfAbsent writes vec only when the slot is empty, so it cannot clobber a
+// newer vector written concurrently. Reports whether it stored the vector.
+func (s *shardedLockCache[T]) PreloadIfAbsent(id uint64, vec []T) bool {
+	for {
+		s.shardedLocks.Lock(id)
+		if int(id) < len(s.cache) {
+			if s.cache[id] != nil {
+				s.shardedLocks.Unlock(id)
+				return false
+			}
+			atomic.AddInt64(&s.count, 1)
+			s.cache[id] = vec
+			s.shardedLocks.Unlock(id)
+			return true
+		}
+		s.shardedLocks.Unlock(id)
+
 		s.Grow(id)
 	}
 }
@@ -795,6 +821,10 @@ func (s *shardedMultipleLockCache[T]) PreloadPassage(id uint64, docID uint64, re
 }
 
 func (s *shardedMultipleLockCache[T]) Preload(docID uint64, vec []T) {
+	panic("not implemented")
+}
+
+func (s *shardedMultipleLockCache[T]) PreloadIfAbsent(docID uint64, vec []T) bool {
 	panic("not implemented")
 }
 

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -764,3 +764,28 @@ func TestShardedLockCache_PageSizeOnFreshCache(t *testing.T) {
 	c := newLazyTestCache[uint64](t, fetch)
 	assert.EqualValues(t, 1, c.PageSize(), "PageSize must work before the locks are allocated")
 }
+
+// TestPreloadCountsOccupiedSlotsOnly: count feeds replaceIfFull's full-cache wipe,
+// so overwrites and if-absent no-ops must not inflate it past true occupancy — and
+// PreloadIfAbsent must never replace a present vector.
+func TestPreloadCountsOccupiedSlotsOnly(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(10)
+
+	c.Preload(5, []float32{9, 9})
+	c.Preload(5, []float32{1, 2}) // overwrite: no recount
+	assert.Equal(t, int64(1), c.CountVectors())
+
+	assert.False(t, c.PreloadIfAbsent(5, []float32{9, 9}))
+	assert.True(t, c.PreloadIfAbsent(6, []float32{3, 4}))
+	assert.Equal(t, int64(2), c.CountVectors())
+
+	got, err := c.Get(context.Background(), 5)
+	assert.NoError(t, err)
+	assert.Equal(t, []float32{1, 2}, got, "PreloadIfAbsent must not overwrite")
+
+	got, err = c.Get(context.Background(), 6)
+	assert.NoError(t, err)
+	assert.Equal(t, []float32{3, 4}, got)
+}

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -113,7 +113,7 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 	enterrors.GoWrapper(func() {
 		defer wg.Done()
 
-		c := cpi.bucket.Cursor()
+		c := cpi.bucket.CursorReplaceReusable()
 		defer c.Close()
 
 		// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf
@@ -164,7 +164,7 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
 
-			c := cpi.bucket.Cursor()
+			c := cpi.bucket.CursorReplaceReusable()
 			defer c.Close()
 
 			// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf
@@ -212,7 +212,7 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 	enterrors.GoWrapper(func() {
 		defer wg.Done()
 
-		c := cpi.bucket.Cursor()
+		c := cpi.bucket.CursorReplaceReusable()
 		defer c.Close()
 
 		// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf
@@ -275,7 +275,7 @@ func (cpi *parallelIterator[T]) iterateAllNoConcurrency(ctx context.Context) (ou
 		defer close(aborted)
 		defer stopTracking()
 
-		c := cpi.bucket.Cursor()
+		c := cpi.bucket.CursorReplaceReusable()
 		defer c.Close()
 
 		// The first call of cpi.fromCompressedBytes will allocate a buffer into localBuf

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -121,6 +121,9 @@ type hnsw struct {
 	waitForCachePrefill bool
 	cachePrefilled      atomic.Bool
 	releaseVectorsOnce  sync.Once
+	prefillWG           sync.WaitGroup
+	prefillCancel       atomic.Pointer[context.CancelFunc]
+	hfreshMode          bool
 
 	commitLog CommitLogger
 
@@ -369,8 +372,9 @@ func New(cfg Config, uc ent.UserConfig,
 		efMax:    int64(uc.DynamicEFMax),
 		efFactor: int64(uc.DynamicEFFactor),
 
-		metrics:   newMetrics(cfg.PrometheusMetrics, cfg.ClassName, cfg.ShardName, cfg.HFreshMode),
-		shardName: cfg.ShardName,
+		metrics:    newMetrics(cfg.PrometheusMetrics, cfg.ClassName, cfg.ShardName, cfg.HFreshMode),
+		hfreshMode: cfg.HFreshMode,
+		shardName:  cfg.ShardName,
 
 		randFunc:                          rand.Float64,
 		compressActionLock:                &sync.RWMutex{},
@@ -761,7 +765,20 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 	return h.nodes[id]
 }
 
+// stopPrefill cancels an in-flight cache prefill and waits for it to exit. Must run
+// before the cache is dropped or the store shut down: the shard-drop path never
+// cancels the PostStartup context before closing lsmkv segments, and a scan cursor
+// opened after segment close would read unmapped memory.
+func (h *hnsw) stopPrefill() {
+	if cancel := h.prefillCancel.Load(); cancel != nil {
+		(*cancel)()
+	}
+	h.prefillWG.Wait()
+}
+
 func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
+	h.stopPrefill()
+
 	// cancel tombstone cleanup goroutine
 	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
@@ -783,6 +800,7 @@ func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
 
 func (h *hnsw) Shutdown(ctx context.Context) error {
 	h.shutdownCtxCancel()
+	h.stopPrefill()
 
 	ec := errorcompounder.New()
 	ec.AddWrapf(h.commitLog.Shutdown(ctx), "shutdown commit log")

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -537,29 +537,44 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 		limit = int(h.cache.CopyMaxSize())
 	}
 
+	// Drop/Shutdown cancel via prefillCancel and wait on prefillWG so no scan cursor
+	// can outlive the cache or the lsmkv store (the shard-drop path never cancels the
+	// PostStartup ctx before closing segments).
+	prefillCtx, cancel := context.WithCancel(ctx)
+	h.prefillCancel.Store(&cancel)
+	h.prefillWG.Add(1)
+
 	prefillCacheFunc := func() {
-		h.logger.WithFields(logrus.Fields{
-			"action":   "prefill_cache",
-			"duration": 60 * time.Minute,
-		}).Debug("context.WithTimeout")
+		defer h.prefillWG.Done()
+		defer cancel()
 
 		var err error
 		if h.compressed.Load() {
 			if !h.multivector.Load() || h.muvera.Load() {
-				h.compressor.PrefillCache(ctx)
+				h.compressor.PrefillCache(prefillCtx)
 			} else {
-				h.compressor.PrefillMultiCache(ctx, h.docIDVectors)
+				h.compressor.PrefillMultiCache(prefillCtx, h.docIDVectors)
 			}
+		} else if h.useMuveraParallelPrefill() {
+			// Unbounded muvera cache: scan the compact muvera vectors bucket with a
+			// parallel cursor instead of looking up every vector by id.
+			err = h.prefillMuveraCacheParallel(prefillCtx)
 		} else if h.useParallelPrefill() {
 			// Unbounded uncompressed cache: scan the objects bucket with a parallel
 			// cursor instead of looking up every vector by id (disk-seek bound).
-			err = h.prefillCacheParallel(ctx)
+			err = h.prefillCacheParallel(prefillCtx)
 		} else {
-			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(context.Background(), limit)
+			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(prefillCtx, limit)
 		}
 
 		if err != nil {
-			h.logger.WithError(err).Error("prefill vector cache")
+			if errors.Is(err, context.Canceled) {
+				// routine on shard shutdown mid-prefill (async runs under shutCtx)
+				h.logger.WithField("action", "hnsw_vector_cache_prefill").
+					Debug("vector cache prefill stopped: context canceled")
+			} else {
+				h.logger.WithField("action", "hnsw_vector_cache_prefill").Error(err)
+			}
 		}
 
 		h.cachePrefilled.Store(true)

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -14,6 +14,7 @@ package hnsw
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"runtime"
@@ -24,54 +25,84 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/multivector"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
+// prefillAllocCheckEvery is how many stored vectors pass between allocChecker probes
+// during a scan prefill.
+const prefillAllocCheckEvery = 4096
+
+var (
+	errPrefillMemoryPressure = errors.New("vector cache prefill aborted under memory pressure")
+	errPrefillCacheFull      = errors.New("vector cache prefill aborted: cache full")
+	// errPrefillCompressionActive is defensive: every compression-activation path is
+	// gated on cachePrefilled, so it cannot fire through current callers.
+	errPrefillCompressionActive = errors.New("vector cache prefill aborted: compression activated")
+)
+
 // useParallelPrefill reports whether the uncompressed cache can be prefilled by a
 // parallel cursor scan of the objects bucket rather than the serial by-id
-// vectorCachePrefiller. Gated to cases where that scan is both safe and complete:
-//   - sync only: an overwriting Preload from a snapshot cursor races live writes;
-//     the serial path's load-if-absent Get does not.
-//   - unbounded cache only: a full scan ignores the size limit the serial path honors.
-//   - single-vector only: a multivector cache holds per-passage vectors, and a muvera
-//     cache holds encoded vectors from the dedicated _muvera_vectors bucket — neither
-//     lives in the objects bucket this scan reads, so both stay on the serial path.
+// vectorCachePrefiller. Multivector caches (per-passage) and muvera caches (sourced
+// from the muvera bucket, see useMuveraParallelPrefill) are not objects-sourced, and
+// neither is the hfresh centroid cache despite its store holding an objects bucket.
 func (h *hnsw) useParallelPrefill() bool {
-	// No real objects bucket (tests wiring only a VectorForID thunk, or pre-attach):
-	// fall back to the serial prefiller.
-	if h.store == nil || h.store.Bucket(helpers.ObjectsBucketLSM) == nil {
+	if h.store == nil || h.store.Bucket(helpers.ObjectsBucketLSM) == nil || h.hfreshMode {
 		return false
 	}
 
+	return parallelPrefillEligible(h.parallelPrefillInputs())
+}
+
+// useMuveraParallelPrefill reports whether the muvera float32 cache can be prefilled
+// by a parallel cursor scan of the muvera vectors bucket (key = big-endian docID =
+// node id, value = raw float32s).
+func (h *hnsw) useMuveraParallelPrefill() bool {
+	if h.store == nil || h.store.Bucket(h.muveraBucketName()) == nil {
+		return false
+	}
+
+	return muveraParallelPrefillEligible(h.parallelPrefillInputs())
+}
+
+func (h *hnsw) muveraBucketName() string {
+	return h.id + "_muvera_vectors"
+}
+
+func (h *hnsw) parallelPrefillInputs() parallelPrefillInputs {
 	h.RLock()
 	nodeCount := int64(len(h.nodes))
 	h.RUnlock()
 
-	return parallelPrefillEligible(parallelPrefillInputs{
-		waitForPrefill: h.waitForCachePrefill,
-		multivector:    h.multivector.Load(),
-		muvera:         h.muvera.Load(),
-		cacheMaxSize:   h.cache.CopyMaxSize(),
-		nodeCount:      nodeCount,
-	})
+	return parallelPrefillInputs{
+		multivector:  h.multivector.Load(),
+		muvera:       h.muvera.Load(),
+		cacheMaxSize: h.cache.CopyMaxSize(),
+		nodeCount:    nodeCount,
+	}
 }
 
 type parallelPrefillInputs struct {
-	waitForPrefill bool
-	multivector    bool
-	muvera         bool
-	cacheMaxSize   int64
-	nodeCount      int64
+	multivector  bool
+	muvera       bool
+	cacheMaxSize int64
+	nodeCount    int64
 }
 
 // parallelPrefillEligible is the pure decision core of useParallelPrefill, split out
-// for direct testing.
+// for direct testing. A full scan ignores the size limit the serial path honors, so
+// the cache must be unbounded relative to the node count.
 func parallelPrefillEligible(in parallelPrefillInputs) bool {
-	if !in.waitForPrefill {
+	if in.multivector || in.muvera {
 		return false
 	}
-	if in.multivector || in.muvera {
+	return in.cacheMaxSize >= in.nodeCount
+}
+
+// muveraParallelPrefillEligible is the pure decision core of useMuveraParallelPrefill.
+func muveraParallelPrefillEligible(in parallelPrefillInputs) bool {
+	if !in.muvera {
 		return false
 	}
 	return in.cacheMaxSize >= in.nodeCount
@@ -81,56 +112,173 @@ func parallelPrefillEligible(in parallelPrefillInputs) bool {
 // scan of the objects bucket. The by-id vectorCachePrefiller issues one random seek
 // per vector (the bucket is UUID-keyed), which is latency-bound and can take hours on
 // network storage with the CPU idle; a cursor reads in storage order and decodes
-// across cores. Mirrors the compressed PrefillCache, but preloads as it scans rather
-// than collecting into a slice first; a second copy of full float32 vectors would
-// roughly double startup memory.
+// across cores.
 func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
-	before := time.Now()
-
 	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
 	if bucket == nil {
 		return fmt.Errorf("prefill cache: objects bucket %q not found", helpers.ObjectsBucketLSM)
 	}
-	targetVector := h.getTargetVector()
 
-	var loaded atomic.Int64
-	onVector := func(id uint64, vec []float32) {
-		// cosine-dot keeps normalized vectors in the cache; the serial path gets this
-		// from the cache's normalizeOnRead wrapper, which Preload bypasses. vec is a
-		// fresh per-vector allocation, so normalizing in place is safe.
-		h.normalizeVecInPlace(vec)
-		// Preload grows the cache on demand, covering ids from writes that
-		// land while the prefill is running
-		h.cache.Preload(id, vec)
-		loaded.Add(1)
+	targetVector := h.getTargetVector()
+	if h.useTargetedPrefillScan(bucket) {
+		return h.prefillFromScan(ctx, func(ctx context.Context, onVector prefillOnVector) error {
+			return h.scanObjectVectorsTargeted(ctx, bucket, targetVector, onVector)
+		})
+	}
+	return h.prefillFromScan(ctx, func(ctx context.Context, onVector prefillOnVector) error {
+		return scanBucketVectorsParallel(ctx, bucket, objectsRowDecoder(targetVector, h.logger), onVector, h.logger)
+	})
+}
+
+// prefillMuveraCacheParallel populates the muvera float32 cache via a parallel cursor
+// scan of the muvera vectors bucket.
+func (h *hnsw) prefillMuveraCacheParallel(ctx context.Context) error {
+	bucket := h.store.Bucket(h.muveraBucketName())
+	if bucket == nil {
+		return fmt.Errorf("prefill cache: muvera bucket %q not found", h.muveraBucketName())
 	}
 
-	if err := scanObjectVectorsParallel(ctx, bucket, targetVector, onVector, h.logger); err != nil {
+	return h.prefillFromScan(ctx, func(ctx context.Context, onVector prefillOnVector) error {
+		return scanBucketVectorsParallel(ctx, bucket, muveraRowDecoder(h.logger), onVector, h.logger)
+	})
+}
+
+// prefillFromScan drives a parallel bucket scan into the cache. PreloadIfAbsent makes
+// it safe to run concurrently with live writes; a delete racing the snapshot cursor
+// can repopulate its slot with the pre-delete value — bounded waste, the node itself
+// stays tombstoned. Memory pressure and a full cache abort gracefully (nil error);
+// the remaining vectors load on demand through cache.Get.
+func (h *hnsw) prefillFromScan(ctx context.Context,
+	scan func(context.Context, prefillOnVector) error,
+) error {
+	before := time.Now()
+
+	h.RLock()
+	preGrown := uint64(len(h.nodes))
+	h.RUnlock()
+
+	var loaded atomic.Int64
+	onVector := func(id uint64, vec []float32) error {
+		if h.compressed.Load() {
+			return errPrefillCompressionActive
+		}
+		// advisory: racing workers can overshoot by their in-flight rows, but
+		// crossing maxSize is the cache's own full behavior (replaceIfFull) and
+		// reachable through inserts regardless
+		if h.cache.CountVectors() >= h.cache.CopyMaxSize() {
+			return errPrefillCacheFull
+		}
+		if id >= preGrown {
+			// the cache is pre-grown to len(h.nodes) at restore; ids beyond it are
+			// either live inserts (which self-preload) or corrupt keys that must not
+			// size the cache
+			return nil
+		}
+		// cosine-dot keeps normalized vectors in the cache; the serial path gets this
+		// from the cache's normalizeOnRead wrapper, which the preload bypasses. vec is
+		// a fresh per-vector allocation, so normalizing in place is safe.
+		h.normalizeVecInPlace(vec)
+		if !h.cache.PreloadIfAbsent(id, vec) {
+			return nil
+		}
+		if n := loaded.Add(1); n%prefillAllocCheckEvery == 0 && h.allocChecker != nil {
+			if err := h.allocChecker.CheckAlloc(prefillAllocCheckEvery * int64(len(vec)) * 4); err != nil {
+				return fmt.Errorf("%w: %w", errPrefillMemoryPressure, err)
+			}
+		}
+		return nil
+	}
+
+	entry := h.logger.WithFields(logrus.Fields{
+		"action":   "hnsw_vector_cache_prefill",
+		"index_id": h.id,
+	})
+
+	if err := scan(ctx, onVector); err != nil {
+		switch {
+		case errors.Is(err, errPrefillMemoryPressure), errors.Is(err, errPrefillCacheFull):
+			entry.WithField("count", loaded.Load()).
+				Warnf("%v; remaining vectors load on demand", err)
+			return nil
+		case errors.Is(err, errPrefillCompressionActive):
+			entry.WithField("count", loaded.Load()).
+				Info("stopping vector cache prefill: compression activated mid-scan")
+			return nil
+		}
 		return err
 	}
 
-	h.logger.WithFields(logrus.Fields{
-		"action":   "hnsw_vector_cache_prefill",
+	entry.WithFields(logrus.Fields{
 		"count":    loaded.Load(),
 		"took":     time.Since(before),
-		"index_id": h.id,
 		"parallel": true,
 	}).Info("prefilled vector cache")
 	return nil
 }
 
-// scanObjectVectorsParallel scans the objects bucket across GOMAXPROCS cursors over
-// disjoint key ranges. onVector must be safe for concurrent use.
-func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
-	onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
-) error {
-	// 2x oversubscription: while one cursor blocks on a disk read another keeps a
-	// core busy decoding — the IO-bound default used across the vector package.
+// prefillOnVector consumes one decoded vector. Must be safe for concurrent use; a
+// non-nil error aborts the whole scan.
+type prefillOnVector func(id uint64, vec []float32) error
+
+// prefillRowDecoder extracts (docID, vector) from one bucket entry; ok=false skips
+// the row. The returned vec must not alias v — cursor buffers are reused.
+type prefillRowDecoder func(k, v []byte) (id uint64, vec []float32, ok bool)
+
+func objectsRowDecoder(targetVector string, logger logrus.FieldLogger) prefillRowDecoder {
+	return func(k, v []byte) (uint64, []float32, bool) {
+		id, err := storobj.DocIDFromBinary(v)
+		if err != nil {
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping object with undecodable doc id: %v", err)
+			return 0, nil, false
+		}
+
+		// nil buffer forces a fresh allocation; a reused buffer would be aliased by
+		// VectorFromBinary across iterations and corrupt previously cached vectors.
+		vec, err := storobj.VectorFromBinary(v, nil, targetVector)
+		if err != nil {
+			var notFound storobj.ErrTargetVectorNotFound
+			if errors.As(err, &notFound) {
+				return 0, nil, false
+			}
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping doc id %d with undecodable vector: %v", id, err)
+			return 0, nil, false
+		}
+		return id, vec, true
+	}
+}
+
+func muveraRowDecoder(logger logrus.FieldLogger) prefillRowDecoder {
+	return func(k, v []byte) (uint64, []float32, bool) {
+		if len(k) != 8 {
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping muvera entry with %d-byte key", len(k))
+			return 0, nil, false
+		}
+		// MuveraFromBytes allocates a fresh slice, so the value never aliases the
+		// cursor buffer.
+		return binary.BigEndian.Uint64(k), multivector.MuveraFromBytes(v), true
+	}
+}
+
+// prefillScanParallelism is 2x GOMAXPROCS: while one reader blocks on disk another
+// keeps a core busy decoding — the IO-bound default used across the vector package.
+func prefillScanParallelism() int {
 	const cursorsPerProc = 2
 	parallel := cursorsPerProc * runtime.GOMAXPROCS(0)
 	if parallel < 1 {
 		parallel = 1
 	}
+	return parallel
+}
+
+// scanBucketVectorsParallel scans a replace-strategy bucket across GOMAXPROCS cursors
+// over disjoint key ranges.
+func scanBucketVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket,
+	decode prefillRowDecoder, onVector prefillOnVector, logger logrus.FieldLogger,
+) error {
+	parallel := prefillScanParallelism()
 
 	// n-1 seeds yield n ranges: [first,seeds[0]), interiors, [seeds[last],end).
 	seeds := bucket.QuantileKeys(parallel - 1)
@@ -160,7 +308,7 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		wg.Add(1)
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
-			if err := scanObjectVectorsRange(scanCtx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
+			if err := scanBucketVectorsRange(scanCtx, bucket, r.start, r.end, decode, onVector); err != nil {
 				e := err
 				if firstErr.CompareAndSwap(nil, &e) {
 					cancel()
@@ -176,14 +324,14 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 	return nil
 }
 
-func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, end []byte,
-	targetVector string, onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
+func scanBucketVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, end []byte,
+	decode prefillRowDecoder, onVector prefillOnVector,
 ) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
 
-	c := bucket.Cursor()
+	c := bucket.CursorReplaceReusable()
 	defer c.Close()
 
 	var k, v []byte
@@ -209,29 +357,13 @@ func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, en
 			continue
 		}
 
-		id, err := storobj.DocIDFromBinary(v)
-		if err != nil {
-			logger.WithField("action", "hnsw_vector_cache_prefill").
-				Debugf("skipping object with undecodable doc id: %v", err)
+		id, vec, ok := decode(k, v)
+		if !ok || len(vec) == 0 {
 			continue
 		}
-
-		// nil buffer forces a fresh allocation; a reused buffer would be aliased by
-		// VectorFromBinary across iterations and corrupt previously cached vectors.
-		vec, err := storobj.VectorFromBinary(v, nil, targetVector)
-		if err != nil {
-			var notFound storobj.ErrTargetVectorNotFound
-			if errors.As(err, &notFound) {
-				continue
-			}
-			logger.WithField("action", "hnsw_vector_cache_prefill").
-				Debugf("skipping doc id %d with undecodable vector: %v", id, err)
-			continue
+		if err := onVector(id, vec); err != nil {
+			return err
 		}
-		if len(vec) == 0 {
-			continue
-		}
-		onVector(id, vec)
 	}
 	return nil
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_bench_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_bench_test.go
@@ -1,0 +1,263 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// prefillBenchConfig shapes the slow-prefill dataset: named target vectors, a
+// properties payload dominating value size, multiple flushed segments.
+type prefillBenchConfig struct {
+	n            int
+	dims         int
+	payloadBytes int
+	segments     int
+}
+
+const prefillBenchTarget = "custom"
+
+func benchVector(i, dims, salt int) []float32 {
+	vec := make([]float32, dims)
+	for j := range vec {
+		vec[j] = float32((i+salt)%977) + float32(j)*0.25
+	}
+	return vec
+}
+
+// putBenchObject mirrors the real objects-bucket write path (16-byte primary key,
+// little-endian docID secondary key at index 0). keyID and docID differ only for
+// rewrites, which model an update landing in a newer segment.
+func putBenchObject(tb testing.TB, bucket *lsmkv.Bucket, keyID, docID uint64, dims int, payload string) {
+	tb.Helper()
+	obj := storobj.New(docID)
+	obj.Object = models.Object{
+		ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", keyID)),
+		Class:      "Bench",
+		Properties: map[string]interface{}{"filler": payload},
+	}
+	obj.Vectors = map[string][]float32{
+		prefillBenchTarget: benchVector(int(docID), dims, 0),
+		"sibling":          benchVector(int(docID), dims, 13),
+	}
+	data, err := obj.MarshalBinary()
+	require.NoError(tb, err)
+
+	docIDBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(docIDBytes, docID)
+	require.NoError(tb, bucket.Put(keyForDocID(keyID), data,
+		lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)))
+}
+
+func buildPrefillBenchStore(tb testing.TB, cfg prefillBenchConfig, opts ...lsmkv.BucketOption) *lsmkv.Store {
+	tb.Helper()
+	dir := tb.TempDir()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroup("objects", logger, 1),
+		cyclemanager.NewCallbackGroup("nonObjects", logger, 1),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(tb, err)
+	tb.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
+		append([]lsmkv.BucketOption{
+			lsmkv.WithStrategy(lsmkv.StrategyReplace),
+			lsmkv.WithSecondaryIndices(1),
+		}, opts...)...))
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	payload := strings.Repeat("x", cfg.payloadBytes)
+	perSegment := (cfg.n + cfg.segments - 1) / cfg.segments
+	for i := 0; i < cfg.n; i++ {
+		putBenchObject(tb, bucket, uint64(i), uint64(i), cfg.dims, payload)
+		if (i+1)%perSegment == 0 {
+			require.NoError(tb, bucket.FlushAndSwitch())
+		}
+	}
+	require.NoError(tb, bucket.FlushAndSwitch())
+	return store
+}
+
+func newPrefillBenchIndex(store *lsmkv.Store, c cache.Cache[float32], n int) *hnsw {
+	logger, _ := test.NewNullLogger()
+	nodes := make([]*vertex, n)
+	for i := range nodes {
+		nodes[i] = &vertex{level: 0}
+	}
+	return &hnsw{
+		store:               store,
+		cache:               c,
+		nodes:               nodes,
+		id:                  helpers.VectorsBucketLSM + "_" + prefillBenchTarget,
+		logger:              logger,
+		distancerProvider:   distancer.NewDotProductProvider(),
+		shardedNodeLocks:    common.NewDefaultShardedRWLocks(),
+		tombstoneLock:       &sync.RWMutex{},
+		tombstones:          map[uint64]struct{}{},
+		currentMaximumLayer: 0,
+	}
+}
+
+// runSerialPrefill measures the by-id path: per node one secondary-index lookup of
+// the full object plus a named-vector decode.
+func runSerialPrefill(tb testing.TB, store *lsmkv.Store, cfg prefillBenchConfig) {
+	tb.Helper()
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	logger, _ := test.NewNullLogger()
+
+	byID := func(ctx context.Context, id uint64) ([]float32, error) {
+		docIDBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(docIDBytes, id)
+		v, err := bucket.GetBySecondary(ctx, helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)
+		if err != nil {
+			return nil, err
+		}
+		if len(v) == 0 {
+			return nil, fmt.Errorf("doc id %d not found", id)
+		}
+		return storobj.VectorFromBinary(v, nil, prefillBenchTarget)
+	}
+	c := cache.NewShardedFloat32LockCache(byID, nil, 1_000_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(cfg.n))
+	h := newPrefillBenchIndex(store, c, cfg.n)
+
+	require.NoError(tb, newVectorCachePrefiller(c, h, logger).Prefill(context.Background(), int(c.CopyMaxSize())))
+	require.Equal(tb, int64(cfg.n), c.CountVectors())
+}
+
+func runParallelPrefill(tb testing.TB, store *lsmkv.Store, cfg prefillBenchConfig) {
+	tb.Helper()
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(cfg.n))
+	h := newPrefillBenchIndex(store, c, cfg.n)
+
+	require.NoError(tb, h.prefillCacheParallel(context.Background()))
+	require.Equal(tb, int64(cfg.n), c.CountVectors())
+}
+
+func runTargetedPrefill(tb testing.TB, store *lsmkv.Store, cfg prefillBenchConfig) {
+	tb.Helper()
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(cfg.n))
+	h := newPrefillBenchIndex(store, c, cfg.n)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	require.NoError(tb, h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+		return h.scanObjectVectorsTargeted(ctx, bucket, prefillBenchTarget, onVector)
+	}))
+	require.Equal(tb, int64(cfg.n), c.CountVectors())
+}
+
+func benchRuns(b *testing.B, vectors int, run func(tb testing.TB)) {
+	for i := 0; i < b.N; i++ {
+		run(b)
+	}
+	b.ReportMetric(float64(vectors)*float64(b.N)/b.Elapsed().Seconds(), "vectors/s")
+}
+
+// BenchmarkPrefillNamedVectorsLargeProps is the read-amplification case the targeted
+// scan exists for: the properties schema dominates the value, so peek+jump reads a
+// small fraction of the bucket while both full-scan variants read all of it.
+// Page-cache hot, so it measures syscalls/copies and decode, not disk latency.
+func BenchmarkPrefillNamedVectorsLargeProps(b *testing.B) {
+	cfg := prefillBenchConfig{n: 5_000, dims: 128, payloadBytes: 16 << 10, segments: 4}
+	store := buildPrefillBenchStore(b, cfg)
+
+	b.Run("serial-by-id", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runSerialPrefill(tb, store, cfg) })
+	})
+	b.Run("parallel-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runParallelPrefill(tb, store, cfg) })
+	})
+	b.Run("targeted-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runTargetedPrefill(tb, store, cfg) })
+	})
+
+	preadStore := buildPrefillBenchStore(b, cfg, lsmkv.WithPread(true), lsmkv.WithMinMMapSize(0))
+	b.Run("pread/parallel-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runParallelPrefill(tb, preadStore, cfg) })
+	})
+	b.Run("pread/targeted-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runTargetedPrefill(tb, preadStore, cfg) })
+	})
+}
+
+// BenchmarkPrefillNamedVectorsChurned: 40% of keys rewritten under fresh doc ids
+// after the base segments flushed, leaving stale rows in older segments. The
+// newest-wins scan hides them via in-memory key probes before any value read; the
+// merged cursor copies their full values into the merge before discarding them.
+func BenchmarkPrefillNamedVectorsChurned(b *testing.B) {
+	cfg := prefillBenchConfig{n: 5_000, dims: 128, payloadBytes: 16 << 10, segments: 3}
+	const rewritten = 2_000
+
+	store := buildPrefillBenchStore(b, cfg, lsmkv.WithPread(true), lsmkv.WithMinMMapSize(0))
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	payload := strings.Repeat("x", cfg.payloadBytes)
+	for i := 0; i < rewritten; i++ {
+		putBenchObject(b, bucket, uint64(i), uint64(cfg.n+i), cfg.dims, payload)
+	}
+	require.NoError(b, bucket.FlushAndSwitch())
+
+	// live: unmodified originals plus the rewrites; doc ids 0..rewritten-1 are dead
+	total := cfg.n + rewritten
+	run := func(tb testing.TB, scan func(h *hnsw) error) {
+		logger, _ := test.NewNullLogger()
+		c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000_000, 1, logger, false, 0, nil)
+		c.Grow(uint64(total))
+		h := newPrefillBenchIndex(store, c, total)
+		for i := 0; i < rewritten; i++ {
+			h.nodes[i] = nil
+		}
+		require.NoError(tb, scan(h))
+		require.Equal(tb, int64(cfg.n), c.CountVectors())
+	}
+
+	b.Run("pread/parallel-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) {
+			run(tb, func(h *hnsw) error {
+				return h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+					return scanBucketVectorsParallel(ctx, bucket, objectsRowDecoder(prefillBenchTarget, h.logger), onVector, h.logger)
+				})
+			})
+		})
+	})
+	b.Run("pread/targeted-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) {
+			run(tb, func(h *hnsw) error {
+				return h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+					return h.scanObjectVectorsTargeted(ctx, bucket, prefillBenchTarget, onVector)
+				})
+			})
+		})
+	})
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
@@ -61,10 +61,10 @@ func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *l
 }
 
 // TestUseParallelPrefillRoutingRealIndex builds real indexes (objects bucket present,
-// sync prefill, unbounded cache) and confirms the config→atomic→gate wiring routes
-// each index type to the right prefill path: only a plain single-vector index takes
-// the parallel objects-bucket scan; multivector and muvera stay on the serial path
-// because their caches are not sourced from the objects bucket.
+// unbounded cache) and confirms the config→atomic→gate wiring routes each index type
+// to the right prefill path: a plain single-vector index takes the parallel
+// objects-bucket scan, muvera takes the parallel muvera-bucket scan, and multivector
+// stays on the serial path because its cache is per-passage.
 // prefillRoutingUserConfig is the baseline single-vector config that satisfies the
 // parallel-prefill gate (unbounded cache); tests layer Multivector/Muvera on top to
 // flip the expected routing.
@@ -82,9 +82,10 @@ func muveraUserConfig() ent.UserConfig {
 }
 
 func TestUseParallelPrefillRoutingRealIndex(t *testing.T) {
-	t.Run("single-vector uncompressed is eligible", func(t *testing.T) {
+	t.Run("single-vector uncompressed takes the objects scan", func(t *testing.T) {
 		idx := newPrefillRoutingIndex(t, "single", prefillRoutingUserConfig(), storeWithObjectsBucket(t))
 		require.True(t, idx.useParallelPrefill())
+		require.False(t, idx.useMuveraParallelPrefill())
 	})
 
 	t.Run("true multivector keeps serial path", func(t *testing.T) {
@@ -92,20 +93,65 @@ func TestUseParallelPrefillRoutingRealIndex(t *testing.T) {
 		uc.Multivector = ent.MultivectorConfig{Enabled: true}
 		idx := newPrefillRoutingIndex(t, "multivector", uc, storeWithObjectsBucket(t))
 		require.False(t, idx.useParallelPrefill())
+		require.False(t, idx.useMuveraParallelPrefill())
 	})
 
-	t.Run("muvera keeps serial path", func(t *testing.T) {
+	t.Run("muvera takes the muvera-bucket scan", func(t *testing.T) {
 		idx := newPrefillRoutingIndex(t, "muvera", muveraUserConfig(), storeWithObjectsBucket(t))
 		require.False(t, idx.useParallelPrefill())
+		require.True(t, idx.useMuveraParallelPrefill())
 	})
 }
 
-// TestMuveraSerialPrefillPopulatesCacheRealIndex is the end-to-end guard for the bug
-// the parallel path introduced: a muvera index's float32 cache is loaded from the
-// dedicated _muvera_vectors bucket, not the objects bucket. After clearing the cache
-// (cold-restart shape), the serial prefiller muvera routes to must repopulate it
-// fully with the correct muvera-encoded vectors — the parallel path would have left
-// it empty while marking it prefilled.
+// muveraPrefillGroundTruth reads the expected cache contents straight from the
+// encoder/bucket, so a prefill that loads wrong or missing vectors fails loudly.
+func muveraPrefillGroundTruth(t *testing.T, idx *hnsw) map[uint64][]float32 {
+	t.Helper()
+	expected := make(map[uint64][]float32, len(multiVectors))
+	for i := range multiVectors {
+		v, err := idx.muveraEncoder.GetMuveraVectorForID(uint64(i), idx.id+"_muvera_vectors")
+		require.NoError(t, err)
+		expected[uint64(i)] = v
+	}
+	return expected
+}
+
+func requireMuveraCacheMatches(t *testing.T, idx *hnsw, expected map[uint64][]float32) {
+	t.Helper()
+	require.Equal(t, int64(len(expected)), idx.cache.CountVectors())
+	for id, want := range expected {
+		got, err := idx.cache.Get(context.Background(), id)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}
+
+// TestMuveraParallelPrefillPopulatesCacheRealIndex: cold-restart shape against a real
+// muvera index — the parallel scan of the _muvera_vectors bucket must fully repopulate
+// the float32 cache with the encoded vectors.
+func TestMuveraParallelPrefillPopulatesCacheRealIndex(t *testing.T) {
+	ctx := context.Background()
+	store := storeWithObjectsBucket(t)
+
+	idx := newPrefillRoutingIndex(t, "muvera-prefill-parallel", muveraUserConfig(), store)
+
+	for i, vec := range multiVectors {
+		require.NoError(t, idx.AddMulti(ctx, uint64(i), vec))
+	}
+
+	require.True(t, idx.useMuveraParallelPrefill())
+	expected := muveraPrefillGroundTruth(t, idx)
+
+	idx.cache.Drop()
+	require.Equal(t, int64(0), idx.cache.CountVectors())
+
+	require.NoError(t, idx.prefillMuveraCacheParallel(ctx))
+	requireMuveraCacheMatches(t, idx, expected)
+}
+
+// TestMuveraSerialPrefillPopulatesCacheRealIndex guards the serial by-id fallback
+// muvera still uses when the parallel gate fails (e.g. bounded cache): it must load
+// from the dedicated _muvera_vectors bucket, not the objects bucket.
 func TestMuveraSerialPrefillPopulatesCacheRealIndex(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
@@ -118,26 +164,13 @@ func TestMuveraSerialPrefillPopulatesCacheRealIndex(t *testing.T) {
 	}
 
 	require.False(t, idx.useParallelPrefill(),
-		"muvera must route to the serial prefiller, not the objects-bucket scan")
+		"muvera must never take the objects-bucket scan")
 
-	expected := make(map[uint64][]float32, len(multiVectors))
-	for i := range multiVectors {
-		v, err := idx.muveraEncoder.GetMuveraVectorForID(uint64(i), idx.id+"_muvera_vectors")
-		require.NoError(t, err)
-		expected[uint64(i)] = v
-	}
+	expected := muveraPrefillGroundTruth(t, idx)
 
-	// Cold-restart shape: drop the cache, then run the serial prefiller muvera is
-	// routed to and confirm full, correct repopulation.
 	idx.cache.Drop()
 	require.Equal(t, int64(0), idx.cache.CountVectors())
 
 	require.NoError(t, newVectorCachePrefiller(idx.cache, idx, logger).Prefill(ctx, int(idx.cache.CopyMaxSize())))
-
-	require.Equal(t, int64(len(multiVectors)), idx.cache.CountVectors())
-	for id, want := range expected {
-		got, err := idx.cache.Get(ctx, id)
-		require.NoError(t, err)
-		require.Equal(t, want, got)
-	}
+	requireMuveraCacheMatches(t, idx, expected)
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/multivector"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -43,7 +45,8 @@ func newTestObjectsStore(t *testing.T) *lsmkv.Store {
 	t.Cleanup(func() { store.Shutdown(context.Background()) })
 
 	require.NoError(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
-		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+		lsmkv.WithStrategy(lsmkv.StrategyReplace),
+		lsmkv.WithCalcCountNetAdditions(true))) // like the real objects bucket
 	return store
 }
 
@@ -77,18 +80,27 @@ func keyForDocID(docID uint64) []byte {
 	return key
 }
 
+// scanObjectVectorsParallel is the objects-bucket specialization of the generic scan,
+// kept as a helper so the scan tests read at the domain level.
+func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
+	onVector prefillOnVector, logger logrus.FieldLogger,
+) error {
+	return scanBucketVectorsParallel(ctx, bucket, objectsRowDecoder(targetVector, logger), onVector, logger)
+}
+
 func collectScan(t *testing.T, bucket *lsmkv.Bucket, target string) map[uint64][]float32 {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	var mu sync.Mutex
 	got := map[uint64][]float32{}
 	err := scanObjectVectorsParallel(context.Background(), bucket, target,
-		func(id uint64, vec []float32) {
+		func(id uint64, vec []float32) error {
 			mu.Lock()
 			defer mu.Unlock()
 			_, exists := got[id]
 			require.Falsef(t, exists, "doc id %d emitted more than once", id)
 			got[id] = vec
+			return nil
 		}, logger)
 	require.NoError(t, err)
 	return got
@@ -169,18 +181,17 @@ func TestScanObjectVectorsParallel(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		logger, _ := test.NewNullLogger()
-		err := scanObjectVectorsParallel(ctx, bucket, "", func(uint64, []float32) {}, logger)
+		err := scanObjectVectorsParallel(ctx, bucket, "", func(uint64, []float32) error { return nil }, logger)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }
 
 func TestParallelPrefillEligible(t *testing.T) {
 	base := parallelPrefillInputs{
-		waitForPrefill: true,
-		multivector:    false,
-		muvera:         false,
-		cacheMaxSize:   1e12,
-		nodeCount:      1000,
+		multivector:  false,
+		muvera:       false,
+		cacheMaxSize: 1e12,
+		nodeCount:    1000,
 	}
 
 	tests := []struct {
@@ -188,14 +199,12 @@ func TestParallelPrefillEligible(t *testing.T) {
 		mod  func(*parallelPrefillInputs)
 		want bool
 	}{
-		{"sync + unbounded + single-vector", func(*parallelPrefillInputs) {}, true},
-		{"async prefill keeps serial path", func(in *parallelPrefillInputs) { in.waitForPrefill = false }, false},
+		{"unbounded single-vector is eligible", func(*parallelPrefillInputs) {}, true},
 		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
 		// muvera's float32 cache is sourced from the _muvera_vectors bucket, not the
-		// objects bucket the parallel scan reads, so it must stay on the serial path —
-		// regardless of whether the multivector flag happens to be set alongside it.
-		{"muvera keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, false},
-		{"muvera without multivector flag keeps serial path", func(in *parallelPrefillInputs) { in.multivector = false; in.muvera = true }, false},
+		// objects bucket this scan reads — it takes the muvera scan instead.
+		{"muvera does not take the objects scan", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, false},
+		{"muvera without multivector flag does not take the objects scan", func(in *parallelPrefillInputs) { in.multivector = false; in.muvera = true }, false},
 		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},
 		{"cache exactly fits nodes is eligible", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, true},
 		{"empty index (0 nodes) is eligible", func(in *parallelPrefillInputs) { in.nodeCount = 0 }, true},
@@ -209,10 +218,43 @@ func TestParallelPrefillEligible(t *testing.T) {
 	}
 }
 
+func TestMuveraParallelPrefillEligible(t *testing.T) {
+	base := parallelPrefillInputs{
+		multivector:  true,
+		muvera:       true,
+		cacheMaxSize: 1e12,
+		nodeCount:    1000,
+	}
+
+	tests := []struct {
+		name string
+		mod  func(*parallelPrefillInputs)
+		want bool
+	}{
+		{"unbounded muvera is eligible", func(*parallelPrefillInputs) {}, true},
+		{"non-muvera is not", func(in *parallelPrefillInputs) { in.muvera = false }, false},
+		{"single-vector is not", func(in *parallelPrefillInputs) { in.multivector = false; in.muvera = false }, false},
+		{"bounded cache keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},
+		{"cache exactly fits nodes is eligible", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base
+			tt.mod(&in)
+			assert.Equal(t, tt.want, muveraParallelPrefillEligible(in))
+		})
+	}
+}
+
+// errOnCacheMiss is the VectorForID for prefill tests: every post-prefill Get must
+// be a cache hit, so any miss fails the test.
+func errOnCacheMiss(_ context.Context, id uint64) ([]float32, error) {
+	return nil, fmt.Errorf("unexpected cache miss for id %d", id)
+}
+
 // prefillParallelIntoCache fills an objects bucket with vecs (a legacy vector per id),
 // then runs prefillCacheParallel against a real cache wired so any miss errors. h.nodes
-// is sized to preGrown (and the cache grown to match when preGrown>0); preGrown==0
-// forces the defensive in-scan Grow path. Returns the populated cache.
+// and the cache are sized to preGrown. Returns the populated cache.
 func prefillParallelIntoCache(t *testing.T, vecs map[uint64][]float32, preGrown int,
 	dp distancer.Provider, normalizeOnRead bool,
 ) cache.Cache[float32] {
@@ -266,16 +308,20 @@ func TestPrefillCacheParallelEndToEnd(t *testing.T) {
 	requireCacheContains(t, c, exp)
 }
 
-// TestPrefillCacheParallelGrowsBeyondPreGrown exercises the defensive Grow path: with
-// preGrown == 0 every id triggers cache.Grow from concurrent scanners, swapping the
-// cache slice under load. Run with -race to catch a missing lock on the grow.
-func TestPrefillCacheParallelGrowsBeyondPreGrown(t *testing.T) {
-	const n = 2000
-	exp := make(map[uint64][]float32, n)
+// TestPrefillCacheParallelSkipsBeyondNodeRange: ids at or beyond the restored node
+// range are not preloaded — live inserts self-preload, and a corrupt key must not
+// size the cache.
+func TestPrefillCacheParallelSkipsBeyondNodeRange(t *testing.T) {
+	const n = 100
+	vecs := make(map[uint64][]float32, n)
 	for i := uint64(0); i < n; i++ {
-		exp[i] = []float32{float32(i), float32(i) + 1}
+		vecs[i] = []float32{float32(i), float32(i) + 1}
 	}
-	c := prefillParallelIntoCache(t, exp, 0, distancer.NewDotProductProvider(), false)
+	exp := map[uint64][]float32{}
+	for i := uint64(0); i < 40; i++ {
+		exp[i] = vecs[i]
+	}
+	c := prefillParallelIntoCache(t, vecs, 40, distancer.NewDotProductProvider(), false)
 	requireCacheContains(t, c, exp)
 }
 
@@ -390,4 +436,204 @@ func TestPrefillCacheParallelNormalizesForCosine(t *testing.T) {
 		require.Equalf(t, distancer.Normalize(raw[i]), got,
 			"cosine-dot cache must hold normalized vectors for doc %d", i)
 	}
+}
+
+// TestPrefillCacheParallelDoesNotOverwriteNewerVectors is the PreloadIfAbsent
+// invariant end-to-end: ids already in the cache (e.g. written by an insert racing an
+// async prefill) keep their value, and count is not double-incremented for them.
+func TestPrefillCacheParallelDoesNotOverwriteNewerVectors(t *testing.T) {
+	const n = 100
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i), float32(i)}
+		putTestObject(t, bucket, i, vec, nil)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(n)
+
+	inserted := map[uint64][]float32{3: {42, 42}, 7: {43, 43}}
+	for id, vec := range inserted {
+		c.Preload(id, vec)
+		exp[id] = vec
+	}
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+	}
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+
+	requireCacheContains(t, c, exp)
+}
+
+type failingAllocChecker struct{}
+
+func (failingAllocChecker) CheckAlloc(int64) error {
+	return fmt.Errorf("out of memory")
+}
+func (failingAllocChecker) CheckMappingAndReserve(int64, int) error { return nil }
+func (failingAllocChecker) Refresh(bool)                            {}
+
+// TestPrefillCacheParallelAbortsUnderMemoryPressure: with a failing allocChecker the
+// scan stops at the first probe and prefill degrades gracefully (nil error, partial
+// cache); the memtable-only bucket forces a single scan range, making the abort point
+// deterministic.
+func TestPrefillCacheParallelAbortsUnderMemoryPressure(t *testing.T) {
+	const n = prefillAllocCheckEvery + 500
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	for i := uint64(0); i < n; i++ {
+		putTestObject(t, bucket, i, []float32{float32(i)}, nil)
+	}
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(n)
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+		allocChecker:      failingAllocChecker{},
+	}
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(prefillAllocCheckEvery), c.CountVectors())
+}
+
+// TestPrefillCacheParallelStopsWhenCompressionActivates: once h.compressed flips, the
+// uncompressed cache is no longer the live cache and the scan must stop loading into it.
+func TestPrefillCacheParallelStopsWhenCompressionActivates(t *testing.T) {
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	for i := uint64(0); i < 50; i++ {
+		putTestObject(t, bucket, i, []float32{float32(i)}, nil)
+	}
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(50)
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, 50),
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+	}
+	h.compressed.Store(true)
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(0), c.CountVectors())
+}
+
+func putMuveraVector(t *testing.T, bucket *lsmkv.Bucket, id uint64, vec []float32) {
+	t.Helper()
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, id)
+	require.NoError(t, bucket.Put(key, multivector.MuveraBytesFromFloat32(vec)))
+}
+
+// TestPrefillMuveraCacheParallelEndToEnd scans a real muvera vectors bucket (key =
+// big-endian docID = node id, value = raw float32s) into the cache, across flushed
+// segments and with a deleted entry that must not resurface.
+func TestPrefillMuveraCacheParallelEndToEnd(t *testing.T) {
+	const n = 300
+	store := newTestObjectsStore(t)
+	bucketName := "m_muvera_vectors"
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(), bucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+	bucket := store.Bucket(bucketName)
+
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i) + 0.5, float32(i) - 0.5, float32(i)}
+		putMuveraVector(t, bucket, i, vec)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, 42)
+	require.NoError(t, bucket.Delete(key))
+	require.NoError(t, bucket.FlushAndSwitch())
+	delete(exp, 42)
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(n)
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "m",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+	}
+	require.NoError(t, h.prefillMuveraCacheParallel(context.Background()))
+	requireCacheContains(t, c, exp)
+}
+
+// TestPrefillCacheParallelStopsWhenCacheFull: the scan must stop once count reaches
+// maxSize instead of feeding replaceIfFull's full-cache wipe; memtable-only data
+// forces a single scan range so the stop point is deterministic.
+func TestPrefillCacheParallelStopsWhenCacheFull(t *testing.T) {
+	const n = 50
+	const maxSize = 10
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+	for i := uint64(0); i < n; i++ {
+		putTestObject(t, bucket, i, []float32{float32(i)}, nil)
+	}
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(nil, nil, maxSize, 1, logger, false, 0, nil)
+	c.Grow(n)
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+	}
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	require.Equal(t, int64(maxSize), c.CountVectors())
+}
+
+// TestUseParallelPrefillExcludesHFresh: the hfresh centroid index shares the shard's
+// store (objects bucket present) but its cache holds centroid vectors, so the
+// objects scan must never run for it.
+func TestUseParallelPrefillExcludesHFresh(t *testing.T) {
+	store := newTestObjectsStore(t)
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		id:                "main_centroids",
+		logger:            logger,
+		hfreshMode:        true,
+		distancerProvider: distancer.NewDotProductProvider(),
+	}
+	require.False(t, h.useParallelPrefill())
+
+	h.hfreshMode = false
+	require.True(t, h.useParallelPrefill())
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted.go
@@ -1,0 +1,184 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+const (
+	// prefillPeekBytes covers the fixed header, a small legacy vector, the class
+	// name, and the schema length prefix; objects whose front sections exceed it
+	// fall back to whole-value reads.
+	prefillPeekBytes = 512
+	// prefillTargetedMinSchemaLen gates the two-read path: below it, skipping the
+	// properties schema saves too little to justify a second read.
+	prefillTargetedMinSchemaLen = 8 << 10
+	// prefillTargetedMinAvgEntrySize keeps small-object buckets on the cursor
+	// scan, where the targeted path would only add index-walk overhead.
+	prefillTargetedMinAvgEntrySize = 4 << 10
+)
+
+func prefillTargetedReadsEnabled() bool {
+	return entcfg.Enabled(os.Getenv("HNSW_PREFILL_TARGETED_READS"))
+}
+
+func (h *hnsw) useTargetedPrefillScan(bucket *lsmkv.Bucket) bool {
+	return prefillTargetedReadsEnabled() &&
+		bucket.EstimatedEntrySize() >= prefillTargetedMinAvgEntrySize
+}
+
+// scanObjectVectorsTargeted reads a bounded peek per row plus, for large
+// schemas, only the vector-bearing tail. The scan hides superseded and deleted
+// rows itself; the liveness filter covers HNSW-side exclusions only.
+func (h *hnsw) scanObjectVectorsTargeted(ctx context.Context, bucket *lsmkv.Bucket,
+	targetVector string, onVector prefillOnVector,
+) error {
+	return bucket.ScanTargetedReplace(ctx, prefillPeekBytes, prefillScanParallelism(),
+		h.targetedRowCallback(targetVector, onVector), h.logger)
+}
+
+func (h *hnsw) targetedRowCallback(targetVector string, onVector prefillOnVector) func(*lsmkv.TargetedScanEntry) error {
+	h.RLock()
+	nodesLen := uint64(len(h.nodes))
+	h.RUnlock()
+
+	// tombstoned nodes stay in h.nodes until cleanup while their bucket rows may
+	// still be live — they must not be prefilled
+	h.tombstoneLock.RLock()
+	tombstoned := make(map[uint64]struct{}, len(h.tombstones))
+	for id := range h.tombstones {
+		tombstoned[id] = struct{}{}
+	}
+	h.tombstoneLock.RUnlock()
+
+	return func(e *lsmkv.TargetedScanEntry) error {
+		id, err := storobj.DocIDFromBinary(e.Peek)
+		if err != nil {
+			h.prefillSkipDebug("undecodable doc id", err)
+			return nil
+		}
+		if !h.nodeAlive(id, nodesLen) {
+			return nil
+		}
+		if _, dead := tombstoned[id]; dead {
+			return nil
+		}
+		vec, ok := h.targetedVectorFromEntry(e, targetVector)
+		if !ok || len(vec) == 0 {
+			return nil
+		}
+		return onVector(id, vec)
+	}
+}
+
+// nodeAlive: doc ids are never reused, so a superseded or deleted row's id has
+// no live node; ids beyond the snapshot come from inserts that self-preload.
+func (h *hnsw) nodeAlive(id uint64, nodesLen uint64) bool {
+	if id >= nodesLen {
+		return false
+	}
+	h.shardedNodeLocks.RLock(id)
+	defer h.shardedNodeLocks.RUnlock(id)
+	// h.nodes can shrink under LockAll (index reset); re-check under the shard lock
+	nodes := h.nodes
+	if id >= uint64(len(nodes)) {
+		return false
+	}
+	return nodes[id] != nil
+}
+
+func (h *hnsw) prefillSkipDebug(reason string, err error) {
+	h.logger.WithField("action", "hnsw_vector_cache_prefill").
+		Debugf("skipping object with %s: %v", reason, err)
+}
+
+func (h *hnsw) targetedVectorFromEntry(e *lsmkv.TargetedScanEntry, targetVector string) ([]float32, bool) {
+	if targetVector == "" {
+		return h.legacyVectorFromEntry(e)
+	}
+
+	tailStart, schemaLen, ok, err := storobj.VectorTailOffsetFromPeek(e.Peek)
+	if err != nil {
+		h.prefillSkipDebug("undecodable header", err)
+		return nil, false
+	}
+	if !ok || schemaLen < prefillTargetedMinSchemaLen || tailStart >= e.ValueSize {
+		return h.wholeVectorFromEntry(e, targetVector)
+	}
+
+	tail, err := e.ReadRange(tailStart, 0)
+	if err != nil {
+		h.prefillSkipDebug("unreadable vector tail", err)
+		return nil, false
+	}
+	vec, err := storobj.VectorFromTail(tail, targetVector)
+	if err != nil {
+		var notFound storobj.ErrTargetVectorNotFound
+		if !errors.As(err, &notFound) {
+			h.prefillSkipDebug("undecodable vector tail", err)
+		}
+		return nil, false
+	}
+	return vec, true
+}
+
+// legacyVectorFromEntry: the legacy vector sits at a fixed front offset — served
+// from the peek, or via a bounded prefix read, never the whole value.
+func (h *hnsw) legacyVectorFromEntry(e *lsmkv.TargetedScanEntry) ([]float32, bool) {
+	need, ok, err := storobj.LegacyVectorPrefixLen(e.Peek)
+	if err != nil {
+		h.prefillSkipDebug("undecodable header", err)
+		return nil, false
+	}
+	if !ok || need > e.ValueSize {
+		return h.wholeVectorFromEntry(e, "")
+	}
+
+	buf := e.Peek
+	if uint64(len(buf)) < need {
+		buf, err = e.ReadRange(0, need)
+		if err != nil {
+			h.prefillSkipDebug("unreadable vector prefix", err)
+			return nil, false
+		}
+	}
+	return h.decodeVectorRow(buf, "")
+}
+
+func (h *hnsw) wholeVectorFromEntry(e *lsmkv.TargetedScanEntry, targetVector string) ([]float32, bool) {
+	whole, err := e.ReadRange(0, 0)
+	if err != nil {
+		h.prefillSkipDebug("unreadable value", err)
+		return nil, false
+	}
+	return h.decodeVectorRow(whole, targetVector)
+}
+
+func (h *hnsw) decodeVectorRow(value []byte, targetVector string) ([]float32, bool) {
+	// nil buffer forces a fresh allocation, so the vector never aliases scan buffers
+	vec, err := storobj.VectorFromBinary(value, nil, targetVector)
+	if err != nil {
+		var notFound storobj.ErrTargetVectorNotFound
+		if !errors.As(err, &notFound) {
+			h.prefillSkipDebug("undecodable vector", err)
+		}
+		return nil, false
+	}
+	return vec, true
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted_test.go
@@ -1,0 +1,230 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// putTargetedObject writes an object whose bucket key (keyID) is independent of its
+// docID, so tests can model updates: the same key rewritten with a new docID, the
+// old docID's row surviving in an older segment.
+func putTargetedObject(t *testing.T, bucket *lsmkv.Bucket, keyID, docID uint64,
+	payloadBytes int, legacyVec []float32, named map[string][]float32,
+) {
+	t.Helper()
+	obj := storobj.New(docID)
+	obj.Object = models.Object{
+		ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", keyID)),
+		Class:      "Test",
+		Properties: map[string]interface{}{"filler": strings.Repeat("x", payloadBytes)},
+	}
+	obj.Vector = legacyVec
+	obj.Vectors = named
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+	require.NoError(t, bucket.Put(keyForDocID(keyID), data))
+}
+
+func newTargetedTestIndex(store *lsmkv.Store, c cache.Cache[float32], id string,
+	liveNodes map[uint64]bool, nodesLen int,
+) *hnsw {
+	logger, _ := test.NewNullLogger()
+	nodes := make([]*vertex, nodesLen)
+	for id := range liveNodes {
+		nodes[id] = &vertex{level: 0}
+	}
+	return &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             nodes,
+		id:                id,
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+		shardedNodeLocks:  common.NewDefaultShardedRWLocks(),
+		tombstoneLock:     &sync.RWMutex{},
+		tombstones:        map[uint64]struct{}{},
+	}
+}
+
+// prefillTargeted runs the targeted scan directly, bypassing the avg-entry-size
+// routing gate so both the tail path and the small-schema fallback get exercised.
+func prefillTargeted(t *testing.T, h *hnsw, target string) error {
+	t.Helper()
+	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
+	return h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+		return h.scanObjectVectorsTargeted(ctx, bucket, target, onVector)
+	})
+}
+
+// TestPrefillTargetedMatchesCursorScan is the contract test: on identical data —
+// updates and deletes included — the targeted prefill must produce exactly the
+// cache the existing cursor-scan prefill produces, for named and legacy targets
+// and for schemas below and above the tail-read threshold.
+func TestPrefillTargetedMatchesCursorScan(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload int
+		target  string
+	}{
+		{"named target, small schema (whole-read fallback)", 1024, "custom"},
+		{"named target, large schema (tail reads)", 16 << 10, "custom"},
+		{"legacy target, large schema", 16 << 10, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newTestObjectsStore(t)
+			bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+			live := map[uint64]bool{}
+			put := func(keyID, docID uint64, dims int) {
+				vec := make([]float32, dims)
+				for j := range vec {
+					vec[j] = float32(docID) + float32(j)*0.25
+				}
+				var legacyVec []float32
+				named := map[string][]float32{}
+				if tc.target == "" {
+					legacyVec = vec
+				} else {
+					named[tc.target] = vec
+					named["sibling"] = []float32{9, 9}
+				}
+				putTargetedObject(t, bucket, keyID, docID, tc.payload, legacyVec, named)
+			}
+
+			// segment 1: docs 0..29 (doc 15 with a vector larger than the peek)
+			for i := uint64(0); i < 30; i++ {
+				dims := 3
+				if i == 15 {
+					dims = 300
+				}
+				put(i, i, dims)
+				live[i] = true
+			}
+			require.NoError(t, bucket.FlushAndSwitch())
+			// segment 2: key 5 updated under docID 100, key 7 deleted
+			put(5, 100, 4)
+			live[100] = true
+			delete(live, 5)
+			require.NoError(t, bucket.Delete(keyForDocID(7)))
+			delete(live, 7)
+			require.NoError(t, bucket.FlushAndSwitch())
+			// memtable: docs 30..34
+			for i := uint64(30); i < 35; i++ {
+				put(i, i, 3)
+				live[i] = true
+			}
+
+			id := "vectors_" + tc.target
+			if tc.target == "" {
+				id = "main"
+			}
+			logger, _ := test.NewNullLogger()
+			collect := func(prefill func(h *hnsw) error) map[uint64][]float32 {
+				c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000, 1, logger, false, 0, nil)
+				c.Grow(101)
+				h := newTargetedTestIndex(store, c, id, live, 101)
+				require.NoError(t, prefill(h))
+				out := map[uint64][]float32{}
+				for docID := range live {
+					v, err := c.Get(context.Background(), docID)
+					require.NoError(t, err)
+					out[docID] = v
+				}
+				require.Equal(t, int64(len(live)), c.CountVectors())
+				return out
+			}
+
+			viaCursor := collect(func(h *hnsw) error {
+				return h.prefillCacheParallel(context.Background())
+			})
+			viaTargeted := collect(func(h *hnsw) error {
+				return prefillTargeted(t, h, tc.target)
+			})
+			require.Equal(t, viaCursor, viaTargeted)
+		})
+	}
+}
+
+// TestPrefillTargetedHNSWExclusions covers the deliberate divergences from the
+// cursor scan: rows whose doc is not indexed, or whose node is HNSW-tombstoned
+// while the bucket row is still live, must not be prefilled.
+func TestPrefillTargetedHNSWExclusions(t *testing.T) {
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	exp := map[uint64][]float32{}
+	live := map[uint64]bool{}
+	for i := uint64(0); i < 10; i++ {
+		vec := []float32{float32(i), float32(i) + 0.5}
+		putTargetedObject(t, bucket, i, i, 16<<10, nil, map[string][]float32{"custom": vec})
+		exp[i] = vec
+		live[i] = true
+	}
+	// doc 20: in the bucket, never indexed; doc 5: indexed but HNSW-tombstoned
+	putTargetedObject(t, bucket, 20, 20, 16<<10, nil, map[string][]float32{"custom": {5, 5}})
+	require.NoError(t, bucket.FlushAndSwitch())
+	delete(exp, 5)
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(21)
+	h := newTargetedTestIndex(store, c, "vectors_custom", live, 21)
+	h.tombstones[5] = struct{}{}
+	require.NoError(t, prefillTargeted(t, h, "custom"))
+
+	requireCacheContains(t, c, exp)
+}
+
+// TestUseTargetedPrefillScanGate: the env flag alone is not enough — small-entry
+// buckets stay on the cursor scan, where targeted reads would only add index-walk
+// overhead.
+func TestUseTargetedPrefillScanGate(t *testing.T) {
+	build := func(n uint64, payload int) *lsmkv.Bucket {
+		store := newTestObjectsStore(t)
+		bucket := store.Bucket(helpers.ObjectsBucketLSM)
+		for i := uint64(0); i < n; i++ {
+			putTargetedObject(t, bucket, i, i, payload, nil, map[string][]float32{"custom": {1, 2}})
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+		return bucket
+	}
+	// enough entries that per-segment fixed overhead does not dominate the average
+	small := build(200, 100)
+	large := build(20, 16<<10)
+
+	h := newTargetedTestIndex(nil, nil, "vectors_custom", nil, 0)
+
+	t.Setenv("HNSW_PREFILL_TARGETED_READS", "true")
+	require.False(t, h.useTargetedPrefillScan(small))
+	require.True(t, h.useTargetedPrefillScan(large))
+
+	t.Setenv("HNSW_PREFILL_TARGETED_READS", "false")
+	require.False(t, h.useTargetedPrefillScan(large))
+}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -109,6 +109,10 @@ func (f *fakeCache) Preload(id uint64, vec []float32) {
 	panic("not implemented")
 }
 
+func (f *fakeCache) PreloadIfAbsent(id uint64, vec []float32) bool {
+	panic("not implemented")
+}
+
 func (f *fakeCache) PreloadNoLock(id uint64, vec []float32) {
 	panic("not implemented")
 }

--- a/entities/storobj/targeted_vector.go
+++ b/entities/storobj/targeted_vector.go
@@ -1,0 +1,109 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+// VectorTailOffsetFromPeek locates the vector-bearing tail (the meta length
+// prefix after the properties schema) from a value prefix. ok=false: the prefix
+// is too short to tell; fall back to the whole value.
+func VectorTailOffsetFromPeek(peek []byte) (tailStart uint64, schemaLen uint32, ok bool, err error) {
+	pos, ok, err := legacyVectorEnd(peek)
+	if err != nil || !ok {
+		return 0, 0, ok, err
+	}
+	if pos+2 > len(peek) {
+		return 0, 0, false, nil
+	}
+
+	classNameLen := binary.LittleEndian.Uint16(peek[pos : pos+2])
+	pos += 2 + int(classNameLen)
+	if pos+4 > len(peek) {
+		return 0, 0, false, nil
+	}
+
+	schemaLen = binary.LittleEndian.Uint32(peek[pos : pos+4])
+	return uint64(pos) + 4 + uint64(schemaLen), schemaLen, true, nil
+}
+
+// legacyVectorEnd is the value offset just past the legacy-vector section;
+// ok=false when peek cannot reach the length field.
+func legacyVectorEnd(peek []byte) (pos int, ok bool, err error) {
+	if len(peek) == 0 {
+		return 0, false, fmt.Errorf("empty value")
+	}
+	if version := peek[0]; version != 1 {
+		return 0, false, fmt.Errorf("unsupported marshaller version %d", version)
+	}
+	if len(peek) < marshallerV1HeaderLen+2 {
+		return 0, false, nil
+	}
+	vecLen := binary.LittleEndian.Uint16(peek[marshallerV1HeaderLen : marshallerV1HeaderLen+2])
+	return marshallerV1HeaderLen + 2 + int(vecLen)*4, true, nil
+}
+
+// LegacyVectorPrefixLen: how many leading value bytes hold the legacy vector; a
+// reader with that prefix can decode it via VectorFromBinary.
+func LegacyVectorPrefixLen(peek []byte) (need uint64, ok bool, err error) {
+	pos, ok, err := legacyVectorEnd(peek)
+	return uint64(pos), ok, err
+}
+
+// VectorFromTail extracts one named target vector from value[tailStart:] bytes
+// (tailStart from VectorTailOffsetFromPeek). (nil, nil) when the object predates
+// target vectors; ErrTargetVectorNotFound when it lacks the requested one.
+func VectorFromTail(tail []byte, targetVector string) ([]float32, error) {
+	if targetVector == "" {
+		return nil, fmt.Errorf("vector from tail requires a named target vector")
+	}
+
+	rw := byteops.NewReadWriter(tail)
+
+	// skip meta and vectorWeights
+	for i := 0; i < 2; i++ {
+		if rw.Position+4 > uint64(len(tail)) {
+			return nil, fmt.Errorf("truncated vector tail at section %d", i)
+		}
+		sectionLen := uint64(rw.ReadUint32())
+		if rw.Position+sectionLen > uint64(len(tail)) {
+			return nil, fmt.Errorf("truncated vector tail at section %d", i)
+		}
+		rw.MoveBufferPositionForward(sectionLen)
+	}
+
+	// validate both target-vector prefixes and the segment bound: the shared
+	// decoder assumes a well-formed buffer and would panic on a mislocated tail
+	pos := rw.Position
+	if pos >= uint64(len(tail)) {
+		return unmarshalSingleTargetVector(&rw, targetVector, nil) // pre-target-vector object
+	}
+	if pos+4 > uint64(len(tail)) {
+		return nil, fmt.Errorf("truncated target-vector offsets length")
+	}
+	offsetsLen := uint64(rw.ReadUint32())
+	if rw.Position+offsetsLen+4 > uint64(len(tail)) {
+		return nil, fmt.Errorf("truncated target-vector offsets")
+	}
+	rw.MoveBufferPositionForward(offsetsLen)
+	segLen := uint64(rw.ReadUint32())
+	if rw.Position+segLen > uint64(len(tail)) {
+		return nil, fmt.Errorf("truncated target-vector segment")
+	}
+	rw.MoveBufferToAbsolutePosition(pos)
+
+	return unmarshalSingleTargetVector(&rw, targetVector, nil)
+}

--- a/entities/storobj/targeted_vector_test.go
+++ b/entities/storobj/targeted_vector_test.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func marshalledTestObject(t *testing.T, className string, legacyVec []float32,
+	named map[string][]float32, payloadBytes int,
+) []byte {
+	t.Helper()
+	obj := New(42)
+	obj.Object = models.Object{
+		ID:         strfmt.UUID("00000000-0000-4000-8000-00000000002a"),
+		Class:      className,
+		Properties: map[string]interface{}{"filler": strings.Repeat("x", payloadBytes)},
+	}
+	obj.Vector = legacyVec
+	obj.Vectors = named
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+	return data
+}
+
+// TestVectorTailOffsetAgainstFullDecode: for every layout variant, the tail computed
+// from a bounded prefix plus VectorFromTail must yield exactly what the full-value
+// VectorFromBinary yields.
+func TestVectorTailOffsetAgainstFullDecode(t *testing.T) {
+	named := map[string][]float32{
+		"custom":  {1.5, -2.5, 3.25},
+		"sibling": {9, 8, 7, 6},
+	}
+
+	cases := []struct {
+		name      string
+		className string
+		legacyVec []float32
+		payload   int
+		peekSize  int
+		wantOK    bool
+	}{
+		{"named only, short class, 512B peek", "Test", nil, 10_000, 512, true},
+		{"long class name still within peek", strings.Repeat("C", 100), nil, 10_000, 512, true},
+		{"legacy vector pushes schemaLen past small peek", "Test", make([]float32, 200), 10_000, 512, false},
+		{"legacy vector within large peek", "Test", make([]float32, 100), 10_000, 512, true},
+		{"tiny peek cannot reach schemaLen", "Test", nil, 10_000, 44, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := marshalledTestObject(t, tc.className, tc.legacyVec, named, tc.payload)
+			peek := data[:min(tc.peekSize, len(data))]
+
+			tailStart, schemaLen, ok, err := VectorTailOffsetFromPeek(peek)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantOK, ok)
+			if !ok {
+				return
+			}
+			require.Greater(t, int(schemaLen), tc.payload, "schema JSON includes the payload")
+			require.Less(t, tailStart, uint64(len(data)))
+
+			for name, want := range named {
+				got, err := VectorFromTail(data[tailStart:], name)
+				require.NoError(t, err)
+				require.Equal(t, want, got)
+
+				full, err := VectorFromBinary(data, nil, name)
+				require.NoError(t, err)
+				require.Equal(t, full, got)
+			}
+
+			_, err = VectorFromTail(data[tailStart:], "does-not-exist")
+			var notFound ErrTargetVectorNotFound
+			require.ErrorAs(t, err, &notFound)
+		})
+	}
+}
+
+func TestVectorTailOffsetFromPeekErrors(t *testing.T) {
+	_, _, _, err := VectorTailOffsetFromPeek(nil)
+	assert.Error(t, err)
+
+	_, _, _, err = VectorTailOffsetFromPeek([]byte{9, 0, 0})
+	assert.Error(t, err, "unsupported version must error")
+
+	// version byte alone is valid input but cannot resolve the offset
+	_, _, ok, err := VectorTailOffsetFromPeek([]byte{1})
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestVectorFromTailErrors(t *testing.T) {
+	_, err := VectorFromTail([]byte{1, 2, 3}, "custom")
+	assert.Error(t, err, "truncated tail must error, not panic")
+
+	_, err = VectorFromTail(nil, "")
+	assert.Error(t, err, "legacy target is not served from the tail")
+}
+
+// TestVectorFromTailLegacyOnlyObject: objects written before target vectors existed
+// have no trailing sections; the tail decode must mirror VectorFromBinary and report
+// no vector rather than fail.
+func TestVectorFromTailPreTargetVectorObject(t *testing.T) {
+	data := marshalledTestObject(t, "Test", []float32{1, 2}, nil, 100)
+	tailStart, _, ok, err := VectorTailOffsetFromPeek(data[:min(512, len(data))])
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	got, err := VectorFromTail(data[tailStart:], "custom")
+	require.NoError(t, err)
+	require.Nil(t, got)
+}
+
+// TestVectorFromTailCorruptSections: a mislocated or truncated tail must fail as an
+// error, never panic in the shared decoder.
+func TestVectorFromTailCorruptSections(t *testing.T) {
+	data := marshalledTestObject(t, "Test", nil, map[string][]float32{"custom": {1, 2}}, 200)
+	tailStart, _, ok, err := VectorTailOffsetFromPeek(data[:min(512, len(data))])
+	require.NoError(t, err)
+	require.True(t, ok)
+	tail := data[tailStart:]
+
+	for cut := 1; cut < len(tail); cut++ {
+		_, err := VectorFromTail(tail[:cut], "custom")
+		_ = err // any outcome but a panic is acceptable for a truncated tail
+	}
+	// garbage bytes where the section lengths should be
+	_, err = VectorFromTail([]byte{9, 9, 9, 9, 9}, "custom")
+	require.Error(t, err)
+}


### PR DESCRIPTION
Split of #12329 — this is the **hnsw/storobj half**. Rebased from `stable/v1.36` onto `stable/v1.37`.

> **Stacked on #12390** (the lsmkv half) — it needs `Bucket.ScanTargetedReplace` and `Bucket.EstimatedEntrySize` to compile. Review #12390 first; this PR retargets to `stable/v1.37` once it merges. The diff below is this branch only.

## Motivation

#11838 parallelized the uncompressed vector-cache prefill, but only for the sync + unbounded + single-vector case, and the scan still reads every full object to extract ~4·dims bytes of vector. In practice that left the worst-affected deployments on the slowest path: lazy-load setups force `waitForCachePrefill=false`, so they always ran the serial one-random-read-per-vector prefiller from #11837 — and even the parallel scan stayed bandwidth-bound on property JSON (~96% of object bytes on the incident cluster). This PR closes both gaps.

## 1. Coverage: the parallel scan reaches async, muvera, and lazy-load deployments

- `cache.PreloadIfAbsent`: load-if-absent preload. The sync-only gate existed because `Preload` overwrites — a snapshot value could clobber a concurrently inserted newer vector. With if-absent semantics the insert wins in every interleaving, so the gate is dropped and async/lazy-load deployments get the parallel scan.
- Muvera prefills by scanning its compact `_muvera_vectors` bucket (BE docID = node id, raw float32s) — zero read amplification.
- Cache `count` now tracks occupied slots (overwrites and `handleCacheMiss` no longer double-increment): drift could push `count` past `maxSize` and trigger `replaceIfFull`'s full-cache wipe once scans run concurrently with traffic. The scan also stops at `CopyMaxSize` and aborts under allocChecker pressure.
- Prefill registers a cancelable context + WaitGroup; `hnsw.Shutdown`/`Drop` cancel-and-wait, closing a use-after-munmap window (the shard-drop path never cancels the PostStartup ctx, and lsmkv has no guard against cursors opened after its shutdown refcount wait).
- hfresh centroid indexes are excluded from the objects scan (`cfg.HFreshMode`): they share the shard's store, so the gate could previously scan object vectors into the centroid cache — a pre-existing #11838 hole reachable after a lost `PersistCompression` commit-log tail.
- Rows with ids at or beyond the restored node range are skipped instead of growing the cache: live inserts self-preload, and a corrupt or mixed-endian key must not size an allocation.
- The compressed parallel iterator switches to `CursorReplaceReusable`, avoiding the per-node reader allocation chain on the pread path.

Multivector (per-passage) and bounded caches keep the serial path: `PreloadMulti` overwrites, and only the serial prefiller honors the level-priority + size-limit semantics.

## 2. Targeted LSM reads: stop reading whole objects (opt-in via `HNSW_PREFILL_TARGETED_READS`)

- `scanObjectVectorsTargeted` drives lsmkv's `ScanTargetedReplace`: peek the value's front to learn where the properties schema ends, then read only the vector-bearing tail.
- `storobj` helpers locate the vector from the peek: `VectorTailOffsetFromPeek` (handles legacy vectors and long class names), `VectorFromTail`, `LegacyVectorPrefixLen`. Named vectors read only the post-schema tail; legacy vectors read only a bounded front prefix; schemas under 8KB fall back to one whole-value read. `VectorFromTail` validates both target-vector section prefixes and the segment bound, so a mislocated tail fails as an error the scan skips rather than a panic that aborts it.
- Gated per bucket by `EstimatedEntrySize` (≥4KB) so small-object collections stay on the cursor scan. The flag is process-global but collections route individually.
- The bucket hides superseded and deleted rows itself (newest-wins probes, see the lsmkv PR); the remaining hnsw-side filters cover only what it cannot see — unindexed docs, and HNSW-tombstoned nodes whose bucket rows are still live. `nodeAlive` re-checks its bound against `h.nodes` under the shard lock, since an index reset can shrink the slice mid-scan.

## Benchmarks

Hot page cache, Apple M3 Max, 5k live objects × 128d, 16KB properties, two named vectors, 4 segments:

| pread prefill path | clean bucket | 40% churned |
|---|---|---|
| serial by-id (pre-#11838; what async deployments ran) | 29.9 ms | — |
| parallel merged cursor (#11838) | 13.1 ms | 18.6 ms |
| targeted + newest-wins (flag on) | **9.2 ms** | **9.3 ms** |

mmap mode: 1.9 ms → 1.5 ms. Churned scans run at clean-bucket speed because stale rows are hidden before any read. Hot-cache numbers measure syscalls/copies; the design target is cold network storage, where the scan reads ~5KB instead of ~16.5KB per row here (and ~28× less on the RFC-shaped cluster behind #11837) — to be validated on a cold-cache harness before the flag default changes.

## Tests

- hnsw contract: targeted prefill produces exactly the cursor-scan prefill's cache on identical data (named + legacy targets, schemas below/above the tail threshold, vectors larger than the peek, updates/deletes); one test pins the deliberate divergences (unindexed docs, HNSW-tombstoned nodes).
- `PreloadIfAbsent`/count-invariant unit tests; muvera scan end-to-end incl. deletes and normalization parity; async-safety, alloc-pressure, cache-full, and routing-gate tests; storobj tail helpers round-trip against `VectorFromBinary`.
- Benchmarks committed (`BenchmarkPrefillNamedVectors{LargeProps,Churned}`). Full `hnsw`, `cache`, `storobj` suites green with `-race`; golangci-lint and the goroutine linter clean.

## Risk

Behavior changes: async prefill now uses the parallel scan (previously serial — strictly faster, same load-if-absent semantics); everything else is opt-in or a bug fix. Known accepted risks: a delete racing an async scan can transiently re-cache one dead vector (bounded, reclaimed by the deletion cycle), and N named-vector indexes may run N concurrent background scans — a concurrency knob is deferred until a cold-cache harness shows interference.

## Note on the port to 1.37

`stable/v1.37` made the vector cache lazily allocated, so `Preload` grows on demand instead of assuming coverage. `PreloadIfAbsent` mirrors that grow-retry loop, and the occupied-slot count fix moved inside it. The cache is still grown to `len(h.nodes)` at restore (`startup.go`), so the prefill's node-range bound is unchanged.

Refs #11837, #2825. Builds on #11838.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
