### PR TITLE
inverted: batch flat ContainsAny/ContainsAll/ContainsNone under one consistent view

### DIFF
--- a/adapters/repos/db/helpers/slow_queries_details.go
+++ b/adapters/repos/db/helpers/slow_queries_details.go
@@ -60,7 +60,16 @@ func AnnotateSlowQueryLog(ctx context.Context, key string, value any) {
 }
 
 func AnnotateSlowQueryLogAppend[T any](ctx context.Context, key string, value T) {
-	if ctx == nil {
+	AnnotateSlowQueryLogAppendFunc(ctx, key, func() T { return value })
+}
+
+// AnnotateSlowQueryLogAppendFunc is AnnotateSlowQueryLogAppend with the value
+// built lazily: build runs only when the ctx carries slow-query details, so
+// callers on hot paths pay nothing to construct a value that would be
+// discarded. build is called outside the details lock. A nil build is
+// tolerated like every other bad input here: diagnostics never fail loudly.
+func AnnotateSlowQueryLogAppendFunc[T any](ctx context.Context, key string, build func() T) {
+	if ctx == nil || build == nil {
 		return
 	}
 	val := ctx.Value("slow_query_details")
@@ -72,6 +81,8 @@ func AnnotateSlowQueryLogAppend[T any](ctx context.Context, key string, value T)
 	if !ok {
 		return
 	}
+
+	value := build()
 
 	details.Lock()
 	defer details.Unlock()

--- a/adapters/repos/db/helpers/slow_queries_details_test.go
+++ b/adapters/repos/db/helpers/slow_queries_details_test.go
@@ -44,3 +44,45 @@ func TestSlowQueryDetailsJourney(t *testing.T) {
 		assert.Equal(t, value, details[key])
 	}
 }
+
+func TestAnnotateSlowQueryLogAppendFunc(t *testing.T) {
+	t.Run("built values append into one list with eager values", func(t *testing.T) {
+		ctx := InitSlowQueryDetails(context.Background())
+		calls := 0
+		AnnotateSlowQueryLogAppendFunc(ctx, "k", func() string {
+			calls++
+			return "lazy"
+		})
+		AnnotateSlowQueryLogAppend(ctx, "k", "eager")
+		require.Equal(t, 1, calls, "build must run exactly once")
+		require.Equal(t, []string{"lazy", "eager"}, ExtractSlowQueryDetails(ctx)["k"])
+	})
+
+	t.Run("nil build is tolerated even with details present", func(t *testing.T) {
+		ctx := InitSlowQueryDetails(context.Background())
+		AnnotateSlowQueryLogAppendFunc[string](ctx, "k", nil)
+		require.NotContains(t, ExtractSlowQueryDetails(ctx), "k")
+	})
+
+	t.Run("build is skipped when ctx carries no details", func(t *testing.T) {
+		calls := 0
+		build := func() string {
+			calls++
+			return "lazy"
+		}
+		AnnotateSlowQueryLogAppendFunc(context.Background(), "k", build)
+		AnnotateSlowQueryLogAppendFunc(nil, "k", build) //nolint:staticcheck // pins the nil-ctx guard
+		require.Zero(t, calls)
+	})
+
+	t.Run("skip path allocates nothing", func(t *testing.T) {
+		ctx := context.Background()
+		reason := "declined"
+		allocs := testing.AllocsPerRun(100, func() {
+			AnnotateSlowQueryLogAppendFunc(ctx, "k", func() map[string]any {
+				return map[string]any{"reason": reason}
+			})
+		})
+		require.Zero(t, allocs, "guards must bail before build; closure must not escape")
+	})
+}

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -29,21 +29,22 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-// GH-12242 Go-level A/B instrument for ContainsAny/ContainsAll fan-out cost.
+// Go-level A/B instrument for ContainsAny/ContainsAll fan-out cost.
 //
 // Benchmarks Searcher.DocIDs (the full extract + resolve + merge path, no
 // HNSW) on a filterable roaringset text property with strictly-unique values
 // (1 value == 1 docID), the reported pathological shape. The primary metric is
 // allocs/op + B/op via -benchmem: deterministic and thermal-independent, unlike
-// server-level throughput. The optimization target ("cost F") is the O(N)
-// per-value filters.Clause + propValuePair construction at extraction, so the
-// benchmark deliberately includes extraction rather than only resolution.
+// server-level throughput. The optimization target is the O(N) per-value
+// filters.Clause + propValuePair construction at extraction, so the benchmark
+// deliberately includes extraction rather than only resolution.
 //
 // Run:
 //   go test -tags integrationTest -run '^$' -bench 'DocIDs_Contains' \
@@ -92,6 +93,14 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 	for i := 0; i < numDocs; i++ {
 		require.NoError(tb, bucket.RoaringSetAddList([]byte(benchValue(i)), []uint64{uint64(i)}))
 	}
+	// A few multi-doc values on top of the unique corpus: each shared value
+	// is held by the same two docs, so ContainsAll over them is non-empty;
+	// the padded value is stored trimmed, as the FIELD write path would
+	// store it, so unnormalized query values must trim to match.
+	for _, v := range containsSharedValues {
+		require.NoError(tb, bucket.RoaringSetAddList([]byte(v), containsSharedDocIDs))
+	}
+	require.NoError(tb, bucket.RoaringSetAddList([]byte(containsPaddedValue), []uint64{containsPaddedDocID}))
 	require.NoError(tb, bucket.FlushAndSwitch())
 
 	maxDocID := uint64(numDocs + 1)
@@ -105,6 +114,16 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 }
 
 func benchValue(i int) string { return fmt.Sprintf("val_%08d", i) }
+
+var (
+	containsSharedValues = []string{"shared_a", "shared_b", "shared_c"}
+	containsSharedDocIDs = []uint64{11, 17}
+)
+
+const (
+	containsPaddedValue = "padded-value"
+	containsPaddedDocID = uint64(23)
+)
 
 // sampleValues picks `size` values spread evenly across the corpus (strided),
 // so the selection touches the whole keyspace. Deterministic and identical
@@ -177,6 +196,98 @@ func BenchmarkDocIDs_ContainsAll(b *testing.B) {
 	}
 }
 
+// resolveDocIDs runs DocIDs with filter and returns the sorted doc-ID slice.
+func (f *containsFixture) resolveDocIDs(t *testing.T, ctx context.Context, filter *filters.LocalFilter) []uint64 {
+	t.Helper()
+	al, err := f.searcher.DocIDs(ctx, filter, additional.Properties{}, className)
+	require.NoError(t, err)
+	defer al.Close()
+	got := al.Slice()
+	sorted := append([]uint64(nil), got...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	return sorted
+}
+
+// equalCompoundFilter builds the compound the desugared path would produce
+// for the same values: OperatorEqual leaves under Or (ContainsAny) / And
+// (ContainsAll). The batch gate only intercepts Contains clauses, so
+// resolving this compound always exercises the per-value path.
+func equalCompoundFilter(op filters.Operator, values []string) *filters.LocalFilter {
+	compound := filters.OperatorOr
+	if op == filters.ContainsAll {
+		compound = filters.OperatorAnd
+	}
+	operands := make([]filters.Clause, len(values))
+	for i, v := range values {
+		operands[i] = filters.Clause{
+			Operator: filters.OperatorEqual,
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(benchPropName)},
+			Value:    &filters.Value{Value: v, Type: schema.DataTypeText},
+		}
+	}
+	return &filters.LocalFilter{
+		Root: &filters.Clause{Operator: compound, Operands: operands},
+	}
+}
+
+// TestDocIDs_BatchedMatchesDesugared is the differential gate for the batched
+// Contains path: the same value set resolved through the Contains filter
+// (batched) and through a hand-built compound of OperatorEqual leaves (never
+// intercepted by the gate) must produce identical doc-ID sets. This is also
+// what makes mixed execution safe: within one logical query, one shard can
+// take the batch path while another (e.g. a non-roaringset bucket) desugars,
+// and their results are combined.
+func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
+	f := newContainsFixture(t, 5_000)
+	ctx := context.Background()
+
+	sampled, _ := f.sampleValues(200)
+	cases := []struct {
+		name   string
+		values []string
+	}{
+		{"unique corpus values", sampled},
+		{"shared values, non-empty ContainsAll", containsSharedValues},
+		{"shared plus unique", append([]string{benchValue(11)}, containsSharedValues...)},
+		{
+			"unnormalized values need FIELD trimming",
+			[]string{"  " + containsPaddedValue + " ", " " + benchValue(3), containsSharedValues[0]},
+		},
+		{"absent values", []string{"absent_1", "absent_2", benchValue(5)}},
+	}
+
+	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll} {
+		for _, tc := range cases {
+			t.Run(op.Name()+"/"+tc.name, func(t *testing.T) {
+				batched := f.resolveDocIDs(t, ctx, containsFilter(op, tc.values))
+				desugared := f.resolveDocIDs(t, ctx, equalCompoundFilter(op, tc.values))
+				require.Equal(t, desugared, batched,
+					"batched Contains must resolve the same doc IDs as the desugared Equal compound")
+			})
+		}
+	}
+
+	t.Run("[]interface{} values from the API layer", func(t *testing.T) {
+		values := []string{containsSharedValues[0], containsSharedValues[1], benchValue(11)}
+		iface := make([]interface{}, len(values))
+		for i, v := range values {
+			iface[i] = v
+		}
+		filter := &filters.LocalFilter{
+			Root: &filters.Clause{
+				Operator: filters.ContainsAll,
+				On:       &filters.Path{Class: className, Property: schema.PropertyName(benchPropName)},
+				Value:    &filters.Value{Value: iface, Type: schema.DataTypeText},
+			},
+		}
+		batched := f.resolveDocIDs(t, ctx, filter)
+		desugared := f.resolveDocIDs(t, ctx, equalCompoundFilter(filters.ContainsAll, values))
+		require.Equal(t, desugared, batched)
+		require.Equal(t, []uint64{11}, batched,
+			"docID 11 holds its unique value plus every shared value")
+	})
+}
+
 // TestDocIDs_ContainsCorrectness is the correctness gate for the benchmark
 // fixture: it pins that DocIDs returns exactly the expected doc-ID set on the
 // same corpus the benchmark measures, so an optimization cannot "win" by
@@ -214,10 +325,12 @@ func TestDocIDs_ContainsCorrectness(t *testing.T) {
 }
 
 // TestDocIDs_GoroutinePeak measures peak live goroutines during concurrent
-// DocIDs(100K) resolution — the structural signal for the fan-out fix. It does
-// not hard-assert a low bound (the baseline is expected to explode); it records
-// the peak via t.Log so baseline vs optimized can be compared. A generous
-// sanity ceiling guards against a runaway only.
+// DocIDs(100K) resolution — the structural signal for the fan-out fix. The
+// batched path spawns no per-value goroutines, only sroar's bounded merge
+// workers (at most the per-query budget per caller), so the peak is asserted
+// against a generous multiple of that structural bound; the old per-value
+// fan-out (one goroutine per value per caller) exceeds it by orders of
+// magnitude.
 func TestDocIDs_GoroutinePeak(t *testing.T) {
 	f := newContainsFixture(t, benchCorpusSize)
 	ctx := context.Background()
@@ -262,5 +375,10 @@ func TestDocIDs_GoroutinePeak(t *testing.T) {
 
 	t.Logf("goroutine peak: baseline=%d peak=%d (delta=%d) during %d concurrent DocIDs(100K), GOMAXPROCS=%d",
 		baseline, peak, peak-int64(baseline), concurrentCallers, runtime.GOMAXPROCS(0))
-	require.Less(t, peak, int64(2_000_000), "runaway goroutine growth")
+	// structural bound: each caller may run at most SROAR_MERGE merge workers
+	// at a time (plus its own goroutine); 4x headroom absorbs runtime and
+	// test-infra goroutines without ever admitting a per-value fan-out
+	bound := int64(baseline) + 4*concurrentCallers*int64(concurrency.SROAR_MERGE+1)
+	require.LessOrEqual(t, peak, bound,
+		"peak goroutines must stay within the bounded merge fan-out (per-value fan-out would exceed this by orders of magnitude)")
 }

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -1,0 +1,266 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package inverted
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// GH-12242 Go-level A/B instrument for ContainsAny/ContainsAll fan-out cost.
+//
+// Benchmarks Searcher.DocIDs (the full extract + resolve + merge path, no
+// HNSW) on a filterable roaringset text property with strictly-unique values
+// (1 value == 1 docID), the reported pathological shape. The primary metric is
+// allocs/op + B/op via -benchmem: deterministic and thermal-independent, unlike
+// server-level throughput. The optimization target ("cost F") is the O(N)
+// per-value filters.Clause + propValuePair construction at extraction, so the
+// benchmark deliberately includes extraction rather than only resolution.
+//
+// Run:
+//   go test -tags integrationTest -run '^$' -bench 'DocIDs_Contains' \
+//       -benchmem -benchtime 20x -count 6 ./adapters/repos/db/inverted/ | tee baseline.txt
+// then compare A/B with: benchstat baseline.txt optimized.txt
+
+const benchPropName = "inverted-text-roaringset"
+
+// containsFixture is a shared, deterministic corpus reused across every
+// sub-benchmark size so the (expensive) 300K-entry bucket build happens once.
+type containsFixture struct {
+	searcher *Searcher
+	store    *lsmkv.Store
+	numDocs  int
+}
+
+func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
+	tb.Helper()
+	dir := tb.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	// Use the production pooled buffer pool (NewBitmapBufPoolDefault with the
+	// server's default 32MB/128MB sizing), matching what the real server wires
+	// in configure_api.go, so allocation/GC numbers reflect production behaviour
+	// (pooled+reused read buffers) rather than the noop pool's per-read
+	// allocations, which overstate cost.
+	bufPool, bufPoolClose := roaringset.NewBitmapBufPoolDefault(logger, nil,
+		config.DefaultQueryBitmapBufsMaxBufSize, config.DefaultQueryBitmapBufsMaxMemory)
+	tb.Cleanup(bufPoolClose)
+
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(tb, err)
+	tb.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	bucketName := helpers.BucketFromPropNameLSM(benchPropName)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), bucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(bufPool),
+	))
+	bucket := store.Bucket(bucketName)
+
+	// value i ("val_%08d") maps to exactly docID i: strictly unique, 1:1.
+	for i := 0; i < numDocs; i++ {
+		require.NoError(tb, bucket.RoaringSetAddList([]byte(benchValue(i)), []uint64{uint64(i)}))
+	}
+	require.NoError(tb, bucket.FlushAndSwitch())
+
+	maxDocID := uint64(numDocs + 1)
+	bitmapFactory := roaringset.NewBitmapFactory(bufPool, newFakeMaxIDGetter(maxDocID))
+	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
+		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false },
+		func(string) bool { return false }, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	return &containsFixture{searcher: searcher, store: store, numDocs: numDocs}
+}
+
+func benchValue(i int) string { return fmt.Sprintf("val_%08d", i) }
+
+// sampleValues picks `size` values spread evenly across the corpus (strided),
+// so the selection touches the whole keyspace. Deterministic and identical
+// across A/B runs. Returns the values and the docIDs they resolve to.
+func (f *containsFixture) sampleValues(size int) (values []string, docIDs []uint64) {
+	stride := f.numDocs / size
+	if stride < 1 {
+		stride = 1
+	}
+	values = make([]string, 0, size)
+	docIDs = make([]uint64, 0, size)
+	for i := 0; i < f.numDocs && len(values) < size; i += stride {
+		values = append(values, benchValue(i))
+		docIDs = append(docIDs, uint64(i))
+	}
+	return values, docIDs
+}
+
+func containsFilter(op filters.Operator, values []string) *filters.LocalFilter {
+	return &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: op,
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(benchPropName)},
+			Value:    &filters.Value{Value: values, Type: schema.DataTypeText},
+		},
+	}
+}
+
+const benchCorpusSize = 300_000
+
+var benchSizes = []int{100, 1_000, 10_000, 100_000}
+
+func BenchmarkDocIDs_ContainsAny(b *testing.B) {
+	f := newContainsFixture(b, benchCorpusSize)
+	ctx := context.Background()
+	for _, size := range benchSizes {
+		values, _ := f.sampleValues(size)
+		filter := containsFilter(filters.ContainsAny, values)
+		b.Run(fmt.Sprintf("N=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				al, err := f.searcher.DocIDs(ctx, filter, additional.Properties{}, className)
+				if err != nil {
+					b.Fatal(err)
+				}
+				al.Close()
+			}
+		})
+	}
+}
+
+func BenchmarkDocIDs_ContainsAll(b *testing.B) {
+	f := newContainsFixture(b, benchCorpusSize)
+	ctx := context.Background()
+	for _, size := range benchSizes {
+		values, _ := f.sampleValues(size)
+		filter := containsFilter(filters.ContainsAll, values)
+		b.Run(fmt.Sprintf("N=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				al, err := f.searcher.DocIDs(ctx, filter, additional.Properties{}, className)
+				if err != nil {
+					b.Fatal(err)
+				}
+				al.Close()
+			}
+		})
+	}
+}
+
+// TestDocIDs_ContainsCorrectness is the correctness gate for the benchmark
+// fixture: it pins that DocIDs returns exactly the expected doc-ID set on the
+// same corpus the benchmark measures, so an optimization cannot "win" by
+// returning wrong results. ContainsAny(sample) == the sampled docIDs;
+// ContainsAll(sample) over strictly-unique values == empty (no doc holds >1
+// value), which still fully exercises the AND-fold extraction/merge path.
+func TestDocIDs_ContainsCorrectness(t *testing.T) {
+	f := newContainsFixture(t, 20_000)
+	ctx := context.Background()
+
+	for _, size := range []int{1, 100, 1_000, 10_000} {
+		values, wantAny := f.sampleValues(size)
+		t.Run(fmt.Sprintf("ContainsAny_N=%d", size), func(t *testing.T) {
+			al, err := f.searcher.DocIDs(ctx, containsFilter(filters.ContainsAny, values),
+				additional.Properties{}, className)
+			require.NoError(t, err)
+			defer al.Close()
+			got := al.Slice()
+			sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+			require.Equal(t, wantAny, got)
+		})
+		t.Run(fmt.Sprintf("ContainsAll_N=%d", size), func(t *testing.T) {
+			al, err := f.searcher.DocIDs(ctx, containsFilter(filters.ContainsAll, values),
+				additional.Properties{}, className)
+			require.NoError(t, err)
+			defer al.Close()
+			if size == 1 {
+				require.Equal(t, wantAny, al.Slice()) // single value: AND == that value's docID
+			} else {
+				require.True(t, al.IsEmpty(),
+					"ContainsAll over %d strictly-unique values must be empty", size)
+			}
+		})
+	}
+}
+
+// TestDocIDs_GoroutinePeak measures peak live goroutines during concurrent
+// DocIDs(100K) resolution — the structural signal for the fan-out fix. It does
+// not hard-assert a low bound (the baseline is expected to explode); it records
+// the peak via t.Log so baseline vs optimized can be compared. A generous
+// sanity ceiling guards against a runaway only.
+func TestDocIDs_GoroutinePeak(t *testing.T) {
+	f := newContainsFixture(t, benchCorpusSize)
+	ctx := context.Background()
+	values, _ := f.sampleValues(100_000)
+	filter := containsFilter(filters.ContainsAny, values)
+
+	const concurrentCallers = 8
+
+	stop := make(chan struct{})
+	var peak int64
+	var samplerWg sync.WaitGroup
+	samplerWg.Add(1)
+	go func() {
+		defer samplerWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if n := int64(runtime.NumGoroutine()); n > peak {
+					peak = n
+				}
+				time.Sleep(50 * time.Microsecond)
+			}
+		}
+	}()
+
+	baseline := runtime.NumGoroutine()
+	var wg sync.WaitGroup
+	for c := 0; c < concurrentCallers; c++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			al, err := f.searcher.DocIDs(ctx, filter, additional.Properties{}, className)
+			require.NoError(t, err)
+			al.Close()
+		}()
+	}
+	wg.Wait()
+	close(stop)
+	samplerWg.Wait()
+
+	t.Logf("goroutine peak: baseline=%d peak=%d (delta=%d) during %d concurrent DocIDs(100K), GOMAXPROCS=%d",
+		baseline, peak, peak-int64(baseline), concurrentCallers, runtime.GOMAXPROCS(0))
+	require.Less(t, peak, int64(2_000_000), "runaway goroutine growth")
+}

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -156,6 +156,68 @@ const benchCorpusSize = 300_000
 
 var benchSizes = []int{100, 1_000, 10_000, 100_000}
 
+// clusteredValues picks `size` values whose docIDs are consecutive, so the
+// whole result lands in one or two 64K containers — the Accumulator's
+// best-case staging shape. sampleValues (strided) is the opposite extreme:
+// every doc in its own 64K range, one staging block per doc.
+func (f *containsFixture) clusteredValues(size int) []string {
+	start := f.numDocs / 2
+	values := make([]string, 0, size)
+	for i := start; i < start+size && i < f.numDocs; i++ {
+		values = append(values, benchValue(i))
+	}
+	return values
+}
+
+// BenchmarkDocIDs_ContainsAnyAccumulatorGate sweeps the
+// containsAnyAccumulatorMinKeys crossover: the same DocIDs call at small key
+// counts with the gate forced to always-accumulator vs always-incremental,
+// over both result-spread extremes. Run:
+//
+//	go test -tags integrationTest -run '^$' -bench 'AccumulatorGate' \
+//	    -benchmem -count 6 ./adapters/repos/db/inverted/ | tee gate.txt
+func BenchmarkDocIDs_ContainsAnyAccumulatorGate(b *testing.B) {
+	f := newContainsFixture(b, benchCorpusSize)
+	ctx := context.Background()
+	oldGate := containsAnyAccumulatorMinKeys
+	defer func() { containsAnyAccumulatorMinKeys = oldGate }()
+
+	shapes := []struct {
+		name   string
+		values func(size int) []string
+	}{
+		{"spread", func(size int) []string { v, _ := f.sampleValues(size); return v }},
+		{"clustered", f.clusteredValues},
+	}
+	modes := []struct {
+		name string
+		gate int
+	}{
+		{"incremental", int(^uint(0) >> 1)}, // MaxInt: fold never uses the Accumulator
+		{"accumulator", 2},                  // every batched fold uses the Accumulator
+	}
+
+	for _, shape := range shapes {
+		for _, size := range []int{2, 4, 8, 16, 32, 64, 128, 256, 512, 1024} {
+			values := shape.values(size)
+			filter := containsFilter(filters.ContainsAny, values)
+			for _, mode := range modes {
+				b.Run(fmt.Sprintf("%s/N=%04d/%s", shape.name, size, mode.name), func(b *testing.B) {
+					containsAnyAccumulatorMinKeys = mode.gate
+					b.ReportAllocs()
+					for i := 0; i < b.N; i++ {
+						al, err := f.searcher.DocIDs(ctx, filter, additional.Properties{}, className)
+						if err != nil {
+							b.Fatal(err)
+						}
+						al.Close()
+					}
+				})
+			}
+		}
+	}
+}
+
 func BenchmarkDocIDs_ContainsAny(b *testing.B) {
 	f := newContainsFixture(b, benchCorpusSize)
 	ctx := context.Background()

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -196,11 +196,15 @@ func (f *containsFixture) sampleValues(size int) (values []string, docIDs []uint
 }
 
 func containsFilter(op filters.Operator, values []string) *filters.LocalFilter {
+	return containsFilterOn(op, benchPropName, schema.DataTypeText, values)
+}
+
+func containsFilterOn(op filters.Operator, prop string, dt schema.DataType, value interface{}) *filters.LocalFilter {
 	return &filters.LocalFilter{
 		Root: &filters.Clause{
 			Operator: op,
-			On:       &filters.Path{Class: className, Property: schema.PropertyName(benchPropName)},
-			Value:    &filters.Value{Value: values, Type: schema.DataTypeText},
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(prop)},
+			Value:    &filters.Value{Value: value, Type: dt},
 		},
 	}
 }
@@ -329,6 +333,14 @@ func (f *containsFixture) resolveDocIDs(t *testing.T, ctx context.Context, filte
 // Contains clauses, so resolving this compound always exercises the per-value
 // path.
 func equalCompoundFilter(op filters.Operator, values []string) *filters.LocalFilter {
+	leafValues := make([]interface{}, len(values))
+	for i, v := range values {
+		leafValues[i] = v
+	}
+	return equalCompoundFilterOn(op, benchPropName, schema.DataTypeText, leafValues)
+}
+
+func equalCompoundFilterOn(op filters.Operator, prop string, dt schema.DataType, values []interface{}) *filters.LocalFilter {
 	compound := filters.OperatorOr
 	if op == filters.ContainsAll {
 		compound = filters.OperatorAnd
@@ -337,8 +349,8 @@ func equalCompoundFilter(op filters.Operator, values []string) *filters.LocalFil
 	for i, v := range values {
 		operands[i] = filters.Clause{
 			Operator: filters.OperatorEqual,
-			On:       &filters.Path{Class: className, Property: schema.PropertyName(benchPropName)},
-			Value:    &filters.Value{Value: v, Type: schema.DataTypeText},
+			On:       &filters.Path{Class: className, Property: schema.PropertyName(prop)},
+			Value:    &filters.Value{Value: v, Type: dt},
 		}
 	}
 	root := &filters.Clause{Operator: compound, Operands: operands}
@@ -372,6 +384,10 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 			[]string{"  " + containsPaddedValue + " ", " " + benchValue(3), containsSharedValues[0]},
 		},
 		{"absent values", []string{"absent_1", "absent_2", benchValue(5)}},
+		// "" and "   " both FIELD-tokenize to the empty-string token — the
+		// degenerate boundary of the one-token-per-value invariant, and a
+		// duplicate key within one batch.
+		{"empty and whitespace-only values", []string{"", "   ", benchValue(5)}},
 	}
 
 	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
@@ -497,32 +513,6 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 	// per family, so differential equality alone would survive an encoding
 	// bug that breaks lookups on both sides.
 	t.Run("int and uuid families end-to-end", func(t *testing.T) {
-		containsOn := func(op filters.Operator, prop string, dt schema.DataType, value interface{}) *filters.LocalFilter {
-			return &filters.LocalFilter{Root: &filters.Clause{
-				Operator: op,
-				On:       &filters.Path{Class: className, Property: schema.PropertyName(prop)},
-				Value:    &filters.Value{Value: value, Type: dt},
-			}}
-		}
-		equalCompoundOn := func(op filters.Operator, prop string, dt schema.DataType, values []interface{}) *filters.LocalFilter {
-			compound := filters.OperatorOr
-			if op == filters.ContainsAll {
-				compound = filters.OperatorAnd
-			}
-			operands := make([]filters.Clause, len(values))
-			for i, v := range values {
-				operands[i] = filters.Clause{
-					Operator: filters.OperatorEqual,
-					On:       &filters.Path{Class: className, Property: schema.PropertyName(prop)},
-					Value:    &filters.Value{Value: v, Type: dt},
-				}
-			}
-			root := &filters.Clause{Operator: compound, Operands: operands}
-			if op == filters.ContainsNone {
-				root = &filters.Clause{Operator: filters.OperatorNot, Operands: []filters.Clause{*root}}
-			}
-			return &filters.LocalFilter{Root: root}
-		}
 		ints := func(vs ...int) []interface{} {
 			out := make([]interface{}, len(vs))
 			for i, v := range vs {
@@ -588,8 +578,8 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 
 		for _, tc := range cases {
 			t.Run(tc.name, func(t *testing.T) {
-				batched := f.resolveDocIDs(t, ctx, containsOn(tc.op, tc.prop, tc.dt, tc.filterValue))
-				desugared := f.resolveDocIDs(t, ctx, equalCompoundOn(tc.op, tc.prop, tc.dt, tc.leafValues))
+				batched := f.resolveDocIDs(t, ctx, containsFilterOn(tc.op, tc.prop, tc.dt, tc.filterValue))
+				desugared := f.resolveDocIDs(t, ctx, equalCompoundFilterOn(tc.op, tc.prop, tc.dt, tc.leafValues))
 				require.Equal(t, desugared, batched,
 					"batched Contains must resolve the same doc IDs as the desugared Equal compound")
 				if tc.exact != nil {

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -32,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
+	entinverted "github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -103,6 +105,40 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 	require.NoError(tb, bucket.RoaringSetAddList([]byte(containsPaddedValue), []uint64{containsPaddedDocID}))
 	require.NoError(tb, bucket.FlushAndSwitch())
 
+	// Small int and uuid corpora for the family end-to-end rows: value i maps
+	// to docID i, plus one shared value held by two docs so ContainsAll is
+	// non-empty. Keys are written with the same encoding the analyzer uses
+	// for these property types, which the exact-docs assertions depend on.
+	intBucketName := helpers.BucketFromPropNameLSM(benchIntPropName)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), intBucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(bufPool),
+	))
+	intBucket := store.Bucket(intBucketName)
+	for i := 0; i < containsFamilyDocs; i++ {
+		key, err := entinverted.LexicographicallySortableInt64(int64(i))
+		require.NoError(tb, err)
+		require.NoError(tb, intBucket.RoaringSetAddList(key, []uint64{uint64(i)}))
+	}
+	sharedIntKey, err := entinverted.LexicographicallySortableInt64(containsSharedInt)
+	require.NoError(tb, err)
+	require.NoError(tb, intBucket.RoaringSetAddList(sharedIntKey, containsFamilySharedDocIDs))
+	require.NoError(tb, intBucket.FlushAndSwitch())
+
+	uuidBucketName := helpers.BucketFromPropNameLSM(benchUUIDPropName)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), uuidBucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(bufPool),
+	))
+	uuidBucket := store.Bucket(uuidBucketName)
+	for i := 0; i < containsFamilyDocs; i++ {
+		parsed := uuid.MustParse(benchUUIDValue(i))
+		require.NoError(tb, uuidBucket.RoaringSetAddList(parsed[:], []uint64{uint64(i)}))
+	}
+	sharedUUID := uuid.MustParse(containsSharedUUIDValue)
+	require.NoError(tb, uuidBucket.RoaringSetAddList(sharedUUID[:], containsFamilySharedDocIDs))
+	require.NoError(tb, uuidBucket.FlushAndSwitch())
+
 	maxDocID := uint64(numDocs + 1)
 	bitmapFactory := roaringset.NewBitmapFactory(bufPool, newFakeMaxIDGetter(maxDocID))
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
@@ -124,6 +160,23 @@ const (
 	containsPaddedValue = "padded-value"
 	containsPaddedDocID = uint64(23)
 )
+
+// int and uuid corpora for the family end-to-end rows.
+const (
+	benchIntPropName   = "inverted-without-frequency-roaringset"
+	benchUUIDPropName  = "inverted-uuid-roaringset"
+	containsFamilyDocs = 50
+	containsSharedInt  = 1000
+)
+
+var (
+	containsFamilySharedDocIDs = []uint64{7, 9}
+	containsSharedUUIDValue    = benchUUIDValue(999_999)
+)
+
+func benchUUIDValue(i int) string {
+	return fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
+}
 
 // sampleValues picks `size` values spread evenly across the corpus (strided),
 // so the selection touches the whole keyspace. Deterministic and identical
@@ -350,6 +403,206 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 		require.Equal(t, desugared, batched)
 		require.Equal(t, []uint64{11}, batched,
 			"docID 11 holds its unique value plus every shared value")
+	})
+
+	// A batched ContainsNone resolves to a deny list: a bitmap of the docs to
+	// EXCLUDE, which every parent And/Or/Not merge arm must honor. The rows
+	// above only place Contains at the filter root, where the deny list is
+	// inverted once against the universe, so the merge arms go unexercised.
+	// The membership spot-checks pin the algebra itself, which the
+	// differential alone cannot: both trees feed deny lists through the same
+	// merge arms, so an arm bug would corrupt both sides identically.
+	t.Run("deny-list composition under compound parents", func(t *testing.T) {
+		// exclusion rows: valuesA -> docs {1, 2, 11, 17}, valuesB -> docs {2, 3, 11, 17}
+		valuesA := []string{benchValue(1), benchValue(2), containsSharedValues[0]}
+		valuesB := []string{benchValue(2), benchValue(3), containsSharedValues[1]}
+
+		equalLeaf := func(v string) filters.Clause {
+			return filters.Clause{
+				Operator: filters.OperatorEqual,
+				On:       &filters.Path{Class: className, Property: schema.PropertyName(benchPropName)},
+				Value:    &filters.Value{Value: v, Type: schema.DataTypeText},
+			}
+		}
+		tree := func(op filters.Operator, operands ...filters.Clause) *filters.LocalFilter {
+			return &filters.LocalFilter{Root: &filters.Clause{Operator: op, Operands: operands}}
+		}
+
+		cases := []struct {
+			name        string
+			batched     *filters.LocalFilter
+			desugared   *filters.LocalFilter
+			exact       []uint64
+			contains    []uint64
+			notContains []uint64
+		}{
+			{
+				name:      "And(ContainsNone, Equal)",
+				batched:   tree(filters.OperatorAnd, *containsFilter(filters.ContainsNone, valuesA).Root, equalLeaf(benchValue(3))),
+				desugared: tree(filters.OperatorAnd, *equalCompoundFilter(filters.ContainsNone, valuesA).Root, equalLeaf(benchValue(3))),
+				exact:     []uint64{3},
+			},
+			{
+				name:        "Or(ContainsNone, Equal) re-adds a denied doc",
+				batched:     tree(filters.OperatorOr, *containsFilter(filters.ContainsNone, valuesA).Root, equalLeaf(benchValue(1))),
+				desugared:   tree(filters.OperatorOr, *equalCompoundFilter(filters.ContainsNone, valuesA).Root, equalLeaf(benchValue(1))),
+				contains:    []uint64{1, 3},
+				notContains: []uint64{2, 11, 17},
+			},
+			{
+				name:        "And(ContainsNone, ContainsNone)",
+				batched:     tree(filters.OperatorAnd, *containsFilter(filters.ContainsNone, valuesA).Root, *containsFilter(filters.ContainsNone, valuesB).Root),
+				desugared:   tree(filters.OperatorAnd, *equalCompoundFilter(filters.ContainsNone, valuesA).Root, *equalCompoundFilter(filters.ContainsNone, valuesB).Root),
+				contains:    []uint64{4},
+				notContains: []uint64{1, 2, 3, 11, 17},
+			},
+			{
+				name:        "Or(ContainsNone, ContainsNone) keeps docs denied by only one side",
+				batched:     tree(filters.OperatorOr, *containsFilter(filters.ContainsNone, valuesA).Root, *containsFilter(filters.ContainsNone, valuesB).Root),
+				desugared:   tree(filters.OperatorOr, *equalCompoundFilter(filters.ContainsNone, valuesA).Root, *equalCompoundFilter(filters.ContainsNone, valuesB).Root),
+				contains:    []uint64{1, 3, 4},
+				notContains: []uint64{2, 11, 17},
+			},
+			{
+				name:        "Not(ContainsAny) equals ContainsNone",
+				batched:     tree(filters.OperatorNot, *containsFilter(filters.ContainsAny, valuesA).Root),
+				desugared:   equalCompoundFilter(filters.ContainsNone, valuesA),
+				contains:    []uint64{3},
+				notContains: []uint64{1, 2, 11, 17},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				batched := f.resolveDocIDs(t, ctx, tc.batched)
+				desugared := f.resolveDocIDs(t, ctx, tc.desugared)
+				require.Equal(t, desugared, batched,
+					"batched deny-list leaf must compose like its desugared reference")
+				if tc.exact != nil {
+					require.Equal(t, tc.exact, batched)
+				}
+				for _, id := range tc.contains {
+					require.Contains(t, batched, id)
+				}
+				for _, id := range tc.notContains {
+					require.NotContains(t, batched, id)
+				}
+			})
+		}
+	})
+
+	// The rows above all read the text FIELD property, so the uuid and
+	// primitive classify arms never cross a real bucket in this test. The
+	// exact-docs assertions matter here: both query paths share one encoder
+	// per family, so differential equality alone would survive an encoding
+	// bug that breaks lookups on both sides.
+	t.Run("int and uuid families end-to-end", func(t *testing.T) {
+		containsOn := func(op filters.Operator, prop string, dt schema.DataType, value interface{}) *filters.LocalFilter {
+			return &filters.LocalFilter{Root: &filters.Clause{
+				Operator: op,
+				On:       &filters.Path{Class: className, Property: schema.PropertyName(prop)},
+				Value:    &filters.Value{Value: value, Type: dt},
+			}}
+		}
+		equalCompoundOn := func(op filters.Operator, prop string, dt schema.DataType, values []interface{}) *filters.LocalFilter {
+			compound := filters.OperatorOr
+			if op == filters.ContainsAll {
+				compound = filters.OperatorAnd
+			}
+			operands := make([]filters.Clause, len(values))
+			for i, v := range values {
+				operands[i] = filters.Clause{
+					Operator: filters.OperatorEqual,
+					On:       &filters.Path{Class: className, Property: schema.PropertyName(prop)},
+					Value:    &filters.Value{Value: v, Type: dt},
+				}
+			}
+			root := &filters.Clause{Operator: compound, Operands: operands}
+			if op == filters.ContainsNone {
+				root = &filters.Clause{Operator: filters.OperatorNot, Operands: []filters.Clause{*root}}
+			}
+			return &filters.LocalFilter{Root: root}
+		}
+		ints := func(vs ...int) []interface{} {
+			out := make([]interface{}, len(vs))
+			for i, v := range vs {
+				out[i] = v
+			}
+			return out
+		}
+
+		cases := []struct {
+			name string
+			prop string
+			dt   schema.DataType
+			op   filters.Operator
+			// filterValue is the Contains filter's value in the typed shape
+			// the extractor accepts; leafValues are the same values as the
+			// per-leaf Equal shape for the desugared reference.
+			filterValue interface{}
+			leafValues  []interface{}
+			exact       []uint64
+			contains    []uint64
+			notContains []uint64
+		}{
+			{
+				name: "int ContainsAny", prop: benchIntPropName, dt: schema.DataTypeInt,
+				op:          filters.ContainsAny,
+				filterValue: []int{1, 2, containsSharedInt}, leafValues: ints(1, 2, containsSharedInt),
+				exact: []uint64{1, 2, 7, 9},
+			},
+			{
+				name: "int ContainsAll", prop: benchIntPropName, dt: schema.DataTypeInt,
+				op:          filters.ContainsAll,
+				filterValue: []int{containsSharedInt, 7}, leafValues: ints(containsSharedInt, 7),
+				exact: []uint64{7},
+			},
+			{
+				name: "int ContainsNone", prop: benchIntPropName, dt: schema.DataTypeInt,
+				op:          filters.ContainsNone,
+				filterValue: []int{1, containsSharedInt}, leafValues: ints(1, containsSharedInt),
+				contains: []uint64{2, 3}, notContains: []uint64{1, 7, 9},
+			},
+			{
+				name: "uuid ContainsAny", prop: benchUUIDPropName, dt: schema.DataTypeText,
+				op:          filters.ContainsAny,
+				filterValue: []interface{}{benchUUIDValue(1), benchUUIDValue(2), containsSharedUUIDValue},
+				leafValues:  []interface{}{benchUUIDValue(1), benchUUIDValue(2), containsSharedUUIDValue},
+				exact:       []uint64{1, 2, 7, 9},
+			},
+			{
+				name: "uuid ContainsAll", prop: benchUUIDPropName, dt: schema.DataTypeText,
+				op:          filters.ContainsAll,
+				filterValue: []interface{}{containsSharedUUIDValue, benchUUIDValue(7)},
+				leafValues:  []interface{}{containsSharedUUIDValue, benchUUIDValue(7)},
+				exact:       []uint64{7},
+			},
+			{
+				name: "uuid ContainsNone", prop: benchUUIDPropName, dt: schema.DataTypeText,
+				op:          filters.ContainsNone,
+				filterValue: []interface{}{benchUUIDValue(1), containsSharedUUIDValue},
+				leafValues:  []interface{}{benchUUIDValue(1), containsSharedUUIDValue},
+				contains:    []uint64{2, 3}, notContains: []uint64{1, 7, 9},
+			},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				batched := f.resolveDocIDs(t, ctx, containsOn(tc.op, tc.prop, tc.dt, tc.filterValue))
+				desugared := f.resolveDocIDs(t, ctx, equalCompoundOn(tc.op, tc.prop, tc.dt, tc.leafValues))
+				require.Equal(t, desugared, batched,
+					"batched Contains must resolve the same doc IDs as the desugared Equal compound")
+				if tc.exact != nil {
+					require.Equal(t, tc.exact, batched)
+				}
+				for _, id := range tc.contains {
+					require.Contains(t, batched, id)
+				}
+				for _, id := range tc.notContains {
+					require.NotContains(t, batched, id)
+				}
+			})
+		}
 	})
 }
 

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -210,8 +210,9 @@ func (f *containsFixture) resolveDocIDs(t *testing.T, ctx context.Context, filte
 
 // equalCompoundFilter builds the compound the desugared path would produce
 // for the same values: OperatorEqual leaves under Or (ContainsAny) / And
-// (ContainsAll). The batch gate only intercepts Contains clauses, so
-// resolving this compound always exercises the per-value path.
+// (ContainsAll) / Not-of-Or (ContainsNone). The batch gate only intercepts
+// Contains clauses, so resolving this compound always exercises the per-value
+// path.
 func equalCompoundFilter(op filters.Operator, values []string) *filters.LocalFilter {
 	compound := filters.OperatorOr
 	if op == filters.ContainsAll {
@@ -225,9 +226,11 @@ func equalCompoundFilter(op filters.Operator, values []string) *filters.LocalFil
 			Value:    &filters.Value{Value: v, Type: schema.DataTypeText},
 		}
 	}
-	return &filters.LocalFilter{
-		Root: &filters.Clause{Operator: compound, Operands: operands},
+	root := &filters.Clause{Operator: compound, Operands: operands}
+	if op == filters.ContainsNone {
+		root = &filters.Clause{Operator: filters.OperatorNot, Operands: []filters.Clause{*root}}
 	}
+	return &filters.LocalFilter{Root: root}
 }
 
 // TestDocIDs_BatchedMatchesDesugared is the differential gate for the batched
@@ -256,7 +259,7 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 		{"absent values", []string{"absent_1", "absent_2", benchValue(5)}},
 	}
 
-	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll} {
+	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
 		for _, tc := range cases {
 			t.Run(op.Name()+"/"+tc.name, func(t *testing.T) {
 				batched := f.resolveDocIDs(t, ctx, containsFilter(op, tc.values))
@@ -320,6 +323,26 @@ func TestDocIDs_ContainsCorrectness(t *testing.T) {
 				require.True(t, al.IsEmpty(),
 					"ContainsAll over %d strictly-unique values must be empty", size)
 			}
+		})
+		t.Run(fmt.Sprintf("ContainsNone_N=%d", size), func(t *testing.T) {
+			// The deny list inverts against the BitmapFactory universe,
+			// which is [0, maxDocID] inclusive with the fixture's
+			// maxDocID = numDocs+1. Expected: the exact complement of the
+			// sampled docIDs within that universe.
+			sampledSet := make(map[uint64]struct{}, len(wantAny))
+			for _, id := range wantAny {
+				sampledSet[id] = struct{}{}
+			}
+			maxDocID := uint64(f.numDocs + 1)
+			wantNone := make([]uint64, 0, maxDocID+1-uint64(len(wantAny)))
+			for id := uint64(0); id <= maxDocID; id++ {
+				if _, ok := sampledSet[id]; !ok {
+					wantNone = append(wantNone, id)
+				}
+			}
+
+			got := f.resolveDocIDs(t, ctx, containsFilter(filters.ContainsNone, values))
+			require.Equal(t, wantNone, got)
 		})
 	}
 }

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -1309,6 +1309,13 @@ func createSchema() *schema.Schema {
 							IndexRangeFilters: &vFalse,
 						},
 						{
+							Name:              "inverted-uuid-roaringset",
+							DataType:          schema.DataTypeUUID.PropString(),
+							IndexFilterable:   &vTrue,
+							IndexSearchable:   &vFalse,
+							IndexRangeFilters: &vFalse,
+						},
+						{
 							Name:              "inverted-roaringsetrange-on-disk",
 							DataType:          schema.DataTypeInt.PropString(),
 							IndexFilterable:   &vFalse,

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -43,6 +43,12 @@ type propValuePair struct {
 	hasRangeableIndex  bool
 	nested             nestedInfo
 	Class              *models.Class // The schema
+
+	// containsValues holds pre-encoded on-disk keys for a flat, single-property
+	// Contains(Any|All) filter. When non-nil, resolveDocIDs routes to
+	// fetchContainsBatch instead of the children-based dispatch below;
+	// operator distinguishes ContainsAny (OR-fold) from ContainsAll (AND-fold).
+	containsValues [][]byte
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
@@ -55,6 +61,10 @@ func newPropValuePair(class *models.Class) (*propValuePair, error) {
 func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	if err := ctxExpired(ctx); err != nil {
 		return nil, err
+	}
+
+	if pv.containsValues != nil {
+		return pv.fetchContainsBatch(ctx, s)
 	}
 
 	// Correlated nested AND created during extraction: all children target the
@@ -340,6 +350,23 @@ func mergeDocIDs(operator filters.Operator, dbms []*docBitmap, maxConc int) []*d
 // fetchDocIDs resolves a value filter on a flat (non-nested) property.
 func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	return pv.readFromBucket(ctx, s, limit)
+}
+
+// fetchContainsBatch resolves a batched Contains(Any|All) filter whose keys
+// were already encoded into pv.containsValues, folding every key's bitmap
+// through docBitmapContainsBatch under a single consistent view.
+func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (*docBitmap, error) {
+	bucketName := pv.getBucketName()
+	b := s.store.Bucket(bucketName)
+	if b == nil {
+		return nil, errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
+	}
+
+	dbm, err := s.docBitmapContainsBatch(ctx, b, pv)
+	if err != nil {
+		return nil, err
+	}
+	return &dbm, nil
 }
 
 // readFromBucket is the shared low-level implementation for all fetch methods.

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -46,9 +46,7 @@ type propValuePair struct {
 
 	// containsValues holds pre-encoded on-disk keys for a flat, single-property
 	// Contains(Any|All|None) filter. When non-nil, resolveDocIDs routes to
-	// fetchContainsBatch instead of the children-based dispatch below;
-	// operator selects the fold: ContainsAll intersects, ContainsAny unions,
-	// ContainsNone unions and marks the result a deny list.
+	// fetchContainsBatch instead of the children-based dispatch below.
 	containsValues [][]byte
 }
 

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -45,9 +45,10 @@ type propValuePair struct {
 	Class              *models.Class // The schema
 
 	// containsValues holds pre-encoded on-disk keys for a flat, single-property
-	// Contains(Any|All) filter. When non-nil, resolveDocIDs routes to
+	// Contains(Any|All|None) filter. When non-nil, resolveDocIDs routes to
 	// fetchContainsBatch instead of the children-based dispatch below;
-	// operator distinguishes ContainsAny (OR-fold) from ContainsAll (AND-fold).
+	// operator selects the fold: ContainsAll intersects, ContainsAny unions,
+	// ContainsNone unions and marks the result a deny list.
 	containsValues [][]byte
 }
 
@@ -64,6 +65,9 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 	}
 
 	if pv.containsValues != nil {
+		if !pv.operator.IsContains() {
+			return nil, fmt.Errorf("pre-encoded contains keys with non-contains operator %q", pv.operator.Name())
+		}
 		return pv.fetchContainsBatch(ctx, s)
 	}
 
@@ -352,7 +356,7 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 	return pv.readFromBucket(ctx, s, limit)
 }
 
-// fetchContainsBatch resolves a batched Contains(Any|All) filter whose keys
+// fetchContainsBatch resolves a batched Contains(Any|All|None) filter whose keys
 // were already encoded into pv.containsValues, folding every key's bitmap
 // through docBitmapContainsBatch under a single consistent view.
 func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (*docBitmap, error) {

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1018,6 +1018,9 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 	if operator != filters.ContainsAny && operator != filters.ContainsAll {
 		return nil, false, nil
 	}
+	if entcfg.BatchedContainsDisabled() {
+		return nil, false, nil
+	}
 
 	props := path.Slice()
 	if len(props) != 1 {

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1338,11 +1338,13 @@ func getContainsOperands[T any](propType schema.DataType, path *filters.Path, va
 func (s *Searcher) desugaredContains(ctx context.Context, operator filters.Operator,
 	class *models.Class, path *filters.Path, operands []filters.Clause, declineReason string,
 ) (*propValuePair, error) {
-	helpers.AnnotateSlowQueryLogAppend(ctx, "contains_desugared", map[string]any{
-		"prop":       string(path.Property),
-		"operator":   operator.Name(),
-		"reason":     declineReason,
-		"num_values": len(operands),
+	helpers.AnnotateSlowQueryLogAppendFunc(ctx, "contains_desugared", func() map[string]any {
+		return map[string]any{
+			"prop":       string(path.Property),
+			"operator":   operator.Name(),
+			"reason":     declineReason,
+			"num_values": len(operands),
+		}
 	})
 
 	children, err := s.extractPropValuePairs(ctx, operands, operator, schema.ClassName(class.Class))

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1053,9 +1053,13 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 	// gate check (bucket, strategy) has passed.
 	var encode func() ([][]byte, error)
 
+	// Only base value types are eligible: the API layers normalize Contains
+	// value types to the base type before the searcher, and the desugared
+	// per-value leaf extractors error on array value types — accepting them
+	// here would succeed where the fallback path errors.
 	switch {
 	case s.onUUIDProp(property):
-		if propType != schema.DataTypeText && propType != schema.DataTypeTextArray {
+		if propType != schema.DataTypeText {
 			return nil, false, nil
 		}
 		values, err := s.extractStringArray(value)
@@ -1070,7 +1074,7 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 		}
 
 	case s.onTokenizableProp(property):
-		if propType != schema.DataTypeText && propType != schema.DataTypeTextArray {
+		if propType != schema.DataTypeText {
 			return nil, false, nil
 		}
 		// tokenizeField always produces exactly one token (a TrimFunc of the
@@ -1108,7 +1112,7 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 
 	default:
 		switch propType {
-		case schema.DataTypeInt, schema.DataTypeIntArray:
+		case schema.DataTypeInt:
 			values, err := s.extractIntArray(value)
 			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
 				return nil, false, nil
@@ -1116,7 +1120,7 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 			encode = func() ([][]byte, error) {
 				return encodeContainsKeys(values, func(v int) ([]byte, error) { return s.extractIntValue(v) })
 			}
-		case schema.DataTypeNumber, schema.DataTypeNumberArray:
+		case schema.DataTypeNumber:
 			values, err := s.extractFloat64Array(value)
 			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
 				return nil, false, nil
@@ -1124,7 +1128,7 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 			encode = func() ([][]byte, error) {
 				return encodeContainsKeys(values, func(v float64) ([]byte, error) { return s.extractNumberValue(v) })
 			}
-		case schema.DataTypeBoolean, schema.DataTypeBooleanArray:
+		case schema.DataTypeBoolean:
 			values, err := s.extractBoolArray(value)
 			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
 				return nil, false, nil
@@ -1132,7 +1136,7 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 			encode = func() ([][]byte, error) {
 				return encodeContainsKeys(values, func(v bool) ([]byte, error) { return s.extractBoolValue(v) })
 			}
-		case schema.DataTypeDate, schema.DataTypeDateArray:
+		case schema.DataTypeDate:
 			values, err := s.extractStringArray(value)
 			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
 				return nil, false, nil
@@ -1157,7 +1161,10 @@ func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
 
 	pv, err := newPropValuePair(class)
 	if err != nil {
-		return nil, false, nil
+		// the shape fully matched, so per the 3-state contract a failure
+		// here is an error, not a fall-through (unreachable today: a nil
+		// class is rejected by the property lookup above)
+		return nil, true, err
 	}
 	pv.prop = property.Name
 	pv.operator = operator

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1000,7 +1000,7 @@ const (
 )
 
 // classifyContainsBatch runs every shape check for the batched flat
-// ContainsAny/ContainsAll fast path and reconciles the property with the
+// ContainsAny/ContainsAll/ContainsNone fast path and reconciles the property with the
 // filter's value type, in one place: flat single-property path, no
 // internal/length/nested/ref/geo shape, filterable index backed by an actual
 // roaringset bucket, and a base value type matching the property (the
@@ -1016,7 +1016,7 @@ const (
 func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.DataType,
 	operator filters.Operator, class *models.Class,
 ) (*models.Property, containsBatchType) {
-	if operator != filters.ContainsAny && operator != filters.ContainsAll {
+	if !operator.IsContains() {
 		return nil, containsNotBatchable
 	}
 	if entcfg.BatchedContainsDisabled() {

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -322,7 +322,11 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	}
 
 	beforeResolve := time.Now()
-	helpers.AnnotateSlowQueryLog(ctx, "build_allow_list_resolve_len", len(pv.children))
+	n := len(pv.children)
+	if pv.containsValues != nil {
+		n = len(pv.containsValues)
+	}
+	helpers.AnnotateSlowQueryLog(ctx, "build_allow_list_resolve_len", n)
 	dbm, err := pv.resolveDocIDs(ctx, s, limit)
 	if err != nil {
 		return nil, fmt.Errorf("resolve doc ids for prop/value pair: %w", err)
@@ -976,10 +980,197 @@ func (s *Searcher) extractPropertyNull(prop *models.Property, propType schema.Da
 	}, nil
 }
 
+// encodeContainsKeys encodes every element of values to its on-disk key via
+// encode, wrapping the first failure with its position so the caller can
+// report which element was malformed.
+func encodeContainsKeys[T any](values []T, encode func(T) ([]byte, error)) ([][]byte, error) {
+	keys := make([][]byte, len(values))
+	for i, v := range values {
+		k, err := encode(v)
+		if err != nil {
+			return nil, fmt.Errorf("value %d: %w", i, err)
+		}
+		keys[i] = k
+	}
+	return keys, nil
+}
+
+// extractContainsBatch is the shape gate for the batched flat
+// ContainsAny/ContainsAll fast path. It recognizes a flat (non-nested),
+// single-property, roaringset-filterable Contains filter over a
+// one-value-maps-to-one-key type and, when eligible, pre-encodes every
+// value to its on-disk key using the exact same per-value encoders
+// buildPropValuePair would otherwise call once per value via N
+// propValuePair leaves.
+//
+// Returns a strict 3-state contract:
+//   - eligible == false: shape rejected before touching any value; err is
+//     always nil. The caller must fall through to the existing desugared
+//     extraction.
+//   - eligible == true, err == nil: pv is fully built; return it directly.
+//   - eligible == true, err != nil: the shape matched (property,
+//     tokenization, bucket all confirmed eligible) but encoding one of the
+//     values failed; the caller should return the error immediately rather
+//     than falling through to re-derive the identical failure.
+func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
+	propType schema.DataType, value interface{}, operator filters.Operator, class *models.Class,
+) (*propValuePair, bool, error) {
+	if operator != filters.ContainsAny && operator != filters.ContainsAll {
+		return nil, false, nil
+	}
+
+	props := path.Slice()
+	if len(props) != 1 {
+		return nil, false, nil
+	}
+
+	propName := filnested.RootPropName(props[0])
+	if s.onInternalProp(propName) {
+		return nil, false, nil
+	}
+	if _, ok := schema.IsPropertyLength(propName, 0); ok {
+		return nil, false, nil
+	}
+
+	property, err := schema.GetPropertyByName(class, propName)
+	if err != nil {
+		// The existing per-value path will raise the identical "property not
+		// found" error; no need to duplicate that error text here.
+		return nil, false, nil
+	}
+	if _, ok := schema.AsNested(property.DataType); ok {
+		return nil, false, nil
+	}
+	if s.onRefProp(property) || s.onGeoProp(property) {
+		return nil, false, nil
+	}
+
+	// encode is populated by whichever family below matches; it performs the
+	// actual per-value key encoding and is only invoked once every remaining
+	// gate check (bucket, strategy) has passed.
+	var encode func() ([][]byte, error)
+
+	switch {
+	case s.onUUIDProp(property):
+		if propType != schema.DataTypeText && propType != schema.DataTypeTextArray {
+			return nil, false, nil
+		}
+		values, err := s.extractStringArray(value)
+		if err != nil || len(values) < 2 {
+			return nil, false, nil
+		}
+		if !HasFilterableIndex(property) {
+			return nil, false, nil
+		}
+		encode = func() ([][]byte, error) {
+			return encodeContainsKeys(values, func(v string) ([]byte, error) { return s.extractUUIDValue(v) })
+		}
+
+	case s.onTokenizableProp(property):
+		if propType != schema.DataTypeText && propType != schema.DataTypeTextArray {
+			return nil, false, nil
+		}
+		// tokenizeField always produces exactly one token (a TrimFunc of the
+		// input, never zero, never more than one), so FIELD is provably a
+		// 1-value-to-1-key tokenization; any other tokenization can turn one
+		// value into zero or several tokens and must fall through.
+		effectiveTok := ResolveTokenization(s.tokResolver, property.Name, property.Tokenization)
+		if effectiveTok != models.PropertyTokenizationField {
+			return nil, false, nil
+		}
+		values, err := s.extractStringArray(value)
+		if err != nil || len(values) < 2 {
+			return nil, false, nil
+		}
+		if !HasFilterableIndex(property) || s.isFallbackToSearchable() {
+			return nil, false, nil
+		}
+		prepared := tokenizer.NewPreparedAnalyzer(property.TextAnalyzer)
+		encode = func() ([][]byte, error) {
+			// One batched analysis for all values: per-batch metrics and a
+			// shared token backing array instead of per-value Analyze calls.
+			batch, err := tokenizer.AnalyzeBatch(values, effectiveTok, class.Class, prepared, nil)
+			if err != nil {
+				return nil, err
+			}
+			keys := make([][]byte, batch.Len())
+			for i, valueTokens := range batch.All() {
+				if len(valueTokens) != 1 {
+					return nil, fmt.Errorf("value %d: FIELD tokenization produced %d tokens, want exactly 1", i, len(valueTokens))
+				}
+				keys[i] = []byte(valueTokens[0])
+			}
+			return keys, nil
+		}
+
+	default:
+		switch propType {
+		case schema.DataTypeInt, schema.DataTypeIntArray:
+			values, err := s.extractIntArray(value)
+			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
+				return nil, false, nil
+			}
+			encode = func() ([][]byte, error) {
+				return encodeContainsKeys(values, func(v int) ([]byte, error) { return s.extractIntValue(v) })
+			}
+		case schema.DataTypeNumber, schema.DataTypeNumberArray:
+			values, err := s.extractFloat64Array(value)
+			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
+				return nil, false, nil
+			}
+			encode = func() ([][]byte, error) {
+				return encodeContainsKeys(values, func(v float64) ([]byte, error) { return s.extractNumberValue(v) })
+			}
+		case schema.DataTypeBoolean, schema.DataTypeBooleanArray:
+			values, err := s.extractBoolArray(value)
+			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
+				return nil, false, nil
+			}
+			encode = func() ([][]byte, error) {
+				return encodeContainsKeys(values, func(v bool) ([]byte, error) { return s.extractBoolValue(v) })
+			}
+		case schema.DataTypeDate, schema.DataTypeDateArray:
+			values, err := s.extractStringArray(value)
+			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
+				return nil, false, nil
+			}
+			encode = func() ([][]byte, error) {
+				return encodeContainsKeys(values, func(v string) ([]byte, error) { return s.extractDateValue(v) })
+			}
+		default:
+			return nil, false, nil
+		}
+	}
+
+	b := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
+	if b == nil || b.Strategy() != lsmkv.StrategyRoaringSet {
+		return nil, false, nil
+	}
+
+	keys, err := encode()
+	if err != nil {
+		return nil, true, fmt.Errorf("extract contains values: %w", err)
+	}
+
+	pv, err := newPropValuePair(class)
+	if err != nil {
+		return nil, false, nil
+	}
+	pv.prop = property.Name
+	pv.operator = operator
+	pv.hasFilterableIndex = true
+	pv.containsValues = keys
+	return pv, true, nil
+}
+
 func (s *Searcher) extractContains(ctx context.Context,
 	path *filters.Path, propType schema.DataType, value interface{},
 	operator filters.Operator, class *models.Class,
 ) (*propValuePair, error) {
+	if pv, eligible, err := s.extractContainsBatch(ctx, path, propType, value, operator, class); eligible {
+		return pv, err
+	}
+
 	var operands []filters.Clause
 	switch propType {
 	case schema.DataTypeText, schema.DataTypeTextArray:

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -999,6 +999,28 @@ const (
 	containsBatchPrimitive
 )
 
+// containsDecline* are the reasons surfaced in the "contains_desugared"
+// slow-query annotation when classifyContainsBatch (or the value-count gate
+// in extractContains) routes a Contains filter through the desugared
+// per-value path instead of the batched fold.
+const (
+	containsDeclineNonContainsOperator  = "non-contains-operator"
+	containsDeclineDisabledByEnv        = "disabled-by-env"
+	containsDeclineMultiSegmentPath     = "multi-segment-path"
+	containsDeclineInternalProperty     = "internal-property"
+	containsDeclineLengthFilter         = "length-filter"
+	containsDeclinePropertyNotFound     = "property-not-found"
+	containsDeclineNestedObjectProperty = "nested-object-property"
+	containsDeclineReferenceProperty    = "reference-property"
+	containsDeclineGeoProperty          = "geo-property"
+	containsDeclineNoFilterableIndex    = "no-filterable-index"
+	containsDeclineNoRoaringSetBucket   = "no-roaringset-bucket"
+	containsDeclineValueTypeMismatch    = "value-type-mismatch"
+	containsDeclineTokenizationNotField = "tokenization-not-field"
+	containsDeclineFallbackToSearchable = "fallback-to-searchable"
+	containsDeclineFewerThanTwoValues   = "fewer-than-two-values"
+)
+
 // classifyContainsBatch runs every shape check for the batched flat
 // ContainsAny/ContainsAll/ContainsNone fast path and reconciles the property with the
 // filter's value type, in one place: flat single-property path, no
@@ -1008,6 +1030,10 @@ const (
 // searcher, and the desugared per-value leaf extractors error on array value
 // types — batching them would succeed where the fallback path errors).
 //
+// On decline it returns containsNotBatchable plus a containsDecline* reason,
+// which desugaredContains surfaces in the slow-query details; on success the
+// reason is empty.
+//
 // The checks must classify the property exactly as the desugared per-value
 // path (buildPropValuePair's dispatch) would classify each Equal leaf:
 // batching is only safe when every leaf would have been a plain 1-key
@@ -1015,75 +1041,78 @@ const (
 // end-to-end.
 func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.DataType,
 	operator filters.Operator, class *models.Class,
-) (*models.Property, containsBatchType) {
+) (*models.Property, containsBatchType, string) {
 	if !operator.IsContains() {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineNonContainsOperator
 	}
 	if entcfg.BatchedContainsDisabled() {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineDisabledByEnv
 	}
 
 	props := path.Slice()
 	if len(props) != 1 {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineMultiSegmentPath
 	}
 
 	propName := filnested.RootPropName(props[0])
 	if s.onInternalProp(propName) {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineInternalProperty
 	}
 	if _, ok := schema.IsPropertyLength(propName, 0); ok {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineLengthFilter
 	}
 
 	property, err := schema.GetPropertyByName(class, propName)
 	if err != nil {
 		// the desugared per-value path raises the identical "property not
 		// found" error; no need to duplicate it here
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclinePropertyNotFound
 	}
 	if _, ok := schema.AsNested(property.DataType); ok {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineNestedObjectProperty
 	}
-	if s.onRefProp(property) || s.onGeoProp(property) {
-		return nil, containsNotBatchable
+	if s.onRefProp(property) {
+		return nil, containsNotBatchable, containsDeclineReferenceProperty
+	}
+	if s.onGeoProp(property) {
+		return nil, containsNotBatchable, containsDeclineGeoProperty
 	}
 	if !HasFilterableIndex(property) {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineNoFilterableIndex
 	}
 
 	b := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
 	if b == nil || b.Strategy() != lsmkv.StrategyRoaringSet {
-		return nil, containsNotBatchable
+		return nil, containsNotBatchable, containsDeclineNoRoaringSetBucket
 	}
 
 	switch {
 	case s.onUUIDProp(property):
 		if propType != schema.DataTypeText {
-			return nil, containsNotBatchable
+			return nil, containsNotBatchable, containsDeclineValueTypeMismatch
 		}
-		return property, containsBatchUUID
+		return property, containsBatchUUID, ""
 	case s.onTokenizableProp(property):
 		if propType != schema.DataTypeText {
-			return nil, containsNotBatchable
+			return nil, containsNotBatchable, containsDeclineValueTypeMismatch
 		}
 		// tokenizeField always produces exactly one token (a TrimFunc of the
 		// input, never zero, never more than one), so FIELD is provably a
 		// 1-value-to-1-key tokenization; any other tokenization can turn one
 		// value into zero or several tokens and must desugar.
 		if ResolveTokenization(s.tokResolver, property.Name, property.Tokenization) != models.PropertyTokenizationField {
-			return nil, containsNotBatchable
+			return nil, containsNotBatchable, containsDeclineTokenizationNotField
 		}
 		if s.isFallbackToSearchable() {
-			return nil, containsNotBatchable
+			return nil, containsNotBatchable, containsDeclineFallbackToSearchable
 		}
-		return property, containsBatchTextField
+		return property, containsBatchTextField, ""
 	default:
 		switch propType {
 		case schema.DataTypeInt, schema.DataTypeNumber, schema.DataTypeBoolean, schema.DataTypeDate:
-			return property, containsBatchPrimitive
+			return property, containsBatchPrimitive, ""
 		default:
-			return nil, containsNotBatchable
+			return nil, containsNotBatchable, containsDeclineValueTypeMismatch
 		}
 	}
 }
@@ -1211,7 +1240,12 @@ func (s *Searcher) extractContains(ctx context.Context,
 	path *filters.Path, propType schema.DataType, value interface{},
 	operator filters.Operator, class *models.Class,
 ) (*propValuePair, error) {
-	property, batchType := s.classifyContainsBatch(path, propType, operator, class)
+	property, batchType, declineReason := s.classifyContainsBatch(path, propType, operator, class)
+	if declineReason == "" {
+		// the classifier approved the shape; if the filter still desugars in
+		// the arms below, the value count is the only remaining cause
+		declineReason = containsDeclineFewerThanTwoValues
+	}
 
 	switch propType {
 	case schema.DataTypeText, schema.DataTypeTextArray:
@@ -1229,7 +1263,7 @@ func (s *Searcher) extractContains(ctx context.Context,
 				// containsNotBatchable: desugar below
 			}
 		}
-		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+		return s.desugaredContains(ctx, operator, class, path, getContainsOperands(propType, path, values), declineReason)
 
 	case schema.DataTypeInt, schema.DataTypeIntArray:
 		values, err := s.extractIntArray(value)
@@ -1239,7 +1273,7 @@ func (s *Searcher) extractContains(ctx context.Context,
 		if batchType == containsBatchPrimitive && len(values) >= 2 {
 			return s.batchedContainsInt(property, operator, class, values)
 		}
-		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+		return s.desugaredContains(ctx, operator, class, path, getContainsOperands(propType, path, values), declineReason)
 
 	case schema.DataTypeNumber, schema.DataTypeNumberArray:
 		values, err := s.extractFloat64Array(value)
@@ -1249,7 +1283,7 @@ func (s *Searcher) extractContains(ctx context.Context,
 		if batchType == containsBatchPrimitive && len(values) >= 2 {
 			return s.batchedContainsNumber(property, operator, class, values)
 		}
-		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+		return s.desugaredContains(ctx, operator, class, path, getContainsOperands(propType, path, values), declineReason)
 
 	case schema.DataTypeBoolean, schema.DataTypeBooleanArray:
 		values, err := s.extractBoolArray(value)
@@ -1259,7 +1293,7 @@ func (s *Searcher) extractContains(ctx context.Context,
 		if batchType == containsBatchPrimitive && len(values) >= 2 {
 			return s.batchedContainsBool(property, operator, class, values)
 		}
-		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+		return s.desugaredContains(ctx, operator, class, path, getContainsOperands(propType, path, values), declineReason)
 
 	case schema.DataTypeDate, schema.DataTypeDateArray:
 		values, err := s.extractStringArray(value)
@@ -1269,7 +1303,7 @@ func (s *Searcher) extractContains(ctx context.Context,
 		if batchType == containsBatchPrimitive && len(values) >= 2 {
 			return s.batchedContainsDate(property, operator, class, values)
 		}
-		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+		return s.desugaredContains(ctx, operator, class, path, getContainsOperands(propType, path, values), declineReason)
 
 	default:
 		return nil, fmt.Errorf("unsupported type '%T' for '%v' operator", propType, operator)
@@ -1298,9 +1332,21 @@ func getContainsOperands[T any](propType schema.DataType, path *filters.Path, va
 
 // desugaredContains resolves the filter through the per-value path: one
 // Equal leaf per operand, combined under the operator.
+//
+// declineReason is the containsDecline* reason the filter did not take the
+// batched path (extractContains guarantees it is always set); it is surfaced
+// in the slow-query details so an operator can see why a Contains filter
+// desugared.
 func (s *Searcher) desugaredContains(ctx context.Context, operator filters.Operator,
-	class *models.Class, operands []filters.Clause,
+	class *models.Class, path *filters.Path, operands []filters.Clause, declineReason string,
 ) (*propValuePair, error) {
+	helpers.AnnotateSlowQueryLogAppend(ctx, "contains_desugared", map[string]any{
+		"prop":       string(path.Property),
+		"operator":   operator.Name(),
+		"reason":     declineReason,
+		"num_values": len(operands),
+	})
+
 	children, err := s.extractPropValuePairs(ctx, operands, operator, schema.ClassName(class.Class))
 	if err != nil {
 		return nil, err

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -980,10 +980,120 @@ func (s *Searcher) extractPropertyNull(prop *models.Property, propType schema.Da
 	}, nil
 }
 
-// encodeContainsKeys encodes every element of values to its on-disk key via
-// encode, wrapping the first failure with its position so the caller can
-// report which element was malformed.
-func encodeContainsKeys[T any](values []T, encode func(T) ([]byte, error)) ([][]byte, error) {
+// containsBatchType identifies which batched key encoding applies to a
+// Contains filter — or that the filter must resolve through the desugared
+// per-value path.
+type containsBatchType int
+
+const (
+	// containsNotBatchable: the filter must desugar into per-value Equal
+	// leaves — the property, value type, index, or bucket does not
+	// support the 1-value-1-key batched fold.
+	containsNotBatchable containsBatchType = iota
+	// containsBatchUUID: string values encode via extractUUIDValue.
+	containsBatchUUID
+	// containsBatchTextField: string values encode via FIELD tokenization.
+	containsBatchTextField
+	// containsBatchPrimitive: values encode via the primitive encoder of
+	// the value type (int/number/boolean/date).
+	containsBatchPrimitive
+)
+
+// classifyContainsBatch runs every shape check for the batched flat
+// ContainsAny/ContainsAll fast path and reconciles the property with the
+// filter's value type, in one place: flat single-property path, no
+// internal/length/nested/ref/geo shape, filterable index backed by an actual
+// roaringset bucket, and a base value type matching the property (the
+// API layers normalize Contains value types to the base type before the
+// searcher, and the desugared per-value leaf extractors error on array value
+// types — batching them would succeed where the fallback path errors).
+//
+// The checks must classify the property exactly as the desugared per-value
+// path (buildPropValuePair's dispatch) would classify each Equal leaf:
+// batching is only safe when every leaf would have been a plain 1-key
+// roaringset lookup. TestDocIDs_BatchedMatchesDesugared pins that agreement
+// end-to-end.
+func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.DataType,
+	operator filters.Operator, class *models.Class,
+) (*models.Property, containsBatchType) {
+	if operator != filters.ContainsAny && operator != filters.ContainsAll {
+		return nil, containsNotBatchable
+	}
+	if entcfg.BatchedContainsDisabled() {
+		return nil, containsNotBatchable
+	}
+
+	props := path.Slice()
+	if len(props) != 1 {
+		return nil, containsNotBatchable
+	}
+
+	propName := filnested.RootPropName(props[0])
+	if s.onInternalProp(propName) {
+		return nil, containsNotBatchable
+	}
+	if _, ok := schema.IsPropertyLength(propName, 0); ok {
+		return nil, containsNotBatchable
+	}
+
+	property, err := schema.GetPropertyByName(class, propName)
+	if err != nil {
+		// the desugared per-value path raises the identical "property not
+		// found" error; no need to duplicate it here
+		return nil, containsNotBatchable
+	}
+	if _, ok := schema.AsNested(property.DataType); ok {
+		return nil, containsNotBatchable
+	}
+	if s.onRefProp(property) || s.onGeoProp(property) {
+		return nil, containsNotBatchable
+	}
+	if !HasFilterableIndex(property) {
+		return nil, containsNotBatchable
+	}
+
+	b := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
+	if b == nil || b.Strategy() != lsmkv.StrategyRoaringSet {
+		return nil, containsNotBatchable
+	}
+
+	switch {
+	case s.onUUIDProp(property):
+		if propType != schema.DataTypeText {
+			return nil, containsNotBatchable
+		}
+		return property, containsBatchUUID
+	case s.onTokenizableProp(property):
+		if propType != schema.DataTypeText {
+			return nil, containsNotBatchable
+		}
+		// tokenizeField always produces exactly one token (a TrimFunc of the
+		// input, never zero, never more than one), so FIELD is provably a
+		// 1-value-to-1-key tokenization; any other tokenization can turn one
+		// value into zero or several tokens and must desugar.
+		if ResolveTokenization(s.tokResolver, property.Name, property.Tokenization) != models.PropertyTokenizationField {
+			return nil, containsNotBatchable
+		}
+		if s.isFallbackToSearchable() {
+			return nil, containsNotBatchable
+		}
+		return property, containsBatchTextField
+	default:
+		switch propType {
+		case schema.DataTypeInt, schema.DataTypeNumber, schema.DataTypeBoolean, schema.DataTypeDate:
+			return property, containsBatchPrimitive
+		default:
+			return nil, containsNotBatchable
+		}
+	}
+}
+
+// encodeBatchedContainsKeys encodes every value to its on-disk key via encode,
+// wrapping the first failure with its position so the caller can report
+// which element was malformed. encode takes interface{} — the shared
+// signature of the extract*Value encoders — so method values pass directly;
+// each typed value boxes at the call.
+func encodeBatchedContainsKeys[T any](values []T, encode func(interface{}) ([]byte, error)) ([][]byte, error) {
 	keys := make([][]byte, len(values))
 	for i, v := range values {
 		k, err := encode(v)
@@ -995,228 +1105,202 @@ func encodeContainsKeys[T any](values []T, encode func(T) ([]byte, error)) ([][]
 	return keys, nil
 }
 
-// extractContainsBatch is the shape gate for the batched flat
-// ContainsAny/ContainsAll fast path. It recognizes a flat (non-nested),
-// single-property, roaringset-filterable Contains filter over a
-// one-value-maps-to-one-key type and, when eligible, pre-encodes every
-// value to its on-disk key using the exact same per-value encoders
-// buildPropValuePair would otherwise call once per value via N
-// propValuePair leaves.
-//
-// Returns a strict 3-state contract:
-//   - eligible == false: shape rejected before touching any value; err is
-//     always nil. The caller must fall through to the existing desugared
-//     extraction.
-//   - eligible == true, err == nil: pv is fully built; return it directly.
-//   - eligible == true, err != nil: the shape matched (property,
-//     tokenization, bucket all confirmed eligible) but encoding one of the
-//     values failed; the caller should return the error immediately rather
-//     than falling through to re-derive the identical failure.
-func (s *Searcher) extractContainsBatch(ctx context.Context, path *filters.Path,
-	propType schema.DataType, value interface{}, operator filters.Operator, class *models.Class,
-) (*propValuePair, bool, error) {
-	if operator != filters.ContainsAny && operator != filters.ContainsAll {
-		return nil, false, nil
-	}
-	if entcfg.BatchedContainsDisabled() {
-		return nil, false, nil
-	}
-
-	props := path.Slice()
-	if len(props) != 1 {
-		return nil, false, nil
-	}
-
-	propName := filnested.RootPropName(props[0])
-	if s.onInternalProp(propName) {
-		return nil, false, nil
-	}
-	if _, ok := schema.IsPropertyLength(propName, 0); ok {
-		return nil, false, nil
-	}
-
-	property, err := schema.GetPropertyByName(class, propName)
-	if err != nil {
-		// The existing per-value path will raise the identical "property not
-		// found" error; no need to duplicate that error text here.
-		return nil, false, nil
-	}
-	if _, ok := schema.AsNested(property.DataType); ok {
-		return nil, false, nil
-	}
-	if s.onRefProp(property) || s.onGeoProp(property) {
-		return nil, false, nil
-	}
-
-	// encode is populated by whichever family below matches; it performs the
-	// actual per-value key encoding and is only invoked once every remaining
-	// gate check (bucket, strategy) has passed.
-	var encode func() ([][]byte, error)
-
-	// Only base value types are eligible: the API layers normalize Contains
-	// value types to the base type before the searcher, and the desugared
-	// per-value leaf extractors error on array value types — accepting them
-	// here would succeed where the fallback path errors.
-	switch {
-	case s.onUUIDProp(property):
-		if propType != schema.DataTypeText {
-			return nil, false, nil
-		}
-		values, err := s.extractStringArray(value)
-		if err != nil || len(values) < 2 {
-			return nil, false, nil
-		}
-		if !HasFilterableIndex(property) {
-			return nil, false, nil
-		}
-		encode = func() ([][]byte, error) {
-			return encodeContainsKeys(values, func(v string) ([]byte, error) { return s.extractUUIDValue(v) })
-		}
-
-	case s.onTokenizableProp(property):
-		if propType != schema.DataTypeText {
-			return nil, false, nil
-		}
-		// tokenizeField always produces exactly one token (a TrimFunc of the
-		// input, never zero, never more than one), so FIELD is provably a
-		// 1-value-to-1-key tokenization; any other tokenization can turn one
-		// value into zero or several tokens and must fall through.
-		effectiveTok := ResolveTokenization(s.tokResolver, property.Name, property.Tokenization)
-		if effectiveTok != models.PropertyTokenizationField {
-			return nil, false, nil
-		}
-		values, err := s.extractStringArray(value)
-		if err != nil || len(values) < 2 {
-			return nil, false, nil
-		}
-		if !HasFilterableIndex(property) || s.isFallbackToSearchable() {
-			return nil, false, nil
-		}
-		prepared := tokenizer.NewPreparedAnalyzer(property.TextAnalyzer)
-		encode = func() ([][]byte, error) {
-			// One batched analysis for all values: per-batch metrics and a
-			// shared token backing array instead of per-value Analyze calls.
-			batch, err := tokenizer.AnalyzeBatch(values, effectiveTok, class.Class, prepared, nil)
-			if err != nil {
-				return nil, err
-			}
-			keys := make([][]byte, batch.Len())
-			for i, valueTokens := range batch.All() {
-				if len(valueTokens) != 1 {
-					return nil, fmt.Errorf("value %d: FIELD tokenization produced %d tokens, want exactly 1", i, len(valueTokens))
-				}
-				keys[i] = []byte(valueTokens[0])
-			}
-			return keys, nil
-		}
-
-	default:
-		switch propType {
-		case schema.DataTypeInt:
-			values, err := s.extractIntArray(value)
-			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
-				return nil, false, nil
-			}
-			encode = func() ([][]byte, error) {
-				return encodeContainsKeys(values, func(v int) ([]byte, error) { return s.extractIntValue(v) })
-			}
-		case schema.DataTypeNumber:
-			values, err := s.extractFloat64Array(value)
-			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
-				return nil, false, nil
-			}
-			encode = func() ([][]byte, error) {
-				return encodeContainsKeys(values, func(v float64) ([]byte, error) { return s.extractNumberValue(v) })
-			}
-		case schema.DataTypeBoolean:
-			values, err := s.extractBoolArray(value)
-			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
-				return nil, false, nil
-			}
-			encode = func() ([][]byte, error) {
-				return encodeContainsKeys(values, func(v bool) ([]byte, error) { return s.extractBoolValue(v) })
-			}
-		case schema.DataTypeDate:
-			values, err := s.extractStringArray(value)
-			if err != nil || len(values) < 2 || !HasFilterableIndex(property) {
-				return nil, false, nil
-			}
-			encode = func() ([][]byte, error) {
-				return encodeContainsKeys(values, func(v string) ([]byte, error) { return s.extractDateValue(v) })
-			}
-		default:
-			return nil, false, nil
-		}
-	}
-
-	b := s.store.Bucket(helpers.BucketFromPropNameLSM(property.Name))
-	if b == nil || b.Strategy() != lsmkv.StrategyRoaringSet {
-		return nil, false, nil
-	}
-
-	keys, err := encode()
-	if err != nil {
-		return nil, true, fmt.Errorf("extract contains values: %w", err)
-	}
-
+// newBatchedContainsPair builds the batched Contains leaf from pre-encoded keys.
+func newBatchedContainsPair(property *models.Property, operator filters.Operator,
+	class *models.Class, keys [][]byte,
+) (*propValuePair, error) {
 	pv, err := newPropValuePair(class)
 	if err != nil {
-		// the shape fully matched, so per the 3-state contract a failure
-		// here is an error, not a fall-through (unreachable today: a nil
-		// class is rejected by the property lookup above)
-		return nil, true, err
+		return nil, err
 	}
 	pv.prop = property.Name
 	pv.operator = operator
 	pv.hasFilterableIndex = true
 	pv.containsValues = keys
-	return pv, true, nil
+	return pv, nil
 }
 
+// batchedContainsUUID builds the batched leaf for string values on a UUID
+// property. A value that fails to encode is an error, not a fall-through:
+// the shape already matched, so desugaring would only re-derive the
+// identical failure per value. The same applies to every batchedContains*
+// method below.
+func (s *Searcher) batchedContainsUUID(property *models.Property, operator filters.Operator,
+	class *models.Class, values []string,
+) (*propValuePair, error) {
+	keys, err := encodeBatchedContainsKeys(values, s.extractUUIDValue)
+	if err != nil {
+		return nil, fmt.Errorf("extract contains values: %w", err)
+	}
+	return newBatchedContainsPair(property, operator, class, keys)
+}
+
+// batchedContainsTextField builds the batched leaf for string values on a
+// FIELD-tokenized text property: one batched analysis for all values —
+// per-batch metrics and a shared token backing array instead of per-value
+// Analyze calls — yielding one key per value. classifyContainsBatch has
+// already confirmed the property's effective tokenization is FIELD.
+func (s *Searcher) batchedContainsTextField(property *models.Property, operator filters.Operator,
+	class *models.Class, values []string,
+) (*propValuePair, error) {
+	prepared := tokenizer.NewPreparedAnalyzer(property.TextAnalyzer)
+	batch, err := tokenizer.AnalyzeBatch(values, models.PropertyTokenizationField, class.Class, prepared, nil)
+	if err != nil {
+		return nil, fmt.Errorf("extract contains values: %w", err)
+	}
+	keys := make([][]byte, batch.Len())
+	for i, valueTokens := range batch.All() {
+		if len(valueTokens) != 1 {
+			return nil, fmt.Errorf("extract contains values: value %d: FIELD tokenization produced %d tokens, want exactly 1", i, len(valueTokens))
+		}
+		keys[i] = []byte(valueTokens[0])
+	}
+	return newBatchedContainsPair(property, operator, class, keys)
+}
+
+func (s *Searcher) batchedContainsInt(property *models.Property, operator filters.Operator,
+	class *models.Class, values []int,
+) (*propValuePair, error) {
+	keys, err := encodeBatchedContainsKeys(values, s.extractIntValue)
+	if err != nil {
+		return nil, fmt.Errorf("extract contains values: %w", err)
+	}
+	return newBatchedContainsPair(property, operator, class, keys)
+}
+
+func (s *Searcher) batchedContainsNumber(property *models.Property, operator filters.Operator,
+	class *models.Class, values []float64,
+) (*propValuePair, error) {
+	keys, err := encodeBatchedContainsKeys(values, s.extractNumberValue)
+	if err != nil {
+		return nil, fmt.Errorf("extract contains values: %w", err)
+	}
+	return newBatchedContainsPair(property, operator, class, keys)
+}
+
+func (s *Searcher) batchedContainsBool(property *models.Property, operator filters.Operator,
+	class *models.Class, values []bool,
+) (*propValuePair, error) {
+	keys, err := encodeBatchedContainsKeys(values, s.extractBoolValue)
+	if err != nil {
+		return nil, fmt.Errorf("extract contains values: %w", err)
+	}
+	return newBatchedContainsPair(property, operator, class, keys)
+}
+
+func (s *Searcher) batchedContainsDate(property *models.Property, operator filters.Operator,
+	class *models.Class, values []string,
+) (*propValuePair, error) {
+	keys, err := encodeBatchedContainsKeys(values, s.extractDateValue)
+	if err != nil {
+		return nil, fmt.Errorf("extract contains values: %w", err)
+	}
+	return newBatchedContainsPair(property, operator, class, keys)
+}
+
+// extractContains resolves a ContainsAny/ContainsAll/ContainsNone filter.
+// classifyContainsBatch decides once whether the batched fast path applies
+// and with which key encoding; each value-type arm then extracts its typed
+// values once and either builds the batched leaf or desugars the same slice
+// into per-value Equal operands.
+//
+// Batching additionally requires len(values) >= 2: a single desugared leaf
+// threads the query limit into its resolution, which the batched fold does
+// not — and one value has no per-value overhead to amortize anyway.
 func (s *Searcher) extractContains(ctx context.Context,
 	path *filters.Path, propType schema.DataType, value interface{},
 	operator filters.Operator, class *models.Class,
 ) (*propValuePair, error) {
-	if pv, eligible, err := s.extractContainsBatch(ctx, path, propType, value, operator, class); eligible {
-		return pv, err
-	}
+	property, batchType := s.classifyContainsBatch(path, propType, operator, class)
 
-	var operands []filters.Clause
 	switch propType {
 	case schema.DataTypeText, schema.DataTypeTextArray:
-		valueStringArray, err := s.extractStringArray(value)
+		values, err := s.extractStringArray(value)
 		if err != nil {
 			return nil, err
 		}
-		operands = getContainsOperands(propType, path, valueStringArray)
+		if len(values) >= 2 {
+			switch batchType {
+			case containsBatchUUID:
+				return s.batchedContainsUUID(property, operator, class, values)
+			case containsBatchTextField:
+				return s.batchedContainsTextField(property, operator, class, values)
+			default:
+				// containsNotBatchable: desugar below
+			}
+		}
+		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+
 	case schema.DataTypeInt, schema.DataTypeIntArray:
-		valueIntArray, err := s.extractIntArray(value)
+		values, err := s.extractIntArray(value)
 		if err != nil {
 			return nil, err
 		}
-		operands = getContainsOperands(propType, path, valueIntArray)
+		if batchType == containsBatchPrimitive && len(values) >= 2 {
+			return s.batchedContainsInt(property, operator, class, values)
+		}
+		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+
 	case schema.DataTypeNumber, schema.DataTypeNumberArray:
-		valueFloat64Array, err := s.extractFloat64Array(value)
+		values, err := s.extractFloat64Array(value)
 		if err != nil {
 			return nil, err
 		}
-		operands = getContainsOperands(propType, path, valueFloat64Array)
+		if batchType == containsBatchPrimitive && len(values) >= 2 {
+			return s.batchedContainsNumber(property, operator, class, values)
+		}
+		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+
 	case schema.DataTypeBoolean, schema.DataTypeBooleanArray:
-		valueBooleanArray, err := s.extractBoolArray(value)
+		values, err := s.extractBoolArray(value)
 		if err != nil {
 			return nil, err
 		}
-		operands = getContainsOperands(propType, path, valueBooleanArray)
+		if batchType == containsBatchPrimitive && len(values) >= 2 {
+			return s.batchedContainsBool(property, operator, class, values)
+		}
+		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+
 	case schema.DataTypeDate, schema.DataTypeDateArray:
-		valueDateArray, err := s.extractStringArray(value)
+		values, err := s.extractStringArray(value)
 		if err != nil {
 			return nil, err
 		}
-		operands = getContainsOperands(propType, path, valueDateArray)
+		if batchType == containsBatchPrimitive && len(values) >= 2 {
+			return s.batchedContainsDate(property, operator, class, values)
+		}
+		return s.desugaredContains(ctx, operator, class, getContainsOperands(propType, path, values))
+
 	default:
 		return nil, fmt.Errorf("unsupported type '%T' for '%v' operator", propType, operator)
 	}
+}
 
+// getContainsOperands builds one Equal clause per value — the bridge from a
+// value type's typed slice to the untyped operands the desugared
+// resolution consumes. It is the one Contains helper that must stay generic,
+// which is why it is a free function next to the desugaredContains method:
+// Go methods cannot have type parameters.
+func getContainsOperands[T any](propType schema.DataType, path *filters.Path, values []T) []filters.Clause {
+	operands := make([]filters.Clause, len(values))
+	for i := range values {
+		operands[i] = filters.Clause{
+			Operator: filters.OperatorEqual,
+			On:       path,
+			Value: &filters.Value{
+				Type:  propType,
+				Value: values[i],
+			},
+		}
+	}
+	return operands
+}
+
+// desugaredContains resolves the filter through the per-value path: one
+// Equal leaf per operand, combined under the operator.
+func (s *Searcher) desugaredContains(ctx context.Context, operator filters.Operator,
+	class *models.Class, operands []filters.Clause,
+) (*propValuePair, error) {
 	children, err := s.extractPropValuePairs(ctx, operands, operator, schema.ClassName(class.Class))
 	if err != nil {
 		return nil, err
@@ -1426,21 +1510,6 @@ func (s *Searcher) extractBoolArray(value interface{}) ([]bool, error) {
 	default:
 		return nil, fmt.Errorf("value type should be []bool but is %T", value)
 	}
-}
-
-func getContainsOperands[T any](propType schema.DataType, path *filters.Path, values []T) []filters.Clause {
-	operands := make([]filters.Clause, len(values))
-	for i := range values {
-		operands[i] = filters.Clause{
-			Operator: filters.OperatorEqual,
-			On:       path,
-			Value: &filters.Value{
-				Type:  propType,
-				Value: values[i],
-			},
-		}
-	}
-	return operands
 }
 
 type docIDsIterator interface {

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1022,13 +1022,11 @@ const (
 )
 
 // classifyContainsBatch runs every shape check for the batched flat
-// ContainsAny/ContainsAll/ContainsNone fast path and reconciles the property with the
-// filter's value type, in one place: flat single-property path, no
-// internal/length/nested/ref/geo shape, filterable index backed by an actual
-// roaringset bucket, and a base value type matching the property (the
+// ContainsAny/ContainsAll/ContainsNone fast path and reconciles the property
+// with the filter's value type, in one place. Array value types decline: the
 // API layers normalize Contains value types to the base type before the
 // searcher, and the desugared per-value leaf extractors error on array value
-// types — batching them would succeed where the fallback path errors).
+// types — batching them would succeed where the fallback path errors.
 //
 // On decline it returns containsNotBatchable plus a containsDecline* reason,
 // which desugaredContains surfaces in the slow-query details; on success the
@@ -1127,7 +1125,7 @@ func encodeBatchedContainsKeys[T any](values []T, encode func(interface{}) ([]by
 	for i, v := range values {
 		k, err := encode(v)
 		if err != nil {
-			return nil, fmt.Errorf("value %d: %w", i, err)
+			return nil, fmt.Errorf("extract contains values: value %d: %w", i, err)
 		}
 		keys[i] = k
 	}
@@ -1159,7 +1157,7 @@ func (s *Searcher) batchedContainsUUID(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeBatchedContainsKeys(values, s.extractUUIDValue)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1192,7 +1190,7 @@ func (s *Searcher) batchedContainsInt(property *models.Property, operator filter
 ) (*propValuePair, error) {
 	keys, err := encodeBatchedContainsKeys(values, s.extractIntValue)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1202,7 +1200,7 @@ func (s *Searcher) batchedContainsNumber(property *models.Property, operator fil
 ) (*propValuePair, error) {
 	keys, err := encodeBatchedContainsKeys(values, s.extractNumberValue)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1212,7 +1210,7 @@ func (s *Searcher) batchedContainsBool(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeBatchedContainsKeys(values, s.extractBoolValue)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1222,7 +1220,7 @@ func (s *Searcher) batchedContainsDate(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeBatchedContainsKeys(values, s.extractDateValue)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1234,7 +1232,7 @@ func (s *Searcher) batchedContainsDate(property *models.Property, operator filte
 // into per-value Equal operands.
 //
 // Batching additionally requires len(values) >= 2: a single desugared leaf
-// threads the query limit into its resolution, which the batched fold does
+// applies the query limit while resolving, which the batched fold does
 // not — and one value has no per-value overhead to amortize anyway.
 func (s *Searcher) extractContains(ctx context.Context,
 	path *filters.Path, propType schema.DataType, value interface{},

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -1,0 +1,367 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/tokenizer"
+)
+
+const containsBatchTestClass = "ContainsBatchGateTest"
+
+// containsBatchGateFixture wires one Searcher/Store against a class carrying
+// one property per gate branch under test, each with a matching (or
+// deliberately mismatching) LSM bucket.
+type containsBatchGateFixture struct {
+	searcher *Searcher
+	class    *models.Class
+	fallback bool // read by the Searcher's isFallbackToSearchable closure
+}
+
+func newContainsBatchGateFixture(t *testing.T) *containsBatchGateFixture {
+	t.Helper()
+	dir := t.TempDir()
+	logger := logrus.New()
+
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Shutdown(context.Background())) })
+
+	vTrue, vFalse := true, false
+	class := &models.Class{
+		Class: containsBatchTestClass,
+		Properties: []*models.Property{
+			{Name: "prop-uuid", DataType: schema.DataTypeUUID.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-text-field", DataType: schema.DataTypeText.PropString(), Tokenization: models.PropertyTokenizationField, IndexFilterable: &vTrue},
+			{Name: "prop-int", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-number", DataType: schema.DataTypeNumber.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-bool", DataType: schema.DataTypeBoolean.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-date", DataType: schema.DataTypeDate.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-text-word", DataType: schema.DataTypeText.PropString(), Tokenization: models.PropertyTokenizationWord, IndexFilterable: &vTrue},
+			{Name: "prop-text-whitespace", DataType: schema.DataTypeText.PropString(), Tokenization: models.PropertyTokenizationWhitespace, IndexFilterable: &vTrue},
+			{Name: "prop-fallback", DataType: schema.DataTypeText.PropString(), Tokenization: models.PropertyTokenizationField, IndexFilterable: &vTrue, IndexSearchable: &vTrue},
+			{Name: "prop-not-filterable", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vFalse, IndexSearchable: &vTrue},
+			{Name: "prop-nonroaringset", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-no-bucket", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+			{Name: "prop-ref", DataType: []string{"SomeOtherClass"}},
+			{Name: "prop-geo", DataType: schema.DataTypeGeoCoordinates.PropString()},
+			{Name: "prop-nested", DataType: schema.DataTypeObject.PropString()},
+		},
+	}
+
+	ctx := context.Background()
+	roaringProps := []string{
+		"prop-uuid", "prop-text-field", "prop-int", "prop-number", "prop-bool",
+		"prop-date", "prop-text-word", "prop-text-whitespace", "prop-fallback",
+		"prop-not-filterable",
+	}
+	for _, propName := range roaringProps {
+		require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.BucketFromPropNameLSM(propName),
+			lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+			lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop())))
+	}
+	// deliberately not roaringset: simulates a filterable index backed by a
+	// different (e.g. not-yet-migrated) bucket strategy
+	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.BucketFromPropNameLSM("prop-nonroaringset"),
+		lsmkv.WithStrategy(lsmkv.StrategyMapCollection)))
+	// "prop-no-bucket" deliberately has no backing bucket at all
+
+	f := &containsBatchGateFixture{class: class}
+	f.searcher = &Searcher{
+		store:                  store,
+		logger:                 logger,
+		getClass:               func(name string) *models.Class { return f.class },
+		isFallbackToSearchable: func() bool { return f.fallback },
+		stopwordProvider:       stopwords.NewProvider(fakeStopwordDetector{}, nil),
+	}
+	return f
+}
+
+func containsPath(propName string) *filters.Path {
+	return &filters.Path{Property: schema.PropertyName(propName)}
+}
+
+func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	s := f.searcher
+	ctx := context.Background()
+
+	t.Run("uuid", func(t *testing.T) {
+		values := []string{
+			"11111111-1111-1111-1111-111111111111",
+			"22222222-2222-2222-2222-222222222222",
+			"33333333-3333-3333-3333-333333333333",
+		}
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-uuid"),
+			schema.DataTypeText, values, filters.ContainsAny, f.class)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		require.NotNil(t, pv)
+		require.Equal(t, filters.ContainsAny, pv.operator)
+		require.Equal(t, "prop-uuid", pv.prop)
+		require.True(t, pv.hasFilterableIndex)
+		require.Len(t, pv.containsValues, len(values))
+		for i, v := range values {
+			want, err := s.extractUUIDValue(v)
+			require.NoError(t, err)
+			require.Equal(t, want, pv.containsValues[i])
+		}
+	})
+
+	t.Run("text FIELD", func(t *testing.T) {
+		values := []string{"alpha", "beta", "gamma"}
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-text-field"),
+			schema.DataTypeText, values, filters.ContainsAll, f.class)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		require.NotNil(t, pv)
+		require.Equal(t, filters.ContainsAll, pv.operator)
+		require.Len(t, pv.containsValues, len(values))
+		prepared := tokenizer.NewPreparedAnalyzer(nil)
+		for i, v := range values {
+			result := tokenizer.Analyze(v, models.PropertyTokenizationField, f.class.Class, prepared, nil)
+			require.Equal(t, []byte(result.Query[0]), pv.containsValues[i])
+		}
+	})
+
+	t.Run("int", func(t *testing.T) {
+		values := []int{1, 2, 3}
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
+			schema.DataTypeInt, values, filters.ContainsAny, f.class)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		require.Len(t, pv.containsValues, len(values))
+		for i, v := range values {
+			want, err := s.extractIntValue(v)
+			require.NoError(t, err)
+			require.Equal(t, want, pv.containsValues[i])
+		}
+	})
+
+	t.Run("number", func(t *testing.T) {
+		values := []float64{1.5, 2.5, 3.5}
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-number"),
+			schema.DataTypeNumber, values, filters.ContainsAny, f.class)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		require.Len(t, pv.containsValues, len(values))
+		for i, v := range values {
+			want, err := s.extractNumberValue(v)
+			require.NoError(t, err)
+			require.Equal(t, want, pv.containsValues[i])
+		}
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		values := []bool{true, false}
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-bool"),
+			schema.DataTypeBoolean, values, filters.ContainsAny, f.class)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		require.Len(t, pv.containsValues, len(values))
+		for i, v := range values {
+			want, err := s.extractBoolValue(v)
+			require.NoError(t, err)
+			require.Equal(t, want, pv.containsValues[i])
+		}
+	})
+
+	t.Run("date", func(t *testing.T) {
+		values := []string{"2021-01-01T00:00:00Z", "2022-02-02T00:00:00Z", "2023-03-03T00:00:00Z"}
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-date"),
+			schema.DataTypeDate, values, filters.ContainsAny, f.class)
+		require.NoError(t, err)
+		require.True(t, eligible)
+		require.Len(t, pv.containsValues, len(values))
+		for i, v := range values {
+			want, err := s.extractDateValue(v)
+			require.NoError(t, err)
+			require.Equal(t, want, pv.containsValues[i])
+		}
+	})
+}
+
+func TestExtractContainsBatch_Ineligible(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	s := f.searcher
+	ctx := context.Background()
+
+	assertFallThrough := func(t *testing.T, pv *propValuePair, eligible bool, err error) {
+		t.Helper()
+		require.False(t, eligible)
+		require.NoError(t, err)
+		require.Nil(t, pv)
+	}
+
+	t.Run("ContainsNone is out of scope", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
+			schema.DataTypeInt, []int{1, 2}, filters.ContainsNone, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("nested path", func(t *testing.T) {
+		path := &filters.Path{Property: "addresses", Child: &filters.Path{Property: "city"}}
+		pv, eligible, err := s.extractContainsBatch(ctx, path,
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("internal prop", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath(filters.InternalPropID),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("property length meta-filter", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"+filters.InternalPropertyLength),
+			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("property not found", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-does-not-exist"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("nested object property", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-nested"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("ref prop", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-ref"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("geo prop", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-geo"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("non-FIELD tokenization WORD", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-text-word"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("non-FIELD tokenization WHITESPACE", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-text-whitespace"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("fallback to searchable", func(t *testing.T) {
+		f.fallback = true
+		t.Cleanup(func() { f.fallback = false })
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-fallback"),
+			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("IndexFilterable false", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-not-filterable"),
+			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("bucket strategy not roaringset", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-nonroaringset"),
+			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("bucket not created", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-no-bucket"),
+			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("N=0 values", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
+			schema.DataTypeInt, []int{}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+
+	t.Run("N=1 value", func(t *testing.T) {
+		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
+			schema.DataTypeInt, []int{1}, filters.ContainsAny, f.class)
+		assertFallThrough(t, pv, eligible, err)
+	})
+}
+
+func TestExtractContainsBatch_EncodingErrorIsEligibleButFails(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	s := f.searcher
+	ctx := context.Background()
+
+	values := []string{
+		"11111111-1111-1111-1111-111111111111",
+		"not-a-valid-uuid",
+	}
+	pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-uuid"),
+		schema.DataTypeText, values, filters.ContainsAny, f.class)
+	require.True(t, eligible)
+	require.Error(t, err)
+	require.Nil(t, pv)
+}
+
+// TestExtractContains_FallsThroughToPerValuePath proves that once the gate
+// declines a shape, extractContains's existing per-value dispatch still
+// runs unchanged, producing children (not containsValues).
+func TestExtractContains_FallsThroughToPerValuePath(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	s := f.searcher
+	ctx := context.Background()
+
+	path := &filters.Path{Property: "prop-text-word"}
+	pv, err := s.extractContains(ctx, path, schema.DataTypeText, []string{"hello world", "goodbye"},
+		filters.ContainsAny, f.class)
+	require.NoError(t, err)
+	require.Nil(t, pv.containsValues)
+	require.NotEmpty(t, pv.children)
+}
+
+// TestExtractContains_UsesBatchedPathWhenEligible proves the interception at
+// the top of extractContains actually wires extractContainsBatch's result
+// through, rather than always falling back to the desugared body.
+func TestExtractContains_UsesBatchedPathWhenEligible(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	s := f.searcher
+	ctx := context.Background()
+
+	pv, err := s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
+		[]int{1, 2, 3}, filters.ContainsAny, f.class)
+	require.NoError(t, err)
+	require.NotNil(t, pv)
+	require.Nil(t, pv.children)
+	require.Len(t, pv.containsValues, 3)
+}

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -364,4 +365,28 @@ func TestExtractContains_UsesBatchedPathWhenEligible(t *testing.T) {
 	require.NotNil(t, pv)
 	require.Nil(t, pv.children)
 	require.Len(t, pv.containsValues, 3)
+}
+
+// TestExtractContainsBatch_KillSwitch pins the operator escape hatch: with
+// WEAVIATE_DISABLE_BATCHED_CONTAINS set, an otherwise eligible shape
+// declines and extractContains resolves through the per-value desugared
+// path.
+func TestExtractContainsBatch_KillSwitch(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	s := f.searcher
+	ctx := context.Background()
+
+	t.Setenv(entcfg.EnvDisableBatchedContains, "true")
+
+	pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
+		schema.DataTypeInt, []int{1, 2, 3}, filters.ContainsAny, f.class)
+	require.False(t, eligible)
+	require.NoError(t, err)
+	require.Nil(t, pv)
+
+	pv, err = s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
+		[]int{1, 2, 3}, filters.ContainsAny, f.class)
+	require.NoError(t, err)
+	require.Nil(t, pv.containsValues)
+	require.NotEmpty(t, pv.children, "with the kill switch on, Contains must desugar per value")
 }

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -112,99 +112,89 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 	s := f.searcher
 	ctx := context.Background()
 
-	t.Run("uuid", func(t *testing.T) {
-		values := []string{
-			"11111111-1111-1111-1111-111111111111",
-			"22222222-2222-2222-2222-222222222222",
-			"33333333-3333-3333-3333-333333333333",
-		}
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-uuid"),
-			schema.DataTypeText, values, filters.ContainsAny, f.class)
+	uuidValues := []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+		"33333333-3333-3333-3333-333333333333",
+	}
+	uuidKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractUUIDValue(uuidValues[i])
 		require.NoError(t, err)
-		require.True(t, eligible)
-		require.NotNil(t, pv)
-		require.Equal(t, filters.ContainsAny, pv.operator)
-		require.Equal(t, "prop-uuid", pv.prop)
-		require.True(t, pv.hasFilterableIndex)
-		require.Len(t, pv.containsValues, len(values))
-		for i, v := range values {
-			want, err := s.extractUUIDValue(v)
-			require.NoError(t, err)
-			require.Equal(t, want, pv.containsValues[i])
-		}
-	})
-
-	t.Run("text FIELD", func(t *testing.T) {
-		values := []string{"alpha", "beta", "gamma"}
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-text-field"),
-			schema.DataTypeText, values, filters.ContainsAll, f.class)
-		require.NoError(t, err)
-		require.True(t, eligible)
-		require.NotNil(t, pv)
-		require.Equal(t, filters.ContainsAll, pv.operator)
-		require.Len(t, pv.containsValues, len(values))
+		return want
+	}
+	textValues := []string{"alpha", "beta", "gamma"}
+	textKey := func(t *testing.T, i int) []byte {
 		prepared := tokenizer.NewPreparedAnalyzer(nil)
-		for i, v := range values {
-			result := tokenizer.Analyze(v, models.PropertyTokenizationField, f.class.Class, prepared, nil)
-			require.Equal(t, []byte(result.Query[0]), pv.containsValues[i])
-		}
-	})
-
-	t.Run("int", func(t *testing.T) {
-		values := []int{1, 2, 3}
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
-			schema.DataTypeInt, values, filters.ContainsAny, f.class)
+		result := tokenizer.Analyze(textValues[i], models.PropertyTokenizationField, f.class.Class, prepared, nil)
+		return []byte(result.Query[0])
+	}
+	intValues := []int{1, 2, 3}
+	intKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractIntValue(intValues[i])
 		require.NoError(t, err)
-		require.True(t, eligible)
-		require.Len(t, pv.containsValues, len(values))
-		for i, v := range values {
-			want, err := s.extractIntValue(v)
-			require.NoError(t, err)
-			require.Equal(t, want, pv.containsValues[i])
-		}
-	})
-
-	t.Run("number", func(t *testing.T) {
-		values := []float64{1.5, 2.5, 3.5}
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-number"),
-			schema.DataTypeNumber, values, filters.ContainsAny, f.class)
+		return want
+	}
+	numberValues := []float64{1.5, 2.5, 3.5}
+	numberKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractNumberValue(numberValues[i])
 		require.NoError(t, err)
-		require.True(t, eligible)
-		require.Len(t, pv.containsValues, len(values))
-		for i, v := range values {
-			want, err := s.extractNumberValue(v)
-			require.NoError(t, err)
-			require.Equal(t, want, pv.containsValues[i])
-		}
-	})
-
-	t.Run("bool", func(t *testing.T) {
-		values := []bool{true, false}
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-bool"),
-			schema.DataTypeBoolean, values, filters.ContainsAny, f.class)
+		return want
+	}
+	boolValues := []bool{true, false}
+	boolKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractBoolValue(boolValues[i])
 		require.NoError(t, err)
-		require.True(t, eligible)
-		require.Len(t, pv.containsValues, len(values))
-		for i, v := range values {
-			want, err := s.extractBoolValue(v)
-			require.NoError(t, err)
-			require.Equal(t, want, pv.containsValues[i])
-		}
-	})
-
-	t.Run("date", func(t *testing.T) {
-		values := []string{"2021-01-01T00:00:00Z", "2022-02-02T00:00:00Z", "2023-03-03T00:00:00Z"}
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-date"),
-			schema.DataTypeDate, values, filters.ContainsAny, f.class)
+		return want
+	}
+	dateValues := []string{"2021-01-01T00:00:00Z", "2022-02-02T00:00:00Z", "2023-03-03T00:00:00Z"}
+	dateKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractDateValue(dateValues[i])
 		require.NoError(t, err)
-		require.True(t, eligible)
-		require.Len(t, pv.containsValues, len(values))
-		for i, v := range values {
-			want, err := s.extractDateValue(v)
+		return want
+	}
+
+	tests := []struct {
+		name     string
+		prop     string
+		propType schema.DataType
+		operator filters.Operator
+		// value is what the filter layer hands over: typed slices from
+		// internal callers, []interface{} from the GraphQL/gRPC layer
+		value   interface{}
+		numVals int
+		wantKey func(t *testing.T, i int) []byte
+	}{
+		{"uuid", "prop-uuid", schema.DataTypeText, filters.ContainsAny, uuidValues, 3, uuidKey},
+		{"uuid []interface{}", "prop-uuid", schema.DataTypeText, filters.ContainsAny, []interface{}{uuidValues[0], uuidValues[1], uuidValues[2]}, 3, uuidKey},
+		{"text FIELD", "prop-text-field", schema.DataTypeText, filters.ContainsAll, textValues, 3, textKey},
+		{"text FIELD []interface{}", "prop-text-field", schema.DataTypeText, filters.ContainsAll, []interface{}{"alpha", "beta", "gamma"}, 3, textKey},
+		{"int", "prop-int", schema.DataTypeInt, filters.ContainsAny, intValues, 3, intKey},
+		// the API layers unmarshal numeric values as float64
+		{"int []interface{}", "prop-int", schema.DataTypeInt, filters.ContainsAny, []interface{}{float64(1), float64(2), float64(3)}, 3, intKey},
+		{"number", "prop-number", schema.DataTypeNumber, filters.ContainsAny, numberValues, 3, numberKey},
+		{"number []interface{}", "prop-number", schema.DataTypeNumber, filters.ContainsAny, []interface{}{1.5, 2.5, 3.5}, 3, numberKey},
+		{"bool", "prop-bool", schema.DataTypeBoolean, filters.ContainsAny, boolValues, 2, boolKey},
+		{"bool []interface{}", "prop-bool", schema.DataTypeBoolean, filters.ContainsAny, []interface{}{true, false}, 2, boolKey},
+		{"date", "prop-date", schema.DataTypeDate, filters.ContainsAny, dateValues, 3, dateKey},
+		{"date []interface{}", "prop-date", schema.DataTypeDate, filters.ContainsAny, []interface{}{dateValues[0], dateValues[1], dateValues[2]}, 3, dateKey},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pv, eligible, err := s.extractContainsBatch(ctx, containsPath(tt.prop),
+				tt.propType, tt.value, tt.operator, f.class)
 			require.NoError(t, err)
-			require.Equal(t, want, pv.containsValues[i])
-		}
-	})
+			require.True(t, eligible)
+			require.NotNil(t, pv)
+			require.Equal(t, tt.operator, pv.operator)
+			require.Equal(t, tt.prop, pv.prop)
+			require.True(t, pv.hasFilterableIndex)
+			require.Len(t, pv.containsValues, tt.numVals)
+			for i := 0; i < tt.numVals; i++ {
+				require.Equal(t, tt.wantKey(t, i), pv.containsValues[i], "key %d", i)
+			}
+		})
+	}
 }
 
 func TestExtractContainsBatch_Ineligible(t *testing.T) {
@@ -212,111 +202,125 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 	s := f.searcher
 	ctx := context.Background()
 
-	assertFallThrough := func(t *testing.T, pv *propValuePair, eligible bool, err error) {
-		t.Helper()
-		require.False(t, eligible)
-		require.NoError(t, err)
-		require.Nil(t, pv)
+	tests := []struct {
+		name     string
+		path     *filters.Path
+		propType schema.DataType
+		value    interface{}
+		operator filters.Operator
+		setup    func(t *testing.T)
+	}{
+		{
+			name: "ContainsNone is out of scope",
+			path: containsPath("prop-int"), propType: schema.DataTypeInt,
+			value: []int{1, 2}, operator: filters.ContainsNone,
+		},
+		{
+			name:     "nested path",
+			path:     &filters.Path{Property: "addresses", Child: &filters.Path{Property: "city"}},
+			propType: schema.DataTypeText, value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "internal prop",
+			path: containsPath(filters.InternalPropID), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "property length meta-filter",
+			path: containsPath("prop-int" + filters.InternalPropertyLength), propType: schema.DataTypeInt,
+			value: []int{1, 2}, operator: filters.ContainsAny,
+		},
+		{
+			name: "property not found",
+			path: containsPath("prop-does-not-exist"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "nested object property",
+			path: containsPath("prop-nested"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "ref prop",
+			path: containsPath("prop-ref"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "geo prop",
+			path: containsPath("prop-geo"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "non-FIELD tokenization WORD",
+			path: containsPath("prop-text-word"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "non-FIELD tokenization WHITESPACE",
+			path: containsPath("prop-text-whitespace"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "fallback to searchable",
+			path: containsPath("prop-fallback"), propType: schema.DataTypeText,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			setup: func(t *testing.T) {
+				f.fallback = true
+				t.Cleanup(func() { f.fallback = false })
+			},
+		},
+		{
+			name: "IndexFilterable false",
+			path: containsPath("prop-not-filterable"), propType: schema.DataTypeInt,
+			value: []int{1, 2}, operator: filters.ContainsAny,
+		},
+		{
+			name: "bucket strategy not roaringset",
+			path: containsPath("prop-nonroaringset"), propType: schema.DataTypeInt,
+			value: []int{1, 2}, operator: filters.ContainsAny,
+		},
+		{
+			name: "bucket not created",
+			path: containsPath("prop-no-bucket"), propType: schema.DataTypeInt,
+			value: []int{1, 2}, operator: filters.ContainsAny,
+		},
+		{
+			name: "N=0 values",
+			path: containsPath("prop-int"), propType: schema.DataTypeInt,
+			value: []int{}, operator: filters.ContainsAny,
+		},
+		{
+			name: "N=1 value",
+			path: containsPath("prop-int"), propType: schema.DataTypeInt,
+			value: []int{1}, operator: filters.ContainsAny,
+		},
+		// array value types must decline: the desugared per-value leaf
+		// extractors error on them, so accepting them here would succeed
+		// where the fallback path errors
+		{
+			name: "array value type text",
+			path: containsPath("prop-text-field"), propType: schema.DataTypeTextArray,
+			value: []string{"a", "b"}, operator: filters.ContainsAny,
+		},
+		{
+			name: "array value type int",
+			path: containsPath("prop-int"), propType: schema.DataTypeIntArray,
+			value: []int{1, 2}, operator: filters.ContainsAny,
+		},
 	}
 
-	t.Run("ContainsNone is out of scope", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
-			schema.DataTypeInt, []int{1, 2}, filters.ContainsNone, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("nested path", func(t *testing.T) {
-		path := &filters.Path{Property: "addresses", Child: &filters.Path{Property: "city"}}
-		pv, eligible, err := s.extractContainsBatch(ctx, path,
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("internal prop", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath(filters.InternalPropID),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("property length meta-filter", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"+filters.InternalPropertyLength),
-			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("property not found", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-does-not-exist"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("nested object property", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-nested"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("ref prop", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-ref"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("geo prop", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-geo"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("non-FIELD tokenization WORD", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-text-word"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("non-FIELD tokenization WHITESPACE", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-text-whitespace"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("fallback to searchable", func(t *testing.T) {
-		f.fallback = true
-		t.Cleanup(func() { f.fallback = false })
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-fallback"),
-			schema.DataTypeText, []string{"a", "b"}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("IndexFilterable false", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-not-filterable"),
-			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("bucket strategy not roaringset", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-nonroaringset"),
-			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("bucket not created", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-no-bucket"),
-			schema.DataTypeInt, []int{1, 2}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("N=0 values", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
-			schema.DataTypeInt, []int{}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
-
-	t.Run("N=1 value", func(t *testing.T) {
-		pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
-			schema.DataTypeInt, []int{1}, filters.ContainsAny, f.class)
-		assertFallThrough(t, pv, eligible, err)
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+			pv, eligible, err := s.extractContainsBatch(ctx, tt.path, tt.propType,
+				tt.value, tt.operator, f.class)
+			require.False(t, eligible)
+			require.NoError(t, err)
+			require.Nil(t, pv)
+		})
+	}
 }
 
 func TestExtractContainsBatch_EncodingErrorIsEligibleButFails(t *testing.T) {

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -169,6 +169,8 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 		{"text FIELD", "prop-text-field", schema.DataTypeText, filters.ContainsAll, textValues, 3, textKey},
 		{"text FIELD []interface{}", "prop-text-field", schema.DataTypeText, filters.ContainsAll, []interface{}{"alpha", "beta", "gamma"}, 3, textKey},
 		{"int", "prop-int", schema.DataTypeInt, filters.ContainsAny, intValues, 3, intKey},
+		{"int ContainsNone", "prop-int", schema.DataTypeInt, filters.ContainsNone, intValues, 3, intKey},
+		{"text FIELD ContainsNone", "prop-text-field", schema.DataTypeText, filters.ContainsNone, textValues, 3, textKey},
 		// the API layers unmarshal numeric values as float64
 		{"int []interface{}", "prop-int", schema.DataTypeInt, filters.ContainsAny, []interface{}{float64(1), float64(2), float64(3)}, 3, intKey},
 		{"number", "prop-number", schema.DataTypeNumber, filters.ContainsAny, numberValues, 3, numberKey},
@@ -215,11 +217,6 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 		setup    func(t *testing.T)
 		wantErr  bool
 	}{
-		{
-			name: "ContainsNone is out of scope",
-			path: containsPath("prop-int"), propType: schema.DataTypeInt,
-			value: []int{1, 2}, operator: filters.ContainsNone,
-		},
 		{
 			name:     "nested path",
 			path:     &filters.Path{Property: "addresses", Child: &filters.Path{Property: "city"}},

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -183,11 +183,14 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := helpers.InitSlowQueryDetails(ctx)
 			pv, err := s.extractContains(ctx, containsPath(tt.prop),
 				tt.propType, tt.value, tt.operator, f.class)
 			require.NoError(t, err)
 			require.NotNil(t, pv)
 			require.Nil(t, pv.children, "eligible shape must resolve batched, not desugared")
+			require.Empty(t, extractContainsDesugaredReason(t, ctx),
+				"an eligible shape must not annotate a desugar reason")
 			require.Equal(t, tt.operator, pv.operator)
 			require.Equal(t, tt.prop, pv.prop)
 			require.True(t, pv.hasFilterableIndex)
@@ -204,69 +207,89 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 	s := f.searcher
 	ctx := context.Background()
 
-	// Every row must NOT resolve through the batched path. Rows with
-	// wantErr expect the desugared continuation to fail on its own terms
-	// (which also proves the gate declined: a wrongly-accepted shape would
-	// have succeeded with containsValues instead of erroring).
+	// Every row must NOT resolve through the batched path and must surface
+	// its decline reason in the slow-query details. Rows with wantErr expect
+	// the desugared continuation to fail on its own terms (which also proves
+	// the gate declined: a wrongly-accepted shape would have succeeded with
+	// containsValues instead of erroring); the annotation is written before
+	// the failure, so the reason is asserted on those rows too.
 	tests := []struct {
-		name     string
-		path     *filters.Path
-		propType schema.DataType
-		value    interface{}
-		operator filters.Operator
-		setup    func(t *testing.T)
-		wantErr  bool
+		name       string
+		path       *filters.Path
+		propType   schema.DataType
+		value      interface{}
+		operator   filters.Operator
+		setup      func(t *testing.T)
+		wantErr    bool
+		wantReason string
 	}{
 		{
 			name:     "nested path",
 			path:     &filters.Path{Property: "addresses", Child: &filters.Path{Property: "city"}},
 			propType: schema.DataTypeText, value: []string{"a", "b"}, operator: filters.ContainsAny,
-			wantErr: true, // fixture class has no "addresses" property
+			wantErr:    true, // fixture class has no "addresses" property
+			wantReason: containsDeclineMultiSegmentPath,
 		},
 		{
 			name: "internal prop",
 			path: containsPath(filters.InternalPropID), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantReason: containsDeclineInternalProperty,
 		},
 		{
-			name: "property length meta-filter",
+			name: "property length meta-filter, suffix spelling",
 			path: containsPath("prop-int" + filters.InternalPropertyLength), propType: schema.DataTypeInt,
 			value: []int{1, 2}, operator: filters.ContainsAny,
 			wantErr: true, // fixture class does not index property lengths
+			// the suffix spelling is not a schema property name, so the
+			// classifier declines it one check later than len()
+			wantReason: containsDeclinePropertyNotFound,
+		},
+		{
+			name: "property length meta-filter, len() spelling",
+			path: containsPath("len(prop-int)"), propType: schema.DataTypeInt,
+			value: []int{1, 2}, operator: filters.ContainsAny,
+			wantReason: containsDeclineLengthFilter,
 		},
 		{
 			name: "property not found",
 			path: containsPath("prop-does-not-exist"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
-			wantErr: true,
+			wantErr:    true,
+			wantReason: containsDeclinePropertyNotFound,
 		},
 		{
 			name: "nested object property",
 			path: containsPath("prop-nested"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
-			wantErr: true, // nested filtering preview gate is off in tests
+			wantErr:    true, // nested filtering preview gate is off in tests
+			wantReason: containsDeclineNestedObjectProperty,
 		},
 		{
 			name: "ref prop",
 			path: containsPath("prop-ref"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
-			wantErr: true, // desugared leaf rejects text values on a reference
+			wantErr:    true, // desugared leaf rejects text values on a reference
+			wantReason: containsDeclineReferenceProperty,
 		},
 		{
 			name: "geo prop",
 			path: containsPath("prop-geo"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
-			wantErr: true, // desugared leaf rejects text values on a geo prop
+			wantErr:    true, // desugared leaf rejects text values on a geo prop
+			wantReason: containsDeclineGeoProperty,
 		},
 		{
 			name: "non-FIELD tokenization WORD",
 			path: containsPath("prop-text-word"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantReason: containsDeclineTokenizationNotField,
 		},
 		{
 			name: "non-FIELD tokenization WHITESPACE",
 			path: containsPath("prop-text-whitespace"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantReason: containsDeclineTokenizationNotField,
 		},
 		{
 			name: "fallback to searchable",
@@ -276,33 +299,39 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 				f.fallback = true
 				t.Cleanup(func() { f.fallback = false })
 			},
+			wantReason: containsDeclineFallbackToSearchable,
 		},
 		{
 			name: "IndexFilterable false",
 			path: containsPath("prop-not-filterable"), propType: schema.DataTypeInt,
 			value: []int{1, 2}, operator: filters.ContainsAny,
-			wantErr: true, // int props have no searchable fallback; the leaf demands the filterable index
+			wantErr:    true, // int props have no searchable fallback; the leaf demands the filterable index
+			wantReason: containsDeclineNoFilterableIndex,
 		},
 		{
 			name: "bucket strategy not roaringset",
 			path: containsPath("prop-nonroaringset"), propType: schema.DataTypeInt,
 			value: []int{1, 2}, operator: filters.ContainsAny,
+			wantReason: containsDeclineNoRoaringSetBucket,
 		},
 		{
 			name: "bucket not created",
 			path: containsPath("prop-no-bucket"), propType: schema.DataTypeInt,
 			value: []int{1, 2}, operator: filters.ContainsAny,
+			wantReason: containsDeclineNoRoaringSetBucket,
 		},
 		{
 			name: "N=0 values",
 			path: containsPath("prop-int"), propType: schema.DataTypeInt,
 			value: []int{}, operator: filters.ContainsAny,
-			wantErr: true, // the desugared path rejects an empty value set
+			wantErr:    true, // the desugared path rejects an empty value set
+			wantReason: containsDeclineFewerThanTwoValues,
 		},
 		{
 			name: "N=1 value",
 			path: containsPath("prop-int"), propType: schema.DataTypeInt,
 			value: []int{1}, operator: filters.ContainsAny,
+			wantReason: containsDeclineFewerThanTwoValues,
 		},
 		// array value types must decline: the desugared per-value leaf
 		// extractors error on them, so accepting them in the gate would
@@ -311,13 +340,15 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			name: "array value type text",
 			path: containsPath("prop-text-field"), propType: schema.DataTypeTextArray,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
-			wantErr: true,
+			wantErr:    true,
+			wantReason: containsDeclineValueTypeMismatch,
 		},
 		{
 			name: "array value type int",
 			path: containsPath("prop-int"), propType: schema.DataTypeIntArray,
 			value: []int{1, 2}, operator: filters.ContainsAny,
-			wantErr: true,
+			wantErr:    true,
+			wantReason: containsDeclineValueTypeMismatch,
 		},
 	}
 
@@ -326,8 +357,11 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(t)
 			}
+			ctx := helpers.InitSlowQueryDetails(ctx)
 			pv, err := s.extractContains(ctx, tt.path, tt.propType,
 				tt.value, tt.operator, f.class)
+			require.Equal(t, tt.wantReason, extractContainsDesugaredReason(t, ctx),
+				"decline reason must be surfaced in the slow-query details")
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -337,6 +371,24 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			require.Nil(t, pv.containsValues, "shape must not resolve through the batched path")
 		})
 	}
+}
+
+// extractContainsDesugaredReason returns the reason of the single
+// "contains_desugared" slow-query annotation in ctx, or "" if none was
+// written.
+func extractContainsDesugaredReason(t *testing.T, ctx context.Context) string {
+	t.Helper()
+	details := helpers.ExtractSlowQueryDetails(ctx)
+	entry, ok := details["contains_desugared"]
+	if !ok {
+		return ""
+	}
+	entries, ok := entry.([]map[string]any)
+	require.True(t, ok, "contains_desugared must hold []map[string]any, got %T", entry)
+	require.Len(t, entries, 1)
+	reason, ok := entries[0]["reason"].(string)
+	require.True(t, ok)
+	return reason
 }
 
 func TestExtractContainsBatch_EncodingErrorIsEligibleButFails(t *testing.T) {
@@ -399,9 +451,11 @@ func TestExtractContainsBatch_KillSwitch(t *testing.T) {
 
 	t.Setenv(entcfg.EnvDisableBatchedContains, "true")
 
+	ctx = helpers.InitSlowQueryDetails(ctx)
 	pv, err := s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
 		[]int{1, 2, 3}, filters.ContainsAny, f.class)
 	require.NoError(t, err)
 	require.Nil(t, pv.containsValues)
 	require.NotEmpty(t, pv.children, "with the kill switch on, Contains must desugar per value")
+	require.Equal(t, containsDeclineDisabledByEnv, extractContainsDesugaredReason(t, ctx))
 }

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -181,11 +181,11 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pv, eligible, err := s.extractContainsBatch(ctx, containsPath(tt.prop),
+			pv, err := s.extractContains(ctx, containsPath(tt.prop),
 				tt.propType, tt.value, tt.operator, f.class)
 			require.NoError(t, err)
-			require.True(t, eligible)
 			require.NotNil(t, pv)
+			require.Nil(t, pv.children, "eligible shape must resolve batched, not desugared")
 			require.Equal(t, tt.operator, pv.operator)
 			require.Equal(t, tt.prop, pv.prop)
 			require.True(t, pv.hasFilterableIndex)
@@ -202,6 +202,10 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 	s := f.searcher
 	ctx := context.Background()
 
+	// Every row must NOT resolve through the batched path. Rows with
+	// wantErr expect the desugared continuation to fail on its own terms
+	// (which also proves the gate declined: a wrongly-accepted shape would
+	// have succeeded with containsValues instead of erroring).
 	tests := []struct {
 		name     string
 		path     *filters.Path
@@ -209,6 +213,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 		value    interface{}
 		operator filters.Operator
 		setup    func(t *testing.T)
+		wantErr  bool
 	}{
 		{
 			name: "ContainsNone is out of scope",
@@ -219,6 +224,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			name:     "nested path",
 			path:     &filters.Path{Property: "addresses", Child: &filters.Path{Property: "city"}},
 			propType: schema.DataTypeText, value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantErr: true, // fixture class has no "addresses" property
 		},
 		{
 			name: "internal prop",
@@ -229,26 +235,31 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			name: "property length meta-filter",
 			path: containsPath("prop-int" + filters.InternalPropertyLength), propType: schema.DataTypeInt,
 			value: []int{1, 2}, operator: filters.ContainsAny,
+			wantErr: true, // fixture class does not index property lengths
 		},
 		{
 			name: "property not found",
 			path: containsPath("prop-does-not-exist"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantErr: true,
 		},
 		{
 			name: "nested object property",
 			path: containsPath("prop-nested"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantErr: true, // nested filtering preview gate is off in tests
 		},
 		{
 			name: "ref prop",
 			path: containsPath("prop-ref"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantErr: true, // desugared leaf rejects text values on a reference
 		},
 		{
 			name: "geo prop",
 			path: containsPath("prop-geo"), propType: schema.DataTypeText,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantErr: true, // desugared leaf rejects text values on a geo prop
 		},
 		{
 			name: "non-FIELD tokenization WORD",
@@ -273,6 +284,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			name: "IndexFilterable false",
 			path: containsPath("prop-not-filterable"), propType: schema.DataTypeInt,
 			value: []int{1, 2}, operator: filters.ContainsAny,
+			wantErr: true, // int props have no searchable fallback; the leaf demands the filterable index
 		},
 		{
 			name: "bucket strategy not roaringset",
@@ -288,6 +300,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			name: "N=0 values",
 			path: containsPath("prop-int"), propType: schema.DataTypeInt,
 			value: []int{}, operator: filters.ContainsAny,
+			wantErr: true, // the desugared path rejects an empty value set
 		},
 		{
 			name: "N=1 value",
@@ -295,17 +308,19 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			value: []int{1}, operator: filters.ContainsAny,
 		},
 		// array value types must decline: the desugared per-value leaf
-		// extractors error on them, so accepting them here would succeed
-		// where the fallback path errors
+		// extractors error on them, so accepting them in the gate would
+		// succeed where the fallback path errors
 		{
 			name: "array value type text",
 			path: containsPath("prop-text-field"), propType: schema.DataTypeTextArray,
 			value: []string{"a", "b"}, operator: filters.ContainsAny,
+			wantErr: true,
 		},
 		{
 			name: "array value type int",
 			path: containsPath("prop-int"), propType: schema.DataTypeIntArray,
 			value: []int{1, 2}, operator: filters.ContainsAny,
+			wantErr: true,
 		},
 	}
 
@@ -314,11 +329,15 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			if tt.setup != nil {
 				tt.setup(t)
 			}
-			pv, eligible, err := s.extractContainsBatch(ctx, tt.path, tt.propType,
+			pv, err := s.extractContains(ctx, tt.path, tt.propType,
 				tt.value, tt.operator, f.class)
-			require.False(t, eligible)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
-			require.Nil(t, pv)
+			require.NotNil(t, pv)
+			require.Nil(t, pv.containsValues, "shape must not resolve through the batched path")
 		})
 	}
 }
@@ -332,10 +351,11 @@ func TestExtractContainsBatch_EncodingErrorIsEligibleButFails(t *testing.T) {
 		"11111111-1111-1111-1111-111111111111",
 		"not-a-valid-uuid",
 	}
-	pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-uuid"),
+	pv, err := s.extractContains(ctx, containsPath("prop-uuid"),
 		schema.DataTypeText, values, filters.ContainsAny, f.class)
-	require.True(t, eligible)
 	require.Error(t, err)
+	require.ErrorContains(t, err, "extract contains values",
+		"the matched shape must fail in the gate, not fall through to desugar")
 	require.Nil(t, pv)
 }
 
@@ -382,13 +402,7 @@ func TestExtractContainsBatch_KillSwitch(t *testing.T) {
 
 	t.Setenv(entcfg.EnvDisableBatchedContains, "true")
 
-	pv, eligible, err := s.extractContainsBatch(ctx, containsPath("prop-int"),
-		schema.DataTypeInt, []int{1, 2, 3}, filters.ContainsAny, f.class)
-	require.False(t, eligible)
-	require.NoError(t, err)
-	require.Nil(t, pv)
-
-	pv, err = s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
+	pv, err := s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
 		[]int{1, 2, 3}, filters.ContainsAny, f.class)
 	require.NoError(t, err)
 	require.Nil(t, pv.containsValues)

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -213,11 +213,11 @@ type containsBatchBucket interface {
 
 // mergeAllowlistBitmaps folds b into a under op (ContainsAny -> union,
 // ContainsAll -> intersection) and returns the result bitmap plus its release,
-// releasing whichever operand does not become the result. Both operands must be
-// allowlists, so it needs none of mergeBitmapsAndOrWithDenyList's deny-list
-// algebra — but it mirrors that function's swap-for-efficiency: union the
-// smaller bitmap into the larger, intersect the larger into the smaller, to
-// minimize container operations. NumContainers is an O(1) header read.
+// releasing whichever operand does not become the result. Both operands must
+// be allowlists. It mirrors mergeBitmapsAndOrWithDenyList's
+// swap-for-efficiency: union the smaller bitmap into the larger, intersect
+// the larger into the smaller, to minimize container operations.
+// NumContainers is an O(1) header read.
 func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 	a *sroar.Bitmap, aRelease func(), b *sroar.Bitmap, bRelease func(),
 ) (*sroar.Bitmap, func(), error) {
@@ -259,13 +259,9 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 	defer view.ReleaseView()
 	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
-	// Every value is an Equal leaf, so every fetched bitmap is an allowlist,
-	// never a deny list. Fold the raw bitmaps directly into one accumulator (Or
-	// for ContainsAny, And for ContainsAll), releasing each after folding. This
-	// skips both the per-value docBitmap wrapper and the deny-list algebra of
-	// mergeBitmapsAndOrWithDenyList (unnecessary here, as no operand is a deny
-	// list). The first fetched bitmap becomes the accumulator and is mutated in
-	// place by subsequent folds, exactly as the previous per-value merge did.
+	// The first fetched bitmap becomes the accumulator; subsequent bitmaps
+	// are folded into it in place (Or for ContainsAny, And for ContainsAll)
+	// and released.
 	var acc *sroar.Bitmap
 	accRelease := noopRelease
 	for _, key := range pv.containsValues {

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -241,12 +241,18 @@ func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 	return a, aRelease, nil
 }
 
+// containsAnyAccumulatorMinKeys gates the ContainsAny fold: below this many
+// keys the plain incremental Or fold is used — an Accumulator's staging
+// blocks and finalize scan are not worth setting up to union a handful of
+// rows. Package var so benchmarks can sweep it.
+var containsAnyAccumulatorMinKeys = 16
+
 // docBitmapContainsBatch folds every key in pv.containsValues into a single
-// docBitmap under one consistent view of b, using the OR-fold for
-// ContainsAny and the AND-fold for ContainsAll. Every per-key fetch is an
-// OperatorEqual read on a roaringset bucket, so it is always an allowlist
-// (never a denylist), which is why mergeAllowlistBitmaps can skip the
-// deny-list algebra entirely.
+// docBitmap under one consistent view of b: a dense Accumulator fold for
+// ContainsAny, an incremental intersection with empty-result early exit for
+// ContainsAll. Every per-key fetch is an OperatorEqual read on a roaringset
+// bucket, so it is always an allowlist (never a denylist), which is why both
+// folds can skip mergeBitmapsAndOrWithDenyList's deny-list algebra entirely.
 func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBucket,
 	pv *propValuePair,
 ) (docBitmap, error) {
@@ -259,42 +265,17 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 	defer view.ReleaseView()
 	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
-	// The first fetched bitmap becomes the accumulator; subsequent bitmaps
-	// are folded into it in place (Or for ContainsAny, And for ContainsAll)
-	// and released.
 	var acc *sroar.Bitmap
-	accRelease := noopRelease
-	for _, key := range pv.containsValues {
-		if err := ctxExpired(ctx); err != nil {
-			accRelease()
-			return docBitmap{}, err
-		}
-
-		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
-		if err != nil {
-			accRelease()
-			return docBitmap{}, fmt.Errorf("read row: %w", err)
-		}
-
-		if acc == nil {
-			acc, accRelease = bm, release
-		} else {
-			acc, accRelease, err = mergeAllowlistBitmaps(pv.operator, maxConc, acc, accRelease, bm, release)
-			if err != nil {
-				return docBitmap{}, err
-			}
-		}
-
-		// ContainsAll: once the intersection is empty no remaining key can change
-		// the result, so stop early (ContainsAny's union only grows, never
-		// shrinks). Every fetched bitmap is an allowlist, so this only skips
-		// reads that cannot matter, never the result.
-		if pv.operator == filters.ContainsAll && acc.IsEmpty() {
-			break
-		}
+	var accRelease func()
+	var err error
+	if pv.operator == filters.ContainsAny {
+		acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues, maxConc)
+	} else {
+		acc, accRelease, err = foldContainsAllIncremental(ctx, b, view, pv.containsValues, maxConc)
 	}
-	// containsValues is non-empty (checked above) and each iteration adopts or
-	// folds a fetched bitmap, so acc is non-nil here.
+	if err != nil {
+		return docBitmap{}, err
+	}
 	took := time.Since(before)
 	helpers.AnnotateSlowQueryLogAppend(ctx, "build_allow_list_doc_bitmap", map[string]any{
 		"prop":           pv.prop,
@@ -306,6 +287,117 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 		"batched_values": len(pv.containsValues),
 	})
 	return docBitmap{docIDs: acc, release: accRelease}, nil
+}
+
+// foldContainsAnyAccumulator unions the rows of all keys through a
+// sroar.Accumulator: each fetched row is deposited into the accumulator's
+// dense per-64K-range staging blocks and its buffer released immediately, and
+// the final bitmap is assembled once, exactly sized, in Bitmap(). This
+// replaces one structural Or per key (an O(container) memmove even for a
+// single-doc row) with O(1) bit deposits, and bounds peak memory at the
+// staging blocks (proportional to the doc-ID spread of the result, not to
+// the number of keys) plus a single row in flight.
+//
+// Unions of fewer than containsAnyAccumulatorMinKeys keys use the
+// incremental Or fold instead — the staging setup and finalize scan are not
+// worth it there.
+func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
+	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
+) (*sroar.Bitmap, func(), error) {
+	if len(keys) < containsAnyAccumulatorMinKeys {
+		return foldContainsAnyIncremental(ctx, b, view, keys, maxConc)
+	}
+
+	acc := sroar.NewAccumulator()
+	for _, key := range keys {
+		if err := ctxExpired(ctx); err != nil {
+			return nil, nil, err
+		}
+		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
+		if err != nil {
+			return nil, nil, fmt.Errorf("read row: %w", err)
+		}
+		// Or never retains bm, so the row's buffer goes straight back.
+		acc.Or(bm)
+		release()
+	}
+
+	return acc.Bitmap(), noopRelease, nil
+}
+
+// foldContainsAnyIncremental unions rows one key at a time. Only used for
+// small key counts, where builder staging is not worth its setup; the
+// swap-for-efficiency Or keeps the accumulator the larger operand.
+func foldContainsAnyIncremental(ctx context.Context, b containsBatchBucket,
+	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
+) (*sroar.Bitmap, func(), error) {
+	var acc *sroar.Bitmap
+	accRelease := noopRelease
+	for _, key := range keys {
+		if err := ctxExpired(ctx); err != nil {
+			accRelease()
+			return nil, nil, err
+		}
+
+		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
+		if err != nil {
+			accRelease()
+			return nil, nil, fmt.Errorf("read row: %w", err)
+		}
+
+		if acc == nil {
+			acc, accRelease = bm, release
+		} else {
+			acc, accRelease, err = mergeAllowlistBitmaps(filters.ContainsAny, maxConc, acc, accRelease, bm, release)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+	// keys is non-empty (docBitmapContainsBatch returns early otherwise) and
+	// the first iteration always adopts its fetched bitmap, so acc is non-nil.
+	return acc, accRelease, nil
+}
+
+// foldContainsAllIncremental intersects rows one key at a time, stopping as
+// soon as the intersection is empty: no remaining key can change an empty
+// result (the intersection only shrinks), so this only skips reads that
+// cannot matter, never the result. On disjoint-ish data the early exit reads
+// a handful of keys, which no batch-read grouping can beat — hence
+// ContainsAll deliberately does not use an accumulator path.
+func foldContainsAllIncremental(ctx context.Context, b containsBatchBucket,
+	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
+) (*sroar.Bitmap, func(), error) {
+	var acc *sroar.Bitmap
+	accRelease := noopRelease
+	for _, key := range keys {
+		if err := ctxExpired(ctx); err != nil {
+			accRelease()
+			return nil, nil, err
+		}
+
+		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
+		if err != nil {
+			accRelease()
+			return nil, nil, fmt.Errorf("read row: %w", err)
+		}
+
+		if acc == nil {
+			acc, accRelease = bm, release
+		} else {
+			acc, accRelease, err = mergeAllowlistBitmaps(filters.ContainsAll, maxConc, acc, accRelease, bm, release)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		if acc.IsEmpty() {
+			break
+		}
+	}
+	// keys is non-empty (docBitmapContainsBatch returns early otherwise) and
+	// the first iteration always adopts its fetched bitmap, so acc is non-nil.
+	return acc, accRelease, nil
 }
 
 func (s *Searcher) docBitmapGeo(ctx context.Context, pv *propValuePair) (docBitmap, error) {

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -204,6 +204,114 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 	return out, nil
 }
 
+// containsBatchBucket is the minimal surface docBitmapContainsBatch needs
+// from a roaringset bucket; *lsmkv.Bucket satisfies it.
+type containsBatchBucket interface {
+	GetConsistentView() lsmkv.BucketConsistentView
+	RoaringSetGetFromView(ctx context.Context, view lsmkv.BucketConsistentView, key []byte) (*sroar.Bitmap, func(), error)
+}
+
+// mergeAllowlistBitmaps folds b into a under op (ContainsAny -> union,
+// ContainsAll -> intersection) and returns the result bitmap plus its release,
+// releasing whichever operand does not become the result. Both operands must be
+// allowlists, so it needs none of mergeBitmapsAndOrWithDenyList's deny-list
+// algebra — but it mirrors that function's swap-for-efficiency: union the
+// smaller bitmap into the larger, intersect the larger into the smaller, to
+// minimize container operations. NumContainers is an O(1) header read.
+func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
+	a *sroar.Bitmap, aRelease func(), b *sroar.Bitmap, bRelease func(),
+) (*sroar.Bitmap, func(), error) {
+	switch op {
+	case filters.ContainsAny:
+		if a.NumContainers() < b.NumContainers() {
+			a, aRelease, b, bRelease = b, bRelease, a, aRelease
+		}
+		a.OrConc(b, maxConc)
+	case filters.ContainsAll:
+		if a.NumContainers() > b.NumContainers() {
+			a, aRelease, b, bRelease = b, bRelease, a, aRelease
+		}
+		a.AndConc(b, maxConc)
+	default:
+		aRelease()
+		bRelease()
+		return nil, nil, fmt.Errorf("unsupported operator %q for batched contains", op.Name())
+	}
+	bRelease()
+	return a, aRelease, nil
+}
+
+// docBitmapContainsBatch folds every key in pv.containsValues into a single
+// docBitmap under one consistent view of b, using the OR-fold for
+// ContainsAny and the AND-fold for ContainsAll. Every per-key fetch is an
+// OperatorEqual read on a roaringset bucket, so it is always an allowlist
+// (never a denylist), which is why mergeAllowlistBitmaps can skip the
+// deny-list algebra entirely.
+func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBucket,
+	pv *propValuePair,
+) (docBitmap, error) {
+	if len(pv.containsValues) == 0 {
+		return newDocBitmap(), nil
+	}
+
+	before := time.Now()
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+
+	// Every value is an Equal leaf, so every fetched bitmap is an allowlist,
+	// never a deny list. Fold the raw bitmaps directly into one accumulator (Or
+	// for ContainsAny, And for ContainsAll), releasing each after folding. This
+	// skips both the per-value docBitmap wrapper and the deny-list algebra of
+	// mergeBitmapsAndOrWithDenyList (unnecessary here, as no operand is a deny
+	// list). The first fetched bitmap becomes the accumulator and is mutated in
+	// place by subsequent folds, exactly as the previous per-value merge did.
+	var acc *sroar.Bitmap
+	accRelease := noopRelease
+	for _, key := range pv.containsValues {
+		if err := ctxExpired(ctx); err != nil {
+			accRelease()
+			return docBitmap{}, err
+		}
+
+		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
+		if err != nil {
+			accRelease()
+			return docBitmap{}, fmt.Errorf("read row: %w", err)
+		}
+
+		if acc == nil {
+			acc, accRelease = bm, release
+		} else {
+			acc, accRelease, err = mergeAllowlistBitmaps(pv.operator, maxConc, acc, accRelease, bm, release)
+			if err != nil {
+				return docBitmap{}, err
+			}
+		}
+
+		// ContainsAll: once the intersection is empty no remaining key can change
+		// the result, so stop early (ContainsAny's union only grows, never
+		// shrinks). Every fetched bitmap is an allowlist, so this only skips
+		// reads that cannot matter, never the result.
+		if pv.operator == filters.ContainsAll && acc.IsEmpty() {
+			break
+		}
+	}
+	// containsValues is non-empty (checked above) and each iteration adopts or
+	// folds a fetched bitmap, so acc is non-nil here.
+	took := time.Since(before)
+	helpers.AnnotateSlowQueryLogAppend(ctx, "build_allow_list_doc_bitmap", map[string]any{
+		"prop":           pv.prop,
+		"operator":       pv.operator,
+		"took":           took,
+		"took_string":    took.String(),
+		"count":          acc.GetCardinality(),
+		"strategy":       lsmkv.StrategyRoaringSet,
+		"batched_values": len(pv.containsValues),
+	})
+	return docBitmap{docIDs: acc, release: accRelease}, nil
+}
+
 func (s *Searcher) docBitmapGeo(ctx context.Context, pv *propValuePair) (docBitmap, error) {
 	out := newDocBitmap()
 	propIndex, ok := s.propIndices.ByProp(pv.prop)

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -215,10 +215,10 @@ type containsBatchBucket interface {
 // mergeAllowlistBitmaps folds b into a under op (ContainsAny -> union,
 // ContainsAll -> intersection) and returns the result bitmap plus its release,
 // releasing whichever operand does not become the result. Both operands must
-// be allowlists. It mirrors mergeBitmapsAndOrWithDenyList's
-// swap-for-efficiency: union the smaller bitmap into the larger, intersect
-// the larger into the smaller, to minimize container operations.
-// NumContainers is an O(1) header read.
+// be allowlists. It picks the fold direction the same way
+// mergeBitmapsAndOrWithDenyList does: union the smaller bitmap into the
+// larger, intersect the larger into the smaller, to minimize container
+// operations. NumContainers is an O(1) header read.
 func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 	a *sroar.Bitmap, aRelease func(), b *sroar.Bitmap, bRelease func(),
 ) (*sroar.Bitmap, func(), error) {
@@ -248,12 +248,10 @@ func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 // rows. Package var so benchmarks can sweep it
 // (BenchmarkDocIDs_ContainsAnyAccumulatorGate).
 //
-// The measured crossover is shape-dependent: Go-level, the Accumulator wins
-// from ~16 keys when the result doc IDs are clustered and from ~64-100 when
-// they are spread across the ID space; server-level QA sweeps under
-// concurrent load place it higher (~512). 256 is the conservative middle
-// until those measurements are reconciled — the large-N folds this path
-// exists for sit far above it either way.
+// The crossover is shape-dependent — clustered result doc IDs favor the
+// Accumulator at far fewer keys than doc IDs spread across the ID space —
+// so 256 is deliberately conservative; the large-N folds this path exists
+// for sit far above it either way.
 var containsAnyAccumulatorMinKeys = 256
 
 // docBitmapContainsBatch folds every key in pv.containsValues into a single
@@ -309,14 +307,16 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 		return docBitmap{}, err
 	}
 	took := time.Since(before)
-	helpers.AnnotateSlowQueryLogAppend(ctx, "build_allow_list_doc_bitmap", map[string]any{
-		"prop":           pv.prop,
-		"operator":       pv.operator,
-		"took":           took,
-		"took_string":    took.String(),
-		"count":          acc.GetCardinality(),
-		"strategy":       lsmkv.StrategyRoaringSet,
-		"batched_values": len(pv.containsValues),
+	helpers.AnnotateSlowQueryLogAppendFunc(ctx, "build_allow_list_doc_bitmap", func() map[string]any {
+		return map[string]any{
+			"prop":           pv.prop,
+			"operator":       pv.operator.Name(),
+			"took":           took,
+			"took_string":    took.String(),
+			"count":          acc.GetCardinality(),
+			"strategy":       lsmkv.StrategyRoaringSet,
+			"batched_values": len(pv.containsValues),
+		}
 	})
 	return docBitmap{docIDs: acc, release: accRelease, isDenyList: isDenyList}, nil
 }
@@ -357,7 +357,8 @@ func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
 // foldContainsIncremental merges rows one key at a time under op: union for
 // ContainsAny (used below containsAnyAccumulatorMinKeys keys, where the
 // Accumulator's staging is not worth its setup), intersection for
-// ContainsAll. The swap-for-efficiency merge keeps the cheaper operand shape.
+// ContainsAll. mergeAllowlistBitmaps picks which operand to fold into by
+// container count, so merge cost tracks the smaller operand.
 //
 // ContainsAll additionally stops as soon as the intersection is empty: no
 // remaining key can change an empty result (the intersection only shrinks),

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -244,8 +244,16 @@ func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 // containsAnyAccumulatorMinKeys gates the ContainsAny fold: below this many
 // keys the plain incremental Or fold is used — an Accumulator's staging
 // blocks and finalize scan are not worth setting up to union a handful of
-// rows. Package var so benchmarks can sweep it.
-var containsAnyAccumulatorMinKeys = 16
+// rows. Package var so benchmarks can sweep it
+// (BenchmarkDocIDs_ContainsAnyAccumulatorGate).
+//
+// The measured crossover is shape-dependent: Go-level, the Accumulator wins
+// from ~16 keys when the result doc IDs are clustered and from ~64-100 when
+// they are spread across the ID space; server-level QA sweeps under
+// concurrent load place it higher (~512). 256 is the conservative middle
+// until those measurements are reconciled — the large-N folds this path
+// exists for sit far above it either way.
+var containsAnyAccumulatorMinKeys = 256
 
 // docBitmapContainsBatch folds every key in pv.containsValues into a single
 // docBitmap under one consistent view of b: a dense Accumulator fold for
@@ -279,9 +287,17 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 	var err error
 	switch pv.operator {
 	case filters.ContainsAll:
-		acc, accRelease, err = foldContainsAllIncremental(ctx, b, view, pv.containsValues, maxConc)
+		acc, accRelease, err = foldContainsIncremental(ctx, b, view, pv.containsValues, filters.ContainsAll, maxConc)
 	case filters.ContainsAny, filters.ContainsNone:
-		acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues, maxConc)
+		// ContainsNone folds the same union as ContainsAny; the deny flag is
+		// applied to the result, not the fold. Below
+		// containsAnyAccumulatorMinKeys keys the Accumulator's staging setup
+		// and finalize scan are not worth it — union incrementally instead.
+		if len(pv.containsValues) < containsAnyAccumulatorMinKeys {
+			acc, accRelease, err = foldContainsIncremental(ctx, b, view, pv.containsValues, filters.ContainsAny, maxConc)
+		} else {
+			acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues, maxConc)
+		}
 	default:
 		// defensive: a non-Contains operator must never pick a fold — a
 		// silent union here would return plausible but wrong results
@@ -311,17 +327,9 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 // single-doc row) with O(1) bit deposits, and bounds peak memory at the
 // staging blocks (proportional to the doc-ID spread of the result, not to
 // the number of keys) plus a single row in flight.
-//
-// Unions of fewer than containsAnyAccumulatorMinKeys keys use the
-// incremental Or fold instead — the staging setup and finalize scan are not
-// worth it there.
 func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
 	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
 ) (*sroar.Bitmap, func(), error) {
-	if len(keys) < containsAnyAccumulatorMinKeys {
-		return foldContainsAnyIncremental(ctx, b, view, keys, maxConc)
-	}
-
 	acc := sroar.NewAccumulator()
 	for _, key := range keys {
 		if err := ctxExpired(ctx); err != nil {
@@ -339,11 +347,19 @@ func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
 	return acc.Bitmap(), noopRelease, nil
 }
 
-// foldContainsAnyIncremental unions rows one key at a time. Only used for
-// small key counts, where builder staging is not worth its setup; the
-// swap-for-efficiency Or keeps the accumulator the larger operand.
-func foldContainsAnyIncremental(ctx context.Context, b containsBatchBucket,
-	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
+// foldContainsIncremental merges rows one key at a time under op: union for
+// ContainsAny (used below containsAnyAccumulatorMinKeys keys, where the
+// Accumulator's staging is not worth its setup), intersection for
+// ContainsAll. The swap-for-efficiency merge keeps the cheaper operand shape.
+//
+// ContainsAll additionally stops as soon as the intersection is empty: no
+// remaining key can change an empty result (the intersection only shrinks),
+// so this only skips reads that cannot matter, never the result. On
+// disjoint-ish data the early exit reads a handful of keys, which no
+// batch-read grouping can beat — hence ContainsAll deliberately has no
+// accumulator path.
+func foldContainsIncremental(ctx context.Context, b containsBatchBucket,
+	view lsmkv.BucketConsistentView, keys [][]byte, op filters.Operator, maxConc int,
 ) (*sroar.Bitmap, func(), error) {
 	var acc *sroar.Bitmap
 	accRelease := noopRelease
@@ -362,50 +378,13 @@ func foldContainsAnyIncremental(ctx context.Context, b containsBatchBucket,
 		if acc == nil {
 			acc, accRelease = bm, release
 		} else {
-			acc, accRelease, err = mergeAllowlistBitmaps(filters.ContainsAny, maxConc, acc, accRelease, bm, release)
-			if err != nil {
-				return nil, nil, err
-			}
-		}
-	}
-	// keys is non-empty (docBitmapContainsBatch returns early otherwise) and
-	// the first iteration always adopts its fetched bitmap, so acc is non-nil.
-	return acc, accRelease, nil
-}
-
-// foldContainsAllIncremental intersects rows one key at a time, stopping as
-// soon as the intersection is empty: no remaining key can change an empty
-// result (the intersection only shrinks), so this only skips reads that
-// cannot matter, never the result. On disjoint-ish data the early exit reads
-// a handful of keys, which no batch-read grouping can beat — hence
-// ContainsAll deliberately does not use an accumulator path.
-func foldContainsAllIncremental(ctx context.Context, b containsBatchBucket,
-	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
-) (*sroar.Bitmap, func(), error) {
-	var acc *sroar.Bitmap
-	accRelease := noopRelease
-	for _, key := range keys {
-		if err := ctxExpired(ctx); err != nil {
-			accRelease()
-			return nil, nil, err
-		}
-
-		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
-		if err != nil {
-			accRelease()
-			return nil, nil, fmt.Errorf("read row: %w", err)
-		}
-
-		if acc == nil {
-			acc, accRelease = bm, release
-		} else {
-			acc, accRelease, err = mergeAllowlistBitmaps(filters.ContainsAll, maxConc, acc, accRelease, bm, release)
+			acc, accRelease, err = mergeAllowlistBitmaps(op, maxConc, acc, accRelease, bm, release)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 
-		if acc.IsEmpty() {
+		if op == filters.ContainsAll && acc.IsEmpty() {
 			break
 		}
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -330,6 +330,9 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
 	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
 ) (*sroar.Bitmap, func(), error) {
+	// TODO aliszka:gh12242 wire maxConc into the accumulator's Or once sroar
+	// supports concurrent deposits; today the accumulator is single-threaded
+	// and the budget goes unused here.
 	acc := sroar.NewAccumulator()
 	for _, key := range keys {
 		if err := ctxExpired(ctx); err != nil {

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
 )
@@ -296,7 +297,8 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 		if len(pv.containsValues) < containsAnyAccumulatorMinKeys {
 			acc, accRelease, err = foldContainsIncremental(ctx, b, view, pv.containsValues, filters.ContainsAny, maxConc)
 		} else {
-			acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues, maxConc)
+			acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues,
+				s.bitmapFactory.BufPool(), maxConc)
 		}
 	default:
 		// defensive: a non-Contains operator must never pick a fold — a
@@ -322,13 +324,14 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 // foldContainsAnyAccumulator unions the rows of all keys through a
 // sroar.Accumulator: each fetched row is deposited into the accumulator's
 // dense per-64K-range staging blocks and its buffer released immediately, and
-// the final bitmap is assembled once, exactly sized, in Bitmap(). This
+// the final bitmap is assembled once, exactly sized, into a pooled buffer
+// (the returned release puts it back). This
 // replaces one structural Or per key (an O(container) memmove even for a
 // single-doc row) with O(1) bit deposits, and bounds peak memory at the
 // staging blocks (proportional to the doc-ID spread of the result, not to
 // the number of keys) plus a single row in flight.
 func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
-	view lsmkv.BucketConsistentView, keys [][]byte, maxConc int,
+	view lsmkv.BucketConsistentView, keys [][]byte, pool roaringset.BitmapBufPool, maxConc int,
 ) (*sroar.Bitmap, func(), error) {
 	// TODO aliszka:gh12242 wire maxConc into the accumulator's Or once sroar
 	// supports concurrent deposits; today the accumulator is single-threaded
@@ -347,7 +350,8 @@ func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
 		release()
 	}
 
-	return acc.Bitmap(), noopRelease, nil
+	result, put := pool.AccumulatorToBuf(acc)
+	return result, put, nil
 }
 
 // foldContainsIncremental merges rows one key at a time under op: union for

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -249,15 +249,24 @@ var containsAnyAccumulatorMinKeys = 16
 
 // docBitmapContainsBatch folds every key in pv.containsValues into a single
 // docBitmap under one consistent view of b: a dense Accumulator fold for
-// ContainsAny, an incremental intersection with empty-result early exit for
-// ContainsAll. Every per-key fetch is an OperatorEqual read on a roaringset
-// bucket, so it is always an allowlist (never a denylist), which is why both
-// folds can skip mergeBitmapsAndOrWithDenyList's deny-list algebra entirely.
+// ContainsAny and ContainsNone, an incremental intersection with empty-result
+// early exit for ContainsAll. Every per-key fetch is an OperatorEqual read on
+// a roaringset bucket, so it is always an allowlist (never a denylist), which
+// is why all folds can skip mergeBitmapsAndOrWithDenyList's deny-list algebra
+// entirely.
+//
+// ContainsNone is NOT(ContainsAny): it computes the same union and marks the
+// result a deny list, exactly as the desugared NOT(OR(Equal...)) tree does in
+// resolveDocIDsNot. The flag composes through AND/OR merges and is inverted
+// against the universe once at the top of Searcher.docIDs.
 func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBucket,
 	pv *propValuePair,
 ) (docBitmap, error) {
+	isDenyList := pv.operator == filters.ContainsNone
 	if len(pv.containsValues) == 0 {
-		return newDocBitmap(), nil
+		dbm := newDocBitmap()
+		dbm.isDenyList = isDenyList
+		return dbm, nil
 	}
 
 	before := time.Now()
@@ -268,10 +277,15 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 	var acc *sroar.Bitmap
 	var accRelease func()
 	var err error
-	if pv.operator == filters.ContainsAny {
-		acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues, maxConc)
-	} else {
+	switch pv.operator {
+	case filters.ContainsAll:
 		acc, accRelease, err = foldContainsAllIncremental(ctx, b, view, pv.containsValues, maxConc)
+	case filters.ContainsAny, filters.ContainsNone:
+		acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues, maxConc)
+	default:
+		// defensive: a non-Contains operator must never pick a fold — a
+		// silent union here would return plausible but wrong results
+		return docBitmap{}, fmt.Errorf("unsupported operator %q for batched contains", pv.operator.Name())
 	}
 	if err != nil {
 		return docBitmap{}, err
@@ -286,7 +300,7 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 		"strategy":       lsmkv.StrategyRoaringSet,
 		"batched_values": len(pv.containsValues),
 	})
-	return docBitmap{docIDs: acc, release: accRelease}, nil
+	return docBitmap{docIDs: acc, release: accRelease, isDenyList: isDenyList}, nil
 }
 
 // foldContainsAnyAccumulator unions the rows of all keys through a

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -104,6 +104,22 @@ func (c *expireAfterNDoneCtx) Err() error {
 	}
 }
 
+// TestMergeAllowlistBitmaps_UnsupportedOperator pins the defensive default
+// arm: an operator that is neither ContainsAny nor ContainsAll must error
+// and release both operands, so the backstop cannot rot into a silent
+// nil return or a buffer leak.
+func TestMergeAllowlistBitmaps_UnsupportedOperator(t *testing.T) {
+	var aReleased, bReleased bool
+	res, release, err := mergeAllowlistBitmaps(filters.OperatorEqual, 1,
+		sroar.NewBitmap(), func() { aReleased = true },
+		sroar.NewBitmap(), func() { bReleased = true })
+	require.Error(t, err)
+	require.Nil(t, res)
+	require.Nil(t, release)
+	require.True(t, aReleased, "unsupported operator must release the accumulator")
+	require.True(t, bReleased, "unsupported operator must release the fetched operand")
+}
+
 func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 	ctx := context.Background()
 	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
@@ -171,6 +187,27 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		require.Empty(t, dbm.docIDs.ToArray())
 		require.Equal(t, []string{"a", "b"}, spy.reads,
 			"key c must not be read once the AND accumulator is provably empty")
+	})
+
+	t.Run("absent key empties the intersection and stops reading", func(t *testing.T) {
+		spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+			"a": {1, 2, 3},
+			"c": {1, 2, 3}, // must never be read: the absent key already emptied the AND
+		})
+
+		pv := &propValuePair{
+			operator:       filters.ContainsAll,
+			containsValues: [][]byte{[]byte("a"), []byte("missing"), []byte("c")},
+		}
+
+		s := &Searcher{}
+		dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		require.Empty(t, dbm.docIDs.ToArray())
+		require.Equal(t, []string{"a", "missing"}, spy.reads,
+			"key c must not be read once the absent key emptied the accumulator")
 	})
 }
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -1,0 +1,199 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+// spyContainsBatchBucket wraps a real roaringset *lsmkv.Bucket, recording
+// every key passed to RoaringSetGetFromView and counting how many of the
+// returned release funcs get called, so tests can assert both which keys
+// docBitmapContainsBatch actually read and that it never leaks a bitmap.
+type spyContainsBatchBucket struct {
+	*lsmkv.Bucket
+	reads        []string
+	releaseCalls int
+}
+
+func (s *spyContainsBatchBucket) RoaringSetGetFromView(
+	ctx context.Context, view lsmkv.BucketConsistentView, key []byte,
+) (*sroar.Bitmap, func(), error) {
+	s.reads = append(s.reads, string(key))
+	bm, release, err := s.Bucket.RoaringSetGetFromView(ctx, view, key)
+	return bm, func() {
+		s.releaseCalls++
+		release()
+	}, err
+}
+
+func buildContainsBatchBucket(t *testing.T, ctx context.Context, rows map[string][]uint64) *spyContainsBatchBucket {
+	t.Helper()
+
+	logger, _ := test.NewNullLogger()
+	tmpDir := t.TempDir()
+
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	b.SetMemtableThreshold(1e9) // no auto-flush; keep the fixture deterministic
+
+	for key, values := range rows {
+		require.NoError(t, b.RoaringSetAddList([]byte(key), values))
+	}
+	require.NoError(t, b.FlushAndSwitch())
+
+	return &spyContainsBatchBucket{Bucket: b}
+}
+
+// expireAfterNDoneCtx reports ctx.Done() as closed starting with the (n+1)th
+// call to Done(), letting a test deterministically cancel a synchronous
+// per-key loop after exactly n keys have been checked, without goroutines or
+// wall-clock timing.
+type expireAfterNDoneCtx struct {
+	context.Context
+	n     int
+	calls int
+	done  chan struct{}
+}
+
+func newExpireAfterNDoneCtx(parent context.Context, n int) *expireAfterNDoneCtx {
+	return &expireAfterNDoneCtx{Context: parent, n: n, done: make(chan struct{})}
+}
+
+func (c *expireAfterNDoneCtx) Done() <-chan struct{} {
+	c.calls++
+	if c.calls > c.n {
+		select {
+		case <-c.done:
+		default:
+			close(c.done)
+		}
+	}
+	return c.done
+}
+
+func (c *expireAfterNDoneCtx) Err() error {
+	select {
+	case <-c.done:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
+	ctx := context.Background()
+	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		"present-a": {1, 2, 3},
+		"present-b": {3, 4, 5},
+	})
+
+	pv := &propValuePair{
+		operator:       filters.ContainsAny,
+		containsValues: [][]byte{[]byte("present-a"), []byte("missing"), []byte("present-b")},
+	}
+
+	s := &Searcher{}
+	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	require.NoError(t, err)
+	defer dbm.release()
+
+	require.Equal(t, []uint64{1, 2, 3, 4, 5}, dbm.docIDs.ToArray())
+	require.False(t, dbm.IsDenyList())
+	require.Equal(t, []string{"present-a", "missing", "present-b"}, spy.reads,
+		"every key must be read for ContainsAny, absent key included")
+}
+
+func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-empty intersection", func(t *testing.T) {
+		spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+			"a": {1, 2, 3},
+			"b": {2, 3, 4},
+			"c": {2, 3, 5},
+		})
+
+		pv := &propValuePair{
+			operator:       filters.ContainsAll,
+			containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		}
+
+		s := &Searcher{}
+		dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		require.Equal(t, []uint64{2, 3}, dbm.docIDs.ToArray())
+		require.Equal(t, []string{"a", "b", "c"}, spy.reads)
+	})
+
+	t.Run("folds to empty and stops reading remaining keys", func(t *testing.T) {
+		spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+			"a": {1, 2, 3},
+			"b": {4, 5, 6}, // disjoint from "a" -> accumulator becomes empty here
+			"c": {1, 2, 3}, // must never be read: the AND result can't change
+		})
+
+		pv := &propValuePair{
+			operator:       filters.ContainsAll,
+			containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+		}
+
+		s := &Searcher{}
+		dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		require.Empty(t, dbm.docIDs.ToArray())
+		require.Equal(t, []string{"a", "b"}, spy.reads,
+			"key c must not be read once the AND accumulator is provably empty")
+	})
+}
+
+func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
+	spy := buildContainsBatchBucket(t, context.Background(), map[string][]uint64{
+		"a": {1, 2, 3},
+		"b": {4, 5, 6},
+		"c": {7, 8, 9},
+	})
+
+	pv := &propValuePair{
+		operator:       filters.ContainsAny,
+		containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+	}
+
+	// expires right after key "a" is read, before "b" is checked
+	ctx := newExpireAfterNDoneCtx(context.Background(), 1)
+
+	s := &Searcher{}
+	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, docBitmap{}, dbm)
+
+	require.Equal(t, []string{"a"}, spy.reads, "loop must stop reading once ctx is expired")
+	require.Equal(t, 1, spy.releaseCalls, "accumulator built from key \"a\" must be released, not leaked")
+}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -143,6 +143,41 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 		"every key must be read for ContainsAny, absent key included")
 }
 
+// Same fold as above but forced through the Accumulator path, which the
+// containsAnyAccumulatorMinKeys gate would otherwise route to the incremental
+// fold at this key count.
+func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
+	oldGate := containsAnyAccumulatorMinKeys
+	containsAnyAccumulatorMinKeys = 2
+	defer func() { containsAnyAccumulatorMinKeys = oldGate }()
+
+	ctx := context.Background()
+	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		"present-a": {1, 2, 3},
+		"present-b": {3, 4, 5},
+		// A row spilling into further 64K ranges, so the union spans
+		// multiple result containers.
+		"present-c": {70_000, 200_000},
+	})
+
+	pv := &propValuePair{
+		operator: filters.ContainsAny,
+		containsValues: [][]byte{
+			[]byte("present-a"), []byte("missing"), []byte("present-b"), []byte("present-c"),
+		},
+	}
+
+	s := &Searcher{}
+	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	require.NoError(t, err)
+	defer dbm.release()
+
+	require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
+	require.False(t, dbm.IsDenyList())
+	require.Equal(t, []string{"present-a", "missing", "present-b", "present-c"}, spy.reads,
+		"every key must be read for ContainsAny, absent key included")
+}
+
 func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 	ctx := context.Background()
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -168,12 +168,23 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 }
 
 func TestResolveDocIDs_ContainsKeysRequireContainsOperator(t *testing.T) {
-	pv := &propValuePair{
-		operator:       filters.OperatorEqual,
-		containsValues: [][]byte{[]byte("a"), []byte("b")},
+	tests := []struct {
+		name     string
+		operator filters.Operator
+	}{
+		{name: "defined non-contains operator", operator: filters.OperatorEqual},
+		{name: "operator outside the enum", operator: filters.Operator(999)},
 	}
-	_, err := pv.resolveDocIDs(context.Background(), &Searcher{}, 0)
-	require.ErrorContains(t, err, "non-contains operator")
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := &propValuePair{
+				operator:       tc.operator,
+				containsValues: [][]byte{[]byte("a"), []byte("b")},
+			}
+			_, err := pv.resolveDocIDs(context.Background(), &Searcher{}, 0)
+			require.ErrorContains(t, err, "non-contains operator")
+		})
+	}
 }
 
 // TestDocBitmapContainsBatch_ContainsNoneFold pins ContainsNone as

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -143,6 +143,76 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 		"every key must be read for ContainsAny, absent key included")
 }
 
+// TestDocBitmapContainsBatch_UnsupportedOperator pins the defensive default
+// arm of the fold dispatch: a propValuePair that carries pre-encoded keys but
+// a non-Contains operator must error instead of silently running the union
+// fold and returning plausible but wrong results. Its sibling backstop, the
+// routing check in resolveDocIDs, is pinned by
+// TestResolveDocIDs_ContainsKeysRequireContainsOperator.
+func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
+	ctx := context.Background()
+	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		"present-a": {1, 2, 3},
+	})
+
+	pv := &propValuePair{
+		operator:       filters.OperatorEqual,
+		containsValues: [][]byte{[]byte("present-a"), []byte("present-b")},
+	}
+
+	s := &Searcher{}
+	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	require.ErrorContains(t, err, "unsupported operator")
+	require.Nil(t, dbm.docIDs)
+	require.Empty(t, spy.reads, "no key may be read for an unsupported operator")
+}
+
+func TestResolveDocIDs_ContainsKeysRequireContainsOperator(t *testing.T) {
+	pv := &propValuePair{
+		operator:       filters.OperatorEqual,
+		containsValues: [][]byte{[]byte("a"), []byte("b")},
+	}
+	_, err := pv.resolveDocIDs(context.Background(), &Searcher{}, 0)
+	require.ErrorContains(t, err, "non-contains operator")
+}
+
+// TestDocBitmapContainsBatch_ContainsNoneFold pins ContainsNone as
+// NOT(ContainsAny): the docIDs are the same union the ContainsAny fold
+// produces, with isDenyList set so downstream merges and the final
+// universe inversion treat it as a negation.
+func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
+	ctx := context.Background()
+	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		"present-a": {1, 2, 3},
+		"present-b": {3, 4, 5},
+	})
+
+	pv := &propValuePair{
+		operator:       filters.ContainsNone,
+		containsValues: [][]byte{[]byte("present-a"), []byte("missing"), []byte("present-b")},
+	}
+
+	s := &Searcher{}
+	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	require.NoError(t, err)
+	defer dbm.release()
+
+	require.Equal(t, []uint64{1, 2, 3, 4, 5}, dbm.docIDs.ToArray(),
+		"ContainsNone folds the same union as ContainsAny")
+	require.True(t, dbm.IsDenyList())
+	require.Equal(t, []string{"present-a", "missing", "present-b"}, spy.reads)
+
+	t.Run("empty key set is an empty deny list", func(t *testing.T) {
+		empty := &propValuePair{operator: filters.ContainsNone}
+		dbm, err := s.docBitmapContainsBatch(ctx, spy, empty)
+		require.NoError(t, err)
+		defer dbm.release()
+		require.True(t, dbm.docIDs.IsEmpty())
+		require.True(t, dbm.IsDenyList(),
+			"NOT over an empty union must deny nothing, i.e. match everything")
+	})
+}
+
 // Same fold as above but forced through the Accumulator path, which the
 // containsAnyAccumulatorMinKeys gate would otherwise route to the incremental
 // fold at this key count.

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -237,15 +237,19 @@ func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
 		},
 	}
 
-	s := &Searcher{}
+	pool := roaringset.NewBitmapBufPoolTrackingForTests()
+	s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
 	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
 	require.NoError(t, err)
-	defer dbm.release()
 
 	require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
 	require.False(t, dbm.IsDenyList())
 	require.Equal(t, []string{"present-a", "missing", "present-b", "present-c"}, spy.reads,
 		"every key must be read for ContainsAny, absent key included")
+
+	dbm.release()
+	require.Zero(t, pool.Outstanding(),
+		"the pooled result buffer must flow back through dbm.release")
 }
 
 func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {

--- a/entities/config/feature_flags.go
+++ b/entities/config/feature_flags.go
@@ -67,3 +67,18 @@ func NestedFilteringEnabled() bool {
 func NestedFilteringDisabledError() error {
 	return fmt.Errorf("filtering on nested properties is a preview feature, disabled by default; set %s=true to enable", EnvNestedFilteringPreview)
 }
+
+// EnvDisableBatchedContains is the env var that disables the batched
+// ContainsAny/ContainsAll filter resolution, forcing every Contains filter
+// through the per-value desugared path. Operator escape hatch: the batched
+// path is behaviorally equivalent (pinned by a differential test), but this
+// switch restores the previous execution shape without a rollback.
+const EnvDisableBatchedContains = "WEAVIATE_DISABLE_BATCHED_CONTAINS"
+
+// BatchedContainsDisabled reports whether the batched Contains resolution is
+// switched off for this server. Reads the env var on each call (no cache) so
+// tests can override via t.Setenv; the call site runs once per Contains
+// filter extraction, not per value.
+func BatchedContainsDisabled() bool {
+	return Enabled(os.Getenv(EnvDisableBatchedContains))
+}

--- a/entities/config/feature_flags.go
+++ b/entities/config/feature_flags.go
@@ -69,16 +69,16 @@ func NestedFilteringDisabledError() error {
 }
 
 // EnvDisableBatchedContains is the env var that disables the batched
-// ContainsAny/ContainsAll filter resolution, forcing every Contains filter
-// through the per-value desugared path. Operator escape hatch: the batched
-// path is behaviorally equivalent (pinned by a differential test), but this
-// switch restores the previous execution shape without a rollback.
+// ContainsAny/ContainsAll/ContainsNone filter resolution, forcing every
+// Contains filter through the per-value desugared path. Operator escape
+// hatch: the batched path is behaviorally equivalent (pinned by a
+// differential test).
 const EnvDisableBatchedContains = "WEAVIATE_DISABLE_BATCHED_CONTAINS"
 
 // BatchedContainsDisabled reports whether the batched Contains resolution is
-// switched off for this server. Reads the env var on each call (no cache) so
-// tests can override via t.Setenv; the call site runs once per Contains
-// filter extraction, not per value.
+// switched off for this server. Reads the env var on each call rather than
+// caching; the call site runs once per Contains filter extraction, not per
+// value, so caching would buy nothing.
 func BatchedContainsDisabled() bool {
 	return Enabled(os.Getenv(EnvDisableBatchedContains))
 }

--- a/entities/filters/filters.go
+++ b/entities/filters/filters.go
@@ -13,6 +13,7 @@ package filters
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -95,7 +96,9 @@ func (o Operator) Name() string {
 	case OperatorNot:
 		return "Not"
 	default:
-		panic("Unknown operator")
+		// tolerate values outside the enum so error messages built from a
+		// rogue operator report it instead of panicking mid-diagnostic
+		return fmt.Sprintf("Unknown(%d)", int(o))
 	}
 }
 

--- a/entities/filters/filters_test.go
+++ b/entities/filters/filters_test.go
@@ -39,6 +39,7 @@ func TestOperators(t *testing.T) {
 		{op: ContainsAll, expectedName: "ContainsAll", expectedOnValue: true},
 		{op: ContainsNone, expectedName: "ContainsNone", expectedOnValue: true},
 		{op: OperatorNot, expectedName: "Not", expectedOnValue: false},
+		{op: Operator(999), expectedName: "Unknown(999)", expectedOnValue: false},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Motivation

Part 5 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242) — the feature PR that turns the previous four into user-visible behavior. Today a Contains filter desugars into one `Equal` leaf per value: at 100K values that is 100K classifications, per-value tokenization, a per-leaf goroutine fan-out, and a 100K-way merge tree — the shape that collapses in the issue's reproduction (0.00–0.07 rps, 88–100% timeouts). This PR resolves an eligible Contains filter as **one batched fold**: classify once, encode every value once, read all keys under a single consistent view, fold sequentially with zero goroutines. It also gives the stack's dormant surfaces their callers (PR2's `AnalyzeBatch`, PR4's `RoaringSetGetFromView` and `AccumulatorToBuf`), so numbers span the stack: Go-level `ContainsAny` N=100K **235ms → 21.6ms, 5.98M → ~100K allocs/op**; e2e single-query p50 **4.14s → 78ms**; 16–100 concurrent workers **0.07 → 81–86 rps, 0 errors**.

## Approach

- **Classify once, extract once** (`classifyContainsBatch`): flat single-property path, filterable roaringset bucket, and a value family where one value provably encodes to one key (UUID, FIELD-tokenized text, int/number/boolean/date). Its godoc pins the lockstep contract with `buildPropValuePair`'s leaf dispatch. Anything else **desugars into the unchanged per-value path**, with the decline reason surfaced in a `contains_desugared` slow-query annotation — a one-look diagnosis for a filter missing the fast path.
- **One fold, allowlist-only algebra** (`docBitmapContainsBatch`): every fetched bitmap is an allowlist, so the fold skips deny-list merge algebra. `ContainsAll` intersects incrementally and stops on an empty intersection; `ContainsAny` at ≥ `containsAnyAccumulatorMinKeys` (256) unions through `sroar.Accumulator` into a pooled buffer, below the gate it keeps the incremental Or.
- **`ContainsNone` = deny-listed `ContainsAny`**: same union, result marked a deny list — exactly what the desugared `NOT(OR(Equal...))` tree produces; the flag composes through AND/OR and inverts once in `Searcher.docIDs`.
- **N≥2 gate**: one-value filters stay on the per-value path (a single desugared leaf applies the query limit while resolving; nothing to amortize anyway).
- **Kill switch**: `WEAVIATE_DISABLE_BATCHED_CONTAINS` forces the desugared path.
- **Open item — the 256 gate**: Go-level sweeps (`BenchmarkDocIDs_ContainsAnyAccumulatorGate`) put the crossover at ~16 (clustered) to ~100 (spread); server-level QA sweeps suggested ~512. 256 is the conservative middle until reconciled.

## Risks and testing

- **Batched ≠ desugared divergence**: `TestDocIDs_BatchedMatchesDesugared` resolves the same value sets both ways over real buckets — unique/shared/whitespace-padded/absent/duplicate/empty values; text + int + uuid with exact-doc assertions (both paths share one encoder per family, so equality alone would survive an encoding bug); batched `ContainsNone` composed under And/Or/Not parents. The kill switch is the operational backstop.
- **Wrong fold for an unexpected operator**: explicit switches with error defaults at both dispatch sites, pinned; `Operator.Name()` now formats out-of-enum values as `Unknown(N)` instead of panicking mid-diagnostic.
- **Pooled-buffer leaks**: tracking pool asserts nothing outstanding after the docBitmap's release; mid-fold cancellation and read errors release before returning.
- **Perf claims going stale**: the bench harness carries a correctness gate (exact doc-ID set on the benchmarked corpus) and a goroutine-peak test asserting no fan-out.
- **Accepted coverage gaps**: no row for `containsDeclineNonContainsOperator` (defensive-only, unreachable through `extractContains`); number/boolean/date families pinned at key-encoding level only (text/int/uuid cross a real bucket); a batched *allow-list* leaf under an And/Or parent untested (deny-listed leaves are).
- Unit + integration suites `go test -race` green (inverted, helpers, filters); both linters clean.