### PR TITLE
fix(backup): seal shard state on every HaltForTransfer, not only the first

### DIFF
--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -47,10 +47,19 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 	s.haltForTransferCount++
 
 	defer func() {
-		if err == nil && inactivityTimeout > 0 {
+		if err != nil {
+			return
+		}
+		if inactivityTimeout > 0 {
 			s.mayUpdateInactivityTimeout(inactivityTimeout)
 			s.mayInitInactivityMonitoring()
 		}
+		// A successful halt is liveness, and a stronger signal of it than a file
+		// read. An overlapping consumer otherwise inherits the first consumer's
+		// deadline untouched while the seal steps it just ran consumed wall-clock
+		// time against it, so the monitor could force-resume the shard the moment
+		// the halt returns.
+		s.mayResetInactivityDeadline()
 	}()
 
 	if offloading {

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -59,11 +59,10 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		s.mayStopAsyncReplication()
 	}
 
-	if s.haltForTransferCount > 1 {
-		// shard was already halted
-		return nil
-	}
-
+	// Placed before the pause branch so it also covers count>1 callers: on error
+	// mayForceResumeMaintenanceCycles(ctx, false) decrements our own increment and
+	// only truly resumes at count==0, so a failed count>1 caller rolls back 2->1
+	// without unhalting the shard the first op still holds.
 	defer func() {
 		if err != nil {
 			// each preparation step below wraps its own error; only append
@@ -74,18 +73,28 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		}
 	}()
 
-	if err = s.store.PauseCompaction(innerCtx); err != nil {
-		return fmt.Errorf("pause compaction: %w", err)
+	// Pause steps run only on the first halt. Re-pausing per halt would strand the
+	// per-bucket pause-timer refcount (1 pause : 1 stop) and never observe the
+	// Prometheus pause-duration timer.
+	if s.haltForTransferCount == 1 {
+		if err = s.store.PauseCompaction(innerCtx); err != nil {
+			return fmt.Errorf("pause compaction: %w", err)
+		}
+		if err = s.cycleCallbacks.vectorCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
+			return fmt.Errorf("pause vector maintenance: %w", err)
+		}
+		if err = s.cycleCallbacks.geoPropsCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
+			return fmt.Errorf("pause geo props maintenance: %w", err)
+		}
+	} else {
+		s.index.logger.WithField("shard", s.name).
+			Debugf("shard already halted for transfer (count=%d); re-sealing state on shared halt", s.haltForTransferCount)
 	}
-	if err = s.store.FlushMemtables(innerCtx); err != nil {
-		return fmt.Errorf("flush memtables: %w", err)
-	}
-	if err = s.cycleCallbacks.vectorCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
-		return fmt.Errorf("pause vector maintenance: %w", err)
-	}
-	if err = s.cycleCallbacks.geoPropsCombinedCallbacksCtrl.Deactivate(innerCtx); err != nil {
-		return fmt.Errorf("pause geo props maintenance: %w", err)
-	}
+
+	// Seal steps run on EVERY halt: a second consumer's snapshot deliberately
+	// excludes the active memtable/WAL and the active HNSW commit-log, so any
+	// write that landed after the first consumer's flush must be re-sealed here or
+	// it is silently dropped from the second consumer's snapshot.
 
 	// get the queues ready for backup (e.g. enable maintenance mode, switch to new chunks)
 	_ = s.ForEachVectorQueue(func(targetVector string, q *VectorIndexQueue) error {
@@ -114,7 +123,23 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		}
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Flush memtables after draining the queues and preparing the indexes.
+	// Queue tasks (e.g. HNSW insertions) and index PrepareForBackup (e.g.
+	// HFresh queue drains) may have written compressed vectors to the LSM
+	// store. Without this flush those compressed vectors stay in the memtable
+	// (WAL only) and are absent from the backup while the HNSW commit log
+	// references them — including potentially as the entrypoint. On restore
+	// this leads to "entrypoint was deleted in the object store" errors on
+	// every search.
+	if err = s.store.FlushMemtables(innerCtx); err != nil {
+		return fmt.Errorf("flush memtables after queue drain: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Shard) mayUpdateInactivityTimeout(inactivityTimeout time.Duration) {

--- a/adapters/repos/db/shard_backup_shared_halt_test.go
+++ b/adapters/repos/db/shard_backup_shared_halt_test.go
@@ -188,6 +188,40 @@ func TestShard_HaltForTransferSealsQueueDrainWrites(t *testing.T) {
 		"write performed by the queue drain is missing from the file list — the memtable flush runs before the drain instead of after it")
 }
 
+// The seal steps an overlapping halt runs consume wall-clock time budgeted
+// against an inactivity deadline it never pushed forward, so a successful halt
+// has to count as activity or the monitor force-resumes the shard immediately
+// after it returns and the consumer's first ListBackupFiles fails.
+func TestShard_HaltForTransferExtendsInactivityDeadline(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+	t.Cleanup(func() {
+		_ = idx.drop()
+		_ = os.RemoveAll(idx.Config.RootPath)
+	})
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	// Stands in for a halt whose preparation outlasted the remaining budget.
+	s.haltForTransferMux.Lock()
+	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+	s.haltForTransferMux.Unlock()
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	s.haltForTransferMux.Lock()
+	deadline := s.haltForTransferInactivityDeadline
+	s.haltForTransferMux.Unlock()
+	require.True(t, deadline.After(time.Now()),
+		"an overlapping halt left the deadline in the past — the monitor will force-resume a shard two consumers still hold")
+
+	for s.haltForTransferCount > 0 {
+		require.NoError(t, s.resumeMaintenanceCycles(ctx))
+	}
+}
+
 // A failed halt at count>1 must roll back to the holder's count rather than
 // unhalting the shard the first consumer still holds.
 func TestShard_SharedHaltPrepErrorKeepsShardHalted(t *testing.T) {

--- a/adapters/repos/db/shard_backup_shared_halt_test.go
+++ b/adapters/repos/db/shard_backup_shared_halt_test.go
@@ -294,6 +294,12 @@ func TestShard_SharedHaltSealsLateVectors(t *testing.T) {
 	baseline.Vector = []float32{1, 0, 0}
 	require.NoError(t, s.PutObject(ctx, baseline))
 
+	// Commit-log file names are unix seconds, so a switch within the same second
+	// as the file it is switching away from reopens that same path in append mode
+	// and the file stays active, hence unlisted. Both halts need their own second
+	// or the baseline is unlisted too and stops being a usable control.
+	time.Sleep(commitLogNameGranularity)
+
 	require.NoError(t, s.HaltForTransfer(ctx, false, 0))
 	t.Cleanup(func() {
 		for s.haltForTransferCount > 0 {
@@ -301,10 +307,7 @@ func TestShard_SharedHaltSealsLateVectors(t *testing.T) {
 		}
 	})
 
-	// Commit-log file names are unix seconds, so a switch within the same second
-	// as the previous one reopens the same path in append mode and the late
-	// write's file stays the active — and therefore unlisted — one.
-	time.Sleep(1100 * time.Millisecond)
+	time.Sleep(commitLogNameGranularity)
 
 	late := testObject(className)
 	late.Vector = []float32{0, 1, 0}
@@ -401,6 +404,9 @@ func docIDOf(t *testing.T, s *Shard, id strfmt.UUID) uint64 {
 	require.NotNil(t, obj)
 	return obj.DocID
 }
+
+// hnswCommitLogger names new files with fmt.Sprintf("%d", time.Now().Unix()).
+const commitLogNameGranularity = 1100 * time.Millisecond
 
 type sharedHaltNoopBucketView struct{}
 

--- a/adapters/repos/db/shard_backup_shared_halt_test.go
+++ b/adapters/repos/db/shard_backup_shared_halt_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -27,9 +28,17 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	dbqueue "github.com/weaviate/weaviate/adapters/repos/db/queue"
+	vcommon "github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	vhnsw "github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 // Pins the shared-halt lost-write bug: a transfer consumer that halts a shard
@@ -214,20 +223,9 @@ func objectsSnapshotHas(t *testing.T, rootPath string, files []string, id string
 	ctx := context.Background()
 
 	bucketDir := filepath.Join(t.TempDir(), helpers.ObjectsBucketLSM)
-	require.NoError(t, os.MkdirAll(bucketDir, 0o755))
-
-	segmentPrefix := filepath.Join("lsm", helpers.ObjectsBucketLSM) + string(filepath.Separator)
-	copied := 0
-	for _, relPath := range files {
-		if !strings.Contains(relPath, segmentPrefix) {
-			continue
-		}
-		data, err := os.ReadFile(filepath.Join(rootPath, relPath))
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(filepath.Join(bucketDir, filepath.Base(relPath)), data, 0o644))
-		copied++
-	}
-	require.Positive(t, copied, "no objects-bucket segment was listed for the snapshot")
+	segmentDir := filepath.Join("lsm", helpers.ObjectsBucketLSM) + string(filepath.Separator)
+	require.Positive(t, copyListedFiles(t, rootPath, files, segmentDir, bucketDir),
+		"no objects-bucket segment was listed for the snapshot")
 
 	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketDir, "", logrus.New(), nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
@@ -273,3 +271,137 @@ func (t *lateWriteTask) Execute(ctx context.Context) error {
 		return ctx.Err()
 	}
 }
+
+// The HNSW half of the same defect, and the half that stays exposed even where
+// the LSM half does not: IncomingListFiles flushes memtables itself before
+// listing, but nothing outside index.PrepareForBackup switches the commit log,
+// and hnsw.ListFiles deliberately excludes the active one. So a replica COPY
+// overlapping another COPY — which the replication FSM explicitly permits on a
+// shared source shard — silently ships a replica missing every vector written
+// since the first COPY halted.
+func TestShard_SharedHaltSealsLateVectors(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShardWithSettings(t, ctx, &models.Class{Class: className},
+		enthnsw.NewDefaultUserConfig(), false, false, false)
+	t.Cleanup(func() {
+		_ = idx.drop()
+		_ = os.RemoveAll(idx.Config.RootPath)
+	})
+	s := shd.(*Shard)
+
+	baseline := testObject(className)
+	baseline.Vector = []float32{1, 0, 0}
+	require.NoError(t, s.PutObject(ctx, baseline))
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, 0))
+	t.Cleanup(func() {
+		for s.haltForTransferCount > 0 {
+			require.NoError(t, s.resumeMaintenanceCycles(ctx))
+		}
+	})
+
+	// Commit-log file names are unix seconds, so a switch within the same second
+	// as the previous one reopens the same path in append mode and the late
+	// write's file stays the active — and therefore unlisted — one.
+	time.Sleep(1100 * time.Millisecond)
+
+	late := testObject(className)
+	late.Vector = []float32{0, 1, 0}
+	require.NoError(t, s.PutObject(ctx, late))
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, 0))
+	require.Equal(t, 2, s.haltForTransferCount)
+
+	files, err := s.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+	require.NoError(t, err)
+
+	baselineDocID := docIDOf(t, s, baseline.ID())
+	lateDocID := docIDOf(t, s, late.ID())
+
+	restored := restoreIndexFromListedCommitLogs(t, s.index.Config.RootPath, files, map[uint64][]float32{
+		baselineDocID: baseline.Vector,
+		lateDocID:     late.Vector,
+	})
+
+	require.True(t, restored.ContainsDoc(baselineDocID),
+		"vector sealed before any halt is missing from the restored index — the reconstruction itself is broken")
+	require.True(t, restored.ContainsDoc(lateDocID),
+		"vector written before this consumer's halt is missing from its file list — the commit log was never switched")
+
+	ids, _, err := restored.SearchByVector(ctx, late.Vector, 2, nil)
+	require.NoError(t, err)
+	require.Contains(t, ids, lateDocID, "late vector is present but unreachable in the restored graph")
+}
+
+// restoreIndexFromListedCommitLogs rebuilds an HNSW index from exactly the
+// commit-log files in the listing — what a transfer target receives — by
+// replaying them into a throwaway root. vectors backs the restored index's
+// VectorForID, standing in for the LSM store that would be shipped alongside.
+func restoreIndexFromListedCommitLogs(t *testing.T, rootPath string, files []string, vectors map[uint64][]float32) *vhnsw.HNSW {
+	t.Helper()
+
+	// The commit-log directory name embeds the shard's legacy (unnamed) vector
+	// index id, which is what a default single-vector collection uses.
+	const commitLogDir = "main.hnsw.commitlog.d"
+	restoreRoot := filepath.Join(t.TempDir(), "shard")
+	// Deliberately not asserting a non-zero copy count: when the switch never
+	// happens the listing legitimately holds no commit log at all, and that
+	// belongs on the missing-vector assertion rather than on file plumbing.
+	copyListedFiles(t, rootPath, files, commitLogDir, filepath.Join(restoreRoot, commitLogDir))
+
+	logger := logrus.New()
+	restored, err := vhnsw.New(vhnsw.Config{
+		RootPath:         restoreRoot,
+		ID:               "main",
+		Logger:           logger,
+		DistanceProvider: distancer.NewCosineDistanceProvider(),
+		AllocChecker:     memwatch.NewDummyMonitor(),
+		DisableSnapshots: true,
+		MakeCommitLoggerThunk: func() (vhnsw.CommitLogger, error) {
+			return vhnsw.NewCommitLogger(restoreRoot, "main", logger,
+				cyclemanager.NewCallbackGroupNoop(), vhnsw.WithSnapshotDisabled(true))
+		},
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[id], nil
+		},
+		GetViewThunk:      func() vcommon.BucketView { return sharedHaltNoopBucketView{} },
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, enthnsw.NewDefaultUserConfig(), cyclemanager.NewCallbackGroupNoop(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = restored.Shutdown(context.Background()) })
+
+	return restored
+}
+
+// copyListedFiles copies every listed file whose path contains dirMarker into
+// dstDir, flattened, and returns how many were copied.
+func copyListedFiles(t *testing.T, rootPath string, files []string, dirMarker, dstDir string) int {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dstDir, 0o755))
+
+	copied := 0
+	for _, relPath := range files {
+		if !strings.Contains(relPath, dirMarker) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(rootPath, relPath))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dstDir, filepath.Base(relPath)), data, 0o644))
+		copied++
+	}
+	return copied
+}
+
+func docIDOf(t *testing.T, s *Shard, id strfmt.UUID) uint64 {
+	t.Helper()
+
+	obj, err := s.ObjectByID(context.Background(), id, search.SelectProperties{}, additional.Properties{})
+	require.NoError(t, err)
+	require.NotNil(t, obj)
+	return obj.DocID
+}
+
+type sharedHaltNoopBucketView struct{}
+
+func (sharedHaltNoopBucketView) ReleaseView() {}

--- a/adapters/repos/db/shard_backup_shared_halt_test.go
+++ b/adapters/repos/db/shard_backup_shared_halt_test.go
@@ -1,0 +1,275 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	dbqueue "github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// Pins the shared-halt lost-write bug: a transfer consumer that halts a shard
+// another consumer already holds used to hit an early return and skip every
+// preparation step. A write that landed after the first consumer's flush then
+// lived only in the active memtable/WAL, which ListBackupFiles excludes, so the
+// second consumer's file list silently dropped it.
+//
+// The two successive overlaps prove the re-seal is repeatable rather than
+// one-shot: obj2 halts at count 1->2 and obj3 at 2->3.
+func TestShard_SharedHaltSealsLateWrites(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+	t.Cleanup(func() {
+		_ = idx.drop()
+		_ = os.RemoveAll(idx.Config.RootPath)
+	})
+	s := shd.(*Shard)
+
+	// Sealed into a segment by op A's halt below, so its presence in every file
+	// list distinguishes a genuinely empty snapshot from a dropped late write.
+	baseline := testObject(className)
+	require.NoError(t, s.PutObject(ctx, baseline))
+
+	// op A halts first and never resumes, holding the shard for both overlaps.
+	require.NoError(t, s.HaltForTransfer(ctx, false, 0))
+	t.Cleanup(func() {
+		for s.haltForTransferCount > 0 {
+			require.NoError(t, s.resumeMaintenanceCycles(ctx))
+		}
+	})
+
+	for _, tc := range []struct {
+		name          string
+		expectedCount int
+	}{
+		{name: "second consumer", expectedCount: 2},
+		{name: "third consumer", expectedCount: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Lands in the memtable/WAL freshly created by the previous halt's
+			// flush; a halt never trips the bucket read-only guard, so the write
+			// is accepted but unsealed.
+			late := testObject(className)
+			require.NoError(t, s.PutObject(ctx, late))
+
+			require.NoError(t, s.HaltForTransfer(ctx, false, 0))
+			require.Equal(t, tc.expectedCount, s.haltForTransferCount)
+
+			files, err := s.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+			require.NoError(t, err)
+
+			require.True(t, objectsSnapshotHas(t, s.index.Config.RootPath, files, baseline.ID().String()),
+				"write sealed before any halt is missing from the file list — the snapshot reconstruction itself is broken")
+			require.True(t, objectsSnapshotHas(t, s.index.Config.RootPath, files, late.ID().String()),
+				"write applied before this consumer's halt is missing from its file list — the shared halt skipped the re-seal")
+		})
+	}
+}
+
+// Pins the position of the trailing FlushMemtables. The queue and vector-index
+// preparation steps drain in-flight tasks that write into the shard's LSM store
+// (compressed vectors, HFresh postings). A flush placed before those steps
+// leaves such writes in the WAL only, absent from the file list while the HNSW
+// commit log already references them.
+//
+// The write is driven through a real in-flight queue task so the assertion
+// covers production HaltForTransfer rather than a copy of its step order.
+func TestShard_HaltForTransferSealsQueueDrainWrites(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+	t.Cleanup(func() {
+		_ = idx.drop()
+		_ = os.RemoveAll(idx.Config.RootPath)
+	})
+	s := shd.(*Shard)
+
+	// Establishes the objects bucket on disk so the reconstruction below has a
+	// segment to read even when the drain write is lost.
+	require.NoError(t, s.PutObject(ctx, testObject(className)))
+
+	drained := testObject(className)
+	drainedKey, err := uuid.MustParse(drained.ID().String()).MarshalBinary()
+	require.NoError(t, err)
+	drainedValue, err := drained.MarshalBinary()
+	require.NoError(t, err)
+
+	const queueID = "geo-drain-write"
+	taskStarted := make(chan struct{})
+	releaseTask := make(chan struct{})
+
+	scheduler := dbqueue.NewScheduler(dbqueue.SchedulerOptions{
+		Logger:           s.index.logger,
+		Workers:          1,
+		ScheduleInterval: time.Millisecond,
+	})
+	scheduler.Start()
+	t.Cleanup(func() { scheduler.Close(context.Background()) })
+
+	q, err := dbqueue.NewDiskQueue(dbqueue.DiskQueueOptions{
+		ID:        queueID,
+		Scheduler: scheduler,
+		Logger:    s.index.logger,
+		Dir:       t.TempDir(),
+		TaskDecoder: &lateWriteTaskDecoder{
+			started: taskStarted,
+			release: releaseTask,
+			write: func() error {
+				return s.store.Bucket(helpers.ObjectsBucketLSM).Put(drainedKey, drainedValue,
+					lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, drainedKey))
+			},
+		},
+		StaleTimeout: time.Millisecond,
+		ChunkSize:    50,
+	})
+	require.NoError(t, err)
+	require.NoError(t, q.Init())
+	scheduler.RegisterQueue(q)
+
+	s.propertyIndicesLock.Lock()
+	s.geoQueues["location"] = &VectorIndexQueue{DiskQueue: q}
+	s.propertyIndicesLock.Unlock()
+
+	require.NoError(t, q.Push([]byte{1}))
+	require.NoError(t, q.Flush())
+	<-taskStarted
+
+	halted := make(chan error, 1)
+	enterrors.GoWrapper(func() { halted <- s.HaltForTransfer(ctx, false, 0) }, s.index.logger)
+
+	// The queue is marked paused before PrepareForBackup blocks waiting on the
+	// in-flight task, so this is a precise signal that the halt has entered its
+	// seal steps — releasing earlier would let an early flush capture the write
+	// and mask the defect.
+	require.Eventually(t, func() bool { return scheduler.IsQueuePaused(queueID) },
+		10*time.Second, time.Millisecond, "halt never reached queue preparation")
+	close(releaseTask)
+	require.NoError(t, <-halted)
+	t.Cleanup(func() { require.NoError(t, s.resumeMaintenanceCycles(ctx)) })
+
+	files, err := s.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+	require.NoError(t, err)
+
+	require.True(t, objectsSnapshotHas(t, s.index.Config.RootPath, files, drained.ID().String()),
+		"write performed by the queue drain is missing from the file list — the memtable flush runs before the drain instead of after it")
+}
+
+// A failed halt at count>1 must roll back to the holder's count rather than
+// unhalting the shard the first consumer still holds.
+func TestShard_SharedHaltPrepErrorKeepsShardHalted(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShard(t, ctx, className)
+	t.Cleanup(func() {
+		_ = idx.drop()
+		_ = os.RemoveAll(idx.Config.RootPath)
+	})
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, 0))
+
+	// At count>1 the pause steps are gated out, so the cancelled context can
+	// only be observed by a seal step — which is the point being pinned.
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.Error(t, s.HaltForTransfer(cancelledCtx, false, 0))
+
+	require.Equal(t, 1, s.haltForTransferCount,
+		"failed count>1 halt must roll back to the first consumer's hold")
+
+	require.NoError(t, s.resumeMaintenanceCycles(ctx))
+	require.Equal(t, 0, s.haltForTransferCount)
+}
+
+// objectsSnapshotHas rebuilds the objects bucket from exactly the listed files —
+// what a transfer target receives — and reports whether id is retrievable, i.e.
+// whether the write survives in a sealed, listable segment.
+func objectsSnapshotHas(t *testing.T, rootPath string, files []string, id string) bool {
+	t.Helper()
+	ctx := context.Background()
+
+	bucketDir := filepath.Join(t.TempDir(), helpers.ObjectsBucketLSM)
+	require.NoError(t, os.MkdirAll(bucketDir, 0o755))
+
+	segmentPrefix := filepath.Join("lsm", helpers.ObjectsBucketLSM) + string(filepath.Separator)
+	copied := 0
+	for _, relPath := range files {
+		if !strings.Contains(relPath, segmentPrefix) {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(rootPath, relPath))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(bucketDir, filepath.Base(relPath)), data, 0o644))
+		copied++
+	}
+	require.Positive(t, copied, "no objects-bucket segment was listed for the snapshot")
+
+	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketDir, "", logrus.New(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1))
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+
+	key, err := uuid.MustParse(id).MarshalBinary()
+	require.NoError(t, err)
+	value, err := bucket.Get(key)
+	require.NoError(t, err)
+	return value != nil
+}
+
+type lateWriteTaskDecoder struct {
+	started chan struct{}
+	release chan struct{}
+	write   func() error
+	once    sync.Once
+}
+
+func (d *lateWriteTaskDecoder) DecodeTask([]byte) (dbqueue.Task, error) {
+	return &lateWriteTask{started: d.started, release: d.release, write: d.write, once: &d.once}, nil
+}
+
+type lateWriteTask struct {
+	started chan struct{}
+	release chan struct{}
+	write   func() error
+	once    *sync.Once
+}
+
+func (t *lateWriteTask) Op() uint8 { return 1 }
+
+func (t *lateWriteTask) Key() uint64 { return 0 }
+
+func (t *lateWriteTask) Execute(ctx context.Context) error {
+	t.once.Do(func() { close(t.started) })
+	select {
+	case <-t.release:
+		return t.write()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
Backport of #12218 to `stable/v1.37`. Closes weaviate/0-weaviate-issues#403.

When two transfer consumers halt the same shard at overlapping times, the second one hit an early return, skipped every preparation step, and got a file list that omits everything written since the first one halted. Its copy of the shard silently lost those writes. No error on either side.

`stable/v1.37` carries the defect verbatim: `if s.haltForTransferCount > 1 { return nil }`.

### Why this is not a cherry-pick

v1.37's step order inside `HaltForTransfer` differs from the v1.38 base the upstream diff was written against, because **v1.37 never received #10991**:

| step | `stable/v1.37` | `stable/v1.38` pre-#12218 |
|---|---|---|
| `PauseCompaction` | 1 | 1 |
| `FlushMemtables` | **2** | **7 (last)** |
| vector / geo cycle `Deactivate` | 3, 4 | 2, 3 |
| vector / geo queue `PrepareForBackup` | 5, 6 | 4, 5 |
| vector index `PrepareForBackup` | 7 | 6 |

#10991 (`1474b09e2`, 2026-04-22) moved the flush after the queue drain. It landed on v1.38 and never came down — the same one-directional-merge mechanism behind weaviate/0-weaviate-issues#401.

### How the pause/seal split was redrawn

- **Pause steps** — `PauseCompaction`, vector and geo cycle `Deactivate` — stay behind a count guard, now `== 1`. Re-pausing per halt would strand the per-bucket pause-timer refcount, which is 1 pause : 1 stop.
- **Seal steps** — queue `PrepareForBackup`, vector index `PrepareForBackup` (the HNSW commit-log switch), `FlushMemtables` — run on every halt.
- **`FlushMemtables` moves to last**, adopting #10991's position. Not optional here: with the flush left at position 2, the second consumer's own queue drain still writes compressed vectors and HFresh postings into the LSM store *after* its flush. Deleting the early return without moving the flush is a partial fix.
- The error-cleanup defer moves above the pause branch, so a failed `count>1` halt rolls back 2→1 through the refcount-aware resume instead of unhalting the shard the first consumer still holds.

The resulting `HaltForTransfer` is line-identical to `stable/v1.38`'s post-#12218 version except for the `refuseIfReindexInFlight` / `structuralVectorOpInFlight` guard, whose symbols do not exist on v1.37, and the inactivity fix below. The next forward merge of this file should be conflict-free.

### A regression that #12218 also shipped to v1.38 and main

Sealing on every halt turns an overlapping halt from a no-op into real I/O. That time is spent against an inactivity deadline the halt never pushes forward: `mayInitInactivityMonitoring` sets the deadline only when it *spawns* a monitor, and `mayUpdateInactivityTimeout` returns early when the existing timeout is already shorter. So a second consumer inherits the first's deadline, already expiring. `handleInactivityFire` then force-resumes — zeroing the count for **every** holder — right after a halt returns success, and that consumer's first `ListBackupFiles` fails with `not paused for transfer`.

Measured on `TestShard_ConcurrentTransfers`, `-tags integrationTest -race -count 30`:

| branch | failures / 30 |
|---|---|
| `stable/v1.37` unmodified | 0 |
| this branch, seal change only | 16 |
| this branch, with the deadline reset | **0** |
| `stable/v1.38` tip (ec170ba3a) | **4** |
| `stable/v1.38` tip + the same one-liner | **0** |

So this is not a backport artifact: **`stable/v1.38` and `main` have it today** (identical defer, identical seal-on-every-halt). Fixed here by treating a successful halt as activity — a stronger liveness signal than the file reads that already reset the deadline. `mayResetInactivityDeadline` no-ops when no monitor is armed. v1.38 and main need the same one-liner; filing separately rather than folding it in.

### Tests

v1.37 has no `replica_snapshot.go` — `IncomingCreateReplicaSnapshot` and the hardlink staging path are v1.38+ — so the upstream regression test does not port. These drive `ListBackupFiles`, the surface shared by the backup consumer (`backup.go`) and the replica COPY consumer (`replication.go` `IncomingListFiles`).

Because this is silent data loss, every assertion is on snapshot **contents** — the bucket or index is rebuilt from exactly the returned file list, which is what a transfer target receives, and the write must be retrievable from it. A snapshot that merely succeeds does not discriminate: the pre-existing `TestShard_ConcurrentTransfers` already covers the double-halt journey and passes on broken code because every assertion is `NoError`.

Both halves of the loss are covered. `SealsLateWrites` covers objects/LSM. `SealsLateVectors` covers the HNSW commit log, which is the half that stays exposed even for replica COPY — `IncomingListFiles` flushes memtables itself, but nothing outside `index.PrepareForBackup` switches the commit log, and COPY+COPY on a shared source shard is exactly what `shard_replication_apply.go` permits.

`SealsQueueDrainWrites` pins the flush position by driving **production** `HaltForTransfer` with a real in-flight `DiskQueue` task, using `Scheduler.IsQueuePaused` as the ordering oracle rather than a sleep. Worth noting why that matters: #10991's own test asserted against `haltForTransferForTest`, a test-local reimplementation of the step order. That is why the 2026-07-08 v1.37→v1.38 merge could silently revert #10991 and stay green until a human noticed two hours later.

### Revert-proof

Full matrix, every cell measured. Each test reddens on its own hunk and no other. Every red is the late-write assertion; the baseline assertion — a write sealed *before* any halt — passes throughout, proving the reconstruction works and the failure is the lost write rather than broken plumbing.

| reverted hunk | `SealsLateWrites` | `SealsLateVectors` | `SealsQueueDrainWrites` | `PrepErrorKeepsShardHalted` | `ExtendsInactivityDeadline` |
|---|---|---|---|---|---|
| whole file → `stable/v1.37` | 🔴 | 🔴 | 🔴 | 🔴 | 🔴 |
| only `count > 1` early return restored | 🔴 | 🔴 | ✅ | 🔴 | ✅ |
| only vector-index prep gated to first halt | ✅ | 🔴 | ✅ | ✅ | ✅ |
| only `FlushMemtables` moved back before the drain | ✅ | ✅ | 🔴 | ✅ | ✅ |
| only `mayResetInactivityDeadline()` removed | ✅ | ✅ | ✅ | ✅ | 🔴 |

```
write applied before this consumer's halt is missing from its file list — the shared halt skipped the re-seal
vector written before this consumer's halt is missing from its file list — the commit log was never switched
write performed by the queue drain is missing from the file list — the memtable flush runs before the drain instead of after it
an overlapping halt left the deadline in the past — the monitor will force-resume a shard two consumers still hold
```

One test-design note: commit-log file names are unix seconds, so `SealsLateVectors` spaces both halts by >1s. Without the gap before the *first* halt, that switch reopens the same path in append mode, nothing is listed at all, and the red lands on the baseline control instead of the late vector — discriminating, but pointing at the wrong thing.

### Local verification

- `go test -count 1 -race ./adapters/repos/db/` — ok, 73.9s
- `go test -tags integrationTest -count 1 -race -run 'TestShard_|TestBackup' ./adapters/repos/db/` — ok, 189.3s, 0 failures
- `go test -count 10 -race` over the five new tests — ok
- `golangci-lint run ./adapters/repos/db/...` — 0 issues
- `./tools/linter_go_routines.sh` — clean

### Scope note

Carrying #10991's flush relocation is required for #12218's guarantee to hold on v1.37. It is separately a data-loss gap on `stable/v1.37` in its own right — it affects *every* halt, not only overlapping ones — and it is not among the eight tracked in weaviate/0-weaviate-issues#401.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
