### PR TITLE
Fix RBAC leak in node handler (backport of #12002 to stable/v1.37)

### DIFF
--- a/test/acceptance/authz/nodes_test.go
+++ b/test/acceptance/authz/nodes_test.go
@@ -44,6 +44,7 @@ func TestAuthzNodesFilter(t *testing.T) {
 	helper.CreateClassAuth(t, clsP, adminKey)
 	helper.CreateClassAuth(t, clsA, adminKey)
 	helper.CreateObjectsBatchAuth(t, []*models.Object{articles.NewArticle().WithTitle("article1").Object()}, adminKey)
+	helper.CreateObjectsBatchAuth(t, []*models.Object{articles.NewParagraph().WithContents("p1").Object()}, adminKey)
 
 	helper.DeleteRole(t, adminKey, roleName)
 	defer helper.DeleteRole(t, adminKey, roleName)
@@ -52,16 +53,29 @@ func TestAuthzNodesFilter(t *testing.T) {
 	}})
 	helper.AssignRoleToUser(t, adminKey, roleName, customUser)
 
-	// only permissions for one of the classes
+	// Confined caller sees only its own class. The node-wide Stats must be rebuilt
+	// from the visible shard (ShardCount is 1, not the cluster's 2) so it doesn't
+	// leak the hidden class. BatchStats is node-wide queue/throughput telemetry
+	// with no per-class data, so it stays intact for the caller's dynamic batching.
+	// ObjectCount is a disk-async counter that lags unflushed writes, so it is not
+	// asserted.
 	resp, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(String(verbosity.OutputVerbose)), helper.CreateAuth(customKey))
-	require.NoError(t, err)
-	require.Len(t, resp.Payload.Nodes[0].Shards, 1)
-	require.Equal(t, resp.Payload.Nodes[0].Shards[0].Class, clsA.Class)
+	require.Nil(t, err)
+	node := resp.Payload.Nodes[0]
+	require.Len(t, node.Shards, 1)
+	require.Equal(t, clsA.Class, node.Shards[0].Class)
+	require.NotNil(t, node.Stats)
+	require.Equal(t, int64(1), node.Stats.ShardCount, "shard count must reflect only the visible shard")
+	require.NotNil(t, node.BatchStats, "node-wide batch stats leak no per-class data and must be preserved")
 
-	// admin gets back shards for two classes
+	// Admin sees both classes with untouched cluster-wide Stats and BatchStats.
 	resp, err = helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithOutput(String(verbosity.OutputVerbose)), helper.CreateAuth(adminKey))
-	require.NoError(t, err)
-	require.Len(t, resp.Payload.Nodes[0].Shards, 2)
+	require.Nil(t, err)
+	node = resp.Payload.Nodes[0]
+	require.Len(t, node.Shards, 2)
+	require.NotNil(t, node.Stats)
+	require.Equal(t, int64(2), node.Stats.ShardCount)
+	require.NotNil(t, node.BatchStats, "admin keeps cluster-wide batch stats")
 }
 
 func TestAuthzNodes(t *testing.T) {

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -72,7 +72,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 		resourceFilter := filter.New[*models.NodeShardStatus](m.authorizer, m.rbacconfig)
 
 		for i, nodeS := range status {
-			status[i].Shards = resourceFilter.Filter(
+			filtered := resourceFilter.Filter(
 				ctx,
 				m.logger,
 				principal,
@@ -82,10 +82,34 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 					return authorization.Nodes(verbosityString, shard.Class)[0]
 				},
 			)
+			if len(filtered) == len(nodeS.Shards) {
+				continue // caller is authorized for every shard on this node
+			}
+			// Hidden shards mean the node-wide Stats still aggregate classes the
+			// caller can't see, so rebuild them from the visible shards. BatchStats
+			// is node-wide queue/throughput telemetry with no per-class data, so it
+			// leaks nothing and is left intact for the caller's dynamic batching.
+			status[i].Shards = filtered
+			if status[i].Stats != nil {
+				status[i].Stats = statsFromShards(filtered)
+			}
 		}
 	}
 
 	return status, nil
+}
+
+// statsFromShards sums the object count over the given shards and reports how
+// many there are.
+func statsFromShards(shards []*models.NodeShardStatus) *models.NodeStats {
+	var objectCount int64
+	for _, shard := range shards {
+		objectCount += shard.ObjectCount
+	}
+	return &models.NodeStats{
+		ObjectCount: objectCount,
+		ShardCount:  int64(len(shards)),
+	}
 }
 
 func (m *Manager) GetNodeStatistics(ctx context.Context,

--- a/usecases/nodes/handler_test.go
+++ b/usecases/nodes/handler_test.go
@@ -1,0 +1,178 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package nodes
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
+)
+
+// allowlistAuthorizer authorizes only the resources it was seeded with, letting
+// a test simulate a caller confined to a subset of classes.
+type allowlistAuthorizer struct {
+	allowed []string
+}
+
+func (a *allowlistAuthorizer) authorized(resources ...string) bool {
+	for _, r := range resources {
+		if !slices.Contains(a.allowed, r) {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *allowlistAuthorizer) Authorize(ctx context.Context, principal *models.Principal, verb string, resources ...string) error {
+	if !a.authorized(resources...) {
+		return errForbidden
+	}
+	return nil
+}
+
+func (a *allowlistAuthorizer) AuthorizeSilent(ctx context.Context, principal *models.Principal, verb string, resources ...string) error {
+	return a.Authorize(ctx, principal, verb, resources...)
+}
+
+func (a *allowlistAuthorizer) FilterAuthorizedResources(ctx context.Context, principal *models.Principal, verb string, resources ...string) ([]string, error) {
+	filtered := make([]string, 0, len(resources))
+	for _, r := range resources {
+		if a.authorized(r) {
+			filtered = append(filtered, r)
+		}
+	}
+	return filtered, nil
+}
+
+var errForbidden = &forbiddenError{}
+
+type forbiddenError struct{}
+
+func (*forbiddenError) Error() string { return "forbidden" }
+
+// fakeDB returns a single node's verbose status with shards from two classes
+// plus cluster-wide Stats and BatchStats, mirroring what LocalNodeStatus builds.
+type fakeDB struct {
+	status []*models.NodeStatus
+}
+
+func (f *fakeDB) GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error) {
+	return f.status, nil
+}
+
+func (f *fakeDB) GetNodeStatistics(ctx context.Context) ([]*models.Statistics, error) {
+	return nil, nil
+}
+
+func nodeResource(class string) string {
+	return authorization.Nodes(verbosity.OutputVerbose, class)[0]
+}
+
+func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	// One node holding shards from "Mine" (2 objects) and "Other" (100 objects).
+	// Stats and BatchStats reflect the cluster-wide totals across both.
+	newStatus := func() []*models.NodeStatus {
+		healthy := models.NodeStatusStatusHEALTHY
+		queueLen := int64(7)
+		return []*models.NodeStatus{{
+			Name:   "node1",
+			Status: &healthy,
+			Shards: []*models.NodeShardStatus{
+				{Name: "s1", Class: "Mine", ObjectCount: 2},
+				{Name: "s2", Class: "Other", ObjectCount: 100},
+			},
+			Stats:      &models.NodeStats{ObjectCount: 102, ShardCount: 2},
+			BatchStats: &models.BatchStats{RatePerSecond: 5, QueueLength: &queueLen},
+		}}
+	}
+
+	// BatchStats is node-wide queue/throughput telemetry with no per-class data,
+	// so it is always preserved regardless of how many shards the caller can see.
+	tests := []struct {
+		name             string
+		rbacEnabled      bool
+		allowed          []string
+		wantShardClasses []string
+		wantObjectCount  int64
+		wantShardCount   int64
+	}{
+		{
+			name:             "rbac disabled leaves everything untouched",
+			rbacEnabled:      false,
+			allowed:          []string{nodeResource("")}, // wildcard: upfront authorize gate
+			wantShardClasses: []string{"Mine", "Other"},
+			wantObjectCount:  102,
+			wantShardCount:   2,
+		},
+		{
+			name:             "confined caller sees only own class in shards and stats, keeps batch",
+			rbacEnabled:      true,
+			allowed:          []string{nodeResource("Mine")},
+			wantShardClasses: []string{"Mine"},
+			wantObjectCount:  2,
+			wantShardCount:   1,
+		},
+		{
+			name:             "caller with no access sees zeroed stats, keeps batch",
+			rbacEnabled:      true,
+			allowed:          []string{},
+			wantShardClasses: []string{},
+			wantObjectCount:  0,
+			wantShardCount:   0,
+		},
+		{
+			name:             "caller with full access keeps cluster-wide stats",
+			rbacEnabled:      true,
+			allowed:          []string{nodeResource("Mine"), nodeResource("Other")},
+			wantShardClasses: []string{"Mine", "Other"},
+			wantObjectCount:  102,
+			wantShardCount:   2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authz := &allowlistAuthorizer{allowed: tt.allowed}
+			m := NewManager(logger, authz, &fakeDB{status: newStatus()}, nil,
+				rbacconf.Config{Enabled: tt.rbacEnabled}, time.Second)
+
+			status, err := m.GetNodeStatus(context.Background(), &models.Principal{},
+				"", "", verbosity.OutputVerbose)
+			require.NoError(t, err)
+			require.Len(t, status, 1)
+
+			gotClasses := make([]string, 0, len(status[0].Shards))
+			for _, s := range status[0].Shards {
+				gotClasses = append(gotClasses, s.Class)
+			}
+			require.ElementsMatch(t, tt.wantShardClasses, gotClasses)
+
+			require.NotNil(t, status[0].Stats)
+			require.Equal(t, tt.wantObjectCount, status[0].Stats.ObjectCount)
+			require.Equal(t, tt.wantShardCount, status[0].Stats.ShardCount)
+
+			require.NotNil(t, status[0].BatchStats,
+				"node-wide batch stats leak no per-class data and must always be preserved")
+		})
+	}
+}


### PR DESCRIPTION
Backport of #12002 to `stable/v1.37`. Closes weaviate/0-weaviate-issues#404.

### What's being changed

`GET /v1/nodes?output=verbose` (no class) filtered the per-shard status by RBAC but left `Stats` (`ObjectCount`/`ShardCount`) as node-wide aggregates summed across every collection, leaking the existence and data volume of collections the caller cannot see. When the shard filter hides anything on a node, `Stats` is now recomputed from the retained shards; when nothing is hidden, the aggregates are left intact.

`BatchStats` is node-wide queue/throughput telemetry with no per-collection attribution, so it is preserved in both cases — clients rely on it for dynamic batching.

### Why the gap existed

Forward merges run `v1.36 → v1.37 → v1.38 → main`. #12002 merged directly to `stable/v1.38`, so it could never flow down to `stable/v1.37`. Verified per-signature off the branch tip rather than inferred from topology: `statsFromShards` had **0** occurrences on `stable/v1.37` at `34a7228d6` and **3** on `stable/v1.38`/`main`.

### What was adapted for v1.37

**One line.** `filter.ResourceFilter.Filter` on this branch still takes a `logrus.FieldLogger` as its second argument, which v1.38 later dropped, so `m.logger` is retained at the call site. Everything else is byte-identical to the original — the production hunk, `usecases/nodes/handler_test.go`, and the `test/acceptance/authz/nodes_test.go` changes all diff clean against the upstream merge commit `f2c7c16`, and the diffstat matches it exactly (225 insertions, 9 deletions).

### Verification

Both tests were confirmed to fail without the production hunk and pass with it, against a committed baseline.

| Tier | Unfixed | Fixed |
|---|---|---|
| `usecases/nodes` unit | ❌ confined caller reads `ObjectCount: 102` — includes the 100 objects of the collection it cannot see; zero-permission caller also reads `102` | ✅ `2` and `0` respectively |
| `test/acceptance/authz` e2e | ❌ confined caller reads `ShardCount: 2` — the cluster total including the hidden collection | ✅ `1` |

The e2e leg ran against purpose-built images of this branch with and without the hunk. `go test -race ./usecases/nodes/...` is green; `gofumpt` and `goimports` are clean; both packages land in existing CI shards (`usecases/nodes` in the non-adapters unit shard, `test/acceptance/authz` in the `authz` acceptance job), so neither test is orphaned.

Manually confirmed end-to-end on a live RBAC container: a caller holding `read_nodes` on one collection out of two now reads `shardCount: 1` instead of `2`, and a caller with no permissions at all reads `{objectCount: 0, shardCount: 0}` with an empty `shards` array.

### Scope note

Two adjacent authorization defects surfaced while auditing the neighbouring aggregations on this endpoint. Both reproduce on `main` and every stable line, so neither is a backport gap and neither is fixed here — fixing them only on `stable/v1.37` would invert the very problem weaviate/0-weaviate-issues#401 documents. They are filed separately as weaviate/0-weaviate-issues#433 (`/nodes?output=verbose` has no authorization gate at all) and weaviate/0-weaviate-issues#434 (`WildcardPath` defeats the collection-vs-tenant guard on `GET /v1/schema`).
