### PR TITLE
Fix replica-movement restore crashloop and chained-move data loss (backport of #11895 to stable/v1.37)

### DIFF
--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -36,7 +36,11 @@ func (s *ShardReplicationFSM) Replicate(id uint64, c *api.ReplicationReplicateSh
 		TransferType:    api.ShardReplicationTransferType(c.TransferType),
 		StartTimeUnixMs: time.Now().UnixMilli(),
 	}
-	return s.writeOpIntoFSM(op, NewShardReplicationStatus(api.REGISTERED))
+	if err := s.validateReplicationAdmission(op); err != nil {
+		return err
+	}
+	s.insertOpIntoFSM(op, NewShardReplicationStatus(api.REGISTERED))
+	return nil
 }
 
 func (s *ShardReplicationFSM) RegisterError(c *api.ReplicationRegisterErrorRequest) error {
@@ -59,46 +63,57 @@ func (s *ShardReplicationFSM) RegisterError(c *api.ReplicationRegisterErrorReque
 	return nil
 }
 
-// writeOpIntoFSM writes the op with status into the FSM. It *does* not holds the lock onto the maps so the callee must make sure the lock
-// is held
-func (s *ShardReplicationFSM) writeOpIntoFSM(op ShardReplicationOp, status ShardReplicationOpStatus) error {
-	if _, ok := s.opsByTargetFQDN[op.TargetShard]; ok {
-		// First check the status of the existing op. If it's READY or CANCELLED we can accept a new op
-		if existingOpStatus, ok := s.statusById[op.ID]; ok {
-			if existingOpStatus.GetCurrentState() != api.READY && existingOpStatus.GetCurrentState() != api.CANCELLED {
-				return fmt.Errorf("op %s in targetFQDN: %w", op.UUID, ErrShardAlreadyReplicating)
-			}
+// validateReplicationAdmission runs only on the write path (Restore must not re-validate
+// already-admitted state). Callers must hold s.opsLock.
+func (s *ShardReplicationFSM) validateReplicationAdmission(op ShardReplicationOp) error {
+	if err := s.checkNoConflictingOp(op, s.opsByTargetFQDN[op.TargetShard], "target"); err != nil {
+		return err
+	}
+	if err := s.checkNoConflictingOp(op, s.opsBySourceFQDN[op.SourceShard], "source"); err != nil {
+		return err
+	}
+	return s.checkSourceNotInFlightAsTarget(op)
+}
+
+func (s *ShardReplicationFSM) checkSourceNotInFlightAsTarget(op ShardReplicationOp) error {
+	for _, existingOp := range s.opsByTargetFQDN[op.SourceShard] {
+		status, ok := s.statusById[existingOp.ID]
+		if !ok {
+			return fmt.Errorf("could not find op status for op %d", existingOp.ID)
+		}
+		switch status.GetCurrentState() {
+		case api.READY, api.CANCELLED:
+			// settled target, safe to source from (DEHYDRATING is complete too, but we
+			// err closed and wait for READY rather than reason about the drain boundary)
+		default:
+			return fmt.Errorf("op %s sources replica %s, the in-flight target of op %d: %w", op.UUID, op.SourceShard, existingOp.ID, ErrShardAlreadyReplicating)
 		}
 	}
+	return nil
+}
 
-	if existingOps, ok := s.opsBySourceFQDN[op.SourceShard]; ok {
-		for _, existingOp := range existingOps {
-			// First check the status of the existing op. If it's READY or CANCELLED we can accept a new op
-			// If it's ongoing we need to check if it's a move, in which case we can't accept any new op
-			// Otherwise we can accept a copy if the existing op is also a copy
-			if existingOpStatus, ok := s.statusById[existingOp.ID]; !ok {
-				// This should never happen
-				return fmt.Errorf("could not find op status for op %d", existingOp.ID)
-			} else if existingOpStatus.GetCurrentState() == api.CANCELLED {
-				continue
-			} else if existingOpStatus.GetCurrentState() == api.READY && existingOp.TransferType == api.COPY {
-				continue
-			}
-
-			// If any of the ops we're handling is a move we can't accept any new op
-			if existingOp.TransferType == api.MOVE {
-				return fmt.Errorf("existing op %s is a MOVE: %w", op.UUID, ErrShardAlreadyReplicating)
-			}
-
-			// At this point we know the existing op is a copy, if our new op is a move we can't accept it
-			if op.TransferType == api.MOVE {
-				return fmt.Errorf("existing op %s is a COPY, but new op is a MOVE: %w", op.UUID, ErrShardAlreadyReplicating)
-			}
-
-			// Existing op is an ongoing copy, our new op is also a copy, we can accept it
+func (s *ShardReplicationFSM) checkNoConflictingOp(op ShardReplicationOp, existingOps []ShardReplicationOp, scope string) error {
+	for _, existingOp := range existingOps {
+		status, ok := s.statusById[existingOp.ID]
+		if !ok {
+			return fmt.Errorf("could not find op status for op %d", existingOp.ID)
+		}
+		switch {
+		case status.GetCurrentState() == api.CANCELLED:
+			continue
+		case status.GetCurrentState() == api.READY && existingOp.TransferType == api.COPY:
+			continue
+		case existingOp.TransferType == api.MOVE:
+			return fmt.Errorf("existing op %s shares a %s replica and is a MOVE: %w", op.UUID, scope, ErrShardAlreadyReplicating)
+		case op.TransferType == api.MOVE:
+			return fmt.Errorf("existing op %s shares a %s replica (COPY), but new op is a MOVE: %w", op.UUID, scope, ErrShardAlreadyReplicating)
 		}
 	}
+	return nil
+}
 
+// insertOpIntoFSM inserts op into every in-memory index. Callers must hold s.opsLock.
+func (s *ShardReplicationFSM) insertOpIntoFSM(op ShardReplicationOp, status ShardReplicationOpStatus) {
 	s.idsByUuid[op.UUID] = op.ID
 	s.opsBySource[op.SourceShard.NodeId] = append(s.opsBySource[op.SourceShard.NodeId], op)
 	s.opsByTarget[op.TargetShard.NodeId] = append(s.opsByTarget[op.TargetShard.NodeId], op)
@@ -108,14 +123,12 @@ func (s *ShardReplicationFSM) writeOpIntoFSM(op ShardReplicationOp, status Shard
 	}
 	s.opsByCollectionAndShard[op.SourceShard.CollectionId][op.SourceShard.ShardId] = append(s.opsByCollectionAndShard[op.SourceShard.CollectionId][op.SourceShard.ShardId], op)
 	s.opsByCollection[op.SourceShard.CollectionId] = append(s.opsByCollection[op.SourceShard.CollectionId], op)
-	s.opsByTargetFQDN[op.TargetShard] = op
+	s.opsByTargetFQDN[op.TargetShard] = append(s.opsByTargetFQDN[op.TargetShard], op)
 	s.opsBySourceFQDN[op.SourceShard] = append(s.opsBySourceFQDN[op.SourceShard], op)
 	s.opsById[op.ID] = op
 	s.statusById[op.ID] = status
 
 	s.opsByStateGauge.WithLabelValues(status.GetCurrentState().String()).Inc()
-
-	return nil
 }
 
 func (s *ShardReplicationFSM) UpdateReplicationOpStatus(c *api.ReplicationUpdateOpStateRequest) error {
@@ -440,15 +453,22 @@ func (s *ShardReplicationFSM) hasOngoingSourceReplication(sourceFQDN shardFQDN) 
 }
 
 func (s *ShardReplicationFSM) hasOngoingTargetReplication(targetFQDN shardFQDN) bool {
-	op, ok := s.opsByTargetFQDN[targetFQDN]
+	ops, ok := s.opsByTargetFQDN[targetFQDN]
 	if !ok {
 		return false
 	}
-	status, ok := s.statusById[op.ID]
-	if !ok {
-		return false
+
+	for _, op := range ops {
+		status, ok := s.statusById[op.ID]
+		if !ok {
+			continue
+		}
+
+		if status.ShouldConsumeOps() {
+			return true
+		}
 	}
-	return status.ShouldConsumeOps()
+	return false
 }
 
 func (s *ShardReplicationFSM) HasOngoingReplication(collection string, shard string, replica string) bool {
@@ -503,6 +523,22 @@ func (s *ShardReplicationFSM) removeReplicationOp(id uint64) error {
 		s.opsBySourceFQDN[op.SourceShard] = opsReplace
 	}
 
+	// Unlike opsBySourceFQDN above, delete the target key when its slice empties: a
+	// present key is OR-folded by filterOneReplicaReadWrite, so a lingering empty slice
+	// would read (false,false) instead of falling through to the source check.
+	ops, ok = s.opsByTargetFQDN[op.TargetShard]
+	if !ok {
+		err = multierror.Append(err, fmt.Errorf("could not find op in ops by target fqdn, this should not happen"))
+	}
+	opsReplace, ok = findAndDeleteOp(op.ID, ops)
+	if ok {
+		if len(opsReplace) == 0 {
+			delete(s.opsByTargetFQDN, op.TargetShard)
+		} else {
+			s.opsByTargetFQDN[op.TargetShard] = opsReplace
+		}
+	}
+
 	shardOps, ok := s.opsByCollectionAndShard[op.SourceShard.CollectionId]
 	if !ok {
 		err = multierror.Append(err, fmt.Errorf("could not find op in ops by collection and shard, this should not happen"))
@@ -525,7 +561,6 @@ func (s *ShardReplicationFSM) removeReplicationOp(id uint64) error {
 	}
 
 	delete(s.idsByUuid, op.UUID)
-	delete(s.opsByTargetFQDN, op.TargetShard)
 	delete(s.opsById, op.ID)
 	delete(s.statusById, op.ID)
 

--- a/cluster/replication/shard_replication_apply_test.go
+++ b/cluster/replication/shard_replication_apply_test.go
@@ -1,0 +1,344 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/replication"
+)
+
+func seedOpFull(t *testing.T, fsm *replication.ShardReplicationFSM, opID uint64, srcNode, tgtNode, collection, shard string, transferType api.ShardReplicationTransferType) strfmt.UUID {
+	t.Helper()
+	uuid := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", opID))
+	require.NoError(t, fsm.Replicate(opID, &api.ReplicationReplicateShardRequest{
+		Version:          api.ReplicationCommandVersionV0,
+		Uuid:             uuid,
+		SourceNode:       srcNode,
+		SourceCollection: collection,
+		SourceShard:      shard,
+		TargetNode:       tgtNode,
+		TransferType:     transferType.String(),
+	}))
+	return uuid
+}
+
+// driveToState advances the op via UpdateReplicationOpStatus. CANCELLED
+// requires CancellationComplete (the FSM rejects it here) — see driveToCancelled.
+func driveToState(t *testing.T, fsm *replication.ShardReplicationFSM, opID uint64, state api.ShardReplicationState) {
+	t.Helper()
+	if state == api.REGISTERED {
+		return
+	}
+	require.NoError(t, fsm.UpdateReplicationOpStatus(&api.ReplicationUpdateOpStateRequest{
+		Version: api.ReplicationCommandVersionV0,
+		Id:      opID,
+		State:   state,
+	}))
+}
+
+func driveToCancelled(t *testing.T, fsm *replication.ShardReplicationFSM, opID uint64) {
+	t.Helper()
+	require.NoError(t, fsm.CancellationComplete(&api.ReplicationCancellationCompleteRequest{
+		Version: api.ReplicationCommandVersionV0,
+		Id:      opID,
+	}))
+}
+
+// seededOp declares one op a table row wants present before the assertion: it is
+// admitted via Replicate (itself subject to admission), then driven to its state.
+type seededOp struct {
+	id           uint64
+	srcNode      string
+	tgtNode      string
+	transferType api.ShardReplicationTransferType
+	state        api.ShardReplicationState
+}
+
+func seedAll(t *testing.T, fsm *replication.ShardReplicationFSM, collection, shard string, ops []seededOp) {
+	t.Helper()
+	for _, op := range ops {
+		seedOpFull(t, fsm, op.id, op.srcNode, op.tgtNode, collection, shard, op.transferType)
+		if op.state == api.CANCELLED {
+			driveToCancelled(t, fsm, op.id)
+			continue
+		}
+		driveToState(t, fsm, op.id, op.state)
+	}
+}
+
+func TestReplicate_Admission(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+
+	cases := []struct {
+		name string
+		// setup ops are admitted (all must succeed) and driven to their state, then
+		// final is the op under test.
+		setup   []seededOp
+		final   seededOp
+		wantErr bool // true ⇒ final must be rejected with ErrShardAlreadyReplicating
+	}{
+		// --- source-guard isolation: shared source FQDN, disjoint targets ---
+		{
+			name:    "source: two active MOVEs rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node1", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "source: cancelled MOVE then new MOVE allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.CANCELLED}},
+			final:   seededOp{id: 2, srcNode: "node1", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: false,
+		},
+		{
+			name:    "source: completed COPY (READY) then new MOVE allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY}},
+			final:   seededOp{id: 2, srcNode: "node1", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: false,
+		},
+		{
+			name:    "source: active COPY then COPY allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node1", tgtNode: "node3", transferType: api.COPY, state: api.REGISTERED},
+			wantErr: false,
+		},
+		// --- target-guard isolation: shared target FQDN, disjoint sources. Every row
+		// here is admitted unconditionally before the fix: the guard keyed its status
+		// lookup on the incoming op's own id, which is never already in statusById.
+		{
+			name:    "target: two active MOVEs from distinct sources rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "target: active COPY then MOVE from distinct source rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "target: cancelled MOVE then active MOVE from distinct source allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.CANCELLED}},
+			final:   seededOp{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: false,
+		},
+		{
+			name:    "target: completed COPY (READY) then active COPY from distinct source allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY}},
+			final:   seededOp{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.REGISTERED},
+			wantErr: false,
+		},
+		{
+			name:    "target: two active COPYs from distinct sources allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.REGISTERED},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			seedAll(t, fsm, coll, shard, tc.setup)
+
+			err := fsm.Replicate(tc.final.id, &api.ReplicationReplicateShardRequest{
+				Version:          api.ReplicationCommandVersionV0,
+				Uuid:             strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", tc.final.id)),
+				SourceNode:       tc.final.srcNode,
+				SourceCollection: coll,
+				SourceShard:      shard,
+				TargetNode:       tc.final.tgtNode,
+				TransferType:     tc.final.transferType.String(),
+			})
+
+			if tc.wantErr {
+				require.ErrorIs(t, err, replication.ErrShardAlreadyReplicating)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestReplicate_RejectsSourceFromInFlightTarget pins the chained-move guard: a move
+// A→B followed by B→C must not be admitted while B is still being hydrated by the
+// first leg. Both legs running at once seals the second leg's change-capture log
+// before the first has drained its writes into B, and those writes never reach C.
+func TestReplicate_RejectsSourceFromInFlightTarget(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+	cases := []struct {
+		name    string
+		setup   []seededOp
+		final   seededOp
+		wantErr bool
+	}{
+		{
+			name:    "MOVE sourcing a replica still being moved in is rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "COPY sourcing a replica still being moved in is rejected (incomplete read)",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.COPY, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "MOVE sourcing a replica still being copied in is rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "MOVE sourcing a FINALIZING target is rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.FINALIZING}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "MOVE sourcing a REGISTERED target is rejected",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.REGISTERED}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			// DEHYDRATING n2 is complete (its drain finished before this state), but we
+			// err closed and reject until READY — pins the conservative boundary.
+			name:    "MOVE sourcing a DEHYDRATING target is rejected (conservative)",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.DEHYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: true,
+		},
+		{
+			name:    "sourcing a READY target is allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.READY}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: false,
+		},
+		{
+			name:    "sourcing a CANCELLED target is allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.CANCELLED}},
+			final:   seededOp{id: 2, srcNode: "node2", tgtNode: "node3", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: false,
+		},
+		{
+			name:    "disjoint moves are allowed",
+			setup:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.HYDRATING}},
+			final:   seededOp{id: 2, srcNode: "node3", tgtNode: "node4", transferType: api.MOVE, state: api.REGISTERED},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			seedAll(t, fsm, coll, shard, tc.setup)
+
+			err := fsm.Replicate(tc.final.id, &api.ReplicationReplicateShardRequest{
+				Version:          api.ReplicationCommandVersionV0,
+				Uuid:             strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", tc.final.id)),
+				SourceNode:       tc.final.srcNode,
+				SourceCollection: coll,
+				SourceShard:      shard,
+				TargetNode:       tc.final.tgtNode,
+				TransferType:     tc.final.transferType.String(),
+			})
+
+			if tc.wantErr {
+				require.ErrorIs(t, err, replication.ErrShardAlreadyReplicating)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestReplicationFSM_HasOngoingReplication_TargetCoexistence covers the target arm of
+// HasOngoingReplication, which gates HOT→COLD tenant deactivation in
+// schema.metaClass.UpdateTenants. A false negative deactivates and unloads the shard
+// out from under a replication op still hydrating into it.
+//
+// HasOngoingReplication has no equivalent on v1.38/main, so the upstream fix carries
+// no coverage for this path.
+func TestReplicationFSM_HasOngoingReplication_TargetCoexistence(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+
+	cases := []struct {
+		name  string
+		ops   []seededOp
+		query string
+		want  bool
+	}{
+		{
+			name: "settled COPY beside a hydrating COPY into the same target is ongoing",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING},
+				{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+			},
+			query: "node2",
+			want:  true,
+		},
+		{
+			name: "both settled into the same target is not ongoing",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+				{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+			},
+			query: "node2",
+			want:  false,
+		},
+		{
+			name:  "single hydrating target is ongoing",
+			ops:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			query: "node2",
+			want:  true,
+		},
+		{
+			name:  "single settled target is not ongoing",
+			ops:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY}},
+			query: "node2",
+			want:  false,
+		},
+		{
+			name:  "uninvolved replica is not ongoing",
+			ops:   []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			query: "node4",
+			want:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			seedAll(t, fsm, coll, shard, tc.ops)
+			require.Equal(t, tc.want, fsm.HasOngoingReplication(coll, shard, tc.query))
+		})
+	}
+}

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -70,9 +70,9 @@ type ShardReplicationFSM struct {
 	opsByCollection map[string][]ShardReplicationOp
 	// opsByCollectionAndShard stores the array of ShardReplicationOp for each collection and shard
 	opsByCollectionAndShard map[string]map[string][]ShardReplicationOp
-	// opsByTargetFQDN stores the registered ShardReplicationOp (if any) for each destination replica
-	opsByTargetFQDN map[shardFQDN]ShardReplicationOp
-	// opsBySourceFQDN stores the registered ShardReplicationOp (if any) for each source replica
+	// opsByTargetFQDN stores the registered ShardReplicationOps for each destination replica.
+	opsByTargetFQDN map[shardFQDN][]ShardReplicationOp
+	// opsBySourceFQDN stores the registered ShardReplicationOps for each source replica
 	opsBySourceFQDN map[shardFQDN][]ShardReplicationOp
 	// opsById stores opId -> replicationOp
 	opsById map[uint64]ShardReplicationOp
@@ -89,7 +89,7 @@ func NewShardReplicationFSM(reg prometheus.Registerer) *ShardReplicationFSM {
 		opsBySource:             make(map[string][]ShardReplicationOp),
 		opsByCollection:         make(map[string][]ShardReplicationOp),
 		opsByCollectionAndShard: make(map[string]map[string][]ShardReplicationOp),
-		opsByTargetFQDN:         make(map[shardFQDN]ShardReplicationOp),
+		opsByTargetFQDN:         make(map[shardFQDN][]ShardReplicationOp),
 		opsBySourceFQDN:         make(map[shardFQDN][]ShardReplicationOp),
 		opsById:                 make(map[uint64]ShardReplicationOp),
 		statusById:              make(map[uint64]ShardReplicationOpStatus),
@@ -136,9 +136,7 @@ func (s *ShardReplicationFSM) Restore(bytes []byte) error {
 	s.resetState()
 
 	for op, status := range snap.Ops {
-		if err := s.writeOpIntoFSM(op, status); err != nil {
-			return err
-		}
+		s.insertOpIntoFSM(op, status)
 	}
 
 	return nil
@@ -347,29 +345,30 @@ func (s *ShardReplicationFSM) readWriteReplicas(collection, shard string, shardR
 // It returns a tuple of boolean (readOk, writeOk)
 func (s *ShardReplicationFSM) filterOneReplicaReadWrite(node string, collection string, shard string) (bool, bool) {
 	replicaFQDN := newShardFQDN(node, collection, shard)
-	op, ok := s.opsByTargetFQDN[replicaFQDN]
+	ops, ok := s.opsByTargetFQDN[replicaFQDN]
 	// No target replication ops for that replica, ensure we check if it's a source
 	if !ok {
 		return s.filterOneReplicaAsSourceReadWrite(node, collection, shard)
 	}
 
-	opState, ok := s.statusById[op.ID]
-	if !ok {
-		// TODO: This should never happens
-		return true, true
-	}
-
-	// Filter read/write based on the state of the replica op
-	readOk := false
-	writeOk := false
-	switch opState.GetCurrentState() {
-	case api.READY:
-		readOk = true
-		writeOk = true
-	case api.DEHYDRATING:
-		readOk = true
-		writeOk = true
-	default:
+	readOk, writeOk := false, false
+outer:
+	for _, op := range ops {
+		opState, ok := s.statusById[op.ID]
+		if !ok {
+			// A missing status should never happen (every indexed op has one). Bail
+			// conservatively as read+write allowed; this early-returns rather than
+			// continuing the fold, discarding any routability accumulated so far —
+			// acceptable precisely because the branch is unreachable.
+			return true, true
+		}
+		switch opState.GetCurrentState() {
+		case api.READY, api.DEHYDRATING:
+			readOk = true
+			writeOk = true
+			break outer
+		default:
+		}
 	}
 	return readOk, writeOk
 }

--- a/cluster/replication/shard_replication_fsm_test.go
+++ b/cluster/replication/shard_replication_fsm_test.go
@@ -1,0 +1,241 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/replication"
+)
+
+// TestShardReplicationFSM_FilterOneReplica_Coexistence pins the OR-fold over the ops
+// sharing a target replica. Before the fix the index held one op per target FQDN, so
+// the last op written decided routing for the whole replica.
+func TestShardReplicationFSM_FilterOneReplica_Coexistence(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+	replicas := []string{"node2"}
+
+	cases := []struct {
+		name string
+		ops  []seededOp
+		want []string
+	}{
+		{
+			// The cancelled recopy is written last, so before the fix it is the op the
+			// single slot retains and node2 drops out of read and write routing even
+			// though the completed copy makes it a perfectly good replica.
+			name: "completed COPY beside a cancelled recopy stays routable",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+				{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.CANCELLED},
+			},
+			want: []string{"node2"},
+		},
+		{
+			name: "hydrating COPY beside a completed COPY stays routable",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+				{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING},
+			},
+			want: []string{"node2"},
+		},
+		{
+			name: "cancelled only is excluded",
+			ops:  []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.CANCELLED}},
+			want: []string{},
+		},
+		{
+			name: "single completed COPY is routable",
+			ops:  []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY}},
+			want: []string{"node2"},
+		},
+		{
+			name: "single hydrating COPY is not yet routable",
+			ops:  []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.HYDRATING}},
+			want: []string{},
+		},
+		{
+			name: "single finalizing MOVE is not yet routable",
+			ops:  []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.FINALIZING}},
+			want: []string{},
+		},
+		{
+			name: "single dehydrating MOVE is routable",
+			ops:  []seededOp{{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.DEHYDRATING}},
+			want: []string{"node2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			seedAll(t, fsm, coll, shard, tc.ops)
+
+			require.Equal(t, tc.want, fsm.FilterOneShardReplicasRead(coll, shard, replicas))
+			write, _ := fsm.FilterOneShardReplicasWrite(coll, shard, replicas)
+			require.Equal(t, tc.want, write)
+		})
+	}
+}
+
+// TestShardReplicationFSM_RemoveOneOfTwoTargetOps pins the per-target slice remove path.
+// Before the fix removal deleted the whole target key, so removing either of two ops
+// sharing a replica also dropped the survivor — and with no entry left, routing fell
+// through to the source check and happily routed reads to a still-hydrating replica.
+func TestShardReplicationFSM_RemoveOneOfTwoTargetOps(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+	replicas := []string{"node2"}
+
+	fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+	remove := func(id uint64) {
+		t.Helper()
+		require.NoError(t, fsm.RemoveReplicationOp(&api.ReplicationRemoveOpRequest{
+			Version: api.ReplicationCommandVersionV0,
+			Id:      id,
+		}))
+	}
+	requireRoutable := func(msg string, want []string) {
+		t.Helper()
+		require.Equal(t, want, fsm.FilterOneShardReplicasRead(coll, shard, replicas), msg)
+		write, _ := fsm.FilterOneShardReplicasWrite(coll, shard, replicas)
+		require.Equal(t, want, write, msg)
+	}
+
+	seedAll(t, fsm, coll, shard, []seededOp{
+		{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.MOVE, state: api.CANCELLED},
+		{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.MOVE, state: api.HYDRATING},
+	})
+	require.Len(t, fsm.GetOpsForTarget("node2"), 2)
+	requireRoutable("node2 is still hydrating, so it is not routable", []string{})
+
+	// Removing the cancelled op must leave the hydrating op governing the replica.
+	remove(1)
+	require.Len(t, fsm.GetOpsForTarget("node2"), 1)
+	requireRoutable("the hydrating survivor still keeps node2 out of routing", []string{})
+
+	// Removing the last op empties the slice; the key must be deleted so routing falls
+	// through to the source check rather than OR-folding an empty slice to (false,false).
+	remove(2)
+	require.Empty(t, fsm.GetOpsForTarget("node2"))
+	requireRoutable("with no op left node2 routes as an ordinary replica", []string{"node2"})
+}
+
+// TestShardReplicationFSM_RestoreIsOrderIndependent pins snapshot restore as a total,
+// order-independent rebuild. snap.Ops is a map, so each restore ranges it in a fresh
+// random order. Before the fix restore replayed ops through the admission-validating
+// write path, which both rejected legally-committed snapshots (failing the RAFT restore
+// and crashlooping the node) and let whichever op landed last win the target index,
+// leaving nodes to route the same shard differently.
+func TestShardReplicationFSM_RestoreIsOrderIndependent(t *testing.T) {
+	const (
+		coll  = "TestClass"
+		shard = "shard1"
+	)
+
+	cases := []struct {
+		name string
+		// seeded in id order; a settled op must precede the active op it coexists with.
+		ops []seededOp
+		// per target replica: how many ops the per-node index holds, and whether the
+		// replica is read+write routable.
+		wantOpsPerTarget map[string]int
+		wantRoutable     map[string]bool
+	}{
+		{
+			// Admission accepts a MOVE off a source whose only other op is a completed
+			// COPY. Replayed MOVE-first, the old restore path saw the MOVE and rejected
+			// the COPY, so ~half of all restores failed outright.
+			name: "completed COPY and ongoing MOVE sharing a source",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+				{id: 2, srcNode: "node1", tgtNode: "node3", transferType: api.MOVE, state: api.HYDRATING},
+			},
+			wantOpsPerTarget: map[string]int{"node2": 1, "node3": 1},
+			wantRoutable:     map[string]bool{"node2": true, "node3": false},
+		},
+		{
+			// Both ops share target node2, so the single-valued index kept only one.
+			name: "completed COPY and cancelled recopy sharing a target",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+				{id: 2, srcNode: "node3", tgtNode: "node2", transferType: api.COPY, state: api.CANCELLED},
+			},
+			wantOpsPerTarget: map[string]int{"node2": 2},
+			wantRoutable:     map[string]bool{"node2": true},
+		},
+		{
+			name: "combined snapshot mixing both coexistences",
+			ops: []seededOp{
+				{id: 1, srcNode: "node1", tgtNode: "node2", transferType: api.COPY, state: api.READY},
+				{id: 2, srcNode: "node1", tgtNode: "node3", transferType: api.MOVE, state: api.HYDRATING},
+				{id: 3, srcNode: "node4", tgtNode: "node5", transferType: api.COPY, state: api.READY},
+				{id: 4, srcNode: "node6", tgtNode: "node5", transferType: api.COPY, state: api.CANCELLED},
+			},
+			wantOpsPerTarget: map[string]int{"node2": 1, "node3": 1, "node5": 2},
+			wantRoutable:     map[string]bool{"node2": true, "node3": false, "node5": true},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			seedAll(t, src, coll, shard, tc.ops)
+			blob, err := src.Snapshot()
+			require.NoError(t, err)
+
+			const restores = 100
+			var prevStatus map[replication.ShardReplicationOp]replication.ShardReplicationOpStatus
+			for i := 1; i <= restores; i++ {
+				dst := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+				require.NoErrorf(t, dst.Restore(blob), "restore %d/%d must not error", i, restores)
+
+				gotStatus := dst.GetStatusByOps()
+				require.Lenf(t, gotStatus, len(tc.ops), "restore %d: op count", i)
+				for _, op := range tc.ops {
+					_, ok := dst.GetOpById(op.id)
+					require.Truef(t, ok, "restore %d: op %d present", i, op.id)
+				}
+
+				for node, count := range tc.wantOpsPerTarget {
+					require.Lenf(t, dst.GetOpsForTarget(node), count,
+						"restore %d: per-node target index for %s", i, node)
+				}
+
+				for node, routable := range tc.wantRoutable {
+					want := []string{}
+					if routable {
+						want = []string{node}
+					}
+					require.Equalf(t, want, dst.FilterOneShardReplicasRead(coll, shard, []string{node}),
+						"restore %d: %s read routing", i, node)
+					write, _ := dst.FilterOneShardReplicasWrite(coll, shard, []string{node})
+					require.Equalf(t, want, write, "restore %d: %s write routing", i, node)
+				}
+
+				if prevStatus != nil {
+					require.Equalf(t, prevStatus, gotStatus, "restore %d state must match restore %d", i, i-1)
+				}
+				prevStatus = gotStatus
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport of [weaviate/weaviate#11895](https://github.com/weaviate/weaviate/issues/11895) to `stable/v1.37`. Closes the `stable/v1.37` half of `weaviate/0-weaviate-issues#402` (sub-issue of `weaviate/0-weaviate-issues#401`).

### The gap is still real on the v1.37 tip

Measured per-signature off `origin/stable/v1.37` (`34a7228d6`), not inferred from branch topology:

| signature | stable/v1.37 | stable/v1.38 |
|---|---|---|
| `opsByTargetFQDN` value type | **single `ShardReplicationOp`** | `[]ShardReplicationOp` |
| `insertOpIntoFSM` / `validateReplicationAdmission` | **absent** | present |
| `checkSourceNotInFlightAsTarget` | **absent** | present |
| `writeOpIntoFSM` called inside `Restore` | **yes** | no |
| unconditional `delete(opsByTargetFQDN, …)` on removal | **yes** | guarded |

No prior backport exists on any base.

### What's being ported

- **Snapshot restore no longer re-runs admission validation.** Restore is reconstructing already-agreed state, so it must be total and order-independent. `writeOpIntoFSM` is split into an infallible `insertOpIntoFSM` (used by restore and the write path) and a write-path-only `validateReplicationAdmission`.
- **`opsByTargetFQDN` becomes a slice**, symmetric with `opsBySourceFQDN`. Removal deletes the emptied key, because a present-but-empty slice would OR-fold to `(false,false)` instead of falling through to the source check.
- **The dead target-FQDN admission guard is corrected.** It keyed its status lookup on the incoming op's own id, which is never already in `statusById`, so it never fired. The two near-identical admission loops are unified into `checkNoConflictingOp`.
- **Admission rejects an op that sources a replica another op is still hydrating.** A chained move `n1→n2` then `n2→n3` ran both legs at once; the second sealed its change-capture log before the first drained its writes into `n2`, and those writes were lost on `n3`.

### Adapted for v1.37

**1. `api.INTEGRATING` does not exist on this line** — zero occurrences in the Go tree; `ShardReplicationState` has six constants here versus seven on v1.38. The `filterOneReplicaReadWrite` fold ports as `case api.READY, api.DEHYDRATING:`, and the upstream comment explaining the `INTEGRATING` arm goes with it.

**2. `hasOngoingTargetReplication` is v1.37-only and the upstream change carries no guidance for it.** It has no counterpart on v1.38 or `main` (that line replaced it with `HasActiveReplicationForShard`), so a verbatim cherry-pick does not compile. It reads `opsByTargetFQDN` and is therefore subject to the same clobber, so it now folds over the slice exactly like its `hasOngoingSourceReplication` sibling. This matters: via `HasOngoingReplication` it gates the HOT→COLD tenant transition in `schema.metaClass.UpdateTenants`, and it runs inside the deterministic RAFT apply path. A false negative deactivates and unloads a shard out from under an op still hydrating into it; a per-node divergence writes different tenant activity status on different nodes with no error surfaced.

This is the part the parent issue's characterisation ("near-clean, drop the `INTEGRATING` fold") did not capture — that description was written against `stable/v1.36`.

### Tests, and proof they bite

Every claim in `weaviate/0-weaviate-issues#402` that was marked INFERRED is now measured. Reverting the two production files to the `stable/v1.37` tip while keeping the tests fails **20 lines, identically across 5 consecutive runs**:

| red subtest | failure | mechanism |
|---|---|---|
| `TestReplicate_RejectsSourceFromInFlightTarget` (6 rows) | expected `ErrShardAlreadyReplicating`, got nil | no chained-move guard — **this converts the INFERRED reachability into a measurement** |
| `TestReplicate_Admission` target rows (2) | expected error, got nil | the dead target guard never fires |
| `TestShardReplicationFSM_RestoreIsOrderIndependent` / shared source | `restore 1/100 must not error` | restore re-litigates admission → RAFT restore failure → crashloop |
| `TestShardReplicationFSM_RestoreIsOrderIndependent` / shared target (2 rows) | `restore 2: node2 read routing` | clobber under randomized map iteration |
| `TestShardReplicationFSM_FilterOneReplica_Coexistence` (2 rows) | expected `["node2"]`, got `[]` | clobber drops a healthy replica from read+write routing |
| `TestShardReplicationFSM_RemoveOneOfTwoTargetOps` | expected `[]`, got `["node2"]` | removal wiped the surviving op, so reads routed to a **still-hydrating** replica |
| `TestReplicationFSM_HasOngoingReplication_TargetCoexistence` | expected `true`, got `false` | clobber hides an in-flight op from the tenant-deactivation gate |

The subtests that stay green under the revert are the ones where fixed and unfixed genuinely agree (single-op routing, disjoint ops, the allowed-admission rows) — they are regression guards, not passengers.

### Verification

- `go test -race -count 1 ./cluster/...` — green.
- The six new tests, `-race`, 5 consecutive runs — green (300 snapshot restores per run across the determinism rows, zero failures).
- `golangci-lint run ./cluster/...` — `0 issues`.
- `./tools/linter_go_routines.sh` — clean.
- `gofumpt` / `goimports` — clean.
- No skipped tests.

### Reviewer notes

- The removal asymmetry is deliberate: the target key is deleted when its slice empties, the source key is not. `filterOneReplicaAsSourceReadWrite` initialises to `(true,true)` and only narrows, so an empty source slice is harmless; the target fold initialises to `(false,false)`, so an empty target slice would silently de-route the replica. `TestShardReplicationFSM_RemoveOneOfTwoTargetOps` pins both halves.
- `FilterOneShardReplicasWrite` returns `([]string, []string)` on this line and one value upstream, so the ported tests read `write, _ :=`. The second return, `additionalWriteReplicas`, is untouched: it reads `opsByCollectionAndShard`, which was already a slice, and its consumer in `usecases/replica/coordinator.go` broadcasts to it best-effort outside the consistency-level count, so it cannot inflate a quorum.