### PR TITLE
fix(gcp): treat auth-broker 429 as retryable (backport of #12025 to stable/v1.37)

### DIFF
--- a/usecases/modulecomponents/gcpcommon/auth_broker.go
+++ b/usecases/modulecomponents/gcpcommon/auth_broker.go
@@ -104,7 +104,7 @@ func (b *AuthBrokerTokenSource) fetchToken(ctx context.Context, identityToken st
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode >= 500 {
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusTooManyRequests {
 		return nil, fmt.Errorf("%w: auth broker returned status %d", ErrRetryableAuthBroker, resp.StatusCode)
 	}
 

--- a/usecases/modulecomponents/gcpcommon/auth_broker_test.go
+++ b/usecases/modulecomponents/gcpcommon/auth_broker_test.go
@@ -48,8 +48,8 @@ func TestFetchTokenSuccess(t *testing.T) {
 	assert.Equal(t, expected.Expiry, tok.Expiry)
 }
 
-func TestFetchToken5xxReturnsRetryable(t *testing.T) {
-	for _, status := range []int{500, 502, 503, 504} {
+func TestFetchTokenRetryableStatuses(t *testing.T) {
+	for _, status := range []int{429, 500, 502, 503, 504} {
 		t.Run(fmt.Sprintf("status_%d", status), func(t *testing.T) {
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(status)


### PR DESCRIPTION
Backport of [weaviate/weaviate#12025](https://github.com/weaviate/weaviate/pull/12025) to `stable/v1.37`. Closes [weaviate/0-weaviate-issues#407](https://github.com/weaviate/0-weaviate-issues/issues/407), a sub-issue of [weaviate/0-weaviate-issues#401](https://github.com/weaviate/0-weaviate-issues/issues/401).

## What was broken

`fetchToken`'s retryable classification covered only `>= 500`, so a `429` fell through to the non-200 branch and returned an error that does **not** wrap `ErrRetryableAuthBroker`. The caller's retry/backoff never engaged, so a rate-limited auth broker failed the token fetch outright — at exactly the moment backing off is the correct response.

## The gap is real on the v1.37 tip

Measured off `34a7228d6`, not inferred from branch topology:

| signature | `stable/v1.37` | `origin/main` |
|---|---|---|
| guard at `auth_broker.go:107` | `if resp.StatusCode >= 500 {` | `... \|\| resp.StatusCode == http.StatusTooManyRequests` |
| `TooManyRequests` / `429` in the file | **0** | 1 |

## The change

One production line, byte-identical to `origin/main` (verified with `diff` over the region), plus the upstream test change: `TestFetchToken5xxReturnsRetryable` → `TestFetchTokenRetryableStatuses` with `429` added to its status list. `TestFetchToken4xxNotRetryable` covers `{400, 401, 403, 404}` and does not include 429, so the two tables stay disjoint.

## The test bites, and only on this change

Committed first, then reverted the production hunk to the v1.37 tip:

```
--- FAIL: TestFetchTokenRetryableStatuses (0.03s)
    --- FAIL: TestFetchTokenRetryableStatuses/status_429 (0.02s)
```

`status_429` is the **only** case that reddens — `500/502/503/504` and all four `4xxNotRetryable` rows stay green, so the attribution is disjoint rather than merely numerous. Clean tree after restore.

`go test -race` green over the package (`ok ... 2.674s`), `go build ./usecases/modulecomponents/...` clean, `gofmt`/`gofumpt`/`goimports` all clean. No skipped tests.

The renamed test still runs in CI: `run_unit_tests` selects packages by path via `go list ./...` with no `-run` name filter, so a rename cannot orphan it.
