### PR TITLE
fix(hnsw): guard nil DirEntry in ListFiles (backport of #12300 to v1.37)

### DIFF
--- a/adapters/repos/db/vector/hnsw/backup.go
+++ b/adapters/repos/db/vector/hnsw/backup.go
@@ -54,6 +54,9 @@ func (h *hnsw) ListFiles(ctx context.Context, basePath string) ([]string, error)
 	)
 
 	err := filepath.WalkDir(logRoot, func(pth string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
 		if d.IsDir() {
 			return nil
 		}

--- a/adapters/repos/db/vector/hnsw/backup_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_test.go
@@ -114,6 +114,38 @@ func TestBackup_ListFiles(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestBackup_ListFilesMissingCommitLogDir(t *testing.T) {
+	ctx := context.Background()
+
+	dirName := t.TempDir()
+	indexID := "backup-list-files-missing-dir-test"
+
+	idx, err := New(Config{
+		RootPath:         dirName,
+		ID:               indexID,
+		Logger:           logrus.New(),
+		DistanceProvider: distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: testVectorForID,
+		GetViewThunk:     func() common.BucketView { return &backupNoopBucketView{} },
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return NewCommitLogger(dirName, indexID, logrus.New(), cyclemanager.NewCallbackGroupNoop())
+		},
+	}, enthnsw.NewDefaultUserConfig(), cyclemanager.NewCallbackGroupNoop(), nil)
+	require.Nil(t, err)
+	idx.PostStartup(context.Background())
+
+	// The directory can disappear under a live index (partially initialized
+	// shard, permissions change, operator removal). WalkDir then calls the
+	// callback with a nil DirEntry, and ListFiles is on the replica file-list
+	// path as well as the backup path, so a deref here takes down whichever
+	// touches the shard first.
+	require.NoError(t, os.RemoveAll(path.Join(dirName, fmt.Sprintf("%s.hnsw.commitlog.d", indexID))))
+
+	var listErr error
+	require.NotPanics(t, func() { _, listErr = idx.ListFiles(ctx, dirName) })
+	require.Error(t, listErr)
+}
+
 func TestBackup_HFreshListFiles(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
Backport of [weaviate/weaviate#12300](https://github.com/weaviate/weaviate/pull/12300) to `stable/v1.37`. Closes [weaviate/0-weaviate-issues#406](https://github.com/weaviate/0-weaviate-issues/issues/406), a sub-issue of [weaviate/0-weaviate-issues#401](https://github.com/weaviate/0-weaviate-issues/issues/401).

## What was broken

`filepath.WalkDir` is documented to call `fn(root, nil, err)` when it cannot `Lstat` the root — the `fs.DirEntry` is **nil**. The callback's first statement was `if d.IsDir()`, with the `err` parameter never checked, so a missing or unreadable commit-log directory dereferenced nil instead of returning an error.

`ListFiles` serves the replica file-list path as well as the backup path, so the panic took down whichever reached the shard first.

## The gap is real on the v1.37 tip

Measured off `34a7228d6`:

| signature | `stable/v1.37` | `origin/main` |
|---|---|---|
| callback's first statement | `if d.IsDir()` | `if err != nil { return err }` |
| `err` guard in callback | **absent** | present |

## The change

Three lines, byte-identical to `origin/main`. The upstream PR's other two hunks touch code that does not exist on this line and are correctly N/A — `ListFiles` has since diverged substantially upstream (it gained an `ActiveFilePath()` identity filter), so only this hunk ports.

## The test bites, on the actual defect

`TestBackup_ListFilesMissingCommitLogDir` builds an index the way the neighbouring tests do, then removes the commit-log directory underneath the live index — the scenario the issue names. Committed first, then reverted the production hunk to the v1.37 tip:

```
--- FAIL: TestBackup_ListFilesMissingCommitLogDir (0.01s)
    Error: func (assert.PanicTestFunc)(0x103363180) should not panic
    panic: ... invalid memory address or nil pointer dereference
```

The recovered panic is the nil deref itself, so the test fails on the defect rather than on a proxy for it. It is written as `require.NotPanics` around the call plus `require.Error` on the result, so an unfixed build produces an attributable assertion failure instead of a bare process panic that takes the package's other tests with it.

Full package green: `ok github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw 65.166s`. `go build` clean, `gofmt`/`gofumpt`/`goimports` clean. No skipped tests.
