### PR TITLE
fix(backup): reset the inactivity deadline on a successful halt

### DIFF
--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -67,11 +67,6 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 			s.mayUpdateInactivityTimeout(inactivityTimeout)
 			s.mayInitInactivityMonitoring()
 		}
-		// A successful halt is liveness. An overlapping consumer otherwise
-		// inherits the first consumer's deadline untouched while the seal steps
-		// it just ran spent wall-clock time against it, so the monitor can
-		// force-resume the moment the halt returns — and a force-resume zeroes
-		// the count for every holder, not just the one that timed out.
 		s.mayResetInactivityDeadline()
 	}()
 

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -60,10 +60,19 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 	s.haltForTransferCount++
 
 	defer func() {
-		if err == nil && inactivityTimeout > 0 {
+		if err != nil {
+			return
+		}
+		if inactivityTimeout > 0 {
 			s.mayUpdateInactivityTimeout(inactivityTimeout)
 			s.mayInitInactivityMonitoring()
 		}
+		// A successful halt is liveness. An overlapping consumer otherwise
+		// inherits the first consumer's deadline untouched while the seal steps
+		// it just ran spent wall-clock time against it, so the monitor can
+		// force-resume the moment the halt returns — and a force-resume zeroes
+		// the count for every holder, not just the one that timed out.
+		s.mayResetInactivityDeadline()
 	}()
 
 	if offloading {

--- a/adapters/repos/db/shard_backup_inactivity_test.go
+++ b/adapters/repos/db/shard_backup_inactivity_test.go
@@ -14,8 +14,10 @@ package db
 import (
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,4 +50,37 @@ func TestTransferActivityReader_ResetsPerChunk(t *testing.T) {
 	assert.Greater(t, readCalls, 1, "payload must span multiple chunks for this to be meaningful")
 	assert.Equal(t, readCalls, resets,
 		"the watchdog must be reset on every chunk read, not just at file open")
+}
+
+// A halt that returns successfully is itself liveness. Without pushing the
+// deadline forward, an overlapping consumer inherits a deadline the first
+// consumer's seal steps already spent, and the watchdog's force-resume drops
+// the halt for every holder rather than only the one that timed out.
+func TestShard_HaltForTransferExtendsInactivityDeadline(t *testing.T) {
+	ctx := testCtx()
+	shd, idx := testShard(t, ctx, "TestClass")
+	t.Cleanup(func() {
+		_ = idx.drop()
+		_ = os.RemoveAll(idx.Config.RootPath)
+	})
+	s := shd.(*Shard)
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	// Stands in for a halt whose preparation outlasted the remaining budget.
+	s.haltForTransferMux.Lock()
+	s.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+	s.haltForTransferMux.Unlock()
+
+	require.NoError(t, s.HaltForTransfer(ctx, false, time.Hour))
+
+	s.haltForTransferMux.Lock()
+	deadline := s.haltForTransferInactivityDeadline
+	s.haltForTransferMux.Unlock()
+	require.True(t, deadline.After(time.Now()),
+		"an overlapping halt left the deadline in the past — the monitor will force-resume a shard two consumers still hold")
+
+	for s.haltForTransferCount > 0 {
+		require.NoError(t, s.resumeMaintenanceCycles(ctx))
+	}
 }


### PR DESCRIPTION
Closes [weaviate/0-weaviate-issues#443](https://github.com/weaviate/0-weaviate-issues/issues/443). Targets `stable/v1.38`; `main` gets it by forward merge.

## The regression

[weaviate/weaviate#12218](https://github.com/weaviate/weaviate/pull/12218) fixed overlapping-transfer data loss by making every halt seal. That turned an overlapping halt into real I/O — but `HaltForTransfer` never recorded a successful halt as activity.

So the second consumer inherits a deadline that its own seal steps have just spent wall-clock time against, and the watchdog can force-resume the moment the halt returns. The force-resume zeroes `haltForTransferCount` for **every** holder, not only the one that timed out, so a second consumer's halt drops the protection the first is still relying on. That is the same shape as the defect 12218 exists to fix.

## The change

One call added to the success path of `HaltForTransfer`'s deferred block. `mayResetInactivityDeadline` takes no lock of its own — it is a bare field write whose other caller wraps it — and the defer runs while `haltForTransferMux` is still held (LIFO, registered after the lock), so there is no deadlock and no new locking.

The `if err == nil && inactivityTimeout > 0` condition is split into an early return plus the timeout branch. Behaviour for the existing branch is unchanged; the split is what lets the reset run on success regardless of whether an inactivity timeout was supplied.

## The test bites

`TestShard_HaltForTransferExtendsInactivityDeadline` is deterministic — no sleeps, no timing. It halts, forces the deadline into the past to stand in for a halt whose preparation outlasted its budget, halts again, and asserts the overlapping halt pushed the deadline forward.

Committed first, then reverted the production hunk to the `stable/v1.38` tip (`0a9bfdcdf`):

```
--- FAIL: TestShard_HaltForTransferExtendsInactivityDeadline (0.03s)
    Messages: an overlapping halt left the deadline in the past — the monitor
              will force-resume a shard two consumers still hold
```

Clean tree after restore.

## Prior measurement

Found while backporting 12218 to `stable/v1.37`. `TestShard_ConcurrentTransfers` under `-race`, 30 runs per cell: `stable/v1.38` tip **4 failures**, tip plus this one-liner **0**. Those cells were measured in a worktree that has since been removed, so this PR's own deterministic test is the durable evidence and that run is context.

`go build ./adapters/repos/db/...` clean, `gofmt`/`gofumpt`/`goimports` clean, no skipped tests added.

One pre-existing `go vet` finding sits at `adapters/repos/db/helper_for_test.go:233` (a discarded `context.WithTimeout` cancel). It is present on the base branch, is not gated by `golangci-lint`, and is untouched here.
