### PR TITLE
fix(aggregate): group ref beacons by string so shards merge (v1.37)

### DIFF
--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply.go
@@ -14,6 +14,7 @@ package v1
 import (
 	"fmt"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/schema"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
@@ -95,6 +96,13 @@ func (r *AggregateReplier) parseAggregateGroupedBy(in *aggregation.GroupedBy) (*
 			return &pb.AggregateReply_Group_GroupedBy{
 				Path:  in.Path,
 				Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: val},
+			}, nil
+		case strfmt.URI:
+			// Defensive: the grouper emits beacons as plain string; this only
+			// catches a stray named type so it can't fall through to the 500.
+			return &pb.AggregateReply_Group_GroupedBy{
+				Path:  in.Path,
+				Value: &pb.AggregateReply_Group_GroupedBy_Text{Text: string(val)},
 			}, nil
 		case bool:
 			return &pb.AggregateReply_Group_GroupedBy{

--- a/adapters/handlers/grpc/v1/prepare_aggregate_reply_ref_test.go
+++ b/adapters/handlers/grpc/v1/prepare_aggregate_reply_ref_test.go
@@ -1,0 +1,35 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/aggregation"
+)
+
+// A grouped-by value that is still a strfmt.URI must render as text rather than
+// reaching the default arm, which returns an error and surfaces as a 500.
+func TestParseAggregateGroupedByAcceptsURI(t *testing.T) {
+	const beacon = "weaviate://localhost/SomeClass/6c2f5a1e-0000-4000-8000-000000000001"
+	r := &AggregateReplier{}
+
+	got, err := r.parseAggregateGroupedBy(&aggregation.GroupedBy{
+		Path:  []string{"refProp"},
+		Value: strfmt.URI(beacon),
+	})
+	require.NoError(t, err)
+	require.Equal(t, beacon, got.GetText())
+}

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -955,7 +955,7 @@ func testNumericalAggregationsWithGrouping(repo *DB, exact bool) func(t *testing
 						Count: 10,
 						GroupedBy: &aggregation.GroupedBy{
 							Path:  []string{"makesProduct"},
-							Value: strfmt.URI("weaviate://localhost/1295c052-263d-4aae-99dd-920c5a370d06"),
+							Value: "weaviate://localhost/1295c052-263d-4aae-99dd-920c5a370d06",
 						},
 						Properties: map[string]aggregation.Property{
 							"dividendYield": {

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -198,7 +198,11 @@ func (g *grouper) addElementById(s *models.PropertySchema, docID uint64) error {
 		}
 	case models.MultipleRef:
 		for i := range val {
-			g.addItem(val[i].Beacon, docID)
+			// Emit a plain string, not strfmt.URI: remote shards JSON-decode
+			// the beacon back to string while local shards keep the named
+			// type, and the two are unequal interface keys — so ShardCombiner
+			// would split one ref target into two buckets with halved counts.
+			g.addItem(string(val[i].Beacon), docID)
 		}
 	default:
 		g.addItem(val, docID)

--- a/adapters/repos/db/aggregator/grouper_ref_beacon_test.go
+++ b/adapters/repos/db/aggregator/grouper_ref_beacon_test.go
@@ -1,0 +1,54 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package aggregator
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/aggregation"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// A local shard reaches the grouper with models.MultipleRef, whose Beacon is a
+// strfmt.URI; a remote shard's reply has been through JSON and arrives as a
+// plain string. g.values is keyed by the boxed interface, and the two are
+// unequal despite identical bytes — so one ref target used to land in two
+// groups, each carrying part of the count.
+func TestGrouperRefBeaconMergesAcrossShardShapes(t *testing.T) {
+	const beacon = "weaviate://localhost/SomeClass/6c2f5a1e-0000-4000-8000-000000000001"
+
+	g := &grouper{
+		Aggregator: &Aggregator{
+			params: aggregation.Params{
+				GroupBy: &filters.Path{Property: schema.PropertyName("refProp")},
+			},
+		},
+		values: map[interface{}]map[uint64]struct{}{},
+	}
+
+	local := models.PropertySchema(map[string]interface{}{
+		"refProp": models.MultipleRef{{Beacon: strfmt.URI(beacon)}},
+	})
+	require.NoError(t, g.addElementById(&local, 1))
+
+	// What a JSON-decoded remote shard reply yields for the same target.
+	g.addItem(beacon, 2)
+
+	require.Len(t, g.values, 1,
+		"the same beacon from a local and a remote shard must group together, not split the count across two buckets")
+	require.Len(t, g.values[beacon], 2, "both doc IDs belong to the single merged group")
+}


### PR DESCRIPTION
Backport of [weaviate/weaviate#11526](https://github.com/weaviate/weaviate/pull/11526) to `stable/v1.37`. Closes [weaviate/0-weaviate-issues#408](https://github.com/weaviate/0-weaviate-issues/issues/408), a sub-issue of [weaviate/0-weaviate-issues#401](https://github.com/weaviate/0-weaviate-issues/issues/401).

## What was broken

`grouper.values` is `map[interface{}]map[uint64]struct{}` — keyed by the **boxed** value. A local shard reaches the grouper with `models.MultipleRef`, whose `Beacon` is a `strfmt.URI`; a remote shard's reply has been through JSON and arrives as a plain `string`. `strfmt.URI("beacon://…")` and `string("beacon://…")` are unequal as interface values despite identical bytes, so one reference target landed in **two** groups, each holding part of the count.

A mixed local/remote fan-out produces both shapes, so the same beacon could split inside a single query result.

## The change

Two hunks, both from upstream:

- `adapters/repos/db/aggregator/grouper.go` — emit the beacon as `string`.
- `adapters/handlers/grpc/v1/prepare_aggregate_reply.go` — a `case strfmt.URI:` arm. Defensive only: the grouper now emits `string`, and this stops a stray named type falling through to the default arm, which returns an error and surfaces as a 500.

**The namespace-stripping half of the upstream PR is deliberately not ported.** `StripOwnNamespace` has zero occurrences in the Go tree on this branch, and `r.principal` does not exist here either; that part depends on machinery never backported, and dropping it does not affect this defect.

## Both hunks bite, independently

Committed first, then each hunk reverted **on its own** against the `stable/v1.37` tip (`34a7228d6`):

| reverted | red test | message |
|---|---|---|
| grouper only | `TestGrouperRefBeaconMergesAcrossShardShapes` | `the same beacon from a local and a remote shard must group together, not split the count across two buckets` |
| reply only | `TestParseAggregateGroupedByAcceptsURI` | `unrecognized grouped by value type: strfmt.URI` |

Disjoint — each hunk reddens only its own case, so the reds are not standing in for one another.

The grouper test reproduces the user-visible defect rather than the code shape: it feeds the **same beacon** through both paths — `models.MultipleRef` (local) and a plain string (what a JSON-decoded remote reply yields) — and asserts one group holding both doc IDs.

## A third guard, and it was already there encoding the defect

CI surfaced `Test_Aggregations/.../no_filters,__grouped_by_ref_prop` and its `Test_Aggregations_MultiShard` twin. That failure **is** this PR's, and it is the right kind:

```
- Value: (strfmt.URI) (len=57) "weaviate://localhost/1295c052-..."
+ Value: (string)     (len=57) "weaviate://localhost/1295c052-..."
```

Identical bytes, different dynamic type. The existing integration expectation asserted `strfmt.URI` — the exact shape that fails to merge with a remote shard's JSON-decoded `string`. The test encoded the defect, so it had to be updated consciously rather than worked around; `origin/main` carries the same update (zero `strfmt.URI(` remain in that file upstream).

The updated expectation is proven to track the fix rather than made to pass: reverting only the grouper hunk reddens it with `+ Value: (strfmt.URI)`.

One process note, since it nearly misled me: running those subtests under a narrow `-run` filter fails everything with `tried to browse non-existing index`, because the filter excludes the sibling subtest that builds the fixture. The functions have to be run whole.

`ok .../adapters/repos/db/aggregator` and `ok .../adapters/handlers/grpc/v1`, `go build` clean, `go vet` clean, `gofmt`/`gofumpt`/`goimports` clean. No skipped tests.

