### PR TITLE
fix(dynamic): retry a failed index upgrade instead of pausing forever

### DIFF
--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -110,7 +110,7 @@ type dynamic struct {
 	threshold                    uint64
 	index                        VectorIndex
 	upgraded                     atomic.Bool
-	upgradeOnce                  sync.Once
+	upgradeInFlight              atomic.Bool
 	tombstoneCallbacks           cyclemanager.CycleCallbackGroup
 	uc                           ent.UserConfig
 	db                           *bbolt.DB
@@ -540,19 +540,29 @@ func (dynamic *dynamic) Upgrade(callback func()) error {
 		return dynamic.index.(upgradableIndexer).Upgrade(callback)
 	}
 
-	dynamic.upgradeOnce.Do(func() {
-		enterrors.GoWrapper(func() {
-			defer callback()
-			dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
+	// A gate rather than a sync.Once: a Once is spent by a FAILED attempt, after
+	// which every later call starts no goroutine, fires no callback and returns
+	// nil — leaving the caller's paused queue with nothing left to resume it.
+	// Once-ever semantics already come from dynamic.upgraded above.
+	if !dynamic.upgradeInFlight.CompareAndSwap(false, true) {
+		// Another upgrade is running; its callback resumes the queue, and the
+		// scheduler's paused flag is a boolean, so that one resume covers this
+		// caller's pause too.
+		return nil
+	}
 
-			err := dynamic.doUpgrade()
-			if err != nil {
-				dynamic.logger.WithError(err).Error("failed to upgrade index")
-				return
-			}
-			dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW completed")
-		}, dynamic.logger)
-	})
+	enterrors.GoWrapper(func() {
+		defer callback()
+		defer dynamic.upgradeInFlight.Store(false)
+		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
+
+		err := dynamic.doUpgrade()
+		if err != nil {
+			dynamic.logger.WithError(err).Error("failed to upgrade index")
+			return
+		}
+		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW completed")
+	}, dynamic.logger)
 
 	return nil
 }

--- a/adapters/repos/db/vector/dynamic/upgrade_retry_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_retry_test.go
@@ -1,0 +1,55 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package dynamic
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+)
+
+// BeforeSchedule pauses the queue and delivers the resume through Upgrade's
+// callback. A failed upgrade leaves ShouldUpgrade() true, so the scheduler comes
+// back — and the retry has to actually run, or the queue stays paused for the
+// lifetime of the shard with nothing left to resume it.
+func TestUpgradeRetriesAfterFailedAttempt(t *testing.T) {
+	idx, _, _ := newDynamicAboveThreshold(t)
+
+	var attempts atomic.Int64
+	idx.makeCommitLoggerThunk = func() (hnsw.CommitLogger, error) {
+		attempts.Add(1)
+		return nil, errors.New("commit logger unavailable")
+	}
+
+	upgradeOnce := func(t *testing.T, what string) {
+		t.Helper()
+		done := make(chan struct{})
+		require.NoError(t, idx.Upgrade(func() { close(done) }))
+		select {
+		case <-done:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("%s: callback never ran, so the caller's paused queue is never resumed", what)
+		}
+	}
+
+	upgradeOnce(t, "first attempt")
+	require.False(t, idx.Upgraded(), "the upgrade failed, so the index must not report itself upgraded")
+
+	upgradeOnce(t, "retry after failure")
+	require.GreaterOrEqual(t, attempts.Load(), int64(2),
+		"the retry must re-attempt the upgrade rather than silently no-op")
+}

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -307,6 +307,9 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 		})
 		if err != nil {
 			iq.DiskQueue.Logger.WithError(err).Error("failed to upgrade vector index")
+			// Upgrade returns early on a closed index without running the
+			// callback, so nothing else would lift the pause above.
+			iq.scheduler.ResumeQueue(iq.DiskQueue.ID())
 		}
 
 		return true


### PR DESCRIPTION
Backport of [weaviate/weaviate#11983](https://github.com/weaviate/weaviate/pull/11983) to `stable/v1.37`. Closes [weaviate/0-weaviate-issues#405](https://github.com/weaviate/0-weaviate-issues/issues/405), the last open sub-issue of [weaviate/0-weaviate-issues#401](https://github.com/weaviate/0-weaviate-issues/issues/401).

## What was broken

If a dynamic index upgrade (flat → HNSW) failed once, the shard's vector index queue stayed **paused forever**. Async indexing was dead for that shard, `vectorQueueSize` never returned to zero, and anything waiting on `wait_for_vector_indexing` hung indefinitely — with no further error logged after the first failure.

Two halves, both required.

**The queue** pauses and delivers the resume only through `Upgrade`'s callback:

```go
iq.scheduler.PauseQueue(iq.DiskQueue.ID())
err := ci.Upgrade(func() { iq.scheduler.ResumeQueue(iq.DiskQueue.ID()) })
if err != nil { /* logged, and that was all */ }
```

**`dynamic.Upgrade`** could return without ever running that callback:

- **Closed index** — returns `ctx.Err()` before reaching the callback.
- **Failed `doUpgrade`** — the work sat inside `upgradeOnce.Do`. The first attempt fired the callback, but `doUpgrade` had failed so `upgraded` stayed false, `ShouldUpgrade()` stayed true, and `BeforeSchedule` re-paused and called `Upgrade` again. By then the `sync.Once` was **spent**: no goroutine started, no callback ran, and the function returned `nil` — so even the queue's error branch was never reached.

## The change

`sync.Once` was doing two jobs, mutual exclusion and once-ever semantics. Only the first is wanted — `upgraded atomic.Bool` already provides the second — so it becomes a CAS gate that reopens when an attempt fails:

```go
if !dynamic.upgradeInFlight.CompareAndSwap(false, true) {
    return nil
}
enterrors.GoWrapper(func() {
    defer callback()
    defer dynamic.upgradeInFlight.Store(false)
    ...
```

The concurrent-caller path returns without a callback of its own, and that is deliberate: `Scheduler`'s `q.paused` is a **boolean**, not a counter (`queue/scheduler.go:241`, `:276`), so the in-flight upgrade's single resume clears the second caller's pause too.

The queue's error branch now also resumes, which covers the closed-index path where `Upgrade` never runs the callback at all.

## The test bites, on the permanent-hang path

`TestUpgradeRetriesAfterFailedAttempt` reuses the package's existing `newDynamicAboveThreshold` helper, then points the index's commit-logger thunk at a failing one — `Config.MakeCommitLoggerThunk` is a public field typed `func() (CommitLogger, error)`, so this is the configuration surface working as designed rather than a seam added for the test.

Committed first, then the dynamic hunk reverted to the `stable/v1.37` tip (`34a7228d6`):

```
--- FAIL: TestUpgradeRetriesAfterFailedAttempt (30.05s)
    retry after failure: callback never ran, so the caller's paused queue is never resumed
```

It fails by **hanging until the timeout**, which is the defect itself rather than a proxy for it: the second `Upgrade` finds the `Once` spent and silently does nothing. Clean tree after restore.

`ok .../adapters/repos/db/vector/dynamic 7.778s`, `go build ./adapters/repos/db/...` clean, `gofmt`/`gofumpt`/`goimports` clean, no skipped tests.

## Note on the issue thread

I posted a design on `weaviate/0-weaviate-issues#405` claiming the test fixture was blocked without a production seam. That was wrong and I retracted it there before writing this. The fixture was available through the existing public config the whole time.
