### PR TITLE
fix(schema): aggregate shard status and vectorQueueSize over all replicas in GET /schema/{class}/shards

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3491,41 +3491,6 @@ func waitForCycleStop(ctx context.Context, stopResult chan bool) error {
 	return nil
 }
 
-func (i *Index) getShardsQueueSize(ctx context.Context, tenant string) (map[string]int64, error) {
-	className := i.Config.ClassName.String()
-	shardNames, err := i.schemaReader.Shards(className)
-	if err != nil {
-		return nil, err
-	}
-
-	shardsQueueSize := make(map[string]int64)
-	for _, shardName := range shardNames {
-		if tenant != "" && shardName != tenant {
-			continue
-		}
-		var size int64
-		err := i.withShardOrRemote(ctx, tenant, shardName, localShardOperationRead, 0,
-			func(shard ShardLike) error {
-				return shard.ForEachVectorQueue(func(_ string, queue *VectorIndexQueue) error {
-					size += queue.Size()
-					return nil
-				})
-			},
-			func() error {
-				var err error
-				size, err = i.remote.GetShardQueueSize(ctx, shardName)
-				return err
-			})
-		if err != nil {
-			return nil, errors.Wrapf(err, "shard %s", shardName)
-		}
-
-		shardsQueueSize[shardName] = size
-	}
-
-	return shardsQueueSize, nil
-}
-
 func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string) (int64, error) {
 	shard, release, err := i.GetShard(ctx, shardName)
 	if err != nil {
@@ -3548,38 +3513,114 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	return size, nil
 }
 
-func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
+// getShardsStatus reports, per shard, the status and vector-index queue size
+// aggregated over ALL replicas of that shard: a shard is only READY when every
+// replica is READY, and the queue size is the sum of every replica's queues.
+// Anything less lets clients that poll this endpoint (e.g. the python client's
+// wait_for_vector_indexing) observe a single drained replica and declare async
+// indexing finished while the remaining replicas — any of which can serve a
+// subsequent search — are still consuming their queues.
+func (i *Index) getShardsStatus(ctx context.Context, tenant string) (models.ShardStatusList, error) {
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)
 	if err != nil {
 		return nil, err
 	}
 
-	shardsStatus := make(map[string]string)
+	localNode := i.getSchema.NodeName()
+	shardsStatus := make(models.ShardStatusList, 0, len(shardNames))
 
 	for _, shardName := range shardNames {
 		if tenant != "" && shardName != tenant {
 			continue
 		}
-		var status string
-		err := i.withShardOrRemote(ctx, tenant, shardName, localShardOperationRead, 0,
-			func(shard ShardLike) error {
-				status = shard.GetStatus().String()
-				return nil
-			},
-			func() error {
-				var err error
-				status, err = i.remote.GetShardStatus(ctx, shardName)
-				return err
-			})
+		replicas, err := i.schemaReader.ShardReplicas(className, shardName)
 		if err != nil {
-			return nil, errors.Wrapf(err, "shard %s", shardName)
+			return nil, errors.Wrapf(err, "shard %s: resolve replicas", shardName)
 		}
 
-		shardsStatus[shardName] = status
+		statuses := make([]string, 0, len(replicas))
+		var queueSize int64
+		for _, node := range replicas {
+			status, size, err := i.shardReplicaStatusAndQueueSize(ctx, tenant, shardName, node, localNode)
+			if err != nil {
+				return nil, errors.Wrapf(err, "shard %s: replica on node %s", shardName, node)
+			}
+			statuses = append(statuses, status)
+			queueSize += size
+		}
+
+		shardsStatus = append(shardsStatus, &models.ShardStatusGetResponse{
+			Name:            shardName,
+			Status:          aggregateShardStatuses(statuses),
+			VectorQueueSize: queueSize,
+		})
 	}
 
 	return shardsStatus, nil
+}
+
+func (i *Index) shardReplicaStatusAndQueueSize(ctx context.Context,
+	tenant, shardName, node, localNode string,
+) (status string, queueSize int64, err error) {
+	if node != localNode {
+		if status, err = i.remote.GetShardStatusFromNode(ctx, node, shardName); err != nil {
+			return "", 0, err
+		}
+		queueSize, err = i.remote.GetShardQueueSizeFromNode(ctx, node, shardName)
+		return status, queueSize, err
+	}
+
+	err = i.withShardOrRemote(ctx, tenant, shardName, localShardOperationRead, 0,
+		func(shard ShardLike) error {
+			status = shard.GetStatus().String()
+			return shard.ForEachVectorQueue(func(_ string, queue *VectorIndexQueue) error {
+				queueSize += queue.Size()
+				return nil
+			})
+		},
+		func() error {
+			// Sharding state lists this node as a replica but the shard is not
+			// directly reachable (e.g. still initializing); go through the
+			// cluster API like for any other node.
+			var err error
+			if status, err = i.remote.GetShardStatusFromNode(ctx, node, shardName); err != nil {
+				return err
+			}
+			queueSize, err = i.remote.GetShardQueueSizeFromNode(ctx, node, shardName)
+			return err
+		})
+	return status, queueSize, err
+}
+
+// shardStatusSeverity orders the non-READY statuses by how they should
+// dominate a multi-replica aggregate; INDEXING first, because pending queue
+// consumption is the transient state readiness pollers care about.
+var shardStatusSeverity = []storagestate.Status{
+	storagestate.StatusIndexing,
+	storagestate.StatusLoading,
+	storagestate.StatusLazyLoading,
+	storagestate.StatusShutdown,
+	storagestate.StatusReadOnly,
+}
+
+// aggregateShardStatuses reduces per-replica statuses to the least-ready one:
+// READY only when every replica reports READY.
+func aggregateShardStatuses(statuses []string) string {
+	for _, severe := range shardStatusSeverity {
+		if slices.Contains(statuses, severe.String()) {
+			return severe.String()
+		}
+	}
+	for _, status := range statuses {
+		if status != storagestate.StatusReady.String() {
+			return status
+		}
+	}
+	if len(statuses) == 0 {
+		return ""
+	}
+	return storagestate.StatusReady.String()
 }
 
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3543,6 +3543,11 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (models.Shar
 		if err != nil {
 			return nil, errors.Wrapf(err, "shard %s: resolve replicas", shardName)
 		}
+		if len(replicas) == 0 {
+			// A shard with no replicas would otherwise be reported with an
+			// empty status, which pollers would wait on forever.
+			return nil, fmt.Errorf("shard %s: sharding state lists no replicas", shardName)
+		}
 
 		statuses := make([]string, len(replicas))
 		queueSizes := make([]int64, len(replicas))

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3520,6 +3520,11 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 // wait_for_vector_indexing) observe a single drained replica and declare async
 // indexing finished while the remaining replicas — any of which can serve a
 // subsequent search — are still consuming their queues.
+//
+// Operational contract: a replica that rejects the read because its shard is
+// still loading is reported as LOADING; an unreachable replica fails the whole
+// request (as it previously did for the single resolved owner), so pollers
+// retry. Reading the queue size loads lazy shards on every replica.
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (models.ShardStatusList, error) {
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)
@@ -3539,17 +3544,28 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (models.Shar
 			return nil, errors.Wrapf(err, "shard %s: resolve replicas", shardName)
 		}
 
-		statuses := make([]string, 0, len(replicas))
-		var queueSize int64
-		for _, node := range replicas {
-			status, size, err := i.shardReplicaStatusAndQueueSize(ctx, tenant, shardName, node, localNode)
-			if err != nil {
-				return nil, errors.Wrapf(err, "shard %s: replica on node %s", shardName, node)
-			}
-			statuses = append(statuses, status)
-			queueSize += size
+		statuses := make([]string, len(replicas))
+		queueSizes := make([]int64, len(replicas))
+		eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
+		for ri, node := range replicas {
+			eg.Go(func() error {
+				status, size, err := i.shardReplicaStatusAndQueueSize(egCtx, tenant, shardName, node, localNode)
+				if err != nil {
+					return errors.Wrapf(err, "replica on node %s", node)
+				}
+				statuses[ri] = status
+				queueSizes[ri] = size
+				return nil
+			}, node)
+		}
+		if err := eg.Wait(); err != nil {
+			return nil, errors.Wrapf(err, "shard %s", shardName)
 		}
 
+		var queueSize int64
+		for _, size := range queueSizes {
+			queueSize += size
+		}
 		shardsStatus = append(shardsStatus, &models.ShardStatusGetResponse{
 			Name:            shardName,
 			Status:          aggregateShardStatuses(statuses),
@@ -3561,6 +3577,18 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (models.Shar
 }
 
 func (i *Index) shardReplicaStatusAndQueueSize(ctx context.Context,
+	tenant, shardName, node, localNode string,
+) (string, int64, error) {
+	status, queueSize, err := i.readShardReplica(ctx, tenant, shardName, node, localNode)
+	if err != nil && replicaShardNotReady(err) {
+		// The replica is up but its shard is still loading: that is a status,
+		// not a request failure.
+		return storagestate.StatusLoading.String(), 0, nil
+	}
+	return status, queueSize, err
+}
+
+func (i *Index) readShardReplica(ctx context.Context,
 	tenant, shardName, node, localNode string,
 ) (status string, queueSize int64, err error) {
 	if node != localNode {
@@ -3581,16 +3609,27 @@ func (i *Index) shardReplicaStatusAndQueueSize(ctx context.Context,
 		},
 		func() error {
 			// Sharding state lists this node as a replica but the shard is not
-			// directly reachable (e.g. still initializing); go through the
-			// cluster API like for any other node.
+			// reachable through the direct path; use the incoming handlers a
+			// remote peer would hit, without the loop-back HTTP hop.
 			var err error
-			if status, err = i.remote.GetShardStatusFromNode(ctx, node, shardName); err != nil {
+			if status, err = i.IncomingGetShardStatus(ctx, shardName); err != nil {
 				return err
 			}
-			queueSize, err = i.remote.GetShardQueueSizeFromNode(ctx, node, shardName)
+			queueSize, err = i.IncomingGetShardQueueSize(ctx, shardName)
 			return err
 		})
 	return status, queueSize, err
+}
+
+// replicaShardNotReady reports whether err is the shard-still-loading
+// rejection — the local typed error, or its HTTP 422 form when it crossed the
+// cluster API (clusterapi maps enterrors.ErrUnprocessable to 422, which the
+// remote client does not retry).
+func replicaShardNotReady(err error) bool {
+	if errors.As(err, &enterrors.ErrUnprocessable{}) {
+		return true
+	}
+	return strings.Contains(err.Error(), "status code: 422")
 }
 
 // shardStatusSeverity orders the non-READY statuses by how they should

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -552,22 +552,7 @@ func (m *Migrator) UpdateProperty(ctx context.Context, className string, propert
 	return idx.updateProperty(ctx, property)
 }
 
-func (m *Migrator) GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error) {
-	indexID := indexID(schema.ClassName(className))
-
-	m.classLocks.Lock(indexID)
-	defer m.classLocks.Unlock(indexID)
-
-	idx := m.db.GetIndex(schema.ClassName(className))
-	if idx == nil {
-		// index not yet local (RAFT schema not applied on this node) or class does not exist
-		return nil, fmt.Errorf("cannot get shards queue size for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
-	}
-
-	return idx.getShardsQueueSize(ctx, tenant)
-}
-
-func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
+func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (models.ShardStatusList, error) {
 	indexID := indexID(schema.ClassName(className))
 
 	m.classLocks.Lock(indexID)

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -555,10 +555,14 @@ func (m *Migrator) UpdateProperty(ctx context.Context, className string, propert
 func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (models.ShardStatusList, error) {
 	indexID := indexID(schema.ClassName(className))
 
+	// Resolve the index under the class lock only: the per-replica fan-out
+	// below performs network I/O, and the same lock key serializes schema
+	// applies (AddClass etc.) on the RAFT FSM apply path. The Index's own
+	// read gates protect against a concurrent class drop.
 	m.classLocks.Lock(indexID)
-	defer m.classLocks.Unlock(indexID)
-
 	idx := m.db.GetIndex(schema.ClassName(className))
+	m.classLocks.Unlock(indexID)
+
 	if idx == nil {
 		// index not yet local (RAFT schema not applied on this node) or class does not exist
 		return nil, fmt.Errorf("cannot get shards status for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -377,13 +377,6 @@ func TestShardsStatusNonExistingIndexWrapsNotFound(t *testing.T) {
 			},
 		},
 		{
-			name: "GetShardsQueueSize",
-			call: func() error {
-				_, err := migrator.GetShardsQueueSize(context.Background(), "DoesNotExist", "")
-				return err
-			},
-		},
-		{
 			name: "UpdateShardStatus",
 			call: func() error {
 				return migrator.UpdateShardStatus(context.Background(), "DoesNotExist", "shard1", models.TenantActivityStatusHOT, 0)

--- a/adapters/repos/db/shards_status_test.go
+++ b/adapters/repos/db/shards_status_test.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregateShardStatuses(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []string
+		expected string
+	}{
+		{
+			name:     "no replicas",
+			statuses: nil,
+			expected: "",
+		},
+		{
+			name:     "single ready replica",
+			statuses: []string{"READY"},
+			expected: "READY",
+		},
+		{
+			name:     "all replicas ready",
+			statuses: []string{"READY", "READY", "READY"},
+			expected: "READY",
+		},
+		{
+			name:     "one replica still indexing",
+			statuses: []string{"READY", "INDEXING", "READY"},
+			expected: "INDEXING",
+		},
+		{
+			name:     "all replicas indexing",
+			statuses: []string{"INDEXING", "INDEXING"},
+			expected: "INDEXING",
+		},
+		{
+			name:     "one replica loading",
+			statuses: []string{"READY", "LOADING"},
+			expected: "LOADING",
+		},
+		{
+			name:     "indexing dominates loading",
+			statuses: []string{"LOADING", "INDEXING", "READY"},
+			expected: "INDEXING",
+		},
+		{
+			name:     "one replica lazy loading",
+			statuses: []string{"LAZY_LOADING", "READY"},
+			expected: "LAZY_LOADING",
+		},
+		{
+			name:     "one replica shut down",
+			statuses: []string{"READY", "SHUTDOWN"},
+			expected: "SHUTDOWN",
+		},
+		{
+			name:     "one replica read-only",
+			statuses: []string{"READONLY", "READY"},
+			expected: "READONLY",
+		},
+		{
+			name:     "unknown non-ready status is passed through",
+			statuses: []string{"READY", "SOMETHING_NEW"},
+			expected: "SOMETHING_NEW",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, aggregateShardStatuses(tt.statuses))
+		})
+	}
+}

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -266,7 +266,7 @@ func TestSchemaReaderClass(t *testing.T) {
 	assert.Empty(t, shard)
 	assert.Empty(t, sc.ShardFromUUID("Cx", nil))
 
-	_, err = sc.GetShardsStatus("C", "")
+	_, err = sc.GetShardsStatus(context.Background(), "C", "")
 	assert.Nil(t, err)
 
 	// Add Multi Tenant Class (PartitioningEnabled: true)
@@ -471,7 +471,7 @@ type MockShardReader struct {
 	err error
 }
 
-func (m *MockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (m *MockShardReader) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	return m.lst, m.err
 }
 

--- a/cluster/schema/reader.go
+++ b/cluster/schema/reader.go
@@ -262,11 +262,11 @@ func (rs SchemaReader) TenantsShards(class string, tenants ...string) (map[strin
 	return rs.TenantsShardsWithVersion(context.TODO(), 0, class, tenants...)
 }
 
-func (rs SchemaReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (rs SchemaReader) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	t := prometheus.NewTimer(monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues("GetShardsStatus"))
 	defer t.ObserveDuration()
 
-	return rs.schema.GetShardsStatus(class, tenant)
+	return rs.schema.GetShardsStatus(ctx, class, tenant)
 }
 
 func (rs SchemaReader) Len() int { return rs.schema.len() }

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -12,6 +12,7 @@
 package schema
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -321,12 +322,12 @@ func (s *schema) CopyShardingState(class string) (*sharding.State, uint64) {
 	return &shardingState, meta.version()
 }
 
-func (s *schema) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	return s.shardReader.GetShardsStatus(class, tenant)
+func (s *schema) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
+	return s.shardReader.GetShardsStatus(ctx, class, tenant)
 }
 
 type shardReader interface {
-	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
+	GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error)
 }
 
 func (s *schema) len() int {

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -12,6 +12,7 @@
 package schema
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -737,7 +738,7 @@ func testConcurrentShardingStateOperations(t *testing.T, s *schema) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				status, _ := s.GetShardsStatus("TestClass", "")
+				status, _ := s.GetShardsStatus(context.Background(), "TestClass", "")
 				if status != nil {
 					assert.NotEmpty(t, status)
 				}
@@ -752,7 +753,7 @@ func testConcurrentShardingStateOperations(t *testing.T, s *schema) {
 // Additional mock for shard reader
 type mockShardReader struct{}
 
-func (m *mockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (m *mockShardReader) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	return models.ShardStatusList{
 		{Status: "HOT", Name: "shard1"},
 	}, nil

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -42,7 +42,7 @@ type Indexer interface {
 	ReconcileAsyncReplicationForShard(class, shard string) error
 	LoadShard(class, shard string)     // is a no-op
 	ShutdownShard(class, shard string) // is a no-op
-	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
+	GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error)
 
 	TriggerSchemaUpdateCallbacks()
 

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -861,6 +861,6 @@ type MockShardReader struct {
 	err error
 }
 
-func (m MockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (m MockShardReader) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	return m.lst, m.err
 }

--- a/test/acceptance/shards_status/shards_status_async_test.go
+++ b/test/acceptance/shards_status/shards_status_async_test.go
@@ -28,20 +28,67 @@ import (
 )
 
 const (
-	className  = "ShardsStatusAsync"
-	numObjects = 12000
-	dims       = 64
-	batchSize  = 500
+	dims      = 64
+	batchSize = 500
 )
 
-// TestShardsStatusReportsAsyncIndexingQueues covers weaviate/0-weaviate-issues#449:
-// GET /schema/{class}/shards must populate vectorQueueSize (it was hardwired to
-// 0) and must not report READY while any replica of a shard is still consuming
+// shardsPoller polls GET /schema/{class}/shards and tracks the largest
+// vectorQueueSize and any non-READY status it observes.
+type shardsPoller struct {
+	className    string
+	tenant       *string
+	maxQueueSize int64
+	sawNonReady  bool
+}
+
+// poll returns done=true once every returned shard is READY with an empty
+// (all-replica) vector queue. Transient request errors (e.g. a replica
+// rejecting reads while loading) are returned, not fatal, so callers inside
+// require.Eventually can retry.
+func (p *shardsPoller) poll(t *testing.T) (bool, error) {
+	params := clschema.NewSchemaObjectsShardsGetParams().WithClassName(p.className)
+	if p.tenant != nil {
+		params = params.WithTenant(p.tenant)
+	}
+	resp, err := helper.Client(t).Schema.SchemaObjectsShardsGet(params, nil)
+	if err != nil {
+		return false, err
+	}
+	if len(resp.Payload) == 0 {
+		return false, fmt.Errorf("empty shards response")
+	}
+
+	done := true
+	for _, shard := range resp.Payload {
+		if shard.VectorQueueSize > p.maxQueueSize {
+			p.maxQueueSize = shard.VectorQueueSize
+		}
+		if shard.Status != "READY" {
+			p.sawNonReady = true
+		}
+		if shard.Status != "READY" || shard.VectorQueueSize != 0 {
+			done = false
+		}
+	}
+	return done, nil
+}
+
+func randVector(rnd *rand.Rand) []float32 {
+	vec := make([]float32, dims)
+	for i := range vec {
+		vec[i] = rnd.Float32()
+	}
+	return vec
+}
+
+// TestShardsStatus covers weaviate/0-weaviate-issues#449: GET
+// /schema/{class}/shards must populate vectorQueueSize (it was hardwired to 0)
+// and must not report READY while any replica of a shard is still consuming
 // its async vector-index queues. Clients such as the python client's
 // wait_for_vector_indexing poll exactly this endpoint and previously declared
 // indexing finished the moment a single replica looked drained.
-func TestShardsStatusReportsAsyncIndexingQueues(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+func TestShardsStatus(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
 	compose, err := docker.New().
@@ -55,85 +102,127 @@ func TestShardsStatusReportsAsyncIndexingQueues(t *testing.T) {
 
 	helper.SetupClient(compose.GetWeaviate().URI())
 
-	class := &models.Class{
-		Class: className,
-		Properties: []*models.Property{
-			{Name: "name", DataType: []string{"text"}},
-		},
-		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
-		VectorConfig: map[string]models.VectorConfig{
-			"first": {
-				Vectorizer:      map[string]any{"none": map[string]any{}},
-				VectorIndexType: "hnsw",
+	t.Run("replicated collection with named vectors", func(t *testing.T) {
+		className := "ShardsStatusAsync"
+		helper.CreateClass(t, &models.Class{
+			Class: className,
+			Properties: []*models.Property{
+				{Name: "name", DataType: []string{"text"}},
 			},
-			"second": {
-				Vectorizer:      map[string]any{"none": map[string]any{}},
-				VectorIndexType: "flat",
-			},
-		},
-	}
-	helper.CreateClass(t, class)
-	defer helper.DeleteClass(t, className)
-
-	var maxQueueSize int64
-	sawNonReady := false
-
-	// pollOnce returns true once every shard is READY with an empty
-	// (all-replica) vector queue, tracking the largest queue size seen.
-	pollOnce := func(t *testing.T) bool {
-		resp, err := helper.Client(t).Schema.SchemaObjectsShardsGet(
-			clschema.NewSchemaObjectsShardsGetParams().WithClassName(className), nil)
-		require.NoError(t, err)
-		require.NotEmpty(t, resp.Payload)
-
-		done := true
-		for _, shard := range resp.Payload {
-			if shard.VectorQueueSize > maxQueueSize {
-				maxQueueSize = shard.VectorQueueSize
-			}
-			if shard.Status != "READY" {
-				sawNonReady = true
-			}
-			if shard.Status != "READY" || shard.VectorQueueSize != 0 {
-				done = false
-			}
-		}
-		return done
-	}
-
-	rnd := rand.New(rand.NewSource(42))
-	randVector := func() []float32 {
-		vec := make([]float32, dims)
-		for i := range vec {
-			vec[i] = rnd.Float32()
-		}
-		return vec
-	}
-
-	// Poll while importing so at least one sample lands mid-indexing.
-	for start := 0; start < numObjects; start += batchSize {
-		batch := make([]*models.Object, 0, batchSize)
-		for i := start; i < start+batchSize && i < numObjects; i++ {
-			batch = append(batch, &models.Object{
-				Class:      className,
-				Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
-				Vectors: models.Vectors{
-					"first":  randVector(),
-					"second": randVector(),
+			ReplicationConfig: &models.ReplicationConfig{Factor: 3},
+			VectorConfig: map[string]models.VectorConfig{
+				"first": {
+					Vectorizer:      map[string]any{"none": map[string]any{}},
+					VectorIndexType: "hnsw",
 				},
-			})
+				"second": {
+					Vectorizer:      map[string]any{"none": map[string]any{}},
+					VectorIndexType: "flat",
+				},
+			},
+		})
+		defer helper.DeleteClass(t, className)
+
+		poller := &shardsPoller{className: className}
+		rnd := rand.New(rand.NewSource(42))
+
+		// Poll while importing so at least one sample lands mid-indexing.
+		const numObjects = 12000
+		for start := 0; start < numObjects; start += batchSize {
+			batch := make([]*models.Object, 0, batchSize)
+			for i := start; i < start+batchSize && i < numObjects; i++ {
+				batch = append(batch, &models.Object{
+					Class:      className,
+					Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
+					Vectors: models.Vectors{
+						"first":  randVector(rnd),
+						"second": randVector(rnd),
+					},
+				})
+			}
+			helper.CreateObjectsBatch(t, batch)
+			_, err := poller.poll(t)
+			require.NoError(t, err)
 		}
-		helper.CreateObjectsBatch(t, batch)
-		pollOnce(t)
-	}
 
-	require.Eventually(t, func() bool { return pollOnce(t) },
-		5*time.Minute, 200*time.Millisecond,
-		"shards never converged to READY with empty vector queues")
+		require.Eventually(t, func() bool {
+			done, err := poller.poll(t)
+			return err == nil && done
+		}, 5*time.Minute, 200*time.Millisecond,
+			"shards never converged to READY with empty vector queues")
 
-	// The distinguishing regression assertions: before the fix the endpoint
-	// hardwired vectorQueueSize to 0, so with 12k objects x 2 target vectors
-	// x 3 replicas at least one poll must have observed a non-empty queue.
-	assert.Positive(t, maxQueueSize, "vectorQueueSize was never populated while async indexing was in flight")
-	assert.True(t, sawNonReady, "status never left READY while async indexing was in flight")
+		// The distinguishing regression assertions: before the fix the endpoint
+		// hardwired vectorQueueSize to 0, so with 12k objects x 2 target vectors
+		// x 3 replicas at least one poll must have observed a non-empty queue.
+		assert.Positive(t, poller.maxQueueSize,
+			"vectorQueueSize was never populated while async indexing was in flight")
+		assert.True(t, poller.sawNonReady,
+			"status never left READY while async indexing was in flight")
+	})
+
+	t.Run("multi tenant collection", func(t *testing.T) {
+		className := "ShardsStatusAsyncMT"
+		helper.CreateClass(t, &models.Class{
+			Class: className,
+			Properties: []*models.Property{
+				{Name: "name", DataType: []string{"text"}},
+			},
+			ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+			VectorConfig: map[string]models.VectorConfig{
+				"first": {
+					Vectorizer:      map[string]any{"none": map[string]any{}},
+					VectorIndexType: "hnsw",
+				},
+			},
+		})
+		defer helper.DeleteClass(t, className)
+
+		tenants := []string{"tenant1", "tenant2"}
+		helper.CreateTenants(t, className, []*models.Tenant{
+			{Name: tenants[0]}, {Name: tenants[1]},
+		})
+
+		poller := &shardsPoller{className: className}
+		rnd := rand.New(rand.NewSource(43))
+
+		const objectsPerTenant = 6000
+		for _, tenant := range tenants {
+			for start := 0; start < objectsPerTenant; start += batchSize {
+				batch := make([]*models.Object, 0, batchSize)
+				for i := start; i < start+batchSize && i < objectsPerTenant; i++ {
+					batch = append(batch, &models.Object{
+						Class:      className,
+						Tenant:     tenant,
+						Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
+						Vectors:    models.Vectors{"first": randVector(rnd)},
+					})
+				}
+				helper.CreateObjectsBatch(t, batch)
+				_, err := poller.poll(t)
+				require.NoError(t, err)
+			}
+		}
+
+		require.Eventually(t, func() bool {
+			done, err := poller.poll(t)
+			return err == nil && done
+		}, 5*time.Minute, 200*time.Millisecond,
+			"tenant shards never converged to READY with empty vector queues")
+
+		assert.Positive(t, poller.maxQueueSize,
+			"vectorQueueSize was never populated for tenant shards while async indexing was in flight")
+
+		// The ?tenant= filter must return exactly that tenant's shard, with
+		// the aggregated queue drained.
+		tenant := tenants[0]
+		resp, err := helper.Client(t).Schema.SchemaObjectsShardsGet(
+			clschema.NewSchemaObjectsShardsGetParams().
+				WithClassName(className).WithTenant(&tenant), nil)
+		require.NoError(t, err)
+		require.Len(t, resp.Payload, 1)
+		assert.Equal(t, tenant, resp.Payload[0].Name)
+		assert.Equal(t, "READY", resp.Payload[0].Status)
+		assert.Zero(t, resp.Payload[0].VectorQueueSize)
+	})
 }

--- a/test/acceptance/shards_status/shards_status_async_test.go
+++ b/test/acceptance/shards_status/shards_status_async_test.go
@@ -1,0 +1,139 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shards_status
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+const (
+	className  = "ShardsStatusAsync"
+	numObjects = 12000
+	dims       = 64
+	batchSize  = 500
+)
+
+// TestShardsStatusReportsAsyncIndexingQueues covers weaviate/0-weaviate-issues#449:
+// GET /schema/{class}/shards must populate vectorQueueSize (it was hardwired to
+// 0) and must not report READY while any replica of a shard is still consuming
+// its async vector-index queues. Clients such as the python client's
+// wait_for_vector_indexing poll exactly this endpoint and previously declared
+// indexing finished the moment a single replica looked drained.
+func TestShardsStatusReportsAsyncIndexingQueues(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		With3NodeCluster().
+		WithWeaviateEnv("ASYNC_INDEXING", "true").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: "name", DataType: []string{"text"}},
+		},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
+		VectorConfig: map[string]models.VectorConfig{
+			"first": {
+				Vectorizer:      map[string]any{"none": map[string]any{}},
+				VectorIndexType: "hnsw",
+			},
+			"second": {
+				Vectorizer:      map[string]any{"none": map[string]any{}},
+				VectorIndexType: "flat",
+			},
+		},
+	}
+	helper.CreateClass(t, class)
+	defer helper.DeleteClass(t, className)
+
+	var maxQueueSize int64
+	sawNonReady := false
+
+	// pollOnce returns true once every shard is READY with an empty
+	// (all-replica) vector queue, tracking the largest queue size seen.
+	pollOnce := func(t *testing.T) bool {
+		resp, err := helper.Client(t).Schema.SchemaObjectsShardsGet(
+			clschema.NewSchemaObjectsShardsGetParams().WithClassName(className), nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Payload)
+
+		done := true
+		for _, shard := range resp.Payload {
+			if shard.VectorQueueSize > maxQueueSize {
+				maxQueueSize = shard.VectorQueueSize
+			}
+			if shard.Status != "READY" {
+				sawNonReady = true
+			}
+			if shard.Status != "READY" || shard.VectorQueueSize != 0 {
+				done = false
+			}
+		}
+		return done
+	}
+
+	rnd := rand.New(rand.NewSource(42))
+	randVector := func() []float32 {
+		vec := make([]float32, dims)
+		for i := range vec {
+			vec[i] = rnd.Float32()
+		}
+		return vec
+	}
+
+	// Poll while importing so at least one sample lands mid-indexing.
+	for start := 0; start < numObjects; start += batchSize {
+		batch := make([]*models.Object, 0, batchSize)
+		for i := start; i < start+batchSize && i < numObjects; i++ {
+			batch = append(batch, &models.Object{
+				Class:      className,
+				Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
+				Vectors: models.Vectors{
+					"first":  randVector(),
+					"second": randVector(),
+				},
+			})
+		}
+		helper.CreateObjectsBatch(t, batch)
+		pollOnce(t)
+	}
+
+	require.Eventually(t, func() bool { return pollOnce(t) },
+		5*time.Minute, 200*time.Millisecond,
+		"shards never converged to READY with empty vector queues")
+
+	// The distinguishing regression assertions: before the fix the endpoint
+	// hardwired vectorQueueSize to 0, so with 12k objects x 2 target vectors
+	// x 3 replicas at least one poll must have observed a non-empty queue.
+	assert.Positive(t, maxQueueSize, "vectorQueueSize was never populated while async indexing was in flight")
+	assert.True(t, sawNonReady, "status never left READY while async indexing was in flight")
+}

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -115,7 +115,7 @@ func (m *MockSchemaExecutor) UpdateShardStatus(req *cmd.UpdateShardStatusRequest
 	return args.Error(0)
 }
 
-func (m *MockSchemaExecutor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (m *MockSchemaExecutor) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	args := m.Called(class, tenant)
 	return models.ShardStatusList{}, args.Error(1)
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -362,8 +362,7 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 	return e.migrator.UpdateShardStatus(ctx, req.Class, req.Shard, req.Status, req.SchemaVersion)
 }
 
-func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	ctx := context.Background()
+func (e *executor) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	return e.migrator.GetShardsStatus(ctx, class, tenant)
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -364,21 +364,7 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 
 func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
 	ctx := context.Background()
-	shardsStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant)
-	if err != nil {
-		return nil, err
-	}
-
-	resp := models.ShardStatusList{}
-
-	for name, status := range shardsStatus {
-		resp = append(resp, &models.ShardStatusGetResponse{
-			Name:   name,
-			Status: status,
-		})
-	}
-
-	return resp, nil
+	return e.migrator.GetShardsStatus(ctx, class, tenant)
 }
 
 func (e *executor) TriggerSchemaUpdateCallbacks() {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -199,7 +199,7 @@ func TestExecutor(t *testing.T) {
 		}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, nil)
 		x := newMockExecutor(migrator, store)
-		resp, err := x.GetShardsStatus("A", "")
+		resp, err := x.GetShardsStatus(context.Background(), "A", "")
 		assert.Nil(t, err)
 		assert.Equal(t, status, resp)
 	})
@@ -207,7 +207,7 @@ func TestExecutor(t *testing.T) {
 		migrator := &fakeMigrator{}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(models.ShardStatusList{}, ErrAny)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus("A", "")
+		_, err := x.GetShardsStatus(context.Background(), "A", "")
 		assert.ErrorIs(t, err, ErrAny)
 	})
 	t.Run("UpdateShardStatus", func(t *testing.T) {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -194,16 +194,18 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("GetShardsStatus", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		status := map[string]string{"A": "B"}
+		status := models.ShardStatusList{
+			{Name: "A", Status: "INDEXING", VectorQueueSize: 33},
+		}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, nil)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus("A", "")
+		resp, err := x.GetShardsStatus("A", "")
 		assert.Nil(t, err)
+		assert.Equal(t, status, resp)
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		status := map[string]string{"A": "B"}
-		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, ErrAny)
+		migrator.On("GetShardsStatus", Anything, "A", "").Return(models.ShardStatusList{}, ErrAny)
 		x := newMockExecutor(migrator, store)
 		_, err := x.GetShardsStatus("A", "")
 		assert.ErrorIs(t, err, ErrAny)

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -299,7 +299,7 @@ func (f *fakeSchemaManager) LocalActiveShardsCount(class string) (int, error) {
 	return args.Get(0).(int), args.Error(1)
 }
 
-func (f *fakeSchemaManager) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (f *fakeSchemaManager) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	args := f.Called(class, tenant)
 	return args.Get(0).(models.ShardStatusList), args.Error(1)
 }

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -131,7 +131,7 @@ type SchemaReader interface {
 	Shards(class string) ([]string, error)
 	LocalShards(class string) ([]string, error)
 	LocalActiveShardsCount(class string) (int, error)
-	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
+	GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error)
 	ResolveAlias(alias string) string
 	GetAliasesForClass(class string) []*models.Alias
 
@@ -379,7 +379,7 @@ func (h *Handler) ShardsStatus(ctx context.Context,
 		return nil, err
 	}
 
-	return h.schemaReader.GetShardsStatus(class, shard)
+	return h.schemaReader.GetShardsStatus(ctx, class, shard)
 }
 
 // JoinNode adds the given node to the cluster.

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -159,7 +159,7 @@ func (f *fakeDB) UpdateShardStatus(cmd *command.UpdateShardStatusRequest) error 
 	return nil
 }
 
-func (f *fakeDB) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (f *fakeDB) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	args := f.Called(class, tenant)
 	return args.Get(0).(models.ShardStatusList), nil
 }

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -292,10 +292,6 @@ type fakeMigrator struct {
 	mock.Mock
 }
 
-func (f *fakeMigrator) GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error) {
-	return nil, nil
-}
-
 func (f *fakeMigrator) AddClass(ctx context.Context, cls *models.Class) error {
 	args := f.Called(ctx, cls)
 	return args.Error(0)
@@ -351,9 +347,9 @@ func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants 
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
+func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (models.ShardStatusList, error) {
 	args := f.Called(ctx, className, tenant)
-	return args.Get(0).(map[string]string), args.Error(1)
+	return args.Get(0).(models.ShardStatusList), args.Error(1)
 }
 
 func (f *fakeMigrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error {

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -37,7 +37,6 @@ type Migrator interface {
 	AddClass(ctx context.Context, class *models.Class) error
 	DropClass(ctx context.Context, className string, hasFrozen bool) error
 	// UpdateClass(ctx context.Context, className string,newClassName *string) error
-	GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error)
 	LoadShard(ctx context.Context, class, shard string) error
 	DropShard(ctx context.Context, class, shard string) error
 	ShutdownShard(ctx context.Context, class, shard string) error
@@ -53,7 +52,7 @@ type Migrator interface {
 	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload, implicitUpdate bool) error
 	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error
 
-	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
+	GetShardsStatus(ctx context.Context, className, tenant string) (models.ShardStatusList, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error
 
 	UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error

--- a/usecases/schema/mock_schema_reader.go
+++ b/usecases/schema/mock_schema_reader.go
@@ -285,9 +285,9 @@ func (_c *MockSchemaReader_GetAliasesForClass_Call) RunAndReturn(run func(string
 	return _c
 }
 
-// GetShardsStatus provides a mock function with given fields: class, tenant
-func (_m *MockSchemaReader) GetShardsStatus(class string, tenant string) (models.ShardStatusList, error) {
-	ret := _m.Called(class, tenant)
+// GetShardsStatus provides a mock function with given fields: ctx, class, tenant
+func (_m *MockSchemaReader) GetShardsStatus(ctx context.Context, class string, tenant string) (models.ShardStatusList, error) {
+	ret := _m.Called(ctx, class, tenant)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetShardsStatus")
@@ -295,19 +295,19 @@ func (_m *MockSchemaReader) GetShardsStatus(class string, tenant string) (models
 
 	var r0 models.ShardStatusList
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (models.ShardStatusList, error)); ok {
-		return rf(class, tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) (models.ShardStatusList, error)); ok {
+		return rf(ctx, class, tenant)
 	}
-	if rf, ok := ret.Get(0).(func(string, string) models.ShardStatusList); ok {
-		r0 = rf(class, tenant)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) models.ShardStatusList); ok {
+		r0 = rf(ctx, class, tenant)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(models.ShardStatusList)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(class, tenant)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
+		r1 = rf(ctx, class, tenant)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -321,15 +321,16 @@ type MockSchemaReader_GetShardsStatus_Call struct {
 }
 
 // GetShardsStatus is a helper method to define mock.On call
+//   - ctx context.Context
 //   - class string
 //   - tenant string
-func (_e *MockSchemaReader_Expecter) GetShardsStatus(class interface{}, tenant interface{}) *MockSchemaReader_GetShardsStatus_Call {
-	return &MockSchemaReader_GetShardsStatus_Call{Call: _e.mock.On("GetShardsStatus", class, tenant)}
+func (_e *MockSchemaReader_Expecter) GetShardsStatus(ctx interface{}, class interface{}, tenant interface{}) *MockSchemaReader_GetShardsStatus_Call {
+	return &MockSchemaReader_GetShardsStatus_Call{Call: _e.mock.On("GetShardsStatus", ctx, class, tenant)}
 }
 
-func (_c *MockSchemaReader_GetShardsStatus_Call) Run(run func(class string, tenant string)) *MockSchemaReader_GetShardsStatus_Call {
+func (_c *MockSchemaReader_GetShardsStatus_Call) Run(run func(ctx context.Context, class string, tenant string)) *MockSchemaReader_GetShardsStatus_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string))
 	})
 	return _c
 }
@@ -339,7 +340,7 @@ func (_c *MockSchemaReader_GetShardsStatus_Call) Return(_a0 models.ShardStatusLi
 	return _c
 }
 
-func (_c *MockSchemaReader_GetShardsStatus_Call) RunAndReturn(run func(string, string) (models.ShardStatusList, error)) *MockSchemaReader_GetShardsStatus_Call {
+func (_c *MockSchemaReader_GetShardsStatus_Call) RunAndReturn(run func(context.Context, string, string) (models.ShardStatusList, error)) *MockSchemaReader_GetShardsStatus_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -378,29 +378,23 @@ func (ri *RemoteIndex) DeleteObjectBatch(ctx context.Context, shardName string,
 	return ri.client.DeleteObjectBatch(ctx, host, ri.class, shardName, uuids, deletionTime, dryRun, schemaVersion)
 }
 
-func (ri *RemoteIndex) GetShardQueueSize(ctx context.Context, shardName string) (int64, error) {
-	owner, err := ri.stateGetter.ShardOwner(ri.class, shardName)
-	if err != nil {
-		return 0, fmt.Errorf("class %s has no physical shard %q: %w", ri.class, shardName, err)
-	}
-
-	host, ok := ri.nodeResolver.NodeHostname(owner)
+// GetShardQueueSizeFromNode reads the summed vector-index queue size of the
+// shard replica held by the given node.
+func (ri *RemoteIndex) GetShardQueueSizeFromNode(ctx context.Context, nodeName, shardName string) (int64, error) {
+	host, ok := ri.nodeResolver.NodeHostname(nodeName)
 	if !ok {
-		return 0, fmt.Errorf("resolve node name %q to host", owner)
+		return 0, fmt.Errorf("resolve node name %q to host", nodeName)
 	}
 
 	return ri.client.GetShardQueueSize(ctx, host, ri.class, shardName)
 }
 
-func (ri *RemoteIndex) GetShardStatus(ctx context.Context, shardName string) (string, error) {
-	owner, err := ri.stateGetter.ShardOwner(ri.class, shardName)
-	if err != nil {
-		return "", fmt.Errorf("class %s has no physical shard %q: %w", ri.class, shardName, err)
-	}
-
-	host, ok := ri.nodeResolver.NodeHostname(owner)
+// GetShardStatusFromNode reads the status of the shard replica held by the
+// given node.
+func (ri *RemoteIndex) GetShardStatusFromNode(ctx context.Context, nodeName, shardName string) (string, error) {
+	host, ok := ri.nodeResolver.NodeHostname(nodeName)
 	if !ok {
-		return "", fmt.Errorf("resolve node name %q to host", owner)
+		return "", fmt.Errorf("resolve node name %q to host", nodeName)
 	}
 
 	return ri.client.GetShardStatus(ctx, host, ri.class, shardName)


### PR DESCRIPTION
Fixes weaviate/0-weaviate-issues#449 (surfaced by e2e CI [run 30418351757](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/30418351757/job/90469796032): `wait_for_vector_indexing()` returned instantly on a 3-replica cluster, queries then hit a still-indexing replica).

## Motivation

`GET /schema/{class}/shards` had two defects that break every client polling it for async-indexing readiness (the python client's `collection.batch.wait_for_vector_indexing()` waits for `status == READY && vectorQueueSize == 0` on exactly this endpoint):

1. **`vectorQueueSize` was never populated.** The response was built from name+status only; the correct implementation (`Migrator.GetShardsQueueSize`, summing all named-vector queues) existed but had no callers.
2. **Status was single-replica.** Each shard's status came from the local replica (or one resolved owner). At RF>1 the other replicas' queues were invisible, while searches read one replica per request — so a client could see one drained replica, stop waiting, and then query a replica still consuming its queue.

## Approach

`Index.getShardsStatus` now enumerates `schemaReader.ShardReplicas` per shard and aggregates over **all** replicas:

- **Status**: READY only when every replica is READY; otherwise the most relevant non-READY status (INDEXING ranked first, since pending queue consumption is what readiness pollers care about — see `aggregateShardStatuses`).
- **`vectorQueueSize`**: sum of every replica's vector-index queues (all named vectors), local replica read directly, remote replicas via the existing cluster-API `GetShardStatus`/`GetShardQueueSize` routes — no new internal API, so mixed-version clusters during rolling upgrades keep working, and **already-released clients get a sound readiness signal with no client change** (they have checked `vectorQueueSize == 0` all along; the server just never fed it).

The migrator now returns the assembled `models.ShardStatusList` (executor is a pass-through, response order is deterministic by schema shard order instead of map iteration). Owner-based `RemoteIndex.GetShardStatus`/`GetShardQueueSize` are replaced by node-targeted variants; dead `Migrator.GetShardsQueueSize` / `Index.getShardsQueueSize` are removed.

## Semantics / risk notes

- **Cost**: the endpoint now performs status+queue reads per replica (2 sequential cluster-API calls per remote replica) instead of one per shard. It is a diagnostics endpoint polled at ~4Hz by waiting clients; RF is small (≤ node count). MT collections iterate tenant shards exactly as before, filtered by `?tenant=`.
- **Error semantics unchanged**: any unreachable/not-ready replica fails the request, as it already did when the single resolved owner was unreachable (`IncomingGetShardStatus` rejects LOADING shards). Fanning out to all replicas makes this window more visible during rolling restarts; polling clients already retry with backoff.
- A shard that previously reported READY off one replica may now report INDEXING/LOADING — that is the fix, but callers treating this endpoint as "is my local shard up" will now see cluster-wide truth.

## Testing

- `TestAggregateShardStatuses` (unit, table-driven): all replica-status combinations incl. unknown-status passthrough.
- Updated executor/migrator unit tests for the new signature.
- New acceptance test `test/acceptance/shards_status` (3-node testcontainers cluster, `ASYNC_INDEXING=true`, RF3, two named vectors hnsw+flat, 12k objects): polls the endpoint during import and asserts (a) a non-empty `vectorQueueSize` is observed while indexing is in flight, (b) status leaves READY, (c) convergence to READY/0. **Red/green verified**: FAILS against stock `semitechnologies/weaviate:1.38.7` with `"0" is not positive — vectorQueueSize was never populated`, PASSES against this branch's image (39s). Auto-picked into acceptance fast group 5.
- `golangci-lint` clean on touched packages.

An end-to-end validation against a 3-node k8s cluster (python client, named vectors / multivector / legacy vector scenarios, before/after this PR's image) is being run alongside; results will be posted on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
