### PR TITLE
fix(hnsw): cancel and drain the cache prefill before teardown

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -64,6 +64,10 @@ type hnsw struct {
 	// indicates the index is shutting down
 	shutdownCtx       context.Context
 	shutdownCtxCancel context.CancelFunc
+	// prefillWg tracks the background cache prefill so Shutdown can wait for it.
+	// The prefiller reads the shard's objects bucket, and the shard tears that
+	// bucket down as soon as the vector indexes report they are shut.
+	prefillWg sync.WaitGroup
 
 	// make sure the very first insert happens just once, otherwise we
 	// accidentally overwrite previous entrypoints on parallel imports on an
@@ -783,6 +787,7 @@ func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
 
 func (h *hnsw) Shutdown(ctx context.Context) error {
 	h.shutdownCtxCancel()
+	h.prefillWg.Wait()
 
 	ec := errorcompounder.New()
 	ec.AddWrapf(h.commitLog.Shutdown(ctx), "shutdown commit log")

--- a/adapters/repos/db/vector/hnsw/prefill_test.go
+++ b/adapters/repos/db/vector/hnsw/prefill_test.go
@@ -1,0 +1,121 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+func TestShutdownDrainsCachePrefill(t *testing.T) {
+	const indexID = "prefill_drain_test"
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	dummyStore := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+	vectors, _ := testinghelpers.RandomVecs(5, 0, 8)
+
+	uc := ent.UserConfig{}
+	uc.SetDefaults()
+
+	var (
+		armed    atomic.Bool
+		entered  = make(chan struct{}, 1)
+		released = make(chan struct{})
+	)
+	cfg := Config{
+		RootPath:            tempDir,
+		ID:                  indexID,
+		DistanceProvider:    distancer.NewL2SquaredProvider(),
+		WaitForCachePrefill: false,
+		AllocChecker:        memwatch.NewDummyMonitor(),
+		MakeBucketOptions:   lsmkv.MakeNoopBucketOptions,
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return NewCommitLogger(tempDir, indexID, logger, cyclemanager.NewCallbackGroupNoop())
+		},
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			if armed.Load() {
+				select {
+				case entered <- struct{}{}:
+				default:
+				}
+				<-released
+			}
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[int(id)], nil
+		},
+		GetViewThunk: func() common.BucketView { return &noopBucketView{} },
+		TempVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+			copy(container.Slice, vectors[int(id)])
+			return container.Slice, nil
+		},
+	}
+
+	// commit-log state for the restart below to prefill
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.Nil(t, err)
+	for id, vec := range vectors {
+		require.Nil(t, index.Add(ctx, uint64(id), vec))
+	}
+	require.Nil(t, index.Flush())
+	require.Nil(t, index.Shutdown(ctx))
+	dummyStore.FlushMemtables(ctx)
+
+	index, err = New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.Nil(t, err)
+
+	// New() replays the commit log through the same thunk, so arm only once the
+	// index is built or the restart itself parks
+	armed.Store(true)
+	index.PostStartup(ctx)
+
+	select {
+	case <-entered:
+	case <-time.After(30 * time.Second):
+		t.Fatal("prefill never reached VectorForID")
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- index.Shutdown(ctx) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Shutdown returned while the prefill was still reading: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(released)
+
+	select {
+	case err := <-done:
+		require.Nil(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Shutdown did not return after the prefill finished")
+	}
+}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -537,7 +537,13 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 		limit = int(h.cache.CopyMaxSize())
 	}
 
+	ctx, cancelPrefill := context.WithCancel(ctx)
+	stopOnIndexShutdown := context.AfterFunc(h.shutdownCtx, cancelPrefill)
+
 	prefillCacheFunc := func() {
+		defer stopOnIndexShutdown()
+		defer cancelPrefill()
+
 		h.logger.WithFields(logrus.Fields{
 			"action":   "prefill_cache",
 			"duration": 60 * time.Minute,
@@ -555,7 +561,7 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 			// cursor instead of looking up every vector by id (disk-seek bound).
 			err = h.prefillCacheParallel(ctx)
 		} else {
-			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(context.Background(), limit)
+			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(ctx, limit)
 		}
 
 		if err != nil {
@@ -576,6 +582,10 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 			"action":                 "hnsw_prefill_cache_async",
 			"wait_for_cache_prefill": false,
 		}).Info("not waiting for vector cache prefill, running in background")
-		enterrors.GoWrapper(prefillCacheFunc, h.logger)
+		h.prefillWg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer h.prefillWg.Done()
+			prefillCacheFunc()
+		}, h.logger)
 	}
 }


### PR DESCRIPTION
### What's being changed:
The HNSW cache prefill runs in a background goroutine that reads the shard's objects bucket. Nothing cancelled it  and nothing waited for it. The shard shuts vector indexes down, then deregisters its buckets, so in progress prefiller dereferenced a nil bucket and killed the node.


e.g of the panic 
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x17368a6]

goroutine 61646 [running]:
github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).GetConsistentView(0x0)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:712 +0xc6
github.com/weaviate/weaviate/adapters/repos/db.(*Shard).GetObjectsBucketView(0xc0010ee008)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/shard_read.go:434 +0xd4
github.com/weaviate/weaviate/adapters/repos/db.(*Shard).vectorByIndexID(0xc0010ee008, {0x452ab40, 0x7ac8840}, 0x3, {0x0, 0x0})
	/home/runner/work/weaviate/weaviate/adapters/repos/db/shard_read.go:393 +0xf2
github.com/weaviate/weaviate/adapters/repos/db/vector/common.TargetVectorForID[...].VectorForID(0x0?, {0x452ab40?, 0x7ac8840?}, 0x3?)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/common/vector_id.go:152 +0xce
github.com/weaviate/weaviate/adapters/repos/db/vector/cache.NewShardedFloat32LockCache.func1({0x452ab40, 0x7ac8840}, 0x3)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/cache/sharded_lock_cache.go:103 +0x69
github.com/weaviate/weaviate/adapters/repos/db/vector/cache.(*shardedLockCache[...]).handleCacheMiss(0x3, {0x452ab40?, 0x7ac8840}, 0x3)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/cache/sharded_lock_cache.go:227 +0x159
github.com/weaviate/weaviate/adapters/repos/db/vector/cache.(*shardedLockCache[...]).Get(0x4566ea0, {0x452ab40, 0x7ac8840}, 0x3)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/cache/sharded_lock_cache.go:191 +0x21b
github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*vectorCachePrefiller[...]).prefillLevel(0x452b9c0, {0x452ab40, 0x7ac8840}, 0x0, 0xe8d4a51000)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go:89 +0x5a5
github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*vectorCachePrefiller[...]).Prefill(0x452b9c0, {0x452ab40, 0x7ac8840}, 0xe8d4a51000)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go:41 +0x145
github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw.(*hnsw).prefillCache.func1()
	/home/runner/work/weaviate/weaviate/adapters/repos/db/vector/hnsw/startup.go:558 +0x4c5
```

shall close this https://github.com/weaviate/0-weaviate-issues/issues/340 and https://github.com/weaviate/weaviate/issues/12285
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
