### PR TITLE
Add nested object filtering support to usage module

### DIFF
--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -256,7 +256,13 @@ func CalculateUnloadedIndicesSize(lsmPath string, directories []string) (uint64,
 	totalSize := uint64(0)
 
 	// get the storage of all lsm properties that are not objects or vector
-	includedPrefixes := []string{helpers.DimensionsBucketLSM, helpers.BucketFromPropNameLSM("")}
+	includedPrefixes := []string{
+		helpers.DimensionsBucketLSM,
+		helpers.BucketFromPropNameLSM(""),
+		// nested buckets use "property." not "property_", so the prefix above misses them
+		helpers.BucketNestedFromPropNameLSM(""),
+		helpers.BucketNestedMetaFromPropNameLSM(""),
+	}
 
 	// check all folders and add their sizes
 	for _, directory := range directories {

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -14,6 +14,7 @@ package shardusage
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -215,6 +216,43 @@ func getFileTypeCount(t *testing.T, path string) map[string]int {
 	return fileTypes
 }
 
+// Nothing deletes the pre-calculated usage of a shard that stays cold, so the
+// version check is the only guard against serving outdated sizes.
+func TestLoadComputedUsageDataVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   int
+		wantError bool
+	}{
+		{name: "current version is served", version: types.UsageDiskVersion},
+		{name: "older version is rejected", version: types.UsageDiskVersion - 1, wantError: true},
+		{name: "newer version is rejected", version: types.UsageDiskVersion + 1, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			require.NoError(t, os.MkdirAll(filepath.Join(dirName, "shard1"), 0o777))
+
+			stored := &types.UsageDisk{
+				Version:    tt.version,
+				ShardUsage: &types.ShardUsage{Name: "shard1", IndexStorageBytes: 42},
+			}
+			data, err := json.Marshal(stored)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(usageTmpFilePath(dirName, "shard1"), data, 0o600))
+
+			usage, err := LoadComputedUsageData(dirName, "shard1")
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, uint64(42), usage.IndexStorageBytes)
+		})
+	}
+}
+
 func TestStorageCalculation(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
@@ -224,7 +262,16 @@ func TestStorageCalculation(t *testing.T) {
 	lsmFolder := shardPathLSM(dirName, "shard1")
 	require.NoError(t, os.MkdirAll(lsmFolder, 0o777))
 
-	buckets := []string{helpers.ObjectsBucketLSM, helpers.DimensionsBucketLSM, "vectors", "vectors_compressed", "vectors_compressed_named_vector", "property_someProp_searchable", "property_someProp", "property__id"}
+	// a bucket that exists but holds nothing yet
+	emptyBucket := helpers.BucketNestedFromPropNameLSM("emptyNestedProp")
+	indexBuckets := []string{
+		helpers.DimensionsBucketLSM,
+		"property_someProp_searchable", "property_someProp", "property__id",
+		helpers.BucketNestedFromPropNameLSM("someNestedProp"),
+		helpers.BucketNestedMetaFromPropNameLSM("someNestedProp"),
+		emptyBucket,
+	}
+	buckets := append([]string{helpers.ObjectsBucketLSM, "vectors", "vectors_compressed", "vectors_compressed_named_vector"}, indexBuckets...)
 	sizeTracker := make(map[string]uint64, len(buckets))
 
 	// create different buckets with dummy files with varying sizes
@@ -233,13 +280,18 @@ func TestStorageCalculation(t *testing.T) {
 		require.NoError(t, os.MkdirAll(bucketPath, 0o777))
 		sizeTracker[bucket] = 0
 
-		// create some dummy files
-		for i := 0; i < rand.Intn(10); i++ {
+		if bucket == emptyBucket {
+			continue
+		}
+
+		// non-empty, so a bucket left out of the calculation always changes the result
+		numFiles := rand.Intn(10) + 1
+		for i := 0; i < numFiles; i++ {
 			filePath := filepath.Join(bucketPath, fmt.Sprintf("file%d.db", i))
 			f, err := os.Create(filePath)
 			require.NoError(t, err)
 
-			size := rand.Intn(10000)
+			size := rand.Intn(10000) + 1
 			sizeTracker[bucket] += uint64(size)
 			data := make([]byte, size)
 			_, err = f.Write(data)
@@ -264,7 +316,11 @@ func TestStorageCalculation(t *testing.T) {
 
 	indexBytes, err := CalculateUnloadedIndicesSize(lsmFolder, buckets)
 	require.NoError(t, err)
-	require.Equal(t, sizeTracker["property_someProp_searchable"]+sizeTracker["property_someProp"]+sizeTracker["property__id"]+sizeTracker[helpers.DimensionsBucketLSM], indexBytes)
+	expectedIndexBytes := uint64(0)
+	for _, bucket := range indexBuckets {
+		expectedIndexBytes += sizeTracker[bucket]
+	}
+	require.Equal(t, expectedIndexBytes, indexBytes)
 
 	vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, err := CalculateNonLSMStorage(dirName, "shard1")
 	require.NoError(t, err)

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -11,6 +11,8 @@
 
 package types
 
+// UsageDiskVersion invalidates usage already stored on disk. Bump it when reported
+// sizes change meaning, or shards that stay cold keep serving the old numbers.
 const UsageDiskVersion int = 1
 
 // UsageDisk defines format of saved pre-computed shard usage data

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,8 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/test/docker"
@@ -503,6 +506,7 @@ func TestRestart(t *testing.T) {
 	compose, err := docker.New().
 		WithWeaviateWithDebugPort().
 		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
+		WithWeaviateEnv(entcfg.EnvNestedFilteringPreview, "true").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -527,6 +531,24 @@ func TestRestart(t *testing.T) {
 				Name:     "first",
 				DataType: []string{string(schema.DataTypeText)},
 			},
+			{
+				Name:     "cars",
+				DataType: []string{string(schema.DataTypeObjectArray)},
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:            "make",
+						DataType:        []string{string(schema.DataTypeText)},
+						Tokenization:    models.NestedPropertyTokenizationField,
+						IndexFilterable: new(true),
+					},
+					{
+						Name:            "model",
+						DataType:        []string{string(schema.DataTypeText)},
+						Tokenization:    models.NestedPropertyTokenizationField,
+						IndexFilterable: new(true),
+					},
+				},
+			},
 		},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	}
@@ -538,7 +560,8 @@ func TestRestart(t *testing.T) {
 	}
 	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).WithTenants(tenants...).Do(ctx))
 
-	// add some data
+	// add some data. Only even tenants get nested values, leaving the odd ones as
+	// a baseline with the same schema and object count.
 	for i, tenant := range tenants {
 		objs := make([]*models.Object, 10)
 		for j := range objs {
@@ -546,24 +569,37 @@ func TestRestart(t *testing.T) {
 			for k := range vector {
 				vector[k] = float32(i+j+k) / 10000.0
 			}
+			props := map[string]any{
+				"first": fmt.Sprintf("hello%d-%d", i, j),
+			}
+			if i%2 == 0 {
+				props["cars"] = nestedCars(i, j)
+			}
 			objs[j] = &models.Object{
-				Class: className,
-				Properties: map[string]interface{}{
-					"first": fmt.Sprintf("hello%d-%d", i, j),
-				},
-				Vector: vector,
-				Tenant: tenant.Name,
+				Class:      className,
+				Properties: props,
+				Vector:     vector,
+				Tenant:     tenant.Name,
 			}
 		}
 
-		_, err := c.Batch().ObjectsBatcher().WithObjects(objs...).Do(ctx)
+		batchResp, err := c.Batch().ObjectsBatcher().WithObjects(objs...).Do(ctx)
 		require.NoError(t, err)
+		for _, r := range batchResp {
+			require.NotNil(t, r.Result)
+			require.NotNil(t, r.Result.Status)
+			require.Equal(t, models.ObjectsGetResponseAO2ResultStatusSUCCESS, *r.Result.Status)
+		}
 	}
+
+	loaded := strings.ToLower(models.TenantActivityStatusACTIVE)
+	fromDisk := strings.ToLower(models.TenantActivityStatusINACTIVE)
 
 	// collect with concurrent shard readers, compare with the default report after restart
 	usage, err := getDebugUsageWithPort(debug, 4)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
+	assertNestedIndexStorageCounted(t, usage, className, loaded)
 
 	require.NoError(t, compose.Stop(ctx, compose.GetWeaviate().Name(), nil))
 
@@ -574,6 +610,77 @@ func TestRestart(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, usage2)
 	require.NoError(t, ReportsDifference(usage, usage2))
+	assertNestedIndexStorageCounted(t, usage2, className, loaded)
+
+	// cold tenants are measured from the bucket directories instead of the shard
+	cold := make([]models.Tenant, len(tenants))
+	for i := range tenants {
+		cold[i] = models.Tenant{Name: tenants[i].Name, ActivityStatus: models.TenantActivityStatusCOLD}
+	}
+	// the restart gave the container a new mapped port
+	c, err = client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
+	require.NoError(t, err)
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).WithTenants(cold...).Do(ctx))
+
+	usage3, err := getDebugUsageWithPort(compose.GetWeaviate().DebugURI())
+	require.NoError(t, err)
+	require.NotNil(t, usage3)
+	assertNestedIndexStorageCounted(t, usage3, className, fromDisk)
+}
+
+// nestedCars keeps every leaf value distinct, so each entry adds its own keys to
+// the nested property buckets.
+func nestedCars(tenant, object int) []any {
+	cars := make([]any, 20)
+	for i := range cars {
+		cars[i] = map[string]any{
+			"make":  fmt.Sprintf("make-%d-%d-%d", tenant, object, i),
+			"model": fmt.Sprintf("model-%d-%d-%d", tenant, object, i),
+		}
+	}
+	return cars
+}
+
+func collectionShards(t *testing.T, report *usagetypes.Report, className string) usagetypes.ShardsUsage {
+	t.Helper()
+
+	for _, col := range report.Collections {
+		if col != nil && col.Name == className {
+			return col.Shards
+		}
+	}
+	require.FailNow(t, "collection missing from usage report: "+className)
+	return nil
+}
+
+// assertNestedIndexStorageCounted checks that tenants with nested values report more
+// than double the index storage of those without — nested data lives only in the
+// property.nested_ / property.nestedmeta_ buckets, so skipping those makes the two
+// groups equal. wantStatus is active for a loaded shard, inactive for one from disk.
+func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, className, wantStatus string) {
+	t.Helper()
+
+	// per shard rather than summed, so one shard reporting nothing cannot hide
+	var smallestNested, largestBaseline uint64
+	for _, shard := range collectionShards(t, report, className) {
+		require.Equal(t, wantStatus, shard.Status, "shard %s", shard.Name)
+		require.GreaterOrEqual(t, shard.FullShardStorageBytes, shard.IndexStorageBytes,
+			"shard %s full storage must contain its index storage", shard.Name)
+
+		tenant, err := strconv.Atoi(strings.TrimPrefix(shard.Name, "tenant"))
+		require.NoError(t, err)
+		if tenant%2 == 0 {
+			if smallestNested == 0 || shard.IndexStorageBytes < smallestNested {
+				smallestNested = shard.IndexStorageBytes
+			}
+		} else if shard.IndexStorageBytes > largestBaseline {
+			largestBaseline = shard.IndexStorageBytes
+		}
+	}
+
+	require.Greater(t, largestBaseline, uint64(0), "baseline tenants should report index storage")
+	require.Greater(t, smallestNested, 2*largestBaseline,
+		"every tenant with nested values must report the nested property buckets on top of the baseline")
 }
 
 func testAllObjectsIndexed(t *testing.T, c *client.Client, className string) {


### PR DESCRIPTION
### What's being changed:

The nested object filtering buckets were not counted towards disk use

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
