### PR TITLE
config, inverted: make batched Contains opt-in via runtime-overridable gate

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -525,6 +525,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		QuerySlowLogEnabled:                          appState.ServerConfig.Config.QuerySlowLogEnabled,
 		QuerySlowLogThreshold:                        appState.ServerConfig.Config.QuerySlowLogThreshold,
 		InvertedSorterDisabled:                       appState.ServerConfig.Config.InvertedSorterDisabled,
+		QueryBatchedContainsEnabled:                  appState.ServerConfig.Config.QueryBatchedContainsEnabled,
 		LazyPropertyLengthsEnabled:                   appState.ServerConfig.Config.LazyPropertyLengthsEnabled,
 		MaintenanceModeEnabled:                       appState.Cluster.MaintenanceModeEnabledForLocalhost,
 		AsyncIndexingEnabled:                         appState.ServerConfig.Config.AsyncIndexingEnabled,
@@ -2669,6 +2670,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.QuerySlowLogEnabled = appState.ServerConfig.Config.QuerySlowLogEnabled
 		registered.QuerySlowLogThreshold = appState.ServerConfig.Config.QuerySlowLogThreshold
 		registered.InvertedSorterDisabled = appState.ServerConfig.Config.InvertedSorterDisabled
+		registered.QueryBatchedContainsEnabled = appState.ServerConfig.Config.QueryBatchedContainsEnabled
 		registered.LazyPropertyLengthsEnabled = appState.ServerConfig.Config.LazyPropertyLengthsEnabled
 		registered.BM25FilterTombMergeGateRatio = appState.ServerConfig.Config.BM25FilterTombMergeGateRatio
 		registered.DefaultQuantization = appState.ServerConfig.Config.DefaultQuantization

--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/modules"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
@@ -69,6 +70,10 @@ type Aggregator struct {
 	// bucketPinResolver, when non-nil, is propagated to every BM25Searcher
 	// built by this aggregator. See [inverted.SearchableBucketPinningResolver].
 	bucketPinResolver inverted.SearchableBucketPinningResolver
+	// batchedContainsEnabled is propagated to the inverted.Searcher built
+	// by this aggregator. Nil (the default) means the batched Contains
+	// resolution stays off.
+	batchedContainsEnabled *runtime.DynamicValue[bool]
 }
 
 // WithSearchableBucketPinningResolver: nil (the default) keeps non-pinning behavior.
@@ -76,6 +81,13 @@ func (a *Aggregator) WithSearchableBucketPinningResolver(
 	r inverted.SearchableBucketPinningResolver,
 ) *Aggregator {
 	a.bucketPinResolver = r
+	return a
+}
+
+// WithBatchedContainsEnabled: nil (the default) keeps the batched Contains
+// resolution off. See [inverted.Searcher.WithBatchedContainsEnabled].
+func (a *Aggregator) WithBatchedContainsEnabled(v *runtime.DynamicValue[bool]) *Aggregator {
+	a.batchedContainsEnabled = v
 	return a
 }
 

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -98,6 +98,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 			a.classSearcher, a.stopwordProvider, a.shardVersion, a.isFallbackToSearchable,
 			a.isRangeableLocallyReady, a.tenant, a.nestedCrossRefLimit, a.bitmapFactory).
 			WithTokenizationResolver(a.tokResolver).
+			WithBatchedContainsEnabled(a.batchedContainsEnabled).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},
 				a.params.ClassName)
 		if err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1157,11 +1157,12 @@ type IndexConfig struct {
 	VisitedListPoolMaxSize                       int
 	BM25FilterTombMergeGateRatio                 *configRuntime.DynamicValue[float64]
 
-	QuerySlowLogEnabled        *configRuntime.DynamicValue[bool]
-	QuerySlowLogThreshold      *configRuntime.DynamicValue[time.Duration]
-	InvertedSorterDisabled     *configRuntime.DynamicValue[bool]
-	LazyPropertyLengthsEnabled *configRuntime.DynamicValue[bool]
-	MaintenanceModeEnabled     func() bool
+	QuerySlowLogEnabled         *configRuntime.DynamicValue[bool]
+	QuerySlowLogThreshold       *configRuntime.DynamicValue[time.Duration]
+	InvertedSorterDisabled      *configRuntime.DynamicValue[bool]
+	QueryBatchedContainsEnabled *configRuntime.DynamicValue[bool]
+	LazyPropertyLengthsEnabled  *configRuntime.DynamicValue[bool]
+	MaintenanceModeEnabled      func() bool
 
 	HFreshEnabled bool
 

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -205,6 +205,7 @@ func (db *DB) init(ctx context.Context) error {
 				QuerySlowLogEnabled:          db.config.QuerySlowLogEnabled,
 				QuerySlowLogThreshold:        db.config.QuerySlowLogThreshold,
 				InvertedSorterDisabled:       db.config.InvertedSorterDisabled,
+				QueryBatchedContainsEnabled:  db.config.QueryBatchedContainsEnabled,
 				LazyPropertyLengthsEnabled:   db.config.LazyPropertyLengthsEnabled,
 				MaintenanceModeEnabled:       db.config.MaintenanceModeEnabled,
 				HFreshEnabled:                db.config.HFreshEnabled,

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -36,6 +36,7 @@ import (
 	entinverted "github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 // Go-level A/B instrument for ContainsAny/ContainsAll fan-out cost.
@@ -144,7 +145,8 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false },
 		func(string) bool { return false }, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(configRuntime.NewDynamicValue(true))
 
 	return &containsFixture{searcher: searcher, store: store, numDocs: numDocs}
 }

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 const (
@@ -93,7 +94,8 @@ func Test_Filters_String(t *testing.T) {
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 	type test struct {
 		name                     string
@@ -371,7 +373,8 @@ func Test_Filters_Int(t *testing.T) {
 	bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 	type test struct {
 		name                     string
@@ -1154,7 +1157,8 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 	type test struct {
 		name                     string

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 // Nested filtering is preview-gated. Enable the gate at package init via
@@ -114,7 +115,8 @@ func newNestedTestSearcher(t *testing.T, bucketNames ...string) (*Searcher, *lsm
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
 		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
 		func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 	return searcher, store
 }
@@ -2805,7 +2807,8 @@ func newSearcherForClass(t *testing.T, class *models.Class, bucketNames ...strin
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
 		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
 		func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 	return searcher, store
 }
 
@@ -4984,7 +4987,8 @@ func newIsNullCorrelationSearcher(t *testing.T, prop string) (*Searcher, *lsmkv.
 	*searcher = *NewSearcher(logger, store, func(string) *models.Class { return class },
 		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
 		func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 	return searcher, store.Bucket(vbName), store.Bucket(mbName)
 }
 

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -81,6 +81,11 @@ type Searcher struct {
 	// use prop.Tokenization directly (tests and callers with no
 	// in-flight migration).
 	tokResolver TokenizationResolver
+	// batchedContainsEnabled gates the batched flat Contains resolution.
+	// Runtime-overridable; nil (the default) means disabled, so the
+	// feature is opt-in and callers that don't wire it keep the
+	// desugared per-value path.
+	batchedContainsEnabled *runtime.DynamicValue[bool]
 }
 
 // WithTokenizationResolver attaches a [TokenizationResolver] used by query
@@ -96,6 +101,17 @@ type Searcher struct {
 // Pass nil (the default) to use the schema-stored value directly.
 func (s *Searcher) WithTokenizationResolver(r TokenizationResolver) *Searcher {
 	s.tokResolver = r
+	return s
+}
+
+// WithBatchedContainsEnabled attaches the runtime-overridable gate for the
+// batched flat ContainsAny/ContainsAll/ContainsNone resolution. Returns the
+// receiver for fluent chaining at construction sites.
+//
+// Nil (the default) means disabled: every Contains filter takes the
+// desugared per-value path, so the batched fast path is strictly opt-in.
+func (s *Searcher) WithBatchedContainsEnabled(v *runtime.DynamicValue[bool]) *Searcher {
+	s.batchedContainsEnabled = v
 	return s
 }
 
@@ -1005,7 +1021,7 @@ const (
 // per-value path instead of the batched fold.
 const (
 	containsDeclineNonContainsOperator  = "non-contains-operator"
-	containsDeclineDisabledByEnv        = "disabled-by-env"
+	containsDeclineNotEnabled           = "not-enabled"
 	containsDeclineMultiSegmentPath     = "multi-segment-path"
 	containsDeclineInternalProperty     = "internal-property"
 	containsDeclineLengthFilter         = "length-filter"
@@ -1043,8 +1059,8 @@ func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.Dat
 	if !operator.IsContains() {
 		return nil, containsNotBatchable, containsDeclineNonContainsOperator
 	}
-	if entcfg.BatchedContainsDisabled() {
-		return nil, containsNotBatchable, containsDeclineDisabledByEnv
+	if !s.batchedContainsEnabled.Get() {
+		return nil, containsNotBatchable, containsDeclineNotEnabled
 	}
 
 	props := path.Slice()

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -22,12 +22,12 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
-	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/tokenizer"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 const containsBatchTestClass = "ContainsBatchGateTest"
@@ -99,6 +99,7 @@ func newContainsBatchGateFixture(t *testing.T) *containsBatchGateFixture {
 		getClass:               func(name string) *models.Class { return f.class },
 		isFallbackToSearchable: func() bool { return f.fallback },
 		stopwordProvider:       stopwords.NewProvider(fakeStopwordDetector{}, nil),
+		batchedContainsEnabled: runtime.NewDynamicValue(true),
 	}
 	return f
 }
@@ -440,22 +441,51 @@ func TestExtractContains_UsesBatchedPathWhenEligible(t *testing.T) {
 	require.Len(t, pv.containsValues, 3)
 }
 
-// TestExtractContainsBatch_KillSwitch pins the operator escape hatch: with
-// WEAVIATE_DISABLE_BATCHED_CONTAINS set, an otherwise eligible shape
-// declines and extractContains resolves through the per-value desugared
-// path.
-func TestExtractContainsBatch_KillSwitch(t *testing.T) {
+// TestExtractContainsBatch_OptInGate pins that the batched resolution is
+// opt-in: an unwired (nil) gate and a gate flipped off at runtime both
+// route an otherwise eligible shape through the per-value desugared path,
+// and flipping the gate back on at runtime restores batching without a
+// searcher rebuild.
+func TestExtractContainsBatch_OptInGate(t *testing.T) {
 	f := newContainsBatchGateFixture(t)
 	s := f.searcher
-	ctx := context.Background()
 
-	t.Setenv(entcfg.EnvDisableBatchedContains, "true")
+	extract := func(ctx context.Context) (*propValuePair, error) {
+		return s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
+			[]int{1, 2, 3}, filters.ContainsAny, f.class)
+	}
 
-	ctx = helpers.InitSlowQueryDetails(ctx)
-	pv, err := s.extractContains(ctx, containsPath("prop-int"), schema.DataTypeInt,
-		[]int{1, 2, 3}, filters.ContainsAny, f.class)
-	require.NoError(t, err)
-	require.Nil(t, pv.containsValues)
-	require.NotEmpty(t, pv.children, "with the kill switch on, Contains must desugar per value")
-	require.Equal(t, containsDeclineDisabledByEnv, extractContainsDesugaredReason(t, ctx))
+	t.Run("nil gate declines", func(t *testing.T) {
+		s.batchedContainsEnabled = nil
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		pv, err := extract(ctx)
+		require.NoError(t, err)
+		require.Nil(t, pv.containsValues)
+		require.NotEmpty(t, pv.children, "with the gate unwired, Contains must desugar per value")
+		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
+	})
+
+	t.Run("runtime toggle", func(t *testing.T) {
+		gate := runtime.NewDynamicValue(false)
+		s.batchedContainsEnabled = gate
+
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		pv, err := extract(ctx)
+		require.NoError(t, err)
+		require.Nil(t, pv.containsValues)
+		require.NotEmpty(t, pv.children, "with the gate off, Contains must desugar per value")
+		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
+
+		require.NoError(t, gate.SetValue(true))
+		pv, err = extract(context.Background())
+		require.NoError(t, err)
+		require.Len(t, pv.containsValues, 3, "gate flipped on at runtime must batch")
+
+		require.NoError(t, gate.SetValue(false))
+		ctx = helpers.InitSlowQueryDetails(context.Background())
+		pv, err = extract(ctx)
+		require.NoError(t, err)
+		require.Nil(t, pv.containsValues, "gate flipped off at runtime must desugar again")
+		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
+	})
 }

--- a/adapters/repos/db/inverted/searcher_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_integration_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/tokenizer"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 func TestObjects(t *testing.T) {
@@ -105,7 +106,8 @@ func TestObjects(t *testing.T) {
 
 		searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 			stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-			config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+			config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+			WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 		t.Run("NotEqual", func(t *testing.T) {
 			t.Parallel()
@@ -160,7 +162,8 @@ func TestObjects(t *testing.T) {
 
 		searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 			stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-			config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+			config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+			WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 		t.Run("sanity check", func(t *testing.T) {
 			bm, release := bitmapFactory.GetBitmap()
@@ -314,7 +317,8 @@ func TestDocIDs(t *testing.T) {
 
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 	type testCase struct {
 		expectedMatches int
@@ -437,7 +441,8 @@ func TestSearcher_ResolveDocIds(t *testing.T) {
 		bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(maxDocID))
 		searcher = NewSearcher(logger, store, createSchema().GetClass, nil, nil,
 			stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-			config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+			config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+			WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 		bucketName := helpers.BucketFromPropNameLSM(propName)
 		require.NoError(tt, store.CreateOrLoadBucket(context.Background(), bucketName,
@@ -903,7 +908,8 @@ func TestFilterASCIIFold(t *testing.T) {
 	bitmapFactory := roaringset.NewBitmapFactory(roaringset.NewBitmapBufPoolNoop(), newFakeMaxIDGetter(docID))
 	searcher := NewSearcher(logger, store, accentSchema.GetClass, nil, nil,
 		stopwords.NewProvider(fakeStopwordDetector{}, nil), 2, func() bool { return false }, nil, "",
-		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory).
+		WithBatchedContainsEnabled(runtime.NewDynamicValue(true))
 
 	makeFilter := func(prop string, op filters.Operator, val string) *filters.LocalFilter {
 		return &filters.LocalFilter{Root: &filters.Clause{

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -228,6 +228,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			QuerySlowLogEnabled:          m.db.config.QuerySlowLogEnabled,
 			QuerySlowLogThreshold:        m.db.config.QuerySlowLogThreshold,
 			InvertedSorterDisabled:       m.db.config.InvertedSorterDisabled,
+			QueryBatchedContainsEnabled:  m.db.config.QueryBatchedContainsEnabled,
 			LazyPropertyLengthsEnabled:   m.db.config.LazyPropertyLengthsEnabled,
 			MaintenanceModeEnabled:       m.db.config.MaintenanceModeEnabled,
 			HFreshEnabled:                m.db.config.HFreshEnabled,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -483,6 +483,7 @@ type Config struct {
 	QuerySlowLogEnabled         *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold       *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled      *configRuntime.DynamicValue[bool]
+	QueryBatchedContainsEnabled *configRuntime.DynamicValue[bool]
 	LazyPropertyLengthsEnabled  *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled      func() bool
 	AsyncIndexingEnabled        bool

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -37,5 +37,6 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params, module
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory, modules, s.index.Config.QueryHybridMaximumResults,
 		s.TokenizationFor).
 		WithSearchableBucketPinningResolver(s.PinTokenizationAndSearchableBucket).
+		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).
 		Do(ctx)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -540,6 +540,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 				s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit,
 				s.bitmapFactory).
 				WithTokenizationResolver(s.TokenizationFor).
+				WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
 			if err != nil {
 				return nil, nil, err
@@ -573,6 +574,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		WithTokenizationResolver(s.TokenizationFor).
+		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName, properties,
 			s.index.Config.InvertedSorterDisabled)
 	return objs, nil, err
@@ -898,6 +900,7 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 		s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		WithTokenizationResolver(s.TokenizationFor).
+		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)
 	if err != nil {
 		return nil, errors.Wrap(err, "build inverted filter allow list")

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -175,6 +175,7 @@ func (s *Shard) FindUUIDs(ctx context.Context, filters *filters.LocalFilter, lim
 		nil, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.version, s.isFallbackToSearchable,
 		s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		WithTokenizationResolver(s.TokenizationFor).
+		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).
 		DocIDsLimited(ctx, filters, additional.Properties{}, s.index.Config.ClassName, limit)
 	if err != nil {
 		return nil, fmt.Errorf("docIds: %w", err)

--- a/entities/config/feature_flags.go
+++ b/entities/config/feature_flags.go
@@ -67,18 +67,3 @@ func NestedFilteringEnabled() bool {
 func NestedFilteringDisabledError() error {
 	return fmt.Errorf("filtering on nested properties is a preview feature, disabled by default; set %s=true to enable", EnvNestedFilteringPreview)
 }
-
-// EnvDisableBatchedContains is the env var that disables the batched
-// ContainsAny/ContainsAll/ContainsNone filter resolution, forcing every
-// Contains filter through the per-value desugared path. Operator escape
-// hatch: the batched path is behaviorally equivalent (pinned by a
-// differential test).
-const EnvDisableBatchedContains = "WEAVIATE_DISABLE_BATCHED_CONTAINS"
-
-// BatchedContainsDisabled reports whether the batched Contains resolution is
-// switched off for this server. Reads the env var on each call rather than
-// caching; the call site runs once per Contains filter extraction, not per
-// value, so caching would buy nothing.
-func BatchedContainsDisabled() bool {
-	return Enabled(os.Getenv(EnvDisableBatchedContains))
-}

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/weaviate/fgprof v0.0.1
 	github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b
+	github.com/weaviate/sroar v0.0.16
 	github.com/weaviate/tiktoken-go v0.0.3
 	github.com/zeebo/xxh3 v1.1.0
 	go.etcd.io/bbolt v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -695,8 +695,8 @@ github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2 h1:lJpPgu+7Vx9K2
 github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2/go.mod h1:6cErcTSXUX3sGQEY+FQlxBztdlzVPoArKdMRNq6XKlE=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b h1:DMWSAV5e8QCQ1JTm4W4m7/sv5VA73AqCrA+hy4UAsRk=
-github.com/weaviate/sroar v0.0.16-0.20260728084040-bd6aaff5bb3b/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.16 h1:9Ga/DKcdVh6UXuOcUWL0rbO9MgGfLYqpXu45cLUpbXk=
+github.com/weaviate/sroar v0.0.16/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -194,7 +194,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/weaviate/s5cmd/v2 v2.0.1 // indirect
-	github.com/weaviate/sroar v0.0.15 // indirect
+	github.com/weaviate/sroar v0.0.16 // indirect
 	github.com/weaviate/tiktoken-go v0.0.3 // indirect
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -535,8 +535,8 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
-github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.16 h1:9Ga/DKcdVh6UXuOcUWL0rbO9MgGfLYqpXu45cLUpbXk=
+github.com/weaviate/sroar v0.0.16/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/weaviate/weaviate-go-client/v5 v5.7.3-0.20260413120914-0d665cebe735 h1:bNIIkKU7/Ex4XaOfntkKcbfxHCqdt5ShIGwFctflDy0=

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -85,7 +85,7 @@ require (
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
-	github.com/weaviate/sroar v0.0.15 // indirect
+	github.com/weaviate/sroar v0.0.16 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
 	go.mongodb.org/mongo-driver v1.17.6 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -282,8 +282,8 @@ github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IU
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
-github.com/weaviate/sroar v0.0.15 h1:DtqivKp0ndMz9sLRh6gpy6SrQN+3n6J0QHzwe2Oe87M=
-github.com/weaviate/sroar v0.0.15/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.16 h1:9Ga/DKcdVh6UXuOcUWL0rbO9MgGfLYqpXu45cLUpbXk=
+github.com/weaviate/sroar v0.0.16/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/weaviate-go-client/v5 v5.0.2 h1:aptmTJy6d4OxGHBTGnqHheJe0WDbzH2SVmQkvy7+EGY=
 github.com/weaviate/weaviate-go-client/v5 v5.0.2/go.mod h1:CwZehIL4s3VfkzTu12Wy8VAUtELRtQFUt2ZniBF/lQM=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -303,6 +303,13 @@ type Config struct {
 	// This flat may be removed in the future.
 	InvertedSorterDisabled *runtime.DynamicValue[bool] `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
 
+	// QueryBatchedContainsEnabled turns on the batched resolution of flat
+	// ContainsAny/ContainsAll/ContainsNone filters (many keys read under one
+	// consistent view, folded without per-value goroutines). Off by default;
+	// when off, every Contains filter takes the desugared per-value path. The
+	// batched path is behaviorally equivalent (pinned by a differential test).
+	QueryBatchedContainsEnabled *runtime.DynamicValue[bool] `json:"query_batched_contains_enabled" yaml:"query_batched_contains_enabled"`
+
 	// LazyPropertyLengthsEnabled defers loading an inverted segment's property
 	// length map until first use and frees it after a compaction drops the
 	// segment, trading a one-time load on the first cold BM25 query for memory.

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1453,6 +1453,9 @@ func FromEnv(config *Config) error {
 	config.LazyPropertyLengthsEnabled = configRuntime.NewDynamicValue(
 		entcfg.Enabled(os.Getenv("PERSISTENCE_LSM_LAZY_PROPLENGTHS")))
 
+	config.QueryBatchedContainsEnabled = configRuntime.NewDynamicValue(
+		entcfg.Enabled(os.Getenv("QUERY_BATCHED_CONTAINS_ENABLED")))
+
 	operationalMode := READ_WRITE
 	if v := os.Getenv("OPERATIONAL_MODE"); v != "" && (v == READ_WRITE || v == READ_ONLY || v == WRITE_ONLY || v == SCALE_OUT) {
 		operationalMode = v

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -57,6 +57,7 @@ type WeaviateRuntimeConfig struct {
 	QuerySlowLogEnabled                       *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
 	QuerySlowLogThreshold                     *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
 	InvertedSorterDisabled                    *runtime.DynamicValue[bool]          `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
+	QueryBatchedContainsEnabled               *runtime.DynamicValue[bool]          `json:"query_batched_contains_enabled" yaml:"query_batched_contains_enabled"`
 	LazyPropertyLengthsEnabled                *runtime.DynamicValue[bool]          `json:"lazy_property_lengths_enabled" yaml:"lazy_property_lengths_enabled"`
 	BM25FilterTombMergeGateRatio              *runtime.DynamicValue[float64]       `json:"bm25_filter_tombstone_merge_gate_ratio" yaml:"bm25_filter_tombstone_merge_gate_ratio"`
 	UsageGCSBucket                            *runtime.DynamicValue[string]        `json:"usage_gcs_bucket" yaml:"usage_gcs_bucket"`


### PR DESCRIPTION
## Motivation

Part 6 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242). The previous PR shipped the batched path default-on with a `WEAVIATE_DISABLE_BATCHED_CONTAINS` kill switch. For a safer rollout this PR **flips the stack's default: batched Contains is now OFF unless explicitly enabled** — via `QUERY_BATCHED_CONTAINS_ENABLED` at startup, or the `query_batched_contains_enabled` runtime-overrides key with no restart needed. It also moves sroar from the pseudo-version to the tagged release it points at.

## Approach

- **Opt-in gate**: the env kill switch is deleted; `QUERY_BATCHED_CONTAINS_ENABLED` (truthy values per `entcfg.Enabled`, default off) seeds a `runtime.DynamicValue[bool]` that the runtime-overrides file can flip live. Naming follows the `QUERY_` family precedent (`QuerySlowLogEnabled`).
- **Plumbing**: Config → `IndexConfig` → `Searcher.WithBatchedContainsEnabled` fluent setter; the aggregator gets its own setter for its internal searcher. A nil gate reads as disabled, so any unwired construction site is fail-safe — the desugared per-value path.
- **Slow-query decline reason**: `disabled-by-env` → `not-enabled`.
- **sroar `v0.0.16`**: same commit as the previous pseudo-version, identical `/go.mod` hash; `make deps` propagated to `test/acceptance_with_go_client` and `test/benchmark_bm25`.

## Risks and testing

- Silently losing the batched path everywhere: the gate test pins the nil-gate decline (with reason) and a live off/on/off toggle via `SetValue` — no restart between flips.
- Test coverage regressing to the per-value path only: fixtures for the differential, integration, and bench suites opt in explicitly, so the batched path stays exercised.