### PR TITLE
fix(cyclemanager): roll back abort when ctx expires while callback runs

### DIFF
--- a/entities/cyclemanager/cyclecallbackgroup.go
+++ b/entities/cyclemanager/cyclecallbackgroup.go
@@ -431,25 +431,41 @@ func (g *cycleCallbackGroup) activate(callbackId uint32, callbackCustomId string
 // abort, then reports one of three outcomes: the callback is absent
 // (needWait=false, err=notFound); it is not running, so commit is applied and the
 // operation is complete (needWait=false, err=nil); or it is running, so the
-// lazily-created done channel is returned to wait on (needWait=true).
+// lazily-created done channel is returned to wait on (needWait=true). prevAbort
+// is the flag's value before this attempt set it, so commitIdle's timeout path
+// can undo a mark this operation introduced.
 func (g *cycleCallbackGroup) tryCommitIdle(callbackId uint32, commit func(*cycleCallbackMeta), notFound error,
-) (done chan struct{}, needWait bool, err error) {
+) (done chan struct{}, prevAbort bool, needWait bool, err error) {
 	g.Lock()
 	defer g.Unlock()
 
 	meta, ok := g.metas[callbackId]
 	if !ok {
-		return nil, false, notFound
+		return nil, false, false, notFound
 	}
+	prevAbort = meta.abort
 	meta.abort = true
 	if !meta.running {
 		commit(meta)
-		return nil, false, nil
+		return nil, prevAbort, false, nil
 	}
 	if meta.done == nil {
 		meta.done = make(chan struct{})
 	}
-	return meta.done, true, nil
+	return meta.done, prevAbort, true, nil
+}
+
+// rollbackAbort clears the abort flag after a timed-out deactivate/unregister.
+// It re-checks the callback still exists under the lock; clearing a flag a
+// racing deactivate/unregister set independently is accepted — that waiter
+// merely loses cooperative abort and completes when the run finishes naturally.
+func (g *cycleCallbackGroup) rollbackAbort(callbackId uint32) {
+	g.Lock()
+	defer g.Unlock()
+
+	if meta, ok := g.metas[callbackId]; ok {
+		meta.abort = false
+	}
 }
 
 // commitIdle drives the try/wait/re-check protocol shared by deactivate and
@@ -458,7 +474,10 @@ func (g *cycleCallbackGroup) tryCommitIdle(callbackId uint32, commit func(*cycle
 // retries tryCommitIdle after each finished run; commit is applied only once
 // tryCommitIdle observes the callback not running. A ctx deadline hit while
 // waiting returns ctx.Err(), but an already-finished run takes priority so a
-// completed operation is never reported as a timeout. Every result passes through
+// completed operation is never reported as a timeout. On timeout the abort mark
+// this operation set is rolled back, so a failed operation leaves the callback
+// fully operational; a mark that predates the operation (a concurrent
+// deactivate/unregister owns it) is left in place. Every result passes through
 // wrap (which maps nil to nil).
 func (g *cycleCallbackGroup) commitIdle(ctx context.Context, callbackId uint32,
 	commit func(*cycleCallbackMeta), notFound error, wrap func(error) error,
@@ -467,8 +486,10 @@ func (g *cycleCallbackGroup) commitIdle(ctx context.Context, callbackId uint32,
 		return wrap(ctx.Err())
 	}
 
+	// Only the first attempt's prevAbort reflects the state before this
+	// operation — retries observe the mark the first attempt set itself.
+	done, prevAbort, needWait, err := g.tryCommitIdle(callbackId, commit, notFound)
 	for {
-		done, needWait, err := g.tryCommitIdle(callbackId, commit, notFound)
 		if !needWait {
 			return wrap(err)
 		}
@@ -481,12 +502,17 @@ func (g *cycleCallbackGroup) commitIdle(ctx context.Context, callbackId uint32,
 			case <-done:
 				// re-check under the lock on the next iteration
 			default:
-				// Timeout: leave the callback in place (abort stays set). The running
-				// callback finishes eventually and endRun reschedules it; the caller
-				// can retry, and Activate resets abort.
+				// Timeout with the callback still running: the operation failed, and
+				// callers treat the error as "nothing changed" — they never Activate
+				// afterwards, so a lingering abort would silently short-circuit every
+				// subsequent run. Undo the mark unless it predates this operation.
+				if !prevAbort {
+					g.rollbackAbort(callbackId)
+				}
 				return wrap(ctx.Err())
 			}
 		}
+		done, _, needWait, err = g.tryCommitIdle(callbackId, commit, notFound)
 	}
 }
 

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -1967,8 +1967,9 @@ func TestCycleCallback_CombinedCtrl_DeactivateTimeoutRollback(t *testing.T) {
 }
 
 // TestCycleCallback_DeactivateTimeoutState is a white-box test that verifies the
-// documented post-timeout state (active=true, abort=true) and confirms that a
-// subsequent Deactivate with a valid ctx succeeds and commits active=false.
+// documented post-timeout state (active=true, abort rolled back to false) and
+// confirms that a subsequent Deactivate with a valid ctx succeeds and commits
+// active=false.
 func TestCycleCallback_DeactivateTimeoutState(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
@@ -1995,7 +1996,8 @@ func TestCycleCallback_DeactivateTimeoutState(t *testing.T) {
 	err := ctrl.Deactivate(ctxTimeout)
 	require.Error(t, err, "Deactivate must return an error on ctx timeout")
 
-	// Under the lock: the callback is still running; state must be active=true, abort=true.
+	// Under the lock: the callback is still running; state must be active=true
+	// with the abort mark rolled back, as if the failed Deactivate never ran.
 	g.Lock()
 	var meta *cycleCallbackMeta
 	for _, m := range g.metas {
@@ -2003,7 +2005,7 @@ func TestCycleCallback_DeactivateTimeoutState(t *testing.T) {
 	}
 	require.NotNil(t, meta)
 	assert.True(t, meta.active, "active must remain true after Deactivate timeout")
-	assert.True(t, meta.abort, "abort must remain true after Deactivate timeout")
+	assert.False(t, meta.abort, "abort must be rolled back after Deactivate timeout")
 	g.Unlock()
 
 	// Release the callback so the tick can finish.
@@ -2019,6 +2021,138 @@ func TestCycleCallback_DeactivateTimeoutState(t *testing.T) {
 	assert.False(t, meta.active, "active must be false after successful Deactivate")
 	assert.True(t, meta.abort, "abort remains true after Deactivate; only Activate clears it")
 	g.Unlock()
+}
+
+// ctxCancelledWhileRunningSpec parameterizes testCtxCancelledWhileRunning with
+// the controller op under test (Deactivate or Unregister): which op is invoked
+// with the cancellable ctx, which op-specific assertions run after it failed,
+// and the op-specific regression block at the end.
+type ctxCancelledWhileRunningSpec struct {
+	// mutate is the controller op called with the cancellable ctx while the
+	// callback is still running.
+	mutate func(ctrl CycleCallbackCtrl, ctx context.Context) error
+	// afterFailedMutate runs right after mutate returned context.Canceled
+	// (may be nil); the shared body already asserts the abort flag was
+	// restored.
+	afterFailedMutate func(t *testing.T, ctrl CycleCallbackCtrl)
+	// tail is the op-specific regression block proving the regular flow is
+	// unaffected by the failed op. startedCounter reports how often the
+	// callback body has run so far.
+	tail func(t *testing.T, callbacks CycleCallbackGroup, ctrl CycleCallbackCtrl,
+		shouldNotAbort ShouldAbortCallback, startedCounter func() int)
+}
+
+func TestCycleCallback_DeactivateCtxCancelledWhileRunning(t *testing.T) {
+	testCtxCancelledWhileRunning(t, ctxCancelledWhileRunningSpec{
+		mutate: func(ctrl CycleCallbackCtrl, ctx context.Context) error {
+			return ctrl.Deactivate(ctx)
+		},
+		tail: func(t *testing.T, callbacks CycleCallbackGroup, ctrl CycleCallbackCtrl,
+			shouldNotAbort ShouldAbortCallback, startedCounter func() int,
+		) {
+			// regular deactivate/activate flow is unaffected
+			require.NoError(t, ctrl.Deactivate(context.Background()))
+			assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, 2, startedCounter())
+
+			require.NoError(t, ctrl.Activate())
+			assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, 3, startedCounter())
+		},
+	})
+}
+
+func TestCycleCallback_UnregisterCtxCancelledWhileRunning(t *testing.T) {
+	testCtxCancelledWhileRunning(t, ctxCancelledWhileRunningSpec{
+		mutate: func(ctrl CycleCallbackCtrl, ctx context.Context) error {
+			return ctrl.Unregister(ctx)
+		},
+		afterFailedMutate: func(t *testing.T, ctrl CycleCallbackCtrl) {
+			// failed unregister must not drop the callback either,
+			// otherwise every subsequent cycle would lose it
+			assert.True(t, ctrl.IsActive())
+		},
+		tail: func(t *testing.T, callbacks CycleCallbackGroup, ctrl CycleCallbackCtrl,
+			shouldNotAbort ShouldAbortCallback, startedCounter func() int,
+		) {
+			// regular unregister is unaffected
+			require.NoError(t, ctrl.Unregister(context.Background()))
+			assert.False(t, callbacks.CycleCallback(shouldNotAbort))
+			assert.Equal(t, 2, startedCounter())
+		},
+	})
+}
+
+func testCtxCancelledWhileRunning(t *testing.T, spec ctxCancelledWhileRunningSpec) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	shouldNotAbort := func() bool { return false }
+
+	chStarted := make(chan struct{}, 1)
+	chGate := make(chan struct{})
+	startedCounter := 0
+	callback := func(shouldAbort ShouldAbortCallback) bool {
+		if shouldAbort() {
+			return false
+		}
+		startedCounter++
+		if startedCounter == 1 {
+			chStarted <- struct{}{}
+		}
+		<-chGate
+		return true
+	}
+
+	callbacks := NewCallbackGroup("id", logger, 1)
+	ctrl := callbacks.Register("c", callback)
+
+	// single registered callback gets id 0
+	isAbortSet := func() bool {
+		group := callbacks.(*cycleCallbackGroup)
+		group.Lock()
+		defer group.Unlock()
+		return group.metas[0].abort
+	}
+
+	// 1st cycle with the callback blocking on the gate
+	chCycle1 := make(chan bool, 1)
+	go func() {
+		chCycle1 <- callbacks.CycleCallback(shouldNotAbort)
+	}()
+	<-chStarted
+
+	// mutate with ctx cancelled while the callback is still running
+	ctxMutate, cancelMutate := context.WithCancel(ctx)
+	chMutated := make(chan error, 1)
+	go func() {
+		chMutated <- spec.mutate(ctrl, ctxMutate)
+	}()
+
+	// wait for the abort flag to make sure the op marked the callback
+	// and is now waiting for the running one to finish
+	require.Eventually(t, isAbortSet, time.Second, time.Millisecond)
+	cancelMutate()
+
+	err := <-chMutated
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// the failed op must not leave the abort flag behind,
+	// otherwise it would silently abort every subsequent cycle
+	assert.False(t, isAbortSet())
+	if spec.afterFailedMutate != nil {
+		spec.afterFailedMutate(t, ctrl)
+	}
+
+	close(chGate)
+	assert.True(t, <-chCycle1)
+
+	// subsequent cycle executes the callback again
+	assert.True(t, callbacks.CycleCallback(shouldNotAbort))
+	assert.Equal(t, 2, startedCounter)
+
+	// op-specific regression block
+	spec.tail(t, callbacks, ctrl, shouldNotAbort, func() int { return startedCounter })
 }
 
 // TestCycleCallback_ConcurrentWaiters verifies that two concurrent callers waiting on the


### PR DESCRIPTION
Port of https://github.com/weaviate/weaviate/pull/12265 to stable/v1.37.

### Motivation

Same bug as on v1.36 (weaviate/0-weaviate-issues#350): the single-callback cycle controller's `Deactivate`/`Unregister` set the abort flag before knowing whether the operation can complete. If the caller's ctx expires while an in-flight callback run is still going, the operation returns `ctx.Err()` leaving `abort=true, active=true`. Callers treat the error as "nothing changed" and never call `Activate`, so every subsequent cycle aborts immediately — compaction and tombstone cleanup silently no-op forever on that callback.

### Approach

Not a cherry-pick: v1.37's controller was rewritten around the shared `commitIdle` try/wait/re-check protocol, so the fix is re-derived for it. `tryCommitIdle` now also reports the abort flag's value before this attempt set it, and `commitIdle`'s timeout path rolls the mark back — but only if this operation introduced it, so a mark owned by a concurrent deactivate/unregister is left in place.

### Key areas for review

- `entities/cyclemanager/cyclecallbackgroup.go:commitIdle` — `prevAbort` is captured from the first `tryCommitIdle` attempt only and hoisted out of the retry loop; retries would observe the mark the first attempt set itself.
- `rollbackAbort` — accepted race documented in the comment: clearing a mark a racing deactivate/unregister set independently only costs that waiter cooperative abort; it still completes when the run finishes.

### Risks and mitigations

- **Clobbering a concurrent operation's abort mark**: rollback is gated on `prevAbort == false`, and `rollbackAbort` re-checks callback existence under the lock.

### Testing

New regression tests park a callback mid-run, cancel the deactivate/unregister ctx, and pin: `context.Canceled` returned, the abort flag restored, and the callback executing again on the next cycle. The pre-existing timeout-state test pinned the leak as documented behavior and is updated to the new contract. `go test ./entities/cyclemanager/... -race -count=1` green.