### PR TITLE
fix(lsmkv): serialize FlushAndSwitch so concurrent callers can't strand a memtable

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -84,7 +84,29 @@ type Bucket struct {
 
 	// Lock() means a move from active to flushing is happening, RLock() is
 	// normal operation
-	flushLock        sync.RWMutex
+	flushLock sync.RWMutex
+
+	// flushAndSwitchMu serializes [FlushAndSwitch] calls. The bucket was
+	// written assuming a single flusher (the cycle-manager flush
+	// callback or a control-plane caller — backup, runtime migration,
+	// startup finalize); the data hot path never invokes
+	// [FlushAndSwitch] directly (writes go through memtable.put without
+	// it). When two callers overlap — most visibly seen on the objects
+	// bucket with concurrent runtime-reindex migrations — the second
+	// caller's atomicallySwitchMemtable observes `active.Size() == 0`
+	// and returns early, racing the first caller's still-in-flight
+	// flush. Any follow-up `CursorOnDisk` would miss data parked in
+	// `b.flushing`. Serializing here gives every caller the invariant
+	// "after FlushAndSwitch returns, all data written before the call
+	// is durably in segments." See GH https://github.com/weaviate/0-weaviate-issues/issues/212 Issues C+D.
+	//
+	// Lock ordering: flushAndSwitchMu MUST be acquired BEFORE flushLock.
+	// FlushAndSwitch takes flushAndSwitchMu for its full duration and
+	// internally takes flushLock during atomicallySwitchMemtable +
+	// atomicallyAddDiskSegmentAndRemoveFlushing. Reverse-order callers
+	// would deadlock.
+	flushAndSwitchMu sync.Mutex
+
 	haltedFlushTimer *interval.BackoffTimer
 
 	minWalThreshold   uint64
@@ -1692,6 +1714,16 @@ func (b *Bucket) isReadOnly() bool {
 // calling, but there are some situations where this might be intended, such as
 // in test scenarios or when a force flush is desired.
 func (b *Bucket) FlushAndSwitch() error {
+	// Serialize against any other in-flight FlushAndSwitch on this bucket.
+	// See the [flushAndSwitchMu] godoc and GH https://github.com/weaviate/0-weaviate-issues/issues/212
+	// Issues C+D for the rationale. This ensures the invariant
+	// "after FlushAndSwitch returns, all data written before the call is
+	// durably in segments" holds even when two callers race — the second
+	// caller waits for the first's flush to land before its own
+	// atomicallySwitchMemtable runs.
+	b.flushAndSwitchMu.Lock()
+	defer b.flushAndSwitchMu.Unlock()
+
 	before := time.Now()
 	var err error
 

--- a/adapters/repos/db/lsmkv/bucket_flush_and_switch_concurrency_test.go
+++ b/adapters/repos/db/lsmkv/bucket_flush_and_switch_concurrency_test.go
@@ -1,0 +1,102 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// FlushAndSwitch has more than one caller — the flush cycle callback plus
+// control-plane paths like backup and force-flush — and nothing stopped two of
+// them from running at once. b.flushing is written under flushLock but read
+// unlocked for the whole flush, so an overlapping caller could rebind it to its
+// own memtable and strand the first caller's, dropping those keys out of every
+// read path until the bucket is reopened from the WAL.
+func TestBucketConcurrentFlushAndSwitch(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	const (
+		flushers = 4
+		rounds   = 25
+		perRound = 20
+	)
+
+	key := func(i int) []byte { return []byte(fmt.Sprintf("key-%05d", i)) }
+	value := func(i int) []byte { return []byte(fmt.Sprintf("value-%05d", i)) }
+
+	writesDone := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Writers and flushers overlap so a switch lands mid-write, the arrangement
+	// the flush callback and a control-plane caller produce in production.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(writesDone)
+		for i := 0; i < rounds*perRound; i++ {
+			if err := b.Put(key(i), value(i)); err != nil {
+				t.Errorf("put %d: %v", i, err)
+				return
+			}
+		}
+	}()
+
+	errs := make(chan error, flushers*rounds)
+	for range flushers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-writesDone:
+					return
+				default:
+				}
+				if err := b.FlushAndSwitch(); err != nil {
+					errs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, b.FlushAndSwitch())
+
+	// Every key must still be reachable. A stranded memtable is invisible to
+	// Get even though its WAL survives on disk.
+	for i := 0; i < rounds*perRound; i++ {
+		got, err := b.Get(key(i))
+		require.NoError(t, err, "get %s", key(i))
+		require.Equal(t, value(i), got, "key %s lost by a concurrent flush", key(i))
+	}
+}


### PR DESCRIPTION
`FlushAndSwitch` has several callers — the flush cycle callback, plus control-plane paths like backup's `FlushMemtable` — and nothing stopped two of them running at once on the same bucket. `b.flushing` is written under `flushLock` inside `atomicallySwitchMemtable` and `atomicallyAddDiskSegmentAndRemoveFlushing`, but read **unlocked** for the whole flush body in between.

## Impact

Two overlapping callers corrupt each other, in two distinct ways:

**Silent data loss.** The second caller's `atomicallySwitchMemtable` rebinds `b.flushing` to its own memtable while the first is still flushing. The first caller's memtable is no longer referenced by the bucket, so its keys vanish from every read path until the bucket is reopened and the WAL replayed.

**Segfault.** The first caller's `atomicallyAddDiskSegmentAndRemoveFlushing` sets `b.flushing = nil` while the second dereferences it:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x48]
lsmkv.(*Bucket).atomicallyAddDiskSegmentAndRemoveFlushing()
	adapters/repos/db/lsmkv/bucket.go:1872
lsmkv.(*Bucket).FlushAndSwitch()
	adapters/repos/db/lsmkv/bucket.go:1749
```

Both are reachable in production. `FlushMemtable`'s godoc says it "should be run only if flushCycle is not running", but nothing enforces that, and backup calls it on live buckets.

This surfaced as a `WARNING: DATA RACE` in `cluster/usage` CI on `stable/v1.37`, racing `FlushMemtable` against the cycle callback's `flushAndSwitchIfThresholdsMet`.

## Fix

Take a dedicated `flushAndSwitchMu` for the full duration of `FlushAndSwitch`. Both existing callers release `flushLock` before calling in, so the documented ordering (`flushAndSwitchMu` OUTER, `flushLock` INNER) holds with no inversion.

This is the same serialization `stable/v1.38` already carries (from `cac1920c05`). The mutex and its godoc are copied **verbatim** so the branches merge forward cleanly.

## Regression test

`TestBucketConcurrentFlushAndSwitch` overlaps four flushers with a writer, then checks every written key is still readable.

Against the unfixed bucket it reports the same race pair CI hit — write in `atomicallySwitchMemtable` vs unlocked read in `FlushAndSwitch`:

```
WARNING: DATA RACE
Write at 0x00c0002cc030 by goroutine 148:
  lsmkv.(*Bucket).atomicallySwitchMemtable()  bucket.go:1830
  lsmkv.(*Bucket).FlushAndSwitch()            bucket.go:1704
Previous read at 0x00c0002cc030 by goroutine 146:
  lsmkv.(*Bucket).FlushAndSwitch()            bucket.go:1728
```

and without `-race` it segfaults. With the fix: clean over `-count 3 -race` and `-count 10` without.

## Verification

- `go test -race ./adapters/repos/db/lsmkv/` — pass
- `go test -race ./cluster/usage/...` — pass (the suite CI flagged)
- `go build ./...`, `gofumpt`, `golangci-lint run ./adapters/repos/db/lsmkv/...`, `tools/linter_go_routines.sh` — all clean

## Branch targeting

Based on `stable/v1.36`, the oldest affected branch — `stable/v1.37` has identical unguarded code, and `stable/v1.38` already has the fix. Forward-porting to 1.37 happens via the existing merge chain (#12413).
