### PR TITLE
Dont read file sizes in usage module when not needed

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -298,7 +298,7 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 
 	lsmPath := shardPathLSM(i.path(), shard.Name())
 
-	_, directories, err := diskio.GetFileWithSizes(lsmPath)
+	directories, err := diskio.GetSubdirNames(lsmPath)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 	lsmPath := shardPathLSM(i.path(), shardName)
 
-	_, directories, err := diskio.GetFileWithSizes(lsmPath)
+	directories, err := diskio.GetSubdirNames(lsmPath)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -303,7 +303,7 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 				lsmPath := filepath.Join(index.path(), shard.Name(), "lsm")
-				_, directories, err := diskio.GetFileWithSizes(lsmPath)
+				directories, err := diskio.GetSubdirNames(lsmPath)
 				require.NoError(t, err)
 
 				vectorStorageSize, uncompressed, err := lazyShard.shard.VectorStorageSize(ctx, lsmPath, directories)
@@ -365,7 +365,7 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 				require.NoError(t, lazyShard.Load(ctx))
 
 				lsmPath := filepath.Join(index.path(), shard.Name(), "lsm")
-				_, directories, err := diskio.GetFileWithSizes(lsmPath)
+				directories, err := diskio.GetSubdirNames(lsmPath)
 				require.NoError(t, err)
 
 				vectorStorageSize, _, err := lazyShard.shard.VectorStorageSize(ctx, lsmPath, directories)
@@ -804,7 +804,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	require.True(t, ok)
 
 	lsmPath := filepath.Join(index.path(), shard.Name(), "lsm")
-	_, directories, err := diskio.GetFileWithSizes(lsmPath)
+	directories, err := diskio.GetSubdirNames(lsmPath)
 	require.NoError(t, err)
 
 	activeVectorStorageSize, uncompressed, err := shard.VectorStorageSize(ctx, lsmPath, directories)

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -15,7 +15,9 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -192,15 +194,30 @@ func CalculateUnloadedVectorsMetrics(lsmPath string, directories []string) (int6
 		if !strings.HasPrefix(directory, "vector") {
 			continue
 		}
-		fullPath := filepath.Join(lsmPath, directory)
-
-		files, _, err := diskio.GetFileWithSizes(fullPath)
+		size, err := bucketSize(filepath.Join(lsmPath, directory))
 		if err != nil {
 			return 0, err
 		}
-		for _, size := range files {
-			totalSize += size
-		}
+		totalSize += int64(size)
+	}
+	return totalSize, nil
+}
+
+// bucketSize sums the sizes of the files in a bucket directory. A bucket that was deleted
+// after the directory listing was taken counts as zero, so dropping one property or vector
+// bucket does not zero out the whole shard's usage.
+func bucketSize(bucketPath string) (uint64, error) {
+	files, _, err := diskio.GetFileWithSizes(bucketPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+
+	totalSize := uint64(0)
+	for _, size := range files {
+		totalSize += uint64(size)
 	}
 	return totalSize, nil
 }
@@ -273,14 +290,11 @@ func CalculateUnloadedIndicesSize(lsmPath string, directories []string) (uint64,
 			continue
 		}
 
-		fullPath := filepath.Join(lsmPath, directory)
-		files, _, err := diskio.GetFileWithSizes(fullPath)
+		size, err := bucketSize(filepath.Join(lsmPath, directory))
 		if err != nil {
 			return 0, err
 		}
-		for _, size := range files {
-			totalSize += uint64(size)
-		}
+		totalSize += size
 	}
 	return totalSize, nil
 }

--- a/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
+++ b/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shardusage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+)
+
+// A bucket can be deleted between the lsm directory listing and the size calculation, e.g.
+// while a property index is being dropped. The vanished bucket must be skipped so the rest
+// of the shard is still counted.
+func TestUnloadedSizesSkipVanishedBucket(t *testing.T) {
+	const bucketSizeBytes = 1000
+
+	tests := []struct {
+		name string
+		// calc is the function under test, over the lsm path and the bucket names.
+		calc func(lsmPath string, directories []string) (uint64, error)
+		// present buckets are created on disk, vanished ones only appear in the listing.
+		present  []string
+		vanished []string
+		want     uint64
+	}{
+		{
+			name:    "vectors, all buckets present",
+			calc:    vectorsSize,
+			present: []string{"vectors", "vectors_compressed"},
+			want:    2 * bucketSizeBytes,
+		},
+		{
+			name:     "vectors, one bucket vanished",
+			calc:     vectorsSize,
+			present:  []string{"vectors"},
+			vanished: []string{"vectors_compressed"},
+			want:     bucketSizeBytes,
+		},
+		{
+			name:     "vectors, every bucket vanished",
+			calc:     vectorsSize,
+			vanished: []string{"vectors", "vectors_compressed"},
+			want:     0,
+		},
+		{
+			name:    "indices, all buckets present",
+			calc:    CalculateUnloadedIndicesSize,
+			present: []string{helpers.BucketFromPropNameLSM("title"), helpers.DimensionsBucketLSM},
+			want:    2 * bucketSizeBytes,
+		},
+		{
+			name:     "indices, one bucket vanished",
+			calc:     CalculateUnloadedIndicesSize,
+			present:  []string{helpers.BucketFromPropNameLSM("title")},
+			vanished: []string{helpers.BucketFromPropNameLSM("author")},
+			want:     bucketSizeBytes,
+		},
+		{
+			name:     "indices, every bucket vanished",
+			calc:     CalculateUnloadedIndicesSize,
+			vanished: []string{helpers.BucketFromPropNameLSM("title"), helpers.DimensionsBucketLSM},
+			want:     0,
+		},
+		{
+			name:     "vanished bucket the filter ignores is not read at all",
+			calc:     vectorsSize,
+			present:  []string{"vectors"},
+			vanished: []string{helpers.BucketFromPropNameLSM("title")},
+			want:     bucketSizeBytes,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lsmPath := filepath.Join(t.TempDir(), "lsm")
+			require.NoError(t, os.MkdirAll(lsmPath, 0o700))
+
+			for _, bucket := range tc.present {
+				bucketPath := filepath.Join(lsmPath, bucket)
+				require.NoError(t, os.Mkdir(bucketPath, 0o700))
+				require.NoError(t, os.WriteFile(filepath.Join(bucketPath, "segment-1.db"),
+					make([]byte, bucketSizeBytes), 0o600))
+			}
+
+			// The listing names every bucket, including the ones no longer on disk.
+			directories := append(append([]string{}, tc.present...), tc.vanished...)
+
+			got, err := tc.calc(lsmPath, directories)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// vectorsSize adapts CalculateUnloadedVectorsMetrics to the table's uint64 signature.
+func vectorsSize(lsmPath string, directories []string) (uint64, error) {
+	size, err := CalculateUnloadedVectorsMetrics(lsmPath, directories)
+	return uint64(size), err
+}

--- a/entities/diskio/files.go
+++ b/entities/diskio/files.go
@@ -67,7 +67,9 @@ func Fsync(path string) error {
 	return f.Sync()
 }
 
-// GetFileWithSizes gets all files in a directory including their filesize
+// GetFileWithSizes gets all files in a directory including their filesize. Symlinks are not
+// followed. Callers that only need the subdirectory names should use GetSubdirNames, which
+// avoids a stat per entry.
 func GetFileWithSizes(dirPath string) (map[string]int64, []string, error) {
 	dir, err := os.Open(dirPath)
 	if err != nil {
@@ -92,6 +94,31 @@ func GetFileWithSizes(dirPath string) (map[string]int64, []string, error) {
 	}
 
 	return fileSizes, dirs, nil
+}
+
+// GetSubdirNames returns the names of the subdirectories of dirPath. Entry types come from the
+// directory read itself where the filesystem reports them, avoiding a stat per entry. Symlinks
+// are not followed, so a symlink pointing at a directory is not returned.
+func GetSubdirNames(dirPath string) ([]string, error) {
+	dir, err := os.Open(dirPath)
+	if err != nil {
+		return nil, err
+	}
+	defer dir.Close()
+
+	entries, err := dir.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			dirs = append(dirs, entry.Name())
+		}
+	}
+
+	return dirs, nil
 }
 
 // GetDirSize calculates the total size of a directory recursively

--- a/entities/diskio/files_test.go
+++ b/entities/diskio/files_test.go
@@ -12,11 +12,120 @@
 package diskio
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetSubdirNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		dirs  []string
+		files []string
+		// link name -> target, both relative to the temp root
+		symlinks map[string]string
+		// path handed to the function, relative to the temp root; empty means the root itself
+		subPath string
+		want    []string
+		wantErr bool
+	}{
+		{name: "empty directory"},
+		{name: "only files", files: []string{"segment-1.db", "segment-2.db"}},
+		{name: "single subdirectory", dirs: []string{"objects"}, want: []string{"objects"}},
+		{
+			name:  "files and subdirectories",
+			dirs:  []string{"objects", "property_title", "vectors_text", ".migrations"},
+			files: []string{"segment-1.db", "segment-1.db.bloom"},
+			want:  []string{"objects", "property_title", "vectors_text", ".migrations"},
+		},
+		{
+			name:     "symlink to directory is not reported",
+			dirs:     []string{"objects"},
+			symlinks: map[string]string{"objects_link": "objects"},
+			want:     []string{"objects"},
+		},
+		{
+			name:     "symlink to file is not reported",
+			files:    []string{"segment-1.db"},
+			symlinks: map[string]string{"segment-link.db": "segment-1.db"},
+		},
+		{name: "missing directory", subPath: "does-not-exist", wantErr: true},
+		{name: "path is a file", files: []string{"segment-1.db"}, subPath: "segment-1.db", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for _, dir := range tc.dirs {
+				require.NoError(t, os.Mkdir(filepath.Join(root, dir), 0o700))
+			}
+			for _, file := range tc.files {
+				require.NoError(t, os.WriteFile(filepath.Join(root, file), []byte("x"), 0o600))
+			}
+			for link, target := range tc.symlinks {
+				require.NoError(t, os.Symlink(filepath.Join(root, target), filepath.Join(root, link)))
+			}
+
+			path := filepath.Join(root, tc.subPath)
+			got, err := GetSubdirNames(path)
+			// Both functions must report the same subdirectories.
+			_, wantFromSizes, sizesErr := GetFileWithSizes(path)
+
+			if tc.wantErr {
+				require.Error(t, err)
+				require.Error(t, sizesErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, sizesErr)
+			require.ElementsMatch(t, tc.want, got)
+			require.ElementsMatch(t, wantFromSizes, got)
+		})
+	}
+}
+
+// BenchmarkSubdirNames compares reading only the entry types against stat'ing every entry,
+// on a directory shaped like a shard's lsm/ folder.
+func BenchmarkSubdirNames(b *testing.B) {
+	const subdirCount = 30
+
+	root := b.TempDir()
+	for i := range subdirCount {
+		require.NoError(b, os.Mkdir(filepath.Join(root, fmt.Sprintf("property_%d", i)), 0o700))
+	}
+	for i := range 10 {
+		require.NoError(b, os.WriteFile(filepath.Join(root, fmt.Sprintf("segment-%d.db", i)), []byte("x"), 0o600))
+	}
+
+	b.Run("GetSubdirNames", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			dirs, err := GetSubdirNames(root)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(dirs) != subdirCount {
+				b.Fatalf("got %d subdirectories, want %d", len(dirs), subdirCount)
+			}
+		}
+	})
+
+	b.Run("GetFileWithSizes", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			_, dirs, err := GetFileWithSizes(root)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(dirs) != subdirCount {
+				b.Fatalf("got %d subdirectories, want %d", len(dirs), subdirCount)
+			}
+		}
+	})
+}
 
 func TestSanitizeFilePathJoin(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### What's being changed:

Two commits:
1. Fixes a bug that a shard would report 0 if a folder would vanish during the scan
2. Dont read filesizes we dont need:

  ```
  BenchmarkSubdirNames/GetSubdirNames-16      26232 ns/op    7688 B/op     97 allocs/op
  BenchmarkSubdirNames/GetFileWithSizes-16    54826 ns/op   14800 B/op    142 allocs/op
  ```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
