### PR TITLE
flat: fix 'quantizer not initialized' search error during RQ lazy initialization

### DIFF
--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -117,13 +117,15 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 	// If compression is BQ we create the quantizer and cache immediately
 	// For RQ we create when restoring from disk or on first batch
 	if index.compressionType == CompressionBQ {
-		index.compressed.Store(true)
 		builder := NewQuantizerBuilder(cfg.DistanceProvider)
 		quantizer, err := builder.CreateQuantizer(index.compressionType, 0)
 		if err != nil {
 			return nil, err
 		}
+		// the quantizer must be assigned before the compressed flag is set:
+		// readers access it lock-free after observing Compressed() == true
 		index.quantizer = quantizer
+		index.compressed.Store(true)
 	}
 
 	cached, cacheType := extractCache(uc)
@@ -429,12 +431,13 @@ func (index *flat) searchTimeRescore(k int) int {
 }
 
 func (index *flat) SearchByVector(ctx context.Context, vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
-	switch index.compressionType {
-	case CompressionBQ, CompressionRQ1, CompressionRQ8:
+	// route on the runtime compression state, not the configured type: with RQ
+	// the quantizer only exists after the first Add ran initializeDimensionsAndRQ,
+	// and until then the uncompressed bucket is the only complete source
+	if index.Compressed() {
 		return index.searchByVectorQuantized(ctx, vector, k, allow)
-	default:
-		return index.searchByVector(ctx, vector, k, allow)
 	}
+	return index.searchByVector(ctx, vector, k, allow)
 }
 
 func (index *flat) searchByVector(ctx context.Context, vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
@@ -466,14 +469,10 @@ func (index *flat) createDistanceCalc(vector []float32) distanceCalc {
 }
 
 func (index *flat) searchByVectorQuantized(ctx context.Context, vector []float32, k int, allow helpers.AllowList) ([]uint64, []float32, error) {
-	// Ensure quantizer is initialized
+	// defensive: callers only reach this path once Compressed() is true, and
+	// the quantizer is always assigned before the compressed flag is set
 	if index.quantizer == nil {
-		dims := atomic.LoadInt32(&index.dims)
-		if dims == 0 {
-			return []uint64{}, []float32{}, nil
-		} else {
-			return nil, nil, fmt.Errorf("quantizer not initialized")
-		}
+		return nil, nil, fmt.Errorf("quantizer not initialized")
 	}
 
 	// TODO: pass context into inner methods, so it can be checked more granuarly
@@ -1104,12 +1103,11 @@ func (index *flat) PostStartup(ctx context.Context) {
 func (index *flat) ContainsDoc(id uint64) bool {
 	var bucketName string
 
-	// logic modeled after SearchByVector which indicates that the PQ bucket is
-	// the same as the uncompressed bucket "for now"
-	switch index.compressionType {
-	case CompressionBQ, CompressionRQ1, CompressionRQ8:
+	// logic modeled after SearchByVector: the compressed bucket is only
+	// guaranteed complete once the quantizer is initialized
+	if index.Compressed() {
 		bucketName = index.getCompressedBucketName()
-	default:
+	} else {
 		bucketName = index.getBucketName()
 	}
 
@@ -1126,12 +1124,11 @@ func (index *flat) ContainsDoc(id uint64) bool {
 func (index *flat) Iterate(fn func(docID uint64) bool) {
 	var bucketName string
 
-	// logic modeled after SearchByVector which indicates that the PQ bucket is
-	// the same as the uncompressed bucket "for now"
-	switch index.compressionType {
-	case CompressionBQ, CompressionRQ1, CompressionRQ8:
+	// logic modeled after SearchByVector: the compressed bucket is only
+	// guaranteed complete once the quantizer is initialized
+	if index.Compressed() {
 		bucketName = index.getCompressedBucketName()
-	default:
+	} else {
 		bucketName = index.getBucketName()
 	}
 
@@ -1242,7 +1239,10 @@ func (index *flat) QueryVectorDistancer(queryVector []float32) common.QueryVecto
 	}
 	switch index.compressionType {
 	case CompressionBQ, CompressionRQ1, CompressionRQ8:
-		if index.cache == nil {
+		// the quantized paths below dereference the quantizer, which for RQ
+		// only exists once Compressed() reports true; fall back to
+		// full-precision distances from the uncompressed bucket until then
+		if index.cache == nil || !index.Compressed() {
 			distFunc = defaultDistFunc
 		} else {
 			// For RQ-1 bit, use NewDistancer to get 5-bit query quantization for better accuracy

--- a/adapters/repos/db/vector/flat/metadata.go
+++ b/adapters/repos/db/vector/flat/metadata.go
@@ -549,8 +549,10 @@ func (index *flat) restoreRQ1FromMsgpack(rq1Data *RQ1Data) error {
 		return errors.Wrap(err, "restore binary rotational quantizer from msgpack")
 	}
 
-	index.compressed.Store(true)
+	// quantizer before compressed flag: readers access it lock-free after
+	// observing Compressed() == true
 	index.quantizer = &BinaryRotationalQuantizerWrapper{BinaryRotationalQuantizer: rq}
+	index.compressed.Store(true)
 	return nil
 }
 
@@ -570,7 +572,9 @@ func (index *flat) restoreRQ8FromMsgpack(rq8Data *RQ8Data) error {
 		return errors.Wrap(err, "restore rotational quantizer from msgpack")
 	}
 
-	index.compressed.Store(true)
+	// quantizer before compressed flag: readers access it lock-free after
+	// observing Compressed() == true
 	index.quantizer = &RotationalQuantizerWrapper{RotationalQuantizer: rq}
+	index.compressed.Store(true)
 	return nil
 }

--- a/adapters/repos/db/vector/flat/quantizer_test.go
+++ b/adapters/repos/db/vector/flat/quantizer_test.go
@@ -1,0 +1,215 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+)
+
+// Helpers are self-contained rather than shared with index_test.go: that file
+// is excluded from race builds (//go:build !race), and these tests must run
+// under the race detector.
+func newRQTestIndex(t *testing.T, bits int, cache bool) *flat {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	index, err := New(Config{
+		ID:                "quantizer-init-test",
+		RootPath:          dirName,
+		DistanceProvider:  distancer.NewL2SquaredProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, flatent.UserConfig{
+		RQ: flatent.RQUserConfig{
+			Enabled:      true,
+			Bits:         bits,
+			RescoreLimit: 10,
+			Cache:        cache,
+		},
+	}, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+	return index
+}
+
+// simulateInterruptedInit puts the index into the state a concurrent searcher
+// can observe while initializeDimensionsAndRQ is still running (or after it
+// failed partway): dims already published, quantizer not yet assigned. The
+// given vectors exist in the uncompressed bucket only.
+func simulateInterruptedInit(index *flat, vectors [][]float32) {
+	atomic.StoreInt32(&index.dims, int32(len(vectors[0])))
+	for i, vector := range vectors {
+		vector = index.normalized(vector)
+		slice := make([]byte, len(vector)*4)
+		index.storeVector(uint64(i), byteSliceFromFloat32Slice(vector, slice))
+	}
+}
+
+func Test_FlatRQSearchBeforeQuantizerInit(t *testing.T) {
+	ctx := context.Background()
+	vectors := [][]float32{
+		{1, 2, 3, 4},
+		{4, 3, 2, 1},
+		{0, 1, 0, 1},
+	}
+
+	cases := []struct {
+		name string
+		bits int
+	}{
+		{name: "rq1", bits: 1},
+		{name: "rq8", bits: 8},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			index := newRQTestIndex(t, tc.bits, false)
+			simulateInterruptedInit(index, vectors)
+
+			ids, dists, err := index.SearchByVector(ctx, []float32{1, 2, 3, 4}, 3, nil)
+			require.NoError(t, err,
+				"search must fall back to the uncompressed bucket while the quantizer is not initialized")
+			require.Len(t, ids, 3)
+			require.Len(t, dists, 3)
+			assert.Equal(t, uint64(0), ids[0], "nearest neighbor should be the identical vector")
+		})
+
+		t.Run(tc.name+" empty index", func(t *testing.T) {
+			index := newRQTestIndex(t, tc.bits, false)
+
+			ids, dists, err := index.SearchByVector(ctx, []float32{1, 2, 3, 4}, 3, nil)
+			require.NoError(t, err)
+			assert.Empty(t, ids)
+			assert.Empty(t, dists)
+		})
+	}
+}
+
+func Test_FlatRQContainsDocBeforeQuantizerInit(t *testing.T) {
+	index := newRQTestIndex(t, 8, false)
+	simulateInterruptedInit(index, [][]float32{{1, 2, 3, 4}})
+
+	assert.True(t, index.ContainsDoc(0),
+		"ContainsDoc must consult the uncompressed bucket while the quantizer is not initialized")
+
+	var got []uint64
+	index.Iterate(func(docID uint64) bool {
+		got = append(got, docID)
+		return true
+	})
+	assert.Equal(t, []uint64{0}, got,
+		"Iterate must consult the uncompressed bucket while the quantizer is not initialized")
+}
+
+func Test_FlatRQQueryVectorDistancerBeforeQuantizerInit(t *testing.T) {
+	cases := []struct {
+		name string
+		bits int
+	}{
+		{name: "rq1", bits: 1},
+		{name: "rq8", bits: 8},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// cache enabled: the quantized distancer path dereferences the
+			// quantizer, which must not happen while it is nil
+			index := newRQTestIndex(t, tc.bits, true)
+			simulateInterruptedInit(index, [][]float32{{1, 2, 3, 4}})
+
+			distancer := index.QueryVectorDistancer([]float32{1, 2, 3, 4})
+			require.NotNil(t, distancer.DistanceFunc)
+
+			dist, err := distancer.DistanceFunc(0)
+			require.NoError(t, err)
+			assert.InDelta(t, 0.0, dist, 1e-5)
+		})
+	}
+}
+
+// Test_FlatRQConcurrentAddSearch exercises the real init path: the first Add
+// initializes dims and the quantizer while searches run concurrently. Searches
+// must never fail, and under the race detector the quantizer publication must
+// be properly synchronized.
+func Test_FlatRQConcurrentAddSearch(t *testing.T) {
+	ctx := context.Background()
+	index := newRQTestIndex(t, 8, false)
+
+	const (
+		numVectors = 200
+		dims       = 16
+		numReaders = 2
+	)
+
+	query := make([]float32, dims)
+	for i := range query {
+		query[i] = float32(i)
+	}
+
+	done := make(chan struct{})
+	searchErrs := make(chan error, numReaders)
+
+	var wg sync.WaitGroup
+	for r := 0; r < numReaders; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				if _, _, err := index.SearchByVector(ctx, query, 10, nil); err != nil {
+					searchErrs <- err
+					return
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < numVectors; i++ {
+		vector := make([]float32, dims)
+		for j := range vector {
+			vector[j] = float32(i + j)
+		}
+		require.NoError(t, index.Add(ctx, uint64(i), vector))
+	}
+	close(done)
+	wg.Wait()
+	close(searchErrs)
+
+	for err := range searchErrs {
+		t.Errorf("concurrent search failed: %v", err)
+	}
+
+	ids, _, err := index.SearchByVector(ctx, query, 10, nil)
+	require.NoError(t, err)
+	assert.Len(t, ids, 10)
+}


### PR DESCRIPTION
### What's being changed:

Fixes https://github.com/weaviate/0-weaviate-issues/issues/450

With flat+RQ, the quantizer is created lazily by the first `Add` (`initOnce` → `initializeDimensionsAndRQ`), which publishes `dims` first, then performs BoltDB I/O, and only then assigns the quantizer. Any search landing in that window — easily tens of ms under I/O load, and arbitrarily delayed with async indexing — failed with gRPC UNKNOWN `vector search: quantizer not initialized` (or returned silently empty results before `dims` was published). With an RQ vector cache enabled, `QueryVectorDistancer` dereferenced the nil quantizer and panicked. The lock-free `quantizer` read in the search path also raced the init-path write.

This PR routes reads on the runtime compression state instead of the configured compression type, mirroring how HNSW already handles lazy RQ init:

- `SearchByVector`, `ContainsDoc`, `Iterate`, and `QueryVectorDistancer` now check `Compressed()` and fall back to the full-precision uncompressed bucket until the quantizer is initialized. The uncompressed bucket always holds every vector (it is the rescore source), so the fallback returns complete, correct results — just unquantized.
- The quantizer is now assigned before the `compressed` flag is flipped everywhere (lazy init already did; the constructor and the two msgpack restore paths did it backwards), so the atomic flag safely publishes the quantizer to lock-free readers and the data race is gone — no extra locking on the search path.
- BQ behavior is unchanged (its quantizer and flag are set in the constructor).

A side effect worth noting: if init fails partway (e.g. a transient disk error — `sync.Once` never retries), searches now degrade to permanently-correct uncompressed scans instead of permanently failing.

New tests cover the dims-published/quantizer-nil window deterministically for all four entry points, plus a concurrent Add+search stress test; they live outside the `!race`-tagged test file so they run under the race detector.

The same defect pattern exists in `hfresh` (https://github.com/weaviate/0-weaviate-issues/issues/294) and will be addressed in a separate PR.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
