### PR TITLE
feat(hnsw): respect per-query concurrency budget in compressed rescore

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -1162,12 +1163,18 @@ func (h *hnsw) rescore(ctx context.Context, res *priorityqueue.Queue[any], k int
 		}
 	}
 
+	// Respect the per-query concurrency budget if the context carries one
+	// (see entities/concurrency): under concurrent load the budget shrinks
+	// the fan-out, without one we fall back to the full rescore concurrency.
+	// The floor of 1 keeps a zero budget from silently skipping rescoring.
+	workers := max(1, min(concurrency.BudgetFromCtx(ctx, h.rescoreConcurrency), h.rescoreConcurrency, len(ids)))
+
 	eg := enterrors.NewErrorGroupWrapper(h.logger)
-	for workerID := 0; workerID < h.rescoreConcurrency; workerID++ {
+	for workerID := 0; workerID < workers; workerID++ {
 		workerID := workerID
 
 		eg.Go(func() error {
-			for idPos := workerID; idPos < len(ids); idPos += h.rescoreConcurrency {
+			for idPos := workerID; idPos < len(ids); idPos += workers {
 				if err := ctx.Err(); err != nil {
 					return fmt.Errorf("rescore: %w", err)
 				}


### PR DESCRIPTION
### What's being changed:

`rescore()` — the full-precision rescoring pass that runs after every KNN search on a quantized index (PQ/SQ/RQ/BQ) — currently always fans out to a fixed `rescoreConcurrency` (2×GOMAXPROCS) workers per query. This makes it read the per-query concurrency budget from the request context (`entities/concurrency`, the partially-merged concurrency-budget system) instead:

```go
workers := max(1, min(concurrency.BudgetFromCtx(ctx, h.rescoreConcurrency), h.rescoreConcurrency, len(ids)))
```

- **No budget in the context (all current traffic): behavior is unchanged** — `BudgetFromCtx` falls back to `rescoreConcurrency`, so serial-query performance is untouched.
- When the budget system starts setting per-query budgets under concurrent load, the rescore fan-out shrinks accordingly instead of every in-flight query spawning 2×GOMAXPROCS goroutines.
- The raw `BudgetFromCtx` + explicit clamp is used rather than `BudgetFromCtxCapped`, since the capped variant is documented as sroar-specific and honors the `DISABLE_SROAR_MERGE_BUDGET` kill switch, which shouldn't govern vector rescoring. Same precedent as the non-sroar fan-out in `inverted/prop_value_pairs.go`.
- Side effect: never spawns more workers than candidates (previously a query rescoring e.g. 20 candidates still spawned all 2×GOMAXPROCS workers).

Companion to #10536, which applies the same treatment to the Muvera late-interaction rescore.

### How this was tested

Verified with an instrumented `TempVectorForIDWithViewThunk` on a BQ index driving the full `SearchByVector` path: max concurrent vector fetches = `rescoreConcurrency` with no budget in ctx, exactly 1 with `budget=1`, clamped to `rescoreConcurrency` with an oversized budget, and bit-identical search results in all modes. Compression/rescore integration suite passes with `-race`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.