### PR TITLE
Dont write to immutable buckets

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -390,6 +390,7 @@ func (bucketCreator) NewBucket(ctx context.Context, dir, rootDir string, logger 
 			mmapContents:                 b.mmapContents,
 			keepTombstones:               b.keepTombstones,
 			forceCompaction:              b.forceCompaction,
+			immutable:                    b.immutable,
 			useBloomFilter:               b.useBloomFilter,
 			calcCountNetAdditions:        b.calcCountNetAdditions,
 			maxSegmentSize:               b.maxSegmentSize,

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -339,7 +339,8 @@ func (bucketCreator) NewBucket(ctx context.Context, dir, rootDir string, logger 
 		b.memtableThreshold = uint64(b.memtableResizer.Initial())
 	}
 
-	if b.disableCompaction {
+	// Compaction rewrites segment files, so it can never run on an immutable bucket.
+	if b.disableCompaction || b.immutable {
 		compactionCallbacks = cyclemanager.NewCallbackGroupNoop()
 	}
 
@@ -359,12 +360,18 @@ func (bucketCreator) NewBucket(ctx context.Context, dir, rootDir string, logger 
 		metrics.ObserveBucketInitDurationByStrategy(strategy, time.Since(beforeAll))
 	}(b.strategy)
 
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return nil, err
+	// An immutable bucket does not create its directory.
+	if !b.immutable {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return nil, err
+		}
 	}
 
 	files, _, err := diskio.GetFileWithSizes(dir)
-	if err != nil {
+	if b.immutable && os.IsNotExist(err) {
+		// nothing was ever written here, so the bucket is empty
+		files = map[string]int64{}
+	} else if err != nil {
 		return nil, err
 	}
 
@@ -1543,15 +1550,25 @@ func (b *Bucket) DeleteWith(key []byte, deletionTime time.Time, opts ...Secondar
 	return active.setTombstoneWith(key, deletionTime, opts...)
 }
 
-func (b *Bucket) createNewActiveMemtable() (memtable, error) {
+func (b *Bucket) createNewActiveMemtable() (*Memtable, error) {
 	path := filepath.Join(b.dir, fmt.Sprintf("segment-%d", time.Now().UnixNano()))
+
+	// An immutable bucket must not log the write-ahead-logs it reads back into memory.
+	if b.immutable {
+		return b.newMemtableAt(path, &noopMemtableCommitLogger{})
+	}
 
 	cl, err := newLazyCommitLogger(path, b.strategy)
 	if err != nil {
 		return nil, errors.Wrap(err, "init commit logger")
 	}
 
-	mt, err := newMemtable(cl, b.metrics, b.logger, b.allocChecker, memtableConfig{
+	return b.newMemtableAt(path, cl)
+}
+
+// newMemtableAt builds a memtable that flushes to path and logs to cl.
+func (b *Bucket) newMemtableAt(path string, cl memtableCommitLogger) (*Memtable, error) {
+	return newMemtable(cl, b.metrics, b.logger, b.allocChecker, memtableConfig{
 		path:                         path,
 		strategy:                     b.strategy,
 		secondaryIndices:             b.secondaryIndices,
@@ -1561,11 +1578,6 @@ func (b *Bucket) createNewActiveMemtable() (memtable, error) {
 		skipSecondaryKeyCheck:        b.skipSecondaryKeyCheck,
 		bm25config:                   b.bm25Config,
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	return mt, nil
 }
 
 func (b *Bucket) Count(ctx context.Context) (int, error) {
@@ -1733,6 +1745,13 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 
 	if err := b.flushCallbackCtrl.Unregister(ctx); err != nil {
 		return fmt.Errorf("long-running flush in progress: %w", ctx.Err())
+	}
+
+	// An immutable bucket has nothing to persist. Flushing would fsync the bucket
+	// directory, and turn a write-ahead-log above the reuse threshold into a new
+	// segment, in a directory the caller only reads.
+	if b.immutable {
+		return nil
 	}
 
 	b.flushLock.Lock()
@@ -1961,7 +1980,9 @@ func (b *Bucket) FlushAndSwitch() error {
 		WithField("path", bucketPath).
 		Trace("start flush and switch")
 
-	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	switched, err := b.atomicallySwitchMemtable(func() (memtable, error) {
+		return b.createNewActiveMemtable()
+	})
 	if err != nil {
 		b.logger.WithField("action", "lsm_memtable_flush_start").
 			WithField("path", bucketPath).

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -344,6 +344,12 @@ func (bucketCreator) NewBucket(ctx context.Context, dir, rootDir string, logger 
 		compactionCallbacks = cyclemanager.NewCallbackGroupNoop()
 	}
 
+	// Segment cleanup rewrites segment files and creates a bolt db in the bucket
+	// directory as soon as an interval is set, so it too must stay off.
+	if b.immutable {
+		b.segmentsCleanupInterval = 0
+	}
+
 	b.desiredStrategy = b.strategy
 
 	metrics.IncBucketInitCountByStrategy(b.strategy)

--- a/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
+++ b/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
@@ -252,6 +252,32 @@ func TestOpenImmutableBucketWithCrashResidue(t *testing.T) {
 	}
 }
 
+// The switch after a compaction marks the left of its two source segments for deletion first,
+// so a compacted segment still sitting next to a present left source never came from a switch.
+// That left source is live and must keep being read.
+func TestOpenImmutableBucketWithOrphanedCompactionOutput(t *testing.T) {
+	// no segment carries this id, a later compaction consumed that source
+	const consumedSourceID = "1800000000000000000"
+
+	dir, older, newer := seedTwoSegments(t)
+	// the newer segment is the left source of the leftover, the consumed one its right
+	writeFile(t, dir, compactedName(newer, consumedSourceID)+".tmp", compactedSegment(t))
+	before := dirSnapshot(t, dir)
+
+	b := openAndReadValues(t, dir, map[string]string{"k1": "v1", "k2": "v2"},
+		WithImmutable(true), WithUseBloomFilter(false))
+
+	var mounted []string
+	for _, segment := range b.disk.segments {
+		mounted = append(mounted, filepath.Base(segment.getPath()))
+	}
+	require.Equal(t, []string{older, newer}, mounted)
+	require.NoError(t, b.Shutdown(context.Background()))
+
+	require.Equal(t, before, dirSnapshot(t, dir),
+		"an immutable open must not add, change or remove a file")
+}
+
 // requireRecovered requires that a writable open has cleaned up every leftover: no temporary
 // file, no file marked for deletion and no scratch directory is left in dir.
 func requireRecovered(t *testing.T, dir string) {

--- a/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
+++ b/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -136,6 +137,237 @@ func TestOpenImmutableBucketWithReadOnlyWAL(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrPermission)
 }
 
+// TestOpenImmutableBucketWithCrashResidue covers the leftovers a crash mid-flush,
+// mid-compaction or mid-cleanup leaves in a bucket directory. Recovering from them is a
+// write, so an immutable open must read around them and leave them for the owner of the
+// shard — which then still recovers from them.
+func TestOpenImmutableBucketWithCrashResidue(t *testing.T) {
+	wantValues := map[string]string{"k1": "v1", "k2": "v2"}
+
+	tests := []struct {
+		name string
+		// seed adds the leftovers of an interrupted operation to a directory holding two
+		// flushed segments
+		seed func(t *testing.T, dir, older, newer string)
+		// wantSegments is how many segments an immutable open reads the values from; the
+		// rest of the data comes from the write-ahead-logs it merged into the memtable
+		wantSegments int
+	}{
+		{
+			name: "compacted segment next to both its sources",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, compactedName(older, newer)+".tmp", compactedSegment(t))
+			},
+			// the compaction may still have been writing the file, so both sources count
+			wantSegments: 2,
+		},
+		{
+			name: "compacted segment whose older source is marked for deletion",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, compactedName(older, newer)+".tmp", compactedSegment(t))
+				markSegmentDeleted(t, dir, older)
+			},
+			// the compacted segment replaces the source that is still there
+			wantSegments: 1,
+		},
+		{
+			name: "compacted segment whose sources are both marked for deletion",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, compactedName(older, newer)+".tmp", compactedSegment(t))
+				markSegmentDeleted(t, dir, older)
+				markSegmentDeleted(t, dir, newer)
+			},
+			wantSegments: 1,
+		},
+		{
+			name: "rewritten segment left over from a cleanup",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, newer+".tmp", readFile(t, dir, newer))
+			},
+			wantSegments: 2,
+		},
+		{
+			name: "precomputed bloom filter left over from a cleanup",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, bloomName(newer)+".tmp", []byte("partially written"))
+			},
+			wantSegments: 2,
+		},
+		{
+			name: "sidecar marked for deletion",
+			seed: func(t *testing.T, dir, older, newer string) {
+				markDeleted(t, dir, bloomName(newer))
+			},
+			wantSegments: 2,
+		},
+		{
+			name: "stale scratch directory",
+			seed: func(t *testing.T, dir, older, newer string) {
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "segment-x.scratch.d"), 0o700))
+			},
+			wantSegments: 2,
+		},
+		{
+			name: "segment shadowed by its write-ahead-log",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, walName(older), walBytes(t, []walEntry{{"k1", "v1"}}))
+			},
+			// the shadowed segment is left out, its log carries k1 instead
+			wantSegments: 1,
+		},
+		{
+			name: "leftovers of several interrupted operations",
+			seed: func(t *testing.T, dir, older, newer string) {
+				writeFile(t, dir, compactedName(older, newer)+".tmp", compactedSegment(t))
+				writeFile(t, dir, newer+".tmp", readFile(t, dir, newer))
+				writeFile(t, dir, bloomName(newer)+".tmp", []byte("partially written"))
+				markDeleted(t, dir, bloomName(newer))
+				require.NoError(t, os.Mkdir(filepath.Join(dir, "segment-x.scratch.d"), 0o700))
+				writeFile(t, dir, walName(older), walBytes(t, []walEntry{{"k1", "v1"}}))
+			},
+			wantSegments: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, older, newer := seedTwoSegments(t)
+			tt.seed(t, dir, older, newer)
+			before := dirSnapshot(t, dir)
+
+			// without bloom filters, as the usage module opens these buckets
+			b := openAndReadValues(t, dir, wantValues,
+				WithImmutable(true), WithUseBloomFilter(false))
+			// reading a key twice over is harmless, but counting it twice is not
+			require.Len(t, b.disk.segments, tt.wantSegments)
+			require.NoError(t, b.Shutdown(context.Background()))
+
+			require.Equal(t, before, dirSnapshot(t, dir),
+				"an immutable open must not add, change or remove a file")
+
+			// the leftovers are still there to be recovered from by the owner of the shard
+			readValues(t, dir, wantValues)
+			requireRecovered(t, dir)
+		})
+	}
+}
+
+// requireRecovered requires that a writable open has cleaned up every leftover: no temporary
+// file, no file marked for deletion and no scratch directory is left in dir.
+func requireRecovered(t *testing.T, dir string) {
+	t.Helper()
+
+	for name := range dirSnapshot(t, dir) {
+		require.NotEqual(t, ".tmp", filepath.Ext(name), "leftover after recovery")
+		require.NotEqual(t, DeleteMarkerSuffix, filepath.Ext(name), "leftover after recovery")
+		require.NotContains(t, name, ".scratch.d", "leftover after recovery")
+	}
+}
+
+// seedTwoSegments builds a bucket directory holding two flushed segments, the older one with
+// k1 and the newer one with k2, and returns it along with the two segment file names.
+func seedTwoSegments(t *testing.T) (dir, older, newer string) {
+	t.Helper()
+
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+
+	dir = filepath.Join(t.TempDir(), "bucket")
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+
+	for _, e := range []walEntry{{"k1", "v1"}, {"k2", "v2"}} {
+		require.NoError(t, b.Put([]byte(e.key), []byte(e.value)))
+		require.NoError(t, b.FlushMemtable())
+	}
+	require.NoError(t, b.Shutdown(ctx))
+
+	segments := segmentNames(t, dir)
+	require.Len(t, segments, 2)
+	return dir, segments[0], segments[1]
+}
+
+// compactedSegment returns the contents of the segment that compacting the two segments of a
+// seedTwoSegments directory produces.
+func compactedSegment(t *testing.T) []byte {
+	t.Helper()
+
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+
+	dir, _, _ := seedTwoSegments(t)
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+		WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+
+	compacted, err := b.disk.compactOnce(ctx)
+	require.NoError(t, err)
+	require.True(t, compacted)
+	require.NoError(t, b.Shutdown(ctx))
+
+	segments := segmentNames(t, dir)
+	require.Len(t, segments, 1)
+	return readFile(t, dir, segments[0])
+}
+
+// segmentNames returns the segment file names in dir, oldest first.
+func segmentNames(t *testing.T, dir string) []string {
+	t.Helper()
+
+	// ids are fixed-width unix-nano, so the names sort chronologically
+	names, err := filepath.Glob(filepath.Join(dir, "segment-*.db"))
+	require.NoError(t, err)
+
+	sort.Strings(names)
+	for i, name := range names {
+		names[i] = filepath.Base(name)
+	}
+	return names
+}
+
+// compactedName is the name of the segment file compacting older and newer produces.
+func compactedName(older, newer string) string {
+	return fmt.Sprintf("segment-%s_%s.db", segmentID(older), segmentID(newer))
+}
+
+func bloomName(segment string) string {
+	return fmt.Sprintf("segment-%s.bloom", segmentID(segment))
+}
+
+func walName(segment string) string {
+	return fmt.Sprintf("segment-%s.wal", segmentID(segment))
+}
+
+// markSegmentDeleted marks a segment file and its bloom filter for deletion, as the switch
+// after a compaction does.
+func markSegmentDeleted(t *testing.T, dir, segment string) {
+	t.Helper()
+
+	markDeleted(t, dir, segment)
+	markDeleted(t, dir, bloomName(segment))
+}
+
+func markDeleted(t *testing.T, dir, name string) {
+	t.Helper()
+
+	marker := fmt.Sprintf("%s.%013d%s", name, 0, DeleteMarkerSuffix)
+	require.NoError(t, os.Rename(filepath.Join(dir, name), filepath.Join(dir, marker)))
+}
+
+func writeFile(t *testing.T, dir, name string, contents []byte) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), contents, 0o600))
+}
+
+func readFile(t *testing.T, dir, name string) []byte {
+	t.Helper()
+
+	contents, err := os.ReadFile(filepath.Join(dir, name))
+	require.NoError(t, err)
+	return contents
+}
+
 // recordingCallbackGroup notes the ids registered on it and otherwise does nothing.
 type recordingCallbackGroup struct {
 	cyclemanager.CycleCallbackGroup
@@ -228,6 +460,15 @@ func TestOpenImmutableBucketWithCleanupIntervalOnReadOnlyDir(t *testing.T) {
 func readValues(t *testing.T, dir string, want map[string]string, opts ...BucketOption) {
 	t.Helper()
 
+	b := openAndReadValues(t, dir, want, opts...)
+	require.NoError(t, b.Shutdown(context.Background()))
+}
+
+// openAndReadValues opens a bucket on dir and requires every wanted key to read back. The
+// caller shuts the returned bucket down.
+func openAndReadValues(t *testing.T, dir string, want map[string]string, opts ...BucketOption) *Bucket {
+	t.Helper()
+
 	ctx := context.Background()
 	noopCB := cyclemanager.NewCallbackGroupNoop()
 
@@ -241,7 +482,7 @@ func readValues(t *testing.T, dir string, want map[string]string, opts ...Bucket
 		require.Equal(t, value, string(got), "key %q", key)
 	}
 
-	require.NoError(t, b.Shutdown(ctx))
+	return b
 }
 
 // seedBucketDir builds a bucket directory holding one write-ahead-log per entry in logs, in
@@ -304,8 +545,8 @@ func walBytes(t *testing.T, entries []walEntry) []byte {
 	return data
 }
 
-// dirSnapshot maps every file in dir to a hash of its contents. A directory that does not
-// exist maps to nil.
+// dirSnapshot maps every file in dir to a hash of its contents and every subdirectory to a
+// fixed marker. A directory that does not exist maps to nil.
 func dirSnapshot(t *testing.T, dir string) map[string]string {
 	t.Helper()
 
@@ -317,6 +558,10 @@ func dirSnapshot(t *testing.T, dir string) map[string]string {
 
 	snapshot := map[string]string{}
 	for _, entry := range entries {
+		if entry.IsDir() {
+			snapshot[entry.Name()] = "directory"
+			continue
+		}
 		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 		require.NoError(t, err)
 		snapshot[entry.Name()] = fmt.Sprintf("%x", sha256.Sum256(data))

--- a/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
+++ b/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
@@ -1,0 +1,294 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+type walEntry struct {
+	key   string
+	value string
+}
+
+// TestOpenImmutableBucketWithWAL covers what an immutable open does to a bucket directory
+// that still holds write-ahead-logs. The immutable arm must leave every byte in place and
+// still see the logged data; the writable arm shows the same directory being rewritten.
+func TestOpenImmutableBucketWithWAL(t *testing.T) {
+	bigValue := strings.Repeat("x", 5000)
+
+	type dirCounts struct {
+		wals     int
+		segments int
+	}
+
+	tests := []struct {
+		name string
+		// seed writes the bucket directory; an empty logs entry becomes a zero-length WAL
+		logs         [][]walEntry
+		truncateLast int
+		wantValues   map[string]string
+		// wantWritable is the directory a writable open leaves behind, for contrast
+		wantWritable dirCounts
+	}{
+		{
+			name:         "single log below the reuse threshold",
+			logs:         [][]walEntry{{{"k1", "v1"}}},
+			wantValues:   map[string]string{"k1": "v1"},
+			wantWritable: dirCounts{wals: 1, segments: 0},
+		},
+		{
+			name:         "empty log next to a populated one",
+			logs:         [][]walEntry{{}, {{"k1", "v1"}}},
+			wantValues:   map[string]string{"k1": "v1"},
+			wantWritable: dirCounts{wals: 1, segments: 0},
+		},
+		{
+			name:         "two logs, the newer one overwriting a key",
+			logs:         [][]walEntry{{{"k1", "v1"}, {"k2", "old"}}, {{"k2", "new"}}},
+			wantValues:   map[string]string{"k1": "v1", "k2": "new"},
+			wantWritable: dirCounts{wals: 1, segments: 1},
+		},
+		{
+			name:         "log above the reuse threshold",
+			logs:         [][]walEntry{{{"k1", bigValue}}},
+			wantValues:   map[string]string{"k1": bigValue},
+			wantWritable: dirCounts{wals: 0, segments: 1},
+		},
+		{
+			name:         "log that ends abruptly",
+			logs:         [][]walEntry{{{"k1", "v1"}, {"k2", "v2"}}},
+			truncateLast: 3,
+			wantValues:   map[string]string{"k1": "v1"},
+			wantWritable: dirCounts{wals: 0, segments: 1},
+		},
+		{
+			name:         "directory that does not exist",
+			wantValues:   map[string]string{},
+			wantWritable: dirCounts{wals: 0, segments: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/immutable", func(t *testing.T) {
+			dir := seedBucketDir(t, tt.logs, tt.truncateLast)
+			before := dirSnapshot(t, dir)
+
+			readValues(t, dir, tt.wantValues, WithImmutable(true))
+
+			require.Equal(t, before, dirSnapshot(t, dir),
+				"an immutable open must not add, change or remove a write-ahead-log")
+
+			// the logs are still there to be recovered by the owner of the shard
+			readValues(t, dir, tt.wantValues)
+		})
+
+		t.Run(tt.name+"/writable", func(t *testing.T) {
+			dir := seedBucketDir(t, tt.logs, tt.truncateLast)
+
+			readValues(t, dir, tt.wantValues)
+
+			require.Equal(t, tt.wantWritable.wals, countFilesWithExt(t, dir, ".wal"))
+			require.Equal(t, tt.wantWritable.segments, countFilesWithExt(t, dir, ".db"))
+		})
+	}
+}
+
+// A write-ahead-log the process may not write to is the sharpest statement of the contract:
+// an immutable open must still read it, a writable open must fail on it.
+func TestOpenImmutableBucketWithReadOnlyWAL(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the write permission this test relies on")
+	}
+
+	dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}}, 0)
+	logs, err := filepath.Glob(filepath.Join(dir, "*.wal"))
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	require.NoError(t, os.Chmod(logs[0], 0o444))
+
+	readValues(t, dir, map[string]string{"k1": "v1"}, WithImmutable(true))
+
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+	_, err = NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+		WithStrategy(StrategyReplace))
+	require.ErrorIs(t, err, os.ErrPermission)
+}
+
+// recordingCallbackGroup notes the ids registered on it and otherwise does nothing.
+type recordingCallbackGroup struct {
+	cyclemanager.CycleCallbackGroup
+	registered []string
+}
+
+func (g *recordingCallbackGroup) Register(id string, cycleCallback cyclemanager.CycleCallback,
+	options ...cyclemanager.RegisterOption,
+) cyclemanager.CycleCallbackCtrl {
+	g.registered = append(g.registered, id)
+	return g.CycleCallbackGroup.Register(id, cycleCallback, options...)
+}
+
+// Compaction rewrites segment files, so an immutable bucket must not register for it even
+// when the caller hands it a live compaction cycle.
+func TestImmutableBucketRegistersNoCompaction(t *testing.T) {
+	tests := []struct {
+		name           string
+		opts           []BucketOption
+		wantRegistered int
+	}{
+		{name: "writable", wantRegistered: 1},
+		{name: "immutable", opts: []BucketOption{WithImmutable(true)}, wantRegistered: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}}, 0)
+			compaction := &recordingCallbackGroup{CycleCallbackGroup: cyclemanager.NewCallbackGroupNoop()}
+
+			b, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil,
+				compaction, cyclemanager.NewCallbackGroupNoop(),
+				append([]BucketOption{WithStrategy(StrategyReplace)}, tt.opts...)...)
+			require.NoError(t, err)
+			require.NoError(t, b.Shutdown(ctx))
+
+			require.Len(t, compaction.registered, tt.wantRegistered)
+		})
+	}
+}
+
+// readValues opens a bucket on dir, requires every wanted key to read back, and shuts it
+// down again.
+func readValues(t *testing.T, dir string, want map[string]string, opts ...BucketOption) {
+	t.Helper()
+
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+		append([]BucketOption{WithStrategy(StrategyReplace)}, opts...)...)
+	require.NoError(t, err)
+
+	for key, value := range want {
+		got, err := b.Get([]byte(key))
+		require.NoError(t, err)
+		require.Equal(t, value, string(got), "key %q", key)
+	}
+
+	require.NoError(t, b.Shutdown(ctx))
+}
+
+// seedBucketDir builds a bucket directory holding one write-ahead-log per entry in logs, in
+// the order given. An empty entry becomes a zero-length log. The last log is shortened by
+// truncateLast bytes, which makes it end abruptly. No logs at all means the directory is
+// never created.
+func seedBucketDir(t *testing.T, logs [][]walEntry, truncateLast int) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "bucket")
+	if len(logs) == 0 {
+		return dir
+	}
+	require.NoError(t, os.MkdirAll(dir, 0o700))
+
+	for i, entries := range logs {
+		data := walBytes(t, entries)
+		if i == len(logs)-1 && truncateLast > 0 {
+			require.Greater(t, len(data), truncateLast)
+			data = data[:len(data)-truncateLast]
+		}
+		// fixed width so the names sort chronologically, as real ones do
+		name := fmt.Sprintf("segment-17000000000000000%02d.wal", i)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), data, 0o600))
+	}
+
+	return dir
+}
+
+// walBytes returns the contents of a write-ahead-log holding the given puts.
+func walBytes(t *testing.T, entries []walEntry) []byte {
+	t.Helper()
+
+	if len(entries) == 0 {
+		return nil
+	}
+
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+
+	dir := t.TempDir()
+	// a threshold no log can reach keeps the log on shutdown instead of flushing a segment
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+		WithStrategy(StrategyReplace), WithMinWalThreshold(1<<40))
+	require.NoError(t, err)
+
+	for _, e := range entries {
+		require.NoError(t, b.Put([]byte(e.key), []byte(e.value)))
+	}
+	require.NoError(t, b.Shutdown(ctx))
+
+	names, err := filepath.Glob(filepath.Join(dir, "*.wal"))
+	require.NoError(t, err)
+	require.Len(t, names, 1)
+
+	data, err := os.ReadFile(names[0])
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	return data
+}
+
+// dirSnapshot maps every file in dir to a hash of its contents. A directory that does not
+// exist maps to nil.
+func dirSnapshot(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+
+	snapshot := map[string]string{}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		require.NoError(t, err)
+		snapshot[entry.Name()] = fmt.Sprintf("%x", sha256.Sum256(data))
+	}
+	return snapshot
+}
+
+func countFilesWithExt(t *testing.T, dir, ext string) int {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	count := 0
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ext {
+			count++
+		}
+	}
+	return count
+}

--- a/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
+++ b/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
@@ -115,6 +115,119 @@ func TestOpenImmutableBucketWithWAL(t *testing.T) {
 	}
 }
 
+// The owner of the directory deletes a write-ahead-log once the flush that wrote its segment
+// is through, which can happen between the listing an immutable open takes and the moment it
+// reads the logs in that listing. The open then has to leave the log out and hand back the
+// rest of the bucket — failing reports the whole shard as empty to the usage module.
+func TestOpenImmutableBucketWithVanishedWAL(t *testing.T) {
+	tests := []struct {
+		name string
+		// vanished are the indexes of the seeded logs that go away after the listing
+		vanished   []int
+		wantValues map[string]string
+	}{
+		{
+			name:       "every log still there",
+			wantValues: map[string]string{"k1": "v1", "k2": "v2"},
+		},
+		{
+			name:       "the older log vanished",
+			vanished:   []int{0},
+			wantValues: map[string]string{"k2": "v2"},
+		},
+		{
+			name:       "the newer log vanished",
+			vanished:   []int{1},
+			wantValues: map[string]string{"k1": "v1"},
+		},
+		{
+			name:       "every log vanished",
+			vanished:   []int{0, 1},
+			wantValues: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}, {{"k2", "v2"}}}, 0)
+
+			logs := namesWithExt(t, dir, ".wal")
+			for _, i := range tt.vanished {
+				vanishFile(t, dir, logs[i])
+			}
+			before := dirSnapshot(t, dir)
+
+			b := openAndReadValues(t, dir, tt.wantValues, WithImmutable(true))
+			for _, key := range []string{"k1", "k2"} {
+				if _, wanted := tt.wantValues[key]; wanted {
+					continue
+				}
+				got, err := b.Get([]byte(key))
+				require.NoError(t, err)
+				require.Nil(t, got, "key %q", key)
+			}
+			require.NoError(t, b.Shutdown(context.Background()))
+
+			require.Equal(t, before, dirSnapshot(t, dir),
+				"an immutable open must not add, change or remove a file")
+		})
+	}
+}
+
+// A segment is left out while the log it was flushed from is there, because a crash can have
+// interrupted the flush. Once the owner deletes that log the flush is through, so the segment
+// holds the log's entries and has to be read in its place.
+func TestOpenImmutableBucketWithVanishedWALNextToItsSegment(t *testing.T) {
+	tests := []struct {
+		name         string
+		vanished     bool
+		wantSegments int
+	}{
+		{name: "log still there", wantSegments: 1},
+		{name: "log vanished", vanished: true, wantSegments: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, older, _ := seedTwoSegments(t)
+			// the flush of the older segment has not deleted its log yet
+			writeFile(t, dir, walName(older), walBytes(t, []walEntry{{"k1", "v1"}}))
+			if tt.vanished {
+				vanishFile(t, dir, walName(older))
+			}
+			before := dirSnapshot(t, dir)
+
+			b := openAndReadValues(t, dir, map[string]string{"k1": "v1", "k2": "v2"},
+				WithImmutable(true), WithUseBloomFilter(false))
+			// reading a key twice over is harmless, but counting it twice is not
+			require.Len(t, b.disk.segments, tt.wantSegments)
+			require.NoError(t, b.Shutdown(context.Background()))
+
+			require.Equal(t, before, dirSnapshot(t, dir),
+				"an immutable open must not add, change or remove a file")
+		})
+	}
+}
+
+// Only a log that is gone may be left out. One that is still there but cannot be opened
+// fails the open instead of quietly dropping its data from the bucket.
+func TestOpenImmutableBucketWithUnreadableWAL(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the read permission this test relies on")
+	}
+
+	dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}}, 0)
+	logs := namesWithExt(t, dir, ".wal")
+	require.Len(t, logs, 1)
+	require.NoError(t, os.Chmod(filepath.Join(dir, logs[0]), 0o000))
+
+	ctx := context.Background()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+	_, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+		WithStrategy(StrategyReplace), WithImmutable(true))
+	require.ErrorIs(t, err, os.ErrPermission)
+}
+
 // A write-ahead-log the process may not write to is the sharpest statement of the contract:
 // an immutable open must still read it, a writable open must fail on it.
 func TestOpenImmutableBucketWithReadOnlyWAL(t *testing.T) {
@@ -123,16 +236,15 @@ func TestOpenImmutableBucketWithReadOnlyWAL(t *testing.T) {
 	}
 
 	dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}}, 0)
-	logs, err := filepath.Glob(filepath.Join(dir, "*.wal"))
-	require.NoError(t, err)
+	logs := namesWithExt(t, dir, ".wal")
 	require.Len(t, logs, 1)
-	require.NoError(t, os.Chmod(logs[0], 0o444))
+	require.NoError(t, os.Chmod(filepath.Join(dir, logs[0]), 0o444))
 
 	readValues(t, dir, map[string]string{"k1": "v1"}, WithImmutable(true))
 
 	ctx := context.Background()
 	noopCB := cyclemanager.NewCallbackGroupNoop()
-	_, err = NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
+	_, err := NewBucketCreator().NewBucket(ctx, dir, "", testLogger(), nil, noopCB, noopCB,
 		WithStrategy(StrategyReplace))
 	require.ErrorIs(t, err, os.ErrPermission)
 }
@@ -309,7 +421,7 @@ func seedTwoSegments(t *testing.T) (dir, older, newer string) {
 	}
 	require.NoError(t, b.Shutdown(ctx))
 
-	segments := segmentNames(t, dir)
+	segments := namesWithExt(t, dir, ".db")
 	require.Len(t, segments, 2)
 	return dir, segments[0], segments[1]
 }
@@ -332,17 +444,17 @@ func compactedSegment(t *testing.T) []byte {
 	require.True(t, compacted)
 	require.NoError(t, b.Shutdown(ctx))
 
-	segments := segmentNames(t, dir)
+	segments := namesWithExt(t, dir, ".db")
 	require.Len(t, segments, 1)
 	return readFile(t, dir, segments[0])
 }
 
-// segmentNames returns the segment file names in dir, oldest first.
-func segmentNames(t *testing.T, dir string) []string {
+// namesWithExt returns the names of the files in dir carrying the given extension, sorted.
+// Segment ids are fixed-width unix-nano, so segment names come out oldest first.
+func namesWithExt(t *testing.T, dir, ext string) []string {
 	t.Helper()
 
-	// ids are fixed-width unix-nano, so the names sort chronologically
-	names, err := filepath.Glob(filepath.Join(dir, "segment-*.db"))
+	names, err := filepath.Glob(filepath.Join(dir, "*"+ext))
 	require.NoError(t, err)
 
 	sort.Strings(names)
@@ -379,6 +491,16 @@ func markDeleted(t *testing.T, dir, name string) {
 
 	marker := fmt.Sprintf("%s.%013d%s", name, 0, DeleteMarkerSuffix)
 	require.NoError(t, os.Rename(filepath.Join(dir, name), filepath.Join(dir, marker)))
+}
+
+// vanishFile replaces a file with a symlink to a name that does not exist, so a listing still
+// reports it while opening it fails the way it does for a file the owner removed in between.
+func vanishFile(t *testing.T, dir, name string) {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.Remove(path))
+	require.NoError(t, os.Symlink(path+".gone", path))
 }
 
 func writeFile(t *testing.T, dir, name string, contents []byte) {
@@ -589,6 +711,10 @@ func dirSnapshot(t *testing.T, dir string) map[string]string {
 			continue
 		}
 		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if os.IsNotExist(err) {
+			snapshot[entry.Name()] = "vanished"
+			continue
+		}
 		require.NoError(t, err)
 		snapshot[entry.Name()] = fmt.Sprintf("%x", sha256.Sum256(data))
 	}
@@ -597,15 +723,5 @@ func dirSnapshot(t *testing.T, dir string) map[string]string {
 
 func countFilesWithExt(t *testing.T, dir, ext string) int {
 	t.Helper()
-
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-
-	count := 0
-	for _, entry := range entries {
-		if filepath.Ext(entry.Name()) == ext {
-			count++
-		}
-	}
-	return count
+	return len(namesWithExt(t, dir, ext))
 }

--- a/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
+++ b/adapters/repos/db/lsmkv/bucket_immutable_open_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -175,6 +176,51 @@ func TestImmutableBucketRegistersNoCompaction(t *testing.T) {
 			require.Len(t, compaction.registered, tt.wantRegistered)
 		})
 	}
+}
+
+// Segment cleanup rewrites segment files and persists its progress in a bolt db next to
+// them, so an immutable bucket must not start it even when the caller configures an
+// interval.
+func TestImmutableBucketRunsNoSegmentCleanup(t *testing.T) {
+	tests := []struct {
+		name          string
+		opts          []BucketOption
+		wantCleanupDb bool
+	}{
+		{name: "writable", wantCleanupDb: true},
+		{name: "immutable", opts: []BucketOption{WithImmutable(true)}, wantCleanupDb: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}}, 0)
+
+			opts := append(tt.opts, WithSegmentsCleanupInterval(time.Second))
+			readValues(t, dir, map[string]string{"k1": "v1"}, opts...)
+
+			_, err := os.Stat(filepath.Join(dir, cleanupDbFileName))
+			if tt.wantCleanupDb {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
+}
+
+// A configured cleanup interval must not make an immutable open reach for write access on
+// the bucket directory.
+func TestOpenImmutableBucketWithCleanupIntervalOnReadOnlyDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores the write permission this test relies on")
+	}
+
+	dir := seedBucketDir(t, [][]walEntry{{{"k1", "v1"}}}, 0)
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { os.Chmod(dir, 0o700) })
+
+	readValues(t, dir, map[string]string{"k1": "v1"},
+		WithImmutable(true), WithSegmentsCleanupInterval(time.Second))
 }
 
 // readValues opens a bucket on dir, requires every wanted key to read back, and shuts it

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -341,7 +341,13 @@ func WithSkipSecondaryKeyCheck(skip bool) BucketOption {
 
 // WithImmutable marks the bucket as immutable. All write operations (Put,
 // Delete, SetAdd, MapSet, FlushAndSwitch, etc.) will return ErrImmutable.
-// Used by NewSnapshotBucket to prevent accidental writes to snapshot data.
+//
+// Opening and closing the bucket is read-only too: the directory is not
+// created, write-ahead-logs are opened read-only and merged into the active
+// memtable instead of being flushed to segments, and shutdown neither fsyncs
+// nor deletes anything. Segment files are still repaired on load when a crash
+// left the directory inconsistent, and missing .bloom / .cna sidecars are
+// still recomputed and written.
 //
 // This is distinct from the shard-level read-only status
 // (storagestate.StatusReadOnly) which temporarily halts flushes during

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -346,9 +346,10 @@ func WithSkipSecondaryKeyCheck(skip bool) BucketOption {
 // created, write-ahead-logs are opened read-only and merged into the active
 // memtable instead of being flushed to segments, and shutdown neither fsyncs
 // nor deletes anything. Compaction and segment cleanup never run, so
-// WithSegmentsCleanupInterval is ignored. Segment files are still repaired on
-// load when a crash left the directory inconsistent, and missing .bloom /
-// .cna / .metadata sidecars are still recomputed and written.
+// WithSegmentsCleanupInterval is ignored. What a crash left behind is read
+// around rather than repaired: temporary files, files marked for deletion and
+// a segment shadowed by its write-ahead-log all stay where they are. A missing
+// .bloom / .cna / .metadata sidecar is still recomputed and written.
 //
 // This is distinct from the shard-level read-only status
 // (storagestate.StatusReadOnly) which temporarily halts flushes during

--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -345,9 +345,10 @@ func WithSkipSecondaryKeyCheck(skip bool) BucketOption {
 // Opening and closing the bucket is read-only too: the directory is not
 // created, write-ahead-logs are opened read-only and merged into the active
 // memtable instead of being flushed to segments, and shutdown neither fsyncs
-// nor deletes anything. Segment files are still repaired on load when a crash
-// left the directory inconsistent, and missing .bloom / .cna sidecars are
-// still recomputed and written.
+// nor deletes anything. Compaction and segment cleanup never run, so
+// WithSegmentsCleanupInterval is ignored. Segment files are still repaired on
+// load when a crash left the directory inconsistent, and missing .bloom /
+// .cna / .metadata sidecars are still recomputed and written.
 //
 // This is distinct from the shard-level read-only status
 // (storagestate.StatusReadOnly) which temporarily halts flushes during

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -207,9 +207,16 @@ func (b *Bucket) replayCommitLogsIntoMemtable(sg *SegmentGroup, walFileNames []s
 	return nil
 }
 
-// readCommitLogFile opens a write-ahead-log read-only and reads it into mt.
+// readCommitLogFile opens a write-ahead-log read-only and reads it into mt. A log the owner
+// of the directory removed since the bucket listed its files is left out.
 func (b *Bucket) readCommitLogFile(path string, mt *Memtable) error {
 	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		b.logger.WithField("action", "lsm_recover_from_active_wal").
+			WithField("path", path).
+			Warn("write-ahead-log was removed while the bucket was being opened, leaving it out")
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "open write-ahead-log")
 	}

--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -47,11 +47,11 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 			continue
 		}
 
-		path := filepath.Join(b.dir, file)
-
 		if size == 0 {
-			err := os.Remove(path)
-			if err != nil {
+			if b.immutable {
+				continue
+			}
+			if err := os.Remove(filepath.Join(b.dir, file)); err != nil {
 				return errors.Wrap(err, "remove empty wal file")
 			}
 			continue
@@ -66,8 +66,8 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 	}
 
 	// Names are segment-<unix-nano>.wal (fixed-width, so lexicographic == chronological).
-	// Recovery relies on order: only the last WAL is kept as the active memtable, the
-	// rest are flushed to segments. The source is a map, whose iteration order is random.
+	// Recovery relies on chronological order, and the source is a map, whose iteration
+	// order is random.
 	sort.Strings(walFileNames)
 
 	logOnceWhenRecoveringFromWAL.Do(func() {
@@ -92,6 +92,10 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 		b.metrics.ObserveWalRecoveryDuration(b.strategy, time.Since(start))
 	}()
 
+	if b.immutable {
+		return b.replayCommitLogsIntoMemtable(sg, walFileNames)
+	}
+
 	recovered := false
 
 	// recover from each log
@@ -112,16 +116,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 			cl.pause()
 			defer cl.unpause()
 
-			mt, err := newMemtable(cl, b.metrics, b.logger, b.allocChecker, memtableConfig{
-				path:                         path,
-				strategy:                     b.strategy,
-				secondaryIndices:             b.secondaryIndices,
-				enableChecksumValidation:     b.enableChecksumValidation,
-				writeSegmentInfoIntoFileName: b.writeSegmentInfoIntoFileName,
-				shouldSkipKeyFunc:            b.shouldSkipKey,
-				skipSecondaryKeyCheck:        b.skipSecondaryKeyCheck,
-				bm25config:                   b.bm25Config,
-			})
+			mt, err := b.newMemtableAt(path, cl)
 			if err != nil {
 				return err
 			}
@@ -131,13 +126,7 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 				return err
 			}
 
-			meteredReader := diskio.NewMeteredReader(cl.file, b.metrics.TrackStartupReadWALDiskIO)
-			errRecovery := newCommitLoggerParser(b.strategy, bufio.NewReaderSize(meteredReader, 32*1024), mt).Do()
-			if errRecovery != nil {
-				b.logger.WithField("action", "lsm_recover_from_active_wal_corruption").
-					WithField("path", filepath.Join(b.dir, fname)).
-					Error(errors.Wrap(errRecovery, "write-ahead-log ended abruptly, some elements may not have been recovered"))
-			}
+			errRecovery := b.parseCommitLog(cl.file, mt, filepath.Join(b.dir, fname))
 
 			if mt.strategy == StrategyInverted {
 				mt.averagePropLength, mt.propLengthCount = sg.GetAveragePropertyLength()
@@ -192,4 +181,56 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 	}
 
 	return nil
+}
+
+// replayCommitLogsIntoMemtable reads the write-ahead-logs of an immutable bucket, oldest
+// first, into a single active memtable. Merging them in memory keeps the same read
+// precedence as flushing the older ones to segments would, without creating, changing or
+// removing a single file in the bucket directory.
+func (b *Bucket) replayCommitLogsIntoMemtable(sg *SegmentGroup, walFileNames []string) error {
+	mt, err := b.createNewActiveMemtable()
+	if err != nil {
+		return err
+	}
+
+	for _, fname := range walFileNames {
+		if err := b.readCommitLogFile(filepath.Join(b.dir, fname), mt); err != nil {
+			return err
+		}
+	}
+
+	if mt.strategy == StrategyInverted {
+		mt.averagePropLength, mt.propLengthCount = sg.GetAveragePropertyLength()
+	}
+
+	b.active = mt
+	return nil
+}
+
+// readCommitLogFile opens a write-ahead-log read-only and reads it into mt.
+func (b *Bucket) readCommitLogFile(path string, mt *Memtable) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.Wrap(err, "open write-ahead-log")
+	}
+	defer f.Close()
+
+	// an abrupt end is already logged, and what was read before it stays readable
+	_ = b.parseCommitLog(f, mt, path)
+	return nil
+}
+
+// parseCommitLog reads a write-ahead-log into mt and returns the error of a log that ended
+// abruptly. The entries read before that point stay in the memtable.
+func (b *Bucket) parseCommitLog(r diskio.Reader, mt *Memtable, logPath string) error {
+	meteredReader := diskio.NewMeteredReader(r, b.metrics.TrackStartupReadWALDiskIO)
+
+	err := newCommitLoggerParser(b.strategy, bufio.NewReaderSize(meteredReader, 32*1024), mt).Do()
+	if err != nil {
+		b.logger.WithField("action", "lsm_recover_from_active_wal_corruption").
+			WithField("path", logPath).
+			Errorf("write-ahead-log ended abruptly, some elements may not have been recovered: %v", err)
+	}
+
+	return err
 }

--- a/adapters/repos/db/lsmkv/bucket_snapshot.go
+++ b/adapters/repos/db/lsmkv/bucket_snapshot.go
@@ -278,8 +278,9 @@ func SnapshotBucketFromDisk(srcDir, snapshotsRoot, snapshotName string) (string,
 }
 
 // NewSnapshotBucket opens a read-only bucket backed by hard-linked segment
-// files (created by CreateSnapshot). It has no compaction and no flush cycle.
-// An empty memtable and WAL are created in snapshotDir but never written to.
+// files (created by CreateSnapshot). It has no compaction, no segment cleanup
+// and no flush cycle. An empty memtable is created with a no-op commit logger,
+// so the open writes nothing into snapshotDir — not even a write-ahead-log.
 //
 // The directory base name must start with SnapshotDirPrefix. The bucket is
 // opened in immutable mode — all write operations will return ErrImmutable.

--- a/adapters/repos/db/lsmkv/bucket_snapshot_test.go
+++ b/adapters/repos/db/lsmkv/bucket_snapshot_test.go
@@ -500,6 +500,58 @@ func TestSnapshotFromDisk_WALIsolation(t *testing.T) {
 	}
 }
 
+// Opening and shutting down a snapshot bucket must leave the snapshot directory
+// byte-for-byte alone — no write-ahead-log, no cleanup db, nothing.
+func TestSnapshotOpenWritesNothing(t *testing.T) {
+	tests := []struct {
+		name string
+		// flush moves the data into a segment; without it the source shuts down WAL-only
+		flush bool
+		opts  []BucketOption
+	}{
+		{name: "segment", flush: true},
+		{name: "wal only"},
+		{
+			name:  "segment, caller asks for cleanup",
+			flush: true,
+			opts:  []BucketOption{WithSegmentsCleanupInterval(time.Second)},
+		},
+		{
+			name: "wal only, caller asks for cleanup",
+			opts: []BucketOption{WithSegmentsCleanupInterval(time.Second)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			noopCB := cyclemanager.NewCallbackGroupNoop()
+			bucketDir := t.TempDir()
+
+			bucket, err := NewBucketCreator().NewBucket(ctx, bucketDir, bucketDir,
+				testLogger(), nil, noopCB, noopCB, WithStrategy(StrategyReplace))
+			require.NoError(t, err)
+			require.NoError(t, bucket.Put([]byte("key"), []byte("value")))
+			if tt.flush {
+				require.NoError(t, bucket.FlushAndSwitch())
+			}
+			require.NoError(t, bucket.Shutdown(ctx))
+
+			snapshotDir, err := SnapshotBucketFromDisk(bucketDir, t.TempDir(), "no-writes")
+			require.NoError(t, err)
+			before := dirSnapshot(t, snapshotDir)
+
+			opts := append(tt.opts, WithStrategy(StrategyReplace))
+			snapBucket, err := NewSnapshotBucket(ctx, snapshotDir, testLogger(), opts...)
+			require.NoError(t, err)
+			require.Equal(t, 1, cursorCount(t, snapBucket))
+			require.NoError(t, snapBucket.Shutdown(ctx))
+
+			require.Equal(t, before, dirSnapshot(t, snapshotDir))
+		})
+	}
+}
+
 func cursorCount(t *testing.T, b *Bucket) int {
 	t.Helper()
 	c := b.Cursor()

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -794,7 +794,9 @@ func TestCountApproximate(t *testing.T) {
 		b := newBucket(t)
 		putKeys(t, b, 5)
 
-		switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+		switched, err := b.atomicallySwitchMemtable(func() (memtable, error) {
+			return b.createNewActiveMemtable()
+		})
 		require.NoError(t, err)
 		require.True(t, switched)
 
@@ -3125,7 +3127,9 @@ func TestApplyToObjectDigestsWithFlushingMemtable(t *testing.T) {
 	require.NoError(t, b.Put(keyA, objValue(t, keyA, 3, updateTime+1)))
 	require.NoError(t, b.Put(keyC, objValue(t, keyC, 4, updateTime)))
 
-	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	switched, err := b.atomicallySwitchMemtable(func() (memtable, error) {
+		return b.createNewActiveMemtable()
+	})
 	require.NoError(t, err)
 	require.True(t, switched)
 	require.NotNil(t, b.flushing, "the scan must run against a live flushing memtable")

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -47,6 +47,7 @@ type memtableCommitLogger interface {
 var (
 	_ memtableCommitLogger = (*lazyCommitLogger)(nil)
 	_ memtableCommitLogger = (*commitLogger)(nil)
+	_ memtableCommitLogger = (*noopMemtableCommitLogger)(nil)
 )
 
 type lazyCommitLogger struct {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -214,12 +214,12 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 
 		if sg.immutable {
 			// Renaming the compacted segment over its sources is a write, so a read-only
-			// open reads it where it is instead — but only once the switch has taken a
-			// source away, as until then the compaction may still have been writing it.
-			if remaining, started := compactionSwitchStarted(jointSegmentsIDs, files); started {
+			// open reads it where it is instead — but only once the switch has taken the
+			// left source away, as until then the compaction may still have been writing it.
+			if rightSource, started := compactionSwitchStarted(jointSegmentsIDs, files); started {
 				compactedSegments[entry] = struct{}{}
-				for _, name := range remaining {
-					delete(files, name)
+				if rightSource != "" {
+					delete(files, rightSource)
 				}
 
 				logger.WithField("action", "lsm_segment_init").
@@ -622,21 +622,21 @@ func compactionSourceIDs(entry string) []string {
 	return strings.Split(segmentID(segmentFileName), "_")
 }
 
-// compactionSwitchStarted reports whether the switch replacing the segments with the given
-// ids by their compacted segment had already begun, and returns the ones still on disk. The
-// compacted segment is fsynced and closed before the first source is marked for deletion, so
-// a missing source means it is complete and holds the only copy of their data.
-func compactionSwitchStarted(sourceIDs []string, files map[string]int64) (remaining []string, started bool) {
+// compactionSwitchStarted reports whether the switch replacing the segments with the given ids
+// by their compacted segment had already begun, and names the right source if it is still on
+// disk. The switch marks the left source first, and the compacted segment is fsynced and closed
+// before that mark, so once the left source is gone it is complete and supersedes both sources.
+func compactionSwitchStarted(sourceIDs []string, files map[string]int64) (rightSource string, started bool) {
 	if len(sourceIDs) != 2 {
-		return nil, false
+		return "", false
 	}
 
-	for _, id := range sourceIDs {
-		if found, name := segmentExistsWithID(id, files); found {
-			remaining = append(remaining, name)
-		}
+	if leftFound, _ := segmentExistsWithID(sourceIDs[0], files); leftFound {
+		return "", false
 	}
-	return remaining, len(remaining) < len(sourceIDs)
+
+	_, rightSource = segmentExistsWithID(sourceIDs[1], files)
+	return rightSource, true
 }
 
 func (sg *SegmentGroup) pauseCompaction(ctx context.Context) error {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -89,6 +89,7 @@ type SegmentGroup struct {
 	useBloomFilter           bool // see bucket for more details
 	calcCountNetAdditions    bool // see bucket for more details
 	compactLeftOverSegments  bool // see bucket for more details
+	immutable                bool // see bucket for more details
 	enableChecksumValidation bool
 	MinMMapSize              int64
 	keepLevelCompaction      bool // see bucket for more details
@@ -137,6 +138,7 @@ type sgConfig struct {
 	useBloomFilter               bool
 	calcCountNetAdditions        bool
 	forceCompaction              bool
+	immutable                    bool
 	keepLevelCompaction          bool
 	maxSegmentSize               int64
 	cleanupInterval              time.Duration
@@ -171,6 +173,7 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		useBloomFilter:               cfg.useBloomFilter,
 		calcCountNetAdditions:        cfg.calcCountNetAdditions,
 		compactLeftOverSegments:      cfg.forceCompaction,
+		immutable:                    cfg.immutable,
 		maxSegmentSize:               cfg.maxSegmentSize,
 		cleanupInterval:              cfg.cleanupInterval,
 		enableChecksumValidation:     cfg.enableChecksumValidation,
@@ -189,23 +192,15 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		deleteMarkerCounter:          deleteMarkerCounter,
 	}
 
-	// Clean up stale scratch directories left behind by a prior version that
-	// used scratch files during compaction/flushing. These are no longer
-	// created, but may linger after an upgrade if the process crashed mid-
-	// compaction before the old code could remove them.
-	if entries, err := os.ReadDir(cfg.dir); err == nil {
-		for _, e := range entries {
-			if e.IsDir() && strings.HasSuffix(e.Name(), ".scratch.d") {
-				p := filepath.Join(cfg.dir, e.Name())
-				if err := os.RemoveAll(p); err != nil {
-					logger.WithError(err).WithField("path", p).
-						Warn("failed to remove stale scratch directory")
-				}
-			}
-		}
+	if !sg.immutable {
+		removeStaleScratchDirs(cfg.dir, logger)
 	}
 
 	segmentIndex := 0
+
+	// compacted segments a read-only open mounts under their .tmp name, in place of the
+	// source segments an interrupted switch already took away
+	compactedSegments := map[string]struct{}{}
 
 	// Note: it's important to process first the compacted segments
 	// TODO: a single iteration may be possible
@@ -215,9 +210,27 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 			continue
 		}
 
-		potentialCompactedSegmentFileName := strings.TrimSuffix(entry, ".tmp")
+		jointSegmentsIDs := compactionSourceIDs(entry)
 
-		if filepath.Ext(potentialCompactedSegmentFileName) != ".db" {
+		if sg.immutable {
+			// Renaming the compacted segment over its sources is a write, so a read-only
+			// open reads it where it is instead — but only once the switch has taken a
+			// source away, as until then the compaction may still have been writing it.
+			if remaining, started := compactionSwitchStarted(jointSegmentsIDs, files); started {
+				compactedSegments[entry] = struct{}{}
+				for _, name := range remaining {
+					delete(files, name)
+				}
+
+				logger.WithField("action", "lsm_segment_init").
+					WithField("path", filepath.Join(sg.dir, entry)).
+					Info("read a compacted LSM segment in place of its source segments, " +
+						"because a read-only open cannot complete the compaction")
+			}
+			continue
+		}
+
+		if jointSegmentsIDs == nil {
 			// A non-.db segment .tmp (e.g. a precomputed segment-X.bloom.tmp) is a
 			// leftover from a crash during a compaction/cleanup switch — no such
 			// work runs during init — so remove it. The derived files are
@@ -229,9 +242,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 			}
 			continue
 		}
-
-		jointSegments := segmentID(potentialCompactedSegmentFileName)
-		jointSegmentsIDs := strings.Split(jointSegments, "_")
 
 		if len(jointSegmentsIDs) == 1 {
 			// cleanup leftover, to be removed
@@ -365,20 +375,26 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 
 	for _, entry := range fileList {
 		if filepath.Ext(entry) == DeleteMarkerSuffix {
+			if sg.immutable {
+				// a read-only open leaves the file for the owner of the bucket to delete
+				continue
+			}
+
 			// marked for deletion, but never actually deleted. Delete now.
 			if err := os.Remove(filepath.Join(sg.dir, entry)); err != nil {
 				// don't abort if the delete fails, we can still continue (albeit
 				// without freeing disk space that should have been freed)
-				sg.logger.WithError(err).WithFields(logrus.Fields{
+				sg.logger.WithFields(logrus.Fields{
 					"action": "lsm_segment_init_deleted_previously_marked_files",
 					"file":   entry,
-				}).Error("failed to delete file already marked for deletion")
+				}).Errorf("failed to delete file already marked for deletion: %v", err)
 			}
 			continue
 
 		}
 
-		if filepath.Ext(entry) != ".db" {
+		_, compacted := compactedSegments[entry]
+		if filepath.Ext(entry) != ".db" && !compacted {
 			// skip, this could be commit log, etc.
 			continue
 		}
@@ -390,6 +406,12 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		walFileName += ".wal"
 		_, ok := files[walFileName]
 		if ok {
+			if sg.immutable {
+				// the write-ahead-log is read instead, so the partially written segment
+				// stays on disk untouched
+				continue
+			}
+
 			// the segment will be recovered from the WAL
 			err := os.Remove(filepath.Join(sg.dir, entry))
 			if err != nil {
@@ -567,6 +589,54 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 	sg.compactionCallbackCtrl = compactionCallbacks.Register(id, sg.compactOrCleanup)
 
 	return sg, nil
+}
+
+// removeStaleScratchDirs cleans up scratch directories left behind by a prior version that
+// used scratch files during compaction/flushing. These are no longer created, but may
+// linger after an upgrade if the process crashed mid-compaction before the old code could
+// remove them.
+func removeStaleScratchDirs(dir string, logger logrus.FieldLogger) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasSuffix(e.Name(), ".scratch.d") {
+			continue
+		}
+		p := filepath.Join(dir, e.Name())
+		if err := os.RemoveAll(p); err != nil {
+			logger.WithField("path", p).Warnf("failed to remove stale scratch directory: %v", err)
+		}
+	}
+}
+
+// compactionSourceIDs returns the ids of the segments whose compaction produced the segment
+// file entry, or nil if entry does not name a segment.
+func compactionSourceIDs(entry string) []string {
+	segmentFileName := strings.TrimSuffix(entry, ".tmp")
+	if filepath.Ext(segmentFileName) != ".db" {
+		return nil
+	}
+	return strings.Split(segmentID(segmentFileName), "_")
+}
+
+// compactionSwitchStarted reports whether the switch replacing the segments with the given
+// ids by their compacted segment had already begun, and returns the ones still on disk. The
+// compacted segment is fsynced and closed before the first source is marked for deletion, so
+// a missing source means it is complete and holds the only copy of their data.
+func compactionSwitchStarted(sourceIDs []string, files map[string]int64) (remaining []string, started bool) {
+	if len(sourceIDs) != 2 {
+		return nil, false
+	}
+
+	for _, id := range sourceIDs {
+		if found, name := segmentExistsWithID(id, files); found {
+			remaining = append(remaining, name)
+		}
+	}
+	return remaining, len(remaining) < len(sourceIDs)
 }
 
 func (sg *SegmentGroup) pauseCompaction(ctx context.Context) error {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -405,6 +405,15 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		walFileName, _, _ := strings.Cut(entry, ".")
 		walFileName += ".wal"
 		_, ok := files[walFileName]
+		if ok && sg.immutable {
+			// The listing can name a log the owner has since deleted, which it only does
+			// once the flush that wrote this segment is through. Ask the disk rather than
+			// the listing, so a segment is not left out for a log that is no longer there.
+			if _, err := os.Stat(filepath.Join(sg.dir, walFileName)); os.IsNotExist(err) {
+				delete(files, walFileName)
+				ok = false
+			}
+		}
 		if ok {
 			if sg.immutable {
 				// the write-ahead-log is read instead, so the partially written segment

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -109,7 +109,9 @@ var unloadedDimensionsBucketLocks = entsync.NewKeyLockerContext()
 
 // openUnloadedDimensionsBucket opens the dimensions bucket of an unloaded shard without
 // loading the shard into memory. The bucket is opened with a sequential-access hint, as the
-// dimension calculations scan it with cursors.
+// dimension calculations scan it with cursors, and immutable, so reporting usage does not
+// fsync an unloaded tenant's directory or turn its write-ahead-log into a segment. Repairing
+// a directory a crash left inconsistent, and recomputing missing sidecars, still write.
 // Callers must hold the unloadedDimensionsBucketLocks lock for bucketPath until the returned
 // bucket is shut down.
 func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger, path, bucketPath string) (*lsmkv.Bucket, error) {
@@ -127,6 +129,7 @@ func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger
 		cyclemanager.NewCallbackGroupNoop(),
 		lsmkv.WithStrategy(strategy),
 		lsmkv.WithSequentialAccess(true),
+		lsmkv.WithImmutable(true),
 	)
 }
 

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -110,8 +110,8 @@ var unloadedDimensionsBucketLocks = entsync.NewKeyLockerContext()
 // openUnloadedDimensionsBucket opens the dimensions bucket of an unloaded shard without
 // loading the shard into memory. The bucket is opened with a sequential-access hint, as the
 // dimension calculations scan it with cursors, and immutable, so reporting usage does not
-// fsync an unloaded tenant's directory or turn its write-ahead-log into a segment. Repairing
-// a directory a crash left inconsistent, and recomputing missing sidecars, still write.
+// fsync an unloaded tenant's directory or turn its write-ahead-log into a segment. Bloom
+// filters are off because cursors never consult them.
 // Callers must hold the unloadedDimensionsBucketLocks lock for bucketPath until the returned
 // bucket is shut down.
 func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger, path, bucketPath string) (*lsmkv.Bucket, error) {
@@ -130,6 +130,7 @@ func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger
 		lsmkv.WithStrategy(strategy),
 		lsmkv.WithSequentialAccess(true),
 		lsmkv.WithImmutable(true),
+		lsmkv.WithUseBloomFilter(false),
 	)
 }
 

--- a/adapters/repos/db/shard_usage/usage_immutable_bucket_test.go
+++ b/adapters/repos/db/shard_usage/usage_immutable_bucket_test.go
@@ -1,0 +1,156 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shardusage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// Reporting usage opens the dimensions bucket of an unloaded tenant. That must stay a read:
+// the tenant is not ours to write to, and a write-ahead-log left there by the last shutdown
+// would otherwise be fsynced, flushed into a new segment or deleted on every collection.
+func TestCalculateUnloadedDimensionsUsageDoesNotWrite(t *testing.T) {
+	const (
+		tenantName   = "tenant"
+		targetVector = "text"
+		dims         = 128
+	)
+
+	tests := []struct {
+		name string
+		// docIDs is how many documents get their dimensions recorded; 0 leaves the bucket
+		// directory uncreated
+		docIDs int
+		// flush moves the dimensions out of the write-ahead-log into a segment
+		flush bool
+		// minWALSize is the smallest write-ahead-log the seeded bucket may leave
+		// behind; 0 expects none
+		minWALSize int64
+	}{
+		{name: "dimensions flushed to a segment", docIDs: 3, flush: true},
+		{name: "dimensions in a small write-ahead-log", docIDs: 3, minWALSize: 1},
+		{
+			// above this size the log is flushed into a new segment instead of reused
+			name:       "dimensions in a write-ahead-log over 4KB",
+			docIDs:     2000,
+			minWALSize: 4097,
+		},
+		{name: "no dimensions bucket at all"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			ctx := context.Background()
+			indexPath := t.TempDir()
+			bucketPath := shardPathDimensionsLSM(indexPath, tenantName)
+
+			want := types.Dimensionality{}
+			if tt.docIDs > 0 {
+				seedDimensionsBucket(t, bucketPath, targetVector, dims, tt.docIDs, tt.flush)
+				want = types.Dimensionality{Dimensions: dims, Count: tt.docIDs}
+			}
+
+			walSize := totalWALSize(t, bucketPath)
+			if tt.minWALSize == 0 {
+				require.Zero(t, walSize, "the case only holds without a write-ahead-log")
+			} else {
+				require.GreaterOrEqual(t, walSize, tt.minWALSize,
+					"the case only holds with a write-ahead-log of at least that size")
+			}
+
+			before := dirSnapshot(t, bucketPath)
+
+			got, err := CalculateUnloadedDimensionsUsage(ctx, logger, indexPath, tenantName, targetVector)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+
+			require.Equal(t, before, dirSnapshot(t, bucketPath),
+				"reporting usage must not add, change or remove a file")
+		})
+	}
+}
+
+// seedDimensionsBucket records the dimensions of docIDs documents and shuts the bucket down
+// again. Without flush the entries stay in the write-ahead-log.
+func seedDimensionsBucket(t *testing.T, bucketPath, targetVector string, dims uint32, docIDs int, flush bool) {
+	t.Helper()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+
+	// a reuse threshold no log can reach leaves the log behind on shutdown, whatever its size
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketPath, "", logger, nil, noopCB, noopCB,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet), lsmkv.WithMinWalThreshold(1<<40))
+	require.NoError(t, err)
+
+	key := make([]byte, len(targetVector)+4)
+	copy(key, targetVector)
+	binary.LittleEndian.PutUint32(key[len(targetVector):], dims)
+	for docID := 1; docID <= docIDs; docID++ {
+		require.NoError(t, b.RoaringSetAddOne(key, uint64(docID)))
+	}
+
+	if flush {
+		require.NoError(t, b.FlushMemtable())
+	}
+	require.NoError(t, b.Shutdown(ctx))
+}
+
+func totalWALSize(t *testing.T, dir string) int64 {
+	t.Helper()
+
+	names, err := filepath.Glob(filepath.Join(dir, "*.wal"))
+	require.NoError(t, err)
+
+	total := int64(0)
+	for _, name := range names {
+		info, err := os.Stat(name)
+		require.NoError(t, err)
+		total += info.Size()
+	}
+	return total
+}
+
+// dirSnapshot maps every file in dir to a hash of its contents. A directory that does not
+// exist maps to nil.
+func dirSnapshot(t *testing.T, dir string) map[string]string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	require.NoError(t, err)
+
+	snapshot := map[string]string{}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		require.NoError(t, err)
+		snapshot[entry.Name()] = fmt.Sprintf("%x", sha256.Sum256(data))
+	}
+	return snapshot
+}

--- a/adapters/repos/db/shard_usage/usage_immutable_bucket_test.go
+++ b/adapters/repos/db/shard_usage/usage_immutable_bucket_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -48,6 +49,8 @@ func TestCalculateUnloadedDimensionsUsageDoesNotWrite(t *testing.T) {
 		// minWALSize is the smallest write-ahead-log the seeded bucket may leave
 		// behind; 0 expects none
 		minWALSize int64
+		// residue adds the leftovers of a crash to the seeded bucket directory
+		residue func(t *testing.T, bucketPath string)
 	}{
 		{name: "dimensions flushed to a segment", docIDs: 3, flush: true},
 		{name: "dimensions in a small write-ahead-log", docIDs: 3, minWALSize: 1},
@@ -58,6 +61,20 @@ func TestCalculateUnloadedDimensionsUsageDoesNotWrite(t *testing.T) {
 			minWALSize: 4097,
 		},
 		{name: "no dimensions bucket at all"},
+		{
+			// a crash between writing a segment and removing the log it was written from
+			// leaves a segment that may be incomplete, so the log is what counts
+			name:       "partially written segment next to its write-ahead-log",
+			docIDs:     3,
+			minWALSize: 1,
+			residue:    writePartialSegmentForWAL,
+		},
+		{
+			name:    "leftovers of an interrupted segment cleanup next to a flushed segment",
+			docIDs:  3,
+			flush:   true,
+			residue: writeCleanupLeftovers,
+		},
 	}
 
 	for _, tt := range tests {
@@ -71,6 +88,9 @@ func TestCalculateUnloadedDimensionsUsageDoesNotWrite(t *testing.T) {
 			if tt.docIDs > 0 {
 				seedDimensionsBucket(t, bucketPath, targetVector, dims, tt.docIDs, tt.flush)
 				want = types.Dimensionality{Dimensions: dims, Count: tt.docIDs}
+			}
+			if tt.residue != nil {
+				tt.residue(t, bucketPath)
 			}
 
 			walSize := totalWALSize(t, bucketPath)
@@ -120,6 +140,38 @@ func seedDimensionsBucket(t *testing.T, bucketPath, targetVector string, dims ui
 	require.NoError(t, b.Shutdown(ctx))
 }
 
+// writePartialSegmentForWAL puts a segment file next to the write-ahead-log it would have
+// been written from, holding too few bytes to be readable.
+func writePartialSegmentForWAL(t *testing.T, bucketPath string) {
+	t.Helper()
+
+	logs, err := filepath.Glob(filepath.Join(bucketPath, "*.wal"))
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+
+	segment := strings.TrimSuffix(logs[0], ".wal") + ".db"
+	require.NoError(t, os.WriteFile(segment, []byte("partially written"), 0o600))
+}
+
+// writeCleanupLeftovers adds what a crash in the middle of a segment cleanup leaves behind:
+// the rewritten segment, a bloom filter marked for deletion and a scratch directory.
+func writeCleanupLeftovers(t *testing.T, bucketPath string) {
+	t.Helper()
+
+	segments, err := filepath.Glob(filepath.Join(bucketPath, "*.db"))
+	require.NoError(t, err)
+	require.Len(t, segments, 1)
+
+	contents, err := os.ReadFile(segments[0])
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(segments[0]+".tmp", contents, 0o600))
+
+	bloom := strings.TrimSuffix(segments[0], ".db") + ".bloom.0000000000000" + lsmkv.DeleteMarkerSuffix
+	require.NoError(t, os.WriteFile(bloom, []byte("marked for deletion"), 0o600))
+
+	require.NoError(t, os.Mkdir(filepath.Join(bucketPath, "segment-x.scratch.d"), 0o700))
+}
+
 func totalWALSize(t *testing.T, dir string) int64 {
 	t.Helper()
 
@@ -135,8 +187,8 @@ func totalWALSize(t *testing.T, dir string) int64 {
 	return total
 }
 
-// dirSnapshot maps every file in dir to a hash of its contents. A directory that does not
-// exist maps to nil.
+// dirSnapshot maps every file in dir to a hash of its contents and every subdirectory to a
+// fixed marker. A directory that does not exist maps to nil.
 func dirSnapshot(t *testing.T, dir string) map[string]string {
 	t.Helper()
 
@@ -148,6 +200,10 @@ func dirSnapshot(t *testing.T, dir string) map[string]string {
 
 	snapshot := map[string]string{}
 	for _, entry := range entries {
+		if entry.IsDir() {
+			snapshot[entry.Name()] = "directory"
+			continue
+		}
 		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 		require.NoError(t, err)
 		snapshot[entry.Name()] = fmt.Sprintf("%x", sha256.Sum256(data))


### PR DESCRIPTION
### What's being changed:

This disables (most) writes for immutable buckets. There are still some edge cases but the PR is already big enough.

This mainly saves:
- on .wal open is much easer (read-only os.Open vs O_APPEND|O_CREATE|O_RDWR plus a seek+read of the trailing CRC32 to reseed the checksum writer)
- on shutdown we do not need to sync the commitlogger and the dir

The usage module is now using the immutable buckets to get these savings which should make it a bit more efficient, especially in big MT scnearions.

In addition, we do not open .bloom files any more in the usage module and the exporter which are not used.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
