### PR TITLE
Reduce allocations in tenant activity tracking

### DIFF
--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -38,13 +38,15 @@ type nodeWideMetricsObserver struct {
 	// allocating new ones.
 	activitySnapshot activityByCollection
 
-	// The most tenants each collection has held since its tenant maps were last
+	// The most tenants each collection has held since its counters map was last
 	// replaced. Cleared and pruned maps keep their buckets, so a collection down
-	// to less than a quarter of its peak gets fresh ones. Only the observeShards
+	// to less than a quarter of this gets fresh maps: the usage map on the cycle
+	// the drop shows, the counters map on the next. Only the observeShards
 	// goroutine touches it.
 	tenantPeaks map[string]int
 
-	activityLock sync.Mutex
+	// Guards usage only. The two fields above are written outside it.
+	activityLock sync.RWMutex
 	// Tenant usage as of the most recent cycle. Each cycle updates it in place
 	// instead of building a new one, so repeated observations do not allocate.
 	usage usageByCollection
@@ -273,8 +275,8 @@ func (o *nodeWideMetricsObserver) updateUsage(currentActivity activityByCollecti
 	}
 }
 
-// Whether a collection has lost so many tenants that reusing its maps would
-// keep far more buckets than the tenants that are left need.
+// Whether a collection is down to less than a quarter of the tenants it peaked
+// at, so that reusing its maps would keep far more buckets than it needs.
 func (o *nodeWideMetricsObserver) lostMostTenants(class string, live int) bool {
 	return live*4 < o.tenantPeaks[class]
 }
@@ -349,9 +351,12 @@ func (o *nodeWideMetricsObserver) getCurrentActivity() activityByCollection {
 			tenants = make(activityByTenant)
 		case o.lostMostTenants(cn, len(tenants)):
 			// len is last cycle's tenant count, as this cycle's is only known once
-			// the map has been filled
-			tenants = make(activityByTenant, len(tenants))
-			delete(o.tenantPeaks, cn)
+			// the map has been filled. The replacement's size becomes the peak the
+			// next drop is measured against, so a collection that keeps draining
+			// keeps shrinking.
+			size := len(tenants)
+			tenants = make(activityByTenant, size)
+			o.tenantPeaks[cn] = size
 		default:
 			clear(tenants)
 		}
@@ -410,8 +415,8 @@ func (o *nodeWideMetricsObserver) Usage(filter tenantactivity.UsageFilter) tenan
 		return tenantactivity.ByCollection{}
 	}
 
-	o.activityLock.Lock()
-	defer o.activityLock.Unlock()
+	o.activityLock.RLock()
+	defer o.activityLock.RUnlock()
 
 	usage := make(tenantactivity.ByCollection, len(o.usage))
 	for class, tenants := range o.usage {

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -38,6 +38,12 @@ type nodeWideMetricsObserver struct {
 	// allocating new ones.
 	activitySnapshot activityByCollection
 
+	// The most tenants each collection has held since its tenant maps were last
+	// replaced. Cleared and pruned maps keep their buckets, so a collection down
+	// to less than a quarter of its peak gets fresh ones. Only the observeShards
+	// goroutine touches it.
+	tenantPeaks map[string]int
+
 	activityLock sync.Mutex
 	// Tenant usage as of the most recent cycle. Each cycle updates it in place
 	// instead of building a new one, so repeated observations do not allocate.
@@ -67,7 +73,11 @@ type (
 )
 
 func newNodeWideMetricsObserver(db *DB) *nodeWideMetricsObserver {
-	return &nodeWideMetricsObserver{db: db, shutdown: make(chan struct{})}
+	return &nodeWideMetricsObserver{
+		db:          db,
+		shutdown:    make(chan struct{}),
+		tenantPeaks: map[string]int{},
+	}
 }
 
 // Start goroutines for periodically polling node-wide metrics.
@@ -221,7 +231,9 @@ func (o *nodeWideMetricsObserver) logActivity(col, tenant, activityType string, 
 
 // Update the usage state from the newly observed counters. Collections and
 // tenants that no longer appear are deleted, the rest are updated in place, so
-// repeated observations do not allocate.
+// repeated observations do not allocate. A collection that lost most of its
+// tenants gets a new map, carrying over the records of the tenants that are
+// left.
 func (o *nodeWideMetricsObserver) updateUsage(currentActivity activityByCollection) {
 	now := time.Now()
 
@@ -233,28 +245,38 @@ func (o *nodeWideMetricsObserver) updateUsage(currentActivity activityByCollecti
 	for class := range o.usage {
 		if _, ok := currentActivity[class]; !ok {
 			delete(o.usage, class)
+			delete(o.tenantPeaks, class)
 		}
 	}
 
 	for class, current := range currentActivity {
-		byTenant := o.usage[class]
-		if byTenant == nil {
+		previous := o.usage[class]
+
+		byTenant := previous
+		if byTenant == nil || o.lostMostTenants(class, len(current)) {
 			byTenant = make(usageByTenant, len(current))
 			o.usage[class] = byTenant
-		}
-
-		for tenant := range byTenant {
-			if _, ok := current[tenant]; !ok {
-				delete(byTenant, tenant)
+		} else {
+			for tenant := range byTenant {
+				if _, ok := current[tenant]; !ok {
+					delete(byTenant, tenant)
+				}
 			}
 		}
+		o.tenantPeaks[class] = max(o.tenantPeaks[class], len(current))
 
 		for tenant, act := range current {
-			// each record is read before it is overwritten, so the previous values
-			// can come from the map being updated
-			byTenant[tenant] = o.tenantUsageDelta(class, tenant, act, byTenant, now)
+			// each record is read before it is overwritten, so previous can be the
+			// map being written to
+			byTenant[tenant] = o.tenantUsageDelta(class, tenant, act, previous, now)
 		}
 	}
+}
+
+// Whether a collection has lost so many tenants that reusing its maps would
+// keep far more buckets than the tenants that are left need.
+func (o *nodeWideMetricsObserver) lostMostTenants(class string, live int) bool {
+	return live*4 < o.tenantPeaks[class]
 }
 
 // Derive a tenant's usage from its current counters and its record from the
@@ -322,9 +344,15 @@ func (o *nodeWideMetricsObserver) getCurrentActivity() activityByCollection {
 		// the previous counters are already kept in o.usage, so the map they were
 		// read from can be refilled instead of allocated again
 		tenants := previous[cn]
-		if tenants == nil {
+		switch {
+		case tenants == nil:
 			tenants = make(activityByTenant)
-		} else {
+		case o.lostMostTenants(cn, len(tenants)):
+			// len is last cycle's tenant count, as this cycle's is only known once
+			// the map has been filled
+			tenants = make(activityByTenant, len(tenants))
+			delete(o.tenantPeaks, cn)
+		default:
 			clear(tenants)
 		}
 		current[cn] = tenants

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -39,9 +39,9 @@ type nodeWideMetricsObserver struct {
 	activitySnapshot activityByCollection
 
 	activityLock sync.Mutex
-	usage        usageByCollection
-	// The maps usage replaced on the last cycle, refilled by the next one.
-	usageScratch usageByCollection
+	// Tenant usage as of the most recent cycle. Each cycle updates it in place
+	// instead of building a new one, so repeated observations do not allocate.
+	usage usageByCollection
 }
 
 // internal types used for tenant activity aggregation, not exposed to the user
@@ -181,9 +181,7 @@ func (o *nodeWideMetricsObserver) observeActivity() {
 	o.activityLock.Lock()
 	defer o.activityLock.Unlock()
 
-	next := o.analyzeActivityDelta(current, o.usageScratch)
-	o.usageScratch = o.usage
-	o.usage = next
+	o.updateUsage(current)
 
 	took := time.Since(start)
 	o.db.logger.WithFields(logrus.Fields{
@@ -221,41 +219,42 @@ func (o *nodeWideMetricsObserver) logActivity(col, tenant, activityType string, 
 	logBase.Logf(level, "tenant %s activity change: %s", tenant, activityType)
 }
 
-// Rebuild the usage state from the newly observed counters. The map built two
-// cycles ago is passed in as reuse and refilled, so repeated observations do not
-// allocate a map per collection.
-func (o *nodeWideMetricsObserver) analyzeActivityDelta(currentActivity activityByCollection, reuse usageByCollection) usageByCollection {
+// Update the usage state from the newly observed counters. Collections and
+// tenants that no longer appear are deleted, the rest are updated in place, so
+// repeated observations do not allocate.
+func (o *nodeWideMetricsObserver) updateUsage(currentActivity activityByCollection) {
 	now := time.Now()
 
-	next := reuse
-	if next == nil {
-		next = make(usageByCollection, len(currentActivity))
+	if o.usage == nil {
+		o.usage = make(usageByCollection, len(currentActivity))
 	}
 
 	// drop whatever doesn't appear in the new list anymore
-	for class := range next {
+	for class := range o.usage {
 		if _, ok := currentActivity[class]; !ok {
-			delete(next, class)
+			delete(o.usage, class)
 		}
 	}
 
 	for class, current := range currentActivity {
-		previous := o.usage[class]
-
-		byTenant := next[class]
+		byTenant := o.usage[class]
 		if byTenant == nil {
 			byTenant = make(usageByTenant, len(current))
-			next[class] = byTenant
-		} else {
-			clear(byTenant)
+			o.usage[class] = byTenant
+		}
+
+		for tenant := range byTenant {
+			if _, ok := current[tenant]; !ok {
+				delete(byTenant, tenant)
+			}
 		}
 
 		for tenant, act := range current {
-			byTenant[tenant] = o.tenantUsageDelta(class, tenant, act, previous, now)
+			// each record is read before it is overwritten, so the previous values
+			// can come from the map being updated
+			byTenant[tenant] = o.tenantUsageDelta(class, tenant, act, byTenant, now)
 		}
 	}
-
-	return next
 }
 
 // Derive a tenant's usage from its current counters and its record from the

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -33,11 +33,15 @@ type nodeWideMetricsObserver struct {
 	// Goroutines spawned by nodeWideMetricsObserver must exit after receiving on this channel.
 	shutdown chan struct{}
 
-	activityLock          sync.Mutex
-	activityTracker       activityByCollection
-	lastTenantUsage       tenantactivity.ByCollection
-	lastTenantUsageReads  tenantactivity.ByCollection
-	lastTenantUsageWrites tenantactivity.ByCollection
+	// Shard activity counters as of the most recent cycle. Only the observeShards
+	// goroutine touches it, and the next cycle refills its maps rather than
+	// allocating new ones.
+	activitySnapshot activityByCollection
+
+	activityLock sync.Mutex
+	usage        usageByCollection
+	// The maps usage replaced on the last cycle, refilled by the next one.
+	usageScratch usageByCollection
 }
 
 // internal types used for tenant activity aggregation, not exposed to the user
@@ -47,6 +51,18 @@ type (
 	activity             struct {
 		read  int32
 		write int32
+	}
+
+	usageByCollection map[string]usageByTenant
+	usageByTenant     map[string]tenantUsage
+	// tenantUsage holds what the next cycle needs to compute a delta: the counter
+	// values last seen, and the times those counters last changed.
+	tenantUsage struct {
+		read         int32
+		write        int32
+		lastActivity time.Time
+		lastRead     time.Time
+		lastWrite    time.Time
 	}
 )
 
@@ -165,8 +181,9 @@ func (o *nodeWideMetricsObserver) observeActivity() {
 	o.activityLock.Lock()
 	defer o.activityLock.Unlock()
 
-	o.lastTenantUsage, o.lastTenantUsageReads, o.lastTenantUsageWrites = o.analyzeActivityDelta(current)
-	o.activityTracker = current
+	next := o.analyzeActivityDelta(current, o.usageScratch)
+	o.usageScratch = o.usage
+	o.usage = next
 
 	took := time.Since(start)
 	o.db.logger.WithFields(logrus.Fields{
@@ -204,115 +221,143 @@ func (o *nodeWideMetricsObserver) logActivity(col, tenant, activityType string, 
 	logBase.Logf(level, "tenant %s activity change: %s", tenant, activityType)
 }
 
-func (o *nodeWideMetricsObserver) analyzeActivityDelta(currentActivity activityByCollection) (total, reads, writes tenantactivity.ByCollection) {
-	previousActivity := o.activityTracker
-	if previousActivity == nil {
-		previousActivity = make(activityByCollection)
-	}
-
+// Rebuild the usage state from the newly observed counters. The map built two
+// cycles ago is passed in as reuse and refilled, so repeated observations do not
+// allocate a map per collection.
+func (o *nodeWideMetricsObserver) analyzeActivityDelta(currentActivity activityByCollection, reuse usageByCollection) usageByCollection {
 	now := time.Now()
 
-	// create a new map, this way we will automatically drop anything that
-	// doesn't appear in the new list anymore
-	newUsageTotal := make(tenantactivity.ByCollection)
-	newUsageReads := make(tenantactivity.ByCollection)
-	newUsageWrites := make(tenantactivity.ByCollection)
+	next := reuse
+	if next == nil {
+		next = make(usageByCollection, len(currentActivity))
+	}
 
-	for class, current := range currentActivity {
-		newUsageTotal[class] = make(tenantactivity.ByTenant)
-		newUsageReads[class] = make(tenantactivity.ByTenant)
-		newUsageWrites[class] = make(tenantactivity.ByTenant)
-
-		for tenant, act := range current {
-			if _, ok := previousActivity[class]; !ok {
-				previousActivity[class] = make(activityByTenant)
-			}
-
-			previous, ok := previousActivity[class][tenant]
-			if !ok {
-				// this tenant didn't appear on the previous list, so we need to consider
-				// it recently active
-				newUsageTotal[class][tenant] = now
-
-				// only track detailed value if the value is greater than the initial
-				// value, otherwise we consider it just an activation without any user
-				// activity
-				if act.read > 1 {
-					newUsageReads[class][tenant] = now
-					o.logActivity(class, tenant, "read", act.read)
-				}
-				if act.write > 1 {
-					newUsageWrites[class][tenant] = now
-					o.logActivity(class, tenant, "write", act.write)
-				}
-
-				if act.read == 1 && act.write == 1 {
-					// no specific activity, just an activation
-					o.logActivity(class, tenant, "activation", 1)
-				}
-				continue
-			}
-
-			if act.read == previous.read && act.write == previous.write {
-				// unchanged, we can copy the current state
-				newUsageTotal[class][tenant] = o.lastTenantUsage[class][tenant]
-
-				// only copy previous reads+writes if they existed before
-				if lastRead, ok := o.lastTenantUsageReads[class][tenant]; ok {
-					newUsageReads[class][tenant] = lastRead
-				}
-				if lastWrite, ok := o.lastTenantUsageWrites[class][tenant]; ok {
-					newUsageWrites[class][tenant] = lastWrite
-				}
-			} else {
-				// activity changed we need to update it
-				newUsageTotal[class][tenant] = now
-				if act.read > previous.read {
-					newUsageReads[class][tenant] = now
-					o.logActivity(class, tenant, "read", act.read)
-				} else if lastRead, ok := o.lastTenantUsageReads[class][tenant]; ok {
-					newUsageReads[class][tenant] = lastRead
-				}
-
-				if act.write > previous.write {
-					newUsageWrites[class][tenant] = now
-					o.logActivity(class, tenant, "write", act.write)
-				} else if lastWrite, ok := o.lastTenantUsageWrites[class][tenant]; ok {
-					newUsageWrites[class][tenant] = lastWrite
-				}
-
-			}
+	// drop whatever doesn't appear in the new list anymore
+	for class := range next {
+		if _, ok := currentActivity[class]; !ok {
+			delete(next, class)
 		}
 	}
 
-	return newUsageTotal, newUsageReads, newUsageWrites
+	for class, current := range currentActivity {
+		previous := o.usage[class]
+
+		byTenant := next[class]
+		if byTenant == nil {
+			byTenant = make(usageByTenant, len(current))
+			next[class] = byTenant
+		} else {
+			clear(byTenant)
+		}
+
+		for tenant, act := range current {
+			byTenant[tenant] = o.tenantUsageDelta(class, tenant, act, previous, now)
+		}
+	}
+
+	return next
+}
+
+// Derive a tenant's usage from its current counters and its record from the
+// previous cycle. A timestamp only moves when the matching counter changed.
+func (o *nodeWideMetricsObserver) tenantUsageDelta(class, tenant string, act activity, previous usageByTenant, now time.Time) tenantUsage {
+	prev, ok := previous[tenant]
+	if !ok {
+		// this tenant didn't appear on the previous list, so we need to consider
+		// it recently active
+		usage := tenantUsage{read: act.read, write: act.write, lastActivity: now}
+
+		// only track detailed value if the value is greater than the initial
+		// value, otherwise we consider it just an activation without any user
+		// activity
+		if act.read > 1 {
+			usage.lastRead = now
+			o.logActivity(class, tenant, "read", act.read)
+		}
+		if act.write > 1 {
+			usage.lastWrite = now
+			o.logActivity(class, tenant, "write", act.write)
+		}
+
+		if act.read == 1 && act.write == 1 {
+			// no specific activity, just an activation
+			o.logActivity(class, tenant, "activation", 1)
+		}
+		return usage
+	}
+
+	usage := prev
+	usage.read, usage.write = act.read, act.write
+	if act.read == prev.read && act.write == prev.write {
+		// unchanged, keep the previous timestamps
+		return usage
+	}
+
+	// activity changed we need to update it
+	usage.lastActivity = now
+	if act.read > prev.read {
+		usage.lastRead = now
+		o.logActivity(class, tenant, "read", act.read)
+	}
+	if act.write > prev.write {
+		usage.lastWrite = now
+		o.logActivity(class, tenant, "write", act.write)
+	}
+
+	return usage
 }
 
 func (o *nodeWideMetricsObserver) getCurrentActivity() activityByCollection {
 	o.db.indexLock.RLock()
 	defer o.db.indexLock.RUnlock()
 
-	current := make(activityByCollection)
+	previous := o.activitySnapshot
+	current := make(activityByCollection, len(o.db.indices))
 	for _, index := range o.db.indices {
 		if !index.partitioningEnabled {
 			continue
 		}
 		cn := index.Config.ClassName.String()
-		current[cn] = make(activityByTenant)
+
+		// the previous counters are already kept in o.usage, so the map they were
+		// read from can be refilled instead of allocated again
+		tenants := previous[cn]
+		if tenants == nil {
+			tenants = make(activityByTenant)
+		} else {
+			clear(tenants)
+		}
+		current[cn] = tenants
+
 		index.ForEachShard(func(name string, shard ShardLike) error {
 			index.shardCreateLocks.RLock(name)
 			defer index.shardCreateLocks.RUnlock(name)
 
 			act := activity{}
 			act.read, act.write = shard.Activity()
-			current[cn][name] = act
+			tenants[name] = act
 			return nil
 		})
 	}
+	o.activitySnapshot = current
 
 	return current
 }
 
+// A zero time means the tenant saw no activity of that kind.
+func (u tenantUsage) timestampFor(filter tenantactivity.UsageFilter) time.Time {
+	switch filter {
+	case tenantactivity.UsageFilterOnlyReads:
+		return u.lastRead
+	case tenantactivity.UsageFilterOnlyWrites:
+		return u.lastWrite
+	default:
+		return u.lastActivity
+	}
+}
+
+// Usage returns a copy, so that callers can read it while the observer keeps
+// updating its own state.
 func (o *nodeWideMetricsObserver) Usage(filter tenantactivity.UsageFilter) tenantactivity.ByCollection {
 	if o == nil {
 		// not loaded yet, requests could come in before the db is initialized yet
@@ -323,17 +368,18 @@ func (o *nodeWideMetricsObserver) Usage(filter tenantactivity.UsageFilter) tenan
 	o.activityLock.Lock()
 	defer o.activityLock.Unlock()
 
-	switch filter {
-
-	case tenantactivity.UsageFilterOnlyReads:
-		return o.lastTenantUsageReads
-	case tenantactivity.UsageFilterOnlyWrites:
-		return o.lastTenantUsageWrites
-	case tenantactivity.UsageFilterAll:
-		return o.lastTenantUsage
-	default:
-		return o.lastTenantUsage
+	usage := make(tenantactivity.ByCollection, len(o.usage))
+	for class, tenants := range o.usage {
+		byTenant := make(tenantactivity.ByTenant, len(tenants))
+		for tenant, u := range tenants {
+			if ts := u.timestampFor(filter); !ts.IsZero() {
+				byTenant[tenant] = ts
+			}
+		}
+		usage[class] = byTenant
 	}
+
+	return usage
 }
 
 // ----------------------------------------------------------------------------

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -56,7 +56,7 @@ type (
 	usageByCollection map[string]usageByTenant
 	usageByTenant     map[string]tenantUsage
 	// tenantUsage holds what the next cycle needs to compute a delta: the counter
-	// values last seen, and the times those counters last changed.
+	// values last seen, and the timestamps derived from them.
 	tenantUsage struct {
 		read         int32
 		write        int32
@@ -259,7 +259,8 @@ func (o *nodeWideMetricsObserver) analyzeActivityDelta(currentActivity activityB
 }
 
 // Derive a tenant's usage from its current counters and its record from the
-// previous cycle. A timestamp only moves when the matching counter changed.
+// previous cycle. lastActivity moves when either counter changes, lastRead and
+// lastWrite only when their own counter increases.
 func (o *nodeWideMetricsObserver) tenantUsageDelta(class, tenant string, act activity, previous usageByTenant, now time.Time) tenantUsage {
 	prev, ok := previous[tenant]
 	if !ok {

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -33,9 +33,10 @@ type nodeWideMetricsObserver struct {
 	// Goroutines spawned by nodeWideMetricsObserver must exit after receiving on this channel.
 	shutdown chan struct{}
 
-	// Shard activity counters as of the most recent cycle. Only the observeShards
-	// goroutine touches it, and the next cycle refills its maps rather than
-	// allocating new ones.
+	// The tenant maps that the most recent cycle filled, kept so the next cycle
+	// can refill them instead of allocating new ones. The counters a cycle
+	// compares against are kept in usage. Only the observeShards goroutine
+	// touches it.
 	activitySnapshot activityByCollection
 
 	// The most tenants each collection has held since its counters map was last
@@ -406,8 +407,9 @@ func (tenants usageByTenant) countMatching(filter tenantactivity.UsageFilter) in
 	return count
 }
 
-// Usage returns a copy, so that callers can read it while the observer keeps
-// updating its own state.
+// Usage returns a copy: every cycle rewrites the observer's own maps in place,
+// so handing those out would let a caller range over a map while a cycle writes
+// to it, aborting the process with "concurrent map iteration and map write".
 func (o *nodeWideMetricsObserver) Usage(filter tenantactivity.UsageFilter) tenantactivity.ByCollection {
 	if o == nil {
 		// not loaded yet, requests could come in before the db is initialized yet

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -356,6 +356,23 @@ func (u tenantUsage) timestampFor(filter tenantactivity.UsageFilter) time.Time {
 	}
 }
 
+// How many tenants a filter reports. Every tenant has a total-activity
+// timestamp, but a read or write filter typically matches only a few of them, so
+// counting keeps Usage's result map from reserving space for the rest.
+func (tenants usageByTenant) countMatching(filter tenantactivity.UsageFilter) int {
+	if filter == tenantactivity.UsageFilterAll {
+		return len(tenants)
+	}
+
+	count := 0
+	for _, u := range tenants {
+		if !u.timestampFor(filter).IsZero() {
+			count++
+		}
+	}
+	return count
+}
+
 // Usage returns a copy, so that callers can read it while the observer keeps
 // updating its own state.
 func (o *nodeWideMetricsObserver) Usage(filter tenantactivity.UsageFilter) tenantactivity.ByCollection {
@@ -370,7 +387,7 @@ func (o *nodeWideMetricsObserver) Usage(filter tenantactivity.UsageFilter) tenan
 
 	usage := make(tenantactivity.ByCollection, len(o.usage))
 	for class, tenants := range o.usage {
-		byTenant := make(tenantactivity.ByTenant, len(tenants))
+		byTenant := make(tenantactivity.ByTenant, tenants.countMatching(filter))
 		for tenant, u := range tenants {
 			if ts := u.timestampFor(filter); !ts.IsZero() {
 				byTenant[tenant] = ts

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -47,6 +47,21 @@ func newActivityTestIndex(className string, partitioningEnabled bool) *Index {
 	}
 }
 
+// newWarmActivityObserver returns an observer that has already observed a
+// multi-tenant collection, so its tenant maps are allocated and reused from
+// here on.
+func newWarmActivityObserver(tenants int) (*nodeWideMetricsObserver, *Index, *DB) {
+	logger, _ := test.NewNullLogger()
+	col := newActivityTestIndex("Col1", true)
+	for i := 0; i < tenants; i++ {
+		col.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
+	}
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col}}
+	o := newNodeWideMetricsObserver(db)
+	o.observeActivity()
+	return o, col, db
+}
+
 func TestShardActivity(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	db := &DB{
@@ -561,47 +576,36 @@ func TestShardActivityUsageIsIndependent(t *testing.T) {
 }
 
 // Recycling a tenant map keeps the buckets of the largest tenant count its
-// collection ever held, so a collection that drained has to get a new one.
+// collection ever held, so a collection that drained has to be handed a new map
+// instead. Map identity is what shows that it was.
 func TestShardActivityTenantMapReuse(t *testing.T) {
 	const peak = 40
 
 	address := func(m any) uintptr { return reflect.ValueOf(m).Pointer() }
 
-	// a collection whose tenant maps are allocated and reused from here on
-	warm := func() (*nodeWideMetricsObserver, *Index, *DB) {
-		logger, _ := test.NewNullLogger()
-		col := newActivityTestIndex("Col1", true)
-		for i := 0; i < peak; i++ {
-			col.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
-		}
-		db := &DB{logger: logger, indices: map[string]*Index{"Col1": col}}
-		o := newNodeWideMetricsObserver(db)
-		o.observeActivity()
-		return o, col, db
-	}
-
 	tests := []struct {
 		name string
 		// how many of the initial tenants are left once the drain is done, how
-		// many tenants leave per cycle (0 removes them all in one), and how many
-		// tenants are added on top
+		// many tenants leave per cycle (0 removes them all in one), how many
+		// tenants are added on top, and the peak the collection settles on
 		keep         int
 		perCycle     int
 		add          int
 		wantReplaced bool
+		wantPeak     int
 	}{
-		{name: "most tenants stay", keep: 30},
-		{name: "down to exactly a quarter", keep: peak / 4},
-		{name: "just past a quarter", keep: peak/4 - 1, wantReplaced: true},
-		{name: "down to a single tenant", keep: 1, wantReplaced: true},
-		{name: "every tenant leaves", keep: 0, wantReplaced: true},
-		{name: "a few tenants leave per cycle", keep: 1, perCycle: 4, wantReplaced: true},
-		{name: "collection grows", keep: peak, add: peak},
+		{name: "most tenants stay", keep: 30, wantPeak: peak},
+		{name: "down to exactly a quarter", keep: peak / 4, wantPeak: peak},
+		{name: "just past a quarter", keep: peak/4 - 1, wantReplaced: true, wantPeak: peak/4 - 1},
+		{name: "down to a single tenant", keep: 1, wantReplaced: true, wantPeak: 1},
+		{name: "every tenant leaves", keep: 0, wantReplaced: true, wantPeak: 0},
+		{name: "a few tenants leave per cycle", keep: 1, perCycle: 4, wantReplaced: true, wantPeak: 1},
+		{name: "collection grows", keep: peak, add: peak, wantPeak: 2 * peak},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			o, col, _ := warm()
+			o, col, _ := newWarmActivityObserver(peak)
 			// holding on to the maps keeps a replacement from landing on the same
 			// address
 			snapshotBefore := o.activitySnapshot["Col1"]
@@ -627,7 +631,9 @@ func TestShardActivityTenantMapReuse(t *testing.T) {
 			// so it is replaced on the cycle after
 			o.observeActivity()
 
-			require.Len(t, o.Usage(tenantactivity.UsageFilterAll)["Col1"], tt.keep+tt.add,
+			usage := o.Usage(tenantactivity.UsageFilterAll)
+			require.Contains(t, usage, "Col1")
+			require.Len(t, usage["Col1"], tt.keep+tt.add,
 				"every surviving tenant should still be reported")
 			require.Equal(t, tt.wantReplaced,
 				address(o.activitySnapshot["Col1"]) != address(snapshotBefore),
@@ -635,6 +641,21 @@ func TestShardActivityTenantMapReuse(t *testing.T) {
 			require.Equal(t, tt.wantReplaced,
 				address(o.usage["Col1"]) != address(usageBefore),
 				"usage map replaced")
+			// a peak that stayed above the tenants that are left would either keep
+			// replacing the maps every cycle or leave them sized for tenants that
+			// are gone
+			require.Equal(t, tt.wantPeak, o.tenantPeaks["Col1"])
+
+			t.Run("idle cycles change nothing", func(t *testing.T) {
+				settledSnapshot := o.activitySnapshot["Col1"]
+				settledUsage := o.usage["Col1"]
+				for i := 0; i < 3; i++ {
+					o.observeActivity()
+				}
+				require.Equal(t, address(settledSnapshot), address(o.activitySnapshot["Col1"]))
+				require.Equal(t, address(settledUsage), address(o.usage["Col1"]))
+				require.Equal(t, tt.wantPeak, o.tenantPeaks["Col1"])
+			})
 		})
 	}
 
@@ -642,7 +663,7 @@ func TestShardActivityTenantMapReuse(t *testing.T) {
 	// map has to carry them over instead of reporting every tenant that is left
 	// as newly active.
 	t.Run("a surviving tenant keeps its record", func(t *testing.T) {
-		o, col, _ := warm()
+		o, col, _ := newWarmActivityObserver(peak)
 
 		survivor := col.shards.Load("tenant-0").(*Shard)
 		survivor.activityTrackerRead.Add(1)
@@ -670,7 +691,7 @@ func TestShardActivityTenantMapReuse(t *testing.T) {
 	})
 
 	t.Run("a removed collection leaves no peak behind", func(t *testing.T) {
-		o, _, db := warm()
+		o, _, db := newWarmActivityObserver(peak)
 		require.Contains(t, o.tenantPeaks, "Col1")
 
 		delete(db.indices, "Col1")
@@ -691,17 +712,7 @@ func TestShardActivityObserveAllocations(t *testing.T) {
 		runs              = 10
 	)
 
-	logger, _ := test.NewNullLogger()
-	col1 := newActivityTestIndex("Col1", true)
-	for i := 0; i < tenants; i++ {
-		col1.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
-	}
-
-	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
-	o := newNodeWideMetricsObserver(db)
-
-	// the maps are allocated on the first cycle and reused from then on
-	o.observeActivity()
+	o, _, _ := newWarmActivityObserver(tenants)
 
 	var before, after runtime.MemStats
 	runtime.GC()
@@ -732,15 +743,7 @@ func TestShardActivityUsageAllocations(t *testing.T) {
 		maxBytesPerTenant = 140
 	)
 
-	logger, _ := test.NewNullLogger()
-	col1 := newActivityTestIndex("Col1", true)
-	for i := 0; i < tenants; i++ {
-		col1.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
-	}
-
-	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
-	o := newNodeWideMetricsObserver(db)
-	o.observeActivity()
+	o, col1, _ := newWarmActivityObserver(tenants)
 
 	for i := 0; i < readers; i++ {
 		col1.shards.Load(fmt.Sprintf("tenant-%d", i)).(*Shard).activityTrackerRead.Add(1)

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -376,6 +376,33 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 			},
 		},
 		{
+			// the collection is still there, it just has nothing left to report
+			name:   "collection loses its last tenant",
+			mutate: func() { col2.shards.LoadAndDelete("t5") },
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: kept},
+					"t4": {all: kept},
+				},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "tenant returns to the emptied collection",
+			mutate: add(col2, "t5", 3, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: kept},
+					"t4": {all: kept},
+				},
+				"Col2": {"t5": {all: fresh, read: fresh}},
+			},
+		},
+		{
 			name:   "collection removed",
 			mutate: func() { delete(db.indices, "Col2") },
 			want: map[string]map[string]tenantWant{
@@ -537,8 +564,9 @@ func TestShardActivityUsageIsIndependent(t *testing.T) {
 func TestShardActivityObserveAllocations(t *testing.T) {
 	const (
 		tenants = 2000
-		// steady state is ~41 bytes per tenant, and dropping either reuse buffer
-		// costs 149 or more, so the budget sits between the two
+		// steady state is ~40 bytes per tenant, and giving up the reuse of either
+		// the counters or the usage records costs 149 or more, so the budget sits
+		// between the two
 		maxBytesPerTenant = 60
 		runs              = 10
 	)
@@ -552,10 +580,8 @@ func TestShardActivityObserveAllocations(t *testing.T) {
 	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
 	o := newNodeWideMetricsObserver(db)
 
-	// the buffers are only fully in place once a cycle has replaced a cycle
-	for i := 0; i < 3; i++ {
-		o.observeActivity()
-	}
+	// the maps are allocated on the first cycle and reused from then on
+	o.observeActivity()
 
 	var before, after runtime.MemStats
 	runtime.GC()

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"maps"
 	"math"
+	"reflect"
 	"runtime"
 	"slices"
 	"sync"
@@ -556,6 +557,125 @@ func TestShardActivityUsageIsIndependent(t *testing.T) {
 		}
 		close(stop)
 		wg.Wait()
+	})
+}
+
+// Recycling a tenant map keeps the buckets of the largest tenant count its
+// collection ever held, so a collection that drained has to get a new one.
+func TestShardActivityTenantMapReuse(t *testing.T) {
+	const peak = 40
+
+	address := func(m any) uintptr { return reflect.ValueOf(m).Pointer() }
+
+	// a collection whose tenant maps are allocated and reused from here on
+	warm := func() (*nodeWideMetricsObserver, *Index, *DB) {
+		logger, _ := test.NewNullLogger()
+		col := newActivityTestIndex("Col1", true)
+		for i := 0; i < peak; i++ {
+			col.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
+		}
+		db := &DB{logger: logger, indices: map[string]*Index{"Col1": col}}
+		o := newNodeWideMetricsObserver(db)
+		o.observeActivity()
+		return o, col, db
+	}
+
+	tests := []struct {
+		name string
+		// how many of the initial tenants are left once the drain is done, how
+		// many tenants leave per cycle (0 removes them all in one), and how many
+		// tenants are added on top
+		keep         int
+		perCycle     int
+		add          int
+		wantReplaced bool
+	}{
+		{name: "most tenants stay", keep: 30},
+		{name: "down to exactly a quarter", keep: peak / 4},
+		{name: "just past a quarter", keep: peak/4 - 1, wantReplaced: true},
+		{name: "down to a single tenant", keep: 1, wantReplaced: true},
+		{name: "every tenant leaves", keep: 0, wantReplaced: true},
+		{name: "a few tenants leave per cycle", keep: 1, perCycle: 4, wantReplaced: true},
+		{name: "collection grows", keep: peak, add: peak},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, col, _ := warm()
+			// holding on to the maps keeps a replacement from landing on the same
+			// address
+			snapshotBefore := o.activitySnapshot["Col1"]
+			usageBefore := o.usage["Col1"]
+
+			for i := 0; i < tt.add; i++ {
+				col.shards.Store(fmt.Sprintf("added-%d", i), &Shard{})
+			}
+
+			leaving := peak - tt.keep
+			perCycle := tt.perCycle
+			if perCycle == 0 {
+				perCycle = leaving
+			}
+			for removed := 0; removed < leaving; {
+				for i := 0; i < perCycle && removed < leaving; i++ {
+					col.shards.LoadAndDelete(fmt.Sprintf("tenant-%d", tt.keep+removed))
+					removed++
+				}
+				o.observeActivity()
+			}
+			// the counters map only reveals its new size once a cycle has filled it,
+			// so it is replaced on the cycle after
+			o.observeActivity()
+
+			require.Len(t, o.Usage(tenantactivity.UsageFilterAll)["Col1"], tt.keep+tt.add,
+				"every surviving tenant should still be reported")
+			require.Equal(t, tt.wantReplaced,
+				address(o.activitySnapshot["Col1"]) != address(snapshotBefore),
+				"counters map replaced")
+			require.Equal(t, tt.wantReplaced,
+				address(o.usage["Col1"]) != address(usageBefore),
+				"usage map replaced")
+		})
+	}
+
+	// The usage records are what the next cycle compares against, so a replaced
+	// map has to carry them over instead of reporting every tenant that is left
+	// as newly active.
+	t.Run("a surviving tenant keeps its record", func(t *testing.T) {
+		o, col, _ := warm()
+
+		survivor := col.shards.Load("tenant-0").(*Shard)
+		survivor.activityTrackerRead.Add(1)
+		survivor.activityTrackerWrite.Add(1)
+		o.observeActivity()
+
+		usageBefore := o.usage["Col1"]
+		before := usageBefore["tenant-0"]
+		require.False(t, before.lastRead.IsZero(), "the survivor should have been read")
+		require.False(t, before.lastWrite.IsZero(), "the survivor should have been written to")
+
+		for i := 1; i < peak; i++ {
+			col.shards.LoadAndDelete(fmt.Sprintf("tenant-%d", i))
+		}
+		col.shards.Store("tenant-new", &Shard{})
+		// a re-stamped timestamp has to be distinguishable from the one it replaces
+		time.Sleep(time.Millisecond)
+		o.observeActivity()
+
+		require.NotEqual(t, address(usageBefore), address(o.usage["Col1"]),
+			"the usage map should have been replaced")
+		require.Equal(t, before, o.usage["Col1"]["tenant-0"])
+		require.True(t, o.usage["Col1"]["tenant-new"].lastActivity.After(before.lastActivity),
+			"a tenant that arrived with the replacement should be newly active")
+	})
+
+	t.Run("a removed collection leaves no peak behind", func(t *testing.T) {
+		o, _, db := warm()
+		require.Contains(t, o.tenantPeaks, "Col1")
+
+		delete(db.indices, "Col1")
+		o.observeActivity()
+		require.NotContains(t, o.tenantPeaks, "Col1")
 	})
 }
 

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -47,6 +47,25 @@ func newActivityTestIndex(className string, partitioningEnabled bool) *Index {
 	}
 }
 
+// addTenant and bumpTenant return their mutation rather than applying it, so a
+// test table can hold it and the cycle loop applies it.
+func addTenant(index *Index, name string, read, write int32) func() {
+	return func() {
+		shard := &Shard{}
+		shard.activityTrackerRead.Store(read)
+		shard.activityTrackerWrite.Store(write)
+		index.shards.Store(name, shard)
+	}
+}
+
+func bumpTenant(index *Index, name string, read, write int32) func() {
+	return func() {
+		shard := index.shards.Load(name).(*Shard)
+		shard.activityTrackerRead.Add(read)
+		shard.activityTrackerWrite.Add(write)
+	}
+}
+
 // newWarmActivityObserver returns an observer that has already observed a
 // multi-tenant collection, so its tenant maps are allocated and reused from
 // here on.
@@ -139,7 +158,7 @@ func TestShardActivity(t *testing.T) {
 		// t1's counter wrapped past MaxInt32 instead of growing, which does not
 		// count as a read, so its read timestamp stays where t2's is even though
 		// its total timestamp has moved on
-		assert.Equal(t, col["t2_only_reads"], col["t1_overflow"],
+		require.Equal(t, col["t2_only_reads"], col["t1_overflow"],
 			"a wrapped counter should not move the read timestamp")
 	})
 
@@ -206,21 +225,6 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 
 	require.Empty(t, o.Usage(tenantactivity.UsageFilterAll), "nothing observed yet")
 
-	add := func(index *Index, name string, read, write int32) func() {
-		return func() {
-			shard := &Shard{}
-			shard.activityTrackerRead.Store(read)
-			shard.activityTrackerWrite.Store(write)
-			index.shards.Store(name, shard)
-		}
-	}
-	bump := func(index *Index, name string, read, write int32) func() {
-		return func() {
-			shard := index.shards.Load(name).(*Shard)
-			shard.activityTrackerRead.Add(read)
-			shard.activityTrackerWrite.Add(write)
-		}
-	}
 	on := func(index *Index, name string, fn func(*Shard)) func() {
 		return func() { fn(index.shards.Load(name).(*Shard)) }
 	}
@@ -237,7 +241,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "tenant appears at its initial counters",
-			mutate: add(col1, "t1", 1, 1),
+			mutate: addTenant(col1, "t1", 1, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {"t1": {all: fresh}},
 				"Col2": {},
@@ -253,7 +257,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "tenant is read",
-			mutate: bump(col1, "t1", 1, 0),
+			mutate: bumpTenant(col1, "t1", 1, 0),
 			want: map[string]map[string]tenantWant{
 				"Col1": {"t1": {all: fresh, read: fresh}},
 				"Col2": {},
@@ -269,7 +273,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "tenant is written to",
-			mutate: bump(col1, "t1", 0, 1),
+			mutate: bumpTenant(col1, "t1", 0, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {"t1": {all: fresh, read: kept, write: fresh}},
 				"Col2": {},
@@ -277,7 +281,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "read and write in the same cycle",
-			mutate: bump(col1, "t1", 1, 1),
+			mutate: bumpTenant(col1, "t1", 1, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {"t1": {all: fresh, read: fresh, write: fresh}},
 				"Col2": {},
@@ -317,7 +321,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "tenant first seen one read above its initial counter",
-			mutate: add(col1, "t2", 2, 1),
+			mutate: addTenant(col1, "t2", 2, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {
 					"t1": {all: kept, read: kept, write: kept},
@@ -328,7 +332,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "tenant first seen one write above its initial counter",
-			mutate: add(col1, "t3", 1, 2),
+			mutate: addTenant(col1, "t3", 1, 2),
 			want: map[string]map[string]tenantWant{
 				"Col1": {
 					"t1": {all: kept, read: kept, write: kept},
@@ -353,7 +357,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "activity in one collection leaves the other alone",
-			mutate: add(col2, "t5", 3, 1),
+			mutate: addTenant(col2, "t5", 3, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {
 					"t1": {all: kept, read: kept, write: kept},
@@ -380,7 +384,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 			// the tenant is new to the observer again, so the write timestamp it
 			// used to have is gone rather than resurrected
 			name:   "tenant returns at its initial counters",
-			mutate: add(col1, "t3", 1, 1),
+			mutate: addTenant(col1, "t3", 1, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {
 					"t1": {all: kept, read: kept, write: kept},
@@ -407,7 +411,7 @@ func TestShardActivityAcrossCycles(t *testing.T) {
 		},
 		{
 			name:   "tenant returns to the emptied collection",
-			mutate: add(col2, "t5", 3, 1),
+			mutate: addTenant(col2, "t5", 3, 1),
 			want: map[string]map[string]tenantWant{
 				"Col1": {
 					"t1": {all: kept, read: kept, write: kept},
@@ -700,31 +704,51 @@ func TestShardActivityTenantMapReuse(t *testing.T) {
 	})
 }
 
-// The observe cycle runs on every node every 10 seconds, so its allocations must
-// not grow with the number of tenants.
-func TestShardActivityObserveAllocations(t *testing.T) {
-	const (
-		tenants = 2000
-		// steady state is ~40 bytes per tenant, and giving up the reuse of either
-		// the counters or the usage records costs 149 or more, so the budget sits
-		// between the two
-		maxBytesPerTenant = 60
-		runs              = 10
-	)
-
-	o, _, _ := newWarmActivityObserver(tenants)
+// bytesPerCall runs fn over a window long enough that a cost fn only pays every
+// so often still lands inside it. TotalAlloc counts the whole process, so the
+// result can be inflated but never hides an allocation.
+func bytesPerCall(fn func()) uint64 {
+	const runs = 200
 
 	var before, after runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&before)
 	for i := 0; i < runs; i++ {
-		o.observeActivity()
+		fn()
 	}
 	runtime.ReadMemStats(&after)
 
-	perCycle := (after.TotalAlloc - before.TotalAlloc) / runs
-	require.Less(t, perCycle, uint64(maxBytesPerTenant*tenants),
-		"observing %d unchanged tenants allocated %d bytes per cycle", tenants, perCycle)
+	return (after.TotalAlloc - before.TotalAlloc) / runs
+}
+
+// The observe cycle runs on every node every 10 seconds, so its allocations must
+// not grow with the number of tenants: what one tenant costs has to stay flat,
+// and stay below what a cycle that reallocated its maps would spend.
+func TestShardActivityObserveAllocations(t *testing.T) {
+	const (
+		// steady state is ~40 bytes per tenant, and giving up the reuse of either
+		// the counters or the usage records costs 149 or more, so the budget sits
+		// between the two
+		maxBytesPerTenant = 60
+		fewTenants        = 1000
+		manyTenants       = 8000
+	)
+
+	perTenant := func(tenants int) uint64 {
+		o, _, _ := newWarmActivityObserver(tenants)
+		return bytesPerCall(o.observeActivity) / uint64(tenants)
+	}
+
+	few, many := perTenant(fewTenants), perTenant(manyTenants)
+	require.Less(t, few, uint64(maxBytesPerTenant),
+		"observing %d unchanged tenants allocated %d bytes per tenant per cycle", fewTenants, few)
+	require.Less(t, many, uint64(maxBytesPerTenant),
+		"observing %d unchanged tenants allocated %d bytes per tenant per cycle", manyTenants, many)
+	// the fixed cost of a cycle is spread over more tenants, so a collection that
+	// grew may only ever cost less per tenant, never more
+	require.LessOrEqual(t, many, few,
+		"a cycle cost %d bytes per tenant at %d tenants and %d at %d",
+		few, fewTenants, many, manyTenants)
 }
 
 // A read or write filter reports only the tenants that saw that kind of
@@ -735,7 +759,6 @@ func TestShardActivityUsageAllocations(t *testing.T) {
 		tenants = 2000
 		readers = 3
 		writers = 2
-		runs    = 10
 		// a map holding every tenant costs ~98 bytes per tenant when it is sized
 		// upfront and ~194 when it grows into it, so the budget sits between the
 		// two, and a handful of matches has to stay far below either
@@ -769,15 +792,7 @@ func TestShardActivityUsageAllocations(t *testing.T) {
 			// a budget on its own would also pass on an answer that is too small
 			require.Len(t, o.Usage(tt.filter)["Col1"], tt.want)
 
-			var before, after runtime.MemStats
-			runtime.GC()
-			runtime.ReadMemStats(&before)
-			for i := 0; i < runs; i++ {
-				o.Usage(tt.filter)
-			}
-			runtime.ReadMemStats(&after)
-
-			perCall := (after.TotalAlloc - before.TotalAlloc) / runs
+			perCall := bytesPerCall(func() { o.Usage(tt.filter) })
 			require.Less(t, perCall, tt.maxBytes,
 				"reporting %d of %d tenants allocated %d bytes per call", tt.want, tenants, perCall)
 		})
@@ -871,22 +886,6 @@ func TestShardActivityLogging(t *testing.T) {
 	db.config.TenantActivityWriteLogLevel = configRuntime.NewDynamicValue("info")
 	o := newNodeWideMetricsObserver(db)
 
-	addTenant := func(name string, read, write int32) func() {
-		return func() {
-			shard := &Shard{}
-			shard.activityTrackerRead.Store(read)
-			shard.activityTrackerWrite.Store(write)
-			col1.shards.Store(name, shard)
-		}
-	}
-	bump := func(name string, read, write int32) func() {
-		return func() {
-			shard := col1.shards.Load(name).(*Shard)
-			shard.activityTrackerRead.Add(read)
-			shard.activityTrackerWrite.Add(write)
-		}
-	}
-
 	cycles := []struct {
 		name   string
 		mutate func()
@@ -894,27 +893,27 @@ func TestShardActivityLogging(t *testing.T) {
 	}{
 		{
 			name:   "new tenant at its initial counters",
-			mutate: addTenant("t_activation", 1, 1),
+			mutate: addTenant(col1, "t_activation", 1, 1),
 			want:   map[string]string{"t_activation": "activation"},
 		},
 		{
 			name:   "new tenant that has already been read",
-			mutate: addTenant("t_new_read", 5, 1),
+			mutate: addTenant(col1, "t_new_read", 5, 1),
 			want:   map[string]string{"t_new_read": "read"},
 		},
 		{
 			name:   "new tenant that has already been written to",
-			mutate: addTenant("t_new_write", 1, 5),
+			mutate: addTenant(col1, "t_new_write", 1, 5),
 			want:   map[string]string{"t_new_write": "write"},
 		},
 		{
 			name:   "known tenant is read",
-			mutate: bump("t_activation", 1, 0),
+			mutate: bumpTenant(col1, "t_activation", 1, 0),
 			want:   map[string]string{"t_activation": "read"},
 		},
 		{
 			name:   "known tenant is written to",
-			mutate: bump("t_activation", 0, 1),
+			mutate: bumpTenant(col1, "t_activation", 0, 1),
 			want:   map[string]string{"t_activation": "write"},
 		},
 		{

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -570,6 +570,71 @@ func TestShardActivityObserveAllocations(t *testing.T) {
 		"observing %d unchanged tenants allocated %d bytes per cycle", tenants, perCycle)
 }
 
+// A read or write filter reports only the tenants that saw that kind of
+// activity, so on a large but mostly idle collection its answer has to cost what
+// the matches cost, not what the collection costs.
+func TestShardActivityUsageAllocations(t *testing.T) {
+	const (
+		tenants = 2000
+		readers = 3
+		writers = 2
+		runs    = 10
+		// a map holding every tenant costs ~98 bytes per tenant when it is sized
+		// upfront and ~194 when it grows into it, so the budget sits between the
+		// two, and a handful of matches has to stay far below either
+		maxBytesFiltered  = 4096
+		maxBytesPerTenant = 140
+	)
+
+	logger, _ := test.NewNullLogger()
+	col1 := newActivityTestIndex("Col1", true)
+	for i := 0; i < tenants; i++ {
+		col1.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
+	}
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
+	o := newNodeWideMetricsObserver(db)
+	o.observeActivity()
+
+	for i := 0; i < readers; i++ {
+		col1.shards.Load(fmt.Sprintf("tenant-%d", i)).(*Shard).activityTrackerRead.Add(1)
+	}
+	for i := 0; i < writers; i++ {
+		col1.shards.Load(fmt.Sprintf("tenant-%d", i)).(*Shard).activityTrackerWrite.Add(1)
+	}
+	o.observeActivity()
+
+	cases := []struct {
+		name     string
+		filter   tenantactivity.UsageFilter
+		want     int
+		maxBytes uint64
+	}{
+		{"only reads", tenantactivity.UsageFilterOnlyReads, readers, maxBytesFiltered},
+		{"only writes", tenantactivity.UsageFilterOnlyWrites, writers, maxBytesFiltered},
+		{"all tenants", tenantactivity.UsageFilterAll, tenants, maxBytesPerTenant * tenants},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			// a budget on its own would also pass on an answer that is too small
+			require.Len(t, o.Usage(tt.filter)["Col1"], tt.want)
+
+			var before, after runtime.MemStats
+			runtime.GC()
+			runtime.ReadMemStats(&before)
+			for i := 0; i < runs; i++ {
+				o.Usage(tt.filter)
+			}
+			runtime.ReadMemStats(&after)
+
+			perCall := (after.TotalAlloc - before.TotalAlloc) / runs
+			require.Less(t, perCall, tt.maxBytes,
+				"reporting %d of %d tenants allocated %d bytes per call", tt.want, tenants, perCall)
+		})
+	}
+}
+
 func TestShardActivityUsageWithoutObserver(t *testing.T) {
 	var o *nodeWideMetricsObserver
 	require.Empty(t, o.Usage(tenantactivity.UsageFilterAll))

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -13,43 +13,46 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"maps"
 	"math"
+	"runtime"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/schema"
 	esync "github.com/weaviate/weaviate/entities/sync"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 
 	"github.com/weaviate/weaviate/entities/tenantactivity"
 )
+
+func newActivityTestIndex(className string, partitioningEnabled bool) *Index {
+	return &Index{
+		Config: IndexConfig{
+			ClassName:         schema.ClassName(className),
+			ReplicationFactor: 1,
+		},
+		closingCtx:          context.Background(),
+		partitioningEnabled: partitioningEnabled,
+		shards:              shardMap{},
+		shardCreateLocks:    esync.NewKeyRWLocker(),
+	}
+}
 
 func TestShardActivity(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	db := &DB{
 		logger: logger,
 		indices: map[string]*Index{
-			"Col1": {
-				Config: IndexConfig{
-					ClassName:         "Col1",
-					ReplicationFactor: 1,
-				},
-				closingCtx:          context.Background(),
-				partitioningEnabled: true,
-				shards:              shardMap{},
-				shardCreateLocks:    esync.NewKeyRWLocker(),
-			},
-			"NonMT": {
-				Config: IndexConfig{
-					ClassName:         "NonMT",
-					ReplicationFactor: 1,
-				},
-				closingCtx:          context.Background(),
-				partitioningEnabled: false,
-				shards:              shardMap{},
-				shardCreateLocks:    esync.NewKeyRWLocker(),
-			},
+			"Col1":  newActivityTestIndex("Col1", true),
+			"NonMT": newActivityTestIndex("NonMT", false),
 		},
 	}
 
@@ -116,6 +119,12 @@ func TestShardActivity(t *testing.T) {
 		assert.False(t, ok, "t3 should not be contained")
 		_, ok = col["t4_only_writes"]
 		assert.False(t, ok, "t4 should not be contained")
+
+		// t1's counter wrapped past MaxInt32 instead of growing, which does not
+		// count as a read, so its read timestamp stays where t2's is even though
+		// its total timestamp has moved on
+		assert.Equal(t, col["t2_only_reads"], col["t1_overflow"],
+			"a wrapped counter should not move the read timestamp")
 	})
 
 	t.Run("display only writes", func(t *testing.T) {
@@ -145,4 +154,583 @@ func TestShardActivity(t *testing.T) {
 
 		assert.True(t, col["t5_reads_and_writes"].After(col["t4_only_writes"]), "t5 should have a newer timestamp than t4")
 	})
+
+	t.Run("unrecognized filter", func(t *testing.T) {
+		usage := o.Usage(tenantactivity.UsageFilter(42))
+		require.Len(t, usage["Col1"], 5, "falls back to the total usage")
+		require.Equal(t, o.Usage(tenantactivity.UsageFilterAll), usage)
+	})
+}
+
+// Observation buffers are recycled between cycles, so every cycle has to derive
+// its whole answer from the counters as they stand: what disappeared is gone,
+// and a timestamp only moves when the counter behind it moved.
+func TestShardActivityAcrossCycles(t *testing.T) {
+	// how a tenant should appear in one cycle: missing from the map, carrying a
+	// timestamp from this cycle, or still carrying the one it already had
+	const (
+		absent = ""
+		fresh  = "fresh"
+		kept   = "kept"
+	)
+
+	type tenantWant struct{ all, read, write string }
+
+	logger, _ := test.NewNullLogger()
+	col1 := newActivityTestIndex("Col1", true)
+	col2 := newActivityTestIndex("Col2", true)
+	nonMT := newActivityTestIndex("NonMT", false)
+	nonMT.shards.Store("shard1", &Shard{})
+
+	db := &DB{
+		logger:  logger,
+		indices: map[string]*Index{"Col1": col1, "Col2": col2, "NonMT": nonMT},
+	}
+	o := newNodeWideMetricsObserver(db)
+
+	require.Empty(t, o.Usage(tenantactivity.UsageFilterAll), "nothing observed yet")
+
+	add := func(index *Index, name string, read, write int32) func() {
+		return func() {
+			shard := &Shard{}
+			shard.activityTrackerRead.Store(read)
+			shard.activityTrackerWrite.Store(write)
+			index.shards.Store(name, shard)
+		}
+	}
+	bump := func(index *Index, name string, read, write int32) func() {
+		return func() {
+			shard := index.shards.Load(name).(*Shard)
+			shard.activityTrackerRead.Add(read)
+			shard.activityTrackerWrite.Add(write)
+		}
+	}
+	on := func(index *Index, name string, fn func(*Shard)) func() {
+		return func() { fn(index.shards.Load(name).(*Shard)) }
+	}
+
+	cycles := []struct {
+		name   string
+		mutate func()
+		want   map[string]map[string]tenantWant
+	}{
+		{
+			name:   "no tenants",
+			mutate: func() {},
+			want:   map[string]map[string]tenantWant{"Col1": {}, "Col2": {}},
+		},
+		{
+			name:   "tenant appears at its initial counters",
+			mutate: add(col1, "t1", 1, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "idle cycle changes nothing",
+			mutate: func() {},
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: kept}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "tenant is read",
+			mutate: bump(col1, "t1", 1, 0),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: fresh}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "read timestamp survives an idle cycle",
+			mutate: func() {},
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: kept, read: kept}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "tenant is written to",
+			mutate: bump(col1, "t1", 0, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: kept, write: fresh}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "read and write in the same cycle",
+			mutate: bump(col1, "t1", 1, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: fresh, write: fresh}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "write counter reaches the maximum",
+			mutate: on(col1, "t1", func(s *Shard) { s.activityTrackerWrite.Store(math.MaxInt32) }),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: kept, write: fresh}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "write counter wraps instead of growing",
+			mutate: on(col1, "t1", func(s *Shard) { s.activityTrackerWrite.Add(1) }),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: kept, write: kept}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "read counter reaches the maximum",
+			mutate: on(col1, "t1", func(s *Shard) { s.activityTrackerRead.Store(math.MaxInt32) }),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: fresh, write: kept}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "read counter wraps instead of growing",
+			mutate: on(col1, "t1", func(s *Shard) { s.activityTrackerRead.Add(1) }),
+			want: map[string]map[string]tenantWant{
+				"Col1": {"t1": {all: fresh, read: kept, write: kept}},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "tenant first seen one read above its initial counter",
+			mutate: add(col1, "t2", 2, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: fresh, read: fresh},
+				},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "tenant first seen one write above its initial counter",
+			mutate: add(col1, "t3", 1, 2),
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: fresh, write: fresh},
+				},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "cold tenant reports no counters at all",
+			mutate: func() { col1.shards.Store("t4", newColdShard(col1, "t4")) },
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: kept, write: kept},
+					"t4": {all: fresh},
+				},
+				"Col2": {},
+			},
+		},
+		{
+			name:   "activity in one collection leaves the other alone",
+			mutate: add(col2, "t5", 3, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: kept, write: kept},
+					"t4": {all: kept},
+				},
+				"Col2": {"t5": {all: fresh, read: fresh}},
+			},
+		},
+		{
+			name:   "tenant removed",
+			mutate: func() { col1.shards.LoadAndDelete("t3") },
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t4": {all: kept},
+				},
+				"Col2": {"t5": {all: kept, read: kept}},
+			},
+		},
+		{
+			// the tenant is new to the observer again, so the write timestamp it
+			// used to have is gone rather than resurrected
+			name:   "tenant returns at its initial counters",
+			mutate: add(col1, "t3", 1, 1),
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: fresh},
+					"t4": {all: kept},
+				},
+				"Col2": {"t5": {all: kept, read: kept}},
+			},
+		},
+		{
+			name:   "collection removed",
+			mutate: func() { delete(db.indices, "Col2") },
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: kept, read: kept, write: kept},
+					"t2": {all: kept, read: kept},
+					"t3": {all: kept},
+					"t4": {all: kept},
+				},
+			},
+		},
+		{
+			name:   "last collection removed",
+			mutate: func() { delete(db.indices, "Col1") },
+			want:   map[string]map[string]tenantWant{},
+		},
+		{
+			// t1's counters wrapped into the negative earlier, so on re-sighting
+			// they no longer read as activity beyond the initial value
+			name: "collections return with their tenants",
+			mutate: func() {
+				db.indices["Col1"], db.indices["Col2"] = col1, col2
+			},
+			want: map[string]map[string]tenantWant{
+				"Col1": {
+					"t1": {all: fresh},
+					"t2": {all: fresh, read: fresh},
+					"t3": {all: fresh},
+					"t4": {all: fresh},
+				},
+				"Col2": {"t5": {all: fresh, read: fresh}},
+			},
+		},
+	}
+
+	filters := []struct {
+		name   string
+		filter tenantactivity.UsageFilter
+		pick   func(tenantWant) string
+	}{
+		{"all", tenantactivity.UsageFilterAll, func(w tenantWant) string { return w.all }},
+		{"reads", tenantactivity.UsageFilterOnlyReads, func(w tenantWant) string { return w.read }},
+		{"writes", tenantactivity.UsageFilterOnlyWrites, func(w tenantWant) string { return w.write }},
+	}
+
+	// the timestamps each filter reported last cycle, keyed by collection/tenant
+	previous := map[string]map[string]time.Time{}
+
+	for _, cycle := range cycles {
+		t.Run(cycle.name, func(t *testing.T) {
+			cycle.mutate()
+			// consecutive cycles have to land on distinguishable timestamps
+			time.Sleep(time.Millisecond)
+			o.observeActivity()
+
+			for _, f := range filters {
+				usage := o.Usage(f.filter)
+				require.Len(t, usage, len(cycle.want),
+					"%s: only multi-tenant collections are reported", f.name)
+
+				current := map[string]time.Time{}
+				for class, tenants := range cycle.want {
+					byTenant, ok := usage[class]
+					require.True(t, ok, "%s: collection %s should be reported", f.name, class)
+
+					want := map[string]string{}
+					for tenant, w := range tenants {
+						if expectation := f.pick(w); expectation != absent {
+							want[tenant] = expectation
+						}
+					}
+					require.ElementsMatch(t, slices.Collect(maps.Keys(want)),
+						slices.Collect(maps.Keys(byTenant)), "%s: tenants of %s", f.name, class)
+
+					for tenant, expectation := range want {
+						key := class + "/" + tenant
+						if expectation == fresh {
+							require.NotEqual(t, previous[f.name][key], byTenant[tenant],
+								"%s: %s should carry a timestamp from this cycle", f.name, key)
+						} else {
+							require.Equal(t, previous[f.name][key], byTenant[tenant],
+								"%s: %s should keep its timestamp", f.name, key)
+						}
+						current[key] = byTenant[tenant]
+					}
+				}
+				previous[f.name] = current
+			}
+		})
+	}
+}
+
+// Usage hands out a copy because the observer keeps rewriting the maps it
+// derives that copy from.
+func TestShardActivityUsageIsIndependent(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	col1 := newActivityTestIndex("Col1", true)
+	col1.shards.Store("t1", &Shard{})
+	col1.shards.Store("t2", &Shard{})
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
+	o := newNodeWideMetricsObserver(db)
+	o.observeActivity()
+
+	t.Run("callers cannot change what the observer reports", func(t *testing.T) {
+		usage := o.Usage(tenantactivity.UsageFilterAll)
+		delete(usage["Col1"], "t1")
+		usage["Col1"]["injected"] = time.Now()
+
+		fresh := o.Usage(tenantactivity.UsageFilterAll)
+		require.Contains(t, fresh["Col1"], "t1")
+		require.NotContains(t, fresh["Col1"], "injected")
+	})
+
+	t.Run("a later observation does not change an earlier result", func(t *testing.T) {
+		earlier := o.Usage(tenantactivity.UsageFilterAll)
+		snapshot := maps.Clone(earlier["Col1"])
+
+		col1.shards.Store("t3", &Shard{})
+		col1.shards.Load("t1").(*Shard).activityTrackerRead.Add(1)
+		o.observeActivity()
+
+		require.Equal(t, snapshot, earlier["Col1"])
+	})
+
+	t.Run("reads while observing", func(t *testing.T) {
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+
+		for i := 0; i < 4; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						for _, byTenant := range o.Usage(tenantactivity.UsageFilterOnlyReads) {
+							for range byTenant {
+							}
+						}
+					}
+				}
+			}()
+		}
+
+		for i := 0; i < 20; i++ {
+			col1.shards.Load("t1").(*Shard).activityTrackerRead.Add(1)
+			o.observeActivity()
+		}
+		close(stop)
+		wg.Wait()
+	})
+}
+
+// The observe cycle runs on every node every 10 seconds, so its allocations must
+// not grow with the number of tenants.
+func TestShardActivityObserveAllocations(t *testing.T) {
+	const (
+		tenants = 2000
+		// steady state is ~41 bytes per tenant, and dropping either reuse buffer
+		// costs 149 or more, so the budget sits between the two
+		maxBytesPerTenant = 60
+		runs              = 10
+	)
+
+	logger, _ := test.NewNullLogger()
+	col1 := newActivityTestIndex("Col1", true)
+	for i := 0; i < tenants; i++ {
+		col1.shards.Store(fmt.Sprintf("tenant-%d", i), &Shard{})
+	}
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
+	o := newNodeWideMetricsObserver(db)
+
+	// the buffers are only fully in place once a cycle has replaced a cycle
+	for i := 0; i < 3; i++ {
+		o.observeActivity()
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for i := 0; i < runs; i++ {
+		o.observeActivity()
+	}
+	runtime.ReadMemStats(&after)
+
+	perCycle := (after.TotalAlloc - before.TotalAlloc) / runs
+	require.Less(t, perCycle, uint64(maxBytesPerTenant*tenants),
+		"observing %d unchanged tenants allocated %d bytes per cycle", tenants, perCycle)
+}
+
+func TestShardActivityUsageWithoutObserver(t *testing.T) {
+	var o *nodeWideMetricsObserver
+	require.Empty(t, o.Usage(tenantactivity.UsageFilterAll))
+}
+
+// newColdShard returns an unloaded LazyLoadShard whose every load attempt fails,
+// so a force-load panics through mustLoad instead of passing unnoticed.
+func newColdShard(index *Index, name string) *LazyLoadShard {
+	return &LazyLoadShard{
+		shardOpts:  &deferredShardOpts{name: name, index: index},
+		memMonitor: failingAllocChecker{},
+	}
+}
+
+// Tenant activity is polled for every shard on the node, so a cold tenant has to
+// be observable without being pulled into memory.
+func TestShardActivityColdShard(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	col1 := newActivityTestIndex("Col1", true)
+	cold := newColdShard(col1, "t_cold")
+	col1.shards.Store("t_cold", cold)
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
+	o := newNodeWideMetricsObserver(db)
+
+	t.Run("observing does not load it", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			for i := 0; i < 3; i++ {
+				o.observeActivity()
+			}
+		})
+		require.False(t, cold.isLoaded(), "a cold tenant must stay cold")
+	})
+
+	t.Run("counted as a tenant but never as a read or a write", func(t *testing.T) {
+		require.Contains(t, o.Usage(tenantactivity.UsageFilterAll)["Col1"], "t_cold")
+		require.NotContains(t, o.Usage(tenantactivity.UsageFilterOnlyReads)["Col1"], "t_cold")
+		require.NotContains(t, o.Usage(tenantactivity.UsageFilterOnlyWrites)["Col1"], "t_cold")
+	})
+
+	t.Run("timestamp does not drift while it stays cold", func(t *testing.T) {
+		first := o.Usage(tenantactivity.UsageFilterAll)["Col1"]["t_cold"]
+		time.Sleep(10 * time.Millisecond)
+		o.observeActivity()
+		require.Equal(t, first, o.Usage(tenantactivity.UsageFilterAll)["Col1"]["t_cold"])
+	})
+}
+
+// A tenant that loads starts reporting the initial counters of 1 after the zeros
+// it reported while cold. The observer reads that step as a read and a write,
+// where a tenant that was already loaded on first sight logs an activation.
+func TestShardActivityColdShardLoads(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	col1 := newActivityTestIndex("Col1", true)
+	cold := newColdShard(col1, "t_cold")
+	col1.shards.Store("t_cold", cold)
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
+	o := newNodeWideMetricsObserver(db)
+	o.observeActivity()
+	require.NotContains(t, o.Usage(tenantactivity.UsageFilterOnlyReads)["Col1"], "t_cold")
+
+	loaded := &Shard{}
+	loaded.activityTrackerRead.Store(1)
+	loaded.activityTrackerWrite.Store(1)
+	cold.mutex.Lock()
+	cold.shard, cold.loaded = loaded, true
+	cold.mutex.Unlock()
+
+	o.observeActivity()
+
+	require.Contains(t, o.Usage(tenantactivity.UsageFilterOnlyReads)["Col1"], "t_cold")
+	require.Contains(t, o.Usage(tenantactivity.UsageFilterOnlyWrites)["Col1"], "t_cold")
+}
+
+// Tenant activity logs are a configurable signal operators rely on, so every
+// branch has to keep emitting the entry it is responsible for.
+func TestShardActivityLogging(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	col1 := newActivityTestIndex("Col1", true)
+	db := &DB{logger: logger, indices: map[string]*Index{"Col1": col1}}
+	db.config.TenantActivityReadLogLevel = configRuntime.NewDynamicValue("info")
+	db.config.TenantActivityWriteLogLevel = configRuntime.NewDynamicValue("info")
+	o := newNodeWideMetricsObserver(db)
+
+	addTenant := func(name string, read, write int32) func() {
+		return func() {
+			shard := &Shard{}
+			shard.activityTrackerRead.Store(read)
+			shard.activityTrackerWrite.Store(write)
+			col1.shards.Store(name, shard)
+		}
+	}
+	bump := func(name string, read, write int32) func() {
+		return func() {
+			shard := col1.shards.Load(name).(*Shard)
+			shard.activityTrackerRead.Add(read)
+			shard.activityTrackerWrite.Add(write)
+		}
+	}
+
+	cycles := []struct {
+		name   string
+		mutate func()
+		want   map[string]string
+	}{
+		{
+			name:   "new tenant at its initial counters",
+			mutate: addTenant("t_activation", 1, 1),
+			want:   map[string]string{"t_activation": "activation"},
+		},
+		{
+			name:   "new tenant that has already been read",
+			mutate: addTenant("t_new_read", 5, 1),
+			want:   map[string]string{"t_new_read": "read"},
+		},
+		{
+			name:   "new tenant that has already been written to",
+			mutate: addTenant("t_new_write", 1, 5),
+			want:   map[string]string{"t_new_write": "write"},
+		},
+		{
+			name:   "known tenant is read",
+			mutate: bump("t_activation", 1, 0),
+			want:   map[string]string{"t_activation": "read"},
+		},
+		{
+			name:   "known tenant is written to",
+			mutate: bump("t_activation", 0, 1),
+			want:   map[string]string{"t_activation": "write"},
+		},
+		{
+			// a cold tenant reports zeros, which is below the initial counters and
+			// so is not an activation either
+			name:   "cold tenant that reports no counters",
+			mutate: func() { col1.shards.Store("t_cold", newColdShard(col1, "t_cold")) },
+			want:   map[string]string{},
+		},
+		{
+			name:   "nothing happened",
+			mutate: func() {},
+			want:   map[string]string{},
+		},
+	}
+
+	for _, cycle := range cycles {
+		t.Run(cycle.name, func(t *testing.T) {
+			hook.Reset()
+			cycle.mutate()
+			o.observeActivity()
+
+			logged := map[string]string{}
+			for _, entry := range hook.AllEntries() {
+				if entry.Data["action"] != "tenant_activity_change" {
+					continue
+				}
+				logged[entry.Data["tenant"].(string)] = entry.Data["activity_type"].(string)
+			}
+			require.Equal(t, cycle.want, logged)
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:

Every node polls all of its tenants every 10 seconds to record when each one was last read from and last written to. That is what the tenant activity endpoint reports, and it is how idle tenants get noticed.

Until now, each of those polls threw away last cycle's bookkeeping and built it again from nothing: one map of counters per collection, plus three maps of timestamps (total, reads, writes). On a node with a lot of tenants that is a steady stream of garbage produced every 10 seconds, forever, purely to arrive at an answer that is mostly identical to the previous one.

  What changed

  - The maps are now filled in again each cycle instead of being replaced. Tenants and collections that disappeared are removed, the rest are updated in place.
  - The three timestamp maps became one map holding a small record per tenant (the counters last seen, plus the three timestamps). One lookup instead of four, and one map to keep alive instead of four.
  - Reused maps never shrink on their own, so a collection that dropped below a quarter of the tenants it once had is handed a fresh, smaller map.

Cost per tenant per cycle went from roughly 150 bytes to roughly 40, and it stays flat as the tenant count grows.

  ## Allocation in the collection cycle

  The observer polls every tenant on the node every 10 seconds, whether or not anything happened. Measured with `BenchmarkObserveActivity` on one multi-tenant collection.

  ### Bytes allocated per cycle

  | Tenants | Active since last cycle | Before | After | Change | Saved / node / day <sup>1</sup> |
  | ------: | :---------------------- | -----: | ----: | -----: | ------------------------------: |
  |   1,000 | none                    | 334 KiB | 40 KiB | **−88.0%** | 2.4 GiB |
  |   1,000 | 10%                     | 534 KiB | 219 KiB | **−59.0%** | 2.6 GiB |
  |   1,000 | all                     | 2.44 MiB | 1.79 MiB | **−26.7%** | 5.5 GiB |
  |  50,000 | none                    | 11.24 MiB | 1.91 MiB | **−83.0%** | 78.8 GiB |
  |  50,000 | 10%                     | 21.43 MiB | 10.61 MiB | **−50.5%** | 91.3 GiB |
  |  50,000 | all                     | 110.22 MiB | 88.89 MiB | **−19.4%** | 180.0 GiB |


 Usage now returns a copy instead of the live map — unavoidable once the cycle writes in place — costing +3.00 MiB per unfiltered request at 50k tenants, against the ~8.9 MiB the JSON encoding already spends.