### PR TITLE
Fix usage module with named vectors where one is a prefix of another

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -318,13 +318,16 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		return nil, err
 	}
 
+	objectsWithoutVectors, vectorsInObjects := i.splitObjectsBucketSize(shard.Name(),
+		uint64(objectStorageSize), uint64(uncompressedVectorSize))
+
 	shardUsage := &types.ShardUsage{
 		Name:                  shard.Name(),
 		Status:                strings.ToLower(models.TenantActivityStatusACTIVE),
 		ObjectsCount:          objectCount,
-		ObjectsStorageBytes:   uint64(objectStorageSize) - uint64(uncompressedVectorSize),                               // objects without vectors
-		VectorStorageBytes:    uint64(vectorStorageSize) + uint64(uncompressedVectorSize) + vectorCommitLogsStorageSize, // lsm/vectors + objects vectors + commit.log folders
-		IndexStorageBytes:     indexUsage,                                                                               // lsm property folders and dimensions folder
+		ObjectsStorageBytes:   objectsWithoutVectors,
+		VectorStorageBytes:    uint64(vectorStorageSize) + vectorsInObjects + vectorCommitLogsStorageSize, // lsm/vectors + objects vectors + commit.log folders
+		IndexStorageBytes:     indexUsage,                                                                 // lsm property folders and dimensions folder
 		FullShardStorageBytes: vectorCommitLogsStorageSize + otherNonLSMFoldersStorageSize + indexUsage + uint64(objectStorageSize) + uint64(vectorStorageSize),
 	}
 	// Get vector usage for each named vector
@@ -464,12 +467,15 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 
 	sort.Sort(namedVectors)
 
+	objectsWithoutVectors, vectorsInObjects := i.splitObjectsBucketSize(shardName,
+		uint64(objectUsage.StorageBytes), uncompressedVectorSize)
+
 	shardUsage := &types.ShardUsage{
 		Name:                  shardName,
 		ObjectsCount:          objectUsage.Count,
 		Status:                strings.ToLower(models.TenantActivityStatusINACTIVE),
-		ObjectsStorageBytes:   uint64(objectUsage.StorageBytes) - uncompressedVectorSize,
-		VectorStorageBytes:    uint64(vectorStorageSize) + uncompressedVectorSize + vectorCommitLogsStorageSize,
+		ObjectsStorageBytes:   objectsWithoutVectors,
+		VectorStorageBytes:    uint64(vectorStorageSize) + vectorsInObjects + vectorCommitLogsStorageSize,
 		IndexStorageBytes:     indexUsage,
 		FullShardStorageBytes: vectorCommitLogsStorageSize + otherNonLSMFoldersStorageSize + indexUsage + uint64(objectUsage.StorageBytes) + uint64(vectorStorageSize),
 		NamedVectors:          namedVectors,
@@ -478,6 +484,22 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		return nil, fmt.Errorf("save usage to disk: %w", err)
 	}
 	return shardUsage, err
+}
+
+// splitObjectsBucketSize divides the objects bucket's measured size into the objects themselves and
+// the uncompressed vectors stored alongside them. The vector part is modelled from the dimensions
+// bucket rather than measured, so a stale bucket can model more bytes than the objects bucket holds
+// — capping it keeps the subtraction from wrapping to a 16 EiB bill.
+func (i *Index) splitObjectsBucketSize(shardName string, objectsBucketSize, uncompressedVectorSize uint64) (withoutVectors, vectors uint64) {
+	if uncompressedVectorSize > objectsBucketSize {
+		i.logger.WithFields(logrus.Fields{
+			"class": i.Config.ClassName.String(),
+			"shard": shardName,
+		}).Warnf("dimensions bucket models %d vector bytes but the objects bucket holds only %d; reporting no object storage for this shard",
+			uncompressedVectorSize, objectsBucketSize)
+		return 0, objectsBucketSize
+	}
+	return objectsBucketSize - uncompressedVectorSize, uncompressedVectorSize
 }
 
 func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.ShardUsage {

--- a/adapters/repos/db/index_usage_split_test.go
+++ b/adapters/repos/db/index_usage_split_test.go
@@ -1,0 +1,122 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	entschema "github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestSplitObjectsBucketSize(t *testing.T) {
+	className := "SplitObjects"
+	shardName := "shard1"
+
+	tests := []struct {
+		name                   string
+		objectsBucketSize      uint64
+		uncompressedVectorSize uint64
+		wantWithoutVectors     uint64
+		wantVectors            uint64
+		wantWarning            bool
+	}{
+		{
+			name:                   "vectors below bucket size",
+			objectsBucketSize:      1000,
+			uncompressedVectorSize: 400,
+			wantWithoutVectors:     600,
+			wantVectors:            400,
+		},
+		{
+			name:                   "no vectors modelled",
+			objectsBucketSize:      1000,
+			uncompressedVectorSize: 0,
+			wantWithoutVectors:     1000,
+			wantVectors:            0,
+		},
+		{
+			name:                   "vectors exactly bucket size",
+			objectsBucketSize:      1000,
+			uncompressedVectorSize: 1000,
+			wantWithoutVectors:     0,
+			wantVectors:            1000,
+		},
+		{
+			name:                   "vectors one byte above bucket size",
+			objectsBucketSize:      1000,
+			uncompressedVectorSize: 1001,
+			wantWithoutVectors:     0,
+			wantVectors:            1000,
+			wantWarning:            true,
+		},
+		{
+			name:                   "vectors far above bucket size",
+			objectsBucketSize:      1000,
+			uncompressedVectorSize: 1 << 40,
+			wantWithoutVectors:     0,
+			wantVectors:            1000,
+			wantWarning:            true,
+		},
+		{
+			name:                   "empty bucket, no vectors modelled",
+			objectsBucketSize:      0,
+			uncompressedVectorSize: 0,
+			wantWithoutVectors:     0,
+			wantVectors:            0,
+		},
+		{
+			name:                   "vectors modelled for an empty bucket",
+			objectsBucketSize:      0,
+			uncompressedVectorSize: 512,
+			wantWithoutVectors:     0,
+			wantVectors:            0,
+			wantWarning:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := logrustest.NewNullLogger()
+			idx := &Index{
+				logger: logger,
+				Config: IndexConfig{ClassName: entschema.ClassName(className)},
+			}
+
+			withoutVectors, vectors := idx.splitObjectsBucketSize(shardName,
+				tt.objectsBucketSize, tt.uncompressedVectorSize)
+
+			assert.Equal(t, tt.wantWithoutVectors, withoutVectors)
+			assert.Equal(t, tt.wantVectors, vectors)
+
+			// the bound is what catches a wrapped subtraction; the sum alone wraps back to the
+			// bucket size and would pass either way
+			assert.LessOrEqual(t, withoutVectors, tt.objectsBucketSize)
+			assert.LessOrEqual(t, vectors, tt.objectsBucketSize)
+			assert.Equal(t, tt.objectsBucketSize, withoutVectors+vectors)
+
+			if !tt.wantWarning {
+				assert.Empty(t, hook.AllEntries())
+				return
+			}
+			require.Len(t, hook.AllEntries(), 1)
+			entry := hook.LastEntry()
+			assert.Equal(t, logrus.WarnLevel, entry.Level)
+			assert.Equal(t, className, entry.Data["class"])
+			assert.Equal(t, shardName, entry.Data["shard"])
+		})
+	}
+}

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -386,6 +386,11 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 				dimensionality.Dimensions = int(dimLength)
 				dimensionality.Count = len(v)
 			}
+			// remaining keys cannot change a complete result, and an empty name
+			// matches every key so the prefix break above never fires
+			if dimensionality.Dimensions != 0 && dimensionality.Count != 0 {
+				break
+			}
 		}
 	default:
 		c := b.CursorRoaringSet()
@@ -410,6 +415,11 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 			if dimLength > 0 && (dimensionality.Dimensions == 0 || dimensionality.Count == 0) {
 				dimensionality.Dimensions = int(dimLength)
 				dimensionality.Count = v.GetCardinality()
+			}
+			// remaining keys cannot change a complete result, and an empty name
+			// matches every key so the prefix break above never fires
+			if dimensionality.Dimensions != 0 && dimensionality.Count != 0 {
+				break
 			}
 		}
 	}

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -373,9 +373,12 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 			k, v = c.Seek(ctx, []byte(targetVector))
 		}
 		for ; k != nil; k, v = c.Next(ctx) {
-			// for named vectors we have to additionally check if the key is prefixed with the vector name
-			if len(k) != expectedKeyLen || !strings.HasPrefix(string(k), targetVector) {
+			if !strings.HasPrefix(string(k), targetVector) {
 				break
+			}
+			// a longer name sharing this prefix can sort before the target's own keys
+			if len(k) != expectedKeyLen {
+				continue
 			}
 
 			dimLength := binary.LittleEndian.Uint32(k[nameLen:])
@@ -395,9 +398,12 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 			k, v = c.Seek([]byte(targetVector))
 		}
 		for ; k != nil; k, v = c.Next() {
-			// for named vectors we have to additionally check if the key is prefixed with the vector name
-			if len(k) != expectedKeyLen || !strings.HasPrefix(string(k), targetVector) {
+			if !strings.HasPrefix(string(k), targetVector) {
 				break
+			}
+			// a longer name sharing this prefix can sort before the target's own keys
+			if len(k) != expectedKeyLen {
+				continue
 			}
 
 			dimLength := binary.LittleEndian.Uint32(k[nameLen:])

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -657,11 +657,6 @@ func TestLoadComputedUsageData(t *testing.T) {
 			version: types.UsageDiskVersion,
 		},
 		{
-			name:    "version written by an earlier release",
-			version: 1,
-			wantErr: true,
-		},
-		{
 			name:    "version from a newer release",
 			version: types.UsageDiskVersion + 1,
 			wantErr: true,

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -14,6 +14,7 @@ package shardusage
 import (
 	"context"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -642,4 +643,49 @@ func TestCalculateTargetVectorDimensionsFromBucket(t *testing.T) {
 		_, err = CalculateTargetVectorDimensionsFromBucket(ctx, b, "text")
 		require.Error(t, err)
 	})
+}
+
+// Only the current format version is served; any other is rejected so the caller recomputes.
+func TestLoadComputedUsageData(t *testing.T) {
+	tests := []struct {
+		name    string
+		version int
+		wantErr bool
+	}{
+		{
+			name:    "current version",
+			version: types.UsageDiskVersion,
+		},
+		{
+			name:    "version written by an earlier release",
+			version: 1,
+			wantErr: true,
+		},
+		{
+			name:    "version from a newer release",
+			version: types.UsageDiskVersion + 1,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexPath := t.TempDir()
+			shardName := "shard"
+			require.NoError(t, os.MkdirAll(filepath.Join(indexPath, shardName), 0o755))
+
+			stored := &types.ShardUsage{Name: shardName, ObjectsCount: 7, ObjectsStorageBytes: 1234}
+			data, err := json.Marshal(&types.UsageDisk{Version: tt.version, ShardUsage: stored})
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(usageTmpFilePath(indexPath, shardName), data, 0o600))
+
+			loaded, err := LoadComputedUsageData(indexPath, shardName)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, stored, loaded)
+		})
+	}
 }

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -449,10 +449,7 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
 	require.NoError(t, err)
 
-	key := make([]byte, 4+4)
-	copy(key, "text")
-	binary.LittleEndian.PutUint32(key[4:], 128)
-	require.NoError(t, b.RoaringSetAddOne(key, 1))
+	writeDims(t, b, "text", 128, []uint64{1})
 	require.NoError(t, b.FlushMemtable())
 	require.NoError(t, b.Shutdown(ctx))
 
@@ -488,19 +485,32 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 	}
 }
 
+// writeDims writes the dimensions-bucket row of a target vector, in whichever strategy the
+// bucket uses.
+func writeDims(t *testing.T, b *lsmkv.Bucket, targetVector string, dims uint32, docIDs []uint64) {
+	t.Helper()
+
+	key := make([]byte, len(targetVector)+4)
+	copy(key, targetVector)
+	binary.LittleEndian.PutUint32(key[len(targetVector):], dims)
+
+	if b.Strategy() == lsmkv.StrategyMapCollection {
+		for _, docID := range docIDs {
+			docIDBytes := make([]byte, 8)
+			binary.LittleEndian.PutUint64(docIDBytes, docID)
+			require.NoError(t, b.MapSet(key, lsmkv.MapPair{Key: docIDBytes, Value: []byte{}}))
+		}
+		return
+	}
+	for _, docID := range docIDs {
+		require.NoError(t, b.RoaringSetAddOne(key, docID))
+	}
+}
+
 func TestCalculateUnloadedDimensionsUsageAll(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx := context.Background()
 	tenantName := "tenant"
-
-	writeDims := func(t *testing.T, b *lsmkv.Bucket, targetVector string, dims uint32, docIDs []uint64) {
-		key := make([]byte, len(targetVector)+4)
-		copy(key, targetVector)
-		binary.LittleEndian.PutUint32(key[len(targetVector):], dims)
-		for _, docID := range docIDs {
-			require.NoError(t, b.RoaringSetAddOne(key, docID))
-		}
-	}
 
 	dirName := t.TempDir()
 	bucketFolder := shardPathDimensionsLSM(dirName, tenantName)
@@ -533,4 +543,103 @@ func TestCalculateUnloadedDimensionsUsageAll(t *testing.T) {
 	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
 	require.NoError(t, err)
 	assert.Nil(t, none)
+}
+
+// TestCalculateTargetVectorDimensionsFromBucket pins that a vector name which is a prefix of a
+// longer name still reports its own dimensions and object count: its dimension bytes sort after
+// the longer name's keys ("texts…" before "text\x80…" at 384 dimensions), so the scan has to skip
+// past those instead of stopping at them. Every vector gets its own dimensions and object count,
+// so a scan that lands on a neighbour's key cannot pass.
+func TestCalculateTargetVectorDimensionsFromBucket(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	stored := []struct {
+		targetVector string
+		dims         uint32
+		docIDs       []uint64
+	}{
+		{targetVector: "image", dims: 512, docIDs: []uint64{1, 2, 3, 4}},
+		{targetVector: "text", dims: 384, docIDs: []uint64{1, 2, 3}},
+		{targetVector: "texts", dims: 256, docIDs: []uint64{4, 5}},
+		{targetVector: "textbook", dims: 192, docIDs: []uint64{1, 2, 3, 4, 5}},
+		{targetVector: "", dims: 128, docIDs: []uint64{1, 2, 3, 4, 5, 6}},
+	}
+
+	tests := []struct {
+		name         string
+		targetVector string
+		expected     types.Dimensionality
+	}{
+		{
+			name:         "no other name shares the prefix",
+			targetVector: "image",
+			expected:     types.Dimensionality{Dimensions: 512, Count: 4},
+		},
+		{
+			name:         "name is a prefix of two longer names",
+			targetVector: "text",
+			expected:     types.Dimensionality{Dimensions: 384, Count: 3},
+		},
+		{
+			name:         "name extends a shorter name",
+			targetVector: "texts",
+			expected:     types.Dimensionality{Dimensions: 256, Count: 2},
+		},
+		{
+			name:         "name extends a shorter name and precedes a sibling",
+			targetVector: "textbook",
+			expected:     types.Dimensionality{Dimensions: 192, Count: 5},
+		},
+		{
+			name:         "unnamed vector alongside named ones",
+			targetVector: "",
+			expected:     types.Dimensionality{Dimensions: 128, Count: 6},
+		},
+		{
+			name:         "vector without entries",
+			targetVector: "missing",
+			expected:     types.Dimensionality{},
+		},
+	}
+
+	// unloaded shards are read from segments only, loaded ones can still hold the entries in the
+	// memtable
+	for _, strategy := range []string{lsmkv.StrategyRoaringSet, lsmkv.StrategyMapCollection} {
+		for _, flushed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/flushed=%v", strategy, flushed), func(t *testing.T) {
+				b, err := lsmkv.NewBucketCreator().NewBucket(ctx, filepath.Join(t.TempDir(), "dimensions"), "",
+					logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+					lsmkv.WithStrategy(strategy))
+				require.NoError(t, err)
+				defer b.Shutdown(ctx)
+
+				for _, entry := range stored {
+					writeDims(t, b, entry.targetVector, entry.dims, entry.docIDs)
+				}
+				if flushed {
+					require.NoError(t, b.FlushMemtable())
+				}
+
+				for _, tt := range tests {
+					t.Run(tt.name, func(t *testing.T) {
+						dimensionality, err := CalculateTargetVectorDimensionsFromBucket(ctx, b, tt.targetVector)
+						require.NoError(t, err)
+						assert.Equal(t, tt.expected, dimensionality)
+					})
+				}
+			})
+		}
+	}
+
+	t.Run("unsupported strategy", func(t *testing.T) {
+		b, err := lsmkv.NewBucketCreator().NewBucket(ctx, filepath.Join(t.TempDir(), "dimensions"), "",
+			logger, nil, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			lsmkv.WithStrategy(lsmkv.StrategyReplace))
+		require.NoError(t, err)
+		defer b.Shutdown(ctx)
+
+		_, err = CalculateTargetVectorDimensionsFromBucket(ctx, b, "text")
+		require.Error(t, err)
+	})
 }

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/test/docker"
@@ -378,9 +379,19 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 
 	className := t.Name() + "Class"
 	tenantName := "tenant"
+	// "vector" is a proper prefix of the other two names, so at 384 dimensions its key sorts
+	// after theirs in the dimensions bucket
+	vectorPrefix := "vector"
 	vector1 := "vector1"
 	vector2 := "vector2"
-	dimensions := 128
+
+	// every vector gets its own dimensions and object count, so a report that attributes one
+	// vector's numbers to another cannot pass
+	expected := map[string]usagetypes.Dimensionality{
+		vectorPrefix: {Dimensions: 384, Count: 100},
+		vector1:      {Dimensions: 128, Count: 60},
+		vector2:      {Dimensions: 256, Count: 30},
+	}
 
 	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
@@ -398,6 +409,12 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 			},
 		},
 		VectorConfig: map[string]models.VectorConfig{
+			vectorPrefix: {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType: "hnsw",
+			},
 			vector1: {
 				Vectorizer: map[string]any{
 					"none": map[string]any{},
@@ -418,10 +435,16 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).
 		WithTenants(models.Tenant{Name: tenantName}).Do(ctx))
 
-	// Insert 100 objects with both named vectors
+	// Insert 100 objects, each carrying the named vectors its index still falls within
 	const numObjects = 100
 	objs := make([]*models.Object, numObjects)
 	for i := range numObjects {
+		vectors := models.Vectors{}
+		for name, dimensionality := range expected {
+			if i < dimensionality.Count {
+				vectors[name] = generateRandomVector(dimensionality.Dimensions)
+			}
+		}
 		objs[i] = &models.Object{
 			Class:  className,
 			ID:     strfmt.UUID(uuid.NewString()),
@@ -430,10 +453,7 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 				"name":        fmt.Sprintf("name %d", i),
 				"description": fmt.Sprintf("description %d", i),
 			},
-			Vectors: models.Vectors{
-				vector1: generateRandomVector(dimensions),
-				vector2: generateRandomVector(dimensions),
-			},
+			Vectors: vectors,
 		}
 	}
 	batchResp, err := c.Batch().ObjectsBatcher().WithObjects(objs...).Do(ctx)
@@ -449,26 +469,23 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	// COLD/HOT cycle flushes to disk so the baseline is comparable post-drop
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
 		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+
+	// the cold shard is reported straight from the dimensions bucket on disk
+	colUsageCold, err := GetDebugUsageForCollection(className)
+	require.NoError(t, err)
+	require.Len(t, colUsageCold.Shards, 1)
+	require.Equal(t, expected, namedVectorDimensionalities(t, colUsageCold.Shards[0]))
+
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
 		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx))
 
-	// Verify both named vectors appear in usage
+	// Verify all named vectors appear in usage
 	colUsageBefore, err := GetDebugUsageForCollection(className)
 	require.NoError(t, err)
 	require.Len(t, colUsageBefore.Shards, 1)
 	shard := colUsageBefore.Shards[0]
 	require.Equal(t, int64(numObjects), shard.ObjectsCount)
-	require.Len(t, shard.NamedVectors, 2)
-
-	vectorNames := map[string]bool{}
-	for _, v := range shard.NamedVectors {
-		vectorNames[v.Name] = true
-		require.NotEmpty(t, v.Dimensionalities)
-		require.Equal(t, dimensions, v.Dimensionalities[0].Dimensions)
-		require.Equal(t, numObjects, v.Dimensionalities[0].Count)
-	}
-	require.True(t, vectorNames[vector1], "expected vector1 in usage report")
-	require.True(t, vectorNames[vector2], "expected vector2 in usage report")
+	require.Equal(t, expected, namedVectorDimensionalities(t, shard))
 
 	initialFullStorage := shard.FullShardStorageBytes
 	initialVectorStorage := shard.VectorStorageBytes
@@ -479,19 +496,16 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	require.NoError(t, c.Schema().VectorIndexDeleter().
 		WithClassName(className).WithVectorIndexName(vector1).Do(ctx))
 
-	// Verify vector1 is no longer in the usage metrics, vector2 remains,
+	// Verify vector1 is no longer in the usage metrics, the others remain,
 	// and storage bytes have decreased
+	delete(expected, vector1)
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		colUsageAfter, err := GetDebugUsageForCollection(className)
 		require.NoError(ct, err)
 		require.Len(ct, colUsageAfter.Shards, 1)
 		shardAfter := colUsageAfter.Shards[0]
 		require.Equal(ct, int64(numObjects), shardAfter.ObjectsCount)
-		require.Len(ct, shardAfter.NamedVectors, 1)
-		require.Equal(ct, vector2, shardAfter.NamedVectors[0].Name)
-		require.NotEmpty(ct, shardAfter.NamedVectors[0].Dimensionalities)
-		require.Equal(ct, dimensions, shardAfter.NamedVectors[0].Dimensionalities[0].Dimensions)
-		require.Equal(ct, numObjects, shardAfter.NamedVectors[0].Dimensionalities[0].Count)
+		require.Equal(ct, expected, namedVectorDimensionalities(ct, shardAfter))
 		assert.Less(ct, shardAfter.FullShardStorageBytes, initialFullStorage)
 		assert.Less(ct, shardAfter.VectorStorageBytes, initialVectorStorage)
 	}, 30*time.Second, 500*time.Millisecond)
@@ -592,6 +606,17 @@ func testAllObjectsIndexed(t *testing.T, c *client.Client, className string) {
 			}
 		}
 	}, 30*time.Second, 500*time.Millisecond)
+}
+
+// namedVectorDimensionalities maps every named vector of a shard usage report to the
+// dimensionality it reports.
+func namedVectorDimensionalities(t require.TestingT, shard *usagetypes.ShardUsage) map[string]usagetypes.Dimensionality {
+	dimensionalities := make(map[string]usagetypes.Dimensionality, len(shard.NamedVectors))
+	for _, v := range shard.NamedVectors {
+		require.NotEmpty(t, v.Dimensionalities, "no dimensionality reported for vector %q", v.Name)
+		dimensionalities[v.Name] = *v.Dimensionalities[0]
+	}
+	return dimensionalities
 }
 
 func generateRandomVector(dimensionality int) []float32 {


### PR DESCRIPTION
### What's being changed:

Fixes two bugs:
- if a named vector name was a prefix of another name it would not be counted (eg `text`was not counted when there was `texts`)
- potential wrap around bug in size computation that could result in a 16EiB number. Unlikely to happen but better to fix

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
