### PR TITLE
Don't allocate a mutex on every key-locker call

### DIFF
--- a/entities/sync/sync.go
+++ b/entities/sync/sync.go
@@ -34,16 +34,22 @@ func NewKeyLocker() *KeyLocker {
 	}
 }
 
+// mutexFor returns ID's mutex, creating it on first use. The Load comes first
+// so that an ID that already exists does not allocate a mutex it would discard.
+func (s *KeyLocker) mutexFor(ID string) *sync.Mutex {
+	iLock, ok := s.m.Load(ID)
+	if !ok {
+		iLock, _ = s.m.LoadOrStore(ID, &sync.Mutex{})
+	}
+	return iLock.(*sync.Mutex)
+}
+
 // Lock it locks a specific bucket by it's ID
 // to hold ant concurrent access to that specific item
 //
 //	do not forget calling Unlock() after locking it.
 func (s *KeyLocker) Lock(ID string) {
-	iLock := &sync.Mutex{}
-	iLocks, _ := s.m.LoadOrStore(ID, iLock)
-
-	iLock = iLocks.(*sync.Mutex)
-	iLock.Lock()
+	s.mutexFor(ID).Lock()
 }
 
 // Unlock it unlocks a specific item by it's ID
@@ -75,16 +81,22 @@ func NewKeyRWLocker() *KeyRWLocker {
 	}
 }
 
+// mutexFor returns ID's mutex, creating it on first use. The Load comes first
+// so that an ID that already exists does not allocate a mutex it would discard.
+func (s *KeyRWLocker) mutexFor(ID string) *sync.RWMutex {
+	iLock, ok := s.m.Load(ID)
+	if !ok {
+		iLock, _ = s.m.LoadOrStore(ID, &sync.RWMutex{})
+	}
+	return iLock.(*sync.RWMutex)
+}
+
 // Lock it locks a specific bucket by it's ID
 // to hold ant concurrent access to that specific item
 //
 //	do not forget calling Unlock() after locking it.
 func (s *KeyRWLocker) Lock(ID string) {
-	iLock := &sync.RWMutex{}
-	iLocks, _ := s.m.LoadOrStore(ID, iLock)
-
-	iLock = iLocks.(*sync.RWMutex)
-	iLock.Lock()
+	s.mutexFor(ID).Lock()
 }
 
 // Unlock it unlocks a specific item by it's ID
@@ -99,21 +111,13 @@ func (s *KeyRWLocker) Unlock(ID string) {
 //
 //	do not forget calling RUnlock() after rlocking it.
 func (s *KeyRWLocker) RLock(ID string) {
-	iLock := &sync.RWMutex{}
-	iLocks, _ := s.m.LoadOrStore(ID, iLock)
-
-	iLock = iLocks.(*sync.RWMutex)
-	iLock.RLock()
+	s.mutexFor(ID).RLock()
 }
 
 // TryRLock attempts to acquire a read lock without blocking.
 // Returns true if the lock was acquired, false otherwise.
 func (s *KeyRWLocker) TryRLock(ID string) bool {
-	iLock := &sync.RWMutex{}
-	iLocks, _ := s.m.LoadOrStore(ID, iLock)
-
-	iLock = iLocks.(*sync.RWMutex)
-	return iLock.TryRLock()
+	return s.mutexFor(ID).TryRLock()
 }
 
 // RUnlock it runlocks a specific item by it's ID
@@ -144,16 +148,22 @@ func NewKeyLockerContext() *KeyLockerContext {
 	}
 }
 
+// mutexFor returns ID's mutex, creating it on first use. The Load comes first
+// so that an ID that already exists does not allocate a mutex it would discard.
+func (s *KeyLockerContext) mutexFor(ID string) *contextMutex {
+	iLock, ok := s.m.Load(ID)
+	if !ok {
+		iLock, _ = s.m.LoadOrStore(ID, newContextMutex())
+	}
+	return iLock.(*contextMutex)
+}
+
 // Lock locks a specific bucket by it's ID
 // to hold any concurrent access to that specific item
 //
 //	do not forget to call Unlock() after locking it.
 func (s *KeyLockerContext) Lock(ID string) {
-	iLock := newContextMutex()
-	iLocks, _ := s.m.LoadOrStore(ID, iLock)
-
-	iLock = iLocks.(*contextMutex)
-	iLock.Lock()
+	s.mutexFor(ID).Lock()
 }
 
 // LockWithContext tries to lock the mutex with a context.
@@ -167,11 +177,7 @@ func (s *KeyLockerContext) Lock(ID string) {
 // You must call Unlock if the returned error is nil to release the lock.
 // Do not call Unlock if the returned error is not nil.
 func (s *KeyLockerContext) LockWithContext(ID string, ctx context.Context) error {
-	iLock := newContextMutex()
-	iLocks, _ := s.m.LoadOrStore(ID, iLock)
-	iLock = iLocks.(*contextMutex)
-	err := iLock.LockWithContext(ctx)
-	return err
+	return s.mutexFor(ID).LockWithContext(ctx)
 }
 
 // Unlock unlocks a specific item by it's ID.

--- a/entities/sync/sync_test.go
+++ b/entities/sync/sync_test.go
@@ -13,6 +13,8 @@ package sync
 
 import (
 	"context"
+	"errors"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -336,6 +338,235 @@ func TestKeyRWLockerTryRLock(t *testing.T) {
 		require.True(t, s.TryRLock("k3"))
 		s.RUnlock("k3")
 	})
+}
+
+// lockPair is one locker's acquire/release pair, so one concurrent test body
+// can drive every locker type.
+type lockPair struct {
+	acquire func(ID string) error
+	release func(ID string)
+}
+
+// TestKeyLockersConcurrentColdKey locks a key that does not exist yet, so every
+// goroutine misses the map and has to create the mutex. They must all end up on
+// the one mutex that wins: run with -race, and a goroutine holding a private
+// mutex shows up as a data race on the counter.
+func TestKeyLockersConcurrentColdKey(t *testing.T) {
+	const (
+		writers    = 16
+		readers    = 16
+		iterations = 200
+		coldKey    = "cold"
+	)
+
+	ctx := t.Context()
+
+	tests := []struct {
+		name string
+		// write is the exclusive pair; read is the shared pair, left zero for
+		// lockers that have no read side.
+		pairs func() (write, read lockPair)
+	}{
+		{
+			name: "KeyLocker",
+			pairs: func() (lockPair, lockPair) {
+				l := NewKeyLocker()
+				return lockPair{
+					acquire: func(ID string) error { l.Lock(ID); return nil },
+					release: l.Unlock,
+				}, lockPair{}
+			},
+		},
+		{
+			name: "KeyRWLocker",
+			pairs: func() (lockPair, lockPair) {
+				l := NewKeyRWLocker()
+				return lockPair{
+						acquire: func(ID string) error { l.Lock(ID); return nil },
+						release: l.Unlock,
+					}, lockPair{
+						acquire: func(ID string) error { l.RLock(ID); return nil },
+						release: l.RUnlock,
+					}
+			},
+		},
+		{
+			name: "KeyRWLocker/TryRLock",
+			pairs: func() (lockPair, lockPair) {
+				l := NewKeyRWLocker()
+				return lockPair{
+						acquire: func(ID string) error { l.Lock(ID); return nil },
+						release: l.Unlock,
+					}, lockPair{
+						acquire: func(ID string) error {
+							for !l.TryRLock(ID) {
+								runtime.Gosched()
+							}
+							return nil
+						},
+						release: l.RUnlock,
+					}
+			},
+		},
+		{
+			name: "KeyLockerContext",
+			pairs: func() (lockPair, lockPair) {
+				l := NewKeyLockerContext()
+				return lockPair{
+					acquire: func(ID string) error { l.Lock(ID); return nil },
+					release: l.Unlock,
+				}, lockPair{}
+			},
+		},
+		{
+			name: "KeyLockerContext/LockWithContext",
+			pairs: func() (lockPair, lockPair) {
+				l := NewKeyLockerContext()
+				return lockPair{
+					acquire: func(ID string) error { return l.LockWithContext(ID, ctx) },
+					release: l.Unlock,
+				}, lockPair{}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			write, read := test.pairs()
+
+			counter := 0
+			lastSeen := atomic.Int64{}
+			acquireErrs := make(chan error, writers+readers)
+
+			wg := sync.WaitGroup{}
+			for i := 0; i < writers; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for j := 0; j < iterations; j++ {
+						if err := write.acquire(coldKey); err != nil {
+							acquireErrs <- err
+							return
+						}
+						counter++
+						write.release(coldKey)
+					}
+				}()
+			}
+
+			if read.acquire != nil {
+				for i := 0; i < readers; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						for j := 0; j < iterations; j++ {
+							if err := read.acquire(coldKey); err != nil {
+								acquireErrs <- err
+								return
+							}
+							// reading the counter here is what the race
+							// detector checks: a reader holding some other
+							// mutex is an unsynchronized read
+							lastSeen.Store(int64(counter))
+							read.release(coldKey)
+						}
+					}()
+				}
+			}
+
+			wg.Wait()
+			close(acquireErrs)
+			for err := range acquireErrs {
+				require.NoError(t, err)
+			}
+			require.Equal(t, writers*iterations, counter)
+			if read.acquire != nil {
+				require.LessOrEqual(t, lastSeen.Load(), int64(writers*iterations))
+			}
+		})
+	}
+}
+
+// TestKeyLockersNoAllocationOnWarmKey pins the steady state: keys are shard,
+// tenant and class names that already exist, so locking one must not allocate.
+func TestKeyLockersNoAllocationOnWarmKey(t *testing.T) {
+	keyLocker := NewKeyLocker()
+	rwLocker := NewKeyRWLocker()
+	ctxLocker := NewKeyLockerContext()
+	ctx := t.Context()
+
+	tests := []struct {
+		name       string
+		lockUnlock func() error
+	}{
+		{
+			name:       "KeyLocker.Lock",
+			lockUnlock: func() error { keyLocker.Lock(id); keyLocker.Unlock(id); return nil },
+		},
+		{
+			name:       "KeyRWLocker.Lock",
+			lockUnlock: func() error { rwLocker.Lock(id); rwLocker.Unlock(id); return nil },
+		},
+		{
+			name:       "KeyRWLocker.RLock",
+			lockUnlock: func() error { rwLocker.RLock(id); rwLocker.RUnlock(id); return nil },
+		},
+		{
+			name: "KeyRWLocker.TryRLock",
+			lockUnlock: func() error {
+				if !rwLocker.TryRLock(id) {
+					return errors.New("TryRLock failed on an uncontended key")
+				}
+				rwLocker.RUnlock(id)
+				return nil
+			},
+		},
+		{
+			name:       "KeyLockerContext.Lock",
+			lockUnlock: func() error { ctxLocker.Lock(id); ctxLocker.Unlock(id); return nil },
+		},
+		{
+			name: "KeyLockerContext.LockWithContext",
+			lockUnlock: func() error {
+				if err := ctxLocker.LockWithContext(id, ctx); err != nil {
+					return err
+				}
+				ctxLocker.Unlock(id)
+				return nil
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// the failure is recorded rather than reported, so that nothing but
+			// the locking itself runs inside the measured window
+			var lockErr error
+			run := func() {
+				if err := test.lockUnlock(); err != nil {
+					lockErr = err
+				}
+			}
+
+			run() // the key exists from here on
+			allocs := testing.AllocsPerRun(100, run)
+
+			require.NoError(t, lockErr)
+			require.Zerof(t, allocs, "locking an existing key allocated %v times per call", allocs)
+		})
+	}
+}
+
+// TestKeyLockerContextLockWithContextColdKeyCanceled pins the miss path: a
+// context that is already done aborts the lock but still registers the key, so
+// Unlock reports an unlocked mutex rather than a missing ID.
+func TestKeyLockerContextLockWithContextColdKeyCanceled(t *testing.T) {
+	s := NewKeyLockerContext()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	require.ErrorIs(t, s.LockWithContext("cold", ctx), context.Canceled)
+	require.PanicsWithValue(t, "unlock of unlocked contextMutex", func() { s.Unlock("cold") })
 }
 
 func TestContextMutex(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

All six key-locker entry points passed a freshly constructed mutex to LoadOrStore. Go evaluates that argument eagerly, so the allocation happened before the map was consulted and was thrown away whenever the key already existed.

This was especially bad on big MT clusters where the tenant activity metric would constantly check tenants

  | Benchmark | ns/op before | ns/op after | Δ | B/op | allocs/op |
  |---|---:|---:|---:|---:|---:|
  | `KeyLocker` | 35.24 ± 57% | 17.39 ± 2% | **−50.66%** | 24 → **0** | 2 → **0** |
  | `KeyLockerContextNormalLock` | 67.38 ± 41% | 31.56 ± 1% | **−53.16%** | 136 → **0** | 3 → **0** |
  | `KeyRWLocker/keys=1/RLock` | 36.95 ± 3% | 17.18 ± 1% | **−53.48%** | 40 → **0** | 2 → **0** |
  | `KeyRWLocker/keys=1/Lock` | 40.06 ± 12% | 19.68 ± 2% | **−50.87%** | 40 → **0** | 2 → **0** |
  | `KeyRWLocker/keys=1/TryRLock` | 37.56 ± 13% | 17.13 ± 1% | **−54.39%** | 40 → **0** | 2 → **0** |
  | `KeyRWLocker/keys=2000/RLock` | 52.82 ± 3% | 31.54 ± 5% | **−40.29%** | 40 → **0** | 2 → **0** |
  | `KeyRWLocker/keys=2000/Lock` | 55.13 ± 3% | 34.18 ± 2% | **−38.01%** | 40 → **0** | 2 → **0** |
  | `KeyRWLocker/keys=2000/TryRLock` | 51.86 ± 3% | 31.56 ± 3% | **−39.15%** | 40 → **0** | 2 → **0** |
  | **geomean** | **45.97** | **23.95** | **−47.90%** | −100% | −100% |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
