### PR TITLE
fix(db): don't silently serve a lost vector index as empty (#453)

### DIFF
--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -368,6 +368,10 @@ func (s *Shard) initTargetVectorWithLock(ctx context.Context, targetVector strin
 
 	s.vectorIndexes[targetVector] = vectorIndex
 	s.queues[targetVector] = queue
+
+	if err := s.guardAgainstLostVectorIndex(ctx, targetVector, vectorIndex); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -389,6 +393,87 @@ func (s *Shard) initLegacyVector(ctx context.Context, lazyLoadSegments bool) err
 	}
 	s.vectorIndex = vectorIndex
 	s.queue = queue
+
+	if err := s.guardAgainstLostVectorIndex(ctx, "", vectorIndex); err != nil {
+		return err
+	}
+	return nil
+}
+
+// guardAgainstLostVectorIndex protects against silently serving an empty vector
+// index for a shard that still holds objects for that target vector.
+//
+// When the on-disk HNSW state is lost or incomplete (e.g. a snapshot went
+// missing after compactV2 pruned the raw commit logs), the loader reconstructs
+// an empty graph. Left alone, the shard is served as a fresh, empty index and
+// every vector search returns 0 results while the objects remain on disk
+// (weaviate/0-weaviate-issues#453). This distinguishes a genuinely new/empty
+// shard from a lost index (by counting the objects that carry this vector) and:
+//   - sync indexing: returns an error so the shard fails to load loudly.
+//   - async indexing: resets the indexing checkpoint so the on-load ConvertQueue
+//     re-enqueues every object and rebuilds the index from the object store.
+func (s *Shard) guardAgainstLostVectorIndex(ctx context.Context, targetVector string, vectorIndex VectorIndex) error {
+	// Cheap emptiness probe — stops at the first indexed doc, so it is O(1) on a
+	// populated index and only the (rare) empty-index case pays for the checks
+	// below.
+	empty := true
+	vectorIndex.Iterate(func(uint64) bool {
+		empty = false
+		return false
+	})
+	if !empty {
+		return nil
+	}
+
+	logger := s.index.logger.WithField("shard", s.ID()).WithField("target_vector", targetVector)
+
+	// An empty index is legitimate for a genuinely new/empty shard. Distinguish
+	// that from a lost index by counting the objects that actually carry this
+	// target vector (authoritative when dimension tracking is enabled).
+	perTargetCount := -1
+	if dim, err := s.calcTargetVectorDimensions(ctx, targetVector); err == nil {
+		perTargetCount = dim.Count
+	}
+	if perTargetCount == 0 {
+		return nil // no objects carry this vector — genuinely empty
+	}
+
+	// perTargetCount > 0 means "lost index" with confidence; perTargetCount == -1
+	// means the per-target count is unavailable, so fall back to "does the shard
+	// hold any objects at all".
+	if perTargetCount < 0 && s.Counter().Get() == 0 {
+		return nil // brand-new empty shard
+	}
+
+	if !s.index.AsyncIndexingEnabled {
+		if perTargetCount <= 0 {
+			// Without a per-target count we can't rule out a named vector that is
+			// legitimately empty (no object carries it), so don't fail the load on
+			// the coarse shard-level signal alone.
+			logger.Warn("vector index loaded empty and the shard has objects, but the per-target " +
+				"vector count is unavailable (dimension tracking off); not failing the load")
+			return nil
+		}
+		return fmt.Errorf(
+			"vector index for target %q loaded empty but the shard has %d object(s) with this vector: "+
+				"HNSW state lost or incomplete; refusing to serve an empty index "+
+				"(restore from backup or rebuild the index)",
+			targetVector, perTargetCount,
+		)
+	}
+
+	// Async: reset the indexing checkpoint to 0 so the on-load ConvertQueue
+	// re-enqueues every object and rebuilds the index. A stale "already indexed"
+	// checkpoint is exactly what stops the rebuild today. Rebuilding is safe even
+	// if this named vector turns out to carry no vectors — FillQueue enqueues
+	// nothing in that case.
+	if s.indexCheckpoints != nil {
+		if err := s.indexCheckpoints.Update(s.ID(), targetVector, 0); err != nil {
+			return fmt.Errorf("reset indexing checkpoint for %q to rebuild lost index: %w", targetVector, err)
+		}
+	}
+	logger.WithField("objects", perTargetCount).Warn(
+		"vector index loaded empty but shard has objects; scheduling a full rebuild from the object store")
 	return nil
 }
 

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -765,6 +765,90 @@ func TestShard_FillQueue(t *testing.T) {
 	}
 }
 
+// TestShard_GuardAgainstLostVectorIndex covers weaviate/0-weaviate-issues#453:
+// when a shard's vector index loads empty while the shard still holds objects
+// for that vector (lost/incomplete HNSW state), Weaviate must not silently serve
+// the empty index. Async indexing must schedule a rebuild (reset the checkpoint
+// so the on-load ConvertQueue re-indexes from the object store); sync indexing
+// must fail the load loudly.
+func TestShard_GuardAgainstLostVectorIndex(t *testing.T) {
+	ctx := context.Background()
+	className := "TestClass"
+
+	// setup builds a shard, imports objects, then simulates a lost index by
+	// deleting every node so the index is empty while the objects remain.
+	setup := func(t *testing.T) (*Shard, VectorIndex, *VectorIndexQueue) {
+		shd, idx := testShardWithSettings(t, ctx, &models.Class{Class: className},
+			hnsw.UserConfig{}, false, true, true /* withCheckpoints */)
+		t.Cleanup(func() { _ = os.RemoveAll(idx.Config.RootPath) })
+
+		s := shd.(*Shard)
+		// Enable per-target dimension tracking so calcTargetVectorDimensions can
+		// report the object count for the vector (needed for the sync error path).
+		s.index.Config.TrackVectorDimensions = true
+		require.NoError(t, s.createDimensionsBucket(ctx, helpers.DimensionsBucketLSM))
+
+		amount := 200
+		var objs []*storobj.Object
+		for i := 0; i < amount; i++ {
+			obj := testObject(className)
+			obj.Vector = randVector(3)
+			objs = append(objs, obj)
+		}
+		for _, err := range shd.PutObjectBatch(ctx, objs) {
+			require.Nil(t, err)
+		}
+
+		vidx, q := getVectorIndexAndQueue(t, shd, "")
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Zero(t, q.Size())
+		}, 5*time.Second, 100*time.Millisecond)
+
+		// Simulate a lost index: delete every node and clear tombstones so the
+		// index iterates empty while the objects stay in the LSM store.
+		for i := 0; i < amount; i++ {
+			require.NoError(t, vidx.Delete(uint64(i)))
+		}
+		require.NoError(t, hnswindex.AsHNSWIndex(vidx).CleanUpTombstonedNodes(func() bool { return false }))
+		empty := true
+		vidx.Iterate(func(uint64) bool { empty = false; return false })
+		require.True(t, empty, "precondition: vector index must be empty")
+
+		return s, vidx, q
+	}
+
+	t.Run("async schedules a full rebuild", func(t *testing.T) {
+		s, vidx, q := setup(t)
+		s.index.AsyncIndexingEnabled = true
+
+		require.NoError(t, s.guardAgainstLostVectorIndex(ctx, "", vidx))
+
+		// The checkpoint must be reset to 0 so the on-load ConvertQueue rebuilds.
+		cp, exists, err := s.indexCheckpoints.Get(s.ID(), "")
+		require.NoError(t, err)
+		require.True(t, exists, "checkpoint should be set so ConvertQueue rebuilds")
+		require.Equal(t, uint64(0), cp, "checkpoint should be reset to 0 for a full rebuild")
+
+		// A full rebuild from the object store must repopulate the index.
+		require.NoError(t, s.FillQueue("", 0))
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			assert.Zero(t, q.Size())
+		}, 10*time.Second, 100*time.Millisecond)
+		repopulated := false
+		vidx.Iterate(func(uint64) bool { repopulated = true; return false })
+		require.True(t, repopulated, "index should be repopulated after the rebuild")
+	})
+
+	t.Run("sync fails loudly", func(t *testing.T) {
+		s, vidx, _ := setup(t)
+		s.index.AsyncIndexingEnabled = false
+
+		err := s.guardAgainstLostVectorIndex(ctx, "", vidx)
+		require.Error(t, err, "sync indexing must fail the load, not serve an empty index")
+		require.Contains(t, err.Error(), "loaded empty")
+	})
+}
+
 func TestShard_resetDimensionsLSM(t *testing.T) {
 	ctx := testCtx()
 	className := "TestClass"


### PR DESCRIPTION
## What

Stop silently serving an **empty** vector index for a shard that still holds objects — the read-path failure where every `near_vector` returns 0 results while the data is intact on disk. Tracked in weaviate/0-weaviate-issues#453.

## Problem

When a shard's HNSW on-disk state is lost or incomplete (e.g. a snapshot went missing after compactV2 pruned the raw commit logs, or an interrupted migration), the loader reconstructs an empty graph. `shard_init_vector` then installs that empty index and the shard is served as if it were a brand-new, empty shard — **no error**. Vector search returns 0 objects / recall 0 even though the LSM `objects` bucket still holds the vectors. This surfaced after a 1.38 → 1.39 upgrade.

Notably, async indexing *would* normally self-heal by re-indexing from the object store, but the on-load `ConvertQueue` resumes from the persisted checkpoint — and a "already fully indexed" checkpoint means it enqueues nothing, so a lost index stays empty.

## Fix

Add a guard in the shard vector-index init path (`initTargetVectorWithLock` and `initLegacyVector`) that runs only when the freshly-loaded index is **empty** (cheap `VectorIndex.Iterate` early-stop probe). It distinguishes a genuinely new/empty shard from a lost index by counting the objects that carry this target vector, then:

- **sync indexing**: returns an error, so the shard fails to load loudly (reported unhealthy) instead of answering queries with an empty result set.
- **async indexing**: resets the indexing checkpoint to `0`, so the existing on-load `ConvertQueue` re-enqueues every object and rebuilds the index from the object store.

A genuinely new/empty shard (no objects for the vector) is unchanged. When per-target object counts aren't available (dimension tracking off), the sync path stays conservative and does not fail the load on the coarse shard-level signal alone.

## Tests

- **New**: `TestShard_GuardAgainstLostVectorIndex` (integrationTest) — imports objects, simulates a lost index (delete all nodes → empty), then asserts:
  - async → the checkpoint is reset to `0` and a full `FillQueue(0)` repopulates the index;
  - sync → the guard returns an error.
- Existing `TestShard_FillQueue`, `TestShard_DebugResetVectorIndex`, `TestShard_RepairIndex` still pass (no regression).
- End-to-end reproduction/guard: weaviate/weaviate-e2e-tests#480 (recovery TC-014).

## Notes / scope

- Detection is per-target-vector via `calcTargetVectorDimensions` (authoritative when dimension tracking is on); a coarse `Counter()` fallback covers the async-rebuild case regardless.
- A deeper durability follow-up (don't make the snapshot a single point of failure — verify-before-delete in compactV2's `createSnapshot`, retain a fallback) is worth tracking separately; this PR addresses the "serve empty silently" defect.
