### PR TITLE
Backup-gcs: add opt-in gRPC transport

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/backup"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	ucfg "github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/gcpcommon"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
@@ -48,7 +49,35 @@ type gcsClient struct {
 	counter   atomic.Uint64 // monotonic counter for unique access-check paths within a node
 }
 
-func storageOptions(ctx context.Context, logger logrus.FieldLogger) ([]option.ClientOption, error) {
+const (
+	// chunkRetryDeadline budgets all attempts at one chunk, backoff pauses
+	// included. The SDK default of 32s expires partway through the ladder
+	// newClient configures (2s, 6s, 18s, 54s), so its 60s ceiling never applies.
+	chunkRetryDeadline = 5 * time.Minute
+
+	// chunkTransferTimeout bounds one chunk request. chunkRetryDeadline does not:
+	// it is only checked between attempts, so without this a stalled request
+	// hangs until the caller's context expires, and backup uploads run under a
+	// 24h timeout. It is a hard timeout on the request rather than a stall
+	// detector, so it must stay well above the time a full chunk takes on a slow
+	// link, and well below chunkRetryDeadline to leave room for retries. Raising
+	// the writer's ChunkSize means revisiting both. HTTP only; the gRPC writer
+	// ignores it.
+	chunkTransferTimeout = time.Minute
+)
+
+// newChunkWriter returns a writer for one backup chunk, tuned for the
+// multi-chunk uploads Write streams.
+func newChunkWriter(ctx context.Context, obj *storage.ObjectHandle, backupID string) *storage.Writer {
+	writer := obj.NewWriter(ctx)
+	writer.ContentType = "application/octet-stream"
+	writer.Metadata = map[string]string{"backup-id": backupID}
+	writer.ChunkRetryDeadline = chunkRetryDeadline
+	writer.ChunkTransferTimeout = chunkTransferTimeout
+	return writer
+}
+
+func storageOptions(ctx context.Context, logger logrus.FieldLogger, transport ucfg.BackupGCS) ([]option.ClientOption, error) {
 	opts := []option.ClientOption{}
 	useAuth := strings.ToLower(os.Getenv("BACKUP_GCS_USE_AUTH")) != "false"
 	backupGCSAuthProxyEndpoint := os.Getenv("BACKUP_GCS_AUTH_PROXY_ENDPOINT")
@@ -74,6 +103,16 @@ func storageOptions(ctx context.Context, logger logrus.FieldLogger) ([]option.Cl
 		opts = append(opts, option.WithoutAuthentication())
 	}
 
+	if transport.UseGRPC {
+		// The SDK exports gRPC client metrics to Cloud Monitoring by default. That
+		// needs monitoring.timeSeries.create and reports its own failures through
+		// the standard library, bypassing our logger.
+		opts = append(opts,
+			option.WithGRPCConnectionPool(transport.GRPCConnPool),
+			storage.WithDisabledClientMetrics(),
+		)
+	}
+
 	return opts, nil
 }
 
@@ -90,12 +129,18 @@ func projectID() string {
 }
 
 func newClient(ctx context.Context, config *clientConfig, dataPath string, logger logrus.FieldLogger) (*gcsClient, error) {
-	opts, err := storageOptions(ctx, logger)
+	opts, err := storageOptions(ctx, logger, config.Transport)
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := storage.NewClient(ctx, opts...)
+	var client *storage.Client
+	if config.Transport.UseGRPC {
+		logger.Infof("backup-gcs: using gRPC transport with a connection pool of %d per client", config.Transport.GRPCConnPool)
+		client, err = storage.NewGRPCClient(ctx, opts...)
+	} else {
+		client, err = storage.NewClient(ctx, opts...)
+	}
 	if err != nil {
 		return nil, errors.Wrap(err, "create client")
 	}
@@ -337,9 +382,7 @@ func (g *gcsClient) Write(ctx context.Context, backupID, key, overrideBucket, ov
 	objectPath := g.makeObjectName(overridePath, []string{backupID, key})
 	writeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	writer := bucket.Object(objectPath).NewWriter(writeCtx)
-	writer.ContentType = "application/octet-stream"
-	writer.Metadata = map[string]string{"backup-id": backupID}
+	writer := newChunkWriter(writeCtx, bucket.Object(objectPath), backupID)
 
 	// copy
 	written, err = io.Copy(writer, r)
@@ -369,8 +412,8 @@ func (g *gcsClient) Read(ctx context.Context, backupID, key, overrideBucket, ove
 
 	bucket, err := g.findBucket(ctx, overrideBucket)
 	if err != nil {
-		err = fmt.Errorf("read: find bucker: %w", err)
-		if errors.Is(err, storage.ErrObjectNotExist) {
+		err = fmt.Errorf("read: find bucket: %w", err)
+		if errors.Is(err, storage.ErrBucketNotExist) {
 			err = backup.NewErrNotFound(err)
 		}
 		return 0, err

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -18,9 +18,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,10 +36,182 @@ import (
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/weaviate/weaviate/entities/backup"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	ubak "github.com/weaviate/weaviate/usecases/backup"
+	ucfg "github.com/weaviate/weaviate/usecases/config"
 )
+
+// connPoolOptionType is the concrete type google.golang.org/api/option gives
+// the connection-pool option; the option carries no exported accessor.
+const connPoolOptionType = "option.withGRPCConnectionPool"
+
+func TestStorageOptionsTransport(t *testing.T) {
+	tests := []struct {
+		name         string
+		transport    ucfg.BackupGCS
+		wantOptions  []string
+		wantConnPool int
+	}{
+		{
+			name:        "http adds no transport options",
+			transport:   ucfg.BackupGCS{},
+			wantOptions: []string{"option.withoutAuthentication"},
+		},
+		{
+			name:         "grpc sizes the connection pool and turns client metrics off",
+			transport:    ucfg.BackupGCS{UseGRPC: true, GRPCConnPool: 8},
+			wantOptions:  []string{"option.withoutAuthentication", connPoolOptionType, "*storage.withDisabledClientMetrics"},
+			wantConnPool: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("BACKUP_GCS_USE_AUTH", "false")
+			t.Setenv("BACKUP_GCS_AUTH_PROXY_ENDPOINT", "")
+
+			opts, err := storageOptions(context.Background(), discardLogger(), tt.transport)
+			require.NoError(t, err)
+
+			types := make([]string, 0, len(opts))
+			for _, opt := range opts {
+				types = append(types, fmt.Sprintf("%T", opt))
+			}
+			assert.Equal(t, tt.wantOptions, types)
+			assert.Equal(t, tt.wantConnPool, grpcConnPoolOption(opts))
+		})
+	}
+}
+
+// The SDK leaves a chunk request unbounded and gives all its retries only 32s.
+// Both defaults are wrong for backup uploads, which stream for hours under a
+// context that allows 24.
+func TestChunkWriterTuning(t *testing.T) {
+	client, err := storage.NewClient(context.Background(), option.WithoutAuthentication())
+	require.NoError(t, err)
+	defer client.Close()
+
+	writer := newChunkWriter(context.Background(), client.Bucket("b").Object("o"), "backup-1")
+
+	assert.Equal(t, chunkRetryDeadline, writer.ChunkRetryDeadline, "retry deadline")
+	assert.Equal(t, chunkTransferTimeout, writer.ChunkTransferTimeout, "transfer timeout")
+	assert.Equal(t, "application/octet-stream", writer.ContentType)
+	assert.Equal(t, map[string]string{"backup-id": "backup-1"}, writer.Metadata)
+
+	// A transfer timeout only buys a retry if the deadline outlasts several of
+	// them; equal values would spend the whole budget on one stalled request.
+	assert.LessOrEqual(t, 3*chunkTransferTimeout, chunkRetryDeadline,
+		"retry deadline must fit at least three transfer timeouts")
+}
+
+// TestNewClientTransport routes one request through a local fake of each API, so
+// the assertion is which wire the client actually used.
+func TestNewClientTransport(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport ucfg.BackupGCS
+		wantCalls []string
+	}{
+		{
+			name:      "default speaks the json api over http",
+			transport: ucfg.BackupGCS{},
+			wantCalls: []string{"/storage/v1/b/my-bucket"},
+		},
+		{
+			name:      "grpc speaks the storage grpc api",
+			transport: ucfg.BackupGCS{UseGRPC: true, GRPCConnPool: ucfg.DefaultBackupGCSGRPCConnPool},
+			wantCalls: []string{"/google.storage.v2.Storage/GetBucket"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Both fakes share one recorder, so the untaken transport is
+			// asserted to have received nothing.
+			calls := &callRecorder{}
+			t.Setenv("BACKUP_GCS_USE_AUTH", "false")
+			t.Setenv("BACKUP_GCS_AUTH_PROXY_ENDPOINT", "")
+			// The SDK reads a separate variable per transport.
+			t.Setenv("STORAGE_EMULATOR_HOST", startFakeGCSOverHTTP(t, calls))
+			t.Setenv("STORAGE_EMULATOR_HOST_GRPC", startFakeGCSOverGRPC(t, calls))
+
+			config := &clientConfig{Bucket: "my-bucket", Transport: tt.transport}
+			c, err := newClient(context.Background(), config, t.TempDir(), discardLogger())
+			require.NoError(t, err)
+			defer c.client.Close()
+
+			_, err = c.findBucket(context.Background(), "")
+			require.ErrorIs(t, err, storage.ErrBucketNotExist)
+			assert.Equal(t, tt.wantCalls, calls.recorded())
+		})
+	}
+}
+
+type callRecorder struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (r *callRecorder) record(method string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, method)
+}
+
+func (r *callRecorder) recorded() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.calls)
+}
+
+// startFakeGCSOverHTTP answers every request with a not-found bucket, which the
+// retry policy does not retry, so one call reaches the recorder.
+func startFakeGCSOverHTTP(t *testing.T, calls *callRecorder) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.record(r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, `{"error":{"code":404,"message":"no such bucket"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func startFakeGCSOverGRPC(t *testing.T, calls *callRecorder) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer(grpc.UnknownServiceHandler(func(_ any, stream grpc.ServerStream) error {
+		method, _ := grpc.MethodFromServerStream(stream)
+		calls.record(method)
+		return status.Error(codes.NotFound, "no such bucket")
+	}))
+	enterrors.GoWrapper(func() { _ = srv.Serve(listener) }, discardLogger())
+	t.Cleanup(srv.Stop)
+	return listener.Addr().String()
+}
+
+func grpcConnPoolOption(opts []option.ClientOption) int {
+	for _, opt := range opts {
+		if v := reflect.ValueOf(opt); v.Type().String() == connPoolOptionType && v.Kind() == reflect.Int {
+			return int(v.Int())
+		}
+	}
+	return 0
+}
+
+func discardLogger() logrus.FieldLogger {
+	logger := logrus.New()
+	logger.Out = io.Discard
+	return logger
+}
 
 func TestInitialize_SkipAccessCheck(t *testing.T) {
 	// Validation runs before the SkipAccessCheck short-circuit: a valid bucket
@@ -110,6 +285,60 @@ func TestFindBucket_EmptyBucket(t *testing.T) {
 		})
 	}
 }
+
+// A restore against a bucket that is gone must be reported as not-found, so the
+// backup coordinator can tell it apart from an internal failure.
+func TestMissingBucketReportsNotFound(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*gcsClient, context.Context) error
+	}{
+		{
+			name: "Read",
+			call: func(g *gcsClient, ctx context.Context) error {
+				_, err := g.Read(ctx, "backup-1", "shard.db", "", "", discardWriteCloser{})
+				return err
+			},
+		},
+		{
+			name: "GetObject",
+			call: func(g *gcsClient, ctx context.Context) error {
+				_, err := g.GetObject(ctx, "backup-1", "shard.db", "", "")
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				fmt.Fprint(w, `{"error":{"code":404,"message":"no such bucket"}}`)
+			}))
+			defer srv.Close()
+
+			ctx := context.Background()
+			gcs, err := storage.NewClient(ctx, option.WithoutAuthentication(), option.WithEndpoint(srv.URL))
+			require.NoError(t, err)
+			defer gcs.Close()
+			gcs.SetRetry(storage.WithPolicy(storage.RetryNever))
+
+			g := &gcsClient{client: gcs, config: clientConfig{Bucket: "gone-bucket"}, logger: discardLogger()}
+
+			err = tt.call(g, ctx)
+			require.Error(t, err)
+			var notFound backup.ErrNotFound
+			assert.ErrorAs(t, err, &notFound)
+		})
+	}
+}
+
+type discardWriteCloser struct{}
+
+func (discardWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
+
+func (discardWriteCloser) Close() error { return nil }
 
 func TestAllBackupsSkipsMissingDescriptors(t *testing.T) {
 	const bucketName = "test-bucket"

--- a/modules/backup-gcs/module.go
+++ b/modules/backup-gcs/module.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	ucfg "github.com/weaviate/weaviate/usecases/config"
 )
 
 const (
@@ -46,6 +47,9 @@ type clientConfig struct {
 
 	// SkipAccessCheck disables the write+delete probe in Initialize.
 	SkipAccessCheck bool
+
+	// Transport selects the GCS API the client talks to.
+	Transport ucfg.BackupGCS
 }
 
 type Module struct {
@@ -81,10 +85,12 @@ func (m *Module) Init(ctx context.Context,
 	m.logger = params.GetLogger()
 	m.dataPath = params.GetStorageProvider().DataPath()
 
+	transport := params.GetConfig().BackupGCS
 	config := &clientConfig{
 		Bucket:          os.Getenv(gcsBucket),
 		BackupPath:      os.Getenv(gcsPath),
 		SkipAccessCheck: params.GetConfig().Backup.SkipAccessCheck,
+		Transport:       transport,
 	}
 	if config.Bucket == "" {
 		return errors.Errorf("backup init: '%s' must be set", gcsBucket)
@@ -100,6 +106,7 @@ func (m *Module) Init(ctx context.Context,
 		Bucket:          "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
 		BackupPath:      "", // export scheduler provides path via EXPORT_DEFAULT_PATH
 		SkipAccessCheck: params.GetConfig().Export.SkipAccessCheck,
+		Transport:       transport,
 	}
 	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
 	if err != nil {

--- a/modules/backup-gcs/module_test.go
+++ b/modules/backup-gcs/module_test.go
@@ -23,9 +23,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-func TestInit_SkipAccessCheckWiring(t *testing.T) {
+func TestInit_ClientConfigWiring(t *testing.T) {
 	// Init must route Backup.SkipAccessCheck to the backup client and
-	// Export.SkipAccessCheck to the export client, without crossing them.
+	// Export.SkipAccessCheck to the export client, without crossing them, while
+	// the transport reaches both.
 	t.Setenv("BACKUP_GCS_BUCKET", "test")
 	t.Setenv("BACKUP_GCS_USE_AUTH", "false")
 
@@ -33,15 +34,21 @@ func TestInit_SkipAccessCheckWiring(t *testing.T) {
 		name       string
 		backupFlag bool
 		exportFlag bool
+		transport  config.BackupGCS
 	}{
 		{name: "backup only", backupFlag: true, exportFlag: false},
 		{name: "export only", backupFlag: false, exportFlag: true},
+		{
+			name:      "grpc transport reaches both clients",
+			transport: config.BackupGCS{UseGRPC: true, GRPCConnPool: config.DefaultBackupGCSGRPCConnPool},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{}
 			cfg.Backup.SkipAccessCheck = tt.backupFlag
 			cfg.Export.SkipAccessCheck = tt.exportFlag
+			cfg.BackupGCS = tt.transport
 
 			params := moduletools.NewMockModuleInitParams(t)
 			params.EXPECT().GetLogger().Return(logrus.New())
@@ -52,6 +59,8 @@ func TestInit_SkipAccessCheckWiring(t *testing.T) {
 			require.NoError(t, m.Init(context.Background(), params))
 			assert.Equal(t, tt.backupFlag, m.config.SkipAccessCheck, "backup client")
 			assert.Equal(t, tt.exportFlag, m.exportClient.config.SkipAccessCheck, "export client")
+			assert.Equal(t, tt.transport, m.config.Transport, "backup client transport")
+			assert.Equal(t, tt.transport, m.exportClient.config.Transport, "export client transport")
 		})
 	}
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -161,6 +161,7 @@ type RuntimeOverrides struct {
 // Config outline of the config file
 type Config struct {
 	Backup                           Backup                   `json:"backup" yaml:"backup"`
+	BackupGCS                        BackupGCS                `json:"backup_gcs" yaml:"backup_gcs"`
 	Name                             string                   `json:"name" yaml:"name"`
 	Debug                            bool                     `json:"debug" yaml:"debug"`
 	QueryDefaults                    QueryDefaults            `json:"query_defaults" yaml:"query_defaults"`
@@ -880,6 +881,32 @@ type Backup struct {
 	// least-privilege credentials that can write but lack DeleteObject.
 	// Env: BACKUP_SKIP_ACCESS_CHECK.
 	SkipAccessCheck bool `json:"skip_access_check" yaml:"skip_access_check"`
+}
+
+const (
+	// DefaultBackupGCSGRPCConnPool is higher than the SDK's default of one
+	// channel, which caps throughput wherever DirectPath does not apply.
+	DefaultBackupGCSGRPCConnPool = 4
+
+	// MaxBackupGCSGRPCConnPool bounds the pool because every channel is a
+	// connection held for the process lifetime, and the GCS module builds one
+	// client for backups and one for exports.
+	MaxBackupGCSGRPCConnPool = 64
+)
+
+// BackupGCS configures which GCS API the backup-gcs module talks to. The
+// GCS_MODULE_ prefix marks it as covering both clients that module builds, the
+// backup one and the export one, unlike the backup-only BACKUP_GCS_BUCKET.
+type BackupGCS struct {
+	// UseGRPC switches from the JSON/HTTP API to the gRPC API. The throughput
+	// gRPC adds comes from DirectPath, which only applies inside GCP, and from
+	// spreading requests over GRPCConnPool channels.
+	// Env: GCS_MODULE_TRANSPORT (http or grpc).
+	UseGRPC bool `json:"use_grpc" yaml:"use_grpc"`
+
+	// GRPCConnPool is how many gRPC channels each client opens.
+	// Env: GCS_MODULE_GRPC_CONN_POOL.
+	GRPCConnPool int `json:"grpc_conn_pool" yaml:"grpc_conn_pool"`
 }
 
 // DefaultQueryDefaultsLimit is the default query limit when no limit is provided

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -420,6 +420,10 @@ func (c *Config) Validate() error {
 		return configErr(err)
 	}
 
+	if err := c.BackupGCS.Validate(); err != nil {
+		return configErr(err)
+	}
+
 	if err := c.validateUsageLimitsReplicationLinkage(); err != nil {
 		return configErr(err)
 	}
@@ -904,9 +908,20 @@ type BackupGCS struct {
 	// Env: GCS_MODULE_TRANSPORT (http or grpc).
 	UseGRPC bool `json:"use_grpc" yaml:"use_grpc"`
 
-	// GRPCConnPool is how many gRPC channels each client opens.
+	// GRPCConnPool is how many gRPC channels each client opens. Zero means
+	// unset and falls back to DefaultBackupGCSGRPCConnPool.
 	// Env: GCS_MODULE_GRPC_CONN_POOL.
 	GRPCConnPool int `json:"grpc_conn_pool" yaml:"grpc_conn_pool"`
+}
+
+// Validate bounds a connection pool that came from the config file. Values from
+// GCS_MODULE_GRPC_CONN_POOL are already bounded when parsed. A negative pool
+// would panic the gRPC client on its first call.
+func (b BackupGCS) Validate() error {
+	if b.GRPCConnPool == 0 {
+		return nil
+	}
+	return validateBackupGCSConnPool(b.GRPCConnPool, "backup_gcs.grpc_conn_pool")
 }
 
 // DefaultQueryDefaultsLimit is the default query limit when no limit is provided

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -257,6 +257,33 @@ func TestConfigParsing(t *testing.T) {
 		assert.ElementsMatch(t, []string{"api-key-1", "api-key-2", "api-key-3"}, config.Authentication.APIKey.AllowedKeys)
 		assert.ElementsMatch(t, []string{"user1@weaviate.io", "user2@weaviate.io"}, config.Authentication.APIKey.Users)
 	})
+
+	t.Run("parse backup_gcs config and survive the env pass - yaml", func(t *testing.T) {
+		for _, key := range []string{"GCS_MODULE_TRANSPORT", "GCS_MODULE_GRPC_CONN_POOL"} {
+			t.Setenv(key, "")
+		}
+
+		configFileName := "config.yaml"
+		configYaml := `backup_gcs:
+  use_grpc: true
+  grpc_conn_pool: 32
+`
+
+		filepath := fmt.Sprintf("%s/%s", t.TempDir(), configFileName)
+		require.NoError(t, os.WriteFile(filepath, []byte(configYaml), 0o600))
+
+		file, err := os.ReadFile(filepath)
+		require.NoError(t, err)
+		weaviateConfig := &WeaviateConfig{}
+		config, err := weaviateConfig.parseConfigFile(file, configFileName)
+		require.NoError(t, err)
+		require.Equal(t, BackupGCS{UseGRPC: true, GRPCConnPool: 32}, config.BackupGCS)
+
+		// LoadConfig reads the file before the environment, so an unset variable
+		// has to leave the parsed value alone.
+		require.NoError(t, FromEnv(&config))
+		assert.Equal(t, BackupGCS{UseGRPC: true, GRPCConnPool: 32}, config.BackupGCS)
+	})
 }
 
 func TestConfigValidation(t *testing.T) {
@@ -280,6 +307,11 @@ func TestConfigValidation(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name:     "backup gcs connection pool out of range",
+			config:   &Config{BackupGCS: BackupGCS{GRPCConnPool: 100}},
+			expected: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -290,6 +322,38 @@ func TestConfigValidation(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestBackupGCSValidate(t *testing.T) {
+	tests := []struct {
+		name     string
+		connPool int
+		wantErr  string
+	}{
+		{name: "unset takes the default", connPool: 0},
+		{name: "at the cap", connPool: MaxBackupGCSGRPCConnPool},
+		{
+			name:     "past the cap",
+			connPool: MaxBackupGCSGRPCConnPool + 1,
+			wantErr:  "backup_gcs.grpc_conn_pool must be an integer between 1 and 64. Got: 65",
+		},
+		{
+			name:     "negative",
+			connPool: -1,
+			wantErr:  "backup_gcs.grpc_conn_pool must be an integer between 1 and 64. Got: -1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := BackupGCS{GRPCConnPool: tt.connPool}.Validate()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -2312,8 +2312,12 @@ const (
 )
 
 func (c *Config) parseBackupGCSConfig() error {
+	// An unset GCS_MODULE_TRANSPORT keeps whatever the config file set, an
+	// explicit one overrides it in either direction.
 	switch t := strings.TrimSpace(strings.ToLower(os.Getenv(gcsModuleTransportEnv))); t {
-	case "", gcsModuleTransportHTTP:
+	case "": // keep the config file value
+	case gcsModuleTransportHTTP:
+		c.BackupGCS.UseGRPC = false
 	case gcsModuleTransportGRPC:
 		c.BackupGCS.UseGRPC = true
 	default:
@@ -2321,7 +2325,13 @@ func (c *Config) parseBackupGCSConfig() error {
 			gcsModuleTransportEnv, gcsModuleTransportHTTP, gcsModuleTransportGRPC, t)
 	}
 
-	if err := parseIntVerify("GCS_MODULE_GRPC_CONN_POOL", DefaultBackupGCSGRPCConnPool,
+	// parseIntVerify always writes the default back, so seed it from the config
+	// file value to keep an unset variable from overwriting it.
+	connPool := DefaultBackupGCSGRPCConnPool
+	if c.BackupGCS.GRPCConnPool != 0 {
+		connPool = c.BackupGCS.GRPCConnPool
+	}
+	if err := parseIntVerify("GCS_MODULE_GRPC_CONN_POOL", connPool,
 		func(val int) { c.BackupGCS.GRPCConnPool = val },
 		validateBackupGCSConnPool); err != nil {
 		return err
@@ -2330,9 +2340,9 @@ func (c *Config) parseBackupGCSConfig() error {
 	return nil
 }
 
-func validateBackupGCSConnPool(val int, envName string) error {
+func validateBackupGCSConnPool(val int, setting string) error {
 	if val < 1 || val > MaxBackupGCSGRPCConnPool {
-		return fmt.Errorf("%s must be an integer between 1 and %d. Got: %v", envName, MaxBackupGCSGRPCConnPool, val)
+		return fmt.Errorf("%s must be an integer between 1 and %d. Got: %v", setting, MaxBackupGCSGRPCConnPool, val)
 	}
 	return nil
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -710,6 +710,10 @@ func FromEnv(config *Config) error {
 
 	config.parseExportConfig()
 
+	if err := config.parseBackupGCSConfig(); err != nil {
+		return err
+	}
+
 	if v := os.Getenv("ORIGIN"); v != "" {
 		config.Origin = v
 	}
@@ -2299,4 +2303,36 @@ func (c *Config) parseExportConfig() {
 	if entcfg.Enabled(os.Getenv("EXPORT_SKIP_ACCESS_CHECK")) {
 		c.Export.SkipAccessCheck = true
 	}
+}
+
+const (
+	gcsModuleTransportEnv  = "GCS_MODULE_TRANSPORT"
+	gcsModuleTransportHTTP = "http"
+	gcsModuleTransportGRPC = "grpc"
+)
+
+func (c *Config) parseBackupGCSConfig() error {
+	switch t := strings.TrimSpace(strings.ToLower(os.Getenv(gcsModuleTransportEnv))); t {
+	case "", gcsModuleTransportHTTP:
+	case gcsModuleTransportGRPC:
+		c.BackupGCS.UseGRPC = true
+	default:
+		return fmt.Errorf("%s must be %q or %q. Got: %v",
+			gcsModuleTransportEnv, gcsModuleTransportHTTP, gcsModuleTransportGRPC, t)
+	}
+
+	if err := parseIntVerify("GCS_MODULE_GRPC_CONN_POOL", DefaultBackupGCSGRPCConnPool,
+		func(val int) { c.BackupGCS.GRPCConnPool = val },
+		validateBackupGCSConnPool); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateBackupGCSConnPool(val int, envName string) error {
+	if val < 1 || val > MaxBackupGCSGRPCConnPool {
+		return fmt.Errorf("%s must be an integer between 1 and %d. Got: %v", envName, MaxBackupGCSGRPCConnPool, val)
+	}
+	return nil
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -450,6 +450,102 @@ func TestEnvironmentSkipAccessCheck(t *testing.T) {
 	})
 }
 
+func TestEnvironmentBackupGCS(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      map[string]string
+		expected BackupGCS
+		wantErr  string
+	}{
+		{
+			name:     "unset selects http",
+			expected: BackupGCS{GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+		},
+		{
+			name:     "empty selects http",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": ""},
+			expected: BackupGCS{GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+		},
+		{
+			name:     "http",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "http"},
+			expected: BackupGCS{GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+		},
+		{
+			name:     "grpc",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+		},
+		{
+			name:     "transport is case insensitive and trimmed",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": " gRPC "},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+		},
+		{
+			name:    "unknown transport is rejected",
+			env:     map[string]string{"GCS_MODULE_TRANSPORT": "https"},
+			wantErr: `GCS_MODULE_TRANSPORT must be "http" or "grpc". Got: https`,
+		},
+		{
+			name:     "connection pool overrides the default",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc", "GCS_MODULE_GRPC_CONN_POOL": "16"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 16},
+		},
+		{
+			name:     "connection pool of one is accepted",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc", "GCS_MODULE_GRPC_CONN_POOL": "1"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 1},
+		},
+		{
+			name:     "connection pool at the cap is accepted",
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc", "GCS_MODULE_GRPC_CONN_POOL": "64"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: MaxBackupGCSGRPCConnPool},
+		},
+		{
+			name:    "connection pool of zero is rejected",
+			env:     map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "0"},
+			wantErr: "GCS_MODULE_GRPC_CONN_POOL must be an integer between 1 and 64. Got: 0",
+		},
+		{
+			name:    "negative connection pool is rejected",
+			env:     map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "-1"},
+			wantErr: "GCS_MODULE_GRPC_CONN_POOL must be an integer between 1 and 64",
+		},
+		{
+			name:    "connection pool past the cap is rejected",
+			env:     map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "65"},
+			wantErr: "GCS_MODULE_GRPC_CONN_POOL must be an integer between 1 and 64",
+		},
+		{
+			name:    "absurd connection pool is rejected",
+			env:     map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "9223372036854775807"},
+			wantErr: "GCS_MODULE_GRPC_CONN_POOL must be an integer between 1 and 64",
+		},
+		{
+			name:    "non-numeric connection pool is rejected",
+			env:     map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "many"},
+			wantErr: "parse GCS_MODULE_GRPC_CONN_POOL as int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{"GCS_MODULE_TRANSPORT", "GCS_MODULE_GRPC_CONN_POOL"} {
+				t.Setenv(key, tt.env[key])
+			}
+
+			conf := Config{}
+			err := FromEnv(&conf)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, conf.BackupGCS)
+		})
+	}
+}
+
 func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -453,6 +453,7 @@ func TestEnvironmentSkipAccessCheck(t *testing.T) {
 func TestEnvironmentBackupGCS(t *testing.T) {
 	tests := []struct {
 		name     string
+		start    BackupGCS
 		env      map[string]string
 		expected BackupGCS
 		wantErr  string
@@ -526,6 +527,46 @@ func TestEnvironmentBackupGCS(t *testing.T) {
 			env:     map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "many"},
 			wantErr: "parse GCS_MODULE_GRPC_CONN_POOL as int",
 		},
+		{
+			name:     "unset transport keeps the config file value",
+			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+		},
+		{
+			name:     "empty transport keeps the config file value",
+			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": ""},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+		},
+		{
+			name:     "http overrides the config file transport",
+			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "http"},
+			expected: BackupGCS{GRPCConnPool: 32},
+		},
+		{
+			name:     "grpc overrides the config file transport",
+			start:    BackupGCS{GRPCConnPool: 32},
+			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+		},
+		{
+			name:     "connection pool overrides the config file value",
+			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			env:      map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "16"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 16},
+		},
+		{
+			name:     "config file connection pool out of range is left for validation",
+			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 100},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 100},
+		},
+		{
+			name:     "connection pool overrides an out of range config file value",
+			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 100},
+			env:      map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "8"},
+			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 8},
+		},
 	}
 
 	for _, tt := range tests {
@@ -534,7 +575,7 @@ func TestEnvironmentBackupGCS(t *testing.T) {
 				t.Setenv(key, tt.env[key])
 			}
 
-			conf := Config{}
+			conf := Config{BackupGCS: tt.start}
 			err := FromEnv(&conf)
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)

--- a/usecases/modulecomponents/gcpcommon/retry_error_func_test.go
+++ b/usecases/modulecomponents/gcpcommon/retry_error_func_test.go
@@ -1,0 +1,65 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package gcpcommon
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRetryErrorFunc(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error is not retried", err: nil},
+		{name: "plain error is not retried", err: errors.New("boom")},
+		{name: "http 401 is retried", err: &googleapi.Error{Code: 401}, want: true},
+		{name: "http 403 is not retried", err: &googleapi.Error{Code: 403}},
+		{name: "http 503 is retried", err: &googleapi.Error{Code: 503}, want: true},
+		{name: "http2 connection lost is retried", err: errors.New("http2: client connection lost"), want: true},
+		{
+			name: "grpc unavailable is retried",
+			err:  status.Error(codes.Unavailable, "backend down"),
+			want: true,
+		},
+		{
+			name: "wrapped grpc unavailable is retried",
+			err:  fmt.Errorf("write object: %w", status.Error(codes.Unavailable, "backend down")),
+			want: true,
+		},
+		{
+			name: "grpc permission denied is not retried",
+			err:  status.Error(codes.PermissionDenied, "no access"),
+		},
+		// grpc-go reports a failure to obtain credentials as Unauthenticated,
+		// so retrying it would loop forever on a permanently bad credential:
+		// the retry policy is RetryAlways and restore runs without a deadline.
+		{
+			name: "grpc unauthenticated is not retried",
+			err:  status.Error(codes.Unauthenticated, "token expired"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RetryErrorFunc(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Adds an optional GRPC backend for GCS upload (export/backup)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
