### PR TITLE
fix: handle context cancellation in cursor operations to prevent incorrect nil returns

### DIFF
--- a/adapters/repos/db/inverted/row_reader_frequency.go
+++ b/adapters/repos/db/inverted/row_reader_frequency.go
@@ -112,7 +112,7 @@ func (rr *RowReaderFrequency) greaterThan(ctx context.Context, readFn ReadFn,
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 // lessThan reads from the very begging to the specified  value. The last
@@ -147,7 +147,7 @@ func (rr *RowReaderFrequency) lessThan(ctx context.Context, readFn ReadFn,
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 func (rr *RowReaderFrequency) like(ctx context.Context, readFn ReadFn) error {
@@ -207,7 +207,7 @@ func (rr *RowReaderFrequency) like(ctx context.Context, readFn ReadFn) error {
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 // newCursor will either return a regular cursor - or a key-only cursor if

--- a/adapters/repos/db/inverted_migrator_filter_to_search.go
+++ b/adapters/repos/db/inverted_migrator_filter_to_search.go
@@ -273,6 +273,9 @@ func (m *filterableToSearchableMigrator) isEmptyMapBucket(ctx context.Context, b
 	defer cur.Close()
 
 	key, _ := cur.First(ctx)
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
 	return key == nil, nil
 }
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -530,7 +530,7 @@ func (b *Bucket) IterateMapObjects(ctx context.Context, f func([]byte, []byte, [
 		}
 	}
 
-	return nil
+	return ctx.Err()
 }
 
 func (b *Bucket) SetMemtableThreshold(size uint64) {

--- a/adapters/repos/db/lsmkv/cursor_bucket_map.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map.go
@@ -204,6 +204,11 @@ func (c *CursorMap) serveCurrentStateAndAdvance(ctx context.Context) ([]byte, []
 
 		merged, err := newSortedMapMerger().do(ctx, perSegmentResults)
 		if err != nil {
+			if ctx.Err() != nil {
+				// end iteration like exhaustion: nil looks like end-of-data, so
+				// callers must check ctx.Err() after their loop to tell them apart
+				return nil, nil
+			}
 			panic(fmt.Errorf("unexpected error decoding map values: %w", err))
 		}
 		if len(merged) == 0 {

--- a/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_map_test.go
@@ -252,6 +252,57 @@ func TestMapCursorKeyOnly_FirstKeyOnNonEmptyBucket(t *testing.T) {
 	require.Equal(t, []byte("only"), k)
 }
 
+// A cancelled context must end iteration like exhaustion (nil, nil), not
+// panic. The sorted-map merger returns ctx.Err() and the cursor used to
+// escalate every merger error to a panic ("unexpected error decoding map
+// values: context canceled").
+func TestMapCursor_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := test.NewNullLogger()
+
+	newBucket := func() *Bucket {
+		return &Bucket{
+			active: newTestMemtableMap(map[string][]MapPair{
+				"key1": {{Key: []byte("k1"), Value: []byte("v1")}},
+				"key2": {{Key: []byte("k2"), Value: []byte("v2")}},
+			}),
+			disk:     &SegmentGroup{logger: logger},
+			strategy: StrategyMapCollection,
+			logger:   logger,
+		}
+	}
+
+	t.Run("First with already-cancelled context", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		cur, err := newBucket().MapCursor()
+		require.NoError(t, err)
+		defer cur.Close()
+
+		k, v := cur.First(ctx)
+		assert.Nil(t, k)
+		assert.Nil(t, v)
+	})
+
+	t.Run("cancel between Next calls", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		cur, err := newBucket().MapCursor()
+		require.NoError(t, err)
+		defer cur.Close()
+
+		k, _ := cur.First(ctx)
+		require.Equal(t, []byte("key1"), k)
+
+		cancel()
+		k, v := cur.Next(ctx)
+		assert.Nil(t, k)
+		assert.Nil(t, v)
+	})
+}
+
 // A key that is live on disk but tombstoned in the newer active memtable must
 // NOT surface from a keyOnly cursor. This guards the merge semantics from the
 // opposite direction of TestMapCursorKeyOnly: capturing values (needed to walk

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -392,9 +392,6 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 				break
 			}
 		}
-		if err := ctx.Err(); err != nil {
-			return dimensionality, err
-		}
 	default:
 		c := b.CursorRoaringSet()
 		defer c.Close()
@@ -427,5 +424,8 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 		}
 	}
 
+	if err := ctx.Err(); err != nil {
+		return dimensionality, err
+	}
 	return dimensionality, nil
 }

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -392,6 +392,9 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 				break
 			}
 		}
+		if err := ctx.Err(); err != nil {
+			return dimensionality, err
+		}
 	default:
 		c := b.CursorRoaringSet()
 		defer c.Close()


### PR DESCRIPTION
### What's being changed:

- canceled map cursors could report misleading panics on context cancellation
- current code pushes the context error "up" so it is reported correctly
- also fixes some scenarios where partial cursor results could be returned on context cancellation

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
