### PR TITLE
fix(aggregator): handle NaN in boolean percentage calculations for empty results

### DIFF
--- a/adapters/repos/db/aggregator/shard_combiner.go
+++ b/adapters/repos/db/aggregator/shard_combiner.go
@@ -273,6 +273,13 @@ func (sc *ShardCombiner) mergeBooleanProp(combined, source *aggregation.Boolean)
 }
 
 func (sc *ShardCombiner) finalizeBoolean(combined *aggregation.Boolean) {
+	// A property that is never set has no values to take a percentage of. The
+	// resulting NaN cannot be encoded as JSON, which fails the entire response
+	// rather than the single field.
+	if combined.Count == 0 {
+		return
+	}
+
 	combined.PercentageFalse = float64(combined.TotalFalse) / float64(combined.Count)
 	combined.PercentageTrue = float64(combined.TotalTrue) / float64(combined.Count)
 }

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -12,10 +12,13 @@
 package aggregator
 
 import (
+	"encoding/json"
+	"math"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/aggregation"
 )
 
@@ -246,4 +249,100 @@ func createRandomSlice() []float64 {
 		array[i] = rand.Float64() * 1000
 	}
 	return array
+}
+
+func boolShardResult(grouped bool, groupValue string, totalTrue, totalFalse int) *aggregation.Result {
+	count := totalTrue + totalFalse
+	b := aggregation.Boolean{}
+	if count > 0 {
+		b = aggregation.Boolean{
+			Count:           count,
+			TotalTrue:       totalTrue,
+			TotalFalse:      totalFalse,
+			PercentageTrue:  float64(totalTrue) / float64(count),
+			PercentageFalse: float64(totalFalse) / float64(count),
+		}
+	}
+
+	group := aggregation.Group{
+		Count: count,
+		Properties: map[string]aggregation.Property{
+			"boolProp": {
+				Type:               aggregation.PropertyTypeBoolean,
+				BooleanAggregation: b,
+			},
+		},
+	}
+	if grouped {
+		group.GroupedBy = &aggregation.GroupedBy{Value: groupValue}
+	}
+
+	return &aggregation.Result{Groups: []aggregation.Group{group}}
+}
+
+// A boolean property with no non-null values yields Count==0, and the combiner
+// used to divide by it. The resulting NaN is unrepresentable in JSON, so it
+// panicked the whole GraphQL response in the go-swagger producer rather than
+// failing the single field.
+func TestShardCombinerBooleanNoValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		grouped bool
+		results []*aggregation.Result
+	}{
+		{
+			name:    "single shard, property present but never set",
+			results: []*aggregation.Result{boolShardResult(false, "", 0, 0)},
+		},
+		{
+			name: "multiple shards, property never set in any shard",
+			results: []*aggregation.Result{
+				boolShardResult(false, "", 0, 0),
+				boolShardResult(false, "", 0, 0),
+			},
+		},
+		{
+			name:    "grouped, group has no values for the property",
+			grouped: true,
+			results: []*aggregation.Result{boolShardResult(true, "groupA", 0, 0)},
+		},
+		{
+			name:    "grouped, one group populated and one empty",
+			grouped: true,
+			results: []*aggregation.Result{
+				boolShardResult(true, "groupA", 3, 1),
+				boolShardResult(true, "groupB", 0, 0),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			combined := NewShardCombiner().Do(tt.results)
+
+			for _, group := range combined.Groups {
+				b := group.Properties["boolProp"].BooleanAggregation
+				assert.False(t, math.IsNaN(b.PercentageTrue), "percentageTrue is NaN")
+				assert.False(t, math.IsNaN(b.PercentageFalse), "percentageFalse is NaN")
+
+				// NaN is not encodable, so it takes the entire response down.
+				_, err := json.Marshal(group.Properties)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestShardCombinerBooleanMergesPercentages(t *testing.T) {
+	combined := NewShardCombiner().Do([]*aggregation.Result{
+		boolShardResult(false, "", 3, 1),
+		boolShardResult(false, "", 1, 5),
+	})
+
+	b := combined.Groups[0].Properties["boolProp"].BooleanAggregation
+	assert.Equal(t, 10, b.Count)
+	assert.Equal(t, 4, b.TotalTrue)
+	assert.Equal(t, 6, b.TotalFalse)
+	assert.InDelta(t, 0.4, b.PercentageTrue, 1e-9)
+	assert.InDelta(t, 0.6, b.PercentageFalse, 1e-9)
 }

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -280,10 +280,9 @@ func boolShardResult(grouped bool, groupValue string, totalTrue, totalFalse int)
 	return &aggregation.Result{Groups: []aggregation.Group{group}}
 }
 
-// A boolean property with no non-null values yields Count==0, and the combiner
-// used to divide by it. The resulting NaN is unrepresentable in JSON, so it
-// panicked the whole GraphQL response in the go-swagger producer rather than
-// failing the single field.
+// A boolean property with no non-null values yields Count==0; percentages must
+// stay 0 rather than NaN, which cannot be encoded as JSON and would fail the
+// entire response rather than the single field.
 func TestShardCombinerBooleanNoValues(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
### What's being changed:

- handle NaN in boolean percentage calculations for empty results

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
