### PR TITLE
fix(backup): release each protected shard's backupLock exactly once

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -521,9 +521,8 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, ba
 	var shard ShardLike
 	var sd backup.ShardDescriptor
 
-	// inactive reports that the shard was already backed up from disk. The active
-	// path below must then be skipped: it would dereference a nil shard, or run a
-	// second backup over a shard the inactive path has protected and left locked.
+	// inactive reports that the shard was already backed up from disk, so the
+	// active path below (nil shard, already locked) must be skipped.
 	inactive, err := func() (bool, error) {
 		// Acquire shardCreateLocks to atomically check shard state and protect
 		// inactive shards. This prevents concurrent activation from racing.
@@ -673,16 +672,14 @@ func backupStagingDir(rootPath, backupID string, className schema.ClassName) str
 	return filepath.Join(rootPath, name)
 }
 
-// ReleaseBackup marks the specified backup as inactive and restarts all async
-// background and maintenance processes. It is a no-op if the backup is not the
-// one running on this index, which is the common case: the uploader fires
-// several releasers per backup and never waits for them.
+// ReleaseBackup marks the given backup inactive and restarts maintenance
+// processes. It is a no-op unless id names the backup currently running on
+// this index; the uploader fires several releasers per backup without waiting.
 func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	i.logger.WithField("backup_id", id).WithField("class", i.Config.ClassName).Info("release backup")
 
-	// Claimed before the work below, so a releaser that outlived its own backup
-	// does not delete a staging dir or resume compaction under a later one. Both
-	// would corrupt that backup: it is still reading the files they touch.
+	// Claimed first so a releaser that outlived its own backup can't delete a
+	// later backup's staging dir or resume its compaction.
 	gen, claimed := i.claimBackup(id)
 	if !claimed {
 		return nil
@@ -702,13 +699,10 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	return i.resumeMaintenanceCycles(ctx)
 }
 
-// claimBackup ends the backup identified by id and reports the generation it ran
-// under. Only the first caller for a given backup claims it, so the several
-// releasers the uploader fires per backup do not each try to end it.
-//
-// An ID is all a releaser carries, so one that arrives after a later backup
-// reused the same ID ends that backup instead. Nothing here can tell the two
-// apart; closing it needs the release call to say which backup it belongs to.
+// claimBackup ends the backup id if it's still running here and reports its
+// generation; only the first caller succeeds. id alone can't distinguish
+// backups, so a releaser delayed past its own backup's end may instead claim
+// a later backup that reused the same id.
 func (i *Index) claimBackup(id string) (uint64, bool) {
 	i.backupStateMu.Lock()
 	defer i.backupStateMu.Unlock()
@@ -721,14 +715,10 @@ func (i *Index) claimBackup(id string) (uint64, bool) {
 	return st.Generation, true
 }
 
-// releaseProtectedShards unlocks each shard protected by backup generation gen
-// or an older one, and clears its flag. A newer generation is left alone: the
-// backup that protected it is still reading those files. Older ones are swept up
-// so a shard cannot stay locked for a backup that is long gone.
-//
-// CompareAndDelete keeps each unlock to exactly one: two releases can overlap,
-// and a shard can be re-protected while Range walks past it. A second Unlock of
-// the same backupLock is a fatal error recover() cannot catch.
+// releaseProtectedShards unlocks shards protected by generation gen or older,
+// leaving newer (still-running) backups' shards locked. CompareAndDelete caps
+// each shard at one Unlock, since a repeat Unlock of the same backupLock is a
+// fatal error recover() cannot catch.
 func (i *Index) releaseProtectedShards(gen uint64) {
 	i.backupProtectedShards.Range(func(key, value any) bool {
 		if protectedBy, ok := value.(uint64); ok && protectedBy <= gen {
@@ -740,14 +730,10 @@ func (i *Index) releaseProtectedShards(gen uint64) {
 	})
 }
 
-// protectShard blocks activation of shard name and records that its
-// backupLock.Lock is held on behalf of backup generation backupGen, for
-// ReleaseBackup to release later.
-//
-// It fails if backupGen is no longer the backup running on this index. That
-// backup's releaser has already run, so nothing would ever clear the flag or
-// unlock the shard, leaving a tenant that can be neither activated nor written
-// until the process restarts.
+// protectShard holds name's backupLock on behalf of backup generation
+// backupGen, for ReleaseBackup to release later. It fails once backupGen has
+// already ended: nothing would then unlock it, leaving the shard stuck until
+// the process restarts.
 func (i *Index) protectShard(name string, backupGen uint64) error {
 	i.backupStateMu.Lock()
 	defer i.backupStateMu.Unlock()

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -671,11 +671,9 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	// Release non-hardlink backup protections: clear the protection flag and
 	// release the held backupLock.Lock for each protected shard.
 	//
-	// LoadAndDelete makes the claim atomic. ReleaseBackup runs concurrently
-	// (usecases/backup fans out one goroutine per class), and a plain
-	// Delete-after-Unlock would let two callers unlock the same shard once
-	// each: the second Unlock hits an unlocked RWMutex, which is a fatal
-	// error that recover() cannot catch.
+	// LoadAndDelete keeps the claim atomic: ReleaseBackup runs concurrently
+	// (one goroutine per class), and a second Unlock on an already-unlocked
+	// shard is a fatal, unrecoverable panic.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
 		name := key.(string)
 		if _, loaded := i.backupProtectedShards.LoadAndDelete(key); loaded {

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -672,8 +672,8 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	// release the held backupLock.Lock for each protected shard.
 	//
 	// LoadAndDelete keeps the claim atomic: ReleaseBackup runs concurrently
-	// (one goroutine per class), and a second Unlock on an already-unlocked
-	// shard is a fatal, unrecoverable panic.
+	// (one goroutine per class), and a second Unlock on an already unlocked
+	// shard is a fatal error that recover() cannot catch.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
 		name := key.(string)
 		if _, loaded := i.backupProtectedShards.LoadAndDelete(key); loaded {

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -670,10 +670,17 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 
 	// Release non-hardlink backup protections: clear the protection flag and
 	// release the held backupLock.Lock for each protected shard.
+	//
+	// LoadAndDelete makes the claim atomic. ReleaseBackup runs concurrently
+	// (usecases/backup fans out one goroutine per class), and a plain
+	// Delete-after-Unlock would let two callers unlock the same shard once
+	// each: the second Unlock hits an unlocked RWMutex, which is a fatal
+	// error that recover() cannot catch.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
 		name := key.(string)
-		i.backupLock.Unlock(name)
-		i.backupProtectedShards.Delete(key)
+		if _, loaded := i.backupProtectedShards.LoadAndDelete(key); loaded {
+			i.backupLock.Unlock(name)
+		}
 		return true
 	})
 

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -671,12 +671,11 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	// Release non-hardlink backup protections: clear the protection flag and
 	// release the held backupLock.Lock for each protected shard.
 	//
-	// CompareAndDelete claims the shard for this backup in one atomic step.
-	// ReleaseBackup runs concurrently (one goroutine per class), so without a
-	// claim two callers unlock the same shard once each and the second Unlock
-	// hits an unlocked RWMutex — a fatal error recover() cannot catch. Matching
-	// on the backup ID also keeps a slow caller from releasing a shard that a
-	// later backup has already re-protected, which Range is free to show it.
+	// CompareAndDelete claims each shard atomically: without it, two concurrent
+	// ReleaseBackup calls (one per class) could each Unlock the same shard — the
+	// second Unlock is a fatal error recover() cannot catch. Matching on id also
+	// stops a slow caller from releasing a shard a later backup already
+	// re-protected; sync.Map.Range can observe that re-store mid-traversal.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
 		if i.backupProtectedShards.CompareAndDelete(key, id) {
 			i.backupLock.Unlock(key.(string))

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -721,7 +721,16 @@ func (i *Index) claimBackup(id string) (uint64, bool) {
 // fatal error recover() cannot catch.
 func (i *Index) releaseProtectedShards(gen uint64) {
 	i.backupProtectedShards.Range(func(key, value any) bool {
-		if protectedBy, ok := value.(uint64); ok && protectedBy <= gen {
+		protectedBy, ok := value.(uint64)
+		if !ok {
+			// Only protectShard writes here, so this cannot happen. Say so anyway:
+			// the shard keeps its write lock for the life of the process, and the
+			// tenant can be neither activated nor written until it restarts.
+			i.logger.WithField("shard", key).Errorf(
+				"backup: protection %v is not a backup generation, cannot release the shard's lock", value)
+			return true
+		}
+		if protectedBy <= gen {
 			if i.backupProtectedShards.CompareAndDelete(key, value) {
 				i.backupLock.Unlock(key.(string))
 			}

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -705,6 +705,10 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 // claimBackup ends the backup identified by id and reports the generation it ran
 // under. Only the first caller for a given backup claims it, so the several
 // releasers the uploader fires per backup do not each try to end it.
+//
+// An ID is all a releaser carries, so one that arrives after a later backup
+// reused the same ID ends that backup instead. Nothing here can tell the two
+// apart; closing it needs the release call to say which backup it belongs to.
 func (i *Index) claimBackup(id string) (uint64, bool) {
 	i.backupStateMu.Lock()
 	defer i.backupStateMu.Unlock()

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -683,9 +683,12 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	// Claimed before the work below, so a releaser that outlived its own backup
 	// does not delete a staging dir or resume compaction under a later one. Both
 	// would corrupt that backup: it is still reading the files they touch.
-	if !i.claimBackup(id) {
+	gen, claimed := i.claimBackup(id)
+	if !claimed {
 		return nil
 	}
+
+	i.releaseProtectedShards(gen)
 
 	// Clean up staging directory (idempotent — RemoveAll on non-existent dir is no-op)
 	stagingDir := backupStagingDir(i.Config.RootPath, id, i.Config.ClassName)
@@ -699,29 +702,38 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	return i.resumeMaintenanceCycles(ctx)
 }
 
-// claimBackup ends the backup identified by id and reports whether this caller
-// is the one that ended it. Only the first caller for a given backup claims it:
-// the second Unlock of a shard's backupLock is a fatal error recover() cannot
-// catch, so releasing must happen once no matter how many releasers arrive.
-func (i *Index) claimBackup(id string) bool {
+// claimBackup ends the backup identified by id and reports the generation it ran
+// under. Only the first caller for a given backup claims it, so the several
+// releasers the uploader fires per backup do not each try to end it.
+func (i *Index) claimBackup(id string) (uint64, bool) {
 	i.backupStateMu.Lock()
 	defer i.backupStateMu.Unlock()
 
 	st := i.lastBackup.Load()
 	if st == nil || st.BackupID != id {
-		return false
+		return 0, false
 	}
 	i.lastBackup.Store(nil)
+	return st.Generation, true
+}
 
-	// Every protected shard belongs to the backup being ended: protectShard
-	// refuses to protect for any other, and the next backup cannot start until
-	// backupStateMu is free again.
-	i.backupProtectedShards.Range(func(key, _ any) bool {
-		i.backupProtectedShards.Delete(key)
-		i.backupLock.Unlock(key.(string))
+// releaseProtectedShards unlocks each shard protected by backup generation gen
+// or an older one, and clears its flag. A newer generation is left alone: the
+// backup that protected it is still reading those files. Older ones are swept up
+// so a shard cannot stay locked for a backup that is long gone.
+//
+// CompareAndDelete keeps each unlock to exactly one: two releases can overlap,
+// and a shard can be re-protected while Range walks past it. A second Unlock of
+// the same backupLock is a fatal error recover() cannot catch.
+func (i *Index) releaseProtectedShards(gen uint64) {
+	i.backupProtectedShards.Range(func(key, value any) bool {
+		if protectedBy, ok := value.(uint64); ok && protectedBy <= gen {
+			if i.backupProtectedShards.CompareAndDelete(key, value) {
+				i.backupLock.Unlock(key.(string))
+			}
+		}
 		return true
 	})
-	return true
 }
 
 // protectShard blocks activation of shard name and records that its

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -473,7 +473,7 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 
 	shards := map[string]*backup.ShardDescriptor{}
 	for _, name := range shardNames {
-		sd, err := i.backupShardWithoutHardlinks(ctx, name, classBaseDescrs)
+		sd, err := i.backupShardWithoutHardlinks(ctx, name, backupID, classBaseDescrs)
 		if err != nil {
 			if errors.Is(err, errShardNoLocalData) {
 				i.logger.WithField("shard", name).Debug("skipping shard with no local data")
@@ -501,7 +501,7 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 //
 // For inactive shards, backupProtectedShards is set and backupLock.Lock is held
 // until ReleaseBackup to block both activation and FREEZE/FROZEN file operations.
-func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, classBaseDescrs []*backup.ClassDescriptor) (*backup.ShardDescriptor, error) {
+func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name, backupID string, classBaseDescrs []*backup.ClassDescriptor) (*backup.ShardDescriptor, error) {
 	shardBaseDescr := i.collectShardBaseDescrs(name, classBaseDescrs)
 
 	i.backupLock.Lock(name)
@@ -525,7 +525,7 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 		if shard == nil {
 			// Not in shardMap => back up from disk if directory exists.
 			// Mark as protected and keep backupLock.Lock held until ReleaseBackup.
-			i.backupProtectedShards.Store(name, struct{}{})
+			i.backupProtectedShards.Store(name, backupID)
 			unlockOnReturn = false
 			return i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
 		}
@@ -537,7 +537,7 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 			defer releaseBlock()
 			if !lazyShard.loaded {
 				// Shard is in the map but not loaded; protect and keep lock held.
-				i.backupProtectedShards.Store(name, struct{}{})
+				i.backupProtectedShards.Store(name, backupID)
 				unlockOnReturn = false
 				return i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
 			}
@@ -671,13 +671,15 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	// Release non-hardlink backup protections: clear the protection flag and
 	// release the held backupLock.Lock for each protected shard.
 	//
-	// LoadAndDelete keeps the claim atomic: ReleaseBackup runs concurrently
-	// (one goroutine per class), and a second Unlock on an already unlocked
-	// shard is a fatal error that recover() cannot catch.
+	// CompareAndDelete claims the shard for this backup in one atomic step.
+	// ReleaseBackup runs concurrently (one goroutine per class), so without a
+	// claim two callers unlock the same shard once each and the second Unlock
+	// hits an unlocked RWMutex — a fatal error recover() cannot catch. Matching
+	// on the backup ID also keeps a slow caller from releasing a shard that a
+	// later backup has already re-protected, which Range is free to show it.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
-		name := key.(string)
-		if _, loaded := i.backupProtectedShards.LoadAndDelete(key); loaded {
-			i.backupLock.Unlock(name)
+		if i.backupProtectedShards.CompareAndDelete(key, id) {
+			i.backupLock.Unlock(key.(string))
 		}
 		return true
 	})

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -723,9 +723,8 @@ func (i *Index) releaseProtectedShards(gen uint64) {
 	i.backupProtectedShards.Range(func(key, value any) bool {
 		protectedBy, ok := value.(uint64)
 		if !ok {
-			// Only protectShard writes here, so this cannot happen. Say so anyway:
-			// the shard keeps its write lock for the life of the process, and the
-			// tenant can be neither activated nor written until it restarts.
+			// Should never happen (only protectShard writes here); log it anyway
+			// since an unreadable protection leaves the shard locked until restart.
 			i.logger.WithField("shard", key).Errorf(
 				"backup: protection %v is not a backup generation, cannot release the shard's lock", value)
 			return true

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -39,9 +39,14 @@ import (
 type BackupState struct {
 	BackupID   string
 	InProgress bool
+	// Generation identifies this backup among the ones run on the same index.
+	Generation uint64
 }
 
-var errShardNoLocalData = errors.New("shard has no local data")
+var (
+	errShardNoLocalData = errors.New("shard has no local data")
+	errBackupReleased   = errors.New("backup was released before the shard could be protected")
+)
 
 const (
 	lsmDir        = "lsm"
@@ -224,7 +229,8 @@ func (i *Index) probeHardlinkSupport() bool {
 
 // descriptor record everything needed to restore a class
 func (i *Index) descriptor(ctx context.Context, backupID string, desc *backup.ClassDescriptor, classBaseDescrs []*backup.ClassDescriptor) (err error) {
-	if err := i.initBackup(backupID); err != nil {
+	backupGen, err := i.initBackup(backupID)
+	if err != nil {
 		return err
 	}
 
@@ -234,7 +240,7 @@ func (i *Index) descriptor(ctx context.Context, backupID string, desc *backup.Cl
 	if useHardlinks {
 		return i.descriptorWithHardlinks(ctx, backupID, desc, classBaseDescrs)
 	}
-	return i.descriptorWithoutHardlinks(ctx, backupID, desc, classBaseDescrs)
+	return i.descriptorWithoutHardlinks(ctx, backupID, backupGen, desc, classBaseDescrs)
 }
 
 // descriptorWithHardlinks creates hard-linked snapshots per shard, allowing compaction
@@ -458,7 +464,7 @@ func copyFile(src, dst string) (err error) {
 
 // descriptorWithoutHardlinks is the fallback path for filesystems that don't support
 // hardlinks. Compaction remains paused for the entire backup upload duration.
-func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string, desc *backup.ClassDescriptor, classBaseDescrs []*backup.ClassDescriptor) (err error) {
+func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string, backupGen uint64, desc *backup.ClassDescriptor, classBaseDescrs []*backup.ClassDescriptor) (err error) {
 	defer func() {
 		if err != nil {
 			// closelock is hold by the caller
@@ -473,7 +479,7 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 
 	shards := map[string]*backup.ShardDescriptor{}
 	for _, name := range shardNames {
-		sd, err := i.backupShardWithoutHardlinks(ctx, name, backupID, classBaseDescrs)
+		sd, err := i.backupShardWithoutHardlinks(ctx, name, backupGen, classBaseDescrs)
 		if err != nil {
 			if errors.Is(err, errShardNoLocalData) {
 				i.logger.WithField("shard", name).Debug("skipping shard with no local data")
@@ -501,7 +507,7 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 //
 // For inactive shards, backupProtectedShards is set and backupLock.Lock is held
 // until ReleaseBackup to block both activation and FREEZE/FROZEN file operations.
-func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name, backupID string, classBaseDescrs []*backup.ClassDescriptor) (*backup.ShardDescriptor, error) {
+func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, backupGen uint64, classBaseDescrs []*backup.ClassDescriptor) (*backup.ShardDescriptor, error) {
 	shardBaseDescr := i.collectShardBaseDescrs(name, classBaseDescrs)
 
 	i.backupLock.Lock(name)
@@ -514,8 +520,11 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name, backupID 
 
 	var shard ShardLike
 	var sd backup.ShardDescriptor
-	var err error
-	if err := func() error {
+
+	// inactive reports that the shard was already backed up from disk. The active
+	// path below must then be skipped: it would dereference a nil shard, or run a
+	// second backup over a shard the inactive path has protected and left locked.
+	inactive, err := func() (bool, error) {
 		// Acquire shardCreateLocks to atomically check shard state and protect
 		// inactive shards. This prevents concurrent activation from racing.
 		i.shardCreateLocks.Lock(name)
@@ -525,9 +534,11 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name, backupID 
 		if shard == nil {
 			// Not in shardMap => back up from disk if directory exists.
 			// Mark as protected and keep backupLock.Lock held until ReleaseBackup.
-			i.backupProtectedShards.Store(name, backupID)
+			if err := i.protectShard(name, backupGen); err != nil {
+				return false, err
+			}
 			unlockOnReturn = false
-			return i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
+			return true, i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
 		}
 
 		// For unloaded LazyLoadShards, block concurrent loading so we can safely
@@ -537,15 +548,21 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name, backupID 
 			defer releaseBlock()
 			if !lazyShard.loaded {
 				// Shard is in the map but not loaded; protect and keep lock held.
-				i.backupProtectedShards.Store(name, backupID)
+				if err := i.protectShard(name, backupGen); err != nil {
+					return false, err
+				}
 				unlockOnReturn = false
-				return i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
+				return true, i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
 			}
 		}
 
-		return nil
-	}(); err != nil {
+		return false, nil
+	}()
+	if err != nil {
 		return nil, err
+	}
+	if inactive {
+		return &sd, nil
 	}
 
 	// Active path => halt compaction (stays paused until ReleaseBackup).
@@ -656,11 +673,19 @@ func backupStagingDir(rootPath, backupID string, className schema.ClassName) str
 	return filepath.Join(rootPath, name)
 }
 
-// ReleaseBackup marks the specified backup as inactive and restarts all
-// async background and maintenance processes. It errors if the backup does not exist
-// or is already inactive.
+// ReleaseBackup marks the specified backup as inactive and restarts all async
+// background and maintenance processes. It is a no-op if the backup is not the
+// one running on this index, which is the common case: the uploader fires
+// several releasers per backup and never waits for them.
 func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	i.logger.WithField("backup_id", id).WithField("class", i.Config.ClassName).Info("release backup")
+
+	// Claimed before the work below, so a releaser that outlived its own backup
+	// does not delete a staging dir or resume compaction under a later one. Both
+	// would corrupt that backup: it is still reading the files they touch.
+	if !i.claimBackup(id) {
+		return nil
+	}
 
 	// Clean up staging directory (idempotent — RemoveAll on non-existent dir is no-op)
 	stagingDir := backupStagingDir(i.Config.RootPath, id, i.Config.ClassName)
@@ -668,52 +693,77 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 		i.logger.WithField("staging_dir", stagingDir).WithError(err).Warn("failed to remove backup staging dir")
 	}
 
-	// Release non-hardlink backup protections: clear the protection flag and
-	// release the held backupLock.Lock for each protected shard.
-	//
-	// CompareAndDelete claims each shard atomically: without it, two concurrent
-	// ReleaseBackup calls (one per class) could each Unlock the same shard — the
-	// second Unlock is a fatal error recover() cannot catch. Matching on id also
-	// stops a slow caller from releasing a shard a later backup already
-	// re-protected; sync.Map.Range can observe that re-store mid-traversal.
-	i.backupProtectedShards.Range(func(key, _ any) bool {
-		if i.backupProtectedShards.CompareAndDelete(key, id) {
-			i.backupLock.Unlock(key.(string))
-		}
-		return true
-	})
-
-	i.resetBackupState()
 	// resumeMaintenanceCycles is still called for safety, but is a no-op since
 	// CreateBackupSnapshot already resumed compaction. Handles edge cases where
 	// a snapshot creation failed mid-way.
-	if err := i.resumeMaintenanceCycles(ctx); err != nil {
-		return err
+	return i.resumeMaintenanceCycles(ctx)
+}
+
+// claimBackup ends the backup identified by id and reports whether this caller
+// is the one that ended it. Only the first caller for a given backup claims it:
+// the second Unlock of a shard's backupLock is a fatal error recover() cannot
+// catch, so releasing must happen once no matter how many releasers arrive.
+func (i *Index) claimBackup(id string) bool {
+	i.backupStateMu.Lock()
+	defer i.backupStateMu.Unlock()
+
+	st := i.lastBackup.Load()
+	if st == nil || st.BackupID != id {
+		return false
 	}
+	i.lastBackup.Store(nil)
+
+	// Every protected shard belongs to the backup being ended: protectShard
+	// refuses to protect for any other, and the next backup cannot start until
+	// backupStateMu is free again.
+	i.backupProtectedShards.Range(func(key, _ any) bool {
+		i.backupProtectedShards.Delete(key)
+		i.backupLock.Unlock(key.(string))
+		return true
+	})
+	return true
+}
+
+// protectShard blocks activation of shard name and records that its
+// backupLock.Lock is held on behalf of backup generation backupGen, for
+// ReleaseBackup to release later.
+//
+// It fails if backupGen is no longer the backup running on this index. That
+// backup's releaser has already run, so nothing would ever clear the flag or
+// unlock the shard, leaving a tenant that can be neither activated nor written
+// until the process restarts.
+func (i *Index) protectShard(name string, backupGen uint64) error {
+	i.backupStateMu.Lock()
+	defer i.backupStateMu.Unlock()
+
+	st := i.lastBackup.Load()
+	if st == nil || st.Generation != backupGen {
+		return errBackupReleased
+	}
+	i.backupProtectedShards.Store(name, backupGen)
 	return nil
 }
 
-func (i *Index) initBackup(id string) error {
-	new := &BackupState{
-		BackupID:   id,
-		InProgress: true,
-	}
-	if !i.lastBackup.CompareAndSwap(nil, new) {
-		bid := ""
-		if x := i.lastBackup.Load(); x != nil {
-			bid = x.BackupID
-		}
-		return errors.Errorf(
+// initBackup registers a backup on this index and returns the generation it runs
+// under.
+func (i *Index) initBackup(id string) (uint64, error) {
+	i.backupStateMu.Lock()
+	defer i.backupStateMu.Unlock()
+
+	if st := i.lastBackup.Load(); st != nil {
+		return 0, errors.Errorf(
 			"cannot create new backup, backup ‘%s’ is not yet released, this "+
 				"means its contents have not yet been fully copied to its destination, "+
-				"try again later", bid)
+				"try again later", st.BackupID)
 	}
 
-	return nil
-}
-
-func (i *Index) resetBackupState() {
-	i.lastBackup.Store(nil)
+	gen := i.backupGeneration.Add(1)
+	i.lastBackup.Store(&BackupState{
+		BackupID:   id,
+		InProgress: true,
+		Generation: gen,
+	})
+	return gen, nil
 }
 
 func (i *Index) resumeMaintenanceCycles(ctx context.Context) (lastErr error) {

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -472,54 +472,78 @@ func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
 	runReleaseBackupWorkloadInChild(t)
 }
 
+// backupTestShardNames builds n shard names.
+func backupTestShardNames(n int) []string {
+	names := make([]string, n)
+	for s := range names {
+		names[s] = "shard" + strconv.Itoa(s)
+	}
+	return names
+}
+
+// newBackupTestIndex returns an Index holding every shard's backupLock with the
+// shard flagged as protected by backupID, the state
+// backupShardWithoutHardlinks leaves behind for a shard it backed up without
+// hardlinks.
+func newBackupTestIndex(t *testing.T, rootDir string, names []string, backupID string) *Index {
+	t.Helper()
+
+	const className = "MyClass"
+	logger, _ := tlog.NewNullLogger()
+
+	idx := &Index{
+		Config: IndexConfig{RootPath: rootDir, ClassName: className},
+		getSchema: &fakeSchemaGetter{
+			schema: schema.Schema{
+				Objects: &models.Schema{Classes: []*models.Class{{Class: className}}},
+			},
+		},
+		logger:           logger,
+		backupLock:       esync.NewKeyRWLocker(),
+		shardCreateLocks: esync.NewKeyRWLocker(),
+		closingCtx:       context.Background(),
+	}
+
+	for _, name := range names {
+		idx.backupLock.Lock(name)
+		idx.backupProtectedShards.Store(name, backupID)
+	}
+	idx.lastBackup.Store(&BackupState{BackupID: backupID, InProgress: true})
+
+	return idx
+}
+
+// spawnBackupReleasers starts n goroutines that each release backupID once
+// start is closed, so the releases overlap.
+func spawnBackupReleasers(t *testing.T, wg *sync.WaitGroup, start <-chan struct{}, idx *Index, backupID string, n int) {
+	for r := 0; r < n; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			assert.NoError(t, idx.ReleaseBackup(context.Background(), backupID))
+		}()
+	}
+}
+
 func releaseBackupCrossGenerationWorkload(t *testing.T) {
 	const (
 		trials         = 200
 		shardsPerTrial = 512
-		className      = "MyClass"
+		releasers      = 2
 		firstBackup    = "backup1"
 		secondBackup   = "backup2"
 	)
 
-	logger, _ := tlog.NewNullLogger()
 	rootDir := t.TempDir()
-	ctx := context.Background()
-
-	names := make([]string, shardsPerTrial)
-	for s := range names {
-		names[s] = "shard" + strconv.Itoa(s)
-	}
+	names := backupTestShardNames(shardsPerTrial)
 
 	for trial := 0; trial < trials; trial++ {
-		idx := &Index{
-			Config: IndexConfig{RootPath: rootDir, ClassName: className},
-			getSchema: &fakeSchemaGetter{
-				schema: schema.Schema{
-					Objects: &models.Schema{Classes: []*models.Class{{Class: className}}},
-				},
-			},
-			logger:           logger,
-			backupLock:       esync.NewKeyRWLocker(),
-			shardCreateLocks: esync.NewKeyRWLocker(),
-			closingCtx:       context.Background(),
-		}
-
-		for _, name := range names {
-			idx.backupLock.Lock(name)
-			idx.backupProtectedShards.Store(name, firstBackup)
-		}
-		idx.lastBackup.Store(&BackupState{BackupID: firstBackup, InProgress: true})
+		idx := newBackupTestIndex(t, rootDir, names, firstBackup)
 
 		start := make(chan struct{})
 		var wg sync.WaitGroup
-		for r := 0; r < 2; r++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				<-start
-				assert.NoError(t, idx.ReleaseBackup(ctx, firstBackup))
-			}()
-		}
+		spawnBackupReleasers(t, &wg, start, idx, firstBackup, releasers)
 
 		// The second backup re-protects each shard as the first one frees it.
 		wg.Add(1)
@@ -552,51 +576,18 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 		trials         = 200
 		shardsPerTrial = 512
 		releasers      = 4
-		className      = "MyClass"
 		backupID       = "backup1"
 	)
 
-	logger, _ := tlog.NewNullLogger()
 	rootDir := t.TempDir()
-	ctx := context.Background()
-
-	names := make([]string, shardsPerTrial)
-	for s := range names {
-		names[s] = "shard" + strconv.Itoa(s)
-	}
+	names := backupTestShardNames(shardsPerTrial)
 
 	for trial := 0; trial < trials; trial++ {
-		idx := &Index{
-			Config: IndexConfig{RootPath: rootDir, ClassName: className},
-			getSchema: &fakeSchemaGetter{
-				schema: schema.Schema{
-					Objects: &models.Schema{Classes: []*models.Class{{Class: className}}},
-				},
-			},
-			logger:           logger,
-			backupLock:       esync.NewKeyRWLocker(),
-			shardCreateLocks: esync.NewKeyRWLocker(),
-			closingCtx:       context.Background(),
-		}
-
-		// Same state backupShardWithoutHardlinks leaves behind for a shard it
-		// backed up without hardlinks: lock held, shard flagged as protected.
-		for _, name := range names {
-			idx.backupLock.Lock(name)
-			idx.backupProtectedShards.Store(name, backupID)
-		}
-		idx.lastBackup.Store(&BackupState{BackupID: backupID, InProgress: true})
+		idx := newBackupTestIndex(t, rootDir, names, backupID)
 
 		start := make(chan struct{})
 		var wg sync.WaitGroup
-		for r := 0; r < releasers; r++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				<-start
-				assert.NoError(t, idx.ReleaseBackup(ctx, backupID))
-			}()
-		}
+		spawnBackupReleasers(t, &wg, start, idx, backupID, releasers)
 		close(start)
 		wg.Wait()
 

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -477,9 +477,8 @@ func requireWaitGroupDone(t *testing.T, wg *sync.WaitGroup, msg string) {
 	}
 }
 
-// waitForBackupSlot spins on initBackup rather than sleeping, to keep the
-// handover race tight. It is a hot spin: a workload that never frees the index
-// burns a core or two until backupWorkloadTimeout, on its way to failing.
+// waitForBackupSlot busy-spins on initBackup instead of sleeping, to keep the
+// handover race tight; a stuck workload burns a core until backupWorkloadTimeout.
 func waitForBackupSlot(idx *Index, backupID string) (uint64, bool) {
 	deadline := time.Now().Add(backupWorkloadTimeout)
 	for {
@@ -875,13 +874,8 @@ func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 	assert.NoDirExists(t, stagingDir)
 }
 
-// Records a known limitation rather than a guarantee: a releaser is matched by
-// backup ID, and IDs are only unique per (backend, bucket, path), so the same
-// name sent to a second bucket produces a backup a straggler cannot be told
-// apart from its own. Every protection then goes at once.
-//
-// Delete this test if the release call ever carries which backup it belongs to.
-// It is written to fail the moment that lands.
+// A releaser is matched only by backup ID; a straggler from a reused ID ends
+// whichever backup currently holds that name, not its own.
 func TestReleaseBackupCannotTellReusedIDsApart(t *testing.T) {
 	const (
 		shardName = "cold-tenant"
@@ -896,10 +890,9 @@ func TestReleaseBackupCannotTellReusedIDsApart(t *testing.T) {
 	idx.backupLock.Lock(shardName)
 	require.NoError(t, idx.protectShard(shardName, firstGen))
 
-	// One releaser ends the first backup. Its siblings are still queued.
 	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
 
-	// The same name is backed up again, to a different bucket.
+	// Same ID, backed up again to a different bucket.
 	secondGen, err := idx.initBackup(backupID)
 	require.NoError(t, err)
 	require.NotEqual(t, firstGen, secondGen)
@@ -908,7 +901,7 @@ func TestReleaseBackupCannotTellReusedIDsApart(t *testing.T) {
 	stagingDir := backupStagingDir(idx.Config.RootPath, backupID, schema.ClassName(className))
 	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
 
-	// A straggler from the first backup arrives and ends the second one.
+	// A straggler from the first backup ends the second one instead.
 	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
 
 	_, protected := idx.backupProtectedShards.Load(shardName)
@@ -919,8 +912,8 @@ func TestReleaseBackupCannotTellReusedIDsApart(t *testing.T) {
 		"the running backup loses its registration, so a third can start alongside it")
 }
 
-// A protection the release cannot read leaves the shard locked for the life of
-// the process. Nothing should have to guess at that from the outside.
+// An unreadable protection must be logged, or the shard stays locked for the
+// life of the process with no signal.
 func TestReleaseProtectedShardsLogsUnreadableProtection(t *testing.T) {
 	const shardName = "cold-tenant"
 
@@ -939,10 +932,8 @@ func TestReleaseProtectedShardsLogsUnreadableProtection(t *testing.T) {
 	assert.Equal(t, shardName, entry.Data["shard"])
 }
 
-// Every other test builds a fresh index, so all of them sweep generation 1.
-// Running one shard through consecutive backups is what holds the release to
-// the caller's own generation: against a fixed one, the first backup works and
-// every backup after it leaks every lock it took.
+// ReleaseBackup must free shards by the caller's own generation: a fixed
+// generation would pass once, then leak every lock after.
 func TestReleaseBackupFreesShardsOnEveryGeneration(t *testing.T) {
 	const shardName = "cold-tenant"
 	ctx := context.Background()

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -397,16 +397,14 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 		idx := newTestIndex()
 		shards := []string{"shardA", "shardB", "shardC"}
 
-		// Simulate what backupShardWithoutHardlinks does: hold lock + set flag.
+		gen, err := idx.initBackup("test-backup")
+		require.NoError(t, err)
 		for _, name := range shards {
 			idx.backupLock.Lock(name)
-			idx.backupProtectedShards.Store(name, "test-backup")
+			require.NoError(t, idx.protectShard(name, gen))
 		}
-		// Set backup state so ReleaseBackup has something to reset.
-		idx.lastBackup.Store(&BackupState{BackupID: "test-backup", InProgress: true})
 
-		err := idx.ReleaseBackup(ctx, "test-backup")
-		require.NoError(t, err)
+		require.NoError(t, idx.ReleaseBackup(ctx, "test-backup"))
 
 		// Verify all protection flags are cleared.
 		for _, name := range shards {
@@ -414,26 +412,34 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 			assert.False(t, protected, "shard %s should no longer be protected", name)
 		}
 
-		// Verify all backupLock.Locks were released by confirming RLock succeeds.
-		for _, name := range shards {
-			done := make(chan struct{})
-			go func() {
-				idx.backupLock.RLock(name)
-				idx.backupLock.RUnlock(name)
-				close(done)
-			}()
-			select {
-			case <-done:
-				// Lock was released.
-			case <-time.After(time.Second):
-				t.Fatalf("RLock on %s should succeed after ReleaseBackup", name)
-			}
-		}
+		requireBackupLocksFree(t, idx, shards)
 
 		// The protection flag is cleared and the lock is released. Combined with the
 		// subtests above (which prove the flag blocks activation), this proves that
 		// activation is no longer blocked after ReleaseBackup.
 	})
+}
+
+// requireBackupLocksFree fails if any of names still has its backupLock write
+// lock held. A held lock blocks RLock forever, so it is probed on a deadline.
+func requireBackupLocksFree(t *testing.T, idx *Index, names []string) {
+	t.Helper()
+
+	var acquired atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		for _, name := range names {
+			idx.backupLock.RLock(name)
+			idx.backupLock.RUnlock(name)
+			acquired.Add(1)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatalf("backupLock on %s still held", names[acquired.Load()])
+	}
 }
 
 const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
@@ -481,7 +487,8 @@ func backupTestShardNames(n int) []string {
 }
 
 // newBackupTestIndex reproduces the state backupShardWithoutHardlinks leaves
-// behind: every shard locked and flagged as protected by backupID.
+// behind: a backup registered on the index, with every shard locked and flagged
+// as protected by it.
 func newBackupTestIndex(t *testing.T, rootDir string, names []string, backupID string) *Index {
 	t.Helper()
 
@@ -501,11 +508,12 @@ func newBackupTestIndex(t *testing.T, rootDir string, names []string, backupID s
 		closingCtx:       context.Background(),
 	}
 
+	gen, err := idx.initBackup(backupID)
+	require.NoError(t, err)
 	for _, name := range names {
 		idx.backupLock.Lock(name)
-		idx.backupProtectedShards.Store(name, backupID)
+		require.NoError(t, idx.protectShard(name, gen))
 	}
-	idx.lastBackup.Store(&BackupState{BackupID: backupID, InProgress: true})
 
 	return idx
 }
@@ -542,14 +550,22 @@ func releaseBackupCrossGenerationWorkload(t *testing.T) {
 		var wg sync.WaitGroup
 		spawnBackupReleasers(t, &wg, start, idx, firstBackup, releasers)
 
-		// The second backup re-protects each shard as the first one frees it.
+		// The second backup takes over each shard as the first one frees it.
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			<-start
+
+			var gen uint64
+			for {
+				var err error
+				if gen, err = idx.initBackup(secondBackup); err == nil {
+					break
+				}
+			}
 			for _, name := range names {
 				idx.backupLock.Lock(name)
-				idx.backupProtectedShards.Store(name, secondBackup)
+				assert.NoError(t, idx.protectShard(name, gen))
 			}
 		}()
 
@@ -557,7 +573,7 @@ func releaseBackupCrossGenerationWorkload(t *testing.T) {
 		wg.Wait()
 
 		// A missing shard means a stale first-backup releaser unlocked it after
-		// the second backup re-protected it.
+		// the second backup protected it.
 		for _, name := range names {
 			if _, ok := idx.backupProtectedShards.Load(name); !ok {
 				t.Fatalf("trial %d: shard %s lost %s's protection",
@@ -594,26 +610,156 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 			}
 		}
 
-		// A still-held write lock blocks RLock forever, so a shard that was
-		// released too few times surfaces as a timeout here. reacquired doubles
-		// as the index of the shard the prober is stuck on.
-		var reacquired atomic.Int64
-		probed := make(chan struct{})
-		go func() {
-			for _, name := range names {
-				idx.backupLock.RLock(name)
-				idx.backupLock.RUnlock(name)
-				reacquired.Add(1)
-			}
-			close(probed)
-		}()
-		select {
-		case <-probed:
-		case <-time.After(30 * time.Second):
-			t.Fatalf("trial %d: backupLock on %s still held after ReleaseBackup",
-				trial, names[reacquired.Load()])
-		}
+		// A shard released too few times keeps its write lock, which blocks RLock
+		// forever, so under-release surfaces as a timeout here.
+		requireBackupLocksFree(t, idx, names)
 	}
+}
+
+// newColdTenantIndex returns an index whose only shard is a COLD tenant: files
+// on disk, absent from the shard map. This is the state the non-hardlink backup
+// path protects, and the one a plain filesystem never reaches through
+// descriptor(), which probes for hardlinks first.
+func newColdTenantIndex(t *testing.T, shardName string) (*Index, string) {
+	t.Helper()
+
+	const className = "TestClass"
+	rootDir := t.TempDir()
+
+	shardState := NewMultiTenantShardingStateBuilder().
+		AddTenant(shardName, models.TenantActivityStatusCOLD).
+		WithReplicationFactor(1).
+		Build()
+
+	idx := newDescriptorTestIndex(t, rootDir, className, shardState)
+	createColdShardFiles(t, rootDir, className, shardName)
+
+	return idx, className
+}
+
+// Regression test: the non-hardlink path must back up a COLD tenant from disk
+// and stop there. Both inactive branches used to return from an inner closure
+// only, so a COLD tenant fell through into the active path and dereferenced the
+// nil shard it had just failed to find.
+func TestBackupShardWithoutHardlinksColdTenant(t *testing.T) {
+	const (
+		shardName = "cold-tenant"
+		backupID  = "backup1"
+	)
+	ctx := context.Background()
+
+	idx, _ := newColdTenantIndex(t, shardName)
+
+	gen, err := idx.initBackup(backupID)
+	require.NoError(t, err)
+
+	var desc backup.ClassDescriptor
+	require.NoError(t, idx.descriptorWithoutHardlinks(ctx, backupID, gen, &desc, nil))
+
+	require.Len(t, desc.Shards, 1)
+	assert.Equal(t, shardName, desc.Shards[0].Name)
+	assert.NotEmpty(t, desc.Shards[0].Files, "COLD descriptor should have files from disk")
+
+	// The shard the producer protected is the shard the releaser must free. A
+	// producer that records anything the releaser does not recognise leaks the
+	// lock, and the tenant can then be neither activated nor written.
+	_, protected := idx.backupProtectedShards.Load(shardName)
+	require.True(t, protected, "COLD tenant must be protected for the duration of the backup")
+	assert.False(t, idx.backupLock.TryRLock(shardName),
+		"backupLock must stay held while the backup uploads")
+
+	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+
+	_, protected = idx.backupProtectedShards.Load(shardName)
+	assert.False(t, protected, "protection must be cleared by ReleaseBackup")
+	requireBackupLocksFree(t, idx, []string{shardName})
+}
+
+// Regression test: an unloaded LazyLoadShard takes the same inactive branch and
+// used to fall through into the active path too. That is silent rather than
+// fatal — the shard is non-nil — so it produced the exact state the release-side
+// double unlock needs: protected, lock held, active path running anyway.
+func TestBackupShardWithoutHardlinksUnloadedLazyShard(t *testing.T) {
+	const (
+		shardName = "cold-tenant"
+		backupID  = "backup1"
+	)
+	ctx := context.Background()
+
+	idx, _ := newColdTenantIndex(t, shardName)
+	idx.shards.Store(shardName, &LazyLoadShard{loaded: false})
+
+	gen, err := idx.initBackup(backupID)
+	require.NoError(t, err)
+
+	// HaltForTransfer on the zero-valued shard would panic, so reaching the
+	// active path fails this outright rather than returning a wrong descriptor.
+	sd, err := idx.backupShardWithoutHardlinks(ctx, shardName, gen, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sd)
+	assert.Equal(t, shardName, sd.Name)
+
+	_, protected := idx.backupProtectedShards.Load(shardName)
+	assert.True(t, protected, "unloaded lazy shard must be protected")
+
+	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+	requireBackupLocksFree(t, idx, []string{shardName})
+}
+
+// A releaser that arrives after its own backup ended must leave the running
+// backup alone: its shards, its staging dir and its compaction pause.
+func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
+	const shardName = "cold-tenant"
+	ctx := context.Background()
+
+	idx, className := newColdTenantIndex(t, shardName)
+
+	gen, err := idx.initBackup("backup2")
+	require.NoError(t, err)
+	idx.backupLock.Lock(shardName)
+	require.NoError(t, idx.protectShard(shardName, gen))
+
+	stagingDir := backupStagingDir(idx.Config.RootPath, "backup2", schema.ClassName(className))
+	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
+
+	// backup1 already ended; this is one of its stragglers.
+	require.NoError(t, idx.ReleaseBackup(ctx, "backup1"))
+
+	_, protected := idx.backupProtectedShards.Load(shardName)
+	assert.True(t, protected, "backup2's shard must stay protected")
+	assert.False(t, idx.backupLock.TryRLock(shardName), "backup2's backupLock must stay held")
+	assert.DirExists(t, stagingDir, "backup2's staging dir must survive backup1's releaser")
+	require.NotNil(t, idx.lastBackup.Load(), "backup2 must stay registered")
+
+	require.NoError(t, idx.ReleaseBackup(ctx, "backup2"))
+	requireBackupLocksFree(t, idx, []string{shardName})
+	assert.NoDirExists(t, stagingDir)
+}
+
+// A shard must never be protected for a backup that has already been released:
+// nothing would ever clear the flag or unlock it again.
+func TestProtectShardRefusesReleasedBackup(t *testing.T) {
+	const (
+		shardName = "cold-tenant"
+		backupID  = "backup1"
+	)
+	ctx := context.Background()
+
+	idx, _ := newColdTenantIndex(t, shardName)
+
+	gen, err := idx.initBackup(backupID)
+	require.NoError(t, err)
+	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+
+	require.ErrorIs(t, idx.protectShard(shardName, gen), errBackupReleased)
+	_, protected := idx.backupProtectedShards.Load(shardName)
+	assert.False(t, protected, "a released backup must not protect anything")
+
+	// The same generation is refused once a later backup owns the index, so the
+	// two cannot be confused even when they share an ID.
+	_, err = idx.initBackup(backupID)
+	require.NoError(t, err)
+	require.ErrorIs(t, idx.protectShard(shardName, gen), errBackupReleased)
 }
 
 func TestBackupFrozenShardOmitted(t *testing.T) {
@@ -832,11 +978,12 @@ func TestDescriptorConcurrentBackupBlocked(t *testing.T) {
 	idx := newDescriptorTestIndex(t, rootDir, className, shardState)
 
 	// First backup: set state.
-	require.NoError(t, idx.initBackup("backup-1"))
+	_, err := idx.initBackup("backup-1")
+	require.NoError(t, err)
 
 	// Second backup: should fail.
 	var desc backup.ClassDescriptor
-	err := idx.descriptor(context.Background(), "backup-2", &desc, nil)
+	err = idx.descriptor(context.Background(), "backup-2", &desc, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not yet released")
 }

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -434,9 +434,8 @@ func requireBackupLocksFree(t *testing.T, idx *Index, names []string) {
 	}
 }
 
-// backupWorkloadTimeout bounds every wait in the racing workloads. Go's
-// deadlock detector is no substitute: it never fires while any goroutine holds
-// a pending timer, and takes a full minute when it does.
+// backupWorkloadTimeout bounds every wait in the racing workloads: Go's
+// deadlock detector never fires while a goroutine holds a pending timer.
 const backupWorkloadTimeout = 30 * time.Second
 
 // requireBackupLocksFreeConcurrently is requireBackupLocksFree for racing
@@ -462,7 +461,6 @@ func requireBackupLocksFreeConcurrently(t *testing.T, idx *Index, names []string
 	}
 }
 
-// requireWaitGroupDone fails if wg does not finish within backupWorkloadTimeout.
 func requireWaitGroupDone(t *testing.T, wg *sync.WaitGroup, msg string) {
 	t.Helper()
 
@@ -478,8 +476,8 @@ func requireWaitGroupDone(t *testing.T, wg *sync.WaitGroup, msg string) {
 	}
 }
 
-// waitForBackupSlot registers backupID once the running backup has released the
-// index. It yields rather than sleeps, to keep the handover race tight.
+// waitForBackupSlot yields rather than sleeps between initBackup retries, to
+// keep the handover race tight.
 func waitForBackupSlot(idx *Index, backupID string) (uint64, bool) {
 	deadline := time.Now().Add(backupWorkloadTimeout)
 	for {
@@ -495,9 +493,9 @@ func waitForBackupSlot(idx *Index, backupID string) (uint64, bool) {
 
 const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
 
-// releaseBackupChildTimeout bounds a child the parent cannot bound: a test
-// binary defaults to -test.timeout=0 and go test -timeout does not reach it, so
-// a wedged child reparents to init and outlives the CI job.
+// releaseBackupChildTimeout bounds the child itself: it defaults to
+// -test.timeout=0, invisible to the parent's go test -timeout, so a wedged
+// child would reparent to init and outlive the CI job.
 const releaseBackupChildTimeout = 5 * time.Minute
 
 // runReleaseBackupWorkloadInChild re-executes this binary to run just the
@@ -542,8 +540,7 @@ func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
 	runReleaseBackupWorkloadInChild(t)
 }
 
-// Regression test: two backups releasing at once must not both unlock a shard
-// only the older one protected.
+// Regression test: two overlapping sweeps must not both unlock the same shard.
 func TestReleaseBackupOverlappingSweepsUnlockEachShardOnce(t *testing.T) {
 	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
 		releaseBackupOverlappingSweepWorkload(t)
@@ -618,10 +615,9 @@ func releaseBackupOverlappingSweepWorkload(t *testing.T) {
 	for trial := 0; trial < trials; trial++ {
 		idx := newBackupTestIndex(t, rootDir, names, firstBackup)
 
-		// The first backup ends with its sweep still pending, so the second one
-		// runs and ends while the first's shards are all still protected. Sweeping
-		// older generations too is what frees a stranded shard, and it is also what
-		// puts both sweeps on the same entries.
+		// backup1's sweep is claimed but not run yet, so backup2 starts and ends
+		// while backup1's shards are still protected. Sweeping older generations too
+		// is what puts both sweeps on the same shard set.
 		firstSweep, claimed := idx.claimBackup(firstBackup)
 		require.True(t, claimed)
 		_, err := idx.initBackup(secondBackup)
@@ -787,13 +783,9 @@ func TestBackupShardWithoutHardlinksColdTenant(t *testing.T) {
 	requireBackupLocksFree(t, idx, []string{shardName})
 }
 
-// Drives the real producer rather than fabricating backupProtectedShards, so
-// what it stores has to be what ReleaseBackup releases. Storing the wrong value
-// or none leaks the shard's lock on every backup, with nothing to show for it.
-//
-// It also covers both inactive branches against the active path they used to
-// fall through into: a nil shard panics there, an unloaded LazyLoadShard does
-// not, which is why only one of the two was ever noticed.
+// Regression test: an inactive shard (absent, or an unloaded LazyLoadShard)
+// must not fall through into the active path, and stays protected and
+// locked even when the descriptor fails.
 func TestBackupShardWithoutHardlinksProtectsAndReleases(t *testing.T) {
 	const (
 		shardName = "cold-tenant"
@@ -834,8 +826,7 @@ func TestBackupShardWithoutHardlinksProtectsAndReleases(t *testing.T) {
 				require.ErrorIs(t, err, errShardNoLocalData)
 			}
 
-			// The shard stays protected and locked either way: the descriptor
-			// failing does not hand the shard back.
+			// Both descriptor outcomes must leave the shard protected and locked.
 			_, protected := idx.backupProtectedShards.Load(shardName)
 			require.True(t, protected, "producer did not protect the inactive shard")
 			require.False(t, idx.backupLock.TryRLock(shardName),
@@ -880,10 +871,9 @@ func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 	assert.NoDirExists(t, stagingDir)
 }
 
-// Shards are released outside backupStateMu, so a later backup can protect one
-// mid-sweep. It only gets there for a shard the releasing backup never held —
-// a tenant that was hot then and is cold now — since every other shard's lock
-// is still held. That one must survive the sweep.
+// Shards release outside backupStateMu, so a later backup can protect one
+// mid-sweep — but only a shard the releasing backup never itself held. That
+// shard must survive the sweep.
 func TestReleaseProtectedShardsLeavesNewerGenerationsAlone(t *testing.T) {
 	const (
 		wasHot  = "hot-then-cold-tenant"

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -16,8 +16,11 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -430,6 +433,108 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 		// subtests above (which prove the flag blocks activation), this proves that
 		// activation is no longer blocked after ReleaseBackup.
 	})
+}
+
+// releaseBackupUnlockChildEnv marks a re-executed test binary as the child that
+// runs the concurrent ReleaseBackup workload.
+const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
+
+// TestReleaseBackupConcurrentUnlocksEachShardOnce asserts that ReleaseBackup
+// releases every protected shard's backupLock exactly once when several
+// ReleaseBackup calls for the same index overlap. Overlapping calls are the
+// normal case: usecases/backup fans out one goroutine per class on the success
+// path.
+//
+// Unlocking twice lands the second Unlock on an already unlocked sync.RWMutex,
+// which Go reports as "fatal error: sync: Unlock of unlocked RWMutex". That is
+// unrecoverable — recover() cannot catch it and the process dies. So the
+// workload cannot run in this process; it runs in a child (this binary
+// re-executed under an env guard) and the parent reports the crash as an
+// ordinary failure.
+func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
+	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
+		releaseBackupConcurrentUnlockWorkload(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run", "^"+t.Name()+"$", "-test.v")
+	cmd.Env = append(os.Environ(), releaseBackupUnlockChildEnv+"=1")
+	out, err := cmd.CombinedOutput()
+
+	require.NoError(t, err, "concurrent ReleaseBackup killed the child process:\n%s", out)
+	require.Contains(t, string(out), "--- PASS: "+t.Name(),
+		"child did not run the workload:\n%s", out)
+}
+
+// releaseBackupConcurrentUnlockWorkload repeatedly builds an index whose shards
+// are all protected, then releases the backup from several goroutines at once.
+func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
+	// Sized empirically: without the fix the process dies within the first
+	// handful of trials, both with and without -race.
+	const (
+		trials         = 200
+		shardsPerTrial = 512
+		releasers      = 4
+		className      = "MyClass"
+		backupID       = "backup1"
+	)
+
+	logger, _ := tlog.NewNullLogger()
+	rootDir := t.TempDir()
+	ctx := context.Background()
+
+	names := make([]string, shardsPerTrial)
+	for s := range names {
+		names[s] = "shard" + strconv.Itoa(s)
+	}
+
+	for trial := 0; trial < trials; trial++ {
+		idx := &Index{
+			Config: IndexConfig{RootPath: rootDir, ClassName: className},
+			getSchema: &fakeSchemaGetter{
+				schema: schema.Schema{
+					Objects: &models.Schema{Classes: []*models.Class{{Class: className}}},
+				},
+			},
+			logger:           logger,
+			backupLock:       esync.NewKeyRWLocker(),
+			shardCreateLocks: esync.NewKeyRWLocker(),
+			closingCtx:       context.Background(),
+		}
+
+		// Same state backupShardWithoutHardlinks leaves behind for a shard it
+		// backed up without hardlinks: lock held, shard flagged as protected.
+		for _, name := range names {
+			idx.backupLock.Lock(name)
+			idx.backupProtectedShards.Store(name, struct{}{})
+		}
+		idx.lastBackup.Store(&BackupState{BackupID: backupID, InProgress: true})
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for r := 0; r < releasers; r++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				assert.NoError(t, idx.ReleaseBackup(ctx, backupID))
+			}()
+		}
+		close(start)
+		wg.Wait()
+
+		// TryRLock only succeeds once the write lock is gone, so it catches a
+		// shard that was never released as well.
+		for _, name := range names {
+			if _, protected := idx.backupProtectedShards.Load(name); protected {
+				t.Fatalf("trial %d: shard %s still protected after ReleaseBackup", trial, name)
+			}
+			if !idx.backupLock.TryRLock(name) {
+				t.Fatalf("trial %d: backupLock on %s still held after ReleaseBackup", trial, name)
+			}
+			idx.backupLock.RUnlock(name)
+		}
+	}
 }
 
 func TestBackupFrozenShardOmitted(t *testing.T) {

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -435,22 +435,9 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 	})
 }
 
-// releaseBackupUnlockChildEnv marks a re-executed test binary as the child that
-// runs the concurrent ReleaseBackup workload.
 const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
 
-// TestReleaseBackupConcurrentUnlocksEachShardOnce asserts that ReleaseBackup
-// releases every protected shard's backupLock exactly once when several
-// ReleaseBackup calls for the same index overlap. Overlapping calls are the
-// normal case: usecases/backup fans out one goroutine per class on the success
-// path.
-//
-// Unlocking twice lands the second Unlock on an already unlocked sync.RWMutex,
-// which Go reports as "fatal error: sync: Unlock of unlocked RWMutex". That is
-// unrecoverable — recover() cannot catch it and the process dies. So the
-// workload cannot run in this process; it runs in a child (this binary
-// re-executed under an env guard) and the parent reports the crash as an
-// ordinary failure.
+// Regression test: concurrent ReleaseBackup calls must not double-unlock a shard.
 func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
 	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
 		releaseBackupConcurrentUnlockWorkload(t)
@@ -466,11 +453,8 @@ func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
 		"child did not run the workload:\n%s", out)
 }
 
-// releaseBackupConcurrentUnlockWorkload repeatedly builds an index whose shards
-// are all protected, then releases the backup from several goroutines at once.
 func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
-	// Sized empirically: without the fix the process dies within the first
-	// handful of trials, both with and without -race.
+	// Sized empirically: reproduces within a few trials, with or without -race.
 	const (
 		trials         = 200
 		shardsPerTrial = 512

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -15,9 +15,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"sync"
@@ -432,6 +434,11 @@ func requireBackupLocksFree(t *testing.T, idx *Index, names []string) {
 	}
 }
 
+// backupWorkloadTimeout bounds every wait in the racing workloads. Go's
+// deadlock detector is no substitute: it never fires while any goroutine holds
+// a pending timer, and takes a full minute when it does.
+const backupWorkloadTimeout = 30 * time.Second
+
 // requireBackupLocksFreeConcurrently is requireBackupLocksFree for racing
 // workloads, where a queued writer can also fail TryRLock; probed on a
 // deadline instead.
@@ -450,12 +457,48 @@ func requireBackupLocksFreeConcurrently(t *testing.T, idx *Index, names []string
 	}()
 	select {
 	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Fatalf("backupLock on %s still held", names[acquired.Load()])
+	case <-time.After(backupWorkloadTimeout):
+		t.Fatalf("backupLock on %s still held", names[min(int(acquired.Load()), len(names)-1)])
+	}
+}
+
+// requireWaitGroupDone fails if wg does not finish within backupWorkloadTimeout.
+func requireWaitGroupDone(t *testing.T, wg *sync.WaitGroup, msg string) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(backupWorkloadTimeout):
+		t.Fatal(msg)
+	}
+}
+
+// waitForBackupSlot registers backupID once the running backup has released the
+// index. It yields rather than sleeps, to keep the handover race tight.
+func waitForBackupSlot(idx *Index, backupID string) (uint64, bool) {
+	deadline := time.Now().Add(backupWorkloadTimeout)
+	for {
+		if gen, err := idx.initBackup(backupID); err == nil {
+			return gen, true
+		}
+		if time.Now().After(deadline) {
+			return 0, false
+		}
+		runtime.Gosched()
 	}
 }
 
 const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
+
+// releaseBackupChildTimeout bounds a child the parent cannot bound: a test
+// binary defaults to -test.timeout=0 and go test -timeout does not reach it, so
+// a wedged child reparents to init and outlives the CI job.
+const releaseBackupChildTimeout = 5 * time.Minute
 
 // runReleaseBackupWorkloadInChild re-executes this binary to run just the
 // calling test, so a workload that dies takes the child down instead of the
@@ -464,7 +507,15 @@ const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
 func runReleaseBackupWorkloadInChild(t *testing.T) {
 	t.Helper()
 
-	cmd := exec.Command(os.Args[0], "-test.run", "^"+t.Name()+"$", "-test.v")
+	timeout := releaseBackupChildTimeout
+	if deadline, ok := t.Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 && remaining < timeout {
+			timeout = remaining
+		}
+	}
+
+	cmd := exec.CommandContext(t.Context(), os.Args[0],
+		"-test.run", "^"+t.Name()+"$", "-test.v", "-test.timeout", timeout.String())
 	cmd.Env = append(os.Environ(), releaseBackupUnlockChildEnv+"=1")
 	out, err := cmd.CombinedOutput()
 
@@ -568,12 +619,9 @@ func releaseBackupCrossGenerationWorkload(t *testing.T) {
 			defer wg.Done()
 			<-start
 
-			var gen uint64
-			for {
-				var err error
-				if gen, err = idx.initBackup(secondBackup); err == nil {
-					break
-				}
+			gen, ok := waitForBackupSlot(idx, secondBackup)
+			if !assert.True(t, ok, "trial %d: %s never got the index", trial, secondBackup) {
+				return
 			}
 			for _, name := range names {
 				idx.backupLock.Lock(name)
@@ -582,7 +630,8 @@ func releaseBackupCrossGenerationWorkload(t *testing.T) {
 		}()
 
 		close(start)
-		wg.Wait()
+		requireWaitGroupDone(t, &wg, fmt.Sprintf(
+			"trial %d: releasers and %s did not finish", trial, secondBackup))
 
 		// A missing shard means a stale first-backup releaser unlocked it after
 		// the second backup protected it.
@@ -614,7 +663,7 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 		var wg sync.WaitGroup
 		spawnBackupReleasers(t, &wg, start, idx, backupID, releasers)
 		close(start)
-		wg.Wait()
+		requireWaitGroupDone(t, &wg, fmt.Sprintf("trial %d: releasers did not finish", trial))
 
 		for _, name := range names {
 			if _, protected := idx.backupProtectedShards.Load(name); protected {
@@ -681,32 +730,67 @@ func TestBackupShardWithoutHardlinksColdTenant(t *testing.T) {
 	requireBackupLocksFree(t, idx, []string{shardName})
 }
 
-// Regression test: an unloaded LazyLoadShard must not fall through the
-// inactive branch into the active path (silent, since the shard is non-nil).
-func TestBackupShardWithoutHardlinksUnloadedLazyShard(t *testing.T) {
+// Drives the real producer rather than fabricating backupProtectedShards, so
+// what it stores has to be what ReleaseBackup releases. Storing the wrong value
+// or none leaks the shard's lock on every backup, with nothing to show for it.
+//
+// It also covers both inactive branches against the active path they used to
+// fall through into: a nil shard panics there, an unloaded LazyLoadShard does
+// not, which is why only one of the two was ever noticed.
+func TestBackupShardWithoutHardlinksProtectsAndReleases(t *testing.T) {
 	const (
 		shardName = "cold-tenant"
 		backupID  = "backup1"
 	)
-	ctx := context.Background()
 
-	idx, _ := newColdTenantIndex(t, shardName)
-	idx.shards.Store(shardName, &LazyLoadShard{loaded: false})
+	tests := []struct {
+		name      string
+		lazyShard bool
+		localData bool
+	}{
+		{name: "shard absent from shardMap, data on disk", localData: true},
+		{name: "shard absent from shardMap, no local data"},
+		{name: "unloaded lazy shard, data on disk", lazyShard: true, localData: true},
+		{name: "unloaded lazy shard, no local data", lazyShard: true},
+	}
 
-	gen, err := idx.initBackup(backupID)
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			idx, _ := newColdTenantIndex(t, shardName)
+			if !test.localData {
+				require.NoError(t, os.RemoveAll(shardPath(idx.path(), shardName)))
+			}
+			if test.lazyShard {
+				idx.shards.Store(shardName, &LazyLoadShard{})
+			}
 
-	// A zero-valued shard panics in HaltForTransfer if the active path runs here.
-	sd, err := idx.backupShardWithoutHardlinks(ctx, shardName, gen, nil)
-	require.NoError(t, err)
-	require.NotNil(t, sd)
-	assert.Equal(t, shardName, sd.Name)
+			gen, err := idx.initBackup(backupID)
+			require.NoError(t, err)
 
-	_, protected := idx.backupProtectedShards.Load(shardName)
-	assert.True(t, protected, "unloaded lazy shard must be protected")
+			sd, err := idx.backupShardWithoutHardlinks(ctx, shardName, gen, nil)
+			if test.localData {
+				require.NoError(t, err)
+				require.NotNil(t, sd)
+				assert.Equal(t, shardName, sd.Name)
+			} else {
+				require.ErrorIs(t, err, errShardNoLocalData)
+			}
 
-	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
-	requireBackupLocksFree(t, idx, []string{shardName})
+			// The shard stays protected and locked either way: the descriptor
+			// failing does not hand the shard back.
+			_, protected := idx.backupProtectedShards.Load(shardName)
+			require.True(t, protected, "producer did not protect the inactive shard")
+			require.False(t, idx.backupLock.TryRLock(shardName),
+				"producer did not keep the shard's lock held")
+
+			require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+
+			_, protected = idx.backupProtectedShards.Load(shardName)
+			assert.False(t, protected, "shard still protected after ReleaseBackup")
+			requireBackupLocksFree(t, idx, []string{shardName})
+		})
+	}
 }
 
 // A releaser for an already-ended backup must not touch a later backup's

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -511,16 +512,30 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 		close(start)
 		wg.Wait()
 
-		// TryRLock only succeeds once the write lock is gone, so it catches a
-		// shard that was never released as well.
 		for _, name := range names {
 			if _, protected := idx.backupProtectedShards.Load(name); protected {
 				t.Fatalf("trial %d: shard %s still protected after ReleaseBackup", trial, name)
 			}
-			if !idx.backupLock.TryRLock(name) {
-				t.Fatalf("trial %d: backupLock on %s still held after ReleaseBackup", trial, name)
+		}
+
+		// A still-held write lock blocks RLock forever, so a shard that was
+		// released too few times surfaces as a timeout here. reacquired doubles
+		// as the index of the shard the prober is stuck on.
+		var reacquired atomic.Int64
+		probed := make(chan struct{})
+		go func() {
+			for _, name := range names {
+				idx.backupLock.RLock(name)
+				idx.backupLock.RUnlock(name)
+				reacquired.Add(1)
 			}
-			idx.backupLock.RUnlock(name)
+			close(probed)
+		}()
+		select {
+		case <-probed:
+		case <-time.After(30 * time.Second):
+			t.Fatalf("trial %d: backupLock on %s still held after ReleaseBackup",
+				trial, names[reacquired.Load()])
 		}
 	}
 }

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -400,7 +400,7 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 		// Simulate what backupShardWithoutHardlinks does: hold lock + set flag.
 		for _, name := range shards {
 			idx.backupLock.Lock(name)
-			idx.backupProtectedShards.Store(name, struct{}{})
+			idx.backupProtectedShards.Store(name, "test-backup")
 		}
 		// Set backup state so ReleaseBackup has something to reset.
 		idx.lastBackup.Store(&BackupState{BackupID: "test-backup", InProgress: true})
@@ -438,24 +438,116 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 
 const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
 
-// Regression test: concurrent ReleaseBackup calls must not double-unlock a shard.
-//
-// The double unlock is a fatal error, not a panic, so it cannot be recovered in
-// process. The workload therefore runs in a child (this binary re-executed
-// under an env guard) and the parent reports the child's crash.
-func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
-	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
-		releaseBackupConcurrentUnlockWorkload(t)
-		return
-	}
+// runReleaseBackupWorkloadInChild re-executes this binary to run just the
+// calling test, so a workload that dies takes the child down instead of the
+// suite. An unlock too many is a fatal error, not a panic, and recover()
+// cannot catch it.
+func runReleaseBackupWorkloadInChild(t *testing.T) {
+	t.Helper()
 
 	cmd := exec.Command(os.Args[0], "-test.run", "^"+t.Name()+"$", "-test.v")
 	cmd.Env = append(os.Environ(), releaseBackupUnlockChildEnv+"=1")
 	out, err := cmd.CombinedOutput()
 
-	require.NoError(t, err, "concurrent ReleaseBackup killed the child process:\n%s", out)
+	require.NoError(t, err, "child process did not survive the workload:\n%s", out)
 	require.Contains(t, string(out), "--- PASS: "+t.Name(),
 		"child did not run the workload:\n%s", out)
+}
+
+// Regression test: concurrent ReleaseBackup calls must not double-unlock a shard.
+func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
+	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
+		releaseBackupConcurrentUnlockWorkload(t)
+		return
+	}
+	runReleaseBackupWorkloadInChild(t)
+}
+
+// Regression test: a ReleaseBackup still traversing must not release a shard
+// that a later backup has already re-protected.
+func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
+	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
+		releaseBackupCrossGenerationWorkload(t)
+		return
+	}
+	runReleaseBackupWorkloadInChild(t)
+}
+
+// releaseBackupCrossGenerationWorkload releases one backup from two goroutines
+// while a second backup re-protects the same shards behind them.
+func releaseBackupCrossGenerationWorkload(t *testing.T) {
+	const (
+		trials         = 200
+		shardsPerTrial = 512
+		className      = "MyClass"
+		firstBackup    = "backup1"
+		secondBackup   = "backup2"
+	)
+
+	logger, _ := tlog.NewNullLogger()
+	rootDir := t.TempDir()
+	ctx := context.Background()
+
+	names := make([]string, shardsPerTrial)
+	for s := range names {
+		names[s] = "shard" + strconv.Itoa(s)
+	}
+
+	for trial := 0; trial < trials; trial++ {
+		idx := &Index{
+			Config: IndexConfig{RootPath: rootDir, ClassName: className},
+			getSchema: &fakeSchemaGetter{
+				schema: schema.Schema{
+					Objects: &models.Schema{Classes: []*models.Class{{Class: className}}},
+				},
+			},
+			logger:           logger,
+			backupLock:       esync.NewKeyRWLocker(),
+			shardCreateLocks: esync.NewKeyRWLocker(),
+			closingCtx:       context.Background(),
+		}
+
+		for _, name := range names {
+			idx.backupLock.Lock(name)
+			idx.backupProtectedShards.Store(name, firstBackup)
+		}
+		idx.lastBackup.Store(&BackupState{BackupID: firstBackup, InProgress: true})
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for r := 0; r < 2; r++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				assert.NoError(t, idx.ReleaseBackup(ctx, firstBackup))
+			}()
+		}
+
+		// The second backup re-protects each shard as the first one frees it.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for _, name := range names {
+				idx.backupLock.Lock(name)
+				idx.backupProtectedShards.Store(name, secondBackup)
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+
+		// The second backup locked and stored every shard, so every shard must
+		// still be protected. A missing one was released by a first-backup
+		// caller that saw the re-protected key mid-Range.
+		for _, name := range names {
+			if _, ok := idx.backupProtectedShards.Load(name); !ok {
+				t.Fatalf("trial %d: shard %s lost %s's protection",
+					trial, name, secondBackup)
+			}
+		}
+	}
 }
 
 func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
@@ -495,7 +587,7 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 		// backed up without hardlinks: lock held, shard flagged as protected.
 		for _, name := range names {
 			idx.backupLock.Lock(name)
-			idx.backupProtectedShards.Store(name, struct{}{})
+			idx.backupProtectedShards.Store(name, backupID)
 		}
 		idx.lastBackup.Store(&BackupState{BackupID: backupID, InProgress: true})
 

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -421,8 +421,21 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 }
 
 // requireBackupLocksFree fails if any of names still has its backupLock write
-// lock held. A held lock blocks RLock forever, so it is probed on a deadline.
+// lock held. Nothing else holds these locks in the tests that call it, so
+// TryRLock is exact and reports a leaked lock immediately.
 func requireBackupLocksFree(t *testing.T, idx *Index, names []string) {
+	t.Helper()
+
+	for _, name := range names {
+		require.True(t, idx.backupLock.TryRLock(name), "backupLock on %s still held", name)
+		idx.backupLock.RUnlock(name)
+	}
+}
+
+// requireBackupLocksFreeConcurrently is requireBackupLocksFree for the racing
+// workloads, where TryRLock can also fail on a writer that is merely queued. A
+// leaked lock blocks RLock forever, so it is probed on a deadline instead.
+func requireBackupLocksFreeConcurrently(t *testing.T, idx *Index, names []string) {
 	t.Helper()
 
 	var acquired atomic.Int64
@@ -612,7 +625,7 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 
 		// A shard released too few times keeps its write lock, which blocks RLock
 		// forever, so under-release surfaces as a timeout here.
-		requireBackupLocksFree(t, idx, names)
+		requireBackupLocksFreeConcurrently(t, idx, names)
 	}
 }
 

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -438,6 +438,10 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 const releaseBackupUnlockChildEnv = "WEAVIATE_TEST_RELEASE_BACKUP_UNLOCK_CHILD"
 
 // Regression test: concurrent ReleaseBackup calls must not double-unlock a shard.
+//
+// The double unlock is a fatal error, not a panic, so it cannot be recovered in
+// process. The workload therefore runs in a child (this binary re-executed
+// under an env guard) and the parent reports the child's crash.
 func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
 	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
 		releaseBackupConcurrentUnlockWorkload(t)

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -875,7 +875,9 @@ func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 }
 
 // A releaser is matched only by backup ID; a straggler from a reused ID ends
-// whichever backup currently holds that name, not its own.
+// whichever backup currently holds that name, not its own. The assertions below
+// record that, they do not ask for it: delete this test once a release call
+// says which backup it belongs to.
 func TestReleaseBackupCannotTellReusedIDsApart(t *testing.T) {
 	const (
 		shardName = "cold-tenant"

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -542,6 +542,16 @@ func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
 	runReleaseBackupWorkloadInChild(t)
 }
 
+// Regression test: two backups releasing at once must not both unlock a shard
+// only the older one protected.
+func TestReleaseBackupOverlappingSweepsUnlockEachShardOnce(t *testing.T) {
+	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
+		releaseBackupOverlappingSweepWorkload(t)
+		return
+	}
+	runReleaseBackupWorkloadInChild(t)
+}
+
 func backupTestShardNames(n int) []string {
 	names := make([]string, n)
 	for s := range names {
@@ -591,6 +601,53 @@ func spawnBackupReleasers(t *testing.T, wg *sync.WaitGroup, start <-chan struct{
 			<-start
 			assert.NoError(t, idx.ReleaseBackup(context.Background(), backupID))
 		}()
+	}
+}
+
+func releaseBackupOverlappingSweepWorkload(t *testing.T) {
+	const (
+		trials         = 200
+		shardsPerTrial = 512
+		firstBackup    = "backup1"
+		secondBackup   = "backup2"
+	)
+
+	rootDir := t.TempDir()
+	names := backupTestShardNames(shardsPerTrial)
+
+	for trial := 0; trial < trials; trial++ {
+		idx := newBackupTestIndex(t, rootDir, names, firstBackup)
+
+		// The first backup ends with its sweep still pending, so the second one
+		// runs and ends while the first's shards are all still protected. Sweeping
+		// older generations too is what frees a stranded shard, and it is also what
+		// puts both sweeps on the same entries.
+		firstSweep, claimed := idx.claimBackup(firstBackup)
+		require.True(t, claimed)
+		_, err := idx.initBackup(secondBackup)
+		require.NoError(t, err)
+		secondSweep, claimed := idx.claimBackup(secondBackup)
+		require.True(t, claimed)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		for _, gen := range []uint64{firstSweep, secondSweep} {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				idx.releaseProtectedShards(gen)
+			}()
+		}
+		close(start)
+		requireWaitGroupDone(t, &wg, fmt.Sprintf("trial %d: sweeps did not finish", trial))
+
+		for _, name := range names {
+			if _, protected := idx.backupProtectedShards.Load(name); protected {
+				t.Fatalf("trial %d: shard %s still protected after both sweeps", trial, name)
+			}
+		}
+		requireBackupLocksFreeConcurrently(t, idx, names)
 	}
 }
 

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -463,8 +463,7 @@ func TestReleaseBackupConcurrentUnlocksEachShardOnce(t *testing.T) {
 	runReleaseBackupWorkloadInChild(t)
 }
 
-// Regression test: a ReleaseBackup still traversing must not release a shard
-// that a later backup has already re-protected.
+// Regression test: ReleaseBackup must not release a shard a later backup already re-protected.
 func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
 	if os.Getenv(releaseBackupUnlockChildEnv) == "1" {
 		releaseBackupCrossGenerationWorkload(t)
@@ -473,8 +472,6 @@ func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
 	runReleaseBackupWorkloadInChild(t)
 }
 
-// releaseBackupCrossGenerationWorkload releases one backup from two goroutines
-// while a second backup re-protects the same shards behind them.
 func releaseBackupCrossGenerationWorkload(t *testing.T) {
 	const (
 		trials         = 200
@@ -538,9 +535,8 @@ func releaseBackupCrossGenerationWorkload(t *testing.T) {
 		close(start)
 		wg.Wait()
 
-		// The second backup locked and stored every shard, so every shard must
-		// still be protected. A missing one was released by a first-backup
-		// caller that saw the re-protected key mid-Range.
+		// A missing shard means a stale first-backup releaser unlocked it after
+		// the second backup re-protected it.
 		for _, name := range names {
 			if _, ok := idx.backupProtectedShards.Load(name); !ok {
 				t.Fatalf("trial %d: shard %s lost %s's protection",

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	tlog "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -476,8 +477,9 @@ func requireWaitGroupDone(t *testing.T, wg *sync.WaitGroup, msg string) {
 	}
 }
 
-// waitForBackupSlot yields rather than sleeps between initBackup retries, to
-// keep the handover race tight.
+// waitForBackupSlot spins on initBackup rather than sleeping, to keep the
+// handover race tight. It is a hot spin: a workload that never frees the index
+// burns a core or two until backupWorkloadTimeout, on its way to failing.
 func waitForBackupSlot(idx *Index, backupID string) (uint64, bool) {
 	deadline := time.Now().Add(backupWorkloadTimeout)
 	for {
@@ -512,6 +514,8 @@ func runReleaseBackupWorkloadInChild(t *testing.T) {
 		}
 	}
 
+	// -test.timeout is what stops a wedged child, not the context: the context
+	// dies with the parent and cannot clean up after it. Do not drop the flag.
 	cmd := exec.CommandContext(t.Context(), os.Args[0],
 		"-test.run", "^"+t.Name()+"$", "-test.v", "-test.timeout", timeout.String())
 	cmd.Env = append(os.Environ(), releaseBackupUnlockChildEnv+"=1")
@@ -869,6 +873,95 @@ func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 	require.NoError(t, idx.ReleaseBackup(ctx, "backup2"))
 	requireBackupLocksFree(t, idx, []string{shardName})
 	assert.NoDirExists(t, stagingDir)
+}
+
+// Records a known limitation rather than a guarantee: a releaser is matched by
+// backup ID, and IDs are only unique per (backend, bucket, path), so the same
+// name sent to a second bucket produces a backup a straggler cannot be told
+// apart from its own. Every protection then goes at once.
+//
+// Delete this test if the release call ever carries which backup it belongs to.
+// It is written to fail the moment that lands.
+func TestReleaseBackupCannotTellReusedIDsApart(t *testing.T) {
+	const (
+		shardName = "cold-tenant"
+		backupID  = "backup1"
+	)
+	ctx := context.Background()
+
+	idx, className := newColdTenantIndex(t, shardName)
+
+	firstGen, err := idx.initBackup(backupID)
+	require.NoError(t, err)
+	idx.backupLock.Lock(shardName)
+	require.NoError(t, idx.protectShard(shardName, firstGen))
+
+	// One releaser ends the first backup. Its siblings are still queued.
+	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+
+	// The same name is backed up again, to a different bucket.
+	secondGen, err := idx.initBackup(backupID)
+	require.NoError(t, err)
+	require.NotEqual(t, firstGen, secondGen)
+	idx.backupLock.Lock(shardName)
+	require.NoError(t, idx.protectShard(shardName, secondGen))
+	stagingDir := backupStagingDir(idx.Config.RootPath, backupID, schema.ClassName(className))
+	require.NoError(t, os.MkdirAll(stagingDir, 0o755))
+
+	// A straggler from the first backup arrives and ends the second one.
+	require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+
+	_, protected := idx.backupProtectedShards.Load(shardName)
+	assert.False(t, protected, "the running backup loses its protection")
+	requireBackupLocksFree(t, idx, []string{shardName})
+	assert.NoDirExists(t, stagingDir, "the running backup loses its staging dir")
+	assert.Nil(t, idx.lastBackup.Load(),
+		"the running backup loses its registration, so a third can start alongside it")
+}
+
+// A protection the release cannot read leaves the shard locked for the life of
+// the process. Nothing should have to guess at that from the outside.
+func TestReleaseProtectedShardsLogsUnreadableProtection(t *testing.T) {
+	const shardName = "cold-tenant"
+
+	idx, _ := newColdTenantIndex(t, shardName)
+	logger, hook := tlog.NewNullLogger()
+	idx.logger = logger
+
+	idx.backupLock.Lock(shardName)
+	idx.backupProtectedShards.Store(shardName, struct{}{})
+
+	idx.releaseProtectedShards(1)
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry, "an unreadable protection must be reported")
+	assert.Equal(t, logrus.ErrorLevel, entry.Level)
+	assert.Equal(t, shardName, entry.Data["shard"])
+}
+
+// Every other test builds a fresh index, so all of them sweep generation 1.
+// Running one shard through consecutive backups is what holds the release to
+// the caller's own generation: against a fixed one, the first backup works and
+// every backup after it leaks every lock it took.
+func TestReleaseBackupFreesShardsOnEveryGeneration(t *testing.T) {
+	const shardName = "cold-tenant"
+	ctx := context.Background()
+
+	idx, _ := newColdTenantIndex(t, shardName)
+
+	for _, backupID := range []string{"backup1", "backup2", "backup3"} {
+		gen, err := idx.initBackup(backupID)
+		require.NoError(t, err)
+		idx.backupLock.Lock(shardName)
+		require.NoError(t, idx.protectShard(shardName, gen))
+
+		require.NoError(t, idx.ReleaseBackup(ctx, backupID))
+
+		_, protected := idx.backupProtectedShards.Load(shardName)
+		require.False(t, protected, "%s: shard still protected", backupID)
+		require.True(t, idx.backupLock.TryRLock(shardName), "%s: backupLock still held", backupID)
+		idx.backupLock.RUnlock(shardName)
+	}
 }
 
 // Shards release outside backupStateMu, so a later backup can protect one

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -823,6 +823,44 @@ func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 	assert.NoDirExists(t, stagingDir)
 }
 
+// Shards are released outside backupStateMu, so a later backup can protect one
+// mid-sweep. It only gets there for a shard the releasing backup never held —
+// a tenant that was hot then and is cold now — since every other shard's lock
+// is still held. That one must survive the sweep.
+func TestReleaseProtectedShardsLeavesNewerGenerationsAlone(t *testing.T) {
+	const (
+		wasHot  = "hot-then-cold-tenant"
+		wasCold = "cold-tenant"
+	)
+
+	idx, _ := newColdTenantIndex(t, wasCold)
+
+	firstGen, err := idx.initBackup("backup1")
+	require.NoError(t, err)
+	idx.backupLock.Lock(wasCold)
+	require.NoError(t, idx.protectShard(wasCold, firstGen))
+
+	// backup1 ends; its releaser is about to sweep.
+	sweepGen, claimed := idx.claimBackup("backup1")
+	require.True(t, claimed)
+
+	// backup2 starts and protects the tenant backup1 never touched.
+	secondGen, err := idx.initBackup("backup2")
+	require.NoError(t, err)
+	idx.backupLock.Lock(wasHot)
+	require.NoError(t, idx.protectShard(wasHot, secondGen))
+
+	idx.releaseProtectedShards(sweepGen)
+
+	_, protected := idx.backupProtectedShards.Load(wasCold)
+	assert.False(t, protected, "backup1 must release its own shard")
+	requireBackupLocksFree(t, idx, []string{wasCold})
+
+	_, protected = idx.backupProtectedShards.Load(wasHot)
+	assert.True(t, protected, "backup1's sweep must not touch backup2's shard")
+	assert.False(t, idx.backupLock.TryRLock(wasHot), "backup2's lock must stay held")
+}
+
 // A shard must never be protected for an already-released backup: nothing
 // would clear the flag or unlock it again.
 func TestProtectShardRefusesReleasedBackup(t *testing.T) {

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -420,9 +420,9 @@ func TestBackupProtectedShardsBlockActivation(t *testing.T) {
 	})
 }
 
-// requireBackupLocksFree fails if any of names still has its backupLock write
-// lock held. Nothing else holds these locks in the tests that call it, so
-// TryRLock is exact and reports a leaked lock immediately.
+// requireBackupLocksFree fails if any name's backupLock write lock is still
+// held. TryRLock is exact here since nothing else holds these locks in the
+// tests that call it.
 func requireBackupLocksFree(t *testing.T, idx *Index, names []string) {
 	t.Helper()
 
@@ -432,9 +432,9 @@ func requireBackupLocksFree(t *testing.T, idx *Index, names []string) {
 	}
 }
 
-// requireBackupLocksFreeConcurrently is requireBackupLocksFree for the racing
-// workloads, where TryRLock can also fail on a writer that is merely queued. A
-// leaked lock blocks RLock forever, so it is probed on a deadline instead.
+// requireBackupLocksFreeConcurrently is requireBackupLocksFree for racing
+// workloads, where a queued writer can also fail TryRLock; probed on a
+// deadline instead.
 func requireBackupLocksFreeConcurrently(t *testing.T, idx *Index, names []string) {
 	t.Helper()
 
@@ -500,8 +500,7 @@ func backupTestShardNames(n int) []string {
 }
 
 // newBackupTestIndex reproduces the state backupShardWithoutHardlinks leaves
-// behind: a backup registered on the index, with every shard locked and flagged
-// as protected by it.
+// behind: a registered backup with every shard locked and protected by it.
 func newBackupTestIndex(t *testing.T, rootDir string, names []string, backupID string) *Index {
 	t.Helper()
 
@@ -630,9 +629,8 @@ func releaseBackupConcurrentUnlockWorkload(t *testing.T) {
 }
 
 // newColdTenantIndex returns an index whose only shard is a COLD tenant: files
-// on disk, absent from the shard map. This is the state the non-hardlink backup
-// path protects, and the one a plain filesystem never reaches through
-// descriptor(), which probes for hardlinks first.
+// on disk, absent from the shard map. descriptor() never reaches this state
+// directly since it probes for hardlinks first.
 func newColdTenantIndex(t *testing.T, shardName string) (*Index, string) {
 	t.Helper()
 
@@ -650,10 +648,8 @@ func newColdTenantIndex(t *testing.T, shardName string) (*Index, string) {
 	return idx, className
 }
 
-// Regression test: the non-hardlink path must back up a COLD tenant from disk
-// and stop there. Both inactive branches used to return from an inner closure
-// only, so a COLD tenant fell through into the active path and dereferenced the
-// nil shard it had just failed to find.
+// Regression test: a COLD tenant must not fall through the inactive branch
+// into the active path and dereference a nil shard.
 func TestBackupShardWithoutHardlinksColdTenant(t *testing.T) {
 	const (
 		shardName = "cold-tenant"
@@ -673,9 +669,6 @@ func TestBackupShardWithoutHardlinksColdTenant(t *testing.T) {
 	assert.Equal(t, shardName, desc.Shards[0].Name)
 	assert.NotEmpty(t, desc.Shards[0].Files, "COLD descriptor should have files from disk")
 
-	// The shard the producer protected is the shard the releaser must free. A
-	// producer that records anything the releaser does not recognise leaks the
-	// lock, and the tenant can then be neither activated nor written.
 	_, protected := idx.backupProtectedShards.Load(shardName)
 	require.True(t, protected, "COLD tenant must be protected for the duration of the backup")
 	assert.False(t, idx.backupLock.TryRLock(shardName),
@@ -688,10 +681,8 @@ func TestBackupShardWithoutHardlinksColdTenant(t *testing.T) {
 	requireBackupLocksFree(t, idx, []string{shardName})
 }
 
-// Regression test: an unloaded LazyLoadShard takes the same inactive branch and
-// used to fall through into the active path too. That is silent rather than
-// fatal — the shard is non-nil — so it produced the exact state the release-side
-// double unlock needs: protected, lock held, active path running anyway.
+// Regression test: an unloaded LazyLoadShard must not fall through the
+// inactive branch into the active path (silent, since the shard is non-nil).
 func TestBackupShardWithoutHardlinksUnloadedLazyShard(t *testing.T) {
 	const (
 		shardName = "cold-tenant"
@@ -705,8 +696,7 @@ func TestBackupShardWithoutHardlinksUnloadedLazyShard(t *testing.T) {
 	gen, err := idx.initBackup(backupID)
 	require.NoError(t, err)
 
-	// HaltForTransfer on the zero-valued shard would panic, so reaching the
-	// active path fails this outright rather than returning a wrong descriptor.
+	// A zero-valued shard panics in HaltForTransfer if the active path runs here.
 	sd, err := idx.backupShardWithoutHardlinks(ctx, shardName, gen, nil)
 	require.NoError(t, err)
 	require.NotNil(t, sd)
@@ -719,8 +709,8 @@ func TestBackupShardWithoutHardlinksUnloadedLazyShard(t *testing.T) {
 	requireBackupLocksFree(t, idx, []string{shardName})
 }
 
-// A releaser that arrives after its own backup ended must leave the running
-// backup alone: its shards, its staging dir and its compaction pause.
+// A releaser for an already-ended backup must not touch a later backup's
+// shards, staging dir, or compaction pause.
 func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 	const shardName = "cold-tenant"
 	ctx := context.Background()
@@ -749,8 +739,8 @@ func TestReleaseBackupIgnoresForeignBackup(t *testing.T) {
 	assert.NoDirExists(t, stagingDir)
 }
 
-// A shard must never be protected for a backup that has already been released:
-// nothing would ever clear the flag or unlock it again.
+// A shard must never be protected for an already-released backup: nothing
+// would clear the flag or unlock it again.
 func TestProtectShardRefusesReleasedBackup(t *testing.T) {
 	const (
 		shardName = "cold-tenant"
@@ -768,8 +758,7 @@ func TestProtectShardRefusesReleasedBackup(t *testing.T) {
 	_, protected := idx.backupProtectedShards.Load(shardName)
 	assert.False(t, protected, "a released backup must not protect anything")
 
-	// The same generation is refused once a later backup owns the index, so the
-	// two cannot be confused even when they share an ID.
+	// The same generation must stay refused even after a later backup reuses id.
 	_, err = idx.initBackup(backupID)
 	require.NoError(t, err)
 	require.ErrorIs(t, idx.protectShard(shardName, gen), errBackupReleased)

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -472,7 +472,6 @@ func TestReleaseBackupLeavesLaterBackupsShardsProtected(t *testing.T) {
 	runReleaseBackupWorkloadInChild(t)
 }
 
-// backupTestShardNames builds n shard names.
 func backupTestShardNames(n int) []string {
 	names := make([]string, n)
 	for s := range names {
@@ -481,10 +480,8 @@ func backupTestShardNames(n int) []string {
 	return names
 }
 
-// newBackupTestIndex returns an Index holding every shard's backupLock with the
-// shard flagged as protected by backupID, the state
-// backupShardWithoutHardlinks leaves behind for a shard it backed up without
-// hardlinks.
+// newBackupTestIndex reproduces the state backupShardWithoutHardlinks leaves
+// behind: every shard locked and flagged as protected by backupID.
 func newBackupTestIndex(t *testing.T, rootDir string, names []string, backupID string) *Index {
 	t.Helper()
 
@@ -513,8 +510,8 @@ func newBackupTestIndex(t *testing.T, rootDir string, names []string, backupID s
 	return idx
 }
 
-// spawnBackupReleasers starts n goroutines that each release backupID once
-// start is closed, so the releases overlap.
+// spawnBackupReleasers starts n goroutines that race to release backupID
+// once start closes.
 func spawnBackupReleasers(t *testing.T, wg *sync.WaitGroup, start <-chan struct{}, idx *Index, backupID string, n int) {
 	for r := 0; r < n; r++ {
 		wg.Add(1)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -295,10 +295,22 @@ type Index struct {
 	// Minimize holding the RW lock as it will block other operations on the same shard such as searches or writes.
 	shardCreateLocks *esync.KeyRWLocker
 
-	// backupProtectedShards tracks shard names protected during non-hardlink backup.
+	// backupProtectedShards maps the name of each shard protected during a
+	// non-hardlink backup to the generation of the backup that protected it.
 	// Activation and destructive status changes are blocked until ReleaseBackup.
 	// non-hardlink backups only occur on niche filesystems so this is not a hot path
 	backupProtectedShards sync.Map
+
+	// backupStateMu serialises starting a backup, protecting a shard for it, and
+	// releasing it, so a shard is never protected for a backup that already ended
+	// and every protected shard is unlocked exactly once. Reads of
+	// backupProtectedShards do not take it.
+	backupStateMu sync.Mutex
+
+	// backupGeneration numbers the backups run on this index. Backup IDs cannot
+	// identify a backup: they are user-supplied and only unique per (backend,
+	// bucket, path), so two backups of this index can share one.
+	backupGeneration atomic.Uint64
 
 	metrics          *Metrics
 	centralJobQueue  chan job

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -295,20 +295,18 @@ type Index struct {
 	// Minimize holding the RW lock as it will block other operations on the same shard such as searches or writes.
 	shardCreateLocks *esync.KeyRWLocker
 
-	// backupProtectedShards maps the name of each shard protected during a
-	// non-hardlink backup to the generation of the backup that protected it.
-	// Activation and destructive status changes are blocked until ReleaseBackup.
-	// non-hardlink backups only occur on niche filesystems so this is not a hot path
+	// backupProtectedShards maps each protected shard's name to the generation
+	// that protected it. Activation and destructive status changes are blocked
+	// until ReleaseBackup. Non-hardlink backups are niche, so this isn't hot.
 	backupProtectedShards sync.Map
 
-	// backupStateMu orders protecting a shard against starting and ending a
-	// backup, so a shard is never protected for a backup that already ended and
-	// left nothing behind to unlock it. It is not held while shards are released.
+	// backupStateMu orders shard protection against starting/ending a backup, so
+	// a shard is never protected for a backup that already ended. Not held while
+	// shards are released.
 	backupStateMu sync.Mutex
 
-	// backupGeneration numbers the backups run on this index. Backup IDs cannot
-	// identify a backup: they are user-supplied and only unique per (backend,
-	// bucket, path), so two backups of this index can share one.
+	// backupGeneration numbers backups run on this index. IDs can't: they're
+	// user-supplied and only unique per (backend, bucket, path).
 	backupGeneration atomic.Uint64
 
 	metrics          *Metrics

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -301,10 +301,9 @@ type Index struct {
 	// non-hardlink backups only occur on niche filesystems so this is not a hot path
 	backupProtectedShards sync.Map
 
-	// backupStateMu serialises starting a backup, protecting a shard for it, and
-	// releasing it, so a shard is never protected for a backup that already ended
-	// and every protected shard is unlocked exactly once. Reads of
-	// backupProtectedShards do not take it.
+	// backupStateMu orders protecting a shard against starting and ending a
+	// backup, so a shard is never protected for a backup that already ended and
+	// left nothing behind to unlock it. It is not held while shards are released.
 	backupStateMu sync.Mutex
 
 	// backupGeneration numbers the backups run on this index. Backup IDs cannot


### PR DESCRIPTION
SuperClaude here.

A backup `POST` returns `200 STARTED`, then the database process dies and the backup never reaches a terminal status.

`Index.ReleaseBackup` unlocked `backupLock` and then deleted the shard from `backupProtectedShards` as two separate steps. An ordinary backup of a single collection runs **three** cleanup goroutines for that same collection (`backend.go:256`, `:306`, `:386`), and cancelling adds a fourth (`:296`). They share one `Index`, one `backupProtectedShards` map and one `backupLock`, so two of them can observe the same key and unlock it once each. The second `Unlock` lands on an already unlocked `RWMutex`, which is a fatal error that `recover()` cannot catch:

```
fatal error: sync: Unlock of unlocked RWMutex

sync.(*RWMutex).Unlock(...)
entities/sync.(*KeyRWLocker).Unlock    entities/sync/sync.go:106
db.(*Index).ReleaseBackup.func1        adapters/repos/db/backup.go:675
sync.(*Map).Range(...)
db.(*Index).ReleaseBackup              adapters/repos/db/backup.go:673
```

Both callers here are releasing the same backup, so that shard's lock is released once more than it was acquired.

There is a second way to release a shard that should not be released. A caller that finishes its `Range` resets the backup state, a new backup can then re-protect the same shard, and a sibling caller still traversing will observe the re-stored key — `sync.Map.Range` is explicitly allowed to show a mapping stored after the traversal began. The slow caller then releases a lock the *new* backup holds. That one is silent: no fatal, just a shard left unprotected for the rest of the backup.

Two preconditions: the non-hardlink path (`ProbeHardlinkSupport` false), plus at least one absent-or-unloaded shard. Both bugs are pre-existing, not introduced by a recent change.

The fix stores a **generation number** as the map value — a counter that goes up by one per backup on the index — and claims each shard with `CompareAndDelete`, so a caller only ever unlocks shards its own backup protected. It deliberately does **not** key on the backup ID: IDs are user-supplied and reusable (the same name against a different bucket is accepted today), so comparing them is not safe. `backupShardWithoutHardlinks` takes the generation from its only caller, `descriptorWithoutHardlinks`. Both protection readers in `index.go` test presence and ignore the value, so they are unaffected.

**Scope.** Three bugs on the same path, all fixed here:

1. **The double-unlock** — the fatal above.
2. **A silent lock theft** — a slow cleanup from an earlier backup could release a lock a *later* backup was holding. Measured at 136 of 300 attempts before the generation change, 0 of 300 after. No crash; the shard was simply left unprotected mid-backup.
3. **The nil-shard fall-through** — when a shard was not loaded, the inner function returned `nil` and execution carried on into the active-shard path with no shard to work on. It now returns early. Note that **success was the crashing case**: a cold tenant with data on disk fell through and panicked, while one that was never written took an early return and survived.

Measured effect of (3), on the fallback path with cold tenants that have data: on released v1.38 the backup never finishes and sits at `STARTED`; on this branch the same journey completes and restores 750 of 750 objects.

**Tests.** Both run their workload in a child process, since a fatal cannot be observed from inside the crashing binary.

- `TestReleaseBackupConcurrentUnlocksEachShardOnce` — the double unlock. The child dies within the first few trials without the fix: 20/20 without `-race`, 10/10 with it.
- `TestReleaseBackupLeavesLaterBackupsShardsProtected` — the cross-backup release. Fails on trial 0 against both the original code and an entry-only `LoadAndDelete` claim; a probe measured the steal at 136/300 trials before the fix and 0/300 after.

Found by @dirkkul. QA Claude reproduced the fatal 5/5 on unpatched non-hardlink runs against real servers. The cross-backup release was caught by Copilot's review on this PR.

— SuperClaude


