### PR TITLE
Remove tmp files in compaction/cleanup on failure

### DIFF
--- a/adapters/repos/db/lsmkv/cleanup_replace_crash_recovery_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_crash_recovery_integration_test.go
@@ -218,18 +218,6 @@ func TestCleanupReplace_InPlaceSwitch_MidSwitchCrashRecovery(t *testing.T) {
 				}
 			}
 
-			// assertNoTempFiles asserts recovery removed all segment .tmp leftovers.
-			assertNoTempFiles := func(t *testing.T, dir string) {
-				t.Helper()
-				entries, err := os.ReadDir(dir)
-				require.NoError(t, err)
-				for _, e := range entries {
-					if strings.HasPrefix(e.Name(), "segment-") && strings.HasSuffix(e.Name(), ".tmp") {
-						t.Errorf("leftover temp file after recovery: %s", e.Name())
-					}
-				}
-			}
-
 			// crash after the sidecars were marked but before the new .db.tmp was
 			// renamed onto the old .db: the old .db is still live, the .db.tmp is a
 			// leftover. Recovery deletes the .db.tmp and keeps the old data.
@@ -289,5 +277,17 @@ func copyDir(t *testing.T, src, dst string) {
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("copy dir: %v: %s", err, out.String())
+	}
+}
+
+// assertNoTempFiles asserts no segment .tmp file is left in dir.
+func assertNoTempFiles(t *testing.T, dir string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "segment-") && strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("leftover temp file: %s", e.Name())
+		}
 	}
 }

--- a/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -860,4 +862,88 @@ func TestSegmentCleaner_AbortDiscardsNewSegment(t *testing.T) {
 	assert.False(t, cleaned)
 	assert.Len(t, bucket.disk.segments, 2, "the candidate segment must survive an aborted cleanup")
 	assertNoTempFiles(t, dir)
+}
+
+// TestSegmentCleaner_FailedPreinitializeDiscardsNewSegment covers the window
+// between the cleaned file being written and switchOnDisk marking anything.
+// preinitializeNewSegment writes the sidecars there, so a directory planted at
+// the bloom path makes it fail with the candidate segment still fully intact.
+func TestSegmentCleaner_FailedPreinitializeDiscardsNewSegment(t *testing.T) {
+	ctx := testCtx()
+	dir := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+		WithSegmentsCleanupInterval(time.Second),
+		WithCalcCountNetAdditions(true),
+	)
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	for seg := 0; seg < 2; seg++ {
+		for i := 0; i < 50; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%04d", seg, i))
+			require.NoError(t, bucket.Put(key, []byte("v")))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.Len(t, bucket.disk.segments, 2)
+
+	// the oldest segment is the cleanup candidate; its cleaned output reuses the
+	// same id, so the sidecars it precomputes carry that id too
+	candidateID := segmentID(bucket.disk.segments[0].getPath())
+	blocker := filepath.Join(dir, "segment-"+candidateID+".bloom.tmp")
+	require.NoError(t, os.Mkdir(blocker, 0o755))
+
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.Error(t, err, "the planted directory must make the sidecar write fail")
+	assert.False(t, cleaned)
+	assert.Len(t, bucket.disk.segments, 2, "the candidate segment must survive")
+
+	_, err = os.Stat(filepath.Join(dir, "segment-"+candidateID+".db.tmp"))
+	assert.True(t, os.IsNotExist(err), "the cleaned file must be discarded")
+}
+
+// TestSegmentCleaner_FailedMarkKeepsNewSegment is the other side of the discard
+// flag on the cleanup path: once switchOnDisk has called back, a later failure
+// must keep the cleaned file. The mark is made to fail by planting a directory
+// where the candidate's bloom filter is renamed to.
+func TestSegmentCleaner_FailedMarkKeepsNewSegment(t *testing.T) {
+	ctx := testCtx()
+	dir := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+		WithSegmentsCleanupInterval(time.Second),
+		WithCalcCountNetAdditions(true),
+	)
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	for seg := 0; seg < 2; seg++ {
+		for i := 0; i < 50; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%04d", seg, i))
+			require.NoError(t, bucket.Put(key, []byte("v")))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.Len(t, bucket.disk.segments, 2)
+
+	candidate, ok := bucket.disk.segments[0].(*segment)
+	require.True(t, ok)
+	blocker := candidate.bloomFilterPath() + candidate.deleteMarkerSuffix
+	require.NoError(t, os.Mkdir(blocker, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blocker, "occupied"), []byte("x"), 0o644))
+
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.Error(t, err, "the planted directory must make the sidecar mark fail")
+	assert.False(t, cleaned)
+
+	candidateID := segmentID(candidate.getPath())
+	_, err = os.Stat(filepath.Join(dir, "segment-"+candidateID+".db.tmp"))
+	require.NoError(t, err, "the cleaned file must survive once the switch has started")
 }

--- a/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
@@ -16,7 +16,9 @@ package lsmkv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -815,4 +817,47 @@ func cleanupReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing.T,
 			assert.Equal(t, len(expectedExising), count)
 		})
 	})
+}
+
+// TestSegmentCleaner_AbortDiscardsNewSegment covers the abort exit of
+// cleanupOnce, which the happy-path cleanup tests never reach: the partially
+// written segment must not be left behind for a later init to find.
+func TestSegmentCleaner_AbortDiscardsNewSegment(t *testing.T) {
+	ctx := testCtx()
+	dir := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+		WithSegmentsCleanupInterval(time.Second),
+		WithCalcCountNetAdditions(true),
+	)
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	// the cleaner samples shouldAbort every 100 keys, so the candidate segment
+	// needs more than that for the abort to land mid-write
+	for seg := 0; seg < 2; seg++ {
+		for i := 0; i < 300; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%04d", seg, i))
+			require.NoError(t, bucket.Put(key, []byte("v")))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.Len(t, bucket.disk.segments, 2)
+
+	// false once to clear the guard before the file is created, then true so the
+	// cleaner aborts on its first sampled key
+	calls := 0
+	shouldAbort := func() bool {
+		calls++
+		return calls > 1
+	}
+
+	cleaned, err := bucket.disk.segmentCleaner.cleanupOnce(shouldAbort)
+	require.Error(t, err)
+	assert.False(t, cleaned)
+	assert.Len(t, bucket.disk.segments, 2, "the candidate segment must survive an aborted cleanup")
+	assertNoTempFiles(t, dir)
 }

--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -16,6 +16,9 @@ package lsmkv
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -137,6 +140,7 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 				require.NoError(t, err)
 				assert.False(t, compacted)
 				assert.Less(t, elapsed, 3*time.Second, "observed %s", elapsed)
+				assertNoTempFiles(t, dirName)
 			})
 
 			// bridge path: shouldAbort=true exercised through compactOrCleanup;
@@ -148,7 +152,121 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 				elapsed := time.Since(start)
 				assert.False(t, didWork)
 				assert.Less(t, elapsed, 3*time.Second, "observed %s", elapsed)
+				assertNoTempFiles(t, dirName)
+			})
+
+			// the aborts above must not have compromised the segments
+			t.Run("compaction still succeeds afterwards", func(t *testing.T) {
+				compacted, err := bucket.disk.compactOnce(ctx)
+				require.NoError(t, err)
+				require.True(t, compacted)
+				require.Len(t, bucket.disk.segments, 1)
+
+				_, err = os.Stat(bucket.disk.segments[0].getPath())
+				require.NoError(t, err, "compacted segment must survive on disk")
+				assertNoTempFiles(t, dirName)
 			})
 		})
 	}
+}
+
+// TestCompactor_FailedCompactionDiscardsNewSegment covers the non-abort failure
+// exit: a compactor error must leave no .tmp behind either. The error is injected
+// through shouldSkipKey, which only the set strategy consults.
+func TestCompactor_FailedCompactionDiscardsNewSegment(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategySetCollection),
+	)
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	for seg := 0; seg < 2; seg++ {
+		for i := 0; i < 100; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%08d", seg, i))
+			require.NoError(t, bucket.SetAdd(key, [][]byte{[]byte("val")}))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.Len(t, bucket.disk.segments, 2)
+
+	// set after flushing so only the compaction sees the failure
+	bucket.disk.shouldSkipKey = func(key []byte, ctx context.Context) (bool, error) {
+		return false, fmt.Errorf("cannot decide on key %q", key)
+	}
+
+	compacted, err := bucket.disk.compactOnce(ctx)
+	require.Error(t, err)
+	assert.False(t, compacted)
+	assert.Len(t, bucket.disk.segments, 2, "both sources must survive a failed compaction")
+	assertNoTempFiles(t, dirName)
+}
+
+// TestCompactor_FailedSwitchKeepsNewSegment pins the other side of the discard
+// flag. Once switchOnDisk has marked a source for deletion the new file is the
+// only copy of the merged data, so a failure after that point must keep it.
+//
+// The switch is made to fail by planting a directory where stripTmpExtensions
+// renames the new segment to. Segment info in the filename keeps that name
+// distinct from the right segment's own file, which is marked for deletion first.
+func TestCompactor_FailedSwitchKeepsNewSegment(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	bucket, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace),
+		WithWriteSegmentInfoIntoFileName(true),
+	)
+	require.NoError(t, err)
+	defer bucket.Shutdown(ctx)
+	bucket.SetMemtableThreshold(1e9)
+
+	for seg := 0; seg < 2; seg++ {
+		for i := 0; i < 10; i++ {
+			key := []byte(fmt.Sprintf("seg-%d-key-%02d", seg, i))
+			require.NoError(t, bucket.Put(key, []byte("v")))
+		}
+		require.NoError(t, bucket.FlushAndSwitch())
+	}
+	require.Len(t, bucket.disk.segments, 2)
+
+	left, right := bucket.disk.segments[0], bucket.disk.segments[1]
+	leftID, rightID := segmentID(left.getPath()), segmentID(right.getPath())
+	// two level-0 segments compact into level 1
+	blocker := filepath.Join(dirName,
+		"segment-"+rightID+segmentExtraInfo(1, left.getStrategy())+".db")
+	require.NoError(t, os.Mkdir(blocker, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blocker, "occupied"), []byte("x"), 0o644))
+
+	compacted, err := bucket.disk.compactOnce(ctx)
+	require.Error(t, err, "the planted directory must make the rename fail")
+	assert.False(t, compacted)
+
+	// both sources are marked by now, so the merged data lives only in the .tmp
+	assert.NotEmpty(t, deleteMarkers(t, dirName),
+		"the switch must have marked a source before failing")
+	tmpName := "segment-" + leftID + "_" + rightID +
+		segmentExtraInfo(1, left.getStrategy()) + ".db.tmp"
+	_, err = os.Stat(filepath.Join(dirName, tmpName))
+	require.NoError(t, err, "the new segment must survive a failed switch")
+}
+
+// deleteMarkers lists the files in dir that are marked for deletion.
+func deleteMarkers(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var names []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), DeleteMarkerSuffix) {
+			names = append(names, e.Name())
+		}
+	}
+	return names
 }

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -503,6 +503,15 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 			return false, err
 		}
 
+		// the candidate segment still holds everything this file has until
+		// replaceSegment swaps it in, so discard it on every earlier exit
+		discardNewSegment := true
+		defer func() {
+			if discardNewSegment {
+				err = discardSegmentFile(file, tmpSegmentPath, err)
+			}
+		}()
+
 		switch c.sg.strategy {
 		case StrategyReplace:
 			c := newSegmentCleanerReplace(file, oldSegment.newCursor(),
@@ -524,6 +533,8 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 			err = fmt.Errorf("close cleaned segment file: %w", err)
 			return false, err
 		}
+
+		discardNewSegment = false
 		return true, nil
 	}()
 	if err != nil {

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -416,7 +416,7 @@ func (c *segmentCleanerCommon) storeSegmentMeta(id, lastProcessedId, size, clean
 }
 
 func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortCallback,
-) (bool, error) {
+) (cleaned bool, err error) {
 	if c.sg.isReadyOnly() {
 		return false, nil
 	}
@@ -424,6 +424,16 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 	var candidateIdx, startIdx, lastIdx int
 	var onCompleted onCompletedFunc
 	var tmpSegmentPath string
+	var newFile *os.File
+
+	// the candidate segment still holds everything the new file has until
+	// switchOnDisk starts marking, so discard it on every earlier exit
+	discardNewSegment := false
+	defer func() {
+		if discardNewSegment {
+			err = discardSegmentFile(newFile, tmpSegmentPath, err)
+		}
+	}()
 
 	ok, err := func() (bool, error) {
 		segments, release := c.sg.getConsistentViewOfSegments()
@@ -502,15 +512,8 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 		if err != nil {
 			return false, err
 		}
-
-		// the candidate segment still holds everything this file has until
-		// replaceSegment swaps it in, so discard it on every earlier exit
-		discardNewSegment := true
-		defer func() {
-			if discardNewSegment {
-				err = discardSegmentFile(file, tmpSegmentPath, err)
-			}
-		}()
+		newFile = file
+		discardNewSegment = true
 
 		switch c.sg.strategy {
 		case StrategyReplace:
@@ -533,8 +536,6 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 			err = fmt.Errorf("close cleaned segment file: %w", err)
 			return false, err
 		}
-
-		discardNewSegment = false
 		return true, nil
 	}()
 	if err != nil {
@@ -544,7 +545,9 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 		return false, nil
 	}
 
-	segment, err := c.sg.replaceSegment(candidateIdx, tmpSegmentPath)
+	segment, err := c.sg.replaceSegment(candidateIdx, tmpSegmentPath, func() {
+		discardNewSegment = false
+	})
 	if err != nil {
 		err = fmt.Errorf("replace compacted segments: %w", err)
 		return false, err
@@ -587,6 +590,7 @@ func (sg *SegmentGroup) makeKeyExistsOnUpperSegments(segments []Segment, startId
 }
 
 func (sg *SegmentGroup) replaceSegment(segmentPos int, tmpSegmentPath string,
+	onCommitted func(),
 ) (*segment, error) {
 	newSegment, err := sg.preinitializeNewSegment(tmpSegmentPath, segmentPos)
 	if err != nil {
@@ -594,7 +598,7 @@ func (sg *SegmentGroup) replaceSegment(segmentPos int, tmpSegmentPath string,
 	}
 
 	replacer := newSegmentReplacer(sg, segmentPos, segmentPos, newSegment)
-	_, oldSegment, err := replacer.switchOnDisk()
+	_, oldSegment, err := replacer.switchOnDisk(onCommitted)
 	if err != nil {
 		return nil, fmt.Errorf("replace cleaned segment on disk: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -271,6 +271,20 @@ func segmentExtraInfo(level uint16, strategy segmentindex.Strategy) string {
 	return fmt.Sprintf(".l%d.s%d", level, strategy)
 }
 
+// discardSegmentFile closes f and removes path, for a new segment file that is
+// not going to be switched in. Failures are joined into err: a leftover .tmp
+// would be renamed onto a live segment name by a later init.
+func discardSegmentFile(f *os.File, path string, err error) error {
+	// f is already closed if the failure came after the write finished
+	if closeErr := f.Close(); closeErr != nil && !stderrors.Is(closeErr, os.ErrClosed) {
+		err = stderrors.Join(err, fmt.Errorf("close new segment file %q: %w", path, closeErr))
+	}
+	if removeErr := os.Remove(path); removeErr != nil && !stderrors.Is(removeErr, os.ErrNotExist) {
+		err = stderrors.Join(err, fmt.Errorf("remove new segment file %q: %w", path, removeErr))
+	}
+	return err
+}
+
 // compactOnce performs one compaction iteration. Cancelling ctx aborts
 // the in-flight merge (sampled every compactor.AbortCheckEveryN keys).
 func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err error) {
@@ -358,11 +372,21 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 		return false, err
 	}
 
+	// Until switchOnDisk marks a source segment for deletion, both sources still
+	// hold everything this file has, so discarding it on every exit before the
+	// switch costs nothing and leaves no .tmp for a later init to adopt.
+	discardNewSegment := true
+	defer func() {
+		if discardNewSegment {
+			err = discardSegmentFile(f, path, err)
+		}
+	}()
+
 	secondaryIndices := left.getSecondaryIndexCount()
 	cleanupTombstones := !sg.keepTombstones && pair[0] == 0
 	maxNewFileSize := left.Size() + right.Size()
 
-	// aborted=true tells the caller to close the partial .tmp and bail
+	// aborted=true tells the caller to bail without reporting an error
 	runCompactor := func(do func(context.Context) error) (aborted bool, err error) {
 		if err := do(ctx); err != nil {
 			if stderrors.Is(err, context.Canceled) || stderrors.Is(err, context.DeadlineExceeded) {
@@ -371,14 +395,6 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		return false, nil
-	}
-
-	abortAndClose := func() error {
-		// orphan .tmp is cleaned by segment_group.init on next start
-		if err := f.Close(); err != nil {
-			return fmt.Errorf("close aborted compactor output: %w", err)
-		}
-		return nil
 	}
 
 	switch strategy {
@@ -395,7 +411,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		if aborted {
-			return false, abortAndClose()
+			return false, nil
 		}
 	case segmentindex.StrategySetCollection:
 		c := newCompactorSetCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),
@@ -407,7 +423,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		if aborted {
-			return false, abortAndClose()
+			return false, nil
 		}
 	case segmentindex.StrategyMapCollection:
 		c := newCompactorMapCollection(f, left.newCollectionCursorReusable(), right.newCollectionCursorReusable(),
@@ -419,7 +435,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		if aborted {
-			return false, abortAndClose()
+			return false, nil
 		}
 	case segmentindex.StrategyRoaringSet:
 		c := roaringset.NewCompactor(f, left.newRoaringSetCursor(), right.newRoaringSetCursor(),
@@ -431,7 +447,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		if aborted {
-			return false, abortAndClose()
+			return false, nil
 		}
 
 	case segmentindex.StrategyRoaringSetRange:
@@ -443,7 +459,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		if aborted {
-			return false, abortAndClose()
+			return false, nil
 		}
 	case segmentindex.StrategyInverted:
 		avgPropLen, _ := sg.GetAveragePropertyLength()
@@ -476,7 +492,7 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 			return false, err
 		}
 		if aborted {
-			return false, abortAndClose()
+			return false, nil
 		}
 	default:
 		return false, errors.Errorf("unrecognized strategy %v", strategy)
@@ -496,6 +512,10 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 	}
 
 	replacer := newSegmentReplacer(sg, pair[0], pair[1], newSegment)
+	// from here on a source may be marked for deletion, which makes the .tmp the
+	// only copy of the merged data
+	discardNewSegment = false
+
 	oldLeft, oldRight, err := replacer.switchOnDisk()
 	if err != nil {
 		return false, fmt.Errorf("replace compacted segments on disk: %w", err)

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -512,11 +512,9 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 	}
 
 	replacer := newSegmentReplacer(sg, pair[0], pair[1], newSegment)
-	// from here on a source may be marked for deletion, which makes the .tmp the
-	// only copy of the merged data
-	discardNewSegment = false
-
-	oldLeft, oldRight, err := replacer.switchOnDisk()
+	oldLeft, oldRight, err := replacer.switchOnDisk(func() {
+		discardNewSegment = false
+	})
 	if err != nil {
 		return false, fmt.Errorf("replace compacted segments on disk: %w", err)
 	}

--- a/adapters/repos/db/lsmkv/segment_group_replacer.go
+++ b/adapters/repos/db/lsmkv/segment_group_replacer.go
@@ -42,10 +42,13 @@ type segmentReplacer struct {
 
 const replaceSegmentWarnThreshold = 300 * time.Millisecond
 
-// replaceCompactedSegmentsOnDisk performs the segment switch on disk without
-// affecting the currently running app. Therefore it is non-blocking to the
-// current application. The in-memory switch has to be done separately.
-func (sr *segmentReplacer) switchOnDisk() (Segment, Segment, error) {
+// switchOnDisk performs the segment switch on disk without affecting the
+// currently running app. Therefore it is non-blocking to the current
+// application. The in-memory switch has to be done separately.
+//
+// onCommitted is called once the switch starts marking old files, after which
+// the new segment file is the only copy of the data and must not be discarded.
+func (sr *segmentReplacer) switchOnDisk(onCommitted func()) (Segment, Segment, error) {
 	var leftSegment, rightSegment Segment
 	var leftSegID, rightSegID string
 
@@ -55,6 +58,10 @@ func (sr *segmentReplacer) switchOnDisk() (Segment, Segment, error) {
 	}
 	rightSegment = sr.sg.segments[sr.oldRightPos]
 	sr.sg.maintenanceLock.RUnlock()
+
+	// after the reads so a panic there still discards the new file, above both
+	// arms so neither can start marking without it
+	onCommitted()
 
 	if sr.replaceSingleSegment {
 		// In-place cleanup switch: the rewritten segment has the same canonical

--- a/adapters/repos/db/lsmkv/segment_group_replacer_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_replacer_test.go
@@ -59,7 +59,7 @@ func TestSegmentReplacer_OnDisk(t *testing.T) {
 		})
 
 		replacer := newSegmentReplacer(diskSegments, 1, 2, segBC)
-		oldLeft, oldRight, err := replacer.switchOnDisk()
+		oldLeft, oldRight, err := replacer.switchOnDisk(func() {})
 		require.NoError(t, err)
 
 		// replaced segments are returned
@@ -90,7 +90,7 @@ func TestSegmentReplacer_OnDisk(t *testing.T) {
 		})
 
 		replacer := newSegmentReplacer(diskSegments, 1, 1, segBB)
-		oldLeft, oldRight, err := replacer.switchOnDisk()
+		oldLeft, oldRight, err := replacer.switchOnDisk(func() {})
 		require.NoError(t, err)
 
 		// replaced segments are returned


### PR DESCRIPTION
### What's being changed:

 When a compaction or a segment cleanup fails or is aborted after the new segment's .tmp file has been created but before the on-disk switch commits, the partial file was left  behind on disk — compaction only closed it and relied on segment_group.init to sweep it on the next start. That leftover is not harmless: a later init's stripTmpExtensions  renames a .tmp onto its live segment name, so a truncated merge output can be adopted as a real segment. 

Both compactOnce and cleanupOnce now close and remove the new segment file on every exit path taken before the switch commits, joining any close/remove failure into the returned error rather than dropping it (the shared discardSegmentFile helper tolerates an already-closed file and an already-removed path). 

Very much an edge case but here are two possible code paths on how this could have caused problems

  Chain A — fd + disk leak, no restart, no coincidences needed

  This one fires on every failed compaction, and it's the reason the discard has to happen in the producer.

  1. A compaction is picked for the adjacent pair (L, R) and os.Create opens segment-L_R.l3.s1.db.tmp (segment_group_compaction.go:370).
  2. The merge writes a few hundred MB into f and then fails — not a ctx cancel, a real error: ENOSPC, a read error off a source segment, the alloc checker tripping mid-merge,
  a checksum mismatch.
  3. Pre-fix, runCompactor returns the error and the strategy arm does return false, err. f is never closed. That's true of all six strategy arms, the default: arm, and the
  f.Sync() failure — eight exits, each leaking one fd plus the partial file.
  4. compact() in segment_group.go:1027 logs "compaction failed" and returns. The cycle manager retries on the next tick.
  5. Next tick picks the same pair, os.Create truncates the same path, fails the same way → another leaked fd.
  6. Repeat. On a disk-full node this is one fd per bucket per compaction cycle, across every shard × every property bucket. You hit too many open files, at which point the
  node can no longer open segments, accept connections, or flush — and the original error (disk full) is now buried under a second, unrelated-looking failure mode.

  The disk side of the same step: between step 3 and the next same-name attempt, a file as large as left.Size() + right.Size() sits there doing nothing. If that bucket never
  compacts again — shard flipped READONLY, tenant deactivated, backup pause, node just runs for months — that space is unreclaimable until restart.

  Chain B — restart adopts the orphan and deletes a live segment

  This one is data loss, but it needs one extra coincidence, so here it is precisely.

  1. Compaction of (L, R) aborts or fails, leaving segment-L_R.l3.s1.db.tmp on disk (steps 1–3 above).
  2. Restarting right now is harmless. Init sees both L and R still on disk and takes the leftSegmentFound && rightSegmentFound arm at segment_group.go:249, which just removes
  the orphan. This is why the old comment ("orphan .tmp is cleaned by segment_group.init on next start") looked sufficient.
  3. The coincidence: the retry must write to a different filename, otherwise os.Create truncates the orphan and the problem self-heals. It does when the level suffix changes —
  SegmentInfoIntoFileNameEnabled defaults to true (environment.go:494), so the name carries .l<level>, and the level for a fixed pair is not fixed: findCompactionCandidates
  returns lLvl+1 normally, but lLvl unchanged when an older segment of the same level exists and can't fit the size limit (segment_group_compaction.go:148-152). So with
  PERSISTENCE_LSM_MAX_SEGMENT_SIZE set, attempt 1 writes ...l2....db.tmp and, once that older same-level segment is gone, attempt 2 writes ...l3....db.tmp.
  4. Attempt 2 succeeds. L is marked deleted and removed; R is renamed to segment-R.l3.s1.db and holds the correct merged data. The .l2. orphan is still sitting there,
  truncated at whatever key step 1 died on.
  5. Node restarts. Init parses the orphan, finds leftFound == false (L is gone) and rightFound == true, and takes the arm at segment_group.go:265: it opens the live
  segment-R.l3.s1.db, calls dropImmediately() on it (:316), then renames the orphan onto segment-R.l2.s1.db (:341).
  6. The correct segment is now deleted and replaced by a partial merge. Best case the truncated file fails its header/index/checksum check and the bucket refuses to open — the
  shard won't load. Worst case it parses and you silently serve a segment that's missing every key past the abort point: objects gone, postings gone, no error anywhere.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
