### PR TITLE
gh-11732 fix silent acceptance of null/wrong-type vectorIndexConfig values

### DIFF
--- a/entities/vectorindex/common/config.go
+++ b/entities/vectorindex/common/config.go
@@ -42,6 +42,10 @@ const (
 // Tries to parse the int value from the map, if it overflows math.MaxInt64, it
 // uses math.MaxInt64 instead. This is to protect from rounding errors from
 // json marshalling where the type may be assumed as float64
+//
+// If the key is present with a value that is neither a json.Number nor a
+// float64 (including an explicit JSON `null`), that is a caller error and is
+// reported rather than silently defaulting the field to 0.
 func OptionalIntFromMap(in map[string]interface{}, name string,
 	setFn func(v int),
 ) error {
@@ -60,6 +64,8 @@ func OptionalIntFromMap(in map[string]interface{}, name string,
 		asInt64, err = typed.Int64()
 	case float64:
 		asInt64 = int64(typed)
+	default:
+		return errors.Errorf("%q must be an integer, got %T", name, value)
 	}
 	if err != nil {
 		// try to recover from error
@@ -75,6 +81,9 @@ func OptionalIntFromMap(in map[string]interface{}, name string,
 	return nil
 }
 
+// If the key is present with a value that is not a bool (including an
+// explicit JSON `null`), that is a caller error and is reported rather than
+// silently leaving the field at its current value.
 func OptionalBoolFromMap(in map[string]interface{}, name string,
 	setFn func(v bool),
 ) error {
@@ -85,13 +94,18 @@ func OptionalBoolFromMap(in map[string]interface{}, name string,
 
 	asBool, ok := value.(bool)
 	if !ok {
-		return nil
+		return errors.Errorf("%q must be a boolean, got %T", name, value)
 	}
 
 	setFn(asBool)
 	return nil
 }
 
+// If the key is present with a value that is not a string (including an
+// explicit JSON `null`), that is a caller error and is reported rather than
+// silently leaving the field at its current value. This is what previously
+// let `"distance": null` in a vectorIndexConfig be silently accepted and
+// resolved to the default distance metric instead of being rejected.
 func OptionalStringFromMap(in map[string]interface{}, name string,
 	setFn func(v string),
 ) error {
@@ -102,7 +116,7 @@ func OptionalStringFromMap(in map[string]interface{}, name string,
 
 	asString, ok := value.(string)
 	if !ok {
-		return nil
+		return errors.Errorf("%q must be a string, got %T", name, value)
 	}
 
 	setFn(asString)

--- a/entities/vectorindex/common/config_test.go
+++ b/entities/vectorindex/common/config_test.go
@@ -1,0 +1,194 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OptionalStringFromMap(t *testing.T) {
+	type test struct {
+		name      string
+		input     map[string]interface{}
+		expectErr bool
+		expected  string
+	}
+
+	tests := []test{
+		{
+			name:      "key absent, setFn not called, no error",
+			input:     map[string]interface{}{},
+			expectErr: false,
+			expected:  "unset",
+		},
+		{
+			name:      "valid string",
+			input:     map[string]interface{}{"distance": "cosine"},
+			expectErr: false,
+			expected:  "cosine",
+		},
+		{
+			name:      "explicit JSON null must error, not silently skip",
+			input:     map[string]interface{}{"distance": nil},
+			expectErr: true,
+			expected:  "unset",
+		},
+		{
+			name:      "wrong type (number) must error, not silently skip",
+			input:     map[string]interface{}{"distance": 123},
+			expectErr: true,
+			expected:  "unset",
+		},
+		{
+			name:      "wrong type (bool) must error, not silently skip",
+			input:     map[string]interface{}{"distance": true},
+			expectErr: true,
+			expected:  "unset",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := "unset"
+			err := OptionalStringFromMap(tt.input, "distance", func(v string) {
+				got = v
+			})
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_OptionalBoolFromMap(t *testing.T) {
+	type test struct {
+		name      string
+		input     map[string]interface{}
+		expectErr bool
+		expected  bool
+	}
+
+	tests := []test{
+		{
+			name:      "key absent, setFn not called, no error",
+			input:     map[string]interface{}{},
+			expectErr: false,
+			expected:  false,
+		},
+		{
+			name:      "valid bool",
+			input:     map[string]interface{}{"skip": true},
+			expectErr: false,
+			expected:  true,
+		},
+		{
+			name:      "explicit JSON null must error, not silently skip",
+			input:     map[string]interface{}{"skip": nil},
+			expectErr: true,
+			expected:  false,
+		},
+		{
+			name:      "wrong type (string) must error, not silently skip",
+			input:     map[string]interface{}{"skip": "true"},
+			expectErr: true,
+			expected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := false
+			err := OptionalBoolFromMap(tt.input, "skip", func(v bool) {
+				got = v
+			})
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_OptionalIntFromMap(t *testing.T) {
+	type test struct {
+		name      string
+		input     map[string]interface{}
+		expectErr bool
+		expected  int
+	}
+
+	tests := []test{
+		{
+			name:      "key absent, setFn not called, no error",
+			input:     map[string]interface{}{},
+			expectErr: false,
+			expected:  -1,
+		},
+		{
+			name:      "valid float64 (from REST API JSON decoding)",
+			input:     map[string]interface{}{"vectorCacheMaxObjects": float64(42)},
+			expectErr: false,
+			expected:  42,
+		},
+		{
+			name:      "valid json.Number (from disk)",
+			input:     map[string]interface{}{"vectorCacheMaxObjects": json.Number("42")},
+			expectErr: false,
+			expected:  42,
+		},
+		{
+			name:      "explicit JSON null must error, not silently default to 0",
+			input:     map[string]interface{}{"vectorCacheMaxObjects": nil},
+			expectErr: true,
+			expected:  -1,
+		},
+		{
+			name:      "wrong type (string) must error, not silently default to 0",
+			input:     map[string]interface{}{"vectorCacheMaxObjects": "42"},
+			expectErr: true,
+			expected:  -1,
+		},
+		{
+			name:      "wrong type (bool) must error, not silently default to 0",
+			input:     map[string]interface{}{"vectorCacheMaxObjects": true},
+			expectErr: true,
+			expected:  -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := -1
+			err := OptionalIntFromMap(tt.input, "vectorCacheMaxObjects", func(v int) {
+				got = v
+			})
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/entities/vectorindex/common/config_test.go
+++ b/entities/vectorindex/common/config_test.go
@@ -19,15 +19,43 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_OptionalStringFromMap(t *testing.T) {
-	type test struct {
-		name      string
-		input     map[string]interface{}
-		expectErr bool
-		expected  string
-	}
+// optionalFromMapCase is the shared table-row shape for Test_Optional*FromMap:
+// each case supplies an input map and asserts both the returned error and the
+// value (or lack thereof) observed through the setFn callback.
+type optionalFromMapCase[T any] struct {
+	name      string
+	input     map[string]interface{}
+	expectErr bool
+	expected  T
+}
 
-	tests := []test{
+// runOptionalFromMapCases drives a table of optionalFromMapCase against fn,
+// factoring out the identical setFn-capture/assert loop that Test_OptionalStringFromMap,
+// Test_OptionalBoolFromMap, and Test_OptionalIntFromMap would otherwise each repeat.
+func runOptionalFromMapCases[T any](
+	t *testing.T,
+	cases []optionalFromMapCase[T],
+	unset T,
+	fn func(input map[string]interface{}, setFn func(T)) error,
+) {
+	t.Helper()
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unset
+			err := fn(tt.input, func(v T) { got = v })
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func Test_OptionalStringFromMap(t *testing.T) {
+	runOptionalFromMapCases(t, []optionalFromMapCase[string]{
 		{
 			name:      "key absent, setFn not called, no error",
 			input:     map[string]interface{}{},
@@ -58,34 +86,13 @@ func Test_OptionalStringFromMap(t *testing.T) {
 			expectErr: true,
 			expected:  "unset",
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := "unset"
-			err := OptionalStringFromMap(tt.input, "distance", func(v string) {
-				got = v
-			})
-
-			if tt.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.expected, got)
-		})
-	}
+	}, "unset", func(input map[string]interface{}, setFn func(string)) error {
+		return OptionalStringFromMap(input, "distance", setFn)
+	})
 }
 
 func Test_OptionalBoolFromMap(t *testing.T) {
-	type test struct {
-		name      string
-		input     map[string]interface{}
-		expectErr bool
-		expected  bool
-	}
-
-	tests := []test{
+	runOptionalFromMapCases(t, []optionalFromMapCase[bool]{
 		{
 			name:      "key absent, setFn not called, no error",
 			input:     map[string]interface{}{},
@@ -110,34 +117,13 @@ func Test_OptionalBoolFromMap(t *testing.T) {
 			expectErr: true,
 			expected:  false,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := false
-			err := OptionalBoolFromMap(tt.input, "skip", func(v bool) {
-				got = v
-			})
-
-			if tt.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.expected, got)
-		})
-	}
+	}, false, func(input map[string]interface{}, setFn func(bool)) error {
+		return OptionalBoolFromMap(input, "skip", setFn)
+	})
 }
 
 func Test_OptionalIntFromMap(t *testing.T) {
-	type test struct {
-		name      string
-		input     map[string]interface{}
-		expectErr bool
-		expected  int
-	}
-
-	tests := []test{
+	runOptionalFromMapCases(t, []optionalFromMapCase[int]{
 		{
 			name:      "key absent, setFn not called, no error",
 			input:     map[string]interface{}{},
@@ -174,21 +160,7 @@ func Test_OptionalIntFromMap(t *testing.T) {
 			expectErr: true,
 			expected:  -1,
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := -1
-			err := OptionalIntFromMap(tt.input, "vectorCacheMaxObjects", func(v int) {
-				got = v
-			})
-
-			if tt.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tt.expected, got)
-		})
-	}
+	}, -1, func(input map[string]interface{}, setFn func(int)) error {
+		return OptionalIntFromMap(input, "vectorCacheMaxObjects", setFn)
+	})
 }

--- a/entities/vectorindex/common/testinghelpers/testinghelpers.go
+++ b/entities/vectorindex/common/testinghelpers/testinghelpers.go
@@ -1,0 +1,33 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package testinghelpers provides shared assertions for the vectorindex
+// config parsers (hnsw, flat, dynamic, hfresh), which each vendor their own
+// ParseAndValidateConfig but should reject malformed input identically.
+package testinghelpers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertNullDistanceRejected verifies that a config parser rejects an
+// explicit `"distance": null` with a type-mismatch error instead of
+// silently leaving the field unset and falling back to the default distance
+// metric. See weaviate/weaviate#11732.
+func AssertNullDistanceRejected(t *testing.T, parseFn func(input map[string]interface{}) error) {
+	t.Helper()
+	err := parseFn(map[string]interface{}{"distance": nil})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"distance" must be a string`)
+}

--- a/entities/vectorindex/dynamic/config_test.go
+++ b/entities/vectorindex/dynamic/config_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/common/testinghelpers"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
@@ -401,18 +402,6 @@ func Test_DynamicUserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "PQ is not currently supported for flat indices",
 		},
-
-		{
-			// Regression test: a `null` distance was previously silently accepted
-			// and resolved to the default distance metric instead of being
-			// rejected. See weaviate/weaviate#11732.
-			name: "with null distance",
-			input: map[string]interface{}{
-				"distance": nil,
-			},
-			expectErr:    true,
-			expectErrMsg: "\"distance\" must be a string",
-		},
 	}
 
 	for _, test := range tests {
@@ -428,4 +417,11 @@ func Test_DynamicUserConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("with null distance", func(t *testing.T) {
+		testinghelpers.AssertNullDistanceRejected(t, func(input map[string]interface{}) error {
+			_, err := ParseAndValidateConfig(input, false)
+			return err
+		})
+	})
 }

--- a/entities/vectorindex/dynamic/config_test.go
+++ b/entities/vectorindex/dynamic/config_test.go
@@ -401,6 +401,18 @@ func Test_DynamicUserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "PQ is not currently supported for flat indices",
 		},
+
+		{
+			// Regression test: a `null` distance was previously silently accepted
+			// and resolved to the default distance metric instead of being
+			// rejected. See weaviate/weaviate#11732.
+			name: "with null distance",
+			input: map[string]interface{}{
+				"distance": nil,
+			},
+			expectErr:    true,
+			expectErrMsg: "\"distance\" must be a string",
+		},
 	}
 
 	for _, test := range tests {

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/common/testinghelpers"
 )
 
 func Test_FlatUserConfig(t *testing.T) {
@@ -341,18 +342,6 @@ func Test_FlatUserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "cannot enable multiple quantization methods at the same time",
 		},
-
-		{
-			// Regression test: a `null` distance was previously silently accepted
-			// and resolved to the default distance metric instead of being
-			// rejected. See weaviate/weaviate#11732.
-			name: "with null distance",
-			input: map[string]interface{}{
-				"distance": nil,
-			},
-			expectErr:    true,
-			expectErrMsg: "\"distance\" must be a string",
-		},
 	}
 
 	for _, test := range tests {
@@ -368,6 +357,13 @@ func Test_FlatUserConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("with null distance", func(t *testing.T) {
+		testinghelpers.AssertNullDistanceRejected(t, func(input map[string]interface{}) error {
+			_, err := ParseAndValidateConfig(input)
+			return err
+		})
+	})
 }
 
 func Test_ParseDefaultQuantization(t *testing.T) {

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -341,6 +341,18 @@ func Test_FlatUserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "cannot enable multiple quantization methods at the same time",
 		},
+
+		{
+			// Regression test: a `null` distance was previously silently accepted
+			// and resolved to the default distance metric instead of being
+			// rejected. See weaviate/weaviate#11732.
+			name: "with null distance",
+			input: map[string]interface{}{
+				"distance": nil,
+			},
+			expectErr:    true,
+			expectErrMsg: "\"distance\" must be a string",
+		},
 	}
 
 	for _, test := range tests {

--- a/entities/vectorindex/hfresh/config_test.go
+++ b/entities/vectorindex/hfresh/config_test.go
@@ -331,6 +331,17 @@ func Test_UserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "invalid hfresh config: maxPostingSizeKB is '1025' but must be less than 1024",
 		},
+		{
+			// Regression test: a `null` distance was previously silently accepted
+			// and resolved to the default distance metric instead of being
+			// rejected. See weaviate/weaviate#11732.
+			name: "with null distance",
+			input: map[string]interface{}{
+				"distance": nil,
+			},
+			expectErr:    true,
+			expectErrMsg: "\"distance\" must be a string",
+		},
 	}
 
 	for _, test := range tests {

--- a/entities/vectorindex/hfresh/config_test.go
+++ b/entities/vectorindex/hfresh/config_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/common/testinghelpers"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -331,17 +332,6 @@ func Test_UserConfig(t *testing.T) {
 			expectErr:    true,
 			expectErrMsg: "invalid hfresh config: maxPostingSizeKB is '1025' but must be less than 1024",
 		},
-		{
-			// Regression test: a `null` distance was previously silently accepted
-			// and resolved to the default distance metric instead of being
-			// rejected. See weaviate/weaviate#11732.
-			name: "with null distance",
-			input: map[string]interface{}{
-				"distance": nil,
-			},
-			expectErr:    true,
-			expectErrMsg: "\"distance\" must be a string",
-		},
 	}
 
 	for _, test := range tests {
@@ -357,4 +347,11 @@ func Test_UserConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("with null distance", func(t *testing.T) {
+		testinghelpers.AssertNullDistanceRejected(t, func(input map[string]interface{}) error {
+			_, err := ParseAndValidateConfig(input, false)
+			return err
+		})
+	})
 }

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -1126,6 +1126,18 @@ func Test_UserConfig(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			// Regression test: a `null` distance was previously silently accepted
+			// and resolved to the default distance metric instead of being
+			// rejected. See weaviate/weaviate#11732.
+			name: "with null distance",
+			input: map[string]interface{}{
+				"distance": nil,
+			},
+			expectErr:    true,
+			expectErrMsg: "\"distance\" must be a string",
+		},
 	}
 
 	for _, test := range tests {

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/common/testinghelpers"
 )
 
 func Test_UserConfig(t *testing.T) {
@@ -1126,18 +1127,6 @@ func Test_UserConfig(t *testing.T) {
 				},
 			},
 		},
-
-		{
-			// Regression test: a `null` distance was previously silently accepted
-			// and resolved to the default distance metric instead of being
-			// rejected. See weaviate/weaviate#11732.
-			name: "with null distance",
-			input: map[string]interface{}{
-				"distance": nil,
-			},
-			expectErr:    true,
-			expectErrMsg: "\"distance\" must be a string",
-		},
 	}
 
 	for _, test := range tests {
@@ -1153,6 +1142,13 @@ func Test_UserConfig(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("with null distance", func(t *testing.T) {
+		testinghelpers.AssertNullDistanceRejected(t, func(input map[string]interface{}) error {
+			_, err := ParseAndValidateConfig(input, false)
+			return err
+		})
+	})
 }
 
 func Test_ParseDefaultQuantization(t *testing.T) {


### PR DESCRIPTION
fixes #11732

### What's being changed:

`OptionalStringFromMap`, `OptionalBoolFromMap`, and `OptionalIntFromMap` (`entities/vectorindex/common/config.go`) all only checked whether a key was *present* in the decoded config map, not whether its value was actually the expected type. A JSON `null` produces a present map entry with a `nil` value, so `"distance": null` in a `vectorIndexConfig` passes the presence check (`value, ok := in[name]` → `ok == true`), fails the type assertion (`value.(string)` → `ok == false`), and silently falls through — leaving `Distance` at whatever `SetDefaults()` had already set it to (`"cosine"`), with no error:

```bash
curl -s -X POST http://localhost:8080/v1/schema -d '{
  "class": "TestClass", "vectorizer": "none",
  "vectorIndexConfig": {"distance": null}
}'
# Expected: 422
# Actual: 200 OK, distance silently becomes "cosine"
```

Any other wrong-typed value for these fields hits the same silent-fallthrough path — not just `null` specifically.

While fixing this, found `OptionalIntFromMap` has a related but distinct bug: its type switch has no `default` case, so an unmatched type leaves `asInt64` at its zero value and the function proceeds to call `setFn(0)` — silently *corrupting* an int field to `0` rather than just ignoring it, worse than the string/bool case's silent no-op.

### Fix

All three functions now return an error when the key is present but the value doesn't match the expected type (including `nil`), instead of silently defaulting/skipping/corrupting. Confirmed these three functions have no callers outside `entities/vectorindex/*` (grepped the whole repo), so the blast radius is fully covered by the tests added here.

### How was this tested?

- Reproduced the exact reported bug live against unpatched `main` first, via `hnsw.ParseAndValidateConfig(map[string]interface{}{"distance": nil}, false)` — confirmed `err == nil` and the parsed config resolved to `"cosine"`.
- Added a new `entities/vectorindex/common/config_test.go` (this package had no tests before) with direct table-driven unit tests for all three functions — valid values, key-absent, explicit `null`, and wrong-type cases.
- Added one regression test case per caller package (`hnsw`, `flat`, `dynamic`, `hfresh`) reproducing the exact `"distance": null` journey through each package's own `ParseAndValidateConfig`, since all four call the same shared function for this field.
- Confirmed all new/changed tests fail against unpatched `config.go` (`git stash`) with the expected error missing, and pass after the fix.
- `go test ./entities/vectorindex/...` — all packages pass, no regressions.
- `go build ./...` — clean.
- `golangci-lint run ./entities/vectorindex/...` — 0 issues.
- `gofmt -l` on all touched files — clean.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: N/A — this fixes an existing validation gap, no new documented behavior.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: Not necessary — pure input-validation change, no runtime/concurrency behavior touched.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not necessary — validation-only change on the schema-creation path, not a hot path.