### PR TITLE
Fixes bugs segment group tmp file recovery

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -201,11 +201,18 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 	// Note: it's important to process first the compacted segments
 	// TODO: a single iteration may be possible
 
+	// Sorted: adopting one .tmp adds and removes segments that decide how the next
+	// one is resolved, so a map range would recover the same directory
+	// differently on every start.
+	tmpEntries := make([]string, 0, len(files))
 	for entry := range files {
-		if filepath.Ext(entry) != ".tmp" {
-			continue
+		if filepath.Ext(entry) == ".tmp" {
+			tmpEntries = append(tmpEntries, entry)
 		}
+	}
+	slices.Sort(tmpEntries)
 
+	for _, entry := range tmpEntries {
 		potentialCompactedSegmentFileName := strings.TrimSuffix(entry, ".tmp")
 
 		if filepath.Ext(potentialCompactedSegmentFileName) != ".db" {
@@ -255,13 +262,13 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		}
 
 		if leftSegmentFound && !rightSegmentFound {
-			return nil, fmt.Errorf("missing right segment %q", rightSegmentFilename)
+			// a switch marks the left segment before the right one, so this state
+			// cannot come from an interrupted switch: the file is a leftover of a
+			// compaction that never switched, and the operator can delete it
+			return nil, fmt.Errorf("compacted segment %q has no right segment with id %s "+
+				"left to replace, delete the compacted segment to recover", entry, jointSegmentsIDs[1])
 		}
 
-		var rightSegmentMetadata *struct {
-			Level    uint16
-			Strategy segmentindex.Strategy
-		}
 		if !leftSegmentFound && rightSegmentFound {
 			// segment is initialized just to be erased
 			// there is no need of bloom filters nor net addition counter re-calculation
@@ -283,14 +290,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 				})
 			if err != nil {
 				return nil, fmt.Errorf("init already compacted right segment %s: %w", rightSegmentFilename, err)
-			}
-
-			rightSegmentMetadata = &struct {
-				Level    uint16
-				Strategy segmentindex.Strategy
-			}{
-				Level:    rightSegment.getLevel(),
-				Strategy: rightSegment.getStrategy(),
 			}
 
 			err = rightSegment.close()
@@ -318,7 +317,7 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 				return nil, fmt.Errorf("delete already compacted right segment %s: %w", rightSegmentFilename, err)
 			}
 			delete(files, rightSegmentFilename)
-			// the compacted segment is renamed to the same name below and would
+			// the compacted segment can take over the same name below and would
 			// otherwise try to load the derived files that were just deleted
 			for _, path := range rightSegment.sidecarPaths() {
 				delete(files, filepath.Base(path))
@@ -330,20 +329,20 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 			}
 		}
 
-		var newRightSegmentFileName string
-		if cfg.writeSegmentInfoIntoFileName && rightSegmentMetadata != nil {
-			newRightSegmentFileName = fmt.Sprintf("segment-%s%s.db", jointSegmentsIDs[1], segmentExtraInfo(rightSegmentMetadata.Level, rightSegmentMetadata.Strategy))
-		} else {
-			newRightSegmentFileName = fmt.Sprintf("segment-%s.db", jointSegmentsIDs[1])
+		// the same rename a completed switch would have done, which keeps whatever
+		// level and strategy the compaction wrote into the name
+		newRightSegmentPath, err := stripTmpExtension(filepath.Join(sg.dir, entry),
+			jointSegmentsIDs[0], jointSegmentsIDs[1])
+		if err != nil {
+			return nil, fmt.Errorf("adopt compacted segment %q: %w", entry, err)
 		}
-		newRightSegmentPath := filepath.Join(sg.dir, newRightSegmentFileName)
 
-		if err := os.Rename(filepath.Join(sg.dir, entry), newRightSegmentPath); err != nil {
-			return nil, fmt.Errorf("rename compacted segment file %q as %q: %w", entry, newRightSegmentFileName, err)
-		}
+		logger.WithField("action", "lsm_segment_init").
+			WithField("path", newRightSegmentPath).
+			Info("took over the segment of a compaction that was interrupted mid-switch")
 
 		// initialize in correct order in the next iteration
-		files[newRightSegmentFileName] = files[entry]
+		files[filepath.Base(newRightSegmentPath)] = files[entry]
 		delete(files, entry)
 	}
 

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -72,7 +72,10 @@ func TestCompactionCleanupBothSegmentsPresent(t *testing.T) {
 					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
 				)
 				if tt.expectErr {
-					require.Error(t, err)
+					// the only failing case is the missing right segment, which the
+					// operator can only act on if both files are named
+					require.ErrorContains(t, err, entriesTmp[1].Name())
+					require.ErrorContains(t, err, segmentID(entriesTmp[2].Name()))
 				} else {
 					require.NoError(t, err)
 					count, err := b2.Count(ctx)
@@ -90,6 +93,18 @@ func TestCompactionCleanupBothSegmentsPresent(t *testing.T) {
 						path := segment.getPath()
 						file := filepath.Base(path)
 						require.NotContains(t, file, "_")
+					}
+
+					if !tt.copyLeft {
+						// with the left source gone the combined file is taken over
+						// under the name the interrupted switch would have given it,
+						// level and strategy included
+						extraInfo := ""
+						if addFileInfo {
+							extraInfo = ".l1.s0"
+						}
+						require.FileExists(t, filepath.Join(testDir, fmt.Sprintf("segment-%s%s.db",
+							segmentID(entriesTmp[2].Name()), extraInfo)))
 					}
 				}
 			})
@@ -341,11 +356,76 @@ func TestCompactionRecoveryDropsRightSegmentDerivedFiles(t *testing.T) {
 				require.Equal(t, fmt.Sprintf("world%d", i), string(value))
 			}
 
+			// the adopted file keeps the level the compaction put into the .tmp
+			// name, which is not the level of the segment it replaces
+			require.Equal(t, fmt.Sprintf("segment-%s%s.db", rightID, extraInfo),
+				singleDbFile(t, testDir))
+
 			fileTypes := countFileTypes(t, testDir)
 			for _, ext := range []string{".bloom", ".cna", ".metadata"} {
 				require.Equal(t, tt.wantDerivedFiles[ext], fileTypes[ext], "number of %s files", ext)
 			}
 		})
+	}
+}
+
+// TestCompactionRecoveryOrdersLeftoverSegments pins that leftover compacted
+// segments are recovered in a fixed order: adopting one of them decides which
+// source segments the next one still finds.
+func TestCompactionRecoveryOrdersLeftoverSegments(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	opts := []BucketOption{WithStrategy(StrategyReplace), WithUseBloomFilter(false)}
+
+	srcDir := t.TempDir()
+	b, err := NewBucketCreator().NewBucket(ctx, srcDir, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+	require.NoError(t, err)
+
+	// three segments of different sizes, so that a segment replaced by another
+	// one is recognizable by its content
+	for _, keys := range []int{5, 10, 15} {
+		for i := range keys {
+			require.NoError(t, b.Put(fmt.Appendf(nil, "hello%d", i), fmt.Appendf(nil, "world%d", i)))
+		}
+		require.NoError(t, b.FlushMemtable())
+	}
+	require.Len(t, b.disk.segments, 3)
+
+	var ids []string
+	for _, seg := range b.disk.segments {
+		ids = append(ids, segmentID(filepath.Base(seg.getPath())))
+	}
+	require.NoError(t, b.Shutdown(ctx))
+
+	// two compactions were interrupted before their switch completed, the second
+	// one over the output of the first
+	fixtureDir := t.TempDir()
+	copyFile(t, filepath.Join(srcDir, "segment-"+ids[0]+".db"),
+		filepath.Join(fixtureDir, fmt.Sprintf("segment-%s_%s.db.tmp", ids[0], ids[1])))
+	copyFile(t, filepath.Join(srcDir, "segment-"+ids[1]+".db"),
+		filepath.Join(fixtureDir, fmt.Sprintf("segment-%s_%s.db.tmp", ids[1], ids[2])))
+	copyFile(t, filepath.Join(srcDir, "segment-"+ids[2]+".db"),
+		filepath.Join(fixtureDir, "segment-"+ids[2]+".db"))
+
+	newest, err := os.ReadFile(filepath.Join(fixtureDir, "segment-"+ids[2]+".db"))
+	require.NoError(t, err)
+
+	// a single run could pick the right order by chance
+	const runs = 20
+	for range runs {
+		testDir := t.TempDir()
+		copyFilesWithPrefix(t, fixtureDir, testDir, "segment-")
+
+		b2, err := NewBucketCreator().NewBucket(ctx, testDir, "", logger, nil,
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		require.NoError(t, err)
+
+		recovered, err := os.ReadFile(filepath.Join(testDir, "segment-"+ids[2]+".db"))
+		require.NoError(t, err)
+		require.Equal(t, newest, recovered, "the newest segment must not be replaced")
+		require.NoError(t, b2.Shutdown(ctx))
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

Fixes two problems:
- with multiple tmp files the order was not deterministic between restarts
- adopted segment got the wrong level written into its filename.
- error with too little information

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
