### PR TITLE
Backup buffered pipe

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -757,7 +757,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	appState.RemoteNodeIncoming = sharding.NewRemoteNodeIncoming(repo)
 
 	backupManager := backup.NewHandler(appState.Logger, appState.ServerConfig.Config.Backup, appState.Authorizer,
-		schemaManager, repo, appState.Modules, appState.RBAC, appState.APIKey.Dynamic)
+		schemaManager, repo, appState.Modules, appState.RBAC, appState.APIKey.Dynamic, appState.MemWatch)
 	appState.BackupManager = backupManager
 
 	// Create export participant early so the cluster API server can register it

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -654,7 +654,7 @@ func backupWithSizes(
 
 		for {
 			var buf bytes.Buffer
-			z, rc, err := backupUC.NewZip(effectivePath, int(backupUC.NoCompression), chunkSize, 0, splitFileSize)
+			z, rc, err := backupUC.NewZip(effectivePath, int(backupUC.NoCompression), chunkSize, 0, splitFileSize, 0) // 0 = default pipe buffer
 			require.NoError(t, err)
 
 			type writeResult struct {

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -636,6 +636,9 @@ func backupWithSizes(
 		effectivePath = classDescs[0].StagingDir
 	}
 
+	// Any positive size works; the reader drains concurrently.
+	const pipeBufferSize = 1 << 20
+
 	var result backupChunkResult
 
 	for _, sd := range classDescs[0].Shards {
@@ -654,7 +657,7 @@ func backupWithSizes(
 
 		for {
 			var buf bytes.Buffer
-			z, rc, err := backupUC.NewZip(effectivePath, int(backupUC.NoCompression), chunkSize, 0, splitFileSize, 0) // 0 = default pipe buffer
+			z, rc, err := backupUC.NewZip(effectivePath, int(backupUC.NoCompression), chunkSize, 0, splitFileSize, pipeBufferSize)
 			require.NoError(t, err)
 
 			type writeResult struct {

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -167,7 +167,7 @@ func (n *node) init(t *testing.T, dirName string, allNodes *[]*node, shardingSta
 
 	backendProvider := newFakeBackupBackendProvider(localDir)
 	n.backupManager = ubak.NewHandler(
-		logger, config.Backup{}, &fakeAuthorizer{}, n.schemaManager, n.repo, backendProvider, fakeRbacBackupWrapper{}, fakeDynUserBackupWrapper{},
+		logger, config.Backup{}, &fakeAuthorizer{}, n.schemaManager, n.repo, backendProvider, fakeRbacBackupWrapper{}, fakeDynUserBackupWrapper{}, memwatch.NewDummyMonitor(),
 	)
 
 	backupClient := clients.NewClusterBackups(&http.Client{})

--- a/entities/concurrency/bufferedpipe/bufferedpipe.go
+++ b/entities/concurrency/bufferedpipe/bufferedpipe.go
@@ -9,7 +9,7 @@
 //  CONTACT: hello@weaviate.io
 //
 
-package export
+package bufferedpipe
 
 import (
 	"fmt"
@@ -18,29 +18,32 @@ import (
 	"sync/atomic"
 )
 
-const defaultPipeBufferSize = 16 * 1024 * 1024 // 16 MB per range pipeline
-
-// bufferedPipe is a bounded, in-memory pipe that decouples a writer (scan
-// side) from a reader (upload side). Unlike io.Pipe, writes do not block
-// until the reader consumes them — they block only when the internal buffer
-// reaches its capacity. This prevents slow uploads from holding LSM cursors
-// open.
+// pipe is a bounded, in-memory pipe that decouples a writer from a reader.
+// Writes block only once the internal buffer reaches its capacity, not until
+// the reader consumes them, so a slow reader does not stall the writer while
+// there is still buffer space.
 //
 // The buffer is a FIFO queue of byte-slice chunks. Each Write call appends
-// one chunk; each Read call dequeues from the head.
+// one chunk; each Read call dequeues from the head. A pipe holds at most
+// maxSize bytes, so a caller running N pipes concurrently must budget
+// N * maxSize of memory.
 //
 // maxSize is a soft limit. Write only blocks once buffered >= maxSize, so a
 // single Write larger than maxSize is accepted and pushes buffered past the
 // limit by one chunk. This is intentional: rejecting or splitting such a
 // write would either deadlock (no reader can drain a chunk that was never
 // enqueued) or require the writer to hand back partial progress, which
-// io.Writer semantics do not express cleanly. In practice chunks are
-// bounded by the LSM scan emit size, which is well below maxSize.
+// io.Writer semantics do not express cleanly.
 //
-// Thread safety: all methods are safe for concurrent use by one writer
-// goroutine and one reader goroutine. Using multiple concurrent writers or
-// multiple concurrent readers is not supported and will return an error.
-type bufferedPipe struct {
+// A writer error only surfaces to the reader once the buffered bytes have
+// been drained, so already-buffered data reaches the reader before the error.
+//
+// Thread safety: all methods are safe for concurrent use as long as at most
+// one Write and one Read are in flight at a time. A second concurrent Write
+// or Read returns an error rather than corrupting the queue. Close and
+// CloseWithError may be called from any goroutine, including while a Write
+// or Read is blocked.
+type pipe struct {
 	mu   sync.Mutex
 	cond *sync.Cond
 
@@ -48,24 +51,23 @@ type bufferedPipe struct {
 	buffered int      // total bytes currently in chunks
 	maxSize  int      // capacity in bytes
 
-	writerClosed bool  // writer has called CloseWriter
-	writerErr    error // error passed to CloseWriter
+	writerClosed bool  // writer has called Close or CloseWithError
+	writerErr    error // error passed to CloseWithError (writer side)
 
 	readerClosed bool  // reader has called Close or CloseWithError
 	readerErr    error // error passed to CloseWithError (reader side)
 }
 
-// bufferedPipeWriter is the write half of a bufferedPipe. It implements
-// io.WriteCloser.
-type bufferedPipeWriter struct {
-	p      *bufferedPipe
+// Writer is the write half of a pipe. It implements io.WriteCloser.
+type Writer struct {
+	p      *pipe
 	active atomic.Int32 // guards against concurrent writers
 }
 
-// bufferedPipeReader is the read half of a bufferedPipe. It implements
-// io.ReadCloser and backup.ReadCloserWithError.
-type bufferedPipeReader struct {
-	p      *bufferedPipe
+// Reader is the read half of a pipe. It implements io.ReadCloser and adds
+// CloseWithError.
+type Reader struct {
+	p      *pipe
 	active atomic.Int32 // guards against concurrent readers
 
 	// partial holds leftover bytes from a chunk that was larger than the
@@ -73,19 +75,21 @@ type bufferedPipeReader struct {
 	partial []byte
 }
 
-func newBufferedPipe(maxSize int) (*bufferedPipeReader, *bufferedPipeWriter) {
-	p := &bufferedPipe{maxSize: maxSize}
+// New returns the two halves of a pipe buffering up to maxSize bytes. A
+// maxSize of zero or less leaves the buffer unbounded.
+func New(maxSize int) (*Reader, *Writer) {
+	p := &pipe{maxSize: maxSize}
 	p.cond = sync.NewCond(&p.mu)
-	return &bufferedPipeReader{p: p}, &bufferedPipeWriter{p: p}
+	return &Reader{p: p}, &Writer{p: p}
 }
 
 // Write appends a copy of b to the buffer. It blocks when the buffer is
 // full, and returns an error if the reader has closed with an error.
 // Write must not be called after Close or CloseWithError.
-func (w *bufferedPipeWriter) Write(b []byte) (int, error) {
+func (w *Writer) Write(b []byte) (int, error) {
 	if v := w.active.Add(1); v != 1 {
 		w.active.Add(-1)
-		return 0, fmt.Errorf("bufferedPipeWriter: concurrent Write calls are not supported")
+		return 0, fmt.Errorf("bufferedpipe: concurrent Write calls are not supported")
 	}
 	defer w.active.Add(-1)
 
@@ -97,11 +101,13 @@ func (w *bufferedPipeWriter) Write(b []byte) (int, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if p.writerClosed {
-		return 0, io.ErrClosedPipe
-	}
-
 	for {
+		// Checked inside the loop so closing either half releases a Write
+		// that is already blocked on a full buffer.
+		if p.writerClosed {
+			return 0, io.ErrClosedPipe
+		}
+
 		if p.readerClosed {
 			if p.readerErr != nil {
 				return 0, p.readerErr
@@ -128,14 +134,14 @@ func (w *bufferedPipeWriter) Write(b []byte) (int, error) {
 }
 
 // Close signals that no more data will be written (EOF on reader side).
-func (w *bufferedPipeWriter) Close() error {
+func (w *Writer) Close() error {
 	return w.CloseWithError(nil)
 }
 
 // CloseWithError signals that no more data will be written. If err is
 // non-nil, subsequent reads will return err after the buffer is drained.
 // If err is nil, reads return io.EOF after the buffer is drained.
-func (w *bufferedPipeWriter) CloseWithError(err error) error {
+func (w *Writer) CloseWithError(err error) error {
 	p := w.p
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -152,10 +158,10 @@ func (w *bufferedPipeWriter) CloseWithError(err error) error {
 // and the writer has not yet closed. After the reader has been closed via
 // Close or CloseWithError, Read returns io.ErrClosedPipe (matching
 // io.PipeReader behavior).
-func (r *bufferedPipeReader) Read(b []byte) (int, error) {
+func (r *Reader) Read(b []byte) (int, error) {
 	if v := r.active.Add(1); v != 1 {
 		r.active.Add(-1)
-		return 0, fmt.Errorf("bufferedPipeReader: concurrent Read calls are not supported")
+		return 0, fmt.Errorf("bufferedpipe: concurrent Read calls are not supported")
 	}
 	defer r.active.Add(-1)
 
@@ -166,9 +172,8 @@ func (r *bufferedPipeReader) Read(b []byte) (int, error) {
 	p := r.p
 	p.mu.Lock()
 
-	// After the reader is closed, discard any buffered data and return
-	// immediately. This matches io.PipeReader: closing the reader aborts
-	// in-progress reads.
+	// A closed reader discards buffered data and aborts in-progress reads,
+	// matching io.PipeReader.
 	if p.readerClosed {
 		p.mu.Unlock()
 		r.partial = nil
@@ -222,13 +227,13 @@ func (r *bufferedPipeReader) Read(b []byte) (int, error) {
 
 // Close closes the reader. Pending and subsequent writes return
 // io.ErrClosedPipe.
-func (r *bufferedPipeReader) Close() error {
+func (r *Reader) Close() error {
 	return r.CloseWithError(nil)
 }
 
 // CloseWithError closes the reader with an error. Pending and subsequent
 // writes return err (or io.ErrClosedPipe if err is nil).
-func (r *bufferedPipeReader) CloseWithError(err error) error {
+func (r *Reader) CloseWithError(err error) error {
 	p := r.p
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/entities/concurrency/bufferedpipe/bufferedpipe.go
+++ b/entities/concurrency/bufferedpipe/bufferedpipe.go
@@ -18,22 +18,31 @@ import (
 	"sync/atomic"
 )
 
+// Unbounded lets a pipe buffer without limit. It is an explicit opt-out of
+// the memory bound: New rejects every other non-positive size, so a zero
+// value cannot select it by accident.
+const Unbounded = -1
+
 // pipe is a bounded, in-memory pipe that decouples a writer from a reader.
 // Writes block only once the internal buffer reaches its capacity, not until
 // the reader consumes them, so a slow reader does not stall the writer while
 // there is still buffer space.
 //
 // The buffer is a FIFO queue of byte-slice chunks. Each Write call appends
-// one chunk; each Read call dequeues from the head. A pipe holds at most
-// maxSize bytes, so a caller running N pipes concurrently must budget
-// N * maxSize of memory.
+// one chunk; each Read call dequeues from the head.
 //
-// maxSize is a soft limit. Write only blocks once buffered >= maxSize, so a
-// single Write larger than maxSize is accepted and pushes buffered past the
-// limit by one chunk. This is intentional: rejecting or splitting such a
-// write would either deadlock (no reader can drain a chunk that was never
-// enqueued) or require the writer to hand back partial progress, which
-// io.Writer semantics do not express cleanly.
+// maxSize is a soft limit: a pipe retains up to maxSize plus two chunks, so a
+// caller running N pipes concurrently must budget N * (maxSize + 2*largest
+// write). One chunk over because Write only blocks once buffered >= maxSize,
+// so a single write is always accepted whole, even one larger than maxSize.
+// The second because Read subtracts a whole chunk from buffered while keeping
+// the unread tail in Reader.partial, which lets the writer refill to maxSize
+// before that tail is consumed.
+//
+// Accepting an oversized write is intentional: rejecting or splitting it
+// would either deadlock (no reader can drain a chunk that was never enqueued)
+// or require the writer to hand back partial progress, which io.Writer
+// semantics do not express cleanly.
 //
 // A writer error only surfaces to the reader once the buffered bytes have
 // been drained, so already-buffered data reaches the reader before the error.
@@ -49,7 +58,7 @@ type pipe struct {
 
 	chunks   [][]byte // FIFO queue of byte chunks
 	buffered int      // total bytes currently in chunks
-	maxSize  int      // capacity in bytes
+	maxSize  int      // capacity in bytes, or Unbounded
 
 	writerClosed bool  // writer has called Close or CloseWithError
 	writerErr    error // error passed to CloseWithError (writer side)
@@ -75,9 +84,14 @@ type Reader struct {
 	partial []byte
 }
 
-// New returns the two halves of a pipe buffering up to maxSize bytes. A
-// maxSize of zero or less leaves the buffer unbounded.
+// New returns the two halves of a pipe buffering up to maxSize bytes, or
+// Unbounded for no limit. maxSize is a soft limit: a pipe retains up to
+// maxSize plus two chunks. It panics on any other non-positive size, since a
+// zero-capacity pipe would block on its first write forever.
 func New(maxSize int) (*Reader, *Writer) {
+	if maxSize <= 0 && maxSize != Unbounded {
+		panic(fmt.Sprintf("bufferedpipe: maxSize must be positive or Unbounded, got %d", maxSize))
+	}
 	p := &pipe{maxSize: maxSize}
 	p.cond = sync.NewCond(&p.mu)
 	return &Reader{p: p}, &Writer{p: p}
@@ -115,7 +129,7 @@ func (w *Writer) Write(b []byte) (int, error) {
 			return 0, io.ErrClosedPipe
 		}
 
-		if p.buffered < p.maxSize || p.maxSize <= 0 {
+		if p.maxSize == Unbounded || p.buffered < p.maxSize {
 			break
 		}
 

--- a/entities/concurrency/bufferedpipe/bufferedpipe_test.go
+++ b/entities/concurrency/bufferedpipe/bufferedpipe_test.go
@@ -9,7 +9,7 @@
 //  CONTACT: hello@weaviate.io
 //
 
-package export
+package bufferedpipe
 
 import (
 	"bytes"
@@ -25,11 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBufferedPipe_ReadWrite(t *testing.T) {
+func TestReadWrite(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name     string
+		maxSize  int
 		writes   []string // data chunks to write
 		readSize int      // 0 means use io.ReadAll
 		expected string   // expected concatenated output
@@ -60,13 +61,29 @@ func TestBufferedPipe_ReadWrite(t *testing.T) {
 			readSize: 3,
 			expected: "0123456789",
 		},
+		{
+			name:     "write larger than maxSize overshoots the soft limit",
+			maxSize:  4,
+			writes:   []string{"much longer than the buffer capacity"},
+			expected: "much longer than the buffer capacity",
+		},
+		{
+			name:     "unbounded buffer accepts everything",
+			maxSize:  -1,
+			writes:   []string{"a", "b", "c"},
+			expected: "abc",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			pr, pw := newBufferedPipe(1024)
+			maxSize := tc.maxSize
+			if maxSize == 0 {
+				maxSize = 1024
+			}
+			pr, pw := New(maxSize)
 
 			for _, chunk := range tc.writes {
 				_, err := pw.Write([]byte(chunk))
@@ -95,19 +112,19 @@ func TestBufferedPipe_ReadWrite(t *testing.T) {
 	}
 }
 
-func TestBufferedPipe_CloseErrors(t *testing.T) {
+func TestCloseErrors(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name      string
-		setup     func(pr *bufferedPipeReader, pw *bufferedPipeWriter)
+		setup     func(pr *Reader, pw *Writer)
 		op        string // "read" or "write"
 		wantErr   error  // nil means check with Contains
 		errSubstr string // used when wantErr is nil
 	}{
 		{
 			name: "write after reader close returns ErrClosedPipe",
-			setup: func(pr *bufferedPipeReader, _ *bufferedPipeWriter) {
+			setup: func(pr *Reader, _ *Writer) {
 				pr.Close()
 			},
 			op:      "write",
@@ -115,7 +132,7 @@ func TestBufferedPipe_CloseErrors(t *testing.T) {
 		},
 		{
 			name: "write after reader close with error returns that error",
-			setup: func(pr *bufferedPipeReader, _ *bufferedPipeWriter) {
+			setup: func(pr *Reader, _ *Writer) {
 				pr.CloseWithError(fmt.Errorf("upload aborted"))
 			},
 			op:        "write",
@@ -123,7 +140,7 @@ func TestBufferedPipe_CloseErrors(t *testing.T) {
 		},
 		{
 			name: "read after reader close returns ErrClosedPipe",
-			setup: func(pr *bufferedPipeReader, pw *bufferedPipeWriter) {
+			setup: func(pr *Reader, pw *Writer) {
 				pw.Write([]byte("buffered data"))
 				pr.Close()
 			},
@@ -132,7 +149,7 @@ func TestBufferedPipe_CloseErrors(t *testing.T) {
 		},
 		{
 			name: "write after writer close returns ErrClosedPipe",
-			setup: func(_ *bufferedPipeReader, pw *bufferedPipeWriter) {
+			setup: func(_ *Reader, pw *Writer) {
 				pw.Close()
 			},
 			op:      "write",
@@ -140,11 +157,30 @@ func TestBufferedPipe_CloseErrors(t *testing.T) {
 		},
 		{
 			name: "read after writer close with error returns that error",
-			setup: func(_ *bufferedPipeReader, pw *bufferedPipeWriter) {
+			setup: func(_ *Reader, pw *Writer) {
 				pw.CloseWithError(fmt.Errorf("scan failed"))
 			},
 			op:        "read",
 			errSubstr: "scan failed",
+		},
+		{
+			name: "repeated close keeps the first error",
+			setup: func(_ *Reader, pw *Writer) {
+				pw.CloseWithError(fmt.Errorf("scan failed"))
+				pw.Close()
+				pw.CloseWithError(fmt.Errorf("second error"))
+			},
+			op:        "read",
+			errSubstr: "scan failed",
+		},
+		{
+			name: "repeated reader close keeps the first error",
+			setup: func(pr *Reader, _ *Writer) {
+				pr.CloseWithError(fmt.Errorf("upload aborted"))
+				pr.Close()
+			},
+			op:        "write",
+			errSubstr: "upload aborted",
 		},
 	}
 
@@ -152,7 +188,7 @@ func TestBufferedPipe_CloseErrors(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			pr, pw := newBufferedPipe(1024)
+			pr, pw := New(1024)
 			tc.setup(pr, pw)
 
 			var err error
@@ -177,10 +213,10 @@ func TestBufferedPipe_CloseErrors(t *testing.T) {
 	}
 }
 
-func TestBufferedPipe_WriterCloseWithErrorDrainsBufferFirst(t *testing.T) {
+func TestWriterCloseWithErrorDrainsBufferFirst(t *testing.T) {
 	t.Parallel()
 
-	pr, pw := newBufferedPipe(1024)
+	pr, pw := New(1024)
 
 	_, err := pw.Write([]byte("some data"))
 	require.NoError(t, err)
@@ -199,13 +235,13 @@ func TestBufferedPipe_WriterCloseWithErrorDrainsBufferFirst(t *testing.T) {
 	require.ErrorIs(t, err, scanErr)
 }
 
-func TestBufferedPipe_ConcurrentReadWrite(t *testing.T) {
+func TestConcurrentReadWrite(t *testing.T) {
 	t.Parallel()
 
 	const totalBytes = 1024 * 1024 // 1 MB
 	const chunkSize = 4096
 
-	pr, pw := newBufferedPipe(32 * 1024) // 32 KB buffer — much smaller than total data
+	pr, pw := New(32 * 1024) // 32 KB buffer — much smaller than total data
 
 	data := make([]byte, totalBytes)
 	_, err := rand.Read(data)
@@ -234,10 +270,10 @@ func TestBufferedPipe_ConcurrentReadWrite(t *testing.T) {
 	assert.Equal(t, data, out)
 }
 
-func TestBufferedPipe_WriterUnblocksAfterDrain(t *testing.T) {
+func TestWriterUnblocksAfterDrain(t *testing.T) {
 	t.Parallel()
 
-	pr, pw := newBufferedPipe(100)
+	pr, pw := New(100)
 
 	// Fill the buffer.
 	_, err := pw.Write(make([]byte, 100))
@@ -265,38 +301,68 @@ func TestBufferedPipe_WriterUnblocksAfterDrain(t *testing.T) {
 	pr.Close()
 }
 
-func TestBufferedPipe_ReaderCloseUnblocksWriter(t *testing.T) {
+// Closing either half must release a Write that is already blocked on a full
+// buffer, otherwise the writer waits for a drain that will never come.
+func TestCloseUnblocksBlockedWriter(t *testing.T) {
 	t.Parallel()
 
-	pr, pw := newBufferedPipe(100)
+	tests := []struct {
+		name      string
+		close     func(pr *Reader, pw *Writer)
+		errSubstr string
+	}{
+		{
+			name:      "reader close with error",
+			close:     func(pr *Reader, _ *Writer) { pr.CloseWithError(fmt.Errorf("reader aborted")) },
+			errSubstr: "reader aborted",
+		},
+		{
+			name:      "writer close",
+			close:     func(_ *Reader, pw *Writer) { pw.Close() },
+			errSubstr: io.ErrClosedPipe.Error(),
+		},
+	}
 
-	_, err := pw.Write(make([]byte, 100))
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	writeDone := make(chan error, 1)
-	go func() {
-		_, err := pw.Write([]byte("more"))
-		writeDone <- err
-	}()
+			pr, pw := New(100)
 
-	pr.CloseWithError(fmt.Errorf("reader aborted"))
+			_, err := pw.Write(make([]byte, 100))
+			require.NoError(t, err)
 
-	select {
-	case err := <-writeDone:
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "reader aborted")
-	case <-time.After(time.Second):
-		t.Fatal("Write did not unblock after reader closed")
+			writeDone := make(chan error, 1)
+			started := make(chan struct{})
+			go func() {
+				close(started)
+				_, err := pw.Write([]byte("more"))
+				writeDone <- err
+			}()
+
+			// Let the Write reach its wait, so the close has to wake it
+			// rather than being seen by the guard on the way in.
+			<-started
+			time.Sleep(50 * time.Millisecond)
+			tc.close(pr, pw)
+
+			select {
+			case err := <-writeDone:
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errSubstr)
+			case <-time.After(time.Second):
+				t.Fatal("Write did not unblock after close")
+			}
+		})
 	}
 }
 
-func TestBufferedPipe_ReaderCloseUnblocksUpload(t *testing.T) {
+func TestReaderCloseUnblocksBlockedRead(t *testing.T) {
 	t.Parallel()
 
-	// Use a zero-capacity buffer so the reader blocks immediately on the
-	// first Read (no data to drain first). Writer is never closed, so the
-	// only way for Read to return is via pr.Close().
-	pr, pw := newBufferedPipe(1024)
+	// The writer is never closed, so the only way for a Read on the empty
+	// buffer to return is via pr.Close().
+	pr, pw := New(1024)
 
 	readDone := make(chan error, 1)
 	go func() {
@@ -305,7 +371,6 @@ func TestBufferedPipe_ReaderCloseUnblocksUpload(t *testing.T) {
 		readDone <- err
 	}()
 
-	// Close the reader — must unblock the blocked Read.
 	pr.Close()
 
 	select {
@@ -319,11 +384,11 @@ func TestBufferedPipe_ReaderCloseUnblocksUpload(t *testing.T) {
 	pw.Close()
 }
 
-func TestBufferedPipe_LargeDataIntegrity(t *testing.T) {
+func TestLargeDataIntegrity(t *testing.T) {
 	t.Parallel()
 
-	const totalBytes = 10 * 1024 * 1024   // 10 MB
-	pr, pw := newBufferedPipe(256 * 1024) // 256 KB buffer
+	const totalBytes = 10 * 1024 * 1024 // 10 MB
+	pr, pw := New(256 * 1024)           // 256 KB buffer
 
 	data := make([]byte, totalBytes)
 	_, err := rand.Read(data)

--- a/entities/concurrency/bufferedpipe/bufferedpipe_test.go
+++ b/entities/concurrency/bufferedpipe/bufferedpipe_test.go
@@ -69,7 +69,7 @@ func TestReadWrite(t *testing.T) {
 		},
 		{
 			name:     "unbounded buffer accepts everything",
-			maxSize:  -1,
+			maxSize:  Unbounded,
 			writes:   []string{"a", "b", "c"},
 			expected: "abc",
 		},
@@ -418,4 +418,86 @@ func TestLargeDataIntegrity(t *testing.T) {
 	wg.Wait()
 
 	assert.Equal(t, data, out.Bytes())
+}
+
+// Unbounded is the one way to opt out of the memory bound. A zero value must
+// not reach it, or a caller who forgets to size its pipe gets the unlimited
+// buffering its memory budget exists to prevent.
+func TestNewRejectsInvalidSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		maxSize   int
+		wantPanic bool
+	}{
+		{name: "zero value", maxSize: 0, wantPanic: true},
+		{name: "negative other than Unbounded", maxSize: -2, wantPanic: true},
+		{name: "Unbounded opts out explicitly", maxSize: Unbounded},
+		{name: "smallest positive size", maxSize: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.wantPanic {
+				require.Panics(t, func() { New(tt.maxSize) })
+				return
+			}
+			pr, pw := New(tt.maxSize)
+			require.NoError(t, pw.Close())
+			require.NoError(t, pr.Close())
+		})
+	}
+}
+
+// A pipe retains more than maxSize, so callers budgeting memory need the real
+// bound: maxSize plus one accepted-whole write plus one unread tail.
+func TestWorstCaseRetention(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		maxSize int
+		largest int // largest single write the producer makes
+	}{
+		{name: "writes larger than the buffer", maxSize: 100, largest: 150},
+		{name: "writes smaller than the buffer", maxSize: 1024, largest: 128},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pr, pw := New(tt.maxSize)
+
+			// Leave an unread tail in the reader: buffered drops by the whole
+			// chunk while partial still holds most of it.
+			_, err := pw.Write(make([]byte, tt.largest))
+			require.NoError(t, err)
+			n, err := pr.Read(make([]byte, 1))
+			require.NoError(t, err)
+			require.Equal(t, 1, n)
+			require.Len(t, pr.partial, tt.largest-1)
+			require.Zero(t, pr.p.buffered)
+
+			// Refill to one byte below the limit, which still admits a write.
+			for remaining := tt.maxSize - 1; remaining > 0; {
+				sz := min(remaining, tt.largest)
+				_, err := pw.Write(make([]byte, sz))
+				require.NoError(t, err)
+				remaining -= sz
+			}
+			_, err = pw.Write(make([]byte, tt.largest))
+			require.NoError(t, err)
+
+			retained := pr.p.buffered + len(pr.partial)
+			require.Equal(t, tt.maxSize+2*tt.largest-2, retained)
+			require.Greater(t, retained, tt.maxSize)
+
+			require.NoError(t, pw.Close())
+			require.NoError(t, pr.Close())
+		})
+	}
 }

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -34,6 +34,7 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -217,12 +218,15 @@ type uploader struct {
 	backend  nodeStore
 	backupID string
 	zipConfig
-	setStatus func(st backup.Status)
-	log       logrus.FieldLogger
+	setStatus    func(st backup.Status)
+	log          logrus.FieldLogger
+	allocChecker memwatch.AllocChecker
+	// set per class before its workers start
+	pipeBufferSize int
 }
 
 func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer fsm.Snapshotter, dynUserSourcer dynUserSnapshotter, users []string, backend nodeStore,
-	backupID string, setstatus func(st backup.Status), l logrus.FieldLogger,
+	backupID string, setstatus func(st backup.Status), l logrus.FieldLogger, allocChecker memwatch.AllocChecker,
 ) *uploader {
 	return &uploader{
 		cfg:            cfg,
@@ -236,8 +240,9 @@ func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer fsm.Snapshotter
 			Level:         GzipDefaultCompression,
 			CPUPercentage: DefaultCPUPercentage,
 		}),
-		setStatus: setstatus,
-		log:       l,
+		setStatus:    setstatus,
+		log:          l,
+		allocChecker: allocChecker,
 	}
 }
 
@@ -425,6 +430,19 @@ func (u *uploader) class(ctx context.Context, id string, desc *backup.ClassDescr
 	if nWorker > nShards {
 		nWorker = nShards
 	}
+	u.pipeBufferSize = affordablePipeBufferSize(u.allocChecker, nWorker)
+	logFields := logrus.Fields{
+		"action":           "upload_class",
+		"class":            desc.Name,
+		"workers":          nWorker,
+		"pipe_buffer_size": u.pipeBufferSize,
+	}
+	if u.pipeBufferSize < maxPipeBufferSize {
+		u.log.WithFields(logFields).Warn("not enough memory for full-size backup pipe buffers, " +
+			"backing off; compression and upload will overlap less")
+	} else {
+		u.log.WithFields(logFields).Debug("backup pipe buffers sized")
+	}
 
 	// jobs produces work for the processor
 	jobs := func(xs []*backup.ShardDescriptor) <-chan *backup.ShardDescriptor {
@@ -547,7 +565,7 @@ func (u *uploader) compress(ctx context.Context,
 	// chunkTargetSize controls the max size when packing small files together; it must be at least bigFilesThreshold.
 	bigFilesThreshold := max(u.cfg.MinChunkSize, filesInShard.BigFilesThreshold)
 	chunkTargetSize := max(u.cfg.ChunkTargetSize, bigFilesThreshold)
-	zip, reader, err := NewZip(sourcePath, u.Level, chunkTargetSize, bigFilesThreshold, u.cfg.SplitFileSize)
+	zip, reader, err := NewZip(sourcePath, u.Level, chunkTargetSize, bigFilesThreshold, u.cfg.SplitFileSize, u.pipeBufferSize)
 	if err != nil {
 		return nil, preCompressionSize.Load(), err
 	}

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -221,7 +221,7 @@ type uploader struct {
 	setStatus    func(st backup.Status)
 	log          logrus.FieldLogger
 	allocChecker memwatch.AllocChecker
-	// set per class before its workers start
+	// set per class before its workers start; must be positive
 	pipeBufferSize int
 }
 

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -505,7 +505,8 @@ func TestProcessShard(t *testing.T) {
 					Level:      int(NoCompression),
 					GoPoolSize: 1,
 				},
-				log: logrus.New(),
+				log:            logrus.New(),
+				pipeBufferSize: maxPipeBufferSize,
 			}
 
 			var lastChunk atomic.Int32
@@ -604,8 +605,9 @@ func TestProcessShard(t *testing.T) {
 			backend: nodeStore{
 				objectStore: objectStore{backend: mockBackend},
 			},
-			zipConfig: zipConfig{Level: int(NoCompression), GoPoolSize: 1},
-			log:       logrus.New(),
+			zipConfig:      zipConfig{Level: int(NoCompression), GoPoolSize: 1},
+			log:            logrus.New(),
+			pipeBufferSize: maxPipeBufferSize,
 		}
 
 		var lastChunk atomic.Int32
@@ -726,8 +728,9 @@ func TestProcessShardEvenSplitSizes(t *testing.T) {
 				backend: nodeStore{
 					objectStore: objectStore{backend: mockBackend},
 				},
-				zipConfig: zipConfig{Level: int(NoCompression), GoPoolSize: 1},
-				log:       logrus.New(),
+				zipConfig:      zipConfig{Level: int(NoCompression), GoPoolSize: 1},
+				log:            logrus.New(),
+				pipeBufferSize: maxPipeBufferSize,
 			}
 
 			var lastChunk atomic.Int32
@@ -1168,8 +1171,9 @@ func (e *incrementalTestEnv) backup(backupID string, shardDescs []*backup.ShardD
 				backupId: backupID + "/node1",
 			},
 		},
-		zipConfig: zipConfig{Level: int(NoCompression), GoPoolSize: 1},
-		log:       logrus.New(),
+		zipConfig:      zipConfig{Level: int(NoCompression), GoPoolSize: 1},
+		log:            logrus.New(),
+		pipeBufferSize: maxPipeBufferSize,
 	}
 
 	var lastChunk atomic.Int32

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 type backupper struct {
@@ -33,11 +34,13 @@ type backupper struct {
 	rbacSourcer    fsm.Snapshotter
 	dynUserSourcer dynUserSnapshotter
 	backends       BackupBackendProvider
+	allocChecker   memwatch.AllocChecker
 	// shardCoordinationChan is sync and coordinate operations
 	shardSyncChan
 }
 
 func newBackupper(node string, logger logrus.FieldLogger, cfg config.Backup, sourcer Sourcer, rbacSourcer fsm.Snapshotter, dynUserSourcer dynUserSnapshotter, backends BackupBackendProvider,
+	allocChecker memwatch.AllocChecker,
 ) *backupper {
 	return &backupper{
 		node:           node,
@@ -48,6 +51,7 @@ func newBackupper(node string, logger logrus.FieldLogger, cfg config.Backup, sou
 		dynUserSourcer: dynUserSourcer,
 		backends:       backends,
 		shardSyncChan:  shardSyncChan{coordChan: make(chan interface{}, 5)},
+		allocChecker:   allocChecker,
 	}
 }
 
@@ -114,7 +118,7 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 			return
 		}
 
-		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, req.Users, store, req.ID, b.lastOp.set, b.logger).
+		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, req.Users, store, req.ID, b.lastOp.set, b.logger, b.allocChecker).
 			withCompression(newZipConfig(req.Compression))
 
 		compressionType, err := CompressionTypeFromLevel(req.Level)

--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 const (
@@ -450,7 +451,7 @@ func createManager(sourcer Sourcer, schema schemaManger, backend modulecapabilit
 	}
 
 	logger, _ := test.NewNullLogger()
-	return NewHandler(logger, config.Backup{}, mocks.NewMockAuthorizer(), schema, sourcer, backends, fakeRbacBackupWrapper{}, fakeDynUserBackupWrapper{})
+	return NewHandler(logger, config.Backup{}, mocks.NewMockAuthorizer(), schema, sourcer, backends, fakeRbacBackupWrapper{}, fakeDynUserBackupWrapper{}, memwatch.NewDummyMonitor())
 }
 
 type fakeRbacBackupWrapper struct{}

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 // classifyCanCommitErr maps a free-form canCommit error to a
@@ -194,6 +195,7 @@ func NewHandler(
 	backends BackupBackendProvider,
 	rbacSourcer fsm.Snapshotter,
 	dynUserSourcer dynUserSnapshotter,
+	allocChecker memwatch.AllocChecker,
 ) *Handler {
 	node := schema.NodeName()
 	m := &Handler{
@@ -203,7 +205,7 @@ func NewHandler(
 		backends:   backends,
 		backupper: newBackupper(node, logger, cfg,
 			sourcer, rbacSourcer, dynUserSourcer,
-			backends),
+			backends, allocChecker),
 		restorer: newRestorer(node, logger,
 			sourcer, rbacSourcer, dynUserSourcer,
 			backends, schema.NamespacesEnabled(),

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	entBackup "github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/concurrency/bufferedpipe"
 	"github.com/weaviate/weaviate/entities/diskio"
 )
 
@@ -62,11 +63,17 @@ type compressor interface {
 	Close() error
 }
 
+// chunkPipeBufferSize lets the tar/compressor producer run ahead of the backend
+// upload so the two overlap instead of taking turns. It covers one GCS or S3
+// upload request; Azure posts 40 MiB blocks and still stalls partway through
+// each one. Peak extra memory is GoPoolSize * chunkPipeBufferSize, one per worker.
+const chunkPipeBufferSize = 16 * 1024 * 1024
+
 type zip struct {
 	sourcePath          string
 	w                   *tar.Writer
 	compressorWriter    compressor
-	pipeWriter          *io.PipeWriter
+	pipeWriter          *bufferedpipe.Writer
 	maxChunkSizeInBytes int64
 	bigFilesThreshold   int64
 	splitFileSizeBytes  int64
@@ -81,8 +88,7 @@ type zip struct {
 //     Must be >= bigFilesThreshold.
 //   - chunkTargetSize: the target size for chunks that pack multiple small files together.
 func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFilesThreshold int64, splitFileSize int64) (zip, entBackup.ReadCloserWithError, error) {
-	pr, pw := io.Pipe()
-	reader := &readCloser{src: pr, n: 0}
+	reader, pw := bufferedpipe.New(chunkPipeBufferSize)
 
 	var gzw compressor
 	var tarW *tar.Writer
@@ -149,7 +155,7 @@ func (z *zip) CloseWithError(err error) error {
 	if z.compressorWriter != nil {
 		err2 = z.compressorWriter.Close()
 	}
-	if closeErr := z.pipeWriter.CloseWithError(err); closeErr != nil && !errors.Is(closeErr, io.ErrClosedPipe) {
+	if closeErr := z.pipeWriter.CloseWithError(err); closeErr != nil {
 		err3 = closeErr
 	}
 	if err1 != nil || err2 != nil || err3 != nil {
@@ -645,24 +651,6 @@ func (v vFileInfo) Mode() os.FileMode  { return 0o644 }
 func (v vFileInfo) ModTime() time.Time { return v.modTime }
 func (v vFileInfo) IsDir() bool        { return false }
 func (v vFileInfo) Sys() interface{}   { return nil }
-
-type readCloser struct {
-	src *io.PipeReader
-	n   int64
-}
-
-func (r *readCloser) Read(p []byte) (n int, err error) {
-	n, err = r.src.Read(p)
-	atomic.AddInt64(&r.n, int64(n))
-	return n, err
-}
-
-func (r *readCloser) Close() error { return r.src.Close() }
-
-// CloseWithError closes the reader and signals the given error to the producer.
-// If err is non-nil, the producer's write will return this error instead of
-// the generic "io: read/write on closed pipe".
-func (r *readCloser) CloseWithError(err error) error { return r.src.CloseWithError(err) }
 
 // ceilDiv returns ⌈a/b⌉ using integer arithmetic.
 func ceilDiv(a, b int64) int64 {

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -66,19 +66,22 @@ type compressor interface {
 
 // The pipe buffer lets the tar/compressor producer run ahead of the backend
 // upload so the two overlap. The max covers one GCS or S3 upload request;
-// Azure posts 40 MiB blocks, so it still stalls partway through each.
+// Azure posts 40 MiB blocks, so it still stalls partway through each. The min
+// is about one compressor block, so it costs roughly what an unbuffered pipe
+// would.
 const (
 	maxPipeBufferSize = 16 * 1024 * 1024
-	minPipeBufferSize = 1024 * 1024
+	minPipeBufferSize = 128 * 1024
 )
 
 // affordablePipeBufferSize halves down from maxPipeBufferSize until the alloc
-// checker approves size*workers, never below minPipeBufferSize.
+// checker approves size*workers. Falls back to minPipeBufferSize when even
+// that is rejected: one block per worker is not worth failing a backup over.
 func affordablePipeBufferSize(allocChecker memwatch.AllocChecker, workers int) int {
 	if allocChecker == nil {
 		return maxPipeBufferSize
 	}
-	for size := maxPipeBufferSize; size > minPipeBufferSize; size /= 2 {
+	for size := maxPipeBufferSize; size >= minPipeBufferSize; size /= 2 {
 		if allocChecker.CheckAlloc(int64(size)*int64(workers)) == nil {
 			return size
 		}
@@ -104,13 +107,8 @@ type zip struct {
 //   - splitFileSize: files exceeding this size are split across multiple chunks.
 //     Must be >= bigFilesThreshold.
 //   - chunkTargetSize: the target size for chunks that pack multiple small files together.
-//   - pipeBufferSize: how far the producer may run ahead of the consumer;
-//     non-positive means the full size.
+//   - pipeBufferSize: how far the producer may run ahead of the consumer.
 func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFilesThreshold int64, splitFileSize int64, pipeBufferSize int) (zip, entBackup.ReadCloserWithError, error) {
-	if pipeBufferSize <= 0 {
-		// a non-positive size would leave the buffer unbounded
-		pipeBufferSize = maxPipeBufferSize
-	}
 	reader, pw := bufferedpipe.New(pipeBufferSize)
 
 	var gzw compressor

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -30,6 +30,7 @@ import (
 	entBackup "github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/concurrency/bufferedpipe"
 	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 // CompressionLevel represents supported compression level
@@ -63,11 +64,27 @@ type compressor interface {
 	Close() error
 }
 
-// chunkPipeBufferSize lets the tar/compressor producer run ahead of the backend
-// upload so the two overlap instead of taking turns. It covers one GCS or S3
-// upload request; Azure posts 40 MiB blocks and still stalls partway through
-// each one. Peak extra memory is GoPoolSize * chunkPipeBufferSize, one per worker.
-const chunkPipeBufferSize = 16 * 1024 * 1024
+// The pipe buffer lets the tar/compressor producer run ahead of the backend
+// upload so the two overlap. The max covers one GCS or S3 upload request;
+// Azure posts 40 MiB blocks, so it still stalls partway through each.
+const (
+	maxPipeBufferSize = 16 * 1024 * 1024
+	minPipeBufferSize = 1024 * 1024
+)
+
+// affordablePipeBufferSize halves down from maxPipeBufferSize until the alloc
+// checker approves size*workers, never below minPipeBufferSize.
+func affordablePipeBufferSize(allocChecker memwatch.AllocChecker, workers int) int {
+	if allocChecker == nil {
+		return maxPipeBufferSize
+	}
+	for size := maxPipeBufferSize; size > minPipeBufferSize; size /= 2 {
+		if allocChecker.CheckAlloc(int64(size)*int64(workers)) == nil {
+			return size
+		}
+	}
+	return minPipeBufferSize
+}
 
 type zip struct {
 	sourcePath          string
@@ -87,8 +104,14 @@ type zip struct {
 //   - splitFileSize: files exceeding this size are split across multiple chunks.
 //     Must be >= bigFilesThreshold.
 //   - chunkTargetSize: the target size for chunks that pack multiple small files together.
-func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFilesThreshold int64, splitFileSize int64) (zip, entBackup.ReadCloserWithError, error) {
-	reader, pw := bufferedpipe.New(chunkPipeBufferSize)
+//   - pipeBufferSize: how far the producer may run ahead of the consumer;
+//     non-positive means the full size.
+func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFilesThreshold int64, splitFileSize int64, pipeBufferSize int) (zip, entBackup.ReadCloserWithError, error) {
+	if pipeBufferSize <= 0 {
+		// a non-positive size would leave the buffer unbounded
+		pipeBufferSize = maxPipeBufferSize
+	}
+	reader, pw := bufferedpipe.New(pipeBufferSize)
 
 	var gzw compressor
 	var tarW *tar.Writer

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -107,7 +107,8 @@ type zip struct {
 //   - splitFileSize: files exceeding this size are split across multiple chunks.
 //     Must be >= bigFilesThreshold.
 //   - chunkTargetSize: the target size for chunks that pack multiple small files together.
-//   - pipeBufferSize: how far the producer may run ahead of the consumer.
+//   - pipeBufferSize: how far the producer may run ahead of the consumer. Must be
+//     positive, or bufferedpipe.Unbounded to buffer without a limit.
 func NewZip(sourcePath string, level int, chunkTargetSize int64, bigFilesThreshold int64, splitFileSize int64, pipeBufferSize int) (zip, entBackup.ReadCloserWithError, error) {
 	reader, pw := bufferedpipe.New(pipeBufferSize)
 

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -2078,34 +2078,6 @@ func TestZipProducerRunsAheadOfConsumer(t *testing.T) {
 	}
 }
 
-// A non-positive size must not leave the pipe unbounded.
-func TestNewZipBoundsPipeBufferForNonPositiveSize(t *testing.T) {
-	for _, size := range []int{0, -1} {
-		t.Run(fmt.Sprint(size), func(t *testing.T) {
-			z, rc, err := NewZip(t.TempDir(), int(NoCompression), 0, 0, 0, size)
-			require.NoError(t, err)
-
-			// Fill the buffer; the next write must not be accepted.
-			_, err = z.pipeWriter.Write(make([]byte, maxPipeBufferSize))
-			require.NoError(t, err)
-
-			accepted := make(chan struct{})
-			go func() {
-				z.pipeWriter.Write([]byte("past the bound"))
-				close(accepted)
-			}()
-
-			select {
-			case <-accepted:
-				t.Fatal("pipe accepted a write past its bound — buffer is unbounded")
-			case <-time.After(100 * time.Millisecond):
-			}
-
-			require.NoError(t, rc.Close()) // releases the blocked write
-		})
-	}
-}
-
 // Every real chunk is larger than the pipe buffer, so the producer fills it,
 // waits for the consumer to drain, and resumes. The bytes must survive that.
 func TestZipStreamLargerThanPipeBuffer(t *testing.T) {
@@ -2257,7 +2229,10 @@ func TestAffordablePipeBufferSize(t *testing.T) {
 		{name: "one worker only needs its own share", grantUp: maxPipeBufferSize, workers: 1, want: maxPipeBufferSize},
 		{name: "one byte short of the full size drops one step", grantUp: (256 << 20) - 1, workers: 16, want: 8 << 20},
 		{name: "halves twice when a quarter fits", grantUp: 64 << 20, workers: 16, want: 4 << 20},
-		{name: "halves to the last step above the floor", grantUp: 32 << 20, workers: 16, want: 2 << 20},
+		{name: "halves three times when an eighth fits", grantUp: 32 << 20, workers: 16, want: 2 << 20},
+		{name: "halves below a megabyte rather than overshooting", grantUp: 8 << 20, workers: 16, want: 512 << 10},
+		{name: "halves all the way down to the floor", grantUp: minPipeBufferSize * 16, workers: 16, want: minPipeBufferSize},
+		{name: "one byte short of the floor still uses the floor", grantUp: minPipeBufferSize*16 - 1, workers: 16, want: minPipeBufferSize},
 		{name: "no memory at all still uses the floor", grantUp: 0, workers: 16, want: minPipeBufferSize},
 	}
 

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -30,6 +30,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/backup"
@@ -2019,4 +2020,197 @@ func newFileList(t *testing.T, sourceDir string, files []string) *backup.FileLis
 		Files:     append([]string{}, files...),
 		FileSizes: fileSizes,
 	}
+}
+
+// The producer must be able to run ahead while the backend upload is still in
+// flight; an unbuffered pipe would block it on the first write instead.
+func TestZipProducerRunsAheadOfConsumer(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       CompressionLevel
+		compression backup.CompressionType
+	}{
+		{name: "no compression", level: NoCompression, compression: backup.CompressionNone},
+		{name: "zstd", level: ZstdDefaultCompression, compression: backup.CompressionZSTD},
+		{name: "gzip", level: GzipBestSpeed, compression: backup.CompressionGZIP},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Small enough that the whole chunk fits the buffer, so the
+			// producer never has to wait for the consumer at all.
+			const fileSize = 1 << 20
+			require.Less(t, int64(fileSize), int64(chunkPipeBufferSize))
+			data := incompressibleData(t, fileSize, 42)
+			dir, sd, fileList := newFileSource(t, data)
+
+			z, rc, err := NewZip(dir, int(tt.level), 0, 0, 0)
+			require.NoError(t, err)
+
+			produced := make(chan error, 1)
+			go func() {
+				_, _, writeErr := z.WriteRegulars(context.Background(), &sd, fileList, &atomic.Int64{}, "chunk")
+				produced <- errors.Join(writeErr, z.Close())
+			}()
+
+			// Nothing reads from rc until the producer reports it is done.
+			select {
+			case err := <-produced:
+				require.NoError(t, err)
+			case <-time.After(10 * time.Second):
+				t.Fatal("producer blocked waiting for the consumer to read")
+			}
+
+			out, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			require.NoError(t, rc.Close())
+
+			tr := tar.NewReader(decompress(t, tt.compression, out))
+			hdr, err := tr.Next()
+			require.NoError(t, err)
+			require.Equal(t, "shard/a.db", hdr.Name)
+			got, err := io.ReadAll(tr)
+			require.NoError(t, err)
+			require.Equal(t, data, got)
+		})
+	}
+}
+
+// Every real chunk is larger than the pipe buffer, so the producer fills it,
+// waits for the consumer to drain, and resumes. The bytes must survive that.
+func TestZipStreamLargerThanPipeBuffer(t *testing.T) {
+	tests := []struct {
+		name        string
+		level       CompressionLevel
+		compression backup.CompressionType
+	}{
+		{name: "no compression", level: NoCompression, compression: backup.CompressionNone},
+		{name: "zstd", level: ZstdDefaultCompression, compression: backup.CompressionZSTD},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := incompressibleData(t, chunkPipeBufferSize+(1<<20), 7)
+			dir, sd, fileList := newFileSource(t, data)
+
+			z, rc, err := NewZip(dir, int(tt.level), 0, 0, 0)
+			require.NoError(t, err)
+
+			produced := make(chan error, 1)
+			go func() {
+				_, _, writeErr := z.WriteRegulars(context.Background(), &sd, fileList, &atomic.Int64{}, "chunk")
+				produced <- errors.Join(writeErr, z.Close())
+			}()
+
+			out, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			require.NoError(t, <-produced)
+			require.NoError(t, rc.Close())
+
+			tr := tar.NewReader(decompress(t, tt.compression, out))
+			hdr, err := tr.Next()
+			require.NoError(t, err)
+			require.Equal(t, "shard/a.db", hdr.Name)
+			got, err := io.ReadAll(tr)
+			require.NoError(t, err)
+			require.Equal(t, data, got)
+		})
+	}
+}
+
+func TestZipErrorPropagation(t *testing.T) {
+	t.Run("producer error reaches the consumer after buffered data", func(t *testing.T) {
+		dir, sd, fileList := newFileSource(t, makeTestData(4096, 1))
+
+		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0)
+		require.NoError(t, err)
+
+		_, _, err = z.WriteRegulars(context.Background(), &sd, fileList, &atomic.Int64{}, "chunk")
+		require.NoError(t, err)
+
+		shardErr := errors.New("shard read failed")
+		require.NoError(t, z.CloseWithError(shardErr))
+
+		out, err := io.ReadAll(rc)
+		require.ErrorIs(t, err, shardErr)
+		require.NotEmpty(t, out, "buffered data must be delivered before the error")
+	})
+
+	t.Run("consumer error reaches the producer", func(t *testing.T) {
+		dir, sd, fileList := newFileSource(t, makeTestData(4096, 1))
+
+		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0)
+		require.NoError(t, err)
+
+		uploadErr := errors.New("upload failed")
+		require.NoError(t, rc.CloseWithError(uploadErr))
+
+		_, _, err = z.WriteRegulars(context.Background(), &sd, fileList, &atomic.Int64{}, "chunk")
+		require.ErrorIs(t, err, uploadErr)
+	})
+
+	t.Run("consumer error reaches a producer blocked on a full buffer", func(t *testing.T) {
+		dir, sd, fileList := newFileSource(t, incompressibleData(t, chunkPipeBufferSize+(1<<20), 9))
+
+		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0)
+		require.NoError(t, err)
+
+		produced := make(chan error, 1)
+		go func() {
+			_, _, writeErr := z.WriteRegulars(context.Background(), &sd, fileList, &atomic.Int64{}, "chunk")
+			produced <- writeErr
+		}()
+
+		// Give the producer time to fill the buffer and block on it.
+		time.Sleep(100 * time.Millisecond)
+		uploadErr := errors.New("upload failed")
+		require.NoError(t, rc.CloseWithError(uploadErr))
+
+		select {
+		case err := <-produced:
+			require.ErrorIs(t, err, uploadErr)
+		case <-time.After(10 * time.Second):
+			t.Fatal("producer did not fail after the consumer closed")
+		}
+	})
+}
+
+// newFileSource creates a source directory holding one shard file with the
+// given contents.
+func newFileSource(t *testing.T, data []byte) (string, backup.ShardDescriptor, *backup.FileList) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "source")
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard"), os.ModePerm))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "shard", "a.db"), data, 0o644))
+	return dir, backup.ShardDescriptor{Name: "shard", Node: "node1"}, newFileList(t, dir, []string{"shard/a.db"})
+}
+
+// incompressibleData keeps every compression level pushing roughly size bytes
+// through the pipe.
+func incompressibleData(t *testing.T, size int, seed int64) []byte {
+	t.Helper()
+	data := make([]byte, size)
+	_, err := mathrand.New(mathrand.NewSource(seed)).Read(data)
+	require.NoError(t, err)
+	return data
+}
+
+func decompress(t *testing.T, compression backup.CompressionType, data []byte) io.Reader {
+	t.Helper()
+	switch compression {
+	case backup.CompressionNone:
+		return bytes.NewReader(data)
+	case backup.CompressionZSTD:
+		r, err := zstd.NewReader(bytes.NewReader(data))
+		require.NoError(t, err)
+		t.Cleanup(r.Close)
+		return r
+	case backup.CompressionGZIP:
+		r, err := gzip.NewReader(bytes.NewReader(data))
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, r.Close()) })
+		return r
+	}
+	t.Fatalf("unsupported compression %v", compression)
+	return nil
 }

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/backup"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 func TestZip(t *testing.T) {
@@ -54,7 +56,7 @@ func TestZip(t *testing.T) {
 
 			// compression writer
 			compressBuf := bytes.NewBuffer(make([]byte, 0, 1000_000))
-			z, rc, err := NewZip(pathDest, int(compressionLevel), 0, 0, 0)
+			z, rc, err := NewZip(pathDest, int(compressionLevel), 0, 0, 0, maxPipeBufferSize)
 			require.NoError(t, err)
 			var zInputLen int64
 			fileList := newFileList(t, pathDest, sd.Files)
@@ -372,7 +374,7 @@ func TestNewZipClampsSplitFileSize(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			z, rc, err := NewZip(dir, int(GzipBestSpeed), tc.chunkTargetSize, tc.bigFilesThreshold, tc.splitFileSize)
+			z, rc, err := NewZip(dir, int(GzipBestSpeed), tc.chunkTargetSize, tc.bigFilesThreshold, tc.splitFileSize, maxPipeBufferSize)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedSplitFileSize, z.splitFileSizeBytes)
 			go func() { io.Copy(io.Discard, rc) }()
@@ -504,7 +506,7 @@ func TestWriteRegulars(t *testing.T) {
 				FileSizes: fileSizes,
 			}
 
-			z, rc, err := NewZip(dir, int(NoCompression), tt.chunkTargetSize, tt.minIndividualSize, tt.splitFileSize)
+			z, rc, err := NewZip(dir, int(NoCompression), tt.chunkTargetSize, tt.minIndividualSize, tt.splitFileSize, maxPipeBufferSize)
 			require.NoError(t, err)
 
 			preCompSize := &atomic.Int64{}
@@ -572,7 +574,7 @@ func TestWriteRegulars(t *testing.T) {
 		}
 
 		// Chunk 1: small files written, big file deferred.
-		z, rc, err := NewZip(dir, int(NoCompression), 10000, 500, 0)
+		z, rc, err := NewZip(dir, int(NoCompression), 10000, 500, 0, maxPipeBufferSize)
 		require.NoError(t, err)
 		preComp := &atomic.Int64{}
 		var writeErr error
@@ -590,7 +592,7 @@ func TestWriteRegulars(t *testing.T) {
 		require.Equal(t, 1, fileList.Len(), "only big file should remain")
 
 		// Chunk 2: big file is first and gets its own chunk.
-		z2, rc2, err := NewZip(dir, int(NoCompression), 10000, 500, 0)
+		z2, rc2, err := NewZip(dir, int(NoCompression), 10000, 500, 0, maxPipeBufferSize)
 		require.NoError(t, err)
 		preComp2 := &atomic.Int64{}
 		go func() {
@@ -641,7 +643,7 @@ func TestWriteRegulars(t *testing.T) {
 			FileSizes: map[string]int64{"shard/meta.db": 2000},
 		}
 
-		z, rc, err := NewZip(dir, int(NoCompression), 10000, 500, 0)
+		z, rc, err := NewZip(dir, int(NoCompression), 10000, 500, 0, maxPipeBufferSize)
 		require.NoError(t, err)
 		preComp := &atomic.Int64{}
 		var writeErr error
@@ -717,7 +719,7 @@ func TestWriteRegulars(t *testing.T) {
 // the pipe. Used to drive a split file across multiple chunks.
 func runZipChunk(t *testing.T, sourceDir string, write func(z *zip, pc *atomic.Int64)) {
 	t.Helper()
-	z, rc, err := NewZip(sourceDir, int(NoCompression), 1000, 1000, 1000)
+	z, rc, err := NewZip(sourceDir, int(NoCompression), 1000, 1000, 1000, maxPipeBufferSize)
 	require.NoError(t, err)
 	pc := &atomic.Int64{}
 	go func() {
@@ -841,7 +843,7 @@ func TestWriteShard(t *testing.T) {
 				FileSizes: fileSizes,
 			}
 
-			z, rc, err := NewZip(dir, int(NoCompression), tt.chunkTargetSize, 0, 0)
+			z, rc, err := NewZip(dir, int(NoCompression), tt.chunkTargetSize, 0, 0, maxPipeBufferSize)
 			require.NoError(t, err)
 
 			var splitFile *SplitFile
@@ -955,7 +957,7 @@ func TestRenamingDuringBackup(t *testing.T) {
 			sd.PropLengthTracker = []byte("12345")
 
 			// start backup process
-			z, rc, err := NewZip(dir, int(compressionLevel), 0, 0, 0)
+			z, rc, err := NewZip(dir, int(compressionLevel), 0, 0, 0, maxPipeBufferSize)
 			require.NoError(t, err)
 			fileList := newFileList(t, dir, sd.Files)
 			// Use assert (not require) in goroutines: require calls t.FailNow() which
@@ -1066,7 +1068,7 @@ func TestSplitFileRoundTrip(t *testing.T) {
 
 			for {
 				var buf bytes.Buffer
-				z, rc, err := NewZip(sourceDir, int(compressionLevel), chunkSize, 0, splitFileSize)
+				z, rc, err := NewZip(sourceDir, int(compressionLevel), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 				require.NoError(t, err)
 
 				type writeResult struct {
@@ -1175,7 +1177,7 @@ func TestSplitFileExactBoundary(t *testing.T) {
 
 	for {
 		var buf bytes.Buffer
-		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize)
+		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		type writeResult struct {
@@ -1277,7 +1279,7 @@ func TestSplitFileBelowThreshold(t *testing.T) {
 
 	for {
 		var buf bytes.Buffer
-		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize)
+		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		type writeResult struct {
@@ -1384,7 +1386,7 @@ func TestSplitFirstFileInChunk(t *testing.T) {
 
 	for {
 		var buf bytes.Buffer
-		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize)
+		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		type writeResult struct {
@@ -1640,7 +1642,7 @@ func TestFirstFileBelowSplitThresholdWrittenWhole(t *testing.T) {
 
 	for {
 		var buf bytes.Buffer
-		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize)
+		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		type writeResult struct {
@@ -1746,7 +1748,7 @@ func TestMultipleSplitFilesInShard(t *testing.T) {
 
 	for {
 		var buf bytes.Buffer
-		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize)
+		z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		type writeResult struct {
@@ -1879,7 +1881,7 @@ func TestBackupRestoreEndToEnd(t *testing.T) {
 
 		for {
 			var buf bytes.Buffer
-			z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize)
+			z, rc, err := NewZip(sourceDir, int(NoCompression), chunkSize, 0, splitFileSize, maxPipeBufferSize)
 			require.NoError(t, err)
 
 			type writeResult struct {
@@ -2040,11 +2042,11 @@ func TestZipProducerRunsAheadOfConsumer(t *testing.T) {
 			// Small enough that the whole chunk fits the buffer, so the
 			// producer never has to wait for the consumer at all.
 			const fileSize = 1 << 20
-			require.Less(t, int64(fileSize), int64(chunkPipeBufferSize))
+			require.Less(t, int64(fileSize), int64(maxPipeBufferSize))
 			data := incompressibleData(t, fileSize, 42)
 			dir, sd, fileList := newFileSource(t, data)
 
-			z, rc, err := NewZip(dir, int(tt.level), 0, 0, 0)
+			z, rc, err := NewZip(dir, int(tt.level), 0, 0, 0, maxPipeBufferSize)
 			require.NoError(t, err)
 
 			produced := make(chan error, 1)
@@ -2076,6 +2078,34 @@ func TestZipProducerRunsAheadOfConsumer(t *testing.T) {
 	}
 }
 
+// A non-positive size must not leave the pipe unbounded.
+func TestNewZipBoundsPipeBufferForNonPositiveSize(t *testing.T) {
+	for _, size := range []int{0, -1} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			z, rc, err := NewZip(t.TempDir(), int(NoCompression), 0, 0, 0, size)
+			require.NoError(t, err)
+
+			// Fill the buffer; the next write must not be accepted.
+			_, err = z.pipeWriter.Write(make([]byte, maxPipeBufferSize))
+			require.NoError(t, err)
+
+			accepted := make(chan struct{})
+			go func() {
+				z.pipeWriter.Write([]byte("past the bound"))
+				close(accepted)
+			}()
+
+			select {
+			case <-accepted:
+				t.Fatal("pipe accepted a write past its bound — buffer is unbounded")
+			case <-time.After(100 * time.Millisecond):
+			}
+
+			require.NoError(t, rc.Close()) // releases the blocked write
+		})
+	}
+}
+
 // Every real chunk is larger than the pipe buffer, so the producer fills it,
 // waits for the consumer to drain, and resumes. The bytes must survive that.
 func TestZipStreamLargerThanPipeBuffer(t *testing.T) {
@@ -2090,10 +2120,10 @@ func TestZipStreamLargerThanPipeBuffer(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := incompressibleData(t, chunkPipeBufferSize+(1<<20), 7)
+			data := incompressibleData(t, maxPipeBufferSize+(1<<20), 7)
 			dir, sd, fileList := newFileSource(t, data)
 
-			z, rc, err := NewZip(dir, int(tt.level), 0, 0, 0)
+			z, rc, err := NewZip(dir, int(tt.level), 0, 0, 0, maxPipeBufferSize)
 			require.NoError(t, err)
 
 			produced := make(chan error, 1)
@@ -2122,7 +2152,7 @@ func TestZipErrorPropagation(t *testing.T) {
 	t.Run("producer error reaches the consumer after buffered data", func(t *testing.T) {
 		dir, sd, fileList := newFileSource(t, makeTestData(4096, 1))
 
-		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0)
+		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		_, _, err = z.WriteRegulars(context.Background(), &sd, fileList, &atomic.Int64{}, "chunk")
@@ -2139,7 +2169,7 @@ func TestZipErrorPropagation(t *testing.T) {
 	t.Run("consumer error reaches the producer", func(t *testing.T) {
 		dir, sd, fileList := newFileSource(t, makeTestData(4096, 1))
 
-		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0)
+		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		uploadErr := errors.New("upload failed")
@@ -2150,9 +2180,9 @@ func TestZipErrorPropagation(t *testing.T) {
 	})
 
 	t.Run("consumer error reaches a producer blocked on a full buffer", func(t *testing.T) {
-		dir, sd, fileList := newFileSource(t, incompressibleData(t, chunkPipeBufferSize+(1<<20), 9))
+		dir, sd, fileList := newFileSource(t, incompressibleData(t, maxPipeBufferSize+(1<<20), 9))
 
-		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0)
+		z, rc, err := NewZip(dir, int(NoCompression), 0, 0, 0, maxPipeBufferSize)
 		require.NoError(t, err)
 
 		produced := make(chan error, 1)
@@ -2214,3 +2244,44 @@ func decompress(t *testing.T, compression backup.CompressionType, data []byte) i
 	t.Fatalf("unsupported compression %v", compression)
 	return nil
 }
+
+func TestAffordablePipeBufferSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		grantUp int64 // largest total approved; negative means no checker
+		workers int
+		want    int
+	}{
+		{name: "no checker keeps the full size", grantUp: -1, workers: 16, want: maxPipeBufferSize},
+		{name: "plenty of memory keeps the full size", grantUp: 1 << 40, workers: 16, want: maxPipeBufferSize},
+		{name: "one worker only needs its own share", grantUp: maxPipeBufferSize, workers: 1, want: maxPipeBufferSize},
+		{name: "one byte short of the full size drops one step", grantUp: (256 << 20) - 1, workers: 16, want: 8 << 20},
+		{name: "halves twice when a quarter fits", grantUp: 64 << 20, workers: 16, want: 4 << 20},
+		{name: "halves to the last step above the floor", grantUp: 32 << 20, workers: 16, want: 2 << 20},
+		{name: "no memory at all still uses the floor", grantUp: 0, workers: 16, want: minPipeBufferSize},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var checker memwatch.AllocChecker
+			if tt.grantUp >= 0 {
+				checker = fakeAllocChecker{limit: tt.grantUp}
+			}
+			require.Equal(t, tt.want, affordablePipeBufferSize(checker, tt.workers))
+		})
+	}
+}
+
+// fakeAllocChecker approves any allocation up to limit bytes.
+type fakeAllocChecker struct{ limit int64 }
+
+func (c fakeAllocChecker) CheckAlloc(sizeInBytes int64) error {
+	if sizeInBytes > c.limit {
+		return enterrors.ErrNotEnoughMemory
+	}
+	return nil
+}
+
+func (fakeAllocChecker) CheckMappingAndReserve(int64, int) error { return nil }
+
+func (fakeAllocChecker) Refresh(bool) {}

--- a/usecases/export/parallel_scan.go
+++ b/usecases/export/parallel_scan.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/concurrency/bufferedpipe"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -225,6 +226,8 @@ type rangeWriterConfig struct {
 	onFlush   func(int64) // called after each successful ParquetWriter flush
 }
 
+const defaultPipeBufferSize = 16 * 1024 * 1024 // 16 MB per range pipeline
+
 // rangePipeline bundles a per-range ParquetWriter, buffered pipe, and upload
 // goroutine. The buffered pipe decouples scan speed from upload speed so that
 // LSM cursors are not held open waiting on network I/O.
@@ -233,7 +236,7 @@ type rangeWriterConfig struct {
 // so empty ranges never instantiate a pipeline at all — there is no
 // CloseEmpty/abort path to worry about.
 type rangePipeline struct {
-	pw         *bufferedPipeWriter
+	pw         *bufferedpipe.Writer
 	writer     *ParquetWriter
 	uploadDone <-chan error
 }
@@ -275,7 +278,7 @@ func (rp *rangePipeline) Shutdown(scanErr error) error {
 // the upload goroutine so that the scan can run at disk speed without being
 // blocked by upload latency.
 func startRangeWriter(ctx context.Context, cfg *rangeWriterConfig, rangeIndex int) (*rangePipeline, error) {
-	pr, pw := newBufferedPipe(defaultPipeBufferSize)
+	pr, pw := bufferedpipe.New(defaultPipeBufferSize)
 
 	fileName := fmt.Sprintf("%s_%s_%04d.parquet", cfg.className, cfg.shardName, rangeIndex)
 

--- a/usecases/export/parallel_scan_test.go
+++ b/usecases/export/parallel_scan_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/concurrency/bufferedpipe"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -630,11 +631,11 @@ func TestScanFieldRoundTrip(t *testing.T) {
 
 // newTestPipeline creates a rangePipeline backed by a buffered pipe and
 // ParquetWriter. The upload goroutine drains the pipe reader and sends
-// uploadErr to the done channel. The bufferedPipeReader is returned so
+// uploadErr to the done channel. The pipe reader is returned so
 // callers can break the pipe for error-path tests.
-func newTestPipeline(t *testing.T, uploadErr error) (*rangePipeline, *bufferedPipeReader) {
+func newTestPipeline(t *testing.T, uploadErr error) (*rangePipeline, *bufferedpipe.Reader) {
 	t.Helper()
-	pr, pw := newBufferedPipe(defaultPipeBufferSize)
+	pr, pw := bufferedpipe.New(defaultPipeBufferSize)
 	uploadDone := make(chan error, 1)
 	go func() {
 		_, err := io.Copy(io.Discard, pr)


### PR DESCRIPTION
### What's being changed:

  Overlap compression and upload in the backup path

Every backup chunk ran its tar/zstd producer and its backend upload through two unbuffered io.Pipes in series. The 16 MiB chunk buffer inside the storage SDK is filled by pulling from that pipe, and nothing pulls while a POST is in flight — so compression and network alternated instead of overlapping. Measured, the baseline is exactly T_compress + T_upload at every sample point.

Now usecases/export's bounded buffered pipe moves to entities/concurrency/bufferedpipe (exported, shared by both callers) and replaces the io.Pipe in NewZip. A second commit sizes those buffers against memwatch.AllocChecker so they can't quietly cost a node its headroom.

Measured (128 MiB chunks, modelled 16 MiB POSTs):

  | | baseline | after |
  |---|---|---|
  | compress ≈ upload | 114 ms | **72 ms** (1.58×) |
  | upload-dominated | 262 ms | **219 ms** (1.20×) |

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
