### PR TITLE
fix(tools): adapt qa_pr.sh log fetch to gh >= 2.97 escape-sequence guard

### DIFF
--- a/tools/dev/qa_pr.sh
+++ b/tools/dev/qa_pr.sh
@@ -246,7 +246,7 @@ fi
 
 log "Extracting docker image tags from job logs..."
 # Use gh api (works even when logs are large / job just completed)
-TAGS=$(gh api "repos/$WEAVIATE_REPO/actions/jobs/$JOB_ID/logs" 2>&1 \
+TAGS=$(gh api --allow-escape-sequences "repos/$WEAVIATE_REPO/actions/jobs/$JOB_ID/logs" 2>&1 \
   | sed 's/\x1b\[[0-9;]*m//g' \
   | grep -oE 'semitechnologies/weaviate:[a-zA-Z0-9._-]+' \
   | sort -u || true)

--- a/tools/dev/qa_pr.sh
+++ b/tools/dev/qa_pr.sh
@@ -245,8 +245,14 @@ if [[ -z "$JOB_ID" ]]; then
 fi
 
 log "Extracting docker image tags from job logs..."
-# Use gh api (works even when logs are large / job just completed)
-TAGS=$(gh api --allow-escape-sequences "repos/$WEAVIATE_REPO/actions/jobs/$JOB_ID/logs" 2>&1 \
+# Use gh api (works even when logs are large / job just completed).
+# gh >= 2.97 refuses to print responses containing terminal escape sequences
+# unless --allow-escape-sequences is passed; older versions lack the flag.
+ALLOW_ESC_FLAG=""
+if gh api --help 2>&1 | grep -q -- '--allow-escape-sequences'; then
+  ALLOW_ESC_FLAG="--allow-escape-sequences"
+fi
+TAGS=$(gh api $ALLOW_ESC_FLAG "repos/$WEAVIATE_REPO/actions/jobs/$JOB_ID/logs" 2>&1 \
   | sed 's/\x1b\[[0-9;]*m//g' \
   | grep -oE 'semitechnologies/weaviate:[a-zA-Z0-9._-]+' \
   | sort -u || true)


### PR DESCRIPTION
### What's being changed:

This PR adapts qa_pr.sh log fetch to gh >= 2.97 adds escape-sequence guard

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
