### PR TITLE
Backups: never store a partially written chunk

### DIFF
--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -432,12 +432,6 @@ func (f *fakeBackupBackend) GetObject(ctx context.Context, backupID, key, overri
 	return b, nil
 }
 
-func (f *fakeBackupBackend) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	f.Lock()
-	defer f.Unlock()
-	return nil
-}
-
 func (f *fakeBackupBackend) Write(ctx context.Context, backupID, key, overrideBucket, overridePath string, r backup.ReadCloserWithError) (int64, error) {
 	f.Lock()
 	defer f.Unlock()

--- a/entities/modulecapabilities/backup.go
+++ b/entities/modulecapabilities/backup.go
@@ -47,11 +47,6 @@ type BackupBackend interface {
 	// AllBackups returns the top level metadata for all attempted backups
 	AllBackups(ctx context.Context) ([]*backup.DistributedBackupDescriptor, error)
 
-	// WriteToFile writes an object in the specified file with path destPath
-	// The file will be created if it doesn't exist
-	// The file will be overwritten if it exists
-	WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error
-
 	// SourceDataPath is data path of all source files
 	SourceDataPath() string
 

--- a/entities/modulecapabilities/mock_backup_backend.go
+++ b/entities/modulecapabilities/mock_backup_backend.go
@@ -561,63 +561,13 @@ func (_c *MockBackupBackend_Write_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
-// WriteToFile provides a mock function with given fields: ctx, backupID, key, destPath, overrideBucket, overridePath
-func (_m *MockBackupBackend) WriteToFile(ctx context.Context, backupID string, key string, destPath string, overrideBucket string, overridePath string) error {
-	ret := _m.Called(ctx, backupID, key, destPath, overrideBucket, overridePath)
-
-	if len(ret) == 0 {
-		panic("no return value specified for WriteToFile")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) error); ok {
-		r0 = rf(ctx, backupID, key, destPath, overrideBucket, overridePath)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockBackupBackend_WriteToFile_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WriteToFile'
-type MockBackupBackend_WriteToFile_Call struct {
-	*mock.Call
-}
-
-// WriteToFile is a helper method to define mock.On call
-//   - ctx context.Context
-//   - backupID string
-//   - key string
-//   - destPath string
-//   - overrideBucket string
-//   - overridePath string
-func (_e *MockBackupBackend_Expecter) WriteToFile(ctx interface{}, backupID interface{}, key interface{}, destPath interface{}, overrideBucket interface{}, overridePath interface{}) *MockBackupBackend_WriteToFile_Call {
-	return &MockBackupBackend_WriteToFile_Call{Call: _e.mock.On("WriteToFile", ctx, backupID, key, destPath, overrideBucket, overridePath)}
-}
-
-func (_c *MockBackupBackend_WriteToFile_Call) Run(run func(ctx context.Context, backupID string, key string, destPath string, overrideBucket string, overridePath string)) *MockBackupBackend_WriteToFile_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
-	})
-	return _c
-}
-
-func (_c *MockBackupBackend_WriteToFile_Call) Return(_a0 error) *MockBackupBackend_WriteToFile_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockBackupBackend_WriteToFile_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *MockBackupBackend_WriteToFile_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // NewMockBackupBackend creates a new instance of MockBackupBackend. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockBackupBackend(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockBackupBackend {
+},
+) *MockBackupBackend {
 	mock := &MockBackupBackend{}
 	mock.Mock.Test(t)
 

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -254,35 +254,6 @@ func (a *azureClient) Initialize(ctx context.Context, backupID, overrideBucket, 
 	return nil
 }
 
-func (a *azureClient) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	containerName, err := a.resolveContainer(overrideBucket)
-	if err != nil {
-		return err
-	}
-
-	dir := path.Dir(destPath)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "make dir %s", dir)
-	}
-
-	file, err := os.Create(destPath)
-	if err != nil {
-		return backup.NewErrInternal(errors.Wrapf(err, "create file: %q", destPath))
-	}
-	defer file.Close()
-
-	objectName := a.makeObjectName(overridePath, []string{backupID, key})
-	_, err = a.client.DownloadFile(ctx, containerName, objectName, file, nil)
-	if err != nil {
-		if bloberror.HasCode(err, bloberror.BlobNotFound) {
-			return backup.NewErrNotFound(errors.Wrapf(err, "get object %s", objectName))
-		}
-		return backup.NewErrInternal(errors.Wrapf(err, "download file for object %s", objectName))
-	}
-
-	return nil
-}
-
 func (a *azureClient) getBlockSize(ctx context.Context) int64 {
 	blockSize := defaultBlockSize
 	blockSizeStr := modulecomponents.GetValueFromContext(ctx, "X-Azure-Block-Size")

--- a/modules/backup-filesystem/backup.go
+++ b/modules/backup-filesystem/backup.go
@@ -175,16 +175,39 @@ func (m *Module) Write(ctx context.Context, backupID, key, overrideBucket, overr
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return 0, fmt.Errorf("make dir %q: %w", dir, err)
 	}
-	f, err := os.OpenFile(backupPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	// Collect the content in a temp file and rename it into place once it is
+	// complete. A failed write then leaves no partial file at backupPath, and
+	// whatever was already stored under that key stays intact.
+	tmpPath := backupPath + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
 	if err != nil {
-		return 0, fmt.Errorf("open file %q: %w", backupPath, err)
+		return 0, fmt.Errorf("open file %q: %w", tmpPath, err)
 	}
-	defer f.Close()
+
+	renamed := false
+	defer func() {
+		if renamed {
+			return
+		}
+		f.Close()
+		if rmErr := os.Remove(tmpPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			m.logger.Warnf("remove temp file %q: %v", tmpPath, rmErr)
+		}
+	}()
 
 	written, err = io.Copy(f, r)
 	if err != nil {
 		return written, fmt.Errorf("write file %q: %w", backupPath, err)
 	}
+	// Close reports write errors that io.Copy is too early to see.
+	if err = f.Close(); err != nil {
+		return written, fmt.Errorf("close file %q: %w", backupPath, err)
+	}
+	if err = os.Rename(tmpPath, backupPath); err != nil {
+		return written, fmt.Errorf("rename to %q: %w", backupPath, err)
+	}
+	renamed = true
+
 	if metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.
 		GetMetricWithLabelValues(m.Name(), "class"); err == nil {
 		metric.Add(float64(written))

--- a/modules/backup-filesystem/backup.go
+++ b/modules/backup-filesystem/backup.go
@@ -74,33 +74,40 @@ func (m *Module) getObjectPath(ctx context.Context, path, backupID, key string) 
 	return metaPath, nil
 }
 
-func (m *Module) copyFile(sourcePath, destinationPath string) (int64, error) {
-	source, err := os.Open(sourcePath)
-	defer func() error {
-		return source.Close()
-	}()
+// writeFileViaTemp collects r in a temp file and renames it onto destPath once it
+// is complete, so a write that returns an error leaves no partial file at destPath
+// and keeps whatever was already there. A machine crash can still leave the temp
+// file behind, as nothing is synced to disk.
+func (m *Module) writeFileViaTemp(destPath string, r io.Reader, perm os.FileMode) (int64, error) {
+	tmpPath := destPath + ".tmp"
+	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
 	if err != nil {
-		return 0, errors.Wrapf(err, "open file %s", sourcePath)
+		return 0, fmt.Errorf("open file %q: %w", tmpPath, err)
 	}
 
-	if _, err := os.Stat(destinationPath); err != nil {
-		if err := os.MkdirAll(path.Dir(destinationPath), os.ModePerm); err != nil {
-			return 0, errors.Wrapf(err, "make dir %s", destinationPath)
+	renamed := false
+	defer func() {
+		if renamed {
+			return
 		}
-	}
-
-	destination, err := os.Create(destinationPath)
-	defer func() error {
-		return destination.Close()
+		f.Close()
+		if rmErr := os.Remove(tmpPath); rmErr != nil && !os.IsNotExist(rmErr) {
+			m.logger.Warnf("remove temp file %q: %v", tmpPath, rmErr)
+		}
 	}()
-	if err != nil {
-		return 0, errors.Wrapf(err, "create destination file %s", destinationPath)
-	}
 
-	written, err := io.Copy(destination, source)
+	written, err := io.Copy(f, r)
 	if err != nil {
-		return 0, errors.Wrapf(err, "copy file from %s to %s", sourcePath, destinationPath)
+		return written, fmt.Errorf("write file %q: %w", destPath, err)
 	}
+	// Close reports write errors that io.Copy is too early to see.
+	if err := f.Close(); err != nil {
+		return written, fmt.Errorf("close file %q: %w", destPath, err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		return written, fmt.Errorf("rename to %q: %w", destPath, err)
+	}
+	renamed = true
 
 	return written, nil
 }
@@ -139,26 +146,6 @@ func (m *Module) Initialize(ctx context.Context, backupID, overrideBucket, overr
 	return nil
 }
 
-func (m *Module) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	basePath, err := m.resolvePath(overridePath)
-	if err != nil {
-		return err
-	}
-	objectPath := filepath.Join(basePath, backupID, key)
-
-	bytesWritten, err := m.copyFile(objectPath, destPath)
-	if err != nil {
-		return err
-	}
-
-	metric, err := monitoring.GetMetrics().BackupRestoreDataTransferred.GetMetricWithLabelValues(m.Name(), "class")
-	if err == nil {
-		metric.Add(float64(bytesWritten))
-	}
-
-	return nil
-}
-
 func (m *Module) Write(ctx context.Context, backupID, key, overrideBucket, overridePath string, r backup.ReadCloserWithError) (written int64, err error) {
 	// Close the reader when done. Use CloseWithError to signal any error to the
 	// producer so it sees the actual error instead of "closed pipe".
@@ -175,38 +162,10 @@ func (m *Module) Write(ctx context.Context, backupID, key, overrideBucket, overr
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return 0, fmt.Errorf("make dir %q: %w", dir, err)
 	}
-	// Collect the content in a temp file and rename it into place once it is
-	// complete. A failed write then leaves no partial file at backupPath, and
-	// whatever was already stored under that key stays intact.
-	tmpPath := backupPath + ".tmp"
-	f, err := os.OpenFile(tmpPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, os.ModePerm)
+	written, err = m.writeFileViaTemp(backupPath, r, os.ModePerm)
 	if err != nil {
-		return 0, fmt.Errorf("open file %q: %w", tmpPath, err)
+		return written, err
 	}
-
-	renamed := false
-	defer func() {
-		if renamed {
-			return
-		}
-		f.Close()
-		if rmErr := os.Remove(tmpPath); rmErr != nil && !os.IsNotExist(rmErr) {
-			m.logger.Warnf("remove temp file %q: %v", tmpPath, rmErr)
-		}
-	}()
-
-	written, err = io.Copy(f, r)
-	if err != nil {
-		return written, fmt.Errorf("write file %q: %w", backupPath, err)
-	}
-	// Close reports write errors that io.Copy is too early to see.
-	if err = f.Close(); err != nil {
-		return written, fmt.Errorf("close file %q: %w", backupPath, err)
-	}
-	if err = os.Rename(tmpPath, backupPath); err != nil {
-		return written, fmt.Errorf("rename to %q: %w", backupPath, err)
-	}
-	renamed = true
 
 	if metric, err := monitoring.GetMetrics().BackupStoreDataTransferred.
 		GetMetricWithLabelValues(m.Name(), "class"); err == nil {

--- a/modules/backup-filesystem/backup_test.go
+++ b/modules/backup-filesystem/backup_test.go
@@ -12,11 +12,15 @@
 package modstgfs
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -95,6 +99,118 @@ func TestResolvePath(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.wantPath, p)
 			}
+		})
+	}
+}
+
+// stubReader yields payload and then fails with readErr, or ends cleanly when
+// readErr is nil. It records the error Write signals back to the producer.
+type stubReader struct {
+	payload    *bytes.Reader
+	readErr    error
+	closedWith error
+}
+
+func (s *stubReader) Read(p []byte) (int, error) {
+	if s.payload.Len() > 0 {
+		return s.payload.Read(p)
+	}
+	if s.readErr != nil {
+		return 0, s.readErr
+	}
+	return 0, io.EOF
+}
+
+func (s *stubReader) Close() error { return nil }
+
+func (s *stubReader) CloseWithError(err error) error {
+	s.closedWith = err
+	return nil
+}
+
+func TestWriteStoresOnlyCompleteFiles(t *testing.T) {
+	readErr := errors.New("scan failed")
+
+	tests := []struct {
+		name string
+		// content already at the target path before the write, if any
+		existing    string
+		payload     string
+		readErr     error
+		wantContent string
+		wantMissing bool
+	}{
+		{
+			name:        "complete copy stores the file",
+			payload:     "full-payload",
+			wantContent: "full-payload",
+		},
+		{
+			name:        "empty payload stores an empty file",
+			wantContent: "",
+		},
+		{
+			name:        "read failing mid-stream stores nothing",
+			payload:     "truncated-par",
+			readErr:     readErr,
+			wantMissing: true,
+		},
+		{
+			name:        "read failing before any byte stores nothing",
+			readErr:     readErr,
+			wantMissing: true,
+		},
+		{
+			name:        "shorter rewrite leaves no trailing bytes",
+			existing:    "a-much-longer-previous-payload",
+			payload:     "short",
+			wantContent: "short",
+		},
+		{
+			name:        "failed rewrite keeps the existing file",
+			existing:    "a-much-longer-previous-payload",
+			payload:     "short",
+			readErr:     readErr,
+			wantContent: "a-much-longer-previous-payload",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			basePath := t.TempDir()
+			backupPath := filepath.Join(basePath, "backup-1", "chunk-0")
+
+			if tt.existing != "" {
+				require.NoError(t, os.MkdirAll(filepath.Dir(backupPath), os.ModePerm))
+				require.NoError(t, os.WriteFile(backupPath, []byte(tt.existing), os.ModePerm))
+			}
+
+			m := &Module{backupsPath: basePath, logger: logrus.New()}
+			r := &stubReader{payload: bytes.NewReader([]byte(tt.payload)), readErr: tt.readErr}
+
+			written, err := m.Write(context.Background(), "backup-1", "chunk-0", "", "", r)
+
+			if tt.readErr != nil {
+				require.ErrorIs(t, err, tt.readErr)
+				require.ErrorIs(t, r.closedWith, tt.readErr)
+			} else {
+				require.NoError(t, err)
+				require.NoError(t, r.closedWith)
+			}
+			// written counts bytes read off the producer, not bytes stored: on the
+			// error path the copied bytes are discarded rather than kept.
+			assert.Equal(t, int64(len(tt.payload)), written)
+
+			content, err := os.ReadFile(backupPath)
+			if tt.wantMissing {
+				require.ErrorIs(t, err, os.ErrNotExist, "no file may be left behind")
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantContent, string(content))
+			}
+
+			_, err = os.Stat(backupPath + ".tmp")
+			require.ErrorIs(t, err, os.ErrNotExist, "temp file must not survive the write")
 		})
 	}
 }

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -343,8 +343,11 @@ func (g *gcsClient) Write(ctx context.Context, backupID, key, overrideBucket, ov
 	written, err = io.Copy(writer, r)
 	if err != nil {
 		// Cancelling abandons the upload. Closing the writer instead would finalize it,
-		// storing the bytes copied so far as a complete object.
+		// storing the bytes copied so far as a complete object. Closing afterwards is
+		// what ends the writer's trace span, and cannot revive the upload: the request
+		// it would take needs the context that was just cancelled.
 		cancel()
+		writer.Close()
 		return written, fmt.Errorf("io.copy for gcs write %q: %w", objectPath, err)
 	}
 

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -389,14 +389,18 @@ func (g *gcsClient) Write(ctx context.Context, backupID, key, overrideBucket, ov
 
 	// create a new writer
 	objectPath := g.makeObjectName(overridePath, []string{backupID, key})
-	writer := bucket.Object(objectPath).NewWriter(ctx)
+	writeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	writer := bucket.Object(objectPath).NewWriter(writeCtx)
 	writer.ContentType = "application/octet-stream"
 	writer.Metadata = map[string]string{"backup-id": backupID}
 
 	// copy
 	written, err = io.Copy(writer, r)
 	if err != nil {
-		writer.Close() // ignore error here as copy already failed
+		// Cancelling abandons the upload. Closing the writer instead would finalize it,
+		// storing the bytes copied so far as a complete object.
+		cancel()
 		return written, fmt.Errorf("io.copy for gcs write %q: %w", objectPath, err)
 	}
 

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -319,62 +319,6 @@ func (g *gcsClient) Initialize(ctx context.Context, backupID, overrideBucket, ov
 	return nil
 }
 
-// WriteToFile downloads an object and store its content in destPath
-// The file destPath will be created if it doesn't exit
-func (g *gcsClient) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) (err error) {
-	bucket, err := g.findBucket(ctx, overrideBucket)
-	if err != nil {
-		return fmt.Errorf("writetofile: find bucket: %w ", err)
-	}
-
-	// validate destination path
-	if st, err := os.Stat(destPath); err == nil {
-		if st.IsDir() {
-			return fmt.Errorf("file is a directory")
-		}
-	} else if !os.IsNotExist(err) {
-		return err
-	}
-
-	// create empty file
-	dir := path.Dir(destPath)
-	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return fmt.Errorf("os.mkdir for writetofile %q: %w", dir, err)
-	}
-	file, err := os.Create(destPath)
-	if err != nil {
-		return fmt.Errorf("os.create for writetofile %q: %w", destPath, err)
-	}
-
-	// make sure to close and delete in case we return early
-	closeAndRemove := true
-	defer func() {
-		if closeAndRemove {
-			file.Close()
-			os.Remove(destPath)
-		}
-	}()
-
-	// create reader
-	object := g.makeObjectName(overridePath, []string{backupID, key})
-	rc, err := bucket.Object(object).NewReader(ctx)
-	if err != nil {
-		return fmt.Errorf("create reader for writetofile %q: %w", object, err)
-	}
-	defer rc.Close()
-
-	// transfer content to the file
-	if _, err := io.Copy(file, rc); err != nil {
-		return fmt.Errorf("io.Copy for writetofile:%q %q: %w", destPath, object, err)
-	}
-	closeAndRemove = false
-	if err = file.Close(); err != nil {
-		return fmt.Errorf("f.Close for writetofile %q: %w", destPath, err)
-	}
-
-	return nil
-}
-
 func (g *gcsClient) Write(ctx context.Context, backupID, key, overrideBucket, overridePath string, r backup.ReadCloserWithError) (written int64, err error) {
 	// Close the reader when done. Use CloseWithError to signal any error to the
 	// producer so it sees the actual error instead of "closed pipe".

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -378,3 +378,85 @@ func TestWriteEndsWriterSpan(t *testing.T) {
 	}
 	assert.Equal(t, 1, writerSpans, "the writer span must be ended on the error path")
 }
+
+func TestWriteResumableUploadIsFinalizedOnlyOnSuccess(t *testing.T) {
+	const bucketName = "test-bucket"
+	// Above the 16 MiB default ChunkSize, so the SDK opens a resumable session
+	// and pushes the first chunk to the backend before the copy ends.
+	payload := bytes.Repeat([]byte("x"), 17*1024*1024)
+
+	readErr := errors.New("scan failed")
+
+	tests := []struct {
+		name          string
+		readErr       error
+		wantFinalized int64
+	}{
+		{
+			name:          "complete copy finalizes the object",
+			wantFinalized: 1,
+		},
+		{
+			name:          "read failing after the first chunk leaves the session unfinalized",
+			readErr:       readErr,
+			wantFinalized: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sessions, chunkPuts, finalizePuts atomic.Int64
+			var finalizeRange atomic.Value
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/upload/storage/v1/b/"+bucketName+"/o", func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, "resumable", r.URL.Query().Get("uploadType"))
+				sessions.Add(1)
+				w.Header().Set("Location", "http://"+r.Host+"/resumable-session")
+			})
+			mux.HandleFunc("/resumable-session", func(w http.ResponseWriter, r *http.Request) {
+				n, err := io.Copy(io.Discard, r.Body)
+				require.NoError(t, err)
+
+				// A trailing "/*" marks a chunk of a still-open session; a byte total
+				// there is the request that finalizes the object.
+				if contentRange := r.Header.Get("Content-Range"); strings.HasSuffix(contentRange, "/*") {
+					chunkPuts.Add(1)
+					// The client sends X-GUploader-No-308, so "resume incomplete" is
+					// signalled by this header rather than by a 308 status.
+					w.Header().Set("X-Http-Status-Code-Override", "308")
+					w.Header().Set("Range", fmt.Sprintf("bytes=0-%d", n-1))
+					return
+				}
+				finalizePuts.Add(1)
+				finalizeRange.Store(r.Header.Get("Content-Range"))
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"kind":"storage#object","bucket":%q,"name":"backup-1/chunk-0"}`, bucketName)
+			})
+
+			g := newFakeGCSClient(t, bucketName, mux)
+
+			r := &stubReader{payload: bytes.NewReader(payload), readErr: tt.readErr}
+			written, err := g.Write(context.Background(), "backup-1", "chunk-0", "", "", r)
+
+			if tt.readErr != nil {
+				require.ErrorIs(t, err, tt.readErr)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, int64(len(payload)), written)
+
+			assert.Equal(t, int64(1), sessions.Load(), "resumable session opened")
+			assert.Equal(t, int64(1), chunkPuts.Load(),
+				"the first chunk reaches the backend before the copy ends")
+			assert.Equal(t, tt.wantFinalized, finalizePuts.Load(),
+				"requests that finalize the object")
+
+			if tt.wantFinalized > 0 {
+				cr, _ := finalizeRange.Load().(string)
+				assert.True(t, strings.HasSuffix(cr, fmt.Sprintf("/%d", len(payload))),
+					"object finalized at the full payload size, got Content-Range %q", cr)
+			}
+		})
+	}
+}

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -12,13 +12,17 @@
 package modstggcs
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -146,12 +150,6 @@ func TestAllBackupsSkipsMissingDescriptors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mux := http.NewServeMux()
 
-			// Bucket attrs: GET /b/{bucket}
-			mux.HandleFunc("/b/"+bucketName, func(w http.ResponseWriter, r *http.Request) {
-				w.Header().Set("Content-Type", "application/json")
-				fmt.Fprintf(w, `{"kind":"storage#bucket","name":%q}`, bucketName)
-			})
-
 			// Object list with delimiter: GET /b/{bucket}/o
 			mux.HandleFunc("/b/"+bucketName+"/o", func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
@@ -172,24 +170,8 @@ func TestAllBackupsSkipsMissingDescriptors(t *testing.T) {
 				w.Write(body)
 			})
 
-			srv := httptest.NewServer(mux)
-			defer srv.Close()
-
 			ctx := context.Background()
-			gcs, err := storage.NewClient(ctx,
-				option.WithoutAuthentication(),
-				option.WithEndpoint(srv.URL),
-			)
-			require.NoError(t, err)
-			defer gcs.Close()
-			// Disable retries so a 500 surfaces immediately instead of looping.
-			gcs.SetRetry(storage.WithPolicy(storage.RetryNever))
-
-			g := &gcsClient{
-				client: gcs,
-				config: clientConfig{Bucket: bucketName},
-				logger: logrus.New(),
-			}
+			g := newFakeGCSClient(t, bucketName, mux)
 
 			got, err := g.AllBackups(ctx)
 			if tt.wantErr {
@@ -203,6 +185,136 @@ func TestAllBackupsSkipsMissingDescriptors(t *testing.T) {
 				ids = append(ids, d.ID)
 			}
 			assert.ElementsMatch(t, tt.wantIDs, ids)
+		})
+	}
+}
+
+// newFakeGCSClient points a real storage.Client at mux, which must serve every
+// API call the test exercises apart from the bucket attrs fetch.
+func newFakeGCSClient(t *testing.T, bucketName string, mux *http.ServeMux) *gcsClient {
+	t.Helper()
+
+	mux.HandleFunc("/b/"+bucketName, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"kind":"storage#bucket","name":%q}`, bucketName)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	gcs, err := storage.NewClient(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithEndpoint(srv.URL),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { gcs.Close() })
+	// Disable retries so an error status surfaces immediately instead of looping,
+	// and so request counts stay exact.
+	gcs.SetRetry(storage.WithPolicy(storage.RetryNever))
+
+	return &gcsClient{
+		client: gcs,
+		config: clientConfig{Bucket: bucketName},
+		logger: logrus.New(),
+	}
+}
+
+// stubReader yields payload and then fails with readErr, or ends cleanly when
+// readErr is nil. It records the error Write signals back to the producer.
+type stubReader struct {
+	payload    *bytes.Reader
+	readErr    error
+	closedWith error
+}
+
+func (s *stubReader) Read(p []byte) (int, error) {
+	if s.payload.Len() > 0 {
+		return s.payload.Read(p)
+	}
+	if s.readErr != nil {
+		return 0, s.readErr
+	}
+	return 0, io.EOF
+}
+
+func (s *stubReader) Close() error { return nil }
+
+func (s *stubReader) CloseWithError(err error) error {
+	s.closedWith = err
+	return nil
+}
+
+func TestWriteUploadsOnlyCompleteObjects(t *testing.T) {
+	const bucketName = "test-bucket"
+
+	readErr := errors.New("scan failed")
+
+	tests := []struct {
+		name        string
+		payload     string
+		readErr     error
+		wantUploads int64
+	}{
+		{
+			name:        "complete copy stores the object",
+			payload:     "full-payload",
+			wantUploads: 1,
+		},
+		{
+			name:        "read failing mid-stream stores nothing",
+			payload:     "truncated-par",
+			readErr:     readErr,
+			wantUploads: 0,
+		},
+		{
+			name:        "read failing before any byte stores nothing",
+			payload:     "",
+			readErr:     readErr,
+			wantUploads: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var uploads atomic.Int64
+			var uploadBody atomic.Value
+
+			mux := http.NewServeMux()
+			// Object creation via the JSON API. These payloads are far below the
+			// 16 MiB ChunkSize, so the upload is always a single multipart POST.
+			mux.HandleFunc("/upload/storage/v1/b/"+bucketName+"/o", func(w http.ResponseWriter, r *http.Request) {
+				uploads.Add(1)
+				body, _ := io.ReadAll(r.Body)
+				uploadBody.Store(string(body))
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(w, `{"kind":"storage#object","bucket":%q,"name":"backup-1/chunk-0"}`, bucketName)
+			})
+
+			ctx := context.Background()
+			g := newFakeGCSClient(t, bucketName, mux)
+
+			r := &stubReader{payload: bytes.NewReader([]byte(tt.payload)), readErr: tt.readErr}
+			written, err := g.Write(ctx, "backup-1", "chunk-0", "", "", r)
+
+			if tt.readErr != nil {
+				require.ErrorIs(t, err, tt.readErr)
+				require.ErrorIs(t, r.closedWith, tt.readErr)
+			} else {
+				require.NoError(t, err)
+				require.NoError(t, r.closedWith)
+			}
+			// written counts bytes read off the producer, not bytes stored: on the
+			// error path the copied bytes are abandoned rather than uploaded.
+			assert.Equal(t, int64(len(tt.payload)), written)
+			assert.Equal(t, tt.wantUploads, uploads.Load(),
+				"object-creating requests that reached the backend")
+
+			if tt.wantUploads > 0 {
+				body, _ := uploadBody.Load().(string)
+				assert.Contains(t, body, `"name":"backup-1/chunk-0"`)
+				assert.Contains(t, body, `"backup-id":"backup-1"`)
+				assert.Contains(t, body, tt.payload)
+			}
 		})
 	}
 }

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -29,6 +30,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/api/option"
 
 	"github.com/weaviate/weaviate/entities/backup"
@@ -317,4 +320,61 @@ func TestWriteUploadsOnlyCompleteObjects(t *testing.T) {
 			}
 		})
 	}
+}
+
+// recordingExporter collects the names of spans that were ended.
+type recordingExporter struct {
+	mu    sync.Mutex
+	names []string
+}
+
+func (e *recordingExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, s := range spans {
+		e.names = append(e.names, s.Name())
+	}
+	return nil
+}
+
+func (e *recordingExporter) Shutdown(context.Context) error { return nil }
+
+func (e *recordingExporter) endedSpans() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return append([]string(nil), e.names...)
+}
+
+// The writer's span is only ended by closing it, so abandoning an upload has to
+// close the writer as well or the span for every failed write is lost.
+func TestWriteEndsWriterSpan(t *testing.T) {
+	const bucketName = "test-bucket"
+
+	exporter := &recordingExporter{}
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() { otel.SetTracerProvider(previous) })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/upload/storage/v1/b/"+bucketName+"/o", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"kind":"storage#object","bucket":%q,"name":"backup-1/chunk-0"}`, bucketName)
+	})
+
+	ctx := context.Background()
+	g := newFakeGCSClient(t, bucketName, mux)
+
+	readErr := errors.New("scan failed")
+	r := &stubReader{payload: bytes.NewReader([]byte("truncated-par")), readErr: readErr}
+	_, err := g.Write(ctx, "backup-1", "chunk-0", "", "", r)
+	require.ErrorIs(t, err, readErr)
+
+	var writerSpans int
+	for _, name := range exporter.endedSpans() {
+		if strings.HasSuffix(name, "Object.Writer") {
+			writerSpans++
+		}
+	}
+	assert.Equal(t, 1, writerSpans, "the writer span must be ended on the error path")
 }

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -395,31 +395,6 @@ func (s *s3Client) Initialize(ctx context.Context, backupID, overrideBucket, ove
 	return nil
 }
 
-// WriteFile downloads contents of an object to a local file destPath
-func (s *s3Client) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	client, err := s.getClient(ctx)
-	if err != nil {
-		return errors.Wrap(err, "write to file: cannot get client")
-	}
-	bucket, remotePath, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
-	if err != nil {
-		return err
-	}
-
-	err = client.FGetObject(ctx, bucket, remotePath, destPath, minio.GetObjectOptions{})
-	if err != nil {
-		return fmt.Errorf("s3.FGetObject %q %q: %w", destPath, remotePath, err)
-	}
-
-	if st, err := os.Stat(destPath); err == nil {
-		metric, err := monitoring.GetMetrics().BackupRestoreDataTransferred.GetMetricWithLabelValues(Name, "class")
-		if err == nil {
-			metric.Add(float64(st.Size()))
-		}
-	}
-	return nil
-}
-
 func (s *s3Client) Write(ctx context.Context, backupID, key, overrideBucket, overridePath string, r backup.ReadCloserWithError) (written int64, err error) {
 	// Close the reader when done. Use CloseWithError to signal any error to the
 	// producer so it sees the actual error instead of "closed pipe".

--- a/test/modules/backup-azure/backup_backend_test.go
+++ b/test/modules/backup-azure/backup_backend_test.go
@@ -285,17 +285,6 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 			require.Nil(t, err)
 			assert.Equal(t, expectedContents, contents)
 		})
-
-		t.Run("fetch file from backend", func(t *testing.T) {
-			destPath := dataDir + "/file_0.copy.db"
-
-			err := azure.WriteToFile(testCtx, backupID, key, destPath, overrideBucket, overridePath)
-			require.Nil(t, err)
-
-			contents, err := os.ReadFile(destPath)
-			require.Nil(t, err)
-			assert.Equal(t, expectedContents, contents)
-		})
 	})
 }
 

--- a/test/modules/backup-filesystem/backup_backend_test.go
+++ b/test/modules/backup-filesystem/backup_backend_test.go
@@ -215,18 +215,6 @@ func moduleLevelCopyFiles(t *testing.T, backupsPath string, override bool, overr
 			require.Nil(t, err)
 			assert.Equal(t, expectedContents, contents)
 		})
-
-		t.Run("fetch file from backend", func(t *testing.T) {
-			destPath := dataDir + "/file_0.copy.db"
-
-			t.Logf("download file with override: %v", override)
-			err := fs.WriteToFile(testCtx, backupID, key, destPath, overrideBucket, overridePath)
-			require.Nil(t, err)
-
-			contents, err := os.ReadFile(destPath)
-			require.Nil(t, err)
-			assert.Equal(t, expectedContents, contents)
-		})
 	})
 }
 

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -253,17 +253,6 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 			require.Nil(t, err)
 			assert.Equal(t, expectedContents, contents)
 		})
-
-		t.Run("fetch file from backend", func(t *testing.T) {
-			destPath := dataDir + "/file_0.copy.db"
-
-			err := gcs.WriteToFile(testCtx, backupID, key, destPath, overrideBucket, overridePath)
-			require.Nil(t, err)
-
-			contents, err := os.ReadFile(destPath)
-			require.Nil(t, err)
-			assert.Equal(t, expectedContents, contents)
-		})
 	})
 }
 

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -255,18 +255,6 @@ func moduleLevelCopyFiles(t *testing.T, override bool, containerName, overrideBu
 			require.Nil(t, err)
 			assert.Equal(t, expectedContents, contents)
 		})
-
-		t.Run("fetch file from backend", func(t *testing.T) {
-			destPath := dataDir + "/file_0.copy.db"
-
-			t.Logf("download file with override: %v", override)
-			err := s3.WriteToFile(testCtx, backupID, key, destPath, overrideBucket, overridePath)
-			require.Nil(t, err)
-
-			contents, err := os.ReadFile(destPath)
-			require.Nil(t, err)
-			assert.Equal(t, expectedContents, contents)
-		})
 	})
 }
 

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -77,10 +77,6 @@ func (s *objectStore) HomeDir(overrideBucket, overridePath string) string {
 	return s.backend.HomeDir(s.backupId, overrideBucket, overridePath)
 }
 
-func (s *objectStore) WriteToFile(ctx context.Context, key, destPath, overrideBucket, overridePath string) error {
-	return s.backend.WriteToFile(ctx, s.backupId, key, destPath, overrideBucket, overridePath)
-}
-
 // SourceDataPath is data path of all source files
 func (s *objectStore) SourceDataPath() string {
 	return s.backend.SourceDataPath()

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -190,13 +190,6 @@ func (fb *fakeBackend) Name() string {
 	return "fakeBackend"
 }
 
-func (fb *fakeBackend) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	fb.Lock()
-	defer fb.Unlock()
-	args := fb.Called(ctx, backupID, key, destPath)
-	return args.Error(0)
-}
-
 func (fb *fakeBackend) Read(ctx context.Context, backupID, key, overrideBucket, overridePath string, w io.WriteCloser) (int64, error) {
 	fb.Lock()
 	defer fb.Unlock()

--- a/usecases/export/helpers_for_test.go
+++ b/usecases/export/helpers_for_test.go
@@ -256,10 +256,6 @@ func (b *fakeBackend) PutObject(context.Context, string, string, string, string,
 	return nil
 }
 
-func (b *fakeBackend) WriteToFile(context.Context, string, string, string, string, string) error {
-	return nil
-}
-
 func (b *fakeBackend) Read(context.Context, string, string, string, string, io.WriteCloser) (int64, error) {
 	return 0, nil
 }

--- a/usecases/modules/modules_test.go
+++ b/usecases/modules/modules_test.go
@@ -517,10 +517,6 @@ func (m *dummyBackupModuleWithAltNames) GetObject(ctx context.Context, backupID,
 	return nil, nil
 }
 
-func (m *dummyBackupModuleWithAltNames) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	return nil
-}
-
 func (m *dummyBackupModuleWithAltNames) Write(ctx context.Context, backupID, key, overrideBucket, overridePath string, r backup.ReadCloserWithError) (int64, error) {
 	return 0, nil
 }


### PR DESCRIPTION
### What's being changed:

Five separate commits fixing related bugs/problems in the backup module:
- Abort upload on copy error instead of finalizing it in backup-gcs
- Write chunks via a temp file and rename in backup-filesystem
- Remove the unused WriteToFile backup backend capability (purely cleanup)
- Close the writer when abandoning a gcs upload
- Pin resumeable chunk uploads

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
