### PR TITLE
test(replication): wait for shard readiness after restart across read_repair suite

### DIFF
--- a/test/acceptance/replication/common/crud_ops.go
+++ b/test/acceptance/replication/common/crud_ops.go
@@ -79,6 +79,16 @@ func WaitForNodeReadyForClass(t *testing.T, hostURI, class string, probeID strfm
 	}, 120*time.Second, 500*time.Millisecond)
 }
 
+// WaitForNodeReadyForTenant is WaitForNodeReadyForClass for multi-tenant classes;
+// probeID must exist in tenant on all replicas.
+func WaitForNodeReadyForTenant(t *testing.T, hostURI, class string, probeID strfmt.UUID, tenant string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		_, err := GetTenantObjectCL(t, hostURI, class, probeID, tenant, types.ConsistencyLevelAll)
+		require.NoError(ct, err)
+	}, 120*time.Second, 500*time.Millisecond)
+}
+
 func GetClass(t *testing.T, host, class string) *models.Class {
 	t.Helper()
 	helper.SetupClient(host)
@@ -128,6 +138,12 @@ func GetTenantObject(t *testing.T, host, class string, id strfmt.UUID, tenant st
 	t.Helper()
 	helper.SetupClient(host)
 	return helper.TenantObject(t, class, id, tenant)
+}
+
+func GetTenantObjectCL(t *testing.T, host, class string, id strfmt.UUID, tenant string, cl types.ConsistencyLevel) (*models.Object, error) {
+	t.Helper()
+	helper.SetupClient(host)
+	return helper.TenantObjectCL(t, class, id, tenant, cl)
 }
 
 func ObjectExistsCL(t *testing.T, host, class string, id strfmt.UUID, cl types.ConsistencyLevel) (bool, error) {

--- a/test/acceptance/replication/read_repair/multi_tenancy_test.go
+++ b/test/acceptance/replication/read_repair/multi_tenancy_test.go
@@ -105,7 +105,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 
 		t.Run("RestartNode-3", func(t *testing.T) {
 			common.StartNodeAt(ctx, t, compose, 3)
-			time.Sleep(time.Second)
+			common.WaitForNodeReadyForTenant(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0], tenantID.String())
 		})
 	})
 
@@ -139,7 +139,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 
 		t.Run("RestartNode-3", func(t *testing.T) {
 			common.StartNodeAt(ctx, t, compose, 3)
-			time.Sleep(time.Second)
+			common.WaitForNodeReadyForTenant(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0], tenantID.String())
 		})
 	})
 
@@ -198,7 +198,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 
 		t.Run("RestartNode-3", func(t *testing.T) {
 			common.StartNodeAt(ctx, t, compose, 3)
-			time.Sleep(time.Second)
+			common.WaitForNodeReadyForTenant(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0], tenantID.String())
 		})
 	})
 
@@ -233,7 +233,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 
 		t.Run("RestartNode-3", func(t *testing.T) {
 			common.StartNodeAt(ctx, t, compose, 3)
-			time.Sleep(time.Second)
+			common.WaitForNodeReadyForTenant(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0], tenantID.String())
 		})
 	})
 
@@ -243,7 +243,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 		})
 
 		t.Run("StopNode-3", func(t *testing.T) {
-			common.StartNodeAt(ctx, t, compose, 3)
+			common.StopNodeAt(ctx, t, compose, 3)
 		})
 
 		t.Run("OnNode-2", func(t *testing.T) {
@@ -254,6 +254,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 
 		t.Run("RestartNode-3", func(t *testing.T) {
 			common.StartNodeAt(ctx, t, compose, 3)
+			common.WaitForNodeReadyForTenant(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0], tenantID.String())
 		})
 	})
 
@@ -274,6 +275,7 @@ func (suite *ReplicationTestSuite) TestMultiTenancyEnabled() {
 
 		t.Run("RestartNode-2", func(t *testing.T) {
 			common.StartNodeAt(ctx, t, compose, 2)
+			common.WaitForNodeReadyForTenant(t, compose.ContainerURI(2), "Paragraph", paragraphIDs[0], tenantID.String())
 		})
 	})
 }

--- a/test/acceptance/replication/read_repair/read_repair_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_test.go
@@ -146,7 +146,7 @@ func (suite *ReplicationTestSuite) TestReadRepair() {
 			require.Nil(collect, err)
 			require.True(collect, exists)
 
-			resp, err := common.GetObjectCL(t, compose.ContainerURI(1),
+			resp, err := common.GetObjectCL(t, compose.ContainerURI(3),
 				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
 			require.Nil(collect, err)
 			require.Equal(collect, replaceObj.ID, resp.ID)

--- a/test/acceptance/replication/read_repair/read_repair_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -94,17 +95,20 @@ func (suite *ReplicationTestSuite) TestReadRepair() {
 
 	t.Run("RestartNode-3", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 3)
-		time.Sleep(time.Second)
+		common.WaitForNodeReadyForClass(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("TriggerRepairQuorumOnNode-3", func(t *testing.T) {
-		resp, err := common.GetObjectCL(t, compose.ContainerURI(3),
-			repairObj.Class, repairObj.ID, types.ConsistencyLevelQuorum)
-		require.Nil(t, err)
-		require.Equal(t, repairObj.ID, resp.ID)
-		require.Equal(t, repairObj.Class, resp.Class)
-		require.EqualValues(t, repairObj.Properties, resp.Properties)
-		require.EqualValues(t, repairObj.Vector, resp.Vector)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 3 may still be loading right after restart
+			resp, err := common.GetObjectCL(t, compose.ContainerURI(3),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelQuorum)
+			require.Nil(collect, err)
+			require.Equal(collect, repairObj.ID, resp.ID)
+			require.Equal(collect, repairObj.Class, resp.Class)
+			require.EqualValues(collect, repairObj.Properties, resp.Properties)
+			require.EqualValues(collect, repairObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("StopNode-3", func(t *testing.T) {
@@ -122,28 +126,34 @@ func (suite *ReplicationTestSuite) TestReadRepair() {
 
 	t.Run("RestartNode-3", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 3)
+		common.WaitForNodeReadyForClass(t, compose.ContainerURI(3), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("TriggerRepairAllOnNode1", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.ContainerURI(1),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.ContainerURI(1),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("UpdatedObjectRepairedOnNode-3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.ContainerURI(3),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.ContainerURI(3),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
 
-		resp, err := common.GetObjectCL(t, compose.ContainerURI(1),
-			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.Equal(t, replaceObj.ID, resp.ID)
-		require.Equal(t, replaceObj.Class, resp.Class)
-		require.EqualValues(t, replaceObj.Properties, resp.Properties)
-		require.EqualValues(t, replaceObj.Vector, resp.Vector)
+			resp, err := common.GetObjectCL(t, compose.ContainerURI(1),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.Equal(collect, replaceObj.ID, resp.ID)
+			require.Equal(collect, replaceObj.Class, resp.Class)
+			require.EqualValues(collect, replaceObj.Properties, resp.Properties)
+			require.EqualValues(collect, replaceObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("stop node2", func(t *testing.T) {
@@ -157,26 +167,33 @@ func (suite *ReplicationTestSuite) TestReadRepair() {
 
 	t.Run("restart node2", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 2)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode2().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("deleted article should be present in node2", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("run exists to trigger read repair with deleted object resolution", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-		require.False(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should still be present in node2 (object deletion is not resolved)", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 }

--- a/test/acceptance/replication/read_repair/read_repair_timebasedresolution_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_timebasedresolution_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -93,21 +94,23 @@ func (suite *ReplicationTestSuite) TestReadRepairTimebasedResolution() {
 
 	t.Run("restart node 2", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 2)
-	})
-
-	t.Run("run fetch to trigger read repair", func(t *testing.T) {
-		_, err := common.GetObjectCL(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode2().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("require new object read repair was made", func(t *testing.T) {
-		resp, err := common.GetObjectCL(t, compose.GetWeaviateNode2().URI(),
-			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.Equal(t, repairObj.ID, resp.ID)
-		require.Equal(t, repairObj.Class, resp.Class)
-		require.EqualValues(t, repairObj.Properties, resp.Properties)
-		require.EqualValues(t, repairObj.Vector, resp.Vector)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 2 may still be loading right after restart
+			_, err := common.GetObjectCL(t, compose.GetWeaviate().URI(), repairObj.Class, repairObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+
+			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode2().URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.Equal(collect, repairObj.ID, resp.ID)
+			require.Equal(collect, repairObj.Class, resp.Class)
+			require.EqualValues(collect, repairObj.Properties, resp.Properties)
+			require.EqualValues(collect, repairObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	replaceObj := repairObj
@@ -125,28 +128,30 @@ func (suite *ReplicationTestSuite) TestReadRepairTimebasedResolution() {
 
 	t.Run("restart node 3", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 3)
-	})
-
-	t.Run("run exists to trigger read repair", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-		require.True(t, exists)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode3().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("require updated object read repair was made", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+			require.True(collect, exists)
 
-		resp, err := common.GetObjectCL(t, compose.GetWeaviateNode3().URI(),
-			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.Equal(t, replaceObj.ID, resp.ID)
-		require.Equal(t, replaceObj.Class, resp.Class)
-		require.EqualValues(t, replaceObj.Properties, resp.Properties)
-		require.EqualValues(t, replaceObj.Vector, resp.Vector)
+			exists, err = common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+
+			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode3().URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.Equal(collect, replaceObj.ID, resp.ID)
+			require.Equal(collect, replaceObj.Class, resp.Class)
+			require.EqualValues(collect, replaceObj.Properties, resp.Properties)
+			require.EqualValues(collect, replaceObj.Vector, resp.Vector)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("stop node 2", func(t *testing.T) {
@@ -160,6 +165,7 @@ func (suite *ReplicationTestSuite) TestReadRepairTimebasedResolution() {
 
 	t.Run("restart node 2", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 2)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode2().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("stop node3", func(t *testing.T) {
@@ -176,41 +182,53 @@ func (suite *ReplicationTestSuite) TestReadRepairTimebasedResolution() {
 	})
 
 	t.Run("deleted article should be present in node2", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("restart node 3", func(t *testing.T) {
 		common.StartNodeAt(ctx, t, compose, 3)
+		common.WaitForNodeReadyForClass(t, compose.GetWeaviateNode3().URI(), "Paragraph", paragraphIDs[0])
 	})
 
 	t.Run("deleted article should not be present in node3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.False(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.False(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("run exists to trigger read repair with deleted object resolution", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			// re-trigger read repair on every attempt; node 3 may still be loading right after restart
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelAll)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should be present in node2", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode2().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	t.Run("deleted article should be present in node3", func(t *testing.T) {
-		exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
-			replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
-		require.Nil(t, err)
-		require.True(t, exists)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode3().URI(),
+				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
+			require.Nil(collect, err)
+			require.True(collect, exists)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 }

--- a/test/helper/objects_assertions.go
+++ b/test/helper/objects_assertions.go
@@ -182,6 +182,17 @@ func TenantObject(t *testing.T, class string, id strfmt.UUID, tenant string) (*m
 	return getResp.Payload, nil
 }
 
+func TenantObjectCL(t *testing.T, class string, id strfmt.UUID, tenant string, cl types.ConsistencyLevel) (*models.Object, error) {
+	cls := string(cl)
+	req := objects.NewObjectsClassGetParams().
+		WithClassName(class).WithID(id).WithTenant(&tenant).WithConsistencyLevel(&cls)
+	getResp, err := Client(t).Objects.ObjectsClassGet(req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return getResp.Payload, nil
+}
+
 func TenantObjectWithInclude(t *testing.T, class string, id strfmt.UUID, tenant string, includes string) (*models.Object, error) {
 	req := objects.NewObjectsClassGetParams().
 		WithClassName(class).WithID(id).WithTenant(&tenant).WithInclude(&includes)


### PR DESCRIPTION
## Motivation

`TestReadRepairTimebasedResolution` failed in CI at a CL=ONE existence check right after a node restart. The container's `/ready` endpoint passes while the shard is still `StatusLoading`; a loading shard rejects replication ops (digests and overwrites), and the read coordinator silently falls back to the remaining replicas — which at that point hold the tombstone. The one-shot assertion then observes pre-repair state and fails. The same unguarded restart-then-assert pattern exists in `TestReadRepair` and `TestMultiTenancyEnabled`; only `TestReadRepairDeleteOnConflict` had been hardened (#11886).

## Approach

Apply the #11886 stabilization pattern to the rest of the package instead of inventing a new mechanism:

- After every restart, block on `WaitForNodeReadyForClass` — a CL=ALL read of a probe object against the restarted node, which cannot succeed until every replica's shard is out of `StatusLoading`. Raw `time.Sleep` was the prior mechanism and is exactly what failed — readiness has to be observed, not waited out.
- Wrap post-restart assertions in `EventuallyWithT`. Where the read is itself the repair trigger, the trigger runs *inside* the retry loop so every attempt re-triggers repair; a one-shot trigger followed by a retried assertion would still race.
- Multi-tenant classes can't use the existing probe (the CL=ALL read requires a tenant), so this adds `helper.TenantObjectCL` and `common.WaitForNodeReadyForTenant`.

Also fixes a latent bug found on the way: in `TestMultiTenancyEnabled`'s `DeleteObject` phase, the `StopNode-3` subtest called `StartNodeAt`, so node 3 was never taken down and the phase never exercised its intended delete-during-node-down window. It now calls `StopNodeAt`, and the phase gains the readiness gate it consequently needs.

## Key areas for review

- `read_repair_timebasedresolution_test.go` — subtests where trigger and assertion were fused into one `EventuallyWithT` block; verify the merged blocks preserve the original trigger/verify semantics
- `multi_tenancy_test.go` (`DeleteObject` phase) — the `StopNodeAt` fix revives previously dead coverage; a CI failure here would be newly exposed behavior, not a regression from this PR
- `common/crud_ops.go:WaitForNodeReadyForTenant` — mirrors `WaitForNodeReadyForClass`; the probe object must exist in the tenant on all replicas at every call site

## Risks and mitigations

- **Retries masking a genuinely broken repair**: bounded (30 s for assertions, 120 s for readiness) and the assertions compare full object content (ID, class, properties, vector), so a wrong repair outcome still fails — retries only absorb slow convergence
- **Negative assertions (`require.False(exists)`) inside `EventuallyWithT` pass on first success**: safe here because no repair trigger runs concurrently in those subtests, so the asserted state cannot flip after the check passes

## Testing

Test-only change; no production code touched. Validated locally against an image built from this branch (`make weaviate-image WEAVIATE_IMAGE=weaviate/test-server`): the full `read_repair` package passed two consecutive `-race` runs (292 s and 291 s), including the revived `DeleteObject` node-down phase. A third run only failed on a local Docker daemon hang while restarting a container (unrelated to the code; the hardened tests passed in that run too).

```bash
make weaviate-image WEAVIATE_IMAGE=weaviate/test-server
go test -count 1 -race -timeout 30m ./test/acceptance/replication/read_repair/...
```

## Known gap documented, not addressed here

While verifying the repair path I confirmed a pre-existing convergence gap, deliberately left out of this test-only PR: **equal-millisecond delete/update conflicts are never repaired and resolve nondeterministically**. Every arbitration point compares update times alone and ignores the deleted flag:

- `usecases/replica/finder_stream.go` (`readOne`/`readExistence`/`readBatchPart`) — a tombstone@T and a live object@T count as *agreeing* votes, so the conflict never reaches the repairer and the returned result depends on reply arrival order
- `usecases/replica/repairer.go` — winner selection uses strict `>` (arrival order decides ties) and the repair loops skip any vote whose time equals the winner's, so the divergent replica is never overwritten
- `adapters/repos/db/replication.go` (`OverwriteObjects`) — an incoming write whose time equals the local time is skipped as "already applied" even when the deleted states differ, so an async-replication tie delete no-ops forever and the hashtrees stay divergent on that leaf
- replay/async-replication LWW sites (`shard_write_delete.go`, `shard_write_put.go` `localIsNewer`, `shard_async_replication.go` `resolveObjectConflict`) — resolve the same tie in the opposite direction (live wins)

Consequence: with RF≥2, an update on one replica and a delete on another landing in the same millisecond diverge permanently; CL=ALL existence flips between true/false across reads. A consistent fix requires one tie rule (e.g. delete wins, as `DeleteOnConflict` and Cassandra already do) applied at all of the sites above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
