### PR TITLE
Use direct map acces for shard movement teardown

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3011,6 +3011,15 @@ func (i *Index) getOrInitShard(ctx context.Context, shardName string) (
 // shardCreateLocks is on the shard's own read and write path and callers can
 // run long. Same reasoning as backupShardWithHardlinks.
 func (i *Index) getLoadedShard(shardName string) (shard ShardLike, release func(), err error) {
+	// Every shard teardown holds one of these two: Index.Shutdown takes closeLock
+	// for write, the unload paths take shardCreateLocks for write.
+	i.closeLock.RLock()
+	defer i.closeLock.RUnlock()
+
+	if i.closed {
+		return nil, func() {}, fmt.Errorf("local shard %q: %w", shardName, errAlreadyShutdown)
+	}
+
 	i.shardCreateLocks.RLock(shardName)
 	defer i.shardCreateLocks.RUnlock(shardName)
 
@@ -3018,8 +3027,9 @@ func (i *Index) getLoadedShard(shardName string) (shard ShardLike, release func(
 	if shard == nil {
 		return nil, func() {}, nil
 	}
-	// Taken under the lock UnloadLocalShard holds for write, so the shard cannot
-	// be shut down between the map read and the refcount.
+	// Both locks span the map read and the refcount: a lazy shard's
+	// preventShutdown loads, so a teardown landing in between would have it
+	// rebuild the shard outside i.shards, where nothing can ever shut it down.
 	release, err = shard.preventShutdown()
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("shard %q, no shutdown: %w", shardName, err)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3003,6 +3003,30 @@ func (i *Index) getOrInitShard(ctx context.Context, shardName string) (
 	return i.getOptInitLocalShard(ctx, shardName, true)
 }
 
+// getLoadedShard returns the shard only if it is already loaded, never
+// materializing one, plus a release that drops the shutdown refcount. A nil
+// shard and a nil error mean the shard is not loaded here.
+//
+// The refcount rather than shardCreateLocks keeps the shard alive, because
+// shardCreateLocks is on the shard's own read and write path and callers can
+// run long. Same reasoning as backupShardWithHardlinks.
+func (i *Index) getLoadedShard(shardName string) (shard ShardLike, release func(), err error) {
+	i.shardCreateLocks.RLock(shardName)
+	defer i.shardCreateLocks.RUnlock(shardName)
+
+	shard = i.shards.Loaded(shardName)
+	if shard == nil {
+		return nil, func() {}, nil
+	}
+	// Taken under the lock UnloadLocalShard holds for write, so the shard cannot
+	// be shut down between the map read and the refcount.
+	release, err = shard.preventShutdown()
+	if err != nil {
+		return nil, func() {}, fmt.Errorf("shard %q, no shutdown: %w", shardName, err)
+	}
+	return shard, release, nil
+}
+
 // getOptInitLocalShard returns the local shard with the given name.
 // It is ensured that the returned instance is a fully loaded shard if ensureInit is set to true.
 // The returned shard may be a lazy shard instance or nil if the shard hasn't yet been initialized.

--- a/adapters/repos/db/replica_snapshot.go
+++ b/adapters/repos/db/replica_snapshot.go
@@ -54,7 +54,7 @@ func (i *Index) IncomingCreateReplicaSnapshot(ctx context.Context, shardName, op
 	}
 
 	// On retry the prior snapshot may be stale relative to current shard contents.
-	if rerr := i.releaseReplicaSnapshot(ctx, opID); rerr != nil {
+	if rerr := i.releaseReplicaSnapshot(ctx, opID, shard); rerr != nil {
 		return nil, fmt.Errorf("clean prior replica snapshot for op %q: %w", opID, rerr)
 	}
 
@@ -101,7 +101,8 @@ func (i *Index) IncomingReleaseReplicaSnapshot(ctx context.Context, opID string)
 	i.replicaSnapshotOpLocks.Lock(opID)
 	defer i.replicaSnapshotOpLocks.Unlock(opID)
 
-	return i.releaseReplicaSnapshot(ctx, opID)
+	// No shard pinned here, unlike IncomingCreateReplicaSnapshot.
+	return i.releaseReplicaSnapshot(ctx, opID, nil)
 }
 
 func (i *Index) IncomingGetReplicaSnapshotFileMetadata(ctx context.Context, opID, relativeFilePath string) (file.FileMetadata, error) {
@@ -191,7 +192,8 @@ func (i *Index) mayResetReplicaSnapshotInactivity(opID string) {
 	if !ok || st.isSnapshot {
 		return
 	}
-	// A shard that is not loaded has no live timer to reset.
+	// A shard that is not loaded has no live timer to reset. Needs no shutdown
+	// guard: resetting the deadline on a torn-down shard restarts nothing.
 	if shard := i.shards.Loaded(st.shardName); shard != nil {
 		shard.MayResetTransferInactivityTimer()
 	}
@@ -235,7 +237,10 @@ func (i *Index) recordReplicaSnapshot(opID string, st replicaSnapshotState) {
 // active cannot refuse the resume. A failed resume cannot be retried:
 // resumeMaintenanceCycles clears the halt count before the work that can fail,
 // so a later release finds nothing halted.
-func (i *Index) releaseReplicaSnapshot(ctx context.Context, opID string) error {
+//
+// held is the caller's already-pinned shard for this op, or nil when the caller
+// holds no pin — then the shard is resolved under the shutdown guard instead.
+func (i *Index) releaseReplicaSnapshot(ctx context.Context, opID string, held ShardLike) error {
 	i.replicaSnapshotsMu.Lock()
 	st, ok := i.replicaSnapshots[opID]
 	delete(i.replicaSnapshots, opID)
@@ -251,10 +256,23 @@ func (i *Index) releaseReplicaSnapshot(ctx context.Context, opID string) error {
 		return removeErr
 	}
 
-	// A shard that is not loaded has nothing halted. No shardCreateLocks here:
-	// IncomingCreateReplicaSnapshot calls this holding a shutdown pin, and an
-	// unload waits ~2s on that pin while holding the same lock for write.
-	if shard := i.shards.Loaded(st.shardName); shard != nil {
+	shard := held
+	if shard == nil {
+		// The pinned caller must not take these locks: it would invert the order
+		// an unload acquires them in, which holds them while waiting on the pin.
+		loaded, release, err := i.getLoadedShard(st.shardName)
+		if err != nil {
+			if removeErr != nil {
+				return fmt.Errorf("%w; resume maintenance after replica transfer: %w", removeErr, err)
+			}
+			return fmt.Errorf("resume maintenance after replica transfer: %w", err)
+		}
+		defer release()
+		shard = loaded
+	}
+
+	// A shard that is not loaded has nothing halted.
+	if shard != nil {
 		if err := shard.resumeMaintenanceCycles(ctx); err != nil {
 			if removeErr != nil {
 				return fmt.Errorf("%w; resume maintenance after replica transfer: %w", removeErr, err)

--- a/adapters/repos/db/replica_snapshot.go
+++ b/adapters/repos/db/replica_snapshot.go
@@ -191,10 +191,9 @@ func (i *Index) mayResetReplicaSnapshotInactivity(opID string) {
 	if !ok || st.isSnapshot {
 		return
 	}
-	shard, release, err := i.GetShard(context.Background(), st.shardName)
-	if err == nil && shard != nil {
+	// A shard that is not loaded has no live timer to reset.
+	if shard := i.shards.Loaded(st.shardName); shard != nil {
 		shard.MayResetTransferInactivityTimer()
-		release()
 	}
 }
 
@@ -232,6 +231,10 @@ func (i *Index) recordReplicaSnapshot(opID string, st replicaSnapshotState) {
 	i.replicaSnapshots[opID] = st
 }
 
+// releaseReplicaSnapshot reads the shard from the map so a namespace that is not
+// active cannot refuse the resume. A failed resume cannot be retried:
+// resumeMaintenanceCycles clears the halt count before the work that can fail,
+// so a later release finds nothing halted.
 func (i *Index) releaseReplicaSnapshot(ctx context.Context, opID string) error {
 	i.replicaSnapshotsMu.Lock()
 	st, ok := i.replicaSnapshots[opID]
@@ -248,15 +251,10 @@ func (i *Index) releaseReplicaSnapshot(ctx context.Context, opID string) error {
 		return removeErr
 	}
 
-	shard, release, err := i.GetShard(ctx, st.shardName)
-	if err != nil {
-		if removeErr != nil {
-			return fmt.Errorf("%w; get shard for replica snapshot release: %w", removeErr, err)
-		}
-		return fmt.Errorf("get shard for replica snapshot release: %w", err)
-	}
-	defer release()
-	if shard != nil {
+	// A shard that is not loaded has nothing halted. No shardCreateLocks here:
+	// IncomingCreateReplicaSnapshot calls this holding a shutdown pin, and an
+	// unload waits ~2s on that pin while holding the same lock for write.
+	if shard := i.shards.Loaded(st.shardName); shard != nil {
 		if err := shard.resumeMaintenanceCycles(ctx); err != nil {
 			if removeErr != nil {
 				return fmt.Errorf("%w; resume maintenance after replica transfer: %w", removeErr, err)

--- a/adapters/repos/db/replica_snapshot_release_guard_test.go
+++ b/adapters/repos/db/replica_snapshot_release_guard_test.go
@@ -1,0 +1,77 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+const releaseGuardOpID = "00000000-0000-0000-0000-0000000000d0"
+
+// IncomingReleaseReplicaSnapshot holds no shutdown pin, so an unload can take
+// the shard out of i.shards while the release is resuming it. The unload's
+// shardCreateLocks write lock has to fence the release: without it the release
+// resumes a shard that is being torn down, and for a lazy shard the resume's
+// Load rebuilds it outside i.shards, where nothing will ever shut it down.
+func TestReleaseReplicaSnapshotFencedByUnload(t *testing.T) {
+	index, shard := newSharedHaltTestShard(t)
+	ctx := context.Background()
+
+	require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+	index.recordReplicaSnapshot(releaseGuardOpID, replicaSnapshotState{shardName: "shard1"})
+
+	// Stand in for the window UnloadLocalShard holds this lock across.
+	index.shardCreateLocks.Lock("shard1")
+
+	released := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		released <- index.IncomingReleaseReplicaSnapshot(ctx, releaseGuardOpID)
+	}, index.logger)
+
+	select {
+	case err := <-released:
+		index.shardCreateLocks.Unlock("shard1")
+		t.Fatalf("release reached the shard while an unload held its create lock: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	_, ok := index.shards.LoadAndDelete("shard1")
+	require.True(t, ok)
+	require.NoError(t, shard.Shutdown(ctx))
+	index.shardCreateLocks.Unlock("shard1")
+
+	require.NoError(t, <-released)
+	require.Nil(t, index.shards.Load("shard1"),
+		"release must not put a shard back after the unload removed it")
+}
+
+// performShutdown leaves haltForTransferCount set, so a release landing after
+// Index.Shutdown finds a shard that looks halted and resumes it on callbacks
+// that are already unregistered. It must report the shutdown instead.
+func TestReleaseReplicaSnapshotAfterIndexShutdown(t *testing.T) {
+	index, shard := newSharedHaltTestShard(t)
+	ctx := context.Background()
+
+	require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+	index.recordReplicaSnapshot(releaseGuardOpID, replicaSnapshotState{shardName: "shard1"})
+
+	require.NoError(t, index.Shutdown(ctx))
+
+	err := index.IncomingReleaseReplicaSnapshot(ctx, releaseGuardOpID)
+	require.ErrorIs(t, err, errAlreadyShutdown)
+}

--- a/adapters/repos/db/replica_snapshot_shared_halt_test.go
+++ b/adapters/repos/db/replica_snapshot_shared_halt_test.go
@@ -151,11 +151,11 @@ func TestHaltForTransferSharedHaltPrepErrorKeepsShardHalted(t *testing.T) {
 	shard.haltForTransferMux.Unlock()
 }
 
-// Fails: pins a bug. mayForceResumeMaintenanceCycles clears the halt count and
-// stops the inactivity monitor before the errgroup that can fail, and restores
-// neither on failure. Compaction and flushes stay paused, and every later resume
-// returns early on a zero count, so nothing can restart them.
-func TestResumeMaintenanceCyclesFailureKeepsShardHalted(t *testing.T) {
+// Documents current behaviour, not the behaviour we want. mayForceResumeMaintenanceCycles
+// clears the halt count and stops the inactivity monitor before the errgroup that can
+// fail, and restores neither, so a failed resume leaves a zero count while the cycles it
+// could not restart stay paused — and every later resume returns early on that count.
+func TestResumeMaintenanceCyclesFailureClearsHalt(t *testing.T) {
 	_, shard := newSharedHaltTestShard(t)
 	ctx := context.Background()
 
@@ -168,8 +168,8 @@ func TestResumeMaintenanceCyclesFailureKeepsShardHalted(t *testing.T) {
 	shard.haltForTransferMux.Lock()
 	haltCount := shard.haltForTransferCount
 	shard.haltForTransferMux.Unlock()
-	require.Equal(t, 1, haltCount,
-		"a failed resume must keep the halt, so a later release can still resume the cycles")
+	require.Zero(t, haltCount,
+		"the halt count is cleared ahead of the resume work, so a failed resume drops it")
 }
 
 // snapshotHasObject reconstructs the snapshot's objects bucket from the wire

--- a/adapters/repos/db/replica_snapshot_shared_halt_test.go
+++ b/adapters/repos/db/replica_snapshot_shared_halt_test.go
@@ -151,6 +151,27 @@ func TestHaltForTransferSharedHaltPrepErrorKeepsShardHalted(t *testing.T) {
 	shard.haltForTransferMux.Unlock()
 }
 
+// Fails: pins a bug. mayForceResumeMaintenanceCycles clears the halt count and
+// stops the inactivity monitor before the errgroup that can fail, and restores
+// neither on failure. Compaction and flushes stay paused, and every later resume
+// returns early on a zero count, so nothing can restart them.
+func TestResumeMaintenanceCyclesFailureKeepsShardHalted(t *testing.T) {
+	_, shard := newSharedHaltTestShard(t)
+	ctx := context.Background()
+
+	require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+
+	// Unregistering makes the resume's Activate fail with ErrorCallbackNotFound.
+	require.NoError(t, shard.cycleCallbacks.vectorCombinedCallbacksCtrl.Unregister(ctx))
+	require.Error(t, shard.resumeMaintenanceCycles(ctx))
+
+	shard.haltForTransferMux.Lock()
+	haltCount := shard.haltForTransferCount
+	shard.haltForTransferMux.Unlock()
+	require.Equal(t, 1, haltCount,
+		"a failed resume must keep the halt, so a later release can still resume the cycles")
+}
+
 // snapshotHasObject reconstructs the snapshot's objects bucket from the wire
 // file list (copying every listed lsm/objects/* file out of sourceRoot into a
 // throwaway dir), opens it read-only, and reports whether id is retrievable —

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -508,70 +508,84 @@ func (i *Index) IncomingStartChangeCapture(ctx context.Context, shardName, opID 
 	return nil
 }
 
+// errShardNotLoaded reports a change-log request for a shard this node does not
+// hold loaded. The message must not contain changelog.ErrMsgNoActiveLog or
+// changelog.ErrMsgNoActiveChangeCaptureLog: isCCLAlreadyGone in
+// cluster/replication matches both and marks the movement complete, but an
+// unloaded shard means writes since the unload were never captured.
+func errShardNotLoaded(action, shardName string) error {
+	return fmt.Errorf("%s: shard %q is not loaded", action, shardName)
+}
+
 // IncomingGetChangeLog returns a tailer over the shard's active log. Caller
-// owns Close; the tailer has its own file handle and outlives the shard pin.
+// owns Close; the tailer has its own file handle and outlives this call.
 // untilLSN is the inclusive upper bound on emitted LSNs.
 func (i *Index) IncomingGetChangeLog(ctx context.Context, shardName, opID string, untilLSN uint64) (*changelog.Tailer, error) {
-	shard, release, err := i.getOrInitShard(ctx, shardName)
+	const action = "incoming get change log"
+	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
-		return nil, fmt.Errorf("incoming get change log: get shard %q: %w", shardName, err)
+		return nil, fmt.Errorf("%s: %w", action, err)
 	}
 	defer release()
 	if shard == nil {
-		return nil, fmt.Errorf("incoming get change log: shard %q not found", shardName)
+		return nil, errShardNotLoaded(action, shardName)
 	}
 	log, ok := shard.GetChangeLog(ctx, opID)
 	if !ok {
-		return nil, fmt.Errorf("incoming get change log: %s %q on shard %q", changelog.ErrMsgNoActiveLog, opID, shardName)
+		return nil, fmt.Errorf("%s: %s %q on shard %q", action, changelog.ErrMsgNoActiveLog, opID, shardName)
 	}
 	return log.NewTailerWithCap(0, untilLSN)
 }
 
 // IncomingSnapshotChangeLogLSN returns the current LSN without sealing the log.
 func (i *Index) IncomingSnapshotChangeLogLSN(ctx context.Context, shardName, opID string) (uint64, error) {
-	shard, release, err := i.getOrInitShard(ctx, shardName)
+	const action = "incoming snapshot change-log LSN"
+	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
-		return 0, fmt.Errorf("incoming snapshot change-log LSN: get shard %q: %w", shardName, err)
+		return 0, fmt.Errorf("%s: %w", action, err)
 	}
 	defer release()
 	if shard == nil {
-		return 0, fmt.Errorf("incoming snapshot change-log LSN: shard %q not found", shardName)
+		return 0, errShardNotLoaded(action, shardName)
 	}
 	lsn, err := shard.SnapshotChangeLogLSN(ctx, opID)
 	if err != nil {
-		return 0, fmt.Errorf("incoming snapshot change-log LSN: op %q: %w", opID, err)
+		return 0, fmt.Errorf("%s: op %q: %w", action, opID, err)
 	}
 	return lsn, nil
 }
 
+// IncomingFinalizeChangeLog seals the log and returns the final LSN. The wait
+// for in-flight writes to drain can run for as long as the caller's context
+// allows, so it holds only the shutdown refcount — an unload attempted mid-seal
+// fails rather than tearing the shard down under it.
 func (i *Index) IncomingFinalizeChangeLog(ctx context.Context, shardName, opID string) (uint64, error) {
-	shard, release, err := i.getOrInitShard(ctx, shardName)
+	const action = "incoming finalize change log"
+	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
-		return 0, fmt.Errorf("incoming finalize change log: get shard %q: %w", shardName, err)
+		return 0, fmt.Errorf("%s: %w", action, err)
 	}
 	defer release()
 	if shard == nil {
-		return 0, fmt.Errorf("incoming finalize change log: shard %q not found", shardName)
+		return 0, errShardNotLoaded(action, shardName)
 	}
 	finalLSN, err := shard.FinalizeChangeLog(ctx, opID)
 	if err != nil {
-		return 0, fmt.Errorf("incoming finalize change log: op %q: %w", opID, err)
+		return 0, fmt.Errorf("%s: op %q: %w", action, opID, err)
 	}
 	return finalLSN, nil
 }
 
-// IncomingStopChangeCapture reads the shard from the map so a namespace that is
-// not active cannot refuse the stop, which would leave the log registered and
-// collecting every later write. An unloaded shard collects nothing, so it is a
-// no-op; its log file is removed when the shard next loads.
+// IncomingStopChangeCapture deactivates the log and removes its file. An
+// unloaded shard collects nothing, so stopping is already done — loading it to
+// serve a teardown would materialize a shard the caller never asked for. Its
+// log file is removed when the shard next loads.
 func (i *Index) IncomingStopChangeCapture(ctx context.Context, shardName, opID string) error {
-	// Held across the call, as the unload paths hold it for write: an unload in
-	// between would let StopChangeCapture's own load reopen a shard the map no
-	// longer holds.
-	i.shardCreateLocks.RLock(shardName)
-	defer i.shardCreateLocks.RUnlock(shardName)
-
-	shard := i.shards.Loaded(shardName)
+	shard, release, err := i.getLoadedShard(shardName)
+	if err != nil {
+		return fmt.Errorf("incoming stop change capture: %w", err)
+	}
+	defer release()
 	if shard == nil {
 		i.logger.WithFields(logrus.Fields{
 			"action":   "change_capture_log",

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -560,14 +560,26 @@ func (i *Index) IncomingFinalizeChangeLog(ctx context.Context, shardName, opID s
 	return finalLSN, nil
 }
 
+// IncomingStopChangeCapture reads the shard from the map so a namespace that is
+// not active cannot refuse the stop, which would leave the log registered and
+// collecting every later write. An unloaded shard collects nothing, so it is a
+// no-op; its log file is removed when the shard next loads.
 func (i *Index) IncomingStopChangeCapture(ctx context.Context, shardName, opID string) error {
-	shard, release, err := i.getOrInitShard(ctx, shardName)
-	if err != nil {
-		return fmt.Errorf("incoming stop change capture: get shard %q: %w", shardName, err)
-	}
-	defer release()
+	// Held across the call, as the unload paths hold it for write: an unload in
+	// between would let StopChangeCapture's own load reopen a shard the map no
+	// longer holds.
+	i.shardCreateLocks.RLock(shardName)
+	defer i.shardCreateLocks.RUnlock(shardName)
+
+	shard := i.shards.Loaded(shardName)
 	if shard == nil {
-		return fmt.Errorf("incoming stop change capture: shard %q not found", shardName)
+		i.logger.WithFields(logrus.Fields{
+			"action":   "change_capture_log",
+			"op_id":    opID,
+			"shard":    shardName,
+			"resident": i.shards.Load(shardName) != nil,
+		}).Debug("no loaded shard to stop change capture on")
+		return nil
 	}
 	if err := shard.StopChangeCapture(ctx, opID); err != nil {
 		return fmt.Errorf("incoming stop change capture: op %q: %w", opID, err)

--- a/adapters/repos/db/replication_changelog_incoming_integration_test.go
+++ b/adapters/repos/db/replication_changelog_incoming_integration_test.go
@@ -1,0 +1,257 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"errors"
+	"io"
+	"math"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/replication/changelog"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// incomingChangeLogEndpoints are the change-capture endpoints a movement's
+// target calls on the source. errorsOnMissingShard splits them: the three
+// drain reads must report a shard they cannot serve, while stop is a teardown
+// an unloaded shard has already satisfied.
+var incomingChangeLogEndpoints = []struct {
+	name                 string
+	errorsOnMissingShard bool
+	call                 func(ctx context.Context, idx *Index, shardName, opID string) error
+}{
+	{
+		name:                 "get change log",
+		errorsOnMissingShard: true,
+		call: func(ctx context.Context, idx *Index, shardName, opID string) error {
+			tailer, err := idx.IncomingGetChangeLog(ctx, shardName, opID, math.MaxUint64)
+			if tailer != nil {
+				_ = tailer.Close()
+			}
+			return err
+		},
+	},
+	{
+		name:                 "snapshot change-log LSN",
+		errorsOnMissingShard: true,
+		call: func(ctx context.Context, idx *Index, shardName, opID string) error {
+			_, err := idx.IncomingSnapshotChangeLogLSN(ctx, shardName, opID)
+			return err
+		},
+	},
+	{
+		name:                 "finalize change log",
+		errorsOnMissingShard: true,
+		call: func(ctx context.Context, idx *Index, shardName, opID string) error {
+			_, err := idx.IncomingFinalizeChangeLog(ctx, shardName, opID)
+			return err
+		},
+	},
+	{
+		name: "stop change capture",
+		call: func(ctx context.Context, idx *Index, shardName, opID string) error {
+			return idx.IncomingStopChangeCapture(ctx, shardName, opID)
+		},
+	},
+}
+
+func changelogPath(idx *Index, shardName, opID string) string {
+	return filepath.Join(shardPath(idx.path(), shardName), changelogDirName, opID+changelogFileExtension)
+}
+
+func replayTestObject(idStr string) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:                 strfmt.UUID(idStr),
+			Class:              "ReplayClass",
+			Properties:         map[string]interface{}{"stringProp": "x"},
+			LastUpdateTimeUnix: 1_000,
+		},
+	}
+}
+
+// Loading a shard sweeps its changelog dir, so a drain read that force-loads
+// deletes the very log it was asked for — and the op registration it would
+// need died with the unload anyway. Stop is in the table too, pinning the
+// other half of the split: a teardown an unloaded shard has already satisfied.
+func TestIncomingChangeLog_UnloadedShardKeepsLogAndStaysUnloaded(t *testing.T) {
+	const opID = "op-drain-unloaded"
+
+	for _, tc := range incomingChangeLogEndpoints {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			_, idx, shardName, _ := setupReplayShard(t)
+			require.NoError(t, idx.IncomingStartChangeCapture(ctx, shardName, opID))
+
+			logPath := changelogPath(idx, shardName, opID)
+			require.FileExists(t, logPath)
+			require.NoError(t, idx.UnloadLocalShard(ctx, shardName))
+			require.Nil(t, idx.shards.Load(shardName), "shard must be unloaded before the call")
+
+			err := tc.call(ctx, idx, shardName, opID)
+
+			if tc.errorsOnMissingShard {
+				require.Error(t, err)
+				// The consumer reads either phrase as "the log is already sealed"
+				// and marks the movement caught up. An unloaded shard is not that:
+				// writes since the unload were never captured.
+				require.NotContains(t, err.Error(), changelog.ErrMsgNoActiveLog)
+				require.NotContains(t, err.Error(), changelog.ErrMsgNoActiveChangeCaptureLog)
+			} else {
+				require.NoError(t, err)
+			}
+			require.FileExists(t, logPath, "serving the call must not delete the log")
+			require.Nil(t, idx.shards.Load(shardName), "serving the call must not load the shard")
+		})
+	}
+}
+
+// A shard name this node never hosted — a malformed or racing RPC — must not
+// leave a shard behind.
+func TestIncomingChangeLog_UnknownShardCreatesNothing(t *testing.T) {
+	const opID = "op-phantom"
+
+	for _, tc := range incomingChangeLogEndpoints {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			_, idx, _, _ := setupReplayShard(t)
+
+			for _, shardName := range []string{"never-created-shard", ""} {
+				err := tc.call(ctx, idx, shardName, opID)
+				if tc.errorsOnMissingShard {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				require.Nil(t, idx.shards.Load(shardName), "must not register shard %q", shardName)
+			}
+
+			require.NoDirExists(t, shardPath(idx.path(), "never-created-shard"),
+				"must not create a shard directory")
+		})
+	}
+}
+
+// The whole drain sequence over a loaded shard, driven through the endpoints
+// the movement's target actually calls.
+func TestIncomingChangeLog_LoadedShardRoundTrip(t *testing.T) {
+	ctx := testCtx()
+	const (
+		opID    = "op-roundtrip"
+		writes  = 2
+		lastLSN = uint64(writes)
+	)
+
+	repo, idx, shardName, class := setupReplayShard(t)
+	require.NoError(t, idx.IncomingStartChangeCapture(ctx, shardName, opID))
+
+	for range writes {
+		obj := &models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      class.Class,
+			Properties: map[string]interface{}{"stringProp": "captured"},
+		}
+		require.NoError(t, repo.PutObject(ctx, obj, []float32{1, 2, 3}, nil, nil, nil, 0))
+	}
+
+	snap, err := idx.IncomingSnapshotChangeLogLSN(ctx, shardName, opID)
+	require.NoError(t, err)
+	require.Equal(t, lastLSN, snap)
+
+	tailer, err := idx.IncomingGetChangeLog(ctx, shardName, opID, snap)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tailer.Close() })
+
+	var drained int
+	for {
+		_, err := tailer.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		drained++
+	}
+	require.Equal(t, writes, drained, "the tailer must emit every captured write up to the cap")
+
+	finalLSN, err := idx.IncomingFinalizeChangeLog(ctx, shardName, opID)
+	require.NoError(t, err)
+	require.Equal(t, lastLSN, finalLSN)
+
+	require.NoError(t, idx.IncomingStopChangeCapture(ctx, shardName, opID))
+
+	// A loaded shard that no longer holds the op is the "already sealed" signal
+	// the consumer acts on, and must stay distinguishable from an unloaded one.
+	// Both drain reads carry it, through different constants.
+	_, err = idx.IncomingSnapshotChangeLogLSN(ctx, shardName, opID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), changelog.ErrMsgNoActiveChangeCaptureLog)
+
+	_, err = idx.IncomingGetChangeLog(ctx, shardName, opID, math.MaxUint64)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), changelog.ErrMsgNoActiveLog)
+}
+
+// The seal holds a shutdown refcount, so an unload attempted mid-seal fails
+// instead of tearing the shard down under it — and the seal still completes.
+func TestIncomingFinalizeChangeLog_UnloadCannotTearDownMidSeal(t *testing.T) {
+	ctx := testCtx()
+	const opID = "op-finalize-unload"
+
+	_, idx, shardName, _ := setupReplayShard(t)
+	logger, _ := logrusTestLogger()
+	require.NoError(t, idx.IncomingStartChangeCapture(ctx, shardName, opID))
+
+	shard, ok := idx.shards.Loaded(shardName).(*Shard)
+	require.True(t, ok)
+
+	// Left uncommitted, so the seal blocks on it.
+	require.Empty(t, shard.preparePutObject(ctx, "req-pending", replayTestObject(uuid.NewString())).Errors)
+
+	finalizeDone := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		_, ferr := idx.IncomingFinalizeChangeLog(ctx, shardName, opID)
+		finalizeDone <- ferr
+	}, logger)
+
+	// Let the seal take its refcount. If it instead returned early the drain
+	// never started, so report that rather than the unload's verdict.
+	time.Sleep(20 * time.Millisecond)
+	select {
+	case ferr := <-finalizeDone:
+		t.Fatalf("seal returned before the in-flight write drained: %v", ferr)
+	default:
+	}
+
+	require.Error(t, idx.UnloadLocalShard(ctx, shardName),
+		"unload must not shut the shard down while a seal is in flight")
+
+	shard.commitReplication(ctx, "req-pending")
+	select {
+	case ferr := <-finalizeDone:
+		require.NoError(t, ferr, "seal must complete once the in-flight write drains")
+	case <-time.After(30 * time.Second):
+		t.Fatal("seal never completed after the in-flight write drained")
+	}
+}

--- a/cluster/replication/copier/copier_changelog.go
+++ b/cluster/replication/copier/copier_changelog.go
@@ -111,8 +111,8 @@ func (c *Copier) FinalizeChangeLog(ctx context.Context, srcNodeId, indexName, sh
 	return resp.FinalLsn, nil
 }
 
-// StopChangeCapture deactivates the source log and removes its file. Safe to
-// call on an unknown opID; the server treats it as a no-op.
+// StopChangeCapture deactivates the source log and removes its file. The server
+// treats an unknown opID or an unloaded source shard as a no-op.
 func (c *Copier) StopChangeCapture(ctx context.Context, srcNodeId, indexName, shardName, opID string) error {
 	client, err := c.dialSource(ctx, srcNodeId)
 	if err != nil {

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -117,7 +117,8 @@ type RemoteIndexIncomingRepo interface {
 	// IncomingFinalizeChangeLog drains the pre-seal in-flight set, seals
 	// the log and returns the final LSN.
 	IncomingFinalizeChangeLog(ctx context.Context, shardName, opID string) (uint64, error)
-	// IncomingStopChangeCapture deactivates and removes the log.
+	// IncomingStopChangeCapture deactivates and removes the log; a no-op when
+	// the shard is not loaded.
 	IncomingStopChangeCapture(ctx context.Context, shardName, opID string) error
 }
 


### PR DESCRIPTION
### What's being changed:

For namespaces we need to implement a guard against shard loading on suspended namespaces/collections. However this clashes with replica movement:
- we want to allow started movements to finish but not allow new ones
- at the end replica movement, getShard was called for some tear down which would be blocked by the guard

This is resolved by getting the shard directly from the shardMap:
- if it is in there => we get it and tear down everything we need to do
- if it is not in there => already down or in the process of shutting down => nothing for us to do

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
