### PR TITLE
Refresh the memory monitor while shards are read-only

### DIFF
--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -56,17 +56,25 @@ func (d *DB) scanResourceUsage() {
 			case <-t.C:
 				updateMappings := i%(memwatch.MappingDelayInS*2) == 0
 				du := d.getDiskUse(d.config.RootPath)
-				if d.resourceScanState.isReadOnly {
-					d.resourceUseRecovery(d.memMonitor, du)
-				} else {
-					d.resourceUseWarn(d.memMonitor, du, updateMappings)
-					d.resourceUseReadonly(d.memMonitor, du)
-				}
+				d.scanResourceUsageOnce(d.memMonitor, du, updateMappings)
 				i += 1
 			}
 		}
 	}
 	enterrors.GoWrapper(f, d.logger)
+}
+
+// scanResourceUsageOnce runs a single scan pass. The monitor is refreshed here
+// because both branches read from it: without it, shards held read-only by
+// memory pressure would never see the usage drop back below the threshold.
+func (db *DB) scanResourceUsageOnce(mon *memwatch.Monitor, du diskUse, updateMappings bool) {
+	mon.Refresh(updateMappings)
+	if db.resourceScanState.isReadOnly {
+		db.resourceUseRecovery(mon, du)
+	} else {
+		db.resourceUseWarn(mon, du)
+		db.resourceUseReadonly(mon, du)
+	}
 }
 
 type resourceScanState struct {
@@ -83,8 +91,7 @@ func newResourceScanState() *resourceScanState {
 }
 
 // logs a warning if user-set threshold is surpassed
-func (db *DB) resourceUseWarn(mon *memwatch.Monitor, du diskUse, updateMappings bool) {
-	mon.Refresh(updateMappings)
+func (db *DB) resourceUseWarn(mon *memwatch.Monitor, du diskUse) {
 	db.diskUseWarn(du)
 	db.memUseWarn(mon)
 }

--- a/adapters/repos/db/resource_use_test.go
+++ b/adapters/repos/db/resource_use_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -512,4 +513,26 @@ func TestSetShardsReady_PartialFailure(t *testing.T) {
 	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should remain true when some shards fail to transition")
 	successShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 	failingShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+}
+
+// Shards held read-only by memory pressure must go ready again once memory
+// drops — the scan pass is the only thing refreshing the monitor.
+func TestScanResourceUsageOnce_SeesMemoryDropWhileReadOnly(t *testing.T) {
+	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
+	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
+	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+
+	var used atomic.Int64
+	used.Store(95)
+	mon := memwatch.NewMonitor(used.Load, func(int64) int64 { return 100 }, 1.0)
+
+	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
+	db.resourceScanState.isReadOnly = true
+
+	used.Store(10)
+	db.scanResourceUsageOnce(mon, diskUse{total: 100, free: 100, avail: 100}, false)
+
+	assert.False(t, db.resourceScanState.isReadOnly, "isReadOnly should lift once memory drops")
+	shard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 }


### PR DESCRIPTION
### What's being changed:

The monitor was only refreshed in the non-read-only branch of the scan  loop, as a side effect of resourceUseWarn. Once shards had been tripped to read-only, the recovery check kept reading the same memory usage that  tripped it, so it could never see memory drop back below the threshold.  And because recovery requires both resources to be below their limits,  a stale-high memory reading also blocked recovery from disk pressure. Disk use itself was unaffected — it is read fresh on every tick.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
