### PR TITLE
docs(backup): mark the non-hardlink backup fallback as deprecated (removed in v1.40)

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -234,6 +234,8 @@ func (i *Index) descriptor(ctx context.Context, backupID string, desc *backup.Cl
 	if useHardlinks {
 		return i.descriptorWithHardlinks(ctx, backupID, desc, classBaseDescrs)
 	}
+	// Deprecated: NO-HARDLINK-BACKUP. Only reachable on filesystems without hardlink
+	// support. Removed in v1.40; bugs here are not fixed.
 	return i.descriptorWithoutHardlinks(ctx, backupID, desc, classBaseDescrs)
 }
 
@@ -458,6 +460,8 @@ func copyFile(src, dst string) (err error) {
 
 // descriptorWithoutHardlinks is the fallback path for filesystems that don't support
 // hardlinks. Compaction remains paused for the entire backup upload duration.
+//
+// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string, desc *backup.ClassDescriptor, classBaseDescrs []*backup.ClassDescriptor) (err error) {
 	defer func() {
 		if err != nil {
@@ -501,6 +505,8 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 //
 // For inactive shards, backupProtectedShards is set and backupLock.Lock is held
 // until ReleaseBackup to block both activation and FREEZE/FROZEN file operations.
+//
+// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, classBaseDescrs []*backup.ClassDescriptor) (*backup.ShardDescriptor, error) {
 	shardBaseDescr := i.collectShardBaseDescrs(name, classBaseDescrs)
 
@@ -568,6 +574,8 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 
 // backupInactiveShardWithoutHardlinks backs up an inactive (unloaded) shard by reading
 // its files directly from disk.
+//
+// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 func (i *Index) backupInactiveShardWithoutHardlinks(name string, sd *backup.ShardDescriptor, shardBaseDescr []backup.ShardAndID) error {
 	shardDir := shardPath(i.path(), name)
 	if _, err := os.Stat(shardDir); err != nil {
@@ -670,6 +678,8 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 
 	// Release non-hardlink backup protections: clear the protection flag and
 	// release the held backupLock.Lock for each protected shard.
+	//
+	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
 		name := key.(string)
 		i.backupLock.Unlock(name)

--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -234,8 +234,8 @@ func (i *Index) descriptor(ctx context.Context, backupID string, desc *backup.Cl
 	if useHardlinks {
 		return i.descriptorWithHardlinks(ctx, backupID, desc, classBaseDescrs)
 	}
-	// Deprecated: NO-HARDLINK-BACKUP. Only reachable on filesystems without hardlink
-	// support. Removed in v1.40; bugs here are not fixed.
+	// NO-HARDLINK-BACKUP: only reachable on filesystems without hardlink support.
+	// Removed in v1.40; bugs here are not fixed.
 	return i.descriptorWithoutHardlinks(ctx, backupID, desc, classBaseDescrs)
 }
 
@@ -679,7 +679,7 @@ func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	// Release non-hardlink backup protections: clear the protection flag and
 	// release the held backupLock.Lock for each protected shard.
 	//
-	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
+	// NO-HARDLINK-BACKUP: removed in v1.40; bugs here are not fixed.
 	i.backupProtectedShards.Range(func(key, _ any) bool {
 		name := key.(string)
 		i.backupLock.Unlock(name)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -298,6 +298,8 @@ type Index struct {
 	// backupProtectedShards tracks shard names protected during non-hardlink backup.
 	// Activation and destructive status changes are blocked until ReleaseBackup.
 	// non-hardlink backups only occur on niche filesystems so this is not a hot path
+	//
+	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 	backupProtectedShards sync.Map
 
 	metrics          *Metrics
@@ -2804,6 +2806,7 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 		return nil
 	}
 
+	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 	if _, protected := i.backupProtectedShards.Load(shardName); protected {
 		return fmt.Errorf("shard %q is protected for backup, activation blocked", shardName)
 	}
@@ -2904,6 +2907,7 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 		// double check if loaded in the meantime by concurrent call, if not load it
 		shard = i.shards.Load(shardName)
 		if shard == nil {
+			// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 			if _, protected := i.backupProtectedShards.Load(shardName); protected {
 				return nil, func() {}, fmt.Errorf("shard %q is protected for backup, activation blocked", shardName)
 			}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2806,7 +2806,7 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 		return nil
 	}
 
-	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
+	// NO-HARDLINK-BACKUP: removed in v1.40; bugs here are not fixed.
 	if _, protected := i.backupProtectedShards.Load(shardName); protected {
 		return fmt.Errorf("shard %q is protected for backup, activation blocked", shardName)
 	}
@@ -2907,7 +2907,7 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 		// double check if loaded in the meantime by concurrent call, if not load it
 		shard = i.shards.Load(shardName)
 		if shard == nil {
-			// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
+			// NO-HARDLINK-BACKUP: removed in v1.40; bugs here are not fixed.
 			if _, protected := i.backupProtectedShards.Load(shardName); protected {
 				return nil, func() {}, fmt.Errorf("shard %q is protected for backup, activation blocked", shardName)
 			}


### PR DESCRIPTION
SuperClaude here.

Backups take one of two paths. On normal filesystems we hardlink the LSM segment files, so compaction can resume within seconds. On filesystems without hardlink support we fall back to copying, which keeps compaction paused for the whole upload.

Etienne and dirkkul agreed this morning to drop that fallback in v1.40 rather than keep maintaining it. This PR adds the markers now so future PRs can point at them to explain why a bug on that path is not being fixed.

**Comments only. No behaviour change** — 14 added lines, all of them comments, nothing else in the diff.

Every marker uses the same token, so the full set is one grep away:

```
grep -rn NO-HARDLINK-BACKUP --include='*.go'
```

**Where the markers are**

| file | what | marker |
|---|---|---|
| `backup.go:237` | the branch that picks the fallback | plain |
| `backup.go:464` | `descriptorWithoutHardlinks` | `Deprecated:` |
| `backup.go:509` | `backupShardWithoutHardlinks` | `Deprecated:` |
| `backup.go:578` | `backupInactiveShardWithoutHardlinks` | `Deprecated:` |
| `backup.go:682` | the cleanup loop in `ReleaseBackup` | plain |
| `index.go:302` | the `backupProtectedShards` field | `Deprecated:` |
| `index.go:2809`, `:2910` | the two places that read it | plain |

**Not marked:** `probeHardlinkSupport`, because export uses it too. Export returns an error when hardlinks are missing instead of falling back, which is the behaviour we eventually want for backup as well. Marking the probe would suggest export is going away too, which it is not. The hardlink path itself is unchanged.

**On the `Deprecated:` keyword:** Go only gives `Deprecated:` special meaning in a declaration's doc comment. Four of the eight markers sit on a declaration (the three functions and the `backupProtectedShards` field) and use the real keyword, so `go doc` renders them. The other four sit in front of a statement, where the keyword would mean nothing to tooling, so those are plain `NO-HARDLINK-BACKUP:` markers rather than something that looks like a marker but is not one. The single grep finds all eight either way, which is the property that actually matters here.

For the four real ones, the thing to check was whether staticcheck would then warn at every call site, which would have been pure noise since all these calls are internal and deliberate. I checked instead of guessing: it does not warn when the caller is in the same package as the deprecated symbol, and all of these are. Confirmed with a throwaway file in the same package holding a deprecated symbol from another package (warns) next to a locally declared one (does not). So the keyword is safe on those four, no `nolint` lines were needed, and `golangci-lint run ./...` is clean. If any of those four declarations are ever exported or moved to another package, the warnings will start, which is what we want.

— SuperClaude
