### PR TITLE
perf(async-repl): size hashbeat digest buffers by set count, not leaf count

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -170,6 +170,10 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords
 		if recordCount > int64(maxRecords) {
 			recordCount = int64(maxRecords)
 		}
+		// a caller-supplied negative bound must not reach make
+		if recordCount < 0 {
+			recordCount = 0
+		}
 		results = make([]types.RepairResponse, 0, int(recordCount))
 	}
 	var buf [replica.DigestObjectsInRangeRecordLength]byte
@@ -249,6 +253,9 @@ func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords
 		recordCount := contentLength / int64(replica.CompareDigestsRecordLength)
 		if recordCount > int64(maxRecords) {
 			recordCount = int64(maxRecords)
+		}
+		if recordCount < 0 {
+			recordCount = 0
 		}
 		results = make([]types.RepairResponse, 0, int(recordCount))
 	}
@@ -864,6 +871,9 @@ func readDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords int) (
 		recordCount := contentLength / int64(hashtree.DigestLength)
 		if recordCount > int64(maxRecords) {
 			recordCount = int64(maxRecords)
+		}
+		if recordCount < 0 {
+			recordCount = 0
 		}
 		digests = make([]hashtree.Digest, 0, int(recordCount))
 	}

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -20,7 +20,6 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
-	"math"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -148,7 +147,7 @@ func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 	}
 
 	if res.Header.Get("X-Response-Encoding") == "binary" {
-		return readDigestsInRangeBinaryStream(res.Body, res.ContentLength)
+		return readDigestsInRangeBinaryStream(res.Body, res.ContentLength, limit)
 	}
 
 	// Legacy JSON fallback for older nodes.
@@ -163,12 +162,15 @@ func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 // by writeDigestsInRangeResponse. Each record is
 // replica.DigestObjectsInRangeRecordLength bytes: 16-byte UUID (RFC-4122
 // binary form) + 8-byte UpdateTime (int64 big-endian).
-func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64) ([]types.RepairResponse, error) {
+func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]types.RepairResponse, error) {
 	var results []types.RepairResponse
 	if contentLength > 0 {
-		if recordCount := contentLength / int64(replica.DigestObjectsInRangeRecordLength); recordCount <= int64(math.MaxInt) {
-			results = make([]types.RepairResponse, 0, int(recordCount))
+		// Content-Length is peer-controlled; never pre-size beyond the request's own bound
+		recordCount := contentLength / int64(replica.DigestObjectsInRangeRecordLength)
+		if recordCount > int64(maxRecords) {
+			recordCount = int64(maxRecords)
 		}
+		results = make([]types.RepairResponse, 0, int(recordCount))
 	}
 	var buf [replica.DigestObjectsInRangeRecordLength]byte
 	for {
@@ -236,17 +238,19 @@ func (c *replicationClient) CompareDigests(ctx context.Context,
 		return nil, fmt.Errorf("status code: %v, error: %s", res.StatusCode, b)
 	}
 
-	return readCompareDigestsBinaryStream(res.Body, res.ContentLength)
+	return readCompareDigestsBinaryStream(res.Body, res.ContentLength, len(digests))
 }
 
 // readCompareDigestsBinaryStream decodes a fixed-size binary stream produced
 // by postCompareDigests. Each record is replica.CompareDigestsRecordLength bytes.
-func readCompareDigestsBinaryStream(r io.Reader, contentLength int64) ([]types.RepairResponse, error) {
+func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]types.RepairResponse, error) {
 	var results []types.RepairResponse
 	if contentLength > 0 {
-		if recordCount := contentLength / int64(replica.CompareDigestsRecordLength); recordCount <= int64(math.MaxInt) {
-			results = make([]types.RepairResponse, 0, int(recordCount))
+		recordCount := contentLength / int64(replica.CompareDigestsRecordLength)
+		if recordCount > int64(maxRecords) {
+			recordCount = int64(maxRecords)
 		}
+		results = make([]types.RepairResponse, 0, int(recordCount))
 	}
 	var buf [replica.CompareDigestsRecordLength]byte
 	for {
@@ -319,7 +323,7 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	}
 
 	if res.Header.Get("X-Response-Encoding") == "binary" {
-		return readDigestsBinaryStream(res.Body, res.ContentLength)
+		return readDigestsBinaryStream(res.Body, res.ContentLength, discriminant.SetCount())
 	}
 
 	// Legacy JSON fallback for older nodes.
@@ -852,15 +856,16 @@ func shouldRetry(code int) bool {
 		code == http.StatusServiceUnavailable
 }
 
-// readDigestsBinaryStream reads fixed-size digest records directly from r
-// without buffering the whole body. contentLength is used only to pre-allocate
-// the result slice; pass -1 when unknown.
-func readDigestsBinaryStream(r io.Reader, contentLength int64) ([]hashtree.Digest, error) {
+// readDigestsBinaryStream reads fixed-size digest records directly from r without
+// buffering the whole body; contentLength only pre-sizes, capped at maxRecords.
+func readDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]hashtree.Digest, error) {
 	var digests []hashtree.Digest
 	if contentLength > 0 {
-		if recordCount := contentLength / int64(hashtree.DigestLength); recordCount <= int64(math.MaxInt) {
-			digests = make([]hashtree.Digest, 0, int(recordCount))
+		recordCount := contentLength / int64(hashtree.DigestLength)
+		if recordCount > int64(maxRecords) {
+			recordCount = int64(maxRecords)
 		}
+		digests = make([]hashtree.Digest, 0, int(recordCount))
 	}
 	var buf [hashtree.DigestLength]byte
 	for {

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -12,6 +12,7 @@
 package clients
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/binary"
@@ -796,6 +797,49 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest in range record")
 	})
+}
+
+func TestBinaryStreamReadersClampNonPositiveMaxRecords(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		recordLen int
+		read      func(r io.Reader, contentLength int64, maxRecords int) (int, error)
+	}{
+		{
+			"digests in range", replica.DigestObjectsInRangeRecordLength,
+			func(r io.Reader, contentLength int64, maxRecords int) (int, error) {
+				results, err := readDigestsInRangeBinaryStream(r, contentLength, maxRecords)
+				return len(results), err
+			},
+		},
+		{
+			"compare digests", replica.CompareDigestsRecordLength,
+			func(r io.Reader, contentLength int64, maxRecords int) (int, error) {
+				results, err := readCompareDigestsBinaryStream(r, contentLength, maxRecords)
+				return len(results), err
+			},
+		},
+		{
+			"hashtree level digests", hashtree.DigestLength,
+			func(r io.Reader, contentLength int64, maxRecords int) (int, error) {
+				digests, err := readDigestsBinaryStream(r, contentLength, maxRecords)
+				return len(digests), err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := make([]byte, 2*tc.recordLen)
+			for _, maxRecords := range []int{-1, 0} {
+				n, err := tc.read(bytes.NewReader(body), int64(len(body)), maxRecords)
+				require.NoError(t, err)
+				require.Equal(t, 2, n)
+			}
+		})
+	}
 }
 
 func TestReplicationOverwriteObjectsCompression(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/async_checkpoint_handler_test.go
+++ b/adapters/handlers/rest/clusterapi/async_checkpoint_handler_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
 	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
 )
 
@@ -280,6 +281,45 @@ func TestAsyncCheckpoint_StatusMapping(t *testing.T) {
 			req.Header.Set("Content-Type", "application/json")
 
 			res, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer res.Body.Close()
+
+			assert.Equal(t, tc.wantStatus, res.StatusCode, "body: %s", readBodyOnce(t, res))
+		})
+	}
+}
+
+func TestHashTreeLevel_StatusMapping(t *testing.T) {
+	cases := []struct {
+		name       string
+		repErr     error
+		wantStatus int
+	}{
+		{
+			name:       "async_rep_inactive_returns_412",
+			repErr:     fmt.Errorf("%w: hashtree not initialized on shard %q", replica.ErrAsyncReplicationNotActive, "s1"),
+			wantStatus: http.StatusPreconditionFailed,
+		},
+		{
+			name:       "other_error_returns_500",
+			repErr:     fmt.Errorf("some unexpected backend failure"),
+			wantStatus: http.StatusInternalServerError,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rep := replicaTypes.NewMockReplicator(t)
+			rep.On("HashTreeLevel", mock.Anything, "MyClass", "s1", 0, mock.Anything).
+				Return(nil, tc.repErr).Once()
+
+			server, cleanup := asyncCheckpointHandlerTestServer(t, rep)
+			defer cleanup()
+
+			discriminant, err := hashtree.NewBitset(1).Set(0).Marshal()
+			require.NoError(t, err)
+
+			url := fmt.Sprintf("%s/replicas/indices/MyClass/shards/s1/objects/hashtree/level/0", server.URL)
+			res, err := http.Post(url, "application/octet-stream", bytes.NewReader(discriminant))
 			require.NoError(t, err)
 			defer res.Body.Close()
 

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -435,5 +435,8 @@ func replicationErrorToGRPC(err error) error {
 	if errors.As(err, &enterrors.ErrUnprocessable{}) {
 		return status.Errorf(codes.FailedPrecondition, "%v", err)
 	}
+	if errors.Is(err, replica.ErrAsyncReplicationNotActive) {
+		return status.Errorf(codes.FailedPrecondition, "%v", err)
+	}
 	return status.Errorf(codes.Internal, "%v", err)
 }

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -1128,7 +1128,7 @@ func (i *indices) getHashTreeLevel() http.Handler {
 
 		var discriminant hashtree.Bitset
 		if err := discriminant.Unmarshal(reqPayload); err != nil {
-			http.Error(w, "unmarshal hashtree level params from json: "+err.Error(),
+			http.Error(w, "unmarshal hashtree level discriminant: "+err.Error(),
 				http.StatusBadRequest)
 			return
 		}
@@ -1136,7 +1136,7 @@ func (i *indices) getHashTreeLevel() http.Handler {
 		results, err := i.shards.HashTreeLevel(r.Context(), index, shard, l, &discriminant)
 		if err != nil {
 			http.Error(w, "hashtree level: "+err.Error(),
-				http.StatusInternalServerError)
+				asyncCheckpointHTTPStatus(err))
 			return
 		}
 

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -512,7 +512,7 @@ func (i *replicatedIndices) getHashTreeLevel() http.Handler {
 
 		var discriminant hashtree.Bitset
 		if err := discriminant.Unmarshal(reqPayload); err != nil {
-			http.Error(w, "unmarshal hashtree level params from json: "+err.Error(),
+			http.Error(w, "unmarshal hashtree level discriminant: "+err.Error(),
 				http.StatusBadRequest)
 			return
 		}
@@ -520,7 +520,7 @@ func (i *replicatedIndices) getHashTreeLevel() http.Handler {
 		results, err := i.replicator.HashTreeLevel(r.Context(), index, shard, l, &discriminant)
 		if err != nil {
 			http.Error(w, "hashtree level: "+err.Error(),
-				http.StatusInternalServerError)
+				asyncCheckpointHTTPStatus(err))
 			return
 		}
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -344,6 +344,8 @@ type Shard struct {
 	// treated as "epoch = very long ago"). Atomic to satisfy the race detector:
 	// initAsyncReplication resets it while runHashbeatCycle reads/writes it.
 	asyncRepLastLog atomic.Int64
+	// asyncRepFailLastLog throttles the failure Warn separately so success Debugs cannot starve it.
+	asyncRepFailLastLog atomic.Int64
 
 	lastComparedHosts                 []string
 	lastComparedHostsMux              sync.RWMutex

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1350,8 +1350,8 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()
 
-	if !s.hashtreeFullyInitialized {
-		return nil, fmt.Errorf("hashtree not initialized on shard %q", s.ID())
+	if s.hashtree == nil || !s.hashtreeFullyInitialized {
+		return nil, fmt.Errorf("%w: hashtree not initialized on shard %q", errAsyncReplicationNotActive, s.ID())
 	}
 
 	if height := s.hashtree.Height(); level > height {

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1347,7 +1347,7 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 		return nil, fmt.Errorf("hashtree level %d: discriminant size %d, expected %d (height mismatch?)",
 			level, discriminant.Size(), expected)
 	}
-	digests = make([]hashtree.Digest, expected)
+	digests = make([]hashtree.Digest, discriminant.SetCount())
 
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -399,6 +399,7 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig, cached hasht
 	s.asyncRepCtx = ctx
 
 	s.asyncRepLastLog.Store(0)
+	s.asyncRepFailLastLog.Store(0)
 	s.asyncReplicationConfig = config
 
 	effectiveConfig := config
@@ -1338,16 +1339,13 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 	if level < 0 {
 		return nil, fmt.Errorf("hashtree level must be non-negative: %d", level)
 	}
+	// the request-supplied level is otherwise unbounded and sizes scale with 2^level
+	if level > maxHashtreeHeight {
+		return nil, fmt.Errorf("hashtree level %d exceeds the maximum height %d", level, maxHashtreeHeight)
+	}
 	if discriminant == nil {
 		return nil, fmt.Errorf("hashtree level %d: nil discriminant", level)
 	}
-
-	expected := hashtree.LeavesCount(level)
-	if discriminant.Size() != expected {
-		return nil, fmt.Errorf("hashtree level %d: discriminant size %d, expected %d (height mismatch?)",
-			level, discriminant.Size(), expected)
-	}
-	digests = make([]hashtree.Digest, discriminant.SetCount())
 
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()
@@ -1355,6 +1353,18 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 	if !s.hashtreeFullyInitialized {
 		return nil, fmt.Errorf("hashtree not initialized on shard %q", s.ID())
 	}
+
+	if height := s.hashtree.Height(); level > height {
+		return nil, fmt.Errorf("hashtree level %d exceeds height %d on shard %q", level, height, s.ID())
+	}
+
+	expected := hashtree.LeavesCount(level)
+	if discriminant.Size() != expected {
+		return nil, fmt.Errorf("hashtree level %d: discriminant size %d, expected %d (height mismatch?)",
+			level, discriminant.Size(), expected)
+	}
+
+	digests = make([]hashtree.Digest, discriminant.SetCount())
 
 	n, err := s.hashtree.Level(level, discriminant, digests)
 	if err != nil {
@@ -1579,8 +1589,8 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 			return false, replicaerrors.ErrNoDiffFound
 		}
 
-		if time.Since(time.Unix(s.asyncRepLastLog.Load(), 0)) >= config.loggingFrequency {
-			s.asyncRepLastLog.Store(time.Now().Unix())
+		if time.Since(time.Unix(s.asyncRepFailLastLog.Load(), 0)) >= config.loggingFrequency {
+			s.asyncRepFailLastLog.Store(time.Now().Unix())
 			s.index.logger.
 				WithField("action", "async_replication").
 				WithField("class_name", s.class.Class).

--- a/adapters/repos/db/shard_async_replication_unit_test.go
+++ b/adapters/repos/db/shard_async_replication_unit_test.go
@@ -188,3 +188,68 @@ func TestGetAsyncReplicationStats(t *testing.T) {
 		})
 	}
 }
+
+func TestShardHashTreeLevel(t *testing.T) {
+	ctx := context.Background()
+	height := 6
+	ht, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	for i := uint64(0); i < uint64(hashtree.LeavesCount(height)); i++ {
+		require.NoError(t, ht.AggregateLeafWith(i, []byte{byte(i)}))
+	}
+	s := &Shard{index: &Index{}, hashtree: ht, hashtreeFullyInitialized: true}
+
+	t.Run("matches full-width reference on every level", func(t *testing.T) {
+		for level := 0; level <= height; level++ {
+			width := hashtree.LeavesCount(level)
+			sparse := hashtree.NewBitset(width)
+			for i := 0; i < width; i += 3 {
+				sparse.Set(i)
+			}
+			for _, disc := range []*hashtree.Bitset{
+				hashtree.NewBitset(width).Set(0),
+				sparse,
+				hashtree.NewBitset(width).SetAll(),
+				hashtree.NewBitset(width),
+			} {
+				want := make([]hashtree.Digest, width)
+				n, err := ht.Level(level, disc, want)
+				require.NoError(t, err)
+
+				got, err := s.HashTreeLevel(ctx, level, disc)
+				require.NoError(t, err)
+				require.Equal(t, want[:n], got)
+				require.Equal(t, disc.SetCount(), cap(got))
+			}
+		}
+	})
+
+	t.Run("rejections", func(t *testing.T) {
+		testCases := []struct {
+			name  string
+			shard *Shard
+			level int
+			disc  *hashtree.Bitset
+		}{
+			{"negative level", s, -1, hashtree.NewBitset(1).Set(0)},
+			{"level above maximum height", s, maxHashtreeHeight + 1, hashtree.NewBitset(1).Set(0)},
+			{"level above tree height", s, height + 1, hashtree.NewBitset(1).Set(0)},
+			{"nil discriminant", s, 0, nil},
+			{"wrong discriminant size", s, 2, hashtree.NewBitset(1).Set(0)},
+			{"hashtree not initialized", &Shard{index: &Index{}}, 0, hashtree.NewBitset(1).Set(0)},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := tc.shard.HashTreeLevel(ctx, tc.level, tc.disc)
+				require.Error(t, err)
+			})
+		}
+	})
+}
+
+func TestLazyLoadShardHashTreeLevelUnloaded(t *testing.T) {
+	l := &LazyLoadShard{}
+	digests, err := l.HashTreeLevel(context.Background(), 0, hashtree.NewBitset(1).Set(0))
+	require.ErrorIs(t, err, errAsyncReplicationNotActive)
+	assert.Nil(t, digests)
+}

--- a/adapters/repos/db/shard_async_replication_unit_test.go
+++ b/adapters/repos/db/shard_async_replication_unit_test.go
@@ -226,22 +226,27 @@ func TestShardHashTreeLevel(t *testing.T) {
 
 	t.Run("rejections", func(t *testing.T) {
 		testCases := []struct {
-			name  string
-			shard *Shard
-			level int
-			disc  *hashtree.Bitset
+			name      string
+			shard     *Shard
+			level     int
+			disc      *hashtree.Bitset
+			wantErrIs error
 		}{
-			{"negative level", s, -1, hashtree.NewBitset(1).Set(0)},
-			{"level above maximum height", s, maxHashtreeHeight + 1, hashtree.NewBitset(1).Set(0)},
-			{"level above tree height", s, height + 1, hashtree.NewBitset(1).Set(0)},
-			{"nil discriminant", s, 0, nil},
-			{"wrong discriminant size", s, 2, hashtree.NewBitset(1).Set(0)},
-			{"hashtree not initialized", &Shard{index: &Index{}}, 0, hashtree.NewBitset(1).Set(0)},
+			{"negative level", s, -1, hashtree.NewBitset(1).Set(0), nil},
+			{"level above maximum height", s, maxHashtreeHeight + 1, hashtree.NewBitset(1).Set(0), nil},
+			{"level above tree height", s, height + 1, hashtree.NewBitset(1).Set(0), nil},
+			{"nil discriminant", s, 0, nil, nil},
+			{"wrong discriminant size", s, 2, hashtree.NewBitset(1).Set(0), nil},
+			{"nil hashtree", &Shard{index: &Index{}}, 0, hashtree.NewBitset(1).Set(0), errAsyncReplicationNotActive},
+			{"hashtree not fully initialized", &Shard{index: &Index{}, hashtree: ht}, 0, hashtree.NewBitset(1).Set(0), errAsyncReplicationNotActive},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
 				_, err := tc.shard.HashTreeLevel(ctx, tc.level, tc.disc)
 				require.Error(t, err)
+				if tc.wantErrIs != nil {
+					require.ErrorIs(t, err, tc.wantErrIs)
+				}
 			})
 		}
 	})

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -807,9 +807,10 @@ func (l *LazyLoadShard) preventShutdown() (release func(), err error) {
 	return l.shard.preventShutdown()
 }
 
+// HashTreeLevel maps unloaded to ErrAsyncReplicationNotActive; an empty level would read as convergence.
 func (l *LazyLoadShard) HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
 	if !l.isLoaded() {
-		return []hashtree.Digest{}, nil
+		return nil, errAsyncReplicationNotActive
 	}
 	return l.shard.HashTreeLevel(ctx, level, discriminant)
 }

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -359,12 +359,13 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		return nil, fmt.Errorf("%w : class %q shard %q", err, f.class, shardName)
 	}
 
+	var digests []hashtree.Digest
+
 	collectDiffForTargetNode := func(targetNodeAddress, targetNodeName string) (*ShardDifferenceReader, error) {
 		ctx, cancel := context.WithTimeout(ctx, diffTimeoutPerNode)
 		defer cancel()
 
 		height := ht.Height()
-		digests := make([]hashtree.Digest, hashtree.LeavesCount(height))
 
 		discriminant := hashtree.NewBitset(1) // nodesAtLevel(0) = 1
 		discriminant.Set(0)                   // seed at root
@@ -372,6 +373,12 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		var leaf *hashtree.Bitset
 
 		for l := 0; l <= height; l++ {
+			if need := discriminant.SetCount(); cap(digests) < need {
+				digests = make([]hashtree.Digest, need)
+			} else {
+				digests = digests[:need]
+			}
+
 			if _, err := ht.Level(l, discriminant, digests); err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
 			}

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -377,8 +377,14 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 			need := discriminant.SetCount()
 			digests = hashtree.SizeDigests(digests, need)
 
-			if _, err := ht.Level(l, discriminant, digests); err != nil {
+			n, err := ht.Level(l, discriminant, digests)
+			if err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
+			}
+			// a short local write would leave stale digests from a previous level or target
+			if n != need {
+				return nil, fmt.Errorf("%q: local hashtree level %d wrote %d digests, expected %d",
+					targetNodeAddress, l, n, need)
 			}
 
 			levelDigests, err := f.client.HashTreeLevel(ctx, targetNodeAddress, f.class, shardName, l, discriminant)

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -359,6 +359,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		return nil, fmt.Errorf("%w : class %q shard %q", err, f.class, shardName)
 	}
 
+	// reused across levels and targets; only safe while targets are probed sequentially
 	var digests []hashtree.Digest
 
 	collectDiffForTargetNode := func(targetNodeAddress, targetNodeName string) (*ShardDifferenceReader, error) {
@@ -373,11 +374,8 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		var leaf *hashtree.Bitset
 
 		for l := 0; l <= height; l++ {
-			if need := discriminant.SetCount(); cap(digests) < need {
-				digests = make([]hashtree.Digest, need)
-			} else {
-				digests = digests[:need]
-			}
+			need := discriminant.SetCount()
+			digests = hashtree.SizeDigests(digests, need)
 
 			if _, err := ht.Level(l, discriminant, digests); err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
@@ -387,9 +385,10 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 			if err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
 			}
-			if len(levelDigests) == 0 {
-				// peer agrees at this level
-				break
+			// anything but one digest per set bit reads as a failed target, never as convergence
+			if len(levelDigests) != need {
+				return nil, fmt.Errorf("%q: hashtree level %d returned %d digests, expected %d",
+					targetNodeAddress, l, len(levelDigests), need)
 			}
 
 			nextDiscriminant, levelDiffCount, err := hashtree.LevelDiff(l, height, discriminant, digests, levelDigests)

--- a/usecases/replica/finder_collect_differences_test.go
+++ b/usecases/replica/finder_collect_differences_test.go
@@ -1,0 +1,164 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica_test
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+func serveHashTreeLevel(ht hashtree.AggregatedHashTree) func(context.Context, string, string, string, int, *hashtree.Bitset) ([]hashtree.Digest, error) {
+	return func(_ context.Context, _, _, _ string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
+		digests := make([]hashtree.Digest, discriminant.SetCount())
+		n, err := ht.Level(level, discriminant, digests)
+		if err != nil {
+			return nil, err
+		}
+		return digests[:n], nil
+	}
+}
+
+func collectRangeLeaves(t *testing.T, rr hashtree.AggregatedHashTreeRangeReader) []uint64 {
+	t.Helper()
+	var leaves []uint64
+	for {
+		start, end, err := rr.Next()
+		if errors.Is(err, hashtree.ErrNoMoreRanges) {
+			return leaves
+		}
+		require.NoError(t, err)
+		for l := start; l <= end; l++ {
+			leaves = append(leaves, l)
+		}
+	}
+}
+
+func TestCollectShardDifferencesConverged(t *testing.T) {
+	const (
+		class = "C1"
+		shard = "SH1"
+	)
+	ctx := context.Background()
+
+	f := newFakeFactory(t, class, shard, []string{"A", "B", "C"}, false)
+	finder := f.newFinder("A")
+
+	ht, err := hashtree.NewHashTree(16)
+	require.NoError(t, err)
+	for i := uint64(0); i < 1000; i++ {
+		require.NoError(t, ht.AggregateLeafWith(i*61, []byte{byte(i), byte(i >> 8)}))
+	}
+
+	f.RClient.EXPECT().
+		HashTreeLevel(mock.Anything, mock.Anything, class, shard, mock.Anything, mock.Anything).
+		RunAndReturn(serveHashTreeLevel(ht))
+
+	dr, err := finder.CollectShardDifferences(ctx, shard, ht, time.Second, nil)
+	require.ErrorIs(t, err, replicaerrors.ErrNoDiffFound)
+	require.NotNil(t, dr)
+
+	const iterations = 50
+	var m1, m2 runtime.MemStats
+	runtime.ReadMemStats(&m1)
+	for i := 0; i < iterations; i++ {
+		_, err := finder.CollectShardDifferences(ctx, shard, ht, time.Second, nil)
+		require.ErrorIs(t, err, replicaerrors.ErrNoDiffFound)
+	}
+	runtime.ReadMemStats(&m2)
+
+	perCall := (m2.TotalAlloc - m1.TotalAlloc) / iterations
+	assert.Less(t, perCall, uint64(256*1024))
+}
+
+func TestCollectShardDifferencesDivergent(t *testing.T) {
+	const (
+		class  = "C1"
+		shard  = "SH1"
+		height = 8
+	)
+	ctx := context.Background()
+	diffLeaves := []uint64{5, 100, 200}
+
+	f := newFakeFactory(t, class, shard, []string{"A", "B", "C"}, false)
+	finder := f.newFinder("A")
+
+	local, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	peer, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	for i := uint64(0); i < uint64(hashtree.LeavesCount(height)); i++ {
+		require.NoError(t, local.AggregateLeafWith(i, []byte{byte(i)}))
+		require.NoError(t, peer.AggregateLeafWith(i, []byte{byte(i)}))
+	}
+	for _, l := range diffLeaves {
+		require.NoError(t, peer.AggregateLeafWith(l, []byte("extra")))
+	}
+
+	f.RClient.EXPECT().
+		HashTreeLevel(mock.Anything, mock.Anything, class, shard, mock.Anything, mock.Anything).
+		RunAndReturn(serveHashTreeLevel(peer))
+
+	dr, err := finder.CollectShardDifferences(ctx, shard, local, time.Second, nil)
+	require.NoError(t, err)
+	require.NotNil(t, dr.RangeReader)
+	assert.Contains(t, []string{"B", "C"}, dr.TargetNodeName)
+	assert.Equal(t, diffLeaves, collectRangeLeaves(t, dr.RangeReader))
+}
+
+func TestCollectShardDifferencesMixedTargets(t *testing.T) {
+	const (
+		class  = "C1"
+		shard  = "SH1"
+		height = 8
+	)
+	ctx := context.Background()
+	diffLeaves := []uint64{5, 100, 200}
+
+	f := newFakeFactory(t, class, shard, []string{"A", "B", "C"}, false)
+	finder := f.newFinder("A")
+
+	local, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	peer, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	for i := uint64(0); i < uint64(hashtree.LeavesCount(height)); i++ {
+		require.NoError(t, local.AggregateLeafWith(i, []byte{byte(i)}))
+		require.NoError(t, peer.AggregateLeafWith(i, []byte{byte(i)}))
+	}
+	for _, l := range diffLeaves {
+		require.NoError(t, peer.AggregateLeafWith(l, []byte("extra")))
+	}
+
+	f.RClient.EXPECT().
+		HashTreeLevel(mock.Anything, "B", class, shard, mock.Anything, mock.Anything).
+		RunAndReturn(serveHashTreeLevel(local)).
+		Maybe()
+	f.RClient.EXPECT().
+		HashTreeLevel(mock.Anything, "C", class, shard, mock.Anything, mock.Anything).
+		RunAndReturn(serveHashTreeLevel(peer))
+
+	dr, err := finder.CollectShardDifferences(ctx, shard, local, time.Second, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "C", dr.TargetNodeName)
+	require.NotNil(t, dr.RangeReader)
+	assert.Equal(t, diffLeaves, collectRangeLeaves(t, dr.RangeReader))
+}

--- a/usecases/replica/finder_collect_differences_test.go
+++ b/usecases/replica/finder_collect_differences_test.go
@@ -37,6 +37,22 @@ func serveHashTreeLevel(ht hashtree.AggregatedHashTree) func(context.Context, st
 	}
 }
 
+func newDivergentTrees(t *testing.T, height int, diffLeaves []uint64) (local, peer *hashtree.HashTree) {
+	t.Helper()
+	local, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	peer, err = hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	for i := uint64(0); i < uint64(hashtree.LeavesCount(height)); i++ {
+		require.NoError(t, local.AggregateLeafWith(i, []byte{byte(i)}))
+		require.NoError(t, peer.AggregateLeafWith(i, []byte{byte(i)}))
+	}
+	for _, l := range diffLeaves {
+		require.NoError(t, peer.AggregateLeafWith(l, []byte("extra")))
+	}
+	return local, peer
+}
+
 func collectRangeLeaves(t *testing.T, rr hashtree.AggregatedHashTreeRangeReader) []uint64 {
 	t.Helper()
 	var leaves []uint64
@@ -101,17 +117,7 @@ func TestCollectShardDifferencesDivergent(t *testing.T) {
 	f := newFakeFactory(t, class, shard, []string{"A", "B", "C"}, false)
 	finder := f.newFinder("A")
 
-	local, err := hashtree.NewHashTree(height)
-	require.NoError(t, err)
-	peer, err := hashtree.NewHashTree(height)
-	require.NoError(t, err)
-	for i := uint64(0); i < uint64(hashtree.LeavesCount(height)); i++ {
-		require.NoError(t, local.AggregateLeafWith(i, []byte{byte(i)}))
-		require.NoError(t, peer.AggregateLeafWith(i, []byte{byte(i)}))
-	}
-	for _, l := range diffLeaves {
-		require.NoError(t, peer.AggregateLeafWith(l, []byte("extra")))
-	}
+	local, peer := newDivergentTrees(t, height, diffLeaves)
 
 	f.RClient.EXPECT().
 		HashTreeLevel(mock.Anything, mock.Anything, class, shard, mock.Anything, mock.Anything).
@@ -136,17 +142,7 @@ func TestCollectShardDifferencesMixedTargets(t *testing.T) {
 	f := newFakeFactory(t, class, shard, []string{"A", "B", "C"}, false)
 	finder := f.newFinder("A")
 
-	local, err := hashtree.NewHashTree(height)
-	require.NoError(t, err)
-	peer, err := hashtree.NewHashTree(height)
-	require.NoError(t, err)
-	for i := uint64(0); i < uint64(hashtree.LeavesCount(height)); i++ {
-		require.NoError(t, local.AggregateLeafWith(i, []byte{byte(i)}))
-		require.NoError(t, peer.AggregateLeafWith(i, []byte{byte(i)}))
-	}
-	for _, l := range diffLeaves {
-		require.NoError(t, peer.AggregateLeafWith(l, []byte("extra")))
-	}
+	local, peer := newDivergentTrees(t, height, diffLeaves)
 
 	f.RClient.EXPECT().
 		HashTreeLevel(mock.Anything, "B", class, shard, mock.Anything, mock.Anything).

--- a/usecases/replica/finder_collect_differences_test.go
+++ b/usecases/replica/finder_collect_differences_test.go
@@ -158,3 +158,34 @@ func TestCollectShardDifferencesMixedTargets(t *testing.T) {
 	require.NotNil(t, dr.RangeReader)
 	assert.Equal(t, diffLeaves, collectRangeLeaves(t, dr.RangeReader))
 }
+
+func TestCollectShardDifferencesRejectsMalformedLevelResponse(t *testing.T) {
+	testCases := []struct {
+		name     string
+		response []hashtree.Digest
+	}{
+		{"empty response", []hashtree.Digest{}},
+		{"overlong response", make([]hashtree.Digest, 3)},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			f := newFakeFactory(t, "C1", "SH1", []string{"A", "B", "C"}, false)
+			finder := f.newFinder("A")
+
+			ht, err := hashtree.NewHashTree(4)
+			require.NoError(t, err)
+			require.NoError(t, ht.AggregateLeafWith(0, []byte("x")))
+
+			f.RClient.EXPECT().
+				HashTreeLevel(mock.Anything, mock.Anything, "C1", "SH1", mock.Anything, mock.Anything).
+				Return(tc.response, nil)
+
+			_, err = finder.CollectShardDifferences(ctx, "SH1", ht, time.Second, nil)
+			require.Error(t, err)
+			require.NotErrorIs(t, err, replicaerrors.ErrNoDiffFound)
+			require.ErrorContains(t, err, "digests")
+		})
+	}
+}

--- a/usecases/replica/hashtree/aggregated_hashtree.go
+++ b/usecases/replica/hashtree/aggregated_hashtree.go
@@ -21,6 +21,9 @@ type AggregatedHashTree interface {
 	AggregateLeafWith(i uint64, val []byte) error
 	Sync()
 	Root() Digest
+	// Level writes one digest per set discriminant bit into digests, densely
+	// from index 0 in ascending node order — the positional layout LevelDiff
+	// relies on. digests must hold at least discriminant.SetCount() entries.
 	Level(level int, discriminant *Bitset, digests []Digest) (n int, err error)
 	Reset()
 	Clone() AggregatedHashTree

--- a/usecases/replica/hashtree/aggregated_hashtree.go
+++ b/usecases/replica/hashtree/aggregated_hashtree.go
@@ -76,6 +76,11 @@ func LevelDiff(l, height int, discriminant *Bitset, digests1, digests2 []Digest)
 			continue
 		}
 
+		// bound reads even if the cached set count understates the bits
+		if n == len(digests1) || n == len(digests2) {
+			return nil, 0, fmt.Errorf("%w: discriminant set count understates its set bits", ErrIllegalArguments)
+		}
+
 		if digests1[n] == digests2[n] {
 			discriminant.Unset(j)
 			n++

--- a/usecases/replica/hashtree/bitset.go
+++ b/usecases/replica/hashtree/bitset.go
@@ -14,6 +14,7 @@ package hashtree
 import (
 	"encoding/binary"
 	"fmt"
+	"math/bits"
 )
 
 type Bitset struct {
@@ -123,9 +124,22 @@ func (bset *Bitset) Unmarshal(b []byte) error {
 	bset.bits = make([]int64, n)
 
 	off := 8
+	setCount := 0
 	for i := 0; i < n; i++ {
 		bset.bits[i] = int64(binary.BigEndian.Uint64(b[off:]))
 		off += 8
+
+		w := uint64(bset.bits[i])
+		if i == n-1 && bset.size%64 != 0 {
+			w &= 1<<(bset.size%64) - 1
+		}
+		setCount += bits.OnesCount64(w)
+	}
+
+	// the carried count sizes downstream digest buffers (Level), so it must match
+	// the actual bits; the mask excludes trailing SetAll bits beyond size
+	if setCount != bset.setCount {
+		return fmt.Errorf("invalid bset serialization")
 	}
 
 	return nil

--- a/usecases/replica/hashtree/bitset.go
+++ b/usecases/replica/hashtree/bitset.go
@@ -111,42 +111,47 @@ func (bset *Bitset) Marshal() ([]byte, error) {
 	return b, nil
 }
 
+// Unmarshal leaves the receiver untouched unless the whole payload validates.
 func (bset *Bitset) Unmarshal(b []byte) error {
 	if len(b) < 8 {
 		return fmt.Errorf("%w: buffer shorter than header", ErrInvalidBsetSerialization)
 	}
 
-	bset.size = int(binary.BigEndian.Uint32(b))
-	bset.setCount = int(binary.BigEndian.Uint32(b[4:]))
+	size := int(binary.BigEndian.Uint32(b))
+	carriedSetCount := int(binary.BigEndian.Uint32(b[4:]))
 
-	n := (bset.size + 63) / 64
+	n := (size + 63) / 64
 
 	if len(b) != 8+n*8 {
-		return fmt.Errorf("%w: %d bytes for size %d", ErrInvalidBsetSerialization, len(b), bset.size)
+		return fmt.Errorf("%w: %d bytes for size %d", ErrInvalidBsetSerialization, len(b), size)
 	}
 
-	bset.bits = make([]int64, n)
+	words := make([]int64, n)
 
 	off := 8
 	setCount := 0
 	for i := 0; i < n; i++ {
-		bset.bits[i] = int64(binary.BigEndian.Uint64(b[off:]))
+		words[i] = int64(binary.BigEndian.Uint64(b[off:]))
 		off += 8
 
-		w := uint64(bset.bits[i])
-		if i == n-1 && bset.size%64 != 0 {
+		w := uint64(words[i])
+		if i == n-1 && size%64 != 0 {
 			// SetAll legitimately leaves trailing bits beyond size in the last word
-			lastWordMask := uint64(1)<<(bset.size%64) - 1
+			lastWordMask := uint64(1)<<(size%64) - 1
 			w &= lastWordMask
 		}
 		setCount += bits.OnesCount64(w)
 	}
 
 	// receivers size digest buffers from the carried count, so it must match the bits
-	if setCount != bset.setCount {
+	if setCount != carriedSetCount {
 		return fmt.Errorf("%w: set count %d, actual set bits %d",
-			ErrInvalidBsetSerialization, bset.setCount, setCount)
+			ErrInvalidBsetSerialization, carriedSetCount, setCount)
 	}
+
+	bset.size = size
+	bset.setCount = carriedSetCount
+	bset.bits = words
 
 	return nil
 }

--- a/usecases/replica/hashtree/bitset.go
+++ b/usecases/replica/hashtree/bitset.go
@@ -13,9 +13,13 @@ package hashtree
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"math/bits"
 )
+
+// ErrInvalidBsetSerialization rejects wire payloads whose header disagrees with their bits.
+var ErrInvalidBsetSerialization = errors.New("invalid bset serialization")
 
 type Bitset struct {
 	size     int
@@ -109,7 +113,7 @@ func (bset *Bitset) Marshal() ([]byte, error) {
 
 func (bset *Bitset) Unmarshal(b []byte) error {
 	if len(b) < 8 {
-		return fmt.Errorf("invalid bset serialization")
+		return fmt.Errorf("%w: buffer shorter than header", ErrInvalidBsetSerialization)
 	}
 
 	bset.size = int(binary.BigEndian.Uint32(b))
@@ -118,7 +122,7 @@ func (bset *Bitset) Unmarshal(b []byte) error {
 	n := (bset.size + 63) / 64
 
 	if len(b) != 8+n*8 {
-		return fmt.Errorf("invalid bset serialization")
+		return fmt.Errorf("%w: %d bytes for size %d", ErrInvalidBsetSerialization, len(b), bset.size)
 	}
 
 	bset.bits = make([]int64, n)
@@ -131,15 +135,17 @@ func (bset *Bitset) Unmarshal(b []byte) error {
 
 		w := uint64(bset.bits[i])
 		if i == n-1 && bset.size%64 != 0 {
-			w &= 1<<(bset.size%64) - 1
+			// SetAll legitimately leaves trailing bits beyond size in the last word
+			lastWordMask := uint64(1)<<(bset.size%64) - 1
+			w &= lastWordMask
 		}
 		setCount += bits.OnesCount64(w)
 	}
 
-	// the carried count sizes downstream digest buffers (Level), so it must match
-	// the actual bits; the mask excludes trailing SetAll bits beyond size
+	// receivers size digest buffers from the carried count, so it must match the bits
 	if setCount != bset.setCount {
-		return fmt.Errorf("invalid bset serialization")
+		return fmt.Errorf("%w: set count %d, actual set bits %d",
+			ErrInvalidBsetSerialization, bset.setCount, setCount)
 	}
 
 	return nil

--- a/usecases/replica/hashtree/bitset_test.go
+++ b/usecases/replica/hashtree/bitset_test.go
@@ -13,6 +13,7 @@ package hashtree
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -80,6 +81,97 @@ func TestBitsetUnmarshalRoundTrip(t *testing.T) {
 			for i := 0; i < tc.bset.Size(); i++ {
 				require.Equal(t, tc.bset.IsSet(i), decoded.IsSet(i))
 			}
+		})
+	}
+}
+
+func TestBitsetUnmarshalFailureLeavesReceiverUntouched(t *testing.T) {
+	valid, err := NewBitset(100).Set(3).Set(50).Set(99).Marshal()
+	require.NoError(t, err)
+
+	badCount := append([]byte(nil), valid...)
+	binary.BigEndian.PutUint32(badCount[4:], 50)
+
+	badLength := append([]byte(nil), valid...)
+	binary.BigEndian.PutUint32(badLength, 200)
+
+	testCases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"short header", []byte{0x01}},
+		{"length mismatch", badLength},
+		{"count mismatch", badCount},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			bset := NewBitset(8).Set(1).Set(5)
+			require.ErrorIs(t, bset.Unmarshal(tc.payload), ErrInvalidBsetSerialization)
+			require.Equal(t, 8, bset.Size())
+			require.Equal(t, 2, bset.SetCount())
+			for i := 0; i < bset.Size(); i++ {
+				require.Equal(t, i == 1 || i == 5, bset.IsSet(i))
+			}
+		})
+	}
+}
+
+func TestBitsetWireFormatGolden(t *testing.T) {
+	testCases := []struct {
+		name    string
+		hexData string
+		size    int
+		wantSet func(i int) bool
+	}{
+		{
+			"root discriminant",
+			"00000001" + "00000001" + "0000000000000001",
+			1, func(i int) bool { return i == 0 },
+		},
+		{
+			"empty",
+			"00000001" + "00000000" + "0000000000000000",
+			1, func(int) bool { return false },
+		},
+		{
+			"sparse",
+			"00000064" + "00000003" + "0004000000000008" + "0000000800000000",
+			100, func(i int) bool { return i == 3 || i == 50 || i == 99 },
+		},
+		{
+			"set all word aligned",
+			"00000040" + "00000040" + "ffffffffffffffff",
+			64, func(int) bool { return true },
+		},
+		{
+			"set all with trailing bits",
+			"00000064" + "00000064" + "ffffffffffffffff" + "ffffffffffffffff",
+			100, func(int) bool { return true },
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload, err := hex.DecodeString(tc.hexData)
+			require.NoError(t, err)
+
+			var decoded Bitset
+			require.NoError(t, decoded.Unmarshal(payload))
+			require.Equal(t, tc.size, decoded.Size())
+
+			wantCount := 0
+			for i := 0; i < tc.size; i++ {
+				require.Equal(t, tc.wantSet(i), decoded.IsSet(i), "bit %d", i)
+				if tc.wantSet(i) {
+					wantCount++
+				}
+			}
+			require.Equal(t, wantCount, decoded.SetCount())
+
+			remarshalled, err := decoded.Marshal()
+			require.NoError(t, err)
+			require.Equal(t, payload, remarshalled)
 		})
 	}
 }

--- a/usecases/replica/hashtree/bitset_test.go
+++ b/usecases/replica/hashtree/bitset_test.go
@@ -102,7 +102,7 @@ func TestBitsetUnmarshalRejectsInconsistentSetCount(t *testing.T) {
 			binary.BigEndian.PutUint32(b[4:], tc.claimedCount)
 
 			var decoded Bitset
-			require.ErrorContains(t, decoded.Unmarshal(b), "invalid bset serialization")
+			require.ErrorIs(t, decoded.Unmarshal(b), ErrInvalidBsetSerialization)
 		})
 	}
 }

--- a/usecases/replica/hashtree/bitset_test.go
+++ b/usecases/replica/hashtree/bitset_test.go
@@ -12,6 +12,7 @@
 package hashtree
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -52,4 +53,56 @@ func TestBitSet(t *testing.T) {
 	require.Panics(t, func() {
 		bset.Unset(bsetSize)
 	})
+}
+
+func TestBitsetUnmarshalRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name string
+		bset *Bitset
+	}{
+		{"empty", NewBitset(1)},
+		{"single bit", NewBitset(1).Set(0)},
+		{"sparse bits", NewBitset(100).Set(3).Set(50).Set(99)},
+		{"set all word aligned", NewBitset(64).SetAll()},
+		{"set all with trailing bits", NewBitset(100).SetAll()},
+		{"set all tiny", NewBitset(8).SetAll()},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := tc.bset.Marshal()
+			require.NoError(t, err)
+
+			var decoded Bitset
+			require.NoError(t, decoded.Unmarshal(b))
+			require.Equal(t, tc.bset.Size(), decoded.Size())
+			require.Equal(t, tc.bset.SetCount(), decoded.SetCount())
+			for i := 0; i < tc.bset.Size(); i++ {
+				require.Equal(t, tc.bset.IsSet(i), decoded.IsSet(i))
+			}
+		})
+	}
+}
+
+func TestBitsetUnmarshalRejectsInconsistentSetCount(t *testing.T) {
+	testCases := []struct {
+		name         string
+		claimedCount uint32
+	}{
+		{"understated count", 0},
+		{"partially understated count", 2},
+		{"overstated count", 50},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := NewBitset(100).Set(3).Set(50).Set(99).Marshal()
+			require.NoError(t, err)
+
+			binary.BigEndian.PutUint32(b[4:], tc.claimedCount)
+
+			var decoded Bitset
+			require.ErrorContains(t, decoded.Unmarshal(b), "invalid bset serialization")
+		})
+	}
 }

--- a/usecases/replica/hashtree/digest.go
+++ b/usecases/replica/hashtree/digest.go
@@ -60,3 +60,11 @@ func (d *Digest) UnmarshalJSON(b []byte) error {
 
 	return d.UnmarshalBinary(bs)
 }
+
+// SizeDigests resizes buf to hold n digests, reallocating only when capacity is insufficient.
+func SizeDigests(buf []Digest, n int) []Digest {
+	if cap(buf) < n {
+		return make([]Digest, n)
+	}
+	return buf[:n]
+}

--- a/usecases/replica/hashtree/hashtree.go
+++ b/usecases/replica/hashtree/hashtree.go
@@ -224,6 +224,10 @@ func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n 
 
 	for i := 0; i < expectedSize; i++ {
 		if discriminant.IsSet(i) {
+			// bound writes even if the cached set count understates the bits
+			if n == len(digests) {
+				return 0, fmt.Errorf("%w: discriminant set count understates its set bits", ErrIllegalArguments)
+			}
 			digests[n] = ht.nodes[offset+i]
 			n++
 		}

--- a/usecases/replica/hashtree/hashtree.go
+++ b/usecases/replica/hashtree/hashtree.go
@@ -213,7 +213,8 @@ func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n 
 			ErrIllegalArguments, discriminant.Size(), expectedSize, level)
 	}
 
-	if len(digests) < expectedSize {
+	// one digest is written per set bit, so SetCount() capacity suffices (see LevelDiff)
+	if len(digests) < discriminant.SetCount() {
 		return 0, fmt.Errorf("%w: output buffer has not enough capacity", ErrIllegalArguments)
 	}
 

--- a/usecases/replica/hashtree/hashtree_diff.go
+++ b/usecases/replica/hashtree/hashtree_diff.go
@@ -32,13 +32,9 @@ func (ht *HashTree) Diff(ht2 AggregatedHashTree) (*Bitset, error) {
 	walk.Set(0) // root
 
 	for l := 0; l <= height; l++ {
-		if need := walk.SetCount(); cap(digests1) < need {
-			digests1 = make([]Digest, need)
-			digests2 = make([]Digest, need)
-		} else {
-			digests1 = digests1[:need]
-			digests2 = digests2[:need]
-		}
+		need := walk.SetCount()
+		digests1 = SizeDigests(digests1, need)
+		digests2 = SizeDigests(digests2, need)
 
 		if _, err := ht.Level(l, walk, digests1); err != nil {
 			return nil, err

--- a/usecases/replica/hashtree/hashtree_diff.go
+++ b/usecases/replica/hashtree/hashtree_diff.go
@@ -26,13 +26,20 @@ func (ht *HashTree) Diff(ht2 AggregatedHashTree) (*Bitset, error) {
 	}
 
 	leavesCount := LeavesCount(height)
-	digests1 := make([]Digest, leavesCount)
-	digests2 := make([]Digest, leavesCount)
+	var digests1, digests2 []Digest
 
 	walk := NewBitset(1)
 	walk.Set(0) // root
 
 	for l := 0; l <= height; l++ {
+		if need := walk.SetCount(); cap(digests1) < need {
+			digests1 = make([]Digest, need)
+			digests2 = make([]Digest, need)
+		} else {
+			digests1 = digests1[:need]
+			digests2 = digests2[:need]
+		}
+
 		if _, err := ht.Level(l, walk, digests1); err != nil {
 			return nil, err
 		}

--- a/usecases/replica/hashtree/hashtree_diff.go
+++ b/usecases/replica/hashtree/hashtree_diff.go
@@ -36,11 +36,15 @@ func (ht *HashTree) Diff(ht2 AggregatedHashTree) (*Bitset, error) {
 		digests1 = SizeDigests(digests1, need)
 		digests2 = SizeDigests(digests2, need)
 
-		if _, err := ht.Level(l, walk, digests1); err != nil {
+		if n, err := ht.Level(l, walk, digests1); err != nil {
 			return nil, err
+		} else if n != need {
+			return nil, fmt.Errorf("%w: level %d wrote %d digests, expected %d", ErrIllegalState, l, n, need)
 		}
-		if _, err := ht2.Level(l, walk, digests2); err != nil {
+		if n, err := ht2.Level(l, walk, digests2); err != nil {
 			return nil, err
+		} else if n != need {
+			return nil, fmt.Errorf("%w: level %d wrote %d digests, expected %d", ErrIllegalState, l, n, need)
 		}
 
 		nextWalk, levelDiffCount, err := LevelDiff(l, height, walk, digests1, digests2)

--- a/usecases/replica/hashtree/level_local_test.go
+++ b/usecases/replica/hashtree/level_local_test.go
@@ -51,9 +51,9 @@ func TestLevelValidation(t *testing.T) {
 		require.ErrorIs(t, err, ErrIllegalArguments)
 	})
 
-	t.Run("output buffer too small", func(t *testing.T) {
+	t.Run("output buffer smaller than set count", func(t *testing.T) {
 		small := make([]Digest, 4)
-		_, err := ht.Level(3, NewBitset(8), small)
+		_, err := ht.Level(3, NewBitset(8).SetAll(), small)
 		require.ErrorIs(t, err, ErrIllegalArguments)
 	})
 }
@@ -273,4 +273,51 @@ func marshalledSize(t *testing.T, b *Bitset) int {
 	buf, err := b.Marshal()
 	require.NoError(t, err)
 	return len(buf)
+}
+
+func TestLevelSetCountSizedBuffer(t *testing.T) {
+	testCases := []struct {
+		name    string
+		newTree func(t *testing.T) AggregatedHashTree
+	}{
+		{"HashTree", func(t *testing.T) AggregatedHashTree {
+			ht, err := NewHashTree(4)
+			require.NoError(t, err)
+			return ht
+		}},
+		{"CompactHashTree", func(t *testing.T) AggregatedHashTree {
+			ht, err := NewCompactHashTree(1024, 4)
+			require.NoError(t, err)
+			return ht
+		}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ht := tc.newTree(t)
+			for i := uint64(0); i < 16; i++ {
+				require.NoError(t, ht.AggregateLeafWith(i, []byte{byte(i)}))
+			}
+
+			discriminant := NewBitset(nodesAtLevel(2)).Set(1).Set(3)
+
+			full := make([]Digest, nodesAtLevel(2))
+			nFull, err := ht.Level(2, discriminant, full)
+			require.NoError(t, err)
+			require.Equal(t, 2, nFull)
+
+			exact := make([]Digest, discriminant.SetCount())
+			nExact, err := ht.Level(2, discriminant, exact)
+			require.NoError(t, err)
+			require.Equal(t, nFull, nExact)
+			assert.Equal(t, full[:nFull], exact[:nExact])
+
+			_, err = ht.Level(2, discriminant, make([]Digest, 1))
+			require.ErrorIs(t, err, ErrIllegalArguments)
+
+			n, err := ht.Level(2, NewBitset(nodesAtLevel(2)), nil)
+			require.NoError(t, err)
+			assert.Equal(t, 0, n)
+		})
+	}
 }

--- a/usecases/replica/hashtree/level_local_test.go
+++ b/usecases/replica/hashtree/level_local_test.go
@@ -367,6 +367,14 @@ func TestLevelRejectsUnderstatedSetCount(t *testing.T) {
 	require.ErrorIs(t, err, ErrIllegalArguments)
 }
 
+func TestLevelDiffRejectsUnderstatedSetCount(t *testing.T) {
+	disc := NewBitset(nodesAtLevel(2)).Set(0).Set(1).Set(2)
+	disc.setCount = 1
+
+	_, _, err := LevelDiff(2, 4, disc, make([]Digest, 1), make([]Digest, 1))
+	require.ErrorIs(t, err, ErrIllegalArguments)
+}
+
 func TestSizeDigests(t *testing.T) {
 	buf := SizeDigests(nil, 3)
 	require.Len(t, buf, 3)

--- a/usecases/replica/hashtree/level_local_test.go
+++ b/usecases/replica/hashtree/level_local_test.go
@@ -355,3 +355,28 @@ func TestLevelResponseEquivalentAcrossBufferSizing(t *testing.T) {
 		}
 	}
 }
+
+func TestLevelRejectsUnderstatedSetCount(t *testing.T) {
+	ht, err := NewHashTree(3)
+	require.NoError(t, err)
+
+	disc := NewBitset(nodesAtLevel(2)).Set(0).Set(1).Set(2)
+	disc.setCount = 1
+
+	_, err = ht.Level(2, disc, make([]Digest, 1))
+	require.ErrorIs(t, err, ErrIllegalArguments)
+}
+
+func TestSizeDigests(t *testing.T) {
+	buf := SizeDigests(nil, 3)
+	require.Len(t, buf, 3)
+
+	grown := SizeDigests(buf, 5)
+	require.Len(t, grown, 5)
+
+	shrunk := SizeDigests(grown, 2)
+	require.Len(t, shrunk, 2)
+	require.Equal(t, 5, cap(shrunk))
+
+	require.Empty(t, SizeDigests(nil, 0))
+}

--- a/usecases/replica/hashtree/level_local_test.go
+++ b/usecases/replica/hashtree/level_local_test.go
@@ -321,3 +321,37 @@ func TestLevelSetCountSizedBuffer(t *testing.T) {
 		})
 	}
 }
+
+func TestLevelResponseEquivalentAcrossBufferSizing(t *testing.T) {
+	height := 6
+	ht, err := NewHashTree(height)
+	require.NoError(t, err)
+	for i := uint64(0); i < uint64(LeavesCount(height)); i++ {
+		require.NoError(t, ht.AggregateLeafWith(i, []byte{byte(i), byte(i >> 3)}))
+	}
+
+	discriminants := func(level int) []*Bitset {
+		width := nodesAtLevel(level)
+		root := NewBitset(width).Set(0)
+		sparse := NewBitset(width)
+		for i := 0; i < width; i += 3 {
+			sparse.Set(i)
+		}
+		return []*Bitset{root, sparse, NewBitset(width).SetAll(), NewBitset(width)}
+	}
+
+	for level := 0; level <= height; level++ {
+		for di, disc := range discriminants(level) {
+			fullWidth := make([]Digest, nodesAtLevel(level))
+			nOld, err := ht.Level(level, disc, fullWidth)
+			require.NoError(t, err, "level %d disc %d", level, di)
+
+			setCountSized := make([]Digest, disc.SetCount())
+			nNew, err := ht.Level(level, disc, setCountSized)
+			require.NoError(t, err, "level %d disc %d", level, di)
+
+			require.Equal(t, nOld, nNew, "level %d disc %d", level, di)
+			require.Equal(t, fullWidth[:nOld], setCountSized[:nNew], "level %d disc %d", level, di)
+		}
+	}
+}


### PR DESCRIPTION
## Motivation

An alloc_space profile from a production v1.38.7 cluster (3000+ single-tenant collections, RF>1, async replication enabled) showed **33% of all process allocations** flat in `replica.(*Finder).CollectShardDifferences.func1`. The per-target closure pre-allocated `LeavesCount(height)` digests — **1 MiB at the single-tenant hashtree height of 16** — before the level descent even started. Converged replicas break at the root having consumed 16 bytes of it, so the fleet paid ~1 MiB × (RF−1) per shard every 30 s (~17 TB/day at that scale) for comparisons that almost always agree. Multi-tenant deployments are hit 64× lighter (height 10 → 16 KiB), which is why this surfaces on single-tenant fleets.

## Change

- `Level` now requires the output buffer to hold `discriminant.SetCount()` digests instead of the full level width. It writes exactly one digest per set bit, which is the contract `LevelDiff` already documents and validates — the old check was over-strict.
- The finder keeps one buffer per `CollectShardDifferences` call, resized per level to the walk's set count and reused across levels and target nodes. Walk width is bounded by 2× the number of diverging nodes at the previous level, so descents allocate proportional to actual divergence: a converged compare costs one 16-byte allocation; k diverging leaves plateau at ~2k digests regardless of depth.
- The server-side `HashTreeLevel` handler and the local `Diff` walk size their buffers the same way.

## Compatibility / risks

- **No wire change**: responses were already truncated to the written prefix (`digests[:n]`); mixed-version clusters are unaffected.
- The `Level` capacity check is only relaxed (wider input domain accepted), never tightened — callers passing full-width buffers remain valid.
- Key review area: buffer-reuse safety. `Level` overwrites the full consumed prefix on every call and `LevelDiff` reads only that same prefix; nothing retains the slice across iterations (the state carried forward is the walk bitset, and the final result is the leaf bitset → range reader, never the digest buffer).

## Tests

- Alloc regression: the converged-path test fails on the previous implementation at ~2.1 MB/call (two targets × 1 MiB) and passes now under a 256 KiB bound.
- Divergent-descent and mixed-target tests assert exact leaf ranges via a mock peer serving levels from a real hashtree, covering buffer growth and cross-target reuse.
- Capacity-contract tests for both `HashTree` and `CompactHashTree`.
- Full `usecases/replica` suite green under `-race`; golangci-lint and the goroutine linter are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Rolling-upgrade hardening (follow-up commits)

Reviewing the mixed-version matrix surfaced a hazard this PR's own sizing commit would have introduced: `Bitset.Unmarshal` trusted the wire-carried set count, and with buffers sized from it, a payload claiming fewer set bits than present could have panicked the receiving node. On the base branch that count was not consumed anywhere on the server path, so a malformed count was harmless there — the validation commit closes an intra-PR hazard, and the shipped state is strictly hardened relative to base (malformed counts are now rejected instead of ignored). `Unmarshal` now rejects any serialization whose carried count disagrees with the masked popcount of its words — the mask preserving `SetAll`'s legitimate trailing bits — closing the panic path at the single wire ingress shared by the REST and gRPC handlers. Well-formed peers of any version are unaffected.

Upgrade safety is machine-checked: a response-equivalence test pins that set-count-sized buffers yield byte-identical digest counts and content to the previous full-width sizing for every level and discriminant shape, and the transport codecs are length-driven on both sides (server marshals the returned slice; client appends fixed-size records until EOF), so un-upgraded peers observe unchanged bytes in both directions.


## Empirical rolling-upgrade validation

Validated on a local 3-node RAFT cluster rolled node-by-node from the official `1.38.7` image to this branch built with `-race` (panic recovery disabled so any panic crashes the node): 10 single-tenant RF=3 collections (height-16 hashtrees) plus one 3-shard collection, hashbeat at 5s, ~460k CL=ONE writes running continuously through all three upgrade windows. Results: zero panics/data races on all six node-lifetimes, zero `invalid bset serialization` rejections in either direction (all 1.38.7 payloads accepted), all hashbeat failures were `503 Node not ready` restart transients, exact replica convergence (per-shard vector counts identical across nodes) in every mixed window and at the end, root pre-filter exercised across versions on the multi-shard collection (812 ok / 1 restart-window error), and the post-upgrade allocation profile shows `CollectShardDifferences` gone from the top allocators (0.64% cumulative for the whole hashtree area, formerly 33% flat).



## Review-response hardening

A subsequent in-depth review prompted one more commit, plus a correction:

**Correction to the earlier hardening note (and my Copilot reply):** on the base branch the wire-carried bitset count was *not* consumed anywhere on the server path — `Level` iterated actual bits into a full-width buffer, so a malformed count was harmless and responses were correct. The count dependency was introduced by this PR's buffer-sizing commit and closed by its validation commit; the shipped state is strictly hardened relative to base (malformed counts are now rejected instead of ignored), but the panic vector was intra-PR, not pre-existing.

The hardening commit adds:
- **Request-level bounds before allocation:** `Shard.HashTreeLevel` rejects `level > maxHashtreeHeight` up front and allocates the digest buffer only after the initialized/height checks under the lock, capping it at the real tree width (the URL-supplied level was previously unbounded; base allocated `2^level` unconditionally, so this also strictly improves on base).
- **Level defends itself:** the write loop bounds against the buffer independently of the discriminant's cached set count, so its memory safety no longer rests solely on `Bitset.Unmarshal` validation two packages away.
- **No convergence from malformed level responses:** the finder now requires exactly one digest per set discriminant bit; an unloaded lazy shard's empty level — or any short/over-long response — reads as a failed target, never as agreement. `LazyLoadShard.HashTreeLevel` reports `ErrAsyncReplicationNotActive` like its checkpoint sibling, mapped to REST 412 / gRPC FailedPrecondition. Note this path is currently unreachable via RPC because `getOptInitLocalShard` → `preventShutdown` force-loads lazy shards regardless of `ensureInit` (contradicting the intent of 55ce1ca2e6); that contradiction affects all GetShard RPC paths and is deliberately left for a follow-up — this change defuses the trap in advance.
- **Client-side allocation clamps:** the three binary stream readers cap their Content-Length-derived preallocation at caller-known bounds (`SetCount()`, the digests-in-range limit, the compare-digests request size); a peer's header alone can no longer drive an unbounded `make` on the requesting node (the previous `<= math.MaxInt` guard was vacuous on 64-bit).
- **Operability:** failure Warns throttle on a dedicated token (success Debugs consumed the shared one even below the enabled log level and could starve them); bset serialization rejections are a typed sentinel (`ErrInvalidBsetSerialization`) with per-cause context; handler labels no longer say "from json" for a binary payload.
- **Contract + dedupe:** `AggregatedHashTree.Level` documents the positional digest contract (one per set bit, dense, ascending — what `LevelDiff` relies on); `SizeDigests` replaces the four hand-copies of the grow-or-reslice sizing.

Declined from the review, with rationale: removing the `Bitset.setCount` cache (post-hardening there are two independent safety layers, and deleting the field changes Bitset performance/API for all users while losing the explicit wire-corruption signal); merging the "twin" tests (their coverage arms are not supersets). The `hashtree_diff.go` sizing change touches what is a test-only path in production terms — kept as it now shares the same helper.



## Second adversarial review round

A two-reviewer deep audit (core-algorithm and wire/mixed-version lenses, probe-verified against both this branch and the base) found **no rolling-upgrade, divergence, or peer-triggerable-panic regression**: the set-count validation cannot reject any payload the frozen v1.35+ `Bitset.Marshal` produces (the mutators cannot drift the cached count — fuzzed across word boundaries and `SetAll`/`Unset` sequences), old servers already return exactly one digest per set bit so the strict finder check never fires against healthy peers of any supported version, and the reused digest buffer never leaks stale entries across the sequential target walk. It did surface two fixes and one hardening, landed as three commits:

- **Clamp caller-supplied record bounds in the binary stream readers.** The preallocation caps introduced earlier in this PR compared against the caller's bound without clamping at zero, so a negative "unlimited" `limit` from a future `DigestObjectsInRange` caller would have reached `make` with a negative capacity and panicked. Intra-PR hazard, caught before merge. The bound remains a sizing hint only — response length is still enforced by the finder, not the readers.
- **Uninitialized hashtree now maps to 412.** The `ErrAsyncReplicationNotActive` → 412/FailedPrecondition wiring described above was dead code on the level path: the only reachable "not active" state — a hashtree still running its init scan, which can take minutes on a large shard — returned a bare error and surfaced as 500, alarm-shaped and inconsistent with `CreateAsyncCheckpoint` on the same shard state (the lazy-shard sentinel branch is unreachable via RPC, as already noted). A handler-level test now pins sentinel → 412 end-to-end across the package boundary.
- **Set-count drift hardening.** The exact-`SetCount()` buffer regime left `LevelDiff`'s positional reads bounded only by the cached count, guaranteed two packages away by `Bitset.Unmarshal`; it now bounds reads in its own loop (error, not panic, on an understated cache). The finder and local `Diff` reject a short local `Level` write (`n != need`) before comparing, closing the stale-tail read an overstated cache would otherwise cause silently. `Bitset.Unmarshal` commits to the receiver only after full validation, so a rejected payload can no longer leave a torn bitset. Golden wire-format vectors (hard-coded bytes, including `SetAll` with trailing bits at a non-word-aligned size) pin the frozen `Marshal` layout all of the above relies on.

Pre-existing findings deliberately left for follow-up (all pre-date this PR): the finder's error compounder masks per-target `ErrNoDiffFound`, so one persistently failing target suppresses the async-checkpoint→live-tree fallback for healthy targets; `Bitset.Unmarshal` accepts peer-declared sizes up to 512 MiB before any level bound is applied (legitimate discriminants max out at 128 KiB, so a cap at `LeavesCount(maxHashtreeHeight)` is a natural companion); the stream-reader caps bound only preallocation while the append loops and the legacy JSON/gRPC decode paths remain uncapped (`io.LimitReader` would finish the job).
