### PR TITLE
fix(raft): retry applies rejected by a leadership transfer

### DIFF
--- a/cluster/backoff.go
+++ b/cluster/backoff.go
@@ -16,7 +16,17 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/weaviate/weaviate/cluster/types"
 )
+
+// applyBackoff retries leadership churn — the next pass re-resolves the leader,
+// which the gRPC policy can't do; it re-sends to the node that stepped down.
+func applyBackoff(err error) error {
+	if types.IsNoLeader(err) {
+		return err
+	}
+	return backoff.Permanent(err)
+}
 
 // backoffConfig creates a backoff configuration based on the election timeout.
 // The initial interval is set to 1/20th of the election timeout, and the max interval

--- a/cluster/backoff_test.go
+++ b/cluster/backoff_test.go
@@ -13,12 +13,52 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/raft"
 	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/cluster/schema"
+	"github.com/weaviate/weaviate/cluster/types"
 )
+
+func TestApplyBackoff(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantRetry bool
+	}{
+		{name: "success", err: nil, wantRetry: false},
+		{name: "ErrNotLeader", err: types.ErrNotLeader, wantRetry: true},
+		{name: "ErrLeaderNotFound", err: types.ErrLeaderNotFound, wantRetry: true},
+		{name: "raft.ErrNotLeader", err: raft.ErrNotLeader, wantRetry: true},
+		{name: "raft.ErrLeadershipLost", err: raft.ErrLeadershipLost, wantRetry: true},
+		{name: "raft.ErrLeadershipTransferInProgress", err: raft.ErrLeadershipTransferInProgress, wantRetry: true},
+		// What a forwarded apply sees once fromRPCError re-chains the sentinel.
+		{
+			name:      "forwarded raft.ErrLeadershipTransferInProgress",
+			err:       errors.Join(errors.New("rpc error: code = ResourceExhausted"), raft.ErrLeadershipTransferInProgress),
+			wantRetry: true,
+		},
+		{name: "ErrUnknownCommand", err: types.ErrUnknownCommand, wantRetry: false},
+		{name: "ErrBadRequest", err: schema.ErrBadRequest, wantRetry: false},
+		{name: "unrelated", err: errors.New("disk on fire"), wantRetry: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyBackoff(tc.err)
+			if tc.err == nil {
+				assert.NoError(t, got)
+				return
+			}
+			var permanent *backoff.PermanentError
+			assert.Equal(t, tc.wantRetry, !errors.As(got, &permanent))
+			assert.ErrorIs(t, got, tc.err)
+		})
+	}
+}
 
 func TestBackoffConfig(t *testing.T) {
 	tests := []struct {

--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -14,11 +14,9 @@ package cluster
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/schema"
@@ -334,11 +332,7 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		// We are the leader, let's apply
 		if s.store.IsLeader() {
 			schemaVersion, err = s.store.Execute(req)
-			// We might fail due to leader not found as we are losing or transferring leadership, retry
-			if errors.Is(err, raft.ErrNotLeader) || errors.Is(err, raft.ErrLeadershipLost) {
-				return err
-			}
-			return backoff.Permanent(err)
+			return applyBackoff(err)
 		}
 
 		leader := s.store.Leader()
@@ -351,8 +345,7 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		var resp *cmd.ApplyResponse
 		resp, err = s.cl.Apply(ctx, leader, req)
 		if err != nil {
-			// Don't retry if the actual apply to the leader failed, we have retry at the network layer already
-			return backoff.Permanent(err)
+			return applyBackoff(err)
 		}
 		schemaVersion = resp.Version
 		return nil

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -328,6 +328,8 @@ func fromRPCError(err error) error {
 			// raft.ErrNotLeader shares types.ErrNotLeader's message and matches
 			// the first arm; ErrLeadershipLost has its own wording.
 			return errors.Join(err, types.ErrNotLeader)
+		case strings.Contains(msg, raft.ErrLeadershipTransferInProgress.Error()):
+			return errors.Join(err, raft.ErrLeadershipTransferInProgress)
 		}
 	case codes.NotFound:
 		switch {

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -281,6 +281,8 @@ func TestFromRPCError_SentinelMessagesMutuallyNonSubstring(t *testing.T) {
 			sentinels: []sentinel{
 				{name: "ErrNotLeader", err: types.ErrNotLeader},
 				{name: "ErrLeaderNotFound", err: types.ErrLeaderNotFound},
+				{name: "raft.ErrLeadershipLost", err: raft.ErrLeadershipLost},
+				{name: "raft.ErrLeadershipTransferInProgress", err: raft.ErrLeadershipTransferInProgress},
 			},
 		},
 	}
@@ -310,6 +312,7 @@ func TestFromRPCError_HashicorpLeadershipSentinelsRoundTrip(t *testing.T) {
 	}{
 		{name: "raft.ErrLeadershipLost", send: raft.ErrLeadershipLost},
 		{name: "raft.ErrNotLeader", send: raft.ErrNotLeader},
+		{name: "raft.ErrLeadershipTransferInProgress", send: raft.ErrLeadershipTransferInProgress},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/hashicorp/raft"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
@@ -390,6 +391,12 @@ func TestToRPCError(t *testing.T) {
 		{
 			name:     "ErrLeaderNotFound maps to NotLeaderRPCCode",
 			err:      types.ErrLeaderNotFound,
+			expected: NotLeaderRPCCode,
+		},
+		{
+			// As codes.Internal the forwarding node would never retry the handover.
+			name:     "raft.ErrLeadershipTransferInProgress maps to NotLeaderRPCCode",
+			err:      raft.ErrLeadershipTransferInProgress,
 			expected: NotLeaderRPCCode,
 		},
 		{

--- a/cluster/types/errs.go
+++ b/cluster/types/errs.go
@@ -31,11 +31,12 @@ var (
 
 // IsNoLeader reports whether err means the operation could not reach a
 // leader. ErrNotLeader/ErrLeaderNotFound come back from a forwarded call;
-// hashicorp's two are returned raw by a leader-local apply that exhausted
+// hashicorp's three are returned raw by a leader-local apply that exhausted
 // its retries.
 func IsNoLeader(err error) bool {
 	return errors.Is(err, ErrNotLeader) ||
 		errors.Is(err, ErrLeaderNotFound) ||
 		errors.Is(err, raft.ErrNotLeader) ||
-		errors.Is(err, raft.ErrLeadershipLost)
+		errors.Is(err, raft.ErrLeadershipLost) ||
+		errors.Is(err, raft.ErrLeadershipTransferInProgress)
 }

--- a/cluster/types/errs_test.go
+++ b/cluster/types/errs_test.go
@@ -31,10 +31,12 @@ func TestIsNoLeader(t *testing.T) {
 		{name: "ErrLeaderNotFound", err: ErrLeaderNotFound, want: true},
 		{name: "raft.ErrNotLeader", err: raft.ErrNotLeader, want: true},
 		{name: "raft.ErrLeadershipLost", err: raft.ErrLeadershipLost, want: true},
+		{name: "raft.ErrLeadershipTransferInProgress", err: raft.ErrLeadershipTransferInProgress, want: true},
 		// The forwarded path wraps, and leaderErr decorates ErrLeaderNotFound
 		// with the unreachable node names.
 		{name: "wrapped ErrLeaderNotFound", err: fmt.Errorf("apply: %w, can not resolve nodes [n1]", ErrLeaderNotFound), want: true},
 		{name: "wrapped raft.ErrLeadershipLost", err: fmt.Errorf("execute: %w", raft.ErrLeadershipLost), want: true},
+		{name: "joined raft.ErrLeadershipTransferInProgress", err: errors.Join(errors.New("rpc error"), raft.ErrLeadershipTransferInProgress), want: true},
 		{name: "joined ErrNotLeader", err: errors.Join(errors.New("rpc error"), ErrNotLeader), want: true},
 		// Neighbours that must not be mistaken for a leadership problem.
 		{name: "ErrNotOpen", err: ErrNotOpen, want: false},


### PR DESCRIPTION
### What's being changed:

Closes weaviate/0-weaviate-issues#476.

hashicorp/raft rejects queued applies with `ErrLeadershipTransferInProgress` while a leader gracefully hands over — every rolling restart. Nothing in the stack treated that as retriable, so a sub-second window failed the request outright. CI caught it as [`rolling-restart-highly-available-qps-benchmark` run 30962886633](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/30962886633/job/92170644383): a 177-object MT batch lost to auto-tenant creation, while all four QPS validations in the same run passed.

Three gaps had to line up, and all three are closed here:

1. **`types.IsNoLeader` omitted the sentinel** — so `toRPCError` fell through to `default: codes.Internal`, which is outside the `Apply` retry set (whose own comment says INTERNAL is never retried) instead of `NotLeaderRPCCode`.
2. **`fromRPCError` couldn't re-chain it** — the `NotLeaderRPCCode` arm matches by message substring, and "leadership transfer in progress" matches neither existing arm, so a forwarding node lost the classification across the hop.
3. **`Raft.Execute` wrapped forward errors in `backoff.Permanent`** — reasoning "we have retry at the network layer already". The leader-local branch enumerated only two of hashicorp's sentinels, though its comment already claimed to cover *"losing or transferring leadership"*.

Both `Execute` branches now route through a shared `applyBackoff`, which retries exactly the `IsNoLeader` set. That is the branch that actually recovers: the app-level loop re-resolves the leader and forwards to the new one, where the gRPC retry policy can only re-send to the node that just stepped down — during a rolling restart, the node on its way out.

**Design note.** Fixing only gap 1 would have worked by accident: the old leader's `Server.Apply` re-enters `Raft.Execute` and forwards to the new leader on its behalf. That relies on the outgoing node still being alive to proxy, which is exactly what a rolling restart takes away. Hence gap 3.

**Blast radius beyond the reported symptom.** The other two `IsNoLeader` consumers were misclassifying the same window: the namespaces REST handler rendered 500 instead of 503, and the namespace-cleanup coordinator logged an error instead of deferring to the new leader. Both are corrected by the same one-line change.

Not a regression — pre-existing since `5f03bd58` (2025-03-03). It surfaced now because this scenario is the first to combine a graceful rolling restart with continuous MT auto-tenant writes.

**Branch target.** `stable/v1.38` is the oldest branch carrying `IsNoLeader`; branch-sync forward-carries to `stable/v1.39` and `main`. The two files that differ between 1.38 and 1.39 (`cluster/rpc/server.go`, `client.go`) differ only in unrelated schema-conflict arms, so the merge is clean.

### Tests

Each new case fails on the parent commit and passes here — verified by reverting `errs.go` and `client.go` and re-running:

- `TestIsNoLeader` — bare and joined forms of the sentinel.
- `TestToRPCError` — the sentinel maps to `NotLeaderRPCCode`, not `Internal`.
- `TestFromRPCError_HashicorpLeadershipSentinelsRoundTrip` — survives the gRPC hop with `IsNoLeader` still holding.
- `TestApplyBackoff` (new) — the retry/permanent split, including the wire-shaped joined error a forwarded apply actually sees.
- `TestFromRPCError_SentinelMessagesMutuallyNonSubstring` — the `NotLeaderRPCCode` arm gained both raft sentinels, pinning that the new match arm can't be shadowed.

`go test ./cluster/ ./cluster/rpc/ ./cluster/types/ -count=1` green; `golangci-lint run ./cluster/...` reports 0 issues.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
