### PR TITLE
perf(hfresh): parallelize rescoring with budget-aware workers

### DIFF
--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -14,10 +14,14 @@ package hfresh
 import (
 	"context"
 	"iter"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
 )
 
@@ -146,18 +150,51 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 		}
 	}
 
-	rescored := NewResultSet(k)
+	candidates := make([]uint64, 0, q.Len())
 	for id := range q.Iter() {
-		vec, err := h.vectorForId(ctx, id)
-		if err != nil {
-			return nil, nil, err
-		}
-		vec = h.normalizeVec(vec)
-		dist, err := h.distancer.distancer.SingleDist(vector, vec)
-		if err != nil {
-			return nil, nil, err
-		}
-		rescored.Insert(id, dist)
+		candidates = append(candidates, id)
+	}
+
+	rescored := NewResultSet(k)
+	var rescoredMu sync.Mutex
+
+	// Budget-aware fan-out: the context budget caps the worker count under
+	// concurrent load; without one we default to 2*GOMAXPROCS (IO-bound).
+	workers := concurrency.NumWorkers(ctx, len(candidates), concurrency.GOMAXPROCSx2)
+	eg := enterrors.NewErrorGroupWrapper(h.logger)
+	for workerID := range workers {
+		workerID := workerID
+		eg.Go(func() error {
+			for pos := workerID; pos < len(candidates); pos += workers {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				id := candidates[pos]
+				vec, err := h.vectorForId(ctx, id)
+				if err != nil {
+					// The object may have been deleted between the posting scan
+					// and the rescore step (race condition). Skip stale entries
+					// gracefully.
+					var notFound storobj.ErrNotFound
+					if errors.As(err, &notFound) {
+						continue
+					}
+					return err
+				}
+				vec = h.normalizeVec(vec)
+				dist, err := h.distancer.distancer.SingleDist(vector, vec)
+				if err != nil {
+					return err
+				}
+				rescoredMu.Lock()
+				rescored.Insert(id, dist)
+				rescoredMu.Unlock()
+			}
+			return nil
+		})
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, nil, err
 	}
 
 	ids := make([]uint64, rescored.Len())

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"iter"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -60,7 +61,9 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 		nAllowList = h.wrapAllowList(ctx, allowList)
 		defer nAllowList.Close()
 	}
+	beforeCentroids := time.Now()
 	centroids, err := h.Centroids.Search(vector, candidateCentroidNum, nAllowList)
+	helpers.AnnotateSlowQueryLog(ctx, "hfresh_centroid_search_took", time.Since(beforeCentroids))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -91,7 +94,9 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	}
 
 	// read all the selected postings
+	beforeRead := time.Now()
 	postings, err = h.PostingStore.MultiGet(ctx, selectedCentroids)
+	helpers.AnnotateSlowQueryLog(ctx, "hfresh_posting_read_took", time.Since(beforeRead))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,6 +106,7 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 
 	var decompressBuf []uint64
 
+	beforeScan := time.Now()
 	for i, p := range postings {
 		if p == nil { // posting nil if not found
 			continue
@@ -149,7 +155,9 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 			}
 		}
 	}
+	helpers.AnnotateSlowQueryLog(ctx, "hfresh_posting_scan_took", time.Since(beforeScan))
 
+	beforeRescore := time.Now()
 	candidates := make([]uint64, 0, q.Len())
 	for id := range q.Iter() {
 		candidates = append(candidates, id)
@@ -193,7 +201,9 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 			return nil
 		})
 	}
-	if err := eg.Wait(); err != nil {
+	err = eg.Wait()
+	helpers.AnnotateSlowQueryLog(ctx, "hfresh_rescore_took", time.Since(beforeRescore))
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -14,7 +14,6 @@ package hfresh
 import (
 	"context"
 	"iter"
-	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -163,28 +162,30 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 		candidates = append(candidates, id)
 	}
 
-	rescored := NewResultSet(k)
-	var rescoredMu sync.Mutex
-
 	// Budget-aware fan-out: the context budget caps the worker count under
 	// concurrent load; without one we default to 2*GOMAXPROCS (IO-bound).
 	workers := concurrency.NumWorkers(ctx, len(candidates), concurrency.GOMAXPROCSx2)
+
+	// Workers compute distances in parallel; results are inserted after,
+	// in candidate order, so ties resolve the same way on every run.
+	candidateDists := make([]float32, len(candidates))
+	skipped := make([]bool, len(candidates))
+
 	eg := enterrors.NewErrorGroupWrapper(h.logger)
 	for workerID := range workers {
-		workerID := workerID
 		eg.Go(func() error {
 			for pos := workerID; pos < len(candidates); pos += workers {
 				if err := ctx.Err(); err != nil {
 					return err
 				}
-				id := candidates[pos]
-				vec, err := h.vectorForId(ctx, id)
+				vec, err := h.vectorForId(ctx, candidates[pos])
 				if err != nil {
 					// The object may have been deleted between the posting scan
 					// and the rescore step (race condition). Skip stale entries
 					// gracefully.
 					var notFound storobj.ErrNotFound
 					if errors.As(err, &notFound) {
+						skipped[pos] = true
 						continue
 					}
 					return err
@@ -194,9 +195,7 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 				if err != nil {
 					return err
 				}
-				rescoredMu.Lock()
-				rescored.Insert(id, dist)
-				rescoredMu.Unlock()
+				candidateDists[pos] = dist
 			}
 			return nil
 		})
@@ -205,6 +204,14 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	helpers.AnnotateSlowQueryLog(ctx, "hfresh_rescore_took", time.Since(beforeRescore))
 	if err != nil {
 		return nil, nil, err
+	}
+
+	rescored := NewResultSet(k)
+	for pos, id := range candidates {
+		if skipped[pos] {
+			continue
+		}
+		rescored.Insert(id, candidateDists[pos])
 	}
 
 	ids := make([]uint64, rescored.Len())

--- a/adapters/repos/db/vector/hfresh/search_flat.go
+++ b/adapters/repos/db/vector/hfresh/search_flat.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 const (
@@ -43,7 +44,7 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 	}
 
 	eg := enterrors.NewErrorGroupWrapper(h.logger)
-	for workerID := 0; workerID < flatSearchConcurrency; workerID++ {
+	for workerID := range flatSearchConcurrency {
 		workerID := workerID
 		eg.Go(func() error {
 			if err := ctx.Err(); err != nil {
@@ -55,6 +56,12 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 
 				dist, err := h.distToNode(ctx, candidate, queryVector)
 				if err != nil {
+					// The object may have been deleted between allowList iteration
+					// and vector fetch. Skip stale entries gracefully.
+					var notFound storobj.ErrNotFound
+					if errors.As(err, &notFound) {
+						continue
+					}
 					return err
 				}
 

--- a/adapters/repos/db/vector/hfresh/search_flat_test.go
+++ b/adapters/repos/db/vector/hfresh/search_flat_test.go
@@ -18,35 +18,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func TestFlatSearchSkipsCandidatesDeletedMidQuery(t *testing.T) {
-	store := testinghelpers.NewDummyStore(t)
-	cfg, uc := makeHFreshConfig(t)
-
-	dims := 32
 	n := 100
-	vectors, _ := testinghelpers.RandomVecs(n, 1, dims)
+	vectors, _ := testinghelpers.RandomVecs(n, 1, 32)
 	const deletedID = uint64(5)
 
-	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
-		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
-			if id == deletedID && ctx.Value(searchMarker{}) != nil {
-				return nil, storobj.NewErrNotFoundf(id, "deleted mid-query")
-			}
-			if int(id) >= len(vectors) {
-				return nil, storobj.NewErrNotFoundf(id, "out of range")
-			}
-			return vectors[id], nil
-		})
-
-	index := makeHFreshWithConfig(t, store, cfg, uc)
-	for i, vec := range vectors {
-		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
-	}
+	index := newSearchTestIndex(t, vectors, func(ctx context.Context, id uint64) error {
+		if id == deletedID && ctx.Value(searchMarker{}) != nil {
+			return storobj.NewErrNotFoundf(id, "deleted mid-query")
+		}
+		return nil
+	})
 
 	// a small allowList (< flatSearchCutoff) routes the search through
 	// flatSearch; it must skip the deleted candidate, not fail the query

--- a/adapters/repos/db/vector/hfresh/search_flat_test.go
+++ b/adapters/repos/db/vector/hfresh/search_flat_test.go
@@ -1,0 +1,65 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hfresh
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+func TestFlatSearchSkipsCandidatesDeletedMidQuery(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+
+	dims := 32
+	n := 100
+	vectors, _ := testinghelpers.RandomVecs(n, 1, dims)
+	const deletedID = uint64(5)
+
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
+		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
+			if id == deletedID && ctx.Value(searchMarker{}) != nil {
+				return nil, storobj.NewErrNotFoundf(id, "deleted mid-query")
+			}
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[id], nil
+		})
+
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
+	}
+
+	// a small allowList (< flatSearchCutoff) routes the search through
+	// flatSearch; it must skip the deleted candidate, not fail the query
+	allowIDs := make([]uint64, n)
+	for i := range allowIDs {
+		allowIDs[i] = uint64(i)
+	}
+	allowList := helpers.NewAllowList(allowIDs...)
+
+	searchCtx := context.WithValue(t.Context(), searchMarker{}, true)
+	ids, _, err := index.SearchByVector(searchCtx, vectors[deletedID], 10, allowList)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+	require.NotContains(t, ids, deletedID,
+		"flatSearch must drop a candidate whose vector vanished mid-query")
+}

--- a/adapters/repos/db/vector/hfresh/search_test.go
+++ b/adapters/repos/db/vector/hfresh/search_test.go
@@ -313,3 +313,49 @@ func TestRescoreSkipsCandidatesDeletedMidQuery(t *testing.T) {
 	require.NotContains(t, ids, deletedID,
 		"a candidate whose vector vanished mid-query must be dropped, not returned")
 }
+
+func TestRescoreTieBreakingIsDeterministic(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+
+	// 30 exact duplicates of the query vector (ids 0-29) followed by 70
+	// distinct vectors: the top-k boundary falls inside a 30-way distance
+	// tie, so which ids are returned depends entirely on tie handling.
+	dims := 32
+	n := 100
+	const dupes = 30
+	vectors, _ := testinghelpers.RandomVecs(n, 1, dims)
+	for i := 1; i < dupes; i++ {
+		vectors[i] = vectors[0]
+	}
+
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
+		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[id], nil
+		})
+
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
+	}
+
+	// tie handling must not depend on worker scheduling or the budget:
+	// every run over the same index must return the same ids
+	ctx := t.Context()
+	first, _, err := index.SearchByVector(ctx, vectors[0], 10, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	for range 5 {
+		again, _, err := index.SearchByVector(ctx, vectors[0], 10, nil)
+		require.NoError(t, err)
+		require.Equal(t, first, again, "rescore tie-breaking drifted between runs")
+	}
+
+	serial, _, err := index.SearchByVector(concurrency.CtxWithBudget(ctx, 1), vectors[0], 10, nil)
+	require.NoError(t, err)
+	require.Equal(t, first, serial, "budget must not change tie handling")
+}

--- a/adapters/repos/db/vector/hfresh/search_test.go
+++ b/adapters/repos/db/vector/hfresh/search_test.go
@@ -215,27 +215,19 @@ func TestSearchCosineDistanceRescore(t *testing.T) {
 // fetches from background split/reassign workers.
 type searchMarker struct{}
 
-func TestRescoreConcurrencyRespectsBudget(t *testing.T) {
+// newSearchTestIndex builds an HFresh index serving the given vectors through
+// VectorForIDThunk. A non-nil intercept runs first on every fetch; a non-nil
+// error from it fails that fetch.
+func newSearchTestIndex(t *testing.T, vectors [][]float32, intercept func(ctx context.Context, id uint64) error) *HFresh {
+	t.Helper()
 	store := testinghelpers.NewDummyStore(t)
 	cfg, uc := makeHFreshConfig(t)
-
-	dims := 32
-	n := 300
-	vectors, queries := testinghelpers.RandomVecs(n, 1, dims)
-
-	var cur, maxSeen atomic.Int64
 	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
 		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
-			if ctx.Value(searchMarker{}) != nil {
-				c := cur.Add(1)
-				for {
-					m := maxSeen.Load()
-					if c <= m || maxSeen.CompareAndSwap(m, c) {
-						break
-					}
+			if intercept != nil {
+				if err := intercept(ctx, id); err != nil {
+					return nil, err
 				}
-				time.Sleep(500 * time.Microsecond) // force worker overlap
-				cur.Add(-1)
 			}
 			if int(id) >= len(vectors) {
 				return nil, storobj.NewErrNotFoundf(id, "out of range")
@@ -247,6 +239,28 @@ func TestRescoreConcurrencyRespectsBudget(t *testing.T) {
 	for i, vec := range vectors {
 		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
 	}
+	return index
+}
+
+func TestRescoreConcurrencyRespectsBudget(t *testing.T) {
+	vectors, queries := testinghelpers.RandomVecs(300, 1, 32)
+
+	var cur, maxSeen atomic.Int64
+	index := newSearchTestIndex(t, vectors, func(ctx context.Context, id uint64) error {
+		if ctx.Value(searchMarker{}) == nil {
+			return nil
+		}
+		c := cur.Add(1)
+		for {
+			m := maxSeen.Load()
+			if c <= m || maxSeen.CompareAndSwap(m, c) {
+				break
+			}
+		}
+		time.Sleep(500 * time.Microsecond) // force worker overlap
+		cur.Add(-1)
+		return nil
+	})
 
 	searchCtx := context.WithValue(t.Context(), searchMarker{}, true)
 	query := queries[0]
@@ -277,32 +291,18 @@ func TestRescoreConcurrencyRespectsBudget(t *testing.T) {
 }
 
 func TestRescoreSkipsCandidatesDeletedMidQuery(t *testing.T) {
-	store := testinghelpers.NewDummyStore(t)
-	cfg, uc := makeHFreshConfig(t)
-
-	dims := 32
-	n := 100
-	vectors, _ := testinghelpers.RandomVecs(n, 1, dims)
+	vectors, _ := testinghelpers.RandomVecs(100, 1, 32)
 	const deletedID = uint64(5)
 
-	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
-		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
-			// simulate a deletion the index has not processed yet: the full
-			// vector is gone from the object store, but only for our search
-			// (background workers still see it, keeping the index intact)
-			if id == deletedID && ctx.Value(searchMarker{}) != nil {
-				return nil, storobj.NewErrNotFoundf(id, "deleted mid-query")
-			}
-			if int(id) >= len(vectors) {
-				return nil, storobj.NewErrNotFoundf(id, "out of range")
-			}
-			return vectors[id], nil
-		})
-
-	index := makeHFreshWithConfig(t, store, cfg, uc)
-	for i, vec := range vectors {
-		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
-	}
+	// simulate a deletion the index has not processed yet: the full vector
+	// is gone from the object store, but only for our search (background
+	// workers still see it, keeping the index intact)
+	index := newSearchTestIndex(t, vectors, func(ctx context.Context, id uint64) error {
+		if id == deletedID && ctx.Value(searchMarker{}) != nil {
+			return storobj.NewErrNotFoundf(id, "deleted mid-query")
+		}
+		return nil
+	})
 
 	// querying with the deleted vector itself guarantees it is a rescore
 	// candidate; the search must skip it without failing
@@ -315,32 +315,16 @@ func TestRescoreSkipsCandidatesDeletedMidQuery(t *testing.T) {
 }
 
 func TestRescoreTieBreakingIsDeterministic(t *testing.T) {
-	store := testinghelpers.NewDummyStore(t)
-	cfg, uc := makeHFreshConfig(t)
-
 	// 30 exact duplicates of the query vector (ids 0-29) followed by 70
 	// distinct vectors: the top-k boundary falls inside a 30-way distance
 	// tie, so which ids are returned depends entirely on tie handling.
-	dims := 32
-	n := 100
 	const dupes = 30
-	vectors, _ := testinghelpers.RandomVecs(n, 1, dims)
+	vectors, _ := testinghelpers.RandomVecs(100, 1, 32)
 	for i := 1; i < dupes; i++ {
 		vectors[i] = vectors[0]
 	}
 
-	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
-		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
-			if int(id) >= len(vectors) {
-				return nil, storobj.NewErrNotFoundf(id, "out of range")
-			}
-			return vectors[id], nil
-		})
-
-	index := makeHFreshWithConfig(t, store, cfg, uc)
-	for i, vec := range vectors {
-		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
-	}
+	index := newSearchTestIndex(t, vectors, nil)
 
 	// tie handling must not depend on worker scheduling or the budget:
 	// every run over the same index must return the same ids

--- a/adapters/repos/db/vector/hfresh/search_test.go
+++ b/adapters/repos/db/vector/hfresh/search_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func TestSearchTreatsPartiallyInitializedDimensionsAsEmptyIndex(t *testing.T) {
@@ -206,4 +208,108 @@ func TestSearchCosineDistanceRescore(t *testing.T) {
 			"result %d (id=%d): returned distance %f != expected cosine distance %f",
 			i, id, dists[i], expected)
 	}
+}
+
+// searchMarker tags contexts issued by the tests below so the instrumented
+// VectorForIDThunk only counts fetches belonging to our search calls, not
+// fetches from background split/reassign workers.
+type searchMarker struct{}
+
+func TestRescoreConcurrencyRespectsBudget(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+
+	dims := 32
+	n := 300
+	vectors, queries := testinghelpers.RandomVecs(n, 1, dims)
+
+	var cur, maxSeen atomic.Int64
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
+		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
+			if ctx.Value(searchMarker{}) != nil {
+				c := cur.Add(1)
+				for {
+					m := maxSeen.Load()
+					if c <= m || maxSeen.CompareAndSwap(m, c) {
+						break
+					}
+				}
+				time.Sleep(500 * time.Microsecond) // force worker overlap
+				cur.Add(-1)
+			}
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[id], nil
+		})
+
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
+	}
+
+	searchCtx := context.WithValue(t.Context(), searchMarker{}, true)
+	query := queries[0]
+
+	// no budget in ctx: fan-out up to 2*GOMAXPROCS allowed
+	cur.Store(0)
+	maxSeen.Store(0)
+	idsFree, distsFree, err := index.SearchByVector(searchCtx, query, 10, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, idsFree)
+	t.Logf("no budget: max concurrent rescore fetches = %d", maxSeen.Load())
+	require.Greater(t, maxSeen.Load(), int64(1),
+		"rescore fetches must overlap when no budget caps them")
+
+	// budget = 1: rescore must be serial
+	cur.Store(0)
+	maxSeen.Store(0)
+	budgetCtx := concurrency.CtxWithBudget(searchCtx, 1)
+	idsBudget, distsBudget, err := index.SearchByVector(budgetCtx, query, 10, nil)
+	require.NoError(t, err)
+	t.Logf("budget=1: max concurrent rescore fetches = %d", maxSeen.Load())
+	require.Equal(t, int64(1), maxSeen.Load(),
+		"a budget of 1 must serialize the rescore")
+
+	// identical inputs must produce identical results either way
+	require.Equal(t, idsFree, idsBudget)
+	require.Equal(t, distsFree, distsBudget)
+}
+
+func TestRescoreSkipsCandidatesDeletedMidQuery(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+
+	dims := 32
+	n := 100
+	vectors, _ := testinghelpers.RandomVecs(n, 1, dims)
+	const deletedID = uint64(5)
+
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
+		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
+			// simulate a deletion the index has not processed yet: the full
+			// vector is gone from the object store, but only for our search
+			// (background workers still see it, keeping the index intact)
+			if id == deletedID && ctx.Value(searchMarker{}) != nil {
+				return nil, storobj.NewErrNotFoundf(id, "deleted mid-query")
+			}
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[id], nil
+		})
+
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
+	}
+
+	// querying with the deleted vector itself guarantees it is a rescore
+	// candidate; the search must skip it without failing
+	searchCtx := context.WithValue(t.Context(), searchMarker{}, true)
+	ids, _, err := index.SearchByVector(searchCtx, vectors[deletedID], 10, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+	require.NotContains(t, ids, deletedID,
+		"a candidate whose vector vanished mid-query must be dropped, not returned")
 }

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -74,3 +74,13 @@ func clampBudget(b, limit int) int {
 	}
 	return b
 }
+
+// NumWorkers returns the per-query worker count for a fan-out over nItems:
+// the context budget when present, capped at fallback and nItems, floored
+// at 1 so a zero or negative budget (or nItems of 0) can never silently
+// skip the work. Unlike BudgetFromCtxCapped it deliberately does not honor
+// the sroar merge kill switch: that escape hatch is scoped to sroar merge
+// concurrency, not to vector-index fan-outs.
+func NumWorkers(ctx context.Context, nItems, fallback int) int {
+	return max(1, min(BudgetFromCtx(ctx, fallback), fallback, nItems))
+}

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -132,3 +132,30 @@ func TestBudgetCapDisabled_KillSwitch(t *testing.T) {
 }
 
 func ptr(i int) *int { return &i }
+
+func TestNumWorkers(t *testing.T) {
+	bg := context.Background()
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		nItems   int
+		fallback int
+		want     int
+	}{
+		{"no budget uses fallback", bg, 100, 8, 8},
+		{"no budget capped by item count", bg, 3, 8, 3},
+		{"budget below fallback wins", CtxWithBudget(bg, 2), 100, 8, 2},
+		{"budget above fallback is clamped", CtxWithBudget(bg, 64), 100, 8, 8},
+		{"budget capped by item count", CtxWithBudget(bg, 6), 4, 8, 4},
+		{"zero items floors to one", bg, 0, 8, 1},
+		{"zero budget floors to one", CtxWithBudget(bg, 0), 100, 8, 1},
+		{"negative budget floors to one", CtxWithBudget(bg, -3), 100, 8, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, NumWorkers(tt.ctx, tt.nItems, tt.fallback))
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

HFresh's per-query rescore loop — the dominant search latency cost — is serial: it re-reads the full vector for up to `rescoreLimit` candidates one LSM read at a time. This PR parallelizes it and lays the groundwork for further search-path optimizations:

- **New `concurrency.NumWorkers(ctx, nItems, fallback)` helper** (`entities/concurrency`): the shared budget-aware worker-count formula — the per-query concurrency budget when the context carries one, capped at `fallback` and `nItems`, floored at 1. Same formula the HNSW rescore paths inlined in #10536/#12421; deliberately does not honor the sroar merge kill switch (documented on the helper).
- **Parallel rescoring in `SearchByVector`** (`adapters/repos/db/vector/hfresh/search.go`): stride-partitioned workers via the error-group wrapper, `NumWorkers(ctx, len(candidates), 2×GOMAXPROCS)`, mutex-protected result set. With no budget in the context behavior falls back to full fan-out; under the (partially merged) concurrency-budget system, concurrent load shrinks the fan-out automatically.
- **Backport of dbe3049a83 from main** (never reached `stable/v1.37`): a document deleted between the posting scan and the rescore — or between allowList iteration and fetch in flat search — no longer fails the entire query; it is skipped, matching main's behavior. Both halves are pinned by regression tests.
- **Per-phase slow-query-log timings**: `hfresh_centroid_search_took`, `hfresh_posting_read_took`, `hfresh_posting_scan_took`, `hfresh_rescore_took` — these decide where follow-up optimizations (parallel posting reads, adaptive rescoring) should focus.

### Benchmarks

<img width="959" height="703" alt="output" src="https://github.com/user-attachments/assets/41071b53-fb8c-479a-8d1c-2a542cd412dd" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.