### PR TITLE
hotfix: put all of runtime reindex behind RUNTIME_REINDEX_ENABLED (off by default)

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1011,6 +1011,12 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 			return
 		}
 
+		// Runs with the flag on OR off: an orphaned task is a task whose
+		// collection is already gone, so there is nothing left to protect
+		// and nothing to resume — only a stale entry that a same-name
+		// recreation could adopt. Cleaning it up is not reindex work.
+		discardOrphanedReindexTasks(serverShutdownCtx, appState)
+
 		if !appState.ServerConfig.Config.RuntimeReindexEnabled {
 			// Everything below this point is reindex-only: the orphan
 			// audit (which deletes state) and the backup-gate lookups.
@@ -1200,11 +1206,13 @@ func initReindexAndDistributedTasks(
 	// interval across nodes. See [distributedtask.SchedulerNotifier].
 	appState.ClusterService.SetDistributedTaskSchedulerNotifier(appState.DistributedTaskScheduler)
 
+	detectorProviders := detectorProvidersFor(providers, reindexProvider)
+
 	// FSM-deterministic conflict reject (closes the multi-node parallel-submit
 	// race that per-node submit locks cannot cover; see
 	// weaviate/0-weaviate-issues#54 / weaviate/weaviate#10675).
 	conflictDetectors := map[string]distributedtask.ConflictDetector{}
-	for ns, p := range providers {
+	for ns, p := range detectorProviders {
 		if cd, ok := p.(distributedtask.ConflictDetector); ok {
 			conflictDetectors[ns] = cd
 		}
@@ -1212,14 +1220,122 @@ func initReindexAndDistributedTasks(
 	appState.ClusterService.SetDistributedTaskConflictDetectors(conflictDetectors)
 
 	// Symmetric guard in the other direction: protect in-flight tasks from
-	// out-of-band schema mutations.
+	// out-of-band schema mutations (DeleteClass, DeleteTenants,
+	// UpdateProperty).
 	schemaMutationDetectors := map[string]distributedtask.SchemaMutationDetector{}
-	for ns, p := range providers {
+	for ns, p := range detectorProviders {
 		if smd, ok := p.(distributedtask.SchemaMutationDetector); ok {
 			schemaMutationDetectors[ns] = smd
 		}
 	}
 	appState.ClusterService.SetDistributedTaskSchemaMutationDetectors(schemaMutationDetectors)
+}
+
+// orphanedReindexTasks returns the live reindex tasks whose collection no
+// longer exists in the schema, paired with the collection name the
+// payload named.
+//
+// A task becomes orphaned when its collection was deleted while the task
+// was live — possible on builds predating the flag-off DeleteClass guard,
+// or on older versions. It is dangerous rather than merely stale because
+// task payloads identify their collection **by name only**: nothing in
+// the payload or descriptor distinguishes the deleted collection from a
+// later one created with the same name, so a recreated collection would
+// adopt the stale task and run its cutover against fresh data.
+//
+// classExists is injected rather than read from a schema manager so the
+// caller controls the schema snapshot, and so this stays a pure function
+// of (tasks, schema).
+func orphanedReindexTasks(
+	tasks []*distributedtask.Task,
+	classExists func(collection string) bool,
+) (orphans []*distributedtask.Task, collections []string) {
+	for _, task := range tasks {
+		if !task.Status.IsActive() {
+			continue
+		}
+		var payload db.ReindexTaskPayload
+		if err := json.Unmarshal(task.Payload, &payload); err != nil {
+			// Undecodable payload: we cannot name a collection, so we
+			// cannot prove it is an orphan. Leave it for the operator.
+			continue
+		}
+		if payload.Collection == "" || classExists(payload.Collection) {
+			continue
+		}
+		orphans = append(orphans, task)
+		collections = append(collections, payload.Collection)
+	}
+	return orphans, collections
+}
+
+// discardOrphanedReindexTasks cancels every reindex task whose collection
+// no longer exists, with a WARN naming the task and the collection.
+//
+// Cancelling (rather than leaving it) is what stops a same-name
+// recreation from adopting the task: cancelled is terminal, so the
+// scheduler will not resume it when the flag goes back on. The cancel
+// goes through RAFT, so concurrent attempts from several nodes converge
+// on the same terminal state.
+func discardOrphanedReindexTasks(ctx context.Context, appState *state.State) {
+	if appState.ClusterService == nil || appState.SchemaManager == nil {
+		return
+	}
+	tasksByNamespace, err := appState.ClusterService.ListDistributedTasks(ctx)
+	if err != nil {
+		appState.Logger.WithField("action", "reindex_orphan_task_discard").
+			Warnf("cannot list distributed tasks; orphaned reindex tasks (if any) stay until the next restart: %v", err)
+		return
+	}
+
+	orphans, collections := orphanedReindexTasks(
+		tasksByNamespace[db.ReindexNamespace],
+		func(collection string) bool {
+			return appState.SchemaManager.ReadOnlyClass(collection) != nil
+		},
+	)
+	for i, task := range orphans {
+		logger := appState.Logger.WithField("action", "reindex_orphan_task_discard").
+			WithField("collection", collections[i]).
+			WithField("task_id", task.ID).
+			WithField("task_version", task.Version)
+		if err := appState.ClusterService.CancelDistributedTask(
+			ctx, db.ReindexNamespace, task.ID, task.Version,
+		); err != nil {
+			logger.Warnf("failed to discard orphaned reindex task; it will be retried on the next restart: %v", err)
+			continue
+		}
+		logger.Warn("discarded a reindex task whose collection no longer exists. " +
+			"Task payloads identify collections by name only, so leaving it would let a collection later " +
+			"created with the same name adopt this task and run its migration against unrelated data.")
+	}
+}
+
+// detectorProvidersFor returns `providers` plus the reindex namespace,
+// which must be present even when RUNTIME_REINDEX_ENABLED left it out of
+// the scheduler's provider map.
+//
+// The detectors built from this map are refusals, not work: they answer
+// "is a reindex task live on this collection?" from the DTM task list,
+// which is cluster state and exists whether or not this node executes
+// reindex work. An empty registry means "allow everything" in
+// [distributedtask.Manager.dispatchSchemaMutation], so dropping the
+// reindex entry does not disable a check — it silently passes one.
+// DeleteClass mid-migration would then be accepted, orphaning a live
+// task that resurrects against a same-name collection once the flag goes
+// back on.
+func detectorProvidersFor(
+	providers map[string]distributedtask.Provider,
+	reindexProvider distributedtask.Provider,
+) map[string]distributedtask.Provider {
+	out := make(map[string]distributedtask.Provider, len(providers)+1)
+	for ns, p := range providers {
+		out[ns] = p
+	}
+	if reindexProvider != nil {
+		out[db.ReindexNamespace] = reindexProvider
+	}
+	return out
 }
 
 // logPausedReindexes names the migrations found on disk that this node is

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -480,6 +480,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		LSMEnableSegmentsChecksumValidation: appState.ServerConfig.Config.Persistence.LSMEnableSegmentsChecksumValidation,
 		LSMSkipWriteClassNameEnabled:        appState.ServerConfig.Config.Persistence.LSMSkipWriteClassNameEnabled,
 		NamespacesEnabled:                   appState.ServerConfig.Config.Namespaces.Enabled,
+		RuntimeReindexDisabled:              !appState.ServerConfig.Config.RuntimeReindexEnabled,
 		// Pass dummy replication config with minimum factor 1. Otherwise the
 		// setting is not backward-compatible. The user may have created a class
 		// with factor=1 before the change was introduced. Now their setup would no
@@ -691,6 +692,11 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		if err := classDirMover(class); err != nil {
 			return err
 		}
+		if !appState.ServerConfig.Config.RuntimeReindexEnabled {
+			// The audit quarantines tracker dirs, so it must not run
+			// while runtime reindex is off.
+			return nil
+		}
 		// Background ctx: invoked from the RAFT FSM apply path,
 		// which does not propagate an audit-scoped ctx.
 		outcome, err := repo.AuditOrphanReindexTrackersIfReady(context.Background())
@@ -799,14 +805,23 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// (written by ReindexProvider.persistRecoveryRecord before reindex
 	// starts), plus the existing started.mig / tidied.mig sentinels to
 	// decide which migrations are still in flight.
-	recoveredReindexes, recoveryErr := db.DiscoverInFlightReindexTasks(
-		appState.ServerConfig.Config.Persistence.DataPath,
-		appState.Logger,
-		appState.SchemaManager,
-	)
-	if recoveryErr != nil {
-		appState.Logger.WithError(recoveryErr).
-			Warn("reindex recovery: disk scan failed; writes during the swap-recovery window may be lost")
+	//
+	// With RUNTIME_REINDEX_ENABLED off the scan is skipped entirely, so a
+	// node that crashed mid-migration resumes nothing. The on-disk state
+	// is only read here, never written, so skipping leaves it intact for
+	// a later restart with the flag on.
+	var recoveredReindexes []db.RecoveredReindex
+	if appState.ServerConfig.Config.RuntimeReindexEnabled {
+		var recoveryErr error
+		recoveredReindexes, recoveryErr = db.DiscoverInFlightReindexTasks(
+			appState.ServerConfig.Config.Persistence.DataPath,
+			appState.Logger,
+			appState.SchemaManager,
+		)
+		if recoveryErr != nil {
+			appState.Logger.WithError(recoveryErr).
+				Warn("reindex recovery: disk scan failed; writes during the swap-recovery window may be lost")
+		}
 	}
 	reindexer := configureReindexer(recoveredReindexes, appState.Logger)
 	repo.SetReindexer(reindexer)
@@ -994,6 +1009,13 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 			return
 		}
 
+		if !appState.ServerConfig.Config.RuntimeReindexEnabled {
+			// Everything below this point is reindex-only: the orphan
+			// audit (which deletes state) and the backup-gate lookups.
+			// With the flag off none of it may run.
+			return
+		}
+
 		// Post-bootstrap orphan-reindex audit. Must run AFTER
 		// Scheduler.Start so the lookup observes the steady-state
 		// view of RAFT-known tasks.
@@ -1148,8 +1170,13 @@ func initReindexAndDistributedTasks(
 	// OnGroupCompleted's swap phase doesn't take the rehydrate path and try
 	// to load already-loaded ingest buckets.
 	db.SeedReindexProviderFromRecovery(reindexProvider, recoveredReindexes)
-	providers[db.ReindexNamespace] = reindexProvider
 	appState.ReindexProvider = reindexProvider
+	// Registering the namespace is what makes the scheduler run reindex
+	// tasks. Leaving it out with the flag off means a task still recorded
+	// in RAFT from an earlier flag-on run is not picked up on this node.
+	if appState.ServerConfig.Config.RuntimeReindexEnabled {
+		providers[db.ReindexNamespace] = reindexProvider
+	}
 
 	appState.DistributedTaskScheduler = distributedtask.NewScheduler(distributedtask.SchedulerParams{
 		CompletionRecorder: appState.ClusterService.Raft,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -806,22 +806,24 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// starts), plus the existing started.mig / tidied.mig sentinels to
 	// decide which migrations are still in flight.
 	//
-	// With RUNTIME_REINDEX_ENABLED off the scan is skipped entirely, so a
-	// node that crashed mid-migration resumes nothing. The on-disk state
-	// is only read here, never written, so skipping leaves it intact for
-	// a later restart with the flag on.
-	var recoveredReindexes []db.RecoveredReindex
-	if appState.ServerConfig.Config.RuntimeReindexEnabled {
-		var recoveryErr error
-		recoveredReindexes, recoveryErr = db.DiscoverInFlightReindexTasks(
-			appState.ServerConfig.Config.Persistence.DataPath,
-			appState.Logger,
-			appState.SchemaManager,
-		)
-		if recoveryErr != nil {
-			appState.Logger.WithError(recoveryErr).
-				Warn("reindex recovery: disk scan failed; writes during the swap-recovery window may be lost")
-		}
+	// The scan itself only reads, so it still runs with
+	// RUNTIME_REINDEX_ENABLED off — that is what lets startup name the
+	// migrations it is leaving alone instead of going silent on a node
+	// that crashed mid-migration. Handing the result to
+	// configureReindexer is what would resume work, so with the flag off
+	// the result is logged and dropped.
+	recoveredReindexes, recoveryErr := db.DiscoverInFlightReindexTasks(
+		appState.ServerConfig.Config.Persistence.DataPath,
+		appState.Logger,
+		appState.SchemaManager,
+	)
+	if recoveryErr != nil {
+		appState.Logger.WithError(recoveryErr).
+			Warn("reindex recovery: disk scan failed; writes during the swap-recovery window may be lost")
+	}
+	if !appState.ServerConfig.Config.RuntimeReindexEnabled {
+		logPausedReindexes(appState.Logger, recoveredReindexes)
+		recoveredReindexes = nil
 	}
 	reindexer := configureReindexer(recoveredReindexes, appState.Logger)
 	repo.SetReindexer(reindexer)
@@ -1218,6 +1220,26 @@ func initReindexAndDistributedTasks(
 		}
 	}
 	appState.ClusterService.SetDistributedTaskSchemaMutationDetectors(schemaMutationDetectors)
+}
+
+// logPausedReindexes names the migrations found on disk that this node is
+// deliberately not resuming because runtime reindex is off.
+//
+// Without it the operator sees a frozen task, a refused submit, and a
+// silent startup, with nothing tying the three together. One line per
+// affected shard turns that into a diagnosable state.
+func logPausedReindexes(logger logrus.FieldLogger, recovered []db.RecoveredReindex) {
+	if len(recovered) == 0 {
+		return
+	}
+	for _, r := range recovered {
+		logger.WithField("action", "reindex_paused_flag_off").
+			WithField("collection", r.Collection).
+			WithField("shard", r.ShardName).
+			WithField("task_id", r.Descriptor.ID).
+			Warn("runtime reindex is disabled: this in-flight migration will NOT resume and its on-disk state is left untouched. " +
+				"Set RUNTIME_REINDEX_ENABLED=true to resume it, or cancel the task via PUT /v1/schema/<class>/indexes/<prop> {\"<indexType>\":{\"cancel\":true}}.")
+	}
 }
 
 func configureReindexer(recovered []db.RecoveredReindex, logger logrus.FieldLogger) db.ShardReindexerV3 {

--- a/adapters/handlers/rest/configure_api_reindex_detectors_test.go
+++ b/adapters/handlers/rest/configure_api_reindex_detectors_test.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+)
+
+// TestDetectorProvidersFor pins that the schema-mutation and conflict
+// detectors keep the reindex namespace even when the flag kept it out of
+// the scheduler's provider map.
+//
+// This is the wiring that made a flag-off DeleteClass mid-migration
+// succeed: the detectors were built by iterating the scheduler's
+// provider map, and an empty detector registry fails OPEN, so removing
+// the provider silently passed the check instead of failing it.
+func TestDetectorProvidersFor(t *testing.T) {
+	reindexProvider := &db.ReindexProvider{}
+	otherProvider := &db.ReindexProvider{} // stands in for any other namespace
+
+	tests := []struct {
+		name         string
+		providers    map[string]distributedtask.Provider
+		wantContains []string
+	}{
+		{
+			name:         "flag off: reindex absent from scheduler providers",
+			providers:    map[string]distributedtask.Provider{},
+			wantContains: []string{db.ReindexNamespace},
+		},
+		{
+			name: "flag off with a sibling namespace registered",
+			providers: map[string]distributedtask.Provider{
+				distributedtask.ShardNoopProviderNamespace: otherProvider,
+			},
+			wantContains: []string{db.ReindexNamespace, distributedtask.ShardNoopProviderNamespace},
+		},
+		{
+			name: "flag on: reindex already present, still exactly once",
+			providers: map[string]distributedtask.Provider{
+				db.ReindexNamespace: reindexProvider,
+			},
+			wantContains: []string{db.ReindexNamespace},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detectorProvidersFor(tt.providers, reindexProvider)
+
+			for _, ns := range tt.wantContains {
+				require.Contains(t, got, ns,
+					"detector registry must cover %q; an absent entry fails open", ns)
+				require.NotNil(t, got[ns])
+			}
+			require.Len(t, got, len(tt.wantContains))
+
+			// The reindex entry must be a real detector, otherwise the
+			// registry is populated but the guard still never runs.
+			_, isMutationDetector := got[db.ReindexNamespace].(distributedtask.SchemaMutationDetector)
+			require.True(t, isMutationDetector,
+				"the reindex provider must satisfy SchemaMutationDetector")
+			_, isConflictDetector := got[db.ReindexNamespace].(distributedtask.ConflictDetector)
+			require.True(t, isConflictDetector,
+				"the reindex provider must satisfy ConflictDetector")
+		})
+	}
+
+	t.Run("does not invent an entry when there is no reindex provider", func(t *testing.T) {
+		got := detectorProvidersFor(map[string]distributedtask.Provider{}, nil)
+		require.Empty(t, got)
+	})
+}
+
+// TestReindexProvider_CheckClassMutation_RefusesLiveTask pins the refusal
+// the wiring above delivers: a live reindex task on the collection blocks
+// DeleteClass. Paired with TestDetectorProvidersFor this covers both
+// halves — the guard exists, and it is registered.
+func TestReindexProvider_CheckClassMutation_RefusesLiveTask(t *testing.T) {
+	provider := &db.ReindexProvider{}
+
+	live := []*distributedtask.Task{{
+		TaskDescriptor: distributedtask.TaskDescriptor{
+			ID:      "Books:enable-filterable:title:abcd",
+			Version: 1,
+		},
+		Status:  distributedtask.TaskStatusStarted,
+		Payload: []byte(`{"migrationType":"enable-filterable","collection":"Books"}`),
+	}}
+
+	err := provider.CheckClassMutation("Books", live)
+	require.Error(t, err, "deleting a collection with a live reindex must be refused")
+	require.Contains(t, err.Error(), "cancel", "the refusal must name the operator's exit")
+
+	require.NoError(t, provider.CheckClassMutation("Movies", live),
+		"a live task on another collection must not block this one")
+}

--- a/adapters/handlers/rest/configure_api_reindex_orphan_test.go
+++ b/adapters/handlers/rest/configure_api_reindex_orphan_test.go
@@ -1,0 +1,119 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+)
+
+func reindexTask(id, collection string, status distributedtask.TaskStatus) *distributedtask.Task {
+	return &distributedtask.Task{
+		Namespace:      "reindex",
+		TaskDescriptor: distributedtask.TaskDescriptor{ID: id, Version: 1},
+		Status:         status,
+		Payload: []byte(`{"migrationType":"enable-filterable","collection":"` +
+			collection + `","properties":["title"]}`),
+	}
+}
+
+// TestOrphanedReindexTasks is the defense-in-depth half of the
+// resurrection chain: a task whose collection was deleted while it was
+// live must be identified so it can be discarded before a same-name
+// collection adopts it.
+//
+// Task payloads carry the collection **by name only** — there is no UUID
+// or creation timestamp on models.Class to compare against — so identity
+// cannot be verified at resume time. Discarding the orphan at startup is
+// therefore the mechanism that breaks the chain, not a backstop for one.
+func TestOrphanedReindexTasks(t *testing.T) {
+	// "Books" was deleted; "Movies" still exists.
+	classExists := func(collection string) bool { return collection == "Movies" }
+
+	tests := []struct {
+		name            string
+		tasks           []*distributedtask.Task
+		wantOrphanIDs   []string
+		wantCollections []string
+	}{
+		{
+			name:            "live task on a deleted collection is an orphan",
+			tasks:           []*distributedtask.Task{reindexTask("t1", "Books", distributedtask.TaskStatusStarted)},
+			wantOrphanIDs:   []string{"t1"},
+			wantCollections: []string{"Books"},
+		},
+		{
+			name:  "live task on a surviving collection is left alone",
+			tasks: []*distributedtask.Task{reindexTask("t2", "Movies", distributedtask.TaskStatusStarted)},
+		},
+		{
+			name: "terminal task on a deleted collection is not touched",
+			tasks: []*distributedtask.Task{
+				reindexTask("t3", "Books", distributedtask.TaskStatusFinished),
+				reindexTask("t4", "Books", distributedtask.TaskStatusCancelled),
+				reindexTask("t5", "Books", distributedtask.TaskStatusFailed),
+			},
+		},
+		{
+			name: "undecodable payload is left for the operator",
+			tasks: []*distributedtask.Task{{
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "t6", Version: 1},
+				Status:         distributedtask.TaskStatusStarted,
+				Payload:        []byte("not json"),
+			}},
+		},
+		{
+			name: "payload without a collection is left for the operator",
+			tasks: []*distributedtask.Task{{
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "t7", Version: 1},
+				Status:         distributedtask.TaskStatusStarted,
+				Payload:        []byte(`{"migrationType":"enable-filterable"}`),
+			}},
+		},
+		{
+			name: "mixed set picks out only the orphan",
+			tasks: []*distributedtask.Task{
+				reindexTask("t8", "Movies", distributedtask.TaskStatusStarted),
+				reindexTask("t9", "Books", distributedtask.TaskStatusStarted),
+				reindexTask("t10", "Books", distributedtask.TaskStatusFinished),
+			},
+			wantOrphanIDs:   []string{"t9"},
+			wantCollections: []string{"Books"},
+		},
+		{
+			name: "no tasks at all",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orphans, collections := orphanedReindexTasks(tt.tasks, classExists)
+
+			gotIDs := make([]string, 0, len(orphans))
+			for _, o := range orphans {
+				gotIDs = append(gotIDs, o.ID)
+			}
+			require.Equal(t, tt.wantOrphanIDs, nilIfEmpty(gotIDs))
+			require.Equal(t, tt.wantCollections, nilIfEmpty(collections))
+		})
+	}
+}
+
+func nilIfEmpty(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	return s
+}

--- a/adapters/handlers/rest/configure_api_reindex_paused_test.go
+++ b/adapters/handlers/rest/configure_api_reindex_paused_test.go
@@ -1,0 +1,68 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+)
+
+// TestLogPausedReindexes pins the operator signal for a node that boots
+// with runtime reindex off while migration state is still on disk. Without
+// it the operator sees a frozen task, a refused submit and a silent
+// startup, with nothing connecting the three.
+func TestLogPausedReindexes(t *testing.T) {
+	t.Run("names every paused migration and both exits", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+
+		logPausedReindexes(logger, []db.RecoveredReindex{
+			{
+				Descriptor: distributedtask.TaskDescriptor{ID: "task-a", Version: 3},
+				Collection: "Books",
+				ShardName:  "shard1",
+			},
+			{
+				Descriptor: distributedtask.TaskDescriptor{ID: "task-b", Version: 4},
+				Collection: "Movies",
+				ShardName:  "shard2",
+			},
+		})
+
+		require.Len(t, hook.Entries, 2, "one line per affected shard")
+		for _, e := range hook.Entries {
+			require.Equal(t, logrus.WarnLevel, e.Level,
+				"a paused migration is a WARN: it is a state the operator has to resolve")
+			require.Contains(t, e.Message, "will NOT resume")
+			require.Contains(t, e.Message, "untouched")
+			require.Contains(t, e.Message, "RUNTIME_REINDEX_ENABLED=true", "must name the resume exit")
+			require.Contains(t, e.Message, "cancel", "must name the cancel exit")
+		}
+
+		first := hook.Entries[0]
+		require.Equal(t, "Books", first.Data["collection"])
+		require.Equal(t, "shard1", first.Data["shard"])
+		require.Equal(t, "task-a", first.Data["task_id"])
+	})
+
+	t.Run("stays quiet when nothing is paused", func(t *testing.T) {
+		logger, hook := test.NewNullLogger()
+		logPausedReindexes(logger, nil)
+		require.Empty(t, hook.Entries,
+			"a node with no migration state must not emit a scary line")
+	})
+}

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -66,8 +66,29 @@ func (h *indexesHandlers) submitLock(collection, propertyName string) *sync.Mute
 	return h.appState.ReindexSubmitLocks.SubmitLockFor(collection, propertyName)
 }
 
+// errRuntimeReindexDisabled is the message every reindex endpoint returns
+// while RUNTIME_REINDEX_ENABLED is off. It names the knob so an operator
+// hitting the endpoint knows exactly what to set.
+var errRuntimeReindexDisabled = errors.New(
+	"runtime reindex is disabled; enable with RUNTIME_REINDEX_ENABLED=true")
+
+// runtimeReindexEnabled reports whether the reindex endpoints may serve.
+func (h *indexesHandlers) runtimeReindexEnabled() bool {
+	return h.appState.ServerConfig.Config.RuntimeReindexEnabled
+}
+
 // getIndexes implements GET /v1/schema/{className}/indexes.
 func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams, principal *models.Principal) middleware.Responder {
+	if !h.runtimeReindexEnabled() {
+		// The operation has no 400 in the spec, so the refusal rides on
+		// the 403 response, which is the only 4xx here that carries a
+		// message body. Status of a task submitted during an earlier
+		// flag-on run is refused too: reporting progress for work this
+		// node is no longer running would be misleading.
+		return schema.NewSchemaObjectsIndexesGetForbidden().
+			WithPayload(errPayloadFromSingleErr(principal, errRuntimeReindexDisabled))
+	}
+
 	// Resolve (alias-aware) before authz so authz and the lookup use the qualified name.
 	collection, _, rErr := namespacing.Resolve(principal, h.appState.SchemaManager,
 		h.appState.ServerConfig.Config.Namespaces.Enabled, params.ClassName)
@@ -199,6 +220,14 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 // repair-searchable blocks change-tokenization on any property since
 // repair-searchable touches all searchable buckets).
 func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdateParams, principal *models.Principal) middleware.Responder {
+	if !h.runtimeReindexEnabled() {
+		// Covers submit and cancel, which share this verb. Cancel is
+		// refused rather than served because cancelling deletes on-disk
+		// migration state, and with the flag off nothing may be deleted.
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().
+			WithPayload(errPayloadFromSingleErr(principal, errRuntimeReindexDisabled))
+	}
+
 	propertyName := params.PropertyName
 
 	// Qualify (no alias resolution, like DeleteClassPropertyIndex) before authz + lookup.

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -66,29 +66,38 @@ func (h *indexesHandlers) submitLock(collection, propertyName string) *sync.Mute
 	return h.appState.ReindexSubmitLocks.SubmitLockFor(collection, propertyName)
 }
 
-// errRuntimeReindexDisabled is the message every reindex endpoint returns
-// while RUNTIME_REINDEX_ENABLED is off. It names the knob so an operator
-// hitting the endpoint knows exactly what to set.
+// errRuntimeReindexDisabled is the message a refused submit returns while
+// RUNTIME_REINDEX_ENABLED is off. It names the knob so an operator hitting
+// the endpoint knows exactly what to set.
 var errRuntimeReindexDisabled = errors.New(
 	"runtime reindex is disabled; enable with RUNTIME_REINDEX_ENABLED=true")
 
-// runtimeReindexEnabled reports whether the reindex endpoints may serve.
-func (h *indexesHandlers) runtimeReindexEnabled() bool {
-	return h.appState.ServerConfig.Config.RuntimeReindexEnabled
+// refuseAsRuntimeReindexDisabled reports whether a PUT
+// /v1/schema/{class}/indexes/{prop} must be refused because runtime
+// reindex is off.
+//
+// Only submits are refused. Cancel stays available: a task left STARTED
+// in RAFT by an earlier flag-on run keeps blocking property mutations
+// through [schemaHandlers.checkReindexConflictForPropertyMutation] and
+// the apply-time MutationGuard, and cancelling it is the only way to
+// clear that. Refusing cancel would strand exactly the operators who
+// turn the flag off to escape a misbehaving migration.
+//
+// GET /v1/schema/{class}/indexes is not gated at all — it is read-only,
+// and an operator cannot decide what to cancel without seeing it.
+func (h *indexesHandlers) refuseAsRuntimeReindexDisabled(body *models.IndexUpdateRequest) bool {
+	if h.appState.ServerConfig.Config.RuntimeReindexEnabled {
+		return false
+	}
+	if body == nil {
+		return true
+	}
+	_, cancelling := requestedCancel(body)
+	return !cancelling
 }
 
 // getIndexes implements GET /v1/schema/{className}/indexes.
 func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams, principal *models.Principal) middleware.Responder {
-	if !h.runtimeReindexEnabled() {
-		// The operation has no 400 in the spec, so the refusal rides on
-		// the 403 response, which is the only 4xx here that carries a
-		// message body. Status of a task submitted during an earlier
-		// flag-on run is refused too: reporting progress for work this
-		// node is no longer running would be misleading.
-		return schema.NewSchemaObjectsIndexesGetForbidden().
-			WithPayload(errPayloadFromSingleErr(principal, errRuntimeReindexDisabled))
-	}
-
 	// Resolve (alias-aware) before authz so authz and the lookup use the qualified name.
 	collection, _, rErr := namespacing.Resolve(principal, h.appState.SchemaManager,
 		h.appState.ServerConfig.Config.Namespaces.Enabled, params.ClassName)
@@ -220,14 +229,6 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 // repair-searchable blocks change-tokenization on any property since
 // repair-searchable touches all searchable buckets).
 func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdateParams, principal *models.Principal) middleware.Responder {
-	if !h.runtimeReindexEnabled() {
-		// Covers submit and cancel, which share this verb. Cancel is
-		// refused rather than served because cancelling deletes on-disk
-		// migration state, and with the flag off nothing may be deleted.
-		return schema.NewSchemaObjectsIndexesUpdateBadRequest().
-			WithPayload(errPayloadFromSingleErr(principal, errRuntimeReindexDisabled))
-	}
-
 	propertyName := params.PropertyName
 
 	// Qualify (no alias resolution, like DeleteClassPropertyIndex) before authz + lookup.
@@ -247,6 +248,14 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 			return schema.NewSchemaObjectsIndexesUpdateForbidden().WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errPayloadFromSingleErr(principal, err))
+	}
+
+	// Deliberately after authz: an unauthorized caller must get the same
+	// 401/403 it gets with the flag on, so feature state never leaks to
+	// someone who may not query it.
+	if h.refuseAsRuntimeReindexDisabled(params.Body) {
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().
+			WithPayload(errPayloadFromSingleErr(principal, errRuntimeReindexDisabled))
 	}
 
 	// Acquire the per-(collection, property) submit lock EARLY — before

--- a/adapters/handlers/rest/handlers_indexes_disabled_test.go
+++ b/adapters/handlers/rest/handlers_indexes_disabled_test.go
@@ -1,0 +1,74 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// disabledIndexesHandlers builds the reindex handlers with runtime reindex
+// off. Nothing beyond the config is populated: a handler that reaches past
+// the disabled check panics, which is itself the assertion that the check
+// comes first.
+func disabledIndexesHandlers() *indexesHandlers {
+	return &indexesHandlers{appState: &state.State{
+		ServerConfig: &config.WeaviateConfig{
+			Config: config.Config{RuntimeReindexEnabled: false},
+		},
+	}}
+}
+
+// recordResponse renders a responder so the test can assert on the status
+// code and body the client actually receives.
+func recordResponse(t *testing.T, resp middleware.Responder) *httptest.ResponseRecorder {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	resp.WriteResponse(rec, runtime.JSONProducer())
+	return rec
+}
+
+func TestUpdateIndex_RuntimeReindexDisabled(t *testing.T) {
+	h := disabledIndexesHandlers()
+
+	resp := h.updateIndex(schema.SchemaObjectsIndexesUpdateParams{
+		ClassName:    "Books",
+		PropertyName: "title",
+		Body:         &models.IndexUpdateRequest{},
+	}, nil)
+
+	rec := recordResponse(t, resp)
+	require.Equal(t, 400, rec.Code, "submit must be refused while runtime reindex is off")
+	require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
+	require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
+		"the refusal must name the knob that turns the feature on")
+}
+
+func TestGetIndexes_RuntimeReindexDisabled(t *testing.T) {
+	h := disabledIndexesHandlers()
+
+	resp := h.getIndexes(schema.SchemaObjectsIndexesGetParams{ClassName: "Books"}, nil)
+
+	rec := recordResponse(t, resp)
+	require.Equal(t, 403, rec.Code, "status must be refused while runtime reindex is off")
+	require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
+	require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED")
+}

--- a/adapters/handlers/rest/handlers_indexes_disabled_test.go
+++ b/adapters/handlers/rest/handlers_indexes_disabled_test.go
@@ -12,71 +12,171 @@
 package rest
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/go-openapi/runtime"
-	"github.com/go-openapi/runtime/middleware"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-// disabledIndexesHandlers builds the reindex handlers with runtime reindex
-// off. Nothing beyond the config is populated: a handler that reaches past
-// the disabled check panics, which is itself the assertion that the check
-// comes first.
-func disabledIndexesHandlers() *indexesHandlers {
+// forbiddenAuthorizer denies every request, standing in for a principal
+// with no permission on the collection.
+type forbiddenAuthorizer struct{ authorization.DummyAuthorizer }
+
+func (*forbiddenAuthorizer) Authorize(_ context.Context, _ *models.Principal, _ string, _ ...string) error {
+	return authzerrors.NewForbidden(&models.Principal{Username: "nobody"}, "update", "Books")
+}
+
+// indexesHandlersWithFlag builds the reindex handlers with runtime reindex
+// in the given state. authorizer nil means "allow everything".
+func indexesHandlersWithFlag(enabled bool, authorizer authorization.Authorizer) *indexesHandlers {
+	if authorizer == nil {
+		authorizer = &authorization.DummyAuthorizer{}
+	}
 	return &indexesHandlers{appState: &state.State{
+		Authorizer: authorizer,
 		ServerConfig: &config.WeaviateConfig{
-			Config: config.Config{RuntimeReindexEnabled: false},
+			Config: config.Config{RuntimeReindexEnabled: enabled},
 		},
 	}}
 }
 
-// TestReindexEndpoints_RuntimeReindexDisabled pins that every reindex
-// endpoint refuses with a 4xx naming the knob while the flag is off.
-func TestReindexEndpoints_RuntimeReindexDisabled(t *testing.T) {
+// updateIndexParams builds a PUT request for the "Books.title" property.
+func updateIndexParams(body *models.IndexUpdateRequest) schema.SchemaObjectsIndexesUpdateParams {
+	return schema.SchemaObjectsIndexesUpdateParams{
+		HTTPRequest:  httptest.NewRequest("PUT", "/", nil),
+		ClassName:    "Books",
+		PropertyName: "title",
+		Body:         body,
+	}
+}
+
+// enableSearchableBody is a submit — the request shape the flag refuses.
+func enableSearchableBody() *models.IndexUpdateRequest {
+	return &models.IndexUpdateRequest{
+		Searchable: &models.IndexUpdateSearchable{Enabled: true},
+	}
+}
+
+// TestRefuseAsRuntimeReindexDisabled pins which requests the flag refuses.
+// Submits are refused; cancel is not, because a task left STARTED in RAFT
+// by an earlier flag-on run keeps blocking property mutations and cancel
+// is the only way to clear it.
+func TestRefuseAsRuntimeReindexDisabled(t *testing.T) {
 	tests := []struct {
-		name     string
-		call     func(*indexesHandlers) middleware.Responder
-		wantCode int
+		name        string
+		flagEnabled bool
+		body        *models.IndexUpdateRequest
+		wantRefused bool
 	}{
 		{
-			name: "submit and cancel",
-			call: func(h *indexesHandlers) middleware.Responder {
-				return h.updateIndex(schema.SchemaObjectsIndexesUpdateParams{
-					ClassName:    "Books",
-					PropertyName: "title",
-					Body:         &models.IndexUpdateRequest{},
-				}, nil)
+			name: "off refuses enable-searchable submit",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Enabled: true},
 			},
-			wantCode: 400,
+			wantRefused: true,
 		},
 		{
-			name: "status",
-			call: func(h *indexesHandlers) middleware.Responder {
-				return h.getIndexes(schema.SchemaObjectsIndexesGetParams{
-					ClassName: "Books",
-				}, nil)
+			name: "off refuses rebuild submit",
+			body: &models.IndexUpdateRequest{
+				Filterable: &models.IndexUpdateFilterable{Rebuild: true},
 			},
-			wantCode: 403,
+			wantRefused: true,
+		},
+		{
+			name:        "off refuses an empty body",
+			body:        &models.IndexUpdateRequest{},
+			wantRefused: true,
+		},
+		{
+			name:        "off refuses a nil body",
+			body:        nil,
+			wantRefused: true,
+		},
+		{
+			name: "off allows searchable cancel",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Cancel: true},
+			},
+			wantRefused: false,
+		},
+		{
+			name: "off allows filterable cancel",
+			body: &models.IndexUpdateRequest{
+				Filterable: &models.IndexUpdateFilterable{Cancel: true},
+			},
+			wantRefused: false,
+		},
+		{
+			name: "off allows rangeable cancel",
+			body: &models.IndexUpdateRequest{
+				Rangeable: &models.IndexUpdateRangeable{Cancel: true},
+			},
+			wantRefused: false,
+		},
+		{
+			name:        "on allows submit",
+			flagEnabled: true,
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Enabled: true},
+			},
+			wantRefused: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			tt.call(disabledIndexesHandlers()).WriteResponse(rec, runtime.JSONProducer())
+			h := indexesHandlersWithFlag(tt.flagEnabled, nil)
+			require.Equal(t, tt.wantRefused, h.refuseAsRuntimeReindexDisabled(tt.body))
+		})
+	}
+}
 
-			require.Equal(t, tt.wantCode, rec.Code,
-				"endpoint must be refused while runtime reindex is off")
-			require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
-			require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
-				"the refusal must name the knob that turns the feature on")
+// TestUpdateIndex_RuntimeReindexDisabled pins the response a refused
+// submit actually puts on the wire, for a caller that IS authorized.
+func TestUpdateIndex_RuntimeReindexDisabled(t *testing.T) {
+	resp := indexesHandlersWithFlag(false, nil).
+		updateIndex(updateIndexParams(enableSearchableBody()), nil)
+
+	rec := httptest.NewRecorder()
+	resp.WriteResponse(rec, runtime.JSONProducer())
+
+	require.Equal(t, 400, rec.Code, "submit must be refused while runtime reindex is off")
+	require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
+	require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
+		"the refusal must name the knob that turns the feature on")
+}
+
+// TestUpdateIndex_AuthzSpeaksBeforeTheFlag pins that authorization is
+// answered first: an ungranted caller gets the same 403 whether the flag
+// is on or off, so feature state never leaks to someone who may not read
+// it. Without this ordering the flag-off build answers 400 and tells an
+// unauthorized caller the feature exists and is disabled.
+func TestUpdateIndex_AuthzSpeaksBeforeTheFlag(t *testing.T) {
+	for _, flagEnabled := range []bool{false, true} {
+		name := "flag off"
+		if flagEnabled {
+			name = "flag on"
+		}
+		t.Run(name, func(t *testing.T) {
+			resp := indexesHandlersWithFlag(flagEnabled, &forbiddenAuthorizer{}).
+				updateIndex(updateIndexParams(enableSearchableBody()), nil)
+
+			rec := httptest.NewRecorder()
+			resp.WriteResponse(rec, runtime.JSONProducer())
+
+			require.Equal(t, 403, rec.Code,
+				"an ungranted caller must get 403 regardless of the flag")
+			require.NotContains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
+				"the 403 must not leak feature state")
 		})
 	}
 }

--- a/adapters/handlers/rest/handlers_indexes_disabled_test.go
+++ b/adapters/handlers/rest/handlers_indexes_disabled_test.go
@@ -37,38 +37,46 @@ func disabledIndexesHandlers() *indexesHandlers {
 	}}
 }
 
-// recordResponse renders a responder so the test can assert on the status
-// code and body the client actually receives.
-func recordResponse(t *testing.T, resp middleware.Responder) *httptest.ResponseRecorder {
-	t.Helper()
-	rec := httptest.NewRecorder()
-	resp.WriteResponse(rec, runtime.JSONProducer())
-	return rec
-}
+// TestReindexEndpoints_RuntimeReindexDisabled pins that every reindex
+// endpoint refuses with a 4xx naming the knob while the flag is off.
+func TestReindexEndpoints_RuntimeReindexDisabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		call     func(*indexesHandlers) middleware.Responder
+		wantCode int
+	}{
+		{
+			name: "submit and cancel",
+			call: func(h *indexesHandlers) middleware.Responder {
+				return h.updateIndex(schema.SchemaObjectsIndexesUpdateParams{
+					ClassName:    "Books",
+					PropertyName: "title",
+					Body:         &models.IndexUpdateRequest{},
+				}, nil)
+			},
+			wantCode: 400,
+		},
+		{
+			name: "status",
+			call: func(h *indexesHandlers) middleware.Responder {
+				return h.getIndexes(schema.SchemaObjectsIndexesGetParams{
+					ClassName: "Books",
+				}, nil)
+			},
+			wantCode: 403,
+		},
+	}
 
-func TestUpdateIndex_RuntimeReindexDisabled(t *testing.T) {
-	h := disabledIndexesHandlers()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			tt.call(disabledIndexesHandlers()).WriteResponse(rec, runtime.JSONProducer())
 
-	resp := h.updateIndex(schema.SchemaObjectsIndexesUpdateParams{
-		ClassName:    "Books",
-		PropertyName: "title",
-		Body:         &models.IndexUpdateRequest{},
-	}, nil)
-
-	rec := recordResponse(t, resp)
-	require.Equal(t, 400, rec.Code, "submit must be refused while runtime reindex is off")
-	require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
-	require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
-		"the refusal must name the knob that turns the feature on")
-}
-
-func TestGetIndexes_RuntimeReindexDisabled(t *testing.T) {
-	h := disabledIndexesHandlers()
-
-	resp := h.getIndexes(schema.SchemaObjectsIndexesGetParams{ClassName: "Books"}, nil)
-
-	rec := recordResponse(t, resp)
-	require.Equal(t, 403, rec.Code, "status must be refused while runtime reindex is off")
-	require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
-	require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED")
+			require.Equal(t, tt.wantCode, rec.Code,
+				"endpoint must be refused while runtime reindex is off")
+			require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
+			require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
+				"the refusal must name the knob that turns the feature on")
+		})
+	}
 }

--- a/adapters/handlers/rest/handlers_indexes_namespace_test.go
+++ b/adapters/handlers/rest/handlers_indexes_namespace_test.go
@@ -41,7 +41,8 @@ func TestUpdateIndex_SubmitLockKeyedOnQualifiedClass(t *testing.T) {
 		ReindexSubmitLocks: locks,
 		Logger:             logger,
 		ServerConfig: &config.WeaviateConfig{Config: config.Config{
-			Namespaces: config.Namespaces{Enabled: true},
+			Namespaces:            config.Namespaces{Enabled: true},
+			RuntimeReindexEnabled: true,
 		}},
 		// SchemaManager left nil: the correctly-keyed handler blocks before the
 		// class read; the buggy path reaches it and panics, which the goroutine recovers.

--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -281,6 +281,12 @@ func TestBackup_BucketLevel(t *testing.T) {
 }
 
 func setupTestDB(t *testing.T, rootDir string, classes ...*models.Class) *DB {
+	return setupTestDBWithConfig(t, rootDir, nil, classes...)
+}
+
+// setupTestDBWithConfig is setupTestDB with a hook to adjust the Config
+// literal before the DB is built.
+func setupTestDBWithConfig(t *testing.T, rootDir string, adjust func(*Config), classes ...*models.Class) *DB {
 	logger, _ := test.NewNullLogger()
 
 	shardState := singleShardState()
@@ -309,12 +315,17 @@ func setupTestDB(t *testing.T, rootDir string, classes ...*models.Class) *DB {
 	mockNodeSelector := cluster.NewMockNodeSelector(t)
 	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
-	db, err := New(logger, "node1", Config{
+	cfg := Config{
 		MemtablesFlushDirtyAfter:  60,
 		RootPath:                  rootDir,
 		QueryMaximumResults:       10,
 		MaxImportGoroutinesFactor: 1,
-	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
+	}
+	if adjust != nil {
+		adjust(&cfg)
+	}
+	db, err := New(logger, "node1", cfg,
+		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
 		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
 	require.Nil(t, err)
 	db.SetSchemaGetter(schemaGetter)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1168,6 +1168,11 @@ type IndexConfig struct {
 	ObjectsTTLPauseEveryNoBatches       *configRuntime.DynamicValue[int]
 	ObjectsTTLPauseDuration             *configRuntime.DynamicValue[time.Duration]
 
+	// RuntimeReindexDisabled is copied from [Config.RuntimeReindexDisabled]
+	// when the index is built. Kept on the index (rather than read through
+	// i.db) so the backup gate can answer without a back-reference.
+	RuntimeReindexDisabled bool
+
 	HNSWMaxLogSize                               int64
 	HNSWDisableSnapshots                         bool
 	HNSWSnapshotIntervalSeconds                  int

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -178,6 +178,7 @@ func (db *DB) init(ctx context.Context) error {
 				HaltForTransferTimeout:                       db.config.HaltForTransferTimeout,
 				LSMEnableSegmentsChecksumValidation:          db.config.LSMEnableSegmentsChecksumValidation,
 				SkipWriteClassNameOnDisk:                     db.config.LSMSkipWriteClassNameEnabled,
+				RuntimeReindexDisabled:                       db.config.RuntimeReindexDisabled,
 				ReplicationFactor:                            class.ReplicationConfig.Factor,
 				AsyncReplicationConfig:                       asyncConfig,
 				AsyncReplicationScheduler:                    db.asyncReplicationScheduler,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -202,6 +202,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			HaltForTransferTimeout:                       m.db.config.HaltForTransferTimeout,
 			LSMEnableSegmentsChecksumValidation:          m.db.config.LSMEnableSegmentsChecksumValidation,
 			SkipWriteClassNameOnDisk:                     m.db.config.LSMSkipWriteClassNameEnabled,
+			RuntimeReindexDisabled:                       m.db.config.RuntimeReindexDisabled,
 			ReplicationFactor:                            class.ReplicationConfig.Factor,
 			AsyncReplicationConfig:                       asyncConfig,
 			AsyncReplicationScheduler:                    m.db.asyncReplicationScheduler,

--- a/adapters/repos/db/reindex_disabled_backup_integration_test.go
+++ b/adapters/repos/db/reindex_disabled_backup_integration_test.go
@@ -1,0 +1,70 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestBackup_RuntimeReindexDisabled_MakesNoGateCalls pins the kill-switch
+// contract for the backup path: with runtime reindex off, a backup must
+// succeed and must not consult the reindex activity lookup at all.
+//
+// The installed lookup reports every shard as having a live reindex, so
+// without the gate the backup fails outright and the call counter is
+// non-zero.
+func TestBackup_RuntimeReindexDisabled_MakesNoGateCalls(t *testing.T) {
+	ctx := testCtx()
+	className := "ReindexDisabledBackupClass"
+
+	db := setupTestDBWithConfig(t, t.TempDir(), func(cfg *Config) {
+		cfg.RuntimeReindexDisabled = true
+	}, makeTestClass(className))
+	defer func() {
+		require.Nil(t, db.Shutdown(context.Background()))
+	}()
+
+	var lookupCalls atomic.Int64
+	db.SetShardReindexActivityLookup(func() ShardReindexActivityLookup {
+		lookupCalls.Add(1)
+		return func(string, string) bool { return true }
+	})
+	db.SetReindexCleanupInProgressLookup(func() CleanupInProgressLookup {
+		lookupCalls.Add(1)
+		return func(string, string) bool { return true }
+	})
+
+	classes := []string{className}
+	require.NoError(t, db.Backupable(ctx, classes),
+		"backup precheck must pass with runtime reindex disabled")
+
+	for d := range db.BackupDescriptors(ctx, "reindex-disabled-backup", classes, nil) {
+		require.NoError(t, d.Error, "backup descriptor must not carry a reindex refusal")
+	}
+
+	require.Zero(t, lookupCalls.Load(),
+		"backup path must make no reindex lookup with runtime reindex disabled")
+
+	// The gate is reachable via the shard-level entry point too.
+	idx := db.GetIndex(schema.ClassName(className))
+	require.NotNil(t, idx)
+	require.NoError(t, idx.refuseIfReindexInFlight("any-shard"))
+	require.Zero(t, lookupCalls.Load())
+}

--- a/adapters/repos/db/reindex_disabled_scan_readonly_test.go
+++ b/adapters/repos/db/reindex_disabled_scan_readonly_test.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// migrationState is one on-disk stop-phase of a runtime reindex, named by
+// the sentinels present in its tracker dir.
+type migrationState struct {
+	dirName   string
+	sentinels []string
+	// discoverable records whether the recovery scan is expected to
+	// reconstruct a task from this state.
+	discoverable bool
+}
+
+// migrationStopPhases covers the four ways a migration can be sitting on
+// disk when a node boots. merged-but-not-tidied is called out separately
+// because that is the state whose finalize path was writable.
+func migrationStopPhases() []migrationState {
+	return []migrationState{
+		{
+			dirName:   "filterable_enable_text_1",
+			sentinels: []string{"started.mig"},
+		},
+		{
+			dirName:      "filterable_enable_body_2",
+			sentinels:    []string{"started.mig", "reindexed.mig", "merged.mig"},
+			discoverable: true,
+		},
+		{
+			dirName:   "filterable_enable_title_3",
+			sentinels: []string{"started.mig", "reindexed.mig", "merged.mig", "swapped.mig", "tidied.mig"},
+		},
+		{
+			dirName:   "filterable_enable_abstract_4",
+			sentinels: []string{"started.mig", "cancelled.mig"},
+		},
+	}
+}
+
+// plantRecoveryLayout writes every stop phase from [migrationStopPhases]
+// into one shard, plus the ingest dir each would swap in. Returns the data
+// root the scan is pointed at.
+func plantRecoveryLayout(t *testing.T, collection, shardName string) string {
+	t.Helper()
+
+	rootPath := t.TempDir()
+	lsmPath := filepath.Join(rootPath, strings.ToLower(collection), shardName, "lsm")
+	migrationsDir := filepath.Join(lsmPath, ".migrations")
+
+	for _, phase := range migrationStopPhases() {
+		migDir := filepath.Join(migrationsDir, phase.dirName)
+		require.NoError(t, os.MkdirAll(migDir, 0o755))
+		for _, s := range phase.sentinels {
+			require.NoError(t, os.WriteFile(filepath.Join(migDir, s), nil, 0o644))
+		}
+
+		rec := reindexRecoveryRecord{
+			TaskID:      "task-" + phase.dirName,
+			TaskVersion: 7,
+			UnitID:      shardName + "__node1",
+			Payload: ReindexTaskPayload{
+				MigrationType: ReindexTypeEnableFilterable,
+				Collection:    collection,
+				Properties:    []string{"body"},
+				UnitToShard:   map[string]string{shardName + "__node1": shardName},
+				UnitToNode:    map[string]string{shardName + "__node1": "node1"},
+			},
+		}
+		blob, err := json.Marshal(rec)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(
+			filepath.Join(migDir, reindexRecoveryPayloadFile), blob, 0o644))
+
+		ingestDir := filepath.Join(lsmPath, "property_body__enable_filterable_ingest_1")
+		require.NoError(t, os.MkdirAll(ingestDir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(ingestDir, "segment.db"), []byte("ingest-"+phase.dirName), 0o644))
+	}
+
+	return rootPath
+}
+
+// TestDiscoverInFlightReindexTasks_IsReadOnly pins the property that makes
+// the flag-off startup WARN safe: the scan behind it looks at every
+// migration stop phase on disk, including merged-but-not-tidied, and
+// writes nothing.
+//
+// With runtime reindex off this scan is the ONLY thing that touches
+// migration state at boot, so "it only reads" is load-bearing rather than
+// incidental — the finalize path in the same area was writable until this
+// PR gated it.
+//
+// The discovery assertion keeps the byte-identity assertion honest: a scan
+// that silently found nothing would trivially write nothing.
+func TestDiscoverInFlightReindexTasks_IsReadOnly(t *testing.T) {
+	const collection, shardName = "ResidueClass", "shard1"
+
+	rootPath := plantRecoveryLayout(t, collection, shardName)
+	before := snapshotTree(t, rootPath)
+
+	logger, _ := test.NewNullLogger()
+	recovered, err := DiscoverInFlightReindexTasks(rootPath, logger, nil)
+	require.NoError(t, err)
+
+	var wantDiscovered int
+	for _, phase := range migrationStopPhases() {
+		if phase.discoverable {
+			wantDiscovered++
+		}
+	}
+	require.Len(t, recovered, wantDiscovered,
+		"the scan must actually walk the layout, otherwise byte-identity proves nothing")
+	require.Equal(t, collection, recovered[0].Collection)
+	require.Equal(t, shardName, recovered[0].ShardName)
+
+	require.Equal(t, before, snapshotTree(t, rootPath),
+		"the flag-off startup scan must not write, rename, or delete anything")
+}

--- a/adapters/repos/db/reindex_disabled_startup_test.go
+++ b/adapters/repos/db/reindex_disabled_startup_test.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// plantMergedResidue lays down the on-disk shape a node leaves behind when
+// a runtime swap dies after markMerged but before markTidied: a tracker
+// with merged.mig but no tidied.mig, plus the ingest dir holding the new
+// bucket data. Returns the shard's lsm path.
+func plantMergedResidue(t *testing.T, rootPath, className, shardName string) string {
+	t.Helper()
+
+	lsmPath := shardPathLSM(filepath.Join(rootPath, strings.ToLower(className)), shardName)
+	migDir := filepath.Join(lsmPath, ".migrations", "searchable_retokenize_text_1")
+	require.NoError(t, os.MkdirAll(migDir, 0o755))
+	for _, s := range []string{"reindexed.mig", "prepended.mig", "merged.mig"} {
+		require.NoError(t, os.WriteFile(filepath.Join(migDir, s), nil, 0o644))
+	}
+	require.NoError(t, os.WriteFile(
+		filepath.Join(migDir, "properties.mig"), []byte("text"), 0o644))
+
+	ingestDir := filepath.Join(lsmPath, "property_text_searchable__retokenize_ingest_1")
+	require.NoError(t, os.MkdirAll(ingestDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(ingestDir, "segment.db"), []byte("ingest-data"), 0o644))
+
+	return lsmPath
+}
+
+// snapshotTree records every path under root plus file contents, so a test
+// can assert that a code path left the tree byte-identical.
+func snapshotTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+
+	out := map[string]string{}
+	require.NoError(t, filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return relErr
+		}
+		if info.IsDir() {
+			out[rel] = "<dir>"
+			return nil
+		}
+		b, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return readErr
+		}
+		out[rel] = string(b)
+		return nil
+	}))
+	return out
+}
+
+func shardForFinalize(t *testing.T, rootPath, className, shardName string, reindexDisabled bool) *Shard {
+	t.Helper()
+
+	logger, _ := test.NewNullLogger()
+	return &Shard{
+		name: shardName,
+		index: &Index{
+			logger: logger,
+			Config: IndexConfig{
+				RootPath:               rootPath,
+				ClassName:              schema.ClassName(className),
+				RuntimeReindexDisabled: reindexDisabled,
+			},
+		},
+	}
+}
+
+// TestFinalizeCompletedMigrations_RuntimeReindexDisabled pins that shard
+// load does not resume a mid-migration node while runtime reindex is off:
+// the merged-but-untidied tracker keeps every byte it had.
+//
+// With the flag on the same layout is promoted — the tracker is consumed
+// and the ingest dir is renamed to its canonical name.
+func TestFinalizeCompletedMigrations_RuntimeReindexDisabled(t *testing.T) {
+	const className, shardName = "ResidueClass", "shard1"
+
+	t.Run("disabled leaves disk untouched", func(t *testing.T) {
+		rootPath := t.TempDir()
+		lsmPath := plantMergedResidue(t, rootPath, className, shardName)
+		before := snapshotTree(t, lsmPath)
+
+		shardForFinalize(t, rootPath, className, shardName, true).finalizeCompletedMigrations()
+
+		require.Equal(t, before, snapshotTree(t, lsmPath),
+			"runtime reindex off must not resume, rename, or delete anything on disk")
+	})
+
+	t.Run("enabled promotes as before", func(t *testing.T) {
+		rootPath := t.TempDir()
+		lsmPath := plantMergedResidue(t, rootPath, className, shardName)
+
+		shardForFinalize(t, rootPath, className, shardName, false).finalizeCompletedMigrations()
+
+		got, err := os.ReadFile(
+			filepath.Join(lsmPath, "property_text_searchable", "segment.db"))
+		require.NoError(t, err, "flag on must still promote the ingest dir")
+		require.Equal(t, "ingest-data", string(got))
+	})
+}

--- a/adapters/repos/db/reindex_inflight.go
+++ b/adapters/repos/db/reindex_inflight.go
@@ -119,9 +119,18 @@ func (db *DB) SetReindexCleanupInProgressLookup(builder CleanupInProgressLookupB
 // [DB.AnyLiveReindexForShard]; the filesystem-marker variant it
 // replaced only saw the local node and lagged DTM's actual state.
 //
+// Returns early with no error when runtime reindex is disabled, so the
+// backup path stays free of reindex calls.
+//
 // If i.db is nil the gate is conservative: it refuses the backup, on
 // the assumption that wiring is in progress.
 func (i *Index) refuseIfReindexInFlight(shardName string) error {
+	if i.Config.RuntimeReindexDisabled {
+		// Runtime reindex is off cluster-wide, so no task can be in
+		// flight. Return before touching the lookup so the backup path
+		// makes no reindex call at all.
+		return nil
+	}
 	if i.db == nil {
 		// Index was constructed without a back-reference (test
 		// fixtures, partial init). Be conservative.

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -459,6 +459,13 @@ type Config struct {
 	ObjectsTTLPauseDuration             *configRuntime.DynamicValue[time.Duration]
 	ObjectsTTLConcurrencyFactor         *configRuntime.DynamicValue[float64]
 
+	// RuntimeReindexDisabled mirrors an off RUNTIME_REINDEX_ENABLED. It is
+	// stated negatively so the zero value keeps the pre-flag behavior: the
+	// only production caller (configure_api) sets it explicitly, while the
+	// many test fixtures that build a Config literal continue to exercise
+	// runtime reindex without having to opt in.
+	RuntimeReindexDisabled bool
+
 	HNSWMaxLogSize                               int64
 	HNSWDisableSnapshots                         bool
 	HNSWSnapshotIntervalSeconds                  int

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -159,7 +159,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	// Finalize any completed migrations whose directory renames were deferred
 	// from a runtime swap. This must run before bucket loading (initNonVector)
 	// so that buckets are found at their canonical directory names.
-	FinalizeCompletedMigrations(s.pathLSM(), s.index.logger)
+	s.finalizeCompletedMigrations()
 
 	// Pessimistically mark any in-flight enable-rangeable / repair-rangeable
 	// migration's target property as "not locally ready" on this shard.

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -169,6 +169,13 @@ func (s *Shard) updatePropertyBuckets(ctx context.Context,
 // affects the next re-enable, which will trigger the defense-in-depth
 // check in OnAfterLsmInitAsync and fail with a clear operator error.
 func (s *Shard) cleanStaleMigrationDirs(propName, indexType string) {
+	if s.index.Config.RuntimeReindexDisabled {
+		// With runtime reindex off, any migration dir on disk is left
+		// over from a period when it was on. Deleting it here would
+		// destroy state the operator may still need after re-enabling,
+		// so leave the directory untouched.
+		return
+	}
 	cleanStaleMigrationDirsAt(s.pathLSM(), propName, indexType, s.index.logger)
 }
 

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -156,6 +156,21 @@ func (s *Shard) updatePropertyBuckets(ctx context.Context,
 	})
 }
 
+// finalizeCompletedMigrations promotes this shard's deferred migration
+// renames at load time.
+//
+// Skipped with runtime reindex off: for a merged-but-untidied generation
+// the finalize writes recovery sentinels and renames ingest dirs into
+// place, which is resuming a migration. The flag-off contract is that a
+// node that crashed mid-migration touches nothing until the flag is
+// turned back on.
+func (s *Shard) finalizeCompletedMigrations() {
+	if s.index.Config.RuntimeReindexDisabled {
+		return
+	}
+	FinalizeCompletedMigrations(s.pathLSM(), s.index.logger)
+}
+
 // cleanStaleMigrationDirs removes the per-property runtime-reindex
 // migration directories whose tidied sentinel would lie now that the
 // (propName, indexType) bucket has been removed. Without this, a

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -15,6 +15,7 @@ package reindexhelpers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -483,4 +485,28 @@ func WithEnv(
 	SetupClass(t, class, props)
 	ImportObjects(t, class, objects)
 	body()
+}
+
+// SingleNodeCompose returns the single-node Weaviate configuration the
+// runtime-reindex acceptance suites share:
+//
+//   - RUNTIME_REINDEX_ENABLED on, because the server default is off and
+//     these suites exist to test the feature. Every suite MUST go through
+//     here (or set the variable itself) or it silently tests nothing.
+//   - USE_INVERTED_SEARCHABLE off, matching the bucket layout the
+//     migrations under test operate on.
+//   - a 1s scheduler tick so task transitions land inside test timeouts.
+//
+// Callers needing extra env keep chaining before calling Start.
+func SingleNodeCompose() *docker.Compose {
+	return docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
+		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
+		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1")
+}
+
+// StartSingleNode starts [SingleNodeCompose] with no further tuning.
+func StartSingleNode(ctx context.Context) (*docker.DockerCompose, error) {
+	return SingleNodeCompose().Start(ctx)
 }

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -93,6 +93,7 @@ func TestMain(m *testing.M) {
 	os.Setenv("AWS_SECRET_KEY", "aws_secret_key")
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithApiKey().
 		WithRBAC().
 		WithUserApiKey(adminUser, adminKey).

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -47,6 +47,7 @@ func TestBackupVsReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithBackendFilesystem().
 		WithWeaviate().
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/concurrent_test.go
+++ b/test/acceptance/reindex_concurrent/concurrent_test.go
@@ -50,6 +50,7 @@ func TestConcurrentReindex(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/concurrent_test.go
+++ b/test/acceptance/reindex_concurrent/concurrent_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -49,12 +48,7 @@ const (
 func TestConcurrentReindex(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
@@ -75,6 +75,7 @@ func TestParallelConflictMatrix(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
@@ -59,7 +59,7 @@ import (
 	"github.com/stretchr/testify/require"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -74,12 +74,7 @@ const matrixObjectCount = 2000
 func TestParallelConflictMatrix(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_concurrent/parallel_same_property_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_same_property_test.go
@@ -64,6 +64,7 @@ func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/parallel_same_property_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_same_property_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -63,12 +63,7 @@ import (
 func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -36,6 +36,7 @@ func TestMultiTenant_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -35,12 +34,7 @@ import (
 func TestMultiTenant_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -41,6 +41,7 @@ func TestMultiNode_CancelClearsAcrossReplicas(t *testing.T) {
 	// wide enough to reproduce reliably on fast hardware.
 	const backupBucket = "cancel-clears-bucket"
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		With3NodeCluster().
 		WithBackendS3(backupBucket, "us-east-1").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -45,6 +45,7 @@ func start3NodeReindexCluster(ctx context.Context, t *testing.T, extraEnv ...str
 	}
 
 	b := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		With3NodeCluster().
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_COMPLETED_TASK_TTL_HOURS", "1").

--- a/test/acceptance/reindex_multinode/rangeable_in_memory_test.go
+++ b/test/acceptance/reindex_multinode/rangeable_in_memory_test.go
@@ -94,6 +94,7 @@ func assertRebuildFinalizeThenNoFallbackWarn(ctx context.Context, t *testing.T, 
 func startSingleNodeRangeableInMemCluster(ctx context.Context, t *testing.T) (*docker.DockerCompose, func()) {
 	t.Helper()
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("INDEX_RANGEABLE_IN_MEMORY", "true").
 		WithWeaviateEnv("LOG_LEVEL", "info").

--- a/test/acceptance/reindex_rangeable/concurrent_writes_test.go
+++ b/test/acceptance/reindex_rangeable/concurrent_writes_test.go
@@ -61,6 +61,7 @@ func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		// 1s scheduler tick keeps the submit→migration-start latency low so
 		// the PATCH storm reliably overlaps the migration window.

--- a/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
+++ b/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
@@ -337,6 +337,7 @@ func TestCancelThenRetry(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
+++ b/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -336,12 +335,7 @@ func TestSuppress_CancelThenRetry(t *testing.T) {
 func TestCancelThenRetry(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/delete_class_guard_test.go
+++ b/test/acceptance/reindex_singlenode/delete_class_guard_test.go
@@ -1,0 +1,120 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_singlenode
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+)
+
+// testDeleteClassBlockedByLiveReindex drives the operator's full exit path
+// for a collection that has a live reindex on it:
+//
+//	DELETE  -> refused, naming cancel as the way out
+//	cancel  -> 202
+//	DELETE  -> succeeds
+//
+// The refusal is what stops a delete from orphaning a live task. Task
+// payloads identify their collection by NAME only, so an orphan left in
+// cluster state would be adopted by any later collection created with the
+// same name and have its migration run against unrelated data.
+//
+// No existing suite pinned this path, which is how a regression that
+// silently dropped the guard reached review.
+func testDeleteClassBlockedByLiveReindex(t *testing.T, restURI string) {
+	className := "DeleteClassGuard"
+	trueVal, falseVal := true, false
+
+	helper.SetupClient(restURI)
+	helper.CreateClass(t, &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: "name", DataType: []string{"text"}, Tokenization: "word", IndexFilterable: &trueVal, IndexSearchable: &trueVal},
+			{Name: "score", DataType: []string{"int"}, IndexFilterable: &falseVal},
+		},
+		Vectorizer: "none",
+	})
+	classDeleted := false
+	defer func() {
+		if !classDeleted {
+			helper.DeleteClass(t, className)
+		}
+	}()
+
+	// Enough objects that enable-filterable stays live long enough to
+	// observe the guard.
+	const n = 3000
+	for i := 0; i < n; i++ {
+		require.NoError(t, helper.CreateObject(t, &models.Object{
+			Class:      className,
+			Properties: map[string]interface{}{"name": fmt.Sprintf("name_%d", i), "score": i},
+		}))
+	}
+
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "score",
+		`{"filterable":{"enabled":true}}`)
+	reindexhelpers.AwaitReindexLive(t, restURI, taskID)
+
+	t.Run("DeleteIsRefusedWhileTheReindexIsLive", func(t *testing.T) {
+		resp, err := helper.DeleteClassObject(t, className)
+		require.Error(t, err,
+			"deleting a collection with a live reindex must be refused, not silently accepted")
+		require.Nil(t, resp)
+
+		// The generated client stringifies its payload as a pointer, so
+		// read the message off the typed error instead.
+		badRequest := &schema.SchemaObjectsDeleteBadRequest{}
+		require.ErrorAs(t, err, &badRequest)
+		require.NotNil(t, badRequest.Payload)
+		require.NotEmpty(t, badRequest.Payload.Error)
+		msg := badRequest.Payload.Error[0].Message
+		require.Contains(t, msg, "cancel",
+			"the refusal must tell the operator how to get out: %s", msg)
+		require.Contains(t, msg, className,
+			"the refusal must name the collection: %s", msg)
+	})
+
+	t.Run("CancelThenDeleteSucceeds", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, className, "score")
+		req, err := http.NewRequest(http.MethodPut, url,
+			bytes.NewReader([]byte(`{"filterable":{"cancel":true}}`)))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusAccepted, resp.StatusCode,
+			"cancel is the documented exit and must be accepted")
+
+		// The delete may need a moment for the cancel to reach terminal
+		// state cluster-wide; the guard only clears once it does.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, delErr := helper.DeleteClassObject(t, className)
+			assert.NoError(c, delErr)
+		}, 60*time.Second, 500*time.Millisecond,
+			"after cancelling, the collection must be deletable")
+		classDeleted = true
+	})
+}

--- a/test/acceptance/reindex_singlenode/finished_race_test.go
+++ b/test/acceptance/reindex_singlenode/finished_race_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -72,12 +71,7 @@ import (
 func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/finished_race_test.go
+++ b/test/acceptance/reindex_singlenode/finished_race_test.go
@@ -73,6 +73,7 @@ func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/restart_during_swap_test.go
+++ b/test/acceptance/reindex_singlenode/restart_during_swap_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -71,15 +70,11 @@ import (
 func TestRestartDuringSwap(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		// 1s tick gives us up to ~1s after FINISHED is reported in RAFT
-		// before OnGroupCompleted fires — comfortably wider than the time
-		// needed to issue StopAt(... 0 timeout) and kill the container.
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	// The shared config's 1s scheduler tick gives us up to ~1s after
+	// FINISHED is reported in RAFT before OnGroupCompleted fires —
+	// comfortably wider than the time needed to issue StopAt(... 0
+	// timeout) and kill the container.
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/restart_during_swap_test.go
+++ b/test/acceptance/reindex_singlenode/restart_during_swap_test.go
@@ -72,6 +72,7 @@ func TestRestartDuringSwap(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		// 1s tick gives us up to ~1s after FINISHED is reported in RAFT

--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -40,6 +40,7 @@ func TestSingleNode_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/weaviate/weaviate/test/docker"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -39,12 +39,7 @@ import (
 func TestSingleNode_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -147,6 +147,11 @@ func TestSingleNode_ReindexSuite(t *testing.T) {
 		testCancelReindex(t, restURI)
 	})
 
+	// --- Subtest 9b: DeleteClass guard + the operator's exit path ---
+	t.Run("DeleteClassBlockedByLiveReindex", func(t *testing.T) {
+		testDeleteClassBlockedByLiveReindex(t, restURI)
+	})
+
 	// --- Subtest 10: Rangeable rebuild ---
 	t.Run("RepairRangeable", func(t *testing.T) {
 		testRepairRangeable(t, restURI)

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -385,6 +385,7 @@ func TestTornResume_StandaloneSmoke(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -384,12 +384,7 @@ func findShardPathInContainer(t *testing.T, container testcontainers.Container, 
 func TestTornResume_StandaloneSmoke(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -245,6 +245,13 @@ type Config struct {
 
 	ReplicaMovementEnabled bool `json:"replica_movement_enabled" yaml:"replica_movement_enabled"`
 
+	// RuntimeReindexEnabled is the master switch for runtime reindex
+	// (RUNTIME_REINDEX_ENABLED, off by default). With it off the reindex
+	// REST endpoints reject every request, the distributed-task reindex
+	// namespace is not registered, no reindex state is discovered or
+	// deleted at startup, and the backup path performs no reindex checks.
+	RuntimeReindexEnabled bool `json:"runtime_reindex_enabled" yaml:"runtime_reindex_enabled"`
+
 	// TenantActivityReadLogLevel is 'debug' by default as every single READ
 	// interaction with a tenant leads to a log line. However, this may
 	// temporarily be desired, e.g. for analysis or debugging purposes. In this

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1405,6 +1405,8 @@ func FromEnv(config *Config) error {
 		config.ReplicaMovementEnabled = entcfg.Enabled(v)
 	}
 
+	config.RuntimeReindexEnabled = entcfg.Enabled(os.Getenv("RUNTIME_REINDEX_ENABLED"))
+
 	revoctorizeCheckDisabled := false
 	if v := os.Getenv("REVECTORIZE_CHECK_DISABLED"); v != "" {
 		revoctorizeCheckDisabled = !(strings.ToLower(v) == "false")

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1405,7 +1405,11 @@ func FromEnv(config *Config) error {
 		config.ReplicaMovementEnabled = entcfg.Enabled(v)
 	}
 
-	config.RuntimeReindexEnabled = entcfg.Enabled(os.Getenv("RUNTIME_REINDEX_ENABLED"))
+	// Only assign when the variable is present: an absent env var must not
+	// overwrite runtime_reindex_enabled loaded from the config file.
+	if v := os.Getenv("RUNTIME_REINDEX_ENABLED"); v != "" {
+		config.RuntimeReindexEnabled = entcfg.Enabled(v)
+	}
 
 	revoctorizeCheckDisabled := false
 	if v := os.Getenv("REVECTORIZE_CHECK_DISABLED"); v != "" {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1925,3 +1925,35 @@ func TestEnvironmentAsyncIndexing(t *testing.T) {
 		})
 	}
 }
+
+// TestEnvironmentRuntimeReindexEnabled pins the precedence contract for
+// the runtime-reindex kill switch: the env var wins when it is set, and an
+// absent env var leaves a config-file value alone. Getting the absent case
+// wrong silently forces every file-configured cluster back to off.
+func TestEnvironmentRuntimeReindexEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue []string
+		fromFile bool
+		expected bool
+	}{
+		{name: "absent env keeps file default off", expected: false},
+		{name: "absent env keeps file value on", fromFile: true, expected: true},
+		{name: "env true enables", envValue: []string{"true"}, expected: true},
+		{name: "env false disables", envValue: []string{"false"}, expected: false},
+		{name: "env false overrides file on", envValue: []string{"false"}, fromFile: true, expected: false},
+		{name: "env on enables", envValue: []string{"on"}, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.envValue) == 1 {
+				t.Setenv("RUNTIME_REINDEX_ENABLED", tt.envValue[0])
+			}
+			conf := Config{RuntimeReindexEnabled: tt.fromFile}
+			require.NoError(t, FromEnv(&conf))
+			require.Equal(t, tt.expected, conf.RuntimeReindexEnabled)
+		})
+	}
+}


### PR DESCRIPTION
Backups are failing in production because runtime reindex's backup gate refuses them. This puts runtime reindex behind `RUNTIME_REINDEX_ENABLED`, **off by default**. With the flag off the backup path performs no reindex check at all — it behaves like a build without the gate.

Base branch: `stable/v1.38`.

## `RUNTIME_REINDEX_ENABLED` (default: off)

| Caller surface | Flag off (default) | Flag on |
| --- | --- | --- |
| Backup precheck + per-shard backup + `HaltForTransfer` | No reindex call at all; backup proceeds | Today's gate, unchanged |
| `PUT .../indexes/{prop}` — **submit** | `400` — `runtime reindex is disabled; enable with RUNTIME_REINDEX_ENABLED=true` | Today's behavior |
| `PUT .../indexes/{prop}` — **cancel** | **Served.** Cancel is remediation, not the feature | Today's behavior |
| `GET .../indexes` (status) | **Served.** Read-only, and you cannot decide what to cancel without it | Today's behavior |
| Any of the above, **caller not authorized** | `401`/`403` exactly as today — authz answers before the flag | Same |
| Startup recovery (`DiscoverInFlightReindexTasks`) | Skipped; a node that crashed mid-migration resumes nothing | Today's behavior |
| Shard-load finalize (`FinalizeCompletedMigrations`) | Skipped — it promotes a merged-but-untidied generation by writing sentinels and renaming dirs | Today's behavior |
| Orphan-tracker audit (startup + post-restore) | Skipped — it deletes state | Today's behavior |
| Stale migration-dir cleanup at shard load | Skipped — leaves dirs untouched | Today's behavior |
| Distributed-task reindex namespace | Not registered, so the scheduler runs no reindex task | Registered |

Flag on is byte-identical to today's `stable/v1.38`. Nothing on disk is written, renamed, or deleted while the flag is off.

**Why cancel stays available.** A task left `STARTED` in RAFT by an earlier flag-on run keeps blocking property mutations through `checkReindexConflictForPropertyMutation` and the apply-time `MutationGuard`. Deregistering the provider stops execution but does not clear that state. Refusing cancel would strand exactly the operators who turn the flag off to escape a misbehaving migration, so only submits are refused.

**Config precedence.** `RUNTIME_REINDEX_ENABLED` is only read when set, so an absent env var does not overwrite `runtime_reindex_enabled` from a config file.

**The flag-off startup scan is read-only, and that property is load-bearing.** With the flag off, startup still walks the on-disk migration state so it can WARN one line per paused migration (naming collection, shard, task, and both exits: set the flag, or cancel). That scan is the only thing that touches migration state at boot, so "it only reads" is what keeps the kill switch a kill switch — the finalize path in the same area was writable until this PR gated it. `TestDiscoverInFlightReindexTasks_IsReadOnly` pins it across four stop phases including merged-but-not-tidied, asserting both that the scan found something and that the tree is byte-identical afterwards.

## Scope

This is a **temporary mitigation** until [weaviate/weaviate#12474](https://github.com/weaviate/weaviate/pull/12474) and [weaviate/weaviate#12471](https://github.com/weaviate/weaviate/pull/12471) merge — those are the real fixes. Tracked in [weaviate/0-weaviate-issues#457](https://github.com/weaviate/0-weaviate-issues/issues/457). Runtime reindex is Preview, so flipping the default to off is within the compatibility contract.

**Intended lifespan:** the current plan is to remove this flag once weaviate/weaviate#12474 and weaviate/weaviate#12471 merge — the failures it works around are what those PRs fix, and a flag that is selectively deaf to their new safety gates would be worse than no flag. Decided when we get there, based on what the team needs at the time.

No swagger change: every response code used here is already declared for its operation.

## Tests

Each is red without the corresponding gate:

- `TestBackup_RuntimeReindexDisabled_MakesNoGateCalls` — installs a lookup reporting every shard as reindexing, then runs `Backupable` + `BackupDescriptors`. Passes with zero lookup calls; without the gate the backup is refused.
- `TestFinalizeCompletedMigrations_RuntimeReindexDisabled` — plants a merged-without-tidied residue and asserts the tree is byte-identical after shard-load finalize; the flag-on subtest asserts the promotion still happens.
- `TestRefuseAsRuntimeReindexDisabled` — submit refused, all three cancel verbs allowed.
- `TestUpdateIndex_AuthzSpeaksBeforeTheFlag` — an ungranted caller gets `403` with the flag off and on, and the body never names the knob.
- `TestEnvironmentRuntimeReindexEnabled` — env precedence, including absent-env-keeps-file-value.
- `TestDiscoverInFlightReindexTasks_IsReadOnly` — the flag-off startup scan writes nothing across four stop phases.
- `TestLogPausedReindexes` — one WARN per paused shard naming both exits, and silence when nothing is paused.

One gap worth naming: the `logPausedReindexes` **call site** in `configure_api` is a single line that no unit test can reach without booting a server, so its wiring is covered black-box rather than in Go.

The flag is wired **on** for every reindex acceptance suite. The nine identical single-node compose blocks now go through `reindexhelpers.SingleNodeCompose`, which carries the flag and documents that a suite bypassing it silently tests nothing. Verified end-to-end: `TestSingleNode_ReindexSuite/EnableFilterable` passes through the shared helper and fails with `400 runtime reindex is disabled` when the flag is removed from it.

