### PR TITLE
fix(schema): return explicit bm25 b/k1 values of 0 in schema responses

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -6590,12 +6590,14 @@ func init() {
         "b": {
           "description": "Calibrates term-weight scaling based on the document length (default: 0.75).",
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "x-omitempty": false
         },
         "k1": {
           "description": "Calibrates term-weight scaling based on the term frequency within a document (default: 1.2).",
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "x-omitempty": false
         }
       }
     },
@@ -16879,12 +16881,14 @@ func init() {
         "b": {
           "description": "Calibrates term-weight scaling based on the document length (default: 0.75).",
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "x-omitempty": false
         },
         "k1": {
           "description": "Calibrates term-weight scaling based on the term frequency within a document (default: 1.2).",
           "type": "number",
-          "format": "float"
+          "format": "float",
+          "x-omitempty": false
         }
       }
     },

--- a/entities/models/b_m25_config.go
+++ b/entities/models/b_m25_config.go
@@ -29,10 +29,10 @@ import (
 type BM25Config struct {
 
 	// Calibrates term-weight scaling based on the document length (default: 0.75).
-	B float32 `json:"b,omitempty"`
+	B float32 `json:"b"`
 
 	// Calibrates term-weight scaling based on the term frequency within a document (default: 1.2).
-	K1 float32 `json:"k1,omitempty"`
+	K1 float32 `json:"k1"`
 }
 
 // Validate validates this b m25 config

--- a/entities/schema/inverted_index_config_test.go
+++ b/entities/schema/inverted_index_config_test.go
@@ -1,0 +1,66 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// b=0 (no length normalization) and k1=0 (IDF-only scoring) are valid settings
+// that Weaviate honors, so they must survive serialization rather than being
+// dropped as Go zero values.
+func TestBM25ConfigSerializesZeroValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		bm25     BM25Config
+		expected string
+	}{
+		{
+			name:     "both zero",
+			bm25:     BM25Config{B: 0, K1: 0},
+			expected: `{"b":0,"k1":0}`,
+		},
+		{
+			name:     "b zero, k1 default",
+			bm25:     BM25Config{B: 0, K1: 1.2},
+			expected: `{"b":0,"k1":1.2}`,
+		},
+		{
+			name:     "k1 zero, b default",
+			bm25:     BM25Config{B: 0.75, K1: 0},
+			expected: `{"b":0.75,"k1":0}`,
+		},
+		{
+			name:     "defaults",
+			bm25:     BM25Config{B: 0.75, K1: 1.2},
+			expected: `{"b":0.75,"k1":1.2}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := InvertedIndexConfigToModel(InvertedIndexConfig{BM25: test.bm25})
+
+			marshalled, err := json.Marshal(model.Bm25)
+			require.Nil(t, err)
+			require.Equal(t, test.expected, string(marshalled))
+
+			var roundTripped models.BM25Config
+			require.Nil(t, json.Unmarshal(marshalled, &roundTripped))
+			require.Equal(t, *model.Bm25, roundTripped)
+		})
+	}
+}

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -996,12 +996,14 @@
         "k1": {
           "description": "Calibrates term-weight scaling based on the term frequency within a document (default: 1.2).",
           "format": "float",
-          "type": "number"
+          "type": "number",
+          "x-omitempty": false
         },
         "b": {
           "description": "Calibrates term-weight scaling based on the document length (default: 0.75).",
           "format": "float",
-          "type": "number"
+          "type": "number",
+          "x-omitempty": false
         }
       },
       "type": "object"


### PR DESCRIPTION
### What's being changed:

Return explicit `b` and `k1` values in schema responses when they are set to `0`.
A collection created with `bm25: { b: 0, k1: 0 }` came back from `GET /v1/schema/{class}` as `"bm25": {}`, which breaks strictly-typed clients (reported against the TS client).

`b: 0` (no document-length normalization) and `k1: 0` (IDF-only, near-boolean ranking) are valid and honored settings:

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
