### PR TITLE
perf(hfresh): read rescore vectors through one bucket view with pooled buffers

### DIFF
--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -261,8 +261,9 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 			Store: hfresh.StoreConfig{
 				MakeBucketOptions: makeBucketOptions,
 			},
-			VectorForIDThunk:   hnsw.NewVectorForIDThunk(targetVector, s.vectorByIndexID),
-			TombstoneCallbacks: s.cycleCallbacks.vectorTombstoneCleanupCallbacks,
+			VectorForIDThunk:             hnsw.NewVectorForIDThunk(targetVector, s.vectorByIndexID),
+			TempVectorForIDWithViewThunk: hnsw.NewTempVectorForIDWithViewThunk(targetVector, s.readVectorByIndexIDIntoSliceWithView),
+			TombstoneCallbacks:           s.cycleCallbacks.vectorTombstoneCleanupCallbacks,
 			Centroids: hfresh.CentroidConfig{
 				HNSWConfig: &hnsw.Config{
 					Logger:                            s.index.logger,

--- a/adapters/repos/db/vector/hfresh/config.go
+++ b/adapters/repos/db/vector/hfresh/config.go
@@ -35,22 +35,23 @@ const (
 )
 
 type Config struct {
-	Logger                    logrus.FieldLogger
-	Scheduler                 *queue.Scheduler
-	DistanceProvider          distancer.Provider
-	RootPath                  string
-	ID                        string
-	TargetVector              string
-	ShardName                 string
-	ClassName                 string
-	PrometheusMetrics         *monitoring.PrometheusMetrics
-	InternalPostingCandidates int                             `json:"internalPostingCandidates,omitempty"` // Number of candidates to consider when running a centroid search internally
-	ReassignNeighbors         int                             `json:"reassignNeighbors,omitempty"`         // Number of neighboring centroids to consider for reassigning vectors
-	MaxDistanceRatio          float32                         `json:"maxDistanceRatio,omitempty"`          // Maximum distance ratio for the search, used to filter out candidates that are too far away
-	Store                     StoreConfig                     `json:"store"`                               // Configuration for the underlying LSMKV store
-	Centroids                 CentroidConfig                  `json:"centroids"`                           // Configuration for the centroid index
-	TombstoneCallbacks        cyclemanager.CycleCallbackGroup // Callbacks for handling tombstones
-	VectorForIDThunk          common.VectorForID[float32]     `json:"vectorForIDThunk,omitempty"` // Function to get a vector by index ID
+	Logger                       logrus.FieldLogger
+	Scheduler                    *queue.Scheduler
+	DistanceProvider             distancer.Provider
+	RootPath                     string
+	ID                           string
+	TargetVector                 string
+	ShardName                    string
+	ClassName                    string
+	PrometheusMetrics            *monitoring.PrometheusMetrics
+	InternalPostingCandidates    int                                     `json:"internalPostingCandidates,omitempty"` // Number of candidates to consider when running a centroid search internally
+	ReassignNeighbors            int                                     `json:"reassignNeighbors,omitempty"`         // Number of neighboring centroids to consider for reassigning vectors
+	MaxDistanceRatio             float32                                 `json:"maxDistanceRatio,omitempty"`          // Maximum distance ratio for the search, used to filter out candidates that are too far away
+	Store                        StoreConfig                             `json:"store"`                               // Configuration for the underlying LSMKV store
+	Centroids                    CentroidConfig                          `json:"centroids"`                           // Configuration for the centroid index
+	TombstoneCallbacks           cyclemanager.CycleCallbackGroup         // Callbacks for handling tombstones
+	VectorForIDThunk             common.VectorForID[float32]             `json:"vectorForIDThunk,omitempty"` // Function to get a vector by index ID
+	TempVectorForIDWithViewThunk common.TempVectorForIDWithView[float32] `json:"-"`
 }
 
 type StoreConfig struct {
@@ -82,6 +83,10 @@ func (c *Config) Validate() error {
 	}
 	if c.MaxDistanceRatio <= 0 {
 		c.MaxDistanceRatio = DefaultMaxDistanceRatio
+	}
+
+	if c.TempVectorForIDWithViewThunk == nil {
+		return errors.New("tempVectorForIDWithViewThunk cannot be nil")
 	}
 
 	return nil

--- a/adapters/repos/db/vector/hfresh/helper_for_test.go
+++ b/adapters/repos/db/vector/hfresh/helper_for_test.go
@@ -69,8 +69,11 @@ func createHFreshIndex(t *testing.T) TestHFresh {
 		scheduler.Close(t.Context())
 	})
 
+	setDelegatingTempThunk(cfg)
+
 	uc := ent.NewDefaultUserConfig()
 	store := testinghelpers.NewDummyStore(t)
+	createObjectsBucket(t, store)
 
 	index, err := New(cfg, uc, store)
 	require.NoError(t, err)

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -91,6 +91,9 @@ type HFresh struct {
 
 	vectorForId common.VectorForID[float32]
 
+	tempVectorForIDThunk common.TempVectorForIDWithView[float32]
+	tempVectors          *common.TempVectorsPool
+
 	rootPath string
 }
 
@@ -116,19 +119,21 @@ func New(cfg *Config, uc ent.UserConfig, store *lsmkv.Store) (*HFresh, error) {
 	logger := cfg.Logger.WithField("component", "HFresh")
 
 	h := HFresh{
-		id:            cfg.ID,
-		logger:        logger,
-		config:        cfg,
-		scheduler:     cfg.Scheduler,
-		store:         store,
-		metrics:       metrics,
-		PostingStore:  postingStore,
-		vectorForId:   cfg.VectorForIDThunk,
-		VersionMap:    NewVersionMap(bucket),
-		PostingMap:    NewPostingMap(bucket),
-		PostingSizes:  NewPostingSizes(bucket, metrics),
-		IndexMetadata: NewIndexMetadataStore(bucket),
-		postingLocks:  common.NewDefaultShardedRWLocks(),
+		id:                   cfg.ID,
+		logger:               logger,
+		config:               cfg,
+		scheduler:            cfg.Scheduler,
+		store:                store,
+		metrics:              metrics,
+		PostingStore:         postingStore,
+		vectorForId:          cfg.VectorForIDThunk,
+		tempVectorForIDThunk: cfg.TempVectorForIDWithViewThunk,
+		tempVectors:          common.NewTempVectorsPool(),
+		VersionMap:           NewVersionMap(bucket),
+		PostingMap:           NewPostingMap(bucket),
+		PostingSizes:         NewPostingSizes(bucket, metrics),
+		IndexMetadata:        NewIndexMetadataStore(bucket),
+		postingLocks:         common.NewDefaultShardedRWLocks(),
 		// TODO: choose a better starting size since we can predict the max number of
 		// visited vectors based on cfg.InternalPostingCandidates.
 		visitedPool:      visited.NewPool(512),

--- a/adapters/repos/db/vector/hfresh/hfresh_test.go
+++ b/adapters/repos/db/vector/hfresh/hfresh_test.go
@@ -117,10 +117,34 @@ func makeHFreshConfig(t *testing.T) (*Config, ent.UserConfig) {
 	cfg.PrometheusMetrics = monitoring.GetMetrics()
 	cfg.PrometheusMetrics.Registerer.MustRegister()
 
+	setDelegatingTempThunk(cfg)
+
 	return cfg, ent.NewDefaultUserConfig()
 }
 
+// setDelegatingTempThunk satisfies the required TempVectorForIDWithViewThunk
+// by delegating to cfg.VectorForIDThunk at call time — tests assign their
+// fixture thunk after building the config, and the pooled read path picks it
+// up automatically. The vector is copied into the pooled container because
+// the caller may normalize the returned slice in place.
+func setDelegatingTempThunk(cfg *Config) {
+	cfg.TempVectorForIDWithViewThunk = func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		vec, err := cfg.VectorForIDThunk(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		if cap(container.Slice) < len(vec) {
+			container.Slice = make([]float32, len(vec))
+		}
+		container.Slice = container.Slice[:len(vec)]
+		copy(container.Slice, vec)
+		return container.Slice, nil
+	}
+}
+
 func makeHFreshWithConfig(t *testing.T, store *lsmkv.Store, cfg *Config, uc ent.UserConfig) *HFresh {
+	createObjectsBucket(t, store)
+
 	index, err := New(cfg, uc, store)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/vector/hfresh/insert.go
+++ b/adapters/repos/db/vector/hfresh/insert.go
@@ -140,6 +140,14 @@ func (h *HFresh) normalizeVec(vec []float32) []float32 {
 	return vec
 }
 
+// normalizeVecInPlace is the allocation-free variant of normalizeVec for
+// vectors living in pooled buffers that no one else can observe.
+func (h *HFresh) normalizeVecInPlace(vec []float32) {
+	if h.config.DistanceProvider.Type() == "cosine-dot" {
+		distancer.NormalizeInPlace(vec)
+	}
+}
+
 // ensureInitialPosting creates a new posting for vector v if the index is empty
 func (h *HFresh) ensureInitialPosting(v []float32, compressed []byte) (*ResultSet, error) {
 	h.initialPostingLock.Lock()

--- a/adapters/repos/db/vector/hfresh/insert_test.go
+++ b/adapters/repos/db/vector/hfresh/insert_test.go
@@ -94,6 +94,7 @@ func TestHFreshOptimizedPostingSize(t *testing.T) {
 				GetViewThunk:          getViewThunk,
 			}
 			cfg.TombstoneCallbacks = cyclemanager.NewCallbackGroupNoop()
+			setDelegatingTempThunk(cfg)
 
 			scheduler.Start()
 			defer scheduler.Close(t.Context())

--- a/adapters/repos/db/vector/hfresh/recall_test.go
+++ b/adapters/repos/db/vector/hfresh/recall_test.go
@@ -170,6 +170,8 @@ func runRecallTest(t *testing.T, testCfg testConfig) {
 		}
 		return nil, fmt.Errorf("vector not found for ID %d", indexID)
 	})
+	setDelegatingTempThunk(cfg)
+	createObjectsBucket(t, store)
 
 	index, err := New(cfg, ent.NewDefaultUserConfig(), store)
 	require.NoError(t, err)

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -169,6 +169,9 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 
 	// One bucket view shared by all workers avoids a lock acquisition per
 	// candidate; pooled buffers avoid allocating per fetched vector.
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	view := h.objectsBucketView()
 	defer view.ReleaseView()
 

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -14,6 +14,7 @@ package hfresh
 import (
 	"context"
 	"iter"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -166,6 +167,11 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	// concurrent load; without one we default to 2*GOMAXPROCS (IO-bound).
 	workers := concurrency.NumWorkers(ctx, len(candidates), concurrency.GOMAXPROCSx2)
 
+	// One bucket view shared by all workers avoids a lock acquisition per
+	// candidate; pooled buffers avoid allocating per fetched vector.
+	view := h.objectsBucketView()
+	defer view.ReleaseView()
+
 	// Workers compute distances in parallel; results are inserted after,
 	// in candidate order, so ties resolve the same way on every run.
 	candidateDists := make([]float32, len(candidates))
@@ -174,11 +180,14 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	eg := enterrors.NewErrorGroupWrapper(h.logger)
 	for workerID := range workers {
 		eg.Go(func() error {
+			slice := h.tempVectors.Get(int(atomic.LoadUint32(&h.dims)))
+			defer h.tempVectors.Put(slice)
+
 			for pos := workerID; pos < len(candidates); pos += workers {
 				if err := ctx.Err(); err != nil {
 					return err
 				}
-				vec, err := h.vectorForId(ctx, candidates[pos])
+				vec, err := h.fetchNormalizedVector(ctx, candidates[pos], slice, view)
 				if err != nil {
 					// The object may have been deleted between the posting scan
 					// and the rescore step (race condition). Skip stale entries
@@ -190,7 +199,6 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 					}
 					return err
 				}
-				vec = h.normalizeVec(vec)
 				dist, err := h.distancer.distancer.SingleDist(vector, vec)
 				if err != nil {
 					return err
@@ -224,6 +232,26 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	}
 
 	return ids, dists, nil
+}
+
+// objectsBucketView returns a consistent view of the objects bucket, valid
+// until ReleaseView. A missing objects bucket is a wiring bug — the shard
+// creates it before any vector index — and panics rather than degrading.
+func (h *HFresh) objectsBucketView() common.BucketView {
+	return h.store.Bucket(helpers.ObjectsBucketLSM).GetConsistentView()
+}
+
+// fetchNormalizedVector reads the full vector for id into the pooled slice
+// through the shared bucket view, normalized for the index distance. The
+// read is allocation-free.
+func (h *HFresh) fetchNormalizedVector(ctx context.Context, id uint64, slice *common.VectorSlice, view common.BucketView) ([]float32, error) {
+	vec, err := h.tempVectorForIDThunk(ctx, id, slice, view)
+	if err != nil {
+		return nil, err
+	}
+	// safe in place: vec lives in the pooled slice owned by this caller
+	h.normalizeVecInPlace(vec)
+	return vec, nil
 }
 
 func (h *HFresh) SearchByVectorDistance(

--- a/adapters/repos/db/vector/hfresh/search_flat.go
+++ b/adapters/repos/db/vector/hfresh/search_flat.go
@@ -15,11 +15,13 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -43,6 +45,12 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 		candidates = append(candidates, candidate)
 	}
 
+	// One bucket view shared by all workers avoids a lock acquisition per
+	// candidate; pooled buffers avoid allocating per fetched vector (see
+	// fetchNormalizedVector).
+	view := h.objectsBucketView()
+	defer view.ReleaseView()
+
 	eg := enterrors.NewErrorGroupWrapper(h.logger)
 	for workerID := range flatSearchConcurrency {
 		workerID := workerID
@@ -50,11 +58,13 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 			if err := ctx.Err(); err != nil {
 				return err
 			}
+			slice := h.tempVectors.Get(int(atomic.LoadUint32(&h.dims)))
+			defer h.tempVectors.Put(slice)
 			localResults := priorityqueue.NewMax[any](k)
 			for idPos := workerID; idPos < len(candidates); idPos += flatSearchConcurrency {
 				candidate := candidates[idPos]
 
-				dist, err := h.distToNode(ctx, candidate, queryVector)
+				dist, err := h.distToNode(ctx, candidate, queryVector, slice, view)
 				if err != nil {
 					// The object may have been deleted between allowList iteration
 					// and vector fetch. Skip stale entries gracefully.
@@ -104,10 +114,8 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 	return ids, dists, nil
 }
 
-func (h *HFresh) distToNode(ctx context.Context, node uint64, vecB []float32) (float32, error) {
-	var vecA []float32
-	var err error
-	vecA, err = h.vectorForId(ctx, node)
+func (h *HFresh) distToNode(ctx context.Context, node uint64, vecB []float32, slice *common.VectorSlice, view common.BucketView) (float32, error) {
+	vecA, err := h.fetchNormalizedVector(ctx, node, slice, view)
 	if err != nil {
 		// not a typed error, we can recover from, return with err
 		return 0, errors.Wrapf(err,
@@ -124,7 +132,6 @@ func (h *HFresh) distToNode(ctx context.Context, node uint64, vecB []float32) (f
 			"got a nil or zero-length vector as search vector")
 	}
 
-	vecA = h.normalizeVec(vecA)
 	return h.distancer.distancer.SingleDist(vecA, vecB)
 }
 

--- a/adapters/repos/db/vector/hfresh/search_flat.go
+++ b/adapters/repos/db/vector/hfresh/search_flat.go
@@ -48,6 +48,9 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 	// One bucket view shared by all workers avoids a lock acquisition per
 	// candidate; pooled buffers avoid allocating per fetched vector (see
 	// fetchNormalizedVector).
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	view := h.objectsBucketView()
 	defer view.ReleaseView()
 

--- a/adapters/repos/db/vector/hfresh/search_test.go
+++ b/adapters/repos/db/vector/hfresh/search_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
@@ -215,31 +217,73 @@ func TestSearchCosineDistanceRescore(t *testing.T) {
 // fetches from background split/reassign workers.
 type searchMarker struct{}
 
+// createObjectsBucket creates an (empty) objects bucket in the test store so
+// that objectsBucketView can hand out views and searches take the pooled read
+// path, like in production. The fake with-view thunks never read from it.
+func createObjectsBucket(t *testing.T, store *lsmkv.Store) {
+	t.Helper()
+	require.NoError(t, store.CreateOrLoadBucket(t.Context(), helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+}
+
 // newSearchTestIndex builds an HFresh index serving the given vectors through
-// VectorForIDThunk. A non-nil intercept runs first on every fetch; a non-nil
-// error from it fails that fetch.
+// both the plain and the pooled (with-view) read paths, so searches exercise
+// the same code shape as production. A non-nil intercept runs first on every
+// fetch; a non-nil error from it fails that fetch.
 func newSearchTestIndex(t *testing.T, vectors [][]float32, intercept func(ctx context.Context, id uint64) error) *HFresh {
 	t.Helper()
 	store := testinghelpers.NewDummyStore(t)
 	cfg, uc := makeHFreshConfig(t)
+
+	serve := func(ctx context.Context, id uint64) ([]float32, error) {
+		if intercept != nil {
+			if err := intercept(ctx, id); err != nil {
+				return nil, err
+			}
+		}
+		if int(id) >= len(vectors) {
+			return nil, storobj.NewErrNotFoundf(id, "out of range")
+		}
+		return vectors[id], nil
+	}
+
 	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
 		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
-			if intercept != nil {
-				if err := intercept(ctx, id); err != nil {
-					return nil, err
-				}
-			}
-			if int(id) >= len(vectors) {
-				return nil, storobj.NewErrNotFoundf(id, "out of range")
-			}
-			return vectors[id], nil
+			return serve(ctx, id)
 		})
+	cfg.TempVectorForIDWithViewThunk = func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		vec, err := serve(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		// copy into the pooled buffer like the production thunk does: the
+		// caller may normalize the returned slice in place, and the shared
+		// fixture vectors must never be mutated
+		if cap(container.Slice) < len(vec) {
+			container.Slice = make([]float32, len(vec))
+		}
+		container.Slice = container.Slice[:len(vec)]
+		copy(container.Slice, vec)
+		return container.Slice, nil
+	}
 
 	index := makeHFreshWithConfig(t, store, cfg, uc)
 	for i, vec := range vectors {
 		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
 	}
 	return index
+}
+
+// TestConfigRequiresTempVectorThunk pins that the pooled read thunk is
+// mandatory: a silent fallback to per-vector reads would massively degrade
+// search throughput, so a missing thunk must fail at construction.
+func TestConfigRequiresTempVectorThunk(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+	cfg.TempVectorForIDWithViewThunk = nil
+
+	_, err := New(cfg, uc, store)
+	require.ErrorContains(t, err, "tempVectorForIDWithViewThunk")
 }
 
 func TestRescoreConcurrencyRespectsBudget(t *testing.T) {
@@ -342,4 +386,46 @@ func TestRescoreTieBreakingIsDeterministic(t *testing.T) {
 	serial, _, err := index.SearchByVector(concurrency.CtxWithBudget(ctx, 1), vectors[0], 10, nil)
 	require.NoError(t, err)
 	require.Equal(t, first, serial, "budget must not change tie handling")
+}
+
+// TestSearchUsesPooledReadsWhenConfigured pins path selection: with an
+// objects bucket present and the with-view thunk configured, rescore reads
+// must go through the pooled thunk, not the per-call fallback.
+func TestSearchUsesPooledReadsWhenConfigured(t *testing.T) {
+	vectors, queries := testinghelpers.RandomVecs(100, 1, 32)
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+
+	var pooledCalls atomic.Int64
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
+		func(ctx context.Context, id uint64, targetVector string) ([]float32, error) {
+			if int(id) >= len(vectors) {
+				return nil, storobj.NewErrNotFoundf(id, "out of range")
+			}
+			return vectors[id], nil
+		})
+	cfg.TempVectorForIDWithViewThunk = func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		pooledCalls.Add(1)
+		if int(id) >= len(vectors) {
+			return nil, storobj.NewErrNotFoundf(id, "out of range")
+		}
+		vec := vectors[id]
+		if cap(container.Slice) < len(vec) {
+			container.Slice = make([]float32, len(vec))
+		}
+		container.Slice = container.Slice[:len(vec)]
+		copy(container.Slice, vec)
+		return container.Slice, nil
+	}
+
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	for i, vec := range vectors {
+		require.NoError(t, index.Add(t.Context(), uint64(i), vec))
+	}
+
+	ids, _, err := index.SearchByVector(t.Context(), queries[0], 10, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+	require.Greater(t, pooledCalls.Load(), int64(0),
+		"rescore must read through the pooled with-view thunk when available")
 }


### PR DESCRIPTION
### What's being changed:

> **Stacked on #12487** — base is that PR's branch; retarget to `stable/v1.37` after it merges.

An allocation audit of HFresh's search path showed that each rescored candidate's `vectorForId` call acquires its own objects-bucket view (a flush-lock acquisition) and allocates ~12–18KB: a key buffer, a read buffer, the parsed vector, and a normalized copy. At the default `rescoreLimit=350` that is ~5–6MB of allocations and 350 lock acquisitions per query — the dominant cost of the search path. This applies the same recipe HNSW got in #10536:

- **`Config.TempVectorForIDWithViewThunk` (required)**: the search path reads full vectors through the shard's `readVectorByIndexIDIntoSliceWithView`. The thunk is validated at construction — a missing one would silently degrade throughput, so it fails loudly instead.
- **One objects-bucket view per query**: HFresh holds the shard's LSM store, so it acquires the view itself (`store.Bucket(objects).GetConsistentView()`) — no view thunk needed. A missing objects bucket is a wiring bug and panics rather than degrading.
- **Pooled buffers + in-place normalization**: workers reuse `common.TempVectorsPool` slices; `normalizeVecInPlace` avoids the per-candidate copy (safe: `VectorFromBinary` copies into the caller's buffer, so pooled vectors never alias LSM memory).
- Both the rescore path and `flatSearch` get the treatment; `VectorForIDThunk` remains for single-read consumers (reassign, `QueryVectorDistancer`).

### Benchmarks

<img width="959" height="703" alt="output" src="https://github.com/user-attachments/assets/08aef738-a592-4932-b6c6-94a3bd6c0149" />

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.