### PR TITLE
hotfix: RUNTIME_REINDEX_ENABLED kill switch (off by default)

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -480,6 +480,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		LSMEnableSegmentsChecksumValidation: appState.ServerConfig.Config.Persistence.LSMEnableSegmentsChecksumValidation,
 		LSMSkipWriteClassNameEnabled:        appState.ServerConfig.Config.Persistence.LSMSkipWriteClassNameEnabled,
 		NamespacesEnabled:                   appState.ServerConfig.Config.Namespaces.Enabled,
+		RuntimeReindexDisabled:              !appState.ServerConfig.Config.RuntimeReindexEnabled,
 		// Pass dummy replication config with minimum factor 1. Otherwise the
 		// setting is not backward-compatible. The user may have created a class
 		// with factor=1 before the change was introduced. Now their setup would no

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -220,6 +220,15 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
+	// Refuse to START a reindex while the feature is off. Cancel and the
+	// status endpoint are deliberately untouched, so a task that was
+	// already running stays observable and stoppable. Placed after authz
+	// so an unauthorized caller still gets its 401/403.
+	if !h.appState.ServerConfig.Config.RuntimeReindexEnabled && !requestsCancel(params.Body) {
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
+			"runtime reindex is disabled; enable with RUNTIME_REINDEX_ENABLED=true"))
+	}
+
 	// Acquire the per-(collection, property) submit lock EARLY — before
 	// reading the class or running any validation — so a parallel DELETE
 	// on /properties/{prop}/index/{name} cannot mutate the schema (drop
@@ -657,6 +666,16 @@ func principalUsername(principal *models.Principal) string {
 // "filterable", "searchable", or "rangeable". Returns ("", false)
 // otherwise. validateBodyExclusivity has already guaranteed at most one
 // cancel field is set across the body.
+// requestsCancel is the nil-safe form of [requestedCancel], used by the
+// RUNTIME_REINDEX_ENABLED check before the body has been validated.
+func requestsCancel(body *models.IndexUpdateRequest) bool {
+	if body == nil {
+		return false
+	}
+	_, cancelling := requestedCancel(body)
+	return cancelling
+}
+
 func requestedCancel(body *models.IndexUpdateRequest) (string, bool) {
 	switch {
 	case body.Searchable != nil && body.Searchable.Cancel:

--- a/adapters/handlers/rest/handlers_indexes_kill_switch_test.go
+++ b/adapters/handlers/rest/handlers_indexes_kill_switch_test.go
@@ -1,0 +1,73 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// TestUpdateIndex_RuntimeReindexDisabled pins the wire response for a
+// submit refused while the feature is off. The accepted-when-on case is
+// covered by the reindex acceptance suites, which submit and expect 202.
+func TestUpdateIndex_RuntimeReindexDisabled(t *testing.T) {
+	h := &indexesHandlers{appState: &state.State{
+		Authorizer:   &authorization.DummyAuthorizer{},
+		ServerConfig: &config.WeaviateConfig{Config: config.Config{RuntimeReindexEnabled: false}},
+	}}
+
+	resp := h.updateIndex(schema.SchemaObjectsIndexesUpdateParams{
+		HTTPRequest:  httptest.NewRequest("PUT", "/", nil),
+		ClassName:    "Books",
+		PropertyName: "title",
+		Body:         &models.IndexUpdateRequest{Searchable: &models.IndexUpdateSearchable{Enabled: true}},
+	}, nil)
+
+	rec := httptest.NewRecorder()
+	resp.WriteResponse(rec, runtime.JSONProducer())
+
+	require.Equal(t, 400, rec.Code)
+	require.Contains(t, rec.Body.String(), "runtime reindex is disabled")
+	require.Contains(t, rec.Body.String(), "RUNTIME_REINDEX_ENABLED",
+		"the refusal must name the knob that turns the feature on")
+}
+
+// TestRequestsCancel pins which bodies the refusal exempts: cancel must
+// survive the flag being off so a task already running stays stoppable.
+func TestRequestsCancel(t *testing.T) {
+	tests := []struct {
+		name string
+		body *models.IndexUpdateRequest
+		want bool
+	}{
+		{name: "nil body"},
+		{name: "submit", body: &models.IndexUpdateRequest{Searchable: &models.IndexUpdateSearchable{Enabled: true}}},
+		{name: "searchable cancel", body: &models.IndexUpdateRequest{Searchable: &models.IndexUpdateSearchable{Cancel: true}}, want: true},
+		{name: "filterable cancel", body: &models.IndexUpdateRequest{Filterable: &models.IndexUpdateFilterable{Cancel: true}}, want: true},
+		{name: "rangeable cancel", body: &models.IndexUpdateRequest{Rangeable: &models.IndexUpdateRangeable{Cancel: true}}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, requestsCancel(tt.body))
+		})
+	}
+}

--- a/adapters/handlers/rest/handlers_indexes_namespace_test.go
+++ b/adapters/handlers/rest/handlers_indexes_namespace_test.go
@@ -41,7 +41,8 @@ func TestUpdateIndex_SubmitLockKeyedOnQualifiedClass(t *testing.T) {
 		ReindexSubmitLocks: locks,
 		Logger:             logger,
 		ServerConfig: &config.WeaviateConfig{Config: config.Config{
-			Namespaces: config.Namespaces{Enabled: true},
+			Namespaces:            config.Namespaces{Enabled: true},
+			RuntimeReindexEnabled: true,
 		}},
 		// SchemaManager left nil: the correctly-keyed handler blocks before the
 		// class read; the buggy path reaches it and panics, which the goroutine recovers.

--- a/adapters/repos/db/reindex_inflight.go
+++ b/adapters/repos/db/reindex_inflight.go
@@ -44,6 +44,12 @@ var unwiredGateWarnOnce sync.Once
 // install path; production HTTP gates on bootstrap completion so the
 // unwired window is unreachable by external traffic.
 func (db *DB) AnyLiveReindexForShard(collection, shardName string) bool {
+	if db.config.RuntimeReindexDisabled {
+		// Runtime reindex is off, so no new task can start. Return before
+		// consulting the lookup so the backup path makes no reindex check
+		// at all — the pre-gate behavior this restores.
+		return false
+	}
 	db.reindexAuditMu.RLock()
 	activityBuilder := db.shardReindexActivityLookupBuilder
 	cleanupBuilder := db.reindexCleanupInProgressLookupBldr

--- a/adapters/repos/db/reindex_inflight_kill_switch_test.go
+++ b/adapters/repos/db/reindex_inflight_kill_switch_test.go
@@ -1,0 +1,52 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAnyLiveReindexForShard_RuntimeReindexDisabled pins the backup half
+// of the kill switch: with the feature off the gate consults nothing, so
+// a backup runs exactly as it would on a build without the gate.
+//
+// The lookup reports every shard as reindexing, so a gate that still ran
+// would both refuse and bump the counter.
+func TestAnyLiveReindexForShard_RuntimeReindexDisabled(t *testing.T) {
+	tests := []struct {
+		name       string
+		disabled   bool
+		wantBlock  bool
+		wantLookup bool
+	}{
+		{name: "disabled skips the check", disabled: true},
+		{name: "enabled keeps the check", wantBlock: true, wantLookup: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var lookups atomic.Int64
+			db := &DB{config: Config{RuntimeReindexDisabled: tt.disabled}}
+			db.SetShardReindexActivityLookup(func() ShardReindexActivityLookup {
+				lookups.Add(1)
+				return func(string, string) bool { return true }
+			})
+
+			require.Equal(t, tt.wantBlock, db.AnyLiveReindexForShard("MyClass", "shard1"))
+			require.Equal(t, tt.wantLookup, lookups.Load() > 0,
+				"the backup path must make no reindex lookup while the feature is off")
+		})
+	}
+}

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -459,6 +459,12 @@ type Config struct {
 	ObjectsTTLPauseDuration             *configRuntime.DynamicValue[time.Duration]
 	ObjectsTTLConcurrencyFactor         *configRuntime.DynamicValue[float64]
 
+	// RuntimeReindexDisabled mirrors an off RUNTIME_REINDEX_ENABLED.
+	// Stated negatively so the zero value keeps today's behavior for the
+	// many test fixtures that build a Config literal; the one production
+	// caller sets it explicitly.
+	RuntimeReindexDisabled bool
+
 	HNSWMaxLogSize                               int64
 	HNSWDisableSnapshots                         bool
 	HNSWSnapshotIntervalSeconds                  int

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -61,6 +61,16 @@ together into one user-visible verb on `PUT
 > The cancel verb and `GET .../indexes` keep working, so a task that was
 > already running stays observable and stoppable. Everything below
 > describes behavior with the flag on.
+>
+> **With the flag off, a replica move can kill a running migration.** The
+> backup path's reindex check is skipped, so a replica move — or any other
+> operation that closes the shard — is admitted even while a migration is
+> still writing to that shard. Closing the shard takes the storage away from
+> the migration, and the migration fails loudly: the task ends in `FAILED`,
+> the schema stays at its pre-migration value, and the copy itself completes
+> normally. Nothing is corrupted, but the migration is lost and has to be
+> resubmitted once the flag is back on. With the flag on, the move is refused
+> and the replication engine retries it until the migration finishes.
 
 ### `PUT /v1/schema/{class}/indexes/{property}`
 

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -54,6 +54,14 @@ together into one user-visible verb on `PUT
 
 ## 2. REST surface
 
+> **Runtime reindex is off by default.** Set
+> `RUNTIME_REINDEX_ENABLED=true` to enable it. While it is off, submitting
+> a migration returns `400 Bad Request` with
+> `runtime reindex is disabled; enable with RUNTIME_REINDEX_ENABLED=true`.
+> The cancel verb and `GET .../indexes` keep working, so a task that was
+> already running stays observable and stoppable. Everything below
+> describes behavior with the flag on.
+
 ### `PUT /v1/schema/{class}/indexes/{property}`
 
 Submit a migration. Body shape selects which one:

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -15,6 +15,7 @@ package reindexhelpers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -483,4 +485,22 @@ func WithEnv(
 	SetupClass(t, class, props)
 	ImportObjects(t, class, objects)
 	body()
+}
+
+// SingleNodeCompose is the single-node configuration the runtime-reindex
+// suites share: the feature flag on (the server default is off, so a suite
+// that bypasses this silently tests nothing), the legacy searchable path
+// off, and a 1s scheduler tick so task transitions land inside test
+// timeouts. Callers needing extra env keep chaining before Start.
+func SingleNodeCompose() *docker.Compose {
+	return docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
+		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
+		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1")
+}
+
+// StartSingleNode starts [SingleNodeCompose] with no further tuning.
+func StartSingleNode(ctx context.Context) (*docker.DockerCompose, error) {
+	return SingleNodeCompose().Start(ctx)
 }

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -93,6 +93,7 @@ func TestMain(m *testing.M) {
 	os.Setenv("AWS_SECRET_KEY", "aws_secret_key")
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithApiKey().
 		WithRBAC().
 		WithUserApiKey(adminUser, adminKey).

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -47,6 +47,7 @@ func TestBackupVsReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithBackendFilesystem().
 		WithWeaviate().
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/concurrent_test.go
+++ b/test/acceptance/reindex_concurrent/concurrent_test.go
@@ -50,6 +50,7 @@ func TestConcurrentReindex(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/concurrent_test.go
+++ b/test/acceptance/reindex_concurrent/concurrent_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -49,12 +48,7 @@ const (
 func TestConcurrentReindex(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
@@ -75,6 +75,7 @@ func TestParallelConflictMatrix(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_conflict_matrix_test.go
@@ -59,7 +59,7 @@ import (
 	"github.com/stretchr/testify/require"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -74,12 +74,7 @@ const matrixObjectCount = 2000
 func TestParallelConflictMatrix(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_concurrent/parallel_same_property_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_same_property_test.go
@@ -64,6 +64,7 @@ func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_concurrent/parallel_same_property_test.go
+++ b/test/acceptance/reindex_concurrent/parallel_same_property_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -63,12 +63,7 @@ import (
 func TestParallelEnableFilterableAndRangeable(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -36,6 +36,7 @@ func TestMultiTenant_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -35,12 +34,7 @@ import (
 func TestMultiTenant_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
+++ b/test/acceptance/reindex_multinode/cancel_cleanup_cluster_wide_test.go
@@ -41,6 +41,7 @@ func TestMultiNode_CancelClearsAcrossReplicas(t *testing.T) {
 	// wide enough to reproduce reliably on fast hardware.
 	const backupBucket = "cancel-clears-bucket"
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		With3NodeCluster().
 		WithBackendS3(backupBucket, "us-east-1").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -45,6 +45,7 @@ func start3NodeReindexCluster(ctx context.Context, t *testing.T, extraEnv ...str
 	}
 
 	b := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		With3NodeCluster().
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_COMPLETED_TASK_TTL_HOURS", "1").

--- a/test/acceptance/reindex_multinode/rangeable_in_memory_test.go
+++ b/test/acceptance/reindex_multinode/rangeable_in_memory_test.go
@@ -94,6 +94,7 @@ func assertRebuildFinalizeThenNoFallbackWarn(ctx context.Context, t *testing.T, 
 func startSingleNodeRangeableInMemCluster(ctx context.Context, t *testing.T) (*docker.DockerCompose, func()) {
 	t.Helper()
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("INDEX_RANGEABLE_IN_MEMORY", "true").
 		WithWeaviateEnv("LOG_LEVEL", "info").

--- a/test/acceptance/reindex_rangeable/concurrent_writes_test.go
+++ b/test/acceptance/reindex_rangeable/concurrent_writes_test.go
@@ -61,6 +61,7 @@ func TestEnableRangeable_ConcurrentWrites(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		// 1s scheduler tick keeps the submit→migration-start latency low so
 		// the PATCH storm reliably overlaps the migration window.

--- a/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
+++ b/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
@@ -337,6 +337,7 @@ func TestCancelThenRetry(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
+++ b/test/acceptance/reindex_singlenode/cancel_then_retry_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -336,12 +335,7 @@ func TestSuppress_CancelThenRetry(t *testing.T) {
 func TestCancelThenRetry(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/finished_race_test.go
+++ b/test/acceptance/reindex_singlenode/finished_race_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -72,12 +71,7 @@ import (
 func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/finished_race_test.go
+++ b/test/acceptance/reindex_singlenode/finished_race_test.go
@@ -73,6 +73,7 @@ func TestSingleNode_FinishedStatusRaceWithSchemaFlag(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/restart_during_swap_test.go
+++ b/test/acceptance/reindex_singlenode/restart_during_swap_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
@@ -71,15 +70,11 @@ import (
 func TestRestartDuringSwap(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		// 1s tick gives us up to ~1s after FINISHED is reported in RAFT
-		// before OnGroupCompleted fires — comfortably wider than the time
-		// needed to issue StopAt(... 0 timeout) and kill the container.
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	// The shared config's 1s scheduler tick gives us up to ~1s after
+	// FINISHED is reported in RAFT before OnGroupCompleted fires —
+	// comfortably wider than the time needed to issue StopAt(... 0
+	// timeout) and kill the container.
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/restart_during_swap_test.go
+++ b/test/acceptance/reindex_singlenode/restart_during_swap_test.go
@@ -72,6 +72,7 @@ func TestRestartDuringSwap(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		// 1s tick gives us up to ~1s after FINISHED is reported in RAFT

--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -40,6 +40,7 @@ func TestSingleNode_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/suite_test.go
+++ b/test/acceptance/reindex_singlenode/suite_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/weaviate/weaviate/test/docker"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
@@ -39,12 +39,7 @@ import (
 func TestSingleNode_ReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -385,6 +385,7 @@ func TestTornResume_StandaloneSmoke(t *testing.T) {
 	ctx := context.Background()
 
 	compose, err := docker.New().
+		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviate().
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").

--- a/test/acceptance/reindex_singlenode/torn_resume_test.go
+++ b/test/acceptance/reindex_singlenode/torn_resume_test.go
@@ -384,12 +384,7 @@ func findShardPathInContainer(t *testing.T, container testcontainers.Container, 
 func TestTornResume_StandaloneSmoke(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithWeaviate().
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		Start(ctx)
+	compose, err := reindexhelpers.StartSingleNode(ctx)
 	require.NoError(t, err)
 	defer func() {
 		if err := compose.Terminate(ctx); err != nil {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -245,6 +245,11 @@ type Config struct {
 
 	ReplicaMovementEnabled bool `json:"replica_movement_enabled" yaml:"replica_movement_enabled"`
 
+	// RuntimeReindexEnabled gates runtime reindex (RUNTIME_REINDEX_ENABLED),
+	// off by default. With it off, new reindex submissions are refused and
+	// the backup path performs no reindex check.
+	RuntimeReindexEnabled bool `json:"runtime_reindex_enabled" yaml:"runtime_reindex_enabled"`
+
 	// TenantActivityReadLogLevel is 'debug' by default as every single READ
 	// interaction with a tenant leads to a log line. However, this may
 	// temporarily be desired, e.g. for analysis or debugging purposes. In this

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1405,6 +1405,12 @@ func FromEnv(config *Config) error {
 		config.ReplicaMovementEnabled = entcfg.Enabled(v)
 	}
 
+	// Assign only when set, so an absent env var does not overwrite a
+	// value loaded from the config file.
+	if v := os.Getenv("RUNTIME_REINDEX_ENABLED"); v != "" {
+		config.RuntimeReindexEnabled = entcfg.Enabled(v)
+	}
+
 	revoctorizeCheckDisabled := false
 	if v := os.Getenv("REVECTORIZE_CHECK_DISABLED"); v != "" {
 		revoctorizeCheckDisabled = !(strings.ToLower(v) == "false")

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1925,3 +1925,34 @@ func TestEnvironmentAsyncIndexing(t *testing.T) {
 		})
 	}
 }
+
+// TestEnvironmentRuntimeReindexEnabled pins the kill switch's precedence:
+// the env var wins when set, and an absent one leaves a config-file value
+// alone. Getting the absent case wrong silently forces every
+// file-configured cluster back to off.
+func TestEnvironmentRuntimeReindexEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue []string
+		fromFile bool
+		expected bool
+	}{
+		{name: "absent env keeps file default off"},
+		{name: "absent env keeps file value on", fromFile: true, expected: true},
+		{name: "env true enables", envValue: []string{"true"}, expected: true},
+		{name: "env false disables", envValue: []string{"false"}},
+		{name: "env false overrides file on", envValue: []string{"false"}, fromFile: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Clearenv()
+			if len(tt.envValue) == 1 {
+				t.Setenv("RUNTIME_REINDEX_ENABLED", tt.envValue[0])
+			}
+			conf := Config{RuntimeReindexEnabled: tt.fromFile}
+			require.NoError(t, FromEnv(&conf))
+			require.Equal(t, tt.expected, conf.RuntimeReindexEnabled)
+		})
+	}
+}


### PR DESCRIPTION
Backups are failing in production because runtime reindex's backup gate refuses them. This adds `RUNTIME_REINDEX_ENABLED`, off by default, with exactly two touch points: starting a reindex is refused, and the backup path's reindex check returns early. Everything else is untouched — running tasks, cancel, status, the delete guard, startup, recovery, finalization, and provider registration all behave exactly as they do today.

Base branch: `stable/v1.38`.

| Surface | Flag off (default) | Flag on |
| --- | --- | --- |
| `PUT .../indexes/{prop}` — submit | `400` — `runtime reindex is disabled; enable with RUNTIME_REINDEX_ENABLED=true` | Today's behavior |
| `PUT .../indexes/{prop}` — cancel, and `GET .../indexes` | Untouched | Untouched |
| Backup reindex check | Returns early; no reindex call at all | Today's gate |
| Everything else (running tasks, startup, recovery, finalization, provider registration, delete guard) | Untouched | Untouched |

**The accepted trade, on the record.** A task already in flight when the flag flips off runs to completion, and the reindex check is skipped meanwhile — so a snapshot can be taken while a migration is actively rewriting an index, which is the exact thing the gate prevents. This covers **backups and replica snapshots both**: the gated check sits in `AnyLiveReindexForShard`, which `HaltForTransfer(ctx, offloading=false, …)` reaches, and replica movement goes through that same door (`replica_snapshot.go`, `shard_replica_snapshot.go`). Gating per-caller would mean threading the flag through each path, which is the complexity this PR exists to avoid — and the rationale is identical either way: this is what the pre-gate build did, and a backup that refuses forever is the worse outage. Tenant offload is unaffected (it passes `offloading=true` and never ran this check).

**What the trade actually costs, measured.** QA swept both paths on running clusters ([results](https://github.com/weaviate/weaviate/pull/12491#issuecomment-5191416669)). Backups are clean at every phase: a mid-migration copy is either fully correct or correct-but-stale with the schema honestly reporting the index as off — no copy that claims to be ready and answers with partial or zero results. The cost lands on replica movement instead, and in the opposite direction from what "a copy might catch a moving index" suggests: the copy is fine, and the in-flight migration is what pays. With the flag off, a move of a shard under an in-flight migration is admitted, closing the shard for the copy takes the storage away from the migration, and the migration dies. It fails loudly — schema reverts to its pre-migration value, cluster stays consistent, nothing corrupted — but the migration is lost and has to be resubmitted with the flag back on. With the flag on the move is refused and the replication engine retries it until the migration finishes. Same note now in `docs/runtime-reindex.md`.

**Why the blast radius is small by construction.** The production diff is 43 added lines across six files and changes nothing at startup. It does not touch startup finalization, the recovery scan, the orphan audit, provider registration, or the schema-mutation guards. In-flight and completed migrations therefore behave identically to today in every respect — including on a node that boots mid-migration, which finalizes and recovers exactly as it does on the current tip. The one gated function, `AnyLiveReindexForShard`, is reachable only from `Backupable`, the two per-shard backup paths, and `HaltForTransfer`.

Temporary mitigation until [weaviate/weaviate#12474](https://github.com/weaviate/weaviate/pull/12474) and [weaviate/weaviate#12471](https://github.com/weaviate/weaviate/pull/12471) merge — those are the real fixes, and this flag should be removed rather than kept once they land. Context in [weaviate/0-weaviate-issues#457](https://github.com/weaviate/0-weaviate-issues/issues/457). Runtime reindex is Preview, so a default-off flip is within the compatibility contract. No swagger change.

**Tests** — one per touch point, each red without its fix: submit refused when off (`TestUpdateIndex_RuntimeReindexDisabled`, plus `TestRequestsCancel` for the cancel exemption); backup check skipped when off and active when on (`TestAnyLiveReindexForShard_RuntimeReindexDisabled`); env precedence including absent-env-keeps-file-value (`TestEnvironmentRuntimeReindexEnabled`). The accepted-when-on case is covered by the reindex acceptance suites, which submit and expect 202 — each suite gets a one-line `RUNTIME_REINDEX_ENABLED=true`, and that wiring is the key test that the suites still exercise the feature rather than silently passing.

