### PR TITLE
lsmkv: stop CheckExpectedStrategy from heap-allocating its variadic slice

### DIFF
--- a/adapters/repos/db/lsmkv/segmentindex/strategies.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies.go
@@ -11,7 +11,11 @@
 
 package segmentindex
 
-import "fmt"
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
 
 type Strategy uint16
 
@@ -44,34 +48,44 @@ func (s Strategy) String() string {
 	}
 }
 
+var allStrategies = []Strategy{
+	StrategyReplace,
+	StrategySetCollection,
+	StrategyMapCollection,
+	StrategyRoaringSet,
+	StrategyRoaringSetRange,
+	StrategyInverted,
+}
+
 func IsExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) bool {
 	if len(expectedStrategies) == 0 {
-		expectedStrategies = []Strategy{
-			StrategyReplace,
-			StrategySetCollection,
-			StrategyMapCollection,
-			StrategyRoaringSet,
-			StrategyRoaringSetRange,
-			StrategyInverted,
-		}
+		expectedStrategies = allStrategies
 	}
-
-	for _, s := range expectedStrategies {
-		if s == strategy {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(expectedStrategies, strategy)
 }
 
 func CheckExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) error {
+	if len(expectedStrategies) == 0 {
+		expectedStrategies = allStrategies
+	}
 	if IsExpectedStrategy(strategy, expectedStrategies...) {
 		return nil
 	}
 	if len(expectedStrategies) == 1 {
 		return fmt.Errorf("strategy %s expected, got %s", expectedStrategies[0], strategy)
 	}
-	return fmt.Errorf("one of strategies %s expected, got %s", expectedStrategies, strategy)
+	// the slice is joined rather than passed to Errorf: an Errorf argument would
+	// make every caller's variadic slice escape to the heap
+	return fmt.Errorf("one of strategies [%s] expected, got %s",
+		joinStrategies(expectedStrategies), strategy)
+}
+
+func joinStrategies(strategies []Strategy) string {
+	labels := make([]string, len(strategies))
+	for i, s := range strategies {
+		labels[i] = s.String()
+	}
+	return strings.Join(labels, " ")
 }
 
 func MustBeExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) {
@@ -80,9 +94,6 @@ func MustBeExpectedStrategy(strategy Strategy, expectedStrategies ...Strategy) {
 	}
 }
 
-// pre-built and never mutated, so the RoaringSet check doesn't allocate per call
-var strategiesRoaringSet = []Strategy{StrategyRoaringSet}
-
 func CheckStrategyRoaringSet(strategy Strategy) error {
-	return CheckExpectedStrategy(strategy, strategiesRoaringSet...)
+	return CheckExpectedStrategy(strategy, StrategyRoaringSet)
 }

--- a/adapters/repos/db/lsmkv/segmentindex/strategies_test.go
+++ b/adapters/repos/db/lsmkv/segmentindex/strategies_test.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package segmentindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckExpectedStrategy(t *testing.T) {
+	// what a corrupt or newer-version segment header can carry
+	unknownStrategy := Strategy(99)
+
+	tests := []struct {
+		name     string
+		strategy Strategy
+		expected []Strategy
+		wantErr  string
+	}{
+		{
+			name:     "single expected strategy matches",
+			strategy: StrategyReplace,
+			expected: []Strategy{StrategyReplace},
+		},
+		{
+			name:     "one of several expected strategies matches",
+			strategy: StrategyInverted,
+			expected: []Strategy{StrategyMapCollection, StrategyInverted},
+		},
+		{
+			name:     "no expected strategies accepts any known strategy",
+			strategy: StrategyRoaringSetRange,
+		},
+		{
+			name:     "single expected strategy mismatches",
+			strategy: StrategyInverted,
+			expected: []Strategy{StrategyReplace},
+			wantErr:  "strategy replace expected, got inverted",
+		},
+		{
+			name:     "several expected strategies all mismatch",
+			strategy: StrategyReplace,
+			expected: []Strategy{StrategyMapCollection, StrategyInverted},
+			wantErr:  "one of strategies [mapcollection inverted] expected, got replace",
+		},
+		{
+			name:     "no expected strategies names them all when rejecting",
+			strategy: unknownStrategy,
+			wantErr: "one of strategies [replace setcollection mapcollection roaringset " +
+				"roaringsetrange inverted] expected, got n/a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckExpectedStrategy(tt.strategy, tt.expected...)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.True(t, IsExpectedStrategy(tt.strategy, tt.expected...))
+				require.NotPanics(t, func() {
+					MustBeExpectedStrategy(tt.strategy, tt.expected...)
+				})
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+			require.False(t, IsExpectedStrategy(tt.strategy, tt.expected...))
+			require.PanicsWithError(t, tt.wantErr, func() {
+				MustBeExpectedStrategy(tt.strategy, tt.expected...)
+			})
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/strategies.go
+++ b/adapters/repos/db/lsmkv/strategies.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 )
@@ -73,7 +74,10 @@ func CheckExpectedStrategy(strategy string, expectedStrategies ...string) error 
 	if len(expectedStrategies) == 1 {
 		return fmt.Errorf("strategy %q expected, got %q", expectedStrategies[0], strategy)
 	}
-	return fmt.Errorf("one of strategies %v expected, got %q", expectedStrategies, strategy)
+	// the slice is joined rather than passed to Errorf: an Errorf argument would
+	// make every caller's variadic slice escape to the heap
+	return fmt.Errorf("one of strategies [%s] expected, got %q",
+		strings.Join(expectedStrategies, " "), strategy)
 }
 
 func MustBeExpectedStrategy(strategy string, expectedStrategies ...string) {
@@ -82,18 +86,12 @@ func MustBeExpectedStrategy(strategy string, expectedStrategies ...string) {
 	}
 }
 
-// pre-built and never mutated, so the strategy checks don't allocate per call
-var (
-	strategiesRoaringSet      = []string{StrategyRoaringSet}
-	strategiesRoaringSetRange = []string{StrategyRoaringSetRange}
-)
-
 func CheckStrategyRoaringSet(strategy string) error {
-	return CheckExpectedStrategy(strategy, strategiesRoaringSet...)
+	return CheckExpectedStrategy(strategy, StrategyRoaringSet)
 }
 
 func CheckStrategyRoaringSetRange(strategy string) error {
-	return CheckExpectedStrategy(strategy, strategiesRoaringSetRange...)
+	return CheckExpectedStrategy(strategy, StrategyRoaringSetRange)
 }
 
 func DefaultSearchableStrategy(useInvertedSearchable bool) string {

--- a/adapters/repos/db/lsmkv/strategies_test.go
+++ b/adapters/repos/db/lsmkv/strategies_test.go
@@ -1,0 +1,64 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckExpectedStrategy(t *testing.T) {
+	tests := []struct {
+		name     string
+		strategy string
+		expected []string
+		wantErr  string
+	}{
+		{
+			name:     "single expected strategy matches",
+			strategy: StrategyReplace,
+			expected: []string{StrategyReplace},
+		},
+		{
+			name:     "single expected strategy mismatches",
+			strategy: StrategyInverted,
+			expected: []string{StrategyReplace},
+			wantErr:  `strategy "replace" expected, got "inverted"`,
+		},
+		{
+			name:     "several expected strategies all mismatch",
+			strategy: StrategyReplace,
+			expected: []string{StrategyMapCollection, StrategyInverted},
+			wantErr:  `one of strategies [mapcollection inverted] expected, got "replace"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckExpectedStrategy(tt.strategy, tt.expected...)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				require.True(t, IsExpectedStrategy(tt.strategy, tt.expected...))
+				require.NotPanics(t, func() {
+					MustBeExpectedStrategy(tt.strategy, tt.expected...)
+				})
+				return
+			}
+			require.EqualError(t, err, tt.wantErr)
+			require.False(t, IsExpectedStrategy(tt.strategy, tt.expected...))
+			require.PanicsWithError(t, tt.wantErr, func() {
+				MustBeExpectedStrategy(tt.strategy, tt.expected...)
+			})
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Passing the expected-strategy slice to fmt.Errorf on the error path marked the parameter as leaking, forcing every call site's variadic slice onto the heap even when the check passes. Join it into a string instead, in both lsmkv and segmentindex.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
