### PR TITLE
Size the roaringsetrange pread read buffer from the segment payload

### DIFF
--- a/adapters/repos/db/lsmkv/compaction_roaring_set_range_checksum_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_range_checksum_integration_test.go
@@ -15,9 +15,10 @@ package lsmkv
 
 import "testing"
 
-// A checksum leaves trailing bytes behind the segment payload that only the
-// pread cursors have to page past. The bucketIntegrationTests matrix pairs
-// checksums with mmap alone, so the combination is covered here instead.
+// A checksum leaves trailing bytes behind the segment payload that a pread
+// cursor must stop short of rather than read as a node. The
+// bucketIntegrationTests matrix pairs checksums with mmap alone, so the
+// combination is covered here instead.
 func TestCompactionRoaringSetRangeStrategy_ChecksumPread(t *testing.T) {
 	compactionRoaringSetRangeStrategy_Random(testCtx(), t, []BucketOption{
 		WithStrategy(StrategyRoaringSetRange),

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_range_checksum_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_range_checksum_integration_test.go
@@ -1,0 +1,27 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import "testing"
+
+// A checksum leaves trailing bytes behind the segment payload that only the
+// pread cursors have to page past. The bucketIntegrationTests matrix pairs
+// checksums with mmap alone, so the combination is covered here instead.
+func TestCompactionRoaringSetRangeStrategy_ChecksumPread(t *testing.T) {
+	compactionRoaringSetRangeStrategy_Random(testCtx(), t, []BucketOption{
+		WithStrategy(StrategyRoaringSetRange),
+		WithSegmentsChecksumValidationEnabled(true),
+		WithPread(true),
+	})
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_roaring_set_range.go
@@ -22,10 +22,11 @@ func (s *segment) newRoaringSetRangeReader() roaringsetrange.InnerReader {
 	if s.readFromMemory {
 		segmentCursor = roaringsetrange.NewSegmentCursorMmap(s.contents[s.dataStartPos:s.dataEndPos])
 	} else {
-		sectionReader := io.NewSectionReader(s.contentFile, int64(s.dataStartPos), int64(s.dataEndPos))
+		payloadSize := int64(s.dataEndPos - s.dataStartPos)
+		sectionReader := io.NewSectionReader(s.contentFile, int64(s.dataStartPos), payloadSize)
 		// since segment reader concurrenlty fetches next segment and merges bitmaps of previous segments
 		// at least 2 buffers needs to be used by cursor not to overwrite data before they are consumed.
-		segmentCursor = roaringsetrange.NewSegmentCursorPread(sectionReader, 2)
+		segmentCursor = roaringsetrange.NewSegmentCursorPread(sectionReader, payloadSize, 2)
 	}
 
 	return roaringsetrange.NewSegmentReader(
@@ -37,8 +38,9 @@ func (s *segment) newRoaringSetRangeCursor() roaringsetrange.SegmentCursor {
 		return roaringsetrange.NewSegmentCursorMmap(s.contents[s.dataStartPos:s.dataEndPos])
 	}
 
-	sectionReader := io.NewSectionReader(s.contentFile, int64(s.dataStartPos), int64(s.dataEndPos))
+	payloadSize := int64(s.dataEndPos - s.dataStartPos)
+	sectionReader := io.NewSectionReader(s.contentFile, int64(s.dataStartPos), payloadSize)
 	// compactor does not work concurrently, next segment is fetched after previous one gets consumed,
 	// therefore just one buffer is sufficient.
-	return roaringsetrange.NewSegmentCursorPread(sectionReader, 1)
+	return roaringsetrange.NewSegmentCursorPread(sectionReader, payloadSize, 1)
 }

--- a/adapters/repos/db/roaringsetrange/segment_cursor.go
+++ b/adapters/repos/db/roaringsetrange/segment_cursor.go
@@ -68,6 +68,22 @@ func (c *SegmentCursorMmap) Next() (uint8, roaringset.BitmapLayer, bool) {
 
 // ================================================================================
 
+// segmentCursorPreadMaxBufferSize caps the read buffer of a single pread cursor.
+// A range query builds one cursor per disk segment and a compaction one per
+// input segment, so this size is paid once per segment every time. Raising the
+// cap does not save reads either: nodes at least this large are read straight
+// into the node buffer, so a bigger buffer only adds a copy.
+const segmentCursorPreadMaxBufferSize = 256 * 1024
+
+// preadBufferSize keeps the read buffer from outgrowing the payload it pages
+// through. A payloadSize of 0 or less means the size is unknown.
+func preadBufferSize(payloadSize int64) int {
+	if payloadSize > 0 && payloadSize < segmentCursorPreadMaxBufferSize {
+		return int(payloadSize)
+	}
+	return segmentCursorPreadMaxBufferSize
+}
+
 // A SegmentCursor iterates over all key-value pairs in a single disk segment.
 // You can start at the beginning using [*SegmentCursorPread.First] and move forward
 // using [*SegmentCursorPread.Next]
@@ -86,16 +102,20 @@ type SegmentCursorPread struct {
 // Similarly, the reader may only read payload, as the EOF
 // is used to determine if more keys can be found.
 //
+// payloadSize is the length of that payload. It only sizes the read buffer, so
+// pass 0 if it is not known; a value that is too small costs extra reads, never
+// correctness.
+//
 // bufferCount tells how many exclusive payload buffers should be used to return
 // expected data. Set multiple buffers if data returned by First/Next will not be used
 // before following call will be made, not to overwrite previously fetched values.
 // (e.g. count 3 means, 3 buffers will be used internally and following calls to First/Next
 // will return data in buffers: 1, 2, 3, 1, 2, 3, ...)
-func NewSegmentCursorPread(readSeeker io.ReadSeeker, bufferCount int) *SegmentCursorPread {
+func NewSegmentCursorPread(readSeeker io.ReadSeeker, payloadSize int64, bufferCount int) *SegmentCursorPread {
 	readSeeker.Seek(0, io.SeekStart)
 	return &SegmentCursorPread{
 		readSeeker:     readSeeker,
-		reader:         bufio.NewReaderSize(readSeeker, 10*1024*1024),
+		reader:         bufio.NewReaderSize(readSeeker, preadBufferSize(payloadSize)),
 		lenBuf:         make([]byte, 8),
 		nodeBufs:       make([][]byte, bufferCount),
 		nodeBufPos:     0,

--- a/adapters/repos/db/roaringsetrange/segment_cursor.go
+++ b/adapters/repos/db/roaringsetrange/segment_cursor.go
@@ -76,9 +76,11 @@ func (c *SegmentCursorMmap) Next() (uint8, roaringset.BitmapLayer, bool) {
 const segmentCursorPreadMaxBufferSize = 256 * 1024
 
 // preadBufferSize keeps the read buffer from outgrowing the payload it pages
-// through. A payloadSize of 0 or less means the size is unknown.
+// through. A negative payloadSize means the size is unknown; a compaction that
+// drops every node leaves a payload of exactly 0, which must not be mistaken
+// for it.
 func preadBufferSize(payloadSize int64) int {
-	if payloadSize > 0 && payloadSize < segmentCursorPreadMaxBufferSize {
+	if payloadSize >= 0 && payloadSize < segmentCursorPreadMaxBufferSize {
 		return int(payloadSize)
 	}
 	return segmentCursorPreadMaxBufferSize
@@ -103,8 +105,8 @@ type SegmentCursorPread struct {
 // is used to determine if more keys can be found.
 //
 // payloadSize is the length of that payload. It only sizes the read buffer, so
-// pass 0 if it is not known; a value that is too small costs extra reads, never
-// correctness.
+// pass a negative value if it is not known; a value that is too small costs
+// extra reads, never correctness.
 //
 // bufferCount tells how many exclusive payload buffers should be used to return
 // expected data. Set multiple buffers if data returned by First/Next will not be used

--- a/adapters/repos/db/roaringsetrange/segment_cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_cursor_test.go
@@ -166,6 +166,9 @@ func TestSegmentCursorPread(t *testing.T) {
 	})
 }
 
+// bufio floors every buffer at this size, whatever smaller size it is asked for.
+const minBufioReadBufferSize = 16
+
 // TestSegmentCursorPreadReadBufferSize pins the read buffer to the smaller of
 // the payload and the cap, so a cursor neither allocates more than it pages
 // through nor grows back to a size that is expensive once per segment.
@@ -181,8 +184,8 @@ func TestSegmentCursorPreadReadBufferSize(t *testing.T) {
 	}{
 		{name: "payload below the cap", payloadSize: int64(len(small)), expected: len(small)},
 		{name: "payload above the cap", payloadSize: int64(len(large)), expected: segmentCursorPreadMaxBufferSize},
-		{name: "payload size unknown", payloadSize: 0, expected: segmentCursorPreadMaxBufferSize},
-		{name: "payload size negative", payloadSize: -1, expected: segmentCursorPreadMaxBufferSize},
+		{name: "empty payload", payloadSize: 0, expected: minBufioReadBufferSize},
+		{name: "payload size unknown", payloadSize: -1, expected: segmentCursorPreadMaxBufferSize},
 	}
 
 	for _, test := range tests {

--- a/adapters/repos/db/roaringsetrange/segment_cursor_test.go
+++ b/adapters/repos/db/roaringsetrange/segment_cursor_test.go
@@ -73,9 +73,10 @@ func TestSegmentCursorMmap(t *testing.T) {
 func TestSegmentCursorPread(t *testing.T) {
 	seg := createDummySegment(t, 5)
 	readSeeker := bytes.NewReader(seg)
+	segSize := int64(len(seg))
 
 	t.Run("starting from beginning", func(t *testing.T) {
-		c := NewSegmentCursorPread(readSeeker, 1)
+		c := NewSegmentCursorPread(readSeeker, segSize, 1)
 		key, layer, ok := c.First()
 		require.True(t, ok)
 		assert.Equal(t, uint8(0), key)
@@ -84,7 +85,7 @@ func TestSegmentCursorPread(t *testing.T) {
 	})
 
 	t.Run("starting from beginning, page through all", func(t *testing.T) {
-		c := NewSegmentCursorPread(readSeeker, 1)
+		c := NewSegmentCursorPread(readSeeker, segSize, 1)
 		i := uint64(0)
 		for key, layer, ok := c.First(); ok; key, layer, ok = c.Next() {
 			assert.Equal(t, uint8(i), key)
@@ -102,7 +103,7 @@ func TestSegmentCursorPread(t *testing.T) {
 	})
 
 	t.Run("no first, page through all", func(t *testing.T) {
-		c := NewSegmentCursorPread(readSeeker, 1)
+		c := NewSegmentCursorPread(readSeeker, segSize, 1)
 		i := uint64(0)
 		for key, layer, ok := c.Next(); ok; key, layer, ok = c.Next() {
 			assert.Equal(t, uint8(i), key)
@@ -118,22 +119,136 @@ func TestSegmentCursorPread(t *testing.T) {
 
 		assert.Equal(t, uint64(5), i)
 	})
+
+	t.Run("empty segment", func(t *testing.T) {
+		c := NewSegmentCursorPread(bytes.NewReader(createDummySegment(t, 0)), 0, 1)
+
+		_, _, ok := c.First()
+		assert.False(t, ok)
+
+		_, _, ok = c.Next()
+		assert.False(t, ok)
+	})
+
+	// once a segment holds real data it outgrows the read buffer, so paging has
+	// to survive refills and nodes that do not fit in the buffer at all
+	t.Run("segment larger than the read buffer", func(t *testing.T) {
+		tests := []struct {
+			name           string
+			nodes          int
+			bufferMultiple int
+		}{
+			{name: "payload spans several buffer fills", nodes: 8, bufferMultiple: 3},
+			{name: "a single node exceeds the buffer", nodes: 1, bufferMultiple: 2},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				seg, additions := createOversizedSegment(t, test.nodes, test.bufferMultiple)
+				c := NewSegmentCursorPread(bytes.NewReader(seg), int64(len(seg)), 1)
+
+				i := 0
+				for key, layer, ok := c.First(); ok; key, layer, ok = c.Next() {
+					require.Equal(t, uint8(i), key)
+					assert.Equal(t, additions[i], layer.Additions.ToArray())
+
+					if i == 0 {
+						assert.Equal(t, []uint64{2, 3}, layer.Deletions.ToArray())
+					} else {
+						assert.True(t, layer.Deletions.IsEmpty())
+					}
+					i++
+				}
+
+				assert.Equal(t, test.nodes, i)
+			})
+		}
+	})
+}
+
+// TestSegmentCursorPreadReadBufferSize pins the read buffer to the smaller of
+// the payload and the cap, so a cursor neither allocates more than it pages
+// through nor grows back to a size that is expensive once per segment.
+func TestSegmentCursorPreadReadBufferSize(t *testing.T) {
+	small := createDummySegment(t, 5)
+	large, _ := createOversizedSegment(t, 8, 3)
+	require.Less(t, len(small), segmentCursorPreadMaxBufferSize)
+
+	tests := []struct {
+		name        string
+		payloadSize int64
+		expected    int
+	}{
+		{name: "payload below the cap", payloadSize: int64(len(small)), expected: len(small)},
+		{name: "payload above the cap", payloadSize: int64(len(large)), expected: segmentCursorPreadMaxBufferSize},
+		{name: "payload size unknown", payloadSize: 0, expected: segmentCursorPreadMaxBufferSize},
+		{name: "payload size negative", payloadSize: -1, expected: segmentCursorPreadMaxBufferSize},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := NewSegmentCursorPread(bytes.NewReader(small), test.payloadSize, 1)
+
+			assert.Equal(t, test.expected, c.reader.Size())
+		})
+	}
+}
+
+// An understated payload only costs extra reads, as NewSegmentCursorPread
+// promises. A size of 1 drops the buffer to the 16 bytes bufio floors it at,
+// below even a single node, so every node arrives across several refills.
+func TestSegmentCursorPreadUnderstatedPayloadSize(t *testing.T) {
+	seg := createDummySegment(t, 5)
+	c := NewSegmentCursorPread(bytes.NewReader(seg), 1, 1)
+
+	i := uint64(0)
+	for key, layer, ok := c.First(); ok; key, layer, ok = c.Next() {
+		require.Equal(t, uint8(i), key)
+		assert.Equal(t, []uint64{i * 4, i*4 + 1}, layer.Additions.ToArray())
+		i++
+	}
+
+	assert.Equal(t, uint64(5), i)
 }
 
 func createDummySegment(t *testing.T, count uint64) []byte {
-	out := []byte{}
-
-	for i := uint64(0); i < count; i++ {
-		key := uint8(i)
-		add := roaringset.NewBitmap(i*4, i*4+1)
-		del := roaringset.NewBitmap(i*4+2, i*4+3) // ignored for key != 0
-		sn, err := NewSegmentNode(key, add, del)
-		require.Nil(t, err)
-
-		out = append(out, sn.ToBuffer()...)
+	entries := make([]segmentEntry, count)
+	for i := range entries {
+		entries[i] = segmentEntry{
+			key:       uint8(i),
+			additions: []uint64{uint64(i) * 4, uint64(i)*4 + 1},
+			deletions: []uint64{uint64(i)*4 + 2, uint64(i)*4 + 3}, // stored only for key 0
+		}
 	}
 
-	return out
+	return createSegmentsFromEntries(t, entries)
+}
+
+// createOversizedSegment builds a segment bufferMultiple times larger than the
+// cursor's read buffer, spread over the given node count, so paging it crosses
+// buffer refills and the direct reads bufio uses for nodes that do not fit.
+func createOversizedSegment(t *testing.T, nodes, bufferMultiple int) ([]byte, [][]uint64) {
+	// the spread-out ids below serialize to just under a byte each, so one id
+	// per wanted byte clears the target with headroom
+	idsPerNode := bufferMultiple * segmentCursorPreadMaxBufferSize / nodes
+
+	entries := make([]segmentEntry, nodes)
+	additions := make([][]uint64, nodes)
+	for i := range entries {
+		ids := make([]uint64, idsPerNode)
+		for j := range ids {
+			// spread the ids out so the bitmaps stay too large to compress away
+			ids[j] = uint64(i*idsPerNode+j) * 7
+		}
+		additions[i] = ids
+		entries[i] = segmentEntry{key: uint8(i), additions: ids, deletions: []uint64{2, 3}}
+	}
+
+	seg := createSegmentsFromEntries(t, entries)
+	require.Greater(t, len(seg), segmentCursorPreadMaxBufferSize,
+		"fixture must exceed the cursor read buffer or it tests nothing")
+
+	return seg, additions
 }
 
 func TestGaplessSegmentCursor(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

`NewSegmentCursorPread` would create a 10MB buffer no matter how big the read was. This PR changes this to only allocate what we actually need.

NewSegmentCursorPread now takes the payload size and sizes the buffer at min(payload, 256 KiB); the cap is deliberate rather than arbitrary, since nodes at least that large are read straight into the node buffer, so a larger buffer would add a copy without saving reads. A negative payload size means "unknown" and falls back to the cap, kept distinct from a payload of exactly 0 (which a compaction that drops every node legitimately produces)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
