### PR TITLE
build: cut Docker build context 467x and stop the Go build cache multiplying per worktree

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,43 +1,112 @@
+# Everything listed here is withheld from the Docker build context.
+#
+# NOTE: Docker does NOT support trailing comments. A line like
+#   **/*.fvecs  # sift data
+# is read as a literal pattern including the "  # sift data" suffix, so it
+# matches nothing. Comments must be on their own line.
+
+# Version control
 .git
+.gitattributes
+
+# Docker/compose scaffolding that is not needed inside the image
 Dockerfile.*
 docker-compose.yml
-data*
-logs/
-snapshots/
-snapshots-fs/
-snapshots-node2/
-snapshots-s3/
-snapshots-gcs/
-backups/
-backups-fs/
-backups-node2/
-backups-s3/
-backups-gcs/
-test/
-tools/
-**/*.fvecs  # sift data
-**/*.png  # profiling
-**/*.out
-**/*.csv
-**/*.md
-**/*_test.go
-**/.DS_Store
-**/testdata/
-**/test_data/
-coverage-integration.txt
-coverage-unit.txt
+docker-compose/
+docker-compose-raft/
 
-# wikipedia dataset when downloaded according to docs
-weaviate-wikipedia-*
-# the local path when extracting the wiki dataset
+# Local runtime state produced by running Weaviate on the host
+data*
+logs
+logs/
+snapshots*
+backups*
+**/*.db
+**/*.wal
 var/weaviate/
 
-# IDE files
+# Test code, fixtures and tooling: the server image builds from source only
+test/
+tools/
+**/*_test.go
+**/testdata/
+**/test_data/
+
+# Datasets used by benchmarks and manual experiments
+**/*.fvecs
+**/*.ivecs
+**/*.bvecs
+**/*.hdf5
+**/*.parquet
+weaviate-wikipedia-*
+
+# Profiling, tracing and coverage output
+**/*.out
+**/*.prof
+**/*.pprof
+**/*.test
+coverage-integration.txt
+coverage-unit.txt
+**/*.csv
+
+# Logs and crash artifacts
+**/*.log
+**/core
+**/core.*
+
+# Documentation and images
+**/*.md
+**/*.png
+**/*.jpg
+**/*.jpeg
+**/*.gif
+**/*.svg
+docs/
+openapi-specs/
+# Note: deprecations/ is NOT excluded, it is a Go package imported by
+# usecases/config.
+
+# Compiled binaries that may be sitting in the working tree. These run to
+# hundreds of MB each and are rebuilt inside the image anyway.
+weaviate
+weaviate-server
+weaviate-debug
+cmd/weaviate-server/weaviate
+cmd/weaviate-server/weaviate-server
+cmd/weaviate-server/weaviate-debug
+
+# Vendored or stale dependency trees kept around by hand. The image resolves
+# dependencies with `go mod download`, so these are dead weight.
+vendor.stale-*
+**/node_modules/
+
+# Agent and IDE scratch space. `.claude/worktrees` in particular holds full
+# checkouts of other branches and measured 7.7 GB of build context.
+.claude/
+.claude-wt/
+.playwright-mcp/
 .idea
 .vscode/
+.devcontainer/
 
-# Local files
+# Python virtualenvs and caches used by helper scripts
+.venv/
+venv/
+**/__pycache__/
+**/*.pyc
+.pytest_cache/
+.mypy_cache/
+
+# Local scratch directories
 _local
+namespace_demo/
 
-# ignore archives, they are most likely part of some debugging and never part of actual code
+# Archives are almost always debugging leftovers, never build inputs
 *.tar.gz
+*.tgz
+*.zip
+
+# macOS / editor noise
+**/.DS_Store
+**/*.swp
+**/*~

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,40 @@ make grpc
 make mocks
 ```
 
+### Build cache hygiene
+
+The Go build cache can grow into the hundreds of GB on a machine running many
+worktrees. It has filled a 926 GB disk once, which took Docker's image store
+down with it. Two things drive the growth:
+
+**The cache key includes the absolute source path.** Without `-trimpath`, the
+same commit checked out at two different paths compiles to two different cache
+entries, so every worktree keeps its own full copy of the compiled dependency
+graph. Measured on this repo, a second worktree at the same commit adds ~672 MB
+for `go build ./...`, versus ~6 MB with `-trimpath` set. `go test` adds test
+binaries on top, and `-race` doubles the whole set again.
+
+If you work across several worktrees, set it once for the toolchain:
+
+```bash
+go env -w GOFLAGS=-trimpath
+```
+
+Trade-off: `-trimpath` rewrites source paths in the binary to module-relative
+ones, so panic traces and profiles show `github.com/weaviate/weaviate/...`
+instead of `/Users/you/...`, and your editor will not jump straight to them.
+Delve needs the real paths, so drop the flag when debugging (`make
+weaviate-debug` never sets it). The image build has always used `-trimpath`, so
+this does not change what ships.
+
+**Nothing trims the cache in practice.** Go only evicts entries untouched for
+five days, and an active machine keeps touching them. Check and reclaim with:
+
+```bash
+make cache-report   # sizes, and whether -trimpath is on
+make clean-caches   # go clean -cache; the next build in every worktree is cold
+```
+
 ## Testing
 
 When creating tests prefer table-driven tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,13 @@ ARG EXTRA_BUILD_ARGS=""
 ARG CGO_ENABLED=1
 ENV CGO_ENABLED=$CGO_ENABLED
 COPY . .
-RUN GOOS=linux GOARCH=${TARGETARCH} \
+# The Go build cache lives in a mount rather than in a layer. Any source change
+# invalidates this step, so without the mount every image rebuild recompiles the
+# entire dependency graph from scratch. The mount is keyed per target arch so
+# cross-platform builds do not evict each other, and locked so that concurrent
+# builds of the same arch serialize. This does not change the produced binary.
+RUN --mount=type=cache,target=/root/.cache/go-build,id=weaviate-gobuild-${TARGETARCH},sharing=locked \
+    GOOS=linux GOARCH=${TARGETARCH} \
     go build $EXTRA_BUILD_ARGS -trimpath \
       -ldflags="-s -w -extldflags '-static' \
         -X github.com/weaviate/weaviate/usecases/build.Branch=${GIT_BRANCH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY . .
 # cross-platform builds do not evict each other, and locked so that concurrent
 # builds of the same arch serialize. This does not change the produced binary.
 RUN --mount=type=cache,target=/root/.cache/go-build,id=weaviate-gobuild-${TARGETARCH},sharing=locked \
-    GOOS=linux GOARCH=${TARGETARCH} \
+    GOOS=linux GOARCH="${TARGETARCH}" \
     go build $EXTRA_BUILD_ARGS -trimpath \
       -ldflags="-s -w -extldflags '-static' \
         -X github.com/weaviate/weaviate/usecases/build.Branch=${GIT_BRANCH} \

--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,15 @@ GO_LDFLAGS         := -X $(VPREFIX).Branch=$(GIT_BRANCH) \
                       -X $(VPREFIX).Revision=$(GIT_REVISION) \
                       -X $(VPREFIX).BuildUser=$(shell whoami)@$(shell hostname) \
                       -X $(VPREFIX).BuildDate=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
-GO_FLAGS           := -ldflags "-extldflags \"-static\" -s -w $(GO_LDFLAGS)" -tags netgo
-DYN_GO_FLAGS       := -ldflags "-s -w $(GO_LDFLAGS)" -tags netgo
+# -trimpath replaces absolute source paths with module-relative ones. The image
+# build already does this. Matching it here means two checkouts of the same
+# commit at different paths (worktrees) produce identical build-cache entries
+# instead of two full copies. See "Build cache hygiene" in CLAUDE.md.
+GO_FLAGS           := -trimpath -ldflags "-extldflags \"-static\" -s -w $(GO_LDFLAGS)" -tags netgo
+DYN_GO_FLAGS       := -trimpath -ldflags "-s -w $(GO_LDFLAGS)" -tags netgo
 
-# Debug build flags
+# Debug build flags. Deliberately no -trimpath: delve needs the real source
+# paths to map frames back to files.
 DEBUG_GO_FLAGS     := -gcflags "all=-N -l" -ldflags "-extldflags \"-static\" $(GO_LDFLAGS)" -tags netgo
 DEBUG_DYN_GO_FLAGS := -gcflags "all=-N -l" -ldflags "$(GO_LDFLAGS)" -tags netgo
 
@@ -113,3 +118,39 @@ grpc:
 
 deps:
 	@echo "Sync go deps in Weaviate, e2e with Go client and benchmark_bm25" && go mod tidy && go mod vendor && cd test/acceptance_with_go_client/ && go mod tidy && go mod vendor && cd ../benchmark_bm25/ && go mod tidy && go mod vendor && cd ../.. && echo "Success" || echo "Failed"
+
+# Build cache hygiene
+#
+# The Go build cache is content-addressed but NOT path-independent: without
+# -trimpath the absolute source path is part of a package's cache key, so each
+# worktree gets its own full copy of the compiled dependency graph. Measured on
+# this repo, a second worktree at the same commit adds ~672 MB for a plain
+# `go build ./...` and ~6 MB once -trimpath is set. Test binaries and -race
+# variants multiply that further. Roughly 20 worktrees running builds and test
+# sweeps is enough to reach hundreds of GB.
+#
+# `make weaviate` already passes -trimpath. Bare `go test` / `go build` do not,
+# so set it for the whole toolchain if you work across many worktrees.
+
+.PHONY: cache-report
+cache-report: ## Show Go build/module cache sizes and whether -trimpath is on
+	@echo "GOCACHE     $$(go env GOCACHE)"
+	@du -sh "$$(go env GOCACHE)" 2>/dev/null || true
+	@echo "GOMODCACHE  $$(go env GOMODCACHE)"
+	@du -sh "$$(go env GOMODCACHE)" 2>/dev/null || true
+	@echo "GOFLAGS     '$$(go env GOFLAGS)'"
+	@case "$$(go env GOFLAGS)" in \
+	  *-trimpath*) echo "  -trimpath is set: worktrees share cache entries." ;; \
+	  *) echo "  -trimpath is NOT set. Every worktree keeps its own copy of the" ; \
+	     echo "  compiled dependency graph. To share them:" ; \
+	     echo "    go env -w GOFLAGS=-trimpath" ;; \
+	esac
+
+.PHONY: clean-caches
+clean-caches: ## Delete the Go build cache (frees disk, next build is cold)
+	@echo "About to delete $$(go env GOCACHE)"
+	@du -sh "$$(go env GOCACHE)" 2>/dev/null || true
+	@echo "The next build in every worktree will be cold. Ctrl-C within 5s to abort."
+	@sleep 5
+	go clean -cache
+	@echo "Done. Module cache left intact; use 'go clean -modcache' to drop that too."


### PR DESCRIPTION
## Why

Rebuilding the image and running acceptance suites is the inner loop for most work in this repo. Two things were making it slower than it needs to be, and one of them recently filled a 926 GB disk, which took the local Docker image store down with it.

All numbers below are measured, not estimated.

## 1. Docker build context: 9,115 MB -> 19.5 MB

Measured from a real dev checkout by applying Docker's own pattern-matching rules to the tree:

| | before | after |
|---|---|---|
| context size | 9,115.2 MB | 19.5 MB |
| files walked | 902,790 | 2,783 |

Two causes.

**Trailing comments do not work in `.dockerignore`.** These two lines were read as literal patterns, suffix included, and matched nothing:

```
**/*.fvecs  # sift data
**/*.png  # profiling
```

**The directories that actually grow were never listed.** Top contributors before the change:

| size | path |
|---:|---|
| 7,693 MB | `.claude/` (nested agent worktrees, full checkouts of other branches) |
| 510 MB | root files (built `weaviate` / `weaviate-server` binaries, logs) |
| 330 MB | `cmd/` (built server binary) |
| 290 MB | `.venv/` |
| 223 MB | `vendor.stale-*` |

`deprecations/` is explicitly **not** excluded and carries a comment saying so: it is a Go package imported by `usecases/config`. The image was built and run from this branch to confirm.

## 2. Image rebuild: compile step 31.4s -> 2.2s

The image build discarded its Go build cache on every run, so any source change recompiled the entire dependency graph. Mounting the cache fixes that. Measured by appending one line to `usecases/build/build.go` between builds:

| | build 1 | build 2 | build 3 |
|---|---|---|---|
| without cache mount | 31.1s | 31.4s | - |
| with cache mount | 2.2s | 2.2s | 2.2s |

The mount is keyed per `TARGETARCH` so cross-platform builds do not evict each other, and `sharing=locked` so concurrent builds of the same arch serialize. The produced binary is unchanged: the build already used `-trimpath` and the flags are untouched.

## 3. Why the build cache reached 298 GB

The Go build cache is content-addressed but **not path-independent**. Without `-trimpath`, a package's absolute source path is part of its cache key, so the same commit checked out at two different paths compiles to two different sets of entries.

Measured with an isolated `GOCACHE`, two worktrees at the same commit:

| | worktree A | worktree B adds |
|---|---:|---:|
| `go build ./usecases/backup/...`, no `-trimpath` | 455 MB | **+69 MB** |
| `go build ./usecases/backup/...`, `-trimpath` | 454 MB | +1 MB |
| `go build ./...`, no `-trimpath` | 1,935 MB | **+672 MB** |
| `go build ./...`, `-trimpath` | 1,859 MB | +6 MB |

Dependencies outside the module are shared either way. What duplicates is the module's own packages, which in this repo is most of the graph. Multiply 672 MB by ~20 active worktrees, then again by test binaries and `-race` variants and by per-commit sweeps, and hundreds of GB is the expected outcome rather than a surprise.

`make weaviate` now passes `-trimpath`, matching what the image build has always done, so Makefile-driven builds across worktrees share cache entries.

**Trade-off, stated plainly:** `-trimpath` rewrites source paths in the binary to module-relative ones, so panic traces and profiles show `github.com/weaviate/weaviate/...` instead of `/Users/you/...`, and an editor will not jump straight to them. Debug builds deliberately keep their absolute paths, since delve needs them. Nothing that ships changes, because the image build already did this.

Setting `-trimpath` for bare `go test` is a per-machine decision, so it is documented rather than forced. `make cache-report` prints cache sizes and whether the flag is on; `make clean-caches` reclaims the space with a confirmation delay.

## What is not in this PR

- **No CI workflow changes.** The cache mount only helps CI if the runner persists a buildx cache, and `-trimpath` for `go test` in CI is a team decision. Both are worth doing and should be proposed separately.
- **Worktree cleanup.** There are 393 registered worktrees consuming ~20 GB, 275 of them untouched for more than 7 days. Several are in active use, so nothing was deleted. Worth a periodic `git worktree prune` policy.
- **Setting `GOFLAGS=-trimpath` on this machine.** Documented only; other work was running against a warm cache.

## Verification

- Image builds clean from this branch (`docker build -f Dockerfile .`, exit 0) and `docker run <image> --help` works.
- `make weaviate` produces a working binary with `-trimpath`.
- `make help`, `make cache-report` both work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DaAhWqZBkx69tc4T2wupyt
