### PR TITLE
Read the dimensions bucket once per usage sweep

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -300,7 +300,7 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		return nil, err
 	}
 
-	vectorStorageSize, uncompressedVectorSize, err := shard.VectorStorageSize(ctx, lsmPath, directories)
+	vectorStorageSize, uncompressedVectorSize, dimensionalities, err := shard.VectorStorageUsage(ctx, lsmPath, directories)
 	if err != nil {
 		return nil, err
 	}
@@ -327,9 +327,20 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		IndexStorageBytes:     indexUsage,                                                                 // lsm property folders and dimensions folder
 		FullShardStorageBytes: vectorCommitLogsStorageSize + otherNonLSMFoldersStorageSize + indexUsage + uint64(objectStorageSize) + uint64(vectorStorageSize),
 	}
-	// Get vector usage for each named vector
+	shardUsage.NamedVectors, err = i.vectorUsages(ctx, shard, dimensionalities)
+	if err != nil {
+		return nil, err
+	}
+	return shardUsage, nil
+}
+
+// vectorUsages builds the usage entry of every vector index of a loaded shard.
+// dimensionalities holds what [Shard.VectorStorageUsage] already read from the
+// dimensions bucket; a target vector missing from it is read on demand.
+func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities map[string]types.Dimensionality) (types.VectorsUsage, error) {
 	vectorConfigs := i.GetVectorIndexConfigs()
-	if err = shard.ForEachVectorIndex(func(targetVector string, vectorIndex VectorIndex) error {
+	var usages types.VectorsUsage
+	if err := shard.ForEachVectorIndex(func(targetVector string, vectorIndex VectorIndex) error {
 		var vectorIndexConfig schemaConfig.VectorIndexConfig
 		if vecCfg, exists := vectorConfigs[targetVector]; exists {
 			vectorIndexConfig = vecCfg
@@ -350,9 +361,14 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 		}
 		dimInfo := GetDimensionCategory(vectorIndexConfig, isDynamicUpgraded)
 
-		dimensionality, err := shard.DimensionsUsage(ctx, targetVector)
-		if err != nil {
-			return err
+		dimensionality, ok := dimensionalities[targetVector]
+		if !ok {
+			// a target vector added since VectorStorageUsage ran would report no dimensionality
+			var err error
+			dimensionality, err = shard.DimensionsUsage(ctx, targetVector)
+			if err != nil {
+				return err
+			}
 		}
 
 		compressionRatio := vectorIndex.CompressionStats().CompressionRatio(dimensionality.Dimensions)
@@ -375,13 +391,13 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 			})
 		}
 
-		shardUsage.NamedVectors = append(shardUsage.NamedVectors, vectorUsage)
+		usages = append(usages, vectorUsage)
 		return nil
 	}); err != nil {
 		return nil, err
 	}
-	sort.Sort(shardUsage.NamedVectors)
-	return shardUsage, nil
+	sort.Sort(usages)
+	return usages, nil
 }
 
 func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig) (*types.ShardUsage, error) {

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -32,6 +32,7 @@ import (
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/cluster/router/types"
+	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/diskio"
 	"github.com/weaviate/weaviate/entities/loadlimiter"
 	"github.com/weaviate/weaviate/entities/models"
@@ -306,18 +307,28 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 				directories, err := diskio.GetSubdirNames(lsmPath)
 				require.NoError(t, err)
 
-				vectorStorageSize, uncompressed, err := lazyShard.shard.VectorStorageSize(ctx, lsmPath, directories)
+				vectorStorageSize, uncompressed, dimensionalities, err := lazyShard.shard.VectorStorageUsage(ctx, lsmPath, directories)
 				vectorStorageSize += uncompressed
 				require.NoError(t, err)
-				dimensions, err := shard.Dimensions(ctx, "")
-				require.NoError(t, err)
-				if len(tt.vectorConfigs) > 0 && tt.vectorConfigs["text"] != nil {
-					// Named vector
-					dimensions, err = shard.Dimensions(ctx, "text")
-					require.NoError(t, err)
+				targetVector := ""
+				if tt.vectorConfigs["text"] != nil {
+					targetVector = "text"
 				}
+				dimensions, err := shard.Dimensions(ctx, targetVector)
+				require.NoError(t, err)
 				objectCount, err := shard.ObjectCount(ctx)
 				require.NoError(t, err)
+
+				// the caller looks these up by target vector name
+				require.Contains(t, dimensionalities, targetVector)
+				assert.Equal(t, tt.objectCount, dimensionalities[targetVector].Count)
+				assert.Equal(t, tt.vectorDimensions, dimensionalities[targetVector].Dimensions)
+				if targetVector != "" {
+					// the legacy index is iterated too and keeps its own entry
+					require.Contains(t, dimensionalities, "")
+					assert.Equal(t, 0, dimensionalities[""].Count)
+					assert.Equal(t, 0, dimensionalities[""].Dimensions)
+				}
 
 				// For PQ compression, we need to account for the actual compression ratio
 				if len(tt.vectorConfigs) == 1 {
@@ -368,7 +379,7 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 				directories, err := diskio.GetSubdirNames(lsmPath)
 				require.NoError(t, err)
 
-				vectorStorageSize, _, err := lazyShard.shard.VectorStorageSize(ctx, lsmPath, directories)
+				vectorStorageSize, _, dimensionalities, err := lazyShard.shard.VectorStorageUsage(ctx, lsmPath, directories)
 				require.NoError(t, err)
 				dimensions, err := shard.Dimensions(ctx, "")
 				require.NoError(t, err)
@@ -378,6 +389,11 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 				assert.Equal(t, tt.expectedVectorStorageSize, vectorStorageSize)
 				assert.Equal(t, 0, dimensions, "Empty shard should have 0 dimensions")
 				assert.Equal(t, 0, objectCount, "Empty shard should have 0 objects")
+
+				// an index with no vectors written yet still gets an entry
+				require.Contains(t, dimensionalities, "")
+				assert.Equal(t, 0, dimensionalities[""].Count)
+				assert.Equal(t, 0, dimensionalities[""].Dimensions)
 
 				// Release the shard (this will flush all data to disk)
 				release()
@@ -807,15 +823,14 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	directories, err := diskio.GetSubdirNames(lsmPath)
 	require.NoError(t, err)
 
-	activeVectorStorageSize, uncompressed, err := shard.VectorStorageSize(ctx, lsmPath, directories)
+	activeVectorStorageSize, uncompressed, dimensionalities, err := shard.VectorStorageUsage(ctx, lsmPath, directories)
 	require.NoError(t, err)
 	activeVectorStorageSize += uncompressed
 	commitLogSize, _, err := shardusage.CalculateNonLSMStorage(index.path(), shard.Name())
 	require.NoError(t, err)
 	activeVectorStorageSize += int64(commitLogSize)
 
-	dimensionality, err := shard.DimensionsUsage(ctx, "")
-	require.NoError(t, err)
+	dimensionality := dimensionalities[""]
 	activeObjectCount, err := activeShard.ObjectCount(ctx)
 	require.NoError(t, err)
 	assert.Greater(t, activeVectorStorageSize, int64(0), "Active shard calculation should have vector storage size > 0")
@@ -826,6 +841,42 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	assert.Equal(t, objectCount, dimensionality.Count, "Active shard object count should match")
 	assert.Equal(t, vectorDimensions, dimensionality.Dimensions, "Active shard dimensions should match")
 	assert.Equal(t, objectCount, activeObjectCount, "Active object count should match")
+
+	// the dimensionalities read once per sweep reach the usage report unchanged
+	loadedUsage, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, class.VectorConfig)
+	require.NoError(t, err)
+	loadedTenants := 0
+	for _, tenant := range loadedUsage.Shards {
+		if tenant.Name != tenantNamePopulated {
+			continue
+		}
+		loadedTenants++
+		require.Len(t, tenant.NamedVectors, 1)
+		require.Len(t, tenant.NamedVectors[0].Dimensionalities, 1)
+		assert.Equal(t, objectCount, tenant.NamedVectors[0].Dimensionalities[0].Count)
+		assert.Equal(t, vectorDimensions, tenant.NamedVectors[0].Dimensionalities[0].Dimensions)
+	}
+	require.Equal(t, 1, loadedTenants, "loaded tenant missing from the usage report")
+
+	// a target vector added after the sweep read the dimensions bucket is absent
+	// from the captured map, and has to be read on demand instead
+	dimensionalitySources := []struct {
+		name             string
+		dimensionalities map[string]usagetypes.Dimensionality
+	}{
+		{name: "captured by the sweep", dimensionalities: dimensionalities},
+		{name: "read on demand", dimensionalities: map[string]usagetypes.Dimensionality{}},
+	}
+	for _, tt := range dimensionalitySources {
+		t.Run(tt.name, func(t *testing.T) {
+			usages, err := index.vectorUsages(ctx, shard, tt.dimensionalities)
+			require.NoError(t, err)
+			require.Len(t, usages, 1)
+			require.Len(t, usages[0].Dimensionalities, 1)
+			assert.Equal(t, objectCount, usages[0].Dimensionalities[0].Count)
+			assert.Equal(t, vectorDimensions, usages[0].Dimensionalities[0].Dimensions)
+		})
+	}
 
 	// Release the shard (this will flush all data to disk)
 	release()

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -37,6 +37,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/cluster/replication/changelog"
 	"github.com/weaviate/weaviate/cluster/router/types"
+	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/backup"
@@ -651,20 +652,23 @@ func (s *Shard) ObjectStorageSize(ctx context.Context) (int64, error) {
 	return metrics.StorageBytes, nil
 }
 
-// VectorStorageSize calculates the total storage size of all vector indexes in the shard
-func (s *Shard) VectorStorageSize(ctx context.Context, lsmPath string, directories []string) (int64, int64, error) {
+// VectorStorageUsage calculates the total storage size of all vector indexes in the shard. It also
+// returns every target vector's dimensionality, so callers need not re-read the dimensions bucket.
+func (s *Shard) VectorStorageUsage(ctx context.Context, lsmPath string, directories []string) (int64, int64, map[string]usagetypes.Dimensionality, error) {
 	vectorSize, err := shardusage.CalculateUnloadedVectorsMetrics(lsmPath, directories)
 	if err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 
 	uncompressedSize := int64(0)
+	dimensionalities := map[string]usagetypes.Dimensionality{}
 	if err := s.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
 		// Get dimensions and object count from the dimensions bucket for this specific target vector
 		dimensionality, err := s.calcTargetVectorDimensions(ctx, targetVector)
 		if err != nil {
 			return err
 		}
+		dimensionalities[targetVector] = dimensionality
 		if dimensionality.Count == 0 || dimensionality.Dimensions == 0 {
 			return nil
 		}
@@ -672,10 +676,10 @@ func (s *Shard) VectorStorageSize(ctx context.Context, lsmPath string, directori
 		uncompressedSize += int64(dimensionality.Count) * int64(dimensionality.Dimensions) * 4
 		return nil
 	}); err != nil {
-		return 0, 0, err
+		return 0, 0, nil, err
 	}
 
-	return vectorSize, uncompressedSize, nil
+	return vectorSize, uncompressedSize, dimensionalities, nil
 }
 
 func (s *Shard) isFallbackToSearchable() bool {


### PR DESCRIPTION
### What's being changed:

title, we were computing the dimensions two times.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
