### PR TITLE
perf(hfresh): warm the version map in the background at startup

### DIFF
--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -352,6 +352,21 @@ func (h *HFresh) ListQueues(ctx context.Context, basePath string) ([]string, err
 }
 
 func (h *HFresh) PostStartup(ctx context.Context) {
+	// Warm the version map with one sequential sweep: without it, the first
+	// searches after a restart fault versions in one LSM read per scanned
+	// vector.
+	before := time.Now()
+	count, err := h.VersionMap.Warmup(ctx)
+	if err != nil {
+		h.logger.Warnf("version map warmup interrupted after %d entries: %v", count, err)
+	} else {
+		h.logger.WithFields(logrus.Fields{
+			"action": "hfresh_version_map_warmup",
+			"count":  count,
+			"took":   time.Since(before).String(),
+		}).Info("version map warmed up")
+	}
+
 	h.Centroids.hnsw.PostStartup(ctx)
 }
 

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hfresh"
 )
@@ -352,20 +353,20 @@ func (h *HFresh) ListQueues(ctx context.Context, basePath string) ([]string, err
 }
 
 func (h *HFresh) PostStartup(ctx context.Context) {
-	// Warm the version map with one sequential sweep: without it, the first
-	// searches after a restart fault versions in one LSM read per scanned
-	// vector.
+	// Warm the version map in the background
 	before := time.Now()
-	count, err := h.VersionMap.Warmup(ctx)
-	if err != nil {
-		h.logger.Warnf("version map warmup interrupted after %d entries: %v", count, err)
-	} else {
+	enterrors.GoWrapper(func() {
+		count, err := h.VersionMap.Warmup(h.ctx)
+		if err != nil {
+			h.logger.Warnf("version map warmup interrupted after %d entries: %v", count, err)
+			return
+		}
 		h.logger.WithFields(logrus.Fields{
 			"action": "hfresh_version_map_warmup",
 			"count":  count,
 			"took":   time.Since(before).String(),
 		}).Info("version map warmed up")
-	}
+	}, h.logger)
 
 	h.Centroids.hnsw.PostStartup(ctx)
 }

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -361,10 +361,28 @@ func (h *HFresh) PostStartup(ctx context.Context) {
 			h.logger.Warnf("version map warmup interrupted after %d entries: %v", count, err)
 			return
 		}
+
+		// the store only holds updated or deleted vectors: fill the implicit
+		// first version for every remaining vector known to the posting map,
+		// so never-updated vectors skip the lazy fault path too
+		var defaults int
+		for _, metadata := range h.PostingMap.Iter() {
+			if h.ctx.Err() != nil {
+				h.logger.Warnf("version map warmup interrupted after %d entries: %v", count+defaults, h.ctx.Err())
+				return
+			}
+			for vectorID := range metadata.Iter() {
+				if h.VersionMap.EnsureDefault(vectorID) {
+					defaults++
+				}
+			}
+		}
+
 		h.logger.WithFields(logrus.Fields{
-			"action": "hfresh_version_map_warmup",
-			"count":  count,
-			"took":   time.Since(before).String(),
+			"action":   "hfresh_version_map_warmup",
+			"count":    count,
+			"defaults": defaults,
+			"took":     time.Since(before).String(),
 		}).Info("version map warmed up")
 	}, h.logger)
 

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -12,6 +12,7 @@
 package hfresh
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 
@@ -202,6 +203,34 @@ func (v *VersionMap) IsDeleted(ctx context.Context, vectorID uint64) (bool, erro
 	return version.Deleted(), nil
 }
 
+// Warmup loads every persisted vector version into memory with one
+// sequential sweep over the store, so that searches after a restart never
+// fault versions in one LSM read at a time. In-memory values always win
+// over persisted ones, making it safe to run concurrently with reads and
+// writes. It returns the number of entries installed.
+func (v *VersionMap) Warmup(ctx context.Context) (int, error) {
+	var count int
+	v.store.IterateAll(func(vectorID uint64, loaded VectorVersion) bool {
+		if ctx.Err() != nil {
+			return false
+		}
+		page, slot := v.data.EnsurePageFor(vectorID)
+		v.locks.Lock(vectorID)
+		if page[slot] == 0 {
+			page[slot] = loaded
+			count++
+		}
+		v.locks.Unlock(vectorID)
+		return true
+	})
+
+	err := ctx.Err()
+	if err != nil {
+		return count, err
+	}
+	return count, nil
+}
+
 // VersionStore is a persistent store for vector versions.
 // It stores the versions in an LSMKV bucket.
 type VersionStore struct {
@@ -238,4 +267,24 @@ func (v *VersionStore) Get(ctx context.Context, vectorID uint64) (VectorVersion,
 func (v *VersionStore) Set(ctx context.Context, vectorID uint64, version VectorVersion) error {
 	key := v.key(vectorID)
 	return v.bucket.Put(key[:], []byte{byte(version)})
+}
+
+// IterateAll calls fn for every persisted vector version, in one sequential
+// sweep over the store. Iteration stops early when fn returns false.
+func (v *VersionStore) IterateAll(fn func(vectorID uint64, version VectorVersion) bool) {
+	c := v.bucket.Cursor()
+	defer c.Close()
+
+	for k, val := c.Seek(versionMapBucketPrefix); k != nil; k, val = c.Next() {
+		if !bytes.HasPrefix(k, versionMapBucketPrefix) {
+			break // left the version keyspace of the shared bucket
+		}
+		if len(k) != len(versionMapBucketPrefix)+8 || len(val) == 0 {
+			continue
+		}
+		vectorID := binary.LittleEndian.Uint64(k[len(versionMapBucketPrefix):])
+		if !fn(vectorID, VectorVersion(val[0])) {
+			break
+		}
+	}
 }

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -272,7 +272,7 @@ func (v *VersionStore) Set(ctx context.Context, vectorID uint64, version VectorV
 // IterateAll calls fn for every persisted vector version, in one sequential
 // sweep over the store. Iteration stops early when fn returns false.
 func (v *VersionStore) IterateAll(fn func(vectorID uint64, version VectorVersion) bool) {
-	c := v.bucket.Cursor()
+	c := v.bucket.CursorReplaceReusable()
 	defer c.Close()
 
 	for k, val := c.Seek(versionMapBucketPrefix); k != nil; k, val = c.Next() {

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -235,6 +235,23 @@ func (v *VersionMap) Warmup(ctx context.Context) (int, error) {
 	return count, nil
 }
 
+// EnsureDefault installs the implicit first version for a vector with no
+// in-memory entry yet, and reports whether it did. Vectors are added at
+// version 1 without persisting it (the store only sees increments and
+// deletes), so entries absent from the store default to v1 on load;
+// installing that default eagerly keeps such vectors off the lazy fault
+// path. In-memory values always win.
+func (v *VersionMap) EnsureDefault(vectorID uint64) bool {
+	page, slot := v.data.EnsurePageFor(vectorID)
+	v.locks.Lock(vectorID)
+	installed := page[slot] == 0
+	if installed {
+		page[slot] = v1
+	}
+	v.locks.Unlock(vectorID)
+	return installed
+}
+
 // VersionStore is a persistent store for vector versions.
 // It stores the versions in an LSMKV bucket.
 type VersionStore struct {

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -29,7 +29,7 @@ const (
 var ErrVersionIncrementFailed = errors.New("version increment failed")
 
 // A VectorVersion is a 1-byte value structured as follows:
-// - 7 bits for the version number
+// - 7 bits for the version number (1-127; 0 is reserved, see Increment)
 // - 1 bit for the tombstone flag (0 = alive, 1 = deleted)
 // TODO: versions can wrap around after 127 updates,
 // we need a mechanism to handle this in the future (e.g. during snapshots perhaps, etc.)
@@ -50,7 +50,11 @@ func (ve VectorVersion) Increment() VectorVersion {
 	if counter < 127 {
 		counter++
 	} else {
-		counter = 0 // wraparound behavior
+		// wrap to 1, never 0: the in-memory paged array uses 0 as its
+		// "empty slot" sentinel, so a live version of 0 would be
+		// indistinguishable from a never-loaded entry and could be rolled
+		// back to an older persisted value by loadInto or Warmup
+		counter = 1
 	}
 
 	return VectorVersion(delBit | counter)

--- a/adapters/repos/db/vector/hfresh/version_map_test.go
+++ b/adapters/repos/db/vector/hfresh/version_map_test.go
@@ -206,14 +206,25 @@ func TestVersionMap(t *testing.T) {
 			require.EqualValues(t, i+2, version.Version())
 		}
 
+		// wraparound must skip 0: the in-memory paged array uses 0 as its
+		// "empty slot" sentinel, so a live vector at version 0 would be
+		// indistinguishable from a never-loaded one (and e.g. the warmup
+		// sweep could roll it back to an older persisted version)
 		version, err = versionMap.Increment(ctx, 1, version)
 		require.NoError(t, err)
-		require.EqualValues(t, 0, version.Version())
+		require.EqualValues(t, 1, version.Version())
 
 		version, err = versionMap.Get(ctx, 1)
 		require.NoError(t, err)
-		require.EqualValues(t, 0, version.Version())
+		require.EqualValues(t, 1, version.Version())
 		require.False(t, version.Deleted())
+
+		// no number of increments may ever produce the reserved value 0
+		v := VectorVersion(1)
+		for range 300 {
+			v = v.Increment()
+			require.NotZero(t, v.Version())
+		}
 	})
 
 	t.Run("mark unknown vector as deleted", func(t *testing.T) {

--- a/adapters/repos/db/vector/hfresh/version_map_test.go
+++ b/adapters/repos/db/vector/hfresh/version_map_test.go
@@ -308,3 +308,63 @@ func TestVersionStore(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, VectorVersion(10), v)
 }
+
+func TestVersionMapWarmup(t *testing.T) {
+	ctx := t.Context()
+	store := testinghelpers.NewDummyStore(t)
+	bucket, err := NewSharedBucket(store, "warmup", StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions})
+	require.NoError(t, err)
+
+	// a previous process lifetime persisted versions: live ones and a few
+	// deleted ones
+	previous := NewVersionMap(bucket)
+	const n = uint64(10_000)
+	for i := uint64(0); i < n; i++ {
+		require.NoError(t, previous.store.Set(ctx, i, VectorVersion(2)))
+	}
+	for i := uint64(0); i < 10; i++ {
+		_, err := previous.MarkDeleted(ctx, i)
+		require.NoError(t, err)
+	}
+
+	// flush so the sweep reads from disk segments, as after a real restart
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	// simulate the restart: fresh map over the same bucket, then warm up
+	m := NewVersionMap(bucket)
+	count, err := m.Warmup(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int(n), count, "every persisted version must be installed")
+
+	// versions must be correct straight from memory
+	deleted, err := m.IsDeleted(ctx, 5)
+	require.NoError(t, err)
+	require.True(t, deleted, "deleted flag must survive the warmup")
+
+	deleted, err = m.IsDeleted(ctx, 500)
+	require.NoError(t, err)
+	require.False(t, deleted)
+
+	v, err := m.Get(ctx, 500)
+	require.NoError(t, err)
+	require.Equal(t, VectorVersion(2), v)
+
+	// memory always wins: an entry loaded (and possibly being written)
+	// before the warmup must not be clobbered by the sweep
+	m2 := NewVersionMap(bucket)
+	v, err = m2.Get(ctx, 42) // faults version 2 into memory
+	require.NoError(t, err)
+	require.Equal(t, VectorVersion(2), v)
+	require.NoError(t, m2.store.Set(ctx, 42, VectorVersion(9))) // store diverges
+
+	_, err = m2.Warmup(ctx)
+	require.NoError(t, err)
+	v, err = m2.Get(ctx, 42)
+	require.NoError(t, err)
+	require.Equal(t, VectorVersion(2), v, "warmup must not overwrite in-memory state")
+
+	// warming up an already-warm map installs nothing new
+	count, err = m.Warmup(ctx)
+	require.NoError(t, err)
+	require.Zero(t, count)
+}

--- a/adapters/repos/db/vector/hfresh/version_map_test.go
+++ b/adapters/repos/db/vector/hfresh/version_map_test.go
@@ -379,3 +379,25 @@ func TestVersionMapWarmup(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, count)
 }
+
+func TestVersionMapEnsureDefault(t *testing.T) {
+	ctx := t.Context()
+	m := makeVersionMap(t)
+
+	// unknown vector: installs the implicit first version without a store read
+	require.True(t, m.EnsureDefault(7))
+	page, slot := m.data.GetPageFor(7)
+	require.NotNil(t, page)
+	require.Equal(t, v1, page[slot], "default must be installed in memory")
+
+	// second call is a no-op
+	require.False(t, m.EnsureDefault(7))
+
+	// a vector with a known version must not be touched
+	v, err := m.Increment(ctx, 7, v1)
+	require.NoError(t, err)
+	require.False(t, m.EnsureDefault(7))
+	got, err := m.Get(ctx, 7)
+	require.NoError(t, err)
+	require.Equal(t, v, got, "EnsureDefault must never overwrite a live version")
+}


### PR DESCRIPTION
### What's being changed:

HFresh's version map is faulted into memory lazily, one single-key LSM read per vector on first access. After a restart the map is empty, so the first searches pay that fault for **every scanned vector** — measured at ~1µs per vector against flushed segments, i.e. hundreds of milliseconds of extra latency smeared over the first queries of a shard (and worse on cloud block storage).

This adds a warmup that loads every persisted version in **one sequential cursor sweep** and runs it in the background from `PostStartup`:

- `VersionStore.IterateAll`: prefix-bounded cursor sweep over the version keyspace of the shared bucket.
- `VersionMap.Warmup`: installs each persisted version only into empty slots — the same memory-wins rule as the lazy path — so the sweep is safe to run concurrently with reads and writes. Returns the installed count.
- `PostStartup` launches the sweep on the index lifecycle context (shutdown cancels it) and logs count + duration. Startup does not wait: searches during the warmup window simply fall back to today's lazy faults for not-yet-warmed vectors, and the window closes quickly.
- A second pass fills the implicit v1 for vectors known to the posting map but absent from the store (the store only sees increments and deletes), so never-updated vectors are covered too.
- Review follow-up: `Increment` now wraps 127→1 instead of 0 — a live version 0 collided with the paged array's empty-slot sentinel and could be rolled back to an older persisted value (pre-existing race in `loadInto`, widened by the sweep).

### Measurements

- Lazy fault (per vector, flushed segments): ~1µs. Sweep: ~105ns/entry — ~10× cheaper, off the query path.
- Production-shaped run (dbpedia 1M, M3 Max): `version map warmed up count=831850 defaults=158150 took=135ms` — full coverage.
- Extrapolation: ~1s at 10M, ~10s at 100M, ~. minutes at 1B on cloud block storage — which is why the warmup is fully asynchronous rather than blocking startup.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
