### PR TITLE
Unmarshal namespace snapshot outside of lock

### DIFF
--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -368,26 +368,32 @@ func (c *Controller) Snapshot() ([]byte, error) {
 	return json.Marshal(c.namespaces)
 }
 
-// Restore replaces the current state with the snapshot contents. A nil or
-// empty snapshot leaves state empty (fresh bootstrap). Unknown JSON fields
+// Restore replaces the current state with the snapshot contents. A nil,
+// empty or "null" snapshot leaves state empty (fresh bootstrap). Unknown JSON fields
 // are tolerated. Entries with empty State are normalized to
 // [cmd.NamespaceStateActive]; entries with an unknown State return an
 // error so a future binary's snapshot is not silently mis-classified.
 // Entries missing the single HomeNodes entry are also rejected — there is
 // no migration path from a pre-HomeNodes snapshot.
 func (c *Controller) Restore(snapshot []byte) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if len(snapshot) == 0 {
+		c.mu.Lock()
+		defer c.mu.Unlock()
 		c.namespaces = make(map[string]*cmd.Namespace)
 		return nil
 	}
 
+	// Decoding and validating scale with the snapshot size and touch only the
+	// local map, so they run off-lock: holding the write lock across them
+	// blocks every reader for the whole install.
 	restored := make(map[string]*cmd.Namespace)
 	if err := json.Unmarshal(snapshot, &restored); err != nil {
 		c.logger.Errorf("restoring namespaces from snapshot failed with: %v", err)
 		return err
+	}
+	// A "null" snapshot decodes to a nil map; writing into it would panic.
+	if restored == nil {
+		restored = make(map[string]*cmd.Namespace)
 	}
 	for name, ns := range restored {
 		if ns == nil {
@@ -406,7 +412,11 @@ func (c *Controller) Restore(snapshot []byte) error {
 			return fmt.Errorf("namespace %q has unknown state %q in snapshot", name, ns.State)
 		}
 	}
+
+	c.mu.Lock()
 	c.namespaces = restored
+	c.mu.Unlock()
+
 	c.logger.Info("successfully restored namespaces from snapshot")
 	return nil
 }

--- a/usecases/namespaces/controller_test.go
+++ b/usecases/namespaces/controller_test.go
@@ -654,6 +654,52 @@ func TestController_RestoreRejectsUnknownState(t *testing.T) {
 	}
 }
 
+// TestController_RestoreEmptyLeavesControllerWritable covers every snapshot
+// that carries no namespaces. "null" is the one Snapshot emits for a nil map,
+// and it decodes to a nil map rather than an empty one, so restoring it must
+// still leave a map the next Create can write into.
+func TestController_RestoreEmptyLeavesControllerWritable(t *testing.T) {
+	tests := []struct {
+		name string
+		snap []byte
+	}{
+		{name: "null", snap: []byte("null")},
+		{name: "empty object", snap: []byte("{}")},
+		{name: "empty snapshot", snap: []byte{}},
+		{name: "nil snapshot", snap: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestController(t)
+			require.NoError(t, c.Create(cmd.Namespace{Name: "stale", HomeNodes: []string{"node-1"}}, createIndex))
+
+			require.NoError(t, c.Restore(tc.snap))
+			assert.Equal(t, 0, c.Count())
+
+			require.NoError(t, c.Create(cmd.Namespace{Name: "customer1", HomeNodes: []string{"node-1"}}, createIndex))
+			assert.Equal(t, 1, c.Count())
+			assert.True(t, nsExists(c, "customer1"))
+		})
+	}
+}
+
+// TestController_SnapshotRestoreRoundTripAfterNull pins the propagation path:
+// a controller that restored "null" must not emit a snapshot that installs a
+// nil map on the next node to restore it.
+func TestController_SnapshotRestoreRoundTripAfterNull(t *testing.T) {
+	c := newTestController(t)
+	require.NoError(t, c.Restore([]byte("null")))
+
+	snap, err := c.Snapshot()
+	require.NoError(t, err)
+
+	other := newTestController(t)
+	require.NoError(t, other.Restore(snap))
+	require.NoError(t, other.Create(cmd.Namespace{Name: "customer1", HomeNodes: []string{"node-1"}}, createIndex))
+	assert.Equal(t, 1, other.Count())
+}
+
 func TestController_Get(t *testing.T) {
 	c := newTestController(t)
 	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1", HomeNodes: []string{"node-1"}}, createIndex))
@@ -771,29 +817,46 @@ func TestController_Restore(t *testing.T) {
 			wantNames: []string{"customer1"},
 		},
 		{
-			name:    "malformed JSON returns an error",
-			snap:    []byte("not-json"),
-			wantErr: true,
+			// Every rejected snapshot leaves the previous state in place:
+			// validation runs on the decoded map before it is swapped in.
+			name:      "malformed JSON returns an error",
+			seed:      []string{"stale"},
+			snap:      []byte("not-json"),
+			wantErr:   true,
+			wantNames: []string{"stale"},
 		},
 		{
 			// Pre-home_node snapshots have no migration path; rather than
 			// loading a broken entry that would fail at first placement
 			// attempt, Restore rejects up front.
-			name:    "missing HomeNodes is rejected",
-			snap:    []byte(`{"customer1":{"Name":"customer1","State":"active"}}`),
-			wantErr: true,
+			name:      "missing HomeNodes is rejected",
+			seed:      []string{"stale"},
+			snap:      []byte(`{"customer1":{"Name":"customer1","State":"active"}}`),
+			wantErr:   true,
+			wantNames: []string{"stale"},
 		},
 		{
-			name:    "empty HomeNodes entry is rejected",
-			snap:    []byte(`{"customer1":{"Name":"customer1","HomeNodes":[""],"State":"active"}}`),
-			wantErr: true,
+			name:      "empty HomeNodes entry is rejected",
+			seed:      []string{"stale"},
+			snap:      []byte(`{"customer1":{"Name":"customer1","HomeNodes":[""],"State":"active"}}`),
+			wantErr:   true,
+			wantNames: []string{"stale"},
 		},
 		{
 			// A truncated or hand-edited snapshot unmarshals a null entry to
 			// a nil pointer; it must be rejected rather than dereferenced.
-			name:    "null entry is rejected",
-			snap:    []byte(`{"customer1":null}`),
-			wantErr: true,
+			name:      "null entry is rejected",
+			seed:      []string{"stale"},
+			snap:      []byte(`{"customer1":null}`),
+			wantErr:   true,
+			wantNames: []string{"stale"},
+		},
+		{
+			name:      "unknown state is rejected",
+			seed:      []string{"stale"},
+			snap:      []byte(`{"customer1":{"Name":"customer1","HomeNodes":["node-1"],"State":"exploding"}}`),
+			wantErr:   true,
+			wantNames: []string{"stale"},
 		},
 	}
 
@@ -806,9 +869,9 @@ func TestController_Restore(t *testing.T) {
 			err := c.Restore(tc.snap)
 			if tc.wantErr {
 				require.Error(t, err)
-				return
+			} else {
+				require.NoError(t, err)
 			}
-			require.NoError(t, err)
 			assert.ElementsMatch(t, tc.wantNames, namesOf(c.List()))
 		})
 	}


### PR DESCRIPTION
### What's being changed:

Fixes https://github.com/weaviate/dirk-claude-issues/issues/1

Small optimization to not block readers during unmarshal

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
