### PR TITLE
Complete updateIndexTenants when one tenant fails

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -441,7 +441,15 @@ func (m *Migrator) updateIndexTenantsStatus(ctx context.Context, idx *Index,
 
 		// a shut index or a dead context fails every tenant that is left, so
 		// carrying on only compounds the same error once per tenant
-		if errors.Is(err, errAlreadyShutdown) || ctx.Err() != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			// a tenant already in the wanted state returns nil, so without this the
+			// break reports success while the remaining tenants went unreconciled
+			if !errors.Is(err, ctxErr) {
+				ec.AddWrapf(ctxErr, "reconcile tenants of index %s", idx.ID())
+			}
+			break
+		}
+		if errors.Is(err, errAlreadyShutdown) {
 			break
 		}
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -428,29 +428,14 @@ func (m *Migrator) updateIndexTenantsStatus(ctx context.Context, idx *Index,
 			continue
 		}
 
-		var err error
 		if phys.Status == models.TenantActivityStatusHOT {
 			// Only load the tenant if activity status == HOT.
-			err = idx.LoadLocalShard(ctx, shardName, false)
-			ec.AddWrapf(err, "add missing tenant shard %s during update index", shardName)
+			ec.AddWrapf(idx.LoadLocalShard(ctx, shardName, false),
+				"add missing tenant shard %s during update index", shardName)
 		} else {
 			// Shutdown the tenant if activity status != HOT
-			err = idx.UnloadLocalShard(ctx, shardName)
-			ec.AddWrapf(err, "shutdown tenant shard %s during update index", shardName)
-		}
-
-		// a shut index or a dead context fails every tenant that is left, so
-		// carrying on only compounds the same error once per tenant
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			// a tenant already in the wanted state returns nil, so without this the
-			// break reports success while the remaining tenants went unreconciled
-			if !errors.Is(err, ctxErr) {
-				ec.AddWrapf(ctxErr, "reconcile tenants of index %s", idx.ID())
-			}
-			break
-		}
-		if errors.Is(err, errAlreadyShutdown) {
-			break
+			ec.AddWrapf(idx.UnloadLocalShard(ctx, shardName),
+				"shutdown tenant shard %s during update index", shardName)
 		}
 	}
 	return ec.ToErrorLimited(maxReportedErrors)

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -406,34 +406,46 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 func (m *Migrator) updateIndexTenants(ctx context.Context, idx *Index,
 	incomingSS *sharding.State,
 ) error {
-	if err := m.updateIndexTenantsStatus(ctx, idx, incomingSS); err != nil {
-		return err
-	}
-	return m.updateIndexDeleteTenants(ctx, idx, incomingSS)
+	// the delete runs even when the status update fails: the status update only
+	// touches tenants incomingSS lists and the delete only tenants it omits, and
+	// skipping the delete leaves a tenant dropped from the schema on disk
+	ec := errorcompounder.New()
+	ec.Add(m.updateIndexTenantsStatus(ctx, idx, incomingSS))
+	ec.Add(m.updateIndexDeleteTenants(ctx, idx, incomingSS))
+	return ec.ToError()
 }
 
 func (m *Migrator) updateIndexTenantsStatus(ctx context.Context, idx *Index,
 	incomingSS *sharding.State,
 ) error {
 	nodeName := m.db.schemaGetter.NodeName()
+
+	// one tenant's failure must not skip the rest: Physical iterates in map
+	// order, so which tenants were reconciled would otherwise vary per run
+	ec := errorcompounder.New()
 	for shardName, phys := range incomingSS.Physical {
 		if !phys.IsLocalShard(nodeName) {
 			continue
 		}
 
+		var err error
 		if phys.Status == models.TenantActivityStatusHOT {
 			// Only load the tenant if activity status == HOT.
-			if err := idx.LoadLocalShard(ctx, shardName, false); err != nil {
-				return fmt.Errorf("add missing tenant shard %s during update index: %w", shardName, err)
-			}
+			err = idx.LoadLocalShard(ctx, shardName, false)
+			ec.AddWrapf(err, "add missing tenant shard %s during update index", shardName)
 		} else {
 			// Shutdown the tenant if activity status != HOT
-			if err := idx.UnloadLocalShard(ctx, shardName); err != nil {
-				return fmt.Errorf("shutdown tenant shard %s during update index: %w", shardName, err)
-			}
+			err = idx.UnloadLocalShard(ctx, shardName)
+			ec.AddWrapf(err, "shutdown tenant shard %s during update index", shardName)
+		}
+
+		// a shut index or a dead context fails every tenant that is left, so
+		// carrying on only compounds the same error once per tenant
+		if errors.Is(err, errAlreadyShutdown) || ctx.Err() != nil {
+			break
 		}
 	}
-	return nil
+	return ec.ToErrorLimited(maxReportedErrors)
 }
 
 func (m *Migrator) updateIndexDeleteTenants(ctx context.Context,

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -160,6 +160,15 @@ func coldTenant(name string) sharding.Physical {
 	}
 }
 
+// hotTenant is a local tenant the reconcile is meant to load.
+func hotTenant(name string) sharding.Physical {
+	return sharding.Physical{
+		Name:           name,
+		BelongsToNodes: []string{"node1"},
+		Status:         models.TenantActivityStatusHOT,
+	}
+}
+
 // shardDirWithData writes the on-disk directory a tenant owns, so whether the
 // reconcile removed it is observable without a real shard.
 func shardDirWithData(t *testing.T, idx *Index, name string) string {
@@ -195,10 +204,9 @@ func droppableShard(t *testing.T, idx *Index, name string, dropErr error) string
 // and every other tenant still has to be attempted, or which ones were reached
 // depends on the order Physical happens to iterate in.
 //
-// A shard whose shutdown fails is what drives a per-tenant failure here, since
-// it needs no more than the mock the package already has.
+// A per-tenant failure is driven either by a shard whose shutdown fails, for the
+// unload branch, or by an index that refuses every load, for the load branch.
 func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
-	ctx := context.Background()
 	shutdownRefused := errors.New("shutdown refused")
 	dropRefused := errors.New("drop refused")
 
@@ -208,16 +216,22 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 		incoming map[string]sharding.Physical
 		// failingUnload are loaded shards, listed in incoming, whose shutdown fails.
 		failingUnload []string
+		// refuseLoad fails the load of every tenant the incoming state lists as HOT.
+		refuseLoad bool
 		// resident are loaded shards absent from incoming, so the delete claims them.
 		resident []string
 		// residentDropErr fails every resident's drop, leaving its directory.
 		residentDropErr error
 		// closed shuts the index, which fails every tenant for the same reason.
 		closed bool
+		// cancelCtx hands the reconcile an already cancelled context.
+		cancelCtx bool
 		// wantErrFor is a substring of the returned error for every failure expected.
 		wantErrFor []string
-		// wantReported, when set, is how many tenants the error may name.
-		wantReported int
+		// wantErrIs, when set, is an error the returned error must still unwrap to.
+		wantErrIs error
+		// wantOnce, when set, is a substring the error must contain exactly once.
+		wantOnce string
 	}{
 		{
 			name:          "a failing tenant still runs the tenant delete",
@@ -251,15 +265,58 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 			},
 		},
 		{
+			name:       "a failing tenant load still runs the tenant delete",
+			incoming:   map[string]sharding.Physical{"hot1": hotTenant("hot1")},
+			refuseLoad: true,
+			resident:   []string{"gone1"},
+			wantErrFor: []string{"add missing tenant shard hot1"},
+		},
+		{
+			name: "every failing tenant load is reported, not just the first",
+			incoming: map[string]sharding.Physical{
+				"hot1": hotTenant("hot1"), "hot2": hotTenant("hot2"), "hot3": hotTenant("hot3"),
+			},
+			refuseLoad: true,
+			resident:   []string{"gone1"},
+			wantErrFor: []string{
+				"add missing tenant shard hot1",
+				"add missing tenant shard hot2",
+				"add missing tenant shard hot3",
+			},
+		},
+		{
 			// The compounding is per tenant, but a shut index fails all of them
 			// for one reason, so it is reported once rather than per tenant.
 			name: "a shut index stops after the first tenant",
 			incoming: map[string]sharding.Physical{
 				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
 			},
-			closed:       true,
-			wantErrFor:   []string{"shutdown tenant shard"},
-			wantReported: 1,
+			closed:     true,
+			wantErrFor: []string{"shutdown tenant shard"},
+			wantOnce:   "shutdown tenant shard",
+		},
+		{
+			// A tenant already in the wanted state reconciles without an error, so
+			// the cancellation is the only thing left to report the skipped ones by.
+			name: "a cancelled context is reported even when no tenant failed",
+			incoming: map[string]sharding.Physical{
+				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
+			},
+			cancelCtx:  true,
+			wantErrFor: []string{"reconcile tenants of index"},
+			wantErrIs:  context.Canceled,
+			wantOnce:   "reconcile tenants of index",
+		},
+		{
+			name: "a cancelled context is reported beside the tenant that failed",
+			incoming: map[string]sharding.Physical{
+				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
+			},
+			failingUnload: []string{"cold1", "cold2", "cold3"},
+			cancelCtx:     true,
+			wantErrFor:    []string{"shutdown tenant shard", "reconcile tenants of index"},
+			wantErrIs:     context.Canceled,
+			wantOnce:      "shutdown tenant shard",
 		},
 		{
 			name:     "no tenants leaves the delete to claim the residents",
@@ -277,9 +334,25 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
 			idx, _ := newDropTestIndex(t)
 			sg := schemaUC.NewMockSchemaGetter(t)
 			sg.EXPECT().NodeName().Return("node1").Maybe()
+			sg.EXPECT().ReadOnlyClass(mock.Anything).
+				Return(&models.Class{Class: idx.Config.ClassName.String()}).Maybe()
+			idx.getSchema = sg
+			if tt.refuseLoad {
+				metrics, err := NewMetrics(idx.logger, nil, idx.Config.ClassName.String(), "")
+				require.NoError(t, err)
+				idx.metrics = metrics
+				idx.allocChecker = failingAllocChecker{}
+			}
 			m := &Migrator{db: &DB{schemaGetter: sg}, logger: idx.logger}
 
 			residentDirs := make(map[string]string, len(tt.resident))
@@ -309,9 +382,11 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 					require.ErrorContains(t, err, want)
 				}
 			}
-			if tt.wantReported > 0 {
-				require.Equal(t, tt.wantReported,
-					strings.Count(err.Error(), "shutdown tenant shard"),
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+			}
+			if tt.wantOnce != "" {
+				require.Equal(t, 1, strings.Count(err.Error(), tt.wantOnce),
 					"a failure that fails every tenant must be reported once")
 			}
 

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -228,10 +227,6 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 		cancelCtx bool
 		// wantErrFor is a substring of the returned error for every failure expected.
 		wantErrFor []string
-		// wantErrIs, when set, is an error the returned error must still unwrap to.
-		wantErrIs error
-		// wantOnce, when set, is a substring the error must contain exactly once.
-		wantOnce string
 	}{
 		{
 			name:          "a failing tenant still runs the tenant delete",
@@ -285,38 +280,40 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 			},
 		},
 		{
-			// The compounding is per tenant, but a shut index fails all of them
-			// for one reason, so it is reported once rather than per tenant.
-			name: "a shut index stops after the first tenant",
+			// A shut index fails every tenant for the same reason, and each one is
+			// still attempted rather than the reconcile stopping at the first.
+			name: "a shut index reports every tenant",
 			incoming: map[string]sharding.Physical{
 				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
 			},
-			closed:     true,
-			wantErrFor: []string{"shutdown tenant shard"},
-			wantOnce:   "shutdown tenant shard",
+			closed: true,
+			wantErrFor: []string{
+				"shutdown tenant shard cold1",
+				"shutdown tenant shard cold2",
+				"shutdown tenant shard cold3",
+			},
 		},
 		{
-			// A tenant already in the wanted state reconciles without an error, so
-			// the cancellation is the only thing left to report the skipped ones by.
-			name: "a cancelled context is reported even when no tenant failed",
+			// Nothing is skipped on a cancelled context, so there is no separate
+			// cancellation to report once every tenant is in the wanted state.
+			name: "a cancelled context alone does not fail the reconcile",
 			incoming: map[string]sharding.Physical{
 				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
 			},
-			cancelCtx:  true,
-			wantErrFor: []string{"reconcile tenants of index"},
-			wantErrIs:  context.Canceled,
-			wantOnce:   "reconcile tenants of index",
+			cancelCtx: true,
 		},
 		{
-			name: "a cancelled context is reported beside the tenant that failed",
+			name: "a cancelled context still attempts every tenant",
 			incoming: map[string]sharding.Physical{
 				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
 			},
 			failingUnload: []string{"cold1", "cold2", "cold3"},
 			cancelCtx:     true,
-			wantErrFor:    []string{"shutdown tenant shard", "reconcile tenants of index"},
-			wantErrIs:     context.Canceled,
-			wantOnce:      "shutdown tenant shard",
+			wantErrFor: []string{
+				"shutdown tenant shard cold1",
+				"shutdown tenant shard cold2",
+				"shutdown tenant shard cold3",
+			},
 		},
 		{
 			name:     "no tenants leaves the delete to claim the residents",
@@ -381,13 +378,6 @@ func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
 				for _, want := range tt.wantErrFor {
 					require.ErrorContains(t, err, want)
 				}
-			}
-			if tt.wantErrIs != nil {
-				require.ErrorIs(t, err, tt.wantErrIs)
-			}
-			if tt.wantOnce != "" {
-				require.Equal(t, 1, strings.Count(err.Error(), tt.wantOnce),
-					"a failure that fails every tenant must be reported once")
 			}
 
 			for name, dir := range keptDirs {

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -17,7 +17,9 @@ import (
 	"hash/crc32"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -145,6 +147,184 @@ func TestUpdateIndexTenants(t *testing.T) {
 
 			// Verify the shard status
 			require.Equal(t, tt.expectedStatus, shard.GetStatus())
+		})
+	}
+}
+
+// coldTenant is a local tenant the reconcile is meant to unload.
+func coldTenant(name string) sharding.Physical {
+	return sharding.Physical{
+		Name:           name,
+		BelongsToNodes: []string{"node1"},
+		Status:         models.TenantActivityStatusCOLD,
+	}
+}
+
+// shardDirWithData writes the on-disk directory a tenant owns, so whether the
+// reconcile removed it is observable without a real shard.
+func shardDirWithData(t *testing.T, idx *Index, name string) string {
+	t.Helper()
+
+	dir := shardPath(idx.path(), name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "objects.db"), []byte("data"), 0o644))
+	return dir
+}
+
+// droppableShard registers a shard whose drop removes its directory, standing in
+// for a tenant the incoming state no longer lists. dropErr, when set, fails the
+// drop and leaves the directory behind.
+func droppableShard(t *testing.T, idx *Index, name string, dropErr error) string {
+	t.Helper()
+
+	dir := shardDirWithData(t, idx, name)
+	shard := NewMockShardLike(t)
+	shard.EXPECT().drop(false).RunAndReturn(func(bool) error {
+		if dropErr != nil {
+			return dropErr
+		}
+		return os.RemoveAll(dir)
+	}).Maybe()
+	shard.EXPECT().ID().Return(name).Maybe()
+	idx.shards.Store(name, shard)
+	return dir
+}
+
+// A tenant that cannot be reconciled must not stop the reconcile: the delete
+// still has to run, or a tenant dropped from the schema keeps its data on disk,
+// and every other tenant still has to be attempted, or which ones were reached
+// depends on the order Physical happens to iterate in.
+//
+// A shard whose shutdown fails is what drives a per-tenant failure here, since
+// it needs no more than the mock the package already has.
+func TestUpdateIndexTenantsCompletesDespiteFailures(t *testing.T) {
+	ctx := context.Background()
+	shutdownRefused := errors.New("shutdown refused")
+	dropRefused := errors.New("drop refused")
+
+	tests := []struct {
+		name string
+		// incoming is the sharding state the reconcile is handed.
+		incoming map[string]sharding.Physical
+		// failingUnload are loaded shards, listed in incoming, whose shutdown fails.
+		failingUnload []string
+		// resident are loaded shards absent from incoming, so the delete claims them.
+		resident []string
+		// residentDropErr fails every resident's drop, leaving its directory.
+		residentDropErr error
+		// closed shuts the index, which fails every tenant for the same reason.
+		closed bool
+		// wantErrFor is a substring of the returned error for every failure expected.
+		wantErrFor []string
+		// wantReported, when set, is how many tenants the error may name.
+		wantReported int
+	}{
+		{
+			name:          "a failing tenant still runs the tenant delete",
+			incoming:      map[string]sharding.Physical{"cold1": coldTenant("cold1")},
+			failingUnload: []string{"cold1"},
+			resident:      []string{"gone1"},
+			wantErrFor:    []string{"shutdown tenant shard cold1"},
+		},
+		{
+			name: "every failing tenant is reported, not just the first",
+			incoming: map[string]sharding.Physical{
+				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
+			},
+			failingUnload: []string{"cold1", "cold2", "cold3"},
+			resident:      []string{"gone1", "gone2"},
+			wantErrFor: []string{
+				"shutdown tenant shard cold1",
+				"shutdown tenant shard cold2",
+				"shutdown tenant shard cold3",
+			},
+		},
+		{
+			name:            "a failing delete is reported beside the failing tenant",
+			incoming:        map[string]sharding.Physical{"cold1": coldTenant("cold1")},
+			failingUnload:   []string{"cold1"},
+			resident:        []string{"gone1"},
+			residentDropErr: dropRefused,
+			wantErrFor: []string{
+				"shutdown tenant shard cold1",
+				"drop tenant shards",
+			},
+		},
+		{
+			// The compounding is per tenant, but a shut index fails all of them
+			// for one reason, so it is reported once rather than per tenant.
+			name: "a shut index stops after the first tenant",
+			incoming: map[string]sharding.Physical{
+				"cold1": coldTenant("cold1"), "cold2": coldTenant("cold2"), "cold3": coldTenant("cold3"),
+			},
+			closed:       true,
+			wantErrFor:   []string{"shutdown tenant shard"},
+			wantReported: 1,
+		},
+		{
+			name:     "no tenants leaves the delete to claim the residents",
+			incoming: map[string]sharding.Physical{},
+			resident: []string{"gone1"},
+		},
+		{
+			name: "a tenant on another node is not touched here",
+			incoming: map[string]sharding.Physical{
+				"other": {Name: "other", BelongsToNodes: []string{"node2"}},
+			},
+			resident: []string{"gone1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, _ := newDropTestIndex(t)
+			sg := schemaUC.NewMockSchemaGetter(t)
+			sg.EXPECT().NodeName().Return("node1").Maybe()
+			m := &Migrator{db: &DB{schemaGetter: sg}, logger: idx.logger}
+
+			residentDirs := make(map[string]string, len(tt.resident))
+			for _, name := range tt.resident {
+				residentDirs[name] = droppableShard(t, idx, name, tt.residentDropErr)
+			}
+			for _, name := range tt.failingUnload {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().Shutdown(mock.Anything).Return(shutdownRefused).Maybe()
+				idx.shards.Store(name, shard)
+			}
+			// A tenant incoming still lists must survive the delete, whatever the
+			// status update did with it.
+			keptDirs := make(map[string]string, len(tt.incoming))
+			for name := range tt.incoming {
+				keptDirs[name] = shardDirWithData(t, idx, name)
+			}
+			idx.closed = tt.closed
+
+			err := m.updateIndexTenants(ctx, idx, &sharding.State{Physical: tt.incoming})
+
+			if len(tt.wantErrFor) == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrFor {
+					require.ErrorContains(t, err, want)
+				}
+			}
+			if tt.wantReported > 0 {
+				require.Equal(t, tt.wantReported,
+					strings.Count(err.Error(), "shutdown tenant shard"),
+					"a failure that fails every tenant must be reported once")
+			}
+
+			for name, dir := range keptDirs {
+				require.DirExists(t, dir, "tenant %q is still in the incoming state", name)
+			}
+			for name, dir := range residentDirs {
+				if tt.residentDropErr != nil || tt.closed {
+					require.DirExists(t, dir, "shard %q could not be dropped", name)
+					continue
+				}
+				require.NoDirExists(t, dir, "shard %q left the schema, so its data must be gone", name)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:

Migrator.updateIndexTenants is the local-node tenant reconcile: it runs when a node's on-disk state has to catch up with the RAFT schema (SchemaManager.ReloadDBFromSchema → executor.ReloadLocalDB → Migrator.UpdateIndex, e.g. after the node was down during a class update). For a multi-tenant class it does two disjoint things:
  1. updateIndexTenantsStatus — for each local tenant listed in the incoming sharding state: load it if HOT, unload it otherwise.
  2. updateIndexDeleteTenants — drop every loaded shard the incoming state omits, locally and from offload/cloud storage.

Both were fail-fast and would abort the full operation.

Now we run all steps unconditionally and report the combined errors

### Issues

Tracker is a separate repo, so GitHub will not auto-close these — they need closing by hand.

- Fixes `weaviate/dirk-claude-issues#47` — the truncated loop and the skipped deletes.

It also **aggravates `#16`** (`UnloadLocalShard` deletes the map entry before `Shutdown`, so a failed unload leaks a live, unreachable shard): previously one failed unload ended the pass and leaked one shard, now the loop continues so a pass can leak several. Severity per shard is unchanged, and #16 records that its own fix is not small.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

