### PR TITLE
Report the tenant's pre-freeze status on an aborted freeze

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -649,7 +649,8 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 
 	hot := make([]string, 0, len(updates))
 	cold := make([]string, 0, len(updates))
-	freezing := make([]string, 0, len(updates))
+	// freeze needs each tenant's pre-freeze status, so it keeps the whole payload
+	freezing := make([]*schemaUC.UpdateTenantPayload, 0, len(updates))
 	frozen := make([]string, 0, len(updates))
 	unfreezing := make([]string, 0, len(updates))
 
@@ -663,7 +664,7 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 			frozen = append(frozen, tenant.Name)
 
 		case types.TenantActivityStatusFREEZING: // never arrives from user
-			freezing = append(freezing, tenant.Name)
+			freezing = append(freezing, tenant)
 		case types.TenantActivityStatusUNFREEZING: // never arrives from user
 			unfreezing = append(unfreezing, tenant.Name)
 		}
@@ -747,7 +748,7 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 	}
 
 	if len(freezing) > 0 {
-		m.logger.WithField("action", "tenants_to_freezing").Debug(freezing)
+		m.logger.WithField("action", "tenants_to_freezing").Debug(tenantNames(freezing))
 		m.freeze(ctx, idx, class.Class, freezing, ec)
 	}
 
@@ -757,6 +758,14 @@ func (m *Migrator) UpdateTenants(ctx context.Context, class *models.Class, updat
 	}
 
 	return ec.ToError()
+}
+
+func tenantNames(tenants []*schemaUC.UpdateTenantPayload) []string {
+	names := make([]string, len(tenants))
+	for i, tenant := range tenants {
+		names[i] = tenant.Name
+	}
+	return names
 }
 
 // DeleteTenants deletes tenant from the database and data from the disk, no matter the current status of the tenant

--- a/adapters/repos/db/migrator_freeze_test.go
+++ b/adapters/repos/db/migrator_freeze_test.go
@@ -1,0 +1,136 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/entities/models"
+	esync "github.com/weaviate/weaviate/entities/sync"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+)
+
+// failingOffloadCloud is an OffloadCloud whose Upload always fails.
+type failingOffloadCloud struct{ uploadErr error }
+
+func (f *failingOffloadCloud) VerifyBucket(context.Context) error { return nil }
+
+func (f *failingOffloadCloud) Upload(context.Context, string, string, string) error {
+	return f.uploadErr
+}
+
+func (f *failingOffloadCloud) Download(context.Context, string, string, string) error { return nil }
+
+func (f *failingOffloadCloud) Delete(context.Context, string, string, string) error { return nil }
+
+// recordingProcessor captures the RAFT command freeze produces.
+type recordingProcessor struct {
+	mu  sync.Mutex
+	req *command.TenantProcessRequest
+}
+
+func (p *recordingProcessor) UpdateTenantsProcess(_ context.Context, _ string, req *command.TenantProcessRequest) (uint64, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.req = req
+	return 0, nil
+}
+
+// TestFreezeAbortReportsPreFreezeStatus: a tenant can be HOT in the schema with no local
+// shard, e.g. after an activation whose shard load failed. Reporting COLD for it on an
+// aborted freeze deactivates it with no user action, so the reported status must be the
+// one the schema handed over.
+func TestFreezeAbortReportsPreFreezeStatus(t *testing.T) {
+	const class = "FreezeAbortStatus"
+
+	cases := []struct {
+		name  string
+		given []*schemaUC.UpdateTenantPayload
+		want  map[string]string // tenant name -> reported abort status
+	}{
+		{
+			name:  "HOT is reported back",
+			given: []*schemaUC.UpdateTenantPayload{{Name: "t1", PreFreezeStatus: models.TenantActivityStatusHOT}},
+			want:  map[string]string{"t1": models.TenantActivityStatusHOT},
+		},
+		{
+			name:  "COLD is reported back",
+			given: []*schemaUC.UpdateTenantPayload{{Name: "t1", PreFreezeStatus: models.TenantActivityStatusCOLD}},
+			want:  map[string]string{"t1": models.TenantActivityStatusCOLD},
+		},
+		{
+			name:  "a missing record falls back to HOT",
+			given: []*schemaUC.UpdateTenantPayload{{Name: "t1", PreFreezeStatus: ""}},
+			want:  map[string]string{"t1": models.TenantActivityStatusHOT},
+		},
+		{
+			name: "each tenant of a batch keeps its own status",
+			given: []*schemaUC.UpdateTenantPayload{
+				{Name: "t1", PreFreezeStatus: models.TenantActivityStatusHOT},
+				{Name: "t2", PreFreezeStatus: models.TenantActivityStatusCOLD},
+				{Name: "t3", PreFreezeStatus: ""},
+			},
+			want: map[string]string{
+				"t1": models.TenantActivityStatusHOT,
+				"t2": models.TenantActivityStatusCOLD,
+				"t3": models.TenantActivityStatusHOT,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			// no shard is stored, so freeze takes the "not resident on this node" path
+			idx := &Index{
+				logger:           logger,
+				backupLock:       esync.NewKeyRWLocker(),
+				shardCreateLocks: esync.NewKeyRWLocker(),
+			}
+
+			m := NewMigrator(nil, logger, "node1")
+			m.SetNode("node1")
+			proc := &recordingProcessor{}
+			m.SetCluster(proc)
+			m.cloud = &failingOffloadCloud{uploadErr: fmt.Errorf("simulated upload failure")}
+
+			// freeze fans out per tenant, so it needs the concurrency-safe compounder
+			// its production caller passes
+			ec := errorcompounder.NewSafe()
+			m.freeze(context.Background(), idx, class, tc.given, ec)
+			require.Error(t, ec.ToError(), "the upload error must be recorded")
+
+			require.Eventually(t, func() bool {
+				proc.mu.Lock()
+				defer proc.mu.Unlock()
+				return proc.req != nil
+			}, 5*time.Second, 10*time.Millisecond, "freeze must report the abort")
+
+			proc.mu.Lock()
+			defer proc.mu.Unlock()
+			require.Len(t, proc.req.TenantsProcesses, len(tc.want))
+			for _, tp := range proc.req.TenantsProcesses {
+				require.Equal(t, command.TenantsProcess_OP_ABORT, tp.Op)
+				require.Equal(t, tc.want[tp.Tenant.Name], tp.Tenant.Status, "tenant %q", tp.Tenant.Name)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/migrator_shard_status_ops.go
+++ b/adapters/repos/db/migrator_shard_status_ops.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 func (m *Migrator) frozen(ctx context.Context, idx *Index, frozen []string, ec errorcompounder.ErrorCompounder) {
@@ -67,7 +68,7 @@ func (m *Migrator) frozen(ctx context.Context, idx *Index, frozen []string, ec e
 	eg.Wait()
 }
 
-func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze []string, ec errorcompounder.ErrorCompounder) {
+func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze []*schemaUC.UpdateTenantPayload, ec errorcompounder.ErrorCompounder) {
 	if m.cloud == nil {
 		ec.Add(fmt.Errorf("offload to cloud module is not enabled"))
 		return
@@ -87,11 +88,22 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 		TenantsProcesses: make([]*command.TenantsProcess, len(freeze)),
 	}
 
-	for uidx, name := range freeze {
+	for uidx, tenant := range freeze {
 		eg.Go(func() error {
+			name := tenant.Name
 			idx.backupLock.RLock(name)
 			defer idx.backupLock.RUnlock(name)
-			originalStatus := models.TenantActivityStatusHOT
+			// the status to restore on abort, as the schema recorded it when the freeze
+			// started. It is never empty here: the schema normalizes before recording.
+			originalStatus := tenant.PreFreezeStatus
+			if originalStatus == "" {
+				originalStatus = models.TenantActivityStatusHOT
+				m.logger.WithFields(logrus.Fields{
+					"action": "freeze_tenant",
+					"name":   class,
+					"tenant": name,
+				}).Error("no pre-freeze status recorded, an abort will report HOT")
+			}
 			shard, release, err := idx.GetShard(ctx, name)
 			if err != nil && !errors.Is(err, errAlreadyShutdown) {
 				m.logger.WithFields(logrus.Fields{
@@ -113,18 +125,13 @@ func (m *Migrator) freeze(ctx context.Context, idx *Index, class string, freeze 
 
 			defer release()
 
-			if shard == nil {
-				// shard already does not exist or inactive
-				originalStatus = models.TenantActivityStatusCOLD
-			}
-
 			idx.shardCreateLocks.Lock(name)
 			defer idx.shardCreateLocks.Unlock(name)
 
 			// restoreAfterAbort reverses an already-run offloading HaltForTransfer.
 			restoreAfterAbort := func() {
 				if shard == nil {
-					return // COLD/inactive: no local shard was halted
+					return // no local shard was halted
 				}
 				if err := idx.resumeAfterAbortedOffload(ctx, name); err != nil {
 					m.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/migrator_shard_status_ops_offload_test.go
+++ b/adapters/repos/db/migrator_shard_status_ops_offload_test.go
@@ -16,7 +16,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,33 +25,8 @@ import (
 	command "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/models"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
-
-// failingOffloadCloud is an OffloadCloud whose Upload always fails.
-type failingOffloadCloud struct{ uploadErr error }
-
-func (f *failingOffloadCloud) VerifyBucket(context.Context) error { return nil }
-
-func (f *failingOffloadCloud) Upload(context.Context, string, string, string) error {
-	return f.uploadErr
-}
-
-func (f *failingOffloadCloud) Download(context.Context, string, string, string) error { return nil }
-
-func (f *failingOffloadCloud) Delete(context.Context, string, string, string) error { return nil }
-
-// recordingProcessor captures the RAFT command freeze produces.
-type recordingProcessor struct {
-	mu  sync.Mutex
-	req *command.TenantProcessRequest
-}
-
-func (p *recordingProcessor) UpdateTenantsProcess(_ context.Context, _ string, req *command.TenantProcessRequest) (uint64, error) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.req = req
-	return 0, nil
-}
 
 // TestFreezeAbortRestoresShardOnUploadFailure: a freeze whose Upload fails must fully restore the shard.
 func TestFreezeAbortRestoresShardOnUploadFailure(t *testing.T) {
@@ -78,7 +52,9 @@ func TestFreezeAbortRestoresShardOnUploadFailure(t *testing.T) {
 	m.cloud = &failingOffloadCloud{uploadErr: fmt.Errorf("simulated upload failure")}
 
 	ec := errorcompounder.New()
-	m.freeze(ctx, idx, class, []string{s.name}, ec)
+	m.freeze(ctx, idx, class, []*schemaUC.UpdateTenantPayload{
+		{Name: s.name, PreFreezeStatus: models.TenantActivityStatusHOT},
+	}, ec)
 
 	require.Equal(t, 0, s.haltForTransferCount, "freeze abort must resume maintenance")
 	require.Empty(t, htFilesInDir(t, s.pathHashTree()), "freeze abort must discard the stale snapshot")

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -49,7 +49,7 @@ func TestRaftEndpoints(t *testing.T) {
 	m.indexer.On("AddProperty", Anything, Anything).Return(nil)
 	m.indexer.On("UpdateShardStatus", Anything).Return(nil)
 	m.indexer.On("AddTenants", Anything, Anything).Return(nil)
-	m.indexer.On("UpdateTenants", Anything, Anything).Return(nil)
+	m.indexer.On("UpdateTenants", Anything, Anything, Anything).Return(nil)
 	m.indexer.On("DeleteTenants", Anything, Anything).Return(nil)
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 	m.indexer.On("AddReplicaToShard", Anything, Anything, Anything).Return(nil)

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -730,14 +730,19 @@ func (s *SchemaManager) UpdateTenants(cmd *command.ApplyRequest, schemaOnly bool
 		}
 	}
 
+	// apply() runs updateSchema before updateStore, so this is complete when the DB reads it
+	preFreezeStatuses := make(map[string]string)
+
 	return s.apply(
 		applyOp{
 			op: cmd.GetType().String(),
 			// updateSchema func will update the request's tenants and therefore we use it as a filter that is then sent
 			// to the updateStore function. This allows us to effectively use the schema update to narrow down work for
 			// the DB update.
-			updateSchema:          func() error { return s.schema.updateTenants(cmd.Class, cmd.Version, req, s.replicationFSM) },
-			updateStore:           func() error { return s.db.UpdateTenants(cmd.Class, req) },
+			updateSchema: func() error {
+				return s.schema.updateTenants(cmd.Class, cmd.Version, req, s.replicationFSM, preFreezeStatuses)
+			},
+			updateStore:           func() error { return s.db.UpdateTenants(cmd.Class, req, preFreezeStatuses) },
 			schemaOnly:            schemaOnly,
 			allowPartialSchemaErr: true,
 		},

--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -446,7 +446,10 @@ func (m *metaClass) UpdateTenantsProcess(nodeID string, req *command.TenantProce
 	return sc, nil
 }
 
-func (m *metaClass) UpdateTenants(nodeID string, req *command.UpdateTenantsRequest, replicationFSM replicationFSM, v uint64) (map[string]int, error) {
+// UpdateTenants applies the requested tenant statuses. For every tenant it puts into
+// FREEZING it records the status the tenant held beforehand in preFreezeStatuses, which
+// the DB layer reports back if the freeze aborts. Callers must pass a non-nil map.
+func (m *metaClass) UpdateTenants(nodeID string, req *command.UpdateTenantsRequest, replicationFSM replicationFSM, v uint64, preFreezeStatuses map[string]string) (map[string]int, error) {
 	m.Lock()
 	defer m.Unlock()
 
@@ -529,6 +532,7 @@ func (m *metaClass) UpdateTenants(nodeID string, req *command.UpdateTenantsReque
 			}
 
 		case requestedToFrozen && !existedSharedFrozen:
+			preFreezeStatuses[requestTenant.Name] = oldTenant.ActivityStatus()
 			m.freeze(i, req, oldTenant)
 		default:
 			// do nothing

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -574,12 +574,12 @@ func (s *schema) deleteTenants(class string, v uint64, req *command.DeleteTenant
 	return nil
 }
 
-func (s *schema) updateTenants(class string, v uint64, req *command.UpdateTenantsRequest, replicationFSM replicationFSM) error {
+func (s *schema) updateTenants(class string, v uint64, req *command.UpdateTenantsRequest, replicationFSM replicationFSM, preFreezeStatuses map[string]string) error {
 	ok, meta, _, err := s.multiTenancyEnabled(class)
 	if !ok {
 		return err
 	}
-	sc, err := meta.UpdateTenants(s.nodeID, req, replicationFSM, v)
+	sc, err := meta.UpdateTenants(s.nodeID, req, replicationFSM, v, preFreezeStatuses)
 	// partial update possible
 	for status, count := range sc {
 		// count can be positive or negative.

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -174,7 +174,7 @@ func Test_schemaShardMetrics(t *testing.T) {
 	err = s.updateTenants(c2.Class, 0, &api.UpdateTenantsRequest{
 		Tenants:      []*api.Tenant{{Name: "tenant2", Status: "HOT"}}, // FROZEN -> HOT
 		ClusterNodes: []string{"testNode"},
-	}, fsm)
+	}, fsm, map[string]string{})
 	require.NoError(t, err)
 	assert.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("UNFREEZING")))
 	assert.Equal(t, float64(0), testutil.ToFloat64(s.shardsCount.WithLabelValues("FROZEN")))
@@ -246,13 +246,13 @@ func Test_UpdateTenants_TransitionalStateRejection(t *testing.T) {
 		require.NoError(t, s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "FROZEN"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm))
+		}, fsm, map[string]string{}))
 
 		// HOT request while FREEZING must be rejected
 		err := s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "HOT"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm)
+		}, fsm, map[string]string{})
 		require.ErrorIs(t, err, ErrTenantTransitionalState)
 	})
 
@@ -266,12 +266,12 @@ func Test_UpdateTenants_TransitionalStateRejection(t *testing.T) {
 		require.NoError(t, s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "FROZEN"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm))
+		}, fsm, map[string]string{}))
 
 		err := s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "COLD"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm)
+		}, fsm, map[string]string{})
 		require.ErrorIs(t, err, ErrTenantTransitionalState)
 	})
 
@@ -285,13 +285,13 @@ func Test_UpdateTenants_TransitionalStateRejection(t *testing.T) {
 		require.NoError(t, s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "FROZEN"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm))
+		}, fsm, map[string]string{}))
 
 		// Second FROZEN request while already FREEZING must succeed (idempotent)
 		require.NoError(t, s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "FROZEN"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm))
+		}, fsm, map[string]string{}))
 	})
 
 	t.Run("UNFREEZING rejects conflicting status", func(t *testing.T) {
@@ -305,13 +305,13 @@ func Test_UpdateTenants_TransitionalStateRejection(t *testing.T) {
 		require.NoError(t, s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "HOT"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm))
+		}, fsm, map[string]string{}))
 
 		// COLD request while UNFREEZING-to-HOT must be rejected
 		err := s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: "COLD"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm)
+		}, fsm, map[string]string{})
 		require.ErrorIs(t, err, ErrTenantTransitionalState)
 	})
 }
@@ -353,7 +353,7 @@ func Test_UpdateTenants_MovementRejection(t *testing.T) {
 		return s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: tenantName, Status: status}},
 			ClusterNodes: []string{nodeID},
-		}, fsm)
+		}, fsm, map[string]string{})
 	}
 
 	t.Run("HOT→COLD blocked during movement", func(t *testing.T) {
@@ -408,7 +408,7 @@ func Test_UpdateTenants_MovementRejection(t *testing.T) {
 		err := s.updateTenants(className, 0, &api.UpdateTenantsRequest{
 			Tenants:      []*api.Tenant{{Name: "tenant1", Status: "COLD"}, {Name: "tenant2", Status: "COLD"}},
 			ClusterNodes: []string{nodeID},
-		}, fsm)
+		}, fsm, map[string]string{})
 		require.ErrorIs(t, err, ErrReplicaMovementInProgress)
 		// tenant1 blocked (stays HOT), tenant2 applied (COLD).
 		require.Equal(t, float64(1), testutil.ToFloat64(s.shardsCount.WithLabelValues("HOT")), "blocked tenant1 stays HOT")
@@ -421,6 +421,126 @@ func Test_UpdateTenants_MovementRejection(t *testing.T) {
 			err := update(s, "COLD", movementFSM(t, true))
 			require.ErrorIs(t, err, ErrReplicaMovementInProgress, "must block on %s", node)
 		}
+	})
+}
+
+// Test_UpdateTenants_RecordsPreFreezeStatus verifies that starting a freeze records the
+// status the tenant held beforehand. The node reports that status back when a freeze
+// aborts, so a wrong or missing entry silently deactivates a tenant that was HOT.
+func Test_UpdateTenants_RecordsPreFreezeStatus(t *testing.T) {
+	const (
+		nodeID    = "testNode"
+		className = "TestClass"
+	)
+	setup := func(t *testing.T, existing []*api.Tenant) *schema {
+		t.Helper()
+		s := NewSchema(nodeID, nil, prometheus.NewPedanticRegistry())
+		require.NoError(t, s.addClass(&models.Class{
+			Class:              className,
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+			ReplicationConfig:  &models.ReplicationConfig{Factor: 1},
+		}, &sharding.State{}, 0))
+		require.NoError(t, s.addTenants(className, 0, &api.AddTenantsRequest{
+			ClusterNodes: []string{nodeID},
+			Tenants:      existing,
+		}))
+		return s
+	}
+	newFSM := func(t *testing.T) replicationFSM {
+		t.Helper()
+		fsm := NewMockreplicationFSM(t)
+		fsm.On("HasActiveReplicationForShard", mock.Anything, mock.Anything).Return(false).Maybe()
+		return fsm
+	}
+	update := func(s *schema, tenants []*api.Tenant, recorded map[string]string, fsm replicationFSM) error {
+		return s.updateTenants(className, 0, &api.UpdateTenantsRequest{
+			Tenants:      tenants,
+			ClusterNodes: []string{nodeID},
+		}, fsm, recorded)
+	}
+
+	cases := []struct {
+		name     string
+		existing []*api.Tenant
+		update   []*api.Tenant
+		want     map[string]string
+		wantErr  error
+	}{
+		{
+			name:     "HOT tenant freezing records HOT",
+			existing: []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusHOT}},
+			update:   []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusFROZEN}},
+			want:     map[string]string{"t1": models.TenantActivityStatusHOT},
+		},
+		{
+			name:     "COLD tenant freezing records COLD",
+			existing: []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusCOLD}},
+			update:   []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusFROZEN}},
+			want:     map[string]string{"t1": models.TenantActivityStatusCOLD},
+		},
+		{
+			name:     "unset status normalizes to HOT",
+			existing: []*api.Tenant{{Name: "t1", Status: ""}},
+			update:   []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusFROZEN}},
+			want:     map[string]string{"t1": models.TenantActivityStatusHOT},
+		},
+		{
+			name:     "non-freeze update records nothing",
+			existing: []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusHOT}},
+			update:   []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusCOLD}},
+			want:     map[string]string{},
+		},
+		{
+			name: "batch records only the freezing tenants",
+			existing: []*api.Tenant{
+				{Name: "t1", Status: models.TenantActivityStatusCOLD},
+				{Name: "t2", Status: models.TenantActivityStatusHOT},
+				{Name: "t3", Status: models.TenantActivityStatusHOT},
+			},
+			update: []*api.Tenant{
+				{Name: "t1", Status: models.TenantActivityStatusFROZEN},
+				{Name: "t2", Status: models.TenantActivityStatusCOLD},
+				{Name: "t3", Status: models.TenantActivityStatusFROZEN},
+			},
+			want: map[string]string{
+				"t1": models.TenantActivityStatusCOLD,
+				"t3": models.TenantActivityStatusHOT,
+			},
+		},
+		{
+			name:     "unknown tenant records nothing",
+			existing: []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusHOT}},
+			update:   []*api.Tenant{{Name: "absent", Status: models.TenantActivityStatusFROZEN}},
+			want:     map[string]string{},
+			wantErr:  ErrShardNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := setup(t, tc.existing)
+			recorded := map[string]string{}
+
+			err := update(s, tc.update, recorded, newFSM(t))
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tc.want, recorded)
+		})
+	}
+
+	t.Run("an already FREEZING tenant records nothing again", func(t *testing.T) {
+		s := setup(t, []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusHOT}})
+		fsm := newFSM(t)
+		require.NoError(t, update(s, []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusFROZEN}},
+			map[string]string{}, fsm))
+
+		recorded := map[string]string{}
+		require.NoError(t, update(s, []*api.Tenant{{Name: "t1", Status: models.TenantActivityStatusFROZEN}},
+			recorded, fsm))
+		require.Empty(t, recorded)
 	})
 }
 

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -685,7 +685,7 @@ func testConcurrentTenantManagementOperations(t *testing.T, s *schema) {
 				}
 				fsm := NewMockreplicationFSM(t)
 				fsm.On("HasActiveReplicationForShard", mock.Anything, mock.Anything).Return(false).Maybe()
-				_ = s.updateTenants("TestClass", uint64(j), req, fsm)
+				_ = s.updateTenants("TestClass", uint64(j), req, fsm, map[string]string{})
 				time.Sleep(time.Microsecond)
 			}
 		}(i)

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -33,7 +33,10 @@ type Indexer interface {
 	AddProperty(class string, req api.AddPropertyRequest) error
 	UpdateProperty(class string, req api.UpdatePropertyRequest) error
 	AddTenants(class string, req *api.AddTenantsRequest) error
-	UpdateTenants(class string, req *api.UpdateTenantsRequest) error
+	// UpdateTenants receives, per tenant entering FREEZING, the status it held
+	// beforehand — an aborted freeze reports that status back to the schema. The
+	// map is complete on entry: the schema update that fills it runs first.
+	UpdateTenants(class string, req *api.UpdateTenantsRequest, preFreezeStatuses map[string]string) error
 	DeleteTenants(class string, tenants []*models.Tenant) error
 	UpdateTenantsProcess(class string, req *api.TenantProcessRequest) error
 	UpdateShardStatus(*api.UpdateShardStatusRequest) error

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -65,6 +65,9 @@ func TestStoreApply(t *testing.T) {
 		PartitioningEnabled: true, // multi-tenant collection
 	}
 
+	// captured by UpdateTenant/FreezeHandsPreFreezeStatusToTheDB
+	var preFreezeStatusesSeenByDB map[string]string
+
 	tests := []struct {
 		name     string
 		req      raft.Log
@@ -466,7 +469,7 @@ func TestStoreApply(t *testing.T) {
 				})
 				// ErrShardNotFound (partial success), so the DB layer is invoked with the
 				// filtered (empty) tenant list before the schema error is propagated.
-				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
+				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error { return nil },
 		},
@@ -489,7 +492,7 @@ func TestStoreApply(t *testing.T) {
 					Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_CLASS, cmd.AddClassRequest{Class: cls, State: ss}, nil),
 				})
 				m.replicationFSM.EXPECT().HasActiveReplicationForShard("C1", "T1").Return(true)
-				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
+				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				want := map[string]sharding.Physical{"T1": {
@@ -525,7 +528,7 @@ func TestStoreApply(t *testing.T) {
 					Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_CLASS, cmd.AddClassRequest{Class: cls, State: ss}, nil),
 				})
 				m.replicationFSM.EXPECT().HasActiveReplicationForShard("C1", "T1").Return(false)
-				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
+				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			doAfter: func(ms *MockStore) error {
 				want := map[string]sharding.Physical{"T1": {
@@ -570,7 +573,7 @@ func TestStoreApply(t *testing.T) {
 				m.store.Apply(&raft.Log{
 					Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_CLASS, cmd.AddClassRequest{Class: cls, State: ss}, nil),
 				})
-				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
+				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				m.replicationFSM.EXPECT().HasActiveReplicationForShard(Anything, Anything).Return(false)
 			},
 			doAfter: func(ms *MockStore) error {
@@ -592,6 +595,49 @@ func TestStoreApply(t *testing.T) {
 				require.Nil(t, err)
 				if got := shardingState.Physical; !reflect.DeepEqual(got, want) {
 					return fmt.Errorf("physical state want: %v got: %v", want, got)
+				}
+				return nil
+			},
+		},
+		{
+			// The DB reports the pre-freeze status back if the freeze aborts, so the
+			// schema update must hand the DB update what it recorded.
+			name: "UpdateTenant/FreezeHandsPreFreezeStatusToTheDB",
+			req: raft.Log{Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_UPDATE_TENANT,
+				nil, &cmd.UpdateTenantsRequest{Tenants: []*cmd.Tenant{
+					{Name: "T1", Status: models.TenantActivityStatusFROZEN},
+					{Name: "T2", Status: models.TenantActivityStatusFROZEN},
+				}})},
+			resp: Response{Error: nil},
+			doBefore: func(m *MockStore) {
+				doFirst(m)
+				ss := &sharding.State{Physical: map[string]sharding.Physical{"T1": {
+					Name:           "T1",
+					BelongsToNodes: []string{"THIS"},
+					Status:         models.TenantActivityStatusHOT,
+				}, "T2": {
+					Name:           "T2",
+					BelongsToNodes: []string{"THIS"},
+					Status:         models.TenantActivityStatusCOLD,
+				}}, PartitioningEnabled: true}
+				m.indexer.On("AddClass", mock.Anything).Return(nil)
+				m.store.Apply(&raft.Log{
+					Data: cmdAsBytes("C1", cmd.ApplyRequest_TYPE_ADD_CLASS, cmd.AddClassRequest{Class: cls, State: ss}, nil),
+				})
+				preFreezeStatusesSeenByDB = nil
+				m.indexer.On("UpdateTenants", mock.Anything, mock.Anything, mock.Anything).
+					Run(func(args mock.Arguments) {
+						preFreezeStatusesSeenByDB = args.Get(2).(map[string]string)
+					}).Return(nil)
+				m.replicationFSM.EXPECT().HasActiveReplicationForShard(Anything, Anything).Return(false)
+			},
+			doAfter: func(ms *MockStore) error {
+				want := map[string]string{
+					"T1": models.TenantActivityStatusHOT,
+					"T2": models.TenantActivityStatusCOLD,
+				}
+				if !reflect.DeepEqual(preFreezeStatusesSeenByDB, want) {
+					return fmt.Errorf("pre-freeze statuses want: %v got: %v", want, preFreezeStatusesSeenByDB)
 				}
 				return nil
 			},

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -95,8 +95,8 @@ func (m *MockSchemaExecutor) AddTenants(class string, req *cmd.AddTenantsRequest
 	return args.Error(0)
 }
 
-func (m *MockSchemaExecutor) UpdateTenants(class string, req *cmd.UpdateTenantsRequest) error {
-	args := m.Called(class, req)
+func (m *MockSchemaExecutor) UpdateTenants(class string, req *cmd.UpdateTenantsRequest, preFreezeStatuses map[string]string) error {
+	args := m.Called(class, req, preFreezeStatuses)
 	return args.Error(0)
 }
 

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -287,7 +287,7 @@ func (e *executor) AddTenants(class string, req *api.AddTenantsRequest) error {
 	return nil
 }
 
-func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest) error {
+func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest, preFreezeStatuses map[string]string) error {
 	ctx := context.Background()
 	cls := e.schemaReader.ReadOnlyClass(class)
 	if cls == nil {
@@ -297,8 +297,9 @@ func (e *executor) UpdateTenants(class string, req *api.UpdateTenantsRequest) er
 	updates := make([]*UpdateTenantPayload, 0, len(req.Tenants))
 	for _, tu := range req.Tenants {
 		updates = append(updates, &UpdateTenantPayload{
-			Name:   tu.Name,
-			Status: tu.Status,
+			Name:            tu.Name,
+			Status:          tu.Status,
+			PreFreezeStatus: preFreezeStatuses[tu.Name],
 		})
 	}
 

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
@@ -140,11 +141,39 @@ func TestExecutor(t *testing.T) {
 	})
 
 	t.Run("UpdateTenants", func(t *testing.T) {
-		migrator := &fakeMigrator{}
-		req := &api.UpdateTenantsRequest{Tenants: tenants}
-		migrator.On("UpdateTenants", Anything, cls, Anything).Return(nil)
-		x := newMockExecutor(migrator, store)
-		assert.Nil(t, x.UpdateTenants("A", req))
+		cases := []struct {
+			name              string
+			preFreezeStatuses map[string]string
+			want              map[string]string // tenant name -> expected PreFreezeStatus
+		}{
+			{
+				name:              "freezing tenant carries its recorded status",
+				preFreezeStatuses: map[string]string{"T1": models.TenantActivityStatusCOLD},
+				want:              map[string]string{"T1": models.TenantActivityStatusCOLD, "T2": ""},
+			},
+			{
+				name:              "no freeze recorded, nothing carried",
+				preFreezeStatuses: map[string]string{},
+				want:              map[string]string{"T1": "", "T2": ""},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				migrator := &fakeMigrator{}
+				var got []*UpdateTenantPayload
+				migrator.On("UpdateTenants", Anything, cls, Anything).
+					Run(func(args mock.Arguments) { got = args.Get(2).([]*UpdateTenantPayload) }).
+					Return(nil)
+				x := newMockExecutor(migrator, store)
+
+				require.NoError(t, x.UpdateTenants("A", &api.UpdateTenantsRequest{Tenants: tenants}, tc.preFreezeStatuses))
+
+				require.Len(t, got, len(tc.want))
+				for _, payload := range got {
+					assert.Equal(t, tc.want[payload.Name], payload.PreFreezeStatus, "tenant %q", payload.Name)
+				}
+			})
+		}
 	})
 
 	t.Run("UpdateTenantsClassNotFound", func(t *testing.T) {
@@ -153,7 +182,7 @@ func TestExecutor(t *testing.T) {
 
 		req := &api.UpdateTenantsRequest{Tenants: tenants}
 		x := newMockExecutor(&fakeMigrator{}, store)
-		assert.ErrorIs(t, x.UpdateTenants("A", req), ErrNotFound)
+		assert.ErrorIs(t, x.UpdateTenants("A", req, map[string]string{}), ErrNotFound)
 	})
 
 	t.Run("UpdateTenantsError", func(t *testing.T) {
@@ -161,7 +190,7 @@ func TestExecutor(t *testing.T) {
 		req := &api.UpdateTenantsRequest{Tenants: tenants}
 		migrator.On("UpdateTenants", Anything, cls, Anything).Return(ErrAny)
 		x := newMockExecutor(migrator, store)
-		assert.ErrorIs(t, x.UpdateTenants("A", req), ErrAny)
+		assert.ErrorIs(t, x.UpdateTenants("A", req, map[string]string{}), ErrAny)
 	})
 
 	t.Run("AddTenants", func(t *testing.T) {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -143,7 +143,7 @@ func (f *fakeDB) AddTenants(class string, cmd *command.AddTenantsRequest) error 
 	return nil
 }
 
-func (f *fakeDB) UpdateTenants(class string, cmd *command.UpdateTenantsRequest) error {
+func (f *fakeDB) UpdateTenants(class string, cmd *command.UpdateTenantsRequest, preFreezeStatuses map[string]string) error {
 	return nil
 }
 

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -30,6 +30,9 @@ type CreateTenantPayload struct {
 type UpdateTenantPayload struct {
 	Name   string
 	Status string
+	// PreFreezeStatus is the status the tenant held when the freeze started. An
+	// aborted freeze reports it back so the schema restores it; empty otherwise.
+	PreFreezeStatus string
 }
 
 // Migrator represents both the input and output interface of the Composer


### PR DESCRIPTION
### What's being changed:

Freezing a tenant means: set it FROZEN in the schema, upload its shard to cloud storage, drop the local copy. It's a two-phase RAFT apply — SchemaManager.apply() runs updateSchema (tenant → FREEZING, one OP_START per node holding the shard) and then updateStore (each node halts its shard, uploads, and reports OP_DONE/OP_ABORT back through RAFT). applyShardProcess collects the reports: all DONE → FROZEN; any ABORT → the tenant goes to whatever status the aborting node reported.

  So on abort, the node has to say what the tenant was. It answered by looking at whether the shard was loaded locally:
```
  originalStatus := models.TenantActivityStatusHOT
  shard, release, err := idx.GetShard(ctx, name)
  ...
  if shard == nil {
      originalStatus = models.TenantActivityStatusCOLD
  }
```

However the previous status in the schema and the current load status on disk are not necessarily the same. This si fixed by recording the tenants status before the freezing 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
