### PR TITLE
Keep error type through the objects manager

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -908,13 +908,7 @@ func (e *objectsRequestsTotal) logError(className string, err error) {
 			e.logUserError(className)
 		}
 	default:
-		if errors.As(err, &uco.ErrInvalidUserInput{}) ||
-			errors.As(err, &uco.ErrMultiTenancy{}) ||
-			errors.As(err, &authzerrors.Forbidden{}) {
-			e.logUserError(className)
-		} else {
-			e.logServerError(className, err)
-		}
+		e.logServerError(className, err)
 	}
 }
 

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -178,7 +178,7 @@ func (m *Manager) checkIDOrAssignNew(ctx context.Context, principal *models.Prin
 			if errors.As(err, &authzerrs.Forbidden{}) {
 				return "", err
 			}
-			return "", NewErrInternal("%v", err)
+			return "", NewErrInternal("%w", err)
 		}
 	}
 

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -28,7 +28,6 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
@@ -148,7 +147,7 @@ func (m *Manager) checkIDOrAssignNew(ctx context.Context, principal *models.Prin
 	if id == "" {
 		validatedID, err := generateUUID()
 		if err != nil {
-			return "", NewErrInternal("could not generate id: %v", err)
+			return "", NewErrInternal("could not generate id: %w", err)
 		}
 		return validatedID, err
 	}
@@ -175,9 +174,6 @@ func (m *Manager) checkIDOrAssignNew(ctx context.Context, principal *models.Prin
 			}
 			return "", err
 		default:
-			if errors.As(err, &authzerrs.Forbidden{}) {
-				return "", err
-			}
 			return "", NewErrInternal("%w", err)
 		}
 	}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -139,7 +139,7 @@ func (b *BatchManager) addObjects(ctx context.Context, principal *models.Princip
 		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", maxSchemaVersion, err)
 	}
 	if res, err = b.vectorRepo.BatchPutObjects(ctx, batchObjects, repl, maxSchemaVersion); err != nil {
-		return nil, NewErrInternal("batch objects: %#v", err)
+		return nil, NewErrInternal("batch objects: %w", err)
 	}
 
 	// Reaggregate a unanimous limit-exceeded into a top-level error so

--- a/usecases/objects/batch_references_add.go
+++ b/usecases/objects/batch_references_add.go
@@ -186,7 +186,7 @@ func (b *BatchManager) addReferences(ctx context.Context, principal *models.Prin
 		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", schemaVersion, err)
 	}
 	if res, err := b.vectorRepo.AddBatchReferences(ctx, refs, repl, schemaVersion); err != nil {
-		return nil, NewErrInternal("could not add batch request to connector: %v", err)
+		return nil, NewErrInternal("could not add batch request to connector: %w", err)
 	} else {
 		return res, nil
 	}

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -85,7 +85,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 		if errors.As(err, &e3) {
 			return fmt.Errorf("delete object from vector repo: %w", err)
 		}
-		return NewErrInternal("could not delete object from vector repo: %v", err)
+		return NewErrInternal("could not delete object from vector repo: %w", err)
 	}
 
 	return nil
@@ -119,7 +119,7 @@ func (m *Manager) deleteObjectFromRepo(ctx context.Context, id strfmt.UUID, dele
 		object := objectRes.Object()
 		err = m.vectorRepo.DeleteObject(ctx, object.Class, id, deletionTime, nil, "", maxSchemaVersion)
 		if err != nil {
-			return NewErrInternal("could not delete object from vector repo: %v", err)
+			return NewErrInternal("could not delete object from vector repo: %w", err)
 		}
 		deleteCounter++
 	}

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -80,10 +79,6 @@ func (m *Manager) DeleteObject(ctx context.Context,
 		var e2 ErrInvalidUserInput
 		if errors.As(err, &e2) {
 			return NewErrMultiTenancy(fmt.Errorf("delete object from vector repo: %w", err))
-		}
-		var e3 authzerrs.Forbidden
-		if errors.As(err, &e3) {
-			return fmt.Errorf("delete object from vector repo: %w", err)
 		}
 		return NewErrInternal("could not delete object from vector repo: %w", err)
 	}

--- a/usecases/objects/errors.go
+++ b/usecases/objects/errors.go
@@ -12,6 +12,7 @@
 package objects
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -78,15 +79,24 @@ func NewErrInvalidUserInput(format string, args ...interface{}) ErrInvalidUserIn
 // ErrInternal indicates something went wrong during processing
 type ErrInternal struct {
 	msg string
+	err error
 }
 
 func (e ErrInternal) Error() string {
 	return e.msg
 }
 
-// NewErrInternal with Errorf signature
+// Unwrap returns the cause wrapped with a %w verb, so callers can classify it
+// with errors.Is/As instead of matching on the message.
+func (e ErrInternal) Unwrap() error {
+	return e.err
+}
+
+// NewErrInternal with Errorf signature. An operand formatted with %w stays
+// reachable through Unwrap; %v flattens it to text.
 func NewErrInternal(format string, args ...interface{}) ErrInternal {
-	return ErrInternal{msg: fmt.Sprintf(format, args...)}
+	formatted := fmt.Errorf(format, args...)
+	return ErrInternal{msg: formatted.Error(), err: errors.Unwrap(formatted)}
 }
 
 // ErrNotFound indicates the desired resource doesn't exist

--- a/usecases/objects/errors.go
+++ b/usecases/objects/errors.go
@@ -12,7 +12,6 @@
 package objects
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -86,25 +85,18 @@ func (e ErrInternal) Error() string {
 	return e.msg
 }
 
-// Unwrap returns the cause wrapped with a %w verb, so callers can classify it
-// with errors.Is/As instead of matching on the message.
+// Unwrap returns the formatted error, through which every cause the format
+// wrapped with %w stays reachable for errors.Is/As. It is never nil, so it
+// cannot be used to probe whether there was a cause at all.
 func (e ErrInternal) Unwrap() error {
 	return e.err
 }
 
-// NewErrInternal with Errorf signature. An operand formatted with %w stays
-// reachable through Unwrap; %v flattens it to text.
+// NewErrInternal with Errorf signature. Operands formatted with %w stay
+// reachable through Unwrap; %v flattens them to text.
 func NewErrInternal(format string, args ...interface{}) ErrInternal {
 	formatted := fmt.Errorf(format, args...)
-	cause := errors.Unwrap(formatted)
-	if cause == nil {
-		// Several %w verbs unwrap to a slice, which errors.Unwrap reports as
-		// nil; keeping the formatted error preserves both causes.
-		if _, multi := formatted.(interface{ Unwrap() []error }); multi {
-			cause = formatted
-		}
-	}
-	return ErrInternal{msg: formatted.Error(), err: cause}
+	return ErrInternal{msg: formatted.Error(), err: formatted}
 }
 
 // ErrNotFound indicates the desired resource doesn't exist

--- a/usecases/objects/errors.go
+++ b/usecases/objects/errors.go
@@ -96,7 +96,15 @@ func (e ErrInternal) Unwrap() error {
 // reachable through Unwrap; %v flattens it to text.
 func NewErrInternal(format string, args ...interface{}) ErrInternal {
 	formatted := fmt.Errorf(format, args...)
-	return ErrInternal{msg: formatted.Error(), err: errors.Unwrap(formatted)}
+	cause := errors.Unwrap(formatted)
+	if cause == nil {
+		// Several %w verbs unwrap to a slice, which errors.Unwrap reports as
+		// nil; keeping the formatted error preserves both causes.
+		if _, multi := formatted.(interface{ Unwrap() []error }); multi {
+			cause = formatted
+		}
+	}
+	return ErrInternal{msg: formatted.Error(), err: cause}
 }
 
 // ErrNotFound indicates the desired resource doesn't exist

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -54,6 +54,7 @@ type fakeSchemaManager struct {
 	// test controls
 	AddTenantsSchemaVersion uint64
 	AutoSchemaVersion       uint64
+	AddClassPropertyErr     error
 	// observed
 	WaitedSchemaVersion    uint64
 	MaxWaitedSchemaVersion uint64
@@ -165,6 +166,10 @@ func (f *fakeSchemaManager) AddClass(ctx context.Context, principal *models.Prin
 func (f *fakeSchemaManager) AddClassProperty(ctx context.Context, principal *models.Principal,
 	className string, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
+	if f.AddClassPropertyErr != nil {
+		return nil, 0, f.AddClassPropertyErr
+	}
+
 	existing := map[string]int{}
 	var existedClass *models.Class
 	for _, c := range f.GetSchemaResponse.Objects.Classes {
@@ -380,6 +385,8 @@ type fakeModulesProvider struct {
 	mock.Mock
 	customExtender  *fakeExtender
 	customProjector *fakeProjector
+	// test control
+	ExtendErr error
 }
 
 func (p *fakeModulesProvider) GetObjectAdditionalExtend(ctx context.Context,
@@ -446,6 +453,10 @@ func (p *fakeModulesProvider) VectorizerName(className string) (string, error) {
 func (p *fakeModulesProvider) additionalExtend(ctx context.Context,
 	in search.Results, moduleParams map[string]interface{}, capability string,
 ) (search.Results, error) {
+	if p.ExtendErr != nil {
+		return nil, p.ExtendErr
+	}
+
 	txt2vec := newNearCustomTextModule(p.getExtender(), p.getProjector(), &fakePathBuilder{})
 	additionalProperties := txt2vec.AdditionalProperties()
 	if err := p.checkCapabilities(additionalProperties, moduleParams, capability); err != nil {
@@ -817,7 +828,7 @@ func getFakeModulesProviderWithCustomExtenders(
 	customProjector *fakeProjector,
 	opts ...func(provider *fakeModulesProvider),
 ) *fakeModulesProvider {
-	p := &fakeModulesProvider{mock.Mock{}, customExtender, customProjector}
+	p := &fakeModulesProvider{customExtender: customExtender, customProjector: customProjector}
 	p.applyOptions(opts...)
 	return p
 }

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -142,7 +142,7 @@ func (m *Manager) getObjectFromRepo(ctx context.Context, class string, id strfmt
 			if errors.As(err, &authzerrs.Forbidden{}) {
 				return nil, fmt.Errorf("repo: object by id: %w", err)
 			}
-			return nil, NewErrInternal("repo: object by id: %v", err)
+			return nil, NewErrInternal("repo: object by id: %w", err)
 		}
 	}
 
@@ -174,7 +174,7 @@ func (m *Manager) getObjectsFromRepo(ctx context.Context,
 	res, err := m.vectorRepo.ObjectSearch(ctx, smartOffset, smartLimit,
 		nil, m.getSort(sort, order), additional, tenant)
 	if err != nil {
-		return nil, NewErrInternal("list objects: %v", err)
+		return nil, NewErrInternal("list objects: %w", err)
 	}
 
 	if m.modulesProvider != nil {

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -24,7 +24,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 )
 
@@ -139,9 +138,6 @@ func (m *Manager) getObjectFromRepo(ctx context.Context, class string, id strfmt
 		case errors.As(err, &ErrMultiTenancy{}):
 			return nil, NewErrMultiTenancy(fmt.Errorf("repo: object by id: %w", err))
 		default:
-			if errors.As(err, &authzerrs.Forbidden{}) {
-				return nil, fmt.Errorf("repo: object by id: %w", err)
-			}
 			return nil, NewErrInternal("repo: object by id: %w", err)
 		}
 	}
@@ -166,7 +162,7 @@ func (m *Manager) getObjectsFromRepo(ctx context.Context,
 ) ([]*models.Object, error) {
 	smartOffset, smartLimit, err := m.localOffsetLimit(offset, limit)
 	if err != nil {
-		return nil, NewErrInternal("list objects: %v", err)
+		return nil, NewErrInternal("list objects: %w", err)
 	}
 	if after != nil {
 		return nil, NewErrInternal("list objects: after parameter not allowed, cursor must be specific to one class, set class query param")
@@ -180,7 +176,7 @@ func (m *Manager) getObjectsFromRepo(ctx context.Context,
 	if m.modulesProvider != nil {
 		res, err = m.modulesProvider.ListObjectsAdditionalExtend(ctx, res, additional.ModuleParams)
 		if err != nil {
-			return nil, NewErrInternal("list extend: %v", err)
+			return nil, NewErrInternal("list extend: %w", err)
 		}
 	}
 

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -116,6 +116,11 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 
 	autoSchemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, false, fetchedClass, updates)
 	if err != nil {
+		// Extending the collection needs its own permission; reporting a denial
+		// as invalid input would hide the missing grant behind a 422.
+		if errors.As(err, &authzerrs.Forbidden{}) {
+			return &Error{err.Error(), StatusForbidden, err}
+		}
 		return &Error{"bad request", StatusBadRequest, NewErrInvalidUserInput("invalid object: %v", err)}
 	}
 	maxSchemaVersion = max(maxSchemaVersion, autoSchemaVersion)

--- a/usecases/objects/references_namespace_test.go
+++ b/usecases/objects/references_namespace_test.go
@@ -114,11 +114,23 @@ func multiTargetNSSchema(qualify bool) []*models.Class {
 	}
 }
 
+// withAutoSchema turns auto-schema on and lets AddClassProperty fail with err,
+// so a write carrying an unknown property can be steered. A nil err accepts
+// the extension.
+func withAutoSchema(err error) func(*config.WeaviateConfig, *fakeSchemaManager) {
+	return func(cfg *config.WeaviateConfig, sm *fakeSchemaManager) {
+		cfg.Config.AutoSchema.Enabled = runtime.NewDynamicValue(true)
+		sm.AddClassPropertyErr = err
+	}
+}
+
 // newNSManagers returns a Manager + BatchManager wired against the same
 // in-memory fakes, with namespaces toggled by nsEnabled. Both managers share
 // the schema, repo and authorizer so a test can exercise single-ref and
 // batch-ref paths through the same world.
-func newNSManagers(t *testing.T, classes []*models.Class, nsEnabled bool) (*Manager, *BatchManager, *fakeVectorRepo, *fakeModulesProvider, *mocks.FakeAuthorizer) {
+func newNSManagers(t *testing.T, classes []*models.Class, nsEnabled bool,
+	opts ...func(*config.WeaviateConfig, *fakeSchemaManager),
+) (*Manager, *BatchManager, *fakeVectorRepo, *fakeModulesProvider, *mocks.FakeAuthorizer) {
 	t.Helper()
 	sch := schema.Schema{Objects: &models.Schema{Classes: classes}}
 	vectorRepo := &fakeVectorRepo{}
@@ -129,6 +141,9 @@ func newNSManagers(t *testing.T, classes []*models.Class, nsEnabled bool) (*Mana
 		},
 	}
 	schemaManager := &fakeSchemaManager{GetSchemaResponse: sch}
+	for _, opt := range opts {
+		opt(cfg, schemaManager)
+	}
 	logger, _ := test.NewNullLogger()
 	authorizer := mocks.NewMockAuthorizer()
 	modulesProvider := getFakeModulesProvider()

--- a/usecases/objects/references_test.go
+++ b/usecases/objects/references_test.go
@@ -325,7 +325,7 @@ func Test_ReferenceUpdate(t *testing.T) {
 			Name: "source object internal error", Req: req,
 			WantCode:     StatusInternalServerError,
 			ErrSrcExists: anyErr,
-			WantErr:      NewErrInternal("repo: object by id: %v", anyErr),
+			WantErr:      anyErr,
 			Stage:        1,
 		},
 		{
@@ -484,7 +484,7 @@ func Test_ReferenceDelete(t *testing.T) {
 			Name: "source object internal error", Req: req,
 			WantCode:     StatusInternalServerError,
 			ErrSrcExists: anyErr,
-			WantErr:      NewErrInternal("repo: object by id: %v", anyErr), Stage: 2,
+			WantErr:      anyErr, Stage: 2,
 		},
 		{
 			Name: "source object missing", Req: req,

--- a/usecases/objects/repo_error_test.go
+++ b/usecases/objects/repo_error_test.go
@@ -1,0 +1,127 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package objects
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+// An error the repo returns has to stay classifiable with errors.Is after the
+// manager wrapped it. The REST layer maps sentinels raised inside the DB onto
+// their own status, and a chain flattened with %v leaves it nothing to match
+// on, so every one of them renders as a 500.
+func TestRepoErrStaysClassifiable(t *testing.T) {
+	sentinel := errors.New("shard refused")
+	repoErr := fmt.Errorf("local shard %q: %w", "s1", sentinel)
+
+	const class = "MyClass"
+	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
+
+	cases := []struct {
+		name    string
+		arrange func(repo *fakeVectorRepo)
+		call    func(m *Manager) error
+	}{
+		{
+			name: "get object of a class",
+			arrange: func(repo *fakeVectorRepo) {
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(nil, repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				_, err := m.GetObject(context.Background(), &models.Principal{}, class, id,
+					additional.Properties{}, nil, "")
+				return err
+			},
+		},
+		{
+			name: "get object without a class",
+			arrange: func(repo *fakeVectorRepo) {
+				repo.On("ObjectByID", id, mock.Anything, mock.Anything).
+					Return(nil, repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				_, err := m.GetObject(context.Background(), &models.Principal{}, "", id,
+					additional.Properties{}, nil, "")
+				return err
+			},
+		},
+		{
+			name: "list objects",
+			arrange: func(repo *fakeVectorRepo) {
+				repo.On("ObjectSearch", mock.Anything, mock.Anything, mock.Anything,
+					mock.Anything, mock.Anything).Return([]search.Result{}, repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				_, err := m.GetObjects(context.Background(), &models.Principal{},
+					nil, nil, nil, nil, nil, additional.Properties{}, "")
+				return err
+			},
+		},
+		{
+			name: "delete object of a class",
+			arrange: func(repo *fakeVectorRepo) {
+				repo.On("DeleteObject", class, id, mock.Anything).Return(repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				return m.DeleteObject(context.Background(), &models.Principal{}, class, id, nil, "")
+			},
+		},
+		{
+			name: "head object",
+			arrange: func(repo *fakeVectorRepo) {
+				repo.On("Exists", class, id).Return(false, repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				_, err := m.HeadObject(context.Background(), &models.Principal{}, class, id, nil, "")
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, repo, _, _ := newDeleteDependency()
+			tc.arrange(repo)
+
+			err := tc.call(manager)
+			require.Error(t, err)
+			require.ErrorIs(t, err, sentinel)
+			repo.AssertExpectations(t)
+		})
+	}
+}
+
+// The repo types a failed shard resolution as user input, which the handler
+// renders as 422. Reaching it means looking through the internal error the
+// manager wraps the read in.
+func TestRepoUserInputErrStaysClassifiable(t *testing.T) {
+	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
+	manager, repo, _, _ := newDeleteDependency()
+	repo.On("Object", "MyClass", id, mock.Anything, mock.Anything, "").
+		Return(nil, NewErrInvalidUserInput("determine shard: %v", errors.New("no shard"))).Once()
+
+	_, err := manager.GetObject(context.Background(), &models.Principal{}, "MyClass", id,
+		additional.Properties{}, nil, "")
+	require.ErrorAs(t, err, &ErrInvalidUserInput{})
+}

--- a/usecases/objects/repo_error_test.go
+++ b/usecases/objects/repo_error_test.go
@@ -22,34 +22,69 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/additional"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
 
 // An error the repo returns has to stay classifiable with errors.Is after the
-// manager wrapped it. The REST layer maps sentinels raised inside the DB onto
-// their own status, and a chain flattened with %v leaves it nothing to match
-// on, so every one of them renders as a 500.
+// manager wrapped it, because the REST layer maps sentinels raised inside the
+// DB onto their own status.
 //
 // Every entry point that funnels a repo error is covered: each has its own
-// funnel, and a fix to one says nothing about the others.
+// funnel, and a fix to one says nothing about the others. Each runs against a
+// plain sentinel and against a denial, which the handlers have to keep at 403.
 func TestRepoErrStaysClassifiable(t *testing.T) {
-	sentinel := errors.New("shard refused")
-	repoErr := fmt.Errorf("local shard %q: %w", "s1", sentinel)
-
 	const class = "Zoo"
 	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
 	refID := strfmt.UUID("a0b1c2d3-1e0d-42ae-bd52-ee09cb5f31cc")
 	principal := &models.Principal{Username: "admin"}
 
+	sentinel := errors.New("shard refused")
+	denied := authzerrs.NewForbidden(principal, authorization.READ, "collections/Zoo")
+	// A tenant left COLD or FROZEN, which the handlers answer with 422 — on the
+	// cross-class list too, where any class holding a same-named tenant in that
+	// state decides the whole request.
+	inactive := NewErrMultiTenancy(fmt.Errorf("%w: %q", enterrors.ErrTenantNotActive, "t1"))
+
+	raised := []struct {
+		name   string
+		err    error
+		assert func(t *testing.T, err error)
+	}{
+		{
+			name: "sentinel",
+			err:  fmt.Errorf("local shard %q: %w", "s1", sentinel),
+			assert: func(t *testing.T, err error) {
+				require.ErrorIs(t, err, sentinel)
+			},
+		},
+		{
+			name: "denial",
+			err:  fmt.Errorf("local shard %q: %w", "s1", denied),
+			assert: func(t *testing.T, err error) {
+				require.ErrorAs(t, err, &authzerrs.Forbidden{})
+			},
+		},
+		{
+			name: "inactive tenant",
+			err:  fmt.Errorf("local shard %q: %w", "s1", inactive),
+			assert: func(t *testing.T, err error) {
+				require.ErrorAs(t, err, &ErrMultiTenancy{})
+			},
+		},
+	}
+
 	cases := []struct {
 		name    string
-		arrange func(repo *fakeVectorRepo, mods *fakeModulesProvider)
+		arrange func(repo *fakeVectorRepo, mods *fakeModulesProvider, repoErr error)
 		call    func(m *Manager, b *BatchManager) error
 	}{
 		{
 			name: "get object of a class",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
 					Return(nil, repoErr).Once()
 			},
@@ -61,7 +96,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "get object without a class",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("ObjectByID", id, mock.Anything, mock.Anything).
 					Return(nil, repoErr).Once()
 			},
@@ -73,7 +108,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "list objects",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("ObjectSearch", mock.Anything, mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything).Return([]search.Result{}, repoErr).Once()
 			},
@@ -85,7 +120,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "head object",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("Exists", class, id).Return(false, repoErr).Once()
 			},
 			call: func(m *Manager, _ *BatchManager) error {
@@ -95,7 +130,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "add object fails its existence check",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("Exists", class, id).Return(false, repoErr).Once()
 			},
 			call: func(m *Manager, _ *BatchManager) error {
@@ -105,8 +140,34 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 			},
 		},
 		{
+			name: "update object",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(nil, repoErr).Once()
+			},
+			call: func(m *Manager, _ *BatchManager) error {
+				_, err := m.UpdateObject(context.Background(), principal, class, id,
+					&models.Object{Class: class, ID: id}, nil)
+				return err
+			},
+		},
+		{
+			name: "merge object",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(nil, repoErr).Once()
+			},
+			call: func(m *Manager, _ *BatchManager) error {
+				if objErr := m.MergeObject(context.Background(), principal,
+					&models.Object{Class: class, ID: id}, nil); objErr != nil {
+					return objErr
+				}
+				return nil
+			},
+		},
+		{
 			name: "delete object of a class",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("DeleteObject", class, id, mock.Anything).Return(repoErr).Once()
 			},
 			call: func(m *Manager, _ *BatchManager) error {
@@ -115,7 +176,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "delete object without a class",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("ObjectByID", id, mock.Anything, mock.Anything).
 					Return(&search.Result{ID: id, ClassName: class}, nil).Once()
 				repo.On("DeleteObject", class, id, mock.Anything).Return(repoErr).Once()
@@ -126,7 +187,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "batch add objects",
-			arrange: func(repo *fakeVectorRepo, mods *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, mods *fakeModulesProvider, repoErr error) {
 				mods.On("BatchUpdateVector").Return(nil, nil)
 				repo.On("BatchPutObjects", mock.Anything).Return(repoErr).Once()
 			},
@@ -138,7 +199,7 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 		{
 			name: "batch add references",
-			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider, repoErr error) {
 				repo.On("AddBatchReferences", mock.Anything).Return(repoErr).Once()
 			},
 			call: func(_ *Manager, b *BatchManager) error {
@@ -152,42 +213,226 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 		},
 	}
 
+	for _, r := range raised {
+		for _, tc := range cases {
+			t.Run(r.name+"/"+tc.name, func(t *testing.T) {
+				m, b, repo, mods, _ := newNSManagers(t, zooAnimalNSSchema(false), false)
+				tc.arrange(repo, mods, r.err)
+
+				err := tc.call(m, b)
+				require.Error(t, err)
+				r.assert(t, err)
+				repo.AssertExpectations(t)
+			})
+		}
+	}
+}
+
+// The repo types a failed shard resolution as user input, which the handler
+// renders as 422 rather than 500. Reaching it means looking through whatever
+// the manager wrapped the call in, on the read itself and on the vectorizer
+// the write drives afterwards.
+func TestRepoUserInputErrStaysClassifiable(t *testing.T) {
+	const class = "Zoo"
+	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
+	repoErr := NewErrInvalidUserInput("determine shard: %v", errors.New("no shard"))
+	found := &search.Result{ID: id, ClassName: class}
+
+	cases := []struct {
+		name    string
+		arrange func(repo *fakeVectorRepo, mods *fakeModulesProvider)
+		call    func(m *Manager) error
+	}{
+		{
+			name: "get object reads the repo",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(nil, repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				_, err := m.GetObject(context.Background(), &models.Principal{}, class, id,
+					additional.Properties{}, nil, "")
+				return err
+			},
+		},
+		{
+			name: "update object reads the repo",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(nil, repoErr).Once()
+			},
+			call: func(m *Manager) error {
+				_, err := m.UpdateObject(context.Background(), &models.Principal{}, class, id,
+					&models.Object{Class: class, ID: id}, nil)
+				return err
+			},
+		},
+		{
+			name: "update object vectorizes",
+			arrange: func(repo *fakeVectorRepo, mods *fakeModulesProvider) {
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(found, nil).Once()
+				mods.On("UpdateVector", mock.Anything, mock.AnythingOfType(FindObjectFn)).
+					Return(nil, repoErr)
+			},
+			call: func(m *Manager) error {
+				_, err := m.UpdateObject(context.Background(), &models.Principal{}, class, id,
+					&models.Object{Class: class, ID: id}, nil)
+				return err
+			},
+		},
+		{
+			name: "list objects extends",
+			arrange: func(repo *fakeVectorRepo, mods *fakeModulesProvider) {
+				repo.On("ObjectSearch", mock.Anything, mock.Anything, mock.Anything,
+					mock.Anything, mock.Anything).Return([]search.Result{*found}, nil).Once()
+				mods.ExtendErr = repoErr
+			},
+			call: func(m *Manager) error {
+				_, err := m.GetObjects(context.Background(), &models.Principal{},
+					nil, nil, nil, nil, nil, additional.Properties{}, "")
+				return err
+			},
+		},
+	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			m, b, repo, mods, _ := newNSManagers(t, zooAnimalNSSchema(false), false)
+			m, _, repo, mods, _ := newNSManagers(t, zooAnimalNSSchema(false), false)
 			tc.arrange(repo, mods)
 
-			err := tc.call(m, b)
-			require.Error(t, err)
-			require.ErrorIs(t, err, sentinel)
+			require.ErrorAs(t, tc.call(m), &ErrInvalidUserInput{})
 			repo.AssertExpectations(t)
 		})
 	}
 }
 
-// The repo types a failed shard resolution as user input, which the handler
-// renders as 422. Reaching it means looking through the internal error the
-// manager wraps the read in.
-func TestRepoUserInputErrStaysClassifiable(t *testing.T) {
-	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
-	m, _, repo, _, _ := newNSManagers(t, zooAnimalNSSchema(false), false)
-	repo.On("Object", "Zoo", id, mock.Anything, mock.Anything, "").
-		Return(nil, NewErrInvalidUserInput("determine shard: %v", errors.New("no shard"))).Once()
-
-	_, err := m.GetObject(context.Background(), &models.Principal{}, "Zoo", id,
-		additional.Properties{}, nil, "")
-	require.ErrorAs(t, err, &ErrInvalidUserInput{})
-}
-
-// A format with several %w verbs produces an error that unwraps to a slice,
-// which errors.Unwrap reports as nil — so the constructor has to keep the
-// formatted error itself to leave either cause reachable.
+// Causes reach through the constructor whatever the format holds: none, one
+// %w, or several.
 func TestNewErrInternalKeepsEveryCause(t *testing.T) {
 	first, second := errors.New("first"), errors.New("second")
 
-	err := NewErrInternal("two causes: %w and %w", first, second)
+	cases := []struct {
+		name    string
+		err     ErrInternal
+		message string
+		causes  []error
+	}{
+		{
+			name:    "no cause",
+			err:     NewErrInternal("plain %s", "text"),
+			message: "plain text",
+		},
+		{
+			name:    "one cause",
+			err:     NewErrInternal("one cause: %w", first),
+			message: "one cause: first",
+			causes:  []error{first},
+		},
+		{
+			name:    "two causes",
+			err:     NewErrInternal("two causes: %w and %w", first, second),
+			message: "two causes: first and second",
+			causes:  []error{first, second},
+		},
+	}
 
-	require.ErrorIs(t, err, first)
-	require.ErrorIs(t, err, second)
-	require.Equal(t, "two causes: first and second", err.Error())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.message, tc.err.Error())
+			for _, cause := range tc.causes {
+				require.ErrorIs(t, tc.err, cause)
+			}
+			if len(tc.causes) == 0 {
+				require.NotErrorIs(t, tc.err, first)
+			}
+		})
+	}
+}
+
+// Writing an object can extend its collection through auto-schema, which needs
+// a permission of its own. Reporting that denial as invalid input hides the
+// missing grant behind a 422, so PUT and PATCH have to keep its status.
+func TestAutoSchemaForbiddenKeepsItsStatus(t *testing.T) {
+	const class = "Zoo"
+	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
+	principal := &models.Principal{Username: "admin"}
+	denied := authzerrs.NewForbidden(principal, authorization.UPDATE, "collections/Zoo")
+	rejected := errors.New("collection is being deleted")
+
+	// "age" is absent from the Zoo schema, so writing it makes auto-schema
+	// extend the collection.
+	updates := func() *models.Object {
+		return &models.Object{
+			Class: class, ID: id,
+			Properties: map[string]interface{}{"age": float64(7)},
+		}
+	}
+
+	cases := []struct {
+		name          string
+		autoSchemaErr error
+		wantForbidden bool
+		wantUserInput bool
+	}{
+		{name: "denied", autoSchemaErr: denied, wantForbidden: true},
+		{name: "rejected", autoSchemaErr: rejected, wantUserInput: true},
+		{name: "permitted", autoSchemaErr: nil},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("update", func(t *testing.T) {
+				m, _, repo, mods, _ := newNSManagers(t, zooAnimalNSSchema(false), false,
+					withAutoSchema(tc.autoSchemaErr))
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(&search.Result{ID: id, ClassName: class}, nil).Once()
+				if tc.autoSchemaErr == nil {
+					mods.On("UpdateVector", mock.Anything, mock.AnythingOfType(FindObjectFn)).
+						Return(nil, nil)
+					repo.On("PutObject", mock.Anything, mock.Anything).Return(nil).Once()
+				}
+
+				_, err := m.UpdateObject(context.Background(), principal, class, id, updates(), nil)
+
+				switch {
+				case tc.wantForbidden:
+					require.ErrorAs(t, err, &authzerrs.Forbidden{})
+					require.NotErrorAs(t, err, &ErrInvalidUserInput{})
+				case tc.wantUserInput:
+					require.ErrorAs(t, err, &ErrInvalidUserInput{})
+				default:
+					require.NoError(t, err)
+				}
+				repo.AssertExpectations(t)
+			})
+
+			t.Run("merge", func(t *testing.T) {
+				m, _, repo, mods, _ := newNSManagers(t, zooAnimalNSSchema(false), false,
+					withAutoSchema(tc.autoSchemaErr))
+				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
+					Return(&search.Result{ID: id, ClassName: class}, nil).Once()
+				if tc.autoSchemaErr == nil {
+					mods.On("UpdateVector", mock.Anything, mock.AnythingOfType(FindObjectFn)).
+						Return(nil, nil)
+					repo.On("Merge", mock.Anything).Return(nil).Once()
+				}
+
+				objErr := m.MergeObject(context.Background(), principal, updates(), nil)
+
+				switch {
+				case tc.wantForbidden:
+					require.NotNil(t, objErr)
+					require.Equal(t, StatusForbidden, objErr.Code)
+				case tc.wantUserInput:
+					// The handler renders a merge BadRequest as 422.
+					require.NotNil(t, objErr)
+					require.Equal(t, StatusBadRequest, objErr.Code)
+				default:
+					require.Nil(t, objErr)
+				}
+				repo.AssertExpectations(t)
+			})
+		})
+	}
 }

--- a/usecases/objects/repo_error_test.go
+++ b/usecases/objects/repo_error_test.go
@@ -30,70 +30,123 @@ import (
 // manager wrapped it. The REST layer maps sentinels raised inside the DB onto
 // their own status, and a chain flattened with %v leaves it nothing to match
 // on, so every one of them renders as a 500.
+//
+// Every entry point that funnels a repo error is covered: each has its own
+// funnel, and a fix to one says nothing about the others.
 func TestRepoErrStaysClassifiable(t *testing.T) {
 	sentinel := errors.New("shard refused")
 	repoErr := fmt.Errorf("local shard %q: %w", "s1", sentinel)
 
-	const class = "MyClass"
+	const class = "Zoo"
 	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
+	refID := strfmt.UUID("a0b1c2d3-1e0d-42ae-bd52-ee09cb5f31cc")
+	principal := &models.Principal{Username: "admin"}
 
 	cases := []struct {
 		name    string
-		arrange func(repo *fakeVectorRepo)
-		call    func(m *Manager) error
+		arrange func(repo *fakeVectorRepo, mods *fakeModulesProvider)
+		call    func(m *Manager, b *BatchManager) error
 	}{
 		{
 			name: "get object of a class",
-			arrange: func(repo *fakeVectorRepo) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
 				repo.On("Object", class, id, mock.Anything, mock.Anything, "").
 					Return(nil, repoErr).Once()
 			},
-			call: func(m *Manager) error {
-				_, err := m.GetObject(context.Background(), &models.Principal{}, class, id,
+			call: func(m *Manager, _ *BatchManager) error {
+				_, err := m.GetObject(context.Background(), principal, class, id,
 					additional.Properties{}, nil, "")
 				return err
 			},
 		},
 		{
 			name: "get object without a class",
-			arrange: func(repo *fakeVectorRepo) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
 				repo.On("ObjectByID", id, mock.Anything, mock.Anything).
 					Return(nil, repoErr).Once()
 			},
-			call: func(m *Manager) error {
-				_, err := m.GetObject(context.Background(), &models.Principal{}, "", id,
+			call: func(m *Manager, _ *BatchManager) error {
+				_, err := m.GetObject(context.Background(), principal, "", id,
 					additional.Properties{}, nil, "")
 				return err
 			},
 		},
 		{
 			name: "list objects",
-			arrange: func(repo *fakeVectorRepo) {
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
 				repo.On("ObjectSearch", mock.Anything, mock.Anything, mock.Anything,
 					mock.Anything, mock.Anything).Return([]search.Result{}, repoErr).Once()
 			},
-			call: func(m *Manager) error {
-				_, err := m.GetObjects(context.Background(), &models.Principal{},
+			call: func(m *Manager, _ *BatchManager) error {
+				_, err := m.GetObjects(context.Background(), principal,
 					nil, nil, nil, nil, nil, additional.Properties{}, "")
 				return err
 			},
 		},
 		{
-			name: "delete object of a class",
-			arrange: func(repo *fakeVectorRepo) {
-				repo.On("DeleteObject", class, id, mock.Anything).Return(repoErr).Once()
+			name: "head object",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+				repo.On("Exists", class, id).Return(false, repoErr).Once()
 			},
-			call: func(m *Manager) error {
-				return m.DeleteObject(context.Background(), &models.Principal{}, class, id, nil, "")
+			call: func(m *Manager, _ *BatchManager) error {
+				_, err := m.HeadObject(context.Background(), principal, class, id, nil, "")
+				return err
 			},
 		},
 		{
-			name: "head object",
-			arrange: func(repo *fakeVectorRepo) {
+			name: "add object fails its existence check",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
 				repo.On("Exists", class, id).Return(false, repoErr).Once()
 			},
-			call: func(m *Manager) error {
-				_, err := m.HeadObject(context.Background(), &models.Principal{}, class, id, nil, "")
+			call: func(m *Manager, _ *BatchManager) error {
+				_, err := m.AddObject(context.Background(), principal,
+					&models.Object{Class: class, ID: id}, nil)
+				return err
+			},
+		},
+		{
+			name: "delete object of a class",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+				repo.On("DeleteObject", class, id, mock.Anything).Return(repoErr).Once()
+			},
+			call: func(m *Manager, _ *BatchManager) error {
+				return m.DeleteObject(context.Background(), principal, class, id, nil, "")
+			},
+		},
+		{
+			name: "delete object without a class",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+				repo.On("ObjectByID", id, mock.Anything, mock.Anything).
+					Return(&search.Result{ID: id, ClassName: class}, nil).Once()
+				repo.On("DeleteObject", class, id, mock.Anything).Return(repoErr).Once()
+			},
+			call: func(m *Manager, _ *BatchManager) error {
+				return m.DeleteObject(context.Background(), principal, "", id, nil, "")
+			},
+		},
+		{
+			name: "batch add objects",
+			arrange: func(repo *fakeVectorRepo, mods *fakeModulesProvider) {
+				mods.On("BatchUpdateVector").Return(nil, nil)
+				repo.On("BatchPutObjects", mock.Anything).Return(repoErr).Once()
+			},
+			call: func(_ *Manager, b *BatchManager) error {
+				_, err := b.AddObjects(context.Background(), principal,
+					[]*models.Object{{Class: class, ID: id}}, []*string{}, nil)
+				return err
+			},
+		},
+		{
+			name: "batch add references",
+			arrange: func(repo *fakeVectorRepo, _ *fakeModulesProvider) {
+				repo.On("AddBatchReferences", mock.Anything).Return(repoErr).Once()
+			},
+			call: func(_ *Manager, b *BatchManager) error {
+				_, err := b.AddReferences(context.Background(), principal,
+					[]*models.BatchReference{{
+						From: strfmt.URI("weaviate://localhost/Zoo/" + string(id) + "/hasAnimals"),
+						To:   strfmt.URI("weaviate://localhost/Animal/" + string(refID)),
+					}}, nil)
 				return err
 			},
 		},
@@ -101,10 +154,10 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			manager, repo, _, _ := newDeleteDependency()
-			tc.arrange(repo)
+			m, b, repo, mods, _ := newNSManagers(t, zooAnimalNSSchema(false), false)
+			tc.arrange(repo, mods)
 
-			err := tc.call(manager)
+			err := tc.call(m, b)
 			require.Error(t, err)
 			require.ErrorIs(t, err, sentinel)
 			repo.AssertExpectations(t)
@@ -117,11 +170,24 @@ func TestRepoErrStaysClassifiable(t *testing.T) {
 // manager wraps the read in.
 func TestRepoUserInputErrStaysClassifiable(t *testing.T) {
 	id := strfmt.UUID("5a1cd361-1e0d-42ae-bd52-ee09cb5f31cc")
-	manager, repo, _, _ := newDeleteDependency()
-	repo.On("Object", "MyClass", id, mock.Anything, mock.Anything, "").
+	m, _, repo, _, _ := newNSManagers(t, zooAnimalNSSchema(false), false)
+	repo.On("Object", "Zoo", id, mock.Anything, mock.Anything, "").
 		Return(nil, NewErrInvalidUserInput("determine shard: %v", errors.New("no shard"))).Once()
 
-	_, err := manager.GetObject(context.Background(), &models.Principal{}, "MyClass", id,
+	_, err := m.GetObject(context.Background(), &models.Principal{}, "Zoo", id,
 		additional.Properties{}, nil, "")
 	require.ErrorAs(t, err, &ErrInvalidUserInput{})
+}
+
+// A format with several %w verbs produces an error that unwraps to a slice,
+// which errors.Unwrap reports as nil — so the constructor has to keep the
+// formatted error itself to leave either cause reachable.
+func TestNewErrInternalKeepsEveryCause(t *testing.T) {
+	first, second := errors.New("first"), errors.New("second")
+
+	err := NewErrInternal("two causes: %w and %w", first, second)
+
+	require.ErrorIs(t, err, first)
+	require.ErrorIs(t, err, second)
+	require.Equal(t, "two causes: first and second", err.Error())
 }

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -13,6 +13,7 @@ package objects
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-openapi/strfmt"
@@ -24,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -92,6 +94,11 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 
 	autoSchemaVersion, err := m.autoSchemaManager.autoSchema(ctx, principal, false, fetchedClasses, updates)
 	if err != nil {
+		// Extending the collection needs its own permission; reporting a denial
+		// as invalid input would hide the missing grant behind a 422.
+		if errors.As(err, &authzerrs.Forbidden{}) {
+			return nil, err
+		}
 		return nil, NewErrInvalidUserInput("invalid object: %v", err)
 	}
 
@@ -119,7 +126,7 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 
 	err = m.modulesProvider.UpdateVector(ctx, updates, class, m.findObject, m.logger)
 	if err != nil {
-		return nil, NewErrInternal("update object: %v", err)
+		return nil, NewErrInternal("update object: %w", err)
 	}
 
 	schema.HashBlobHashProperties(class, updates)


### PR DESCRIPTION
### What's being changed:

NewInternalError lost the type of the underlying error and made any type checks further up fail

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
