### PR TITLE
Collapse BatchStream tenant resolution to one bulk query

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1773,16 +1773,32 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 		}
 	}
 	byShard := map[string]objsAndPos{}
-	for pos, obj := range objects {
-		target, err := i.shardResolver.ResolveShard(ctx, obj)
-		if err != nil {
-			out[pos] = err
-			continue
+	if i.partitioningEnabled {
+		// Bulk tenant validation shares one schema lookup while retaining the
+		// per-object errors this method returns to batch callers.
+		targets, resolutionErrs := i.shardResolver.ResolveShardsWithErrors(ctx, objects)
+		for pos, target := range targets {
+			if err := resolutionErrs[pos]; err != nil {
+				out[pos] = err
+				continue
+			}
+			group := byShard[target.Shard]
+			group.objects = append(group.objects, objects[pos])
+			group.pos = append(group.pos, pos)
+			byShard[target.Shard] = group
 		}
-		group := byShard[target.Shard]
-		group.objects = append(group.objects, obj)
-		group.pos = append(group.pos, pos)
-		byShard[target.Shard] = group
+	} else {
+		for pos, obj := range objects {
+			target, err := i.shardResolver.ResolveShard(ctx, obj)
+			if err != nil {
+				out[pos] = err
+				continue
+			}
+			group := byShard[target.Shard]
+			group.objects = append(group.objects, obj)
+			group.pos = append(group.pos, pos)
+			byShard[target.Shard] = group
+		}
 	}
 
 	wg := &sync.WaitGroup{}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1772,33 +1772,21 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 			return duplicateErr(fmt.Errorf("wait for schema version %d: %w", schemaVersion, err), len(objects))
 		}
 	}
+	// Resolve every object's target shard in one pass. Multi-tenant classes
+	// share a single schema lookup; single-tenant classes fall back to per-object
+	// UUID hashing. Either way the per-object errors this method returns to batch
+	// callers are retained, so a bad object fails without sinking its batch.
 	byShard := map[string]objsAndPos{}
-	if i.partitioningEnabled {
-		// Bulk tenant validation shares one schema lookup while retaining the
-		// per-object errors this method returns to batch callers.
-		targets, resolutionErrs := i.shardResolver.ResolveShardsWithErrors(ctx, objects)
-		for pos, target := range targets {
-			if err := resolutionErrs[pos]; err != nil {
-				out[pos] = err
-				continue
-			}
-			group := byShard[target.Shard]
-			group.objects = append(group.objects, objects[pos])
-			group.pos = append(group.pos, pos)
-			byShard[target.Shard] = group
+	targets, resolutionErrs := i.shardResolver.ResolveShardsWithErrors(ctx, objects)
+	for pos, target := range targets {
+		if err := resolutionErrs[pos]; err != nil {
+			out[pos] = err
+			continue
 		}
-	} else {
-		for pos, obj := range objects {
-			target, err := i.shardResolver.ResolveShard(ctx, obj)
-			if err != nil {
-				out[pos] = err
-				continue
-			}
-			group := byShard[target.Shard]
-			group.objects = append(group.objects, obj)
-			group.pos = append(group.pos, pos)
-			byShard[target.Shard] = group
-		}
+		group := byShard[target.Shard]
+		group.objects = append(group.objects, objects[pos])
+		group.pos = append(group.pos, pos)
+		byShard[target.Shard] = group
 	}
 
 	wg := &sync.WaitGroup{}

--- a/adapters/repos/db/multitenancy/validator.go
+++ b/adapters/repos/db/multitenancy/validator.go
@@ -70,12 +70,30 @@ func newSingleTenantValidator(className string) *singleTenantValidator {
 func (v *singleTenantValidator) ValidateTenants(ctx context.Context, tenants ...string) error {
 	for _, tenant := range tenants {
 		if tenant != "" {
-			return objects.NewErrMultiTenancy(
-				fmt.Errorf("class %s has multi-tenancy disabled, but request was with tenant", v.className),
-			)
+			return v.tenantNotAllowedError()
 		}
 	}
 	return nil
+}
+
+func (v *singleTenantValidator) tenantNotAllowedError() error {
+	return objects.NewErrMultiTenancy(
+		fmt.Errorf("class %s has multi-tenancy disabled, but request was with tenant", v.className),
+	)
+}
+
+// ValidateTenantsIndividually returns validation failures by tenant while
+// allowing valid tenants in the same batch to proceed. A single-tenant class
+// has no schema lookup to share, so each non-empty tenant receives the same
+// validation error it would get from ValidateTenants.
+func (v *singleTenantValidator) ValidateTenantsIndividually(_ context.Context, tenants ...string) map[string]error {
+	failures := make(map[string]error)
+	for _, tenant := range tenants {
+		if tenant != "" {
+			failures[tenant] = v.tenantNotAllowedError()
+		}
+	}
+	return failures
 }
 
 // multiTenantValidator validates requests for collections with multi-tenancy enabled.
@@ -119,15 +137,11 @@ func newMultiTenantValidator(className string, schemaReader schemaReader) *multi
 // Returns an error on the first validation failure, nil if all tenants are valid.
 func (v *multiTenantValidator) ValidateTenants(ctx context.Context, tenants ...string) error {
 	if len(tenants) == 0 {
-		return objects.NewErrMultiTenancy(fmt.Errorf(
-			"class %s has multi-tenancy enabled, but request was without tenant", v.className,
-		))
+		return v.tenantRequiredError()
 	}
 	for _, tenant := range tenants {
 		if tenant == "" {
-			return objects.NewErrMultiTenancy(fmt.Errorf(
-				"class %s has multi-tenancy enabled, but request was without tenant", v.className,
-			))
+			return v.tenantRequiredError()
 		}
 	}
 
@@ -149,6 +163,59 @@ func (v *multiTenantValidator) ValidateTenants(ctx context.Context, tenants ...s
 		}
 	}
 	return nil
+}
+
+func (v *multiTenantValidator) tenantRequiredError() error {
+	return objects.NewErrMultiTenancy(fmt.Errorf(
+		"class %s has multi-tenancy enabled, but request was without tenant", v.className,
+	))
+}
+
+// ValidateTenantsIndividually validates all unique non-empty tenants in one
+// schema lookup and returns the failures keyed by tenant. Unlike
+// ValidateTenants, this method does not turn one invalid tenant into a
+// batch-wide failure: callers can retain their per-object error contract while
+// still sharing the leader status lookup across a batch.
+//
+// Empty tenants have no status to fetch and receive the same required-tenant
+// error as ValidateTenants. If the shared schema lookup itself fails, each
+// non-empty tenant receives the same wrapped lookup error.
+func (v *multiTenantValidator) ValidateTenantsIndividually(ctx context.Context, tenants ...string) map[string]error {
+	failures := make(map[string]error)
+	uniqueTenants := make([]string, 0, len(tenants))
+	seen := make(map[string]struct{}, len(tenants))
+	for _, tenant := range tenants {
+		if _, ok := seen[tenant]; ok {
+			continue
+		}
+		seen[tenant] = struct{}{}
+		if tenant == "" {
+			failures[tenant] = v.tenantRequiredError()
+			continue
+		}
+		uniqueTenants = append(uniqueTenants, tenant)
+	}
+
+	if len(uniqueTenants) == 0 {
+		return failures
+	}
+
+	statusMap, err := v.schemaReader.TenantsShards(ctx, v.className, uniqueTenants...)
+	if err != nil {
+		err = fmt.Errorf("fetch tenant status for class %q: %w", v.className, err)
+		for _, tenant := range uniqueTenants {
+			failures[tenant] = err
+		}
+		return failures
+	}
+
+	for _, tenant := range uniqueTenants {
+		status := statusMap[tenant]
+		if err := v.validateTenantStatus(tenant, status); err != nil {
+			failures[tenant] = err
+		}
+	}
+	return failures
 }
 
 // validateTenantStatus validates a tenant's status and existence.
@@ -201,7 +268,8 @@ func deduplicateTenants(tenants []string) []string {
 // of the collection's multi-tenancy configuration. It delegates to the appropriate
 // validation strategy based on the collection's settings.
 type TenantValidator struct {
-	validateTenants func(ctx context.Context, tenants ...string) error
+	validateTenants             func(ctx context.Context, tenants ...string) error
+	validateTenantsIndividually func(ctx context.Context, tenants ...string) map[string]error
 }
 
 // ValidateTenants validates the provided tenant parameters according to the
@@ -215,6 +283,13 @@ type TenantValidator struct {
 // Returns an error if validation fails, nil if all tenants are valid.
 func (v *TenantValidator) ValidateTenants(ctx context.Context, tenants ...string) error {
 	return v.validateTenants(ctx, tenants...)
+}
+
+// ValidateTenantsIndividually validates a batch of tenant names in bulk and
+// reports failures by tenant. It is intended for callers that need to preserve
+// per-object errors while sharing one schema status lookup for the batch.
+func (v *TenantValidator) ValidateTenantsIndividually(ctx context.Context, tenants ...string) map[string]error {
+	return v.validateTenantsIndividually(ctx, tenants...)
 }
 
 // NewTenantValidator constructs a TenantValidator with the appropriate validation strategy
@@ -234,12 +309,14 @@ func NewTenantValidator(className string, multiTenancyEnabled bool, schemaReader
 	if multiTenancyEnabled {
 		validator := newMultiTenantValidator(className, schemaReader)
 		return &TenantValidator{
-			validateTenants: validator.ValidateTenants,
+			validateTenants:             validator.ValidateTenants,
+			validateTenantsIndividually: validator.ValidateTenantsIndividually,
 		}
 	}
 	validator := newSingleTenantValidator(className)
 	return &TenantValidator{
-		validateTenants: validator.ValidateTenants,
+		validateTenants:             validator.ValidateTenants,
+		validateTenantsIndividually: validator.ValidateTenantsIndividually,
 	}
 }
 
@@ -247,6 +324,7 @@ func NewTenantValidator(className string, multiTenancyEnabled bool, schemaReader
 // This interface ensures consistency across different validation approaches.
 type validatorStrategy interface {
 	ValidateTenants(ctx context.Context, tenants ...string) error
+	ValidateTenantsIndividually(ctx context.Context, tenants ...string) map[string]error
 }
 
 // Interface compliance checks at compile time.

--- a/adapters/repos/db/multitenancy/validator_test.go
+++ b/adapters/repos/db/multitenancy/validator_test.go
@@ -39,12 +39,14 @@ type fakeSchemaReader struct {
 	tenantShards    map[string]string
 	tenantsShardErr error
 	classExists     bool
+	tenantQueries   [][]string
 }
 
 // TenantsShards returns tenant status for requested tenants or the configured error.
 // Only returns status for tenants that exist in the tenantShards map.
 // Tenants not in the map are omitted from the result (simulating non-existent tenants).
 func (f *fakeSchemaReader) TenantsShards(_ context.Context, _ string, tenants ...string) (map[string]string, error) {
+	f.tenantQueries = append(f.tenantQueries, append([]string(nil), tenants...))
 	if f.tenantsShardErr != nil {
 		return nil, f.tenantsShardErr
 	}
@@ -236,6 +238,29 @@ func Test_MultiTenantValidator(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_MultiTenantValidator_ValidateTenantsIndividually(t *testing.T) {
+	// GIVEN
+	schemaReader := &fakeSchemaReader{
+		tenantShards: map[string]string{
+			"hot":  models.TenantActivityStatusHOT,
+			"cold": models.TenantActivityStatusCOLD,
+		},
+		classExists: true,
+	}
+	validator := multitenancy.NewTenantValidator("TestClass", true, schemaReader)
+
+	// WHEN
+	failures := validator.ValidateTenantsIndividually(context.Background(), "hot", "missing", "cold", "", "hot")
+
+	// THEN
+	require.Len(t, schemaReader.tenantQueries, 1)
+	require.ElementsMatch(t, []string{"hot", "missing", "cold"}, schemaReader.tenantQueries[0])
+	require.NotContains(t, failures, "hot")
+	require.ErrorContains(t, failures["missing"], "tenant not found")
+	require.ErrorContains(t, failures["cold"], "tenant not active")
+	require.ErrorContains(t, failures[""], "without tenant")
 }
 
 func Test_MultiTenantValidator_SchemaErrors(t *testing.T) {

--- a/adapters/repos/db/sharding/resolver.go
+++ b/adapters/repos/db/sharding/resolver.go
@@ -226,6 +226,24 @@ func (r *byUUIDShardResolver) ResolveShards(ctx context.Context, objects []*stor
 	return targets, nil
 }
 
+// ResolveShardsWithErrors resolves each object independently and returns a
+// target and error at every input position. UUID-based routing has no shared
+// lookup to optimize, but the positional result preserves the batch API used
+// by both shard resolution strategies.
+func (r *byUUIDShardResolver) ResolveShardsWithErrors(ctx context.Context, objects []*storobj.Object) (ShardTargets, []error) {
+	targets := make(ShardTargets, len(objects))
+	errs := make([]error, len(objects))
+	for pos, object := range objects {
+		target, err := r.ResolveShard(ctx, object)
+		if err != nil {
+			errs[pos] = err
+			continue
+		}
+		targets[pos] = target
+	}
+	return targets, errs
+}
+
 // byTenantShardResolver implements shard resolution using tenant names as shard identifiers.
 // This strategy is used for multi-tenant collections where each tenant's data is
 // isolated in its own shard, with the tenant name directly mapping to the shard name.
@@ -334,6 +352,29 @@ func (r *byTenantShardResolver) ResolveShards(ctx context.Context, objects []*st
 	return targets, nil
 }
 
+// ResolveShardsWithErrors resolves all objects with one bulk tenant-status
+// lookup. The returned targets and errors are aligned with objects: an invalid
+// tenant has a nil target and its own error while valid objects retain targets
+// that can be written in the same batch.
+func (r *byTenantShardResolver) ResolveShardsWithErrors(ctx context.Context, objects []*storobj.Object) (ShardTargets, []error) {
+	targets := make(ShardTargets, len(objects))
+	errs := make([]error, len(objects))
+	if len(objects) == 0 {
+		return targets, errs
+	}
+
+	failures := r.tenantValidator.ValidateTenantsIndividually(ctx, r.extractUniqueTenants(objects)...)
+	for pos, object := range objects {
+		tenant := object.Object.Tenant
+		if err, failed := failures[tenant]; failed {
+			errs[pos] = err
+			continue
+		}
+		targets[pos] = &ShardTarget{Shard: tenant, Object: object}
+	}
+	return targets, errs
+}
+
 // extractUniqueTenants extracts unique tenant names from a collection of objects.
 // This method performs deduplication to minimize the work required for bulk
 // tenant validation and schema operations.
@@ -360,9 +401,10 @@ func (r *byTenantShardResolver) extractUniqueTenants(objects []*storobj.Object) 
 // the collection's multi-tenancy configuration. It delegates to the appropriate
 // resolution strategy (UUID-based or tenant-based) selected at construction time.
 type ShardResolver struct {
-	resolveShard           func(ctx context.Context, object *storobj.Object) (*ShardTarget, error)
-	resolveShards          func(ctx context.Context, objects []*storobj.Object) (ShardTargets, error)
-	resolveShardByObjectID func(ctx context.Context, objectID strfmt.UUID, tenant string) (string, error)
+	resolveShard            func(ctx context.Context, object *storobj.Object) (*ShardTarget, error)
+	resolveShards           func(ctx context.Context, objects []*storobj.Object) (ShardTargets, error)
+	resolveShardsWithErrors func(ctx context.Context, objects []*storobj.Object) (ShardTargets, []error)
+	resolveShardByObjectID  func(ctx context.Context, objectID strfmt.UUID, tenant string) (string, error)
 }
 
 // ResolveShardByObjectID resolves the target shard for an object using its UUID and tenant information.
@@ -424,6 +466,14 @@ func (r *ShardResolver) ResolveShards(ctx context.Context, objects []*storobj.Ob
 	return r.resolveShards(ctx, objects)
 }
 
+// ResolveShardsWithErrors resolves all objects and retains a result for every
+// input position. Targets and errors are aligned with objects; an error at a
+// position means its target is nil. This lets batch callers preserve partial
+// success when shard resolution fails for only some objects.
+func (r *ShardResolver) ResolveShardsWithErrors(ctx context.Context, objects []*storobj.Object) (ShardTargets, []error) {
+	return r.resolveShardsWithErrors(ctx, objects)
+}
+
 // NewShardResolver constructs a ShardResolver with the appropriate resolution strategy
 // based on the collection's multi-tenancy configuration.
 //
@@ -442,16 +492,18 @@ func NewShardResolver(className string, multiTenancyEnabled bool, schemaReader s
 	if multiTenancyEnabled {
 		resolver := newByTenantShardResolver(className, schemaReader)
 		return &ShardResolver{
-			resolveShard:           resolver.ResolveShard,
-			resolveShards:          resolver.ResolveShards,
-			resolveShardByObjectID: resolver.ResolveShardByObjectID,
+			resolveShard:            resolver.ResolveShard,
+			resolveShards:           resolver.ResolveShards,
+			resolveShardsWithErrors: resolver.ResolveShardsWithErrors,
+			resolveShardByObjectID:  resolver.ResolveShardByObjectID,
 		}
 	}
 	resolver := newByUUIDShardResolver(className, schemaReader)
 	return &ShardResolver{
-		resolveShard:           resolver.ResolveShard,
-		resolveShards:          resolver.ResolveShards,
-		resolveShardByObjectID: resolver.ResolveShardByObjectID,
+		resolveShard:            resolver.ResolveShard,
+		resolveShards:           resolver.ResolveShards,
+		resolveShardsWithErrors: resolver.ResolveShardsWithErrors,
+		resolveShardByObjectID:  resolver.ResolveShardByObjectID,
 	}
 }
 
@@ -461,6 +513,7 @@ func NewShardResolver(className string, multiTenancyEnabled bool, schemaReader s
 type resolverStrategy interface {
 	ResolveShard(ctx context.Context, object *storobj.Object) (*ShardTarget, error)
 	ResolveShards(ctx context.Context, objects []*storobj.Object) (ShardTargets, error)
+	ResolveShardsWithErrors(ctx context.Context, objects []*storobj.Object) (ShardTargets, []error)
 	ResolveShardByObjectID(ctx context.Context, objectID strfmt.UUID, tenant string) (string, error)
 }
 

--- a/adapters/repos/db/sharding/resolver_test.go
+++ b/adapters/repos/db/sharding/resolver_test.go
@@ -43,6 +43,7 @@ type fakeSchemaReader struct {
 	shards          []string
 	tenantShards    map[string]string
 	tenantsShardErr error
+	tenantQueries   [][]string
 }
 
 // ShardFromUUID assigns a shard by hashing the first byte of the UUID and
@@ -59,7 +60,8 @@ func (f *fakeSchemaReader) ShardFromUUID(_ string, uuidBytes []byte) string {
 }
 
 // TenantsShards returns a copy of tenantShards or the configured error.
-func (f *fakeSchemaReader) TenantsShards(_ context.Context, _ string, _ ...string) (map[string]string, error) {
+func (f *fakeSchemaReader) TenantsShards(_ context.Context, _ string, tenants ...string) (map[string]string, error) {
+	f.tenantQueries = append(f.tenantQueries, append([]string(nil), tenants...))
 	if f.tenantsShardErr != nil {
 		return nil, f.tenantsShardErr
 	}
@@ -601,6 +603,66 @@ func Test_ShardResolution_MultiTenant_MixedValidInvalid(t *testing.T) {
 	// THEN
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "tenant not found")
+}
+
+func Test_ShardResolution_MultiTenant_WithErrors(t *testing.T) {
+	// GIVEN
+	schemaReader := &fakeSchemaReader{tenantShards: map[string]string{
+		"hot":  models.TenantActivityStatusHOT,
+		"cold": models.TenantActivityStatusCOLD,
+	}}
+	r := resolver.NewShardResolver("TestClass", true, schemaReader)
+	objects := []*storobj.Object{
+		newTestObject(strfmt.UUID(uuid.NewString()), "hot"),
+		newTestObject(strfmt.UUID(uuid.NewString()), "missing"),
+		newTestObject(strfmt.UUID(uuid.NewString()), "cold"),
+		newTestObject(strfmt.UUID(uuid.NewString()), ""),
+		newTestObject(strfmt.UUID(uuid.NewString()), "hot"),
+	}
+
+	// WHEN
+	targets, errs := r.ResolveShardsWithErrors(context.Background(), objects)
+
+	// THEN
+	require.Len(t, schemaReader.tenantQueries, 1)
+	require.ElementsMatch(t, []string{"hot", "missing", "cold"}, schemaReader.tenantQueries[0])
+	require.Len(t, targets, len(objects))
+	require.Len(t, errs, len(objects))
+	require.Equal(t, "hot", targets[0].Shard)
+	require.Same(t, objects[0], targets[0].Object)
+	require.ErrorContains(t, errs[1], "tenant not found")
+	require.Nil(t, targets[1])
+	require.ErrorContains(t, errs[2], "tenant not active")
+	require.Nil(t, targets[2])
+	require.ErrorContains(t, errs[3], "without tenant")
+	require.Nil(t, targets[3])
+	require.Equal(t, "hot", targets[4].Shard)
+	require.Same(t, objects[4], targets[4].Object)
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[4])
+}
+
+func Test_ShardResolution_MultiTenant_WithErrors_SchemaReaderError(t *testing.T) {
+	// GIVEN
+	schemaReader := &fakeSchemaReader{tenantsShardErr: fmt.Errorf("schema reader error")}
+	r := resolver.NewShardResolver("TestClass", true, schemaReader)
+	objects := []*storobj.Object{
+		newTestObject(strfmt.UUID(uuid.NewString()), "tenantA"),
+		newTestObject(strfmt.UUID(uuid.NewString()), "tenantB"),
+	}
+
+	// WHEN
+	targets, errs := r.ResolveShardsWithErrors(context.Background(), objects)
+
+	// THEN
+	require.Len(t, schemaReader.tenantQueries, 1)
+	require.Len(t, targets, len(objects))
+	require.Len(t, errs, len(objects))
+	for pos := range objects {
+		require.Nil(t, targets[pos])
+		require.ErrorContains(t, errs[pos], "fetch tenant status")
+		require.ErrorContains(t, errs[pos], "schema reader error")
+	}
 }
 
 func Test_ShardResolution_MultiTenant_DuplicateTenants(t *testing.T) {

--- a/cluster/batchstream_tenant_resolution_test.go
+++ b/cluster/batchstream_tenant_resolution_test.go
@@ -57,23 +57,48 @@ const (
 	batchStreamTenantResolutionClass   = "BatchStreamTenantResolution"
 	batchStreamTenantResolutionNodeID  = "node1"
 	batchStreamMissingTenant           = "missing-tenant"
+	batchStreamInactiveTenant          = "inactive-tenant"
 	batchStreamTenantResolutionTenants = 10
 )
 
 // TestBatchStreamMultiTenant exercises the public BatchStream path against a
-// single-node Raft schema and a real DB. It is deliberately a small smoke test:
-// the optimization tests below assert the query shape, while this test makes
-// the benchmark fixture independently useful for future BatchStream changes.
+// single-node Raft schema and a real DB. Every request has one write-side
+// activation lookup, followed by one resolver lookup containing the unique
+// tenant names rather than an individual lookup for every object.
 func TestBatchStreamMultiTenant(t *testing.T) {
-	fixture := newBatchStreamTenantResolutionFixture(t)
-	objects := fixture.objects(100)
+	for _, objectCount := range []int{100, 200, 1000} {
+		t.Run(fmt.Sprintf("objects=%d", objectCount), func(t *testing.T) {
+			fixture := newBatchStreamTenantResolutionFixture(t)
+			objects := fixture.objects(objectCount)
+
+			fixture.trace.Reset()
+			replies, err := fixture.write(objects)
+			require.NoError(t, err)
+			requireBatchStreamResults(t, replies, len(objects), 0)
+			fixture.requirePersisted(t, objects)
+			fixture.requireBulkResolution(t, fixture.tenants)
+		})
+	}
+}
+
+func TestBatchStreamMultiTenantMixedValidity(t *testing.T) {
+	fixture := newBatchStreamTenantResolutionFixtureWithInactiveTenant(t)
+	objects := fixture.objects(5)
+	objects[1].Tenant = batchStreamMissingTenant
+	objects[2].Tenant = batchStreamInactiveTenant
+	objects[3].Tenant = ""
 
 	fixture.trace.Reset()
 	replies, err := fixture.write(objects)
 	require.NoError(t, err)
-	requireBatchStreamResults(t, replies, len(objects), 0)
+	requireBatchStreamResults(t, replies, 2, 3)
+	fixture.requireBulkResolution(t, []string{objects[0].Tenant, batchStreamMissingTenant, batchStreamInactiveTenant, objects[4].Tenant})
+	fixture.requirePersisted(t, []*pb.BatchObject{objects[0], objects[4]})
 
-	fixture.requirePersisted(t, objects)
+	errorsByUUID := batchStreamErrorsByUUID(replies)
+	require.Contains(t, errorsByUUID[objects[1].Uuid], "tenant not found")
+	require.Contains(t, errorsByUUID[objects[2].Uuid], "tenant not active")
+	require.Contains(t, errorsByUUID[objects[3].Uuid], "without tenant")
 }
 
 // BenchmarkBatchStreamTenantResolution measures a complete valid BatchStream
@@ -208,6 +233,15 @@ func (m *tracedSchemaManager) ResolutionQueries() int {
 	return max(0, len(m.spans)-1)
 }
 
+func (f *batchStreamTenantResolutionFixture) requireBulkResolution(t testing.TB, tenants []string) {
+	t.Helper()
+
+	spans := f.trace.Spans()
+	require.Len(t, spans, 2, "one activation lookup and one resolver lookup")
+	require.ElementsMatch(t, tenants, spans[1].tenants)
+	require.LessOrEqual(t, spans[0].finished, spans[1].started, "resolver lookup must follow activation")
+}
+
 // batchStreamSchemaReader combines the local Raft schema reader with Raft's
 // WaitForUpdate method, matching the production schema.Manager wiring.
 type batchStreamSchemaReader struct {
@@ -311,6 +345,14 @@ type batchStreamTenantResolutionFixture struct {
 }
 
 func newBatchStreamTenantResolutionFixture(t testing.TB) *batchStreamTenantResolutionFixture {
+	return newBatchStreamTenantResolutionFixtureWithExtraTenant(t, "", "")
+}
+
+func newBatchStreamTenantResolutionFixtureWithInactiveTenant(t testing.TB) *batchStreamTenantResolutionFixture {
+	return newBatchStreamTenantResolutionFixtureWithExtraTenant(t, batchStreamInactiveTenant, models.TenantActivityStatusCOLD)
+}
+
+func newBatchStreamTenantResolutionFixtureWithExtraTenant(t testing.TB, extraTenant, extraTenantStatus string) *batchStreamTenantResolutionFixture {
 	t.Helper()
 
 	ctx := context.Background()
@@ -373,6 +415,14 @@ func newBatchStreamTenantResolutionFixture(t testing.TB) *batchStreamTenantResol
 	tenants := batchStreamTenantNames()
 	class := batchStreamTenantResolutionClassModel()
 	state := batchStreamTenantResolutionState(tenants)
+	if extraTenant != "" {
+		state.Physical[extraTenant] = sharding.Physical{
+			Name:           extraTenant,
+			OwnsPercentage: 1,
+			BelongsToNodes: []string{batchStreamTenantResolutionNodeID},
+			Status:         extraTenantStatus,
+		}
+	}
 	_, err = raftService.AddClass(ctx, class, state)
 	require.NoError(t, err)
 	require.NoError(t, repoDB.NewMigrator(database, storeFixture.logger, batchStreamTenantResolutionNodeID).AddClass(ctx, class))
@@ -575,6 +625,20 @@ func requireBatchStreamResults(t testing.TB, replies []*pb.BatchStreamReply, suc
 	gotSuccesses, gotFailures := batchStreamResultCounts(replies)
 	require.Equal(t, successes, gotSuccesses, "successful objects")
 	require.Equal(t, failures, gotFailures, "failed objects")
+}
+
+func batchStreamErrorsByUUID(replies []*pb.BatchStreamReply) map[string]string {
+	errorsByUUID := make(map[string]string)
+	for _, reply := range replies {
+		results := reply.GetResults()
+		if results == nil {
+			continue
+		}
+		for _, resultErr := range results.Errors {
+			errorsByUUID[resultErr.GetUuid()] = resultErr.GetError()
+		}
+	}
+	return errorsByUUID
 }
 
 // noOpModulesProvider is sufficient for a collection configured with the

--- a/cluster/batchstream_tenant_resolution_test.go
+++ b/cluster/batchstream_tenant_resolution_test.go
@@ -1,0 +1,604 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / _ \/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /  __/ (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ \___|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"runtime/metrics"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	grpcAuth "github.com/weaviate/weaviate/adapters/handlers/grpc/v1/auth"
+	grpcBatch "github.com/weaviate/weaviate/adapters/handlers/grpc/v1/batch"
+	repoDB "github.com/weaviate/weaviate/adapters/repos/db"
+	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
+	"github.com/weaviate/weaviate/cluster/utils"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/search"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	usecaseCluster "github.com/weaviate/weaviate/usecases/cluster"
+	usecaseClusterMocks "github.com/weaviate/weaviate/usecases/cluster/mocks"
+	"github.com/weaviate/weaviate/usecases/config"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/fakes"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+	"github.com/weaviate/weaviate/usecases/objects"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+const (
+	batchStreamTenantResolutionClass   = "BatchStreamTenantResolution"
+	batchStreamTenantResolutionNodeID  = "node1"
+	batchStreamMissingTenant           = "missing-tenant"
+	batchStreamTenantResolutionTenants = 10
+)
+
+// TestBatchStreamMultiTenant exercises the public BatchStream path against a
+// single-node Raft schema and a real DB. It is deliberately a small smoke test:
+// the optimization tests below assert the query shape, while this test makes
+// the benchmark fixture independently useful for future BatchStream changes.
+func TestBatchStreamMultiTenant(t *testing.T) {
+	fixture := newBatchStreamTenantResolutionFixture(t)
+	objects := fixture.objects(100)
+
+	fixture.trace.Reset()
+	replies, err := fixture.write(objects)
+	require.NoError(t, err)
+	requireBatchStreamResults(t, replies, len(objects), 0)
+
+	fixture.requirePersisted(t, objects)
+}
+
+// BenchmarkBatchStreamTenantResolution measures a complete valid BatchStream
+// write. The fixture includes gRPC request parsing, the objects batch use case,
+// DB batch persistence, schema.Manager, and a one-node Raft query endpoint.
+// Tenant-status spans are recorded so the benchmark can report both request
+// latency and the number of resolver lookups made per operation.
+func BenchmarkBatchStreamTenantResolution(b *testing.B) {
+	for _, objectCount := range []int{100, 200, 1000} {
+		b.Run(fmt.Sprintf("objects=%d", objectCount), func(b *testing.B) {
+			fixture := newBatchStreamTenantResolutionFixture(b)
+			objects := fixture.objects(objectCount)
+
+			// Warm shards, the stream worker, and the upsert state outside the
+			// timed request path. Callers of BatchStream retain these resources
+			// between requests too.
+			fixture.trace.Reset()
+			replies, err := fixture.write(objects)
+			require.NoError(b, err)
+			requireBatchStreamResults(b, replies, len(objects), 0)
+
+			latencies := make([]time.Duration, 0, b.N)
+			resolutionQueries := 0
+			cpuStarted := batchStreamUserCPUTime()
+			b.ResetTimer()
+			for b.Loop() {
+				fixture.trace.Reset()
+				started := time.Now()
+				replies, err := fixture.write(objects)
+				latencies = append(latencies, time.Since(started))
+				if err != nil {
+					b.Fatal(err)
+				}
+				if successes, failures := batchStreamResultCounts(replies); successes != len(objects) || failures != 0 {
+					b.Fatalf("unexpected BatchStream result: successes=%d failures=%d", successes, failures)
+				}
+				resolutionQueries += fixture.trace.ResolutionQueries()
+			}
+			b.StopTimer()
+			cpuElapsed := batchStreamUserCPUTime() - cpuStarted
+
+			b.ReportMetric(float64(percentileLatency(latencies, 0.50).Nanoseconds()), "p50-ns/op")
+			b.ReportMetric(float64(percentileLatency(latencies, 0.95).Nanoseconds()), "p95-ns/op")
+			b.ReportMetric(float64(resolutionQueries)/float64(len(latencies)), "resolution-queries/op")
+			b.ReportMetric(float64(cpuElapsed.Nanoseconds())/float64(len(latencies)), "go-user-cpu-ns/op")
+		})
+	}
+}
+
+// batchStreamUserCPUTime returns the Go runtime's cumulative user CPU time.
+// It includes user code and runtime work that executes while the benchmarked
+// BatchStream request is in flight, making it comparable across the benchmark
+// arms without changing the request path.
+func batchStreamUserCPUTime() time.Duration {
+	samples := [1]metrics.Sample{{Name: "/cpu/classes/user:cpu-seconds"}}
+	metrics.Read(samples[:])
+	return time.Duration(samples[0].Value.Float64() * float64(time.Second))
+}
+
+func percentileLatency(latencies []time.Duration, percentile float64) time.Duration {
+	if len(latencies) == 0 {
+		return 0
+	}
+
+	ordered := append([]time.Duration(nil), latencies...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i] < ordered[j] })
+	index := max(0, int(math.Ceil(float64(len(ordered))*percentile))-1)
+	return ordered[index]
+}
+
+type tenantStatusSpan struct {
+	tenants  []string
+	started  time.Time
+	finished time.Time
+}
+
+// tracedSchemaManager decorates the production Raft API used by
+// schema.Manager. Embedding the full interface keeps every non-query method on
+// the real implementation while making the leader-directed tenant-status query
+// observable in the fixture.
+type tracedSchemaManager struct {
+	schemaUC.SchemaManager
+
+	mu    sync.Mutex
+	spans []tenantStatusSpan
+}
+
+func (m *tracedSchemaManager) QueryTenantsShards(class string, tenants ...string) (map[string]string, uint64, error) {
+	started := time.Now()
+	statuses, version, err := m.SchemaManager.QueryTenantsShards(class, tenants...)
+	finished := time.Now()
+
+	m.mu.Lock()
+	m.spans = append(m.spans, tenantStatusSpan{
+		tenants:  append([]string(nil), tenants...),
+		started:  started,
+		finished: finished,
+	})
+	m.mu.Unlock()
+
+	return statuses, version, err
+}
+
+func (m *tracedSchemaManager) Reset() {
+	m.mu.Lock()
+	m.spans = m.spans[:0]
+	m.mu.Unlock()
+}
+
+func (m *tracedSchemaManager) Spans() []tenantStatusSpan {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	spans := make([]tenantStatusSpan, len(m.spans))
+	for i, span := range m.spans {
+		spans[i] = tenantStatusSpan{
+			tenants:  append([]string(nil), span.tenants...),
+			started:  span.started,
+			finished: span.finished,
+		}
+	}
+	return spans
+}
+
+// ResolutionQueries excludes the one write-side activation check performed by
+// BatchManager before Index.putObjectBatch resolves a target shard. The fixture
+// only calls this for one valid class batch, where that activation check is
+// always present and the remaining queries are resolver work.
+func (m *tracedSchemaManager) ResolutionQueries() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return max(0, len(m.spans)-1)
+}
+
+// batchStreamSchemaReader combines the local Raft schema reader with Raft's
+// WaitForUpdate method, matching the production schema.Manager wiring.
+type batchStreamSchemaReader struct {
+	clusterSchema.SchemaReader
+	*Raft
+}
+
+func (r batchStreamSchemaReader) WaitForUpdate(ctx context.Context, version uint64) error {
+	return r.Raft.WaitForUpdate(ctx, version)
+}
+
+type batchStreamStore struct {
+	store   *Store
+	indexer *fakes.MockSchemaExecutor
+	logger  *logrus.Logger
+}
+
+// batchStreamClusterState supplies the memberlist methods used by the schema
+// handler while keeping the fixture single-node and in-process.
+type batchStreamClusterState struct {
+	usecaseCluster.NodeSelector
+}
+
+func (s batchStreamClusterState) Hostnames() []string { return s.AllHostnames() }
+
+func (s batchStreamClusterState) AllNames() []string { return s.AllHostnames() }
+
+func (batchStreamClusterState) SchemaSyncIgnored() bool { return false }
+
+func (batchStreamClusterState) SkipSchemaRepair() bool { return false }
+
+func newBatchStreamStore(t testing.TB, nodeID string) *batchStreamStore {
+	t.Helper()
+
+	indexer := fakes.NewMockSchemaExecutor()
+	parser := fakes.NewMockParser()
+	logger, _ := test.NewNullLogger()
+	replicationFSM := clusterSchema.NewMockreplicationFSM(t)
+
+	indexer.On("Open", mock.Anything).Return(nil)
+	indexer.On("Close", mock.Anything).Return(nil)
+	indexer.On("AddClass", mock.Anything).Return(nil)
+	indexer.On("RestoreClassDir", mock.Anything).Return(nil)
+	indexer.On("UpdateClass", mock.Anything).Return(nil)
+	indexer.On("DeleteClass", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("UpdateProperty", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("UpdateShardStatus", mock.Anything).Return(nil)
+	indexer.On("AddTenants", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("UpdateTenants", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("UpdateTenantsProcess", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("DeleteTenants", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("TriggerSchemaUpdateCallbacks").Return()
+	indexer.On("AddReplicaToShard", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	indexer.On("DeleteReplicaFromShard", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	indexer.On("ReconcileAsyncReplicationForShard", mock.Anything, mock.Anything).Return(nil)
+	indexer.On("LoadShard", mock.Anything, mock.Anything).Return()
+	indexer.On("ShutdownShard", mock.Anything, mock.Anything).Return()
+
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	parser.On("ParseClassUpdate", mock.Anything, mock.Anything).Return(mock.Anything, nil)
+
+	replicationFSM.EXPECT().HasActiveReplicationForCollection(mock.Anything).Return(false).Maybe()
+	replicationFSM.EXPECT().HasActiveReplicationForShard(mock.Anything, mock.Anything).Return(false).Maybe()
+
+	cfg := Config{
+		WorkDir:                t.TempDir(),
+		NodeID:                 nodeID,
+		Host:                   "localhost",
+		RaftPort:               utils.MustGetFreeTCPPort(),
+		Voter:                  true,
+		BootstrapExpect:        1,
+		HeartbeatTimeout:       time.Second,
+		ElectionTimeout:        time.Second,
+		SnapshotInterval:       2 * time.Second,
+		SnapshotThreshold:      125,
+		DB:                     indexer,
+		Parser:                 parser,
+		NodeSelector:           usecaseClusterMocks.NewMockNodeSelector("localhost"),
+		Logger:                 logger,
+		ConsistencyWaitTimeout: 50 * time.Millisecond,
+		NamespacesController:   namespaces.NewController(logger),
+		TelemetryEnabled:       true,
+	}
+
+	store := NewFSM(cfg, nil, nil, prometheus.NewPedanticRegistry())
+	store.schemaManager.SetReplicationFSM(replicationFSM)
+	return &batchStreamStore{store: &store, indexer: indexer, logger: logger}
+}
+
+type batchStreamTenantResolutionFixture struct {
+	className string
+	tenants   []string
+
+	trace        *tracedSchemaManager
+	database     *repoDB.DB
+	stream       *grpcBatch.StreamHandler
+	drain        grpcBatch.Drain
+	raft         *Raft
+	shutdownOnce sync.Once
+}
+
+func newBatchStreamTenantResolutionFixture(t testing.TB) *batchStreamTenantResolutionFixture {
+	t.Helper()
+
+	ctx := context.Background()
+	storeFixture := newBatchStreamStore(t, batchStreamTenantResolutionNodeID)
+	nodeSelector := usecaseClusterMocks.NewMockNodeSelector(batchStreamTenantResolutionNodeID)
+	raftService := NewRaft(nodeSelector, storeFixture.store, nil)
+
+	require.NoError(t, raftService.Open(ctx, storeFixture.indexer))
+	require.NoError(t, storeFixture.store.Notify(batchStreamTenantResolutionNodeID,
+		fmt.Sprintf("%s:%d", storeFixture.store.cfg.Host, storeFixture.store.cfg.RaftPort)))
+	require.Eventually(t, raftService.IsLeader, 10*time.Second, 25*time.Millisecond, "Raft node did not become leader")
+	require.Eventually(t, raftService.Ready, 10*time.Second, 25*time.Millisecond, "Raft node did not become ready")
+
+	trace := &tracedSchemaManager{SchemaManager: raftService}
+	clusterState := batchStreamClusterState{NodeSelector: nodeSelector}
+	collectionRetrievalStrategy := configRuntime.NewFeatureFlag(
+		configRuntime.CollectionRetrievalStrategyLDKey,
+		string(configRuntime.LocalOnly),
+		nil,
+		"",
+		storeFixture.logger,
+	)
+	schemaReader := batchStreamSchemaReader{
+		SchemaReader: raftService.SchemaReader(),
+		Raft:         raftService,
+	}
+	schemaManager, err := schemaUC.NewManager(
+		nil,
+		trace,
+		schemaReader,
+		nil,
+		storeFixture.logger,
+		&authorization.DummyAuthorizer{},
+		nil,
+		config.Config{},
+		nil,
+		nil,
+		nil,
+		nil,
+		clusterState,
+		nil,
+		schemaUC.Parser{},
+		collectionRetrievalStrategy,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	eagerShards := false
+	database, err := repoDB.New(storeFixture.logger, batchStreamTenantResolutionNodeID, repoDB.Config{
+		RootPath:                  t.TempDir(),
+		QueryMaximumResults:       10_000,
+		MaxImportGoroutinesFactor: 1,
+		EnableLazyLoadShards:      &eagerShards,
+	}, nil, nodeSelector, nil, nil, nil, memwatch.NewDummyMonitor(), nodeSelector, schemaReader, raftService.ReplicationFsm())
+	require.NoError(t, err)
+	database.SetSchemaGetter(schemaManager)
+	require.NoError(t, database.WaitForStartup(ctx))
+
+	tenants := batchStreamTenantNames()
+	class := batchStreamTenantResolutionClassModel()
+	state := batchStreamTenantResolutionState(tenants)
+	_, err = raftService.AddClass(ctx, class, state)
+	require.NoError(t, err)
+	require.NoError(t, repoDB.NewMigrator(database, storeFixture.logger, batchStreamTenantResolutionNodeID).AddClass(ctx, class))
+
+	weaviateConfig := &config.WeaviateConfig{Config: config.Config{
+		AutoSchema: config.AutoSchema{Enabled: configRuntime.NewDynamicValue(false)},
+	}}
+	authorizer := &authorization.DummyAuthorizer{}
+	modules := noOpModulesProvider{}
+	autoSchemaManager := objects.NewAutoSchemaManager(schemaManager, database, weaviateConfig, storeFixture.logger, prometheus.NewPedanticRegistry())
+	batchManager := objects.NewBatchManager(database, modules, schemaManager, weaviateConfig, storeFixture.logger, authorizer, nil, autoSchemaManager)
+	authenticator := grpcAuth.NewHandler(true, nil)
+	batchHandler := grpcBatch.NewHandler(authorizer, batchManager, storeFixture.logger, authenticator, schemaManager, false)
+	stream, drain := grpcBatch.Start(authenticator, authorizer, batchHandler, schemaManager, prometheus.NewPedanticRegistry(), 1, storeFixture.logger, false)
+
+	fixture := &batchStreamTenantResolutionFixture{
+		className: batchStreamTenantResolutionClass,
+		tenants:   tenants,
+		trace:     trace,
+		database:  database,
+		stream:    stream,
+		drain:     drain,
+		raft:      raftService,
+	}
+	t.Cleanup(fixture.shutdown)
+	return fixture
+}
+
+func (f *batchStreamTenantResolutionFixture) shutdown() {
+	f.shutdownOnce.Do(func() {
+		f.drain()
+		_ = f.database.Shutdown(context.Background())
+		_ = f.raft.Close(context.Background())
+	})
+}
+
+func batchStreamTenantNames() []string {
+	tenants := make([]string, batchStreamTenantResolutionTenants)
+	for i := range tenants {
+		tenants[i] = fmt.Sprintf("tenant-%02d", i)
+	}
+	return tenants
+}
+
+func batchStreamTenantResolutionClassModel() *models.Class {
+	return &models.Class{
+		Class: batchStreamTenantResolutionClass,
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
+		},
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+		ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+		VectorIndexType:     "hnsw",
+		VectorIndexConfig:   enthnsw.UserConfig{Skip: true},
+		Vectorizer:          "none",
+	}
+}
+
+func batchStreamTenantResolutionState(tenants []string) *sharding.State {
+	state := &sharding.State{
+		IndexID:             batchStreamTenantResolutionClass,
+		PartitioningEnabled: true,
+		ReplicationFactor:   1,
+		Physical:            make(map[string]sharding.Physical, len(tenants)),
+	}
+	for _, tenant := range tenants {
+		state.Physical[tenant] = sharding.Physical{
+			Name:           tenant,
+			OwnsPercentage: 1,
+			BelongsToNodes: []string{batchStreamTenantResolutionNodeID},
+			Status:         models.TenantActivityStatusHOT,
+		}
+	}
+	return state
+}
+
+func (f *batchStreamTenantResolutionFixture) objects(count int) []*pb.BatchObject {
+	objects := make([]*pb.BatchObject, count)
+	for i := range objects {
+		objects[i] = &pb.BatchObject{
+			Uuid:       uuid.NewString(),
+			Collection: f.className,
+			Tenant:     f.tenants[i%len(f.tenants)],
+		}
+	}
+	return objects
+}
+
+func (f *batchStreamTenantResolutionFixture) write(objects []*pb.BatchObject) ([]*pb.BatchStreamReply, error) {
+	stream := newInMemoryBatchStream(objects)
+	if err := f.stream.Handle(stream); err != nil {
+		return stream.Replies(), err
+	}
+	return stream.Replies(), nil
+}
+
+func (f *batchStreamTenantResolutionFixture) requirePersisted(t testing.TB, objects []*pb.BatchObject) {
+	t.Helper()
+
+	expected := make(map[string]int, len(f.tenants))
+	for _, object := range objects {
+		expected[object.Tenant]++
+	}
+	for tenant, count := range expected {
+		actual, err := f.database.CountObjects(context.Background(), f.className, tenant)
+		require.NoError(t, err)
+		require.Equal(t, count, actual, "tenant %q", tenant)
+	}
+}
+
+// inMemoryBatchStream drives the generated server-side interface without a
+// network transport. Its requests and replies follow the same bidi stream
+// sequencing as a gRPC client: Start, one Data message, then EOF.
+type inMemoryBatchStream struct {
+	grpc.ServerStream
+
+	ctx context.Context
+
+	mu       sync.Mutex
+	requests []*pb.BatchStreamRequest
+	next     int
+	replies  []*pb.BatchStreamReply
+
+	resultsSent     chan struct{}
+	resultsSentOnce sync.Once
+}
+
+func newInMemoryBatchStream(objects []*pb.BatchObject) *inMemoryBatchStream {
+	return &inMemoryBatchStream{
+		ctx:         context.Background(),
+		resultsSent: make(chan struct{}),
+		requests: []*pb.BatchStreamRequest{
+			{
+				Message: &pb.BatchStreamRequest_Start_{
+					Start: &pb.BatchStreamRequest_Start{},
+				},
+			},
+			{
+				Message: &pb.BatchStreamRequest_Data_{
+					Data: &pb.BatchStreamRequest_Data{
+						Objects: &pb.BatchStreamRequest_Data_Objects{Values: objects},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (s *inMemoryBatchStream) Context() context.Context { return s.ctx }
+
+func (s *inMemoryBatchStream) Recv() (*pb.BatchStreamRequest, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.next < len(s.requests) {
+		request := s.requests[s.next]
+		s.next++
+		return request, nil
+	}
+
+	// A real client normally keeps its receive half open until it has seen
+	// the result for submitted data. Do the same here so the server's
+	// receiver does not close its reporting queue before the worker replies.
+	s.mu.Unlock()
+	<-s.resultsSent
+	s.mu.Lock()
+	return nil, io.EOF
+}
+
+func (s *inMemoryBatchStream) Send(reply *pb.BatchStreamReply) error {
+	s.mu.Lock()
+	s.replies = append(s.replies, reply)
+	s.mu.Unlock()
+	if reply.GetResults() != nil {
+		s.resultsSentOnce.Do(func() { close(s.resultsSent) })
+	}
+	return nil
+}
+
+func (s *inMemoryBatchStream) Replies() []*pb.BatchStreamReply {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]*pb.BatchStreamReply(nil), s.replies...)
+}
+
+func batchStreamResultCounts(replies []*pb.BatchStreamReply) (successes, failures int) {
+	for _, reply := range replies {
+		results := reply.GetResults()
+		if results == nil {
+			continue
+		}
+		successes += len(results.Successes)
+		failures += len(results.Errors)
+	}
+	return successes, failures
+}
+
+func requireBatchStreamResults(t testing.TB, replies []*pb.BatchStreamReply, successes, failures int) {
+	t.Helper()
+	gotSuccesses, gotFailures := batchStreamResultCounts(replies)
+	require.Equal(t, successes, gotSuccesses, "successful objects")
+	require.Equal(t, failures, gotFailures, "failed objects")
+}
+
+// noOpModulesProvider is sufficient for a collection configured with the
+// built-in "none" vectorizer. It makes the fixture exercise the real batch
+// use case rather than bypassing it while keeping external modules out of the
+// benchmarked path.
+type noOpModulesProvider struct{}
+
+func (noOpModulesProvider) GetObjectAdditionalExtend(_ context.Context, in *search.Result, _ map[string]interface{}) (*search.Result, error) {
+	return in, nil
+}
+
+func (noOpModulesProvider) ListObjectsAdditionalExtend(_ context.Context, in search.Results, _ map[string]interface{}) (search.Results, error) {
+	return in, nil
+}
+
+func (noOpModulesProvider) UsingRef2Vec(string) bool { return false }
+
+func (noOpModulesProvider) UpdateVector(_ context.Context, _ *models.Object, _ *models.Class, _ modulecapabilities.FindObjectFn, _ logrus.FieldLogger) error {
+	return nil
+}
+
+func (noOpModulesProvider) BatchUpdateVector(_ context.Context, _ *models.Class, _ []*models.Object, _ modulecapabilities.FindObjectFn, _ logrus.FieldLogger) (map[int]error, error) {
+	return nil, nil
+}
+
+func (noOpModulesProvider) VectorizerName(string) (string, error) { return "none", nil }


### PR DESCRIPTION
## What

Multi-tenant `BatchStream` writes resolve each object's target shard one at a
time, and for a multi-tenant class every `ResolveShard` runs its own tenant
status lookup. So a batch of N objects spread over a handful of tenants issues N
tenant-resolution queries, even though only a few distinct tenants are involved.

This resolves the whole batch in one pass: look up the distinct tenants once,
map the results back to each object, then group by shard. Per-object errors are
kept, so a batch that includes a missing or inactive tenant still writes its
valid objects and reports the exact failures for the rest. The single-tenant
(UUID-hashed) path is unchanged.

## Why it helps

For a batch of N objects across K distinct tenants, tenant-resolution queries
drop from N to 1. Measured on a single node with a local leader read:

| Batch (objects × tenants) | resolution queries | median time/op |
| --- | --- | --- |
| 100 × 10   | 100 → **1**  | 6.78 ms → 5.34 ms (**−20%**) |
| 200 × 10   | 200 → **1**  | 8.56 ms → 6.42 ms (**−26%**) |
| 1000 × 10  | 1000 → **1** | 32.2 ms → 22.8 ms (**−31%**) |

Deltas are paired medians over 10 runs (significant at ≥19/20 CI). The wall-time
numbers are topology-dependent — the saving comes from dropping the per-object
leader read, so absolute gains will differ on a multi-node cluster, but the
query-count collapse (N → 1) holds regardless.

## Behaviour

Behaviour-preserving. Per-object error semantics are unchanged (a bad tenant
fails only its own objects), and the single-tenant path is untouched.

`cluster/batchstream_tenant_resolution_test.go` adds a benchmark that asserts the
one-query-per-batch property, so the result is reproducible:

```
go test -bench=BenchmarkBatchStreamTenantResolution ./cluster/
```

## Testing

- Valid and mixed-validity multi-tenant batches at 100/200/1000 objects,
  asserting both the surviving writes and the per-object errors.
- Race-enabled BatchStream, positional-error, sharding-resolver, and
  multitenancy-validator tests; repo lint.

---

Contributed by [Perfloop](https://app.perfloop.ai): the numbers above were
co-measured on both trees and independently re-verified before submission —
full public record at
[case_x82s8m33e0](https://app.perfloop.ai/t/oss/case_x82s8m33e0). Replies from
this account are human-approved, and a human operator is accountable for this
contribution.
