### PR TITLE
Namespaces: Gate tenant actions

### DIFF
--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -285,6 +285,13 @@ func (st *Store) Apply(l *raft.Log) any {
 
 	case api.ApplyRequest_TYPE_ADD_TENANT:
 		f = func() {
+			// A namespace that is not active materializes no shard on the
+			// request path, and the schema commits before the DB does, so an
+			// ungated create leaves the tenant listed with nothing behind it.
+			if err := usecasesNamespaces.RequireActive(st.namespaceManager, namespacing.NamespaceFromQualified(cmd.Class)); err != nil {
+				ret.Error = err
+				return
+			}
 			ret.Error = st.schemaManager.AddTenants(&cmd, schemaOnly)
 		}
 

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -290,6 +290,13 @@ func (st *Store) Apply(l *raft.Log) any {
 
 	case api.ApplyRequest_TYPE_UPDATE_TENANT:
 		f = func() {
+			// A namespace that is not active holds its shards closed, so the
+			// node executing a status change has no shard to act on and none to
+			// read the tenant's current status from either.
+			if err := usecasesNamespaces.RequireActive(st.namespaceManager, namespacing.NamespaceFromQualified(cmd.Class)); err != nil {
+				ret.Error = err
+				return
+			}
 			ret.Error = st.schemaManager.UpdateTenants(&cmd, schemaOnly)
 		}
 

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -51,6 +51,7 @@ var namespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_RESTORE_CLASS:            {},
 	api.ApplyRequest_TYPE_CREATE_ALIAS:             {},
 	api.ApplyRequest_TYPE_REPLACE_ALIAS:            {},
+	api.ApplyRequest_TYPE_UPDATE_TENANT:            {},
 	api.ApplyRequest_TYPE_UPSERT_USER:              {},
 	api.ApplyRequest_TYPE_UPSERT_ROLES_PERMISSIONS: {},
 	api.ApplyRequest_TYPE_ADD_ROLES_FOR_USER:       {},
@@ -66,7 +67,6 @@ var nonNamespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_ADD_REPLICA_TO_SHARD:                                       {},
 	api.ApplyRequest_TYPE_DELETE_REPLICA_FROM_SHARD:                                  {},
 	api.ApplyRequest_TYPE_ADD_TENANT:                                                 {},
-	api.ApplyRequest_TYPE_UPDATE_TENANT:                                              {},
 	api.ApplyRequest_TYPE_DELETE_TENANT:                                              {},
 	api.ApplyRequest_TYPE_TENANT_PROCESS:                                             {},
 	api.ApplyRequest_TYPE_DELETE_ALIAS:                                               {},
@@ -161,10 +161,10 @@ func TestSubjectNamespace(t *testing.T) {
 	}
 }
 
-// TestApplyGate_RejectsCreateLikeApplyTypes drives each schema/alias gate
-// through the live apply switch and asserts deleting/missing namespaces
+// TestApplyGate_RejectsGatedSchemaApplyTypes drives each schema/alias/tenant
+// gate through the live apply switch and asserts deleting/missing namespaces
 // are rejected. TYPE_UPSERT_USER is covered by the dynusers manager tests.
-func TestApplyGate_RejectsCreateLikeApplyTypes(t *testing.T) {
+func TestApplyGate_RejectsGatedSchemaApplyTypes(t *testing.T) {
 	cls := func(name string) *models.Class {
 		return &models.Class{
 			Class:              name,
@@ -200,6 +200,16 @@ func TestApplyGate_RejectsCreateLikeApplyTypes(t *testing.T) {
 			name:    "TYPE_REPLACE_ALIAS",
 			cmdType: api.ApplyRequest_TYPE_REPLACE_ALIAS,
 			rpcSub:  &api.ReplaceAliasRequest{Collection: "alpha:Foo", Alias: "alpha:Bar"},
+		},
+		{
+			// A freeze started here would abort against a status no node can
+			// read back, silently activating or deactivating the tenant.
+			name:    "TYPE_UPDATE_TENANT",
+			cmdType: api.ApplyRequest_TYPE_UPDATE_TENANT,
+			rpcSub: &api.UpdateTenantsRequest{
+				Tenants:      []*api.Tenant{{Name: "T1", Status: models.TenantActivityStatusFROZEN}},
+				ClusterNodes: []string{"Node-1"},
+			},
 		},
 	}
 
@@ -265,9 +275,6 @@ func TestApplyGate_RejectsCreateLikeApplyTypes(t *testing.T) {
 // TestApplyGate_PassesActiveNamespace asserts the gate doesn't reject when
 // the namespace is active.
 func TestApplyGate_PassesActiveNamespace(t *testing.T) {
-	ms, log := setupApplyTest(t)
-	require.NoError(t, ms.cfg.NamespacesController.Create(api.Namespace{Name: "alpha", HomeNodes: []string{"node-1"}}, nsCreateIndex))
-
 	cls := &models.Class{
 		Class:              "alpha:Foo",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
@@ -275,14 +282,43 @@ func TestApplyGate_PassesActiveNamespace(t *testing.T) {
 	ss := &sharding.State{Physical: map[string]sharding.Physical{
 		"T1": {Name: "T1", BelongsToNodes: []string{"Node-1"}, Status: "HOT"},
 	}}
-	log.Data = cmdAsBytes("alpha:Foo", api.ApplyRequest_TYPE_ADD_CLASS,
-		api.AddClassRequest{Class: cls, State: ss}, nil)
 
-	result := ms.store.Apply(log)
-	resp, ok := result.(Response)
-	require.True(t, ok)
-	require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceDeleting)
-	require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceGone)
+	tests := []struct {
+		name    string
+		cmdType api.ApplyRequest_Type
+		jsonSub any
+		rpcSub  protoreflect.ProtoMessage
+	}{
+		{
+			name:    "TYPE_ADD_CLASS",
+			cmdType: api.ApplyRequest_TYPE_ADD_CLASS,
+			jsonSub: api.AddClassRequest{Class: cls, State: ss},
+		},
+		{
+			name:    "TYPE_UPDATE_TENANT",
+			cmdType: api.ApplyRequest_TYPE_UPDATE_TENANT,
+			rpcSub: &api.UpdateTenantsRequest{
+				Tenants:      []*api.Tenant{{Name: "T1", Status: models.TenantActivityStatusFROZEN}},
+				ClusterNodes: []string{"Node-1"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ms, log := setupApplyTest(t)
+			require.NoError(t, ms.cfg.NamespacesController.Create(api.Namespace{Name: "alpha", HomeNodes: []string{"node-1"}}, nsCreateIndex))
+
+			log.Data = cmdAsBytes("alpha:Foo", tc.cmdType, tc.jsonSub, tc.rpcSub)
+
+			result := ms.store.Apply(log)
+			resp, ok := result.(Response)
+			require.True(t, ok)
+			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceDeleting)
+			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceGone)
+			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceSuspended)
+		})
+	}
 }
 
 // TestApplyGate_RejectsRoleCreationIntoInactiveNamespace drives the role-

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -51,6 +51,7 @@ var namespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_RESTORE_CLASS:            {},
 	api.ApplyRequest_TYPE_CREATE_ALIAS:             {},
 	api.ApplyRequest_TYPE_REPLACE_ALIAS:            {},
+	api.ApplyRequest_TYPE_ADD_TENANT:               {},
 	api.ApplyRequest_TYPE_UPDATE_TENANT:            {},
 	api.ApplyRequest_TYPE_UPSERT_USER:              {},
 	api.ApplyRequest_TYPE_UPSERT_ROLES_PERMISSIONS: {},
@@ -66,7 +67,6 @@ var nonNamespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_UPDATE_SHARD_STATUS:                                        {},
 	api.ApplyRequest_TYPE_ADD_REPLICA_TO_SHARD:                                       {},
 	api.ApplyRequest_TYPE_DELETE_REPLICA_FROM_SHARD:                                  {},
-	api.ApplyRequest_TYPE_ADD_TENANT:                                                 {},
 	api.ApplyRequest_TYPE_DELETE_TENANT:                                              {},
 	api.ApplyRequest_TYPE_TENANT_PROCESS:                                             {},
 	api.ApplyRequest_TYPE_DELETE_ALIAS:                                               {},
@@ -202,6 +202,16 @@ func TestApplyGate_RejectsGatedSchemaApplyTypes(t *testing.T) {
 			rpcSub:  &api.ReplaceAliasRequest{Collection: "alpha:Foo", Alias: "alpha:Bar"},
 		},
 		{
+			// The schema commits before the DB refuses the shard, so an ungated
+			// create leaves the tenant listed with nothing behind it.
+			name:    "TYPE_ADD_TENANT",
+			cmdType: api.ApplyRequest_TYPE_ADD_TENANT,
+			rpcSub: &api.AddTenantsRequest{
+				Tenants:      []*api.Tenant{{Name: "T2", Status: models.TenantActivityStatusHOT}},
+				ClusterNodes: []string{"Node-1"},
+			},
+		},
+		{
 			// A freeze started here would abort against a status no node can
 			// read back, silently activating or deactivating the tenant.
 			name:    "TYPE_UPDATE_TENANT",
@@ -295,6 +305,14 @@ func TestApplyGate_PassesActiveNamespace(t *testing.T) {
 			jsonSub: api.AddClassRequest{Class: cls, State: ss},
 		},
 		{
+			name:    "TYPE_ADD_TENANT",
+			cmdType: api.ApplyRequest_TYPE_ADD_TENANT,
+			rpcSub: &api.AddTenantsRequest{
+				Tenants:      []*api.Tenant{{Name: "T2", Status: models.TenantActivityStatusHOT}},
+				ClusterNodes: []string{"Node-1"},
+			},
+		},
+		{
 			name:    "TYPE_UPDATE_TENANT",
 			cmdType: api.ApplyRequest_TYPE_UPDATE_TENANT,
 			rpcSub: &api.UpdateTenantsRequest{
@@ -317,6 +335,7 @@ func TestApplyGate_PassesActiveNamespace(t *testing.T) {
 			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceDeleting)
 			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceGone)
 			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceSuspended)
+			require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceResuming)
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:

Require that tenant add + update have an active namespace. Didn't add this originally because any tenant action that "slips through" would be deleted with the namespace. However, with suspend we have further namespace states that are not active and where we do not want any operations

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
