### PR TITLE
fix(db): stop deleted tenant data resurrecting on re-create

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -371,6 +371,47 @@ func (i *Index) snapshotsPath() string {
 	return path.Join(i.path(), lsmkv.SnapshotsRootDir)
 }
 
+// orphanedShardDirs returns shard directories under the index path that keep
+// does not name — the only way to see a tenant resident on disk but unloaded.
+//
+// A directory counts as a shard only if it holds an LSM store, which shard init
+// always creates, so an index-level directory added later is never mistaken for
+// a tenant and deleted.
+func (i *Index) orphanedShardDirs(keep map[string]sharding.Physical) ([]string, error) {
+	dir, err := os.Open(i.path())
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // index dir not created yet
+		}
+		return nil, fmt.Errorf("open index dir %q: %w", i.path(), err)
+	}
+	defer dir.Close()
+
+	entries, err := dir.ReadDir(-1)
+	if err != nil {
+		return nil, fmt.Errorf("read index dir %q: %w", i.path(), err)
+	}
+
+	var orphans []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() {
+			continue
+		}
+		if _, ok := keep[name]; ok {
+			continue
+		}
+		if strings.HasSuffix(name, asyncDeleteSuffix) {
+			continue // already queued for deletion
+		}
+		if info, err := os.Stat(shardPathLSM(i.path(), name)); err != nil || !info.IsDir() {
+			continue // no LSM store, so not a shard
+		}
+		orphans = append(orphans, name)
+	}
+	return orphans, nil
+}
+
 func (i *Index) debugLoggingEnabled() bool {
 	switch logger := i.logger.(type) {
 	case *logrus.Logger:

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -378,7 +378,7 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 					"add missing class %s during update index: %w",
 					incomingClass.Class, err)
 			}
-			return nil
+			idx = m.db.GetIndex(schema.ClassName(incomingClass.Class))
 		}
 	}
 
@@ -439,17 +439,43 @@ func (m *Migrator) updateIndexTenantsStatus(ctx context.Context, idx *Index,
 func (m *Migrator) updateIndexDeleteTenants(ctx context.Context,
 	idx *Index, incomingSS *sharding.State,
 ) error {
-	var toRemove []string
+	remove := map[string]struct{}{}
 
 	idx.ForEachShard(func(name string, _ ShardLike) error {
 		if _, ok := incomingSS.Physical[name]; !ok {
-			toRemove = append(toRemove, name)
+			remove[name] = struct{}{}
 		}
 		return nil
 	})
 
-	if len(toRemove) == 0 {
+	// ForEachShard sees loaded shards only, so a delete this node missed leaves
+	// the data on disk to be served again when the name is re-created. Absence
+	// from Physical marks a directory as garbage, not being unloaded — a COLD
+	// tenant still in the schema keeps its data.
+	orphans, err := idx.orphanedShardDirs(incomingSS.Physical)
+	if err != nil {
+		return fmt.Errorf("list on-disk tenants during update index: %w", err)
+	}
+	if len(orphans) > 0 {
+		// Only reachable when this node missed a delete, so make it visible.
+		m.logger.WithFields(logrus.Fields{
+			"action": "reconcile_tenant_dirs",
+			"class":  idx.Config.ClassName.String(),
+			"count":  len(orphans),
+			"sample": orphans[:min(len(orphans), 10)],
+		}).Warn("dropping tenant directories that are on disk but absent from the schema")
+	}
+	for _, name := range orphans {
+		remove[name] = struct{}{}
+	}
+
+	if len(remove) == 0 {
 		return nil
+	}
+
+	toRemove := make([]string, 0, len(remove))
+	for name := range remove {
+		toRemove = append(toRemove, name)
 	}
 
 	// the cloud delete runs even when the local drop fails, otherwise the

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -95,8 +95,14 @@ func (m *Migrator) SetOffloadProvider(provider provider, moduleName string) {
 }
 
 func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
+	_, err := m.addClass(ctx, class)
+	return err
+}
+
+// addClass returns the index it built.
+func (m *Migrator) addClass(ctx context.Context, class *models.Class) (*Index, error) {
 	if err := replica.ValidateConfig(class, m.db.config.Replication); err != nil {
-		return fmt.Errorf("replication config: %w", err)
+		return nil, fmt.Errorf("replication config: %w", err)
 	}
 
 	indexID := indexID(schema.ClassName(class.Class))
@@ -106,12 +112,12 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 
 	idx := m.db.GetIndex(schema.ClassName(class.Class))
 	if idx != nil {
-		return fmt.Errorf("index for class %v already found locally", idx.ID())
+		return nil, fmt.Errorf("index for class %v already found locally", idx.ID())
 	}
 
 	asyncConfig, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(class.MultiTenancyConfig), class.ReplicationConfig.AsyncConfig, m.logger.WithField("class", class.Class))
 	if err != nil {
-		return fmt.Errorf("async replication config: %w", err)
+		return nil, fmt.Errorf("async replication config: %w", err)
 	}
 
 	isMultiTenant := multitenancy.IsMultiTenant(class.MultiTenancyConfig)
@@ -132,7 +138,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		// to enable lazy load shards
 		localActiveShardsCount, err = m.db.schemaReader.LocalActiveShardsCount(class.Class)
 		if err != nil {
-			return fmt.Errorf("get local shards count for class %q: %w", class.Class, err)
+			return nil, fmt.Errorf("get local shards count for class %q: %w", class.Class, err)
 		}
 		// Only calculate shard sizes if the shard-count condition alone wouldn't
 		// already trigger lazy-loading. This avoids walking all shard directories
@@ -143,7 +149,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			// to enable lazy load shards based on total size
 			localShards, err := m.db.schemaReader.LocalShards(class.Class)
 			if err != nil {
-				return fmt.Errorf("get local shard names for class %q: %w", class.Class, err)
+				return nil, fmt.Errorf("get local shard names for class %q: %w", class.Class, err)
 			}
 			sizeThresholdBytes := uint64(m.db.config.LazyLoadShardSizeThresholdGB * 1024 * 1024 * 1024)
 			totalShardSizeBytes = m.db.totalShardSizeBytes(schema.ClassName(class.Class), localShards, sizeThresholdBytes)
@@ -243,7 +249,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		m.db.replicaClient, &m.db.config.Replication, m.db.promMetrics, class, m.db.jobQueueCh, m.db.scheduler, m.db.indexCheckpoints,
 		m.db.memMonitor, m.db.reindexer, m.db.bitmapBufPool, m.db.AsyncIndexingEnabled, m.db.tenantsManager)
 	if err != nil {
-		return errors.Wrap(err, "create index")
+		return nil, errors.Wrap(err, "create index")
 	}
 
 	idx.usageLimits = m.db.usageLimits
@@ -286,7 +292,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,
 		"size_threshold_gb":       m.db.config.LazyLoadShardSizeThresholdGB,
 	}).Info("lazy load shard auto-detection result")
-	return nil
+	return idx, nil
 }
 
 func (m *Migrator) DropClass(ctx context.Context, className string, hasFrozen bool) error {
@@ -373,12 +379,12 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 
 	{ // add index if missing
 		if idx == nil {
-			if err := m.AddClass(ctx, incomingClass); err != nil {
+			var err error
+			if idx, err = m.addClass(ctx, incomingClass); err != nil {
 				return fmt.Errorf(
 					"add missing class %s during update index: %w",
 					incomingClass.Class, err)
 			}
-			idx = m.db.GetIndex(schema.ClassName(incomingClass.Class))
 		}
 	}
 

--- a/adapters/repos/db/migrator_delete_tenants_test.go
+++ b/adapters/repos/db/migrator_delete_tenants_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package db
 
 import (

--- a/adapters/repos/db/migrator_delete_tenants_test.go
+++ b/adapters/repos/db/migrator_delete_tenants_test.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// A tenant this node never loaded is invisible to ForEachShard, so a delete it
+// missed leaves the data on disk and a re-created tenant of the same name
+// serves it. The cases that keep a directory are the ones that constrain the
+// fix: sweeping everything absent from the sharding state destroys live data.
+func TestUpdateIndexDeleteTenants_UnloadedTenantDirectory(t *testing.T) {
+	const (
+		className = "Abc"
+		tenant    = "doomed"
+	)
+
+	tests := []struct {
+		name        string
+		dirName     string // defaults to tenant
+		noLSM       bool   // directory holds no LSM store, so it is not a shard
+		inSchema    bool   // tenant still present in the incoming sharding state
+		wantDirGone bool
+	}{
+		{name: "deleted while unloaded", wantDirGone: true},
+		{name: "still in schema while unloaded", inSchema: true},
+		{name: "lsmkv snapshots dir", dirName: ".snapshots", noLSM: true},
+		{name: "unrecognised index-level dir", dirName: "some-future-metadata", noLSM: true},
+		// Holds an LSM store, so only the suffix keeps it.
+		{name: "pending async delete", dirName: "doomed.123.abcdef01.deleteme"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, hook := newDropTestIndex(t)
+
+			name := tt.dirName
+			if name == "" {
+				name = tenant
+			}
+
+			// Resident but absent from idx.shards: never loaded here.
+			dir := shardPath(idx.path(), name)
+			payload := dir
+			if !tt.noLSM {
+				payload = shardPathLSM(idx.path(), name)
+			}
+			require.NoError(t, os.MkdirAll(payload, 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(payload, "objects.db"), []byte("pre-delete data"), 0o644))
+			require.Nil(t, idx.shards.Load(name), "precondition: not loaded")
+
+			incomingSS := &sharding.State{
+				PartitioningEnabled: true,
+				Physical:            map[string]sharding.Physical{},
+			}
+			if tt.inSchema {
+				incomingSS.Physical[name] = sharding.Physical{Name: name}
+			}
+
+			m := newDropTestMigrator(idx, className, nil)
+			require.NoError(t, m.updateIndexDeleteTenants(context.Background(), idx, incomingSS))
+
+			// The only signal an operator gets that a delete was missed.
+			var warned *logrus.Entry
+			for _, e := range hook.AllEntries() {
+				if e.Data["action"] == "reconcile_tenant_dirs" {
+					warned = e
+				}
+			}
+
+			if tt.wantDirGone {
+				require.NoDirExists(t, dir,
+					"%q is absent from the schema, so its data must not survive on disk", name)
+				require.NotNil(t, warned, "an orphaned tenant must be logged")
+				require.Equal(t, logrus.WarnLevel, warned.Level)
+				require.Equal(t, className, warned.Data["class"])
+				require.Equal(t, 1, warned.Data["count"])
+				require.Equal(t, []string{name}, warned.Data["sample"])
+				return
+			}
+			require.Nil(t, warned, "nothing was orphaned, so nothing should be logged")
+			require.DirExists(t, dir, "%q must not be swept", name)
+		})
+	}
+}

--- a/test/acceptance/deleted_tenant_resurrection/changes_while_node_down_test.go
+++ b/test/acceptance/deleted_tenant_resurrection/changes_while_node_down_test.go
@@ -1,0 +1,176 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package deleted_tenant_resurrection
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clientschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+const (
+	stableHotTenant  = "stable_hot"
+	stableColdTenant = "stable_cold"
+	addedTenant      = "added_while_down"
+)
+
+var (
+	stableHotObjID   = strfmt.UUID("5c2d7e91-3a4b-4c5d-9e8f-1a2b3c4d5e11")
+	stableColdObjID  = strfmt.UUID("5c2d7e91-3a4b-4c5d-9e8f-1a2b3c4d5e22")
+	lateHotObjID     = strfmt.UUID("5c2d7e91-3a4b-4c5d-9e8f-1a2b3c4d5e33")
+	addedTenantObjID = strfmt.UUID("5c2d7e91-3a4b-4c5d-9e8f-1a2b3c4d5e44")
+	newPropObjID     = strfmt.UUID("5c2d7e91-3a4b-4c5d-9e8f-1a2b3c4d5e55")
+)
+
+// Ordinary multi-tenant changes made while a node is down must survive the same
+// InstallSnapshot catch-up, and the destructive directory sweep on that path
+// must touch none of them. Covers every state a live tenant can arrive in:
+// written to again, deactivated, and created while the node was absent.
+func TestChangesWhileNodeDown(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", strconv.Itoa(raftSnapshotThreshold)).
+		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := compose.Terminate(context.Background()); err != nil {
+			t.Logf("failed to terminate test containers: %v", err)
+		}
+	})
+	t.Cleanup(helper.ResetClient)
+
+	allNodes := []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2}
+	victim, victimC := docker.Weaviate2, compose.GetWeaviateNode3()
+	liveC := []*docker.DockerContainer{compose.GetWeaviate(), compose.GetWeaviateNode2()}
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	class := articles.ParagraphsClass()
+	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+	class.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
+	helper.CreateClass(t, class)
+
+	helper.CreateTenants(t, className, []*models.Tenant{
+		{Name: stableHotTenant, ActivityStatus: models.TenantActivityStatusHOT},
+		{Name: stableColdTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(stableHotObjID).WithContents("hot before outage").
+		WithTenant(stableHotTenant).Object(), types.ConsistencyLevelAll))
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(stableColdObjID).WithContents("cold before outage").
+		WithTenant(stableColdTenant).Object(), types.ConsistencyLevelAll))
+
+	require.False(t, hasRaftSnapshot(victimC),
+		"precondition: node %s must not have a local RAFT snapshot yet", victim)
+	require.NoError(t, compose.StopNode(ctx, 2, nil))
+
+	helper.CreateTenants(t, className, []*models.Tenant{
+		{Name: addedTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(addedTenantObjID).WithContents("added while down").
+		WithTenant(addedTenant).Object(), types.ConsistencyLevelQuorum))
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(lateHotObjID).WithContents("hot during outage").
+		WithTenant(stableHotTenant).Object(), types.ConsistencyLevelQuorum))
+	helper.UpdateTenants(t, className, []*models.Tenant{
+		{Name: stableColdTenant, ActivityStatus: models.TenantActivityStatusCOLD},
+	})
+	_, err = helper.Client(t).Schema.SchemaObjectsPropertiesAdd(
+		clientschema.NewSchemaObjectsPropertiesAddParams().
+			WithClassName(className).
+			WithBody(&models.Property{Name: "author", DataType: schema.DataTypeText.PropString()}),
+		nil)
+	require.NoError(t, err)
+
+	forceRaftLogTruncation(t, liveC)
+	require.NoError(t, compose.StartNode(ctx, 2))
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	// Nothing the schema still names may be swept.
+	for _, tenant := range []string{stableHotTenant, stableColdTenant, addedTenant} {
+		requireTenantDir(ctx, t, victimC, className, tenant, true,
+			"tenant %q is in the schema, so node %s must not sweep it during catch-up",
+			tenant, victim)
+	}
+
+	for _, tc := range []struct {
+		tenant   string
+		id       strfmt.UUID
+		contents string
+	}{
+		{stableHotTenant, stableHotObjID, "hot before outage"},
+		{stableHotTenant, lateHotObjID, "hot during outage"},
+		{addedTenant, addedTenantObjID, "added while down"},
+	} {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			obj, err := helper.GetTenantObjectFromNode(t, className, tc.id, victim, tc.tenant)
+			if !assert.NoError(ct, err) {
+				return
+			}
+			assert.Equal(ct, helper.ObjectContentsProp(tc.contents), obj.Properties)
+		}, 90*time.Second, time.Second,
+			"node %s must converge on object %s of tenant %q after catch-up", victim, tc.id, tc.tenant)
+	}
+
+	// Readable only once reloaded, so its data survived the catch-up.
+	helper.UpdateTenants(t, className, []*models.Tenant{
+		{Name: stableColdTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+	for _, node := range allNodes {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			obj, err := helper.GetTenantObjectFromNode(t, className, stableColdObjID, node, stableColdTenant)
+			if !assert.NoError(ct, err) {
+				return
+			}
+			assert.Equal(ct, helper.ObjectContentsProp("cold before outage"), obj.Properties)
+		}, 90*time.Second, time.Second,
+			"reactivated tenant %q must still hold its data on node %s", stableColdTenant, node)
+	}
+
+	// Usable on the recovered node, not merely present in its schema.
+	obj := articles.NewParagraph().
+		WithID(newPropObjID).WithContents("uses late property").
+		WithTenant(stableHotTenant).Object()
+	obj.Properties.(map[string]interface{})["author"] = "written after catch-up"
+	require.NoError(t, helper.CreateObjectCL(t, obj, types.ConsistencyLevelAll))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		got, err := helper.GetTenantObjectFromNode(t, className, newPropObjID, victim, stableHotTenant)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		props, ok := got.Properties.(map[string]interface{})
+		if !assert.True(ct, ok, "unexpected property payload %T", got.Properties) {
+			return
+		}
+		assert.Equal(ct, "written after catch-up", props["author"])
+	}, 90*time.Second, time.Second,
+		"node %s must accept the property added while it was down", victim)
+}

--- a/test/acceptance/deleted_tenant_resurrection/deleted_tenant_resurrection_test.go
+++ b/test/acceptance/deleted_tenant_resurrection/deleted_tenant_resurrection_test.go
@@ -1,0 +1,262 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package deleted_tenant_resurrection
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+const (
+	className    = "Paragraph"
+	keepTenant   = "keep"
+	doomedTenant = "doomed"
+
+	// Must sit above the RAFT commands the setup emits and below the churn. At a
+	// threshold of 1 the victim snapshots its own pre-delete state every second
+	// or so; restoring that registers the shard, the reconcile then drops it,
+	// and the failure is masked — observed on 4 of 5 runs.
+	raftSnapshotThreshold = 50
+
+	churnClasses = 40 // create+delete pairs, two RAFT commands each
+)
+
+var (
+	doomedObjID   = strfmt.UUID("6f9a5f4b-1f3e-4a6f-9a1c-2b4d6e8f0a11")
+	keepObjID     = strfmt.UUID("6f9a5f4b-1f3e-4a6f-9a1c-2b4d6e8f0a22")
+	sentinelObjID = strfmt.UUID("6f9a5f4b-1f3e-4a6f-9a1c-2b4d6e8f0a33")
+)
+
+// A node that misses a DELETE_TENANT and is caught up by InstallSnapshot keeps
+// the deleted tenant's directory, and a re-created tenant of the same name then
+// serves the pre-delete data.
+//
+// The leader snapshot is the control variable, asserted directly on both sides.
+// With RAFT_TRAILING_LOGS=1 a snapshot means the log was compacted past the
+// delete, leaving the victim no route back except InstallSnapshot; no snapshot
+// means the log survived and replays.
+func TestDeletedTenantResurrection(t *testing.T) {
+	tests := []struct {
+		name            string
+		forceTruncation bool
+	}{
+		{name: "delete_lost_to_raft_snapshot", forceTruncation: true},
+		{name: "delete_replayed_from_raft_log", forceTruncation: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runResurrectionScenario(t, tt.forceTruncation)
+		})
+	}
+}
+
+func runResurrectionScenario(t *testing.T, forceTruncation bool) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", strconv.Itoa(raftSnapshotThreshold)).
+		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := compose.Terminate(context.Background()); err != nil {
+			t.Logf("failed to terminate test containers: %v", err)
+		}
+	})
+	t.Cleanup(helper.ResetClient)
+
+	// RF=3 puts every tenant on every node, so the re-created tenant lands back
+	// on the victim without a placement lottery.
+	allNodes := []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2}
+	victim, victimC := docker.Weaviate2, compose.GetWeaviateNode3()
+	liveC := []*docker.DockerContainer{compose.GetWeaviate(), compose.GetWeaviateNode2()}
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	class := articles.ParagraphsClass()
+	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+	class.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
+	helper.CreateClass(t, class)
+
+	helper.CreateTenants(t, className, []*models.Tenant{
+		{Name: keepTenant, ActivityStatus: models.TenantActivityStatusHOT},
+		{Name: doomedTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(doomedObjID).
+		WithContents("pre-delete data").
+		WithTenant(doomedTenant).
+		Object(), types.ConsistencyLevelAll))
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(keepObjID).
+		WithContents("survivor data").
+		WithTenant(keepTenant).
+		Object(), types.ConsistencyLevelAll))
+
+	for _, node := range allNodes {
+		obj, err := helper.GetTenantObjectFromNode(t, className, doomedObjID, node, doomedTenant)
+		require.NoError(t, err, "precondition: node %s must serve the pre-delete object", node)
+		require.Equal(t, helper.ObjectContentsProp("pre-delete data"), obj.Properties)
+	}
+
+	require.False(t, hasRaftSnapshot(victimC),
+		"precondition: node %s must not have a local RAFT snapshot yet; the setup emitted more than "+
+			"RAFT_SNAPSHOT_THRESHOLD=%d commands and the scenario no longer tests what it claims",
+		victim, raftSnapshotThreshold)
+
+	require.NoError(t, compose.StopNode(ctx, 2, nil))
+
+	require.NoError(t, helper.DeleteTenants(t, className, []string{doomedTenant}))
+
+	_, err = helper.TenantExists(t, className, doomedTenant)
+	require.Error(t, err, "tenant %q must be gone from the schema after the delete", doomedTenant)
+
+	for _, node := range allNodes {
+		if node == victim {
+			continue
+		}
+		_, err := helper.GetTenantObjectFromNode(t, className, doomedObjID, node, doomedTenant)
+		require.Error(t, err,
+			"node %s applied DELETE_TENANT and must no longer serve the object", node)
+	}
+
+	if forceTruncation {
+		forceRaftLogTruncation(t, liveC)
+	} else {
+		for _, c := range liveC {
+			require.False(t, hasRaftSnapshot(c),
+				"control: node %s snapshotted, so its log may have been compacted past the delete "+
+					"and node %s would not replay it — this no longer isolates the trigger",
+				c.Name(), victim)
+		}
+	}
+
+	require.NoError(t, compose.StartNode(ctx, 2))
+	// Stays on the coordinator; the assertions below pin the reader with
+	// node_name, so the victim's own shard answers without catch-up 503s.
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	t.Logf("after restart, node %s tenant directories for class %q: %s",
+		victim, className, tenantDirs(t, victimC, className))
+
+	helper.CreateTenants(t, className, []*models.Tenant{
+		{Name: doomedTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+
+	// Proves the re-created shard is live on the victim, so a "not found" below
+	// cannot just mean "not ready yet".
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(sentinelObjID).
+		WithContents("post-recreate data").
+		WithTenant(doomedTenant).
+		Object(), types.ConsistencyLevelAll))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		obj, err := helper.GetTenantObjectFromNode(t, className, sentinelObjID, victim, doomedTenant)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		assert.Equal(ct, helper.ObjectContentsProp("post-recreate data"), obj.Properties)
+	}, 60*time.Second, time.Second,
+		"the re-created tenant %q must be live on node %s before we assert on the deleted object",
+		doomedTenant, victim)
+
+	for _, node := range allNodes {
+		obj, err := helper.GetTenantObjectFromNode(t, className, doomedObjID, node, doomedTenant)
+		if err == nil {
+			t.Errorf("DATA RESURRECTION on node %s: tenant %q was deleted and re-created, "+
+				"but the node still serves the pre-delete object %s: properties=%v creationTimeUnix=%d",
+				node, doomedTenant, doomedObjID, obj.Properties, obj.CreationTimeUnix)
+			continue
+		}
+		t.Logf("node %s correctly reports the pre-delete object as absent: %v", node, err)
+	}
+
+	for _, node := range allNodes {
+		obj, err := helper.GetTenantObjectFromNode(t, className, keepObjID, node, keepTenant)
+		require.NoError(t, err, "tenant %q must be untouched on node %s", keepTenant, node)
+		require.Equal(t, helper.ObjectContentsProp("survivor data"), obj.Properties)
+	}
+}
+
+// forceRaftLogTruncation churns schema commands until every live node has
+// snapshotted. Churn is the only lever; no endpoint triggers a RAFT snapshot.
+// The classes are multi-tenant with no tenants, so each costs a RAFT command
+// without creating shards.
+func forceRaftLogTruncation(t *testing.T, live []*docker.DockerContainer) {
+	t.Helper()
+
+	for i := 0; i < churnClasses; i++ {
+		name := fmt.Sprintf("Churn_%d", i)
+		helper.CreateClass(t, &models.Class{
+			Class:              name,
+			Vectorizer:         "none",
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		})
+		helper.DeleteClass(t, name)
+	}
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for _, c := range live {
+			assert.True(ct, hasRaftSnapshot(c), "node %s has not snapshotted yet", c.Name())
+		}
+	}, 90*time.Second, time.Second,
+		"RAFT snapshot was never written on the live nodes — the log was not truncated past the delete")
+}
+
+// hasRaftSnapshot answers via the exit code, avoiding the docker stream.
+func hasRaftSnapshot(c *docker.DockerContainer) bool {
+	code, _, err := c.Container().Exec(context.Background(),
+		[]string{"sh", "-c", `[ -n "$(ls -A data/raft/snapshots 2>/dev/null)" ]`})
+	return err == nil && code == 0
+}
+
+// tenantDirs lists a node's shard directories; the index dir is the lowercased
+// class name.
+func tenantDirs(t *testing.T, c *docker.DockerContainer, class string) string {
+	t.Helper()
+
+	_, reader, err := c.Container().Exec(context.Background(),
+		[]string{"sh", "-c", fmt.Sprintf("ls -1 data/%s 2>/dev/null | tr '\\n' ' '", strings.ToLower(class))})
+	if err != nil {
+		return fmt.Sprintf("<unavailable: %v>", err)
+	}
+	out, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Sprintf("<unavailable: %v>", err)
+	}
+	// Strip the docker stream framing bytes.
+	return strings.TrimSpace(strings.Map(func(r rune) rune {
+		if r < 32 || r > 126 {
+			return -1
+		}
+		return r
+	}, string(out)))
+}

--- a/test/acceptance/deleted_tenant_resurrection/inactive_tenant_test.go
+++ b/test/acceptance/deleted_tenant_resurrection/inactive_tenant_test.go
@@ -1,0 +1,200 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package deleted_tenant_resurrection
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+const (
+	doomedColdTenant = "doomed_cold"
+	keepColdTenant   = "keep_cold"
+)
+
+var (
+	doomedColdObjID   = strfmt.UUID("7a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c11")
+	keepColdObjID     = strfmt.UUID("7a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c22")
+	sentinelColdObjID = strfmt.UUID("7a1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c33")
+)
+
+// An inactive tenant is unloaded by design, so it is never in Index.shards
+// however the node recovers — the case a fix keyed on loaded shards cannot
+// reach. keep_cold pins the boundary: equally inactive and equally on disk, so
+// "not loaded" alone must not sweep it. Both are asserted in one run so a fix
+// cannot buy one with the other.
+func TestDeletedInactiveTenantResurrection(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("RAFT_SNAPSHOT_THRESHOLD", strconv.Itoa(raftSnapshotThreshold)).
+		WithWeaviateEnv("RAFT_SNAPSHOT_INTERVAL", "1").
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := compose.Terminate(context.Background()); err != nil {
+			t.Logf("failed to terminate test containers: %v", err)
+		}
+	})
+	t.Cleanup(helper.ResetClient)
+
+	allNodes := []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2}
+	victim, victimC := docker.Weaviate2, compose.GetWeaviateNode3()
+	liveC := []*docker.DockerContainer{compose.GetWeaviate(), compose.GetWeaviateNode2()}
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	class := articles.ParagraphsClass()
+	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+	class.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
+	helper.CreateClass(t, class)
+
+	helper.CreateTenants(t, className, []*models.Tenant{
+		{Name: keepColdTenant, ActivityStatus: models.TenantActivityStatusHOT},
+		{Name: doomedColdTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(doomedColdObjID).
+		WithContents("pre-delete data").
+		WithTenant(doomedColdTenant).
+		Object(), types.ConsistencyLevelAll))
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(keepColdObjID).
+		WithContents("survivor data").
+		WithTenant(keepColdTenant).
+		Object(), types.ConsistencyLevelAll))
+
+	for _, node := range allNodes {
+		_, err := helper.GetTenantObjectFromNode(t, className, doomedColdObjID, node, doomedColdTenant)
+		require.NoError(t, err, "precondition: node %s must serve the pre-delete object", node)
+	}
+
+	helper.UpdateTenants(t, className, []*models.Tenant{
+		{Name: doomedColdTenant, ActivityStatus: models.TenantActivityStatusCOLD},
+		{Name: keepColdTenant, ActivityStatus: models.TenantActivityStatusCOLD},
+	})
+
+	for _, tenant := range []string{doomedColdTenant, keepColdTenant} {
+		requireTenantDir(ctx, t, victimC, className, tenant, true,
+			"precondition: deactivating tenant %q must unload it without removing its data", tenant)
+	}
+
+	require.False(t, hasRaftSnapshot(victimC),
+		"precondition: node %s must not have a local RAFT snapshot yet; the setup emitted more than "+
+			"RAFT_SNAPSHOT_THRESHOLD=%d commands and the scenario no longer tests what it claims",
+		victim, raftSnapshotThreshold)
+	require.NoError(t, compose.StopNode(ctx, 2, nil))
+
+	require.NoError(t, helper.DeleteTenants(t, className, []string{doomedColdTenant}))
+	_, err = helper.TenantExists(t, className, doomedColdTenant)
+	require.Error(t, err, "tenant %q must be gone from the schema after the delete", doomedColdTenant)
+
+	for _, c := range liveC {
+		requireTenantDir(ctx, t, c, className, doomedColdTenant, false,
+			"node %s applied DELETE_TENANT and must not keep the unloaded tenant's data", c.Name())
+	}
+
+	forceRaftLogTruncation(t, liveC)
+	require.NoError(t, compose.StartNode(ctx, 2))
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	requireTenantDir(ctx, t, victimC, className, doomedColdTenant, false,
+		"tenant %q was deleted while node %s was down and unloaded, so its data must not "+
+			"survive the snapshot catch-up", doomedColdTenant, victim)
+
+	requireTenantDir(ctx, t, victimC, className, keepColdTenant, true,
+		"tenant %q is unloaded but still in the schema, so node %s must not sweep it",
+		keepColdTenant, victim)
+
+	helper.CreateTenants(t, className, []*models.Tenant{
+		{Name: doomedColdTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+
+	// Proves the re-created shard is live, so a "not found" below is real.
+	require.NoError(t, helper.CreateObjectCL(t, articles.NewParagraph().
+		WithID(sentinelColdObjID).
+		WithContents("post-recreate data").
+		WithTenant(doomedColdTenant).
+		Object(), types.ConsistencyLevelAll))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		obj, err := helper.GetTenantObjectFromNode(t, className, sentinelColdObjID, victim, doomedColdTenant)
+		if !assert.NoError(ct, err) {
+			return
+		}
+		assert.Equal(ct, helper.ObjectContentsProp("post-recreate data"), obj.Properties)
+	}, 60*time.Second, time.Second,
+		"the re-created tenant %q must be live on node %s before we assert on the deleted object",
+		doomedColdTenant, victim)
+
+	for _, node := range allNodes {
+		obj, err := helper.GetTenantObjectFromNode(t, className, doomedColdObjID, node, doomedColdTenant)
+		if err == nil {
+			t.Errorf("DATA RESURRECTION on node %s: tenant %q was deactivated, deleted and "+
+				"re-created, but the node still serves the pre-delete object %s: "+
+				"properties=%v creationTimeUnix=%d",
+				node, doomedColdTenant, doomedColdObjID, obj.Properties, obj.CreationTimeUnix)
+			continue
+		}
+		t.Logf("node %s correctly reports the pre-delete object as absent: %v", node, err)
+	}
+
+	helper.UpdateTenants(t, className, []*models.Tenant{
+		{Name: keepColdTenant, ActivityStatus: models.TenantActivityStatusHOT},
+	})
+
+	for _, node := range allNodes {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			obj, err := helper.GetTenantObjectFromNode(t, className, keepColdObjID, node, keepColdTenant)
+			if !assert.NoError(ct, err) {
+				return
+			}
+			assert.Equal(ct, helper.ObjectContentsProp("survivor data"), obj.Properties)
+		}, 60*time.Second, time.Second,
+			"tenant %q must be untouched on node %s", keepColdTenant, node)
+	}
+}
+
+// The only assertion that reaches an unloaded tenant: with no shard registered
+// the API serves nothing, so disk is the sole evidence.
+func requireTenantDir(ctx context.Context, t *testing.T, c *docker.DockerContainer,
+	class, tenant string, want bool, msg string, args ...any,
+) {
+	t.Helper()
+
+	dir := fmt.Sprintf("data/%s/%s", strings.ToLower(class), tenant)
+	explanation := fmt.Sprintf(msg, args...)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		code, _, err := c.Container().Exec(ctx, []string{"test", "-d", dir})
+		if !assert.NoError(ct, err, "exec on node %s", c.Name()) {
+			return
+		}
+		assert.Equal(ct, want, code == 0, "%s (%s)", explanation, dir)
+	}, 15*time.Second, 250*time.Millisecond, explanation)
+}


### PR DESCRIPTION
### What's being changed:
A tenant deleted while a node was down came back with its data when the same name was re-created, because `updateIndexDeleteTenants` built its removal set from `Index.ForEachShard` (loaded shards only, so an unloaded tenant was never a candidate) and `UpdateIndex` returned right after `AddClass` before ever reaching that reconcile  which under RAFT is every index.

 Adds `Index.orphanedShardDirs` to also consider directories the sharding state no longer names, identified by holding an LSM store, and lets `UpdateIndex` fall through to the existing reconcile; a directory still in `Physical` is kept whatever its status, so COLD and FROZEN tenants are untouched. 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
