### PR TITLE
fix(index): return statuses of all shard's replicas

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -10947,12 +10947,19 @@ func init() {
           "description": "Name of the shard",
           "type": "string"
         },
+        "per_node_status": {
+          "description": "Status of the shard on each of its replicas",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "status": {
-          "description": "Status of the shard",
+          "description": "Deprecated: value is not consistent in replicated clusters.",
           "type": "string"
         },
         "vectorQueueSize": {
-          "description": "Size of the vector queue of the shard",
+          "description": "Deprecated: value is not consistent in replicated clusters.",
           "type": "integer",
           "x-omitempty": false
         }
@@ -23057,12 +23064,19 @@ func init() {
           "description": "Name of the shard",
           "type": "string"
         },
+        "per_node_status": {
+          "description": "Status of the shard on each of its replicas",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "status": {
-          "description": "Status of the shard",
+          "description": "Deprecated: value is not consistent in replicated clusters.",
           "type": "string"
         },
         "vectorQueueSize": {
-          "description": "Size of the vector queue of the shard",
+          "description": "Deprecated: value is not consistent in replicated clusters.",
           "type": "integer",
           "x-omitempty": false
         }

--- a/adapters/repos/db/fakes_for_tests.go
+++ b/adapters/repos/db/fakes_for_tests.go
@@ -40,6 +40,7 @@ import (
 )
 
 type fakeSchemaGetter struct {
+	nodeName   string
 	schema     schema.Schema
 	shardState *sharding.State
 }
@@ -109,7 +110,10 @@ func (f *fakeSchemaGetter) Nodes() []string {
 }
 
 func (f *fakeSchemaGetter) NodeName() string {
-	return "node1"
+	if f.nodeName == "" {
+		return "node1"
+	}
+	return f.nodeName
 }
 
 func (f *fakeSchemaGetter) ClusterHealthScore() int {
@@ -305,7 +309,9 @@ func fixedMultiShardState() *sharding.State {
 	return s
 }
 
-type FakeRemoteClient struct{}
+type FakeRemoteClient struct {
+	shardStatus map[string]map[string]string
+}
 
 func (f *FakeRemoteClient) BatchPutObjects(ctx context.Context, hostName, indexName, shardName string, objs []*storobj.Object, repl *additional.ReplicationProperties, schemaVersion uint64) []error {
 	return nil
@@ -390,7 +396,10 @@ func (f *FakeRemoteClient) GetShardQueueSize(ctx context.Context,
 func (f *FakeRemoteClient) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {
-	return "", nil
+	if f.shardStatus == nil || f.shardStatus[shardName] == nil {
+		return "", nil
+	}
+	return f.shardStatus[shardName][hostName], nil
 }
 
 func (f *FakeRemoteClient) UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,

--- a/adapters/repos/db/fakes_for_tests.go
+++ b/adapters/repos/db/fakes_for_tests.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -393,13 +394,21 @@ func (f *FakeRemoteClient) GetShardQueueSize(ctx context.Context,
 	return 0, nil
 }
 
+// NodeUnresponsive is a sentinel status that causes
+// [FakeRemoteClient.GetShardStatus] to return an error.
+const NodeUnresponsive = "[node unresponsive]"
+
 func (f *FakeRemoteClient) GetShardStatus(ctx context.Context,
 	hostName, indexName, shardName string,
 ) (string, error) {
 	if f.shardStatus == nil || f.shardStatus[shardName] == nil {
 		return "", nil
 	}
-	return f.shardStatus[shardName][hostName], nil
+	status := f.shardStatus[shardName][hostName]
+	if status == NodeUnresponsive {
+		return "", errors.New(NodeUnresponsive)
+	}
+	return status, nil
 }
 
 func (f *FakeRemoteClient) UpdateShardStatus(ctx context.Context, hostName, indexName, shardName,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3753,16 +3753,21 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 //		"shard-0": { "node-0": "READY", "node-1": "READONLY" },
 //		"shard-1": { "node-1": "READY", "node-1": "READONLY" },
 //	}
-func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]map[string]string, error) {
+//
+// The second return value are shard statuses mirroring the legacy implementation,
+// where the status is returned based on the first replica to contain the shard,
+// preferably local.
+func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]map[string]string, map[string]string, error) {
 	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	var mu sync.Mutex // guards shardsStatus
+	var mu sync.Mutex // guards shardsStatus and legacyStatus
 	shardsStatus := make(map[string]map[string]string, len(shardNames))
+	legacyStatus := make(map[string]string, len(shardNames))
 
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
 	eg.SetLimit(min(len(shardNames), runtime.GOMAXPROCS(0)*4))
@@ -3778,7 +3783,10 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 				return err
 			}
 
-			perNodeStatus := make(map[string]string, len(replicas))
+			var (
+				oneNodeStatus atomic.Value
+				perNodeStatus = make(map[string]string, len(replicas))
+			)
 			for _, nodeName := range replicas {
 				if nodeName == thisNode {
 					shard, release, err := i.getShardForDirectLocalOperation(
@@ -3789,11 +3797,14 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 						0,
 					)
 					if err == nil && shard != nil {
+						ss := shard.GetStatus().String()
+						oneNodeStatus.Store(ss)
 						perNodeStatus[nodeName] = shard.GetStatus().String()
 					}
 					release()
 				} else {
 					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
+						oneNodeStatus.CompareAndSwap(nil, ss)
 						perNodeStatus[nodeName] = ss
 					}
 				}
@@ -3801,15 +3812,18 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 
 			mu.Lock()
 			shardsStatus[shardName] = perNodeStatus
+			if s, ok := oneNodeStatus.Load().(string); ok {
+				legacyStatus[shardName] = s
+			}
 			mu.Unlock()
 			return nil
 		}, shardName)
 	}
 
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return shardsStatus, nil
+	return shardsStatus, legacyStatus, nil
 }
 
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3694,9 +3694,9 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 			}
 
 			var shardStatus atomic.Value
-			for _, node := range replicas {
-				var nodeStatus storagestate.Status
-				if node == thisNode {
+			for _, nodeName := range replicas {
+				nodeStatus := storagestate.StatusIndexing
+				if nodeName == thisNode {
 					shard, release, err := i.getShardForDirectLocalOperation(
 						ctx,
 						shardName,
@@ -3709,14 +3709,14 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 					}
 					release()
 				} else {
-					if ss, err := i.remote.GetShardStatus(ctx, shardName); err == nil {
+					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
 						nodeStatus = storagestate.Status(ss)
 					}
 				}
 
 				// Assume all replicas are READY and search for any which are not.
 				// Fall back to StatusIndexing if we find two different non-ready statuses.
-				if nodeStatus != storagestate.StatusReady {
+				if nodeStatus != "" && nodeStatus != storagestate.StatusReady {
 					if old := shardStatus.Swap(nodeStatus); old != nil && old.(storagestate.Status) != nodeStatus {
 						shardStatus.Store(storagestate.StatusIndexing)
 						break
@@ -3734,6 +3734,10 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 			mu.Unlock()
 			return nil
 		}, shardName)
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return shardsStatus, nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3777,7 +3777,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 
 			var shardStatus atomic.Value
 			for _, nodeName := range replicas {
-				nodeStatus := storagestate.StatusIndexing
+				var nodeStatus storagestate.Status
 				if nodeName == thisNode {
 					shard, release, err := i.getShardForDirectLocalOperation(
 						ctx,
@@ -3791,7 +3791,8 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 					}
 					release()
 				} else {
-					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
+					nodeStatus = storagestate.StatusIndexing
+					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil && ss != "" {
 						nodeStatus = storagestate.Status(ss)
 					}
 				}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3746,38 +3746,114 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	return size, nil
 }
 
+// getShardsStatus returns status of the vector indexing pipeline for each shard
+// in the collection.
+// In a replicated setup, a shard's status is [storagestate.StatusReady] iff all
+// of its replicas report READY and [storagestate.StatusIndexing] otherwise.
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
+	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)
 	if err != nil {
 		return nil, err
 	}
 
-	shardsStatus := make(map[string]string)
+	var mu sync.Mutex // guards shardsStatus
+	shardsStatus := make(map[string]string, len(shardNames))
+
+	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
+	eg.SetLimit(min(len(shardNames), runtime.GOMAXPROCS(0)*4))
 
 	for _, shardName := range shardNames {
 		if tenant != "" && shardName != tenant {
 			continue
 		}
-		var status string
-		err := i.withShardOrRemote(ctx, tenant, shardName, localShardOperationRead, 0,
-			func(shard ShardLike) error {
-				status = shard.GetStatus().String()
+
+		eg.Go(func() error {
+			replicas, err := i.schemaReader.ShardReplicas(className, shardName)
+			if err != nil {
 				return nil
-			},
-			func() error {
-				var err error
-				status, err = i.remote.GetShardStatus(ctx, shardName)
-				return err
-			})
-		if err != nil {
-			return nil, errors.Wrapf(err, "shard %s", shardName)
+			}
+
+			var shardStatus atomic.Value
+			for _, node := range replicas {
+				var nodeStatus storagestate.Status
+				if node == thisNode {
+					shard, release, err := i.getShardForDirectLocalOperation(
+						ctx,
+						shardName,
+						shardName,
+						localShardOperationRead,
+						0,
+					)
+					if err == nil && shard != nil {
+						nodeStatus = shard.GetStatus()
+					}
+					release()
+				} else {
+					if ss, err := i.remote.GetShardStatus(ctx, shardName); err == nil {
+						nodeStatus = storagestate.Status(ss)
+					}
+				}
+
+				// Assume all replicas are READY and search for any which are not.
+				// Fall back to StatusIndexing if we find two different non-ready statuses.
+				if nodeStatus != storagestate.StatusReady {
+					if old := shardStatus.Swap(nodeStatus); old != nil && old.(storagestate.Status) != nodeStatus {
+						shardStatus.Store(storagestate.StatusIndexing)
+						break
+					}
+				}
+			}
+
+			reconciled := storagestate.StatusReady
+			if ss := shardStatus.Load(); ss != nil {
+				reconciled = ss.(storagestate.Status)
+			}
+
+			mu.Lock()
+			shardsStatus[shardName] = reconciled.String()
+			mu.Unlock()
+			return nil
+		}, shardName)
+	}
+	return shardsStatus, nil
+}
+
+// reconcile aggregates counts with the appropriate statistic, such that
+// the returned values is always contained within the input set. If possible,
+// we try to calculate the mode.
+//
+// If we can't calculate the mode, we fallback to median. We can only calculate
+// the true median for an odd-numbered set. If a set has even number of elemets
+// of which none is a mode, then the median would be calculated as an average,
+// which is not contained in the set. In that case we pick the lower value of
+// the two "candidate" values.
+func reconcile(counts []int) int {
+	var mode int
+	var modeHits int
+	hits := make(map[int]int)
+
+	var median int
+	medianIdx := len(counts) / 2
+
+	slices.Sort(counts)
+	for i, count := range counts {
+		hits[count]++
+		if h := hits[count]; h > modeHits {
+			mode = count
+			modeHits = h
 		}
 
-		shardsStatus[shardName] = status
+		if i == medianIdx {
+			median = count
+		}
 	}
 
-	return shardsStatus, nil
+	if modeHits > 1 {
+		return mode
+	}
+	return median
 }
 
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3774,7 +3774,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 		eg.Go(func() error {
 			replicas, err := i.schemaReader.ShardReplicas(className, shardName)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			var shardStatus atomic.Value

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3749,7 +3749,9 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 // getShardsStatus returns status of the vector indexing pipeline for each shard
 // in the collection.
 // In a replicated setup, a shard's status is [storagestate.StatusReady] iff all
-// of its replicas report READY and [storagestate.StatusIndexing] otherwise.
+// of its replicas report READY. Otherwise, the status is either any other status
+// that all replicas can agree on or [storagestate.StatusIndexing] if their statuses
+// diverge or a replica is not reachable.
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
 	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3695,7 +3695,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 
 			var shardStatus atomic.Value
 			for _, nodeName := range replicas {
-				nodeStatus := storagestate.StatusIndexing
+				var nodeStatus storagestate.Status
 				if nodeName == thisNode {
 					shard, release, err := i.getShardForDirectLocalOperation(
 						ctx,
@@ -3709,7 +3709,8 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 					}
 					release()
 				} else {
-					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
+					nodeStatus = storagestate.StatusIndexing
+					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil && ss != "" {
 						nodeStatus = storagestate.Status(ss)
 					}
 				}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3743,42 +3743,6 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 	return shardsStatus, nil
 }
 
-// reconcile aggregates counts with the appropriate statistic, such that
-// the returned values is always contained within the input set. If possible,
-// we try to calculate the mode.
-//
-// If we can't calculate the mode, we fallback to median. We can only calculate
-// the true median for an odd-numbered set. If a set has even number of elemets
-// of which none is a mode, then the median would be calculated as an average,
-// which is not contained in the set. In that case we pick the lower value of
-// the two "candidate" values.
-func reconcile(counts []int) int {
-	var mode int
-	var modeHits int
-	hits := make(map[int]int)
-
-	var median int
-	medianIdx := len(counts) / 2
-
-	slices.Sort(counts)
-	for i, count := range counts {
-		hits[count]++
-		if h := hits[count]; h > modeHits {
-			mode = count
-			modeHits = h
-		}
-
-		if i == medianIdx {
-			median = count
-		}
-	}
-
-	if modeHits > 1 {
-		return mode
-	}
-	return median
-}
-
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {
 	shard, release, err := i.GetShard(ctx, shardName)
 	if err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3692,7 +3692,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 		eg.Go(func() error {
 			replicas, err := i.schemaReader.ShardReplicas(className, shardName)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			var shardStatus atomic.Value

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3788,8 +3788,13 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 				perNodeStatus = make(map[string]string, len(replicas))
 			)
 			for _, nodeName := range replicas {
+				var err error
 				if nodeName == thisNode {
-					shard, release, err := i.getShardForDirectLocalOperation(
+					var (
+						shard   ShardLike
+						release func()
+					)
+					shard, release, err = i.getShardForDirectLocalOperation(
 						ctx,
 						shardName,
 						shardName,
@@ -3797,16 +3802,21 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 						0,
 					)
 					if err == nil && shard != nil {
-						ss := shard.GetStatus().String()
-						oneNodeStatus.Store(ss)
-						perNodeStatus[nodeName] = shard.GetStatus().String()
+						status := shard.GetStatus().String()
+						oneNodeStatus.Store(status)
+						perNodeStatus[nodeName] = status
 					}
 					release()
 				} else {
-					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
-						oneNodeStatus.CompareAndSwap(nil, ss)
-						perNodeStatus[nodeName] = ss
+					var status string
+					if status, err = i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
+						oneNodeStatus.CompareAndSwap(nil, status)
+						perNodeStatus[nodeName] = status
 					}
+				}
+
+				if errors.Is(err, errAlreadyShutdown) {
+					return err
 				}
 			}
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3776,9 +3776,9 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 			}
 
 			var shardStatus atomic.Value
-			for _, node := range replicas {
-				var nodeStatus storagestate.Status
-				if node == thisNode {
+			for _, nodeName := range replicas {
+				nodeStatus := storagestate.StatusIndexing
+				if nodeName == thisNode {
 					shard, release, err := i.getShardForDirectLocalOperation(
 						ctx,
 						shardName,
@@ -3791,14 +3791,14 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 					}
 					release()
 				} else {
-					if ss, err := i.remote.GetShardStatus(ctx, shardName); err == nil {
+					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
 						nodeStatus = storagestate.Status(ss)
 					}
 				}
 
 				// Assume all replicas are READY and search for any which are not.
 				// Fall back to StatusIndexing if we find two different non-ready statuses.
-				if nodeStatus != storagestate.StatusReady {
+				if nodeStatus != "" && nodeStatus != storagestate.StatusReady {
 					if old := shardStatus.Swap(nodeStatus); old != nil && old.(storagestate.Status) != nodeStatus {
 						shardStatus.Store(storagestate.StatusIndexing)
 						break
@@ -3816,6 +3816,10 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 			mu.Unlock()
 			return nil
 		}, shardName)
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
 	}
 	return shardsStatus, nil
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3825,42 +3825,6 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 	return shardsStatus, nil
 }
 
-// reconcile aggregates counts with the appropriate statistic, such that
-// the returned values is always contained within the input set. If possible,
-// we try to calculate the mode.
-//
-// If we can't calculate the mode, we fallback to median. We can only calculate
-// the true median for an odd-numbered set. If a set has even number of elemets
-// of which none is a mode, then the median would be calculated as an average,
-// which is not contained in the set. In that case we pick the lower value of
-// the two "candidate" values.
-func reconcile(counts []int) int {
-	var mode int
-	var modeHits int
-	hits := make(map[int]int)
-
-	var median int
-	medianIdx := len(counts) / 2
-
-	slices.Sort(counts)
-	for i, count := range counts {
-		hits[count]++
-		if h := hits[count]; h > modeHits {
-			mode = count
-			modeHits = h
-		}
-
-		if i == medianIdx {
-			median = count
-		}
-	}
-
-	if modeHits > 1 {
-		return mode
-	}
-	return median
-}
-
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {
 	shard, release, err := i.GetShard(ctx, shardName)
 	if err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3752,7 +3752,7 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 // of its replicas report READY. Otherwise, the status is either any other status
 // that all replicas can agree on or [storagestate.StatusIndexing] if their statuses
 // diverge or a replica is not reachable.
-func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
+func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]map[string]string, error) {
 	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)
@@ -3761,7 +3761,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 	}
 
 	var mu sync.Mutex // guards shardsStatus
-	shardsStatus := make(map[string]string, len(shardNames))
+	shardsStatus := make(map[string]map[string]string, len(shardNames))
 
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
 	eg.SetLimit(min(len(shardNames), runtime.GOMAXPROCS(0)*4))
@@ -3777,9 +3777,8 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 				return err
 			}
 
-			var shardStatus atomic.Value
+			perNodeStatus := make(map[string]string, len(replicas))
 			for _, nodeName := range replicas {
-				var nodeStatus storagestate.Status
 				if nodeName == thisNode {
 					shard, release, err := i.getShardForDirectLocalOperation(
 						ctx,
@@ -3789,33 +3788,18 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 						0,
 					)
 					if err == nil && shard != nil {
-						nodeStatus = shard.GetStatus()
+						perNodeStatus[nodeName] = shard.GetStatus().String()
 					}
 					release()
 				} else {
-					nodeStatus = storagestate.StatusIndexing
-					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil && ss != "" {
-						nodeStatus = storagestate.Status(ss)
+					if ss, err := i.remote.GetShardStatus(ctx, shardName, nodeName); err == nil {
+						perNodeStatus[nodeName] = ss
 					}
 				}
-
-				// Assume all replicas are READY and search for any which are not.
-				// Fall back to StatusIndexing if we find two different non-ready statuses.
-				if nodeStatus != "" && nodeStatus != storagestate.StatusReady {
-					if old := shardStatus.Swap(nodeStatus); old != nil && old.(storagestate.Status) != nodeStatus {
-						shardStatus.Store(storagestate.StatusIndexing)
-						break
-					}
-				}
-			}
-
-			reconciled := storagestate.StatusReady
-			if ss := shardStatus.Load(); ss != nil {
-				reconciled = ss.(storagestate.Status)
 			}
 
 			mu.Lock()
-			shardsStatus[shardName] = reconciled.String()
+			shardsStatus[shardName] = perNodeStatus
 			mu.Unlock()
 			return nil
 		}, shardName)

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3664,38 +3664,114 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	return size, nil
 }
 
+// getShardsStatus returns status of the vector indexing pipeline for each shard
+// in the collection.
+// In a replicated setup, a shard's status is [storagestate.StatusReady] iff all
+// of its replicas report READY and [storagestate.StatusIndexing] otherwise.
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
+	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)
 	if err != nil {
 		return nil, err
 	}
 
-	shardsStatus := make(map[string]string)
+	var mu sync.Mutex // guards shardsStatus
+	shardsStatus := make(map[string]string, len(shardNames))
+
+	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
+	eg.SetLimit(min(len(shardNames), runtime.GOMAXPROCS(0)*4))
 
 	for _, shardName := range shardNames {
 		if tenant != "" && shardName != tenant {
 			continue
 		}
-		var status string
-		err := i.withShardOrRemote(ctx, tenant, shardName, localShardOperationRead, 0,
-			func(shard ShardLike) error {
-				status = shard.GetStatus().String()
+
+		eg.Go(func() error {
+			replicas, err := i.schemaReader.ShardReplicas(className, shardName)
+			if err != nil {
 				return nil
-			},
-			func() error {
-				var err error
-				status, err = i.remote.GetShardStatus(ctx, shardName)
-				return err
-			})
-		if err != nil {
-			return nil, errors.Wrapf(err, "shard %s", shardName)
+			}
+
+			var shardStatus atomic.Value
+			for _, node := range replicas {
+				var nodeStatus storagestate.Status
+				if node == thisNode {
+					shard, release, err := i.getShardForDirectLocalOperation(
+						ctx,
+						shardName,
+						shardName,
+						localShardOperationRead,
+						0,
+					)
+					if err == nil && shard != nil {
+						nodeStatus = shard.GetStatus()
+					}
+					release()
+				} else {
+					if ss, err := i.remote.GetShardStatus(ctx, shardName); err == nil {
+						nodeStatus = storagestate.Status(ss)
+					}
+				}
+
+				// Assume all replicas are READY and search for any which are not.
+				// Fall back to StatusIndexing if we find two different non-ready statuses.
+				if nodeStatus != storagestate.StatusReady {
+					if old := shardStatus.Swap(nodeStatus); old != nil && old.(storagestate.Status) != nodeStatus {
+						shardStatus.Store(storagestate.StatusIndexing)
+						break
+					}
+				}
+			}
+
+			reconciled := storagestate.StatusReady
+			if ss := shardStatus.Load(); ss != nil {
+				reconciled = ss.(storagestate.Status)
+			}
+
+			mu.Lock()
+			shardsStatus[shardName] = reconciled.String()
+			mu.Unlock()
+			return nil
+		}, shardName)
+	}
+	return shardsStatus, nil
+}
+
+// reconcile aggregates counts with the appropriate statistic, such that
+// the returned values is always contained within the input set. If possible,
+// we try to calculate the mode.
+//
+// If we can't calculate the mode, we fallback to median. We can only calculate
+// the true median for an odd-numbered set. If a set has even number of elemets
+// of which none is a mode, then the median would be calculated as an average,
+// which is not contained in the set. In that case we pick the lower value of
+// the two "candidate" values.
+func reconcile(counts []int) int {
+	var mode int
+	var modeHits int
+	hits := make(map[int]int)
+
+	var median int
+	medianIdx := len(counts) / 2
+
+	slices.Sort(counts)
+	for i, count := range counts {
+		hits[count]++
+		if h := hits[count]; h > modeHits {
+			mode = count
+			modeHits = h
 		}
 
-		shardsStatus[shardName] = status
+		if i == medianIdx {
+			median = count
+		}
 	}
 
-	return shardsStatus, nil
+	if modeHits > 1 {
+		return mode
+	}
+	return median
 }
 
 func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (string, error) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3667,7 +3667,9 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 // getShardsStatus returns status of the vector indexing pipeline for each shard
 // in the collection.
 // In a replicated setup, a shard's status is [storagestate.StatusReady] iff all
-// of its replicas report READY and [storagestate.StatusIndexing] otherwise.
+// of its replicas report READY. Otherwise, the status is either any other status
+// that all replicas can agree on or [storagestate.StatusIndexing] if their statuses
+// diverge or a replica is not reachable.
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]string, error) {
 	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3746,12 +3746,13 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	return size, nil
 }
 
-// getShardsStatus returns status of the vector indexing pipeline for each shard
-// in the collection.
-// In a replicated setup, a shard's status is [storagestate.StatusReady] iff all
-// of its replicas report READY. Otherwise, the status is either any other status
-// that all replicas can agree on or [storagestate.StatusIndexing] if their statuses
-// diverge or a replica is not reachable.
+// getShardsStatus returns the status of the collection's shards on each of its
+// replica nodes. Example:
+//
+//	map[string]map[string]string{
+//		"shard-0": { "node-0": "READY", "node-1": "READONLY" },
+//		"shard-1": { "node-1": "READY", "node-1": "READONLY" },
+//	}
 func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]map[string]string, error) {
 	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -302,15 +302,6 @@ func TestIndex_getShardsStatus(t *testing.T) {
 		"all_shutdown":  storagestate.StatusShutdown.String(),
 	}
 
-	shardingState := &sharding.State{
-		Physical: map[string]sharding.Physical{
-			"all_ready":     {BelongsToNodes: clusterNodes},
-			"one_not_ready": {BelongsToNodes: clusterNodes},
-			"two_not_ready": {BelongsToNodes: clusterNodes},
-			"all_shutdown":  {BelongsToNodes: clusterNodes},
-		},
-	}
-
 	var replicas []types.Replica
 	for shard, nodes := range shardReplicas {
 		for _, node := range nodes {
@@ -359,11 +350,8 @@ func TestIndex_getShardsStatus(t *testing.T) {
 		RunAndReturn(func(s string) (string, bool) { return s, true }).Maybe()
 
 	index := Index{
-		Config: IndexConfig{ClassName: schema.ClassName("Songs")},
-		getSchema: &fakeSchemaGetter{
-			nodeName:   targetNode,
-			shardState: shardingState,
-		},
+		Config:           IndexConfig{ClassName: schema.ClassName("Songs")},
+		getSchema:        &fakeSchemaGetter{nodeName: targetNode},
 		schemaReader:     schemaReader,
 		shardCreateLocks: esync.NewKeyRWLocker(),
 		router:           router,

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -307,15 +307,6 @@ func TestIndex_getShardsStatus(t *testing.T) {
 		"all_shutdown":  storagestate.StatusShutdown.String(),
 	}
 
-	shardingState := &sharding.State{
-		Physical: map[string]sharding.Physical{
-			"all_ready":     {BelongsToNodes: clusterNodes},
-			"one_not_ready": {BelongsToNodes: clusterNodes},
-			"two_not_ready": {BelongsToNodes: clusterNodes},
-			"all_shutdown":  {BelongsToNodes: clusterNodes},
-		},
-	}
-
 	var replicas []types.Replica
 	for shard, nodes := range shardReplicas {
 		for _, node := range nodes {
@@ -364,11 +355,8 @@ func TestIndex_getShardsStatus(t *testing.T) {
 		RunAndReturn(func(s string) (string, bool) { return s, true }).Maybe()
 
 	index := Index{
-		Config: IndexConfig{ClassName: schema.ClassName("Songs")},
-		getSchema: &fakeSchemaGetter{
-			nodeName:   targetNode,
-			shardState: shardingState,
-		},
+		Config:           IndexConfig{ClassName: schema.ClassName("Songs")},
+		getSchema:        &fakeSchemaGetter{nodeName: targetNode},
 		schemaReader:     schemaReader,
 		shardCreateLocks: esync.NewKeyRWLocker(),
 		router:           router,

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -29,7 +29,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/assert"
+	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/clients"
@@ -38,10 +39,13 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	esync "github.com/weaviate/weaviate/entities/sync"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 func TestIndex_aggregateCount(t *testing.T) {
@@ -262,6 +266,143 @@ func (f *fakeRouter) GetWriteReplicasLocation(collection, tenant, shard string) 
 func (f *fakeRouter) NodeHostname(nodeName string) (string, bool) {
 	host, ok := f.hostnames[nodeName]
 	return host, ok
+}
+
+func TestIndex_getShardsStatus(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	clusterNodes := []string{"node-0", "node-1", "node-2"}
+	targetNode := clusterNodes[0]
+	shardReplicas := map[string][]string{
+		"all_ready":     clusterNodes,
+		"one_not_ready": clusterNodes,
+		"two_not_ready": clusterNodes,
+		"all_shutdown":  clusterNodes,
+	}
+	shardStatus := map[string]map[string]string{
+		"all_ready": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusReady.String(),
+			"node-2": storagestate.StatusReady.String(),
+		},
+		"one_not_ready": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusLazyLoading.String(),
+			"node-2": storagestate.StatusReady.String(),
+		},
+		"two_not_ready": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusLazyLoading.String(),
+			"node-2": storagestate.StatusReadOnly.String(),
+		},
+		"all_shutdown": {
+			"node-0": storagestate.StatusShutdown.String(),
+			"node-1": storagestate.StatusShutdown.String(),
+			"node-2": storagestate.StatusShutdown.String(),
+		},
+	}
+	want := map[string]string{
+		"all_ready":     storagestate.StatusReady.String(),
+		"one_not_ready": storagestate.StatusLazyLoading.String(),
+		"two_not_ready": storagestate.StatusIndexing.String(),
+		"all_shutdown":  storagestate.StatusShutdown.String(),
+	}
+
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"all_ready":     {BelongsToNodes: clusterNodes},
+			"one_not_ready": {BelongsToNodes: clusterNodes},
+			"two_not_ready": {BelongsToNodes: clusterNodes},
+			"all_shutdown":  {BelongsToNodes: clusterNodes},
+		},
+	}
+
+	var replicas []types.Replica
+	for shard, nodes := range shardReplicas {
+		for _, node := range nodes {
+			replicas = append(replicas, types.Replica{
+				ShardName: shard,
+				NodeName:  node,
+				HostAddr:  node,
+			})
+		}
+	}
+
+	router := &fakeRouter{
+		readSet: types.ReadReplicaSet{
+			Replicas: replicas,
+		},
+	}
+
+	replicator := &replica.Replicator{
+		Finder: replica.NewFinder(
+			"Songs", nil, nil,
+			targetNode, nil, nil,
+			logger, nil,
+		),
+	}
+
+	// Arrange
+	schemaReader := schemaUC.NewMockSchemaReader(t)
+	schemaReader.EXPECT().
+		Shards("Songs").
+		RunAndReturn(func(collectionName string) (shards []string, _ error) {
+			for s := range shardReplicas {
+				shards = append(shards, s)
+			}
+			return
+		}).Maybe()
+	schemaReader.EXPECT().
+		ShardReplicas("Songs", mock.Anything).
+		RunAndReturn(func(collectionName, shardName string) ([]string, error) {
+			assert.Contains(t, shardReplicas, shardName)
+			return shardReplicas[shardName], nil
+		}).Maybe()
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	nodeResolver.EXPECT().
+		NodeHostname(mock.Anything).
+		RunAndReturn(func(s string) (string, bool) { return s, true }).Maybe()
+
+	index := Index{
+		Config: IndexConfig{ClassName: schema.ClassName("Songs")},
+		getSchema: &fakeSchemaGetter{
+			nodeName:   targetNode,
+			shardState: shardingState,
+		},
+		schemaReader:     schemaReader,
+		shardCreateLocks: esync.NewKeyRWLocker(),
+		router:           router,
+		replicator:       replicator,
+		logger:           logger,
+	}
+
+	index.remote = sharding.NewRemoteIndex(
+		"Songs",
+		index.getSchema,
+		nodeResolver,
+		&FakeRemoteClient{shardStatus: shardStatus},
+	)
+
+	for shardName, statusByNode := range shardStatus {
+		mockShard := NewMockShardLike(t)
+		mockShard.EXPECT().
+			preventShutdown().
+			Return(func() {}, nil).Maybe()
+		mockShard.EXPECT().
+			Name().
+			Return(shardName).Maybe()
+		mockShard.EXPECT().
+			GetStatus().
+			Return(storagestate.Status(statusByNode[targetNode])).Maybe()
+		index.shards.Store(shardName, mockShard)
+	}
+
+	// Act
+	got, err := index.getShardsStatus(t.Context(), "")
+
+	// Assert
+	assert.NoError(t, err)
+	require.Equal(t, want, got)
 }
 
 // TestIndex_ShardHasMultipleReplicasWrite_RoutesThroughReplicatorDuringMovement pins the

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -27,15 +27,20 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/clients"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	esync "github.com/weaviate/weaviate/entities/sync"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 func TestIndex_aggregateCount(t *testing.T) {
@@ -256,6 +261,143 @@ func (f *fakeRouter) GetWriteReplicasLocation(collection, tenant, shard string) 
 func (f *fakeRouter) NodeHostname(nodeName string) (string, bool) {
 	host, ok := f.hostnames[nodeName]
 	return host, ok
+}
+
+func TestIndex_getShardsStatus(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	clusterNodes := []string{"node-0", "node-1", "node-2"}
+	targetNode := clusterNodes[0]
+	shardReplicas := map[string][]string{
+		"all_ready":     clusterNodes,
+		"one_not_ready": clusterNodes,
+		"two_not_ready": clusterNodes,
+		"all_shutdown":  clusterNodes,
+	}
+	shardStatus := map[string]map[string]string{
+		"all_ready": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusReady.String(),
+			"node-2": storagestate.StatusReady.String(),
+		},
+		"one_not_ready": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusLazyLoading.String(),
+			"node-2": storagestate.StatusReady.String(),
+		},
+		"two_not_ready": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusLazyLoading.String(),
+			"node-2": storagestate.StatusReadOnly.String(),
+		},
+		"all_shutdown": {
+			"node-0": storagestate.StatusShutdown.String(),
+			"node-1": storagestate.StatusShutdown.String(),
+			"node-2": storagestate.StatusShutdown.String(),
+		},
+	}
+	want := map[string]string{
+		"all_ready":     storagestate.StatusReady.String(),
+		"one_not_ready": storagestate.StatusLazyLoading.String(),
+		"two_not_ready": storagestate.StatusIndexing.String(),
+		"all_shutdown":  storagestate.StatusShutdown.String(),
+	}
+
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"all_ready":     {BelongsToNodes: clusterNodes},
+			"one_not_ready": {BelongsToNodes: clusterNodes},
+			"two_not_ready": {BelongsToNodes: clusterNodes},
+			"all_shutdown":  {BelongsToNodes: clusterNodes},
+		},
+	}
+
+	var replicas []types.Replica
+	for shard, nodes := range shardReplicas {
+		for _, node := range nodes {
+			replicas = append(replicas, types.Replica{
+				ShardName: shard,
+				NodeName:  node,
+				HostAddr:  node,
+			})
+		}
+	}
+
+	router := &fakeRouter{
+		readSet: types.ReadReplicaSet{
+			Replicas: replicas,
+		},
+	}
+
+	replicator := &replica.Replicator{
+		Finder: replica.NewFinder(
+			"Songs", nil, nil,
+			targetNode, nil, nil,
+			logger, nil,
+		),
+	}
+
+	// Arrange
+	schemaReader := schemaUC.NewMockSchemaReader(t)
+	schemaReader.EXPECT().
+		Shards("Songs").
+		RunAndReturn(func(collectionName string) (shards []string, _ error) {
+			for s := range shardReplicas {
+				shards = append(shards, s)
+			}
+			return
+		}).Maybe()
+	schemaReader.EXPECT().
+		ShardReplicas("Songs", mock.Anything).
+		RunAndReturn(func(collectionName, shardName string) ([]string, error) {
+			assert.Contains(t, shardReplicas, shardName)
+			return shardReplicas[shardName], nil
+		}).Maybe()
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	nodeResolver.EXPECT().
+		NodeHostname(mock.Anything).
+		RunAndReturn(func(s string) (string, bool) { return s, true }).Maybe()
+
+	index := Index{
+		Config: IndexConfig{ClassName: schema.ClassName("Songs")},
+		getSchema: &fakeSchemaGetter{
+			nodeName:   targetNode,
+			shardState: shardingState,
+		},
+		schemaReader:     schemaReader,
+		shardCreateLocks: esync.NewKeyRWLocker(),
+		router:           router,
+		replicator:       replicator,
+		logger:           logger,
+	}
+
+	index.remote = sharding.NewRemoteIndex(
+		"Songs",
+		index.getSchema,
+		nodeResolver,
+		&FakeRemoteClient{shardStatus: shardStatus},
+	)
+
+	for shardName, statusByNode := range shardStatus {
+		mockShard := NewMockShardLike(t)
+		mockShard.EXPECT().
+			preventShutdown().
+			Return(func() {}, nil).Maybe()
+		mockShard.EXPECT().
+			Name().
+			Return(shardName).Maybe()
+		mockShard.EXPECT().
+			GetStatus().
+			Return(storagestate.Status(statusByNode[targetNode])).Maybe()
+		index.shards.Store(shardName, mockShard)
+	}
+
+	// Act
+	got, err := index.getShardsStatus(t.Context(), "")
+
+	// Assert
+	assert.NoError(t, err)
+	require.Equal(t, want, got)
 }
 
 // TestIndex_ShardHasMultipleReplicasWrite_RoutesThroughReplicatorDuringMovement pins the

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -303,16 +303,14 @@ func TestIndex_getShardsStatus(t *testing.T) {
 		"one_not_reachable": {
 			"node-0": storagestate.StatusReady.String(),
 			"node-1": storagestate.StatusReady.String(),
-			"node-2": "", // Remote replica failed to report status.
+			"node-2": NodeUnresponsive, // Remote replica failed to report status.
 		},
 	}
-	want := map[string]string{
-		"all_ready":         storagestate.StatusReady.String(),
-		"one_not_ready":     storagestate.StatusLazyLoading.String(),
-		"two_not_ready":     storagestate.StatusIndexing.String(),
-		"all_shutdown":      storagestate.StatusShutdown.String(),
-		"one_not_reachable": storagestate.StatusIndexing.String(),
-	}
+
+	// NodeUnresponsive should not be in the final response.
+	want := maps.Clone(shardStatus)
+	want["one_not_reachable"] = maps.Clone(want["one_not_reachable"])
+	delete(want["one_not_reachable"], "node-2")
 
 	var replicas []types.Replica
 	for shard, nodes := range shardReplicas {

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -278,6 +278,7 @@ func TestIndex_getShardsStatus(t *testing.T) {
 		"two_not_ready":     clusterNodes,
 		"all_shutdown":      clusterNodes,
 		"one_not_reachable": clusterNodes,
+		"shard_not_local":   clusterNodes[1:],
 	}
 	shardStatus := map[string]map[string]string{
 		"all_ready": {
@@ -305,12 +306,25 @@ func TestIndex_getShardsStatus(t *testing.T) {
 			"node-1": storagestate.StatusReady.String(),
 			"node-2": NodeUnresponsive, // Remote replica failed to report status.
 		},
+		"shard_not_local": {
+			"node-1": storagestate.StatusShutdown.String(),
+			"node-2": storagestate.StatusShutdown.String(),
+		},
 	}
 
 	// NodeUnresponsive should not be in the final response.
 	want := maps.Clone(shardStatus)
 	want["one_not_reachable"] = maps.Clone(want["one_not_reachable"])
 	delete(want["one_not_reachable"], "node-2")
+
+	wantLegacy := map[string]string{
+		"all_ready":         storagestate.StatusReady.String(),
+		"one_not_ready":     storagestate.StatusReady.String(),
+		"two_not_ready":     storagestate.StatusReady.String(),
+		"all_shutdown":      storagestate.StatusShutdown.String(),
+		"one_not_reachable": storagestate.StatusReady.String(),
+		"shard_not_local":   storagestate.StatusShutdown.String(),
+	}
 
 	var replicas []types.Replica
 	for shard, nodes := range shardReplicas {
@@ -391,11 +405,12 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	}
 
 	// Act
-	got, err := index.getShardsStatus(t.Context(), "")
+	got, gotLegacy, err := index.getShardsStatus(t.Context(), "")
 
 	// Assert
 	assert.NoError(t, err)
-	require.Equal(t, want, got)
+	require.Equal(t, want, got, "shard statuses")
+	require.Equal(t, wantLegacy, gotLegacy, "legacy statuses")
 }
 
 // TestIndex_ShardHasMultipleReplicasWrite_RoutesThroughReplicatorDuringMovement pins the

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -273,10 +273,11 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	clusterNodes := []string{"node-0", "node-1", "node-2"}
 	targetNode := clusterNodes[0]
 	shardReplicas := map[string][]string{
-		"all_ready":     clusterNodes,
-		"one_not_ready": clusterNodes,
-		"two_not_ready": clusterNodes,
-		"all_shutdown":  clusterNodes,
+		"all_ready":         clusterNodes,
+		"one_not_ready":     clusterNodes,
+		"two_not_ready":     clusterNodes,
+		"all_shutdown":      clusterNodes,
+		"one_not_reachable": clusterNodes,
 	}
 	shardStatus := map[string]map[string]string{
 		"all_ready": {
@@ -299,12 +300,18 @@ func TestIndex_getShardsStatus(t *testing.T) {
 			"node-1": storagestate.StatusShutdown.String(),
 			"node-2": storagestate.StatusShutdown.String(),
 		},
+		"one_not_reachable": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusReady.String(),
+			"node-2": "", // Remote replica failed to report status.
+		},
 	}
 	want := map[string]string{
-		"all_ready":     storagestate.StatusReady.String(),
-		"one_not_ready": storagestate.StatusLazyLoading.String(),
-		"two_not_ready": storagestate.StatusIndexing.String(),
-		"all_shutdown":  storagestate.StatusShutdown.String(),
+		"all_ready":         storagestate.StatusReady.String(),
+		"one_not_ready":     storagestate.StatusLazyLoading.String(),
+		"two_not_ready":     storagestate.StatusIndexing.String(),
+		"all_shutdown":      storagestate.StatusShutdown.String(),
+		"one_not_reachable": storagestate.StatusIndexing.String(),
 	}
 
 	var replicas []types.Replica

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -268,10 +268,11 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	clusterNodes := []string{"node-0", "node-1", "node-2"}
 	targetNode := clusterNodes[0]
 	shardReplicas := map[string][]string{
-		"all_ready":     clusterNodes,
-		"one_not_ready": clusterNodes,
-		"two_not_ready": clusterNodes,
-		"all_shutdown":  clusterNodes,
+		"all_ready":         clusterNodes,
+		"one_not_ready":     clusterNodes,
+		"two_not_ready":     clusterNodes,
+		"all_shutdown":      clusterNodes,
+		"one_not_reachable": clusterNodes,
 	}
 	shardStatus := map[string]map[string]string{
 		"all_ready": {
@@ -294,12 +295,18 @@ func TestIndex_getShardsStatus(t *testing.T) {
 			"node-1": storagestate.StatusShutdown.String(),
 			"node-2": storagestate.StatusShutdown.String(),
 		},
+		"one_not_reachable": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusReady.String(),
+			"node-2": "", // Remote replica failed to report status.
+		},
 	}
 	want := map[string]string{
-		"all_ready":     storagestate.StatusReady.String(),
-		"one_not_ready": storagestate.StatusLazyLoading.String(),
-		"two_not_ready": storagestate.StatusIndexing.String(),
-		"all_shutdown":  storagestate.StatusShutdown.String(),
+		"all_ready":         storagestate.StatusReady.String(),
+		"one_not_ready":     storagestate.StatusLazyLoading.String(),
+		"two_not_ready":     storagestate.StatusIndexing.String(),
+		"all_shutdown":      storagestate.StatusShutdown.String(),
+		"one_not_reachable": storagestate.StatusIndexing.String(),
 	}
 
 	var replicas []types.Replica

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -273,57 +273,36 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	clusterNodes := []string{"node-0", "node-1", "node-2"}
 	targetNode := clusterNodes[0]
 	shardReplicas := map[string][]string{
-		"all_ready":         clusterNodes,
-		"one_not_ready":     clusterNodes,
-		"two_not_ready":     clusterNodes,
-		"all_shutdown":      clusterNodes,
-		"one_not_reachable": clusterNodes,
-		"shard_not_local":   clusterNodes[1:],
+		"shard_local":          clusterNodes,
+		"shard_not_local":      clusterNodes[1:],
+		"remote_not_reachable": clusterNodes,
 	}
 	shardStatus := map[string]map[string]string{
-		"all_ready": {
-			"node-0": storagestate.StatusReady.String(),
-			"node-1": storagestate.StatusReady.String(),
-			"node-2": storagestate.StatusReady.String(),
-		},
-		"one_not_ready": {
+		"shard_local": {
 			"node-0": storagestate.StatusReady.String(),
 			"node-1": storagestate.StatusLazyLoading.String(),
-			"node-2": storagestate.StatusReady.String(),
+			"node-2": storagestate.StatusIndexing.String(),
 		},
-		"two_not_ready": {
-			"node-0": storagestate.StatusReady.String(),
-			"node-1": storagestate.StatusLazyLoading.String(),
-			"node-2": storagestate.StatusReadOnly.String(),
+		"shard_not_local": {
+			"node-1": storagestate.StatusIndexing.String(),
+			"node-2": storagestate.StatusIndexing.String(),
 		},
-		"all_shutdown": {
-			"node-0": storagestate.StatusShutdown.String(),
-			"node-1": storagestate.StatusShutdown.String(),
-			"node-2": storagestate.StatusShutdown.String(),
-		},
-		"one_not_reachable": {
+		"remote_not_reachable": {
 			"node-0": storagestate.StatusReady.String(),
 			"node-1": storagestate.StatusReady.String(),
 			"node-2": NodeUnresponsive, // Remote replica failed to report status.
-		},
-		"shard_not_local": {
-			"node-1": storagestate.StatusShutdown.String(),
-			"node-2": storagestate.StatusShutdown.String(),
 		},
 	}
 
 	// NodeUnresponsive should not be in the final response.
 	want := maps.Clone(shardStatus)
-	want["one_not_reachable"] = maps.Clone(want["one_not_reachable"])
-	delete(want["one_not_reachable"], "node-2")
+	want["remote_not_reachable"] = maps.Clone(want["remote_not_reachable"])
+	delete(want["remote_not_reachable"], "node-2")
 
 	wantLegacy := map[string]string{
-		"all_ready":         storagestate.StatusReady.String(),
-		"one_not_ready":     storagestate.StatusReady.String(),
-		"two_not_ready":     storagestate.StatusReady.String(),
-		"all_shutdown":      storagestate.StatusShutdown.String(),
-		"one_not_reachable": storagestate.StatusReady.String(),
-		"shard_not_local":   storagestate.StatusShutdown.String(),
+		"shard_local":          storagestate.StatusReady.String(),
+		"shard_not_local":      storagestate.StatusIndexing.String(),
+		"remote_not_reachable": storagestate.StatusReady.String(),
 	}
 
 	var replicas []types.Replica

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -570,7 +570,7 @@ func (m *Migrator) GetShardsQueueSize(ctx context.Context, className, tenant str
 	return idx.getShardsQueueSize(ctx, tenant)
 }
 
-func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
+func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, error) {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		// index not yet local (RAFT schema not applied on this node) or class does not exist

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -570,11 +570,11 @@ func (m *Migrator) GetShardsQueueSize(ctx context.Context, className, tenant str
 	return idx.getShardsQueueSize(ctx, tenant)
 }
 
-func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, error) {
+func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error) {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		// index not yet local (RAFT schema not applied on this node) or class does not exist
-		return nil, fmt.Errorf("cannot get shards status for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
+		return nil, nil, fmt.Errorf("cannot get shards status for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
 	}
 
 	return idx.getShardsStatus(ctx, tenant)

--- a/adapters/repos/db/migrator_tenant_locks_test.go
+++ b/adapters/repos/db/migrator_tenant_locks_test.go
@@ -85,7 +85,7 @@ func migratorOpsWithoutClassLock(reachIndex bool) map[string]func(*Migrator) err
 			return m.DeleteTenants(ctx, lockTestClass, nil)
 		},
 		"GetShardsStatus": func(m *Migrator) error {
-			_, err := m.GetShardsStatus(ctx, lockTestClass, "")
+			_, _, err := m.GetShardsStatus(ctx, lockTestClass, "")
 			return err
 		},
 		"GetShardsQueueSize": func(m *Migrator) error {

--- a/adapters/repos/db/migrator_tenant_locks_test.go
+++ b/adapters/repos/db/migrator_tenant_locks_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/cluster"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -60,7 +61,27 @@ func newLockTestMigrator(t *testing.T, reachIndex bool) *Migrator {
 		func(_ string, _ bool, read func(*models.Class, *sharding.State) error) error {
 			return read(nil, state)
 		}).Maybe()
+	reader.EXPECT().ShardReplicas(lockTestClass, mock.Anything).
+		Return([]string{lockTestNode}, nil).Maybe()
 	idx.schemaReader = reader
+
+	shardStatus := make(map[string]map[string]string, len(shards))
+	for _, shard := range shards {
+		shardStatus[shard] = map[string]string{
+			lockTestNode: "READY",
+		}
+	}
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	nodeResolver.EXPECT().
+		NodeHostname(mock.Anything).
+		RunAndReturn(func(s string) (string, bool) { return s, true }).Maybe()
+	idx.remote = sharding.NewRemoteIndex(
+		lockTestClass,
+		idx.getSchema,
+		nodeResolver,
+		&FakeRemoteClient{shardStatus: shardStatus},
+	)
 
 	return newDropTestMigrator(idx, lockTestClass, nil)
 }

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -617,7 +617,7 @@ func TestShardsStatusNonExistingIndexWrapsNotFound(t *testing.T) {
 		{
 			name: "GetShardsStatus",
 			call: func() error {
-				_, err := migrator.GetShardsStatus(context.Background(), "DoesNotExist", "")
+				_, _, err := migrator.GetShardsStatus(context.Background(), "DoesNotExist", "")
 				return err
 			},
 		},

--- a/entities/models/shard_status_get_response.go
+++ b/entities/models/shard_status_get_response.go
@@ -31,10 +31,13 @@ type ShardStatusGetResponse struct {
 	// Name of the shard
 	Name string `json:"name,omitempty"`
 
-	// Status of the shard
+	// Status of the shard on each of its replicas
+	PerNodeStatus map[string]string `json:"per_node_status,omitempty"`
+
+	// Deprecated: value is not consistent in replicated clusters.
 	Status string `json:"status,omitempty"`
 
-	// Size of the vector queue of the shard
+	// Deprecated: value is not consistent in replicated clusters.
 	VectorQueueSize int64 `json:"vectorQueueSize"`
 }
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1998,11 +1998,18 @@
           "type": "string"
         },
         "status": {
-          "description": "Status of the shard",
+          "description": "Deprecated: value is not consistent in replicated clusters.",
           "type": "string"
         },
+        "per_node_status": {
+          "description": "Status of the shard on each of its replicas",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
         "vectorQueueSize": {
-          "description": "Size of the vector queue of the shard",
+          "description": "Deprecated: value is not consistent in replicated clusters.",
           "type": "integer",
           "x-omitempty": false
         }

--- a/test/acceptance/classifications/knn_classification_test.go
+++ b/test/acceptance/classifications/knn_classification_test.go
@@ -36,7 +36,11 @@ func knnClassification(t *testing.T) {
 				shardStatus, err := helper.Client(t).Schema.SchemaObjectsShardsGet(schema.NewSchemaObjectsShardsGetParams().WithClassName("Recipe"), nil)
 				require.Nil(t, err)
 				require.GreaterOrEqual(t, len(shardStatus.Payload), 1)
-				return shardStatus.Payload[0].Status
+
+				for _, status := range shardStatus.Payload[0].PerNodeStatus {
+					return status
+				}
+				return ""
 			}, 250*time.Millisecond, 15*time.Second)
 	})
 

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -415,7 +415,7 @@ func TestNamespaces_ShardsStatus(t *testing.T) {
 		})
 		require.Len(t, shards, 1)
 		for _, s := range shards {
-			assert.NotEmpty(t, s.Status, "shard %q should have a populated status", s.Name)
+			assert.NotEmpty(t, s.PerNodeStatus, "shard %q should have a populated status", s.Name)
 		}
 	})
 
@@ -431,7 +431,7 @@ func TestNamespaces_ShardsStatus(t *testing.T) {
 		})
 		require.Len(t, shards, 1)
 		for _, s := range shards {
-			assert.NotEmpty(t, s.Status, "shard %q should have a populated status", s.Name)
+			assert.NotEmpty(t, s.PerNodeStatus, "shard %q should have a populated status", s.Name)
 		}
 	})
 
@@ -452,7 +452,7 @@ func TestNamespaces_ShardsStatus(t *testing.T) {
 		})
 		require.Len(t, shards, 1)
 		for _, s := range shards {
-			assert.NotEmpty(t, s.Status, "shard %q should have a populated status", s.Name)
+			assert.NotEmpty(t, s.PerNodeStatus, "shard %q should have a populated status", s.Name)
 		}
 	})
 }
@@ -521,7 +521,9 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 			}
 			for _, s := range after {
 				if s.Name == shardName {
-					assert.Equal(c, want, s.Status)
+					for nodeName, shardStatus := range s.PerNodeStatus {
+						assert.Equal(c, want, shardStatus, "%s status on node %s", shardName, nodeName)
+					}
 					return
 				}
 			}
@@ -579,7 +581,7 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 		})
 		require.Len(t, shards, 1)
 		shardName := shards[0].Name
-		initialStatus := shards[0].Status
+		initialStatus := shards[0].PerNodeStatus
 
 		// Wait for the alias entry to be visible on the node handling the
 		// request before asserting that UpdateShardStatus rejects it. On a
@@ -598,7 +600,7 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 		after, err := getShards(t, ns1+":Concerts", adminKey)
 		require.NoError(t, err)
 		require.Len(t, after, 1)
-		assert.Equal(t, initialStatus, after[0].Status, "underlying shard status must be unchanged")
+		assert.Equal(t, initialStatus, after[0].PerNodeStatus, "underlying shard status must be unchanged")
 	})
 
 	t.Run("each namespace updates only its own class", func(t *testing.T) {
@@ -628,7 +630,13 @@ func TestNamespaces_UpdateShardStatus(t *testing.T) {
 		after1, err := getShards(t, ns1+":Books", adminKey)
 		require.NoError(t, err)
 		require.Len(t, after1, 1)
-		assert.NotEqual(t, "READONLY", after1[0].Status, "ns1:Books must be untouched by user2's update")
+		for nodeName, shardStatus := range after1[0].PerNodeStatus {
+			assert.NotEqual(t,
+				"READONLY", shardStatus,
+				"ns1:Books must be untouched by user2's update (shard=%s node=%s)",
+				shardName, nodeName,
+			)
+		}
 	})
 }
 

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/weaviate/weaviate-python-client.git@3106d23afe83c6ef74d022268fce7ba3cd88ab23
+git+https://github.com/weaviate/weaviate-python-client.git@e2fccfd93bbd913192af4ffb8ace560b2e8d20a6
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1
 pytest-benchmark==4.0.0

--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/weaviate/weaviate-python-client.git@e2fccfd93bbd913192af4ffb8ace560b2e8d20a6
+git+https://github.com/weaviate/weaviate-python-client.git@b82cd81cd93b7b5d9480e16ac4680c096cea7446
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1
 pytest-benchmark==4.0.0

--- a/test/acceptance_with_python/test_filter.py
+++ b/test/acceptance_with_python/test_filter.py
@@ -1,7 +1,8 @@
 from typing import List
 
 import pytest
-from weaviate.collections.classes.config import Configure, Property, DataType
+
+from weaviate.collections.classes.config import Configure, DataType, Property
 from weaviate.collections.classes.filters import Filter, _FilterValue
 
 from .conftest import CollectionFactory
@@ -11,17 +12,7 @@ from .conftest import CollectionFactory
 @pytest.mark.parametrize(
     "weaviate_filter,results,skip",
     [
-        (
-            Filter.by_property("textArray").equal([]),
-            [1],
-            True,
-        ),
         (Filter.by_property("textArray", length=True).equal(0), [1], False),
-        (
-            Filter.by_property("textArray").not_equal([]),
-            [0],
-            True,
-        ),
         (Filter.by_property("textArray", length=True).not_equal(0), [0], False),
     ],
 )

--- a/test/acceptance_with_python/test_filter.py
+++ b/test/acceptance_with_python/test_filter.py
@@ -8,22 +8,18 @@ from weaviate.collections.classes.filters import Filter, _FilterValue
 from .conftest import CollectionFactory
 
 
-# bug in client + not supported in weaviate for filter by empty list
 @pytest.mark.parametrize(
-    "weaviate_filter,results,skip",
+    "weaviate_filter,results",
     [
-        (Filter.by_property("textArray", length=True).equal(0), [1], False),
-        (Filter.by_property("textArray", length=True).not_equal(0), [0], False),
+        (Filter.by_property("textArray", length=True).equal(0), [1]),
+        (Filter.by_property("textArray", length=True).not_equal(0), [0]),
     ],
 )
 def test_empty_list_filter(
     collection_factory: CollectionFactory,
     weaviate_filter: _FilterValue,
     results: List[int],
-    skip: bool,
 ) -> None:
-    if skip:
-        pytest.skip("Not supported in this version")
     collection = collection_factory(
         vectorizer_config=Configure.Vectorizer.none(),
         properties=[Property(name="textArray", data_type=DataType.TEXT_ARRAY)],

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -370,7 +370,7 @@ func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList
 		return nil, err
 	}
 
-	resp := make(models.ShardStatusList, len(shardsStatus))
+	resp := make(models.ShardStatusList, 0, len(shardsStatus))
 	for name, status := range shardsStatus {
 		resp = append(resp, &models.ShardStatusGetResponse{
 			Name:          name,

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -365,15 +365,16 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 
 func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
 	ctx := context.Background()
-	shardsStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant)
+	shardsStatus, legacyStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant)
 	if err != nil {
 		return nil, err
 	}
 
 	resp := make(models.ShardStatusList, 0, len(shardsStatus))
-	for name, status := range shardsStatus {
+	for shardName, status := range shardsStatus {
 		resp = append(resp, &models.ShardStatusGetResponse{
-			Name:          name,
+			Name:          shardName,
+			Status:        legacyStatus[shardName],
 			PerNodeStatus: status,
 		})
 	}

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -370,12 +370,11 @@ func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList
 		return nil, err
 	}
 
-	resp := models.ShardStatusList{}
-
+	resp := make(models.ShardStatusList, len(shardsStatus))
 	for name, status := range shardsStatus {
 		resp = append(resp, &models.ShardStatusGetResponse{
-			Name:   name,
-			Status: status,
+			Name:          name,
+			PerNodeStatus: status,
 		})
 	}
 

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -232,7 +232,7 @@ func TestExecutor(t *testing.T) {
 		assert.Len(t, statusList, 1, "number of shards in the status list")
 		statusList0 := statusList[0]
 		assert.Equal(t, statusList0.Name, "A", "shard name")
-		assert.Equal(t, statusList0.Status, "C", "shard legacy status")
+		assert.Equal(t, statusList0.Status, "C", "shard legacy status") // nolint:staticcheck
 		assert.Equal(t, statusList0.PerNodeStatus, map[string]string{"B": "C"})
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -232,7 +232,7 @@ func TestExecutor(t *testing.T) {
 		assert.Len(t, statusList, 1, "number of shards in the status list")
 		statusList0 := statusList[0]
 		assert.Equal(t, statusList0.Name, "A", "shard name")
-		assert.Equal(t, statusList0.Status, "C", "shard legacy status") // nolint:staticcheck
+		assert.Equal(t, statusList0.Status, "C", "shard legacy status") //nolint:staticcheck
 		assert.Equal(t, statusList0.PerNodeStatus, map[string]string{"B": "C"})
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -226,8 +226,12 @@ func TestExecutor(t *testing.T) {
 		status := map[string]map[string]string{"A": {"B": "C"}}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, nil)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus("A", "")
-		assert.Nil(t, err)
+		statusList, err := x.GetShardsStatus("A", "")
+		assert.NoError(t, err)
+		assert.Len(t, statusList, 1, "number of shards in the status list")
+		statusList0 := statusList[0]
+		assert.Equal(t, statusList0.Name, "A", "shard name")
+		assert.Equal(t, statusList0.PerNodeStatus, map[string]string{"B": "C"})
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {
 		migrator := &fakeMigrator{}

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -223,7 +223,7 @@ func TestExecutor(t *testing.T) {
 
 	t.Run("GetShardsStatus", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		status := map[string]string{"A": "B"}
+		status := map[string]map[string]string{"A": {"B": "C"}}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, nil)
 		x := newMockExecutor(migrator, store)
 		_, err := x.GetShardsStatus("A", "")
@@ -231,7 +231,7 @@ func TestExecutor(t *testing.T) {
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
-		status := map[string]string{"A": "B"}
+		status := map[string]map[string]string{"A": {"B": "C"}}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, ErrAny)
 		x := newMockExecutor(migrator, store)
 		_, err := x.GetShardsStatus("A", "")

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -224,19 +224,22 @@ func TestExecutor(t *testing.T) {
 	t.Run("GetShardsStatus", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		status := map[string]map[string]string{"A": {"B": "C"}}
-		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, nil)
+		legacy := map[string]string{"A": "C"}
+		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, legacy, nil)
 		x := newMockExecutor(migrator, store)
 		statusList, err := x.GetShardsStatus("A", "")
 		assert.NoError(t, err)
 		assert.Len(t, statusList, 1, "number of shards in the status list")
 		statusList0 := statusList[0]
 		assert.Equal(t, statusList0.Name, "A", "shard name")
+		assert.Equal(t, statusList0.Status, "C", "shard legacy status")
 		assert.Equal(t, statusList0.PerNodeStatus, map[string]string{"B": "C"})
 	})
 	t.Run("GetShardsStatusError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		status := map[string]map[string]string{"A": {"B": "C"}}
-		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, ErrAny)
+		legacy := map[string]string{"A": "C"}
+		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, legacy, ErrAny)
 		x := newMockExecutor(migrator, store)
 		_, err := x.GetShardsStatus("A", "")
 		assert.ErrorIs(t, err, ErrAny)

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -351,9 +351,9 @@ func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants 
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error) {
+func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, error) {
 	args := f.Called(ctx, className, tenant)
-	return args.Get(0).(map[string]string), args.Error(1)
+	return args.Get(0).(map[string]map[string]string), args.Error(1)
 }
 
 func (f *fakeMigrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -351,9 +351,9 @@ func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants 
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, error) {
+func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error) {
 	args := f.Called(ctx, className, tenant)
-	return args.Get(0).(map[string]map[string]string), args.Error(1)
+	return args.Get(0).(map[string]map[string]string), args.Get(1).(map[string]string), args.Error(2)
 }
 
 func (f *fakeMigrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error {

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -56,7 +56,7 @@ type Migrator interface {
 	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload, implicitUpdate bool) error
 	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error
 
-	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]string, error)
+	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error
 
 	UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -56,7 +56,7 @@ type Migrator interface {
 	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload, implicitUpdate bool) error
 	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error
 
-	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, error)
+	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error
 
 	UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -392,15 +392,10 @@ func (ri *RemoteIndex) GetShardQueueSize(ctx context.Context, shardName string) 
 	return ri.client.GetShardQueueSize(ctx, host, ri.class, shardName)
 }
 
-func (ri *RemoteIndex) GetShardStatus(ctx context.Context, shardName string) (string, error) {
-	owner, err := ri.stateGetter.ShardOwner(ri.class, shardName)
-	if err != nil {
-		return "", fmt.Errorf("class %s has no physical shard %q: %w", ri.class, shardName, err)
-	}
-
-	host, ok := ri.nodeResolver.NodeHostname(owner)
+func (ri *RemoteIndex) GetShardStatus(ctx context.Context, shardName, nodeName string) (string, error) {
+	host, ok := ri.nodeResolver.NodeHostname(nodeName)
 	if !ok {
-		return "", fmt.Errorf("resolve node name %q to host", owner)
+		return "", fmt.Errorf("resolve node name %q to host", nodeName)
 	}
 
 	return ri.client.GetShardStatus(ctx, host, ri.class, shardName)


### PR DESCRIPTION
Shard status might be different on each replica.

If only 1 replica is checked (local or remote), the status is not representative of the actual cluster state. This is particularly evident when we wait for all shards to finish their indexing pipelines: reporting READY when only 1 replica is ready may lead to failed queries, should they land on any of the remaining replicas.

### What's being changed:

Since shard status is a categorical variable, it is impossible to return a meaningful aggregate value for it. The original design of `/schema/{class}/shards` did not take replication into account, so we do not try and remedy the existing solution.

Rather, we will send per-node statuses for every shard and let the consumer of the endpoint decide how they should be interpreted. The 'aggregated' `Status` and `VectorQueueSize` fields are deprecated.

In the test, where we previously checked `shard.Status == want` we will now check that each of `shard.PerNodeStatus` is as expected. Those checks are executed inside the "eventually" helpers, so the statuses in replicated clusters will have the time to converge.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

### Cross-functional impact

- [x] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.

All client libraries should be updated to reflect the new field.
- [x] Python (weaviate-python-client)
- [x] JavaScript/TypeScript (typescript-client)
- [x] Go (weaviate-go-client)
- [x] Java (java-client)

