### PR TITLE
fix(batch): report one error per object when a shard refuses a batch

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1779,8 +1779,8 @@ func parseAsStringToTime(in interface{}) (time.Time, error) {
 	return parsed, nil
 }
 
-// putObjectBatch returns one error per object, at the position that object held
-// in objects. A position left nil is reported to the client as a written object.
+// return value []error gives the error for the index with the positions
+// matching the inputs and nil on positions where the write succeeded
 func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {
@@ -1905,9 +1905,8 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 	return shard.PutObjectBatch(ctx, objects)
 }
 
-// AddReferencesBatch returns one error per reference, at the position that
-// reference held in refs. A position left nil is reported to the client as a
-// written reference.
+// return value []error gives the error for the index with the positions
+// matching the inputs and nil on positions where the write succeeded
 func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1781,8 +1781,8 @@ func parseAsStringToTime(in interface{}) (time.Time, error) {
 	return parsed, nil
 }
 
-// return value []error gives the error for the index with the positions
-// matching the inputs
+// putObjectBatch returns one error per object, at the position that object held
+// in objects. A position left nil is reported to the client as a written object.
 func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {
@@ -1907,7 +1907,9 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 	return shard.PutObjectBatch(ctx, objects)
 }
 
-// return value map[int]error gives the error for the index as it received it
+// AddReferencesBatch returns one error per reference, at the position that
+// reference held in refs. A position left nil is reported to the client as a
+// written reference.
 func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1779,8 +1779,8 @@ func parseAsStringToTime(in interface{}) (time.Time, error) {
 	return parsed, nil
 }
 
-// return value []error gives the error for the index with the positions
-// matching the inputs
+// putObjectBatch returns one error per object, at the position that object held
+// in objects. A position left nil is reported to the client as a written object.
 func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {
@@ -1905,7 +1905,9 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 	return shard.PutObjectBatch(ctx, objects)
 }
 
-// return value map[int]error gives the error for the index as it received it
+// AddReferencesBatch returns one error per reference, at the position that
+// reference held in refs. A position left nil is reported to the client as a
+// written reference.
 func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1781,8 +1781,8 @@ func parseAsStringToTime(in interface{}) (time.Time, error) {
 	return parsed, nil
 }
 
-// putObjectBatch returns one error per object, at the position that object held
-// in objects. A position left nil is reported to the client as a written object.
+// return value []error gives the error for the index with the positions
+// matching the inputs and nil on positions where the write succeeded
 func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {
@@ -1907,9 +1907,8 @@ func (i *Index) IncomingBatchPutObjects(ctx context.Context, shardName string,
 	return shard.PutObjectBatch(ctx, objects)
 }
 
-// AddReferencesBatch returns one error per reference, at the position that
-// reference held in refs. A position left nil is reported to the client as a
-// written reference.
+// return value []error gives the error for the index with the positions
+// matching the inputs and nil on positions where the write succeeded
 func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences,
 	replProps *additional.ReplicationProperties, schemaVersion uint64,
 ) []error {

--- a/adapters/repos/db/index_put_object_batch_test.go
+++ b/adapters/repos/db/index_put_object_batch_test.go
@@ -38,7 +38,7 @@ func TestPutObjectBatchReportsErrorAtEveryGroupPosition(t *testing.T) {
 		// remaining objects form a group whose positions do not start at 0.
 		unresolvableFirst bool
 		schemaVersion     uint64
-		setup             func(t *testing.T, idx *Index)
+		setup             func(t *testing.T, idx *Index, shard *Shard)
 		// wantErrAt maps a position to a substring of the error expected there;
 		// every other position must carry no error.
 		wantErrAt map[int]string
@@ -46,7 +46,7 @@ func TestPutObjectBatchReportsErrorAtEveryGroupPosition(t *testing.T) {
 		{
 			name:          "failed lookup",
 			schemaVersion: schemaVersion,
-			setup: func(t *testing.T, idx *Index) {
+			setup: func(t *testing.T, idx *Index, shard *Shard) {
 				// the caller's own wait succeeds, the one inside the shard lookup does not
 				schemaReader := idx.schemaReader.(*schemaUC.MockSchemaReader)
 				schemaReader.EXPECT().WaitForUpdate(mock.Anything, schemaVersion).Return(nil).Once()
@@ -62,7 +62,7 @@ func TestPutObjectBatchReportsErrorAtEveryGroupPosition(t *testing.T) {
 		{
 			name:              "panicking group",
 			unresolvableFirst: true,
-			setup: func(t *testing.T, idx *Index) {
+			setup: func(t *testing.T, idx *Index, shard *Shard) {
 				router := types.NewMockRouter(t)
 				router.EXPECT().GetWriteReplicasLocation(className, mock.Anything, mock.Anything).
 					RunAndReturn(func(string, string, string) (types.WriteReplicaSet, error) {
@@ -76,11 +76,34 @@ func TestPutObjectBatchReportsErrorAtEveryGroupPosition(t *testing.T) {
 				2: "an unexpected error occurred",
 			},
 		},
+		{
+			name: "read-only shard",
+			setup: func(t *testing.T, idx *Index, shard *Shard) {
+				require.NoError(t, shard.SetStatusReadonly(statusReasonResourcePressure))
+			},
+			wantErrAt: map[int]string{
+				0: "store is read-only",
+				1: "store is read-only",
+				2: "store is read-only",
+			},
+		},
+		{
+			name:              "read-only shard, group not starting at position 0",
+			unresolvableFirst: true,
+			setup: func(t *testing.T, idx *Index, shard *Shard) {
+				require.NoError(t, shard.SetStatusReadonly(statusReasonResourcePressure))
+			},
+			wantErrAt: map[int]string{
+				0: "parse uuid",
+				1: "store is read-only",
+				2: "store is read-only",
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			idx, _ := refCountTestIndex(t, className)
+			idx, shard := refCountTestIndex(t, className)
 
 			objs := []*storobj.Object{
 				testObject(className), testObject(className), testObject(className),
@@ -88,7 +111,7 @@ func TestPutObjectBatchReportsErrorAtEveryGroupPosition(t *testing.T) {
 			if test.unresolvableFirst {
 				objs[0].Object.ID = strfmt.UUID("not-a-uuid")
 			}
-			test.setup(t, idx)
+			test.setup(t, idx, shard)
 
 			out := idx.putObjectBatch(t.Context(), objs, nil, test.schemaVersion)
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -264,8 +264,8 @@ func (l *LazyLoadShard) PutObject(ctx context.Context, object *storobj.Object) e
 
 func (l *LazyLoadShard) PutObjectBatch(ctx context.Context, objects []*storobj.Object) []error {
 	if err := l.Load(ctx); err != nil {
-		return []error{err}
-	} // TODO check
+		return duplicateErr(err, len(objects))
+	}
 	return l.shard.PutObjectBatch(ctx, objects)
 }
 
@@ -430,8 +430,8 @@ func (l *LazyLoadShard) GetChangeLog(ctx context.Context, opID string) (*changel
 
 func (l *LazyLoadShard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {
 	if err := l.Load(ctx); err != nil {
-		return []error{err}
-	} // TODO check
+		return duplicateErr(err, len(refs))
+	}
 	return l.shard.AddReferencesBatch(ctx, refs)
 }
 

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -29,20 +29,18 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-// return value map[int]error gives the error for the index as it received it
+// PutObjectBatch returns one error per object, in input order, refusals of the
+// whole batch included. The caller maps position i onto that object's position
+// in its own batch, so a shorter slice reports the objects it omits as written.
 func (s *Shard) PutObjectBatch(ctx context.Context,
 	objects []*storobj.Object,
 ) []error {
 	if err := s.isReadOnly(); err != nil {
-		return []error{err}
+		return duplicateErr(err, len(objects))
 	}
 
 	if err := s.index.usageLimits.CheckObjects(ctx, int64(len(objects)), s.index.Config.ClassName.String()); err != nil {
-		errs := make([]error, len(objects))
-		for i := range errs {
-			errs[i] = err
-		}
-		return errs
+		return duplicateErr(err, len(objects))
 	}
 
 	return s.putBatch(ctx, objects)

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -30,20 +30,18 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-// return value map[int]error gives the error for the index as it received it
+// PutObjectBatch returns one error per object, in input order, refusals of the
+// whole batch included. The caller maps position i onto that object's position
+// in its own batch, so a shorter slice reports the objects it omits as written.
 func (s *Shard) PutObjectBatch(ctx context.Context,
 	objects []*storobj.Object,
 ) []error {
 	if err := s.isReadOnly(); err != nil {
-		return []error{err}
+		return duplicateErr(err, len(objects))
 	}
 
 	if err := s.index.usageLimits.CheckObjects(ctx, int64(len(objects)), s.index.Config.ClassName.String()); err != nil {
-		errs := make([]error, len(objects))
-		for i := range errs {
-			errs[i] = err
-		}
-		return errs
+		return duplicateErr(err, len(objects))
 	}
 
 	return s.putBatch(ctx, objects)

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -26,11 +26,14 @@ import (
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-// return value map[int]error gives the error for the index as it received it
+// AddReferencesBatch returns one error per reference, in input order, refusals
+// of the whole batch included. The caller maps position i onto that reference's
+// position in its own batch, so a shorter slice reports the references it omits
+// as written.
 func (s *Shard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {
 	s.activityTrackerWrite.Add(1)
 	if err := s.isReadOnly(); err != nil {
-		return []error{err}
+		return duplicateErr(err, len(refs))
 	}
 
 	return newReferencesBatcher(s).References(ctx, refs)

--- a/adapters/repos/db/shard_write_batch_refusal_test.go
+++ b/adapters/repos/db/shard_write_batch_refusal_test.go
@@ -1,0 +1,116 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/schema/crossref"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// TestBatchWriteRefusalReportsOneErrorPerItem asserts that a batch refused as a
+// whole reports an error for every item it was handed. The callers scatter the
+// returned errors over the positions their shard group owns
+// (Index.putObjectBatch, Index.AddReferencesBatch), so a shorter slice leaves
+// the remaining positions nil, and a nil position is reported to the client as a
+// written item. A batch of one hides this: the single error covers the single
+// item.
+func TestBatchWriteRefusalReportsOneErrorPerItem(t *testing.T) {
+	className := "BatchWriteRefusal"
+
+	idx, shard := refCountTestIndex(t, className)
+	require.NoError(t, shard.SetStatusReadonly(statusReasonResourcePressure))
+	unloadable := newColdShard(idx, shard.name+"_unloadable")
+
+	tests := []struct {
+		name string
+		// wantErr is a substring of the refusal, so a batch that fails item by
+		// item for an unrelated reason cannot stand in for the refused batch.
+		wantErr string
+		write   func(t *testing.T, count int) []error
+	}{
+		{
+			name:    "read-only shard, objects",
+			wantErr: "read-only",
+			write: func(t *testing.T, count int) []error {
+				return shard.PutObjectBatch(t.Context(), batchOfObjects(className, count))
+			},
+		},
+		{
+			name:    "read-only shard, references",
+			wantErr: "read-only",
+			write: func(t *testing.T, count int) []error {
+				return shard.AddReferencesBatch(t.Context(), batchOfReferences(className, count))
+			},
+		},
+		{
+			name:    "unloadable shard, objects",
+			wantErr: "memory pressure",
+			write: func(t *testing.T, count int) []error {
+				return unloadable.PutObjectBatch(t.Context(), batchOfObjects(className, count))
+			},
+		},
+		{
+			name:    "unloadable shard, references",
+			wantErr: "memory pressure",
+			write: func(t *testing.T, count int) []error {
+				return unloadable.AddReferencesBatch(t.Context(), batchOfReferences(className, count))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		for _, count := range []int{1, 2, 10, 1000} {
+			t.Run(fmt.Sprintf("%s/%d", test.name, count), func(t *testing.T) {
+				errs := test.write(t, count)
+
+				require.Len(t, errs, count, "a refused batch must report one error per item")
+				for pos := range errs {
+					require.ErrorContainsf(t, errs[pos], test.wantErr,
+						"position %d must carry the refusal", pos)
+				}
+			})
+		}
+	}
+}
+
+func batchOfObjects(className string, count int) []*storobj.Object {
+	out := make([]*storobj.Object, count)
+	for i := range out {
+		out[i] = testObject(className)
+	}
+	return out
+}
+
+func batchOfReferences(className string, count int) objects.BatchReferences {
+	out := make(objects.BatchReferences, count)
+	for i := range out {
+		out[i] = objects.BatchReference{
+			OriginalIndex: i,
+			From: &crossref.RefSource{
+				Class:    schema.ClassName(className),
+				Property: schema.PropertyName("toTarget"),
+				TargetID: strfmt.UUID(uuid.NewString()),
+			},
+			To: &crossref.Ref{Class: "Target", TargetID: strfmt.UUID(uuid.NewString())},
+		}
+	}
+	return out
+}


### PR DESCRIPTION
### What's being changed:

A shard that refuses a whole batch returned a single error for N objects. `Index.putObjectBatch` scatters the returned errors onto the positions the shard group owns, so only the group's first position was marked failed and the rest stayed `nil` — and a `nil` position is reported to the client as a written object. A read-only shard answered a 1000-object batch with one error and 999 UUIDs, having stored nothing.

Four whole-batch refusals now return one error per item via `duplicateErr`: the read-only branches of `Shard.PutObjectBatch` and `Shard.AddReferencesBatch`, and the load-failure branches of the `LazyLoadShard` wrappers. `duplicateErr` is already the convention for the analogous whole-group failures in `index.go`.

Only the non-replicated path was affected. With RF > 1, `writableShard` rejects a read-only shard before the batch is built, and the coordinator already expands that to a full-length error slice.

Verified against a server built from this branch, with read-only forced through the shard-status API: a 30-object batch across 3 shards reports errors at exactly the failing positions and objects on the healthy shards still succeed, and `POST /v1/batch/objects` reports 10 FAILED where it previously reported 1 FAILED and 9 SUCCESS. Found from a support escalation on 1.37.8.

Read-only `DeleteObjectBatch` has a related but distinct problem (one result with an empty UUID, dropping the rest) and is deliberately left for a separate PR.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary, no API or configuration change.
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary — the changed paths are refusals that previously did no work.
