### PR TITLE
fix flaky teardown in async replication acceptance suites

### DIFF
--- a/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
+++ b/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
@@ -72,8 +72,7 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TearDownSuite() {
 }
 
 func (suite *AsyncCheckpointConvergenceTestSuite) TearDownTest() {
-	helper.SetupClient(suite.compose.GetWeaviate().URI())
-	helper.DeleteClassWithoutAssert(suite.T(), "Paragraph", "")
+	helper.DeleteClassEventually(suite.T(), "Paragraph", suite.compose.GetWeaviate().URI())
 }
 
 func TestAsyncCheckpointConvergenceTestSuite(t *testing.T) {

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -94,12 +94,12 @@ func (suite *AsyncReplicationTestSuite) TearDownSuite() {
 }
 
 // TearDownTest drops the shared classes so the next test starts from a clean
-// schema. Every shared-cluster scenario restarts node 1 if it stops it, so it
-// is reachable here.
+// schema. Node 1 may still be settling right after a scenario restarted it, so
+// the delete is retried until the schema no longer reports the class.
 func (suite *AsyncReplicationTestSuite) TearDownTest() {
-	helper.SetupClient(suite.compose.GetWeaviate().URI())
-	helper.DeleteClassWithoutAssert(suite.T(), "Article", "")
-	helper.DeleteClassWithoutAssert(suite.T(), "Paragraph", "")
+	uri := suite.compose.GetWeaviate().URI()
+	helper.DeleteClassEventually(suite.T(), "Article", uri)
+	helper.DeleteClassEventually(suite.T(), "Paragraph", uri)
 }
 
 func TestAsyncReplicationTestSuite(t *testing.T) {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -456,12 +456,12 @@ func DeleteClassWithoutAssert(t *testing.T, class, key string) {
 // DeleteClassEventually retries the class delete until the schema no longer reports it, for teardowns that may race a node restart.
 func DeleteClassEventually(t *testing.T, class, uri string) {
 	t.Helper()
+	c := NewClient(t, uri)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		SetupClient(uri)
 		delParams := schema.NewSchemaObjectsDeleteParams().WithClassName(class)
-		_, delErr := Client(t).Schema.SchemaObjectsDelete(delParams, nil)
+		_, delErr := c.Schema.SchemaObjectsDelete(delParams, nil)
 		getParams := schema.NewSchemaObjectsGetParams().WithClassName(class)
-		_, getErr := Client(t).Schema.SchemaObjectsGet(getParams, nil)
+		_, getErr := c.Schema.SchemaObjectsGet(getParams, nil)
 		var notFound *schema.SchemaObjectsGetNotFound
 		assert.True(ct, errors.As(getErr, &notFound),
 			"class %s still present (delete err: %v, get err: %v)", class, delErr, getErr)

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -453,6 +453,21 @@ func DeleteClassWithoutAssert(t *testing.T, class, key string) {
 	_, _ = Client(t).Schema.SchemaObjectsDelete(params, auth)
 }
 
+// DeleteClassEventually retries the class delete until the schema no longer reports it, for teardowns that may race a node restart.
+func DeleteClassEventually(t *testing.T, class, uri string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		SetupClient(uri)
+		delParams := schema.NewSchemaObjectsDeleteParams().WithClassName(class)
+		_, delErr := Client(t).Schema.SchemaObjectsDelete(delParams, nil)
+		getParams := schema.NewSchemaObjectsGetParams().WithClassName(class)
+		_, getErr := Client(t).Schema.SchemaObjectsGet(getParams, nil)
+		var notFound *schema.SchemaObjectsGetNotFound
+		assert.True(ct, errors.As(getErr, &notFound),
+			"class %s still present (delete err: %v, get err: %v)", class, delErr, getErr)
+	}, 60*time.Second, time.Second)
+}
+
 // DeleteClassAuthWithReturn issues an authenticated class-delete and
 // returns the raw error so callers can assert on rejection (e.g. malformed
 // namespace prefix in the URL).


### PR DESCRIPTION
## Motivation

`TestAsyncReplicationTestSuite/TestAsyncRepairMultiTenancyScenario/create_schema` flaked on the v1.38.9 release run with `422 class name Paragraph already exists` ([job log](https://github.com/weaviate/weaviate/actions/runs/31102814516/job/92628101290)), while the same commit passed the job in its PR run.

Since #11619 the async-replication acceptance suites (`AsyncReplicationTestSuite`, `AsyncCheckpointConvergenceTestSuite`) share one 3-node cluster across all test methods and rely on `TearDownTest` to drop the shared classes between scenarios. That teardown used `DeleteClassWithoutAssert`, which fires a single delete against node 1 and discards the result. Several scenarios restart nodes — `TestAsyncRepairMultiTenancyColdTenantConfigUpdate`, which runs immediately before the flaking test, restarts node 1 itself as its final step — and `StartNodeAt` only waits for the ready endpoint, not for the node to be able to serve a schema delete. When the delete silently fails against the still-settling node, the class leaks into the next test, which then fails on the leader's "already exists" check far from the actual cause.

## Approach

New helper `DeleteClassEventually` (`test/helper/objects.go`) makes teardown verification-based instead of trust-based: it retries delete-then-GET until the schema returns `NotFound` for the class (1s tick, 60s cap), re-pointing the client on every attempt. It deliberately does not trust a successful delete response — the exit condition is the schema no longer reporting the class. On timeout it reports both the delete and GET errors, so a future cleanup failure surfaces in the teardown of the test that caused it rather than as a dirty-schema failure in the next one.

Both suites' `TearDownTest` methods switch to the new helper; no scenario logic changes. `DeleteClassWithoutAssert` remains for its legitimate best-effort uses elsewhere.

## Key areas for review

- `DeleteClassEventually` — exit condition is GET → `NotFound`, not delete success; auth is anonymous (`nil`), matching the empty-key auth both call sites previously passed.
- The 60s cap: generous relative to node-restart settle time, small relative to the suites' overall runtime.

## Risks and mitigations

Test-only change; no production code touched. Worst case is a teardown spending up to 60s before failing loudly where it previously failed silently.

## Testing

`go vet`, `golangci-lint`, and the goroutine linter pass on the changed packages. Both suites pass a full local run against a pre-built `TEST_WEAVIATE_IMAGE` (`-race`, 548s); every test method's teardown exercises the new helper, including right after the node-1 restart that triggers the flake window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
