### PR TITLE
fix(db): move `st.trackDBLoadProgress` inside `st.reloadDBFromSchema`

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -557,6 +557,13 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return fmt.Errorf("failed to read sharding state: %w", err)
 	}
 
+	// db.indices does not receive this Index until every one of its shards has
+	// loaded, so shards are tallied onto the DB here, as each is stored.
+	startupShards := i.Config.StartupShards
+	if startupShards == nil {
+		startupShards = &startupShardCounters{}
+	}
+
 	hotShardNames := make([]string, 0, len(localShards))
 
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
@@ -574,6 +581,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				lazyShard := NewLazyLoadShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.indexCheckpoints,
 					i.allocChecker, i.shardLoadLimiter, i.shardReindexer, true, i.bitmapBufPool)
 				i.shards.Store(shardName, lazyShard)
+				startupShards.lazy.Add(1)
 				return nil
 			default:
 				// avoid footprint of empty shards
@@ -581,6 +589,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 					i.shards.Store(shardName, NewLazyLoadShard(ctx, promMetrics, shardName, i, class,
 						i.centralJobQueue, i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter,
 						i.shardReindexer, false, i.bitmapBufPool))
+					startupShards.lazy.Add(1)
 					return nil
 				}
 				// default behavior is to load all shards immediately
@@ -598,6 +607,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				promMetrics.NewLoadedShard()
 				newShard.metricsRegistered.Store(true)
 				i.shards.Store(shardName, newShard)
+				startupShards.eager.Add(1)
 				return nil
 			}
 		}, shardName)
@@ -1163,6 +1173,7 @@ type IndexConfig struct {
 	TrackVectorDimensionsInterval       time.Duration
 	UsageEnabled                        bool
 	ShardLoadLimiter                    *loadlimiter.LoadLimiter
+	StartupShards                       *startupShardCounters
 	BucketLoadLimiter                   *loadlimiter.LoadLimiter
 	ObjectsTTLBatchSize                 *configRuntime.DynamicValue[int]
 	ObjectsTTLPauseEveryNoBatches       *configRuntime.DynamicValue[int]

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -183,6 +183,7 @@ func (db *DB) init(ctx context.Context) error {
 				AsyncReplicationScheduler:                    db.asyncReplicationScheduler,
 				DeletionStrategy:                             class.ReplicationConfig.DeletionStrategy,
 				ShardLoadLimiter:                             db.shardLoadLimiter,
+				StartupShards:                                &db.startupShards,
 				BucketLoadLimiter:                            db.bucketLoadLimiter,
 				HNSWMaxLogSize:                               db.config.HNSWMaxLogSize,
 				HNSWDisableSnapshots:                         db.config.HNSWDisableSnapshots,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -207,6 +207,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			AsyncReplicationScheduler:                    m.db.asyncReplicationScheduler,
 			DeletionStrategy:                             class.ReplicationConfig.DeletionStrategy,
 			ShardLoadLimiter:                             m.db.shardLoadLimiter,
+			StartupShards:                                &m.db.startupShards,
 			BucketLoadLimiter:                            m.db.bucketLoadLimiter,
 			HNSWMaxLogSize:                               m.db.config.HNSWMaxLogSize,
 			HNSWDisableSnapshots:                         m.db.config.HNSWDisableSnapshots,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -21,8 +21,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/weaviate/weaviate/entities/loadlimiter"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -36,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -66,6 +65,7 @@ type DB struct {
 	indexCheckpoints          *indexcheckpoint.Checkpoints
 	shutdown                  chan struct{}
 	startupComplete           atomic.Bool
+	startupShards             startupShardCounters
 	resourceScanState         *resourceScanState
 	memMonitor                *memwatch.Monitor
 
@@ -220,29 +220,33 @@ func (db *DB) startupClassNames() []string {
 	return names
 }
 
+// startupShardCounters tallies shards as they are stored during startup loading.
+type startupShardCounters struct {
+	eager atomic.Int64
+	lazy  atomic.Int64
+}
+
 // scanStartupProgress computes eager shard-loading progress from scratch for the
 // given classes.
 //
-// total starts from every HOT local shard known to the schema (eager and lazy);
-// lazy shards are then discounted as they are encountered in the index maps,
-// leaving the eager total. Safe to call while the DB is still loading.
+// total starts from every HOT local shard known to the schema (eager and lazy).
+// Both come from initAndStoreShards rather than db.indices, which an
+// Index only reaches once all of its shards have loaded — counting published
+// indices would advance a whole collection at a time, reporting 0% for the
+// entire load of a collection that holds every shard.
 func (db *DB) scanStartupProgress(classNames []string) (loaded, total int64) {
 	for _, className := range classNames {
 		total += db.localShardsToLoad(className)
 	}
 
-	for _, idx := range db.copyIndices() {
-		_ = idx.ForEachShard(func(_ string, shard ShardLike) error {
-			if _, ok := shard.(*LazyLoadShard); ok {
-				total--
-				return nil
-			}
-			loaded++
-			return nil
-		})
+	// The lazy count is monotonic while total is recomputed from the live schema,
+	// so a class dropped or a tenant deactivated after its shards were counted
+	// can push this below zero.
+	if total -= db.startupShards.lazy.Load(); total < 0 {
+		total = 0
 	}
 
-	return loaded, total
+	return db.startupShards.eager.Load(), total
 }
 
 // localShardsToLoad returns the number of local shards that count toward eager

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -66,7 +66,6 @@ type DB struct {
 	indexCheckpoints          *indexcheckpoint.Checkpoints
 	shutdown                  chan struct{}
 	startupComplete           atomic.Bool
-	startupProgress           atomic.Pointer[StartupProgressSnapshot]
 	resourceScanState         *resourceScanState
 	memMonitor                *memwatch.Monitor
 
@@ -177,9 +176,6 @@ func (db *DB) GetScheduler() *queue.Scheduler {
 }
 
 func (db *DB) WaitForStartup(ctx context.Context) error {
-	stop := db.trackStartupProgress(ctx)
-	defer stop()
-
 	err := db.init(ctx)
 	if err != nil {
 		return err
@@ -193,54 +189,25 @@ func (db *DB) WaitForStartup(ctx context.Context) error {
 
 func (db *DB) StartupComplete() bool { return db.startupComplete.Load() }
 
-const startupProgressUpdateInterval = 5 * time.Second
-
 // StartupProgressSnapshot is a consistent reading of eager shard-loading progress
 type StartupProgressSnapshot struct {
 	Loaded int64
 	Total  int64
 }
 
-// StartupLoadingProgress reports the most recently computed eager shard-loading
-// progress: how many eagerly-loaded local shards have finished loading (loaded)
-// against how many are expected to load eagerly (total).
+// StartupLoadingProgress reports eager shard-loading progress: how many
+// eagerly-loaded local shards have finished loading (loaded) against how many
+// are expected to load eagerly (total). Calling it also publishes the pair to
+// the startup gauges.
+//
+// Safe to call while the DB is still loading.
 func (db *DB) StartupLoadingProgress() *StartupProgressSnapshot {
-	return db.startupProgress.Load()
+	loaded, total := db.scanStartupProgress(db.startupClassNames())
+	db.promMetrics.SetStartupShardProgress(loaded, total)
+	return &StartupProgressSnapshot{Loaded: loaded, Total: total}
 }
 
-// trackStartupProgress recomputes eager shard-loading progress on a ticker and
-// caches it. It returns a stop function that halts the ticker and pins the
-// final value; callers should defer it. The goroutine also exits if ctx is done.
-func (db *DB) trackStartupProgress(ctx context.Context) func() {
-	classNames := db.startupClassNames()
-
-	// Publish immediately so a value is available before the first log tick.
-	db.updateStartupProgress(classNames)
-
-	done := make(chan struct{})
-	enterrors.GoWrapper(func() {
-		ticker := time.NewTicker(startupProgressUpdateInterval)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				db.updateStartupProgress(classNames)
-			}
-		}
-	}, db.logger)
-
-	return func() {
-		close(done)
-		// Pin the final value now that loading has finished.
-		db.updateStartupProgress(classNames)
-	}
-}
-
-// startupClassNames snapshots the current class names for the startup progress scan
+// startupClassNames returns the current class names for the startup progress scan
 func (db *DB) startupClassNames() []string {
 	s := db.schemaGetter.GetSchemaSkipAuth()
 	if s.Objects == nil {
@@ -251,14 +218,6 @@ func (db *DB) startupClassNames() []string {
 		names = append(names, class.Class)
 	}
 	return names
-}
-
-// updateStartupProgress recomputes progress once and publishes it to the cached
-// snapshot and the Prometheus gauges.
-func (db *DB) updateStartupProgress(classNames []string) {
-	loaded, total := db.scanStartupProgress(classNames)
-	db.startupProgress.Store(&StartupProgressSnapshot{Loaded: loaded, Total: total})
-	db.promMetrics.SetStartupShardProgress(loaded, total)
 }
 
 // scanStartupProgress computes eager shard-loading progress from scratch for the

--- a/adapters/repos/db/repo_test.go
+++ b/adapters/repos/db/repo_test.go
@@ -12,10 +12,10 @@
 package db
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
@@ -84,18 +84,17 @@ func TestDB_scanStartupProgress(t *testing.T) {
 		return s
 	}
 
-	indexWith := func(t *testing.T, logger logrus.FieldLogger, className string, shards map[string]ShardLike) map[string]*Index {
-		idx := newTestIndex(t, logger, className, nil, shards)
-		return map[string]*Index{idx.ID(): idx}
-	}
-
 	tests := []struct {
-		name       string
-		classes    []*models.Class
-		states     map[string]*sharding.State
-		indices    func(t *testing.T, logger logrus.FieldLogger) map[string]*Index
-		wantLoaded int64
-		wantTotal  int64
+		name string
+		// storeShards mimics what initAndStoreShards does for this class: it
+		// bumps the tallies as each shard is stored. Progress is read from those
+		// counters, not from db.indices, so it moves per shard rather than per
+		// published index.
+		storeShards func(db *DB)
+		classes     []*models.Class
+		states      map[string]*sharding.State
+		wantLoaded  int64
+		wantTotal   int64
 	}{
 		{
 			name:    "eager class: a loaded shard counts toward loaded and total",
@@ -104,11 +103,9 @@ func TestDB_scanStartupProgress(t *testing.T) {
 				// non-multi-tenant shard: empty status normalises to HOT.
 				"Eager": stateWith(sharding.Physical{Name: "s1", BelongsToNodes: []string{localNode}}),
 			},
-			indices: func(t *testing.T, logger logrus.FieldLogger) map[string]*Index {
-				return indexWith(t, logger, "Eager", map[string]ShardLike{"s1": NewMockShardLike(t)})
-			},
-			wantLoaded: 1,
-			wantTotal:  1,
+			storeShards: func(db *DB) { db.startupShards.eager.Add(1) },
+			wantLoaded:  1,
+			wantTotal:   1,
 		},
 		{
 			name:    "lazy class: the shard is discounted from total and not counted as loaded",
@@ -116,11 +113,9 @@ func TestDB_scanStartupProgress(t *testing.T) {
 			states: map[string]*sharding.State{
 				"Lazy": stateWith(sharding.Physical{Name: "s1", BelongsToNodes: []string{localNode}}),
 			},
-			indices: func(t *testing.T, logger logrus.FieldLogger) map[string]*Index {
-				return indexWith(t, logger, "Lazy", map[string]ShardLike{"s1": &LazyLoadShard{}})
-			},
-			wantLoaded: 0,
-			wantTotal:  0,
+			storeShards: func(db *DB) { db.startupShards.lazy.Add(1) },
+			wantLoaded:  0,
+			wantTotal:   0,
 		},
 		{
 			name: "multi-tenant: only HOT local tenants count toward total",
@@ -137,18 +132,151 @@ func TestDB_scanStartupProgress(t *testing.T) {
 			wantLoaded: 0,
 			wantTotal:  1,
 		},
+		{
+			// The counters are monotonic but total is recomputed from the live
+			// schema, so a class dropped mid-load leaves lazy above what the
+			// schema still accounts for.
+			name:    "counters outliving the schema clamp total at zero",
+			classes: []*models.Class{{Class: "Gone"}},
+			states: map[string]*sharding.State{
+				"Gone": stateWith(sharding.Physical{Name: "s1", BelongsToNodes: []string{localNode}}),
+			},
+			storeShards: func(db *DB) { db.startupShards.lazy.Add(5) },
+			wantLoaded:  0,
+			wantTotal:   0,
+		},
+		{
+			name: "partly loaded class: progress advances before the index is published",
+			classes: []*models.Class{
+				{Class: "MT", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true}},
+			},
+			states: map[string]*sharding.State{
+				"MT": stateWith(
+					sharding.Physical{Name: "t1", BelongsToNodes: []string{localNode}, Status: models.TenantActivityStatusHOT},
+					sharding.Physical{Name: "t2", BelongsToNodes: []string{localNode}, Status: models.TenantActivityStatusHOT},
+					sharding.Physical{Name: "t3", BelongsToNodes: []string{localNode}, Status: models.TenantActivityStatusHOT},
+					sharding.Physical{Name: "t4", BelongsToNodes: []string{localNode}, Status: models.TenantActivityStatusHOT},
+				),
+			},
+			// Two of four tenants stored so far and db.indices still empty, as it
+			// is until NewIndex returns. Reading db.indices would report 0/4 here
+			// for the whole load, then jump to 4/4.
+			storeShards: func(db *DB) {
+				db.startupShards.eager.Add(2)
+			},
+			wantLoaded: 2,
+			wantTotal:  4,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			db := testDB(t, t.TempDir(), tt.classes, tt.states)
-			if tt.indices != nil {
-				db.indices = tt.indices(t, db.logger)
+			if tt.storeShards != nil {
+				tt.storeShards(db)
 			}
+			require.Empty(t, db.indices, "progress must not depend on published indices")
 
 			loaded, total := db.scanStartupProgress(db.startupClassNames())
 			assert.Equal(t, tt.wantLoaded, loaded, "loaded")
 			assert.Equal(t, tt.wantTotal, total, "total")
+		})
+	}
+}
+
+// TestDB_scanStartupProgressDuringLoad pins that progress advances while a
+// collection's shards load, before its Index is published to db.indices. With
+// one multi-tenant collection holding every shard, counting published indices
+// reads 0% for the whole load and then jumps to 100%.
+func TestDB_scanStartupProgressDuringLoad(t *testing.T) {
+	const localNode = "node1"
+
+	hotShards := func(class string, n int) *sharding.State {
+		m := make(map[string]sharding.Physical, n)
+		for i := range n {
+			name := fmt.Sprintf("%s-s%d", class, i)
+			m[name] = sharding.Physical{
+				Name:           name,
+				BelongsToNodes: []string{localNode},
+				Status:         models.TenantActivityStatusHOT,
+			}
+		}
+		s := &sharding.State{Physical: m}
+		s.SetLocalName(localNode)
+		return s
+	}
+
+	// step stores more shards, then states the reading expected at that instant.
+	type step struct {
+		eager, lazy           int64
+		wantLoaded, wantTotal int64
+	}
+
+	tests := []struct {
+		name    string
+		classes []*models.Class
+		states  map[string]*sharding.State
+		steps   []step
+	}{
+		{
+			name: "one multi-tenant collection: progress advances as its tenants load",
+			classes: []*models.Class{
+				{Class: "MT", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true}},
+			},
+			states: map[string]*sharding.State{"MT": hotShards("MT", 8)},
+			steps: []step{
+				{eager: 2, wantLoaded: 2, wantTotal: 8},
+				{eager: 2, wantLoaded: 4, wantTotal: 8},
+				{eager: 4, wantLoaded: 8, wantTotal: 8},
+			},
+		},
+		{
+			name: "one multi-tenant collection: empty tenants leave the total as they are skipped",
+			classes: []*models.Class{
+				{Class: "MT", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true}},
+			},
+			states: map[string]*sharding.State{"MT": hotShards("MT", 8)},
+			steps: []step{
+				// Empty tenants become LazyLoadShards and drop out of the total as
+				// that decision is made, rather than all at once at the end.
+				{eager: 1, lazy: 3, wantLoaded: 1, wantTotal: 5},
+				{eager: 4, wantLoaded: 5, wantTotal: 5},
+			},
+		},
+		{
+			name: "many collections: progress advances while later collections still load",
+			classes: []*models.Class{
+				{Class: "Alpha"}, {Class: "Beta"}, {Class: "Gamma"},
+			},
+			states: map[string]*sharding.State{
+				"Alpha": hotShards("Alpha", 4),
+				"Beta":  hotShards("Beta", 4),
+				"Gamma": hotShards("Gamma", 4),
+			},
+			steps: []step{
+				{eager: 4, wantLoaded: 4, wantTotal: 12},
+				{eager: 2, wantLoaded: 6, wantTotal: 12},
+				{eager: 3, wantLoaded: 9, wantTotal: 12},
+				{eager: 3, wantLoaded: 12, wantTotal: 12},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := testDB(t, t.TempDir(), tt.classes, tt.states)
+
+			for i, s := range tt.steps {
+				db.startupShards.eager.Add(s.eager)
+				db.startupShards.lazy.Add(s.lazy)
+
+				// Still inside NewIndex: nothing published yet.
+				require.Empty(t, db.indices, "step %d", i)
+
+				loaded, total := db.scanStartupProgress(db.startupClassNames())
+				assert.Equal(t, s.wantLoaded, loaded, "step %d loaded", i)
+				assert.Equal(t, s.wantTotal, total, "step %d total", i)
+			}
 		})
 	}
 }

--- a/adapters/repos/db/startup_progress_test.go
+++ b/adapters/repos/db/startup_progress_test.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// newStartupProgressDB returns a DB whose schema is empty, as it is while
+// WaitForStartup runs, plus the two steps RAFT performs afterwards: restoring
+// the schema, and loading the local shards it names.
+func newStartupProgressDB(t *testing.T) (db *DB, restoreSchema, loadShards func()) {
+	t.Helper()
+
+	const localNode = "node1"
+
+	classes := []*models.Class{{Class: "Alpha"}}
+	state := &sharding.State{Physical: map[string]sharding.Physical{
+		"s1": {Name: "s1", BelongsToNodes: []string{localNode}},
+	}}
+	state.SetLocalName(localNode)
+
+	db = testDB(t, t.TempDir(), classes, map[string]*sharding.State{"Alpha": state})
+
+	sg := db.schemaGetter.(*fakeMigrationSchemaGetter)
+	restored := sg.sch
+	// Handler.getSchema always returns a non-nil Objects, so an empty FSM
+	// presents as a class list of length zero.
+	sg.sch = schema.Schema{Objects: &models.Schema{}}
+
+	// WaitForStartup starts the resource-usage scanner, which this harness has
+	// no memory monitor for. A closed shutdown channel makes it exit at once.
+	db.shutdown = make(chan struct{})
+	close(db.shutdown)
+
+	restoreSchema = func() { sg.sch = restored }
+
+	loadShards = func() {
+		idx := newTestIndex(t, db.logger, "Alpha", nil, map[string]ShardLike{
+			"s1": NewMockShardLike(t),
+		})
+		db.indexLock.Lock()
+		defer db.indexLock.Unlock()
+		db.indices = map[string]*Index{idx.ID(): idx}
+	}
+
+	return db, restoreSchema, loadShards
+}
+
+// TestDB_StartupLoadingProgressTracksTheRAFTReload walks the startup sequence a
+// restarting node actually follows.
+//
+// Store.Open calls openDatabase, which reaches WaitForStartup through
+// SchemaManager.Load -> executor.Open -> Migrator.WaitForStartup, before it
+// calls raft.NewRaft. The schema lives in the RAFT FSM and is populated only by
+// Store.Restore or Store.Apply, both of which run at or after raft.NewRaft. The
+// local shards are loaded later still, by reloadDBFromSchema. So progress must
+// be computed per call: anything captured during WaitForStartup describes an
+// empty schema and stays 0/0 for the whole load.
+func TestDB_StartupLoadingProgressTracksTheRAFTReload(t *testing.T) {
+	db, restoreSchema, loadShards := newStartupProgressDB(t)
+
+	require.NoError(t, db.WaitForStartup(context.Background()))
+
+	progress := db.StartupLoadingProgress()
+	require.NotNil(t, progress)
+	assert.Equal(t, int64(0), progress.Total, "shards_total before the schema arrives")
+
+	restoreSchema()
+
+	progress = db.StartupLoadingProgress()
+	require.NotNil(t, progress)
+	assert.Equal(t, int64(1), progress.Total, "shards_total once the schema is known")
+	assert.Equal(t, int64(0), progress.Loaded, "shards_loaded before the reload")
+
+	loadShards()
+
+	progress = db.StartupLoadingProgress()
+	require.NotNil(t, progress)
+	assert.Equal(t, int64(1), progress.Total, "shards_total after the reload")
+	assert.Equal(t, int64(1), progress.Loaded, "shards_loaded after the reload")
+}

--- a/adapters/repos/db/startup_progress_test.go
+++ b/adapters/repos/db/startup_progress_test.go
@@ -52,14 +52,7 @@ func newStartupProgressDB(t *testing.T) (db *DB, restoreSchema, loadShards func(
 
 	restoreSchema = func() { sg.sch = restored }
 
-	loadShards = func() {
-		idx := newTestIndex(t, db.logger, "Alpha", nil, map[string]ShardLike{
-			"s1": NewMockShardLike(t),
-		})
-		db.indexLock.Lock()
-		defer db.indexLock.Unlock()
-		db.indices = map[string]*Index{idx.ID(): idx}
-	}
+	loadShards = func() { db.startupShards.eager.Add(1) }
 
 	return db, restoreSchema, loadShards
 }

--- a/adapters/repos/db/startup_progress_wiring_integration_test.go
+++ b/adapters/repos/db/startup_progress_wiring_integration_test.go
@@ -1,0 +1,155 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestStartupShardCounting drives Migrator.AddClass — the path production builds an
+// IndexConfig on — and asserts the DB's startup shard counters moved.
+//
+// The unit tests set db.startupShards by hand, so they pin the arithmetic in
+// scanStartupProgress but nothing that feeds it. Delete the Add(1) calls in
+// initAndStoreShards, or the StartupShards line in migrator.go, and they all
+// stay green while a real node reports 0% for its entire startup.
+func TestStartupShardCounting(t *testing.T) {
+	tests := []struct {
+		name      string
+		tenants   []string // non-empty makes the class multi-tenant
+		wantEager int64
+		wantLazy  int64
+	}{
+		{
+			name:      "a regular class loads its shard eagerly",
+			wantEager: 1,
+		},
+		{
+			// Empty tenants take the "avoid footprint of empty shards" branch and
+			// are stored as LazyLoadShards, which is what keeps them out of the
+			// denominator rather than stalling progress below 100%.
+			name:     "empty tenants are stored lazily and counted apart",
+			tenants:  []string{"t1", "t2", "t3"},
+			wantLazy: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			class := &models.Class{
+				Class:               "Counted",
+				VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+				InvertedIndexConfig: BM25FinvertedConfig(1.2, 0.75, "none"),
+			}
+			state := singleShardState()
+			if len(tt.tenants) > 0 {
+				class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+				state = tenantShardState(tt.tenants)
+			}
+
+			db := newShardCountingDB(t, class, state)
+			require.Zero(t, db.startupShards.eager.Load(), "nothing loaded yet")
+
+			logger, _ := test.NewNullLogger()
+			require.NoError(t, NewMigrator(db, logger, "node1").
+				AddClass(context.Background(), class))
+
+			assert.Equal(t, tt.wantEager, db.startupShards.eager.Load(), "eager count")
+			assert.Equal(t, tt.wantLazy, db.startupShards.lazy.Load(), "lazy count")
+		})
+	}
+}
+
+// tenantShardState returns a partitioned state whose tenants are all local and
+// HOT, so initAndStoreShards has to decide eager-vs-lazy for each.
+func tenantShardState(tenants []string) *sharding.State {
+	physical := make(map[string]sharding.Physical, len(tenants))
+	for _, name := range tenants {
+		physical[name] = sharding.Physical{
+			Name:           name,
+			BelongsToNodes: []string{"node1"},
+			Status:         models.TenantActivityStatusHOT,
+		}
+	}
+	s := &sharding.State{Physical: physical, PartitioningEnabled: true}
+	s.SetLocalName("node1")
+	return s
+}
+
+// newShardCountingDB returns a started DB that does not yet know about class,
+// so AddClass builds a real index against real files.
+func newShardCountingDB(t *testing.T, class *models.Class, state *sharding.State) *DB {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+
+	// The schema is empty when the DB starts, exactly as it is before RAFT
+	// restores it; the class arrives afterwards, via AddClass.
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{}},
+		shardState: state,
+	}
+
+	sr := schemaUC.NewMockSchemaReader(t)
+	sr.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ string, _ bool, read func(*models.Class, *sharding.State) error) error {
+			return read(class, state)
+		}).Maybe()
+	sr.EXPECT().Shards(mock.Anything).Return(state.AllPhysicalShards(), nil).Maybe()
+	sr.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	sr.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	sr.EXPECT().LocalActiveShardsCount(mock.Anything).Return(len(state.Physical), nil).Maybe()
+	sr.EXPECT().LocalShards(mock.Anything).Return(state.AllPhysicalShards(), nil).Maybe()
+
+	fsm := types.NewMockReplicationFSMReader(t)
+	fsm.EXPECT().HasActiveReplicationForShard(mock.Anything, mock.Anything).Return(false).Maybe()
+	fsm.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).
+		Return([]string{"node1"}).Maybe()
+	fsm.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).
+		Return([]string{"node1"}).Maybe()
+
+	nodes := cluster.NewMockNodeSelector(t)
+	nodes.EXPECT().LocalName().Return("node1").Maybe()
+	nodes.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
+
+	db, err := New(logger, "node1", Config{
+		RootPath:                  t.TempDir(),
+		MemtablesFlushDirtyAfter:  60,
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+	}, &FakeRemoteClient{}, nodes, &FakeRemoteNodeClient{}, nil, nil,
+		memwatch.NewDummyMonitor(), nodes, sr, fsm)
+	require.NoError(t, err)
+
+	db.SetSchemaGetter(schemaGetter)
+	require.NoError(t, db.WaitForStartup(context.Background()))
+	t.Cleanup(func() { _ = db.Shutdown(context.Background()) })
+
+	schemaGetter.schema = schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+	return db
+}

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -14,10 +14,12 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -118,6 +120,83 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 
 	// Ensure there was no supplementary call to the underlying DB as we were just recovering the schema
 	m.indexer.AssertExpectations(t)
+}
+
+// TestSnapshotRestoreReloadsDBBeforeWaitToRestoreDB pins the startup ordering
+// that decides where progress logging can live. On a node restarting with a
+// snapshot, the DB reload runs inside raft.NewRaft, inside Store.Open —
+// before the caller can invoke WaitToRestoreDB. So WaitToRestoreDB returns
+// having logged nothing, and only the tracker inside reloadDBFromSchema can
+// report that load.
+func TestSnapshotRestoreReloadsDBBeforeWaitToRestoreDB(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
+	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
+
+	// Seed a node: one class, then snapshot as the last raft entry so the
+	// reopen restores through the snapshot path.
+	m.indexer.On("Open", Anything).Return(nil)
+	require.NoError(t, srv.Open(ctx, m.indexer))
+	require.NoError(t, srv.store.Notify(m.cfg.NodeID, addr))
+	require.NoError(t, srv.WaitUntilDBRestored(ctx, time.Second, make(chan struct{})))
+	require.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
+
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+	m.indexer.On("AddClass", Anything).Return(nil)
+	m.parser.On("ParseClass", mock.Anything).Return(nil)
+	cls := &models.Class{Class: "C", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true}}
+	ss := &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0", Status: "S0"}}}
+	_, err := srv.AddClass(ctx, cls, ss)
+	require.NoError(t, err)
+
+	require.NoError(t, srv.store.raft.Barrier(2*time.Second).Error())
+	require.NoError(t, srv.store.raft.Snapshot().Error())
+
+	m.indexer.On("Close", Anything).Return(nil)
+	require.NoError(t, srv.Close(ctx))
+
+	// Reopen from disk. TriggerSchemaUpdateCallbacks runs inside the reload,
+	// so it records whether Open had already returned at that moment.
+	s := NewFSM(m.cfg, nil, prometheus.NewPedanticRegistry())
+	m.store = &s
+	m.indexer = fakes.NewMockSchemaExecutor()
+	srv = NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
+
+	logHook := logrustest.NewLocal(m.logger)
+	countMsg := func(msg string) int {
+		n := 0
+		for _, e := range logHook.AllEntries() {
+			if e.Message == msg {
+				n++
+			}
+		}
+		return n
+	}
+
+	var openReturned, reloadRanDuringOpen atomic.Bool
+	m.indexer.On("Open", Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Run(func(mock.Arguments) {
+		reloadRanDuringOpen.Store(!openReturned.Load())
+	}).Return()
+
+	require.NoError(t, srv.Open(ctx, m.indexer))
+	openReturned.Store(true)
+
+	m.indexer.AssertCalled(t, "TriggerSchemaUpdateCallbacks")
+	assert.True(t, reloadRanDuringOpen.Load(),
+		"the snapshot-path reload must run inside Open, via raft.NewRaft restoring the FSM")
+	assert.True(t, m.store.dbLoaded.Load(),
+		"the DB must be fully loaded by the time Open returns")
+	assert.Equal(t, 1, countMsg("local DB loaded from schema"),
+		"the tracker inside reloadDBFromSchema is what reported this load")
+
+	require.NoError(t, srv.WaitUntilDBRestored(ctx, time.Second, make(chan struct{})))
+	assert.Equal(t, 0, countMsg("waiting for database to be restored"),
+		"WaitToRestoreDB never logs on this path: the load finished before it was called")
+
+	m.indexer.On("Close", Anything).Return(nil)
+	require.NoError(t, srv.Close(ctx))
 }
 
 func getTenantStatus(t *testing.T, schemaReader interface{}, className, tenantName string) string {

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -691,9 +691,8 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 	}
 	t := time.NewTicker(period)
 	defer t.Stop()
-	// The wait is a phase, not a heartbeat: say so once and leave the rest of
-	// the startup log to trackDBLoadProgress.
-	var announced bool
+	const logInterval = time.Minute
+	var lastLog time.Time
 	for {
 		select {
 		case <-close:
@@ -704,9 +703,9 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 			if st.dbLoaded.Load() {
 				return nil
 			}
-			if !announced {
+			if time.Since(lastLog) >= logInterval {
 				st.log.Info("waiting for database to be restored")
-				announced = true
+				lastLog = time.Now()
 			}
 		}
 	}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -711,8 +711,9 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 	}
 }
 
-// dbLoadProgressFields returns log fields describing shard-loading progress, or
-// nil when no progress source is configured or there are no shards to load.
+// dbLoadProgressFields recomputes shard-loading progress, which also refreshes
+// the startup gauges, and returns it as log fields. It returns nil when no
+// progress source is configured or there are no shards to load.
 func (st *Store) dbLoadProgressFields() logrus.Fields {
 	if st.cfg.DBLoadProgress == nil {
 		return nil
@@ -732,6 +733,44 @@ func (st *Store) dbLoadProgressFields() logrus.Fields {
 		"shards_total":  snapshot.Total,
 		"progress":      fmt.Sprintf("%.0f%%", float64(snapshot.Loaded)/float64(snapshot.Total)*100),
 	}
+}
+
+const (
+	// dbLoadProgressInterval is how often shard-loading progress is recomputed
+	// and published to the startup gauges while the DB reloads from the schema.
+	dbLoadProgressInterval = 5 * time.Second
+	// dbLoadProgressLogInterval is how often that progress is written to the log.
+	dbLoadProgressLogInterval = time.Minute
+)
+
+// trackDBLoadProgress republishes local shard-loading progress every
+// dbLoadProgressInterval and logs it every dbLoadProgressLogInterval, until the
+// returned stop function is called. reloadDBFromSchema brackets its reload with
+// it: the snapshot-path reload runs inside raft.NewRaft, before WaitToRestoreDB
+// starts its heartbeat, so this ticker is the only progress signal there.
+func (st *Store) trackDBLoadProgress() func() {
+	done := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		t := time.NewTicker(dbLoadProgressInterval)
+		defer t.Stop()
+		var lastLog time.Time
+		for {
+			select {
+			case <-done:
+				return
+			case <-t.C:
+				fields := st.dbLoadProgressFields()
+				if fields == nil {
+					continue
+				}
+				if time.Since(lastLog) >= dbLoadProgressLogInterval {
+					st.log.WithFields(fields).Info("loading local DB from schema")
+					lastLog = time.Now()
+				}
+			}
+		}
+	}, st.log)
+	return func() { close(done) }
 }
 
 // WaitForAppliedIndex waits until the update with the given version is propagated to this follower node
@@ -948,7 +987,10 @@ func (st *Store) openDatabase(ctx context.Context) {
 // then later will call Apply() on any new committed log
 func (st *Store) reloadDBFromSchema() {
 	if !st.cfg.MetadataOnlyVoters {
+		stop := st.trackDBLoadProgress()
 		st.schemaManager.ReloadDBFromSchema()
+		stop()
+		st.log.WithFields(st.dbLoadProgressFields()).Info("local DB loaded from schema")
 	} else {
 		st.log.Info("skipping reload DB from schema as the node is metadata only")
 	}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -987,9 +987,11 @@ func (st *Store) openDatabase(ctx context.Context) {
 // then later will call Apply() on any new committed log
 func (st *Store) reloadDBFromSchema() {
 	if !st.cfg.MetadataOnlyVoters {
-		stop := st.trackDBLoadProgress()
-		st.schemaManager.ReloadDBFromSchema()
-		stop()
+		func() {
+			stop := st.trackDBLoadProgress()
+			defer stop()
+			st.schemaManager.ReloadDBFromSchema()
+		}()
 		st.log.WithFields(st.dbLoadProgressFields()).Info("local DB loaded from schema")
 	} else {
 		st.log.Info("skipping reload DB from schema as the node is metadata only")

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -230,6 +230,9 @@ type Store struct {
 	// dbLoaded is set when the DB is loaded at startup
 	dbLoaded atomic.Bool
 
+	// dbLoadInProgress mutes WaitToRestoreDB's logging while reloadDBFromSchema reports the same load.
+	dbLoadInProgress atomic.Bool
+
 	// raft implementation from external library
 	raft          *raft.Raft
 	raftResolver  types.RaftResolver
@@ -703,8 +706,12 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 			if st.dbLoaded.Load() {
 				return nil
 			}
+
+			if st.dbLoadInProgress.Load() {
+				continue
+			}
 			if time.Since(lastLog) >= logInterval {
-				st.log.WithFields(st.dbLoadProgressFields()).Info("waiting for database to be restored")
+				st.log.Info("waiting for database to be restored")
 				lastLog = time.Now()
 			}
 		}
@@ -745,10 +752,15 @@ const (
 
 // trackDBLoadProgress republishes local shard-loading progress every
 // dbLoadProgressInterval and logs it every dbLoadProgressLogInterval, until the
-// returned stop function is called. reloadDBFromSchema brackets its reload with
-// it: the snapshot-path reload runs inside raft.NewRaft, before WaitToRestoreDB
-// starts its heartbeat, so this ticker is the only progress signal there.
+// returned stop function is called.
+//
+// This is the authoritative signal: it covers every path the load takes, while
+// WaitToRestoreDB only reports when it happens to be waiting — never on a single
+// node, where the bootstrap join is serialised behind the load. It therefore
+// mutes WaitToRestoreDB via dbLoadInProgress, which on a restart into a live
+// cluster is waiting throughout and would otherwise log the same counters again.
 func (st *Store) trackDBLoadProgress() func() {
+	st.dbLoadInProgress.Store(true)
 	done := make(chan struct{})
 	enterrors.GoWrapper(func() {
 		t := time.NewTicker(dbLoadProgressInterval)
@@ -770,7 +782,10 @@ func (st *Store) trackDBLoadProgress() func() {
 			}
 		}
 	}, st.log)
-	return func() { close(done) }
+	return func() {
+		close(done)
+		st.dbLoadInProgress.Store(false)
+	}
 }
 
 // WaitForAppliedIndex waits until the update with the given version is propagated to this follower node

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -230,9 +230,6 @@ type Store struct {
 	// dbLoaded is set when the DB is loaded at startup
 	dbLoaded atomic.Bool
 
-	// dbLoadInProgress mutes WaitToRestoreDB's logging while reloadDBFromSchema reports the same load.
-	dbLoadInProgress atomic.Bool
-
 	// raft implementation from external library
 	raft          *raft.Raft
 	raftResolver  types.RaftResolver
@@ -694,8 +691,9 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 	}
 	t := time.NewTicker(period)
 	defer t.Stop()
-	const logInterval = time.Minute
-	var lastLog time.Time
+	// The wait is a phase, not a heartbeat: say so once and leave the rest of
+	// the startup log to trackDBLoadProgress.
+	var announced bool
 	for {
 		select {
 		case <-close:
@@ -706,13 +704,9 @@ func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, clos
 			if st.dbLoaded.Load() {
 				return nil
 			}
-
-			if st.dbLoadInProgress.Load() {
-				continue
-			}
-			if time.Since(lastLog) >= logInterval {
+			if !announced {
 				st.log.Info("waiting for database to be restored")
-				lastLog = time.Now()
+				announced = true
 			}
 		}
 	}
@@ -755,12 +749,9 @@ const (
 // returned stop function is called.
 //
 // This is the authoritative signal: it covers every path the load takes, while
-// WaitToRestoreDB only reports when it happens to be waiting — never on a single
-// node, where the bootstrap join is serialised behind the load. It therefore
-// mutes WaitToRestoreDB via dbLoadInProgress, which on a restart into a live
-// cluster is waiting throughout and would otherwise log the same counters again.
+// WaitToRestoreDB only announces that it is waiting — never on a single node,
+// where the bootstrap join is serialised behind the load.
 func (st *Store) trackDBLoadProgress() func() {
-	st.dbLoadInProgress.Store(true)
 	done := make(chan struct{})
 	enterrors.GoWrapper(func() {
 		t := time.NewTicker(dbLoadProgressInterval)
@@ -782,10 +773,7 @@ func (st *Store) trackDBLoadProgress() func() {
 			}
 		}
 	}, st.log)
-	return func() {
-		close(done)
-		st.dbLoadInProgress.Store(false)
-	}
+	return func() { close(done) }
 }
 
 // WaitForAppliedIndex waits until the update with the given version is propagated to this follower node

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1481,6 +1481,68 @@ func TestStoreDBLoadProgressFields(t *testing.T) {
 	}
 }
 
+// TestStoreDBLoadProgressFieldsRecomputesPerCall pins that each call re-reads
+// the progress source. The schema arrives from RAFT while the shards are still
+// loading, so a value read once would describe the pre-schema state for the
+// whole load.
+func TestStoreDBLoadProgressFieldsRecomputesPerCall(t *testing.T) {
+	var calls int64
+	st := &Store{cfg: Config{DBLoadProgress: func() *db.StartupProgressSnapshot {
+		calls++
+		return &db.StartupProgressSnapshot{Loaded: calls, Total: 10}
+	}}}
+
+	assert.Equal(t, "10%", st.dbLoadProgressFields()["progress"])
+	assert.Equal(t, "20%", st.dbLoadProgressFields()["progress"])
+	assert.Equal(t, int64(2), calls)
+}
+
+// TestStoreReloadDBFromSchemaReportsProgressDuringReload pins that the reload is
+// bracketed by the progress tracker. The snapshot-path reload runs inside
+// raft.NewRaft, before WaitToRestoreDB starts its heartbeat, so a tracker
+// started any later reports nothing for that whole phase.
+func TestStoreReloadDBFromSchemaReportsProgressDuringReload(t *testing.T) {
+	t.Parallel()
+
+	ms := NewMockStore(t, t.Name(), 9092)
+	logHook := logrustest.NewLocal(ms.logger)
+	logged := func(msg string) bool {
+		for _, e := range logHook.AllEntries() {
+			if e.Message == msg {
+				return true
+			}
+		}
+		return false
+	}
+
+	ms.store.cfg.DBLoadProgress = func() *db.StartupProgressSnapshot {
+		return &db.StartupProgressSnapshot{Loaded: 3, Total: 10}
+	}
+
+	st := ms.Store(func(m *MockStore) {
+		// TriggerSchemaUpdateCallbacks runs inside the reload. Holding it open
+		// until the tracker has logged proves the sampling happens while the
+		// reload is in flight, not after.
+		m.indexer.On("TriggerSchemaUpdateCallbacks").Run(func(mock.Arguments) {
+			if !tryNTimesWithWait(3000, 10*time.Millisecond, func() bool {
+				return logged("loading local DB from schema")
+			}) {
+				t.Error("no progress logged while the reload was in flight")
+			}
+		}).Return()
+	})
+
+	st.reloadDBFromSchema()
+
+	require.True(t, st.dbLoaded.Load())
+	require.True(t, logged("local DB loaded from schema"))
+	for _, e := range logHook.AllEntries() {
+		if e.Message == "local DB loaded from schema" {
+			assert.Equal(t, "30%", e.Data["progress"])
+		}
+	}
+}
+
 type MockStore struct {
 	indexer        *fakes.MockSchemaExecutor
 	parser         *fakes.MockParser

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1646,19 +1646,16 @@ func cmdAsBytes(class string,
 	return data
 }
 
-// TestStoreWaitToRestoreDBIsMutedWhileLoading pins that only one progress
-// reporter speaks at a time. On a restart into a live cluster the reload runs on
-// the Apply catch-up path, so WaitToRestoreDB is still waiting while
-// trackDBLoadProgress reports the same counters.
-func TestStoreWaitToRestoreDBIsMutedWhileLoading(t *testing.T) {
+// TestStoreWaitToRestoreDBAnnouncesOnce pins that the wait is reported as a
+// phase, not a heartbeat. Progress belongs to trackDBLoadProgress: on a restart
+// into a live cluster the waiter is still waiting while the load runs, so a
+// per-tick line here would report the same startup twice.
+func TestStoreWaitToRestoreDBAnnouncesOnce(t *testing.T) {
 	t.Parallel()
 
 	ms := NewMockStore(t, t.Name(), utils.MustGetFreeTCPPort())
 	logHook := logrustest.NewLocal(ms.logger)
 	st := ms.store
-	st.cfg.DBLoadProgress = func() *db.StartupProgressSnapshot {
-		return &db.StartupProgressSnapshot{Loaded: 1, Total: 10}
-	}
 
 	countMsg := func(msg string) int {
 		n := 0
@@ -1670,18 +1667,20 @@ func TestStoreWaitToRestoreDBIsMutedWhileLoading(t *testing.T) {
 		return n
 	}
 
-	st.dbLoadInProgress.Store(true)
-
 	done := make(chan struct{})
 	enterrors.GoWrapper(func() {
 		defer close(done)
-		// lastLog starts at the zero time, so an unmuted waiter logs on tick one.
 		_ = st.WaitToRestoreDB(context.Background(), 10*time.Millisecond, make(chan struct{}))
 	}, ms.logger)
 
-	time.Sleep(200 * time.Millisecond)
-	require.Equal(t, 0, countMsg("waiting for database to be restored"),
-		"the waiter must stay quiet while trackDBLoadProgress is reporting")
+	require.True(t, tryNTimesWithWait(200, 10*time.Millisecond, func() bool {
+		return countMsg("waiting for database to be restored") > 0
+	}), "the waiter must announce itself while the DB is not loaded")
+
+	// Many further ticks pass at 10ms; none of them may add another line.
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, 1, countMsg("waiting for database to be restored"),
+		"announced once, not once per tick")
 
 	st.dbLoaded.Store(true)
 	select {
@@ -1689,19 +1688,4 @@ func TestStoreWaitToRestoreDBIsMutedWhileLoading(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("WaitToRestoreDB did not return once dbLoaded flipped")
 	}
-
-	// Muting must not cost it its purpose: with nothing loading it still reports.
-	st.dbLoaded.Store(false)
-	st.dbLoadInProgress.Store(false)
-	done2 := make(chan struct{})
-	enterrors.GoWrapper(func() {
-		defer close(done2)
-		_ = st.WaitToRestoreDB(context.Background(), 10*time.Millisecond, make(chan struct{}))
-	}, ms.logger)
-
-	require.True(t, tryNTimesWithWait(200, 10*time.Millisecond, func() bool {
-		return countMsg("waiting for database to be restored") > 0
-	}), "with no load in flight the waiter must still report")
-	st.dbLoaded.Store(true)
-	<-done2
 }

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -12,6 +12,7 @@
 package cluster
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +36,8 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/schema"
+	"github.com/weaviate/weaviate/cluster/utils"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/cluster/mocks"
 	"github.com/weaviate/weaviate/usecases/fakes"
@@ -1641,4 +1644,64 @@ func cmdAsBytes(class string,
 	}
 
 	return data
+}
+
+// TestStoreWaitToRestoreDBIsMutedWhileLoading pins that only one progress
+// reporter speaks at a time. On a restart into a live cluster the reload runs on
+// the Apply catch-up path, so WaitToRestoreDB is still waiting while
+// trackDBLoadProgress reports the same counters.
+func TestStoreWaitToRestoreDBIsMutedWhileLoading(t *testing.T) {
+	t.Parallel()
+
+	ms := NewMockStore(t, t.Name(), utils.MustGetFreeTCPPort())
+	logHook := logrustest.NewLocal(ms.logger)
+	st := ms.store
+	st.cfg.DBLoadProgress = func() *db.StartupProgressSnapshot {
+		return &db.StartupProgressSnapshot{Loaded: 1, Total: 10}
+	}
+
+	countMsg := func(msg string) int {
+		n := 0
+		for _, e := range logHook.AllEntries() {
+			if e.Message == msg {
+				n++
+			}
+		}
+		return n
+	}
+
+	st.dbLoadInProgress.Store(true)
+
+	done := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		defer close(done)
+		// lastLog starts at the zero time, so an unmuted waiter logs on tick one.
+		_ = st.WaitToRestoreDB(context.Background(), 10*time.Millisecond, make(chan struct{}))
+	}, ms.logger)
+
+	time.Sleep(200 * time.Millisecond)
+	require.Equal(t, 0, countMsg("waiting for database to be restored"),
+		"the waiter must stay quiet while trackDBLoadProgress is reporting")
+
+	st.dbLoaded.Store(true)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitToRestoreDB did not return once dbLoaded flipped")
+	}
+
+	// Muting must not cost it its purpose: with nothing loading it still reports.
+	st.dbLoaded.Store(false)
+	st.dbLoadInProgress.Store(false)
+	done2 := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		defer close(done2)
+		_ = st.WaitToRestoreDB(context.Background(), 10*time.Millisecond, make(chan struct{}))
+	}, ms.logger)
+
+	require.True(t, tryNTimesWithWait(200, 10*time.Millisecond, func() bool {
+		return countMsg("waiting for database to be restored") > 0
+	}), "with no load in flight the waiter must still report")
+	st.dbLoaded.Store(true)
+	<-done2
 }

--- a/test/acceptance/startup_progress/startup_progress_test.go
+++ b/test/acceptance/startup_progress/startup_progress_test.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package startup_progress
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestStartupProgressLogsShardLoading restarts a node that owns several shards
+// and asserts the shard-loading progress reaches the logs.
+//
+// Only the final "local DB loaded from schema" line is asserted. It is emitted
+// whenever the reload runs, with counts freshly scanned from the restored
+// schema, so the assertion holds however fast the load finishes. The periodic
+// "loading local DB from schema" line needs a load slower than its 5s ticker
+// and is left unasserted.
+func TestStartupProgressLogsShardLoading(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		classCount     = 3
+		shardsPerClass = 2
+	)
+
+	compose, err := docker.New().
+		WithWeaviate().
+		// Lazy-loaded shards are discounted from the progress totals; force
+		// eager loading so every shard counts.
+		WithWeaviateEnv("DISABLE_LAZY_LOAD_SHARDS", "true").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	for i := 0; i < classCount; i++ {
+		helper.CreateClass(t, &models.Class{
+			Class: fmt.Sprintf("StartupProgress%d", i),
+			Properties: []*models.Property{
+				{Name: "name", DataType: []string{"text"}},
+			},
+			ShardingConfig: map[string]interface{}{"desiredCount": shardsPerClass},
+		})
+	}
+
+	// The first boot of an empty node never reloads the DB, so everything
+	// asserted below can only come from this restart.
+	require.NoError(t, compose.RestartAt(ctx, 0, nil))
+
+	reader, err := compose.GetWeaviate().Container().Logs(ctx)
+	require.NoError(t, err)
+	defer reader.Close()
+	raw, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	logs := string(raw)
+
+	require.Contains(t, logs, "local DB loaded from schema",
+		"the reload's progress tracker must report the load")
+
+	total := classCount * shardsPerClass
+	assert.True(t,
+		strings.Contains(logs, fmt.Sprintf("shards_total=%d", total)) ||
+			strings.Contains(logs, fmt.Sprintf(`"shards_total":%d`, total)),
+		"progress fields must carry the full shard count %d, logs:\n%s", total, tail(logs, 40))
+	assert.True(t,
+		strings.Contains(logs, "progress=100%") ||
+			strings.Contains(logs, `"progress":"100%"`),
+		"the final progress line must report 100%%, logs:\n%s", tail(logs, 40))
+}
+
+func tail(logs string, n int) string {
+	lines := strings.Split(logs, "\n")
+	if len(lines) > n {
+		lines = lines[len(lines)-n:]
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
### What's being changed:

Avoids logging nothing during shard loading tracking on db startup by
1. re-reading the class list on each tick to ensure it's up-to-date
2. runs during DB reload so it doesn't exit early

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
