### PR TITLE
test(hfresh): wait for background maintenance

### DIFF
--- a/adapters/repos/db/vector/hfresh/helper_for_test.go
+++ b/adapters/repos/db/vector/hfresh/helper_for_test.go
@@ -61,6 +61,31 @@ type TestHFresh struct {
 	mvStore *muveraTestStore
 }
 
+// waitForMaintenance blocks until all HFresh background queues are drained.
+// Callers must stop issuing foreground writes before calling it.
+func (h *HFresh) waitForMaintenance(t testing.TB) {
+	t.Helper()
+
+	queues := []*queue.DiskQueue{
+		h.taskQueue.analyzeQueue.DiskQueue,
+		h.taskQueue.splitQueue,
+		h.taskQueue.mergeQueue,
+		h.taskQueue.reassignQueue,
+	}
+
+	for {
+		require.NoError(t, h.taskQueue.Flush())
+		h.scheduler.Schedule(t.Context())
+
+		for _, q := range queues {
+			require.NoError(t, q.Wait(t.Context()))
+		}
+		if h.taskQueue.Size() == 0 {
+			return
+		}
+	}
+}
+
 // testIndexOption mutates the index config before the index is created.
 // The default distance provider is L2; cosine-sensitive behavior (token
 // normalization, cosine-dot semantics) is only exercised when tests opt in

--- a/adapters/repos/db/vector/hfresh/search_intermediate_rescore_test.go
+++ b/adapters/repos/db/vector/hfresh/search_intermediate_rescore_test.go
@@ -77,6 +77,7 @@ func TestIntermediateRescoreCorrectsRQ1(t *testing.T) {
 	for i := 0; i < nDocs; i++ {
 		addMultiVectorToIndex(t, &tf, uint64(i), randomMultiVector(rng, tokens, dim))
 	}
+	tf.Index.waitForMaintenance(t)
 
 	// rerankBudget = max(k=1, rescoreLimit=1) = 1
 	uc := ent.NewDefaultUserConfig()

--- a/adapters/repos/db/vector/hfresh/search_test.go
+++ b/adapters/repos/db/vector/hfresh/search_test.go
@@ -390,6 +390,7 @@ func TestSearchByMultiVectorSelfRecallCosine(t *testing.T) {
 		docs[i] = randomMultiVector(rng, tokens, dim)
 		addMultiVectorToIndex(t, &tf, uint64(i), docs[i])
 	}
+	tf.Index.waitForMaintenance(t)
 
 	sampleRng := rand.New(rand.NewSource(13))
 	const samples = 50

--- a/adapters/repos/db/vector/hfresh/task_queue_test.go
+++ b/adapters/repos/db/vector/hfresh/task_queue_test.go
@@ -59,6 +59,34 @@ func TestTaskQueueRegisterIsExplicit(t *testing.T) {
 	require.Equal(t, 4, scheduler.QueueCount())
 }
 
+func TestWaitForMaintenanceDrainsQueuedTasks(t *testing.T) {
+	tf := createHFreshIndex(t)
+	const postingID = uint64(42)
+
+	require.NoError(t, tf.Index.taskQueue.EnqueueAnalyze(postingID))
+	require.True(t, tf.Index.taskQueue.analyzeList.Contains(postingID))
+	require.EqualValues(t, 1, tf.Index.taskQueue.Size())
+
+	tf.Index.waitForMaintenance(t)
+
+	require.Zero(t, tf.Index.taskQueue.Size())
+	require.False(t, tf.Index.taskQueue.analyzeList.Contains(postingID))
+}
+
+func TestWaitForMaintenanceDrainsFollowUpTasks(t *testing.T) {
+	vector := []float32{1, 0, 0, 0}
+	tf := createHFreshIndexWithVectorStore(t, [][]float32{vector})
+	addVectorToIndex(t, &tf, 0, vector)
+	tf.Index.waitForMaintenance(t)
+
+	require.NoError(t, tf.Index.taskQueue.EnqueueReassign(42, 0))
+	tf.Index.waitForMaintenance(t)
+
+	require.Zero(t, tf.Index.taskQueue.Size())
+	require.Zero(t, tf.Index.taskQueue.analyzeList.LivePages())
+	require.Zero(t, tf.Index.taskQueue.reassignList.LivePages())
+}
+
 func TestDecodeReassignTaskLegacyFormat(t *testing.T) {
 	tq := &TaskQueue{}
 	vecID := uint64(1234)


### PR DESCRIPTION
### What's being changed:

- Add an internal test-only `(*HFresh).waitForMaintenance(testing.TB)` helper that flushes, schedules, and waits for every HFresh maintenance queue until no queued work remains.
- Keep draining to a fixed point so maintenance tasks created by other maintenance tasks finish before the helper returns.
- Use the helper before the multi-vector cosine self-recall assertions instead of relying on immediate ANN-index visibility.
- Cover both directly queued maintenance and follow-up maintenance with regression tests.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: Not necessary; this adds an internal test helper only.
- [x] Chaos pipeline run or not necessary. Link to pipeline: Not necessary; this changes test synchronization only.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary; there is no production code change.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
