### PR TITLE
lsmkv, inverted: read a batch of roaring set rows through one batch reader

### DIFF
--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -403,6 +403,46 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 		}
 	}
 
+	// Every case above runs against a fully flushed corpus, which is exactly
+	// the shape where the batch reader skips the active memtable — so batched
+	// and desugared can agree by both reading only disk. This case leaves a
+	// write unflushed so the active memtable is non-empty, the one shape where
+	// the two paths could diverge: the batch reader must probe it per key like
+	// the desugared path does.
+	t.Run("unflushed write in the active memtable", func(t *testing.T) {
+		g := newContainsFixture(t, 200)
+		bucket := g.store.Bucket(helpers.BucketFromPropNameLSM(benchPropName))
+		require.NotNil(t, bucket)
+
+		// The doc ID must be inside the universe or ContainsNone's complement is
+		// the same whether the write is seen or not, and it must land on both
+		// values or ContainsAll's intersection excludes it either way — either
+		// slip leaves two of the three operators asserting nothing.
+		const unflushedDocID = 7
+		for _, v := range []string{benchValue(3), benchValue(4)} {
+			require.NoError(t, bucket.RoaringSetAddList([]byte(v), []uint64{unflushedDocID}))
+		}
+
+		values := []string{benchValue(3), benchValue(4)}
+		for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
+			t.Run(op.Name(), func(t *testing.T) {
+				batched := g.resolveDocIDs(t, ctx, containsFilter(op, values))
+				desugared := g.resolveDocIDs(t, ctx, equalCompoundFilter(op, values))
+				require.Equal(t, desugared, batched,
+					"batched Contains must read the active memtable like the desugared path")
+			})
+		}
+
+		// Without these the case is vacuous: if both paths skipped the active
+		// memtable they would agree on results that are missing the write.
+		require.Contains(t, g.resolveDocIDs(t, ctx, containsFilter(filters.ContainsAny, values)),
+			uint64(unflushedDocID), "ContainsAny must see the unflushed write")
+		require.Contains(t, g.resolveDocIDs(t, ctx, containsFilter(filters.ContainsAll, values)),
+			uint64(unflushedDocID), "ContainsAll must see it on both values")
+		require.NotContains(t, g.resolveDocIDs(t, ctx, containsFilter(filters.ContainsNone, values)),
+			uint64(unflushedDocID), "ContainsNone must exclude it")
+	})
+
 	t.Run("[]interface{} values from the API layer", func(t *testing.T) {
 		values := []string{containsSharedValues[0], containsSharedValues[1], benchValue(11)}
 		iface := make([]interface{}, len(values))

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -357,14 +359,50 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 // fetchContainsBatch resolves a batched Contains(Any|All|None) filter whose keys
 // were already encoded into pv.containsValues, folding every key's bitmap
 // through docBitmapContainsBatch under a single consistent view.
-func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (*docBitmap, error) {
+//
+// The annotation's window starts before the reader is opened, so a filter that
+// stalls waiting out an in-flight flush shows that time rather than hiding it.
+func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_ *docBitmap, err error) {
 	bucketName := pv.getBucketName()
 	b := s.store.Bucket(bucketName)
 	if b == nil {
 		return nil, errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
 	}
 
-	dbm, err := s.docBitmapContainsBatch(ctx, b, pv)
+	// A batched Contains always carries at least two keys — extraction does not
+	// batch below that, and every path errors rather than dropping a value. Zero
+	// keys is therefore a caller bug, and answering it here would mean inventing
+	// a result for each operator; the fold rejects it for the same reason.
+	if len(pv.containsValues) == 0 {
+		return nil, fmt.Errorf("contains filter on prop %q carries no keys", pv.prop)
+	}
+
+	before := time.Now()
+	// deferred so a filter that fails after the reader opens is still timed
+	var dbm docBitmap
+	defer func() {
+		took := time.Since(before)
+		helpers.AnnotateSlowQueryLogAppendFunc(ctx, "build_allow_list_doc_bitmap", func() map[string]any {
+			return map[string]any{
+				"prop":           pv.prop,
+				"operator":       pv.operator.Name(),
+				"took":           took,
+				"took_string":    took.String(),
+				"count":          dbm.count(),
+				"failed":         err != nil,
+				"strategy":       lsmkv.StrategyRoaringSet,
+				"batched_values": len(pv.containsValues),
+			}
+		})
+	}()
+
+	reader, err := b.NewRoaringSetBatchReader()
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Release()
+
+	dbm, err = s.docBitmapContainsBatch(ctx, reader, pv)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -390,7 +389,7 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 				"took_string":    took.String(),
 				"count":          dbm.count(),
 				"failed":         err != nil,
-				"strategy":       lsmkv.StrategyRoaringSet,
+				"strategy":       b.Strategy(),
 				"batched_values": len(pv.containsValues),
 			}
 		})

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -489,3 +489,224 @@ func TestExtractContainsBatch_OptInGate(t *testing.T) {
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 	})
 }
+
+// TestFetchContainsBatch_EmptyKeySet pins that a batch with no keys is rejected
+// rather than answered. Extraction never produces one — it batches only at two
+// or more values, and every path errors rather than dropping a value — so an
+// empty batch is a caller bug, and inventing a result for it would mean picking
+// semantics per operator with nothing to validate them against.
+func TestFetchContainsBatch_EmptyKeySet(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	ctx := context.Background()
+
+	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
+		t.Run(op.Name(), func(t *testing.T) {
+			pv := &propValuePair{
+				prop:               "prop-int",
+				operator:           op,
+				containsValues:     [][]byte{},
+				hasFilterableIndex: true,
+				Class:              f.class,
+			}
+
+			dbm, err := pv.fetchContainsBatch(ctx, f.searcher)
+			require.ErrorContains(t, err, "carries no keys")
+			require.ErrorContains(t, err, `"prop-int"`, "the error must name the property")
+			require.Nil(t, dbm)
+		})
+	}
+}
+
+// TestFetchContainsBatch_BucketErrors pins the two failure paths that precede
+// any read: a property with no bucket at all, and one whose bucket is not a
+// roaringset (so no batch reader can be opened for it).
+func TestFetchContainsBatch_BucketErrors(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		prop    string
+		wantErr string
+	}{
+		{"no bucket", "prop-no-bucket", "not found"},
+		{"non-roaringset bucket", "prop-nonroaringset", "expected, got"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := &propValuePair{
+				prop:               tc.prop,
+				operator:           filters.ContainsAny,
+				containsValues:     [][]byte{[]byte("a")},
+				hasFilterableIndex: true,
+				Class:              f.class,
+			}
+
+			dbm, err := pv.fetchContainsBatch(ctx, f.searcher)
+			require.ErrorContains(t, err, tc.wantErr)
+			require.Nil(t, dbm)
+		})
+	}
+}
+
+// writeContainsRows writes rows into propName's roaringset bucket and flushes
+// them to a segment, so the batch reader below reads real disk layers.
+func writeContainsRows(t *testing.T, f *containsBatchGateFixture, propName string, rows map[string][]uint64) {
+	t.Helper()
+	b := f.searcher.store.Bucket(helpers.BucketFromPropNameLSM(propName))
+	require.NotNil(t, b)
+	for key, docIDs := range rows {
+		require.NoError(t, b.RoaringSetAddList([]byte(key), docIDs))
+	}
+	require.NoError(t, b.FlushAndSwitch())
+}
+
+// TestFetchContainsBatch_ReadsRows pins the wiring between key extraction and
+// the fold: the bucket getBucketName resolves, the reader opened on it, and the
+// folded result handed back. Fold semantics — which keys are read, absent keys,
+// intersection versus union, multi-segment layouts — are pinned at the fold
+// level, where the spy can observe the reads, so this covers only what the two
+// layers exchange.
+func TestFetchContainsBatch_ReadsRows(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	ctx := context.Background()
+	writeContainsRows(t, f, "prop-int", map[string][]uint64{
+		"a": {1, 2, 3},
+		"b": {3, 4},
+	})
+
+	tests := []struct {
+		name         string
+		operator     filters.Operator
+		keys         [][]byte
+		wantDocIDs   []uint64
+		wantDenyList bool
+	}{
+		{"ContainsAny reaches the rows", filters.ContainsAny, [][]byte{[]byte("a"), []byte("b")}, []uint64{1, 2, 3, 4}, false},
+		// ContainsNone additionally proves the fold's deny flag reaches the caller
+		{"ContainsNone denies", filters.ContainsNone, [][]byte{[]byte("a"), []byte("b")}, []uint64{1, 2, 3, 4}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := &propValuePair{
+				prop:               "prop-int",
+				operator:           tc.operator,
+				containsValues:     tc.keys,
+				hasFilterableIndex: true,
+				Class:              f.class,
+			}
+
+			dbm, err := pv.fetchContainsBatch(ctx, f.searcher)
+			require.NoError(t, err)
+			defer dbm.release()
+
+			require.Equal(t, tc.wantDocIDs, dbm.docIDs.ToArray())
+			require.Equal(t, tc.wantDenyList, dbm.IsDenyList())
+		})
+	}
+}
+
+// TestFetchContainsBatch_AnnotatesSlowQueryLog pins the slow-query annotation
+// for a batched read — that it fires and carries the fields an operator reads —
+// and that an empty key set, which does no work, logs nothing. Where the timing
+// window starts is not observable from here, and neither is the view's release;
+// the refcount assertion for that lives in TestRoaringSetBatchReader_ReleaseGuard
+// (getRefs is unexported in lsmkv).
+func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	writeContainsRows(t, f, "prop-int", map[string][]uint64{"a": {1, 2}, "b": {2, 3}})
+
+	newPV := func(keys [][]byte) *propValuePair {
+		return &propValuePair{
+			prop:               "prop-int",
+			operator:           filters.ContainsAny,
+			containsValues:     keys,
+			hasFilterableIndex: true,
+			Class:              f.class,
+		}
+	}
+
+	t.Run("a batched read is annotated", func(t *testing.T) {
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		dbm, err := newPV([][]byte{[]byte("a"), []byte("b")}).fetchContainsBatch(ctx, f.searcher)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok, "batched contains must annotate the slow query log")
+		require.Len(t, entries, 1)
+
+		require.Equal(t, "prop-int", entries[0]["prop"])
+		require.Equal(t, filters.ContainsAny.Name(), entries[0]["operator"])
+		require.Equal(t, 3, entries[0]["count"])
+		require.Equal(t, false, entries[0]["failed"])
+		require.Equal(t, 2, entries[0]["batched_values"])
+		require.Contains(t, entries[0], "took")
+		require.Contains(t, entries[0], "took_string")
+	})
+
+	t.Run("a bucket rejected at open is still annotated", func(t *testing.T) {
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		pv := &propValuePair{
+			prop:               "prop-nonroaringset",
+			operator:           filters.ContainsAny,
+			containsValues:     [][]byte{[]byte("a"), []byte("b")},
+			hasFilterableIndex: true,
+			Class:              f.class,
+		}
+
+		_, err := pv.fetchContainsBatch(ctx, f.searcher)
+		require.Error(t, err)
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok, "a filter rejected while opening the reader must still be timed")
+		require.Len(t, entries, 1)
+		require.Equal(t, "prop-nonroaringset", entries[0]["prop"])
+		require.Equal(t, 0, entries[0]["count"])
+		require.Equal(t, true, entries[0]["failed"],
+			"a zero count means nothing without this: an empty result looks identical")
+	})
+
+	t.Run("a fold that fails after the reader opened is still annotated", func(t *testing.T) {
+		// distinct from the case above: there the strategy check rejects the
+		// bucket before a view is ever taken, so nothing has been timed yet
+		ctx, cancel := context.WithCancel(helpers.InitSlowQueryDetails(context.Background()))
+		cancel()
+
+		_, err := newPV([][]byte{[]byte("a"), []byte("b")}).fetchContainsBatch(ctx, f.searcher)
+		require.ErrorIs(t, err, context.Canceled)
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok, "a filter that opens the reader and then fails must still be timed")
+		require.Len(t, entries, 1)
+		require.Equal(t, "prop-int", entries[0]["prop"])
+		require.Equal(t, 0, entries[0]["count"])
+		require.Equal(t, true, entries[0]["failed"])
+	})
+
+	// Both returns that precede the timer: nothing has been done, so there is no
+	// duration worth logging.
+	for _, tc := range []struct {
+		name string
+		prop string
+		keys [][]byte
+	}{
+		{name: "an empty key set is not annotated", prop: "prop-int", keys: nil},
+		{name: "a missing bucket is not annotated", prop: "prop-no-bucket", keys: [][]byte{[]byte("a")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := helpers.InitSlowQueryDetails(context.Background())
+			pv := &propValuePair{
+				prop:               tc.prop,
+				operator:           filters.ContainsAny,
+				containsValues:     tc.keys,
+				hasFilterableIndex: true,
+				Class:              f.class,
+			}
+
+			_, err := pv.fetchContainsBatch(ctx, f.searcher)
+			require.Error(t, err)
+			require.NotContains(t, helpers.ExtractSlowQueryDetails(ctx), "build_allow_list_doc_bitmap")
+		})
+	}
+}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -42,6 +42,7 @@ func (s *Searcher) docBitmap(ctx context.Context, b *lsmkv.Bucket, limit int,
 			"took_string": took.String(),
 			"value":       pv.value,
 			"count":       bm.count(),
+			"failed":      err != nil,
 			"strategy":    strategy,
 		}
 
@@ -205,11 +206,13 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 	return out, nil
 }
 
-// containsBatchBucket is the minimal surface docBitmapContainsBatch needs
-// from a roaringset bucket; *lsmkv.Bucket satisfies it.
-type containsBatchBucket interface {
-	GetConsistentView() lsmkv.BucketConsistentView
-	RoaringSetGetFromView(ctx context.Context, view lsmkv.BucketConsistentView, key []byte) (*sroar.Bitmap, func(), error)
+// containsBatchReader reads roaringset rows for one batched Contains fold under
+// a single held view; *lsmkv.RoaringSetBatchReader satisfies it and nothing
+// else implements it in production. It exists so tests can record which keys
+// the fold reads and inject read errors and cancellation. Releasing is absent
+// deliberately: the caller owns the reader's lifetime.
+type containsBatchReader interface {
+	Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error)
 }
 
 // mergeAllowlistBitmaps folds b into a under op (ContainsAny -> union,
@@ -255,48 +258,48 @@ func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 var containsAnyAccumulatorMinKeys = 256
 
 // docBitmapContainsBatch folds every key in pv.containsValues into a single
-// docBitmap under one consistent view of b: a dense Accumulator fold for
+// docBitmap under reader's held view: a dense Accumulator fold for
 // ContainsAny and ContainsNone, an incremental intersection with empty-result
 // early exit for ContainsAll. Every per-key fetch is an OperatorEqual read on
 // a roaringset bucket, so it is always an allowlist (never a denylist), which
 // is why all folds can skip mergeBitmapsAndOrWithDenyList's deny-list algebra
-// entirely.
+// entirely. The caller owns reader (creates and releases it around this call)
+// and must pass at least one key: the folds adopt their first row as the
+// accumulator, so an empty key set has no result to return, and both this
+// function and fetchContainsBatch reject it rather than inventing one.
 //
 // ContainsNone is NOT(ContainsAny): it computes the same union and marks the
 // result a deny list, exactly as the desugared NOT(OR(Equal...)) tree does in
 // resolveDocIDsNot. The flag composes through AND/OR merges and is inverted
 // against the universe once at the top of Searcher.docIDs.
-func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBucket,
+func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBatchReader,
 	pv *propValuePair,
 ) (docBitmap, error) {
-	isDenyList := pv.operator == filters.ContainsNone
 	if len(pv.containsValues) == 0 {
-		dbm := newDocBitmap()
-		dbm.isDenyList = isDenyList
-		return dbm, nil
+		// defensive: the folds adopt their first row as the accumulator, so zero
+		// keys yields a nil bitmap rather than an empty one
+		return docBitmap{}, fmt.Errorf("contains fold on prop %q carries no keys", pv.prop)
 	}
 
-	before := time.Now()
-	view := b.GetConsistentView()
-	defer view.ReleaseView()
-	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+	isDenyList := pv.operator == filters.ContainsNone
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
 
 	var acc *sroar.Bitmap
 	var accRelease func()
 	var err error
 	switch pv.operator {
 	case filters.ContainsAll:
-		acc, accRelease, err = foldContainsIncremental(ctx, b, view, pv.containsValues, filters.ContainsAll, maxConc)
+		acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsValues, filters.ContainsAll, mergeConc)
 	case filters.ContainsAny, filters.ContainsNone:
 		// ContainsNone folds the same union as ContainsAny; the deny flag is
 		// applied to the result, not the fold. Below
 		// containsAnyAccumulatorMinKeys keys the Accumulator's staging setup
 		// and finalize scan are not worth it — union incrementally instead.
 		if len(pv.containsValues) < containsAnyAccumulatorMinKeys {
-			acc, accRelease, err = foldContainsIncremental(ctx, b, view, pv.containsValues, filters.ContainsAny, maxConc)
+			acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsValues, filters.ContainsAny, mergeConc)
 		} else {
-			acc, accRelease, err = foldContainsAnyAccumulator(ctx, b, view, pv.containsValues,
-				s.bitmapFactory.BufPool(), maxConc)
+			acc, accRelease, err = foldContainsAnyAccumulator(ctx, reader, pv.containsValues,
+				s.bitmapFactory.BufPool(), mergeConc)
 		}
 	default:
 		// defensive: a non-Contains operator must never pick a fold — a
@@ -306,18 +309,6 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 	if err != nil {
 		return docBitmap{}, err
 	}
-	took := time.Since(before)
-	helpers.AnnotateSlowQueryLogAppendFunc(ctx, "build_allow_list_doc_bitmap", func() map[string]any {
-		return map[string]any{
-			"prop":           pv.prop,
-			"operator":       pv.operator.Name(),
-			"took":           took,
-			"took_string":    took.String(),
-			"count":          acc.GetCardinality(),
-			"strategy":       lsmkv.StrategyRoaringSet,
-			"batched_values": len(pv.containsValues),
-		}
-	})
 	return docBitmap{docIDs: acc, release: accRelease, isDenyList: isDenyList}, nil
 }
 
@@ -330,18 +321,18 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, b containsBatchBu
 // single-doc row) with O(1) bit deposits, and bounds peak memory at the
 // staging blocks (proportional to the doc-ID spread of the result, not to
 // the number of keys) plus a single row in flight.
-func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
-	view lsmkv.BucketConsistentView, keys [][]byte, pool roaringset.BitmapBufPool, maxConc int,
+func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
+	keys [][]byte, pool roaringset.BitmapBufPool, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
-	// TODO aliszka:gh12242 wire maxConc into the accumulator's Or once sroar
-	// supports concurrent deposits; today the accumulator is single-threaded
-	// and the budget goes unused here.
+	// TODO aliszka:gh12242 wire mergeConc into the accumulator's Or once sroar
+	// supports concurrent deposits; today it bounds only the per-row disk merge
+	// and the deposits themselves are single-threaded.
 	acc := sroar.NewAccumulator()
 	for _, key := range keys {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
+		bm, release, err := reader.Get(key, mergeConc)
 		if err != nil {
 			return nil, nil, fmt.Errorf("read row: %w", err)
 		}
@@ -366,18 +357,18 @@ func foldContainsAnyAccumulator(ctx context.Context, b containsBatchBucket,
 // disjoint-ish data the early exit reads a handful of keys, which no
 // batch-read grouping can beat — hence ContainsAll deliberately has no
 // accumulator path.
-func foldContainsIncremental(ctx context.Context, b containsBatchBucket,
-	view lsmkv.BucketConsistentView, keys [][]byte, op filters.Operator, maxConc int,
+func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
+	keys [][]byte, op filters.Operator, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
 	var acc *sroar.Bitmap
 	accRelease := noopRelease
 	for _, key := range keys {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			accRelease()
 			return nil, nil, err
 		}
 
-		bm, release, err := b.RoaringSetGetFromView(ctx, view, key)
+		bm, release, err := reader.Get(key, mergeConc)
 		if err != nil {
 			accRelease()
 			return nil, nil, fmt.Errorf("read row: %w", err)
@@ -386,7 +377,7 @@ func foldContainsIncremental(ctx context.Context, b containsBatchBucket,
 		if acc == nil {
 			acc, accRelease = bm, release
 		} else {
-			acc, accRelease, err = mergeAllowlistBitmaps(op, maxConc, acc, accRelease, bm, release)
+			acc, accRelease, err = mergeAllowlistBitmaps(op, mergeConc, acc, accRelease, bm, release)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -396,8 +387,9 @@ func foldContainsIncremental(ctx context.Context, b containsBatchBucket,
 			break
 		}
 	}
-	// keys is non-empty (docBitmapContainsBatch returns early otherwise) and
-	// the first iteration always adopts its fetched bitmap, so acc is non-nil.
+	// keys is non-empty (docBitmapContainsBatch's precondition, enforced by
+	// fetchContainsBatch) and the first iteration always adopts its fetched
+	// bitmap, so acc is non-nil.
 	return acc, accRelease, nil
 }
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -13,6 +13,7 @@ package inverted
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -24,37 +25,67 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 )
 
-// spyContainsBatchBucket wraps a real roaringset *lsmkv.Bucket, recording
-// every key passed to RoaringSetGetFromView and counting how many of the
-// returned release funcs get called, so tests can assert both which keys
-// docBitmapContainsBatch actually read and that it never leaks a bitmap.
-type spyContainsBatchBucket struct {
+// containsBatchFixture owns a real roaringset *lsmkv.Bucket and the
+// read-tracking state shared by the readers it hands out: the keys read and
+// how many of the returned release funcs get called, so tests can assert both
+// which keys docBitmapContainsBatch actually read and that it never leaks a
+// bitmap.
+type containsBatchFixture struct {
 	*lsmkv.Bucket
+	// pool backs the bucket's row buffers, so Outstanding() sees a row the fold
+	// read and failed to release
+	pool         *roaringset.BitmapBufPoolTrackingForTests
 	reads        []string
 	releaseCalls int
+	// onRead, when set, runs after each read is recorded — the cancellation
+	// test uses it to cancel a context at a deterministic point in the fold.
+	onRead func(numReads int)
 }
 
-func (s *spyContainsBatchBucket) RoaringSetGetFromView(
-	ctx context.Context, view lsmkv.BucketConsistentView, key []byte,
-) (*sroar.Bitmap, func(), error) {
+// reader opens a real batch reader on the underlying bucket and wraps it so
+// every read and every release func records into the fixture. The reader's view is
+// released once, at test end — releasing is the caller's job, so the fold never
+// does it.
+func (s *containsBatchFixture) reader(t *testing.T) *spyContainsBatchReader {
+	t.Helper()
+	rdr, err := s.NewRoaringSetBatchReader()
+	require.NoError(t, err)
+	t.Cleanup(rdr.Release)
+	return &spyContainsBatchReader{reader: rdr, fixture: s}
+}
+
+// spyContainsBatchReader is the reader the fixture hands the fold: it records
+// every key read and wraps every release so the fixture's counters see the
+// whole batch.
+type spyContainsBatchReader struct {
+	reader  *lsmkv.RoaringSetBatchReader
+	fixture *containsBatchFixture
+}
+
+func (r *spyContainsBatchReader) Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error) {
+	s := r.fixture
 	s.reads = append(s.reads, string(key))
-	bm, release, err := s.Bucket.RoaringSetGetFromView(ctx, view, key)
+	if s.onRead != nil {
+		s.onRead(len(s.reads))
+	}
+	bm, release, err := r.reader.Get(key, mergeConc)
 	return bm, func() {
 		s.releaseCalls++
 		release()
 	}, err
 }
 
-func buildContainsBatchBucket(t *testing.T, ctx context.Context, rows map[string][]uint64) *spyContainsBatchBucket {
+func newContainsBatchFixture(t *testing.T, ctx context.Context, rows map[string][]uint64) *containsBatchFixture {
 	t.Helper()
 
 	logger, _ := test.NewNullLogger()
 	tmpDir := t.TempDir()
 
+	pool := roaringset.NewBitmapBufPoolTrackingForTests()
 	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
-		lsmkv.WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+		lsmkv.WithBitmapBufPool(pool))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
 
@@ -65,43 +96,7 @@ func buildContainsBatchBucket(t *testing.T, ctx context.Context, rows map[string
 	}
 	require.NoError(t, b.FlushAndSwitch())
 
-	return &spyContainsBatchBucket{Bucket: b}
-}
-
-// expireAfterNDoneCtx reports ctx.Done() as closed starting with the (n+1)th
-// call to Done(), letting a test deterministically cancel a synchronous
-// per-key loop after exactly n keys have been checked, without goroutines or
-// wall-clock timing.
-type expireAfterNDoneCtx struct {
-	context.Context
-	n     int
-	calls int
-	done  chan struct{}
-}
-
-func newExpireAfterNDoneCtx(parent context.Context, n int) *expireAfterNDoneCtx {
-	return &expireAfterNDoneCtx{Context: parent, n: n, done: make(chan struct{})}
-}
-
-func (c *expireAfterNDoneCtx) Done() <-chan struct{} {
-	c.calls++
-	if c.calls > c.n {
-		select {
-		case <-c.done:
-		default:
-			close(c.done)
-		}
-	}
-	return c.done
-}
-
-func (c *expireAfterNDoneCtx) Err() error {
-	select {
-	case <-c.done:
-		return context.Canceled
-	default:
-		return nil
-	}
+	return &containsBatchFixture{Bucket: b, pool: pool}
 }
 
 // TestMergeAllowlistBitmaps_UnsupportedOperator pins the defensive default
@@ -122,7 +117,7 @@ func TestMergeAllowlistBitmaps_UnsupportedOperator(t *testing.T) {
 
 func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 	ctx := context.Background()
-	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 		"present-a": {1, 2, 3},
 		"present-b": {3, 4, 5},
 	})
@@ -133,13 +128,13 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 	}
 
 	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
 	require.NoError(t, err)
 	defer dbm.release()
 
 	require.Equal(t, []uint64{1, 2, 3, 4, 5}, dbm.docIDs.ToArray())
 	require.False(t, dbm.IsDenyList())
-	require.Equal(t, []string{"present-a", "missing", "present-b"}, spy.reads,
+	require.Equal(t, []string{"present-a", "missing", "present-b"}, fixture.reads,
 		"every key must be read for ContainsAny, absent key included")
 }
 
@@ -151,7 +146,7 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 // TestResolveDocIDs_ContainsKeysRequireContainsOperator.
 func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 	ctx := context.Background()
-	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 		"present-a": {1, 2, 3},
 	})
 
@@ -161,10 +156,95 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 	}
 
 	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
 	require.ErrorContains(t, err, "unsupported operator")
 	require.Nil(t, dbm.docIDs)
-	require.Empty(t, spy.reads, "no key may be read for an unsupported operator")
+	require.Empty(t, fixture.reads, "no key may be read for an unsupported operator")
+}
+
+// TestDocBitmapContainsBatch_NoKeys pins the fold's other defensive backstop:
+// its accumulator is the first row it reads, so zero keys has no result to
+// return. Erroring keeps that a loud caller bug rather than a docBitmap with a
+// nil bitmap flowing into the merges. fetchContainsBatch answers the empty case
+// before calling in, which TestFetchContainsBatch_EmptyKeySet pins.
+func TestDocBitmapContainsBatch_NoKeys(t *testing.T) {
+	ctx := context.Background()
+	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{"present-a": {1, 2, 3}})
+
+	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
+		t.Run(op.Name(), func(t *testing.T) {
+			s := &Searcher{}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
+				&propValuePair{prop: "some-prop", operator: op, containsValues: [][]byte{}})
+			require.ErrorContains(t, err, "carries no keys")
+			require.ErrorContains(t, err, `"some-prop"`, "the error must name the property")
+			require.Nil(t, dbm.docIDs)
+			require.Empty(t, fixture.reads, "no key may be read")
+		})
+	}
+}
+
+// failingContainsBatchReader fails one key and reads every other through the
+// wrapped reader, so a fold can be stopped at a chosen point mid-batch.
+type failingContainsBatchReader struct {
+	containsBatchReader
+	failKey string
+}
+
+func (r *failingContainsBatchReader) Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error) {
+	if string(key) == r.failKey {
+		return nil, noopRelease, fmt.Errorf("injected read failure")
+	}
+	return r.containsBatchReader.Get(key, mergeConc)
+}
+
+// TestDocBitmapContainsBatch_ReadError pins what a failed row read costs: the
+// error reaches the caller wrapped rather than becoming a silently short
+// result, the fold stops, and the rows it had already accumulated go back to
+// the bucket's buffer pool instead of leaking.
+func TestDocBitmapContainsBatch_ReadError(t *testing.T) {
+	tests := []struct {
+		name string
+		gate int // containsAnyAccumulatorMinKeys, lowered to force the accumulator
+	}{
+		{name: "incremental fold", gate: 256},
+		{name: "accumulator fold", gate: 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGate := containsAnyAccumulatorMinKeys
+			containsAnyAccumulatorMinKeys = tc.gate
+			defer func() { containsAnyAccumulatorMinKeys = oldGate }()
+
+			ctx := context.Background()
+			fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
+				"a": {1, 2, 3},
+				"c": {7, 8},
+			})
+
+			pool := roaringset.NewBitmapBufPoolTrackingForTests()
+			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
+
+			// "a" is read and accumulated, "poison" fails, "c" must never be read
+			dbm, err := s.docBitmapContainsBatch(ctx,
+				&failingContainsBatchReader{containsBatchReader: fixture.reader(t), failKey: "poison"},
+				&propValuePair{
+					operator:       filters.ContainsAny,
+					containsValues: [][]byte{[]byte("a"), []byte("poison"), []byte("c")},
+				})
+			require.ErrorContains(t, err, "read row")
+			require.ErrorContains(t, err, "injected read failure")
+			require.Equal(t, docBitmap{}, dbm, "a failed read must not yield a partial result")
+
+			// the poisoned key is answered by the wrapper, so it never reaches
+			// the fixture; "c" missing is what proves the fold stopped
+			require.Equal(t, []string{"a"}, fixture.reads, "no key after the failure may be read")
+			require.Equal(t, len(fixture.reads), fixture.releaseCalls,
+				"every row the fold received must be released")
+			require.Zero(t, fixture.pool.Outstanding(),
+				"no row buffer may outlive the failed fold")
+		})
+	}
 }
 
 func TestResolveDocIDs_ContainsKeysRequireContainsOperator(t *testing.T) {
@@ -193,7 +273,7 @@ func TestResolveDocIDs_ContainsKeysRequireContainsOperator(t *testing.T) {
 // universe inversion treat it as a negation.
 func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 	ctx := context.Background()
-	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 		"present-a": {1, 2, 3},
 		"present-b": {3, 4, 5},
 	})
@@ -204,70 +284,109 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 	}
 
 	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
 	require.NoError(t, err)
 	defer dbm.release()
 
 	require.Equal(t, []uint64{1, 2, 3, 4, 5}, dbm.docIDs.ToArray(),
 		"ContainsNone folds the same union as ContainsAny")
 	require.True(t, dbm.IsDenyList())
-	require.Equal(t, []string{"present-a", "missing", "present-b"}, spy.reads)
-
-	t.Run("empty key set is an empty deny list", func(t *testing.T) {
-		empty := &propValuePair{operator: filters.ContainsNone}
-		dbm, err := s.docBitmapContainsBatch(ctx, spy, empty)
-		require.NoError(t, err)
-		defer dbm.release()
-		require.True(t, dbm.docIDs.IsEmpty())
-		require.True(t, dbm.IsDenyList(),
-			"NOT over an empty union must deny nothing, i.e. match everything")
-	})
+	require.Equal(t, []string{"present-a", "missing", "present-b"}, fixture.reads)
 }
 
-// Same fold as above but forced through the Accumulator path, which the
+// Same folds as above but forced through the Accumulator path, which the
 // containsAnyAccumulatorMinKeys gate would otherwise route to the incremental
-// fold at this key count.
+// fold at this key count. ContainsNone is covered here too: it shares the union
+// but must still come back a deny list, and losing the flag on this arm alone
+// would invert the filter against the universe at large key counts.
 func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
 	oldGate := containsAnyAccumulatorMinKeys
 	containsAnyAccumulatorMinKeys = 2
 	defer func() { containsAnyAccumulatorMinKeys = oldGate }()
 
 	ctx := context.Background()
-	spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+	rows := map[string][]uint64{
 		"present-a": {1, 2, 3},
 		"present-b": {3, 4, 5},
 		// A row spilling into further 64K ranges, so the union spans
 		// multiple result containers.
 		"present-c": {70_000, 200_000},
-	})
-
-	pv := &propValuePair{
-		operator: filters.ContainsAny,
-		containsValues: [][]byte{
-			[]byte("present-a"), []byte("missing"), []byte("present-b"), []byte("present-c"),
-		},
 	}
 
-	pool := roaringset.NewBitmapBufPoolTrackingForTests()
-	s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
-	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
-	require.NoError(t, err)
+	keys := [][]byte{
+		[]byte("present-a"), []byte("missing"), []byte("present-b"), []byte("present-c"),
+	}
+	for _, tc := range []struct {
+		operator     filters.Operator
+		wantDenyList bool
+	}{
+		{operator: filters.ContainsAny, wantDenyList: false},
+		{operator: filters.ContainsNone, wantDenyList: true},
+	} {
+		t.Run(tc.operator.Name(), func(t *testing.T) {
+			fixture := newContainsBatchFixture(t, ctx, rows)
 
-	require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
-	require.False(t, dbm.IsDenyList())
-	require.Equal(t, []string{"present-a", "missing", "present-b", "present-c"}, spy.reads,
-		"every key must be read for ContainsAny, absent key included")
+			pool := roaringset.NewBitmapBufPoolTrackingForTests()
+			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
+				&propValuePair{operator: tc.operator, containsValues: keys})
+			require.NoError(t, err)
 
-	dbm.release()
-	require.Zero(t, pool.Outstanding(),
-		"the pooled result buffer must flow back through dbm.release")
+			require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
+			require.Equal(t, tc.wantDenyList, dbm.IsDenyList())
+			require.Equal(t, []string{"present-a", "missing", "present-b", "present-c"}, fixture.reads,
+				"every key must be read, absent key included")
+
+			dbm.release()
+			require.Zero(t, pool.Outstanding(),
+				"the pooled result buffer must flow back through dbm.release")
+		})
+	}
+}
+
+// TestDocBitmapContainsBatch_SingleKey covers the 1 of 0/1/N. The folds adopt
+// their first row as the accumulator and merge every row after it, so a single
+// key is the one count that exercises the adopt without any merge — and a fold
+// that returned its accumulator unset here would hand back a docBitmap with a
+// nil bitmap, which is exactly what the folds' closing comments claim cannot
+// happen.
+func TestDocBitmapContainsBatch_SingleKey(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		operator filters.Operator
+		key      string
+		want     []uint64
+	}{
+		{operator: filters.ContainsAny, key: "a", want: []uint64{1, 2, 3}},
+		{operator: filters.ContainsAll, key: "a", want: []uint64{1, 2, 3}},
+		{operator: filters.ContainsAny, key: "missing", want: []uint64{}},
+		{operator: filters.ContainsAll, key: "missing", want: []uint64{}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.operator.Name()+"/"+tc.key, func(t *testing.T) {
+			fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{"a": {1, 2, 3}})
+
+			s := &Searcher{}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
+				operator:       tc.operator,
+				containsValues: [][]byte{[]byte(tc.key)},
+			})
+			require.NoError(t, err)
+			defer dbm.release()
+
+			require.NotNil(t, dbm.docIDs, "a fold must never return a nil bitmap")
+			require.Equal(t, tc.want, dbm.docIDs.ToArray())
+			require.Equal(t, []string{tc.key}, fixture.reads)
+		})
+	}
 }
 
 func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("non-empty intersection", func(t *testing.T) {
-		spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 			"a": {1, 2, 3},
 			"b": {2, 3, 4},
 			"c": {2, 3, 5},
@@ -279,16 +398,16 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		}
 
 		s := &Searcher{}
-		dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
 		require.NoError(t, err)
 		defer dbm.release()
 
 		require.Equal(t, []uint64{2, 3}, dbm.docIDs.ToArray())
-		require.Equal(t, []string{"a", "b", "c"}, spy.reads)
+		require.Equal(t, []string{"a", "b", "c"}, fixture.reads)
 	})
 
 	t.Run("folds to empty and stops reading remaining keys", func(t *testing.T) {
-		spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 			"a": {1, 2, 3},
 			"b": {4, 5, 6}, // disjoint from "a" -> accumulator becomes empty here
 			"c": {1, 2, 3}, // must never be read: the AND result can't change
@@ -300,17 +419,17 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		}
 
 		s := &Searcher{}
-		dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
 		require.NoError(t, err)
 		defer dbm.release()
 
 		require.Empty(t, dbm.docIDs.ToArray())
-		require.Equal(t, []string{"a", "b"}, spy.reads,
+		require.Equal(t, []string{"a", "b"}, fixture.reads,
 			"key c must not be read once the AND accumulator is provably empty")
 	})
 
 	t.Run("absent key empties the intersection and stops reading", func(t *testing.T) {
-		spy := buildContainsBatchBucket(t, ctx, map[string][]uint64{
+		fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 			"a": {1, 2, 3},
 			"c": {1, 2, 3}, // must never be read: the absent key already emptied the AND
 		})
@@ -321,36 +440,61 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		}
 
 		s := &Searcher{}
-		dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
+		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
 		require.NoError(t, err)
 		defer dbm.release()
 
 		require.Empty(t, dbm.docIDs.ToArray())
-		require.Equal(t, []string{"a", "missing"}, spy.reads,
+		require.Equal(t, []string{"a", "missing"}, fixture.reads,
 			"key c must not be read once the absent key emptied the accumulator")
 	})
 }
 
+// TestDocBitmapContainsBatch_ContextCancelledMidLoop pins fold cancellation on
+// both arms: each checks the context before every read, so a context cancelled
+// during the first read stops the loop before the second and releases the row
+// already adopted. The accumulator arm is the one guarding the large-N folds it
+// exists for, which the default gate would otherwise route past.
 func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
-	spy := buildContainsBatchBucket(t, context.Background(), map[string][]uint64{
-		"a": {1, 2, 3},
-		"b": {4, 5, 6},
-		"c": {7, 8, 9},
-	})
-
-	pv := &propValuePair{
-		operator:       filters.ContainsAny,
-		containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+	tests := []struct {
+		name string
+		gate int // containsAnyAccumulatorMinKeys, lowered to force the accumulator
+	}{
+		{name: "incremental fold", gate: 256},
+		{name: "accumulator fold", gate: 2},
 	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			oldGate := containsAnyAccumulatorMinKeys
+			containsAnyAccumulatorMinKeys = tc.gate
+			defer func() { containsAnyAccumulatorMinKeys = oldGate }()
 
-	// expires right after key "a" is read, before "b" is checked
-	ctx := newExpireAfterNDoneCtx(context.Background(), 1)
+			fixture := newContainsBatchFixture(t, context.Background(), map[string][]uint64{
+				"a": {1, 2, 3},
+				"b": {4, 5, 6},
+				"c": {7, 8, 9},
+			})
 
-	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, spy, pv)
-	require.ErrorIs(t, err, context.Canceled)
-	require.Equal(t, docBitmap{}, dbm)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			// cancel as key "a" is read, so the check before "b" sees it
+			fixture.onRead = func(numReads int) {
+				if numReads == 1 {
+					cancel()
+				}
+			}
 
-	require.Equal(t, []string{"a"}, spy.reads, "loop must stop reading once ctx is expired")
-	require.Equal(t, 1, spy.releaseCalls, "accumulator built from key \"a\" must be released, not leaked")
+			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(fixture.pool, func() uint64 { return 300_000 })}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
+				operator:       filters.ContainsAny,
+				containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			})
+			require.ErrorIs(t, err, context.Canceled)
+			require.Equal(t, docBitmap{}, dbm)
+
+			require.Equal(t, []string{"a"}, fixture.reads, "the fold must stop reading once ctx is cancelled")
+			require.Equal(t, 1, fixture.releaseCalls, "the row read before cancellation must be released")
+			require.Zero(t, fixture.pool.Outstanding(), "no row buffer may outlive the cancelled fold")
+		})
+	}
 }

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -638,6 +638,10 @@ func (b *Bucket) SetMemtableThreshold(size uint64) {
 }
 
 type BucketConsistentView struct {
+	// Active is nil for a bucket with no active memtable, and a holder may nil
+	// it to drop the layer from its own copy — RoaringSetBatchReader does when
+	// the memtable is empty. Most read paths here dereference it without
+	// checking, so nil it only in a copy you own.
 	Active   memtable
 	Flushing memtable
 	Disk     []Segment

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -638,10 +638,8 @@ func (b *Bucket) SetMemtableThreshold(size uint64) {
 }
 
 type BucketConsistentView struct {
-	// Active is nil for a bucket with no active memtable, and a holder may nil
-	// it to drop the layer from its own copy — RoaringSetBatchReader does when
-	// the memtable is empty. Most read paths here dereference it without
-	// checking, so nil it only in a copy you own.
+	// Active is nil for a bucket with no active memtable. Most reads below
+	// dereference it unguarded, so nil it only in a copy you own.
 	Active   memtable
 	Flushing memtable
 	Disk     []Segment

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -126,7 +127,8 @@ func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitma
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	return b.roaringSetGetFromConsistentView(ctx, view, key)
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+	return b.roaringSetGetFromConsistentView(view, key, mergeConc)
 }
 
 // RoaringSetGetFromView reads key using a caller-held BucketConsistentView,
@@ -137,6 +139,9 @@ func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitma
 // RoaringSetGetFromView call, then call view.ReleaseView() exactly once when
 // done. The view must come from this bucket's GetConsistentView: a view of
 // another bucket is not detected and would silently read that bucket's data.
+//
+// For a batch of many keys, NewRoaringSetBatchReader avoids repeating this
+// method's per-call strategy check and per-call budget derivation.
 func (b *Bucket) RoaringSetGetFromView(
 	ctx context.Context, view BucketConsistentView, key []byte,
 ) (bm *sroar.Bitmap, release func(), err error) {
@@ -144,15 +149,16 @@ func (b *Bucket) RoaringSetGetFromView(
 		return nil, noopRelease, err
 	}
 
-	return b.roaringSetGetFromConsistentView(ctx, view, key)
+	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
+	return b.roaringSetGetFromConsistentView(view, key, mergeConc)
 }
 
+// A nil view.Active is skipped, the same way a nil view.Flushing is: the caller
+// has established that the layer contributes nothing.
 func (b *Bucket) roaringSetGetFromConsistentView(
-	ctx context.Context, view BucketConsistentView, key []byte,
+	view BucketConsistentView, key []byte, mergeConc int,
 ) (bm *sroar.Bitmap, release func(), err error) {
-	maxConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
-
-	diskBM, diskRelease, err := b.disk.roaringSetGet(key, view.Disk, maxConc)
+	diskBM, diskRelease, err := b.disk.roaringSetGet(key, view.Disk, mergeConc)
 	if err != nil {
 		return nil, noopRelease, err
 	}
@@ -169,29 +175,78 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 	// without materializing a []BitmapLayer. diskBM is the pooled base (with
 	// headroom); on a disk miss it is nil and the merger adopts the first
 	// memtable layer's clone instead of copying it.
-	merger := roaringset.NewLayerMerger(diskBM, false, maxConc)
+	merger := roaringset.NewLayerMerger(diskBM, false, mergeConc)
 
-	if view.Flushing != nil {
-		flushing, flushErr := view.Flushing.roaringSetGet(key)
-		if flushErr != nil {
-			if !errors.Is(flushErr, lsmkv.NotFound) {
-				err = flushErr
+	// Oldest first: the merger replays each layer's deletions before its
+	// additions, so a doc deleted in flushing and re-added in active survives
+	// only in this order.
+	for _, mt := range [2]memtable{view.Flushing, view.Active} {
+		if mt == nil {
+			continue
+		}
+		layer, mtErr := mt.roaringSetGet(key)
+		if mtErr != nil {
+			if !errors.Is(mtErr, lsmkv.NotFound) {
+				err = mtErr
 				return nil, noopRelease, err
 			}
-		} else {
-			merger.Add(flushing)
+			continue
 		}
-	}
-
-	activeBM, activeErr := view.Active.roaringSetGet(key)
-	if activeErr != nil {
-		if !errors.Is(activeErr, lsmkv.NotFound) {
-			err = activeErr
-			return nil, noopRelease, err
-		}
-	} else {
-		merger.Add(activeBM)
+		merger.Add(layer)
 	}
 
 	return merger.Result(), diskRelease, nil
+}
+
+// ErrReaderReleased signals a lifetime bug in the caller, never a storage
+// failure.
+var ErrReaderReleased = errors.New("roaring set batch reader: Get after Release")
+
+// RoaringSetBatchReader reads many roaringset rows under one view, held until
+// Release. It must not outlive the bucket; Get is safe to call concurrently.
+//
+// An active memtable empty at view time is skipped for the whole batch, so a
+// write into it afterwards is invisible to all keys rather than to only the
+// tail. Callers needing per-read freshness must use RoaringSetGet.
+type RoaringSetBatchReader struct {
+	view     BucketConsistentView
+	released atomic.Bool
+}
+
+// NewRoaringSetBatchReader opens a reader on b. See RoaringSetBatchReader for
+// the lifetime and visibility contract.
+func (b *Bucket) NewRoaringSetBatchReader() (*RoaringSetBatchReader, error) {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
+		return nil, err
+	}
+	view := b.GetConsistentView()
+	if view.Active != nil && view.Active.Size() == 0 {
+		// Read outside flushLock, which is safe only because a memtable's size
+		// never decreases: a racing write leaves it stale-low, never stale-high,
+		// so the skip can miss that write but never drops a committed one.
+		view.Active = nil
+	}
+	return &RoaringSetBatchReader{view: view}, nil
+}
+
+// Get reads key's row under the held view. mergeConc reaches sroar unclamped —
+// pass what concurrency.BudgetFromCtxCapped returned, since SROAR_MERGE itself
+// bypasses the query's budget and a non-positive value means unbounded.
+// Returns ErrReaderReleased after Release: those segments may be unmapped.
+func (r *RoaringSetBatchReader) Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error) {
+	if r.released.Load() {
+		return nil, noopRelease, ErrReaderReleased
+	}
+	return r.view.Bucket.roaringSetGetFromConsistentView(r.view, key, mergeConc)
+}
+
+// Release releases the held view. Later calls are no-ops: a second decRef could
+// take a concurrent reader's count to zero, and compaction then unmaps and
+// deletes a segment that reader is using. The guard detects misuse; it does not
+// synchronize a Release racing an in-flight Get.
+func (r *RoaringSetBatchReader) Release() {
+	if r.released.Swap(true) {
+		return
+	}
+	r.view.ReleaseView()
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -131,28 +131,6 @@ func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitma
 	return b.roaringSetGetFromConsistentView(view, key, mergeConc)
 }
 
-// RoaringSetGetFromView reads key using a caller-held BucketConsistentView,
-// skipping the per-call GetConsistentView()/ReleaseView() pair (RLock +
-// disk-segment pinning) that RoaringSetGet performs on every invocation.
-// Intended for callers that read many keys from the same bucket in one
-// logical operation: call GetConsistentView() once, pass the result to every
-// RoaringSetGetFromView call, then call view.ReleaseView() exactly once when
-// done. The view must come from this bucket's GetConsistentView: a view of
-// another bucket is not detected and would silently read that bucket's data.
-//
-// For a batch of many keys, NewRoaringSetBatchReader avoids repeating this
-// method's per-call strategy check and per-call budget derivation.
-func (b *Bucket) RoaringSetGetFromView(
-	ctx context.Context, view BucketConsistentView, key []byte,
-) (bm *sroar.Bitmap, release func(), err error) {
-	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
-		return nil, noopRelease, err
-	}
-
-	mergeConc := concurrency.BudgetFromCtxCapped(ctx, concurrency.SROAR_MERGE)
-	return b.roaringSetGetFromConsistentView(view, key, mergeConc)
-}
-
 // A nil view.Active is skipped, the same way a nil view.Flushing is: the caller
 // has established that the layer contributes nothing.
 func (b *Bucket) roaringSetGetFromConsistentView(

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -246,12 +246,13 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	})
 }
 
-// TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet proves the new
-// batched-read primitive returns byte-identical results to the per-key
-// RoaringSetGet entry point, whether the key is present across several
-// on-disk segments plus the active memtable, or absent entirely, and that a
-// single GetConsistentView() call serves every RoaringSetGetFromView read.
-func TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet(t *testing.T) {
+// TestBucket_RoaringSetBatchReader_MatchesRoaringSetGet proves the batched-read
+// primitive returns byte-identical results to the per-key RoaringSetGet entry
+// point, whether the key is present across several on-disk segments plus the
+// active memtable, or absent entirely, and that one reader serves every read.
+// The active memtable holds unflushed data when the reader is built, so the
+// batch reads it too and parity is exact.
+func TestBucket_RoaringSetBatchReader_MatchesRoaringSetGet(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 	tmpDir := t.TempDir()
@@ -297,31 +298,31 @@ func TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet(t *testing.T) {
 	releaseWantMissing()
 	require.Empty(t, arrWantMissing, "absent key must resolve to an empty, non-nil bitmap")
 
-	// one shared view serves all three RoaringSetGetFromView reads below
-	view := b.GetConsistentView()
+	// one reader serves all three reads below
+	reader, err := b.NewRoaringSetBatchReader()
+	require.NoError(t, err)
+	defer reader.Release()
 
-	gotA, releaseA, err := b.RoaringSetGetFromView(ctx, view, keyA)
+	gotA, releaseA, err := reader.Get(keyA, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	require.Equal(t, arrWantA, gotA.ToArray())
 	releaseA()
 
-	gotB, releaseB, err := b.RoaringSetGetFromView(ctx, view, keyB)
+	gotB, releaseB, err := reader.Get(keyB, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	require.Equal(t, arrWantB, gotB.ToArray())
 	releaseB()
 
-	gotMissing, releaseMissing, err := b.RoaringSetGetFromView(ctx, view, keyMissing)
+	gotMissing, releaseMissing, err := reader.Get(keyMissing, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	require.NotNil(t, gotMissing)
 	require.Empty(t, gotMissing.ToArray())
 	releaseMissing()
-
-	view.ReleaseView()
 }
 
-// TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch pins the view
-// stability that justifies the caller-held-view API: reads through a view
-// taken before a FlushAndSwitch must keep resolving without error (the
+// TestBucket_RoaringSetBatchReader_SurvivesFlushAndSwitch pins the view
+// stability that justifies holding one view for a whole batch: reads through a
+// reader built before a FlushAndSwitch must keep resolving without error (the
 // flushed-away memtable stays readable through the held reference) and keep
 // returning the pre-switch state — writes landing in the new active memtable
 // must stay invisible. A fresh RoaringSetGet sees the post-switch write,
@@ -330,7 +331,7 @@ func TestBucket_RoaringSetGetFromView_MatchesRoaringSetGet(t *testing.T) {
 // (A view is not a write snapshot: writes before the switch go to the old
 // active memtable the view references, so only post-switch invisibility is
 // asserted.)
-func TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch(t *testing.T) {
+func TestBucket_RoaringSetBatchReader_SurvivesFlushAndSwitch(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 
@@ -351,10 +352,11 @@ func TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch(t *testing.T) {
 	require.NoError(t, b.FlushAndSwitch())
 	require.NoError(t, b.RoaringSetAddList(key, []uint64{4}))
 
-	view := b.GetConsistentView()
-	defer view.ReleaseView()
+	reader, err := b.NewRoaringSetBatchReader()
+	require.NoError(t, err)
+	defer reader.Release()
 
-	before, releaseBefore, err := b.RoaringSetGetFromView(ctx, view, key)
+	before, releaseBefore, err := reader.Get(key, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	arrBefore := append([]uint64(nil), before.ToArray()...)
 	releaseBefore()
@@ -364,7 +366,7 @@ func TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch(t *testing.T) {
 	require.NoError(t, b.FlushAndSwitch())
 	require.NoError(t, b.RoaringSetAddList(key, []uint64{5}))
 
-	after, releaseAfter, err := b.RoaringSetGetFromView(ctx, view, key)
+	after, releaseAfter, err := reader.Get(key, concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	require.Equal(t, arrBefore, after.ToArray(),
 		"view read must keep returning the pre-switch state")
@@ -375,29 +377,6 @@ func TestBucket_RoaringSetGetFromView_SurvivesFlushAndSwitch(t *testing.T) {
 	require.Equal(t, []uint64{1, 2, 3, 4, 5}, fresh.ToArray(),
 		"a fresh read must see the post-switch write the view cannot")
 	releaseFresh()
-}
-
-// TestBucket_RoaringSetGetFromView_WrongStrategy pins the strategy guard: a
-// view read on a non-roaringset bucket must error before touching the view
-// at all (a zero view makes that observable — reaching the memtable read
-// would nil-panic), and the returned release must be safe to call. The
-// deeper layers reject the wrong strategy too, so without the guard the
-// error would only surface after the disk descent.
-func TestBucket_RoaringSetGetFromView_WrongStrategy(t *testing.T) {
-	ctx := context.Background()
-	logger, _ := test.NewNullLogger()
-
-	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-		WithStrategy(StrategyReplace))
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
-
-	bm, release, err := b.RoaringSetGetFromView(ctx, BucketConsistentView{}, []byte("key"))
-	require.Error(t, err)
-	require.Nil(t, bm)
-	require.NotNil(t, release)
-	release()
 }
 
 // TestBucket_RoaringSet_DeleteThenReaddAcrossSegments is a read-path regression

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -102,7 +102,7 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		}
 		view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}}
 
-		bm, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte("key1"))
+		bm, release, err := b.roaringSetGetFromConsistentView(view, []byte("key1"), concurrency.SROAR_MERGE)
 		require.ErrorIs(t, err, readErr)
 		require.Nil(t, bm)
 		require.NotNil(t, release)
@@ -128,7 +128,7 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		}
 		view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}}
 
-		bm, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte("key1"))
+		bm, release, err := b.roaringSetGetFromConsistentView(view, []byte("key1"), concurrency.SROAR_MERGE)
 		require.ErrorIs(t, err, readErr)
 		require.Nil(t, bm)
 		require.Equal(t, 1, diskSeg.roaringSetReleases,
@@ -149,7 +149,7 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		}
 		view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}}
 
-		bm, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte("key1"))
+		bm, release, err := b.roaringSetGetFromConsistentView(view, []byte("key1"), concurrency.SROAR_MERGE)
 		require.NoError(t, err)
 		require.NotNil(t, bm)
 
@@ -589,4 +589,265 @@ func requireRoaringSetElements(t *testing.T, ctx context.Context, b *Bucket, key
 	require.NoError(t, err)
 	defer release()
 	require.ElementsMatch(t, want, bm.ToArray())
+}
+
+// TestRoaringSetBatchReader pins the batch reader's contract: it validates the
+// strategy once, and it folds exactly the layers a per-key read would — except
+// that an active memtable empty at view time is skipped for the whole batch,
+// the behavior the reader exists for.
+func TestRoaringSetBatchReader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wrong strategy errors before taking a view", func(t *testing.T) {
+		b := Bucket{strategy: StrategyReplace, logger: nullLogger()}
+		reader, err := b.NewRoaringSetBatchReader()
+		require.Error(t, err)
+		require.Nil(t, reader)
+	})
+
+	// A bucket with no active memtable at all is distinct from one whose active
+	// memtable is empty, and the read path accepts it — so the constructor must
+	// too. It takes the view before inspecting the memtable, and no caller holds
+	// the reader yet, so a panic there leaves the segment refs held for good and
+	// Shutdown waits on them forever.
+	t.Run("no active memtable reads disk only", func(t *testing.T) {
+		b := Bucket{
+			strategy: StrategyRoaringSet,
+			disk: &SegmentGroup{segments: []Segment{newFakeRoaringSetSegment(
+				map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})}},
+			logger: nullLogger(),
+		}
+
+		reader, err := b.NewRoaringSetBatchReader()
+		require.NoError(t, err)
+		defer reader.Release()
+
+		bm, release, err := reader.Get([]byte("k"), 1)
+		require.NoError(t, err)
+		defer release()
+		require.Equal(t, []uint64{1, 2}, bm.ToArray())
+	})
+
+	// The eight presence combinations of the three layers — a new case belongs
+	// in one of these rows, not beside them. The flushing rows are the only
+	// thing pinning that a flushing memtable is always probed; the disk-less
+	// rows exercise the merger's adopt-the-first-memtable-layer branch, which a
+	// disk row would hide. Every row is a single container, so sroar merges it
+	// sequentially whatever mergeConc says: this table pins which layers are
+	// folded, never how the fold fans out.
+	layerTests := []struct {
+		name     string
+		disk     []uint64 // nil: key absent from the disk segment
+		flushing []uint64 // nil: no flushing memtable at all
+		active   []uint64 // nil: empty active memtable, so it gets skipped
+		// flushingDeletes are tombstoned by the flushing memtable. The merger
+		// replays each layer's deletions before its additions, so a doc deleted
+		// here and re-added by the (newer) active memtable survives only if the
+		// layers are folded oldest first.
+		flushingDeletes []uint64
+		// activeOtherKey seeds the active memtable under a different key, so it
+		// is non-empty (and therefore probed) while missing the key under test
+		activeOtherKey bool
+		want           []uint64
+	}{
+		{name: "disk only", disk: []uint64{1, 2}, want: []uint64{1, 2}},
+		{name: "disk and active", disk: []uint64{1, 2}, active: []uint64{3}, want: []uint64{1, 2, 3}},
+		{name: "disk and flushing, active skipped", disk: []uint64{1, 2}, flushing: []uint64{3}, want: []uint64{1, 2, 3}},
+		{
+			name: "all three layers", disk: []uint64{1}, flushing: []uint64{2}, active: []uint64{3},
+			want: []uint64{1, 2, 3},
+		},
+		{name: "flushing only", flushing: []uint64{7, 8}, want: []uint64{7, 8}},
+		{name: "active only", active: []uint64{7, 8}, want: []uint64{7, 8}},
+		{name: "flushing and active, no disk row", flushing: []uint64{7}, active: []uint64{8}, want: []uint64{7, 8}},
+		{name: "key absent from every layer", want: []uint64{}},
+		// the active memtable holds data, so it is probed rather than skipped,
+		// but not this key — the layer's NotFound branch, which every row above
+		// either skips outright or answers
+		{name: "active probed, holds another key", disk: []uint64{1, 2}, activeOtherKey: true, want: []uint64{1, 2}},
+		// Layer order: the flushing memtable's tombstone is older than the
+		// active memtable's re-add, so the doc must survive. Folding newest
+		// first would apply the delete last and silently drop it.
+		{
+			name: "flushing deletes what active re-adds",
+			disk: []uint64{1, 2, 3}, flushingDeletes: []uint64{2}, active: []uint64{2},
+			want: []uint64{1, 2, 3},
+		},
+		// The same tombstone with nothing re-adding it must still take effect.
+		{
+			name: "flushing deletes, active untouched",
+			disk: []uint64{1, 2, 3}, flushingDeletes: []uint64{2}, active: []uint64{9},
+			want: []uint64{1, 3, 9},
+		},
+	}
+	for _, tc := range layerTests {
+		t.Run(tc.name, func(t *testing.T) {
+			diskRows := map[string]*sroar.Bitmap{}
+			if tc.disk != nil {
+				diskRows["k"] = bitmapFromSlice(tc.disk)
+			}
+			b := Bucket{
+				strategy: StrategyRoaringSet,
+				disk:     &SegmentGroup{segments: []Segment{newFakeRoaringSetSegment(diskRows)}},
+				active:   newTestMemtableRoaringSet(rowOrNil(tc.active)),
+				logger:   nullLogger(),
+			}
+			if tc.activeOtherKey {
+				b.active = newTestMemtableRoaringSet(map[string][]uint64{"other": {42}})
+			}
+			if tc.flushing != nil {
+				b.flushing = newTestMemtableRoaringSet(map[string][]uint64{"k": tc.flushing})
+			}
+			if tc.flushingDeletes != nil {
+				mt := newTestMemtableRoaringSet(nil)
+				mt.roaringSet.Insert([]byte("k"), roaringset.Insert{Deletions: tc.flushingDeletes})
+				b.flushing = mt
+			}
+
+			reader, err := b.NewRoaringSetBatchReader()
+			require.NoError(t, err)
+			defer reader.Release()
+
+			bm, release, err := reader.Get([]byte("k"), concurrency.SROAR_MERGE)
+			require.NoError(t, err)
+			defer release()
+			require.Equal(t, tc.want, bm.ToArray())
+		})
+	}
+
+	t.Run("write into a then-empty active memtable is invisible to the batch", func(t *testing.T) {
+		b := Bucket{
+			strategy: StrategyRoaringSet,
+			disk: &SegmentGroup{segments: []Segment{newFakeRoaringSetSegment(
+				map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})}},
+			active: newTestMemtableRoaringSet(nil), // empty when the view is taken
+			logger: nullLogger(),
+		}
+
+		reader, err := b.NewRoaringSetBatchReader()
+		require.NoError(t, err)
+		defer reader.Release()
+
+		// a racing write into the active memtable the reader snapshotted as
+		// empty, through the same path a real writer takes so the size
+		// accounting is exercised too
+		require.NoError(t, b.RoaringSetAddList([]byte("k"), []uint64{99}))
+
+		bm, release, err := reader.Get([]byte("k"), 1)
+		require.NoError(t, err)
+		defer release()
+		require.Equal(t, []uint64{1, 2}, bm.ToArray(),
+			"a write into the then-empty active memtable must be skipped for the whole batch")
+	})
+}
+
+// rowOrNil maps a nil slice to a nil map, so newTestMemtableRoaringSet builds
+// an empty memtable rather than one holding an empty row.
+func rowOrNil(docIDs []uint64) map[string][]uint64 {
+	if docIDs == nil {
+		return nil
+	}
+	return map[string][]uint64{"k": docIDs}
+}
+
+// TestRoaringSetBatchReader_ActiveTombstones pins the invariant the
+// empty-active-memtable skip rests on: a delete makes the active memtable
+// non-empty, so the batch still reads it. If deletions ever stopped counting
+// towards Memtable.Size(), the skip would silently resurrect every deleted doc
+// — a wrong-results bug with no error anywhere, and the read-path tests that
+// use RoaringSetGet would not catch it.
+func TestRoaringSetBatchReader_ActiveTombstones(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+
+	b.SetMemtableThreshold(1e9) // flush only where the test says so
+
+	key := []byte("k")
+	require.NoError(t, b.RoaringSetAddList(key, []uint64{1, 2, 3}))
+	require.NoError(t, b.FlushAndSwitch()) // additions land on disk
+
+	// the tombstone stays in the otherwise-empty active memtable
+	require.NoError(t, b.RoaringSetRemoveOne(key, 2))
+
+	reader, err := b.NewRoaringSetBatchReader()
+	require.NoError(t, err)
+	defer reader.Release()
+
+	bm, release, err := reader.Get(key, 1)
+	require.NoError(t, err)
+	defer release()
+	require.Equal(t, []uint64{1, 3}, bm.ToArray(),
+		"a tombstone-only active memtable must not be treated as empty")
+}
+
+// TestRoaringSetBatchReader_ReleaseGuard pins the reader's lifetime guard. The
+// case that matters is the one that never panics: with a second reader holding
+// the same segments, an unguarded double release drops the refcount to zero
+// while that reader is live, and the compaction cycle then unmaps and deletes
+// the segment out from under it. Asserting refcounts rather than
+// absence-of-panic is therefore the point.
+func TestRoaringSetBatchReader_ReleaseGuard(t *testing.T) {
+	t.Parallel()
+
+	newBucket := func(seg *fakeSegment) Bucket {
+		return Bucket{
+			strategy: StrategyRoaringSet,
+			disk:     &SegmentGroup{segments: []Segment{seg}},
+			active:   newTestMemtableRoaringSet(nil),
+			logger:   nullLogger(),
+		}
+	}
+
+	t.Run("double release keeps a concurrent reader's segment refs", func(t *testing.T) {
+		seg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})
+		b := newBucket(seg)
+
+		reader, err := b.NewRoaringSetBatchReader()
+		require.NoError(t, err)
+		other, err := b.NewRoaringSetBatchReader()
+		require.NoError(t, err)
+		defer other.Release()
+		require.Equal(t, 2, seg.getRefs(), "both readers pin the segment")
+
+		reader.Release()
+		reader.Release()
+		require.Equal(t, 1, seg.getRefs(),
+			"the surviving reader's ref must outlive the other's double release")
+
+		// the surviving reader still reads its pinned segment
+		bm, release, err := other.Get([]byte("k"), 1)
+		require.NoError(t, err)
+		defer release()
+		require.Equal(t, []uint64{1, 2}, bm.ToArray())
+	})
+
+	t.Run("get after release errors instead of reading a freed view", func(t *testing.T) {
+		seg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})
+		b := newBucket(seg)
+
+		reader, err := b.NewRoaringSetBatchReader()
+		require.NoError(t, err)
+
+		bm, release, err := reader.Get([]byte("k"), 1)
+		require.NoError(t, err)
+		require.Equal(t, []uint64{1, 2}, bm.ToArray(), "reads before Release still work")
+		release()
+
+		reader.Release()
+
+		bm, release, err = reader.Get([]byte("k"), 1)
+		require.ErrorIs(t, err, ErrReaderReleased)
+		require.Nil(t, bm)
+		require.NotNil(t, release, "the returned release must stay safe to call")
+		release()
+	})
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -1132,7 +1132,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 		}
 
 		for k, expectedV := range expected {
-			v, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte(k))
+			v, release, err := b.roaringSetGetFromConsistentView(view, []byte(k), concurrency.SROAR_MERGE)
 			require.NoError(t, err)
 			require.Equal(t, expectedV.ToArray(), v.ToArray())
 			release()
@@ -1161,7 +1161,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 		}
 
 		for k, expectedV := range expected {
-			v, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte(k))
+			v, release, err := b.roaringSetGetFromConsistentView(view, []byte(k), concurrency.SROAR_MERGE)
 			require.NoError(t, err)
 			require.Equal(t, expectedV.ToArray(), v.ToArray())
 			release()

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -1134,7 +1134,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 		}
 
 		for k, expectedV := range expected {
-			v, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte(k))
+			v, release, err := b.roaringSetGetFromConsistentView(view, []byte(k), concurrency.SROAR_MERGE)
 			require.NoError(t, err)
 			require.Equal(t, expectedV.ToArray(), v.ToArray())
 			release()
@@ -1163,7 +1163,7 @@ func TestBucketRoaringSetStrategyConsistentView(t *testing.T) {
 		}
 
 		for k, expectedV := range expected {
-			v, release, err := b.roaringSetGetFromConsistentView(context.Background(), view, []byte(k))
+			v, release, err := b.roaringSetGetFromConsistentView(view, []byte(k), concurrency.SROAR_MERGE)
 			require.NoError(t, err)
 			require.Equal(t, expectedV.ToArray(), v.ToArray())
 			release()


### PR DESCRIPTION
## Motivation

Part 8 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242). PR 5's fold reads every key through `RoaringSetGetFromView`, which repeats per key what depends only on the bucket and the view: it validates the strategy, derives the sroar merge budget from the context, and takes an `RLock` to probe the active memtable whether or not that memtable holds anything. At 100K keys those constants are the read path's overhead, and the `RLock` is contention every concurrent query pays. **End-to-end throughput rises 57%** — 89.2 → 140.1 queries/sec at 16 workers, median 177.5ms → 109.0ms, p99 down 22%.

## Approach

- **`RoaringSetBatchReader`** (`lsmkv`) opens once and holds one `BucketConsistentView` until `Release`. Strategy is checked once, before the view is taken; `mergeConc` becomes a `Get` argument rather than a context lookup, so a caller splitting a batch across workers can hand each read its own share; and an active memtable found empty at view time is skipped for the whole batch, dropping the per-key probe **and its `RLock`**.
- **The fold reads through it** (`inverted`): `docBitmapContainsBatch` takes the reader, `fetchContainsBatch` owns its lifetime. Releasing stays off the seam the tests substitute — a fold able to release a view it does not own is a double-release waiting to happen. `RoaringSetGetFromView` had no other caller and goes with the change.
- **Slow-query timing moves up** to `fetchContainsBatch`, keeping the view acquisition inside the timed window: that wait is on the `flushLock`, and a filter stalled behind an in-flight flush is what the log exists to show.

## Behaviour change

A write landing in an active memtable **empty when the view was taken** is invisible to the whole batch, not just to keys read after it. A memtable that already held data is still probed per key; the flushing memtable always is. `RoaringSetGet` is unchanged for callers needing per-read freshness. One Contains now sees one snapshot — a consistency improvement, but a behaviour change, and why the skip is conditional on emptiness.

## Risks and testing

- **Double release is silent in the dangerous case**, so `Release` is idempotent and `Get` fails after it. A second release decRefs the view's segments twice: with no other holder that trips decRef's own panic, but **with a concurrent reader the count merely reaches zero** — and compaction then unmaps and deletes the file that reader is still reading. The tests assert segment refcounts for exactly that case.
- **The visibility skip must not drop flushed data**: covered for writes into an empty active memtable, a non-empty one, and a flush-and-switch mid-batch. `RoaringSetGetFromView`'s multi-segment parity tests move onto the reader, which holds a view longer than that method ever did.

`go test -race` on `inverted`, `lsmkv`, `roaringset`; `-tags integrationTest -race` on the db packages; both linters clean. No on-disk or API change.

## Numbers

300K-object reproduction corpus vs `stable/v1.38`; 3 round-robin rounds, 60s per cell, distinct id-sets per request:

| workers | stable | this PR | Δ throughput | Δ p99 |
|---|---|---|---|---|
| 16 | 89.2 q/s | **140.1 q/s** | **+57.1%** | −21.7% |
| 32 | 86.0 | **139.2** | +61.9% | +4.1% |
| 64 | 86.9 | **136.6** | +57.2% | −5.7% |
| 100 | 89.3 | **135.2** | +51.3% | −18.1% |
| 100 (10K ids) | 808.3 | **928.3** | +14.8% | −14.3% |