### PR TITLE
fix(raft): guard the bootstrap candidates map against concurrent notifies

### DIFF
--- a/cluster/store.go
+++ b/cluster/store.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -248,7 +249,9 @@ type Store struct {
 	logCache *raft.LogCache
 
 	// cluster bootstrap related attributes
-	candidates map[string]string
+	// candidatesMu guards candidates: concurrent NotifyPeer RPCs mutate it during bootstrap.
+	candidatesMu sync.Mutex
+	candidates   map[string]string
 	// bootstrapped is set once the node has either bootstrapped or recovered from RAFT log entries
 	bootstrapped atomic.Bool
 
@@ -492,7 +495,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 
 	// Only if node recovery is enabled will we check if we are either forcing it or automating the detection of a one
 	// node cluster
-	if st.cfg.EnableOneNodeRecovery && (st.cfg.ForceOneNodeRecovery || (st.cfg.BootstrapExpect == 1 && len(st.candidates) < 2)) {
+	if st.cfg.EnableOneNodeRecovery && (st.cfg.ForceOneNodeRecovery || (st.cfg.BootstrapExpect == 1 && st.candidatesLen() < 2)) {
 		if err := st.recoverSingleNode(st.cfg.ForceOneNodeRecovery); err != nil {
 			return err
 		}
@@ -820,7 +823,7 @@ func (st *Store) Stats() map[string]any {
 	stats["is_voter"] = st.IsVoter()
 	stats["open"] = st.open.Load()
 	stats["bootstrapped"] = st.bootstrapped.Load()
-	stats["candidates"] = st.candidates
+	stats["candidates"] = st.candidatesSnapshot()
 	stats["last_store_log_applied_index"] = st.lastAppliedIndexToDB.Load()
 	stats["last_applied_index"] = st.lastIndex()
 	stats["db_loaded"] = st.dbLoaded.Load()
@@ -1008,16 +1011,16 @@ func lastSnapshotIndex(snapshotStore *raft.FileSnapshotStore) uint64 {
 // used in a single cluster node.
 // for more details see : https://github.com/hashicorp/raft/blob/main/api.go#L279
 func (st *Store) recoverSingleNode(force bool) error {
-	if !force && (st.cfg.BootstrapExpect > 1 || len(st.candidates) > 1) {
+	if !force && (st.cfg.BootstrapExpect > 1 || st.candidatesLen() > 1) {
 		return fmt.Errorf("bootstrap expect %v, candidates %v, "+
-			"can't perform auto recovery in multi node cluster", st.cfg.BootstrapExpect, st.candidates)
+			"can't perform auto recovery in multi node cluster", st.cfg.BootstrapExpect, st.candidatesSnapshot())
 	}
 	servers := st.raft.GetConfiguration().Configuration().Servers
 	// nothing to do here, wasn't a single node
 	if !force && len(servers) != 1 {
 		st.log.WithFields(logrus.Fields{
 			"servers_from_previous_configuration": servers,
-			"candidates":                          st.candidates,
+			"candidates":                          st.candidatesSnapshot(),
 		}).Warn("didn't perform cluster recovery")
 		return nil
 	}

--- a/cluster/store_cluster_rpc.go
+++ b/cluster/store_cluster_rpc.go
@@ -62,6 +62,11 @@ func (st *Store) Notify(id, addr string) (err error) {
 		return nil
 	}
 
+	// Concurrent NotifyPeer RPCs land here during bootstrap; the whole
+	// candidates read-modify-drain below must be atomic.
+	st.candidatesMu.Lock()
+	defer st.candidatesMu.Unlock()
+
 	st.candidates[id] = addr
 	if len(st.candidates) < st.cfg.BootstrapExpect {
 		st.log.WithFields(logrus.Fields{
@@ -99,4 +104,21 @@ func (st *Store) Notify(id, addr string) (err error) {
 	}
 	st.bootstrapped.Store(true)
 	return nil
+}
+
+func (st *Store) candidatesLen() int {
+	st.candidatesMu.Lock()
+	defer st.candidatesMu.Unlock()
+	return len(st.candidates)
+}
+
+// candidatesSnapshot returns a copy safe to hand to loggers and stats.
+func (st *Store) candidatesSnapshot() map[string]string {
+	st.candidatesMu.Lock()
+	defer st.candidatesMu.Unlock()
+	out := make(map[string]string, len(st.candidates))
+	for id, addr := range st.candidates {
+		out[id] = addr
+	}
+	return out
 }

--- a/cluster/store_cluster_rpc.go
+++ b/cluster/store_cluster_rpc.go
@@ -67,6 +67,11 @@ func (st *Store) Notify(id, addr string) (err error) {
 	st.candidatesMu.Lock()
 	defer st.candidatesMu.Unlock()
 
+	// Re-evaluate under the lock: a competing notify may have bootstrapped while we waited.
+	if st.bootstrapped.Load() || st.Leader() != "" {
+		return nil
+	}
+
 	st.candidates[id] = addr
 	if len(st.candidates) < st.cfg.BootstrapExpect {
 		st.log.WithFields(logrus.Fields{

--- a/cluster/store_cluster_rpc_test.go
+++ b/cluster/store_cluster_rpc_test.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNotifyConcurrentCandidates hammers Notify the way concurrent NotifyPeer
+// RPC handlers do during cluster bootstrap; run with -race.
+func TestNotifyConcurrentCandidates(t *testing.T) {
+	ms := NewMockStore(t, "N1", 9526)
+	st := ms.Store(nil)
+	st.cfg.BootstrapExpect = 1_000_000 // never reach the bootstrap threshold
+	st.open.Store(true)
+
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				require.NoError(t, st.Notify(fmt.Sprintf("node-%d-%d", g, j), "10.0.0.1:8300"))
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/cluster/store_cluster_rpc_test.go
+++ b/cluster/store_cluster_rpc_test.go
@@ -12,11 +12,17 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"testing"
 
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/utils"
+	"github.com/weaviate/weaviate/usecases/cluster/mocks"
 )
 
 // TestNotifyConcurrentCandidates hammers Notify the way concurrent NotifyPeer
@@ -38,4 +44,46 @@ func TestNotifyConcurrentCandidates(t *testing.T) {
 		}(g)
 	}
 	wg.Wait()
+}
+
+// TestNotifyConcurrentBootstrapOnce races notifies across the bootstrap threshold; run with -race.
+func TestNotifyConcurrentBootstrapOnce(t *testing.T) {
+	ctx := context.Background()
+	m := NewMockStore(t, "N1", utils.MustGetFreeTCPPort())
+	hook := logrustest.NewLocal(m.logger)
+	st := m.Store(nil)
+	st.cfg.BootstrapExpect = 3
+	m.indexer.On("Open", mock.Anything).Return(nil)
+	m.indexer.On("Close", mock.Anything).Return(nil)
+	srv := NewRaft(mocks.NewMockNodeSelector(), st, nil)
+	require.NoError(t, srv.Open(ctx, m.indexer))
+	defer srv.Close(ctx)
+
+	require.NoError(t, st.Notify(m.cfg.NodeID, fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)))
+	require.NoError(t, st.Notify("seed", "10.1.0.1:8300"))
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for g := 0; g < 16; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 50; j++ {
+				require.NoError(t, st.Notify(fmt.Sprintf("node-%d-%d", g, j), fmt.Sprintf("10.0.%d.%d:8300", g, j)))
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+
+	bootstraps := 0
+	for _, e := range hook.AllEntries() {
+		if e.Message == "starting cluster bootstrapping" {
+			bootstraps++
+		}
+	}
+	require.Equal(t, 1, bootstraps)
+	require.True(t, st.bootstrapped.Load())
+	require.Zero(t, st.candidatesLen())
 }


### PR DESCRIPTION
## Motivation

During cluster bootstrap every starting node notifies its peers, so `NotifyPeer` gRPC handlers invoke `Store.Notify` concurrently — and `Notify` performs an unsynchronized read-modify-drain on the `candidates` map. The race detector flagged this during 3-node bootstrap in the async-replication battle suite (#12195). Outside `-race` builds this is worse than a data race on values: a concurrent map write is a fatal runtime throw that panics the node mid-join, not an error anything can catch or retry.

## Approach

A dedicated leaf mutex (`candidatesMu`) rather than reusing an existing store lock. The write side must hold it across the entire insert → threshold check → drain → `BootstrapCluster` sequence: guarding only the map operations would let two concurrent notifies both observe the threshold met and race into bootstrap with partially drained candidate sets. Making the whole section atomic guarantees exactly one notify crosses the threshold and it sees the full set.

The `bootstrapped`/`Leader()` gate is re-evaluated once the lock is held: a notify that passed the pre-lock gate and then waited on the mutex while a competing notify bootstrapped would otherwise mutate the map after the drain — leaving stale entries in stats and re-invoking `BootstrapCluster` with a candidate set that may not even contain the local node (surfacing as `node is not a voter` errors). The recheck turns those stale waiters into no-ops.

Readers never touch the raw map anymore: `Stats`, the one-node-recovery gate in `Open`, and `recoverSingleNode` go through `candidatesLen()` / `candidatesSnapshot()`. The snapshot hands loggers and stats a copy, so nothing can iterate the live map while a notify mutates it.

## Key areas for review

- `cluster/store_cluster_rpc.go` `Notify` — the critical section deliberately spans `BootstrapCluster` and its future; verify the atomicity argument above and that `candidatesMu` stays a leaf (nothing else is acquired under it). `Leader()` under the mutex follows the already-established `candidatesMu` → raft-lib nesting direction (`BootstrapCluster` runs in the same critical section), and nothing acquires `candidatesMu` from inside raft callbacks
- `cluster/store.go` `recoverSingleNode` — the warn log previously passed the raw map to logrus; this unguarded reader was found during review of the fix and folded in

## Risks and mitigations

- **Holding the mutex across `BootstrapCluster` + `fut.Error()`**: bounded, one-time work at cluster formation; the only other acquirers are cheap len/copy readers and no other lock is taken while holding `candidatesMu`, so no ordering deadlock is possible. Steady-state notifies exit early on `bootstrapped`/`Leader()` before ever reaching the lock, so there is no post-bootstrap contention.
- **Behavior change**: none intended — same drain and bootstrap semantics, now atomic and exactly-once.

## Testing

- `TestNotifyConcurrentCandidates` — 16 goroutines × 200 notifies each through a `MockStore` with an unreachable bootstrap threshold, mirroring how concurrent `NotifyPeer` handlers hammer `Notify`. Fails under `-race` without the fix (`fatal error: concurrent map writes`), passes with it.
- `TestNotifyConcurrentBootstrapOnce` — races 16 × 50 notifies across a reachable threshold (`BootstrapExpect = 3`) on a real raft instance and asserts exactly one `BootstrapCluster` attempt, `bootstrapped` set, and a drained candidate map. Fails without the under-lock recheck (6 bootstrap attempts observed, including stale drains erroring with `node is not a voter`), passes with it.
- Originally reproduced by the race detector during multi-node bootstrap in the async-replication battle suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
