### PR TITLE
fix(memberlist): stop reading live Node fields the gossip goroutine mutates

### DIFF
--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -141,6 +141,8 @@ type nodeIdentity struct {
 
 // setIdentity captures a member's identity; called from the events delegate
 // (and once for the local node at startup), where the Node fields are stable.
+// memberlist v0.5.x fires join/update for every accepted endpoint change
+// (live-member address conflicts are rejected), so the cache never goes stale.
 func (d *delegate) setIdentity(node *memberlist.Node) {
 	id := nodeIdentity{addr: node.Addr.String(), port: node.Port}
 	if len(node.Meta) > 0 {

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -120,9 +120,50 @@ type delegate struct {
 	sync.RWMutex
 	Cache map[string]NodeInfo
 
+	// identities caches each member's network identity: memberlist mutates
+	// Node fields in place on alive updates, so raw *memberlist.Node field
+	// reads race with the gossip goroutine — events callbacks are the safe
+	// capture point.
+	identities map[string]nodeIdentity
+
 	hostInfo NodeInfo
 
 	metadata NodeMetadata
+}
+
+// nodeIdentity is a member's captured address, gossip port, and parsed metadata.
+type nodeIdentity struct {
+	addr    string
+	port    uint16
+	meta    NodeMetadata
+	hasMeta bool
+}
+
+// setIdentity captures a member's identity; called from the events delegate
+// (and once for the local node at startup), where the Node fields are stable.
+func (d *delegate) setIdentity(node *memberlist.Node) {
+	id := nodeIdentity{addr: node.Addr.String(), port: node.Port}
+	if len(node.Meta) > 0 {
+		if err := json.Unmarshal(node.Meta, &id.meta); err == nil {
+			id.hasMeta = true
+		} else {
+			d.log.WithField("node", node.Name).Debugf("unmarshal node metadata: %v", err)
+		}
+	}
+	d.Lock()
+	defer d.Unlock()
+	if d.identities == nil {
+		d.identities = make(map[string]nodeIdentity, 32)
+	}
+	d.identities[node.Name] = id
+}
+
+// identity returns a member's cached identity; false until its join event fired.
+func (d *delegate) identity(name string) (nodeIdentity, bool) {
+	d.RLock()
+	defer d.RUnlock()
+	id, ok := d.identities[name]
+	return id, ok
 }
 
 type NodeMetadata struct {
@@ -254,6 +295,7 @@ func (d *delegate) delete(node string) {
 	d.Lock()
 	defer d.Unlock()
 	delete(d.Cache, node)
+	delete(d.identities, node)
 }
 
 // sortCandidates by the amount of free space in descending order
@@ -311,6 +353,7 @@ func (e events) NotifyJoin(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
+	e.d.setIdentity(node)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "join",
@@ -341,6 +384,7 @@ func (e events) NotifyUpdate(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
+	e.d.setIdentity(node)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "update",

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -12,7 +12,6 @@
 package cluster
 
 import (
-	"encoding/json"
 	"fmt"
 	"net"
 	"slices"
@@ -207,6 +206,10 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 		return nil, errors.Wrap(err, "create memberlist")
 	}
 
+	// Seed the local node's identity: its own join event may not fire, and
+	// nothing else populates the cache for self.
+	state.delegate.setIdentity(state.list.LocalNode())
+
 	// memberlist.Create has bound the gossip sockets. Any error from here on
 	// returns a nil State, so no caller is left with a handle to close them
 	defer func() {
@@ -280,38 +283,35 @@ func (s *State) Hostnames() []string {
 			continue
 		}
 
-		out[i] = net.JoinHostPort(m.Addr.String(), fmt.Sprintf("%d", s.dataPort(m)))
+		addr, ok := s.hostAddr(m.Name)
+		if !ok {
+			continue // join event not processed yet
+		}
+		out[i] = addr
 		i++
 	}
 
 	return out[:i]
 }
 
-func nodeMetadata(m *memberlist.Node) (NodeMetadata, error) {
-	if len(m.Meta) == 0 {
-		return NodeMetadata{}, errors.New("no metadata available")
+// hostAddr returns a member's data-plane host:port from the identity cache;
+// false until the member's join event has fired (raw *memberlist.Node field
+// reads race with the gossip goroutine's in-place alive updates).
+func (s *State) hostAddr(name string) (string, bool) {
+	id, ok := s.delegate.identity(name)
+	if !ok {
+		return "", false
 	}
-
-	var meta NodeMetadata
-	if err := json.Unmarshal(m.Meta, &meta); err != nil {
-		return NodeMetadata{}, errors.Wrap(err, "unmarshal node metadata")
-	}
-
-	return meta, nil
+	return net.JoinHostPort(id.addr, fmt.Sprintf("%d", identityDataPort(id))), true
 }
 
-func (s *State) dataPort(m *memberlist.Node) int {
-	meta, err := nodeMetadata(m)
-	if err != nil {
-		s.delegate.log.WithFields(logrus.Fields{
-			"action": "data_port_fallback",
-			"node":   m.Name,
-		}).WithError(err).Debug("unable to get node metadata, falling back to default data port")
-
-		return int(m.Port) + 1 // the convention that it's 1 higher than the gossip port
+// identityDataPort keeps the gossip-port+1 fallback convention for members
+// without parsable metadata.
+func identityDataPort(id nodeIdentity) int {
+	if id.hasMeta {
+		return id.meta.RestPort
 	}
-
-	return meta.RestPort
+	return int(id.port) + 1
 }
 
 // AllHostnames for live members, including self.
@@ -321,10 +321,12 @@ func (s *State) AllHostnames() []string {
 	}
 
 	mem := s.list.Members()
-	out := make([]string, len(mem))
+	out := make([]string, 0, len(mem))
 
-	for i, m := range mem {
-		out[i] = net.JoinHostPort(m.Addr.String(), fmt.Sprintf("%d", s.dataPort(m)))
+	for _, m := range mem {
+		if addr, ok := s.hostAddr(m.Name); ok {
+			out = append(out, addr)
+		}
 	}
 
 	return out
@@ -401,6 +403,9 @@ func (s *State) LocalName() string {
 // LocalAddr() returns local address
 func (s *State) LocalAddr() string {
 	if s.config.AdvertiseAddr == "" {
+		if id, ok := s.delegate.identity(s.delegate.Name); ok {
+			return id.addr
+		}
 		return s.list.LocalNode().Addr.String()
 	}
 
@@ -419,13 +424,7 @@ func (s *State) ClusterHealthScore() int {
 }
 
 func (s *State) NodeHostname(nodeName string) (string, bool) {
-	for _, mem := range s.list.Members() {
-		if mem.Name == nodeName {
-			return net.JoinHostPort(mem.Addr.String(), fmt.Sprintf("%d", s.dataPort(mem))), true
-		}
-	}
-
-	return "", false
+	return s.hostAddr(nodeName)
 }
 
 // extractHost extracts the host portion from an address string,
@@ -464,7 +463,11 @@ func (s *State) AllOtherClusterMembers(port int) map[string]string {
 			// skip self
 			continue
 		}
-		result[m.Name] = net.JoinHostPort(m.Addr.String(), fmt.Sprintf("%d", port))
+		id, ok := s.delegate.identity(m.Name)
+		if !ok {
+			continue // join event not processed yet
+		}
+		result[m.Name] = net.JoinHostPort(id.addr, fmt.Sprintf("%d", port))
 	}
 
 	return result
@@ -496,10 +499,8 @@ func (s *State) Shutdown() error {
 }
 
 func (s *State) NodeGRPCPort(nodeID string) (int, error) {
-	for _, mem := range s.list.Members() {
-		if mem.Name == nodeID {
-			return s.dataPort(mem), nil
-		}
+	if id, ok := s.delegate.identity(nodeID); ok {
+		return identityDataPort(id), nil
 	}
 	return 0, fmt.Errorf("node not found: %s", nodeID)
 }

--- a/usecases/cluster/state_identity_race_test.go
+++ b/usecases/cluster/state_identity_race_test.go
@@ -1,0 +1,61 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeHostnameConcurrentWithAliveUpdates: the resolvers must not read live
+// memberlist Node fields, which the gossip goroutine rewrites in place on
+// every alive update; run with -race.
+func TestNodeHostnameConcurrentWithAliveUpdates(t *testing.T) {
+	logger, _ := logrustest.NewNullLogger()
+
+	port1 := freeGossipPort(t)
+	s1, err := Init(Config{Hostname: "identity-node1", Localhost: true, GossipBindPort: port1}, 1, t.TempDir(), nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s1.list.Shutdown() })
+
+	s2, err := Init(Config{
+		Hostname: "identity-node2", Localhost: true,
+		GossipBindPort: freeGossipPort(t),
+		Join:           fmt.Sprintf("127.0.0.1:%d", port1),
+	}, 1, t.TempDir(), nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.list.Shutdown() })
+
+	require.Eventually(t, func() bool {
+		_, ok := s2.NodeHostname("identity-node1")
+		return ok
+	}, 10*time.Second, 100*time.Millisecond, "node2 never resolved node1 after join")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Each UpdateNode bumps the incarnation, making node2's gossip goroutine
+		// rewrite node1's Node fields in place.
+		for i := 0; i < 100; i++ {
+			_ = s1.list.UpdateNode(2 * time.Second)
+		}
+	}()
+	for i := 0; i < 2000; i++ {
+		s2.NodeHostname("identity-node1")
+		s2.AllHostnames()
+	}
+	<-done
+}

--- a/usecases/cluster/state_identity_race_test.go
+++ b/usecases/cluster/state_identity_race_test.go
@@ -13,6 +13,7 @@ package cluster
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,10 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNodeHostnameConcurrentWithAliveUpdates: the resolvers must not read live
-// memberlist Node fields, which the gossip goroutine rewrites in place on
-// every alive update; run with -race.
-func TestNodeHostnameConcurrentWithAliveUpdates(t *testing.T) {
+// TestResolversConcurrentWithAliveUpdates: run with -race; each UpdateNode makes the gossip goroutines rewrite Node fields in place.
+func TestResolversConcurrentWithAliveUpdates(t *testing.T) {
 	logger, _ := logrustest.NewNullLogger()
 
 	port1 := freeGossipPort(t)
@@ -44,18 +43,51 @@ func TestNodeHostnameConcurrentWithAliveUpdates(t *testing.T) {
 		return ok
 	}, 10*time.Second, 100*time.Millisecond, "node2 never resolved node1 after join")
 
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		// Each UpdateNode bumps the incarnation, making node2's gossip goroutine
-		// rewrite node1's Node fields in place.
-		for i := 0; i < 100; i++ {
-			_ = s1.list.UpdateNode(2 * time.Second)
-		}
-	}()
-	for i := 0; i < 2000; i++ {
-		s2.NodeHostname("identity-node1")
-		s2.AllHostnames()
+	var writers sync.WaitGroup
+	for _, s := range []*State{s1, s2} {
+		writers.Add(1)
+		go func() {
+			defer writers.Done()
+			for i := 0; i < 100; i++ {
+				if err := s.list.UpdateNode(2 * time.Second); err != nil {
+					t.Logf("update node: %v", err)
+				}
+			}
+		}()
 	}
-	<-done
+	stop := make(chan struct{})
+	go func() {
+		writers.Wait()
+		close(stop)
+	}()
+
+	// One dedicated goroutine per resolver: interleaving them in a single loop dilutes the post-Members() race window.
+	resolvers := []func(){
+		func() { s2.NodeHostname("identity-node1") },
+		func() { s2.AllHostnames() },
+		func() { s2.Hostnames() },
+		func() { s2.AllOtherClusterMembers(8300) },
+		func() {
+			if _, err := s2.NodeGRPCPort("identity-node1"); err != nil {
+				t.Error(err)
+			}
+		},
+		func() { s2.LocalAddr() },
+	}
+	var readers sync.WaitGroup
+	for _, resolve := range resolvers {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					resolve()
+				}
+			}
+		}()
+	}
+	readers.Wait()
 }


### PR DESCRIPTION
## Motivation

`State`'s resolvers (`NodeHostname`, `Hostnames`, `AllHostnames`, `NodeGRPCPort`, `AllOtherClusterMembers`, `LocalAddr`) read `.Meta`, `.Addr`, and `.Port` directly from the `*memberlist.Node` pointers returned by `Members()`. memberlist's gossip goroutine rewrites those fields in place on every alive update (`aliveNode`), so every resolution races with gossip. The race detector flagged both the metadata and the address reads repeatedly under node churn in the async-replication battle suite (#12195); beyond the race itself, a torn address read can misroute internal RPCs during a node's address change or rejoin.

## Approach

Node identity (address, gossip port, parsed `NodeMetadata`) is captured in the memberlist events delegate — `NotifyJoin`/`NotifyUpdate` are the documented safe points, invoked by the same goroutine that just wrote the fields and never concurrently — into an `identities` cache guarded by the delegate's existing mutex. `NotifyLeave` evicts alongside the existing disk-info cache eviction. The local node is seeded once right after `memberlist.Create`, since no event fires for self.

All resolvers now read the cache. A member whose join event has not yet fired resolves as unknown (skipped in list results, `false` from `NodeHostname`) — a transient window in which the node was not safely routable anyway; previously the same window returned values read from a data race. The gossip-port+1 fallback for members without parsable metadata is preserved via `identityDataPort`.

## Key areas for review

- `usecases/cluster/delegate.go` — `setIdentity`/`identity` and the eviction in `delete`; the safety argument for parsing `node.Meta` inside the callbacks
- `usecases/cluster/state.go` — resolver rewrites; the skip-on-miss semantics for not-yet-joined members, and `LocalAddr`'s cache-then-raw fallback

## Risks and mitigations

- **Semantics for not-yet-joined members**: resolvers now report them unknown instead of returning racy reads. Membership-name listings (`AllNames`, `storageNodes`) are untouched — `Name` is immutable.
- **Stale identity on address change**: memberlist fires `NotifyUpdate` for the same alive message that rewrites the fields, so the cache is refreshed by the event that made it stale.

## Testing

- `TestNodeHostnameConcurrentWithAliveUpdates` — two joined in-process memberlists; one loops `UpdateNode` (each bumps the incarnation, forcing the peer's gossip goroutine to rewrite the Node in place) while the other hammers `NodeHostname`/`AllHostnames`. Reports data races without the fix, clean with it (run with `-race`).
- Full `usecases/cluster` package passes under `-race`; the async-replication battle suite's tenant-race scenario, which surfaced the bug, passes with this fix in the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
