### PR TITLE
fix(async-repl): repair endpoints never load shards; cold replicas return not-ready

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -143,6 +143,9 @@ func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 
 	if res.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(res.Body)
+		if err := asyncNotReadyError(res.StatusCode, b); err != nil {
+			return nil, err
+		}
 		return nil, fmt.Errorf("status code: %v, error: %s", res.StatusCode, b)
 	}
 
@@ -239,6 +242,9 @@ func (c *replicationClient) CompareDigests(ctx context.Context,
 
 	if res.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(res.Body)
+		if err := asyncNotReadyError(res.StatusCode, b); err != nil {
+			return nil, err
+		}
 		return nil, fmt.Errorf("status code: %v, error: %s", res.StatusCode, b)
 	}
 
@@ -284,6 +290,18 @@ func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords
 
 // HashTreeLevel fetches hash tree level digests. discriminant.Size() must
 // equal hashtree.LeavesCount(level).
+
+// asyncNotReadyError converts the typed retry-later statuses of the async
+// replication RPCs — 412 (replica not ready: unloaded or hashtree still
+// initializing) and 503 (node still booting behind the cluster-API readiness
+// gate) — to the sentinel; nil for any other status (pre-1.38 peers send 500).
+func asyncNotReadyError(code int, body []byte) error {
+	if code == http.StatusPreconditionFailed || code == http.StatusServiceUnavailable {
+		return fmt.Errorf("%w: %s", replica.ErrAsyncReplicationNotActive, body)
+	}
+	return nil
+}
+
 func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	host, index, shard string, level int, discriminant *hashtree.Bitset,
 ) ([]hashtree.Digest, error) {
@@ -326,11 +344,8 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 
 	if code := res.StatusCode; !successCode(code) {
 		errBody, _ := io.ReadAll(res.Body)
-		// 412 = replica not ready (unloaded or hashtree still initializing);
-		// 503 = the whole node still booting (cluster-API readiness gate).
-		// Both are typed retry-later signals, not faults (pre-1.38 peers send 500).
-		if code == http.StatusPreconditionFailed || code == http.StatusServiceUnavailable {
-			return nil, fmt.Errorf("%w: %s", replica.ErrAsyncReplicationNotActive, errBody)
+		if err := asyncNotReadyError(code, errBody); err != nil {
+			return nil, err
 		}
 		return nil, fmt.Errorf("status code: %v, error: %s", code, errBody)
 	}
@@ -575,6 +590,9 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 
 	if res.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(res.Body)
+		if err := asyncNotReadyError(res.StatusCode, b); err != nil {
+			return nil, err
+		}
 		return nil, fmt.Errorf("status code: %v, error: %s", res.StatusCode, b)
 	}
 

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -378,6 +378,9 @@ func (c *grpcReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 		Limit:       int32(limit),
 	})
 	if err != nil {
+		if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
+			return nil, nrErr
+		}
 		return nil, fmt.Errorf("gRPC DigestObjectsInRange: %w", err)
 	}
 
@@ -401,6 +404,9 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 	}
 	resp, err := client.CompareDigests(ctx, req)
 	if err != nil {
+		if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
+			return nil, nrErr
+		}
 		return nil, fmt.Errorf("gRPC CompareDigests: %w", err)
 	}
 	return protoToRepairResponses(resp.GetDigests()), nil
@@ -471,6 +477,9 @@ func (c *grpcReplicationClient) OverwriteObjects(ctx context.Context, host, inde
 		Encoding:     encoding,
 	})
 	if err != nil {
+		if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
+			return nil, nrErr
+		}
 		return nil, fmt.Errorf("gRPC OverwriteObjects: %w", err)
 	}
 
@@ -510,6 +519,17 @@ func (c *grpcReplicationClient) FindUUIDs(ctx context.Context, host, index, shar
 
 // HashTreeLevel fetches hash tree level digests via gRPC. discriminant must
 // be a level-local bitset of size hashtree.LeavesCount(level).
+
+// asyncNotReadyGRPCError maps FailedPrecondition (replica not ready, see
+// replicationErrorToGRPC) and Unavailable (node-level boot gate) to the typed
+// retry-later sentinel for the async replication RPCs; nil for other codes.
+func asyncNotReadyGRPCError(err error) error {
+	if c := status.Code(err); c == codes.FailedPrecondition || c == codes.Unavailable {
+		return fmt.Errorf("%w: %w", replica.ErrAsyncReplicationNotActive, err)
+	}
+	return nil
+}
+
 func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, shard string,
 	level int, discriminant *hashtree.Bitset,
 ) ([]hashtree.Digest, error) {
@@ -545,11 +565,8 @@ func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 		Discriminant: discData,
 	})
 	if err != nil {
-		// FailedPrecondition on this RPC only ever means replica-not-ready (see
-		// replicationErrorToGRPC); Unavailable is the node-level boot gate. Both
-		// are typed retry-later signals, not faults.
-		if c := status.Code(err); c == codes.FailedPrecondition || c == codes.Unavailable {
-			return nil, fmt.Errorf("%w: %w", replica.ErrAsyncReplicationNotActive, err)
+		if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
+			return nil, nrErr
 		}
 		return nil, fmt.Errorf("gRPC HashTreeLevel: %w", err)
 	}

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -68,8 +68,9 @@ type fakeGRPCReplicationServer struct {
 	// commitPayload is the JSON payload returned by Commit on success.
 	commitPayload []byte
 
-	// hashTreeLevelErr, when set, is returned verbatim by HashTreeLevel.
-	hashTreeLevelErr error
+	// hashTreeLevelErr/compareDigestsErr, when set, are returned verbatim.
+	hashTreeLevelErr  error
+	compareDigestsErr error
 }
 
 func newFakeGRPCReplicationServer(t *testing.T) *fakeGRPCReplicationServer {
@@ -111,6 +112,13 @@ func (f *fakeGRPCReplicationServer) HashTreeLevel(_ context.Context, _ *pb.HashT
 		return nil, f.hashTreeLevelErr
 	}
 	return &pb.HashTreeLevelResponse{DigestsData: []byte("[]")}, nil
+}
+
+func (f *fakeGRPCReplicationServer) CompareDigests(_ context.Context, _ *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
+	if f.compareDigestsErr != nil {
+		return nil, f.compareDigestsErr
+	}
+	return &pb.CompareDigestsResponse{}, nil
 }
 
 func (f *fakeGRPCReplicationServer) PutObject(_ context.Context, req *pb.PutObjectRequest) (*pb.PutObjectResponse, error) {
@@ -825,6 +833,17 @@ func TestGRPCReplicationHashTreeLevelNotReady(t *testing.T) {
 		_, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
 		require.ErrorIs(t, err, replica.ErrAsyncReplicationNotActive,
 			"FailedPrecondition on HashTreeLevel means replica not ready and must map to the typed sentinel")
+	})
+
+	t.Run("CompareDigestsFailedPreconditionMapsToSentinel", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsErr = status.Error(codes.FailedPrecondition, "shard not loaded on this node")
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.CompareDigests(ctx, "passthrough:bufnet", "C1", "S1",
+			[]types.RepairResponse{{ID: UUID1.String(), UpdateTime: 1}})
+		require.ErrorIs(t, err, replica.ErrAsyncReplicationNotActive)
 	})
 
 	t.Run("UnavailableMapsToSentinel", func(t *testing.T) {

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -604,6 +604,18 @@ func TestReplicationOverwriteObjects(t *testing.T) {
 	assert.Equal(t, expected[0].ID, resp[0].ID)
 	assert.Equal(t, expected[0].Version, resp[0].Version)
 	assert.Equal(t, expected[0].UpdateTime, resp[0].UpdateTime)
+
+	t.Run("NotReady412MapsToSentinel", func(t *testing.T) {
+		notReady := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "shard \"S1\" not loaded on this node", http.StatusPreconditionFailed)
+		}))
+		defer notReady.Close()
+
+		c := newReplicationClient(t, notReady.Client())
+		_, err := c.OverwriteObjects(context.Background(), notReady.URL[7:], "C1", "S1", input)
+		require.ErrorIs(t, err, replica.ErrAsyncReplicationNotActive,
+			"a 412 from a cold replica must map to the typed retry-later sentinel")
+	})
 }
 
 func TestReplicationHashTreeLevel(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -429,8 +429,9 @@ func repairResponsesToProto(results []types.RepairResponse) []*pb.RepairResponse
 }
 
 // replicationErrorToGRPC maps typed replication errors to gRPC codes. The
-// HashTreeLevel client maps FailedPrecondition back to ErrAsyncReplicationNotActive
-// (retry-later); keep that RPC's server path free of other FailedPrecondition sources.
+// async replication clients (HashTreeLevel, DigestObjectsInRange, CompareDigests,
+// OverwriteObjects) map FailedPrecondition back to ErrAsyncReplicationNotActive
+// (retry-later); keep those RPCs' server paths free of other FailedPrecondition sources.
 func replicationErrorToGRPC(err error) error {
 	if err == nil {
 		return nil

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -474,7 +474,7 @@ func (i *replicatedIndices) getObjectsDigestsInRange() http.Handler {
 		digests, err := i.replicator.DigestObjectsInRange(r.Context(), index, shard, rangeReq.InitialUUID, rangeReq.FinalUUID, rangeReq.Limit)
 		if err != nil {
 			http.Error(w, "digest objects in range: "+err.Error(),
-				http.StatusInternalServerError)
+				asyncCheckpointHTTPStatus(err))
 			return
 		}
 
@@ -731,7 +731,7 @@ func (i *replicatedIndices) putOverwriteObjects() http.Handler {
 		results, err := i.replicator.OverwriteObjects(r.Context(), index, shard, vobjs)
 		if err != nil {
 			http.Error(w, "overwrite objects: "+err.Error(),
-				http.StatusInternalServerError)
+				asyncCheckpointHTTPStatus(err))
 			return
 		}
 
@@ -797,7 +797,7 @@ func (i *replicatedIndices) postCompareDigests() http.Handler {
 
 		stale, err := i.replicator.CompareDigests(r.Context(), index, shard, sourceDigests)
 		if err != nil {
-			http.Error(w, "compare digests: "+err.Error(), http.StatusInternalServerError)
+			http.Error(w, "compare digests: "+err.Error(), asyncCheckpointHTTPStatus(err))
 			return
 		}
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -684,14 +684,16 @@ func (s *Shard) filePutter(ctx context.Context,
 func (idx *Index) OverwriteObjects(ctx context.Context,
 	shard string, updates []*objects.VObject,
 ) ([]types.RepairResponse, error) {
-	s, release, err := idx.GetShard(ctx, shard)
+	// Never load from a repair write: a cold replica is activated by real
+	// traffic, not by async replication or read repair.
+	s, release, err := idx.getLoadedShard(shard)
 	if err != nil {
-		return nil, fmt.Errorf("shard %q not found locally", shard)
+		return nil, fmt.Errorf("shard %q: %w", shard, err)
 	}
 
 	defer release()
 	if s == nil {
-		return nil, fmt.Errorf("shard %q not found locally", shard)
+		return nil, fmt.Errorf("%w: shard %q not loaded on this node", errAsyncReplicationNotActive, shard)
 	}
 
 	if err := idx.ensureShardLocallyReady(s); err != nil {
@@ -1070,13 +1072,14 @@ func (i *Index) IncomingDigestObjectsInRange(ctx context.Context,
 func (i *Index) CompareDigests(ctx context.Context,
 	shardName string, sourceDigests []types.RepairResponse,
 ) ([]types.RepairResponse, error) {
-	shard, release, err := i.GetShard(ctx, shardName)
+	// Never load from async replication's propagation pre-check.
+	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w: shard %q", err, shardName)
 	}
 	defer release()
 	if shard == nil {
-		return nil, fmt.Errorf("shard %q is not yet initialized on this node", shardName)
+		return nil, fmt.Errorf("%w: shard %q not loaded on this node", errAsyncReplicationNotActive, shardName)
 	}
 
 	return shard.CompareDigests(ctx, sourceDigests)

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -859,6 +859,42 @@ func TestReconcileDoesNotForceLoadUnloadedShard(t *testing.T) {
 	require.False(t, lazy.isLoaded(), "reconcile must not force-load an unloaded shard")
 }
 
+// TestRepairEndpointsDoNotForceLoadUnloadedShard: the async-replication data
+// endpoints must return the typed not-ready error for a cold shard, never load it.
+func TestRepairEndpointsDoNotForceLoadUnloadedShard(t *testing.T) {
+	ctx := context.Background()
+	const class = "RepairEndpointsNoForceLoad"
+
+	_, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	setShardReplicas(t, idx, "node1", "node2")
+
+	const lazyName = "lazy-cold-shard-repair"
+	sl, err := idx.initShard(ctx, lazyName, &models.Class{Class: class}, nil, false, false)
+	require.NoError(t, err)
+	lazy, ok := sl.(*LazyLoadShard)
+	require.True(t, ok, "expected a *LazyLoadShard")
+	require.False(t, lazy.isLoaded(), "precondition: shard must start unloaded")
+	idx.shards.Store(lazyName, sl)
+
+	t.Run("OverwriteObjects", func(t *testing.T) {
+		_, err := idx.OverwriteObjects(ctx, lazyName, []*objects.VObject{{}})
+		require.ErrorIs(t, err, errAsyncReplicationNotActive)
+		require.False(t, lazy.isLoaded(), "OverwriteObjects must not force-load an unloaded shard")
+	})
+
+	t.Run("CompareDigests", func(t *testing.T) {
+		_, err := idx.CompareDigests(ctx, lazyName, []routerTypes.RepairResponse{{ID: string(uuidLow)}})
+		require.ErrorIs(t, err, errAsyncReplicationNotActive)
+		require.False(t, lazy.isLoaded(), "CompareDigests must not force-load an unloaded shard")
+	})
+
+	t.Run("DigestObjectsInRange", func(t *testing.T) {
+		_, err := idx.DigestObjectsInRange(ctx, lazyName, uuidLow, uuidHigh, 10)
+		require.ErrorIs(t, err, errAsyncReplicationNotActive)
+		require.False(t, lazy.isLoaded(), "DigestObjectsInRange must not force-load an unloaded shard")
+	})
+}
+
 // TestDBReconcileAsyncReplicationWalksEveryIndex verifies that
 // DB.ReconcileAsyncReplication visits every index (not just the first) and
 // applies the per-shard decision to each one's loaded shards after a runtime


### PR DESCRIPTION
Stacked on #12195 (uses its `getLoadedShard` accessor and typed not-ready client mapping); retarget to the release branch once it merges.

## Motivation

`OverwriteObjects` and `CompareDigests` still reached cold shards through `GetShard`, whose unconditional `preventShutdown()` loads lazy shards even with `ensureInit=false` — the flag only skips shard *creation*. So async replication's propagation pre-check and repair writes (and read repair's overwrites) force-loaded cold tenants, violating the contract that nothing async-replication-related may trigger shard loading.

A second gap surfaced while wiring this: the earlier not-ready mapping for `DigestObjectsInRange` was in effect gRPC-only — the REST handlers for the repair data routes flattened every error to 500, so the typed signal never crossed the REST wire.

## Approach

- `OverwriteObjects` and `CompareDigests` use `getLoadedShard` and return `ErrAsyncReplicationNotActive` for a shard that is not loaded here. `DigestObjectsInRange` already did.
- The REST handlers for overwrite, compare-digests, and digests-in-range map errors through the shared typed-status table (412 for not-ready) instead of a blanket 500; the gRPC service already mapped via `replicationErrorToGRPC`.
- All four async data RPC clients (REST and gRPC) translate 412/503 and `FailedPrecondition`/`Unavailable` back to the retry-later sentinel through shared helpers, so hashbeat classifies a cold peer quietly instead of counting failures.

Deliberately unchanged: `DigestObjects` (read-repair-only — user traffic legitimately activates tenants), `OverwriteObjectsFromChangeLog` (movement replay), the replicated user-write path, and the copier's target-node-override endpoints (replica movement).

## Key areas for review

- `adapters/repos/db/replication.go` — the two accessor swaps; semantics for a cold replica are now "typed error, repaired once real traffic loads it"
- Read-repair impact: the repairer's overwrite against a cold replica now fails typed instead of activating it — verify that matches operational expectations

## Testing

- `TestRepairEndpointsDoNotForceLoadUnloadedShard` pins all three endpoints against a cold `LazyLoadShard`: typed error returned, shard stays unloaded. Red-validated — without the fix the shard force-loads.
- Client-mapping tests on both transports (REST 412 → sentinel for overwrite; gRPC `FailedPrecondition` → sentinel for compare-digests), alongside the existing HashTreeLevel mapping tests that cover the shared helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
