### PR TITLE
fix(hybrid): fetch Boost.Depth-deep candidates in hybrid sub-searches

### DIFF
--- a/usecases/traverser/explorer_boost_test.go
+++ b/usecases/traverser/explorer_boost_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -375,27 +376,39 @@ func Test_Explorer_BoostThenMMR(t *testing.T) {
 	})
 }
 
-// Test_Explorer_BoostDepthUnderMMR: Boost.Depth sets the fetch/rerank pool; the query Limit is the MMR pool.
+// newHybridDepthTestExplorer builds an Explorer configured for the hybrid
+// boost-depth tests below, with QueryHybridMaximumResults deliberately much
+// smaller than the Boost.Depth used in those tests.
+func newHybridDepthTestExplorer(searcher *fakeVectorSearcher) *Explorer {
+	log, _ := test.NewNullLogger()
+	metrics := &fakeMetrics{}
+	metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	conf := config.Config{
+		QueryDefaults:             config.QueryDefaults{Limit: 100},
+		QueryMaximumResults:       10000,
+		QueryHybridMaximumResults: 100,
+	}
+	explorer := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, conf)
+	explorer.SetSchemaGetter(newFakeSchemaGetter("TestClass"))
+	return explorer
+}
+
+// Test_Explorer_HybridBoostDepthBeyondHybridMaximum: a candidate can only be
+// boosted if some leg actually fetched it into the fused pool, so all legs
+// exercised by a hybrid query (vector, keyword/BM25, or both under a mixed
+// Alpha) must fetch Boost.Depth deep, not silently stop at
+// QueryHybridMaximumResults.
 func Test_Explorer_HybridBoostDepthBeyondHybridMaximum(t *testing.T) {
-	t.Run("hybrid legs fetch Boost.Depth deep when it exceeds QueryHybridMaximumResults", func(t *testing.T) {
+	t.Run("vector leg (Alpha=1) fetches Boost.Depth deep when it exceeds QueryHybridMaximumResults", func(t *testing.T) {
 		searcher := &fakeVectorSearcher{}
-		log, _ := test.NewNullLogger()
-		metrics := &fakeMetrics{}
-		metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-		conf := config.Config{
-			QueryDefaults:             config.QueryDefaults{Limit: 100},
-			QueryMaximumResults:       10000,
-			QueryHybridMaximumResults: 100,
-		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, conf)
-		explorer.SetSchemaGetter(newFakeSchemaGetter("TestClass"))
+		explorer := newHybridDepthTestExplorer(searcher)
 
 		var fetchLimit int
 		searcher.On("VectorSearch", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				fetchLimit = args.Get(0).(dto.GetParams).Pagination.Limit
 			}).
-			Return(makeHybridVectorResults(10), nil)
+			Return(makeHybridVectorResults(150), nil)
 
 		params := dto.GetParams{
 			ClassName:    "TestClass",
@@ -414,18 +427,66 @@ func Test_Explorer_HybridBoostDepthBeyondHybridMaximum(t *testing.T) {
 			"hybrid sub-searches must fetch Boost.Depth deep, not stop at QueryHybridMaximumResults")
 	})
 
+	t.Run("keyword/BM25 leg (Alpha=0) fetches Boost.Depth deep when it exceeds QueryHybridMaximumResults", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		explorer := newHybridDepthTestExplorer(searcher)
+
+		var fetchLimit int
+		searcher.sparseObjectSearchFn = func(params dto.GetParams) ([]*storobj.Object, []float32, error) {
+			fetchLimit = params.Pagination.Limit
+			return nil, nil, nil
+		}
+
+		params := dto.GetParams{
+			ClassName:    "TestClass",
+			Pagination:   &filters.Pagination{Offset: 0, Limit: 1},
+			HybridSearch: &searchparams.HybridSearch{Query: "needle", Alpha: 0},
+			Boost:        likesBoost(1.0, 150),
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		// This is the path #12536's own regression check (below) doesn't reach:
+		// the keyword leg computes its own enforced-minimum limit inside
+		// sparseSearch() rather than reusing the vector leg's call site, so a
+		// future change there wouldn't be caught by the Alpha=1 case above.
+		assert.Equal(t, 150, fetchLimit,
+			"the keyword/BM25 leg must also fetch Boost.Depth deep, not stop at QueryHybridMaximumResults")
+	})
+
+	t.Run("mixed Alpha fetches Boost.Depth deep on both legs", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		explorer := newHybridDepthTestExplorer(searcher)
+
+		var vectorFetchLimit, keywordFetchLimit int
+		searcher.On("VectorSearch", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				vectorFetchLimit = args.Get(0).(dto.GetParams).Pagination.Limit
+			}).
+			Return(makeHybridVectorResults(150), nil)
+		searcher.sparseObjectSearchFn = func(params dto.GetParams) ([]*storobj.Object, []float32, error) {
+			keywordFetchLimit = params.Pagination.Limit
+			return nil, nil, nil
+		}
+
+		params := dto.GetParams{
+			ClassName:    "TestClass",
+			Pagination:   &filters.Pagination{Offset: 0, Limit: 1},
+			HybridSearch: &searchparams.HybridSearch{Query: "needle", Alpha: 0.5, Vector: []float32{0.1, 0.2, 0.3}},
+			Boost:        likesBoost(1.0, 150),
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		assert.Equal(t, 150, vectorFetchLimit, "vector leg must fetch Boost.Depth deep under a mixed Alpha")
+		assert.Equal(t, 150, keywordFetchLimit, "keyword leg must fetch Boost.Depth deep under a mixed Alpha")
+	})
+
 	t.Run("without boost, hybrid legs keep the QueryHybridMaximumResults floor", func(t *testing.T) {
 		searcher := &fakeVectorSearcher{}
-		log, _ := test.NewNullLogger()
-		metrics := &fakeMetrics{}
-		metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
-		conf := config.Config{
-			QueryDefaults:             config.QueryDefaults{Limit: 100},
-			QueryMaximumResults:       10000,
-			QueryHybridMaximumResults: 100,
-		}
-		explorer := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, conf)
-		explorer.SetSchemaGetter(newFakeSchemaGetter("TestClass"))
+		explorer := newHybridDepthTestExplorer(searcher)
 
 		var fetchLimit int
 		searcher.On("VectorSearch", mock.Anything, mock.Anything).
@@ -448,6 +509,7 @@ func Test_Explorer_HybridBoostDepthBeyondHybridMaximum(t *testing.T) {
 	})
 }
 
+// Test_Explorer_BoostDepthUnderMMR: Boost.Depth sets the fetch/rerank pool; the query Limit is the MMR pool.
 func Test_Explorer_BoostDepthUnderMMR(t *testing.T) {
 	t.Run("nearVector: Depth deepens fetch/rerank, MMR over top Limit", func(t *testing.T) {
 		searcher := &fakeVectorSearcher{}

--- a/usecases/traverser/explorer_boost_test.go
+++ b/usecases/traverser/explorer_boost_test.go
@@ -376,6 +376,78 @@ func Test_Explorer_BoostThenMMR(t *testing.T) {
 }
 
 // Test_Explorer_BoostDepthUnderMMR: Boost.Depth sets the fetch/rerank pool; the query Limit is the MMR pool.
+func Test_Explorer_HybridBoostDepthBeyondHybridMaximum(t *testing.T) {
+	t.Run("hybrid legs fetch Boost.Depth deep when it exceeds QueryHybridMaximumResults", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		log, _ := test.NewNullLogger()
+		metrics := &fakeMetrics{}
+		metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		conf := config.Config{
+			QueryDefaults:             config.QueryDefaults{Limit: 100},
+			QueryMaximumResults:       10000,
+			QueryHybridMaximumResults: 100,
+		}
+		explorer := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, conf)
+		explorer.SetSchemaGetter(newFakeSchemaGetter("TestClass"))
+
+		var fetchLimit int
+		searcher.On("VectorSearch", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				fetchLimit = args.Get(0).(dto.GetParams).Pagination.Limit
+			}).
+			Return(makeHybridVectorResults(10), nil)
+
+		params := dto.GetParams{
+			ClassName:    "TestClass",
+			Pagination:   &filters.Pagination{Offset: 0, Limit: 1},
+			HybridSearch: &searchparams.HybridSearch{Query: "needle", Alpha: 1, Vector: []float32{0.1, 0.2, 0.3}},
+			Boost:        likesBoost(1.0, 150),
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		// A candidate can only be boosted if a leg fetched it: with depth=150 the
+		// legs must fetch 150, not silently stop at QueryHybridMaximumResults=100
+		// (which would make e.g. a top-boost candidate at BM25 rank 121 unreachable).
+		assert.Equal(t, 150, fetchLimit,
+			"hybrid sub-searches must fetch Boost.Depth deep, not stop at QueryHybridMaximumResults")
+	})
+
+	t.Run("without boost, hybrid legs keep the QueryHybridMaximumResults floor", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		log, _ := test.NewNullLogger()
+		metrics := &fakeMetrics{}
+		metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		conf := config.Config{
+			QueryDefaults:             config.QueryDefaults{Limit: 100},
+			QueryMaximumResults:       10000,
+			QueryHybridMaximumResults: 100,
+		}
+		explorer := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, conf)
+		explorer.SetSchemaGetter(newFakeSchemaGetter("TestClass"))
+
+		var fetchLimit int
+		searcher.On("VectorSearch", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				fetchLimit = args.Get(0).(dto.GetParams).Pagination.Limit
+			}).
+			Return(makeHybridVectorResults(10), nil)
+
+		params := dto.GetParams{
+			ClassName:    "TestClass",
+			Pagination:   &filters.Pagination{Offset: 0, Limit: 1},
+			HybridSearch: &searchparams.HybridSearch{Query: "needle", Alpha: 1, Vector: []float32{0.1, 0.2, 0.3}},
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		assert.Equal(t, 100, fetchLimit,
+			"without boost the legs fetch the QueryHybridMaximumResults floor")
+	})
+}
+
 func Test_Explorer_BoostDepthUnderMMR(t *testing.T) {
 	t.Run("nearVector: Depth deepens fetch/rerank, MMR over top Limit", func(t *testing.T) {
 		searcher := &fakeVectorSearcher{}

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -221,12 +221,16 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		Autocut: params.Pagination.Autocut,
 	}
 
-	// Sub-search sizing should reflect the user's actual limit, not any
-	// boost-inflated overfetch. Boost overfetch only needs to affect how many
-	// fused results Hybrid returns (controlled by origParams.Pagination.Limit).
+	// Sub-search sizing must cover the boost re-rank depth, not just the
+	// user's limit: a candidate can only be re-ranked by boost if some leg
+	// fetched it into the fused pool, so when Boost.Depth exceeds
+	// QueryHybridMaximumResults the legs must fetch Depth-deep (capped at
+	// QueryMaximumResults, like the non-hybrid boost overfetch). Otherwise a
+	// boost.depth beyond the hybrid default is silently truncated and a
+	// high-boost candidate below the cutoff can never be promoted.
 	subSearchLimit := params.Pagination.Limit
 	if params.Boost != nil && params.Boost.OriginalLimit > 0 {
-		subSearchLimit = params.Boost.OriginalLimit
+		subSearchLimit = e.mmrFetchDepth(params.Boost, params.Boost.OriginalOffset+params.Boost.OriginalLimit)
 	}
 	// Under MMR, fetch deep enough to reach the [offset:offset+limit] window (and
 	// Boost.Depth deep when boost is active so it re-ranks that deep).

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -79,6 +79,8 @@ type fakeVectorSearcher struct {
 	diversifyCalledSel               *searchparams.Selection
 	diversifyCalledTarget            string
 	diversifyCalledRelevanceFromDist bool
+
+	sparseObjectSearchFn func(params dto.GetParams) ([]*storobj.Object, []float32, error)
 }
 
 func (f *fakeVectorSearcher) CrossClassVectorSearch(ctx context.Context,
@@ -130,6 +132,9 @@ func (f *fakeVectorSearcher) ObjectsByID(ctx context.Context, id strfmt.UUID,
 func (f *fakeVectorSearcher) SparseObjectSearch(ctx context.Context,
 	params dto.GetParams,
 ) ([]*storobj.Object, []float32, error) {
+	if f.sparseObjectSearchFn != nil {
+		return f.sparseObjectSearchFn(params)
+	}
 	return nil, nil, nil
 }
 


### PR DESCRIPTION
A hybrid query with boost sized its sub-searches by the user's original limit, so both legs fetched at most QueryHybridMaximumResults candidates regardless of boost.depth. A candidate can only be re-ranked by boost if some leg fetched it into the fused pool, so any depth beyond the hybrid default was silently truncated: a top-boost object at primary-search rank 121 could never be promoted, with no error or warning, while the documentation states depth is limited by QueryMaximumResults.

Size the sub-searches by the effective boost fetch depth instead (Depth, defaulted and capped at QueryMaximumResults, at least offset+limit) -- the same depth computation the MMR path already uses. Without boost, sub-search sizing is unchanged.

Fixes #12536

### What's being changed:

usecases/traverser/explorer_hybrid.go: hybrid sub-search sizing now uses the same Boost.Depth-aware computation the MMR path already used, instead of the user's plain limit. usecases/traverser/explorer_boost_test.go: regression coverage for the vector leg (Alpha=1), the keyword/BM25 leg (Alpha=0), and a mixed Alpha, plus the no-boost floor case.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.