### PR TITLE
fix(validation): reject year 0000 in date property values

### DIFF
--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -411,7 +411,11 @@ func boolVal(val interface{}) (bool, error) {
 
 func dateVal(val interface{}) (time.Time, error) {
 	if dateStr, ok := val.(string); ok {
-		if date, err := time.Parse(time.RFC3339, dateStr); err == nil {
+		// time.Parse's fixed-width year field already rejects a negative or
+		// 5+ digit year, but it happily parses the literal digits "0000" as
+		// year 0. RFC 3339 (via ISO 8601 §4.3.2) requires the year to be in
+		// 0001-9999, so year 0000 must be rejected explicitly.
+		if date, err := time.Parse(time.RFC3339, dateStr); err == nil && date.Year() >= 1 {
 			return date, nil
 		}
 	}

--- a/usecases/objects/validation/properties_validation_test.go
+++ b/usecases/objects/validation/properties_validation_test.go
@@ -722,6 +722,27 @@ func TestValidator_ValuesCasting(t *testing.T) {
 				expectedValue: time.Unix(1704164645, 0).UTC(),
 				expectedErr:   false,
 			},
+			{
+				// RFC 3339 / ISO 8601 requires the year to be in 0001-9999;
+				// year 0000 must be rejected even though Go's time.Parse
+				// accepts the literal digits "0000" as year 0.
+				value:         "0000-01-01T00:00:00Z",
+				expectedValue: time.Time{},
+				expectedErr:   true,
+			},
+			{
+				// The lower boundary of the valid range must still be accepted.
+				value:         "0001-01-01T00:00:00Z",
+				expectedValue: time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC),
+				expectedErr:   false,
+			},
+			{
+				// Pre-1970 dates are syntactically valid RFC 3339 and must
+				// still be accepted (only year 0000 is rejected).
+				value:         "1800-06-15T08:30:00Z",
+				expectedValue: time.Date(1800, time.June, 15, 8, 30, 0, 0, time.UTC),
+				expectedErr:   false,
+			},
 
 			{
 				value:         float64(123),


### PR DESCRIPTION
dateVal() accepted any string time.Parse(time.RFC3339, ...) could parse. Go's fixed-width year field already rejects a negative or 5+ digit year, but it happily parses the literal digits "0000" as year 0, so a date property silently stored "0000-01-01T00:00:00Z" with no validation error. RFC 3339 (via ISO 8601 section 4.3.2) requires the year to be in 0001-9999; year 0000 is explicitly invalid.

Reject a successfully-parsed date whose year is less than 1. Pre-1970 dates remain valid, since a negative Unix timestamp is not itself an RFC 3339 violation.

Fixes #11737

### What's being changed:

`usecases/objects/validation/properties_validation.go`: after a date string parses successfully via `time.Parse(time.RFC3339, ...)`, reject it if `.Year() < 1`. Added test cases in `properties_validation_test.go` covering year 0000 (rejected), year 0001 (accepted), and a pre-1970 date (still accepted).

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.