### PR TITLE
Testcontainer endpoint + docstring fixes

### DIFF
--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -305,8 +305,9 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 }
 
 // weaviateNodeIndex resolves the containers-slice position of weaviate node n
-// (1-based) by name, so callers are unaffected by sidecar containers (e.g.
-// MinIO) that may precede the cluster nodes in the slice.
+// (0-based, matching the weaviate-<n> container name) so callers are unaffected
+// by sidecar containers (e.g. MinIO) that may precede the cluster nodes in the
+// slice. Note GetWeaviateNode counts from 1 instead.
 func (d *DockerCompose) weaviateNodeIndex(n int) (int, error) {
 	name := fmt.Sprintf("weaviate-%d", n)
 	for i, c := range d.containers {
@@ -317,7 +318,7 @@ func (d *DockerCompose) weaviateNodeIndex(n int) (int, error) {
 	return -1, fmt.Errorf("weaviate node %d (%q) not found", n, name)
 }
 
-// StopNode stops weaviate node n (1-based).
+// StopNode stops weaviate node n (0-based).
 func (d *DockerCompose) StopNode(ctx context.Context, n int, timeout *time.Duration) error {
 	idx, err := d.weaviateNodeIndex(n)
 	if err != nil {
@@ -326,7 +327,7 @@ func (d *DockerCompose) StopNode(ctx context.Context, n int, timeout *time.Durat
 	return d.StopAt(ctx, idx, timeout)
 }
 
-// StartNode starts weaviate node n (1-based), re-mapping its endpoints.
+// StartNode starts weaviate node n (0-based), re-mapping its endpoints.
 func (d *DockerCompose) StartNode(ctx context.Context, n int) error {
 	idx, err := d.weaviateNodeIndex(n)
 	if err != nil {
@@ -335,7 +336,7 @@ func (d *DockerCompose) StartNode(ctx context.Context, n int) error {
 	return d.StartAt(ctx, idx)
 }
 
-// EnsureRunning starts weaviate node n (1-based) if it is not currently
+// EnsureRunning starts weaviate node n (0-based) if it is not currently
 // running; a no-op when the node is already up.
 func (d *DockerCompose) EnsureRunning(ctx context.Context, n int) error {
 	idx, err := d.weaviateNodeIndex(n)

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -235,18 +235,18 @@ func (d *DockerCompose) StartAt(ctx context.Context, nodeIndex int) error {
 			return fmt.Errorf("failed to get new uri for container %q: %w", c.name, err)
 		}
 		endPoints[name] = endpoint{e.port, newURI}
+	}
+	// Published before the readiness wait: a wait that times out must not leave
+	// callers holding the ports the container had before it was stopped.
+	c.endpoints = endPoints
 
-		// wait until node is ready
-		if name != HTTP {
-			continue
-		}
+	if e, ok := endPoints[HTTP]; ok {
 		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port))
 		if err := waitStrategy.WaitUntilReady(ctx, c.container); err != nil {
 			return fmt.Errorf("StartAt[%s]: readiness check /v1/.well-known/ready failed: %w",
 				c.name, err)
 		}
 	}
-	c.endpoints = endPoints
 	return nil
 }
 
@@ -289,17 +289,18 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 				c.name, e.port, err)
 		}
 		endPoints[name] = endpoint{e.port, newURI}
+	}
+	// Published before the readiness wait: a wait that times out must not leave
+	// callers holding the ports the container had before it was restarted.
+	c.endpoints = endPoints
 
-		if name != HTTP {
-			continue
-		}
+	if e, ok := endPoints[HTTP]; ok {
 		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port))
 		if err := waitStrategy.WaitUntilReady(ctx, c.container); err != nil {
 			return fmt.Errorf("RestartAt[%s]: readiness check /v1/.well-known/ready failed: %w",
 				c.name, err)
 		}
 	}
-	c.endpoints = endPoints
 	return nil
 }
 


### PR DESCRIPTION
### What's being changed:

This PR contains two commits:

1. Endpoints are published before the readiness wait. StartAt/RestartAt re-resolve a container's host ports — Docker hands out fresh ones on every start — then wait on /v1/.well-known/ready. The assignment c.endpoints = endPoints sat after the wait, so a readiness timeout returned with the endpoints still pointing at the pre-stop ports, and nothing re-maps them later: EnsureRunning short-circuits on state.Running, so a node that started but failed readiness keeps dead URIs for the rest of the run. 

2. The node helpers are documented as 0-based. weaviateNodeIndex formats weaviate-%d with n unmodified and containers are named weaviate-0..2, so StopNode/StartNode/EnsureRunning have always been 0-based; the godoc said 1-based. Doc-only — all existing call sites already pass 0-based indices.

The neighbouring GetWeaviateNode genuinely is 1-based (n-1), so the comment now names that asymmetry. (I might fix this in a follow up PR to make them behave the same)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
