### PR TITLE
fix(async-repl): backport #12079 and #12127 to stable/v1.37

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -1269,6 +1269,23 @@ func (sched *AsyncReplicationScheduler) deferDescent(entry *asyncSchedulerEntry)
 	sched.resultCh <- asyncSchedulerResult{entry: entry, deferDescent: true}
 }
 
+// prefilterCtx builds the context for one batched pre-filter. It must abort when
+// the index closes: index.drop() cancels closingCtx etc.
+func (sched *AsyncReplicationScheduler) prefilterCtx(
+	idx *Index, timeout time.Duration,
+) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(sched.ctx, timeout)
+
+	if idx == nil || idx.closingCtx == nil {
+		return ctx, cancel
+	}
+	stop := context.AfterFunc(idx.closingCtx, cancel)
+	return ctx, func() {
+		stop()
+		cancel()
+	}
+}
+
 // classifyBatch runs the root pre-filter, recording confirmed-in-sync entries in
 // scratch.skip; ineligible shards and any failure classify "descend" (conservative).
 func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEntry, scratch *batchScratch) {
@@ -1300,9 +1317,9 @@ func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEnt
 
 	s0 := batch[0].shard
 	cfg := sched.effectiveConfig(s0)
-	ctx, cancel := context.WithTimeout(sched.ctx, cfg.diffPerNodeTimeout)
+	ctx, cancel := sched.prefilterCtx(s0.index, cfg.diffPerNodeTimeout)
 	// defer so the timer is released even if PrefilterShardRoots panics (an inline
-	// cancel() would be skipped, leaking it until sched.ctx is done).
+	// cancel() would be skipped, leaking it until the parent is done).
 	defer cancel()
 	needFull, stats := s0.index.replicator.PrefilterShardRoots(ctx, scratch.roots)
 	sched.metrics.observeRootPrefilterBatch(len(scratch.roots))

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -83,6 +83,21 @@ type asyncSchedulerEntry struct {
 	// is pushed onto the heap. Entries with the same nextRunAt are served in
 	// the order they were enqueued (FIFO within a tie).
 	seq uint64
+	// true while a dispatch's asyncRepWg.Add(1) awaits its Done(); the CAS winner
+	// owns it. Assumes at most one outstanding dispatch per entry.
+	pendingDone atomic.Bool
+}
+
+// tryOwnDone takes ownership of the pending Done(); false when already owned.
+func (e *asyncSchedulerEntry) tryOwnDone() bool {
+	return e.pendingDone.CompareAndSwap(true, false)
+}
+
+// settleDone settles the pending Done() unless a worker already owns the cycle.
+func (e *asyncSchedulerEntry) settleDone() {
+	if e.tryOwnDone() {
+		e.shard.asyncRepWg.Done()
+	}
 }
 
 // asyncSchedulerHeap is a min-heap ordered by nextRunAt with FIFO tie-breaking
@@ -749,7 +764,7 @@ func (sched *AsyncReplicationScheduler) dispatcher() {
 	defer timer.Stop()
 	// Sole drain mechanism for workCh. Workers exit promptly on ctx.Done()
 	// without competing for items; the dispatcher is the only producer so
-	// anything left here on exit gets its Add(1) balanced by Done().
+	// anything left here on exit gets its still-pending Add(1) settled by Done().
 	defer sched.drainWorkChOnExit()
 
 	resetTimer := func() {
@@ -853,7 +868,7 @@ func (sched *AsyncReplicationScheduler) effectiveBatchSize() int {
 // could not be dispatched, re-queuing it with a fresh seq. mu must be held.
 func (sched *AsyncReplicationScheduler) rollbackReservedLocked(entry *asyncSchedulerEntry) {
 	entry.inFlight = false
-	entry.shard.asyncRepWg.Done()
+	entry.settleDone()
 	entry.seq = sched.nextSeq
 	sched.nextSeq++
 	heap.Push(&sched.h, entry)
@@ -912,6 +927,7 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 			// Diverging shard: ship as a standalone singleton so its descent runs on
 			// any free worker. Clear descendDirect only on a successful send.
 			entry.shard.asyncRepWg.Add(1)
+			entry.pendingDone.Store(true)
 			entry.inFlight = true
 			heap.Pop(&sched.h)
 			if sched.trySendBatchLocked([]*asyncSchedulerEntry{entry}) {
@@ -927,6 +943,7 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 
 		// Add(1) before send so Deregister+asyncRepWg.Wait() catches the cycle; pop to advance.
 		entry.shard.asyncRepWg.Add(1)
+		entry.pendingDone.Store(true)
 		entry.inFlight = true
 		heap.Pop(&sched.h)
 
@@ -1044,9 +1061,9 @@ func (sched *AsyncReplicationScheduler) onAddLocked(s *Shard) {
 	sched.metrics.setQueueDepth(len(sched.h))
 }
 
-// onRemoveLocked removes a shard from the registry (and heap if not in-flight).
-// If in-flight, the worker's eventual result will be discarded by onResultLocked
-// (entry no longer in sched.entries). mu must be held.
+// onRemoveLocked removes a shard from the registry/heap and settles Done()s
+// still pending on queued batches so asyncRepWg.Wait() can't be pinned by them;
+// a worker that already owns the cycle keeps its Done(). mu must be held.
 func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 	entry, ok := sched.entries[s]
 	if !ok {
@@ -1054,14 +1071,16 @@ func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 	}
 	delete(sched.entries, s)
 	sched.metrics.decShardsRegistered()
-	if !entry.inFlight {
+	if entry.heapIdx >= 0 {
 		heap.Remove(&sched.h, entry.heapIdx)
 	}
+	entry.settleDone()
+	entry.inFlight = false
 	sched.metrics.setQueueDepth(len(sched.h))
 }
 
-// drainWorkChOnExit empties workCh after the dispatcher returned, balancing each
-// reserved entry's Add(1). Single non-blocking pass suffices (sole producer).
+// drainWorkChOnExit empties workCh after the dispatcher returned, settling each
+// still-unowned Done. Single non-blocking pass suffices (sole producer).
 func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 	for {
 		select {
@@ -1071,7 +1090,7 @@ func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 			}
 			for _, entry := range *bp {
 				entry.inFlight = false
-				entry.shard.asyncRepWg.Done()
+				entry.settleDone()
 			}
 		default:
 			return
@@ -1236,6 +1255,16 @@ func (sched *AsyncReplicationScheduler) runBatch(bp *[]*asyncSchedulerEntry, scr
 		*bp = (*bp)[:0]
 		sched.batchPool.Put(bp)
 	}()
+
+	// Own each entry's Done before touching any shard; already-settled
+	// (deregistered) entries are dropped without a run, Done, or result.
+	kept := batch[:0]
+	for _, entry := range batch {
+		if entry.tryOwnDone() {
+			kept = append(kept, entry)
+		}
+	}
+	batch = kept
 
 	if len(batch) <= 1 {
 		if len(batch) == 1 {

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1875,6 +1875,108 @@ func TestClassifyBatchExcludesIneligible(t *testing.T) {
 	}
 }
 
+// TestPrefilterCtxCancelledByIndexClose pins the deadlock regression: a pre-filter
+// rooted only at sched.ctx outlives index.drop() and blocks every replica.
+func TestPrefilterCtxCancelledByIndexClose(t *testing.T) {
+	newIndex := func() (*Index, context.CancelFunc) {
+		idx := &Index{Config: IndexConfig{ClassName: "C"}}
+		idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
+		return idx, idx.closingCancel
+	}
+
+	tests := []struct {
+		name     string
+		stop     func(sched *AsyncReplicationScheduler, closeIndex context.CancelFunc)
+		wantDone bool
+	}{
+		{
+			name:     "index closes",
+			stop:     func(_ *AsyncReplicationScheduler, closeIndex context.CancelFunc) { closeIndex() },
+			wantDone: true,
+		},
+		{
+			name:     "scheduler shuts down",
+			stop:     func(sched *AsyncReplicationScheduler, _ context.CancelFunc) { sched.cancel() },
+			wantDone: true,
+		},
+		{
+			name:     "nothing stops",
+			stop:     func(*AsyncReplicationScheduler, context.CancelFunc) {},
+			wantDone: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(512, 1)
+			sched.ctx, sched.cancel = context.WithCancel(context.Background())
+			defer sched.cancel()
+
+			idx, closeIndex := newIndex()
+			defer closeIndex()
+			// time.Hour: a done ctx can only mean a stop signal propagated.
+			ctx, cancel := sched.prefilterCtx(idx, time.Hour)
+			defer cancel()
+			require.NoError(t, ctx.Err())
+
+			tc.stop(sched, closeIndex)
+
+			if !tc.wantDone {
+				time.Sleep(50 * time.Millisecond)
+				assert.NoError(t, ctx.Err(), "ctx must stay live while the index is open")
+				return
+			}
+
+			select {
+			case <-ctx.Done():
+				assert.ErrorIs(t, ctx.Err(), context.Canceled)
+			case <-time.After(5 * time.Second):
+				t.Fatal("pre-filter ctx was not cancelled; index.drop() would deadlock the replicas")
+			}
+		})
+	}
+}
+
+func TestPrefilterCtxHonoursTimeout(t *testing.T) {
+	sched := newBareScheduler(512, 1)
+	sched.ctx, sched.cancel = context.WithCancel(context.Background())
+	defer sched.cancel()
+
+	idx := &Index{Config: IndexConfig{ClassName: "C"}}
+	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
+	defer idx.closingCancel()
+
+	ctx, cancel := sched.prefilterCtx(idx, 50*time.Millisecond)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	case <-time.After(5 * time.Second):
+		t.Fatal("pre-filter ctx ignored its timeout")
+	}
+}
+
+// TestPrefilterCtxNilIndex: unit-test shards carry no index.
+func TestPrefilterCtxNilIndex(t *testing.T) {
+	sched := newBareScheduler(512, 1)
+	sched.ctx, sched.cancel = context.WithCancel(context.Background())
+	defer sched.cancel()
+
+	idx := &Index{Config: IndexConfig{ClassName: "C"}}
+
+	ctx, cancel := sched.prefilterCtx(idx, time.Hour)
+	defer cancel()
+	require.NoError(t, ctx.Err())
+
+	sched.cancel()
+	select {
+	case <-ctx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("a nil index must fall back to the scheduler context")
+	}
+}
+
 func TestEffectiveBatchSize(t *testing.T) {
 	t.Run("configured value is used", func(t *testing.T) {
 		sched := newBareScheduler(256, 1)

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -1698,6 +1698,7 @@ func TestRunBatchEmitsOneResultPerEntry(t *testing.T) {
 		s := &Shard{class: &models.Class{Class: "C"}}
 		s.asyncRepWg.Add(1)
 		entries[i] = &asyncSchedulerEntry{shard: s}
+		entries[i].pendingDone.Store(true)
 	}
 
 	sched.runBatch(&entries, newBatchScratch())
@@ -2121,4 +2122,159 @@ func TestDescendDirectSurvivesFullChannel(t *testing.T) {
 	sched.dispatchDueLocked()
 	assert.ElementsMatch(t, []int{1, 1}, drainBatchSizes(sched.workCh),
 		"remaining divergers keep dispatching as singletons")
+}
+
+func awaitAsyncRepWg(t *testing.T, s *Shard, msg string) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { s.asyncRepWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal(msg)
+	}
+}
+
+// TestDeregisterSettlesQueuedDone: deregistration settles a queued batch's pending Done instead of pinning asyncRepWg until Close.
+func TestDeregisterSettlesQueuedDone(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		descendDirect bool
+	}{
+		{name: "bucket dispatch"},
+		{name: "descendDirect dispatch", descendDirect: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(512, 4)
+			sched.ctx = context.Background()
+			sched.resultCh = make(chan asyncSchedulerResult, 8)
+
+			s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+			sched.onAddLocked(s)
+			sched.entries[s].descendDirect = tc.descendDirect
+
+			sched.dispatchDueLocked()
+			batches := drainBatches(sched.workCh)
+			require.Len(t, batches, 1)
+
+			sched.onRemoveLocked(s)
+			awaitAsyncRepWg(t, s, "asyncRepWg must drain once deregistration settles the queued Done")
+
+			sched.runBatch(batches[0], newBatchScratch())
+			assert.Empty(t, drainResults(sched.resultCh), "released entry must not produce a result")
+			s.asyncRepWg.Wait()
+		})
+	}
+}
+
+// TestDrainSkipsSettledDones: Close's drain must not settle a Done that deregistration already settled.
+func TestDrainSkipsSettledDones(t *testing.T) {
+	sched := newBareScheduler(512, 4)
+	sched.ctx = context.Background()
+
+	s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+	sched.onAddLocked(s)
+	sched.dispatchDueLocked()
+
+	sched.onRemoveLocked(s)
+	awaitAsyncRepWg(t, s, "asyncRepWg must drain on deregistration")
+
+	sched.drainWorkChOnExit()
+	s.asyncRepWg.Wait()
+	assert.Empty(t, drainBatches(sched.workCh))
+}
+
+// TestStaleBatchDroppedAfterReRegister: a previous registration's stranded batch is dropped; the new one runs once.
+func TestStaleBatchDroppedAfterReRegister(t *testing.T) {
+	sched := newBareScheduler(512, 4)
+	sched.ctx = context.Background()
+	sched.resultCh = make(chan asyncSchedulerResult, 8)
+
+	s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+	sched.onAddLocked(s)
+	e1 := sched.entries[s]
+	sched.dispatchDueLocked()
+	b1 := drainBatches(sched.workCh)
+	require.Len(t, b1, 1)
+
+	sched.onRemoveLocked(s)
+	awaitAsyncRepWg(t, s, "asyncRepWg must drain on deregistration")
+
+	sched.onAddLocked(s)
+	e2 := sched.entries[s]
+	require.NotSame(t, e1, e2)
+	sched.dispatchDueLocked()
+	b2 := drainBatches(sched.workCh)
+	require.Len(t, b2, 1)
+
+	sched.runBatch(b1[0], newBatchScratch())
+	assert.Empty(t, drainResults(sched.resultCh), "stale batch must be dropped without a result")
+
+	sched.runBatch(b2[0], newBatchScratch())
+	results := drainResults(sched.resultCh)
+	require.Len(t, results, 1)
+	assert.Same(t, e2, results[0].entry)
+	s.asyncRepWg.Wait()
+}
+
+// TestRollbackSettlesPendingDone: full-workCh rollback re-queues the entry with asyncRepWg balanced and no pending Done.
+func TestRollbackSettlesPendingDone(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		descendDirect bool
+	}{
+		{name: "bucket dispatch"},
+		{name: "descendDirect dispatch", descendDirect: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(512, 0)
+			sched.ctx = context.Background()
+
+			s := &Shard{index: &Index{Config: IndexConfig{ClassName: "C"}}, class: &models.Class{Class: "C"}}
+			sched.onAddLocked(s)
+			e := sched.entries[s]
+			e.descendDirect = tc.descendDirect
+
+			sched.dispatchDueLocked()
+
+			assert.False(t, e.inFlight)
+			assert.GreaterOrEqual(t, e.heapIdx, 0, "entry must be re-queued")
+			assert.False(t, e.pendingDone.Load())
+			s.asyncRepWg.Wait()
+		})
+	}
+}
+
+// TestDeregisterDrainsWithSingleWorker: every deregistered shard's asyncRepWg drains before Close despite batches queued behind one worker.
+func TestDeregisterDrainsWithSingleWorker(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	sched, err := NewAsyncReplicationScheduler(context.Background(), replication.GlobalConfig{
+		AsyncReplicationSchedulerWorkers:       configRuntime.NewDynamicValue(1),
+		AsyncReplicationDisabled:               configRuntime.NewDynamicValue(false),
+		AsyncReplicationRootPrefilterBatchSize: configRuntime.NewDynamicValue(3),
+	}, nil, logger)
+	require.NoError(t, err)
+
+	idx := &Index{Config: IndexConfig{ClassName: "MT"}, partitioningEnabled: true}
+	shards := make([]*Shard, 30)
+	for i := range shards {
+		shards[i] = &Shard{index: idx, class: &models.Class{Class: "MT"}, name: fmt.Sprintf("t%02d", i)}
+	}
+
+	var wg sync.WaitGroup
+	for _, s := range shards {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = sched.Register(s)
+			time.Sleep(2 * time.Millisecond)
+			_ = sched.Deregister(s)
+		}()
+	}
+	wg.Wait()
+
+	for _, s := range shards {
+		awaitAsyncRepWg(t, s, "asyncRepWg must drain after Deregister without Close")
+	}
+	sched.Close()
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -265,7 +265,8 @@ type Shard struct {
 	// Done() for hashbeat cycles is called before the result is sent back to
 	// the dispatcher, so the scheduler cannot re-dispatch until Done() fires.
 	// Callers that need a strict happens-before guarantee call asyncRepWg.Wait()
-	// after Deregister to ensure all goroutines have fully exited.
+	// after Deregister; Deregister settles Done()s for batches still queued, so
+	// Wait() only covers cycles that actually started.
 	asyncRepWg sync.WaitGroup
 
 	// asyncRepNeedsRebuild is set by runEntry when the effective hashtree height

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -865,10 +865,19 @@ func (s *Shard) mayStopAsyncReplication() {
 			s.index.logger.WithField("action", "async_replication").Error(err)
 		}
 	}
+	drainStart := time.Now()
 	workersDone := make(chan struct{})
 	enterrors.GoWrapper(func() {
 		defer close(workersDone)
 		s.asyncRepWg.Wait()
+		// Distinguish a late drain from a permanently leaked waiter in goroutine dumps.
+		if elapsed := time.Since(drainStart); elapsed > asyncReplicationWorkerDrainTimeout {
+			s.index.logger.
+				WithField("action", "async_replication").
+				WithField("class_name", s.class.Class).
+				WithField("shard_name", s.name).
+				Warnf("async replication drain completed after deadline (took %s)", elapsed)
+		}
 	}, s.index.logger)
 	select {
 	case <-workersDone:

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -154,6 +154,10 @@ func (s *Shard) MultiObjectRawByID(ctx context.Context, ids []strfmt.UUID) ([][]
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	for i, id := range ids {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 		if err != nil {
 			return nil, err
@@ -181,6 +185,10 @@ func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	for i, q := range query {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
 		idBytes, err := uuid.MustParse(q.ID).MarshalBinary()
 		if err != nil {
 			return nil, err

--- a/adapters/repos/db/shard_read_integration_test.go
+++ b/adapters/repos/db/shard_read_integration_test.go
@@ -1,0 +1,59 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/entities/multi"
+)
+
+// TestShardReadsHonorCtxCancellation: batch read loops must abort on a cancelled ctx.
+func TestShardReadsHonorCtxCancellation(t *testing.T) {
+	ctx := context.Background()
+	_, idx := testShard(t, ctx, "ShardReadCtxCancel")
+	s := firstShard(t, idx)
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	for _, tc := range []struct {
+		name string
+		call func(context.Context) error
+	}{
+		{
+			name: "MultiObjectRawByID",
+			call: func(ctx context.Context) error {
+				_, err := s.MultiObjectRawByID(ctx, []strfmt.UUID{strfmt.UUID(uuid.NewString())})
+				return err
+			},
+		},
+		{
+			name: "ObjectDigests",
+			call: func(ctx context.Context) error {
+				_, err := s.ObjectDigests(ctx, []multi.Identifier{{ID: uuid.NewString()}})
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ErrorIs(t, tc.call(cancelledCtx), context.Canceled)
+		})
+	}
+}


### PR DESCRIPTION
Closes weaviate/0-weaviate-issues#519

### Why 1.37 needs this

On 1.37, deleting a collection blocks the RAFT FSM apply goroutine for 10 seconds per shard. `Store.Apply` runs each raft entry synchronously on hashicorp/raft's single `runFSM` goroutine, and the chain `DeleteClass` → `DB.DeleteIndex` → `Index.drop` → `Shard.drop` → `mayStopAsyncReplication` waits on `asyncRepWg`, bounded by `asyncReplicationWorkerDrainTimeout` (10s). `asyncRepWg.Add(1)` happens at scheduler dispatch, and 1.37's `onRemoveLocked` never settles that pending `Done()`, so a batch still sitting in `workCh` holds the wait for the full timeout. Cancelling the shard context does not release it, because no worker owns the batch yet. While that goroutine is blocked the node applies no raft entries at all, so every schema change on it stops.

This caused ten test failures in [weaviate-e2e-tests run 31350805527](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/31350805527/job/93341279991) on `1.37.14-c041aac`. A fixture deleted 50 collections in sequence; both followers logged 399 drain-deadline warnings, froze schema apply for about 5 minutes and then 1.5 minutes more, and reported `fsmPending` 127 and 128 against raft's `fsmMutateCh` capacity of 128. Full write-up and reproducer in weaviate/0-weaviate-issues#519.

Both fixes have been on `stable/v1.38`, `stable/v1.39` and `main` since July. Branch-sync only carries fixes upward, so 1.37 is the only live branch that still has the bug.

### What's being changed:

- `c9a1bb79a0` — cherry-pick of `f1ba0d093b` (#12079): `prefilterCtx` ties the batched root pre-filter RPC to `index.closingCtx`, so dropping the index cancels an in-flight pre-filter instead of letting it run to `diffPerNodeTimeout`.
- `24955ff00c` — cherry-pick of `3769142842` (#12127): a per-entry CAS flag (`pendingDone`/`tryOwnDone`) makes exactly one of {worker, rollback, deregister, `Close` drain} own each dispatched `Done()`, so `onRemoveLocked` can settle the `Done()`s owed by queued batches without risking a double `Done()`.

Both picked cleanly, no conflicts and no edits on top. I diffed each pick against its upstream commit: the patches are identical apart from hunk offsets and blob hashes. After the picks, `onRemoveLocked`, `prefilterCtx`, `settleDone`, `tryOwnDone`, `runBatch` and `drainWorkChOnExit` match `stable/v1.38` byte for byte.

### Key areas for review

Given the picks are unmodified, the useful review is "does 1.37 have anything the upstream fix assumed away", not the fix design itself (already reviewed in #12079 / #12127):

- `async_replication_scheduler.go:1067` `onRemoveLocked` — the heap guard changed from `!entry.inFlight` to `entry.heapIdx >= 0`. Confirm 1.37 maintains `heapIdx` the same way (it does: same `asyncSchedulerHeap` implementation).
- `async_replication_scheduler.go:1252` `runBatch` — the ownership filter runs before `classifyBatch` and before the singleton fast path, so a deregistered shard is never touched.
- `async_replication_scheduler.go:1303` `prefilterCtx` — depends on `Index.closingCtx` existing and being cancelled by `index.drop()` on 1.37. It is, and the helper nil-checks both the index and the ctx.

### Risks

- **Dropped cycle for a deregistered shard**: a queued batch whose `Done()` was settled by Deregister is skipped instead of run. That only happens for a shard that is shutting down or already removed, where running the cycle was wrong anyway — on 1.37 today a post-timeout worker still runs the cycle against a shut-down shard.
- **Double `Done()` panicking the WaitGroup**: prevented by the CAS; the `Close` drain and the worker both go through `tryOwnDone`. `TestDrainSkipsSettledDones` and `TestRollbackSettlesPendingDone` cover the two paths.
- **Early return from `MultiObjectRawByID` / `ObjectDigests`**: these now return `ctx.Err()` per iteration. Callers already handle an error return; the only new case is aborting a propagation batch whose shard ctx is already cancelled.
- No on-disk format, API, config or RAFT message change, so no upgrade/downgrade or mixed-version concern.

### Verification

Unit tests: the 8 tests that ship with the two commits pass under `-race`, and the full `./adapters/repos/db` unit package passes.

End to end: built an image from this branch and ran the reproducer from weaviate/0-weaviate-issues#519 — a 3-node cluster where one node stops answering replication RPCs on the cluster data port but stays alive in memberlist. Same script and same fault injection across all three builds:

| build | per delete | drain deadlines per follower | follower catch-up |
|---|---|---|---|
| 1.37.14 stock | 10.4s | 18 | 66s |
| this branch | 0.4-0.6s | 0 | 6s |
| 1.39.0 | 0.4s | 0 | 6s |

The fault injection was active in the passing run: node1 logged 6 hung hashbeat RPCs before the deletes started.

### Out of scope

`DB.DeleteIndex` write-holds `db.indexLock` across the whole `index.drop()` on both `stable/v1.37` and `stable/v1.38`; only 1.39 narrowed it to the map mutation. That is a separate stall and is tracked in weaviate/0-weaviate-issues#519, not fixed here.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary, no API or behaviour change beyond the fix
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary — unmodified cherry-picks of commits that have been on `stable/v1.38` since July, plus the reproducer run above
- [x] All new code is covered by tests where it is reasonable. Both commits bring their own tests
- [x] Performance tests have been run or not necessary. Not necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
