### PR TITLE
fix(backup): serve a failed backup's reason from the participant status

### DIFF
--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -267,16 +267,24 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		//  release indexes under all conditions
 		u.releaseIndexes(classes, desc.ID)
 
-		//  make sure context is not cancelled when uploading metadata
-		ctx := context.Background()
+		//  make sure context is not cancelled when uploading metadata. Its own
+		//  name, so the cancellation check below still reads the operation's
+		//  context rather than this one, which can never be cancelled.
+		metaCtx := context.Background()
 
 		// Handle success case first
 		if err == nil {
 			u.log.Info("start uploading metadata")
-			if err = u.backend.PutMeta(ctx, desc, overrideBucket, overridePath); err != nil {
+			if err = u.backend.PutMeta(metaCtx, desc, overrideBucket, overridePath); err != nil {
+				// Nothing to restore from without the descriptor, so this ends
+				// as a failure. Publishing SUCCESS here would have the
+				// coordinator count the node done and report a backup that
+				// cannot be restored as good.
 				desc.Status = backup.Transferred
+				u.slot.setFailed(publishableErrMsg(err))
+			} else {
+				u.slot.set(backup.Success)
 			}
-			u.slot.set(backup.Success)
 			u.log.Info("finish uploading metadata")
 			return
 		}
@@ -284,24 +292,26 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		desc.Error = publishableErrMsg(err)
 
 		// Handle error cases
-		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		cancelled := errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+		if cancelled {
 			u.slot.set(backup.Cancelled)
 			desc.Status = backup.Cancelled
 		} else {
+			desc.Status = backup.Failed
 			monitoring.GetBackgroundProcessMetrics().Failed(monitoring.ProcessBackup)
 		}
 
 		u.log.Info("start uploading metadata for cancelled or failed backup")
-		if metaErr := u.backend.PutMeta(ctx, desc, overrideBucket, overridePath); metaErr != nil {
+		if metaErr := u.backend.PutMeta(metaCtx, desc, overrideBucket, overridePath); metaErr != nil {
 			// combine errors for shadowing the original error in case
 			// of putMeta failure
 			err = fmt.Errorf("upload %w: %w", err, metaErr)
 		}
-		// After the meta write either way, since it's the operation that may
-		// have just failed and the reason must survive it. err is published
-		// rather than desc.Error, which was fixed before the write and so says
-		// nothing when the write is what failed.
-		if desc.Status != backup.Cancelled {
+		// After the meta write, which has to carry the reason by the time a
+		// poll can see FAILED. err is published rather than desc.Error, which
+		// was fixed before the write and so says nothing when the write is
+		// what failed.
+		if !cancelled {
 			u.slot.setFailed(publishableErrMsg(err))
 		}
 		u.log.Info("finish uploading metadata for cancelled or failed backup")

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -281,7 +281,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 				// coordinator count the node done and report a backup that
 				// cannot be restored as good.
 				desc.Status = backup.Transferred
-				u.slot.setFailed(publishableErrMsg(err))
+				u.slot.setFailed(err.Error())
 			} else {
 				u.slot.set(backup.Success)
 			}
@@ -289,7 +289,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 			return
 		}
 
-		desc.Error = publishableErrMsg(err)
+		desc.Error = nonEmptyErrMsg(err)
 
 		// Handle error cases
 		cancelled := errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
@@ -312,7 +312,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		// was fixed before the write and so says nothing when the write is
 		// what failed.
 		if !cancelled {
-			u.slot.setFailed(publishableErrMsg(err))
+			u.slot.setFailed(err.Error())
 		}
 		u.log.Info("finish uploading metadata for cancelled or failed backup")
 	}()
@@ -386,15 +386,13 @@ Loop:
 	return nil
 }
 
-// publishableErrMsg is the failure text safe to serve from the status API.
-func publishableErrMsg(err error) string {
-	msg := err.Error()
-	if msg == "" {
-		// A failure published with no text at all reads as no failure; say at
-		// least that there was one.
-		return "backup failed without a reported reason"
+// nonEmptyErrMsg is err's text, or a stand-in when it has none. The failure
+// text is served verbatim from the status API, backend messages and all.
+func nonEmptyErrMsg(err error) string {
+	if msg := err.Error(); msg != "" {
+		return msg
 	}
-	return msg
+	return failureWithoutReason
 }
 
 func (u *uploader) releaseIndexes(classes []string, bakID string) {

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -281,7 +281,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 			return
 		}
 
-		desc.Error = err.Error()
+		desc.Error = publishableErrMsg(err)
 
 		// Handle error cases
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
@@ -297,12 +297,14 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 			// of putMeta failure
 			err = fmt.Errorf("upload %w: %w", err, metaErr)
 		}
-		u.log.Info("finish uploading metadata for cancelled or failed backup")
-		// After the meta write, since the reason has to be readable from the
-		// descriptor by the time a poll can see FAILED.
+		// After the meta write either way, since it's the operation that may
+		// have just failed and the reason must survive it. err is published
+		// rather than desc.Error, which was fixed before the write and so says
+		// nothing when the write is what failed.
 		if desc.Status != backup.Cancelled {
-			u.slot.setFailed(desc.Error)
+			u.slot.setFailed(publishableErrMsg(err))
 		}
+		u.log.Info("finish uploading metadata for cancelled or failed backup")
 	}()
 
 	contextChecker := func(ctx context.Context) error {
@@ -372,6 +374,17 @@ Loop:
 	// After all classes, set desc.PreCompressionSizeBytes as the sum of all class sizes
 	desc.PreCompressionSizeBytes = totalPreCompressionSize
 	return nil
+}
+
+// publishableErrMsg is the failure text safe to serve from the status API.
+func publishableErrMsg(err error) string {
+	msg := err.Error()
+	if msg == "" {
+		// A failure published with no text at all reads as no failure; say at
+		// least that there was one.
+		return "backup failed without a reported reason"
+	}
+	return msg
 }
 
 func (u *uploader) releaseIndexes(classes []string, bakID string) {

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -214,12 +214,22 @@ type uploader struct {
 	backend  nodeStore
 	backupID string
 	zipConfig
-	setStatus func(st backup.Status)
-	log       logrus.FieldLogger
+	// slot is the node's own operation slot, which is what a status poll reads
+	// until the descriptor is written to the backend.
+	slot statusPublisher
+	log  logrus.FieldLogger
+}
+
+// statusPublisher is the observable half of a node's operation slot. Failing
+// goes through its own method so a failure can never be published without the
+// reason that belongs to it; see [backupStat.setFailed].
+type statusPublisher interface {
+	set(st backup.Status)
+	setFailed(reason string)
 }
 
 func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer RBACSnapshotter, dynUserSourcer dynUserSnapshotter, users, roles []string, backend nodeStore,
-	backupID string, setstatus func(st backup.Status), l logrus.FieldLogger,
+	backupID string, slot statusPublisher, l logrus.FieldLogger,
 ) *uploader {
 	return &uploader{
 		cfg:            cfg,
@@ -234,8 +244,8 @@ func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer RBACSnapshotter
 			Level:         GzipDefaultCompression,
 			CPUPercentage: DefaultCPUPercentage,
 		}),
-		setStatus: setstatus,
-		log:       l,
+		slot: slot,
+		log:  l,
 	}
 }
 
@@ -246,7 +256,7 @@ func (u *uploader) withCompression(cfg zipConfig) *uploader {
 
 // all uploads all files in addition to the metadata file
 func (u *uploader) all(ctx context.Context, classes []string, desc *backup.BackupDescriptor, baseDescr []*backup.BackupDescriptor, overrideBucket, overridePath string) (err error) {
-	u.setStatus(backup.Transferring)
+	u.slot.set(backup.Transferring)
 	desc.Status = backup.Transferring
 	ch := u.sourcer.BackupDescriptors(ctx, desc.ID, classes, baseDescr)
 	var totalPreCompressionSize int64 // Track total pre-compression bytes
@@ -266,7 +276,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 			if err = u.backend.PutMeta(ctx, desc, overrideBucket, overridePath); err != nil {
 				desc.Status = backup.Transferred
 			}
-			u.setStatus(backup.Success)
+			u.slot.set(backup.Success)
 			u.log.Info("finish uploading metadata")
 			return
 		}
@@ -275,7 +285,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 
 		// Handle error cases
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			u.setStatus(backup.Cancelled)
+			u.slot.set(backup.Cancelled)
 			desc.Status = backup.Cancelled
 		} else {
 			monitoring.GetBackgroundProcessMetrics().Failed(monitoring.ProcessBackup)
@@ -288,12 +298,17 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 			err = fmt.Errorf("upload %w: %w", err, metaErr)
 		}
 		u.log.Info("finish uploading metadata for cancelled or failed backup")
+		// After the meta write, since the reason has to be readable from the
+		// descriptor by the time a poll can see FAILED.
+		if desc.Status != backup.Cancelled {
+			u.slot.setFailed(desc.Error)
+		}
 	}()
 
 	contextChecker := func(ctx context.Context) error {
 		ctxerr := ctx.Err()
 		if ctxerr != nil {
-			u.setStatus(backup.Cancelled)
+			u.slot.set(backup.Cancelled)
 			desc.Status = backup.Cancelled
 			u.releaseIndexes(classes, desc.ID)
 		}
@@ -352,7 +367,7 @@ Loop:
 		return fmt.Errorf("includeUsers requested but DB Users are not enabled")
 	}
 
-	u.setStatus(backup.Transferred)
+	u.slot.set(backup.Transferred)
 	desc.Status = backup.Success
 	// After all classes, set desc.PreCompressionSizeBytes as the sum of all class sizes
 	desc.PreCompressionSizeBytes = totalPreCompressionSize

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -93,7 +93,7 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqState,
 // only that its metadata is missing.
 func (b *backupper) publishFailure(err error) {
 	b.lastAsyncError = err
-	b.lastOp.setFailed(publishableErrMsg(err))
+	b.lastOp.setFailed(err.Error())
 }
 
 // backup checks if the node is ready to back up (can commit phase)

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -57,6 +57,12 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqState,
 		return st, nil // st contains path, which is the homedir, a combination of bucket and path
 	}
 
+	// Before the backend, because the backend has nothing to say about the
+	// failure remembered here.
+	if reason, ok := b.lastOp.rememberedFailure(req.ID); ok {
+		return reqState{ID: req.ID, Status: backup.Failed, Err: reason}, nil
+	}
+
 	// The backup might have been already created.
 	store, err := nodeBackend(b.node, b.backends, req.Backend, req.ID, req.Bucket, req.Path)
 	if err != nil {

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -57,12 +57,6 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqState,
 		return st, nil // st contains path, which is the homedir, a combination of bucket and path
 	}
 
-	// Before the backend, because the backend has nothing to say about the
-	// failure remembered here.
-	if reason, ok := b.lastOp.rememberedFailure(req.ID); ok {
-		return reqState{ID: req.ID, Status: backup.Failed, Err: reason}, nil
-	}
-
 	// The backup might have been already created.
 	store, err := nodeBackend(b.node, b.backends, req.Backend, req.ID, req.Bucket, req.Path)
 	if err != nil {
@@ -71,6 +65,13 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqState,
 
 	meta, err := store.Meta(ctx, req.ID, store.bucket, store.path)
 	if err != nil {
+		// Only once the descriptor turns out to have nothing to say. It is the
+		// durable record of the operation; the remembered failure covers the
+		// single case that leaves none, which is a descriptor that was never
+		// written.
+		if reason, ok := b.lastOp.rememberedFailure(req.ID); ok {
+			return reqState{ID: req.ID, Status: backup.Failed, Err: reason}, nil
+		}
 		path := fmt.Sprintf("%s/%s", req.ID, BackupFile)
 		return reqState{}, fmt.Errorf("cannot get status while backing up: %w: %q: %w", errMetaNotFound, path, err)
 	}
@@ -84,6 +85,15 @@ func (b *backupper) OnStatus(ctx context.Context, req *StatusRequest) (reqState,
 		Path:      store.HomeDir(store.bucket, store.path),
 		Status:    backup.Status(meta.Status),
 	}, nil
+}
+
+// publishFailure ends the operation on the slot with its reason. The paths that
+// fail before any descriptor is written have nowhere else to leave one, so
+// without this the operator polls a backup that failed minutes ago and is told
+// only that its metadata is missing.
+func (b *backupper) publishFailure(err error) {
+	b.lastAsyncError = err
+	b.lastOp.setFailed(publishableErrMsg(err))
 }
 
 // backup checks if the node is ready to back up (can commit phase)
@@ -115,7 +125,7 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		if err := b.waitForCoordinator(expiration, id); err != nil {
 			b.logger.WithField("action", "create_backup").
 				Error(err)
-			b.lastAsyncError = err
+			b.publishFailure(err)
 			return
 		}
 
@@ -125,7 +135,7 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		compressionType, err := CompressionTypeFromLevel(req.Level)
 		if err != nil {
 			b.logger.WithField("action", "create_backup").Error(err)
-			b.lastAsyncError = err
+			b.publishFailure(err)
 			return
 		}
 
@@ -141,7 +151,7 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 		if err != nil {
 			if !errors.As(err, &backup.ErrNotFound{}) {
 				b.logger.WithFields(logFields).Error(err)
-				b.lastAsyncError = err
+				b.publishFailure(err)
 				return
 			}
 			// This node was absent from the base backup (it joined the cluster

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -113,7 +113,7 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 			return
 		}
 
-		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, req.Users, req.Roles, store, req.ID, b.lastOp.set, b.logger).
+		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, req.Users, req.Roles, store, req.ID, &b.lastOp, b.logger).
 			withCompression(newZipConfig(req.Compression))
 
 		compressionType, err := CompressionTypeFromLevel(req.Level)

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -487,7 +487,21 @@ func (c *coordinator) OnStatus(ctx context.Context, store coordStore, req *Statu
 		Size:         float64(meta.PreCompressionSizeBytes) / (1024 * 1024 * 1024), // Convert bytes to GiB,
 		BaseBackupID: meta.BaseBackupID,
 	}
+	if reason, ok := c.lastOp.rememberedFailure(req.ID); ok && !isFinalStatus(meta.Status) {
+		// The operation ended failed and writing that outcome to the backend
+		// is what failed, so the descriptor still reads as in progress. Serving
+		// it would report a failed backup as running for as long as this node
+		// is up.
+		status.Status = backup.Failed
+		status.Err = reason
+	}
 	return status, nil
+}
+
+// isFinalStatus reports whether a stored descriptor status is the operation's
+// last word, and so must not be second-guessed from memory.
+func isFinalStatus(st backup.Status) bool {
+	return st == backup.Success || st == backup.Failed || st == backup.Cancelled
 }
 
 // canCommitErrFromResponse promotes a refused [CanCommitResponse] into a

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -375,7 +375,7 @@ func (c *coordinator) Restore(
 				c.descriptor.Status = backup.Success
 			}
 		}
-		c.lastOp.set(c.descriptor.Status)
+		c.publishStatus()
 
 		// Note: No need to check for cancellation after schema apply.
 		// CancelRestore rejects requests when status is Finalizing (see scheduler.go),
@@ -461,7 +461,7 @@ func (c *coordinator) OnStatus(ctx context.Context, store coordStore, req *Statu
 	// check if backup is still active
 	st := c.lastOp.get()
 	if st.ID == req.ID {
-		return &Status{Path: st.Path, StartedAt: st.Starttime, Status: st.Status}, nil
+		return &Status{Path: st.Path, StartedAt: st.Starttime, Status: st.Status, Err: st.Err}, nil
 	}
 	filename := GlobalBackupFile
 	if req.Method == OpRestore {
@@ -723,9 +723,20 @@ func (c *coordinator) commit(ctx context.Context,
 			reason = "restore canceled by user"
 		}
 	}
-	c.lastOp.set(c.descriptor.Status)
 	c.descriptor.Error = reason
+	c.publishStatus()
 	c.descriptor.PreCompressionSizeBytes = totalPreCompressionSize
+}
+
+// publishStatus mirrors the descriptor's outcome on the slot, which is what a
+// poll reads until the descriptor is written to object storage. A failure goes
+// through setFailed so it is never published without the reason next to it.
+func (c *coordinator) publishStatus() {
+	if c.descriptor.Status == backup.Failed {
+		c.lastOp.setFailed(c.descriptor.Error)
+		return
+	}
+	c.lastOp.set(c.descriptor.Status)
 }
 
 // queryAll queries all participant and store their statuses internally

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -130,6 +130,11 @@ func (fb *fakeBackend) PutObject(ctx context.Context, backupID, key, overrideBuc
 	fb.Lock()
 	defer fb.Unlock()
 	args := fb.Called(ctx, backupID, key, bytes)
+	if args.Error(0) != nil {
+		// A write that fails leaves the previous object in place, which is the
+		// whole point of the tests that make one fail.
+		return args.Error(0)
+	}
 	switch key {
 	case BackupFile:
 		json.Unmarshal(bytes, &fb.meta)

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -380,8 +380,6 @@ func (m *Handler) OnStatus(ctx context.Context, req *StatusRequest) *StatusRespo
 		if err != nil {
 			ret.Status = backup.Failed
 			ret.Err = err.Error()
-		} else if st.Err != "" {
-			ret.Err = st.Err
 		}
 	default:
 		ret.Status = backup.Failed

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -368,7 +368,7 @@ func (m *Handler) OnStatus(ctx context.Context, req *StatusRequest) *StatusRespo
 	case OpCreate:
 		st, err := m.backupper.OnStatus(ctx, req)
 		ret.Status = st.Status
-		// mm
+		ret.Err = st.Err
 		if err != nil {
 			ret.Status = backup.Failed
 			ret.Err = err.Error()

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package backup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/backup"
+)
+
+// The coordinator latches the first terminal answer a participant gives and
+// stops polling it, so a reason dropped here is the permanent answer the
+// operator gets: FAILED with nothing to act on.
+func TestHandlerOnStatusServesTheReasonFromTheOperationSlot(t *testing.T) {
+	const backupID = "1"
+
+	cases := []struct {
+		name       string
+		stamp      func(s *backupStat)
+		wantStatus backup.Status
+		wantErr    string
+	}{
+		{
+			name:       "failure carries its reason",
+			stamp:      func(s *backupStat) { s.setFailed("object storage unreachable") },
+			wantStatus: backup.Failed,
+			wantErr:    "object storage unreachable",
+		},
+		{
+			name:       "a running operation has no reason to carry",
+			stamp:      func(s *backupStat) { s.set(backup.Transferring) },
+			wantStatus: backup.Transferring,
+			wantErr:    "",
+		},
+		{
+			name: "a cancelled slot keeps its status and reports no failure",
+			stamp: func(s *backupStat) {
+				s.set(backup.Cancelled)
+				s.setFailed("late failure that must not overwrite the cancellation")
+			},
+			wantStatus: backup.Cancelled,
+			wantErr:    "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bp := &backupper{}
+			require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
+			tc.stamp(&bp.lastOp)
+
+			res := (&Handler{backupper: bp}).OnStatus(context.Background(),
+				&StatusRequest{Method: OpCreate, ID: backupID})
+
+			require.Equal(t, tc.wantStatus, res.Status)
+			require.Equal(t, tc.wantErr, res.Err,
+				"the reason on the slot is the only one a poll can read before the descriptor is written")
+		})
+	}
+}
+
+// renew hands the slot to a new operation, so a reason left by the previous one
+// must not be served as this one's.
+func TestBackupStatRenewClearsThePreviousFailure(t *testing.T) {
+	var s backupStat
+
+	require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+	s.setFailed("object storage unreachable")
+	s.reset()
+
+	require.Empty(t, s.renew("2", "bucket/backups/2", "", ""))
+	require.Empty(t, s.get().Err)
+}

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -45,12 +45,6 @@ func TestHandlerOnStatusServesTheReasonFromTheOperationSlot(t *testing.T) {
 			wantErr:    "object storage unreachable",
 		},
 		{
-			name:       "a running operation has no reason to carry",
-			stamp:      func(s *backupStat) { s.set(backup.Transferring) },
-			wantStatus: backup.Transferring,
-			wantErr:    "",
-		},
-		{
 			name: "a cancelled slot keeps its status and reports no failure",
 			stamp: func(s *backupStat) {
 				s.set(backup.Cancelled)
@@ -93,15 +87,19 @@ func TestBackupStatDropsAReasonThatNoLongerApplies(t *testing.T) {
 		require.Empty(t, s.get().Err)
 	})
 
-	t.Run("renew drops it", func(t *testing.T) {
-		// A free slot (empty ID) is the only one renew takes, so it is stamped
-		// directly here rather than through a failure the slot still owns.
+	// A restore whose commit failed is then found cancelled in object storage,
+	// and the slot moves to Cancelled a moment after the failure was published
+	// on it.
+	t.Run("a later status drops it", func(t *testing.T) {
 		var s backupStat
-		s.Err = reason
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.setFailed(reason)
 
-		require.Empty(t, s.renew("2", "bucket/backups/2", "", ""))
+		s.set(backup.Cancelled)
 
-		require.Empty(t, s.get().Err)
+		got := s.get()
+		require.Equal(t, backup.Cancelled, got.Status)
+		require.Empty(t, got.Err, "a cancellation must not be served with a failure's reason")
 	})
 }
 
@@ -219,6 +217,8 @@ func TestHandlerOnStatusServesTheReasonAFailedUploadPublished(t *testing.T) {
 			require.Equal(t, backup.Failed, res.Status)
 			require.Equal(t, backup.Failed, desc.Status,
 				"the persisted descriptor must not claim the backup was still transferring")
+			require.NotEmpty(t, desc.Error,
+				"the descriptor is what a poll reads once the slot is gone, so it has to state the failure too")
 			for _, want := range tc.wantIn {
 				require.Contains(t, res.Err, want)
 			}
@@ -435,7 +435,6 @@ func TestHandlerOnStatusServesTheReasonACreateFailedWithBeforeUploading(t *testi
 		require.NoError(t, err)
 		return b
 	}
-	gzip := backup.CompressionGZIP
 	zstd := backup.CompressionZSTD
 
 	cases := []struct {
@@ -467,17 +466,6 @@ func TestHandlerOnStatusServesTheReasonACreateFailedWithBeforeUploading(t *testi
 				StartedAt: time.Now().Add(-time.Hour),
 			}),
 			wantIn: `has compression type "zstd", expected "gzip"`,
-		},
-		{
-			name:   "the base backup chain points back at itself",
-			commit: true,
-			level:  GzipDefaultCompression,
-			baseID: baseID,
-			baseMeta: base(backup.BackupDescriptor{
-				ID: baseID, Status: backup.Success, CompressionType: &gzip,
-				StartedAt: time.Now().Add(-time.Hour), BaseBackupID: baseID,
-			}),
-			wantIn: "circular references in backup ids detected",
 		},
 	}
 
@@ -566,52 +554,209 @@ func TestCoordinatorOnStatusServesTheReasonBeforeTheGlobalDescriptorIsWritten(t 
 	const (
 		backupID    = "coordinated"
 		backendName = "s3"
+	)
+	ctx := context.Background()
+
+	cases := []struct {
+		name           string
+		participantErr string
+		wantErr        string
+	}{
+		{
+			name:           "the participant's reason is what the poll gets",
+			participantErr: "no space left on device",
+			wantErr:        "no space left on device",
+		},
+		{
+			// A node still running a pre-fix build, which every participant is
+			// for the length of a rolling upgrade.
+			name:           "a participant that reports no reason still ends as a stated failure",
+			participantErr: "",
+			wantErr:        failureWithoutReason,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFakeCoordinator(newFakeNodeResolver([]string{"N1"}))
+			c := fc.coordinator()
+			c.timeoutNextRound = time.Millisecond
+			c.descriptor = &backup.DistributedBackupDescriptor{
+				ID:          backupID,
+				NodeMapping: map[string]string{},
+				Nodes:       map[string]*backup.NodeDescriptor{"N1": {Classes: []string{"Article"}}},
+			}
+			c.Participants["N1"] = participantStatus{Status: backup.Transferring, LastTime: time.Now()}
+			require.Empty(t, c.lastOp.renew(backupID, "bucket/backups/"+backupID, "", ""))
+
+			fc.client.On("Commit", mock.Anything, "N1", mock.Anything).Return(nil)
+			fc.client.On("Status", mock.Anything, "N1", mock.Anything).Return(&StatusResponse{
+				Status: backup.Failed, Err: tc.participantErr, ID: backupID, Method: OpCreate,
+			}, nil)
+			fc.client.On("Abort", mock.Anything, "N1", mock.Anything).Return(nil)
+
+			req := &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName}
+			c.commit(ctx, req, map[string]string{"N1": "N1"}, false)
+
+			st, err := c.OnStatus(ctx, coordStore{}, req)
+
+			require.NoError(t, err)
+			require.Equal(t, backup.Failed, st.Status)
+			require.Equal(t, tc.wantErr, st.Err,
+				"the descriptor is not on the backend yet, so the slot is the only answer")
+		})
+	}
+}
+
+// The create goroutine publishes the outcome on the slot, writes the global
+// descriptor, and releases the slot. When that write is what fails, the
+// descriptor left on the backend is the one from before the operation ended,
+// and every later poll of GET /backups/{backend}/{id} reads it: a failed backup
+// reporting STARTED for as long as the node is up.
+func TestCoordinatorOnStatusServesTheFailureTheGlobalDescriptorNeverGot(t *testing.T) {
+	const (
+		backupID    = "meta-write-failed"
+		backendName = "s3"
+		class       = "Article"
+		node        = "N1"
 		reason      = "no space left on device"
 	)
 	ctx := context.Background()
 
-	fc := newFakeCoordinator(newFakeNodeResolver([]string{"N1"}))
-	c := fc.coordinator()
-	c.timeoutNextRound = time.Millisecond
-	c.descriptor = &backup.DistributedBackupDescriptor{
-		ID:          backupID,
-		NodeMapping: map[string]string{},
-		Nodes:       map[string]*backup.NodeDescriptor{"N1": {Classes: []string{"Article"}}},
-	}
-	c.Participants["N1"] = participantStatus{Status: backup.Transferring, LastTime: time.Now()}
-	require.Empty(t, c.lastOp.renew(backupID, "bucket/backups/"+backupID, "", ""))
-
-	fc.client.On("Commit", mock.Anything, "N1", mock.Anything).Return(nil)
-	fc.client.On("Status", mock.Anything, "N1", mock.Anything).Return(&StatusResponse{
+	fc := newFakeCoordinator(newFakeNodeResolver([]string{node}))
+	fc.selector.On("Shards", ctx, class).Return([]string{node}, nil)
+	fc.client.On("CanCommit", mock.Anything, node, mock.Anything).
+		Return(&CanCommitResponse{Method: OpCreate, ID: backupID, Timeout: 1}, nil)
+	fc.client.On("Commit", mock.Anything, node, mock.Anything).Return(nil)
+	fc.client.On("Status", mock.Anything, node, mock.Anything).Return(&StatusResponse{
 		Status: backup.Failed, Err: reason, ID: backupID, Method: OpCreate,
 	}, nil)
-	fc.client.On("Abort", mock.Anything, "N1", mock.Anything).Return(nil)
+	fc.client.On("Abort", mock.Anything, node, mock.Anything).Return(nil)
+	fc.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("bucket/" + backupID)
+	// The initial descriptor lands, the one carrying the outcome does not.
+	fc.backend.On("PutObject", mock.Anything, backupID, GlobalBackupFile, mock.Anything).Return(nil).Once()
+	fc.backend.On("PutObject", mock.Anything, backupID, GlobalBackupFile, mock.Anything).Return(ErrAny)
+	fc.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).
+		Return(marshalCoordinatorMeta(backup.DistributedBackupDescriptor{
+			ID: backupID, Status: backup.Started,
+		}), nil)
 
-	req := &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName}
-	c.commit(ctx, req, map[string]string{"N1": "N1"}, false)
+	c := fc.coordinator()
+	c.timeoutNextRound = time.Millisecond
+	req := newReq([]string{class}, backendName, backupID)
+	store := coordStore{objectStore{fc.backend, backupID, "", "", ""}}
+	require.NoError(t, c.Backup(ctx, store, &req))
 
-	st, err := c.OnStatus(ctx, coordStore{}, req)
+	require.Eventually(t, func() bool { return c.lastOp.get().ID == "" },
+		10*time.Second, 5*time.Millisecond, "the create goroutine never released the slot")
+
+	st, err := c.OnStatus(ctx, store, &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName})
+
+	require.NoError(t, err)
+	require.Equal(t, backup.Failed, st.Status,
+		"a backup that failed must not report STARTED once its goroutine is gone")
+	require.Equal(t, reason, st.Err)
+}
+
+// Same hole on the restore side, where the descriptor left behind is the one
+// written when staging began.
+func TestCoordinatorOnStatusServesTheFailureTheGlobalRestoreDescriptorNeverGot(t *testing.T) {
+	const (
+		backupID    = "restore-meta-write-failed"
+		backendName = "s3"
+		class       = "Article"
+		node        = "N1"
+		reason      = "restore class Article: schema apply rejected"
+	)
+	ctx := context.Background()
+
+	fc := newFakeCoordinator(newFakeNodeResolver([]string{node}))
+	fc.client.On("CanCommit", mock.Anything, node, mock.Anything).
+		Return(&CanCommitResponse{Method: OpRestore, ID: backupID, Timeout: 1}, nil)
+	fc.client.On("Commit", mock.Anything, node, mock.Anything).Return(nil)
+	fc.client.On("Status", mock.Anything, node, mock.Anything).Return(&StatusResponse{
+		Status: backup.Failed, Err: reason, ID: backupID, Method: OpRestore,
+	}, nil)
+	fc.client.On("Abort", mock.Anything, node, mock.Anything).Return(nil)
+	fc.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("bucket/" + backupID)
+	// Nothing to cancel yet, and after that the fake serves what was last
+	// written.
+	fc.backend.On("GetObject", mock.Anything, backupID, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
+	// The descriptor written when staging began lands, the one carrying the
+	// outcome does not.
+	fc.backend.On("PutObject", mock.Anything, backupID, GlobalRestoreFile, mock.Anything).Return(nil).Once()
+	fc.backend.On("PutObject", mock.Anything, backupID, GlobalRestoreFile, mock.Anything).Return(ErrAny)
+
+	c := fc.coordinator()
+	c.timeoutNextRound = time.Millisecond
+	req := newReq([]string{class}, backendName, backupID)
+	desc := &backup.DistributedBackupDescriptor{
+		ID:          backupID,
+		Nodes:       map[string]*backup.NodeDescriptor{node: {Classes: []string{class}}},
+		NodeMapping: map[string]string{},
+	}
+	store := coordStore{objectStore{fc.backend, backupID, "", "", ""}}
+	require.NoError(t, c.Restore(ctx, store, &req, desc, nil))
+
+	require.Eventually(t, func() bool { return c.lastOp.get().ID == "" },
+		10*time.Second, 5*time.Millisecond, "the restore goroutine never released the slot")
+
+	st, err := c.OnStatus(ctx, store, &StatusRequest{Method: OpRestore, ID: backupID, Backend: backendName})
+
+	require.NoError(t, err)
+	require.Equal(t, backup.Failed, st.Status,
+		"a restore that failed must not report TRANSFERRING once its goroutine is gone")
+	require.Equal(t, reason, st.Err)
+}
+
+// BackupStatus is what the REST layer calls for GET /backups/{backend}/{id},
+// and it copies the reason straight into the response payload. Everything below
+// it is covered a layer down; this is the whole path an operator polls.
+func TestSchedulerBackupStatusServesTheReasonOfAFailedBackup(t *testing.T) {
+	const (
+		backupID    = "polled"
+		backendName = "s3"
+		class       = "Article"
+		node        = "N1"
+		reason      = "no space left on device"
+	)
+	ctx := context.Background()
+
+	fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+	fs.selector.On("ListClasses", ctx).Return([]string{class})
+	fs.selector.On("Backupable", ctx, []string{class}).Return(nil)
+	fs.selector.On("Shards", ctx, class).Return([]string{node}, nil)
+	fs.client.On("CanCommit", mock.Anything, node, mock.Anything).
+		Return(&CanCommitResponse{Method: OpCreate, ID: backupID, Timeout: 1}, nil)
+	fs.client.On("Commit", mock.Anything, node, mock.Anything).Return(nil)
+	fs.client.On("Status", mock.Anything, node, mock.Anything).Return(&StatusResponse{
+		Status: backup.Failed, Err: reason, ID: backupID, Method: OpCreate,
+	}, nil)
+	fs.client.On("Abort", mock.Anything, node, mock.Anything).Return(nil)
+	fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("bucket/" + backupID)
+	fs.backend.On("Initialize", ctx, backupID).Return(nil)
+	fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
+	// No backup under this id yet, then the descriptor written when the
+	// operation started, which is all the failed write leaves behind.
+	fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{}).Once()
+	fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).
+		Return(marshalCoordinatorMeta(backup.DistributedBackupDescriptor{
+			ID: backupID, Status: backup.Started,
+		}), nil)
+	fs.backend.On("PutObject", mock.Anything, backupID, GlobalBackupFile, mock.Anything).Return(nil).Once()
+	fs.backend.On("PutObject", mock.Anything, backupID, GlobalBackupFile, mock.Anything).Return(ErrAny)
+
+	s := fs.scheduler()
+	s.backupper.timeoutNextRound = time.Millisecond
+	_, err := s.Backup(ctx, nil, &BackupRequest{ID: backupID, Backend: backendName, Include: []string{class}})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool { return s.backupper.lastOp.get().ID == "" },
+		10*time.Second, 5*time.Millisecond, "the create goroutine never released the slot")
+
+	st, err := s.BackupStatus(ctx, nil, backendName, backupID, "", "")
 
 	require.NoError(t, err)
 	require.Equal(t, backup.Failed, st.Status)
-	require.Contains(t, st.Err, reason,
-		"the descriptor is not on the backend yet, so the slot is the only answer")
-}
-
-// Same window on the restore side.
-func TestHandlerOnStatusServesTheReasonARestoreFailedWith(t *testing.T) {
-	const (
-		backupID = "restoring"
-		reason   = "restore class Article: schema apply rejected"
-	)
-
-	r := &restorer{}
-	require.Empty(t, r.lastOp.renew(backupID, "bucket/backups/"+backupID, "", ""))
-	r.lastOp.setFailed(reason)
-
-	res := (&Handler{restorer: r}).OnStatus(context.Background(),
-		&StatusRequest{Method: OpRestore, ID: backupID})
-
-	require.Equal(t, backup.Failed, res.Status)
-	require.Equal(t, reason, res.Err)
+	require.Equal(t, reason, st.Err)
 }

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -13,6 +13,7 @@ package backup
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -216,11 +217,139 @@ func TestHandlerOnStatusServesTheReasonAFailedUploadPublished(t *testing.T) {
 				&StatusRequest{Method: OpCreate, ID: backupID})
 
 			require.Equal(t, backup.Failed, res.Status)
+			require.Equal(t, backup.Failed, desc.Status,
+				"the persisted descriptor must not claim the backup was still transferring")
 			for _, want := range tc.wantIn {
 				require.Contains(t, res.Err, want)
 			}
 		})
 	}
+}
+
+// The descriptor is the whole backup: with no descriptor there is nothing to
+// restore from. Publishing SUCCESS because the file uploads went fine has the
+// coordinator count the node done and report an unrestorable backup as good.
+func TestUploaderPublishesSuccessOnlyOnceTheDescriptorIsWritten(t *testing.T) {
+	const (
+		backupID = "1"
+		class    = "Article"
+	)
+	metaErr := errors.New("meta write rejected by object storage")
+
+	cases := []struct {
+		name       string
+		metaErr    error
+		wantStatus backup.Status
+		wantErr    string
+	}{
+		{
+			name:       "the descriptor lands",
+			wantStatus: backup.Success,
+		},
+		{
+			name:       "the descriptor does not land",
+			metaErr:    metaErr,
+			wantStatus: backup.Failed,
+			wantErr:    metaErr.Error(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			descriptors := make(chan backup.ClassDescriptor, 1)
+			descriptors <- backup.ClassDescriptor{Name: class}
+			close(descriptors)
+
+			sourcer := &fakeSourcer{}
+			sourcer.On("BackupDescriptors", mock.Anything, backupID, []string{class}, mock.Anything).
+				Return((<-chan backup.ClassDescriptor)(descriptors))
+			sourcer.On("ReleaseBackup", mock.Anything, backupID, class).Return(nil)
+
+			backend := newFakeBackend()
+			backend.On("SourceDataPath").Return(t.TempDir())
+			backend.On("PutObject", mock.Anything, backupID, BackupFile, mock.Anything).Return(tc.metaErr)
+
+			logger, _ := test.NewNullLogger()
+			bp := &backupper{logger: logger}
+			require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
+
+			store := nodeStore{objectStore{backend: backend, backupId: backupID}}
+			uploader := newUploader(config.Backup{}, sourcer, nil, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+			desc := backup.BackupDescriptor{ID: backupID}
+			err := uploader.all(context.Background(), []string{class}, &desc, nil, "", "")
+
+			res := (&Handler{backupper: bp}).OnStatus(context.Background(),
+				&StatusRequest{Method: OpCreate, ID: backupID})
+
+			require.Equal(t, tc.wantStatus, res.Status,
+				"a node the coordinator counts as done must really be done")
+			require.Contains(t, res.Err, tc.wantErr)
+			if tc.metaErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tc.metaErr)
+		})
+	}
+}
+
+// An operator abort reaches the uploader as a cancelled context, but the error
+// that comes back from the work it interrupted does not always wrap it. The
+// operation's own context is the signal that says which one it was.
+func TestUploaderPublishesAnAbortAsCancelled(t *testing.T) {
+	const (
+		backupID = "1"
+		class    = "Article"
+	)
+
+	descriptors := make(chan backup.ClassDescriptor, 1)
+	descriptors <- backup.ClassDescriptor{Name: class}
+	close(descriptors)
+
+	sourcer := &fakeSourcer{}
+	sourcer.On("BackupDescriptors", mock.Anything, backupID, []string{class}, mock.Anything).
+		Return((<-chan backup.ClassDescriptor)(descriptors))
+	sourcer.On("ReleaseBackup", mock.Anything, backupID, class).Return(nil)
+
+	backend := newFakeBackend()
+	backend.On("SourceDataPath").Return(t.TempDir())
+	backend.On("PutObject", mock.Anything, backupID, BackupFile, mock.Anything).Return(nil)
+
+	logger, _ := test.NewNullLogger()
+	bp := &backupper{logger: logger}
+	require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// The abort lands while the roles are being snapshotted, and what comes back
+	// is that step's own error, which says nothing about a cancellation.
+	rbac := &abortingSnapshotter{cancel: cancel, err: errors.New("roles snapshot interrupted")}
+
+	store := nodeStore{objectStore{backend: backend, backupId: backupID}}
+	uploader := newUploader(config.Backup{}, sourcer, rbac, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+	desc := backup.BackupDescriptor{ID: backupID}
+	require.Error(t, uploader.all(ctx, []string{class}, &desc, nil, "", ""))
+
+	res := (&Handler{backupper: bp}).OnStatus(context.Background(),
+		&StatusRequest{Method: OpCreate, ID: backupID})
+
+	require.Equal(t, backup.Cancelled, res.Status,
+		"an operator who aborted a backup must not be told it failed")
+	require.Equal(t, backup.Cancelled, desc.Status)
+}
+
+type abortingSnapshotter struct {
+	cancel context.CancelFunc
+	err    error
+}
+
+func (s *abortingSnapshotter) Snapshot(roles ...string) ([]byte, error) {
+	s.cancel()
+	return nil, s.err
+}
+
+func (s *abortingSnapshotter) Restore(snapshot []byte, stripNamespaces bool) error {
+	return nil
 }
 
 // The goroutine that runs a create owns the slot and releases it on the way
@@ -281,4 +410,208 @@ func TestHandlerOnStatusServesTheReasonAfterTheCreateGoroutineExits(t *testing.T
 	require.Equal(t, backup.Failed, res.Status)
 	require.Contains(t, res.Err, uploadErr.Error())
 	require.Contains(t, res.Err, metaErr.Error())
+}
+
+// A create can fail before it ever reaches the upload, and those paths write no
+// descriptor at all. The slot is then the only place the reason can live, and
+// the diagnostics from the base-backup chain are the ones an operator most
+// needs: they say what is wrong with the request.
+func TestHandlerOnStatusServesTheReasonACreateFailedWithBeforeUploading(t *testing.T) {
+	const (
+		backupID    = "before-upload"
+		baseID      = "base"
+		backendName = "s3"
+		class       = "Article"
+	)
+	var (
+		ctx      = context.Background()
+		nodeHome = backupID + "/" + nodeName
+		baseHome = baseID + "/" + nodeName
+		path     = "bucket/backups/" + nodeHome
+	)
+
+	base := func(d backup.BackupDescriptor) []byte {
+		b, err := json.Marshal(d)
+		require.NoError(t, err)
+		return b
+	}
+	gzip := backup.CompressionGZIP
+	zstd := backup.CompressionZSTD
+
+	cases := []struct {
+		name     string
+		commit   bool
+		level    CompressionLevel
+		baseID   string
+		baseMeta []byte
+		wantIn   string
+	}{
+		{
+			name:   "the coordinator never commits",
+			level:  GzipDefaultCompression,
+			wantIn: "timed out waiting for coordinator to commit",
+		},
+		{
+			name:   "the compression level is not one this build knows",
+			commit: true,
+			level:  CompressionLevel(99),
+			wantIn: "invalid compression level: 99",
+		},
+		{
+			name:   "the base backup was taken with another compression type",
+			commit: true,
+			level:  GzipDefaultCompression,
+			baseID: baseID,
+			baseMeta: base(backup.BackupDescriptor{
+				ID: baseID, Status: backup.Success, CompressionType: &zstd,
+				StartedAt: time.Now().Add(-time.Hour),
+			}),
+			wantIn: `has compression type "zstd", expected "gzip"`,
+		},
+		{
+			name:   "the base backup chain points back at itself",
+			commit: true,
+			level:  GzipDefaultCompression,
+			baseID: baseID,
+			baseMeta: base(backup.BackupDescriptor{
+				ID: baseID, Status: backup.Success, CompressionType: &gzip,
+				StartedAt: time.Now().Add(-time.Hour), BaseBackupID: baseID,
+			}),
+			wantIn: "circular references in backup ids detected",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sourcer := &fakeSourcer{}
+			sourcer.On("Backupable", mock.Anything, []string{class}).Return(nil)
+			sourcer.On("ReleaseBackup", mock.Anything, backupID, mock.Anything).Return(nil)
+
+			backend := newFakeBackend()
+			backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+			backend.On("SourceDataPath").Return(t.TempDir())
+			backend.On("Initialize", mock.Anything, nodeHome).Return(nil)
+			// No descriptor for this backup: the operation failed before writing one.
+			backend.On("GetObject", mock.Anything, nodeHome, BackupFile).Return(nil, errNotFound)
+			backend.On("GetObject", mock.Anything, backupID, BackupFile).Return(nil, errNotFound)
+			backend.On("GetObject", mock.Anything, baseHome, BackupFile).Return(tc.baseMeta, nil)
+
+			m := createManager(sourcer, nil, backend, nil)
+			req := Request{
+				Method:       OpCreate,
+				ID:           backupID,
+				Classes:      []string{class},
+				Backend:      backendName,
+				Duration:     50 * time.Millisecond,
+				Compression:  Compression{Level: tc.level, CPUPercentage: DefaultCPUPercentage},
+				BaseBackupID: tc.baseID,
+			}
+			require.Empty(t, m.OnCanCommit(ctx, &req).Err)
+			if tc.commit {
+				require.NoError(t, m.OnCommit(ctx, &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName}))
+			}
+
+			require.Eventually(t, func() bool { return m.backupper.lastOp.get().ID == "" },
+				10*time.Second, 5*time.Millisecond, "the create goroutine never released the slot")
+
+			res := m.OnStatus(ctx, &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName})
+
+			require.Equal(t, backup.Failed, res.Status)
+			require.Contains(t, res.Err, tc.wantIn,
+				"the reason exists, and the slot is the only place a poll can find it")
+		})
+	}
+}
+
+// The remembered failure is a fallback, not an override. A descriptor on the
+// backend is the durable record of what happened to that backup, and answering
+// a poll from memory instead would report a backup that finished as failed.
+func TestHandlerOnStatusPrefersTheDescriptorOverARememberedFailure(t *testing.T) {
+	const (
+		backupID    = "descriptor-wins"
+		backendName = "s3"
+	)
+	var (
+		ctx      = context.Background()
+		nodeHome = backupID + "/" + nodeName
+		path     = "bucket/backups/" + nodeHome
+	)
+
+	meta, err := json.Marshal(backup.BackupDescriptor{
+		ID: backupID, Status: backup.Success, StartedAt: time.Now(),
+	})
+	require.NoError(t, err)
+
+	backend := newFakeBackend()
+	backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+	backend.On("GetObject", mock.Anything, nodeHome, BackupFile).Return(meta, nil)
+
+	m := createManager(nil, nil, backend, nil)
+	require.Empty(t, m.backupper.lastOp.renew(backupID, path, "", ""))
+	m.backupper.lastOp.setFailed("object storage unreachable")
+	m.backupper.lastOp.reset()
+
+	res := m.OnStatus(ctx, &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName})
+
+	require.Equal(t, backup.Success, res.Status)
+	require.Empty(t, res.Err)
+}
+
+// The coordinator publishes the outcome on its slot and only then writes the
+// global descriptor, which is a round trip to object storage. A user polling
+// GET /backups/{backend}/{id} in between is answered from the slot, so a FAILED
+// with no reason there is the same bug one level up, on the path an operator
+// actually hits.
+func TestCoordinatorOnStatusServesTheReasonBeforeTheGlobalDescriptorIsWritten(t *testing.T) {
+	const (
+		backupID    = "coordinated"
+		backendName = "s3"
+		reason      = "no space left on device"
+	)
+	ctx := context.Background()
+
+	fc := newFakeCoordinator(newFakeNodeResolver([]string{"N1"}))
+	c := fc.coordinator()
+	c.timeoutNextRound = time.Millisecond
+	c.descriptor = &backup.DistributedBackupDescriptor{
+		ID:          backupID,
+		NodeMapping: map[string]string{},
+		Nodes:       map[string]*backup.NodeDescriptor{"N1": {Classes: []string{"Article"}}},
+	}
+	c.Participants["N1"] = participantStatus{Status: backup.Transferring, LastTime: time.Now()}
+	require.Empty(t, c.lastOp.renew(backupID, "bucket/backups/"+backupID, "", ""))
+
+	fc.client.On("Commit", mock.Anything, "N1", mock.Anything).Return(nil)
+	fc.client.On("Status", mock.Anything, "N1", mock.Anything).Return(&StatusResponse{
+		Status: backup.Failed, Err: reason, ID: backupID, Method: OpCreate,
+	}, nil)
+	fc.client.On("Abort", mock.Anything, "N1", mock.Anything).Return(nil)
+
+	req := &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName}
+	c.commit(ctx, req, map[string]string{"N1": "N1"}, false)
+
+	st, err := c.OnStatus(ctx, coordStore{}, req)
+
+	require.NoError(t, err)
+	require.Equal(t, backup.Failed, st.Status)
+	require.Contains(t, st.Err, reason,
+		"the descriptor is not on the backend yet, so the slot is the only answer")
+}
+
+// Same window on the restore side.
+func TestHandlerOnStatusServesTheReasonARestoreFailedWith(t *testing.T) {
+	const (
+		backupID = "restoring"
+		reason   = "restore class Article: schema apply rejected"
+	)
+
+	r := &restorer{}
+	require.Empty(t, r.lastOp.renew(backupID, "bucket/backups/"+backupID, "", ""))
+	r.lastOp.setFailed(reason)
+
+	res := (&Handler{restorer: r}).OnStatus(context.Background(),
+		&StatusRequest{Method: OpRestore, ID: backupID})
+
+	require.Equal(t, backup.Failed, res.Status)
+	require.Equal(t, reason, res.Err)
 }

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -13,11 +13,15 @@ package backup
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // The coordinator latches the first terminal answer a participant gives and
@@ -71,15 +75,79 @@ func TestHandlerOnStatusServesTheReasonFromTheOperationSlot(t *testing.T) {
 	}
 }
 
-// renew hands the slot to a new operation, so a reason left by the previous one
-// must not be served as this one's.
-func TestBackupStatRenewClearsThePreviousFailure(t *testing.T) {
-	var s backupStat
+// A reason belongs to the failure that produced it. Every path that moves the
+// slot off that failure has to drop it, or the next reader is served a reason
+// for something that did not happen.
+func TestBackupStatDropsAReasonThatNoLongerApplies(t *testing.T) {
+	const reason = "object storage unreachable"
 
-	require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
-	s.setFailed("object storage unreachable")
-	s.reset()
+	t.Run("set drops it", func(t *testing.T) {
+		var s backupStat
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.setFailed(reason)
 
-	require.Empty(t, s.renew("2", "bucket/backups/2", "", ""))
-	require.Empty(t, s.get().Err)
+		s.set(backup.Success)
+
+		require.Equal(t, backup.Success, s.get().Status)
+		require.Empty(t, s.get().Err)
+	})
+
+	t.Run("reset drops it", func(t *testing.T) {
+		var s backupStat
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.setFailed(reason)
+
+		s.reset()
+
+		require.Empty(t, s.get().Err)
+	})
+
+	t.Run("renew drops it", func(t *testing.T) {
+		// A free slot (empty ID) is the only one renew takes, so it is stamped
+		// directly here rather than through a failure the slot still owns.
+		var s backupStat
+		s.reqState.Err = reason
+
+		require.Empty(t, s.renew("2", "bucket/backups/2", "", ""))
+
+		require.Empty(t, s.get().Err)
+	})
+}
+
+// The reason has to survive the whole way out of the uploader: a poll landing
+// before the operation slot is released reads it from there, not from the
+// descriptor.
+func TestHandlerOnStatusServesTheReasonAFailedUploadPublished(t *testing.T) {
+	const (
+		backupID = "1"
+		class    = "Article"
+	)
+	uploadErr := errors.New("collect shard files: no space left on device")
+
+	descriptors := make(chan backup.ClassDescriptor, 1)
+	descriptors <- backup.ClassDescriptor{Name: class, Error: uploadErr}
+	close(descriptors)
+
+	sourcer := &fakeSourcer{}
+	sourcer.On("BackupDescriptors", mock.Anything, backupID, []string{class}, mock.Anything).
+		Return((<-chan backup.ClassDescriptor)(descriptors))
+	sourcer.On("ReleaseBackup", mock.Anything, backupID, class).Return(nil)
+
+	backend := newFakeBackend()
+	backend.On("PutObject", mock.Anything, backupID, BackupFile, mock.Anything).Return(nil)
+
+	logger, _ := test.NewNullLogger()
+	bp := &backupper{logger: logger}
+	require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
+
+	store := nodeStore{objectStore{backend: backend, backupId: backupID}}
+	uploader := newUploader(config.Backup{}, sourcer, nil, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+	desc := backup.BackupDescriptor{ID: backupID}
+	require.ErrorIs(t, uploader.all(context.Background(), []string{class}, &desc, nil, "", ""), uploadErr)
+
+	res := (&Handler{backupper: bp}).OnStatus(context.Background(),
+		&StatusRequest{Method: OpCreate, ID: backupID})
+
+	require.Equal(t, backup.Failed, res.Status)
+	require.Equal(t, uploadErr.Error(), res.Err)
 }

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -106,7 +106,7 @@ func TestBackupStatDropsAReasonThatNoLongerApplies(t *testing.T) {
 		// A free slot (empty ID) is the only one renew takes, so it is stamped
 		// directly here rather than through a failure the slot still owns.
 		var s backupStat
-		s.reqState.Err = reason
+		s.Err = reason
 
 		require.Empty(t, s.renew("2", "bucket/backups/2", "", ""))
 

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
@@ -81,17 +82,6 @@ func TestHandlerOnStatusServesTheReasonFromTheOperationSlot(t *testing.T) {
 func TestBackupStatDropsAReasonThatNoLongerApplies(t *testing.T) {
 	const reason = "object storage unreachable"
 
-	t.Run("set drops it", func(t *testing.T) {
-		var s backupStat
-		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
-		s.setFailed(reason)
-
-		s.set(backup.Success)
-
-		require.Equal(t, backup.Success, s.get().Status)
-		require.Empty(t, s.get().Err)
-	})
-
 	t.Run("reset drops it", func(t *testing.T) {
 		var s backupStat
 		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
@@ -114,40 +104,181 @@ func TestBackupStatDropsAReasonThatNoLongerApplies(t *testing.T) {
 	})
 }
 
-// The reason has to survive the whole way out of the uploader: a poll landing
-// before the operation slot is released reads it from there, not from the
-// descriptor.
+// The slot is released as soon as the operation returns, so what a failure
+// leaves behind has to outlive it: the descriptor is the other place a poll
+// could read, and there is no descriptor when writing it is what failed.
+func TestBackupStatRemembersAFailureBeyondTheSlot(t *testing.T) {
+	const reason = "object storage unreachable"
+
+	t.Run("a poll after the slot is released still gets the reason", func(t *testing.T) {
+		var s backupStat
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.setFailed(reason)
+
+		s.reset()
+
+		got, ok := s.rememberedFailure("1")
+		require.True(t, ok)
+		require.Equal(t, reason, got)
+	})
+
+	t.Run("a poll for another backup is not answered with this failure", func(t *testing.T) {
+		var s backupStat
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.setFailed(reason)
+		s.reset()
+
+		_, ok := s.rememberedFailure("2")
+		require.False(t, ok)
+	})
+
+	t.Run("a retry under the same id drops it", func(t *testing.T) {
+		var s backupStat
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.setFailed(reason)
+		s.reset()
+
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+
+		_, ok := s.rememberedFailure("1")
+		require.False(t, ok)
+	})
+
+	t.Run("an operation that ended some other way leaves nothing", func(t *testing.T) {
+		var s backupStat
+		require.Empty(t, s.renew("1", "bucket/backups/1", "", ""))
+		s.set(backup.Success)
+		s.reset()
+
+		_, ok := s.rememberedFailure("1")
+		require.False(t, ok)
+	})
+}
+
+// The reason has to survive the whole way out of the uploader, including the
+// meta write that may itself be what failed.
 func TestHandlerOnStatusServesTheReasonAFailedUploadPublished(t *testing.T) {
 	const (
 		backupID = "1"
 		class    = "Article"
 	)
 	uploadErr := errors.New("collect shard files: no space left on device")
+	metaErr := errors.New("meta write rejected by object storage")
+
+	cases := []struct {
+		name      string
+		uploadErr error
+		metaErr   error
+		wantIn    []string
+	}{
+		{
+			name:      "the upload failure is the reason",
+			uploadErr: uploadErr,
+			wantIn:    []string{uploadErr.Error()},
+		},
+		{
+			name:      "a failed meta write reaches the reason too",
+			uploadErr: uploadErr,
+			metaErr:   metaErr,
+			wantIn:    []string{uploadErr.Error(), metaErr.Error()},
+		},
+		{
+			name:      "a failure with no text still says there was one",
+			uploadErr: errors.New(""),
+			wantIn:    []string{"backup failed without a reported reason"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			descriptors := make(chan backup.ClassDescriptor, 1)
+			descriptors <- backup.ClassDescriptor{Name: class, Error: tc.uploadErr}
+			close(descriptors)
+
+			sourcer := &fakeSourcer{}
+			sourcer.On("BackupDescriptors", mock.Anything, backupID, []string{class}, mock.Anything).
+				Return((<-chan backup.ClassDescriptor)(descriptors))
+			sourcer.On("ReleaseBackup", mock.Anything, backupID, class).Return(nil)
+
+			backend := newFakeBackend()
+			backend.On("PutObject", mock.Anything, backupID, BackupFile, mock.Anything).Return(tc.metaErr)
+
+			logger, _ := test.NewNullLogger()
+			bp := &backupper{logger: logger}
+			require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
+
+			store := nodeStore{objectStore{backend: backend, backupId: backupID}}
+			uploader := newUploader(config.Backup{}, sourcer, nil, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+			desc := backup.BackupDescriptor{ID: backupID}
+			require.ErrorIs(t, uploader.all(context.Background(), []string{class}, &desc, nil, "", ""), tc.uploadErr)
+
+			res := (&Handler{backupper: bp}).OnStatus(context.Background(),
+				&StatusRequest{Method: OpCreate, ID: backupID})
+
+			require.Equal(t, backup.Failed, res.Status)
+			for _, want := range tc.wantIn {
+				require.Contains(t, res.Err, want)
+			}
+		})
+	}
+}
+
+// The goroutine that runs a create owns the slot and releases it on the way
+// out, so the poll that matters is the one landing after that. Here the meta
+// write is what failed, which is the case that leaves nothing else to read: a
+// poll falling through to the backend finds no descriptor and can only report
+// that it is missing.
+func TestHandlerOnStatusServesTheReasonAfterTheCreateGoroutineExits(t *testing.T) {
+	const (
+		backupID    = "status-after-release"
+		backendName = "s3"
+		class       = "Article"
+	)
+	var (
+		ctx       = context.Background()
+		nodeHome  = backupID + "/" + nodeName
+		path      = "bucket/backups/" + nodeHome
+		uploadErr = errors.New("collect shard files: no space left on device")
+		metaErr   = errors.New("meta write rejected by object storage")
+	)
 
 	descriptors := make(chan backup.ClassDescriptor, 1)
 	descriptors <- backup.ClassDescriptor{Name: class, Error: uploadErr}
 	close(descriptors)
 
 	sourcer := &fakeSourcer{}
-	sourcer.On("BackupDescriptors", mock.Anything, backupID, []string{class}, mock.Anything).
+	sourcer.On("Backupable", mock.Anything, []string{class}).Return(nil)
+	sourcer.On("BackupDescriptors", mock.Anything, backupID, mock.Anything, mock.Anything).
 		Return((<-chan backup.ClassDescriptor)(descriptors))
-	sourcer.On("ReleaseBackup", mock.Anything, backupID, class).Return(nil)
+	sourcer.On("ReleaseBackup", mock.Anything, backupID, mock.Anything).Return(nil)
 
 	backend := newFakeBackend()
-	backend.On("PutObject", mock.Anything, backupID, BackupFile, mock.Anything).Return(nil)
+	backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+	backend.On("SourceDataPath").Return(t.TempDir())
+	backend.On("GetObject", mock.Anything, nodeHome, BackupFile).Return(nil, errNotFound)
+	// What a poll falling through to the backend would find: the descriptor
+	// this operation failed to write.
+	backend.On("GetObject", mock.Anything, backupID, BackupFile).Return(nil, errNotFound)
+	backend.On("Initialize", mock.Anything, nodeHome).Return(nil)
+	backend.On("PutObject", mock.Anything, nodeHome, BackupFile, mock.Anything).Return(metaErr)
 
-	logger, _ := test.NewNullLogger()
-	bp := &backupper{logger: logger}
-	require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
+	m := createManager(sourcer, nil, backend, nil)
+	req := Request{
+		Method:   OpCreate,
+		ID:       backupID,
+		Classes:  []string{class},
+		Backend:  backendName,
+		Duration: time.Hour,
+	}
+	require.Empty(t, m.OnCanCommit(ctx, &req).Err)
+	require.NoError(t, m.OnCommit(ctx, &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName}))
 
-	store := nodeStore{objectStore{backend: backend, backupId: backupID}}
-	uploader := newUploader(config.Backup{}, sourcer, nil, nil, nil, nil, store, backupID, &bp.lastOp, logger)
-	desc := backup.BackupDescriptor{ID: backupID}
-	require.ErrorIs(t, uploader.all(context.Background(), []string{class}, &desc, nil, "", ""), uploadErr)
+	require.Eventually(t, func() bool { return m.backupper.lastOp.get().ID == "" },
+		10*time.Second, 5*time.Millisecond, "the create goroutine never released the slot")
 
-	res := (&Handler{backupper: bp}).OnStatus(context.Background(),
-		&StatusRequest{Method: OpCreate, ID: backupID})
+	res := m.OnStatus(ctx, &StatusRequest{Method: OpCreate, ID: backupID, Backend: backendName})
 
 	require.Equal(t, backup.Failed, res.Status)
-	require.Equal(t, uploadErr.Error(), res.Err)
+	require.Contains(t, res.Err, uploadErr.Error())
+	require.Contains(t, res.Err, metaErr.Error())
 }

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -266,6 +266,7 @@ func (r *restorer) status(backend, ID string) (Status, error) {
 			Path:      st.Path,
 			StartedAt: st.Starttime,
 			Status:    st.Status,
+			Err:       st.Err,
 		}, nil
 	}
 	ref := basePath(backend, ID)

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -266,7 +266,6 @@ func (r *restorer) status(backend, ID string) (Status, error) {
 			Path:      st.Path,
 			StartedAt: st.Starttime,
 			Status:    st.Status,
-			Err:       st.Err,
 		}, nil
 	}
 	ref := basePath(backend, ID)

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -49,10 +49,15 @@ type backupStat struct {
 	// for the one failure that leaves nothing else to read: the slot is
 	// released as soon as the operation returns, and a later poll is answered
 	// from the descriptor on the backend, which does not exist when writing it
-	// is what failed.
+	// is what failed. Memory only: after a restart such a poll is back to
+	// being answered with "metadata not found".
 	rememberedFailureID     string
 	rememberedFailureReason string
 }
+
+// failureWithoutReason stands in for a failure reported with no text at all,
+// which reads to a poller as no failure.
+const failureWithoutReason = "backup failed without a reported reason"
 
 func (s *backupStat) get() reqState {
 	s.Lock()
@@ -97,18 +102,21 @@ func (s *backupStat) reset() {
 // setFailed ends the operation as failed together with the reason. Failed with
 // no reason is worse than useless to a poller: the coordinator latches whatever
 // a participant reports and stops asking, so an empty reason becomes the
-// permanent answer for a failure that does have one.
+// permanent answer for a failure that does have one. A reason-less failure is
+// therefore substituted here rather than at the call sites, so that every
+// caller gets the guarantee, including the ones passing on a reason a
+// participant gave them.
 func (s *backupStat) setFailed(reason string) {
 	s.Lock()
 	defer s.Unlock()
 	if s.reqState.Status == backup.Cancelled {
 		return
 	}
+	if reason == "" {
+		reason = failureWithoutReason
+	}
 	s.reqState.Status = backup.Failed
 	s.reqState.Err = reason
-	if reason == "" {
-		return
-	}
 	s.rememberedFailureID = s.reqState.ID
 	s.rememberedFailureReason = reason
 }
@@ -134,6 +142,11 @@ func (s *backupStat) set(st backup.Status) {
 		return
 	}
 	s.reqState.Status = st
+	// Every status other than Failed is reached through here, and none of them
+	// has a reason. Keeping an earlier one would serve it next to a status it
+	// does not belong to. The remembered failure is unaffected: it is what a
+	// poll arriving after the slot is gone reads.
+	s.reqState.Err = ""
 }
 
 // shardSyncChan makes sure that a backup operation is mutually exclusive.

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -32,9 +32,9 @@ type reqState struct {
 	Starttime time.Time
 	ID        string
 	Status    backup.Status
-	// Err is why the operation ended, for the statuses that need one. The
-	// descriptor on the backend carries the same text, but only once it is
-	// written; a poll landing before that reads this slot instead.
+	// Err is why the operation ended, for the statuses that need one. It lives
+	// only as long as the slot; a poll arriving after that is answered from
+	// backupStat.rememberedFailure.
 	Err            string
 	Path           string
 	OverrideBucket string
@@ -44,6 +44,14 @@ type reqState struct {
 type backupStat struct {
 	sync.Mutex
 	reqState
+
+	// rememberedFailureID and rememberedFailureReason outlive the slot itself,
+	// for the one failure that leaves nothing else to read: the slot is
+	// released as soon as the operation returns, and a later poll is answered
+	// from the descriptor on the backend, which does not exist when writing it
+	// is what failed.
+	rememberedFailureID     string
+	rememberedFailureReason string
 }
 
 func (s *backupStat) get() reqState {
@@ -67,6 +75,11 @@ func (s *backupStat) renew(id string, path string, overrideBucket, overridePath 
 	s.reqState.Starttime = time.Now().UTC()
 	s.reqState.Status = backup.Started
 	s.reqState.Err = ""
+	if s.rememberedFailureID == id {
+		// A retry under the same id: the earlier failure is no longer the
+		// answer to a poll for it.
+		s.rememberedFailureID, s.rememberedFailureReason = "", ""
+	}
 	return ""
 }
 
@@ -93,6 +106,24 @@ func (s *backupStat) setFailed(reason string) {
 	}
 	s.reqState.Status = backup.Failed
 	s.reqState.Err = reason
+	if reason == "" {
+		return
+	}
+	s.rememberedFailureID = s.reqState.ID
+	s.rememberedFailureReason = reason
+}
+
+// rememberedFailure reports why the operation with this id ended failed, for
+// polls arriving after the slot was released. Absent for anything that did not
+// end failed with a reason. The id has to match: a poll for one backup must
+// never be answered with what happened to another.
+func (s *backupStat) rememberedFailure(id string) (string, bool) {
+	s.Lock()
+	defer s.Unlock()
+	if id == "" || s.rememberedFailureID != id {
+		return "", false
+	}
+	return s.rememberedFailureReason, true
 }
 
 func (s *backupStat) set(st backup.Status) {
@@ -103,10 +134,6 @@ func (s *backupStat) set(st backup.Status) {
 		return
 	}
 	s.reqState.Status = st
-	// Every status other than Failed is reached through here, and none of them
-	// has a reason. Keeping an earlier one would serve it next to a status it
-	// does not belong to.
-	s.reqState.Err = ""
 }
 
 // shardSyncChan makes sure that a backup operation is mutually exclusive.

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -29,9 +29,13 @@ const (
 )
 
 type reqState struct {
-	Starttime      time.Time
-	ID             string
-	Status         backup.Status
+	Starttime time.Time
+	ID        string
+	Status    backup.Status
+	// Err is why the operation ended, for the statuses that need one. The
+	// descriptor on the backend carries the same text, but only once it is
+	// written; a poll landing before that reads this slot instead.
+	Err            string
 	Path           string
 	OverrideBucket string
 	OverridePath   string
@@ -62,6 +66,7 @@ func (s *backupStat) renew(id string, path string, overrideBucket, overridePath 
 	s.reqState.OverridePath = overridePath
 	s.reqState.Starttime = time.Now().UTC()
 	s.reqState.Status = backup.Started
+	s.reqState.Err = ""
 	return ""
 }
 
@@ -70,9 +75,24 @@ func (s *backupStat) reset() {
 	s.reqState.ID = ""
 	s.reqState.Path = ""
 	s.reqState.Status = ""
+	s.reqState.Err = ""
 	s.reqState.OverrideBucket = ""
 	s.reqState.OverridePath = ""
 	s.Unlock()
+}
+
+// setFailed ends the operation as failed together with the reason. Failed with
+// no reason is worse than useless to a poller: the coordinator latches whatever
+// a participant reports and stops asking, so an empty reason becomes the
+// permanent answer for a failure that does have one.
+func (s *backupStat) setFailed(reason string) {
+	s.Lock()
+	defer s.Unlock()
+	if s.reqState.Status == backup.Cancelled {
+		return
+	}
+	s.reqState.Status = backup.Failed
+	s.reqState.Err = reason
 }
 
 func (s *backupStat) set(st backup.Status) {

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -103,6 +103,10 @@ func (s *backupStat) set(st backup.Status) {
 		return
 	}
 	s.reqState.Status = st
+	// Every status other than Failed is reached through here, and none of them
+	// has a reason. Keeping an earlier one would serve it next to a status it
+	// does not belong to.
+	s.reqState.Err = ""
 }
 
 // shardSyncChan makes sure that a backup operation is mutually exclusive.


### PR DESCRIPTION
## Problem

A backup that failed could be polled and give back no reason, and in one case no
failure at all.

**On a participant.** Its operation slot (`reqState`) carried a status but no
reason, the uploader's failure path never touched the slot, and the `OpCreate`
arm of `Handler.OnStatus` had nothing to read. The reason an operator does see
today comes from a different route: the uploader writes it into the descriptor
on the backend and `backupper.OnStatus` reads it back. That leaves no answer at
all when the descriptor never arrives, because writing it is what failed.

**On the coordinator**, which is the node an operator actually polls with
`GET /backups/{backend}/{id}`. Its create goroutine publishes the outcome on the
slot, writes the global descriptor, and releases the slot. The write failing is
only logged, so the descriptor left on the backend is the one from before the
operation ended, and every later poll reads it: a **failed backup reporting
STARTED** for as long as the node is up. Restore has the same shape.

**And on the reason itself.** `coordinator.publishStatus` passes on a
participant's `Reason` verbatim. A participant on a pre-fix build reports none —
which is every participant for the length of a rolling upgrade — so the failure
was published with nothing next to it.

## Fix

- **The slot carries a reason.** `reqState.Err`, written through `setFailed`,
  which pairs the `Failed` status with the text that belongs to it. A
  cancellation stays terminal, and `set` clears the reason so a status that
  follows a failure is not served with the failure's text.
- **The reason outlives the slot.** `backupStat` keeps the last failed
  operation's id and reason past the slot's release. `backupper.OnStatus`
  answers a poll for that id from there ahead of the backend, and
  `coordinator.OnStatus` uses it to override a stored descriptor that is not the
  operation's last word. A retry under the same id clears it.
- **A reason-less failure is substituted inside `setFailed`**, not at the call
  sites, so every current and future caller gets the guarantee — including
  `publishStatus`, which is handed a reason rather than deriving one.
- **The uploader publishes it.** The uploader holds the slot itself (a small
  `statusPublisher` interface) instead of a bare `setStatus` callback.
  `setFailed` runs after the meta write and publishes the *combined* error:
  `desc.Error` is fixed before the write and so says nothing when the write is
  what failed. A `PutMeta` failure now ends the node as failed rather than
  SUCCESS, so the coordinator cannot count an unrestorable backup as good.

## Limitations, stated

- **Remembered failures are in memory.** After a restart, a poll for one of
  these backups is back to "metadata not found". The durable answer is the
  descriptor, and these are exactly the cases where writing it failed.
- **Backend error text reaches the status API verbatim** — bucket names,
  endpoints, paths. That is pre-existing behavior on the paths that already
  served a reason; this PR widens the set of paths that serve one without
  changing what the text contains. `nonEmptyErrMsg` (previously
  `publishableErrMsg`) is named for what it does: substitute empty text, nothing
  else.
- **The restore participant's slot carries no reason.** Its failure path writes
  the reason into `restoreStatusMap` before releasing the slot, so the slot was
  never the only source there.

## Receipts

Each of these mutations reddens exactly one test:

| Mutation | Test that goes red |
| --- | --- |
| Drop the `rememberedFailure` lookup in `backupper.OnStatus` | `TestHandlerOnStatusServesTheReasonAfterTheCreateGoroutineExits` — drives the real `backupper.backup` goroutine and polls after it exits |
| Drop the `rememberedFailure` override in `coordinator.OnStatus` | `TestCoordinatorOnStatusServesTheFailureTheGlobalDescriptorNeverGot` (create), `…TheGlobalRestoreDescriptorNeverGot` (restore), `TestSchedulerBackupStatusServesTheReasonOfAFailedBackup` (the call the REST handler makes) |
| Drop the empty-reason substitution in `setFailed` | `…BeforeTheGlobalDescriptorIsWritten/a participant that reports no reason still ends as a stated failure` |
| Drop the `Err` clear in `set` | `TestBackupStatDropsAReasonThatNoLongerApplies/a later status drops it` |
| Publish `desc.Error` instead of the combined `err` | `…AFailedUploadPublished/a failed meta write reaches the reason too` |
| Drop the empty-text guard on `desc.Error` | `…AFailedUploadPublished/a failure with no text still says there was one` |
| Publish SUCCESS when the descriptor write fails | `TestUploaderPublishesSuccessOnlyOnceTheDescriptorIsWritten/the descriptor does not land` |
| Drop the `setFailed` call in the uploader | `…AFailedUploadPublished` |
| Drop the `Err` clear in `reset` / `renew` | `TestBackupStatDropsAReasonThatNoLongerApplies`, `TestBackupStatRemembersAFailureBeyondTheSlot/a retry under the same id drops it` |
| Drop `ret.Err = st.Err` in the `OpCreate` arm | `TestHandlerOnStatusServesTheReasonFromTheOperationSlot` |
| Drop the `Cancelled` guard in `setFailed` | `…FromTheOperationSlot/a cancelled slot keeps its status` |

---

Split out of the backup ↔ reindex gate work at Dirk's request, so it can be
reviewed on its own instead of inside a 110-file branch. Divergences the parent
has to take are noted on it for the merge. Parent PR:
https://github.com/weaviate/weaviate/pull/12474
