### PR TITLE
fix(db): drain in-flight references before drop tears the shard store down

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -66,6 +66,7 @@ const IdLockPoolSize uint64 = 1024
 var (
 	errAlreadyShutdown    = errors.New("already shut or dropped")
 	errShutdownInProgress = errors.New("shard shutdown in progress")
+	errDropInProgress     = errors.New("shard drop in progress")
 	errShardStillInUse    = errors.New("shard still in use")
 	errTeardownFailed     = errors.New("previous shutdown attempt failed mid-teardown")
 )
@@ -494,6 +495,8 @@ type Shard struct {
 
 	// shutdownRequested marks shard as requested for shutdown
 	shutdownRequested atomic.Bool
+	// dropRequested marks shard as requested for drop.
+	dropRequested atomic.Bool
 
 	HFreshEnabled bool
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -506,6 +506,9 @@ type Shard struct {
 	// (e.g., NewLoadedShard or FinishLoadingShard was called). This prevents double-counting
 	// or incorrect metric updates during partial initialization cleanup.
 	metricsRegistered atomic.Bool
+
+	// tornStoreReported keeps reportTornStoreAccess to one line per shard
+	tornStoreReported atomic.Bool
 }
 
 func (s *Shard) ID() string {
@@ -622,6 +625,31 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 	enterrors.GoWrapper(f, s.index.logger)
 
 	return err
+}
+
+// objectsBucket returns the shard's objects bucket, or an error once the store
+// is torn down
+func (s *Shard) objectsBucket() (*lsmkv.Bucket, error) {
+	b := s.store.Bucket(helpers.ObjectsBucketLSM)
+	if b == nil {
+		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, errAlreadyShutdown)
+		s.reportTornStoreAccess(err)
+		return nil, err
+	}
+	return b, nil
+}
+
+// reportTornStoreAccess makes an outrun drain visible
+func (s *Shard) reportTornStoreAccess(err error) {
+	if !s.tornStoreReported.CompareAndSwap(false, true) {
+		return
+	}
+	s.index.logger.WithFields(logrus.Fields{
+		"action": "objects_bucket_missing",
+		"class":  s.index.Config.ClassName.String(),
+		"shard":  s.name,
+	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun "+
+		"(further occurrences on this shard are suppressed): %v", err)
 }
 
 // ObjectCount returns the exact count at any moment

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -632,7 +632,7 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 func (s *Shard) objectsBucket() (*lsmkv.Bucket, error) {
 	b := s.store.Bucket(helpers.ObjectsBucketLSM)
 	if b == nil {
-		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, errAlreadyShutdown)
+		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, lsmkv.ErrBucketNotFound)
 		s.reportTornStoreAccess(err)
 		return nil, err
 	}
@@ -648,8 +648,7 @@ func (s *Shard) reportTornStoreAccess(err error) {
 		"action": "objects_bucket_missing",
 		"class":  s.index.Config.ClassName.String(),
 		"shard":  s.name,
-	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun "+
-		"(further occurrences on this shard are suppressed): %v", err)
+	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun, %v", err)
 }
 
 // ObjectCount returns the exact count at any moment

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
@@ -34,6 +35,15 @@ import (
 // If keepFiles==true, all files on disk are kept, only in-memory structures are removed. This is used to allow backups
 // to complete before the files are deleted.
 func (s *Shard) drop(keepFiles bool) (err error) {
+	// Drain before anything is torn down.
+	if drainErr := s.drainRefsForDrop(); drainErr != nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action": "drop_shard",
+			"class":  s.class.Class,
+			"shard":  s.name,
+		}).Errorf("proceeding with drop while references are still held; in-flight requests on this shard will fail: %v", drainErr)
+	}
+
 	s.shutCtxCancel(fmt.Errorf("drop %q", s.ID()))
 	s.reindexer.Stop(s, fmt.Errorf("shard drop"))
 

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -15,8 +15,6 @@ package db
 
 import (
 	"context"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -29,10 +27,11 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-// loadTestShard returns the single-shard test index's shard, loaded, as both
-// the map key and the concrete instance the teardown paths operate on.
+// loadTestShard returns the single-shard test index's shard, loaded, by name
+// and as the concrete instance the teardown paths operate on.
 func loadTestShard(t *testing.T, index *Index) (string, *Shard) {
 	t.Helper()
 
@@ -47,8 +46,8 @@ func loadTestShard(t *testing.T, index *Index) (string, *Shard) {
 	return name, entry.(*LazyLoadShard).shard
 }
 
-// dropTestShard pins the shard — the same pin Index.withShardForWrite holds
-// around a write — and starts a drop() racing it in the background.
+// dropTestShard pins the shard as Index.withShardForWrite does, then races a
+// drop() against it. Returns once that drop is inside its drain.
 func dropTestShard(t *testing.T, index *Index) (shard *Shard, release func(), dropped <-chan error) {
 	t.Helper()
 
@@ -62,6 +61,11 @@ func dropTestShard(t *testing.T, index *Index) (shard *Shard, release func(), dr
 
 	ch := make(chan error, 1)
 	go func() { ch <- shard.drop(false) }()
+
+	// the flag is drainRefsForDrop's first action
+	require.Eventually(t, shard.dropRequested.Load, 10*time.Second, time.Millisecond,
+		"drop never entered its drain")
+
 	return shard, release, ch
 }
 
@@ -85,8 +89,7 @@ func dropTestObject(vec []float32) (*storobj.Object, []byte) {
 
 // TestShardDropWaitsForInFlightReferences pins the race that crashed nodes:
 // drop tore the store down while a pinned write was mid-flight, so
-// Store.Bucket(objects) went nil under it (nil *Bucket -> Get ->
-// GetConsistentView -> SIGSEGV).
+// Store.Bucket(objects) went nil under it.
 func TestShardDropWaitsForInFlightReferences(t *testing.T) {
 	index, cleanup := initIndexAndPopulate(t, t.TempDir())
 	defer cleanup()
@@ -107,10 +110,9 @@ func TestShardDropWaitsForInFlightReferences(t *testing.T) {
 	requireDropped(t, dropped)
 }
 
-// TestShardDropDrainsRealBatchWrite is the end-to-end form. The write paths
-// dereference Store.Bucket unguarded, so the drain is the only thing between
-// this batch and a SIGSEGV — every object must succeed, not merely fail
-// cleanly.
+// TestShardDropDrainsRealBatchWrite is the end-to-end form: every object must
+// succeed, not merely fail cleanly. Asserting success is what keeps the drain
+// responsible for this case rather than objectsBucket's backstop.
 func TestShardDropDrainsRealBatchWrite(t *testing.T) {
 	index, cleanup := initIndexAndPopulate(t, t.TempDir())
 	defer cleanup()
@@ -135,9 +137,7 @@ func TestShardDropDrainsRealBatchWrite(t *testing.T) {
 
 // TestShardDropProceedsWhenDrainTimesOut pins the escape hatch: the drain is
 // bounded on purpose, so a reference held past the window must not wedge the
-// delete — and must be logged, since that line is the only warning preceding
-// the crash TestUnguardedWriteAfterTeardownCrashesProcess documents. Runs for
-// the full drain window (~30s).
+// delete, and must be logged. Runs for the full drain window (~30s).
 func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	index, cleanup := initIndexAndPopulate(t, t.TempDir())
 	defer cleanup()
@@ -150,7 +150,7 @@ func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	defer release()
 
 	requireDropped(t, dropped)
-	// the drain window is ~30s; anything near-instant means it never waited
+	// ~30s window; near-instant means it never waited
 	require.Greater(t, time.Since(start), 10*time.Second, "drop gave up well short of the drain window")
 
 	var warned bool
@@ -161,32 +161,57 @@ func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	require.True(t, warned, "a drop that outran its drain must be logged, not silent")
 }
 
-// TestUnguardedWriteAfterTeardownCrashesProcess pins the known-bad path left
-// open on purpose: the write paths dereference Store.Bucket unguarded, so a
-// write outliving a teardown drain kills the node instead of failing the
-// request. The drain keeps it unreachable in practice; this makes the trade
-// visible in code. Subprocess, because the failure is a process-level SIGSEGV.
-//
-// Reintroducing a nil guard on the write path fails this test — delete it in
-// that same change.
-func TestUnguardedWriteAfterTeardownCrashesProcess(t *testing.T) {
-	if os.Getenv("WEAVIATE_TEST_TORN_STORE_CHILD") == "1" {
-		index, cleanup := initIndexAndPopulate(t, t.TempDir())
-		defer cleanup()
+// TestObjectWritesAfterStoreTeardownReturnErrors covers the backstop: a write
+// outliving the drain must fail on the deregistered bucket rather than
+// dereference nil, and must be reported once.
+func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
 
-		_, shard := loadTestShard(t, index)
-		require.NoError(t, shard.store.Shutdown(context.Background()))
+	logger, hook := test.NewNullLogger()
+	index.logger = logger
 
-		obj, idBytes := dropTestObject(nil)
-		_, _ = shard.putObjectLSM(context.Background(), obj, idBytes)
-		t.Fatal("write against a torn-down store returned instead of crashing")
+	_, shard := loadTestShard(t, index)
+	// the state a teardown that outran its drain leaves behind
+	require.NoError(t, shard.store.Shutdown(context.Background()))
+
+	obj, idBytes := dropTestObject(nil)
+	id := obj.ID()
+	merge := objects.MergeDocument{Class: "Test", ID: id}
+
+	mutations := map[string]func() error{
+		"put": func() error {
+			_, err := shard.putObjectLSM(context.Background(), obj, idBytes)
+			return err
+		},
+		"delete": func() error {
+			_, err := shard.deleteObject(context.Background(), id, time.Now(), false)
+			return err
+		},
+		"batch delete": func() error {
+			return shard.batchDeleteObject(context.Background(), id, time.Now())
+		},
+		"merge": func() error {
+			_, _, err := shard.mergeObjectInStorage(context.Background(), merge, idBytes, index.getClass())
+			return err
+		},
+		"mutable merge": func() error {
+			_, err := shard.mutableMergeObjectLSM(context.Background(), merge, idBytes)
+			return err
+		},
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestUnguardedWriteAfterTeardownCrashesProcess")
-	cmd.Env = append(os.Environ(), "WEAVIATE_TEST_TORN_STORE_CHILD=1")
-	out, err := cmd.CombinedOutput()
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, mutate(), errAlreadyShutdown)
+		})
+	}
 
-	require.Errorf(t, err, "child survived a write against a torn-down store:\n%s", out)
-	require.Contains(t, string(out), "nil pointer dereference")
-	require.Contains(t, string(out), "GetConsistentView")
+	var reports int
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "mutation reached a torn-down store") {
+			reports++
+		}
+	}
+	require.Equal(t, 1, reports, "an outrun drain must be reported exactly once per shard")
 }

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -203,7 +204,7 @@ func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
 
 	for name, mutate := range mutations {
 		t.Run(name, func(t *testing.T) {
-			require.ErrorIs(t, mutate(), errAlreadyShutdown)
+			require.ErrorIs(t, mutate(), lsmkv.ErrBucketNotFound)
 		})
 	}
 

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -1,0 +1,192 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// loadTestShard returns the single-shard test index's shard, loaded, as both
+// the map key and the concrete instance the teardown paths operate on.
+func loadTestShard(t *testing.T, index *Index) (string, *Shard) {
+	t.Helper()
+
+	var name string
+	index.shards.Range(func(n string, _ ShardLike) error {
+		name = n
+		return nil
+	})
+	entry := index.shards.Load(name)
+	require.NotNil(t, entry)
+	require.NoError(t, entry.(*LazyLoadShard).Load(context.Background()))
+	return name, entry.(*LazyLoadShard).shard
+}
+
+// dropTestShard pins the shard — the same pin Index.withShardForWrite holds
+// around a write — and starts a drop() racing it in the background.
+func dropTestShard(t *testing.T, index *Index) (shard *Shard, release func(), dropped <-chan error) {
+	t.Helper()
+
+	name, shard := loadTestShard(t, index)
+
+	_, release, err := index.GetShard(context.Background(), name)
+	require.NoError(t, err)
+
+	// keeps cleanup() from retrying Shutdown on the dropped shard
+	t.Cleanup(func() { index.shards.LoadAndDelete(name) })
+
+	ch := make(chan error, 1)
+	go func() { ch <- shard.drop(false) }()
+	return shard, release, ch
+}
+
+func requireDropped(t *testing.T, dropped <-chan error) {
+	t.Helper()
+	select {
+	case err := <-dropped:
+		require.NoError(t, err)
+	case <-time.After(time.Minute):
+		t.Fatal("drop never completed")
+	}
+}
+
+func dropTestObject(vec []float32) (*storobj.Object, []byte) {
+	id := strfmt.UUID(uuid.New().String())
+	idBytes, _ := uuid.MustParse(id.String()).MarshalBinary()
+	return storobj.FromObject(&models.Object{
+		Class: "Test", ID: id, Properties: map[string]interface{}{},
+	}, vec, nil, nil), idBytes
+}
+
+// TestShardDropWaitsForInFlightReferences pins the race that crashed nodes:
+// drop tore the store down while a pinned write was mid-flight, so
+// Store.Bucket(objects) went nil under it (nil *Bucket -> Get ->
+// GetConsistentView -> SIGSEGV).
+func TestShardDropWaitsForInFlightReferences(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	shard, release, dropped := dropTestShard(t, index)
+
+	select {
+	case err := <-dropped:
+		t.Fatalf("drop completed while a write still held a reference: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// no new writer may sneak in behind the drain either
+	_, err := shard.preventShutdown()
+	require.ErrorIs(t, err, errDropInProgress)
+
+	release()
+	requireDropped(t, dropped)
+}
+
+// TestShardDropDrainsRealBatchWrite is the end-to-end form. The write paths
+// dereference Store.Bucket unguarded, so the drain is the only thing between
+// this batch and a SIGSEGV — every object must succeed, not merely fail
+// cleanly.
+func TestShardDropDrainsRealBatchWrite(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	batch := make([]*storobj.Object, 50)
+	for i := range batch {
+		batch[i], _ = dropTestObject([]float32{float32(i), 1, 2, 3})
+	}
+
+	shard, release, dropped := dropTestShard(t, index)
+
+	errs := func() []error {
+		defer release()
+		return shard.PutObjectBatch(context.Background(), batch)
+	}()
+	for i, err := range errs {
+		require.NoErrorf(t, err, "object %d of a batch in flight during drop", i)
+	}
+
+	requireDropped(t, dropped)
+}
+
+// TestShardDropProceedsWhenDrainTimesOut pins the escape hatch: the drain is
+// bounded on purpose, so a reference held past the window must not wedge the
+// delete — and must be logged, since that line is the only warning preceding
+// the crash TestUnguardedWriteAfterTeardownCrashesProcess documents. Runs for
+// the full drain window (~30s).
+func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	logger, hook := test.NewNullLogger()
+	index.logger = logger
+
+	start := time.Now()
+	_, release, dropped := dropTestShard(t, index) // pin is never released
+	defer release()
+
+	requireDropped(t, dropped)
+	// the drain window is ~30s; anything near-instant means it never waited
+	require.Greater(t, time.Since(start), 10*time.Second, "drop gave up well short of the drain window")
+
+	var warned bool
+	for _, e := range hook.AllEntries() {
+		warned = warned || (e.Level == logrus.ErrorLevel &&
+			strings.Contains(e.Message, "proceeding with drop while references are still held"))
+	}
+	require.True(t, warned, "a drop that outran its drain must be logged, not silent")
+}
+
+// TestUnguardedWriteAfterTeardownCrashesProcess pins the known-bad path left
+// open on purpose: the write paths dereference Store.Bucket unguarded, so a
+// write outliving a teardown drain kills the node instead of failing the
+// request. The drain keeps it unreachable in practice; this makes the trade
+// visible in code. Subprocess, because the failure is a process-level SIGSEGV.
+//
+// Reintroducing a nil guard on the write path fails this test — delete it in
+// that same change.
+func TestUnguardedWriteAfterTeardownCrashesProcess(t *testing.T) {
+	if os.Getenv("WEAVIATE_TEST_TORN_STORE_CHILD") == "1" {
+		index, cleanup := initIndexAndPopulate(t, t.TempDir())
+		defer cleanup()
+
+		_, shard := loadTestShard(t, index)
+		require.NoError(t, shard.store.Shutdown(context.Background()))
+
+		obj, idBytes := dropTestObject(nil)
+		_, _ = shard.putObjectLSM(context.Background(), obj, idBytes)
+		t.Fatal("write against a torn-down store returned instead of crashing")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestUnguardedWriteAfterTeardownCrashesProcess")
+	cmd.Env = append(os.Environ(), "WEAVIATE_TEST_TORN_STORE_CHILD=1")
+	out, err := cmd.CombinedOutput()
+
+	require.Errorf(t, err, "child survived a write against a torn-down store:\n%s", out)
+	require.Contains(t, string(out), "nil pointer dereference")
+	require.Contains(t, string(out), "GetConsistentView")
+}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -949,7 +949,10 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return err
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return err
+	}
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -346,6 +346,22 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	return ec.ToError()
 }
 
+// drainRefsForDrop blocks new pins and waits for the in-flight ones to finish,
+// so a drop does not tear the store down underneath a running request.
+func (s *Shard) drainRefsForDrop() error {
+	s.dropRequested.Store(true)
+
+	return backoff.Retry(func() error {
+		s.shutdownLock.Lock()
+		defer s.shutdownLock.Unlock()
+
+		if inUse := s.inUseCounter.Load(); inUse > 0 {
+			return fmt.Errorf("shard %q holds %d reference(s): %w", s.name, inUse, errShardStillInUse)
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(300*time.Millisecond), 100)) // 30 seconds
+}
+
 const msgReleasedMoreThanOnce = "shard reference released more than once per acquire"
 
 func (s *Shard) preventShutdown() (release func(), err error) {
@@ -354,6 +370,10 @@ func (s *Shard) preventShutdown() (release func(), err error) {
 	}
 	s.shutdownLock.RLock()
 	defer s.shutdownLock.RUnlock()
+
+	if s.dropRequested.Load() {
+		return func() {}, errDropInProgress
+	}
 
 	if s.shut.Load() {
 		return func() {}, errAlreadyShutdown

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -348,6 +348,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 
 // drainRefsForDrop blocks new pins and waits for the in-flight ones to finish,
 // so a drop does not tear the store down underneath a running request.
+// Note: this will keep drainRefsForDrop running for 30 seconds.
 func (s *Shard) drainRefsForDrop() error {
 	s.dropRequested.Store(true)
 

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -52,7 +52,10 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return false, err
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return false, err
+	}
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
@@ -158,7 +161,11 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 }
 
 func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) error {
-	className, err := s.store.Bucket(helpers.ObjectsBucketLSM).ClassName()
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return err
+	}
+	className, err := bucket.ClassName()
 	if err != nil {
 		return fmt.Errorf("getting bucket class name: %w", err)
 	}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -138,7 +137,10 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte, class *models.Class,
 ) (*storobj.Object, objectInsertStatus, error) {
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, objectInsertStatus{}, err
+	}
 
 	var prevObj, obj *storobj.Object
 	var status objectInsertStatus
@@ -241,8 +243,12 @@ func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDoc
 func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte,
 ) (mutableMergeResult, error) {
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	out := mutableMergeResult{}
+
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return out, err
+	}
 
 	// Wait outside the RLock; see shard_write_put.go (calling it under RLock is a recursive read-lock deadlock).
 	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -265,7 +265,10 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 		}
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return status, err
+	}
 	var prevObj *storobj.Object
 
 	// First the object bucket is checked if an object with the same uuid is alreadypresent,


### PR DESCRIPTION
### What's being changed:
`Shard.drop()` ignored the shard's in-use refcount that every write path pins, so a tenant/class delete could shut the lsmkv store out from under an in-flight batch, leaving Store.Bucket(objects) nil and crashing the node. drop now blocks new pins and waits (~30s) for outstanding ones to finish to  drain in-flight shard references before drop tears the store down. 


e.g. of races which lead to panics
```
Panic context:
weaviate-0 weaviate panic: runtime error: invalid memory address or nil pointer dereference
weaviate-0 weaviate [signal SIGSEGV: segmentation violation code=0x1 addr=0x78 pc=0x1126581]
weaviate-0 weaviate 
weaviate-0 weaviate goroutine 541690 [running]:
weaviate-0 weaviate sync/atomic.(*Int32).Add(...)
weaviate-0 weaviate 	sync/atomic/type.go:94
weaviate-0 weaviate sync.(*RWMutex).RLock(...)
weaviate-0 weaviate 	sync/rwmutex.go:72
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).GetConsistentView(0x0)
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:819 +0x61
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).get(0x0, {0x22d451b2db70, 0x10, 0x10})
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:887 +0x6c
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).Get(0xf0235d14ed?, {0x22d451b2db70?, 0x4a4077?, 0x49336e?})
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:857 +0x18
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.fetchObject(0x0, {0x22d451b2db70?, 0x22d43d80c9f8?, 0xd86273?})
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/shard_write_put.go:217 +0x25
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Shard).putObjectLSM.func1(0x22d43e515408, 0x22d438cf3508, 0x22d4387b9cc0, 0x22d4387b9c90, 0x22d4387b9ca8, 0x0, {0x22d451b2db70, 0x10, 0x10}, {0x4bd98f8, ...}, ...)
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/shard_write_put.go:294 +0x18c
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Shard).putObjectLSM(0x22d43e515408, {0x4bd98f8, 0x22d454a4aa50}, 0x22d438778000, {0x22d451b2db70, 0x10, 0x10})
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/shard_write_put.go:346 +0x5c5
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*objectsBatcher).storeObjectOfBatchInLSM(0x22d43396e990, {0x4bd98f8, 0x22d454a4aa50}, 0x22d443efdd90, 0x4, 0x22d438778000)
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/shard_write_batch_objects.go:211 +0x14d
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*objectsBatcher).storeSingleBatchInLSM.func1()
weaviate-0 weaviate 	github.com/weaviate/weaviate/adapters/repos/db/shard_write_batch_objects.go:172 +0x4f
``` 

[e2e CI run where the panic appeared.](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/31350805378/job/93341276205)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x]  E2E: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/31384680497
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
