### PR TITLE
Keep the geo vector cache across deletion cycles

### DIFF
--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	vectorIndexCommon "github.com/weaviate/weaviate/entities/vectorindex/common"
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
@@ -93,10 +94,14 @@ func NewIndex(config Config,
 		SnapshotOnStartup:     config.SnapshotOnStartup,
 		AllocChecker:          config.AllocChecker,
 		GetViewThunk:          func() common.BucketView { return nil },
+		Logger:                config.Logger,
 	}, hnswent.UserConfig{
 		MaxConnections:         64,
 		EFConstruction:         128,
 		CleanupIntervalSeconds: hnswent.DefaultCleanupIntervalSeconds,
+		// The cache drops every vector once its entry count reaches this maximum,
+		// so a zero here empties it every few seconds.
+		VectorCacheMaxObjects: vectorIndexCommon.DefaultVectorCacheMaxObjects,
 	}, tombstoneCleanupCallbacks, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "underlying hnsw index")

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -13,10 +13,13 @@ package geo
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -45,7 +48,7 @@ func TestGeoJourney(t *testing.T) {
 		ID:                 "unit-test",
 		CoordinatesForID:   getCoordinates,
 		DisablePersistence: true,
-		RootPath:           "doesnt-matter-persistence-is-off",
+		RootPath:           t.TempDir(),
 	},
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
 	require.Nil(t, err)
@@ -112,6 +115,64 @@ func TestGeoJourney(t *testing.T) {
 		expectedResults := []uint64{0}
 		assert.Equal(t, expectedResults, results)
 	})
+}
+
+// A geo index that leaves its cache maximum unset reloads every coordinate
+// from disk every few seconds.
+func TestGeoVectorCacheSurvivesDeletionCycle(t *testing.T) {
+	ctx := context.Background()
+	elements := []models.GeoCoordinates{
+		{ // coordinates of munich
+			Latitude:  ptFloat32(48.13743),
+			Longitude: ptFloat32(11.57549),
+		},
+		{ // coordinates of stuttgart
+			Latitude:  ptFloat32(48.78232),
+			Longitude: ptFloat32(9.17702),
+		},
+	}
+
+	var coordinateLoads atomic.Int64
+	getCoordinates := func(ctx context.Context, id uint64) (*models.GeoCoordinates, error) {
+		coordinateLoads.Add(1)
+		return &elements[id], nil
+	}
+
+	geoIndex, err := NewIndex(Config{
+		AllocChecker:       memwatch.NewDummyMonitor(),
+		ID:                 "unit-test-vector-cache",
+		CoordinatesForID:   getCoordinates,
+		DisablePersistence: true,
+		RootPath:           t.TempDir(),
+	},
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, geoIndex.Shutdown(ctx)) })
+
+	for id := range elements {
+		require.NoError(t, geoIndex.Add(ctx, uint64(id), &elements[id]))
+	}
+
+	searchAroundMunich := func() []uint64 {
+		results, err := geoIndex.WithinRange(ctx, filters.GeoRange{
+			GeoCoordinates: &models.GeoCoordinates{
+				Latitude:  ptFloat32(48.13743),
+				Longitude: ptFloat32(11.57549),
+			},
+			Distance: 500 * 1000,
+		})
+		require.NoError(t, err)
+		return results
+	}
+
+	require.Equal(t, []uint64{0, 1}, searchAroundMunich())
+	loadsAfterWarmup := coordinateLoads.Load()
+
+	time.Sleep(2 * cache.DefaultDeletionInterval)
+
+	require.Equal(t, []uint64{0, 1}, searchAroundMunich())
+	require.Equal(t, loadsAfterWarmup, coordinateLoads.Load(),
+		"searching after a deletion cycle must not reload coordinates")
 }
 
 func TestGeoConfig(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

geo.NewIndex built its HNSW UserConfig from a literal that left VectorCacheMaxObjects at the zero value. The cache counts itself full at count >= maxSize, so a zero maximum is full at all times and every vector is dropped on each deletion cycle.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
