### PR TITLE
Parse replace nodes without allocating

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_read_amplification_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_read_amplification_test.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+type countingReaderAt struct {
+	inner readerAt
+	bytes int64
+}
+
+func (c *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	n, err := c.inner.ReadAt(p, off)
+	c.bytes += int64(n)
+	return n, err
+}
+
+// TestSegmentCursorReusablePread_ReadAmplification pins that a sequential scan pulls each data byte through pread roughly once, instead of refilling a whole buffer per node.
+func TestSegmentCursorReusablePread_ReadAmplification(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name           string
+		count          int
+		valueSize      int
+		valuePrefixLen int
+	}{
+		{"full/tiny-values", 4000, 64, 0},
+		{"full/medium-values", 1000, 2048, 0},
+		{"digest/tiny-values", 4000, 64, 42},
+		{"digest/vector-values", 200, 24576, 42},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newReusableTestBucket(t, ctx, WithPread(true), WithMinMMapSize(0))
+			t.Cleanup(func() { b.Shutdown(ctx) })
+
+			value := bytes.Repeat([]byte{'x'}, tc.valueSize)
+			for i := 0; i < tc.count; i++ {
+				require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%08d", i)), value))
+			}
+			require.NoError(t, b.FlushAndSwitch())
+
+			segments, release := b.disk.getConsistentViewOfSegments()
+			t.Cleanup(release)
+			require.Len(t, segments, 1)
+			seg, ok := segments[0].(*segment)
+			require.True(t, ok)
+			require.False(t, seg.readFromMemory)
+
+			c := seg.newReplaceCursorReusableWithPrefix(tc.valuePrefixLen)
+			t.Cleanup(c.releaseReader)
+			counting := &countingReaderAt{inner: c.preadOffset.ra}
+			c.preadOffset.ra = counting
+
+			nodes := 0
+			for n, err := c.first(); !errors.Is(err, lsmkv.NotFound); n, err = c.next() {
+				require.NoError(t, err)
+				require.NotNil(t, n)
+				nodes++
+			}
+
+			require.Equal(t, tc.count, nodes)
+			dataRegion := int64(seg.dataEndPos - seg.dataStartPos)
+			require.LessOrEqual(t, counting.bytes, dataRegion+2*segmentCursorReaderBufSize,
+				"scan of a %d-byte data region read %d bytes through pread", dataRegion, counting.bytes)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -21,9 +21,12 @@ import (
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
-// segmentCursorReaderBufSize matches bufio.NewReader's default so pooled readers
-// behave byte-for-byte like the previous bufio.NewReader(or) call.
-const segmentCursorReaderBufSize = 4096
+// segmentCursorReaderBufSize is the refill size. Skipped bytes drain through the
+// same buffer rather than around it, so one pread covers this many of them, and
+// digest mode — which keeps a short value prefix and skips the remainder of every
+// node — pays that ratio over whole vector payloads. Shrinking it multiplies
+// syscalls across a scan without saving a comparable amount of memory.
+const segmentCursorReaderBufSize = 8192
 
 // segmentCursorReaderPool recycles reusable-cursor read buffers (one per segment
 // per digest RPC), previously the largest allocation source in async-rep scans.

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -321,6 +321,9 @@ type segmentCursorReplaceReusable struct {
 	// avoid allocating a MeteredReader+SectionReader+nodeReader per iteration.
 	preadOffset *offsetReader
 	preadReader *bufio.Reader
+	// preadPos is the position preadReader is parked at (-1 = unknown); parses
+	// landing exactly there keep the buffer instead of resetting it.
+	preadPos int64
 }
 
 func (s *segment) newReplaceCursorReusable() *segmentCursorReplaceReusable {
@@ -348,6 +351,7 @@ func (s *segment) newReplaceCursorReusableWithPrefix(valuePrefixLen int) *segmen
 		or := &offsetReader{ra: s.contentFile}
 		c.preadOffset = or
 		c.preadReader = acquireSegmentCursorReader(or)
+		c.preadPos = -1
 	}
 	return c
 }
@@ -411,8 +415,13 @@ func (s *segmentCursorReplaceReusable) parseInto() (*segmentReplaceNode, error) 
 			return &s.reusableNode, err
 		}
 	} else {
-		s.preadOffset.off = int64(s.currOffset)
-		s.preadReader.Reset(s.preadOffset)
+		pos := int64(s.currOffset)
+		if pos != s.preadPos {
+			s.preadOffset.off = pos
+			s.preadReader.Reset(s.preadOffset)
+		}
+		// unknown until the parse succeeds: an error leaves the reader mid-node
+		s.preadPos = -1
 		if s.valuePrefixLen > 0 {
 			if err := ParseReplaceNodeDigestIntoPread(s.preadReader, s.segment.secondaryIndexCount, s.valuePrefixLen, &s.reusableNode); err != nil {
 				return &s.reusableNode, err
@@ -420,6 +429,7 @@ func (s *segmentCursorReplaceReusable) parseInto() (*segmentReplaceNode, error) 
 		} else if err := ParseReplaceNodeIntoPread(s.preadReader, s.segment.secondaryIndexCount, &s.reusableNode); err != nil {
 			return &s.reusableNode, err
 		}
+		s.preadPos = pos + int64(s.reusableNode.offset)
 	}
 
 	if s.reusableNode.tombstone {

--- a/adapters/repos/db/lsmkv/segment_serialization.go
+++ b/adapters/repos/db/lsmkv/segment_serialization.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"bufio"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -27,8 +28,11 @@ type segmentReplaceNode struct {
 	value               []byte
 	primaryKey          []byte
 	secondaryIndexCount uint16
-	secondaryKeys       [][]byte
-	offset              int
+	// scratch covers the largest uninterrupted pread read (tombstone + value
+	// length); it lives on the node because a local array escapes into io.ReadFull.
+	scratch       [9]byte
+	secondaryKeys [][]byte
+	offset        int
 }
 
 func (s *segmentReplaceNode) KeyIndexAndWriteTo(w io.Writer) (segmentindex.Key, error) {
@@ -181,9 +185,7 @@ func ParseReplaceNode(r io.Reader, secondaryIndexCount uint16) (segmentReplaceNo
 func ParseReplaceNodeIntoPread(r io.Reader, secondaryIndexCount uint16, out *segmentReplaceNode) (err error) {
 	out.offset = 0
 
-	// 9 bytes covers the largest uninterrupted read (tombstone + value length).
-	// Stack-allocated, no heap allocation.
-	var tmpBuf [9]byte
+	tmpBuf := out.scratch[:]
 
 	if _, err := io.ReadFull(r, tmpBuf[:9]); err != nil {
 		return errors.Wrap(err, "read tombstone and value length")
@@ -257,11 +259,10 @@ func ParseReplaceNodeIntoPread(r io.Reader, secondaryIndexCount uint16, out *seg
 // keeps only the first valuePrefixLen value bytes, so out.value never grows to
 // the full (vector-sized) payload. out.offset still spans the whole node so the
 // cursor advances correctly; skipped bytes are read from r but not allocated.
-func ParseReplaceNodeDigestIntoPread(r io.Reader, secondaryIndexCount uint16, valuePrefixLen int, out *segmentReplaceNode) error {
+func ParseReplaceNodeDigestIntoPread(r *bufio.Reader, secondaryIndexCount uint16, valuePrefixLen int, out *segmentReplaceNode) error {
 	out.offset = 0
 
-	// 9 bytes covers the largest uninterrupted read (tombstone + value length).
-	var tmpBuf [9]byte
+	tmpBuf := out.scratch[:]
 
 	if _, err := io.ReadFull(r, tmpBuf[:9]); err != nil {
 		return errors.Wrap(err, "read tombstone and value length")
@@ -283,12 +284,11 @@ func ParseReplaceNodeDigestIntoPread(r io.Reader, secondaryIndexCount uint16, va
 		return errors.Wrap(err, "read value prefix")
 	}
 	out.offset += int(prefix)
-	if valueLength > prefix {
-		skipped, err := io.CopyN(io.Discard, r, int64(valueLength-prefix))
-		if err != nil {
+	if skip := int(valueLength - prefix); skip > 0 {
+		if _, err := r.Discard(skip); err != nil {
 			return errors.Wrap(err, "skip value remainder")
 		}
-		out.offset += int(skipped)
+		out.offset += skip
 	}
 
 	if _, err := io.ReadFull(r, tmpBuf[:4]); err != nil {
@@ -316,11 +316,10 @@ func ParseReplaceNodeDigestIntoPread(r io.Reader, secondaryIndexCount uint16, va
 		if secKeyLen == 0 {
 			continue
 		}
-		skipped, err := io.CopyN(io.Discard, r, int64(secKeyLen))
-		if err != nil {
+		if _, err := r.Discard(int(secKeyLen)); err != nil {
 			return errors.Wrap(err, "skip secondary key")
 		}
-		out.offset += int(skipped)
+		out.offset += int(secKeyLen)
 	}
 
 	out.secondaryIndexCount = secondaryIndexCount

--- a/adapters/repos/db/lsmkv/segment_serialization_digest_test.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_digest_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"testing"
@@ -46,6 +47,14 @@ func makeReplaceNode(valueSize, keySize, secondaryCount, secondaryKeySize int, t
 	}
 }
 
+func serializeReplaceNode(t testing.TB, node segmentReplaceNode) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	_, err := node.KeyIndexAndWriteTo(&buf)
+	require.NoError(t, err)
+	return buf.Bytes()
+}
+
 // TestParseReplaceNodeDigest_ParityWithFull checks digest parsers match the full parser on key/tombstone/offset and retain exactly the requested value prefix.
 func TestParseReplaceNodeDigest_ParityWithFull(t *testing.T) {
 	cases := []struct {
@@ -74,10 +83,7 @@ func TestParseReplaceNodeDigest_ParityWithFull(t *testing.T) {
 		for _, prefix := range prefixes {
 			t.Run(fmt.Sprintf("%s/prefix=%d", tc.name, prefix), func(t *testing.T) {
 				node := makeReplaceNode(tc.valueSize, tc.keySize, tc.secondaryCount, tc.secondaryKeySize, tc.tombstone)
-				var buf bytes.Buffer
-				_, err := node.KeyIndexAndWriteTo(&buf)
-				require.NoError(t, err)
-				raw := buf.Bytes()
+				raw := serializeReplaceNode(t, node)
 				secCount := uint16(tc.secondaryCount)
 
 				var full segmentReplaceNode
@@ -98,7 +104,7 @@ func TestParseReplaceNodeDigest_ParityWithFull(t *testing.T) {
 
 				t.Run("pread", func(t *testing.T) {
 					var got segmentReplaceNode
-					require.NoError(t, ParseReplaceNodeDigestIntoPread(bytes.NewReader(raw), secCount, prefix, &got))
+					require.NoError(t, ParseReplaceNodeDigestIntoPread(bufio.NewReader(bytes.NewReader(raw)), secCount, prefix, &got))
 					assertDigestParity(t, got)
 				})
 
@@ -122,10 +128,7 @@ func TestParseReplaceNodeDigest_BufferReuse(t *testing.T) {
 	var reusedMMAP segmentReplaceNode
 	for _, valueSize := range sizes {
 		node := makeReplaceNode(valueSize, 16, 1, 128, false)
-		var buf bytes.Buffer
-		_, err := node.KeyIndexAndWriteTo(&buf)
-		require.NoError(t, err)
-		raw := buf.Bytes()
+		raw := serializeReplaceNode(t, node)
 
 		wantPrefix := prefix
 		if wantPrefix > valueSize {
@@ -133,7 +136,7 @@ func TestParseReplaceNodeDigest_BufferReuse(t *testing.T) {
 		}
 		wantValue := node.value[:wantPrefix]
 
-		require.NoError(t, ParseReplaceNodeDigestIntoPread(bytes.NewReader(raw), 1, prefix, &reusedPread))
+		require.NoError(t, ParseReplaceNodeDigestIntoPread(bufio.NewReader(bytes.NewReader(raw)), 1, prefix, &reusedPread))
 		require.Equal(t, node.primaryKey, reusedPread.primaryKey)
 		require.True(t, bytes.Equal(wantValue, reusedPread.value), "pread reuse value size=%d", valueSize)
 
@@ -144,20 +147,130 @@ func TestParseReplaceNodeDigest_BufferReuse(t *testing.T) {
 	}
 }
 
+// preadReplaceParsers are the two parsers the reusable pread cursor drives, over the same wire format.
+var preadReplaceParsers = []struct {
+	name  string
+	parse func(*bufio.Reader, uint16, *segmentReplaceNode) error
+}{
+	{"full", func(r *bufio.Reader, secCount uint16, out *segmentReplaceNode) error {
+		return ParseReplaceNodeIntoPread(r, secCount, out)
+	}},
+	{"digest", func(r *bufio.Reader, secCount uint16, out *segmentReplaceNode) error {
+		return ParseReplaceNodeDigestIntoPread(r, secCount, 42, out)
+	}},
+}
+
+// TestPreadReplaceParsers_Truncated pins that a node cut short at any read or skip point returns an error, rather than reporting a short node as successfully parsed and desynchronising the cursor.
+func TestPreadReplaceParsers_Truncated(t *testing.T) {
+	const (
+		valueSize    = 4096
+		keySize      = 16
+		secKeySize   = 128
+		valueStart   = 9
+		keyLenStart  = valueStart + valueSize
+		keyStart     = keyLenStart + 4
+		secLenStart  = keyStart + keySize
+		secKeyStart  = secLenStart + 4
+		nodeByteSize = secKeyStart + secKeySize
+	)
+
+	raw := serializeReplaceNode(t, makeReplaceNode(valueSize, keySize, 1, secKeySize, false))
+	require.Len(t, raw, nodeByteSize)
+
+	// the expected message identifies which read failed, so a skip whose error is
+	// dropped surfaces as the next read's failure and fails the case
+	cases := []struct {
+		name       string
+		keep       int
+		wantFull   string
+		wantDigest string
+	}{
+		{"empty", 0, "read tombstone and value length", "read tombstone and value length"},
+		{"header", valueStart - 1, "read tombstone and value length", "read tombstone and value length"},
+		{"value-prefix", valueStart + 41, "read value", "read value prefix"},
+		{"value-remainder", valueStart + 43, "read value", "skip value remainder"},
+		{"key-length", keyLenStart + 2, "read key length encoding", "read key length encoding"},
+		{"key", keyStart + keySize/2, "read key", "read key"},
+		{"secondary-key-length", secLenStart + 2, "read secondary key length encoding", "read secondary key length encoding"},
+		{"secondary-key", secKeyStart + secKeySize/2, "read secondary key", "skip secondary key"},
+	}
+
+	for _, p := range preadReplaceParsers {
+		for _, tc := range cases {
+			t.Run(p.name+"/"+tc.name, func(t *testing.T) {
+				want := tc.wantFull
+				if p.name == "digest" {
+					want = tc.wantDigest
+				}
+				var out segmentReplaceNode
+				err := p.parse(bufio.NewReader(bytes.NewReader(raw[:tc.keep])), 1, &out)
+				require.ErrorContains(t, err, want)
+			})
+		}
+	}
+}
+
+// TestPreadReplaceParsers_NoAllocs pins both pread parsers at zero allocations per node once the out node's buffers are warm — the reusable cursor parses every node of every segment through them.
+func TestPreadReplaceParsers_NoAllocs(t *testing.T) {
+	cases := []struct {
+		name             string
+		valueSize        int
+		secondaryCount   int
+		secondaryKeySize int
+	}{
+		// value remainder and secondary key are both skipped in digest mode
+		{"one-secondary", 4096, 1, 128},
+		{"two-secondary", 4096, 2, 128},
+		// nothing to skip in digest mode: prefix covers the value, secondary key is empty
+		{"nothing-to-skip", 10, 1, 0},
+		// skip spans several refills of the pooled read buffer
+		{"skip-spans-refills", 8 * segmentCursorReaderBufSize, 1, 128},
+		{"no-secondary", 4096, 0, 0},
+	}
+
+	for _, p := range preadReplaceParsers {
+		for _, tc := range cases {
+			t.Run(p.name+"/"+tc.name, func(t *testing.T) {
+				raw := serializeReplaceNode(t, makeReplaceNode(tc.valueSize, 16, tc.secondaryCount, tc.secondaryKeySize, false))
+				secCount := uint16(tc.secondaryCount)
+
+				src := bytes.NewReader(raw)
+				r := bufio.NewReaderSize(src, segmentCursorReaderBufSize)
+				out := &segmentReplaceNode{}
+
+				var parseErr error
+				allocs := testing.AllocsPerRun(100, func() {
+					src.Reset(raw)
+					r.Reset(src)
+					if err := p.parse(r, secCount, out); err != nil {
+						parseErr = err
+					}
+				})
+				require.NoError(t, parseErr)
+				require.Zero(t, allocs, "parsing into a warm node must not allocate")
+			})
+		}
+	}
+}
+
 // BenchmarkParseReplaceNodeDigestVsFull_Pread shows the alloc drop from skipping the full value on the pread path.
 func BenchmarkParseReplaceNodeDigestVsFull_Pread(b *testing.B) {
-	node := makeReplaceNode(4096, 16, 1, 128, false)
-	var buf bytes.Buffer
-	_, err := node.KeyIndexAndWriteTo(&buf)
-	require.NoError(b, err)
-	raw := buf.Bytes()
+	raw := serializeReplaceNode(b, makeReplaceNode(4096, 16, 1, 128, false))
+
+	src := bytes.NewReader(raw)
+	r := bufio.NewReader(src)
+	rewind := func() {
+		src.Reset(raw)
+		r.Reset(src)
+	}
 
 	b.Run("full", func(b *testing.B) {
 		var out segmentReplaceNode
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			out = segmentReplaceNode{}
-			_ = ParseReplaceNodeIntoPread(bytes.NewReader(raw), 1, &out)
+			rewind()
+			_ = ParseReplaceNodeIntoPread(r, 1, &out)
 		}
 	})
 
@@ -166,7 +279,8 @@ func BenchmarkParseReplaceNodeDigestVsFull_Pread(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			out = segmentReplaceNode{}
-			_ = ParseReplaceNodeDigestIntoPread(bytes.NewReader(raw), 1, 42, &out)
+			rewind()
+			_ = ParseReplaceNodeDigestIntoPread(r, 1, 42, &out)
 		}
 	})
 }


### PR DESCRIPTION
### What's being changed:

During async-replication digest scans, every key in every segment goes through these two parse functions. Both allocated memory on every key. Now neither does.

Two causes:

- A 9-byte scratch array was declared as a local, with a comment claiming it stays on the stack. It doesn't. It gets handed to `io.ReadFull`, which takes an interface, so Go moves it to the heap on every call. It now lives on the node struct, which the cursor already reuses for the whole scan.
- Skipping over data used `io.CopyN`, which allocates a small helper each time. Digest mode skips the rest of the value plus every secondary key, so it paid that several times per key. It now uses `bufio.Reader.Discard`, which allocates nothing.

The second one needs the digest parser to take a `*bufio.Reader` rather than an `io.Reader`. Its only caller already has one.

Measured per key, on a 4 KB value with one secondary key:

| | before | after |
|---|---|---|
| full parser | 131 ns, 1 alloc | 110 ns, 0 allocs |
| digest parser | 195 ns, 3 allocs | 74 ns, 0 allocs |

**One side effect worth knowing about.** `Discard` pulls skipped bytes through the read
buffer; the old code went around it. So the buffer size now decides how many reads it
takes to skip past a value. Left at 4 KB that would have doubled the read count, so it
goes to 8 KB. The cost is 8 KB per pooled reader instead of 4 KB, one per segment per
scan.

**Where to look hardest.** The skip now trusts that `Discard` moved exactly the number
of bytes asked for. It does — it only returns a nil error in that case. But if that
were ever wrong, the cursor would land on the wrong offset and quietly misread the rest
of the segment instead of failing. `TestPreadReplaceParsers_Truncated` cuts a node short
at 8 different points and checks the exact error each time, so a swallowed error fails
the test instead of slipping through.

Also added `TestPreadReplaceParsers_NoAllocs`, which pins both parsers at zero
allocations across five node shapes, including one where the skip spans several buffer
refills.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: n/a, internal code with no user-facing surface
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary, the change is confined to node parsing
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. See the table above.
