### PR TITLE
fix(db): snapshot vector index configs under the config lock during shard init

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3957,6 +3957,20 @@ func (i *Index) GetVectorIndexConfigs() map[string]schemaConfig.VectorIndexConfi
 	return configs
 }
 
+// getTargetVectorIndexConfigs snapshots the named target-vector configs, without
+// the legacy one GetVectorIndexConfigs folds in under "".
+func (i *Index) getTargetVectorIndexConfigs() map[string]schemaConfig.VectorIndexConfig {
+	i.vectorIndexUserConfigLock.Lock()
+	defer i.vectorIndexUserConfigLock.Unlock()
+
+	configs := make(map[string]schemaConfig.VectorIndexConfig, len(i.vectorIndexUserConfigs))
+	for k, v := range i.vectorIndexUserConfigs {
+		configs[k] = v
+	}
+
+	return configs
+}
+
 func convertToVectorIndexConfig(config interface{}) schemaConfig.VectorIndexConfig {
 	if config == nil {
 		return nil

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -574,7 +574,10 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 		return err
 	}
 
-	if err := newCompressedVectorsMigrator(s.index.logger).doUpdate(s, updated); err != nil {
+	legacy := s.index.GetVectorIndexConfig("")
+	targets := s.index.getTargetVectorIndexConfigs()
+
+	if err := newCompressedVectorsMigrator(s.index.logger).doUpdate(s, legacy, targets, updated); err != nil {
 		s.index.logger.WithFields(logrus.Fields{
 			"action":   "init_target_vectors",
 			"shard_id": s.ID(),

--- a/adapters/repos/db/shard_compressed_vectors_migrator.go
+++ b/adapters/repos/db/shard_compressed_vectors_migrator.go
@@ -35,13 +35,17 @@ func newCompressedVectorsMigrator(logger logrus.FieldLogger) compressedVectorsMi
 	return compressedVectorsMigrator{logger: logger.WithField("action", "compressed_vector_migration")}
 }
 
-func (m compressedVectorsMigrator) do(s *Shard) error {
+// do runs the compressed-vectors layout migration. legacy and targets are
+// caller-held snapshots, never the live index fields.
+func (m compressedVectorsMigrator) do(s *Shard, legacy schemaConfig.VectorIndexConfig,
+	targets map[string]schemaConfig.VectorIndexConfig,
+) error {
 	lsmDir := s.store.GetDir()
-	totalVectors := len(s.index.vectorIndexUserConfigs)
-	if s.index.vectorIndexUserConfig != nil {
+	totalVectors := len(targets)
+	if legacy != nil {
 		totalVectors++
 	}
-	hasOnly1NamedVector := s.index.vectorIndexUserConfig == nil && len(s.index.vectorIndexUserConfigs) == 1
+	hasOnly1NamedVector := legacy == nil && len(targets) == 1
 
 	if m.isMigrationDone(lsmDir, hasOnly1NamedVector) {
 		// migration was performed, nothing to do
@@ -54,8 +58,8 @@ func (m compressedVectorsMigrator) do(s *Shard) error {
 		case 0:
 			// do nothing
 		case 1:
-			if len(s.index.vectorIndexUserConfigs) > 0 {
-				for targetVector, vectorIndexConfig := range s.index.vectorIndexUserConfigs {
+			if len(targets) > 0 {
+				for targetVector, vectorIndexConfig := range targets {
 					// rename old bucket to new target vector bucket
 					if err := m.migrate(targetVector, vectorIndexConfig, lsmDir, true); err != nil {
 						return fmt.Errorf("failed to rename old compressed vector bucket for target vector %s: %w", targetVector, err)
@@ -67,12 +71,12 @@ func (m compressedVectorsMigrator) do(s *Shard) error {
 			}
 		default:
 			// copy old buckets to new target vector buckets
-			for targetVector, vectorIndexConfig := range s.index.vectorIndexUserConfigs {
+			for targetVector, vectorIndexConfig := range targets {
 				if err := m.migrate(targetVector, vectorIndexConfig, lsmDir, false); err != nil {
 					return fmt.Errorf("failed to copy from old compressed vector bucket to new bucket for target vector: %s: %w", targetVector, err)
 				}
 			}
-			if s.index.vectorIndexUserConfig == nil {
+			if legacy == nil {
 				// remove the old bucket directory after all copies are complete, only if was not defined for legacy vector
 				if err := os.RemoveAll(vectorsCompressedPath); err != nil {
 					return fmt.Errorf("failed to remove old bucket directory after copying all target vectors: %w", err)
@@ -86,14 +90,14 @@ func (m compressedVectorsMigrator) do(s *Shard) error {
 			}
 		}
 	} else {
-		if s.index.vectorIndexUserConfig != nil && m.isQuantizationEnabled(s.index.vectorIndexUserConfig) {
+		if legacy != nil && m.isQuantizationEnabled(legacy) {
 			// a new legacy vector config was created, quantization is enabled but we didn't create the vectors_compressed
 			// folder yet but we need to mark that the migration was done in order for it to not be trigered on healthy vector indexes
 			if err := m.markMigrationDone(lsmDir); err != nil {
 				return fmt.Errorf("failed to mark migration as done: %w", err)
 			}
 		} else if hasOnly1NamedVector {
-			if err := m.tryToCreateVectorCompressedFolder(lsmDir, s.index.vectorIndexUserConfigs); err != nil {
+			if err := m.tryToCreateVectorCompressedFolder(lsmDir, targets); err != nil {
 				return fmt.Errorf("create 1 named vector config: %w", err)
 			}
 		}
@@ -101,9 +105,11 @@ func (m compressedVectorsMigrator) do(s *Shard) error {
 	return nil
 }
 
-func (m compressedVectorsMigrator) doUpdate(s *Shard, updated map[string]schemaConfig.VectorIndexConfig) error {
+func (m compressedVectorsMigrator) doUpdate(s *Shard, legacy schemaConfig.VectorIndexConfig,
+	targets map[string]schemaConfig.VectorIndexConfig, updated map[string]schemaConfig.VectorIndexConfig,
+) error {
 	lsmDir := s.store.GetDir()
-	hasOnly1NamedVector := s.index.vectorIndexUserConfig == nil && len(s.index.vectorIndexUserConfigs) == 1
+	hasOnly1NamedVector := legacy == nil && len(targets) == 1
 	if hasOnly1NamedVector && !m.isMigrationDone(lsmDir, hasOnly1NamedVector) && len(updated) == 1 {
 		if err := m.tryToCreateVectorCompressedFolder(lsmDir, updated); err != nil {
 			return fmt.Errorf("update vector config: %w", err)

--- a/adapters/repos/db/shard_debug.go
+++ b/adapters/repos/db/shard_debug.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 )
 
 // IMPORTANT:
@@ -45,12 +44,7 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 		return errors.Wrap(err, "drop vector index")
 	}
 
-	var newConfig schemaConfig.VectorIndexConfig
-	if targetVector == "" {
-		newConfig = s.index.vectorIndexUserConfig
-	} else {
-		newConfig = s.index.vectorIndexUserConfigs[targetVector]
-	}
+	newConfig := s.index.GetVectorIndexConfig(targetVector)
 
 	vidx, err = s.initVectorIndex(ctx, targetVector, newConfig, false)
 	if err != nil {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -40,13 +40,19 @@ import (
 )
 
 func (s *Shard) initShardVectors(ctx context.Context) error {
-	if s.index.vectorIndexUserConfig != nil {
-		if err := s.initLegacyVector(ctx, s.lazySegmentLoadingEnabled); err != nil {
+	// Snapshot under the index config lock: updateVectorIndexConfig(s) mutate
+	// these concurrently, and ranging the live map is a fatal
+	// "concurrent map read and map write", not a recoverable race.
+	legacy := s.index.GetVectorIndexConfig("")
+	targets := s.index.getTargetVectorIndexConfigs()
+
+	if legacy != nil {
+		if err := s.initLegacyVector(ctx, legacy, s.lazySegmentLoadingEnabled); err != nil {
 			return err
 		}
 	}
 
-	if err := s.initTargetVectors(ctx, s.lazySegmentLoadingEnabled); err != nil {
+	if err := s.initTargetVectors(ctx, legacy, targets, s.lazySegmentLoadingEnabled); err != nil {
 		return err
 	}
 
@@ -321,21 +327,26 @@ func (s *Shard) getOrInitDynamicVectorIndexDB() (*bbolt.DB, error) {
 	return s.dynamicVectorIndexDB, nil
 }
 
-func (s *Shard) initTargetVectors(ctx context.Context, lazyLoadSegments bool) error {
+// initTargetVectors builds the named target-vector indexes. legacy and configs
+// are caller-held snapshots; the migrator needs legacy to tell a
+// single-named-vector layout from a legacy-plus-named one.
+func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
+	configs map[string]schemaConfig.VectorIndexConfig, lazyLoadSegments bool,
+) error {
 	s.vectorIndexMu.Lock()
 	defer s.vectorIndexMu.Unlock()
 
-	if err := newCompressedVectorsMigrator(s.index.logger).do(s); err != nil {
+	if err := newCompressedVectorsMigrator(s.index.logger).do(s, legacy, configs); err != nil {
 		s.index.logger.WithFields(logrus.Fields{
 			"action":   "init_target_vectors",
 			"shard_id": s.ID(),
 		}).Errorf("failed to migrate vectors compressed folder: %v", err)
 	}
 
-	s.vectorIndexes = make(map[string]VectorIndex, len(s.index.vectorIndexUserConfigs))
-	s.queues = make(map[string]*VectorIndexQueue, len(s.index.vectorIndexUserConfigs))
+	s.vectorIndexes = make(map[string]VectorIndex, len(configs))
+	s.queues = make(map[string]*VectorIndexQueue, len(configs))
 
-	for targetVector, vectorIndexConfig := range s.index.vectorIndexUserConfigs {
+	for targetVector, vectorIndexConfig := range configs {
 		if err := s.initTargetVectorWithLock(ctx, targetVector, vectorIndexConfig, lazyLoadSegments); err != nil {
 			return err
 		}
@@ -375,11 +386,11 @@ func (s *Shard) initTargetVectorWithLock(ctx context.Context, targetVector strin
 	return nil
 }
 
-func (s *Shard) initLegacyVector(ctx context.Context, lazyLoadSegments bool) error {
+func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
 	s.vectorIndexMu.Lock()
 	defer s.vectorIndexMu.Unlock()
 
-	vectorIndex, err := s.initVectorIndex(ctx, "", s.index.vectorIndexUserConfig, lazyLoadSegments)
+	vectorIndex, err := s.initVectorIndex(ctx, "", cfg, lazyLoadSegments)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -139,6 +140,47 @@ func TestUpdateVectorIndexConfigs_FailedInitRestoresStatus(t *testing.T) {
 
 	require.Eventually(t, func() bool { return s.GetStatus() == storagestate.StatusReady }, 5*time.Second, 20*time.Millisecond,
 		"shard left read-only after a failed vector index creation")
+}
+
+// Shard init must snapshot the index vector configs under
+// vectorIndexUserConfigLock. Ranging the live vectorIndexUserConfigs map while
+// updateVectorIndexConfigs writes it aborts the process with "concurrent map
+// read and map write" — a fatal error no recover can catch.
+func TestInitShardVectors_ConcurrentConfigUpdate(t *testing.T) {
+	ctx := context.Background()
+	shardLike, idx := testShard(t, ctx, "VectorConfigRace")
+	shard := underlyingShard(t, shardLike)
+
+	stop := make(chan struct{})
+	writerDone := make(chan struct{})
+	var applied atomic.Int64
+	go func() {
+		defer close(writerDone)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// UpdateVectorIndexConfigs flips the shard read-only and restores it
+			// asynchronously, so back-to-back calls legitimately bounce off it.
+			// Only the calls that get through reach the map write we care about.
+			if err := idx.updateVectorIndexConfigs(ctx, map[string]schemaConfig.VectorIndexConfig{
+				fmt.Sprintf("v%d", i%4): enthnsw.UserConfig{Skip: true},
+			}); err == nil {
+				applied.Add(1)
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < 200; i++ {
+		require.NoError(t, shard.initShardVectors(ctx))
+	}
+
+	close(stop)
+	<-writerDone
+	require.NotZero(t, applied.Load(), "no config update ever landed, so nothing raced the reads")
 }
 
 // underlyingShard returns the concrete *Shard behind a ShardLike, loading it if


### PR DESCRIPTION
### What's being changed:
Shard init read the index's live vector-config map while config updates wrote it. a concurrent map read and map write fatal would aborts the node. it now snapshots under vectorIndexUserConfigLock and passes the snapshot down.

This is needed to remove some of the unnecessary class Locks https://github.com/weaviate/weaviate/pull/12525

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
