### PR TITLE
Drop per-cycle allocations from the idle compaction path

### DIFF
--- a/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_abort_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -144,22 +145,27 @@ func TestCompactor_AbortOnShouldAbort(t *testing.T) {
 			})
 
 			// bridge path: shouldAbort=true exercised through compactOrCleanup;
-			// the bridge inside compactOrCleanup pre-cancels the ctx so the
+			// the bridge inside compactOnceAbortable pre-cancels the ctx so the
 			// compactor sees the abort on its first sample.
 			t.Run("bridge", func(t *testing.T) {
+				var polls atomic.Int64
 				start := time.Now()
-				didWork := bucket.disk.compactOrCleanup(func() bool { return true })
+				didWork := bucket.disk.compactOrCleanup(func() bool {
+					polls.Add(1)
+					return true
+				})
 				elapsed := time.Since(start)
 				assert.False(t, didWork)
+				assert.NotZero(t, polls.Load(), "the bridge must read shouldAbort once there is a pair to merge")
 				assert.Less(t, elapsed, 3*time.Second, "observed %s", elapsed)
 				assertNoTempFiles(t, dirName)
 			})
 
-			// the aborts above must not have compromised the segments
+			// the aborts above must not have compromised the segments. Driven
+			// through compactOrCleanup with a live poller, so the merge runs
+			// alongside the watcher goroutine the bridge starts.
 			t.Run("compaction still succeeds afterwards", func(t *testing.T) {
-				compacted, err := bucket.disk.compactOnce(ctx)
-				require.NoError(t, err)
-				require.True(t, compacted)
+				require.True(t, bucket.disk.compactOrCleanup(func() bool { return false }))
 				require.Len(t, bucket.disk.segments, 1)
 
 				_, err = os.Stat(bucket.disk.segments[0].getPath())

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -31,7 +31,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/diskio"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -1087,6 +1086,20 @@ func (sg *SegmentGroup) isReadyOnly() bool {
 	return sg.status == storagestate.StatusReadOnly
 }
 
+// traceEnabled reports whether the logger emits trace entries, so callers can
+// skip building WithField chains a normal log level would discard. A logger of
+// unknown type is treated as enabled rather than silently losing the line.
+func traceEnabled(logger logrus.FieldLogger) bool {
+	switch l := logger.(type) {
+	case *logrus.Logger:
+		return l.IsLevelEnabled(logrus.TraceLevel)
+	case *logrus.Entry:
+		return l.Logger.IsLevelEnabled(logrus.TraceLevel)
+	default:
+		return true
+	}
+}
+
 func fileExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
@@ -1116,41 +1129,15 @@ func segmentExistsWithID(segmentID string, files map[string]int64) (bool, string
 func (sg *SegmentGroup) compactOrCleanup(shouldAbort cyclemanager.ShouldAbortCallback) bool {
 	sg.monitorSegments()
 
-	// bridge shouldAbort → ctx for the compactor inner loops
-	compactCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	if shouldAbort != nil {
-		if shouldAbort() {
-			cancel()
-		} else {
-			watcher := func() {
-				t := time.NewTicker(50 * time.Millisecond)
-				defer t.Stop()
-				for {
-					select {
-					case <-compactCtx.Done():
-						return
-					case <-t.C:
-						if shouldAbort() {
-							cancel()
-							return
-						}
-					}
-				}
-			}
-			enterrors.GoWrapper(watcher, sg.logger)
-		}
-	}
-
 	compact := func() bool {
 		sg.lastCompactionCall = time.Now()
-		compacted, err := sg.compactOnce(compactCtx)
+		compacted, err := sg.compactOnceAbortable(context.Background(), shouldAbort)
 		if err != nil {
 			sg.logger.WithField("action", "lsm_compaction").
 				WithField("path", sg.dir).
 				WithError(err).
 				Errorf("compaction failed")
-		} else if !compacted {
+		} else if !compacted && traceEnabled(sg.logger) {
 			sg.logger.WithField("action", "lsm_compaction").
 				WithField("path", sg.dir).
 				Trace("no segments eligible for compaction")

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -29,7 +29,9 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
@@ -285,9 +287,52 @@ func discardSegmentFile(f *os.File, path string, err error) error {
 	return err
 }
 
-// compactOnce performs one compaction iteration. Cancelling ctx aborts
-// the in-flight merge (sampled every compactor.AbortCheckEveryN keys).
-func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err error) {
+// abortPollInterval bounds how often the poller reads shouldAbort.
+const abortPollInterval = 50 * time.Millisecond
+
+// compactOnce performs one compaction iteration.
+func (sg *SegmentGroup) compactOnce(ctx context.Context) (bool, error) {
+	return sg.compactOnceAbortable(ctx, nil)
+}
+
+// watchAbort returns a context cancelled once shouldAbort turns true. The poller
+// lives until the returned cancel runs, so callers must always call it.
+func (sg *SegmentGroup) watchAbort(ctx context.Context,
+	shouldAbort cyclemanager.ShouldAbortCallback,
+) (context.Context, context.CancelFunc) {
+	// read before deriving, so a panicking callback leaves no context behind
+	aborting := shouldAbort()
+	ctx, cancel := context.WithCancel(ctx)
+	if aborting {
+		cancel()
+		return ctx, cancel
+	}
+
+	enterrors.GoWrapper(func() {
+		t := time.NewTicker(abortPollInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				if shouldAbort() {
+					cancel()
+					return
+				}
+			}
+		}
+	}, sg.logger)
+	return ctx, cancel
+}
+
+// compactOnceAbortable performs one compaction iteration. Cancelling ctx, or
+// shouldAbort turning true, aborts the in-flight merge (sampled every
+// compactor.AbortCheckEveryN keys). Its shouldAbort bridge is built only once
+// there is a pair to merge, so an idle cycle needs no context, goroutine or ticker.
+func (sg *SegmentGroup) compactOnceAbortable(ctx context.Context,
+	shouldAbort cyclemanager.ShouldAbortCallback,
+) (compacted bool, err error) {
 	// Is it safe to only occasionally lock instead of the entire duration? Yes,
 	// because other than compaction the only change to the segments array could
 	// be an append because of a new flush cycle, so we do not need to guarantee
@@ -345,6 +390,12 @@ func (sg *SegmentGroup) compactOnce(ctx context.Context) (compacted bool, err er
 	// skips above are not real runs
 	backgroundDone := monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessCompaction)
 	defer backgroundDone()
+
+	if shouldAbort != nil {
+		var cancel context.CancelFunc
+		ctx, cancel = sg.watchAbort(ctx, shouldAbort)
+		defer cancel()
+	}
 
 	var left, right Segment
 	func() {

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -14,10 +14,14 @@ package lsmkv
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/storagestate"
 )
 
 var (
@@ -1296,6 +1300,111 @@ func TestSegmentGroup_CompactionPairToFixLevelsOrder(t *testing.T) {
 				assert.Equal(t, tc.expPair, []string{lPath, rPath})
 			}
 			assert.Equal(t, tc.expLvl, lvl)
+		})
+	}
+}
+
+// watchAbort turns a cycle's stop request into the cancellation the compactors
+// poll: immediate abort, delayed abort, and the poller's lifetime.
+func TestSegmentGroup_WatchAbort(t *testing.T) {
+	sg := &SegmentGroup{logger: nullLogger()}
+
+	t.Run("already aborting", func(t *testing.T) {
+		ctx, cancel := sg.watchAbort(context.Background(), func() bool { return true })
+		defer cancel()
+
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	})
+
+	t.Run("aborts once shouldAbort turns true", func(t *testing.T) {
+		var abort atomic.Bool
+		ctx, cancel := sg.watchAbort(context.Background(), abort.Load)
+		defer cancel()
+		require.NoError(t, ctx.Err())
+
+		abort.Store(true)
+		select {
+		case <-ctx.Done():
+		case <-time.After(10 * time.Second):
+			t.Fatal("context still live after shouldAbort turned true")
+		}
+	})
+
+	t.Run("poller stops with the context", func(t *testing.T) {
+		var polls atomic.Int64
+		_, cancel := sg.watchAbort(context.Background(), func() bool {
+			polls.Add(1)
+			return false
+		})
+		cancel()
+
+		// cancel races at most one tick; a poller left running reaches ~7
+		time.Sleep(7 * abortPollInterval)
+		require.LessOrEqual(t, polls.Load(), int64(2), "the poller must not outlive the context")
+	})
+}
+
+// With no pair to compact, the compaction half of the cycle must not read
+// shouldAbort at all, since reading it costs a context, a goroutine and a ticker.
+// The cleaner is a no-op here, so any read seen comes from compaction.
+func TestSegmentGroup_CompactOrCleanupIdleSkipsAbortPoller(t *testing.T) {
+	testCases := []struct {
+		name           string
+		segments       []Segment
+		maxSegmentSize int64
+		status         storagestate.Status
+	}{
+		{
+			name: "no segments",
+		},
+		{
+			name:     "single segment",
+			segments: []Segment{&segment{path: "seg_01", level: 0, size: 100}},
+		},
+		{
+			name: "no pair of matching levels",
+			segments: []Segment{
+				&segment{path: "seg_01", level: 3, size: 100},
+				&segment{path: "seg_02", level: 2, size: 100},
+			},
+		},
+		{
+			name: "pair exceeds max segment size",
+			segments: []Segment{
+				&segment{path: "seg_01", level: 3, size: 8000},
+				&segment{path: "seg_02", level: 3, size: 8000},
+			},
+			maxSegmentSize: 10000,
+		},
+		{
+			name: "shard is read only",
+			segments: []Segment{
+				&segment{path: "seg_01", level: 3, size: 100},
+				&segment{path: "seg_02", level: 3, size: 100},
+			},
+			status: storagestate.StatusReadOnly,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			sg := &SegmentGroup{
+				segments:       tc.segments,
+				maxSegmentSize: tc.maxSegmentSize,
+				status:         tc.status,
+				dir:            t.TempDir(),
+				logger:         nullLogger(),
+				segmentCleaner: &segmentCleanerNoop{},
+			}
+
+			calls := 0
+			didWork := sg.compactOrCleanup(func() bool {
+				calls++
+				return false
+			})
+
+			assert.False(t, didWork)
+			assert.Zero(t, calls, "shouldAbort must not be read when there is nothing to compact")
 		})
 	}
 }

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -1338,9 +1338,13 @@ func TestSegmentGroup_WatchAbort(t *testing.T) {
 		})
 		cancel()
 
-		// cancel races at most one tick; a poller left running reaches ~7
-		time.Sleep(7 * abortPollInterval)
-		require.LessOrEqual(t, polls.Load(), int64(2), "the poller must not outlive the context")
+		// a stopped poller holds the count still; a running one never reads
+		// the same value twice
+		require.Eventually(t, func() bool {
+			settled := polls.Load()
+			time.Sleep(5 * abortPollInterval)
+			return polls.Load() == settled
+		}, 10*time.Second, time.Millisecond, "the poller must not outlive the context")
 	})
 }
 

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -26,6 +27,45 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
+
+// traceEnabled gates whether a hot-path log line is built at all, so a logger it
+// cannot read must still be logged to rather than silently dropped.
+func TestTraceEnabled(t *testing.T) {
+	atLevel := func(level logrus.Level) *logrus.Logger {
+		l, _ := test.NewNullLogger()
+		l.SetLevel(level)
+		return l
+	}
+
+	testCases := []struct {
+		name     string
+		logger   logrus.FieldLogger
+		expected bool
+	}{
+		{name: "logger below trace", logger: atLevel(logrus.InfoLevel), expected: false},
+		{name: "logger at trace", logger: atLevel(logrus.TraceLevel), expected: true},
+		{
+			name:     "entry below trace",
+			logger:   atLevel(logrus.InfoLevel).WithField("action", "lsm_compaction"),
+			expected: false,
+		},
+		{
+			name:     "entry at trace",
+			logger:   atLevel(logrus.TraceLevel).WithField("action", "lsm_compaction"),
+			expected: true,
+		},
+		{name: "unreadable logger", logger: unreadableLogger{}, expected: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, traceEnabled(tc.logger))
+		})
+	}
+}
+
+// unreadableLogger is a FieldLogger whose level traceEnabled cannot inspect.
+type unreadableLogger struct{ logrus.FieldLogger }
 
 // This test proves two things:
 //


### PR DESCRIPTION
### What's being changed:

Guard the "no segments eligible" trace line on IsLevelEnabled, and build the shouldAbort->ctx bridge only once a candidate pair exists. An idle cycle no longer allocates two logrus entries, a cancellable context, a watcher goroutine or a 50ms ticker: 15 allocs/op and 1388 B/op -> 0.

This caused 6% of all allocations on a production cluster.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
