### PR TITLE
Read only the geo property when resolving a coordinate

### DIFF
--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -78,10 +78,15 @@ func (s *Shard) initGeoProp(prop *models.Property) error {
 }
 
 func (s *Shard) makeCoordinatesForID(propName string) geo.CoordinatesForID {
+	// read-only once built, so all lookups can share it
+	propExtraction := storobj.NewPropExtraction().Add(propName)
+
 	return func(ctx context.Context, id uint64) (*models.GeoCoordinates, error) {
-		obj, err := s.objectByIndexID(ctx, id, true)
+		obj, err := s.objectByIndexIDWithProps(ctx, id, propExtraction)
 		if err != nil {
-			return nil, storobj.NewErrNotFoundf(id, "retrieve object")
+			// reporting a read or decode failure as a not-found would make the
+			// geo index tombstone a doc that is still there
+			return nil, err
 		}
 
 		if obj.Properties() == nil {

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -1,0 +1,282 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+const geoPropClass = "GeoPropRead"
+
+func munichCoordinates() *models.GeoCoordinates {
+	return &models.GeoCoordinates{Latitude: ptFloat32(48.13743), Longitude: ptFloat32(11.57549)}
+}
+
+func stuttgartCoordinates() *models.GeoCoordinates {
+	return &models.GeoCoordinates{Latitude: ptFloat32(48.78232), Longitude: ptFloat32(9.17702)}
+}
+
+func testGeoPropShard(t *testing.T, ctx context.Context) *Shard {
+	t.Helper()
+
+	class := &models.Class{
+		Class: geoPropClass,
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
+			{Name: "sizes", DataType: schema.DataTypeNumberArray.PropString()},
+			{Name: "location", DataType: []string{string(schema.DataTypeGeoCoordinates)}},
+			{Name: "home", DataType: []string{string(schema.DataTypeGeoCoordinates)}},
+		},
+	}
+
+	shard, _ := testShardWithSettings(t, ctx, class,
+		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, false)
+	return concreteShard(t, shard)
+}
+
+func putGeoPropObject(t *testing.T, ctx context.Context, s *Shard, props map[string]interface{}) uint64 {
+	t.Helper()
+
+	obj := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      geoPropClass,
+			Properties: props,
+		},
+		Vector: []float32{1, 2, 3},
+	}
+	require.NoError(t, s.PutObject(ctx, obj))
+	return obj.DocID
+}
+
+// putRawObjectPayload stores payload under a fresh uuid with docID as its
+// secondary key, bypassing the write path's marshalling.
+func putRawObjectPayload(t *testing.T, s *Shard, docID uint64, payload []byte) uint64 {
+	t.Helper()
+
+	idBytes, err := uuid.New().MarshalBinary()
+	require.NoError(t, err)
+
+	docIDBuf := make([]byte, 8)
+	binary.LittleEndian.PutUint64(docIDBuf, docID)
+
+	require.NoError(t, s.store.Bucket(helpers.ObjectsBucketLSM).Put(idBytes, payload,
+		lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBuf)))
+	return docID
+}
+
+// payloadWithProps builds an object payload whose property blob is exactly
+// props, including blobs no marshaller would produce. It splices rather than
+// marshals because json.Marshal rejects invalid json.
+func payloadWithProps(t *testing.T, props []byte) []byte {
+	t.Helper()
+
+	payload, err := (&storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      geoPropClass,
+			Properties: map[string]interface{}{},
+		},
+	}).MarshalBinaryDisk(true)
+	require.NoError(t, err)
+
+	// version, docID, kind, uuid, both timestamps, then the vector and
+	// classname lengths, whose bodies are empty for the object above
+	const propLengthPos = 1 + 8 + 1 + 16 + 8 + 8 + 2 + 2
+	propLength := int(binary.LittleEndian.Uint32(payload[propLengthPos:]))
+
+	out := append([]byte{}, payload[:propLengthPos]...)
+	out = binary.LittleEndian.AppendUint32(out, uint32(len(props)))
+	out = append(out, props...)
+	return append(out, payload[propLengthPos+4+propLength:]...)
+}
+
+func TestMakeCoordinatesForID(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	fullProps := map[string]interface{}{
+		"name":     "munich office",
+		"sizes":    []float64{1.5, 2.5},
+		"location": munichCoordinates(),
+		"home":     stuttgartCoordinates(),
+	}
+
+	tests := []struct {
+		name     string
+		propName string
+		docID    func(t *testing.T) uint64
+		want     *models.GeoCoordinates
+		// a doc that is gone, or present without a value for propName: the geo
+		// index tombstones the doc ID for both
+		wantNotFound bool
+		// any other failure, which must not read as a missing doc
+		wantErrContains string
+	}{
+		{
+			name:     "geo prop next to other properties",
+			propName: "location",
+			docID:    func(t *testing.T) uint64 { return putGeoPropObject(t, ctx, s, fullProps) },
+			want:     munichCoordinates(),
+		},
+		{
+			name:     "second geo prop of the same object",
+			propName: "home",
+			docID:    func(t *testing.T) uint64 { return putGeoPropObject(t, ctx, s, fullProps) },
+			want:     stuttgartCoordinates(),
+		},
+		{
+			name:     "object without the requested prop",
+			propName: "location",
+			docID: func(t *testing.T) uint64 {
+				return putGeoPropObject(t, ctx, s, map[string]interface{}{"name": "no coordinates here"})
+			},
+			wantNotFound: true,
+		},
+		{
+			name:         "object with an empty property map",
+			propName:     "location",
+			docID:        func(t *testing.T) uint64 { return putGeoPropObject(t, ctx, s, map[string]interface{}{}) },
+			wantNotFound: true,
+		},
+		{
+			name:         "object without any properties",
+			propName:     "location",
+			docID:        func(t *testing.T) uint64 { return putGeoPropObject(t, ctx, s, nil) },
+			wantNotFound: true,
+		},
+		{
+			name:         "doc id that was never written",
+			propName:     "location",
+			docID:        func(t *testing.T) uint64 { return 1_000_000 },
+			wantNotFound: true,
+		},
+		{
+			name:     "payload of an unsupported marshaller version",
+			propName: "location",
+			docID: func(t *testing.T) uint64 {
+				return putRawObjectPayload(t, s, 2_000_000, []byte{2, 0, 0, 0})
+			},
+			wantErrContains: "unsupported binary marshaller version",
+		},
+		{
+			name:     "property blob without its opening brace",
+			propName: "location",
+			docID: func(t *testing.T) uint64 {
+				return putRawObjectPayload(t, s, 2_000_001,
+					payloadWithProps(t, []byte(`"location":"48.1"}`)))
+			},
+			wantErrContains: "malformed property json",
+		},
+		{
+			name:     "prop that does not hold coordinates",
+			propName: "location",
+			docID: func(t *testing.T) uint64 {
+				return putRawObjectPayload(t, s, 2_000_002,
+					payloadWithProps(t, []byte(`{"location":"48.1"}`)))
+			},
+			wantErrContains: "expected property to be of type",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			coordinates, err := s.makeCoordinatesForID(test.propName)(ctx, test.docID(t))
+
+			if test.want != nil {
+				require.NoError(t, err)
+				require.Equal(t, test.want, coordinates)
+				return
+			}
+
+			require.Error(t, err)
+			var notFound storobj.ErrNotFound
+			if test.wantNotFound {
+				require.ErrorAs(t, err, &notFound)
+				return
+			}
+
+			require.NotEmpty(t, test.wantErrContains, "table case declares no expectation")
+			require.ErrorContains(t, err, test.wantErrContains)
+			require.NotErrorAs(t, err, &notFound,
+				"a read that failed for another reason must not look like a deleted doc")
+		})
+	}
+}
+
+// All lookups share one *storobj.PropertyExtraction.
+func TestMakeCoordinatesForIDConcurrentLookups(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	docID := putGeoPropObject(t, ctx, s, map[string]interface{}{"location": munichCoordinates()})
+	coordinatesForID := s.makeCoordinatesForID("location")
+
+	const lookups = 8
+	coordinates := make([]*models.GeoCoordinates, lookups)
+	errs := make([]error, lookups)
+
+	var wg sync.WaitGroup
+	for i := range lookups {
+		wg.Go(func() {
+			coordinates[i], errs[i] = coordinatesForID(ctx, docID)
+		})
+	}
+	wg.Wait()
+
+	for i := range lookups {
+		require.NoError(t, errs[i])
+		require.Equal(t, munichCoordinates(), coordinates[i])
+	}
+}
+
+func TestObjectByIndexIDWithPropsDecodesOnlyRequestedProps(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	docID := putGeoPropObject(t, ctx, s, map[string]interface{}{
+		"name":     "munich office",
+		"sizes":    []float64{1.5, 2.5},
+		"location": munichCoordinates(),
+	})
+
+	obj, err := s.objectByIndexIDWithProps(ctx, docID, storobj.NewPropExtraction().Add("location"))
+	require.NoError(t, err)
+
+	require.Empty(t, obj.Vector, "the vector must stay undecoded")
+	props, ok := obj.Properties().(map[string]interface{})
+	require.True(t, ok)
+	require.Len(t, props, 1, "only the requested property must be decoded")
+	require.Equal(t, munichCoordinates(), props["location"])
+}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -359,7 +359,15 @@ func (s *Shard) Exists(ctx context.Context, id strfmt.UUID) (bool, error) {
 	return true, nil
 }
 
-func (s *Shard) objectByIndexID(ctx context.Context, indexID uint64, acceptDeleted bool) (*storobj.Object, error) {
+// objectByIndexIDWithProps resolves a doc ID to an object holding only the
+// properties in propExtraction; vectors and unrequested properties stay
+// undecoded. A nil propExtraction decodes every property. Read and decode
+// failures keep their own type and only a missing object is reported as
+// storobj.ErrNotFound, because the geo index takes that as "the doc is gone"
+// and tombstones it.
+func (s *Shard) objectByIndexIDWithProps(ctx context.Context, indexID uint64,
+	propExtraction *storobj.PropertyExtraction,
+) (*storobj.Object, error) {
 	keyBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(keyBuf, indexID)
 
@@ -380,9 +388,9 @@ func (s *Shard) objectByIndexID(ctx context.Context, indexID uint64, acceptDelet
 			"uuid found for docID, but object is nil")
 	}
 
-	obj, err := storobj.FromBinaryDisk(bytes, className)
+	obj, err := storobj.FromBinaryOptionalDisk(bytes, className, additional.Properties{}, propExtraction)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal kind object")
+		return nil, errors.Wrapf(err, "unmarshal object of docID %d", indexID)
 	}
 
 	return obj, nil

--- a/adapters/repos/db/vector/hnsw/dist_to_node_test.go
+++ b/adapters/repos/db/vector/hnsw/dist_to_node_test.go
@@ -13,6 +13,7 @@ package hnsw
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,4 +81,62 @@ func TestDistToNode_ReturnsErrorOnErrNotFound(t *testing.T) {
 	var notFoundErr storobj.ErrNotFound
 	assert.ErrorAs(t, err, &notFoundErr, "error should be storobj.ErrNotFound")
 	assert.Equal(t, deletedNodeID, notFoundErr.DocID)
+}
+
+// Only storobj.ErrNotFound may tombstone a node, so a store that reports a read
+// failure as not-found silently deletes a document that is still there.
+func TestDistBetweenNodes_TombstonesOnlyOnErrNotFound(t *testing.T) {
+	const brokenID, liveID = uint64(1), uint64(2)
+
+	tests := []struct {
+		name          string
+		vectorErr     error
+		wantErr       bool
+		wantTombstone bool
+	}{
+		{
+			name:          "doc gone from the store",
+			vectorErr:     storobj.NewErrNotFoundf(brokenID, "doc deleted from store"),
+			wantTombstone: true,
+		},
+		{
+			name:      "doc still there but unreadable",
+			vectorErr: fmt.Errorf("read objects bucket: input/output error"),
+			wantErr:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index, err := New(Config{
+				RootPath:              t.TempDir(),
+				ID:                    "tombstone-on-vector-error",
+				MakeCommitLoggerThunk: MakeNoopCommitLogger,
+				DistanceProvider:      distancer.NewL2SquaredProvider(),
+				AllocChecker:          memwatch.NewDummyMonitor(),
+				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					if id == brokenID {
+						return nil, test.vectorErr
+					}
+					return []float32{1, 2, 3}, nil
+				},
+				GetViewThunk: func() common.BucketView { return &noopBucketView{} },
+			}, ent.UserConfig{
+				MaxConnections:        16,
+				EFConstruction:        64,
+				VectorCacheMaxObjects: 1000,
+			}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+			require.NoError(t, err)
+			t.Cleanup(func() { index.Shutdown(context.Background()) })
+
+			_, err = index.distBetweenNodes(brokenID, liveID)
+
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.wantTombstone, index.hasTombstone(brokenID))
+		})
+	}
 }

--- a/entities/cyclemanager/cyclemanager.go
+++ b/entities/cyclemanager/cyclemanager.go
@@ -211,14 +211,24 @@ func NewManagerNoop() CycleManager {
 }
 
 type cycleManagerNoop struct {
+	// Start may be called concurrently, so running needs a lock even though
+	// the cycle itself does nothing
+	sync.Mutex
+
 	running bool
 }
 
 func (c *cycleManagerNoop) Start() {
+	c.Lock()
+	defer c.Unlock()
+
 	c.running = true
 }
 
 func (c *cycleManagerNoop) Stop(ctx context.Context) chan bool {
+	c.Lock()
+	defer c.Unlock()
+
 	if !c.running {
 		return c.closedChan(true)
 	}
@@ -238,6 +248,9 @@ func (c *cycleManagerNoop) StopAndWait(ctx context.Context) error {
 }
 
 func (c *cycleManagerNoop) Running() bool {
+	c.Lock()
+	defer c.Unlock()
+
 	return c.running
 }
 

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -251,6 +251,41 @@ func TestCycleManager_doesNotStartMultipleTimesWithWait(t *testing.T) {
 	})
 }
 
+func TestCycleManager_handlesConcurrentStarts(t *testing.T) {
+	tests := []struct {
+		name    string
+		manager func() CycleManager
+	}{
+		{
+			name:    "noop",
+			manager: NewManagerNoop,
+		},
+		{
+			name: "ticking",
+			manager: func() CycleManager {
+				return NewManager("test", NewFixedTicker(5*time.Millisecond),
+					func(shouldAbort ShouldAbortCallback) bool { return false }, logger)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cm := test.manager()
+
+			var wg sync.WaitGroup
+			for range 8 {
+				wg.Go(cm.Start)
+			}
+			wg.Wait()
+
+			assert.True(t, cm.Running())
+			assert.NoError(t, cm.StopAndWait(context.Background()))
+			assert.False(t, cm.Running())
+		})
+	}
+}
+
 func TestCycleManager_handlesMultipleStops(t *testing.T) {
 	cycleInterval := 5 * time.Millisecond
 	cycleDuration := 1 * time.Millisecond

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1331,6 +1331,12 @@ func UnmarshalPropertiesFromObject(data []byte, resultProperties map[string]inte
 func UnmarshalProperties(data []byte, properties map[string]interface{}, propertyPaths [][]string) error {
 	var returnError error
 	jsonparser.EachKey(data, func(idx int, value []byte, dataType jsonparser.ValueType, err error) {
+		if idx < 0 {
+			// data the parser cannot walk at all: it reports that without a path
+			returnError = fmt.Errorf("malformed property json: %w", err)
+			return
+		}
+
 		propertyName := propertyPaths[idx][len(propertyPaths[idx])-1]
 
 		switch dataType {

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -850,6 +850,51 @@ func TestExtractionOfSingleProperties(t *testing.T) {
 	}
 }
 
+func TestUnmarshalProperties(t *testing.T) {
+	tests := []struct {
+		name            string
+		props           []byte
+		want            map[string]interface{}
+		wantErrContains string
+	}{
+		{
+			name:  "requested property present",
+			props: []byte(`{"text":"a","other":1}`),
+			want:  map[string]interface{}{"text": "a"},
+		},
+		{
+			name:  "requested property absent",
+			props: []byte(`{"other":1}`),
+			want:  map[string]interface{}{},
+		},
+		{
+			name:  "no properties at all",
+			props: []byte{},
+			want:  map[string]interface{}{},
+		},
+		{
+			name:            "property blob without its opening brace",
+			props:           []byte(`"text":"a"}`),
+			wantErrContains: "malformed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := map[string]interface{}{}
+			err := UnmarshalProperties(test.props, got, [][]string{{"text"}})
+
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestStorageObjectMarshallingWithGroup(t *testing.T) {
 	before := FromObject(
 		&models.Object{


### PR DESCRIPTION
### What's being changed:

 makeCoordinatesForID is the VectorForID thunk behind every geo property's HNSW index: it runs on each geo-prop write and on every graph hop that misses the vector cache. To read one lat/lon pair it deserialized the whole object — vector, metadata, every property. It now decodes just that property (FromBinaryOptionalDisk + a one-property PropertyExtraction): 2470 → 922 ns/op, 5448 → 1472 B/op, 55 → 25 allocs on a 4-property object with a 768-dim vector. Most of it lands at shard startup, where the geo cache prefill walks every node.

Two bugs found on the way, each fixed with a test that fails without the fix:

  - A read failure tombstoned a live document. makeCoordinatesForID reported every error as storobj.ErrNotFound, which hnsw takes as "the doc is gone" → handleDeletedNode → addTombstone, and that survives restart. A transient LSM read error silently and permanently deleted a live entry from the geo index. Only a missing object is ErrNotFound now. Visible change worth a look: a geo query whose object read fails now returns an error instead of quietly returning fewer results.
- storobj.UnmarshalProperties panicked — index out of range [-1] — on a property blob jsonparser cannot walk, which it signals by calling back with idx = -1. Also reachable from the existing ObjectsByDocID and docid.scan callers.

  entities/cyclemanager: the noop CycleManager left running unguarded while the real one is mutex-protected,
  so two geo properties initializing concurrently raced under -race.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
