### PR TITLE
fix(async-repl): surface root-prefilter skips in asyncReplicationStatus

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -1521,6 +1521,7 @@ func (sched *AsyncReplicationScheduler) runEntry(entry *asyncSchedulerEntry, ski
 		// network descent, but still honor a pending height-change rebuild.
 		needsRebuild = s.asyncRepNeedsRebuild.CompareAndSwap(true, false)
 		sched.metrics.incRootPrefilterSkips()
+		s.recordRootPrefilterNoDiff(ctx)
 		return
 	}
 

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -2330,3 +2330,36 @@ func TestDeregisterDrainsWithSingleWorker(t *testing.T) {
 	}
 	sched.Close()
 }
+
+// TestRunEntrySkipHashbeatRecordsNoDiffStatus pins that a root-prefilter skip surfaces in asyncReplicationStatus like the ErrNoDiffFound descent it replaces.
+func TestRunEntrySkipHashbeatRecordsNoDiffStatus(t *testing.T) {
+	sched := newSchedulerForUnitTest(t)
+	s := &Shard{asyncRepCtx: context.Background(), class: &models.Class{Class: "C"}, name: "S"}
+	s.asyncRepWg.Add(1)
+
+	sched.runEntry(&asyncSchedulerEntry{shard: s}, true)
+
+	stats := s.getAsyncReplicationStats(context.Background())
+	require.Len(t, stats, 1, "a prefilter-skipped cycle proves in-sync and must be visible in asyncReplicationStatus")
+	require.Empty(t, stats[0].TargetNode)
+	require.Positive(t, stats[0].StartDiffTimeUnixMillis)
+}
+
+// TestRecordRootPrefilterNoDiffCancelRaceLeavesStatsEmpty pins that the cancellation check runs under the stats lock: a disable's cancel+clear landing while the recorder awaits the lock must not leave a phantom entry, in every interleaving.
+func TestRecordRootPrefilterNoDiffCancelRaceLeavesStatsEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Shard{}
+
+	s.asyncReplicationStatsMux.Lock()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.recordRootPrefilterNoDiff(ctx)
+	}()
+	cancel()
+	s.asyncReplicationStatsByTargetNode = nil
+	s.asyncReplicationStatsMux.Unlock()
+	<-done
+
+	require.Empty(t, s.getAsyncReplicationStats(context.Background()))
+}

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1214,6 +1214,20 @@ func (s *Shard) removeAllTargetNodeOverrides(ctx context.Context) error {
 	return s.disableAsyncReplication(ctx)
 }
 
+// recordRootPrefilterNoDiff stores the same empty-target stat as an ErrNoDiffFound descent: equal roots proved no differences.
+func (s *Shard) recordRootPrefilterNoDiff(ctx context.Context) {
+	s.asyncReplicationStatsMux.Lock()
+	defer s.asyncReplicationStatsMux.Unlock()
+	// disable cancels before clearing stats, so checking under the lock prevents a phantom entry written after the clear
+	if ctx.Err() != nil {
+		return
+	}
+	if s.asyncReplicationStatsByTargetNode == nil {
+		s.asyncReplicationStatsByTargetNode = make(map[string]*hashBeatHostStats)
+	}
+	s.asyncReplicationStatsByTargetNode[""] = &hashBeatHostStats{hashtreeDiffStartTime: time.Now()}
+}
+
 func (s *Shard) getAsyncReplicationStats(ctx context.Context) []*models.AsyncReplicationStatus {
 	s.asyncReplicationStatsMux.RLock()
 	defer s.asyncReplicationStatsMux.RUnlock()

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -417,12 +417,28 @@ func TestAsyncRepairMultiTenancyRuntimeToggle(t *testing.T) {
 	})
 
 	t.Run("async replication is registered on hot tenant shards", func(t *testing.T) {
+		// Gate on a healthy cluster and allow >1 hashbeat frequency (30s): a first cycle before peers are reachable errors and only repopulates asyncReplicationStatus a full frequency later.
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().
+				WithClassName(paragraphClass.Class).WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, clusterSize)
+			shards := 0
+			for _, node := range body.Payload.Nodes {
+				require.NotNil(ct, node.Status)
+				require.Equal(ct, "HEALTHY", *node.Status)
+				shards += len(node.Shards)
+			}
+			require.Greater(ct, shards, 0, "tenant shards not reported yet")
+
 			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
 			require.NoError(ct, err)
 			require.Greater(ct, n, 0,
 				"asyncReplicationStatus must be populated on hot tenant shards at boot")
-		}, 30*time.Second, 500*time.Millisecond)
+		}, 90*time.Second, 1*time.Second)
 	})
 
 	t.Run("admin disables async replication via the runtime-overrides file", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

`asyncReplicationStatus` in the verbose nodes response is a dump of the per-shard stats map, and the only writer of that map was a completed hashbeat descent. A cycle skipped by the batched root pre-filter proved exactly as much — equal roots, no differences with every target that answered — but wrote nothing.

That gap is not transient. When two or more shards of the same index come due in one dispatch pass they ship as a batch, the pre-filter classifies them in sync, and epoch-relative rescheduling re-arms them at the same instant — so once co-batched they stay co-batched, skipped on every 30s cycle, and the shard reports an empty status indefinitely. Operators (and our own acceptance tests) cannot distinguish a healthy in-sync shard from one where async replication never started; only a disable→enable toggle breaks the cycle.

This is the root cause of the `async_replication_is_registered_*` boot flakes (runs 31373712910, 31380670568): registrations normally stagger >1ms apart and dispatch as singletons whose first cycle stores a stat, but a CPU-starved runner clusters them into one dispatch window and they land in the silent-skip lockstep. The 90s window added by 68072d085a couldn't help — the emptiness is unbounded, not slow.

The fix records the same empty-target stat the `ErrNoDiffFound` descent stores whenever a skip cycle runs. Two pinned regression tests cover it: `TestRunEntrySkipHashbeatRecordsNoDiffStatus` (red before this change) and `TestRecordRootPrefilterNoDiffCancelRaceLeavesStatsEmpty`.

Also included: the multi-tenant boot assertion gets the same healthy-cluster gate and >1-frequency window that 68072d085a gave its sibling; it still had the raw 30s window.

**Where to look hardest.** The stat write can race `disableAsyncReplication`, which clears the map without waiting for in-flight cycles. The guard re-checks the cycle ctx under the stats mutex: disable always cancels that ctx before clearing, so a write that would survive the clear must have entered the critical section after the clear — and therefore after the cancel, where the guard backs off. A phantom write is impossible in either interleaving; the cancel-path test pins this.

### Testing

- Both unit pins red→green; full async-replication unit battery over `adapters/repos/db` and `usecases/replica` green with `-race`.
- Both acceptance tests green end-to-end against a race-enabled image built from this branch, including under CPU throttling of the cluster containers; boot assertions pass in ~1s.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: n/a, fixes reporting of an existing field
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary, the change adds a stats entry on an existing skip path
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary — one map upsert per skipped cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

