### PR TITLE
fix(grpc): don't dereference nil target combination in parseNearVec

### DIFF
--- a/adapters/handlers/grpc/v1/parse_aggregate_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_aggregate_request_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	"github.com/weaviate/weaviate/entities/aggregation"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
@@ -235,6 +236,58 @@ func TestGRPCAggregateRequest(t *testing.T) {
 				Hybrid: &searchparams.HybridSearch{
 					Query:           "hello",
 					FusionAlgorithm: common_filters.HybridFusionDefault,
+				},
+			},
+			error: false,
+		},
+		{
+			name: "near vector with per-target vectors and single target",
+			req: &pb.AggregateRequest{
+				Collection:   mixedVectorsClass,
+				ObjectsCount: true,
+				Search: &pb.AggregateRequest_NearVector{
+					NearVector: &pb.NearVector{
+						Targets:          &pb.Targets{TargetVectors: []string{"first_vec"}},
+						VectorForTargets: []*pb.VectorForTarget{{Name: "first_vec", Vectors: []*pb.Vectors{{VectorBytes: byteVector([]float32{1, 2, 3})}}}},
+					},
+				},
+			},
+			out: &aggregation.Params{
+				ClassName:        schema.ClassName(mixedVectorsClass),
+				IncludeMetaCount: true,
+				NearVector: &searchparams.NearVector{
+					Vectors:       []models.Vector{[]float32{1, 2, 3}},
+					TargetVectors: []string{"first_vec"},
+				},
+			},
+			error: false,
+		},
+		{
+			name: "hybrid near vector with per-target vectors and single target",
+			req: &pb.AggregateRequest{
+				Collection:   mixedVectorsClass,
+				ObjectsCount: true,
+				Search: &pb.AggregateRequest_Hybrid{
+					Hybrid: &pb.Hybrid{
+						Alpha: 0.5,
+						NearVector: &pb.NearVector{
+							VectorForTargets: []*pb.VectorForTarget{{Name: "first_vec", Vectors: []*pb.Vectors{{VectorBytes: byteVector([]float32{1, 2, 3})}}}},
+						},
+						Targets: &pb.Targets{TargetVectors: []string{"first_vec"}},
+					},
+				},
+			},
+			out: &aggregation.Params{
+				ClassName:        schema.ClassName(mixedVectorsClass),
+				IncludeMetaCount: true,
+				Hybrid: &searchparams.HybridSearch{
+					Alpha:           0.5,
+					FusionAlgorithm: common_filters.HybridFusionDefault,
+					NearVectorParams: &searchparams.NearVector{
+						Vectors:       []models.Vector{[]float32{1, 2, 3}},
+						TargetVectors: []string{"first_vec"},
+					},
+					TargetVectors: []string{"first_vec"},
 				},
 			},
 			error: false,

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -1338,6 +1338,13 @@ func parseNearIMU(n *pb.NearIMUSearch, targetVectors []string) (*nearImu.NearIMU
 func parseNearVec(nv *pb.NearVector, targetVectors []string,
 	class *models.Class, targetCombination *dto.TargetCombination,
 ) (*searchparams.NearVector, *dto.TargetCombination, error) {
+	// targetCombination is nil for aggregates and for searches without a
+	// targets message; fall back to the default type instead of dereferencing.
+	combinationType := dto.DefaultTargetCombinationType
+	if targetCombination != nil {
+		combinationType = targetCombination.Type
+	}
+
 	var vector models.Vector
 	var err error
 	// vectors has precedent for being more efficient
@@ -1393,7 +1400,7 @@ func parseNearVec(nv *pb.NearVector, targetVectors []string,
 			targetVectorsTmp = deduplicatedTargetVectorsTmp
 			vectors = make([]models.Vector, len(targetVectorsTmp))
 
-			switch targetCombination.Type {
+			switch combinationType {
 			case dto.ManualWeights, dto.RelativeScore:
 				// do nothing, Manual and Relative Scores don't need adjustment
 			default:
@@ -1476,7 +1483,7 @@ func parseNearVec(nv *pb.NearVector, targetVectors []string,
 		}
 
 		if detectCombinationWeights {
-			switch targetCombination.Type {
+			switch combinationType {
 			case dto.Average:
 				fixedWeights := extractTargetCombinationAverageWeights(detectedTargetVectorNames)
 				adjustedTargetCombination = &dto.TargetCombination{
@@ -1489,7 +1496,7 @@ func parseNearVec(nv *pb.NearVector, targetVectors []string,
 				}
 			default:
 				adjustedTargetCombination = &dto.TargetCombination{
-					Type: targetCombination.Type, Weights: make([]float32, len(detectedTargetVectorNames)),
+					Type: combinationType, Weights: make([]float32, len(detectedTargetVectorNames)),
 				}
 			}
 		}

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -2717,6 +2717,85 @@ func TestGRPCSearchRequest(t *testing.T) {
 			error: false,
 		},
 		{
+			name: "per-target vectors without targets message",
+			req: &pb.SearchRequest{
+				Collection: multiVecClass,
+				Metadata:   &pb.MetadataRequest{Vector: true},
+				Properties: &pb.PropertiesRequest{},
+				NearVector: &pb.NearVector{
+					TargetVectors:    []string{"custom"},
+					VectorForTargets: []*pb.VectorForTarget{{Name: "custom", Vectors: []*pb.Vectors{{VectorBytes: byteVector([]float32{1, 2, 3})}}}},
+				},
+			},
+			out: dto.GetParams{
+				ClassName:               multiVecClass,
+				Pagination:              defaultPagination,
+				Properties:              search.SelectProperties{},
+				AdditionalProperties:    additional.Properties{Vectors: []string{"custom", "first", "second"}, Vector: true, NoProps: true},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
+				NearVector:              &searchparams.NearVector{Vectors: []models.Vector{[]float32{1, 2, 3}}, TargetVectors: []string{"custom"}},
+			},
+			error: false,
+		},
+		{
+			name: "two per-target vectors without targets message",
+			req: &pb.SearchRequest{
+				Collection: multiVecClass,
+				Metadata:   &pb.MetadataRequest{Vector: true},
+				Properties: &pb.PropertiesRequest{},
+				NearVector: &pb.NearVector{
+					TargetVectors: []string{"custom"},
+					VectorForTargets: []*pb.VectorForTarget{{Name: "custom", Vectors: []*pb.Vectors{
+						{VectorBytes: byteVector([]float32{1, 2, 3})},
+						{VectorBytes: byteVector([]float32{2, 3, 4})},
+					}}},
+				},
+			},
+			out: dto.GetParams{
+				ClassName:               multiVecClass,
+				Pagination:              defaultPagination,
+				Properties:              search.SelectProperties{},
+				AdditionalProperties:    additional.Properties{Vectors: []string{"custom", "first", "second"}, Vector: true, NoProps: true},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0, 0}},
+				NearVector:              &searchparams.NearVector{Vectors: []models.Vector{[]float32{1, 2, 3}, []float32{2, 3, 4}}, TargetVectors: []string{"custom", "custom"}},
+			},
+			error: false,
+		},
+		{
+			name: "hybrid per-target vectors without targets message",
+			req: &pb.SearchRequest{
+				Collection: multiVecClass,
+				Metadata:   &pb.MetadataRequest{Vector: true},
+				Properties: &pb.PropertiesRequest{},
+				HybridSearch: &pb.Hybrid{
+					Alpha: 1.0,
+					Query: "nearvecquery",
+					NearVector: &pb.NearVector{
+						VectorForTargets: []*pb.VectorForTarget{{Name: "custom", Vectors: []*pb.Vectors{{VectorBytes: byteVector([]float32{1, 2, 3})}}}},
+					},
+					TargetVectors: []string{"custom"},
+				},
+			},
+			out: dto.GetParams{
+				ClassName:               multiVecClass,
+				Pagination:              defaultPagination,
+				Properties:              search.SelectProperties{},
+				AdditionalProperties:    additional.Properties{Vectors: []string{"custom", "first", "second"}, Vector: true, NoProps: true},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
+				HybridSearch: &searchparams.HybridSearch{
+					Alpha:           1.0,
+					Query:           "nearvecquery",
+					FusionAlgorithm: 1,
+					NearVectorParams: &searchparams.NearVector{
+						Vectors:       []models.Vector{[]float32{1, 2, 3}},
+						TargetVectors: []string{"custom"},
+					},
+					TargetVectors: []string{"custom"},
+				},
+			},
+			error: false,
+		},
+		{
 			name: "mixed vector input near vector targeting legacy vector",
 			req: &pb.SearchRequest{
 				Collection: mixedVectorsClass,


### PR DESCRIPTION
Closes https://github.com/weaviate/0-weaviate-issues/issues/520

### What's being changed:

- Aggregate near-vector and hybrid queries pass no target combination, and search/hybrid requests without a targets message pass nil for a single target
- Any of them using vector_for_targets with the per-target vectors field panicked at the combination-type switches
- Fall back to the default combination type and pin all exposed journeys with regression tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
