### PR TITLE
Keep the parked pread buffer on sequential replace cursor scans

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_read_amplification_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_read_amplification_test.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+type countingReaderAt struct {
+	inner readerAt
+	bytes int64
+}
+
+func (c *countingReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	n, err := c.inner.ReadAt(p, off)
+	c.bytes += int64(n)
+	return n, err
+}
+
+// TestSegmentCursorReusablePread_ReadAmplification pins that a sequential scan pulls each data byte through pread roughly once, instead of refilling a whole buffer per node.
+func TestSegmentCursorReusablePread_ReadAmplification(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name           string
+		count          int
+		valueSize      int
+		valuePrefixLen int
+	}{
+		{"full/tiny-values", 4000, 64, 0},
+		{"full/medium-values", 1000, 2048, 0},
+		{"digest/tiny-values", 4000, 64, 42},
+		{"digest/vector-values", 200, 24576, 42},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := newReusableTestBucket(t, ctx, WithPread(true), WithMinMMapSize(0))
+			t.Cleanup(func() { b.Shutdown(ctx) })
+
+			value := bytes.Repeat([]byte{'x'}, tc.valueSize)
+			for i := 0; i < tc.count; i++ {
+				require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%08d", i)), value))
+			}
+			require.NoError(t, b.FlushAndSwitch())
+
+			segments, release := b.disk.getConsistentViewOfSegments()
+			t.Cleanup(release)
+			require.Len(t, segments, 1)
+			seg, ok := segments[0].(*segment)
+			require.True(t, ok)
+			require.False(t, seg.readFromMemory)
+
+			c := seg.newReplaceCursorReusableWithPrefix(tc.valuePrefixLen)
+			t.Cleanup(c.releaseReader)
+			counting := &countingReaderAt{inner: c.preadOffset.ra}
+			c.preadOffset.ra = counting
+
+			nodes := 0
+			for n, err := c.first(); !errors.Is(err, lsmkv.NotFound); n, err = c.next() {
+				require.NoError(t, err)
+				require.NotNil(t, n)
+				nodes++
+			}
+
+			require.Equal(t, tc.count, nodes)
+			dataRegion := int64(seg.dataEndPos - seg.dataStartPos)
+			require.LessOrEqual(t, counting.bytes, dataRegion+2*segmentCursorReaderBufSize,
+				"scan of a %d-byte data region read %d bytes through pread", dataRegion, counting.bytes)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -321,6 +321,9 @@ type segmentCursorReplaceReusable struct {
 	// avoid allocating a MeteredReader+SectionReader+nodeReader per iteration.
 	preadOffset *offsetReader
 	preadReader *bufio.Reader
+	// preadPos is the position preadReader is parked at (-1 = unknown); parses
+	// landing exactly there keep the buffer instead of resetting it.
+	preadPos int64
 }
 
 func (s *segment) newReplaceCursorReusable() *segmentCursorReplaceReusable {
@@ -348,6 +351,7 @@ func (s *segment) newReplaceCursorReusableWithPrefix(valuePrefixLen int) *segmen
 		or := &offsetReader{ra: s.contentFile}
 		c.preadOffset = or
 		c.preadReader = acquireSegmentCursorReader(or)
+		c.preadPos = -1
 	}
 	return c
 }
@@ -411,8 +415,13 @@ func (s *segmentCursorReplaceReusable) parseInto() (*segmentReplaceNode, error) 
 			return &s.reusableNode, err
 		}
 	} else {
-		s.preadOffset.off = int64(s.currOffset)
-		s.preadReader.Reset(s.preadOffset)
+		pos := int64(s.currOffset)
+		if pos != s.preadPos {
+			s.preadOffset.off = pos
+			s.preadReader.Reset(s.preadOffset)
+		}
+		// unknown until the parse succeeds: an error leaves the reader mid-node
+		s.preadPos = -1
 		if s.valuePrefixLen > 0 {
 			if err := ParseReplaceNodeDigestIntoPread(s.preadReader, s.segment.secondaryIndexCount, s.valuePrefixLen, &s.reusableNode); err != nil {
 				return &s.reusableNode, err
@@ -420,6 +429,7 @@ func (s *segmentCursorReplaceReusable) parseInto() (*segmentReplaceNode, error) 
 		} else if err := ParseReplaceNodeIntoPread(s.preadReader, s.segment.secondaryIndexCount, &s.reusableNode); err != nil {
 			return &s.reusableNode, err
 		}
+		s.preadPos = pos + int64(s.reusableNode.offset)
 	}
 
 	if s.reusableNode.tombstone {


### PR DESCRIPTION
### Motivation

`segmentCursorReplaceReusable` is only ever driven sequentially — replace compaction scans two whole segments front to back, and async-replication digest scans do the same through the bucket-level merge cursor. Yet on the pread path, `parseInto` reset the `bufio.Reader` before every node. A reset discards the buffered bytes, so the first `ReadFull` of the next node refills the full 8 KB buffer from disk — even when the buffer already held that node, which in a sequential scan it almost always did. Every node paid a full buffer refill regardless of its size, so buffer size multiplied read volume: the 4 KB→8 KB bump in #12558 doubled the per-node refill for small nodes. Measured over one segment scan:

| scan (one segment) | data region | pread bytes before | after |
|---|---|---:|---:|
| full, 4000 × 64 B values | 356 KB | 32.8 MB (92×) | 360 KB (1.01×) |
| full, 1000 × 2 KB values | 2.07 MB | 8.2 MB (4.0×) | 2.08 MB (1.00×) |
| digest, 4000 × 64 B values | 356 KB | 32.8 MB (92×) | 360 KB (1.01×) |
| digest, 200 × 24 KB values | 4.92 MB | 6.55 MB (1.33×) | 4.92 MB (1.00×) |

### Approach

The cursor now remembers the stream position the reader is parked at (`preadPos`). Both pread parsers already tally every byte they consume into `node.offset` — the same field `next()` uses to advance — so after a successful parse the reader sits exactly at `pos + offset`, which is exactly where `next()` will land. When the requested position matches the parked one, the reset is skipped and the buffered bytes are kept; any other positioning (`first`, `seek`, resuming after a parse error) resets as before. `preadPos` is invalidated to -1 before each parse and re-established only on success, so an error that leaves the reader mid-node can never be mistaken for a parked position. Cost: one `int64` per cursor. The mmap path is untouched.

### Key areas for review

- `cursor_segment_replace.go:parseInto` — the skip-reset condition and the invalidate-before-parse / publish-after-success ordering
- the parked-position arithmetic: `preadPos = pos + offset` uses the identical `offset` value `next()` advances by, so the two can't drift apart

### Risks and mitigations

- **Buffer misalignment if a parser consumed different bytes than it tallies**: structurally excluded on the success path — `io.ReadFull` and `Discard` only return nil after exactly the requested count, and every such call adds that same count to `offset`. A wrong tally was already fatal before this change (`next()` advances by it), so no new invariant is introduced beyond trusting the reader's logical position.
- **Stale buffer after a failed parse**: the reader stops mid-node on error; `preadPos = -1` before the parse guarantees the next positioning resets. The truncation table in `TestPreadReplaceParsers_Truncated` (parent PR) pins that every mid-node cut surfaces as an error rather than a silent short read.

### Testing

New integration test `TestSegmentCursorReusablePread_ReadAmplification` wraps the segment's `ReaderAt` in a byte counter and pins that a full sequential scan pulls at most the data region plus two buffer fills through pread, across full/digest mode × tiny/medium/vector-sized values (including the multi-refill-per-node case). It fails on the parent branch with the "before" numbers in the table above. The full `Replace|Compact|Pread` lsmkv integration suite passes with `-race`; `golangci-lint` is clean.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: n/a, internal code with no user-facing surface
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary, confined to the reusable cursor's read path
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. See the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
