### PR TITLE
fix(db): reject replicated reads of lazily unloaded shards and warm them in the background

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -367,7 +367,7 @@ func (i *Index) backupShardWithHardlinks(ctx context.Context, name string, class
 	// sufficient to prevent concurrent lazy loading.
 	if lazyShard, ok := shard.(*LazyLoadShard); ok {
 		releaseBlock := lazyShard.blockLoading()
-		if !lazyShard.loaded {
+		if !lazyShard.loaded.Load() {
 			// Shard is in the map but not loaded; read from disk.
 			defer releaseBlock()
 			if err := i.backupInactiveShardWithHardlinks(name, &sd, shardBaseDescr, stagingRoot); err != nil {
@@ -547,7 +547,7 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 		if lazyShard, ok := shard.(*LazyLoadShard); ok {
 			releaseBlock := lazyShard.blockLoading()
 			defer releaseBlock()
-			if !lazyShard.loaded {
+			if !lazyShard.loaded.Load() {
 				// Shard is in the map but not loaded; protect and keep lock held.
 				i.backupProtectedShards.Store(name, struct{}{})
 				unlockOnReturn = false

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -371,7 +371,7 @@ func (i *Index) snapshotShard(
 		release := lazyShard.blockLoading()
 		defer release()
 
-		if !lazyShard.loaded {
+		if !lazyShard.loaded.Load() {
 			return i.snapshotFromDisk(shardName, snapshotsRoot, snapshotName)
 		}
 		shard = lazyShard.shard

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1307,11 +1307,18 @@ func (i *Index) replicationEnabled() bool {
 	return i.Config.ReplicationFactor > 1
 }
 
-// ensureShardLocallyReady rejects reads of a loading shard so the caller retries
-// on a replica. With replication off there is none, so the shard is used as it is
-// rather than failing a read that would otherwise only be slow.
+// ensureShardLocallyReady rejects reads of a loading or lazily unloaded shard
+// so the caller retries on a replica. A lazy shard also gets a background load
+// kicked off, since the rejected read would otherwise have been what loads it.
+// With replication off there is no replica to retry on, so the shard is used
+// as it is rather than failing a read that would otherwise only be slow.
 func (i *Index) ensureShardLocallyReady(shard ShardLike) error {
-	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
+	status := shard.GetStatus()
+	if (status == storagestate.StatusLoading || status == storagestate.StatusLazyLoading) &&
+		i.replicationEnabled() {
+		if lazyShard, ok := shard.(*LazyLoadShard); ok {
+			lazyShard.LoadAsync()
+		}
 		return enterrors.NewErrUnprocessable(
 			fmt.Errorf("local %s shard is not ready", shard.Name()))
 	}
@@ -1535,6 +1542,11 @@ func (i *Index) withShardOrRemote(ctx context.Context, tenantName, shardName str
 		return err
 	}
 	if shard == nil {
+		return remote()
+	}
+	// Reads deflect to a replica rather than waiting on a shard that is still
+	// loading; writes must run locally and force the load if needed.
+	if operation == localShardOperationRead && i.ensureShardLocallyReady(shard) != nil {
 		return remote()
 	}
 	return local(shard)
@@ -2657,7 +2669,9 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 		if err != nil {
 			return nil, nil, err
 		}
-		if shard != nil {
+		// A not-ready local shard falls through to the replica fan-out below
+		// instead of failing the query.
+		if shard != nil && i.ensureShardLocallyReady(shard) == nil {
 			return i.singleLocalShardObjectVectorSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters,
 				sort, groupBy, additionalProps, shard, targetCombination, properties)
 		}
@@ -2709,7 +2723,7 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 		}
 		defer release()
 
-		if shard != nil {
+		if shard != nil && i.ensureShardLocallyReady(shard) == nil {
 			localShardResult, localShardScores, err1 := i.localShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, additionalProps, targetCombination, properties, tenant, shardName)
 			if err1 != nil {
 				return fmt.Errorf(

--- a/adapters/repos/db/index_objects_ttl_test.go
+++ b/adapters/repos/db/index_objects_ttl_test.go
@@ -95,8 +95,8 @@ func TestShardIsLazyUnloaded(t *testing.T) {
 		want  bool
 	}{
 		{name: "absent tenant", shard: nil, want: false},
-		{name: "lazy shard not loaded", shard: &LazyLoadShard{loaded: false}, want: true},
-		{name: "lazy shard loaded", shard: &LazyLoadShard{loaded: true}, want: false},
+		{name: "lazy shard not loaded", shard: &LazyLoadShard{}, want: true},
+		{name: "lazy shard loaded", shard: loadedLazyShard(), want: false},
 		{name: "non-lazy shard", shard: &Shard{}, want: false},
 	}
 
@@ -312,4 +312,10 @@ func TestTenantTTLLoop_DeactivateUsesTimeout(t *testing.T) {
 
 	assert.True(t, call.ctxWasLive, "deactivation context must not be expired at call time")
 	assert.True(t, call.hasDeadline, "deactivation context must have a deadline (from WithTimeout)")
+}
+
+func loadedLazyShard() *LazyLoadShard {
+	l := &LazyLoadShard{}
+	l.loaded.Store(true)
+	return l
 }

--- a/adapters/repos/db/index_shard_readiness_test.go
+++ b/adapters/repos/db/index_shard_readiness_test.go
@@ -1,0 +1,52 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/entities/storagestate"
+)
+
+func TestLazyLoadShardGetStatusDoesNotBlockOnLoadMutex(t *testing.T) {
+	l := &LazyLoadShard{}
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	done := make(chan storagestate.Status, 1)
+	go func() { done <- l.GetStatus() }()
+
+	select {
+	case status := <-done:
+		assert.Equal(t, storagestate.StatusLazyLoading, status)
+	case <-time.After(2 * time.Second):
+		t.Fatal("GetStatus blocked on the load mutex")
+	}
+}
+
+func TestLazyLoadShardLoadAsyncSkips(t *testing.T) {
+	t.Run("while a load holds the mutex", func(t *testing.T) {
+		l := &LazyLoadShard{}
+		l.mutex.Lock()
+		defer l.mutex.Unlock()
+		l.LoadAsync()
+	})
+
+	t.Run("when already loaded", func(t *testing.T) {
+		l := &LazyLoadShard{}
+		l.loaded.Store(true)
+		l.LoadAsync()
+	})
+}

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -225,7 +225,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 				release := lazyShard.blockLoading()
 				defer release()
 
-				if lazyShard.loaded {
+				if lazyShard.loaded.Load() {
 					shardUsage, err2 = i.calculateLoadedShardUsage(ctx, lazyShard.shard, exactObjectCount)
 					if err2 != nil {
 						err2 = fmt.Errorf("loaded lazy shard %s: %w", shardName, err2)

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -865,7 +865,8 @@ func TestShardActivityColdShardLoads(t *testing.T) {
 	loaded.activityTrackerRead.Store(1)
 	loaded.activityTrackerWrite.Store(1)
 	cold.mutex.Lock()
-	cold.shard, cold.loaded = loaded, true
+	cold.shard = loaded
+	cold.loaded.Store(true)
 	cold.mutex.Unlock()
 
 	o.observeActivity()

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/loadlimiter"
@@ -57,9 +58,11 @@ import (
 )
 
 type LazyLoadShard struct {
-	shardOpts        *deferredShardOpts
-	shard            *Shard
-	loaded           bool
+	shardOpts *deferredShardOpts
+	shard     *Shard
+	// loaded is atomic so status checks never block on mutex while a load is
+	// in flight; it is written under mutex, after shard is published.
+	loaded           atomic.Bool
 	mutex            sync.Mutex
 	memMonitor       memwatch.AllocChecker
 	shardLoadLimiter *loadlimiter.LoadLimiter
@@ -120,7 +123,7 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if l.loaded {
+	if l.loaded.Load() {
 		return nil
 	}
 
@@ -157,9 +160,29 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	shard.metricsRegistered.Store(true)
 
 	l.shard = shard
-	l.loaded = true
+	l.loaded.Store(true)
 
 	return nil
+}
+
+// LoadAsync starts loading the shard in the background unless it is already
+// loaded or a load is in flight (the TryLock probe fails while one holds the
+// mutex). Reads rejected by the readiness gate use it so a lazily cold replica
+// still becomes ready, without any caller blocking on the load.
+func (l *LazyLoadShard) LoadAsync() {
+	if l.loaded.Load() {
+		return
+	}
+	if !l.mutex.TryLock() {
+		return
+	}
+	l.mutex.Unlock()
+	enterrors.GoWrapper(func() {
+		if err := l.Load(context.Background()); err != nil {
+			l.shardOpts.index.logger.WithField("shard", l.shardOpts.name).
+				Errorf("background load of lazy shard failed: %v", err)
+		}
+	}, l.shardOpts.index.logger)
 }
 
 func (l *LazyLoadShard) Index() *Index {
@@ -188,21 +211,17 @@ func (l *LazyLoadShard) NotifyReady() {
 	l.shard.NotifyReady()
 }
 
+// GetStatus deliberately does not take the load mutex: the read-readiness gate
+// consults it to fail fast exactly while a load is in flight.
 func (l *LazyLoadShard) GetStatus() storagestate.Status {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-
-	if l.loaded {
+	if l.loaded.Load() {
 		return l.shard.GetStatus()
 	}
 	return storagestate.StatusLazyLoading
 }
 
 func (l *LazyLoadShard) GetStatusReason() string {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-
-	if l.loaded {
+	if l.loaded.Load() {
 		return l.shard.GetStatusReason()
 	}
 	return storagestate.StatusLazyLoading.String()
@@ -237,7 +256,7 @@ func (l *LazyLoadShard) ObjectCount(ctx context.Context) (int, error) {
 
 func (l *LazyLoadShard) ObjectCountAsync(ctx context.Context) (int64, error) {
 	l.mutex.Lock()
-	if l.loaded {
+	if l.loaded.Load() {
 		l.mutex.Unlock()
 		return l.shard.ObjectCountAsync(ctx)
 	}
@@ -327,7 +346,7 @@ func (l *LazyLoadShard) enableAsyncReplication(ctx context.Context, config Async
 
 func (l *LazyLoadShard) disableAsyncReplication(ctx context.Context) error {
 	l.mutex.Lock()
-	loaded := l.loaded
+	loaded := l.loaded.Load()
 	l.mutex.Unlock()
 	if !loaded {
 		return nil
@@ -337,7 +356,7 @@ func (l *LazyLoadShard) disableAsyncReplication(ctx context.Context) error {
 
 func (l *LazyLoadShard) hasActiveAsyncReplicationTargetOverrides() bool {
 	l.mutex.Lock()
-	loaded := l.loaded
+	loaded := l.loaded.Load()
 	l.mutex.Unlock()
 	if !loaded {
 		// An unloaded shard holds no in-memory overrides.
@@ -348,7 +367,7 @@ func (l *LazyLoadShard) hasActiveAsyncReplicationTargetOverrides() bool {
 
 func (l *LazyLoadShard) removePersistedHashtree() error {
 	l.mutex.Lock()
-	loaded := l.loaded
+	loaded := l.loaded.Load()
 	l.mutex.Unlock()
 	if !loaded {
 		return nil // not loaded: a stale .ht is discarded on next load
@@ -482,7 +501,7 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if !l.loaded {
+	if !l.loaded.Load() {
 		idx := l.shardOpts.index
 		className := idx.Config.ClassName.String()
 		shardName := l.shardOpts.name
@@ -692,7 +711,7 @@ func (l *LazyLoadShard) AnalyzeObjectForMigrationWithOverlay(object *storobj.Obj
 
 func (l *LazyLoadShard) Dimensions(ctx context.Context, targetVector string) (int, error) {
 	l.mutex.Lock()
-	if l.loaded {
+	if l.loaded.Load() {
 		l.mutex.Unlock()
 		return l.shard.Dimensions(ctx, targetVector)
 	}
@@ -787,7 +806,7 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if !l.loaded {
+	if !l.loaded.Load() {
 		return nil
 	}
 
@@ -796,7 +815,7 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	}
 
 	// Mark as unloaded so drop() knows the correct state
-	l.loaded = false
+	l.loaded.Store(false)
 	return nil
 }
 
@@ -1041,16 +1060,13 @@ func (l *LazyLoadShard) Metrics() *Metrics {
 }
 
 func (l *LazyLoadShard) isLoaded() bool {
-	l.mutex.Lock()
-	defer l.mutex.Unlock()
-
-	return l.loaded
+	return l.loaded.Load()
 }
 
 func (l *LazyLoadShard) Activity() (int32, int32) {
 	var loaded bool
 	l.mutex.Lock()
-	loaded = l.loaded
+	loaded = l.loaded.Load()
 	l.mutex.Unlock()
 
 	if !loaded {

--- a/adapters/repos/db/shard_loading_guard_test.go
+++ b/adapters/repos/db/shard_loading_guard_test.go
@@ -64,6 +64,17 @@ func TestEnsureShardLocallyReady(t *testing.T) {
 			replicationFactor: 1,
 		},
 		{
+			name:              "lazily unloaded shard is rejected so the read retries on a replica",
+			status:            storagestate.StatusLazyLoading,
+			replicationFactor: 3,
+			wantRejected:      true,
+		},
+		{
+			name:              "lazily unloaded shard is used as is when there is no replica to retry on",
+			status:            storagestate.StatusLazyLoading,
+			replicationFactor: 1,
+		},
+		{
 			name:              "ready shard is used, replicated",
 			status:            storagestate.StatusReady,
 			replicationFactor: 3,

--- a/test/acceptance/replication/lazy_cold_replica/lazy_cold_replica_test.go
+++ b/test/acceptance/replication/lazy_cold_replica/lazy_cold_replica_test.go
@@ -1,0 +1,333 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lazy_cold_replica
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+const (
+	multiShardClass  = "LazyColdMultiShard"
+	singleShardClass = "LazyColdSingleShard"
+	burstSize        = 40
+	burstDeadline    = 2 * time.Second
+	vectorDim        = 48
+)
+
+// TestLazyColdReplicaFastFailover asserts that reads never wait on a lazily
+// unloaded replica after a node restart: the readiness gate rejects it, the
+// coordinator fails over to a warm replica, and the cold shard loads in the
+// background. The bursts run inside the post-restart window before the 1/sec
+// background shard walker warms the restarted node, with the load limiter
+// pinned low so waiting on a load (the pre-fix behavior) blows the deadline.
+func TestLazyColdReplicaFastFailover(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping multi-node lazy-loading test in short mode")
+	}
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateClusterWithGRPC().
+		WithWeaviateEnv("LAZY_LOAD_SHARD_COUNT_THRESHOLD", "0").
+		WithWeaviateEnv("ASYNC_REPLICATION_DISABLED", "true").
+		WithWeaviateEnv("MAXIMUM_CONCURRENT_SHARD_LOADS", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	grpcConn, err := helper.CreateGrpcConnectionClient(compose.GetWeaviate().GrpcURI())
+	require.NoError(t, err)
+	defer grpcConn.Close()
+	grpcClient := helper.CreateGrpcWeaviateClient(grpcConn)
+
+	helper.CreateClass(t, &models.Class{
+		Class:      multiShardClass,
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{Name: "contents", DataType: schema.DataTypeText.PropString()},
+		},
+		ShardingConfig:    map[string]interface{}{"desiredCount": float64(27)},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+	})
+	helper.CreateClass(t, &models.Class{
+		Class:      singleShardClass,
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{Name: "contents", DataType: schema.DataTypeText.PropString()},
+		},
+		ShardingConfig:    map[string]interface{}{"desiredCount": float64(1)},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
+	})
+
+	rnd := rand.New(rand.NewSource(42))
+	randomVector := func() []float32 {
+		vec := make([]float32, vectorDim)
+		for d := range vec {
+			vec[d] = rnd.Float32()
+		}
+		return vec
+	}
+
+	batch := make([]*models.Object, 0, 2000)
+	for i := 0; i < 24000; i++ {
+		batch = append(batch, &models.Object{
+			Class:      multiShardClass,
+			Properties: map[string]interface{}{"contents": fmt.Sprintf("document %d about weaviate lazy loading", i)},
+			Vector:     randomVector(),
+		})
+		if len(batch) == cap(batch) {
+			helper.CreateObjectsBatch(t, batch)
+			batch = batch[:0]
+		}
+	}
+	for i := 0; i < 5000; i++ {
+		batch = append(batch, &models.Object{
+			Class:      singleShardClass,
+			Properties: map[string]interface{}{"contents": fmt.Sprintf("single shard document %d", i)},
+			Vector:     randomVector(),
+		})
+		if len(batch) == cap(batch) {
+			helper.CreateObjectsBatch(t, batch)
+			batch = batch[:0]
+		}
+	}
+	helper.CreateObjectsBatch(t, batch)
+
+	remoteShard, victimNode := findFullyRemoteShard(t, compose.GetWeaviate().URI())
+	victimN, err := strconv.Atoi(strings.TrimPrefix(victimNode, "weaviate-"))
+	require.NoError(t, err)
+	t.Logf("coordinator=weaviate-0 remoteShard=%s victim=%s", remoteShard, victimNode)
+
+	queryVec := randomVector()
+	vectorReq := &pb.SearchRequest{
+		Collection: multiShardClass,
+		Limit:      10,
+		NearVector: &pb.NearVector{Vectors: []*pb.Vectors{{
+			VectorBytes: byteops.Fp32SliceToBytes(queryVec),
+			Type:        pb.Vectors_VECTOR_TYPE_SINGLE_FP32,
+		}}},
+		Uses_127Api: true,
+	}
+	bm25Req := &pb.SearchRequest{
+		Collection:  multiShardClass,
+		Limit:       10,
+		Bm25Search:  &pb.BM25{Query: "weaviate", Properties: []string{"contents"}},
+		Uses_127Api: true,
+	}
+
+	burst := func(req *pb.SearchRequest, deadline time.Duration) (latencies []time.Duration, errs []error) {
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		for i := 0; i < burstSize; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				qctx, cancel := context.WithTimeout(ctx, deadline)
+				defer cancel()
+				start := time.Now()
+				_, err := grpcClient.Search(qctx, req)
+				elapsed := time.Since(start)
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
+				latencies = append(latencies, elapsed)
+			}()
+		}
+		wg.Wait()
+		return latencies, errs
+	}
+
+	t.Run("healthy cluster baseline", func(t *testing.T) {
+		latencies, errs := burst(vectorReq, 10*time.Second)
+		require.Empty(t, errs)
+		require.Len(t, latencies, burstSize)
+	})
+
+	require.NoError(t, compose.StopNode(ctx, victimN, nil))
+	require.NoError(t, compose.StartNode(ctx, victimN))
+	waitAllHealthy(t, compose.GetWeaviate().URI())
+	t.Logf("victim loaded shards at burst start: %d", loadedShardCountOnNode(t, compose.GetWeaviate().URI(), victimNode))
+
+	t.Run("vector burst fails over instead of waiting on cold replicas", func(t *testing.T) {
+		latencies, errs := burst(vectorReq, burstDeadline)
+		logLatencies(t, "vector-cold-replica", latencies, errs)
+		require.Emptyf(t, errs, "queries waited on cold replicas: %v", firstError(errs))
+		assert.Less(t, percentile(latencies, 0.99), time.Second)
+	})
+
+	t.Run("bm25 burst fails over instead of waiting on cold replicas", func(t *testing.T) {
+		latencies, errs := burst(bm25Req, burstDeadline)
+		logLatencies(t, "bm25-cold-replica", latencies, errs)
+		require.Emptyf(t, errs, "queries waited on cold replicas: %v", firstError(errs))
+		assert.Less(t, percentile(latencies, 0.99), time.Second)
+	})
+
+	t.Run("single-shard vector search on the cold node falls through to a replica", func(t *testing.T) {
+		victimConn, err := helper.CreateGrpcConnectionClient(compose.GetWeaviateNode(victimN + 1).GrpcURI())
+		require.NoError(t, err)
+		defer victimConn.Close()
+		victimClient := helper.CreateGrpcWeaviateClient(victimConn)
+
+		qctx, cancel := context.WithTimeout(ctx, burstDeadline)
+		defer cancel()
+		start := time.Now()
+		resp, err := victimClient.Search(qctx, &pb.SearchRequest{
+			Collection: singleShardClass,
+			Limit:      10,
+			NearVector: &pb.NearVector{Vectors: []*pb.Vectors{{
+				VectorBytes: byteops.Fp32SliceToBytes(queryVec),
+				Type:        pb.Vectors_VECTOR_TYPE_SINGLE_FP32,
+			}}},
+			Uses_127Api: true,
+		})
+		elapsed := time.Since(start)
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Results)
+		t.Logf("single-shard cold-local search took %v", elapsed)
+	})
+
+	t.Run("the cold replica warms in the background", func(t *testing.T) {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			assert.True(collect, shardLoadedOnNode(t, compose.GetWeaviate().URI(), victimNode, multiShardClass, remoteShard))
+		}, 120*time.Second, 2*time.Second)
+	})
+}
+
+func firstError(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return errs[0]
+}
+
+func findFullyRemoteShard(t *testing.T, coordinatorURI string) (shard, victim string) {
+	t.Helper()
+	shardNodes := map[string][]string{}
+	for _, node := range common.GetNodes(t, coordinatorURI).Nodes {
+		for _, s := range node.Shards {
+			if s.Class == multiShardClass {
+				shardNodes[s.Name] = append(shardNodes[s.Name], node.Name)
+			}
+		}
+	}
+	require.Len(t, shardNodes, 27)
+	for name, nodes := range shardNodes {
+		require.Lenf(t, nodes, 2, "shard %s must have RF=2", name)
+		if nodes[0] != "weaviate-0" && nodes[1] != "weaviate-0" {
+			sort.Strings(nodes)
+			return name, nodes[1]
+		}
+	}
+	t.Fatal("no shard is fully remote to the coordinator weaviate-0")
+	return "", ""
+}
+
+func loadedShardCountOnNode(t *testing.T, coordinatorURI, nodeName string) int {
+	t.Helper()
+	count := 0
+	for _, node := range common.GetNodes(t, coordinatorURI).Nodes {
+		if node.Name != nodeName {
+			continue
+		}
+		for _, s := range node.Shards {
+			if s.Loaded {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func shardLoadedOnNode(t *testing.T, coordinatorURI, nodeName, className, shardName string) bool {
+	t.Helper()
+	for _, node := range common.GetNodes(t, coordinatorURI).Nodes {
+		if node.Name != nodeName {
+			continue
+		}
+		for _, s := range node.Shards {
+			if s.Class == className && s.Name == shardName {
+				return s.Loaded
+			}
+		}
+	}
+	return false
+}
+
+func waitAllHealthy(t *testing.T, coordinatorURI string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		healthy := 0
+		for _, node := range common.GetNodes(t, coordinatorURI).Nodes {
+			if node.Status != nil && *node.Status == models.NodeStatusStatusHEALTHY {
+				healthy++
+			}
+		}
+		assert.Equal(collect, 3, healthy)
+	}, 90*time.Second, time.Second)
+}
+
+func percentile(latencies []time.Duration, p float64) time.Duration {
+	if len(latencies) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), latencies...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := int(float64(len(sorted))*p) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func logLatencies(t *testing.T, label string, latencies []time.Duration, errs []error) {
+	t.Helper()
+	var max time.Duration
+	for _, l := range latencies {
+		if l > max {
+			max = l
+		}
+	}
+	t.Logf("%s: ok=%d err=%d p50=%v p90=%v p99=%v max=%v",
+		label, len(latencies), len(errs),
+		percentile(latencies, 0.50), percentile(latencies, 0.90),
+		percentile(latencies, 0.99), max)
+}


### PR DESCRIPTION
### What's being changed:

Replicated reads no longer wait on a lazily unloaded shard. The local readiness gate (`ensureShardLocallyReady`) now treats `LAZY_LOADING` the same way it already treats `LOADING`: the read is rejected as unprocessable (HTTP 422 on the internal API, which the coordinator's client does not retry), so the coordinator fails over to a warm replica in ~1 RTT instead of force-loading the shard inline and blocking for the entire load.

Because a rejected read would otherwise have been exactly what loads a lazy shard, rejection also kicks off a **deduplicated background load** (`LazyLoadShard.LoadAsync`): the replica still becomes warm, just without any caller blocking on it. The dedupe needs no extra state — a `TryLock` probe skips triggering whenever a load (or a backup's `blockLoading`) already holds the mutex.

Supporting changes, each closing a gap in the gate's existing "the caller retries on a replica" contract:

- **`loaded` becomes `atomic.Bool`** (no new fields; same write points, under the same mutex). `GetStatus`/`GetStatusReason`/`isLoaded` are now lock-free, so the gate can answer *while a load is in flight* — previously the status check itself blocked on the load mutex, which would have defeated the fast failover for every read after the first. This also stops the nodes status endpoint from blocking on in-flight loads.
- **Single-shard vector fast path**: a not-ready local shard now falls through to the replica fan-out instead of failing the query with "shard is not ready". This was a pre-existing bug for `LOADING` shards too — the gate's contract promises a retry on a replica, but this caller had no retry.
- **Fan-out local branches** (vector `localSearch`, and all `withShardOrRemote` read operations, which covers BM25/keyword search and the object-read local branches): a not-ready local shard deflects to the existing remote fallback, same as when the shard is absent. Write operations through `withShardOrRemote` are untouched — writes must run locally and force the load.

With replication off (RF=1) nothing changes anywhere: there is no replica to retry on, so reads keep using the shard as-is.

### Why

With lazy shard loading, an incoming search against an unloaded shard runs `Load()` synchronously under the shard mutex — WAL replay, segment verification, vector-index restore — while the requester waits, and every further read queues on the same mutex. For big shards that is tens of seconds to minutes, bounded only by min(client deadline, the 20s per-attempt RPC timeout): the same failure signature as a hung replica (see the measurements on PR #10669), except the server *knows* it is not ready and has a warm peer available. Rejecting is deterministic and costs no duplicate query work, which makes it complementary to the hedging of PR #10669: this handles the self-diagnosable slow-replica cause, hedging bounds the causes a server cannot see (overload, GC, partitions).

The window is real in operation: after a restart the background shard walker warms local shards at one per second, so nodes with many shards or tenants stay partially cold for minutes to hours, and any first access to a large cold tenant pays the full load inline.

### Key areas for review

- `OverwriteObjects` (read-repair write) already used the gate and now also skips lazily cold replicas; the repair converges later once the shard warms. This matches the direction that background machinery must not force-load cold shards.
- Consistency-level reads treat the 422 as a per-replica failure: QUORUM/ONE reads are served by the remaining replicas; a CL=ALL read during the cold window fails fast instead of succeeding slowly, and succeeds again once the background load (triggered by that same read) completes.
- The lock-free `GetStatus` relies on the standard publication pattern: `l.shard` is written before `loaded.Store(true)`, both under the mutex; readers observing `true` therefore see the shard.

### Testing

- Unit (red/green): the two new `TestEnsureShardLocallyReady` lazy cases fail against the previous gate; `TestLazyLoadShardGetStatusDoesNotBlockOnLoadMutex` fails against the previous mutex-taking `GetStatus`; `TestLazyLoadShardLoadAsyncSkips` pins the dedupe semantics.
- Full `adapters/repos/db` suite with `-race`, golangci-lint, and the goroutine linter are clean.
- New E2E suite `test/acceptance/replication/lazy_cold_replica`: 3-node cluster with lazy loading forced on, a 27-shard RF=2 collection plus a single-shard RF=3 collection, node restarted, then 40-query vector and BM25 bursts against a coordinator during a verified cold window (the suite logs the restarted node's loaded-shard count — 3 of 19 at burst start): all queries succeed with p99 ≈ 60ms, a direct query to the cold node's single-shard collection falls through to a replica, and the cold shard warms in the background. Note: with test-sized shards the *pre-fix* penalty is small (lazy segments defer most load I/O), so the latency assertions are a behavioral regression suite; the mechanism itself is pinned red/green at the unit level.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
