### PR TITLE
fix(clusterapi): keep the cluster middleware when Sentry is enabled

### DIFF
--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -100,9 +100,8 @@ func NewServer(appState *state.State) *Server {
 		NodeReady:                          appState.ClusterService.Ready,
 	})
 
-	var handler http.Handler
 	// Multiplexing handler: Routes gRPC vs. REST (HTTP)
-	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	var base http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.ProtoMajor == 2 && strings.HasPrefix(r.Header.Get("content-type"), "application/grpc") {
 			grpcServer.ServeHTTP(w, r) // Route to gRPC
 			return
@@ -110,26 +109,7 @@ func NewServer(appState *state.State) *Server {
 		mux.ServeHTTP(w, r) // Route to REST mux (handles HTTP/1.1 or plain HTTP/2)
 	})
 
-	handler = addClusterHandlerMiddleware(handler, appState, auth)
-	if appState.ServerConfig.Config.Sentry.Enabled {
-		// Wrap the default mux with Sentry to capture panics, report errors and
-		// measure performance.
-		//
-		// Alternatively, you can also wrap individual handlers if you need to
-		// use different options for different parts of your app.
-		handler = sentryhttp.New(sentryhttp.Options{}).Handle(mux)
-	}
-
-	if appState.ServerConfig.Config.Monitoring.Enabled {
-		handler = monitoring.InstrumentHTTP(
-			handler,
-			staticRoute(mux),
-			appState.HTTPServerMetrics.InflightRequests,
-			appState.HTTPServerMetrics.RequestDuration,
-			appState.HTTPServerMetrics.RequestBodySize,
-			appState.HTTPServerMetrics.ResponseBodySize,
-		)
-	}
+	handler := buildHandlerChain(base, mux, appState, auth)
 
 	protocols := http.Protocols{}
 	protocols.SetHTTP1(true)
@@ -221,6 +201,39 @@ var clusterv1Regexp = regexp.MustCompile("/v1/cluster/*")
 // If the request doesn't match, it will continue to the next handler.
 // The dedicated http.Handler is wrapped with the provided auth so /v1/cluster/* endpoints
 // require basic auth when it is enabled in the cluster auth config.
+// buildHandlerChain wraps base with the cluster middleware and, where enabled,
+// with Sentry and monitoring.
+//
+// Each layer wraps the handler built before it. Handing a layer anything else --
+// the bare mux, say -- discards every layer already applied, with no error and
+// no log line, so the route set served ends up depending on which options are
+// enabled.
+func buildHandlerChain(base http.Handler, mux *http.ServeMux, appState *state.State, auth auth) http.Handler {
+	handler := addClusterHandlerMiddleware(base, appState, auth)
+
+	if appState.ServerConfig.Config.Sentry.Enabled {
+		// Wrap the chain with Sentry to capture panics, report errors and
+		// measure performance.
+		//
+		// Alternatively, you can also wrap individual handlers if you need to
+		// use different options for different parts of your app.
+		handler = sentryhttp.New(sentryhttp.Options{}).Handle(handler)
+	}
+
+	if appState.ServerConfig.Config.Monitoring.Enabled {
+		handler = monitoring.InstrumentHTTP(
+			handler,
+			staticRoute(mux),
+			appState.HTTPServerMetrics.InflightRequests,
+			appState.HTTPServerMetrics.RequestDuration,
+			appState.HTTPServerMetrics.RequestBodySize,
+			appState.HTTPServerMetrics.ResponseBodySize,
+		)
+	}
+
+	return handler
+}
+
 func addClusterHandlerMiddleware(next http.Handler, appState *state.State, auth auth) http.Handler {
 	// Instantiate the router outside the returned lambda to avoid re-allocating everytime a new request comes in
 	raftRouter := raft.ClusterRouter(appState.SchemaManager.Handler)

--- a/adapters/handlers/rest/clusterapi/serve_test.go
+++ b/adapters/handlers/rest/clusterapi/serve_test.go
@@ -14,10 +14,18 @@ package clusterapi
 import (
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	entsentry "github.com/weaviate/weaviate/entities/sentry"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/schema"
 )
 
 func Test_staticRoute(t *testing.T) {
@@ -76,4 +84,60 @@ func newRequest(t *testing.T, path string) *http.Request {
 func okHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "ok")
 	w.WriteHeader(http.StatusOK)
+}
+
+// Test_buildHandlerChain_SentryKeepsClusterMiddleware guards the wiring of the
+// cluster listener: each wrapper has to wrap the chain built before it. Handing
+// the Sentry wrapper the bare mux instead dropped the cluster middleware, and
+// with it the /v1/cluster/* raft routes and the auth applied to them, whenever
+// Sentry was enabled -- silently, since every other route came from the mux and
+// kept working.
+func Test_buildHandlerChain_SentryKeepsClusterMiddleware(t *testing.T) {
+	for _, sentryEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("sentry_enabled=%v", sentryEnabled), func(t *testing.T) {
+			var baseCalled bool
+			base := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				baseCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Minimal appState: buildHandlerChain reads only the two feature
+			// flags, and addClusterHandlerMiddleware only SchemaManager.Handler,
+			// which an empty-bodied request never reaches.
+			appState := &state.State{
+				SchemaManager: &schema.Manager{},
+				ServerConfig: &config.WeaviateConfig{Config: config.Config{
+					Sentry: &entsentry.ConfigOpts{Enabled: sentryEnabled},
+				}},
+			}
+
+			handler := buildHandlerChain(base, http.NewServeMux(), appState,
+				NewBasicAuthHandler(cluster.AuthConfig{}))
+
+			// /v1/cluster/* belongs to the raft router the middleware installs.
+			// An empty body makes that router answer 400; falling through to the
+			// handler underneath answers 200 and means the middleware is gone.
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, newPostRequest(t, "/v1/cluster/join"))
+			assert.False(t, baseCalled, "cluster route must not fall through to the mux")
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+			// Everything else still reaches the handler underneath.
+			baseCalled = false
+			rec = httptest.NewRecorder()
+			handler.ServeHTTP(rec, newPostRequest(t, "/indices"))
+			assert.True(t, baseCalled, "non-cluster route must reach the mux")
+			assert.Equal(t, http.StatusOK, rec.Code)
+		})
+	}
+}
+
+// newPostRequest builds a request with an empty (but non-nil) body, which the
+// raft handler needs in order to answer rather than dereference a nil body.
+func newPostRequest(t *testing.T, path string) *http.Request {
+	t.Helper()
+
+	r, err := http.NewRequest(http.MethodPost, path, strings.NewReader(""))
+	require.NoError(t, err)
+	return r
 }


### PR DESCRIPTION
Fixes #12579

The Sentry branch wrapped the bare mux instead of the handler built one line earlier. This discarded the layers already applied before it, including the cluster middleware and the routing closure that sends gRPC traffic away from the REST mux.

With `SENTRY_ENABLED=true`, `/v1/cluster/*` raft routes and their authentication middleware were missing from the served handler chain. Cluster gRPC requests could then fall through to the REST mux. Other routes continued working because they were served directly by the mux, so no obvious error was produced.

## Change

Moved handler wrapping into `buildHandlerChain`, ensuring every middleware layer receives the handler produced by the previous layer.

## Test

Added `Test_buildHandlerChain_SentryKeepsClusterMiddleware`, covering both Sentry enabled and disabled cases.

The regression test reproduces the original issue: restoring the previous handler shape causes `/v1/cluster/join` to return `200` from the mux instead of the expected raft router response.