### PR TITLE
Concurrently prefill geo caches using exinsg prefiller

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -355,6 +355,11 @@ func getSingleShardNameFromRepo(repo *DB, className string) string {
 func setupTestShardWithSettings(t *testing.T, ctx context.Context, class *models.Class,
 	vic schemaConfig.VectorIndexConfig, withStopwords, withCheckpoints, multiTenant, withAsyncIndexingEnabled bool, indexOpts ...func(*Index),
 ) (ShardLike, *Index) {
+	// With async indexing on, NewShard reads the checkpoint store from a
+	// goroutine, so a missing one surfaces on an unrelated test.
+	require.False(t, withAsyncIndexingEnabled && !withCheckpoints,
+		"async indexing needs withCheckpoints")
+
 	tmpDir := t.TempDir()
 	logger, _ := test.NewNullLogger()
 	maxResults := int64(10_000)

--- a/adapters/repos/db/idempotent_integration_test.go
+++ b/adapters/repos/db/idempotent_integration_test.go
@@ -517,6 +517,102 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 			assert.Equal(t, 1, shardCount)
 		})
 	})
+
+	t.Run("single tenant, geo properties are not re-initialized", func(t *testing.T) {
+		var (
+			ctx          = context.Background()
+			iterations   = 3
+			locationProp = "someLocation"
+			homeProp     = "someHome"
+			geoDataType  = []string{string(schema.DataTypeGeoCoordinates)}
+			geoClass     = &models.Class{
+				Class: class1Name,
+				Properties: []*models.Property{
+					{Name: intProp, DataType: []string{"int"}},
+					{Name: locationProp, DataType: geoDataType},
+					{Name: homeProp, DataType: geoDataType},
+				},
+				InvertedIndexConfig: invertedConfig(),
+				VectorConfig:        vectorConfig,
+			}
+			ss       = singleTenantShardingState[missingDataClass1]
+			migrator = setupTestMigrator(t, t.TempDir(), ss, geoClass)
+		)
+
+		defer func() {
+			require.NoError(t, migrator.db.Shutdown(context.Background()))
+		}()
+
+		idx := migrator.db.GetIndex(schema.ClassName(class1Name))
+		require.NotNil(t, idx)
+
+		var shard *Shard
+		require.NoError(t, idx.ForEachShard(func(_ string, sl ShardLike) error {
+			shard = underlyingShard(t, sl)
+			return nil
+		}))
+
+		locationBefore, locationQueueBefore := geoIndexAndQueue(t, shard, locationProp)
+		homeBefore, _ := geoIndexAndQueue(t, shard, homeProp)
+
+		for i := 0; i < iterations; i++ {
+			require.NoError(t, migrator.UpdateIndex(ctx, geoClass, ss))
+		}
+
+		locationAfter, locationQueueAfter := geoIndexAndQueue(t, shard, locationProp)
+		homeAfter, _ := geoIndexAndQueue(t, shard, homeProp)
+
+		require.Same(t, locationBefore, locationAfter,
+			"UpdateIndex rebuilt the geo index, blocking on a full cache prefill")
+		require.Same(t, locationQueueBefore, locationQueueAfter,
+			"UpdateIndex rebuilt the geo queue, leaving the old one registered")
+		require.Same(t, homeBefore, homeAfter,
+			"UpdateIndex rebuilt the second geo index")
+	})
+
+	t.Run("single tenant, a geo property the shard lacks is still added", func(t *testing.T) {
+		var (
+			ctx          = context.Background()
+			locationProp = "someLocation"
+			geoDataType  = []string{string(schema.DataTypeGeoCoordinates)}
+			localClass   = &models.Class{
+				Class:               class1Name,
+				Properties:          []*models.Property{{Name: intProp, DataType: []string{"int"}}},
+				InvertedIndexConfig: invertedConfig(),
+				VectorConfig:        vectorConfig,
+			}
+			incomingClass = &models.Class{
+				Class: class1Name,
+				Properties: []*models.Property{
+					{Name: intProp, DataType: []string{"int"}},
+					{Name: locationProp, DataType: geoDataType},
+				},
+				InvertedIndexConfig: invertedConfig(),
+				VectorConfig:        vectorConfig,
+			}
+			ss       = singleTenantShardingState[missingDataClass1]
+			migrator = setupTestMigrator(t, t.TempDir(), ss, localClass)
+		)
+
+		defer func() {
+			require.NoError(t, migrator.db.Shutdown(context.Background()))
+		}()
+
+		idx := migrator.db.GetIndex(schema.ClassName(class1Name))
+		require.NotNil(t, idx)
+
+		var shard *Shard
+		require.NoError(t, idx.ForEachShard(func(_ string, sl ShardLike) error {
+			shard = underlyingShard(t, sl)
+			return nil
+		}))
+		require.False(t, shard.hasGeoIndexForProp(locationProp))
+
+		require.NoError(t, migrator.UpdateIndex(ctx, incomingClass, ss))
+
+		location, _ := geoIndexAndQueue(t, shard, locationProp)
+		require.NotNil(t, location, "a geo property missing from the shard must be added")
+	})
 }
 
 func setupTestMigrator(t *testing.T, rootDir string, shardState *sharding.State, classes ...*models.Class) *Migrator {

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -523,8 +523,7 @@ func (m *Migrator) updateIndexAddMissingProperties(ctx context.Context, idx *Ind
 		errMissingProp := errors.New("missing prop")
 		// Ensure we iterate over loaded shard to avoid force loading a lazy loaded shard
 		err := idx.ForEachLoadedShard(func(name string, shard ShardLike) error {
-			bucket := shard.Store().Bucket(helpers.BucketFromPropNameLSM(prop.Name))
-			if bucket == nil {
+			if !shardHasProperty(shard, prop) {
 				return errMissingProp
 			}
 			return nil
@@ -536,6 +535,16 @@ func (m *Migrator) updateIndexAddMissingProperties(ctx context.Context, idx *Ind
 		}
 	}
 	return nil
+}
+
+// shardHasProperty reports whether prop's value index exists on this shard. Geo
+// props get a property-specific index and no filterable bucket, so probing that
+// bucket would report them missing forever.
+func shardHasProperty(shard ShardLike, prop *models.Property) bool {
+	if dt, _ := schema.AsPrimitive(prop.DataType); dt == schema.DataTypeGeoCoordinates {
+		return shard.hasGeoIndexForProp(prop.Name)
+	}
+	return shard.Store().Bucket(helpers.BucketFromPropNameLSM(prop.Name)) != nil
 }
 
 func (m *Migrator) AddProperty(ctx context.Context, className string, prop ...*models.Property) error {

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
@@ -950,4 +951,70 @@ func newDropTestMigrator(idx *Index, className string, cloud modulecapabilities.
 	m.nodeId = "node1"
 	m.cloud = cloud
 	return m
+}
+
+func TestShardHasProperty(t *testing.T) {
+	locationProp := &models.Property{
+		Name:     "location",
+		DataType: []string{string(schema.DataTypeGeoCoordinates)},
+	}
+	nameProp := &models.Property{
+		Name:     "name",
+		DataType: schema.DataTypeText.PropString(),
+	}
+
+	// a mock fails the test on an unexpected call, so a geo prop that still
+	// probes the bucket is caught here
+	mockShard := func(setup func(*MockShardLike)) func(*testing.T) ShardLike {
+		return func(t *testing.T) ShardLike {
+			s := NewMockShardLike(t)
+			setup(s)
+			return s
+		}
+	}
+
+	tests := []struct {
+		name  string
+		prop  *models.Property
+		shard func(*testing.T) ShardLike
+		want  bool
+	}{
+		{
+			name: "geo property with a registered index",
+			prop: locationProp,
+			shard: mockShard(func(s *MockShardLike) {
+				s.EXPECT().hasGeoIndexForProp("location").Return(true)
+			}),
+			want: true,
+		},
+		{
+			name: "geo property with no index yet",
+			prop: locationProp,
+			shard: mockShard(func(s *MockShardLike) {
+				s.EXPECT().hasGeoIndexForProp("location").Return(false)
+			}),
+			want: false,
+		},
+		{
+			name: "non-geo property with no filterable bucket",
+			prop: nameProp,
+			shard: mockShard(func(s *MockShardLike) {
+				s.EXPECT().Store().Return(&lsmkv.Store{})
+			}),
+			want: false,
+		},
+		{
+			// this shard carries no dependencies, so any attempt to load it panics
+			name:  "geo property on a cold shard reports missing without loading",
+			prop:  locationProp,
+			shard: func(*testing.T) ShardLike { return &LazyLoadShard{} },
+			want:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, shardHasProperty(test.shard(t), test.prop))
+		})
+	}
 }

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -4789,6 +4789,52 @@ func (_c *MockShardLike_hasGeoIndex_Call) RunAndReturn(run func() bool) *MockSha
 	return _c
 }
 
+// hasGeoIndexForProp provides a mock function with given fields: propName
+func (_m *MockShardLike) hasGeoIndexForProp(propName string) bool {
+	ret := _m.Called(propName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for hasGeoIndexForProp")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(propName)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockShardLike_hasGeoIndexForProp_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'hasGeoIndexForProp'
+type MockShardLike_hasGeoIndexForProp_Call struct {
+	*mock.Call
+}
+
+// hasGeoIndexForProp is a helper method to define mock.On call
+//   - propName string
+func (_e *MockShardLike_Expecter) hasGeoIndexForProp(propName interface{}) *MockShardLike_hasGeoIndexForProp_Call {
+	return &MockShardLike_hasGeoIndexForProp_Call{Call: _e.mock.On("hasGeoIndexForProp", propName)}
+}
+
+func (_c *MockShardLike_hasGeoIndexForProp_Call) Run(run func(propName string)) *MockShardLike_hasGeoIndexForProp_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_hasGeoIndexForProp_Call) Return(_a0 bool) *MockShardLike_hasGeoIndexForProp_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardLike_hasGeoIndexForProp_Call) RunAndReturn(run func(string) bool) *MockShardLike_hasGeoIndexForProp_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // initPropertyBuckets provides a mock function with given fields: ctx, eg, lazyLoadSegments, props
 func (_m *MockShardLike) initPropertyBuckets(ctx context.Context, eg *errors.ErrorGroupWrapper, lazyLoadSegments bool, props ...*models.Property) {
 	_va := make([]interface{}, len(props))
@@ -5995,7 +6041,8 @@ func (_c *MockShardLike_uuidFromDocID_Call) RunAndReturn(run func(uint64) (strfm
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockShardLike {
+},
+) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -183,6 +183,7 @@ type ShardLike interface {
 	updateVectorIndexesIgnoreDelete(ctx context.Context, vectors map[string][]float32, status objectInsertStatus) error
 	updateMultiVectorIndexesIgnoreDelete(ctx context.Context, multiVectors map[string][][]float32, status objectInsertStatus) error
 	hasGeoIndex() bool
+	hasGeoIndexForProp(propName string) bool
 	// addTargetNodeOverride adds a target node override to the shard.
 	addTargetNodeOverride(ctx context.Context, targetNodeOverride additional.AsyncReplicationTargetNodeOverride) error
 	// removeTargetNodeOverride removes a target node override from the shard.

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -195,3 +195,10 @@ func (s *Shard) hasGeoIndex() bool {
 	}
 	return false
 }
+
+func (s *Shard) hasGeoIndexForProp(propName string) bool {
+	s.propertyIndicesLock.RLock()
+	defer s.propertyIndicesLock.RUnlock()
+
+	return s.propertyIndices[propName].Type == schema.DataTypeGeoCoordinates
+}

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -36,6 +36,12 @@ func (s *Shard) ConvertQueue(targetVector string) error {
 		return nil
 	}
 
+	// No store, no checkpoint to convert from. This runs on a goroutine, where
+	// a nil dereference takes down the process.
+	if s.indexCheckpoints == nil {
+		return nil
+	}
+
 	// load non-indexed vectors and add them to the queue
 	checkpoint, exists, err := s.indexCheckpoints.Get(s.ID(), targetVector)
 	if err != nil {

--- a/adapters/repos/db/shard_async_test.go
+++ b/adapters/repos/db/shard_async_test.go
@@ -1,0 +1,46 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestShardConvertQueueWithoutCheckpoints pins that a shard with no checkpoint
+// store converts nothing. NewShard calls this on a goroutine, so a nil crashes
+// the process rather than failing a caller.
+func TestShardConvertQueueWithoutCheckpoints(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetVector string
+	}{
+		{name: "legacy vector", targetVector: ""},
+		{name: "named vector", targetVector: "custom"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := &Shard{
+				name: "shard1",
+				index: &Index{
+					Config:               IndexConfig{ClassName: schema.ClassName("MyClass")},
+					AsyncIndexingEnabled: true,
+				},
+			}
+
+			require.NoError(t, s.ConvertQueue(test.targetVector))
+		})
+	}
+}

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -49,6 +49,8 @@ func (s *Shard) initGeoProp(prop *models.Property) error {
 		WaitForCachePrefill:                      s.index.Config.HNSWWaitForCachePrefill,
 		DisablePersistence:                       false,
 		Logger:                                   s.index.logger,
+		ClassName:                                s.index.Config.ClassName.String(),
+		ShardName:                                s.name,
 		HNSWEF:                                   s.index.Config.HNSWGeoIndexEF,
 		SnapshotDisabled:                         s.index.Config.HNSWDisableSnapshots,
 		SnapshotOnStartup:                        s.index.Config.HNSWSnapshotOnStartup,

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -22,12 +22,19 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func (s *Shard) initGeoProp(prop *models.Property) error {
+	// replacing a live index would leave its commit logger and queue registered,
+	// putting two writers on the same files
+	if s.hasGeoIndexForProp(prop.Name) {
+		return nil
+	}
+
 	// starts geo props cycles if actual geo property is present
 	// (safe to start multiple times)
 	s.index.cycleCallbacks.geoPropsCommitLoggerCycle.Start()
@@ -58,6 +65,12 @@ func (s *Shard) initGeoProp(prop *models.Property) error {
 	}
 
 	s.propertyIndicesLock.Lock()
+	if _, ok := s.propertyIndices[prop.Name]; ok {
+		s.propertyIndicesLock.Unlock()
+		// another caller claimed the prop while this index was built; unregister
+		// the cycle callbacks its constructor added
+		return idx.Shutdown(s.shutCtx)
+	}
 	s.propertyIndices[prop.Name] = propertyspecific.Index{
 		Type:     schema.DataTypeGeoCoordinates,
 		GeoIndex: idx,
@@ -71,7 +84,16 @@ func (s *Shard) initGeoProp(prop *models.Property) error {
 	if underlyingVI, ok := idx.UnderlyingVectorIndex().(VectorIndex); ok {
 		geoQueue, err := NewGeoIndexQueue(s, prop.Name, underlyingVI)
 		if err != nil {
-			return errors.Wrapf(err, "create geo index queue for prop %q", prop.Name)
+			// the guard at the top would skip the retry, leaving the prop with an
+			// index but no queue until the shard is reloaded
+			s.propertyIndicesLock.Lock()
+			delete(s.propertyIndices, prop.Name)
+			s.propertyIndicesLock.Unlock()
+
+			ec := errorcompounder.New()
+			ec.AddWrapf(err, "create geo index queue for prop %q", prop.Name)
+			ec.AddWrapf(idx.Shutdown(s.shutCtx), "shutdown geo index for prop %q", prop.Name)
+			return ec.ToError()
 		}
 		s.propertyIndicesLock.Lock()
 		s.geoQueues[prop.Name] = geoQueue

--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -36,6 +37,9 @@ func (s *Shard) initGeoProp(prop *models.Property) error {
 		ID:                                       geoPropID(prop.Name),
 		RootPath:                                 s.path(),
 		CoordinatesForID:                         s.makeCoordinatesForID(prop.Name),
+		Store:                                    s.store,
+		CoordinatesFromObject:                    s.makeCoordinatesFromObject(prop.Name),
+		WaitForCachePrefill:                      s.index.Config.HNSWWaitForCachePrefill,
 		DisablePersistence:                       false,
 		Logger:                                   s.index.logger,
 		HNSWEF:                                   s.index.Config.HNSWGeoIndexEF,
@@ -89,25 +93,59 @@ func (s *Shard) makeCoordinatesForID(propName string) geo.CoordinatesForID {
 			return nil, err
 		}
 
-		if obj.Properties() == nil {
-			return nil, storobj.NewErrNotFoundf(id,
-				"object has no properties")
+		coordinates, err := geoCoordinatesOfProp(obj, propName)
+		if err != nil {
+			return nil, err
 		}
-
-		prop, ok := obj.Properties().(map[string]interface{})[propName]
-		if !ok {
+		if coordinates == nil {
 			return nil, storobj.NewErrNotFoundf(id,
 				"object has no property %q", propName)
 		}
 
-		geoProp, ok := prop.(*models.GeoCoordinates)
-		if !ok {
-			return nil, fmt.Errorf("expected property to be of type %T, got: %T",
-				&models.GeoCoordinates{}, prop)
+		return coordinates, nil
+	}
+}
+
+// makeCoordinatesFromObject reads a coordinate straight out of an object's
+// stored bytes, so the geo cache prefill can scan the objects bucket in storage
+// order instead of seeking once per doc ID. The class name comes from the
+// schema because objects may be written without it on disk.
+func (s *Shard) makeCoordinatesFromObject(propName string) geo.CoordinatesFromObject {
+	// read-only once built, so all lookups can share it
+	propExtraction := storobj.NewPropExtraction().Add(propName)
+	className := s.index.Config.ClassName.String()
+
+	return func(objectBytes []byte) (*models.GeoCoordinates, error) {
+		obj, err := storobj.FromBinaryOptionalDisk(objectBytes, className,
+			additional.Properties{}, propExtraction)
+		if err != nil {
+			return nil, err
 		}
 
-		return geoProp, nil
+		return geoCoordinatesOfProp(obj, propName)
 	}
+}
+
+// geoCoordinatesOfProp returns propName's coordinates, or nil if the object
+// carries no such property.
+func geoCoordinatesOfProp(obj *storobj.Object, propName string) (*models.GeoCoordinates, error) {
+	props, ok := obj.Properties().(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+
+	prop, ok := props[propName]
+	if !ok {
+		return nil, nil
+	}
+
+	geoProp, ok := prop.(*models.GeoCoordinates)
+	if !ok {
+		return nil, fmt.Errorf("expected property to be of type %T, got: %T",
+			&models.GeoCoordinates{}, prop)
+	}
+
+	return geoProp, nil
 }
 
 func geoPropID(propName string) string {

--- a/adapters/repos/db/shard_geo_props_from_object_test.go
+++ b/adapters/repos/db/shard_geo_props_from_object_test.go
@@ -1,0 +1,172 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+const geoFromObjectClass = "GeoPropScan"
+
+func geoScanShard() *Shard {
+	return &Shard{index: &Index{Config: IndexConfig{ClassName: schema.ClassName(geoFromObjectClass)}}}
+}
+
+func geoCoordinates(lat, lon float32) *models.GeoCoordinates {
+	return &models.GeoCoordinates{Latitude: &lat, Longitude: &lon}
+}
+
+// marshalGeoObject produces object bytes exactly as the write path does.
+// skipClassName mirrors LSM_SKIP_WRITE_CLASS_NAME, which leaves the class name
+// off disk and is why the decoder takes it from the schema instead.
+func marshalGeoObject(t *testing.T, props map[string]interface{}, skipClassName bool) []byte {
+	t.Helper()
+
+	obj := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      geoFromObjectClass,
+			Properties: props,
+		},
+		Vector: []float32{7, 8, 9},
+	}
+	data, err := obj.MarshalBinaryDisk(skipClassName)
+	require.NoError(t, err)
+	return data
+}
+
+func TestMakeCoordinatesFromObject(t *testing.T) {
+	munich := geoCoordinates(48.13743, 11.57549)
+	stuttgart := geoCoordinates(48.78232, 9.17702)
+	fullProps := map[string]interface{}{
+		"name":     "munich office",
+		"sizes":    []float64{1.5, 2.5},
+		"location": munich,
+		"home":     stuttgart,
+	}
+
+	tests := []struct {
+		name          string
+		propName      string
+		props         map[string]interface{}
+		skipClassName bool
+		objectBytes   func(t *testing.T) []byte
+		want          *models.GeoCoordinates
+		wantErr       string
+	}{
+		{
+			name:     "geo prop next to other properties",
+			propName: "location",
+			props:    fullProps,
+			want:     munich,
+		},
+		{
+			// each geo prop has its own index, so a scan must not pick up its sibling
+			name:     "second geo prop of the same object",
+			propName: "home",
+			props:    fullProps,
+			want:     stuttgart,
+		},
+		{
+			name:          "class name omitted on disk",
+			propName:      "location",
+			props:         fullProps,
+			skipClassName: true,
+			want:          munich,
+		},
+		{
+			// a nil coordinate means "skip", not "this doc is gone" — unlike the
+			// by-id reader, the scan has no doc to tombstone
+			name:     "object without the requested prop",
+			propName: "location",
+			props:    map[string]interface{}{"name": "no coordinates here"},
+		},
+		{
+			name:     "object with an empty property map",
+			propName: "location",
+			props:    map[string]interface{}{},
+		},
+		{
+			name:     "object without any properties",
+			propName: "location",
+			props:    nil,
+		},
+		{
+			name:        "payload of an unsupported marshaller version",
+			propName:    "location",
+			objectBytes: func(t *testing.T) []byte { return []byte{2, 0, 0, 0} },
+			wantErr:     "unsupported binary marshaller version",
+		},
+		{
+			name:     "prop that does not hold coordinates",
+			propName: "location",
+			props:    map[string]interface{}{"location": "48.1"},
+			wantErr:  "expected property to be of type",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			objectBytes := test.objectBytes
+			if objectBytes == nil {
+				objectBytes = func(t *testing.T) []byte {
+					return marshalGeoObject(t, test.props, test.skipClassName)
+				}
+			}
+
+			coordinates, err := geoScanShard().makeCoordinatesFromObject(test.propName)(objectBytes(t))
+
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				require.Nil(t, coordinates)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, coordinates)
+		})
+	}
+}
+
+// The scan runs one decoder across every cursor, so all of them share a single
+// *storobj.PropertyExtraction.
+func TestMakeCoordinatesFromObjectConcurrentDecodes(t *testing.T) {
+	munich := geoCoordinates(48.13743, 11.57549)
+	objectBytes := marshalGeoObject(t, map[string]interface{}{"location": munich}, false)
+	fromObject := geoScanShard().makeCoordinatesFromObject("location")
+
+	const decodes = 8
+	coordinates := make([]*models.GeoCoordinates, decodes)
+	errs := make([]error, decodes)
+
+	var wg sync.WaitGroup
+	for i := range decodes {
+		wg.Go(func() {
+			coordinates[i], errs[i] = fromObject(objectBytes)
+		})
+	}
+	wg.Wait()
+
+	for i := range decodes {
+		require.NoError(t, errs[i])
+		require.Equal(t, munich, coordinates[i])
+	}
+}

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -488,7 +488,7 @@ func TestInitGeoPropQueueFailureIsRetryable(t *testing.T) {
 		Properties: []*models.Property{{Name: "name", DataType: schema.DataTypeText.PropString()}},
 	}
 	shardLike, _ := testShardWithSettings(t, ctx, class,
-		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, true)
+		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, true, true)
 	s := concreteShard(t, shardLike)
 
 	blockGeoQueueDir(t, s, "location")
@@ -635,7 +635,7 @@ func TestInitPropertyBucketsBatchesGeoProps(t *testing.T) {
 func TestInitPropertyBucketsGeoBatchContinuesAfterError(t *testing.T) {
 	ctx := context.Background()
 	shardLike, _ := testShardWithSettings(t, ctx, &models.Class{Class: geoPropClass},
-		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, true)
+		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, true, true)
 	s := concreteShard(t, shardLike)
 
 	blockGeoQueueDir(t, s, "alpha")

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -16,6 +16,8 @@ package db
 import (
 	"context"
 	"encoding/binary"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -24,6 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
+	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -333,4 +337,164 @@ func TestObjectByIndexIDWithPropsDecodesOnlyRequestedProps(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, props, 1, "only the requested property must be decoded")
 	require.Equal(t, munichCoordinates(), props["location"])
+}
+
+func geoProp(name string) *models.Property {
+	return &models.Property{Name: name, DataType: []string{string(schema.DataTypeGeoCoordinates)}}
+}
+
+// geoIndexAndQueue reads the live index and queue registered for propName.
+func geoIndexAndQueue(t *testing.T, s *Shard, propName string) (*geo.Index, *VectorIndexQueue) {
+	t.Helper()
+
+	s.propertyIndicesLock.RLock()
+	defer s.propertyIndicesLock.RUnlock()
+
+	idx, ok := s.propertyIndices[propName]
+	require.True(t, ok, "no property index for %q", propName)
+	return idx.GeoIndex, s.geoQueues[propName]
+}
+
+// TestInitGeoProp covers when a second initGeoProp call reuses the registered
+// index and when it has to build a new one. Reusing is what keeps a re-init off
+// the blocking cache prefill and stops the old index from being orphaned.
+func TestInitGeoProp(t *testing.T) {
+	tests := []struct {
+		name string
+		prop string
+		// setup runs between capturing the index and calling initGeoProp again.
+		setup    func(t *testing.T, ctx context.Context, s *Shard)
+		wantSame bool
+	}{
+		{
+			name:     "first geo prop of the class is reused",
+			prop:     "location",
+			wantSame: true,
+		},
+		{
+			name:     "second geo prop of the class is reused",
+			prop:     "home",
+			wantSame: true,
+		},
+		{
+			name: "a dropped prop is built from scratch",
+			prop: "location",
+			setup: func(t *testing.T, ctx context.Context, s *Shard) {
+				s.propertyIndicesLock.Lock()
+				defer s.propertyIndicesLock.Unlock()
+				require.NoError(t, s.propertyIndices.DropAll(ctx, false))
+			},
+			wantSame: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := testGeoPropShard(t, ctx)
+
+			before, beforeQueue := geoIndexAndQueue(t, s, test.prop)
+			if test.setup != nil {
+				test.setup(t, ctx, s)
+			}
+
+			require.NoError(t, s.initGeoProp(geoProp(test.prop)))
+
+			after, afterQueue := geoIndexAndQueue(t, s, test.prop)
+			if !test.wantSame {
+				require.NotSame(t, before, after, "the prop must be inited from scratch")
+				return
+			}
+			require.Same(t, before, after,
+				"re-init replaced the live geo index, leaving the old one running")
+			require.Same(t, beforeQueue, afterQueue,
+				"re-init replaced the live geo queue, leaving the old one registered")
+		})
+	}
+}
+
+// TestInitGeoPropKeysOnPropName pins that the guard keys on the property name
+// rather than on the shard having any geo index at all.
+func TestInitGeoPropKeysOnPropName(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	location, _ := geoIndexAndQueue(t, s, "location")
+	home, _ := geoIndexAndQueue(t, s, "home")
+	require.NotSame(t, location, home, "each geo prop must get its own index")
+
+	require.NoError(t, s.initGeoProp(geoProp("office")))
+
+	office, _ := geoIndexAndQueue(t, s, "office")
+	require.NotNil(t, office, "a prop with no index yet must still be inited")
+
+	stillLocation, _ := geoIndexAndQueue(t, s, "location")
+	require.Same(t, location, stillLocation, "initing a new prop disturbed an existing one")
+}
+
+// TestInitGeoPropQueueFailureIsRetryable pins that a failed queue build leaves
+// no index registered. Keeping it would make the guard skip the retry, so the
+// prop would serve reads with an index nothing ever drains into.
+func TestInitGeoPropQueueFailureIsRetryable(t *testing.T) {
+	ctx := context.Background()
+	class := &models.Class{
+		Class:      geoPropClass,
+		Properties: []*models.Property{{Name: "name", DataType: schema.DataTypeText.PropString()}},
+	}
+	shardLike, _ := testShardWithSettings(t, ctx, class,
+		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, true)
+	s := concreteShard(t, shardLike)
+
+	// a regular file where the queue dir belongs makes the queue's MkdirAll fail
+	queueDir := filepath.Join(s.path(), geoPropID("location")+".queue.d")
+	require.NoError(t, os.WriteFile(queueDir, []byte("blocked"), 0o644))
+
+	require.Error(t, s.initGeoProp(geoProp("location")))
+
+	s.propertyIndicesLock.RLock()
+	_, registered := s.propertyIndices["location"]
+	s.propertyIndicesLock.RUnlock()
+	require.False(t, registered, "a failed init must not leave the index registered")
+
+	require.NoError(t, os.Remove(queueDir))
+	require.NoError(t, s.initGeoProp(geoProp("location")), "the retry must be able to run")
+
+	idx, queue := geoIndexAndQueue(t, s, "location")
+	require.NotNil(t, idx)
+	require.NotNil(t, queue, "the retry must produce the queue the first attempt failed on")
+}
+
+// TestInitGeoPropConcurrent pins that racing callers converge on one usable
+// index. It runs under -race; it does not distinguish which of the racing
+// indexes survived.
+func TestInitGeoPropConcurrent(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	const callers = 8
+	var wg sync.WaitGroup
+	errs := make([]error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = s.initGeoProp(geoProp("office"))
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "caller %d", i)
+	}
+
+	idx, _ := geoIndexAndQueue(t, s, "office")
+	require.NotNil(t, idx)
+
+	require.NoError(t, idx.Add(ctx, 1, munichCoordinates()))
+	found, err := idx.WithinRange(ctx, filters.GeoRange{
+		GeoCoordinates: munichCoordinates(),
+		Distance:       10000,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, found)
 }

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -435,6 +435,49 @@ func TestInitGeoPropKeysOnPropName(t *testing.T) {
 	require.Same(t, location, stillLocation, "initing a new prop disturbed an existing one")
 }
 
+// initGeoProp is the only caller holding the collection and shard a geo index
+// belongs to, so an index built without them logs its blocking startup work
+// anonymously on a node running many shards.
+func TestInitGeoPropNamesItsShard(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	// hooking the shard's own logger rather than replacing it: the field is read
+	// unsynchronized from background goroutines the shard already started
+	logger, ok := s.index.logger.(*logrus.Logger)
+	require.True(t, ok, "the test shard no longer carries a hookable logger")
+	hook := test.NewLocal(logger)
+	logger.SetLevel(logrus.DebugLevel)
+
+	props := []string{"office", "depot"}
+	for _, prop := range props {
+		require.NoError(t, s.initGeoProp(geoProp(prop)))
+	}
+
+	namedPerProp := map[string]int{}
+	for _, entry := range hook.AllEntries() {
+		class, ok := entry.Data["class"]
+		if !ok {
+			// the commit logger and the vector cache do not carry these
+			continue
+		}
+		// the id also pins the tagging: without it the shard's geo props and its
+		// main index all log under the same class and shard
+		id, ok := entry.Data["index_id"].(string)
+		if !ok {
+			continue
+		}
+		namedPerProp[id]++
+		require.Equalf(t, geoPropClass, class, "line %q", entry.Message)
+		require.Equalf(t, s.name, entry.Data["shard"], "line %q", entry.Message)
+	}
+
+	for _, prop := range props {
+		require.NotZerof(t, namedPerProp[geoPropID(prop)],
+			"prop %q logged no line naming its class and shard", prop)
+	}
+}
+
 // TestInitGeoPropQueueFailureIsRetryable pins that a failed queue build leaves
 // no index registered. Keeping it would make the guard skip the retry, so the
 // prop would serve reads with an index nothing ever drains into.

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -23,10 +23,13 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -445,9 +448,7 @@ func TestInitGeoPropQueueFailureIsRetryable(t *testing.T) {
 		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, true)
 	s := concreteShard(t, shardLike)
 
-	// a regular file where the queue dir belongs makes the queue's MkdirAll fail
-	queueDir := filepath.Join(s.path(), geoPropID("location")+".queue.d")
-	require.NoError(t, os.WriteFile(queueDir, []byte("blocked"), 0o644))
+	blockGeoQueueDir(t, s, "location")
 
 	require.Error(t, s.initGeoProp(geoProp("location")))
 
@@ -456,7 +457,7 @@ func TestInitGeoPropQueueFailureIsRetryable(t *testing.T) {
 	s.propertyIndicesLock.RUnlock()
 	require.False(t, registered, "a failed init must not leave the index registered")
 
-	require.NoError(t, os.Remove(queueDir))
+	require.NoError(t, os.Remove(filepath.Join(s.path(), geoPropID("location")+".queue.d")))
 	require.NoError(t, s.initGeoProp(geoProp("location")), "the retry must be able to run")
 
 	idx, queue := geoIndexAndQueue(t, s, "location")
@@ -497,4 +498,114 @@ func TestInitGeoPropConcurrent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1}, found)
+}
+
+// blockGeoQueueDir puts a regular file where propName's queue directory belongs,
+// so the queue's MkdirAll fails and initGeoProp errors.
+func blockGeoQueueDir(t *testing.T, s *Shard, propName string) {
+	t.Helper()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(s.path(), geoPropID(propName)+".queue.d"), []byte("blocked"), 0o644))
+}
+
+// geoInitJobs counts the errgroup jobs initPropertyBuckets submits for props.
+// The wrapper reports the count when Wait runs, which is the only place the
+// submission shape is observable from outside.
+func geoInitJobs(t *testing.T, s *Shard, props ...*models.Property) int {
+	t.Helper()
+
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	eg := enterrors.NewErrorGroupWrapper(logger)
+	s.initPropertyBuckets(context.Background(), eg, false, props...)
+	require.NoError(t, eg.Wait())
+
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["action"] == "error_group_wait_initiated" {
+			count, ok := entry.Data["jobs_count"].(int64)
+			require.True(t, ok, "jobs_count field missing or not int64")
+			return int(count)
+		}
+	}
+	t.Fatal("error group never logged its job count")
+	return 0
+}
+
+// TestInitPropertyBucketsBatchesGeoProps pins that geo props share one errgroup
+// job. Each of them prefills its cache by scanning the whole objects bucket, so
+// a job apiece is a full scan apiece running at once.
+func TestInitPropertyBucketsBatchesGeoProps(t *testing.T) {
+	textProp := &models.Property{
+		Name:         "name",
+		DataType:     schema.DataTypeText.PropString(),
+		Tokenization: models.PropertyTokenizationWhitespace,
+	}
+
+	tests := []struct {
+		name     string
+		props    []*models.Property
+		wantJobs int
+	}{
+		{
+			name:     "no props",
+			wantJobs: 0,
+		},
+		{
+			name:     "one text prop",
+			props:    []*models.Property{textProp},
+			wantJobs: 1,
+		},
+		{
+			name:     "one geo prop",
+			props:    []*models.Property{geoProp("location")},
+			wantJobs: 1,
+		},
+		{
+			name:     "three geo props share one job",
+			props:    []*models.Property{geoProp("location"), geoProp("home"), geoProp("office")},
+			wantJobs: 1,
+		},
+		{
+			name:     "geo props batch while other props still fan out",
+			props:    []*models.Property{textProp, geoProp("location"), geoProp("home")},
+			wantJobs: 2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			shardLike, _ := testShardWithSettings(t, ctx, &models.Class{Class: geoPropClass},
+				hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, false)
+
+			require.Equal(t, test.wantJobs,
+				geoInitJobs(t, concreteShard(t, shardLike), test.props...))
+		})
+	}
+}
+
+// TestInitPropertyBucketsGeoBatchContinuesAfterError pins that one geo prop
+// failing still leaves the others initialized. Skipping them would bring the
+// shard up accepting writes it never geo-indexes.
+func TestInitPropertyBucketsGeoBatchContinuesAfterError(t *testing.T) {
+	ctx := context.Background()
+	shardLike, _ := testShardWithSettings(t, ctx, &models.Class{Class: geoPropClass},
+		hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, true)
+	s := concreteShard(t, shardLike)
+
+	blockGeoQueueDir(t, s, "alpha")
+
+	eg := enterrors.NewErrorGroupWrapper(s.index.logger)
+	s.initPropertyBuckets(ctx, eg, false, geoProp("alpha"), geoProp("beta"))
+
+	err := eg.Wait()
+	require.ErrorContains(t, err, `init prop "alpha": value index:`)
+
+	s.propertyIndicesLock.RLock()
+	defer s.propertyIndicesLock.RUnlock()
+
+	require.NotContains(t, s.propertyIndices, "alpha", "the failed prop must not stay registered")
+	require.Contains(t, s.propertyIndices, "beta", "a later prop must still be initialized")
 }

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -261,6 +261,60 @@ func TestMakeCoordinatesForIDConcurrentLookups(t *testing.T) {
 	}
 }
 
+// The prefill scan reads coordinates straight off the stored bytes while every
+// other lookup goes by doc ID. A shard whose two readers disagree would index
+// coordinates it never serves.
+func TestGeoCoordinateReadersAgree(t *testing.T) {
+	ctx := context.Background()
+	s := testGeoPropShard(t, ctx)
+
+	tests := []struct {
+		name  string
+		props map[string]interface{}
+		want  *models.GeoCoordinates
+	}{
+		{
+			name:  "geo prop next to other properties",
+			props: map[string]interface{}{"name": "munich office", "location": munichCoordinates()},
+			want:  munichCoordinates(),
+		},
+		{
+			name:  "two geo props on one object",
+			props: map[string]interface{}{"location": munichCoordinates(), "home": stuttgartCoordinates()},
+			want:  munichCoordinates(),
+		},
+		{
+			name:  "object without the requested prop",
+			props: map[string]interface{}{"name": "no coordinates here"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			docID := putGeoPropObject(t, ctx, s, test.props)
+
+			objectBytes, err := s.store.Bucket(helpers.ObjectsBucketLSM).
+				GetBySecondary(ctx, 0, binary.LittleEndian.AppendUint64(nil, docID))
+			require.NoError(t, err)
+
+			fromObject, err := s.makeCoordinatesFromObject("location")(objectBytes)
+			require.NoError(t, err)
+			require.Equal(t, test.want, fromObject)
+
+			forID, err := s.makeCoordinatesForID("location")(ctx, docID)
+			if test.want == nil {
+				// the by-id reader reports a missing coordinate as a gone doc, the
+				// scan just skips the object
+				var notFound storobj.ErrNotFound
+				require.ErrorAs(t, err, &notFound)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, forID, fromObject)
+		})
+	}
+}
+
 func TestObjectByIndexIDWithPropsDecodesOnlyRequestedProps(t *testing.T) {
 	ctx := context.Background()
 	s := testGeoPropShard(t, ctx)

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -68,6 +69,18 @@ func (s *Shard) initPropertyBuckets(ctx context.Context, eg *enterrors.ErrorGrou
 		makeBucketOptions = s.overwrittenMakeDefaultBucketOptions(lsmkv.WithLazySegmentLoading(lazyLoadSegments))
 	}
 
+	initValueIndex := func(prop *models.Property) error {
+		if err := s.createPropertyValueIndex(ctx, prop, makeBucketOptions); err != nil {
+			return fmt.Errorf("init prop %q: value index: %w", prop.Name, err)
+		}
+		return nil
+	}
+
+	// when the server waits for cache prefill (the default), each geo prop's init
+	// blocks on a 2*GOMAXPROCS-cursor scan of the objects bucket, so they run one
+	// at a time rather than joining the fan-out below
+	var geoProps []*models.Property
+
 	for _, prop := range props {
 		propCopy := *prop // prevent loop variable capture
 
@@ -93,12 +106,13 @@ func (s *Shard) initPropertyBuckets(ctx context.Context, eg *enterrors.ErrorGrou
 			continue
 		}
 
-		eg.Go(func() error {
-			if err := s.createPropertyValueIndex(ctx, &propCopy, makeBucketOptions); err != nil {
-				return fmt.Errorf("init prop %q: value index: %w", propCopy.Name, err)
-			}
-			return nil
-		})
+		if createsGeoIndex(prop) {
+			geoProps = append(geoProps, &propCopy)
+		} else {
+			eg.Go(func() error {
+				return initValueIndex(&propCopy)
+			})
+		}
 
 		if s.index.invertedIndexConfig.IndexNullState {
 			eg.Go(func() error {
@@ -118,6 +132,32 @@ func (s *Shard) initPropertyBuckets(ctx context.Context, eg *enterrors.ErrorGrou
 			})
 		}
 	}
+
+	if len(geoProps) > 0 {
+		eg.Go(func() error {
+			// one prop failing must not skip the rest, which each own a separate
+			// index the shard would otherwise come up without
+			ec := errorcompounder.New()
+			for _, prop := range geoProps {
+				if err := ctx.Err(); err != nil {
+					ec.Add(err)
+					break
+				}
+				ec.Add(initValueIndex(prop))
+			}
+			return ec.ToError()
+		})
+	}
+}
+
+// createsGeoIndex reports whether createPropertyValueIndex builds a geo index
+// for prop rather than inverted buckets.
+func createsGeoIndex(prop *models.Property) bool {
+	if !inverted.HasFilterableIndex(prop) {
+		return false
+	}
+	dt, _ := schema.AsPrimitive(prop.DataType)
+	return dt == schema.DataTypeGeoCoordinates
 }
 
 func (s *Shard) updatePropertyBuckets(ctx context.Context,
@@ -472,11 +512,11 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 		return err
 	}
 
-	if inverted.HasFilterableIndex(prop) {
-		if dt, _ := schema.AsPrimitive(prop.DataType); dt == schema.DataTypeGeoCoordinates {
-			return s.initGeoProp(prop)
-		}
+	if createsGeoIndex(prop) {
+		return s.initGeoProp(prop)
+	}
 
+	if inverted.HasFilterableIndex(prop) {
 		if schema.IsRefDataType(prop.DataType) {
 			if err := s.store.CreateOrLoadBucket(ctx,
 				helpers.BucketFromPropNameMetaCountLSM(prop.Name),

--- a/adapters/repos/db/shard_init_properties_test.go
+++ b/adapters/repos/db/shard_init_properties_test.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// createsGeoIndex decides which props leave the per-property fan-out, so it has
+// to agree with the branch createPropertyValueIndex actually takes.
+func TestCreatesGeoIndex(t *testing.T) {
+	geoDataType := []string{string(schema.DataTypeGeoCoordinates)}
+
+	tests := []struct {
+		name string
+		prop *models.Property
+		want bool
+	}{
+		{
+			name: "geo prop with filterable defaulted",
+			prop: &models.Property{Name: "location", DataType: geoDataType},
+			want: true,
+		},
+		{
+			name: "geo prop with filterable set",
+			prop: &models.Property{Name: "location", DataType: geoDataType, IndexFilterable: boolPtr(true)},
+			want: true,
+		},
+		{
+			// createPropertyValueIndex never reaches initGeoProp for these, so
+			// batching them would claim work that is not happening
+			name: "geo prop with filterable off",
+			prop: &models.Property{Name: "location", DataType: geoDataType, IndexFilterable: boolPtr(false)},
+			want: false,
+		},
+		{
+			name: "text prop",
+			prop: &models.Property{Name: "name", DataType: schema.DataTypeText.PropString()},
+			want: false,
+		},
+		{
+			name: "int prop",
+			prop: &models.Property{Name: "count", DataType: schema.DataTypeInt.PropString()},
+			want: false,
+		},
+		{
+			name: "reference prop",
+			prop: &models.Property{Name: "parkedAt", DataType: []string{"MultiRefParkingGarage"}},
+			want: false,
+		},
+		{
+			name: "prop naming two datatypes",
+			prop: &models.Property{Name: "parkedAt", DataType: []string{"MultiRefParkingGarage", "MultiRefParkingLot"}},
+			want: false,
+		},
+		{
+			name: "prop with no datatype",
+			prop: &models.Property{Name: "broken"},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, createsGeoIndex(test.prop))
+		})
+	}
+}

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -82,8 +82,7 @@ func TestInitTargetVector_ShutsDownIndexWhenQueueCreationFails(t *testing.T) {
 			shardLike, index := testShard(t, context.Background(), "VecQueueOrphan")
 			s := underlyingShard(t, shardLike)
 			// enable async only after NewShard: it makes NewVectorIndexQueue call
-			// q.Init(), but at creation it would spawn a ConvertQueue goroutine that
-			// nil-derefs the test harness's (absent) indexCheckpoints.
+			// q.Init(), but at creation the harness would also need a checkpoint store.
 			index.AsyncIndexingEnabled = true
 
 			const target = "orphanTarget"

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -1035,6 +1035,16 @@ func (l *LazyLoadShard) hasGeoIndex() bool {
 	return l.shard.hasGeoIndex()
 }
 
+// A cold shard reports false rather than loading: the only caller reaches this
+// through ForEachLoadedShard, and the addProperty that false triggers skips cold
+// shards too.
+func (l *LazyLoadShard) hasGeoIndexForProp(propName string) bool {
+	if !l.isLoaded() {
+		return false
+	}
+	return l.shard.hasGeoIndexForProp(propName)
+}
+
 func (l *LazyLoadShard) Metrics() *Metrics {
 	l.mustLoad()
 	return l.shard.Metrics()

--- a/adapters/repos/db/vector/common/logger.go
+++ b/adapters/repos/db/vector/common/logger.go
@@ -1,0 +1,31 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"io"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LoggerOrDiscard substitutes a logger that throws its output away when the
+// caller supplied none. The indexes hand their logger on to commit loggers,
+// caches and quantizers that dereference it without a nil check of their own.
+func LoggerOrDiscard(logger logrus.FieldLogger) logrus.FieldLogger {
+	if logger != nil {
+		return logger
+	}
+
+	discard := logrus.New()
+	discard.Out = io.Discard
+	return discard
+}

--- a/adapters/repos/db/vector/common/logger_test.go
+++ b/adapters/repos/db/vector/common/logger_test.go
@@ -1,0 +1,65 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerOrDiscard(t *testing.T) {
+	supplied := logrus.New()
+
+	tests := []struct {
+		name     string
+		logger   logrus.FieldLogger
+		wantSame bool
+	}{
+		{
+			name:     "a supplied logger is handed back untouched",
+			logger:   supplied,
+			wantSame: true,
+		},
+		{
+			// callers tag the logger before passing it on, and a substitute here
+			// would drop the fields they added
+			name:     "a logger already carrying fields is handed back untouched",
+			logger:   supplied.WithField("index_id", "geo.location"),
+			wantSame: true,
+		},
+		{
+			name:   "no logger yields one that discards its output",
+			logger: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := LoggerOrDiscard(test.logger)
+			require.NotNil(t, got)
+
+			if test.wantSame {
+				require.Same(t, test.logger, got)
+				return
+			}
+
+			// a substitute that wrote to the default output would put an index's
+			// internals on an operator's stderr
+			discard, ok := got.(*logrus.Logger)
+			require.True(t, ok, "the substitute must be a logger this package built")
+			require.Equal(t, io.Discard, discard.Out)
+		})
+	}
+}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -16,7 +16,6 @@ import (
 	"encoding/binary"
 	simpleErrors "errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -185,12 +184,9 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
-	logger := cfg.Logger
-	if logger == nil {
-		l := logrus.New()
-		l.Out = io.Discard
-		logger = l
-	}
+	// in place rather than into a local: the flat config below passes cfg.Logger
+	// on, so a default kept beside it would not travel with the index
+	cfg.Logger = common.LoggerOrDiscard(cfg.Logger)
 
 	flatConfig := flat.Config{
 		ID:                cfg.ID,
@@ -207,7 +203,7 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 	index := &dynamic{
 		id:                           cfg.ID,
 		targetVector:                 cfg.TargetVector,
-		logger:                       logger,
+		logger:                       cfg.Logger,
 		rootPath:                     cfg.RootPath,
 		shardName:                    cfg.ShardName,
 		className:                    cfg.ClassName,

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -85,18 +84,15 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
-	logger := cfg.Logger
-	if logger == nil {
-		l := logrus.New()
-		l.Out = io.Discard
-		logger = l
-	}
+	// in place rather than into a local: the quantizer cache below reads
+	// cfg.Logger again and has no fallback of its own
+	cfg.Logger = common.LoggerOrDiscard(cfg.Logger)
 
 	index := &flat{
 		id:                   cfg.ID,
 		targetVector:         cfg.TargetVector,
 		rootPath:             cfg.RootPath,
-		logger:               logger,
+		logger:               cfg.Logger,
 		distancerProvider:    cfg.DistanceProvider,
 		metadataLock:         &sync.RWMutex{},
 		rescore:              extractCompressionRescore(uc),

--- a/adapters/repos/db/vector/geo/coordinates_for_id.go
+++ b/adapters/repos/db/vector/geo/coordinates_for_id.go
@@ -34,6 +34,22 @@ func (cfid CoordinatesForID) VectorForID(ctx context.Context, id uint64) ([]floa
 	return geoCoordiantesToVector(coordinates)
 }
 
+// CoordinatesFromObject must provide the geo coordinates held by one stored
+// object, or nil if the object holds none.
+type CoordinatesFromObject func(objectBytes []byte) (*models.GeoCoordinates, error)
+
+// VectorFromObject transforms the coordinates of a stored object into the same
+// two-element vector VectorForID produces. An object without coordinates yields
+// a nil vector, which the cache prefill skips.
+func (cfo CoordinatesFromObject) VectorFromObject(objectBytes []byte) ([]float32, error) {
+	coordinates, err := cfo(objectBytes)
+	if err != nil || coordinates == nil {
+		return nil, err
+	}
+
+	return geoCoordiantesToVector(coordinates)
+}
+
 // GeoCoordinatesToVector converts geo coordinates to a vector of [lat, lon].
 func GeoCoordinatesToVector(in *models.GeoCoordinates) ([]float32, error) {
 	return geoCoordiantesToVector(in)

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -14,11 +14,13 @@ package geo
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
@@ -64,6 +66,14 @@ type Config struct {
 	RootPath           string
 	Logger             logrus.FieldLogger
 
+	// Store and CoordinatesFromObject let the cache prefill read every
+	// coordinate from the objects bucket in storage order, which it does only
+	// when WaitForCachePrefill is set. A Store without a decoder is rejected;
+	// leaving the Store out keeps the prefill on one lookup per doc ID.
+	Store                 *lsmkv.Store
+	CoordinatesFromObject CoordinatesFromObject
+	WaitForCachePrefill   bool
+
 	HNSWEF int
 
 	SnapshotDisabled                         bool
@@ -84,8 +94,29 @@ func (c Config) hnswEF() int {
 func NewIndex(config Config,
 	commitLogMaintenanceCallbacks, tombstoneCleanupCallbacks cyclemanager.CycleCallbackGroup,
 ) (*Index, error) {
+	if config.Logger == nil {
+		// the commit logger dereferences this while opening its files, before
+		// hnsw.New gets a chance to substitute a default
+		logger := logrus.New()
+		logger.Out = io.Discard
+		config.Logger = logger
+	}
+
+	// without a decoder the prefill scan would read each object's own vector and
+	// cache it as a coordinate
+	if config.Store != nil && config.CoordinatesFromObject == nil {
+		return nil, errors.Errorf("geo index %q: coordinatesFromObject is required alongside a store", config.ID)
+	}
+
+	var vectorFromObject hnsw.VectorFromObject
+	if config.CoordinatesFromObject != nil {
+		vectorFromObject = config.CoordinatesFromObject.VectorFromObject
+	}
+
 	vi, err := hnsw.New(hnsw.Config{
 		VectorForIDThunk:      config.CoordinatesForID.VectorForID,
+		VectorFromObject:      vectorFromObject,
+		WaitForCachePrefill:   config.WaitForCachePrefill,
 		ID:                    config.ID,
 		RootPath:              config.RootPath,
 		MakeCommitLoggerThunk: makeCommitLoggerFromConfig(config, commitLogMaintenanceCallbacks),
@@ -102,7 +133,7 @@ func NewIndex(config Config,
 		// The cache drops every vector once its entry count reaches this maximum,
 		// so a zero here empties it every few seconds.
 		VectorCacheMaxObjects: vectorIndexCommon.DefaultVectorCacheMaxObjects,
-	}, tombstoneCleanupCallbacks, nil)
+	}, tombstoneCleanupCallbacks, config.Store)
 	if err != nil {
 		return nil, errors.Wrap(err, "underlying hnsw index")
 	}

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -65,6 +65,8 @@ type Config struct {
 	DisablePersistence bool
 	RootPath           string
 	Logger             logrus.FieldLogger
+	ClassName          string
+	ShardName          string
 
 	// Store and CoordinatesFromObject let the cache prefill read every
 	// coordinate from the objects bucket in storage order, which it does only
@@ -108,6 +110,11 @@ func NewIndex(config Config,
 		return nil, errors.Errorf("geo index %q: coordinatesFromObject is required alongside a store", config.ID)
 	}
 
+	// the underlying index identifies its lines by class, shard and target
+	// vector, and a geo index leaves the target vector empty. index_id is the key
+	// its prefill lines already give this id, which also names the files on disk.
+	config.Logger = config.Logger.WithField("index_id", config.ID)
+
 	var vectorFromObject hnsw.VectorFromObject
 	if config.CoordinatesFromObject != nil {
 		vectorFromObject = config.CoordinatesFromObject.VectorFromObject
@@ -118,6 +125,8 @@ func NewIndex(config Config,
 		VectorFromObject:      vectorFromObject,
 		WaitForCachePrefill:   config.WaitForCachePrefill,
 		ID:                    config.ID,
+		ClassName:             config.ClassName,
+		ShardName:             config.ShardName,
 		RootPath:              config.RootPath,
 		MakeCommitLoggerThunk: makeCommitLoggerFromConfig(config, commitLogMaintenanceCallbacks),
 		DistanceProvider:      distancer.NewGeoProvider(),

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -14,7 +14,6 @@ package geo
 import (
 	"context"
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/pkg/errors"
@@ -96,13 +95,9 @@ func (c Config) hnswEF() int {
 func NewIndex(config Config,
 	commitLogMaintenanceCallbacks, tombstoneCleanupCallbacks cyclemanager.CycleCallbackGroup,
 ) (*Index, error) {
-	if config.Logger == nil {
-		// the commit logger dereferences this while opening its files, before
-		// hnsw.New gets a chance to substitute a default
-		logger := logrus.New()
-		logger.Out = io.Discard
-		config.Logger = logger
-	}
+	// the commit-logger thunk below captures this Config by value, so hnsw.New
+	// substituting a default into its own copy would never reach it
+	config.Logger = common.LoggerOrDiscard(config.Logger)
 
 	// without a decoder the prefill scan would read each object's own vector and
 	// cache it as a coordinate

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -16,11 +16,15 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
+	// aliased so the tables below can keep naming their loop variable "test"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
@@ -445,6 +449,121 @@ func TestGeoPrefillReadsCoordinatesFromObjectsBucket(t *testing.T) {
 	}
 	require.Zero(t, byIDLoads.Load(),
 		"the objects-bucket scan must cover every coordinate, leaving no by-id lookup")
+}
+
+// Every geo prop of a shard logs through that shard's one logger, and the
+// underlying index leaves its target vector empty, so class and shard alone
+// would not say which property a line came from.
+func TestNewIndexTagsLogLines(t *testing.T) {
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+
+	const className, shardName = "Article", "shard-a1b2c3"
+	ids := []string{"geo.location", "geo.office"}
+
+	for _, id := range ids {
+		idx, err := NewIndex(Config{
+			AllocChecker: memwatch.NewDummyMonitor(),
+			ID:           id,
+			RootPath:     t.TempDir(),
+			Logger:       logger,
+			ClassName:    className,
+			ShardName:    shardName,
+			CoordinatesForID: func(ctx context.Context, id uint64) (*models.GeoCoordinates, error) {
+				return &models.GeoCoordinates{Latitude: ptFloat32(1), Longitude: ptFloat32(2)}, nil
+			},
+		}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, idx.Shutdown(context.Background())) })
+	}
+
+	linesPerIndex := map[string]int{}
+	var sawUnderlyingIndexLine bool
+	for _, entry := range hook.AllEntries() {
+		id, ok := entry.Data["index_id"]
+		require.Truef(t, ok, "line %q names no index", entry.Message)
+		linesPerIndex[id.(string)]++
+
+		// only the underlying index's own logger carries these; the commit logger
+		// and the vector cache have their own
+		class, ok := entry.Data["class"]
+		if !ok {
+			continue
+		}
+		sawUnderlyingIndexLine = true
+		require.Equalf(t, className, class, "line %q", entry.Message)
+		require.Equalf(t, shardName, entry.Data["shard"], "line %q", entry.Message)
+	}
+
+	require.True(t, sawUnderlyingIndexLine,
+		"no line came from the underlying index, so class/shard went unchecked")
+	for _, id := range ids {
+		require.NotZerof(t, linesPerIndex[id], "%q logged nothing under its own id", id)
+	}
+	require.Len(t, linesPerIndex, len(ids), "two geo props were not separable in the log")
+}
+
+// The prefill is what the fields are for: it is the work that holds up a
+// restart, and PostStartup is the only path that logs it.
+func TestPostStartupTagsPrefillLines(t *testing.T) {
+	ctx := context.Background()
+	rootPath := t.TempDir()
+	const className, shardName, indexID = "Article", "shard-a1b2c3", "geo.location"
+
+	coordinates := []*models.GeoCoordinates{
+		{Latitude: ptFloat32(48.13743), Longitude: ptFloat32(11.57549)},
+		{Latitude: ptFloat32(48.78232), Longitude: ptFloat32(9.17702)},
+	}
+
+	newGeoIndex := func(t *testing.T, logger logrus.FieldLogger) *Index {
+		t.Helper()
+		idx, err := NewIndex(Config{
+			AllocChecker: memwatch.NewDummyMonitor(),
+			ID:           indexID,
+			RootPath:     rootPath,
+			Logger:       logger,
+			ClassName:    className,
+			ShardName:    shardName,
+			// without the wait the prefill runs on a goroutine of its own, which is
+			// not the journey that leaves an operator staring at a stalled startup
+			WaitForCachePrefill: true,
+			CoordinatesForID: func(_ context.Context, id uint64) (*models.GeoCoordinates, error) {
+				return coordinates[id], nil
+			},
+		}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+		require.NoError(t, err)
+		return idx
+	}
+
+	// a reopened index has commit log state to restore, which is what leaves its
+	// cache unfilled; a fresh one skips the prefill altogether
+	built := newGeoIndex(t, nil)
+	for id, c := range coordinates {
+		require.NoError(t, built.Add(ctx, uint64(id), c))
+	}
+	require.NoError(t, built.Flush())
+	require.NoError(t, built.Shutdown(ctx))
+
+	logger, hook := logrustest.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	restarted := newGeoIndex(t, logger)
+	t.Cleanup(func() { require.NoError(t, restarted.Shutdown(ctx)) })
+
+	hook.Reset()
+	restarted.PostStartup(ctx)
+
+	var prefillLines int
+	for _, entry := range hook.AllEntries() {
+		action, _ := entry.Data["action"].(string)
+		if !strings.Contains(action, "prefill") {
+			continue
+		}
+		prefillLines++
+		require.Equalf(t, indexID, entry.Data["index_id"], "line %q", entry.Message)
+		require.Equalf(t, className, entry.Data["class"], "line %q", entry.Message)
+		require.Equalf(t, shardName, entry.Data["shard"], "line %q", entry.Message)
+	}
+	require.NotZero(t, prefillLines, "PostStartup logged no prefill line to check")
 }
 
 func ptFloat32(in float32) *float32 {

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -13,16 +13,25 @@ package geo
 
 import (
 	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
@@ -182,6 +191,260 @@ func TestGeoConfig(t *testing.T) {
 	require.Equal(t, 800, cfg.hnswEF())
 	cfg = Config{HNSWEF: 1900}
 	require.Equal(t, 1900, cfg.hnswEF())
+}
+
+func TestCoordinatesFromObjectVectorFromObject(t *testing.T) {
+	readErr := errors.New("cannot read object")
+
+	tests := []struct {
+		name        string
+		coordinates *models.GeoCoordinates
+		err         error
+		want        []float32
+		wantErr     error
+		wantErrMsg  string
+	}{
+		{
+			name:        "coordinates become a lat/lon vector",
+			coordinates: &models.GeoCoordinates{Latitude: ptFloat32(48.13743), Longitude: ptFloat32(11.57549)},
+			want:        []float32{48.13743, 11.57549},
+		},
+		{
+			// the prefill scan takes a nil vector as "skip this object"
+			name:        "object without coordinates yields no vector",
+			coordinates: nil,
+		},
+		{
+			name:       "read failure is passed on",
+			err:        readErr,
+			wantErr:    readErr,
+			wantErrMsg: "cannot read object",
+		},
+		{
+			name:        "coordinates without latitude",
+			coordinates: &models.GeoCoordinates{Longitude: ptFloat32(11.57549)},
+			wantErrMsg:  "latitude must be set",
+		},
+		{
+			name:        "coordinates without longitude",
+			coordinates: &models.GeoCoordinates{Latitude: ptFloat32(48.13743)},
+			wantErrMsg:  "longitude must be set",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var from CoordinatesFromObject = func([]byte) (*models.GeoCoordinates, error) {
+				return test.coordinates, test.err
+			}
+
+			vec, err := from.VectorFromObject([]byte("ignored"))
+
+			if test.wantErrMsg != "" {
+				require.ErrorContains(t, err, test.wantErrMsg)
+				if test.wantErr != nil {
+					require.ErrorIs(t, err, test.wantErr)
+				}
+				require.Nil(t, vec)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.want, vec)
+		})
+	}
+}
+
+// A store without a decoder would let the prefill scan cache each object's own
+// vector as if it were a coordinate, so NewIndex must refuse the pair.
+func TestNewIndexStoreRequiresCoordinatesFromObject(t *testing.T) {
+	newIndex := func(t *testing.T, store *lsmkv.Store, from CoordinatesFromObject) (*Index, error) {
+		t.Helper()
+		return NewIndex(Config{
+			AllocChecker:          memwatch.NewDummyMonitor(),
+			ID:                    "unit-test",
+			CoordinatesForID:      func(context.Context, uint64) (*models.GeoCoordinates, error) { return nil, nil },
+			CoordinatesFromObject: from,
+			Store:                 store,
+			DisablePersistence:    true,
+			RootPath:              t.TempDir(),
+		}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	}
+	decode := CoordinatesFromObject(func([]byte) (*models.GeoCoordinates, error) { return nil, nil })
+
+	tests := []struct {
+		name    string
+		store   func(t testing.TB) *lsmkv.Store
+		decode  CoordinatesFromObject
+		wantErr string
+	}{
+		{
+			name:    "store without a decoder is rejected",
+			store:   testinghelpers.NewDummyStore,
+			wantErr: "coordinatesFromObject is required alongside a store",
+		},
+		{
+			name:   "store with a decoder is accepted",
+			store:  testinghelpers.NewDummyStore,
+			decode: decode,
+		},
+		{
+			name:  "no store needs no decoder",
+			store: func(testing.TB) *lsmkv.Store { return nil },
+		},
+		{
+			name:   "decoder without a store is unused, not an error",
+			store:  func(testing.TB) *lsmkv.Store { return nil },
+			decode: decode,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idx, err := newIndex(t, test.store(t), test.decode)
+
+			if test.wantErr != "" {
+				require.ErrorContains(t, err, test.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, idx)
+			require.NoError(t, idx.Shutdown(context.Background()))
+		})
+	}
+}
+
+// A persisting geo index builds a commit logger, which dereferences the logger
+// while opening its files.
+func TestNewIndexWithoutLogger(t *testing.T) {
+	idx, err := NewIndex(Config{
+		AllocChecker:     memwatch.NewDummyMonitor(),
+		ID:               "unit-test-no-logger",
+		RootPath:         t.TempDir(),
+		CoordinatesForID: func(context.Context, uint64) (*models.GeoCoordinates, error) { return nil, nil },
+	}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	require.NoError(t, idx.Shutdown(context.Background()))
+}
+
+// putGeoObject stores an object carrying propName, marshalled the way the write
+// path does, under a unique sortable key.
+func putGeoObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, propName string,
+	coordinates *models.GeoCoordinates,
+) {
+	t.Helper()
+
+	obj := storobj.New(docID)
+	obj.Object = models.Object{
+		ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", docID)),
+		Class:      "Test",
+		Properties: map[string]interface{}{propName: coordinates},
+	}
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+
+	key := make([]byte, 16)
+	binary.BigEndian.PutUint64(key[8:], docID)
+	require.NoError(t, bucket.Put(key, data))
+}
+
+func coordinatesFromObjectProp(propName string) CoordinatesFromObject {
+	propExtraction := storobj.NewPropExtraction().Add(propName)
+
+	return func(objectBytes []byte) (*models.GeoCoordinates, error) {
+		obj, err := storobj.FromBinaryOptionalNetwork(objectBytes, additional.Properties{}, propExtraction)
+		if err != nil {
+			return nil, err
+		}
+
+		props, ok := obj.Properties().(map[string]interface{})
+		if !ok {
+			return nil, nil
+		}
+		coordinates, ok := props[propName].(*models.GeoCoordinates)
+		if !ok {
+			return nil, nil
+		}
+		return coordinates, nil
+	}
+}
+
+// TestGeoPrefillReadsCoordinatesFromObjectsBucket restarts a persisted geo index
+// and requires its cache to come back warm off a scan of the objects bucket. The
+// by-id reader fails on the restarted index, so any coordinate the scan missed
+// surfaces as a read error instead of a silent fallback to random seeks.
+func TestGeoPrefillReadsCoordinatesFromObjectsBucket(t *testing.T) {
+	ctx := context.Background()
+	rootPath := t.TempDir()
+	// enough objects, flushed to a segment, for QuantileKeys to seed several
+	// cursors — a memtable-only bucket yields no seeds and scans single-threaded
+	const docs = 2000
+	coordinates := make([]*models.GeoCoordinates, docs)
+	for i := range coordinates {
+		coordinates[i] = &models.GeoCoordinates{
+			Latitude:  ptFloat32(48.13743 + float32(i)*0.001),
+			Longitude: ptFloat32(11.57549 + float32(i)*0.002),
+		}
+	}
+
+	store := testinghelpers.NewDummyStore(t)
+	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+	for id, c := range coordinates {
+		putGeoObject(t, store.Bucket(helpers.ObjectsBucketLSM), uint64(id), "location", c)
+	}
+	require.NoError(t, store.Bucket(helpers.ObjectsBucketLSM).FlushAndSwitch())
+
+	newGeoIndex := func(t *testing.T, forID CoordinatesForID) *Index {
+		t.Helper()
+		idx, err := NewIndex(Config{
+			AllocChecker:          memwatch.NewDummyMonitor(),
+			ID:                    "unit-test-prefill",
+			RootPath:              rootPath,
+			CoordinatesForID:      forID,
+			Store:                 store,
+			CoordinatesFromObject: coordinatesFromObjectProp("location"),
+			WaitForCachePrefill:   true,
+		}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+		require.NoError(t, err)
+		return idx
+	}
+
+	built := newGeoIndex(t, func(_ context.Context, id uint64) (*models.GeoCoordinates, error) {
+		return coordinates[id], nil
+	})
+	for id, c := range coordinates {
+		require.NoError(t, built.Add(ctx, uint64(id), c))
+	}
+	require.NoError(t, built.Flush())
+	require.NoError(t, built.Shutdown(ctx))
+
+	var byIDLoads atomic.Int64
+	restarted := newGeoIndex(t, func(_ context.Context, id uint64) (*models.GeoCoordinates, error) {
+		byIDLoads.Add(1)
+		return nil, errors.New("coordinate must come from the prefilled cache")
+	})
+	t.Cleanup(func() { require.NoError(t, restarted.Shutdown(ctx)) })
+
+	// restoring the graph probes the entrypoint by id to learn the dimensions,
+	// which is not what this test is counting
+	byIDLoads.Store(0)
+	restarted.PostStartup(ctx)
+
+	// asserting per doc rather than through a search: a search only visits the
+	// nodes its descent happens to reach, which would leave gaps unnoticed
+	cached, ok := restarted.UnderlyingVectorIndex().(interface {
+		Get(id uint64) ([]float32, error)
+	})
+	require.True(t, ok)
+	for id, c := range coordinates {
+		vec, err := cached.Get(uint64(id))
+		require.NoErrorf(t, err, "doc id %d was not prefilled", id)
+		require.Equal(t, []float32{*c.Latitude, *c.Longitude}, vec)
+	}
+	require.Zero(t, byIDLoads.Load(),
+		"the objects-bucket scan must cover every coordinate, leaving no by-id lookup")
 }
 
 func ptFloat32(in float32) *float32 {

--- a/adapters/repos/db/vector/geo/geo_test.go
+++ b/adapters/repos/db/vector/geo/geo_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
+
 	// aliased so the tables below can keep naming their loop variable "test"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"

--- a/adapters/repos/db/vector/hfresh/config.go
+++ b/adapters/repos/db/vector/hfresh/config.go
@@ -12,7 +12,6 @@
 package hfresh
 
 import (
-	"io"
 	"math"
 
 	"github.com/pkg/errors"
@@ -69,11 +68,7 @@ const (
 )
 
 func (c *Config) Validate() error {
-	if c.Logger == nil {
-		logger := logrus.New()
-		logger.Out = io.Discard
-		c.Logger = logger
-	}
+	c.Logger = common.LoggerOrDiscard(c.Logger)
 
 	if c.InternalPostingCandidates <= 0 {
 		c.InternalPostingCandidates = DefaultInternalPostingCandidates

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	MakeCommitLoggerThunk             MakeCommitLogger
 	VectorForIDThunk                  common.VectorForID[float32]
 	MultiVectorForIDThunk             common.VectorForID[[]float32]
+	VectorFromObject                  VectorFromObject
 	TempMultiVectorForIDThunk         common.TempVectorForID[[]float32]
 	GetViewThunk                      common.GetViewThunk
 	TempVectorForIDWithViewThunk      common.TempVectorForIDWithView[float32]

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -201,6 +201,7 @@ type hnsw struct {
 	shardName             string
 	VectorForIDThunk      common.VectorForID[float32]
 	MultiVectorForIDThunk common.VectorForID[[]float32]
+	vectorFromObject      VectorFromObject
 	shardedNodeLocks      *common.ShardedRWLocks
 	store                 *lsmkv.Store
 
@@ -394,6 +395,7 @@ func New(cfg Config, uc ent.UserConfig,
 		rqConfig:                          uc.RQ,
 		rescoreConcurrency:                2 * runtime.GOMAXPROCS(0), // our default for IO-bound activties
 		shardedNodeLocks:                  common.NewDefaultShardedRWLocks(),
+		vectorFromObject:                  cfg.VectorFromObject,
 
 		store:                     store,
 		allocChecker:              cfg.AllocChecker,

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -14,7 +14,6 @@ package hnsw
 import (
 	"context"
 	"fmt"
-	"io"
 	"math"
 	"math/rand"
 	"runtime"
@@ -299,11 +298,7 @@ func New(cfg Config, uc ent.UserConfig,
 		return nil, errors.Wrap(err, "invalid config")
 	}
 
-	if cfg.Logger == nil {
-		logger := logrus.New()
-		logger.Out = io.Discard
-		cfg.Logger = logger
-	}
+	cfg.Logger = common.LoggerOrDiscard(cfg.Logger)
 
 	normalizeOnRead := cfg.DistanceProvider.Type() == "cosine-dot"
 

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -91,7 +91,10 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 	if bucket == nil {
 		return fmt.Errorf("prefill cache: objects bucket %q not found", helpers.ObjectsBucketLSM)
 	}
-	targetVector := h.getTargetVector()
+	vectorFromObject := h.vectorFromObject
+	if vectorFromObject == nil {
+		vectorFromObject = targetVectorFromObject(h.getTargetVector())
+	}
 
 	var loaded atomic.Int64
 	onVector := func(id uint64, vec []float32) {
@@ -105,7 +108,7 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 		loaded.Add(1)
 	}
 
-	if err := scanObjectVectorsParallel(ctx, bucket, targetVector, onVector, h.logger); err != nil {
+	if err := scanObjectVectorsParallel(ctx, bucket, vectorFromObject, onVector, h.logger); err != nil {
 		return err
 	}
 
@@ -119,9 +122,31 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 	return nil
 }
 
+// VectorFromObject reads the vector an index caches out of one stored object's
+// binary form. A nil vector means the object carries none, so the scan skips it.
+type VectorFromObject func(objectBytes []byte) ([]float32, error)
+
+// targetVectorFromObject reads the named (or, for an empty name, legacy) vector
+// an index was built on.
+func targetVectorFromObject(targetVector string) VectorFromObject {
+	return func(objectBytes []byte) ([]float32, error) {
+		// nil buffer forces a fresh allocation; a reused buffer would be aliased by
+		// VectorFromBinary across iterations and corrupt previously cached vectors.
+		vec, err := storobj.VectorFromBinary(objectBytes, nil, targetVector)
+		if err != nil {
+			var notFound storobj.ErrTargetVectorNotFound
+			if errors.As(err, &notFound) {
+				return nil, nil
+			}
+			return nil, err
+		}
+		return vec, nil
+	}
+}
+
 // scanObjectVectorsParallel scans the objects bucket across GOMAXPROCS cursors over
 // disjoint key ranges. onVector must be safe for concurrent use.
-func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, targetVector string,
+func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, vectorFromObject VectorFromObject,
 	onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
 ) error {
 	// 2x oversubscription: while one cursor blocks on a disk read another keeps a
@@ -160,7 +185,7 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 		wg.Add(1)
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
-			if err := scanObjectVectorsRange(scanCtx, bucket, r.start, r.end, targetVector, onVector, logger); err != nil {
+			if err := scanObjectVectorsRange(scanCtx, bucket, r.start, r.end, vectorFromObject, onVector, logger); err != nil {
 				e := err
 				if firstErr.CompareAndSwap(nil, &e) {
 					cancel()
@@ -177,7 +202,7 @@ func scanObjectVectorsParallel(ctx context.Context, bucket *lsmkv.Bucket, target
 }
 
 func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, end []byte,
-	targetVector string, onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
+	vectorFromObject VectorFromObject, onVector func(id uint64, vec []float32), logger logrus.FieldLogger,
 ) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -216,14 +241,8 @@ func scanObjectVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, en
 			continue
 		}
 
-		// nil buffer forces a fresh allocation; a reused buffer would be aliased by
-		// VectorFromBinary across iterations and corrupt previously cached vectors.
-		vec, err := storobj.VectorFromBinary(v, nil, targetVector)
+		vec, err := vectorFromObject(v)
 		if err != nil {
-			var notFound storobj.ErrTargetVectorNotFound
-			if errors.As(err, &notFound) {
-				continue
-			}
 			logger.WithField("action", "hnsw_vector_cache_prefill").
 				Debugf("skipping doc id %d with undecodable vector: %v", id, err)
 			continue

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -56,9 +57,18 @@ func newTestObjectsBucket(t *testing.T) *lsmkv.Bucket {
 // scan reads real on-disk data rather than a hand-rolled encoding.
 func putTestObject(t *testing.T, bucket *lsmkv.Bucket, docID uint64, legacyVec []float32, named map[string][]float32) {
 	t.Helper()
+	putTestObjectWithProps(t, bucket, docID, legacyVec, named, nil)
+}
+
+// putTestObjectWithProps also stores properties, for an index whose cached vector
+// is derived from one rather than stored verbatim.
+func putTestObjectWithProps(t *testing.T, bucket *lsmkv.Bucket, docID uint64,
+	legacyVec []float32, named map[string][]float32, props map[string]interface{},
+) {
+	t.Helper()
 	id := strfmt.UUID(fmt.Sprintf("00000000-0000-4000-8000-%012x", docID))
 	obj := storobj.New(docID)
-	obj.Object = models.Object{ID: id, Class: "Test"}
+	obj.Object = models.Object{ID: id, Class: "Test", Properties: props}
 	obj.Vector = legacyVec
 	if named != nil {
 		obj.Vectors = named
@@ -82,7 +92,7 @@ func collectScan(t *testing.T, bucket *lsmkv.Bucket, target string) map[uint64][
 	logger, _ := test.NewNullLogger()
 	var mu sync.Mutex
 	got := map[uint64][]float32{}
-	err := scanObjectVectorsParallel(context.Background(), bucket, target,
+	err := scanObjectVectorsParallel(context.Background(), bucket, targetVectorFromObject(target),
 		func(id uint64, vec []float32) {
 			mu.Lock()
 			defer mu.Unlock()
@@ -169,7 +179,7 @@ func TestScanObjectVectorsParallel(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		logger, _ := test.NewNullLogger()
-		err := scanObjectVectorsParallel(ctx, bucket, "", func(uint64, []float32) {}, logger)
+		err := scanObjectVectorsParallel(ctx, bucket, targetVectorFromObject(""), func(uint64, []float32) {}, logger)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }
@@ -345,6 +355,83 @@ func TestScanObjectVectorsParallelNamedVectorIsolation(t *testing.T) {
 		2: {2, 2},
 		4: {2, 4},
 	}, collectScan(t, bucket, "body"))
+}
+
+// TestPrefillCacheParallelUsesConfiguredDecode covers the geo case: the cached
+// vector is derived from a property, not stored verbatim. The objects carry a
+// vector of their own, so a prefill that ignored vectorFromObject would fill the
+// cache with vectors that are not coordinates instead of failing loudly.
+func TestPrefillCacheParallelUsesConfiguredDecode(t *testing.T) {
+	const n = 300
+	store := newTestObjectsStore(t)
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	// every third object carries no coordinate, and one payload cannot be decoded
+	// at all — both must be skipped without taking the rest of the scan down
+	want := map[uint64][]float32{}
+	for i := uint64(0); i < n; i++ {
+		props := map[string]interface{}{"name": "no coordinates here"}
+		if i%3 != 0 {
+			props = map[string]interface{}{"lat": float64(i), "lon": float64(i) + 0.5}
+			want[i] = []float32{float32(i), float32(i) + 0.5}
+		}
+		putTestObjectWithProps(t, bucket, i, []float32{-1, -2}, nil, props)
+	}
+	require.NoError(t, bucket.Put(keyForDocID(n), undecodablePayload(n)))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	logger, _ := test.NewNullLogger()
+	mustHit := func(_ context.Context, id uint64) ([]float32, error) {
+		return nil, fmt.Errorf("unexpected cache miss for id %d", id)
+	}
+	c := cache.NewShardedFloat32LockCache(mustHit, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(n))
+
+	h := &hnsw{
+		store:             store,
+		cache:             c,
+		nodes:             make([]*vertex, n),
+		id:                "main",
+		logger:            logger,
+		distancerProvider: distancer.NewDotProductProvider(),
+		vectorFromObject:  coordinatesFromTestProps,
+	}
+
+	require.NoError(t, h.prefillCacheParallel(context.Background()))
+	requireCacheContains(t, c, want)
+}
+
+// undecodablePayload carries a readable doc id but an unsupported marshaller
+// version, so the scan reaches the decode and fails there rather than earlier.
+func undecodablePayload(docID uint64) []byte {
+	payload := make([]byte, 9)
+	payload[0] = 2
+	binary.LittleEndian.PutUint64(payload[1:], docID)
+	return payload
+}
+
+// coordinatesFromTestProps stands in for the geo decoder: it builds the cached
+// vector out of properties, and reports an object without them as having none.
+func coordinatesFromTestProps(objectBytes []byte) ([]float32, error) {
+	obj, err := storobj.FromBinaryOptionalNetwork(objectBytes, additional.Properties{},
+		storobj.NewPropExtraction().Add("lat", "lon"))
+	if err != nil {
+		return nil, err
+	}
+
+	props, ok := obj.Properties().(map[string]interface{})
+	if !ok {
+		return nil, nil
+	}
+	lat, ok := props["lat"].(float64)
+	if !ok {
+		return nil, nil
+	}
+	lon, ok := props["lon"].(float64)
+	if !ok {
+		return nil, nil
+	}
+	return []float32{float32(lat), float32(lon)}, nil
 }
 
 // TestPrefillCacheParallelNormalizesForCosine guards the normalization invariant:


### PR DESCRIPTION
### What's being changed:

This adds the concurrent vector cache prefill to geo indices and wait for its completion. 

Before it was warming in the background and every query had to load 100s of random vectors. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
