### PR TITLE
Include GEO HNSW index in backups

### DIFF
--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -17,6 +17,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -178,6 +179,24 @@ func (s *Shard) ForEachGeoQueue(f func(propName string, queue *VectorIndexQueue)
 		}
 
 		if err := f(propName, q); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ForEachGeoIndex iterates through each geo index initialized in the shard.
+// Iteration stops at the first return of non-nil error.
+func (s *Shard) ForEachGeoIndex(f func(propName string, index *geo.Index) error) error {
+	s.propertyIndicesLock.RLock()
+	defer s.propertyIndicesLock.RUnlock()
+
+	for propName, idx := range s.propertyIndices {
+		if idx.Type != schema.DataTypeGeoCoordinates || idx.GeoIndex == nil {
+			continue
+		}
+
+		if err := f(propName, idx.GeoIndex); err != nil {
 			return err
 		}
 	}

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
 	"github.com/weaviate/weaviate/entities/backup"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/file"
@@ -141,6 +142,15 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 		return nil
 	})
 	if err != nil {
+		return err
+	}
+
+	if err := s.ForEachGeoIndex(func(propName string, index *geo.Index) error {
+		if err := index.PrepareForBackup(innerCtx); err != nil {
+			return fmt.Errorf("prepare for backup of geo index %q: %w", propName, err)
+		}
+		return nil
+	}); err != nil {
 		return err
 	}
 
@@ -384,6 +394,17 @@ func (s *Shard) ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor
 	if err != nil {
 		return nil, err
 	}
+
+	if err := s.ForEachGeoIndex(func(propName string, index *geo.Index) error {
+		filesGi, err := index.ListFiles(ctx, s.index.Config.RootPath)
+		if err != nil {
+			return fmt.Errorf("list files of geo index %q: %w", propName, err)
+		}
+		files = append(files, filesGi...)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
 	return files, nil
 }
 
@@ -457,6 +478,14 @@ func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool
 	})
 	g.Go(func() error {
 		return s.ForEachVectorIndex(func(_ string, index VectorIndex) error {
+			if err := index.ResumeAfterBackup(ctx); err != nil {
+				return fmt.Errorf("resuming after backup: %w", err)
+			}
+			return nil
+		})
+	})
+	g.Go(func() error {
+		return s.ForEachGeoIndex(func(_ string, index *geo.Index) error {
 			if err := index.ResumeAfterBackup(ctx); err != nil {
 				return fmt.Errorf("resuming after backup: %w", err)
 			}

--- a/adapters/repos/db/shard_backup_geo_test.go
+++ b/adapters/repos/db/shard_backup_geo_test.go
@@ -1,0 +1,204 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
+	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// A backup that misses the geo commit log restores an empty geo index. An empty
+// geo index answers every withinGeoRange filter with zero results and no error.
+func TestShardListBackupFilesCoversGeoIndex(t *testing.T) {
+	var (
+		berlin  = geoAt(52.520, 13.405)
+		munich  = geoAt(48.137, 11.575)
+		hamburg = geoAt(53.551, 9.993)
+	)
+
+	tests := []struct {
+		name    string
+		props   []string
+		objects []map[string]*models.GeoCoordinates
+	}{
+		{
+			name:    "no geo property",
+			objects: []map[string]*models.GeoCoordinates{{}},
+		},
+		{
+			name:    "one object",
+			props:   []string{"location"},
+			objects: []map[string]*models.GeoCoordinates{{"location": berlin}},
+		},
+		{
+			name:  "several objects",
+			props: []string{"location"},
+			objects: []map[string]*models.GeoCoordinates{
+				{"location": berlin},
+				{"location": munich},
+				{"location": hamburg},
+			},
+		},
+		{
+			name:  "two geo properties",
+			props: []string{"location", "office"},
+			objects: []map[string]*models.GeoCoordinates{
+				{"location": berlin, "office": munich},
+				{"location": munich, "office": hamburg},
+			},
+		},
+		{
+			name:  "geo property without any object",
+			props: []string{"location"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+
+			class := &models.Class{Class: "GeoBackup"}
+			for _, propName := range tc.props {
+				class.Properties = append(class.Properties, &models.Property{
+					Name:     propName,
+					DataType: schema.DataTypeGeoCoordinates.PropString(),
+				})
+			}
+
+			shardLike, index := testShardWithSettings(t, ctx, class,
+				enthnsw.UserConfig{Skip: true}, false, false, false)
+			shard := shardLike.(*Shard)
+
+			indexedPerProp := map[string]int{}
+			for _, coordinatesPerProp := range tc.objects {
+				props := make(map[string]interface{}, len(coordinatesPerProp))
+				for propName, coordinates := range coordinatesPerProp {
+					props[propName] = coordinates
+					indexedPerProp[propName]++
+				}
+				require.NoError(t, shard.PutObject(ctx, &storobj.Object{
+					MarshallerVersion: 1,
+					Object: models.Object{
+						ID:         strfmt.UUID(uuid.NewString()),
+						Class:      class.Class,
+						Properties: props,
+					},
+				}))
+			}
+
+			// 0 timeout disables the inactivity auto-resume, so a slow test body
+			// cannot resume the shard before the files are listed.
+			require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+			files, err := shard.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+			require.NoError(t, err)
+
+			restoredShardPath := restoreBackupFiles(t, index.Config.RootPath, shard.path(), files)
+
+			for _, propName := range tc.props {
+				want := allWithinRange(t, ctx, liveGeoIndex(t, shard, propName))
+				require.Len(t, want, indexedPerProp[propName],
+					"the live geo index for %q lost entries, so the comparison below proves nothing", propName)
+
+				restored := openGeoIndexAt(t, ctx, shard, propName, restoredShardPath)
+				require.ElementsMatch(t, want, allWithinRange(t, ctx, restored),
+					"the backup did not carry the geo index of %q", propName)
+			}
+
+			require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+		})
+	}
+}
+
+func geoAt(latitude, longitude float32) *models.GeoCoordinates {
+	return &models.GeoCoordinates{Latitude: &latitude, Longitude: &longitude}
+}
+
+// restoreBackupFiles copies the listed files into a fresh root, the way a
+// restore lands them on a new node, and returns the restored shard's directory.
+func restoreBackupFiles(t *testing.T, srcRoot, shardPath string, files []string) string {
+	t.Helper()
+
+	dstRoot := t.TempDir()
+	for _, relPath := range files {
+		data, err := os.ReadFile(filepath.Join(srcRoot, relPath))
+		require.NoError(t, err)
+
+		dst := filepath.Join(dstRoot, relPath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0o755))
+		require.NoError(t, os.WriteFile(dst, data, 0o644))
+	}
+
+	relShardPath, err := filepath.Rel(srcRoot, shardPath)
+	require.NoError(t, err)
+	return filepath.Join(dstRoot, relShardPath)
+}
+
+func liveGeoIndex(t *testing.T, s *Shard, propName string) *geo.Index {
+	t.Helper()
+
+	s.propertyIndicesLock.RLock()
+	defer s.propertyIndicesLock.RUnlock()
+
+	index, ok := s.propertyIndices.ByProp(propName)
+	require.True(t, ok, "shard has no geo index for %q", propName)
+	return index.GeoIndex
+}
+
+// openGeoIndexAt reads a geo index back from the commit log under rootPath. It
+// takes its coordinates from the live shard's objects, which a restore gets
+// from the LSM buckets it lands alongside the commit log.
+func openGeoIndexAt(t *testing.T, ctx context.Context, s *Shard, propName, rootPath string) *geo.Index {
+	t.Helper()
+
+	index, err := geo.NewIndex(geo.Config{
+		ID:               geoPropID(propName),
+		RootPath:         rootPath,
+		CoordinatesForID: s.makeCoordinatesForID(propName),
+		Logger:           s.index.logger,
+		AllocChecker:     memwatch.NewDummyMonitor(),
+	}, cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.Shutdown(context.Background())) })
+
+	index.PostStartup(ctx)
+	return index
+}
+
+// allWithinRange returns every doc id in the index, through a range wide enough
+// to span the planet.
+func allWithinRange(t *testing.T, ctx context.Context, index *geo.Index) []uint64 {
+	t.Helper()
+
+	const everywhere = 1e8 // metres
+
+	ids, err := index.WithinRange(ctx, filters.GeoRange{
+		GeoCoordinates: geoAt(0, 0),
+		Distance:       everywhere,
+	})
+	require.NoError(t, err)
+	return ids
+}

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -49,11 +49,13 @@ type vectorIndex interface {
 	KnnSearchByVectorMaxDist(ctx context.Context, query []float32, dist float32, ef int,
 		allowList helpers.AllowList) ([]uint64, error)
 	Delete(id ...uint64) error
-	Dump(...string)
 	Drop(ctx context.Context, keepFiles bool) error
 	Flush() error
 	Shutdown(ctx context.Context) error
 	PostStartup(ctx context.Context)
+	PrepareForBackup(ctx context.Context) error
+	ResumeAfterBackup(ctx context.Context) error
+	ListFiles(ctx context.Context, basePath string) ([]string, error)
 }
 
 // Config is passed to the GeoIndex when its created
@@ -182,6 +184,23 @@ func (i *Index) Flush() error {
 
 func (i *Index) Shutdown(ctx context.Context) error {
 	return i.vectorIndex.Shutdown(ctx)
+}
+
+// PrepareForBackup readies the geo graph for its files to be copied. The graph
+// is an HNSW in its own right, persisted beside the shard rather than inside its
+// LSM buckets, so a backup has to halt, list and resume it like any other vector
+// index.
+func (i *Index) PrepareForBackup(ctx context.Context) error {
+	return i.vectorIndex.PrepareForBackup(ctx)
+}
+
+func (i *Index) ResumeAfterBackup(ctx context.Context) error {
+	return i.vectorIndex.ResumeAfterBackup(ctx)
+}
+
+// ListFiles returns the index files a backup has to copy, relative to basePath.
+func (i *Index) ListFiles(ctx context.Context, basePath string) ([]string, error) {
+	return i.vectorIndex.ListFiles(ctx, basePath)
 }
 
 // UnderlyingVectorIndex returns the underlying vector index (typically HNSW)

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -87,11 +87,6 @@ func TestBackup_Integration(t *testing.T) {
 		}
 	})
 
-	// let the index age for a second so that
-	// the commitlogger filenames, which are
-	// based on current timestamp, can differ
-	time.Sleep(time.Second)
-
 	t.Run("pause maintenance", func(t *testing.T) {
 		err = combinedCtrl.Deactivate(ctx)
 		require.Nil(t, err)

--- a/adapters/repos/db/vector/hnsw/backup_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_test.go
@@ -27,19 +27,27 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 type backupNoopBucketView struct{}
 
 func (n *backupNoopBucketView) ReleaseView() {}
 
+// After every PrepareForBackup, the log it just closed still has to show up in
+// ListFiles. Three rounds run back to back land within the same second, which is
+// what used to make a switch reopen the file the previous one had closed.
 func TestBackup_PrepareForBackup(t *testing.T) {
-	ctx := context.Background()
+	const backups = 3
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
 
 	dirName := t.TempDir()
 	indexID := "backup-switch-commitlogs-test"
 
 	idx, err := New(Config{
+		AllocChecker:     memwatch.NewDummyMonitor(),
 		RootPath:         dirName,
 		ID:               indexID,
 		Logger:           logrus.New(),
@@ -50,17 +58,20 @@ func TestBackup_PrepareForBackup(t *testing.T) {
 			return NewCommitLogger(dirName, indexID, logrus.New(), cyclemanager.NewCallbackGroupNoop())
 		},
 	}, enthnsw.NewDefaultUserConfig(), cyclemanager.NewCallbackGroupNoop(), nil)
-	require.Nil(t, err)
-	idx.PostStartup(context.Background())
+	require.NoError(t, err)
+	idx.PostStartup(ctx)
 
-	ctx, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
+	for i := range backups {
+		require.NoError(t, idx.Add(ctx, uint64(i), testVectors[i]))
+		require.NoError(t, idx.PrepareForBackup(ctx))
 
-	err = idx.PrepareForBackup(ctx)
-	assert.Nil(t, err)
+		files, err := idx.ListFiles(ctx, dirName)
+		require.NoError(t, err)
+		assert.Len(t, files, i+1,
+			"a closed commit log went missing from the backup file list")
+	}
 
-	err = idx.Shutdown(ctx)
-	require.Nil(t, err)
+	require.NoError(t, idx.Shutdown(ctx))
 }
 
 func TestBackup_ListFiles(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -666,11 +666,12 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 		return false, err
 	}
 
-	// naming the next log before closing the old one means that on a name we
-	// cannot derive, the index is left with a log it can still write to
-	fileName, err := nextCommitLogFileName(oldFileName)
-	if err != nil {
-		return false, err
+	fileName, derived := nextCommitLogFileName(oldFileName)
+	if !derived {
+		l.logger.WithField("action", "commit_log_file_switched").
+			WithField("id", l.id).
+			WithField("old_file_name", oldFileName).
+			Warn("commit log file name carries no timestamp, naming the next log after the current second instead")
 	}
 
 	if err := l.commitLogger.Close(); err != nil {
@@ -709,16 +710,22 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 // second would land on the name of the file just closed and carry on writing to
 // it. A backup only copies logs that are closed, so everything written to that
 // file from then on would be left out.
-func nextCommitLogFileName(current string) (string, error) {
+//
+// derived reports whether the name was advanced past current. A name without a
+// timestamp offers nothing to advance past, so the current second is used; it
+// cannot collide with current, which is not a timestamp to begin with.
+func nextCommitLogFileName(current string) (name string, derived bool) {
+	now := time.Now().Unix()
+
 	ts, err := endTimeStamp(current)
 	if err != nil {
-		return "", fmt.Errorf("parse commit log file name %q: %w", current, err)
+		return fmt.Sprintf("%d", now), false
 	}
 
-	if now := time.Now().Unix(); now > ts {
-		return fmt.Sprintf("%d", now), nil
+	if now > ts {
+		return fmt.Sprintf("%d", now), true
 	}
-	return fmt.Sprintf("%d", ts+1), nil
+	return fmt.Sprintf("%d", ts+1), true
 }
 
 func (l *hnswCommitLogger) condenseLogs() (bool, error) {

--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -666,12 +666,16 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 		return false, err
 	}
 
+	// naming the next log before closing the old one means that on a name we
+	// cannot derive, the index is left with a log it can still write to
+	fileName, err := nextCommitLogFileName(oldFileName)
+	if err != nil {
+		return false, err
+	}
+
 	if err := l.commitLogger.Close(); err != nil {
 		return true, err
 	}
-
-	// this is a new commit log, initialize with the current time stamp
-	fileName := fmt.Sprintf("%d", time.Now().Unix())
 
 	if force {
 		l.logger.WithField("action", "commit_log_file_switched").
@@ -698,6 +702,23 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 	l.commitLogger = commitlog.NewLoggerWithFile(fd)
 
 	return true, nil
+}
+
+// nextCommitLogFileName picks the name for the log that follows current. Logs
+// are named after the second they were created in, so two switches within one
+// second would land on the name of the file just closed and carry on writing to
+// it. A backup only copies logs that are closed, so everything written to that
+// file from then on would be left out.
+func nextCommitLogFileName(current string) (string, error) {
+	ts, err := endTimeStamp(current)
+	if err != nil {
+		return "", fmt.Errorf("parse commit log file name %q: %w", current, err)
+	}
+
+	if now := time.Now().Unix(); now > ts {
+		return fmt.Sprintf("%d", now), nil
+	}
+	return fmt.Sprintf("%d", ts+1), nil
 }
 
 func (l *hnswCommitLogger) condenseLogs() (bool, error) {

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -488,6 +488,12 @@ func (l *hnswCommitLogger) initSnapshotData() error {
 		if l.snapshotCreateInterval > 0 {
 			l.snapshotLastCreatedAt = time.Unix(createdAt, 0)
 			l.snapshotLastCheckedAt = time.Now()
+			// a commit log can be named a second or two ahead of the clock, and the
+			// snapshot takes its name from that log; treating it as the last
+			// creation time would delay the next snapshot by the same amount
+			if l.snapshotLastCreatedAt.After(l.snapshotLastCheckedAt) {
+				l.snapshotLastCreatedAt = l.snapshotLastCheckedAt
+			}
 			l.snapshotCheckInterval = min(snapshotCheckInterval, l.snapshotCreateInterval)
 
 			fields["last_created_at"] = l.snapshotLastCreatedAt

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -12,6 +12,7 @@
 package hnsw
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -2203,6 +2204,44 @@ func TestCleanupCompactV2TempFiles(t *testing.T) {
 		// don't create commitlog dir
 		require.NoError(t, newLogger(rootDir, "main").cleanupCompactV2TempFiles())
 	})
+}
+
+// A snapshot is named after the last commit log it covers, and a commit log can
+// be named a little ahead of the clock.
+func TestInitSnapshotLastCreatedAt(t *testing.T) {
+	tests := []struct {
+		name        string
+		offset      time.Duration
+		wantClamped bool
+	}{
+		{name: "snapshot named in the past", offset: -time.Hour},
+		{name: "snapshot named ahead of the clock", offset: time.Hour, wantClamped: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rootDir := t.TempDir()
+			id := "snapshot-last-created-at"
+
+			snapshotDir := snapshotDirectory(rootDir, id)
+			require.NoError(t, os.MkdirAll(snapshotDir, 0o755))
+			stamp := time.Now().Add(tc.offset).Unix()
+			require.NoError(t, os.WriteFile(
+				filepath.Join(snapshotDir, fmt.Sprintf("%d.snapshot", stamp)), nil, 0o644))
+
+			cl, err := NewCommitLogger(rootDir, id, logrus.New(), cyclemanager.NewCallbackGroupNoop(),
+				WithSnapshotDisabled(false), WithSnapshotCreateInterval(time.Hour))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, cl.Shutdown(context.Background())) })
+
+			if tc.wantClamped {
+				assert.False(t, cl.snapshotLastCreatedAt.After(time.Now()),
+					"a snapshot dated ahead of the clock delays the next snapshot by the same amount")
+				return
+			}
+			assert.Equal(t, stamp, cl.snapshotLastCreatedAt.Unix())
+		})
+	}
 }
 
 func TestSnapshotFileName(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/commit_logger_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_test.go
@@ -15,12 +15,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
@@ -132,6 +135,102 @@ func TestEndTimeStamp(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNextCommitLogFileName(t *testing.T) {
+	now := time.Now().Unix()
+
+	tests := []struct {
+		name    string
+		current string
+		wantErr bool
+	}{
+		{name: "log from an earlier second", current: fmt.Sprintf("%d", now-3600)},
+		{name: "log from the current second", current: fmt.Sprintf("%d", now)},
+		{name: "log timestamped ahead of the clock", current: fmt.Sprintf("%d", now+3600)},
+		{name: "condensed log", current: fmt.Sprintf("%d.condensed", now)},
+		{name: "combined log covering a range", current: fmt.Sprintf("%d_%d.sorted", now-3600, now)},
+		{name: "malformed name", current: "not-a-number", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			next, err := nextCommitLogFileName(tc.current)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			nextTS, err := asTimeStamp(next)
+			require.NoError(t, err)
+			currentTS, err := endTimeStamp(tc.current)
+			require.NoError(t, err)
+			// a name that does not sort after the previous one reopens the log that
+			// was just closed, and closed logs are what a backup copies
+			assert.Greater(t, nextTS, currentTS)
+		})
+	}
+}
+
+// Several backups of the same shard starting at once switch the log several
+// times inside one second. Each switch has to leave a file of its own behind,
+// and a restart has to carry on writing to the newest of them.
+func TestSwitchCommitLogsBurst(t *testing.T) {
+	ctx := context.Background()
+	rootDir := t.TempDir()
+	id := "burst-switch"
+
+	cl, err := NewCommitLogger(rootDir, id, logrus.New(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+
+	const switches = 5
+	for i := range switches {
+		require.NoError(t, cl.AddNode(&vertex{id: uint64(i), level: 0}))
+		require.NoError(t, cl.Flush())
+
+		switched, err := cl.switchCommitLogs(true)
+		require.NoError(t, err)
+		require.True(t, switched)
+	}
+	require.NoError(t, cl.Shutdown(ctx))
+
+	// one file per switch, plus the log the last switch opened; a switch that
+	// reused the previous name would leave one file fewer
+	names, err := getCommitFileNames(rootDir, id, 0, common.NewOSFS())
+	require.NoError(t, err)
+	require.Len(t, names, switches+1)
+
+	reopened, err := NewCommitLogger(rootDir, id, logrus.New(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Shutdown(ctx)) })
+
+	active, err := reopened.commitLogger.FileName()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Base(names[len(names)-1]), active,
+		"a restart has to continue on the newest commit log, not an earlier one")
+}
+
+// Switching closes the open log first, so a name we cannot read has to be
+// rejected before that happens, or the index is left with nothing to write to.
+func TestSwitchCommitLogsUnparseableName(t *testing.T) {
+	ctx := context.Background()
+	rootDir := t.TempDir()
+	id := "unparseable-name"
+
+	require.NoError(t, os.MkdirAll(commitLogDirectory(rootDir, id), 0o755))
+	require.NoError(t, os.WriteFile(
+		commitLogFileName(rootDir, id, "not-a-timestamp"), nil, 0o644))
+
+	cl, err := NewCommitLogger(rootDir, id, logrus.New(), cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cl.Shutdown(ctx)) })
+
+	_, err = cl.switchCommitLogs(true)
+	require.ErrorContains(t, err, `parse commit log file name "not-a-timestamp"`)
+
+	require.NoError(t, cl.AddNode(&vertex{id: 1, level: 0}))
+	require.NoError(t, cl.Flush())
 }
 
 func TestFilterNewerCommitLogFiles(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/commit_logger_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_test.go
@@ -141,29 +141,34 @@ func TestNextCommitLogFileName(t *testing.T) {
 	now := time.Now().Unix()
 
 	tests := []struct {
-		name    string
-		current string
-		wantErr bool
+		name        string
+		current     string
+		wantDerived bool
 	}{
-		{name: "log from an earlier second", current: fmt.Sprintf("%d", now-3600)},
-		{name: "log from the current second", current: fmt.Sprintf("%d", now)},
-		{name: "log timestamped ahead of the clock", current: fmt.Sprintf("%d", now+3600)},
-		{name: "condensed log", current: fmt.Sprintf("%d.condensed", now)},
-		{name: "combined log covering a range", current: fmt.Sprintf("%d_%d.sorted", now-3600, now)},
-		{name: "malformed name", current: "not-a-number", wantErr: true},
+		{name: "log from an earlier second", current: fmt.Sprintf("%d", now-3600), wantDerived: true},
+		{name: "log from the current second", current: fmt.Sprintf("%d", now), wantDerived: true},
+		{name: "log timestamped ahead of the clock", current: fmt.Sprintf("%d", now+3600), wantDerived: true},
+		{name: "condensed log", current: fmt.Sprintf("%d.condensed", now), wantDerived: true},
+		{name: "combined log covering a range", current: fmt.Sprintf("%d_%d.sorted", now-3600, now), wantDerived: true},
+		{name: "malformed name", current: "not-a-number"},
+		{name: "empty name", current: ""},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			next, err := nextCommitLogFileName(tc.current)
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
+			next, derived := nextCommitLogFileName(tc.current)
+			require.Equal(t, tc.wantDerived, derived)
 
 			nextTS, err := asTimeStamp(next)
 			require.NoError(t, err)
+
+			if !derived {
+				// nothing to advance past, but the name still has to be usable and
+				// must not reopen the file that was just closed
+				assert.NotEqual(t, tc.current, next)
+				return
+			}
+
 			currentTS, err := endTimeStamp(tc.current)
 			require.NoError(t, err)
 			// a name that does not sort after the previous one reopens the log that
@@ -213,6 +218,9 @@ func TestSwitchCommitLogsBurst(t *testing.T) {
 
 // Switching closes the open log first, so a name we cannot read has to be
 // rejected before that happens, or the index is left with nothing to write to.
+// A file the naming scheme cannot read still has to leave the index able to
+// switch. Refusing the switch would block backup, replica movement and tenant
+// offload on that shard for good, since nothing ever renames the file back.
 func TestSwitchCommitLogsUnparseableName(t *testing.T) {
 	ctx := context.Background()
 	rootDir := t.TempDir()
@@ -226,11 +234,22 @@ func TestSwitchCommitLogsUnparseableName(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, cl.Shutdown(ctx)) })
 
-	_, err = cl.switchCommitLogs(true)
-	require.ErrorContains(t, err, `parse commit log file name "not-a-timestamp"`)
+	switched, err := cl.switchCommitLogs(true)
+	require.NoError(t, err)
+	require.True(t, switched)
 
 	require.NoError(t, cl.AddNode(&vertex{id: 1, level: 0}))
 	require.NoError(t, cl.Flush())
+
+	// the switch moved off the unreadable file, so a backup can copy it
+	name, err := cl.commitLogger.FileName()
+	require.NoError(t, err)
+	require.NotEqual(t, "not-a-timestamp", name)
+
+	// and the shard is not stuck: a backup succeeds, now and on every later try
+	for range 3 {
+		require.NoError(t, cl.PrepareForBackup(true))
+	}
 }
 
 func TestFilterNewerCommitLogFiles(t *testing.T) {

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -569,6 +569,14 @@ func (d *Compose) WithWeaviateWithGRPC() *Compose {
 	return d
 }
 
+// WithWeaviateExposeGRPCPort publishes the gRPC port on a cluster that is sized
+// separately, which the WithGRPC helpers above cannot do because they pick the
+// node count themselves.
+func (d *Compose) WithWeaviateExposeGRPCPort() *Compose {
+	d.withWeaviateExposeGRPCPort = true
+	return d
+}
+
 func (d *Compose) WithMCP() *Compose {
 	d.WithWeaviateEnv("MCP_SERVER_ENABLED", "true")
 	d.WithWeaviateEnv("MCP_SERVER_WRITE_ACCESS_ENABLED", "true")

--- a/test/helper/backuptest/suite.go
+++ b/test/helper/backuptest/suite.go
@@ -36,6 +36,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
@@ -255,6 +256,9 @@ func (s *BackupTestSuite) SetupCompose(ctx context.Context) error {
 	if s.config.WithVectorizer {
 		compose = compose.WithText2VecContextionary()
 	}
+
+	// VerifyGeoSearch queries over gRPC
+	compose = compose.WithWeaviateExposeGRPCPort()
 
 	// Start cluster or single node
 	var err error
@@ -567,6 +571,64 @@ func (s *BackupTestSuite) VerifyObjectDataIntegrity(t *testing.T) {
 		})
 	}
 	require.NoError(t, g.Wait())
+}
+
+// VerifyGeoSearch runs a withinGeoRange filter per tenant and compares the hits
+// against the objects that were placed inside the queried range.
+//
+// The filter is answered by a separate index kept per geo property, which is
+// stored in files of its own rather than alongside the objects. A backup that
+// misses those files restores an empty index, and an empty index returns nothing
+// at all without reporting an error — which neither a count nor an
+// object-by-object comparison can notice.
+func (s *BackupTestSuite) VerifyGeoSearch(t *testing.T) {
+	t.Helper()
+
+	helper.SetupGRPCClient(t, s.compose.GetWeaviate().GrpcURI())
+	client := helper.ClientGRPC(t)
+
+	for tenant, objects := range s.dataGen.ObjectsByTenant(s.objects) {
+		want := make([]string, 0, len(objects))
+		var outside int
+		for _, obj := range objects {
+			if inGeoRange(obj) {
+				want = append(want, obj.ID.String())
+			} else {
+				outside++
+			}
+		}
+		// unless both groups have objects, a search returning everything or
+		// nothing would satisfy the comparison below without proving anything
+		require.NotEmpty(t, want, "tenant %q has no object inside the geo range", tenant)
+		require.NotZero(t, outside, "tenant %q has no object outside the geo range", tenant)
+
+		resp, err := client.Search(context.Background(), &pb.SearchRequest{
+			Collection: s.config.ClassName,
+			Tenant:     tenant,
+			Limit:      uint32(len(objects)),
+			Metadata:   &pb.MetadataRequest{Uuid: true},
+			Filters: &pb.Filters{
+				Operator: pb.Filters_OPERATOR_WITHIN_GEO_RANGE,
+				Target: &pb.FilterTarget{
+					Target: &pb.FilterTarget_Property{Property: geoPropName},
+				},
+				TestValue: &pb.Filters_ValueGeo{ValueGeo: &pb.GeoCoordinatesFilter{
+					Latitude:  *geoInRange.Latitude,
+					Longitude: *geoInRange.Longitude,
+					Distance:  geoRangeDistance,
+				}},
+			},
+		})
+		require.NoError(t, err, "geo range search on tenant %q", tenant)
+
+		got := make([]string, len(resp.Results))
+		for i, result := range resp.Results {
+			got[i] = result.Metadata.Id
+		}
+
+		require.ElementsMatch(t, want, got,
+			"the geo range search on tenant %q did not return the objects inside the range", tenant)
+	}
 }
 
 // VerifyObjectsDoNotExist checks that objects no longer exist (after class deletion).
@@ -884,6 +946,12 @@ func (s *BackupTestSuite) RunBasicBackupRestoreTest(t *testing.T) {
 		s.VerifyObjectsExist(t)
 	})
 
+	// establishes that the geo index answers before the backup, so the same
+	// check after the restore can only fail on what the backup carried
+	t.Run("verify geo search", func(t *testing.T) {
+		s.VerifyGeoSearch(t)
+	})
+
 	if s.config.MultiTenant.Enabled {
 		t.Run("deactivate some tenants", func(t *testing.T) {
 			s.DeactivateTestTenants(t)
@@ -923,6 +991,10 @@ func (s *BackupTestSuite) RunBasicBackupRestoreTest(t *testing.T) {
 
 	t.Run("verify object data integrity", func(t *testing.T) {
 		s.VerifyObjectDataIntegrity(t)
+	})
+
+	t.Run("verify geo search restored", func(t *testing.T) {
+		s.VerifyGeoSearch(t)
 	})
 
 	// For compressed backups, verify vectors are restored correctly

--- a/test/helper/backuptest/testdata.go
+++ b/test/helper/backuptest/testdata.go
@@ -22,6 +22,36 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
+// geoPropName is the geo property every generated class carries.
+const geoPropName = "location"
+
+// Generated objects sit at one of two points a continent apart, so a range
+// query around geoInRange selects exactly the objects placed there. Both
+// coordinates are exact in float32, so they come back unchanged from the JSON
+// round trip that the data-integrity check compares.
+var (
+	geoInRange = &models.GeoCoordinates{Latitude: geoDegrees(52.5), Longitude: geoDegrees(13.5)}
+	geoFarOff  = &models.GeoCoordinates{Latitude: geoDegrees(37.75), Longitude: geoDegrees(-122.5)}
+)
+
+// geoRangeDistance in metres, wide enough to reach every object at geoInRange.
+const geoRangeDistance = 100000
+
+func geoDegrees(d float32) *float32 { return &d }
+
+// inGeoRange reports whether a range query around geoInRange has to return obj.
+func inGeoRange(obj *models.Object) bool {
+	props, ok := obj.Properties.(map[string]interface{})
+	if !ok {
+		return false
+	}
+
+	coordinates, ok := props[geoPropName].(*models.GeoCoordinates)
+	return ok &&
+		*coordinates.Latitude == *geoInRange.Latitude &&
+		*coordinates.Longitude == *geoInRange.Longitude
+}
+
 // TestDataConfig contains configuration for generating test data.
 type TestDataConfig struct {
 	// ClassName is the name of the class to create.
@@ -61,6 +91,9 @@ func DefaultTestDataConfig() *TestDataConfig {
 type TestDataGenerator struct {
 	config *TestDataConfig
 	rng    *rand.Rand
+	// generated counts the objects handed out so far, so their locations can
+	// alternate rather than being drawn at random.
+	generated int
 }
 
 // NewTestDataGenerator creates a new TestDataGenerator with the given config.
@@ -110,6 +143,10 @@ func (g *TestDataGenerator) GenerateClass() *models.Class {
 			{
 				Name:     "tags",
 				DataType: schema.DataTypeTextArray.PropString(),
+			},
+			{
+				Name:     geoPropName,
+				DataType: schema.DataTypeGeoCoordinates.PropString(),
 			},
 		},
 	}
@@ -167,16 +204,26 @@ func (g *TestDataGenerator) GenerateTenantModels() []*models.Tenant {
 
 // GenerateObject creates a single test object with random data.
 func (g *TestDataGenerator) GenerateObject(tenantName string) *models.Object {
+	// alternating rather than picking at random means any batch of two or more
+	// objects has some inside the range and some outside, so a range query can
+	// never match all of them or none of them by chance
+	location := geoInRange
+	if g.generated%2 == 1 {
+		location = geoFarOff
+	}
+	g.generated++
+
 	obj := &models.Object{
 		Class: g.config.ClassName,
 		ID:    strfmt.UUID(uuid.New().String()),
 		Properties: map[string]interface{}{
-			"title":   g.randomTitle(),
-			"content": g.randomContent(),
-			"count":   g.rng.Intn(1000),
-			"score":   g.rng.Float64() * 100,
-			"active":  g.rng.Intn(2) == 1,
-			"tags":    g.randomTags(),
+			"title":     g.randomTitle(),
+			"content":   g.randomContent(),
+			"count":     g.rng.Intn(1000),
+			"score":     g.rng.Float64() * 100,
+			"active":    g.rng.Intn(2) == 1,
+			"tags":      g.randomTags(),
+			geoPropName: location,
 		},
 	}
 

--- a/test/helper/backuptest/testdata_test.go
+++ b/test/helper/backuptest/testdata_test.go
@@ -40,6 +40,7 @@ func TestTestDataGenerator_GenerateClass(t *testing.T) {
 		assert.True(t, propNames["score"])
 		assert.True(t, propNames["active"])
 		assert.True(t, propNames["tags"])
+		assert.True(t, propNames["location"])
 	})
 
 	t.Run("custom class name", func(t *testing.T) {
@@ -359,4 +360,5 @@ func TestTestDataGenerator_ClassPropertyTypes(t *testing.T) {
 	assert.Equal(t, string(schema.DataTypeNumber), propTypes["score"])
 	assert.Equal(t, string(schema.DataTypeBoolean), propTypes["active"])
 	assert.Equal(t, string(schema.DataTypeTextArray), propTypes["tags"])
+	assert.Equal(t, string(schema.DataTypeGeoCoordinates), propTypes["location"])
 }

--- a/test/modules/backup-azure/setup_test.go
+++ b/test/modules/backup-azure/setup_test.go
@@ -140,6 +140,7 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 		WithBackendAzure(azureContainerName).
 		WithText2VecContextionary().
 		WithWeaviateCluster(3).
+		WithWeaviateExposeGRPCPort().
 		Start(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start docker compose")

--- a/test/modules/backup-filesystem/setup_test.go
+++ b/test/modules/backup-filesystem/setup_test.go
@@ -88,6 +88,7 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 		WithText2VecContextionary().
 		WithWeaviateEnv("PERSISTENCE_LSM_MAX_SEGMENT_SIZE", "1024").
 		With1NodeCluster().
+		WithWeaviateExposeGRPCPort().
 		Start(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start docker compose")

--- a/test/modules/backup-gcs/setup_test.go
+++ b/test/modules/backup-gcs/setup_test.go
@@ -160,6 +160,7 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 		WithBackendGCS(gcsBucketName).
 		WithText2VecContextionary().
 		WithWeaviateCluster(3).
+		WithWeaviateExposeGRPCPort().
 		Start(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start docker compose")

--- a/test/modules/backup-s3/setup_test.go
+++ b/test/modules/backup-s3/setup_test.go
@@ -90,6 +90,7 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 		WithWeaviateEnv("AWS_REGION", defaultS3Region).
 		WithText2VecContextionary().
 		WithWeaviateCluster(3).
+		WithWeaviateExposeGRPCPort().
 		WithWeaviateEnv("BACKUP_MIN_CHUNK_SIZE", "1024").            // allow incremental backups in tests
 		WithWeaviateEnv("PERSISTENCE_LSM_MAX_SEGMENT_SIZE", "1024"). // avoid compactions so incremental backups have unchanged files
 		Start(ctx)


### PR DESCRIPTION
### What's being changed:

Before the files from their geo-index HNSW was not backed up. After a restore a geo search would have returned nothing.

Fixes a related bug that commit logs are named after the unix second they were created in. The old code closed the active log, then named its successor from the wall clock. If that switch happened in the same second as the previous log's creation, the "new" name was the existing file's name, and the logger reopened it in append mode. That file then became the active log again — and hnsw.ListFiles, which backups use, deliberately excludes the active log. So everything in it was left out of the backup, with a SUCCESS status and no error anywhere.

Closes https://github.com/weaviate/dirk-claude-issues/issues/44

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
