### PR TITLE
Keep one failing tenant from truncating the reconcile

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3008,6 +3008,9 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 	return nil
 }
 
+// UnloadLocalShard removes the shard from the index without touching its files.
+// It returns errAlreadyShutdown only for a closed index — a shard that was
+// already shut down is the outcome the caller asked for.
 func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 	i.closeLock.RLock()
 	defer i.closeLock.RUnlock()
@@ -3028,7 +3031,7 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 		if !errors.Is(err, errAlreadyShutdown) {
 			return errors.Wrapf(err, "shutdown shard %q", shardName)
 		}
-		return errors.Wrapf(errAlreadyShutdown, "shutdown shard %q", shardName)
+		i.logger.WithField("shard", shardName).Debug("was already shut or dropped")
 	}
 
 	return nil

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/backup"
@@ -105,6 +106,86 @@ func TestIndexDropShards(t *testing.T) {
 			if !tt.loaded {
 				_, err := os.Stat(shardDir)
 				require.Equal(t, tt.blockRemoval, err == nil)
+			}
+		})
+	}
+}
+
+// TestIndexUnloadLocalShard pins which failures return errAlreadyShutdown.
+// updateIndexTenantsStatus reads that sentinel as "the whole index is gone" and
+// stops reconciling the remaining tenants, so a per-shard failure carrying it
+// would silently truncate the reconcile.
+func TestIndexUnloadLocalShard(t *testing.T) {
+	const shardName = "shard1"
+
+	tests := []struct {
+		name string
+		// loaded stores a mock shard under shardName whose Shutdown returns
+		// shardShutdownErr
+		loaded           bool
+		shardShutdownErr error
+		closed           bool
+		wantErrContains  string
+		wantErrIs        error
+		wantShardKept    bool
+	}{
+		{
+			name:   "loaded shard is unloaded",
+			loaded: true,
+		},
+		{
+			name: "absent shard is already unloaded",
+		},
+		{
+			name:             "shard that was already shut down is not a failure",
+			loaded:           true,
+			shardShutdownErr: errAlreadyShutdown,
+		},
+		{
+			// the entry is deleted before Shutdown runs, so a failed unload
+			// leaves nothing behind and the shard stays live and unreachable
+			name:             "shard shutdown failure is reported without the sentinel",
+			loaded:           true,
+			shardShutdownErr: errors.New("still in use"),
+			wantErrContains:  "still in use",
+		},
+		{
+			name:          "closed index reports the sentinel and keeps the shard",
+			loaded:        true,
+			closed:        true,
+			wantErrIs:     errAlreadyShutdown,
+			wantShardKept: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, _ := newDropTestIndex(t)
+
+			if tt.loaded {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().Shutdown(mock.Anything).Return(tt.shardShutdownErr).Maybe()
+				idx.shards.Store(shardName, shard)
+			}
+			idx.closed = tt.closed
+
+			err := idx.UnloadLocalShard(context.Background(), shardName)
+
+			if tt.wantErrContains == "" && tt.wantErrIs == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				if tt.wantErrContains != "" {
+					require.Contains(t, err.Error(), tt.wantErrContains)
+				}
+			}
+			// only a closed index may report the sentinel
+			require.Equal(t, tt.wantErrIs != nil, errors.Is(err, errAlreadyShutdown))
+
+			if tt.wantShardKept {
+				require.NotNil(t, idx.shards.Load(shardName))
+			} else {
+				require.Nil(t, idx.shards.Load(shardName))
 			}
 		})
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -408,34 +408,62 @@ func (m *Migrator) UpdateIndex(ctx context.Context, incomingClass *models.Class,
 func (m *Migrator) updateIndexTenants(ctx context.Context, idx *Index,
 	incomingSS *sharding.State,
 ) error {
-	if err := m.updateIndexTenantsStatus(ctx, idx, incomingSS); err != nil {
-		return err
+	// the deletes run even when a tenant failed to load or unload. Otherwise the
+	// tenants the schema no longer lists keep their local directories and their
+	// offloaded copies until a later reload finishes the loop.
+	ec := errorcompounder.New()
+	ec.Add(m.updateIndexTenantsStatus(ctx, idx, incomingSS))
+
+	// a dead context cannot finish the cloud delete, and dropping only the local
+	// copy orphans the offloaded one for good: the shard leaves the index, so no
+	// later reload lists it again
+	if err := ctx.Err(); err != nil {
+		ec.Add(err)
+		return ec.ToError()
 	}
-	return m.updateIndexDeleteTenants(ctx, idx, incomingSS)
+
+	ec.Add(m.updateIndexDeleteTenants(ctx, idx, incomingSS))
+	return ec.ToError()
 }
 
 func (m *Migrator) updateIndexTenantsStatus(ctx context.Context, idx *Index,
 	incomingSS *sharding.State,
 ) error {
 	nodeName := m.db.schemaGetter.NodeName()
+	ec := errorcompounder.New()
+
 	for shardName, phys := range incomingSS.Physical {
 		if !phys.IsLocalShard(nodeName) {
 			continue
 		}
 
+		var err error
 		if phys.Status == models.TenantActivityStatusHOT {
 			// Only load the tenant if activity status == HOT.
-			if err := idx.LoadLocalShard(ctx, shardName, false); err != nil {
-				return fmt.Errorf("add missing tenant shard %s during update index: %w", shardName, err)
+			if err = idx.LoadLocalShard(ctx, shardName, false); err != nil {
+				err = fmt.Errorf("add missing tenant shard %s during update index: %w", shardName, err)
 			}
 		} else {
 			// Shutdown the tenant if activity status != HOT
-			if err := idx.UnloadLocalShard(ctx, shardName); err != nil {
-				return fmt.Errorf("shutdown tenant shard %s during update index: %w", shardName, err)
+			if err = idx.UnloadLocalShard(ctx, shardName); err != nil {
+				err = fmt.Errorf("shutdown tenant shard %s during update index: %w", shardName, err)
 			}
 		}
+		if err == nil {
+			continue
+		}
+		ec.Add(err)
+
+		// one failing tenant must not stop the loop, but a closed index or a
+		// dead context would fail every tenant behind it anyway. Say so, or the
+		// single tenant named below reads like the only one left unreconciled.
+		if ctx.Err() != nil || errors.Is(err, errAlreadyShutdown) {
+			ec.Addf("stopped reconciling the remaining tenants of %s", idx.ID())
+			break
+		}
 	}
-	return nil
+
+	return ec.ToErrorLimited(maxReportedErrors)
 }
 
 func (m *Migrator) updateIndexDeleteTenants(ctx context.Context,
@@ -490,7 +518,7 @@ func (m *Migrator) updateIndexShards(ctx context.Context, idx *Index,
 		if !slices.Contains(requestedShards, shardName) {
 			if err := idx.UnloadLocalShard(ctx, shardName); err != nil {
 				// TODO: an error should be returned but keeping the old behavior for now
-				m.logger.WithField("shard", shardName).Error("shutdown shard during update index: %w", err)
+				m.logger.WithField("shard", shardName).Errorf("shutdown shard during update index: %v", err)
 				continue
 			}
 		}

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -14,10 +14,12 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"hash/crc32"
 	"io"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -688,6 +690,246 @@ func TestUpdateIndexDeleteTenants(t *testing.T) {
 	}
 }
 
+// A tenant that fails to load or unload must not stop the tenants behind it in
+// map order, nor the deletes the incoming state asks for.
+func TestUpdateIndexTenantsPartialFailure(t *testing.T) {
+	const (
+		className    = "Abc"
+		removedShard = "removed"
+	)
+
+	shutdownFailed := errors.New("shutdown failed")
+
+	type tenant struct {
+		name   string
+		status string
+		// node defaults to the local node1
+		node string
+		// shutdownErr is what a non-HOT tenant's loaded shard returns from Shutdown
+		shutdownErr error
+		// protected makes a HOT tenant's load fail
+		protected bool
+	}
+
+	tests := []struct {
+		name    string
+		tenants []tenant
+		// extraFailing appends that many more tenants whose unload fails
+		extraFailing int
+		// closed and cancelCtx are the two systemic failures that stop the loop
+		closed    bool
+		cancelCtx bool
+		// wantTenantsNamed is how many tenants the returned error mentions
+		wantTenantsNamed int
+		wantErrContains  []string
+		wantErrIs        error
+		// removedDropErr is what dropping that shard returns
+		removedDropErr error
+		// wantDeletesSkipped says the removed shard survived the reconcile
+		wantDeletesSkipped bool
+	}{
+		{
+			name:             "one failing tenant still deletes the tenants the state dropped",
+			tenants:          []tenant{{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed}},
+			wantTenantsNamed: 1,
+			wantErrContains:  []string{"shutdown tenant shard cold1", "shutdown failed"},
+		},
+		{
+			name: "every failing unload is reported",
+			tenants: []tenant{
+				{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+				{name: "cold2", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+				{name: "cold3", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+			},
+			wantTenantsNamed: 3,
+			wantErrContains:  []string{"shutdown failed"},
+		},
+		{
+			name: "every failing load is reported",
+			tenants: []tenant{
+				{name: "hot1", status: models.TenantActivityStatusHOT, protected: true},
+				{name: "hot2", status: models.TenantActivityStatusHOT, protected: true},
+				{name: "hot3", status: models.TenantActivityStatusHOT, protected: true},
+			},
+			wantTenantsNamed: 3,
+			wantErrContains:  []string{"add missing tenant shard", "activation blocked"},
+		},
+		{
+			name: "a failing load and a failing unload are both reported",
+			tenants: []tenant{
+				{name: "hot1", status: models.TenantActivityStatusHOT, protected: true},
+				{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+			},
+			wantTenantsNamed: 2,
+			wantErrContains:  []string{"add missing tenant shard hot1", "shutdown tenant shard cold1"},
+		},
+		{
+			name: "tenants behind a failing one are still unloaded",
+			tenants: []tenant{
+				{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+				{name: "cold2", status: models.TenantActivityStatusCOLD},
+				{name: "cold3", status: models.TenantActivityStatusCOLD},
+				{name: "cold4", status: models.TenantActivityStatusCOLD},
+			},
+			wantTenantsNamed: 1,
+			wantErrContains:  []string{"shutdown tenant shard cold1"},
+		},
+		{
+			name:    "a tenant that was already shut down is not a failure",
+			tenants: []tenant{{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: errAlreadyShutdown}},
+		},
+		{
+			name: "a closed index stops the loop and drops nothing",
+			tenants: []tenant{
+				{name: "cold1", status: models.TenantActivityStatusCOLD},
+				{name: "cold2", status: models.TenantActivityStatusCOLD},
+				{name: "cold3", status: models.TenantActivityStatusCOLD},
+			},
+			closed:             true,
+			wantTenantsNamed:   1,
+			wantErrIs:          errAlreadyShutdown,
+			wantErrContains:    []string{"stopped reconciling the remaining tenants"},
+			wantDeletesSkipped: true,
+		},
+		{
+			// dropping the local copy without the cloud copy the dead context
+			// cannot reach would orphan the offloaded data for good
+			name: "a dead context stops the loop and skips the deletes",
+			tenants: []tenant{
+				{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+				{name: "cold2", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+				{name: "cold3", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed},
+			},
+			cancelCtx:          true,
+			wantTenantsNamed:   1,
+			wantErrIs:          context.Canceled,
+			wantErrContains:    []string{"shutdown failed", "stopped reconciling the remaining tenants"},
+			wantDeletesSkipped: true,
+		},
+		{
+			name:             "a failing tenant and a failing delete are both reported",
+			tenants:          []tenant{{name: "cold1", status: models.TenantActivityStatusCOLD, shutdownErr: shutdownFailed}},
+			removedDropErr:   errors.New("shard drop failed"),
+			wantTenantsNamed: 1,
+			wantErrContains:  []string{"shutdown tenant shard cold1", "drop tenant shards", "shard drop failed"},
+		},
+		{
+			// a class can hold tens of thousands of tenants, so a failure that
+			// hits all of them must not build one message out of every one
+			name:             "the reported failures are bounded",
+			extraFailing:     15,
+			wantTenantsNamed: maxReportedErrors,
+			wantErrContains:  []string{"(and 5 more)"},
+		},
+		{
+			name:             "a tenant on another node is left alone",
+			tenants:          []tenant{{name: "cold1", status: models.TenantActivityStatusCOLD, node: "node2"}},
+			wantTenantsNamed: 0,
+		},
+		{
+			name:             "no tenant to reconcile",
+			wantTenantsNamed: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenants := tt.tenants
+			for i := 0; i < tt.extraFailing; i++ {
+				tenants = append(tenants, tenant{
+					name:        fmt.Sprintf("bulk%02d", i),
+					status:      models.TenantActivityStatusCOLD,
+					shutdownErr: shutdownFailed,
+				})
+			}
+
+			idx, _ := newDropTestIndex(t)
+			sg := schemaUC.NewMockSchemaGetter(t)
+			sg.On("NodeName").Return("node1").Maybe()
+			sg.On("ReadOnlyClass", className).Return(&models.Class{Class: className}).Maybe()
+			idx.getSchema = sg
+
+			// the shard the incoming state no longer lists, which the deletes
+			// must reclaim even when a tenant failed
+			if tt.wantDeletesSkipped {
+				idx.shards.Store(removedShard, NewMockShardLike(t))
+			} else {
+				storeDroppableShard(t, idx, removedShard, tt.removedDropErr)
+			}
+
+			physical := make(map[string]sharding.Physical, len(tenants))
+			for _, tn := range tenants {
+				node := tn.node
+				if node == "" {
+					node = "node1"
+				}
+				physical[tn.name] = sharding.Physical{
+					Name:           tn.name,
+					BelongsToNodes: []string{node},
+					Status:         tn.status,
+				}
+				if tn.protected {
+					// a protected shard must stay out of the map, or the load
+					// returns before it reaches the backup guard
+					idx.backupProtectedShards.Store(tn.name, struct{}{})
+					continue
+				}
+				shard := NewMockShardLike(t)
+				if node == "node1" {
+					shard.EXPECT().Shutdown(mock.Anything).Return(tn.shutdownErr).Maybe()
+				}
+				idx.shards.Store(tn.name, shard)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancelCtx {
+				cancel()
+			}
+			idx.closed = tt.closed
+
+			err := newDropTestMigrator(idx, className, fakeOffloadCloud{}).
+				updateIndexTenants(ctx, idx, &sharding.State{Physical: physical, PartitioningEnabled: true})
+
+			if len(tt.wantErrContains) == 0 && tt.wantErrIs == nil {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				for _, want := range tt.wantErrContains {
+					require.Contains(t, err.Error(), want)
+				}
+				if tt.wantErrIs != nil {
+					require.ErrorIs(t, err, tt.wantErrIs)
+				}
+			}
+
+			named := 0
+			for _, tn := range tenants {
+				if err != nil && strings.Contains(err.Error(), tn.name) {
+					named++
+				}
+			}
+			require.Equal(t, tt.wantTenantsNamed, named, "tenants named in %v", err)
+
+			if tt.wantDeletesSkipped {
+				require.NotNil(t, idx.shards.Load(removedShard))
+			} else {
+				require.Nil(t, idx.shards.Load(removedShard))
+			}
+
+			// a shard leaves the map as soon as its unload is attempted, so a
+			// shard still there is one the loop never reached
+			if !tt.closed && !tt.cancelCtx {
+				for _, tn := range tenants {
+					if !tn.protected && tn.node == "" {
+						require.Nil(t, idx.shards.Load(tn.name), "tenant %s was never reconciled", tn.name)
+					}
+				}
+			}
+		})
+	}
+}
+
 // storeDroppableShard stores a mock shard under name whose drop returns dropErr.
 func storeDroppableShard(t *testing.T, idx *Index, name string, dropErr error) {
 	t.Helper()
@@ -700,7 +942,10 @@ func storeDroppableShard(t *testing.T, idx *Index, name string, dropErr error) {
 // newDropTestMigrator returns a migrator serving idx under className, offloading
 // to cloud unless it is nil.
 func newDropTestMigrator(idx *Index, className string, cloud modulecapabilities.OffloadCloud) *Migrator {
-	db := &DB{indices: map[string]*Index{indexID(schema.ClassName(className)): idx}}
+	db := &DB{
+		indices:      map[string]*Index{indexID(schema.ClassName(className)): idx},
+		schemaGetter: idx.getSchema,
+	}
 	m := NewMigrator(db, idx.logger, "node1")
 	m.nodeId = "node1"
 	m.cloud = cloud


### PR DESCRIPTION
### What's being changed:

`Migrator.updateIndexTenantsStatus` is the local-node tenant reconcile, reached from `SchemaManager.ReloadDBFromSchema` → `executor.ReloadLocalDB` → `Migrator.UpdateIndex` on RAFT snapshot install and startup catch-up. Both arms of its `for shardName, phys := range incomingSS.Physical` loop returned on their first error, so one tenant failing for any ordinary reason — memory pressure via the alloc checker, a corrupt shard, a disk error — did two things:

1. **truncated the loop**, leaving every tenant behind it in map order neither loaded nor unloaded; and
2. **propagated out of `updateIndexTenants`**, so `updateIndexDeleteTenants` never ran — the tenants the schema no longer lists kept their local directories *and* their offloaded cloud copies.

`Physical` is a map, so which tenants were reconciled before the abort differed per node and per run: one reload could leave three replicas in three different states. Nothing retries it — `ReloadLocalDB`'s error is discarded by its caller at `cluster/schema/manager.go:314` — so the skipped work stayed skipped until the next snapshot install, which may never come.

**The fix.** `updateIndexTenantsStatus` compounds per-tenant errors instead of returning on the first, and `updateIndexTenants` runs the deletes regardless, compounding both. The loop breaks early only on a *systemic* failure — a closed index or a dead context — where every remaining tenant would fail identically anyway, and says so explicitly so the single tenant named in the error is not mistaken for the only casualty.

### Design decisions worth reviewing

- **The report is capped at `maxReportedErrors`.** Compounding one error per tenant is unbounded by design: a class can hold tens of thousands of tenants, and a mass failure (the alloc checker under memory pressure fails *every* HOT tenant) built a ~1 MB error string that `executor.go:79` then logs whole. Uses the same bound as `dropShards`, `dropCloudShards`, `Index.Shutdown` and `DB.Shutdown`.

- **The deletes are skipped when the context is dead.** `idx.dropShards` takes no context and removes the local directories regardless, while `idx.dropCloudShards` needs the context and fails — and because the shard is then gone from `idx.shards`, no later `ForEachShard` pass lists it again. That orphans the offloaded copy for good, which is exactly what the existing comment in `updateIndexDeleteTenants` exists to prevent. Skipping is recoverable; orphaning is not.

- **`Index.UnloadLocalShard` now treats an already-shut-down shard as success**, matching `Migrator.ShutdownShard` and the cold arm of `UpdateTenants`. Note this is a **no-op in production today**: no real `ShardLike` can return that sentinel from `Shutdown`. Its value is making `errAlreadyShutdown` out of that function mean unambiguously "the index is closed" — the invariant the new break relies on. `TestIndexUnloadLocalShard` pins it, because nothing else would fail if a future error path wrapped the sentinel for a per-shard reason.

### Known interactions

- **Aggravates `weaviate/dirk-claude-issues#16`** (`UnloadLocalShard` deletes the map entry before `Shutdown`, so a failed unload leaks a live, unreachable shard). Previously one failed unload ended the pass and leaked one shard; now the loop continues, so a pass can leak several. Severity per shard is unchanged. Not fixed here on purpose — #16's own analysis shows the fix needs `initLocalShardWithForcedLoading` and `getOptInitLocalShard` to replace a shut-down entry (otherwise a self-healing orphan becomes a permanent zombie), `ForEachShard` to skip unusable entries (or `setShardsReadOnly`'s `Fatalf` exits the node), and a typed `errShardShuttingDown` on the read path.
- **Overlaps #12507** ("Complete updateIndexTenants when one tenant fails"), which changes the same two functions on the same base. These should not both land — see the comparison in review.

### Deliberately out of scope

Three filed issues share this code path and are *not* addressed here: `#9` (the same truncation shape in `updateIndexShards`), `#11` (`updateIndexAddMissingProperties` sitting behind the shard block), and `#6` (what `updateIndexDeleteTenants` derives `toRemove` from when it does run).

### Issues

Tracker is a separate repo, so GitHub will not auto-close these — they need closing by hand.

- Fixes `weaviate/dirk-claude-issues#47` — the truncated loop and the skipped deletes.
- Partially addresses `weaviate/dirk-claude-issues#13` — fixes the literal `%w` passed to `logrus.Error` in `updateIndexShards`. The five `WithError` sites in `usecases/schema/executor.go` that #13 also covers are untouched, so **#13 stays open**.

### Testing

- `TestUpdateIndexTenantsPartialFailure` (12 cases) — 11 of 12 fail without the production change. Covers: one failing tenant still runs the deletes; every failing load and every failing unload reported; tenants behind a failing one still unloaded; an already-shut-down tenant is not a failure; a closed index and a dead context each stop the loop; a failing tenant and a failing delete both reported; the report is bounded; a tenant on another node is left alone; no tenants.
- `TestIndexUnloadLocalShard` (5 cases) — pins that only a closed index yields `errAlreadyShutdown`.
- Both stable over 10 `-race` runs, so map iteration order does not flake them.

No end-to-end proof: `test/acceptance/multi_tenancy/` does not drive the reload path, and "a shard whose `Shutdown` fails" has no e2e handle.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
