### PR TITLE
Give each replica-add apply its own shard-load caller

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -316,7 +316,19 @@ func (m *Migrator) UpdateClass(ctx context.Context, className string, newClassNa
 	return nil
 }
 
-func (m *Migrator) LoadShard(ctx context.Context, class, shard string) error {
+// LoadShardForReplication loads the target shard of a replica movement.
+func (m *Migrator) LoadShardForReplication(ctx context.Context, class, shard string) error {
+	return m.loadShard(ctx, class, shard)
+}
+
+// LoadShardForReplicaAdd loads a shard for the apply that adds a replica to it
+// with no replica movement under way.
+func (m *Migrator) LoadShardForReplicaAdd(ctx context.Context, class, shard string) error {
+	return m.loadShard(ctx, class, shard)
+}
+
+// loadShard is the load both replica-add callers drive.
+func (m *Migrator) loadShard(ctx context.Context, class, shard string) error {
 	idx := m.db.GetIndex(schema.ClassName(class))
 	if idx == nil {
 		return fmt.Errorf("could not find collection %s", class)

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -829,7 +829,7 @@ func (s *SchemaManager) ReplicationAddReplicaToShard(cmd *command.ApplyRequest, 
 			},
 			updateStore: func() error {
 				if req.TargetNode == s.schema.nodeID {
-					if err := s.db.AddReplicaToShard(req.Class, req.Shard, req.TargetNode); err != nil {
+					if err := s.db.AddReplicaToShardForMovement(req.Class, req.Shard, req.TargetNode); err != nil {
 						return err
 					}
 				}

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -594,6 +594,77 @@ func TestSchemaManager_ReplicationAddReplicaToShard_AtomicallySetsUnCancellable(
 	})
 }
 
+// The two replica-add command types reach different indexer entry points on the
+// node gaining the replica. The plain type carries no op id and registers no
+// replication op, so it must not reach the movement's entry point.
+func TestSchemaManagerReplicaAddRoutesByCommandType(t *testing.T) {
+	const (
+		className = "TestClass"
+		shardName = "shard1"
+		nodeID    = "local-node"
+		schemaVer = uint64(1)
+		applyVer  = uint64(2)
+	)
+
+	tests := []struct {
+		name        string
+		cmdType     cmd.ApplyRequest_Type
+		subCommand  any
+		apply       func(*SchemaManager, *cmd.ApplyRequest) error
+		wantIndexer string
+	}{
+		{
+			name:       "a plain replica add",
+			cmdType:    cmd.ApplyRequest_TYPE_ADD_REPLICA_TO_SHARD,
+			subCommand: &cmd.AddReplicaToShard{Class: className, Shard: shardName, TargetNode: nodeID},
+			apply: func(sm *SchemaManager, req *cmd.ApplyRequest) error {
+				return sm.AddReplicaToShard(req, false)
+			},
+			wantIndexer: "AddReplicaToShard",
+		},
+		{
+			name:    "a replica movement",
+			cmdType: cmd.ApplyRequest_TYPE_REPLICATION_REPLICATE_ADD_REPLICA_TO_SHARD,
+			subCommand: &cmd.ReplicationAddReplicaToShard{
+				OpId: 42, Class: className, Shard: shardName,
+				TargetNode: nodeID, SchemaVersion: schemaVer,
+			},
+			apply: func(sm *SchemaManager, req *cmd.ApplyRequest) error {
+				return sm.ReplicationAddReplicaToShard(req, false)
+			},
+			wantIndexer: "AddReplicaToShardForMovement",
+		},
+	}
+
+	for _, tc := range tests {
+		// The indexer panics on any call it has no expectation for, so reaching
+		// the other entry point fails the row rather than passing it silently.
+		t.Run(tc.name+" reaches "+tc.wantIndexer, func(t *testing.T) {
+			parser := fakes.NewMockParser()
+			parser.On("ParseClass", mock.Anything).Return(nil)
+			indexer := fakes.NewMockSchemaExecutor()
+			indexer.On(tc.wantIndexer, className, shardName, nodeID).Return(nil)
+			indexer.On("ReconcileAsyncReplicationForShard", className, shardName).Return(nil)
+
+			sm := NewSchemaManager(nodeID, indexer, parser, prometheus.NewPedanticRegistry(), logrus.New())
+			sm.SetReplicationFSM(&fakeReplicationFSM{})
+
+			ss := &sharding.State{Physical: map[string]sharding.Physical{
+				shardName: {Name: shardName, BelongsToNodes: []string{"other-node"}},
+			}}
+			require.NoError(t, sm.schema.addClass(&models.Class{Class: className}, ss, schemaVer))
+
+			sub, err := json.Marshal(tc.subCommand)
+			require.NoError(t, err)
+
+			require.NoError(t, tc.apply(sm, &cmd.ApplyRequest{
+				Type: tc.cmdType, Class: className, Version: applyVer, SubCommand: sub,
+			}))
+			indexer.AssertExpectations(t)
+		})
+	}
+}
+
 // recordingMutationGuard captures every CheckPropertyUpdate call and
 // optionally rejects with a configured error. Used to pin the
 // SchemaManager.UpdateProperty guard call site (https://github.com/weaviate/0-weaviate-issues/issues/218).

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -40,7 +40,12 @@ type Indexer interface {
 	DeleteTenants(class string, tenants []*models.Tenant) error
 	UpdateTenantsProcess(class string, req *api.TenantProcessRequest) error
 	UpdateShardStatus(*api.UpdateShardStatusRequest) error
+	// AddReplicaToShard materializes a replica the schema just assigned to this
+	// node, with no replica movement under way.
 	AddReplicaToShard(class, shard, targetNode string) error
+	// AddReplicaToShardForMovement materializes the target shard of a replica
+	// movement, which the schema assigns while the movement is still running.
+	AddReplicaToShardForMovement(class, shard, targetNode string) error
 	DeleteReplicaFromShard(class, shard, targetNode string) error
 	ReconcileAsyncReplicationForShard(class, shard string) error
 	LoadShard(class, shard string)     // is a no-op

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -229,7 +229,7 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 
 	logger, _ := logrus.NewNullLogger()
 	migrator := db.NewMigrator(repo, logger, nodeName)
-	require.NoError(t, migrator.LoadShard(context.Background(), class.Class, hotTenant))
+	require.NoError(t, migrator.LoadShardForReplication(context.Background(), class.Class, hotTenant))
 
 	mockBackupProvider := backupusecase.NewMockBackupBackendProvider(t)
 	mockBackupProvider.EXPECT().EnabledBackupBackends().Return([]modulecapabilities.BackupBackend{})
@@ -677,7 +677,7 @@ func TestService_Usage_MultipleCollectionsConcurrent(t *testing.T) {
 	logger, _ := logrus.NewNullLogger()
 	migrator := db.NewMigrator(repo, logger, nodeName)
 	for _, class := range classes {
-		require.NoError(t, migrator.LoadShard(ctx, class.Class, shardName))
+		require.NoError(t, migrator.LoadShardForReplication(ctx, class.Class, shardName))
 		putObjectAndFlush(t, repo, class.Class, "", map[string][]float32{vectorName: {0.1, 0.2, 0.3}})
 	}
 	repo.Shutdown(ctx)
@@ -764,7 +764,7 @@ func TestService_Usage_MultipleCollectionsError(t *testing.T) {
 	logger, _ := logrus.NewNullLogger()
 	migrator := db.NewMigrator(repo, logger, nodeName)
 	for _, class := range classes {
-		require.NoError(t, migrator.LoadShard(ctx, class.Class, shardName))
+		require.NoError(t, migrator.LoadShardForReplication(ctx, class.Class, shardName))
 		putObjectAndFlush(t, repo, class.Class, "", map[string][]float32{vectorName: {0.1, 0.2, 0.3}})
 	}
 	repo.Shutdown(ctx)
@@ -829,7 +829,7 @@ func createTestDb(t *testing.T, sg schemaUC.SchemaGetter, shardingState *shardin
 	if class != nil && shardingState != nil {
 		migrator.AddClass(context.Background(), class)
 		for _, shard := range shardingState.Physical {
-			require.NoError(t, migrator.LoadShard(context.Background(), class.Class, shard.Name))
+			require.NoError(t, migrator.LoadShardForReplication(context.Background(), class.Class, shard.Name))
 			if shard.ActivityStatus() == models.TenantActivityStatusCOLD {
 				require.NoError(t, migrator.ShutdownShard(context.Background(), class.Class, shard.Name))
 			}

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -48,6 +48,11 @@ func (m *MockSchemaExecutor) AddReplicaToShard(class string, shard string, targe
 	return args.Error(0)
 }
 
+func (m *MockSchemaExecutor) AddReplicaToShardForMovement(class string, shard string, targetNode string) error {
+	args := m.Called(class, shard, targetNode)
+	return args.Error(0)
+}
+
 func (m *MockSchemaExecutor) DeleteReplicaFromShard(class string, shard string, targetNode string) error {
 	args := m.Called(class, shard, targetNode)
 	return args.Error(0)

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -105,14 +105,34 @@ func (e *executor) AddClass(pl api.AddClassRequest) error {
 	return nil
 }
 
+// AddReplicaToShard loads the shard the schema now lists this node as a replica
+// of, with no replica movement under way.
 func (e *executor) AddReplicaToShard(class string, shard string, targetNode string) error {
-	ctx := context.Background()
-	if replicas, err := e.schemaReader.ShardReplicas(class, shard); err != nil {
+	if err := e.requireShardReplica(class, shard, targetNode); err != nil {
+		return err
+	}
+	return e.migrator.LoadShardForReplicaAdd(context.Background(), class, shard)
+}
+
+// AddReplicaToShardForMovement loads the target shard of a replica movement.
+func (e *executor) AddReplicaToShardForMovement(class string, shard string, targetNode string) error {
+	if err := e.requireShardReplica(class, shard, targetNode); err != nil {
+		return err
+	}
+	return e.migrator.LoadShardForReplication(context.Background(), class, shard)
+}
+
+// requireShardReplica fails unless the schema already lists targetNode among the
+// shard's replicas.
+func (e *executor) requireShardReplica(class, shard, targetNode string) error {
+	replicas, err := e.schemaReader.ShardReplicas(class, shard)
+	if err != nil {
 		return fmt.Errorf("error reading replicas for collection %s shard %s: %w", class, shard, err)
-	} else if !slices.Contains(replicas, targetNode) {
+	}
+	if !slices.Contains(replicas, targetNode) {
 		return fmt.Errorf("replica %s does not exists for collection %s shard %s", targetNode, class, shard)
 	}
-	return e.migrator.LoadShard(ctx, class, shard)
+	return nil
 }
 
 func (e *executor) DeleteReplicaFromShard(class string, shard string, targetNode string) error {
@@ -131,7 +151,7 @@ func (e *executor) ReconcileAsyncReplicationForShard(class string, shard string)
 
 func (e *executor) LoadShard(class string, shard string) {
 	ctx := context.Background()
-	if err := e.migrator.LoadShard(ctx, class, shard); err != nil {
+	if err := e.migrator.LoadShardForReplicaAdd(ctx, class, shard); err != nil {
 		e.logger.WithFields(logrus.Fields{
 			"action": "load_shard",
 			"class":  class,

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -123,6 +123,52 @@ func TestExecutor(t *testing.T) {
 		assert.Nil(t, x.AddProperty("A", req))
 	})
 
+	// The two replica-add entry points differ only in which load they drive, and
+	// the migrator fake panics on any call it has no expectation for, so driving
+	// the other one fails the row.
+	replicaAdds := []struct {
+		name       string
+		call       func(*executor) error
+		wantLoader string
+	}{
+		{
+			name:       "a plain replica add",
+			call:       func(x *executor) error { return x.AddReplicaToShard("A", "S", "N") },
+			wantLoader: "LoadShardForReplicaAdd",
+		},
+		{
+			name:       "a replica movement",
+			call:       func(x *executor) error { return x.AddReplicaToShardForMovement("A", "S", "N") },
+			wantLoader: "LoadShardForReplication",
+		},
+	}
+
+	for _, tc := range replicaAdds {
+		t.Run(tc.name+" drives "+tc.wantLoader, func(t *testing.T) {
+			store := &fakeSchemaManager{}
+			store.On("ShardReplicas", "A", "S").Return([]string{"N"}, nil)
+			migrator := &fakeMigrator{}
+			migrator.On(tc.wantLoader, Anything, "A", "S").Return(nil)
+
+			assert.NoError(t, tc.call(newMockExecutor(migrator, store)))
+			migrator.AssertExpectations(t)
+		})
+
+		t.Run(tc.name+" loads nothing when the schema does not list the replica", func(t *testing.T) {
+			store := &fakeSchemaManager{}
+			store.On("ShardReplicas", "A", "S").Return([]string{"other"}, nil)
+
+			assert.Error(t, tc.call(newMockExecutor(&fakeMigrator{}, store)))
+		})
+
+		t.Run(tc.name+" loads nothing when the replicas cannot be read", func(t *testing.T) {
+			store := &fakeSchemaManager{}
+			store.On("ShardReplicas", "A", "S").Return([]string(nil), ErrAny)
+
+			assert.ErrorIs(t, tc.call(newMockExecutor(&fakeMigrator{}, store)), ErrAny)
+		})
+	}
+
 	tenants := []*api.Tenant{{Name: "T1"}, {Name: "T2"}}
 
 	t.Run("DeleteTenants", func(t *testing.T) {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -101,6 +101,10 @@ func (f *fakeDB) AddReplicaToShard(class string, shard string, targetNode string
 	return nil
 }
 
+func (f *fakeDB) AddReplicaToShardForMovement(class string, shard string, targetNode string) error {
+	return nil
+}
+
 func (f *fakeDB) DeleteReplicaFromShard(class string, shard string, targetNode string) error {
 	return nil
 }
@@ -316,7 +320,12 @@ func (f *fakeMigrator) UpdateProperty(ctx context.Context, className string, pro
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) LoadShard(ctx context.Context, class string, shard string) error {
+func (f *fakeMigrator) LoadShardForReplication(ctx context.Context, class string, shard string) error {
+	args := f.Called(ctx, class, shard)
+	return args.Error(0)
+}
+
+func (f *fakeMigrator) LoadShardForReplicaAdd(ctx context.Context, class string, shard string) error {
 	args := f.Called(ctx, class, shard)
 	return args.Error(0)
 }

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -41,7 +41,8 @@ type Migrator interface {
 	DropClass(ctx context.Context, className string, hasFrozen bool) error
 	// UpdateClass(ctx context.Context, className string,newClassName *string) error
 	GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error)
-	LoadShard(ctx context.Context, class, shard string) error
+	LoadShardForReplication(ctx context.Context, class, shard string) error
+	LoadShardForReplicaAdd(ctx context.Context, class, shard string) error
 	DropShard(ctx context.Context, class, shard string) error
 	ShutdownShard(ctx context.Context, class, shard string) error
 	ReconcileAsyncReplicationForShard(ctx context.Context, class, shard string) error


### PR DESCRIPTION
Groundwork for namespace suspend. A suspended namespace stops opening shards, but a replica movement that is already running still needs to open its target shard, or it gets stuck half-finished. Right now there is no way to tell those two apart. 

Two different RAFT commands add a replica to a node: one creates an empty replica, the other takes over a shard the copier has already filled. Both went through the same `AddReplicaToShard` and the same shard load, so the node receiving the replica cannot tell which kind it is handling, and a rule meant for only one of them has nowhere to go.

This gives each its own path, from `AddReplicaToShard` down to the load, and moves the duplicated replica check both were doing into one shared helper. Nothing behaves differently yet — both paths still end in the same load — but now they can.
