### PR TITLE
perf(lsmkv): read targeted-scan ranges straight from the file

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_targeted_scan.go
+++ b/adapters/repos/db/lsmkv/bucket_targeted_scan.go
@@ -15,8 +15,8 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"math"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -370,6 +370,12 @@ func (s *segment) indexNodeSplits(parts int) [][2]int {
 // readRange serves the segment bytes in [offset.start, offset.end). In mmap mode
 // the result is a zero-copy slice of the segment contents; otherwise *buf is
 // grown as needed, filled via a single pread, and the result aliases it.
+//
+// The read goes straight to the file rather than through newNodeReader: that
+// stack exists for callers that stream a segment, where the buffering pays and a
+// section reader keeps them off the shared file offset. This one knows its range
+// and owns its destination, and ReadAt needs neither — it is one pread that
+// touches no shared state, so the scan pays no allocation per row.
 func (s *segment) readRange(offset nodeOffset, operation string, buf *[]byte) ([]byte, error) {
 	// capacity is clamped to the requested range everywhere below: these slices
 	// are windows into the segment or into a reused buffer, and spare capacity
@@ -377,20 +383,25 @@ func (s *segment) readRange(offset nodeOffset, operation string, buf *[]byte) ([
 	if s.readFromMemory {
 		return s.contents[offset.start:offset.end:offset.end], nil
 	}
+	if s.contentFile == nil {
+		return nil, fmt.Errorf("targeted scan: nil contentFile for segment at %s", s.path)
+	}
 
 	need := offset.end - offset.start
 	if uint64(cap(*buf)) < need {
 		*buf = make([]byte, need)
 	}
 	b := (*buf)[:need:need]
-	r, err := s.newNodeReader(offset, operation)
+
+	// ReadAt reports an error whenever it returns short, so it carries io.ReadFull's
+	// guarantee without the wrapper
+	observe := readObserver.GetOrCreate(readMetricName(operation), s.metrics)
+	start := time.Now()
+	n, err := s.contentFile.ReadAt(b, int64(offset.start))
 	if err != nil {
-		return nil, err
-	}
-	defer r.Release()
-	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, errors.Wrap(err, "targeted scan: read range")
 	}
+	observe(int64(n), time.Since(start).Nanoseconds())
 	return b, nil
 }
 


### PR DESCRIPTION
Follow-up to #12396, standalone.

`readRange` went through `newNodeReader`, which builds a metered reader, a section reader, a pooled `bufio` and a release closure on every call. That stack is for callers that *stream* a segment — buffering pays there, and a section reader keeps them off the shared file offset. `readRange` is not one of them: it knows its byte range up front and owns its destination buffer.

`os.File.ReadAt` needs neither. It is a single `pread` against no shared state, and it already returns an error whenever it reads short, so it carries `io.ReadFull`'s guarantee. `diskio.MeteredReader` has its own `ReadAt`, which shows the metering never required the streaming path either — the observer is invoked directly under the same metric key.

## Measured

200k rows of 4 KiB, pread, linux/amd64 (Ryzen 5900X):

| | allocs/op | B/op |
|---|---|---|
| before | 800,098 | 22.4 MB |
| after | **87** | **8.9 KB** |

That puts pread on the same allocation profile as mmap (83 allocs). Against `Bucket.Cursor` the scan moves from 2.8x to **10.1x** at one segment, and 3.6x to **8.2x** at sixteen.

End to end on a 1M-object x 1536d prefill it is worth ~18% of wall clock (1.088s -> 0.889s) and takes pread allocations from 20.0M to 12.0M — the same as mmap. What remains there is the vector cache's per-vector allocation, not the scan.

## Scope

One function body. No interface change, no new state, no new lifetime rules. `readRange` has no caller outside the targeted scan, and the existing tests cover it in both access modes, including the capacity-clamp assertions and the corruption guards.
