### PR TITLE
fix(cache): count occupied slots, and add PreloadIfAbsent

### DIFF
--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -36,6 +36,7 @@ type Cache[T any] interface {
 	CountVectors() int64
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vec []T)
+	PreloadIfAbsent(id uint64, vec []T) bool
 	PreloadNoLock(id uint64, vec []T)
 	SetSizeAndGrowNoLock(id uint64)
 	Prefetch(id uint64)

--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -48,10 +48,9 @@ type Cache[T any] interface {
 	UnlockAll()
 }
 
-// IfAbsentPreloader fills empty cache slots without clobbering a vector written
+// IfAbsentPreloader fills an empty cache slot without clobbering a vector written
 // concurrently. Only the single-vector caches implement it: a multivector slot is
-// addressed by (docID, relativeID), for which a single-id write has no meaning.
-// Callers holding a Cache[T] must type-assert.
+// addressed by (docID, relativeID), which has no single-id write.
 type IfAbsentPreloader[T any] interface {
 	PreloadIfAbsent(id uint64, vec []T) bool
 }

--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -36,7 +36,6 @@ type Cache[T any] interface {
 	CountVectors() int64
 	Delete(ctx context.Context, id uint64)
 	Preload(id uint64, vec []T)
-	PreloadIfAbsent(id uint64, vec []T) bool
 	PreloadNoLock(id uint64, vec []T)
 	SetSizeAndGrowNoLock(id uint64)
 	Prefetch(id uint64)
@@ -47,4 +46,12 @@ type Cache[T any] interface {
 	All() [][]T
 	LockAll()
 	UnlockAll()
+}
+
+// IfAbsentPreloader fills empty cache slots without clobbering a vector written
+// concurrently. Only the single-vector caches implement it: a multivector slot is
+// addressed by (docID, relativeID), for which a single-id write has no meaning.
+// Callers holding a Cache[T] must type-assert.
+type IfAbsentPreloader[T any] interface {
+	PreloadIfAbsent(id uint64, vec []T) bool
 }

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -171,10 +171,9 @@ func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int,
 	return vc
 }
 
-// emptyToNil collapses an empty vector to nil so that a slot is either nil or
-// holds a usable vector. Both spellings of the occupancy test in this file
-// (`== nil` and `len() == 0`) then agree on which slots are filled, and count —
-// which is derived from the same test — cannot drift from real occupancy.
+// emptyToNil collapses an empty vector to nil, so a slot is either nil or holds a
+// usable vector and the two spellings of the occupancy test in this file
+// (`== nil`, `len() == 0`) cannot disagree.
 func emptyToNil[T any](vec []T) []T {
 	if len(vec) == 0 {
 		return nil
@@ -182,8 +181,8 @@ func emptyToNil[T any](vec []T) []T {
 	return vec
 }
 
-// occupancyDelta returns how the occupied-slot count changes when oldVec is
-// replaced by newVec. Both must already have passed through emptyToNil.
+// occupancyDelta returns the change in occupied slots when oldVec is replaced by
+// newVec. Both must have passed through emptyToNil.
 func occupancyDelta[T any](oldVec, newVec []T) int64 {
 	switch {
 	case oldVec == nil && newVec != nil:
@@ -227,10 +226,9 @@ func (s *shardedLockCache[T]) Delete(ctx context.Context, id uint64) {
 	s.storeLocked(id, nil)
 }
 
-// storeLocked puts vec in slot id and keeps count in step with the number of
-// occupied slots: count feeds replaceIfFull, which wipes the whole cache once it
-// believes the cache is full, so every write must account for both the slot's old
-// and new state. Caller holds the stripe lock for id (LockAll also suffices).
+// storeLocked writes slot id and moves count with it. count feeds replaceIfFull,
+// which wipes the whole cache once it reaches maxSize, so a write that leaves
+// occupancy unchanged must not move it. Caller holds the stripe lock for id.
 func (s *shardedLockCache[T]) storeLocked(id uint64, vec []T) {
 	vec = emptyToNil(vec)
 	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {
@@ -379,15 +377,13 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 // newer vector written concurrently. Reports whether it stored the vector.
 func (s *shardedLockCache[T]) PreloadIfAbsent(id uint64, vec []T) bool {
 	if len(vec) == 0 {
-		// an if-absent write must never empty a slot, and there is nothing to
-		// count either, so refuse rather than grow the cache to cover id
+		// nothing to store, and refusing here avoids growing the cache to cover id
 		return false
 	}
 	return s.preload(id, vec, true)
 }
 
-// preload stores vec in slot id, growing the cache to cover id first if needed.
-// With ifAbsent an occupied slot is left untouched. Reports whether it stored.
+// preload stores vec in slot id, growing the cache to cover id if needed.
 func (s *shardedLockCache[T]) preload(id uint64, vec []T, ifAbsent bool) bool {
 	for {
 		s.shardedLocks.Lock(id)
@@ -413,13 +409,10 @@ func (s *shardedLockCache[T]) preload(id uint64, vec []T, ifAbsent bool) bool {
 	}
 }
 
-// PreloadNoLock stores without taking a stripe lock; the caller holds LockAll.
 func (s *shardedLockCache[T]) PreloadNoLock(id uint64, vec []T) {
 	s.storeLocked(id, vec)
 }
 
-// SetSizeAndGrowNoLock grows the cache to cover size; the caller holds LockAll.
-// It does not touch count — PreloadNoLock counts the slots it actually fills.
 func (s *shardedLockCache[T]) SetSizeAndGrowNoLock(size uint64) {
 	if size < uint64(len(s.cache)) {
 		return
@@ -772,10 +765,7 @@ func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
 	s.vectorDocID[id] = CacheKeys{}
 }
 
-// storeLocked puts vec in slot id and keeps count in step with the number of
-// occupied slots: count feeds replaceIfFull, which wipes the whole cache once it
-// believes the cache is full, so every write must account for both the slot's old
-// and new state. Caller holds the stripe lock for id.
+// storeLocked writes slot id and moves count with it; see shardedLockCache.storeLocked.
 func (s *shardedMultipleLockCache[T]) storeLocked(id uint64, vec []T) {
 	vec = emptyToNil(vec)
 	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {
@@ -849,8 +839,7 @@ func (s *shardedMultipleLockCache[T]) PreloadMulti(docID uint64, ids []uint64, v
 	for i, id := range ids {
 		s.shardedLocks.Lock(id)
 		s.storeLocked(id, vecs[i])
-		// the keys are recorded even for an empty vec: they are what a later miss
-		// on this id needs to fetch it
+		// keys are recorded even for an empty vec: a later miss needs them to fetch
 		s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: uint64(i)}
 		s.shardedLocks.Unlock(id)
 	}

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -171,9 +171,8 @@ func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int,
 	return vc
 }
 
-// emptyToNil collapses an empty vector to nil, so a slot is either nil or holds a
-// usable vector and the two spellings of the occupancy test in this file
-// (`== nil`, `len() == 0`) cannot disagree.
+// emptyToNil collapses an empty vector to nil, so the two spellings of the occupancy
+// test in this file (`== nil`, `len() == 0`) cannot disagree about a slot.
 func emptyToNil[T any](vec []T) []T {
 	if len(vec) == 0 {
 		return nil
@@ -181,8 +180,7 @@ func emptyToNil[T any](vec []T) []T {
 	return vec
 }
 
-// occupancyDelta returns the change in occupied slots when oldVec is replaced by
-// newVec. Both must have passed through emptyToNil.
+// occupancyDelta requires both vectors to have passed through emptyToNil.
 func occupancyDelta[T any](oldVec, newVec []T) int64 {
 	switch {
 	case oldVec == nil && newVec != nil:
@@ -226,9 +224,8 @@ func (s *shardedLockCache[T]) Delete(ctx context.Context, id uint64) {
 	s.storeLocked(id, nil)
 }
 
-// storeLocked writes slot id and moves count with it. count feeds replaceIfFull,
-// which wipes the whole cache once it reaches maxSize, so a write that leaves
-// occupancy unchanged must not move it. Caller holds the stripe lock for id.
+// storeLocked writes slot id, moving count only when occupancy changes: count reaching
+// maxSize makes replaceIfFull wipe the whole cache. Caller holds id's stripe lock.
 func (s *shardedLockCache[T]) storeLocked(id uint64, vec []T) {
 	vec = emptyToNil(vec)
 	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {
@@ -383,7 +380,6 @@ func (s *shardedLockCache[T]) PreloadIfAbsent(id uint64, vec []T) bool {
 	return s.preload(id, vec, true)
 }
 
-// preload stores vec in slot id, growing the cache to cover id if needed.
 func (s *shardedLockCache[T]) preload(id uint64, vec []T, ifAbsent bool) bool {
 	for {
 		s.shardedLocks.Lock(id)
@@ -765,7 +761,7 @@ func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
 	s.vectorDocID[id] = CacheKeys{}
 }
 
-// storeLocked writes slot id and moves count with it; see shardedLockCache.storeLocked.
+// storeLocked: see shardedLockCache.storeLocked.
 func (s *shardedMultipleLockCache[T]) storeLocked(id uint64, vec []T) {
 	vec = emptyToNil(vec)
 	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -47,6 +47,12 @@ type shardedLockCache[T float32 | byte | uint64] struct {
 	maintenanceLock sync.RWMutex
 }
 
+var (
+	_ IfAbsentPreloader[float32] = (*shardedLockCache[float32])(nil)
+	_ IfAbsentPreloader[byte]    = (*shardedLockCache[byte])(nil)
+	_ IfAbsentPreloader[uint64]  = (*shardedLockCache[uint64])(nil)
+)
+
 const (
 	InitialSize                = 1000
 	RelativeInitialSize        = 100
@@ -165,6 +171,30 @@ func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int,
 	return vc
 }
 
+// emptyToNil collapses an empty vector to nil so that a slot is either nil or
+// holds a usable vector. Both spellings of the occupancy test in this file
+// (`== nil` and `len() == 0`) then agree on which slots are filled, and count —
+// which is derived from the same test — cannot drift from real occupancy.
+func emptyToNil[T any](vec []T) []T {
+	if len(vec) == 0 {
+		return nil
+	}
+	return vec
+}
+
+// occupancyDelta returns how the occupied-slot count changes when oldVec is
+// replaced by newVec. Both must already have passed through emptyToNil.
+func occupancyDelta[T any](oldVec, newVec []T) int64 {
+	switch {
+	case oldVec == nil && newVec != nil:
+		return 1
+	case oldVec != nil && newVec == nil:
+		return -1
+	default:
+		return 0
+	}
+}
+
 func (s *shardedLockCache[T]) All() [][]T {
 	return s.cache
 }
@@ -194,8 +224,19 @@ func (s *shardedLockCache[T]) Delete(ctx context.Context, id uint64) {
 		return
 	}
 
-	s.cache[id] = nil
-	atomic.AddInt64(&s.count, -1)
+	s.storeLocked(id, nil)
+}
+
+// storeLocked puts vec in slot id and keeps count in step with the number of
+// occupied slots: count feeds replaceIfFull, which wipes the whole cache once it
+// believes the cache is full, so every write must account for both the slot's old
+// and new state. Caller holds the stripe lock for id (LockAll also suffices).
+func (s *shardedLockCache[T]) storeLocked(id uint64, vec []T) {
+	vec = emptyToNil(vec)
+	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {
+		atomic.AddInt64(&s.count, delta)
+	}
+	s.cache[id] = vec
 }
 
 func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([]T, error) {
@@ -213,7 +254,8 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 				"action": "vector_cache_miss",
 				"event":  "vector_load_skipped_oom",
 				"doc_id": id,
-			}).Warnf("cannot load vector into cache due to memory pressure: %v", err)
+			}).WithError(err).
+				Warnf("cannot load vector into cache due to memory pressure")
 			return nil, err
 		}
 	}
@@ -223,12 +265,9 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 		return nil, err
 	}
 
-	if vec != nil {
+	if len(vec) != 0 {
 		s.shardedLocks.Lock(id)
-		if s.cache[id] == nil {
-			atomic.AddInt64(&s.count, 1)
-		}
-		s.cache[id] = vec
+		s.storeLocked(id, vec)
 		s.shardedLocks.Unlock(id)
 	}
 
@@ -333,6 +372,23 @@ func (s *shardedLockCache[T]) Prefetch(id uint64) {
 }
 
 func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
+	s.preload(id, vec, false)
+}
+
+// PreloadIfAbsent writes vec only when the slot is empty, so it cannot clobber a
+// newer vector written concurrently. Reports whether it stored the vector.
+func (s *shardedLockCache[T]) PreloadIfAbsent(id uint64, vec []T) bool {
+	if len(vec) == 0 {
+		// an if-absent write must never empty a slot, and there is nothing to
+		// count either, so refuse rather than grow the cache to cover id
+		return false
+	}
+	return s.preload(id, vec, true)
+}
+
+// preload stores vec in slot id, growing the cache to cover id first if needed.
+// With ifAbsent an occupied slot is left untouched. Reports whether it stored.
+func (s *shardedLockCache[T]) preload(id uint64, vec []T, ifAbsent bool) bool {
 	for {
 		s.shardedLocks.Lock(id)
 		// reading len(s.cache) under a stripe lock is safe: the slice is
@@ -340,14 +396,13 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 		// it here keeps the common case as cheap as before the cache became
 		// lazy: one stripe lock, no maintenanceLock traffic.
 		if int(id) < len(s.cache) {
-			// count tracks occupied slots, not calls; replaceIfFull wipes the
-			// cache when count reaches maxSize, so overwrites must not inflate it.
-			if s.cache[id] == nil {
-				atomic.AddInt64(&s.count, 1)
+			if ifAbsent && s.cache[id] != nil {
+				s.shardedLocks.Unlock(id)
+				return false
 			}
-			s.cache[id] = vec
+			s.storeLocked(id, vec)
 			s.shardedLocks.Unlock(id)
-			return
+			return true
 		}
 		s.shardedLocks.Unlock(id)
 
@@ -358,34 +413,14 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 	}
 }
 
-// PreloadIfAbsent writes vec only when the slot is empty, so it cannot clobber a
-// newer vector written concurrently. Reports whether it stored the vector.
-func (s *shardedLockCache[T]) PreloadIfAbsent(id uint64, vec []T) bool {
-	for {
-		s.shardedLocks.Lock(id)
-		if int(id) < len(s.cache) {
-			if s.cache[id] != nil {
-				s.shardedLocks.Unlock(id)
-				return false
-			}
-			atomic.AddInt64(&s.count, 1)
-			s.cache[id] = vec
-			s.shardedLocks.Unlock(id)
-			return true
-		}
-		s.shardedLocks.Unlock(id)
-
-		s.Grow(id)
-	}
-}
-
+// PreloadNoLock stores without taking a stripe lock; the caller holds LockAll.
 func (s *shardedLockCache[T]) PreloadNoLock(id uint64, vec []T) {
-	s.cache[id] = vec
+	s.storeLocked(id, vec)
 }
 
+// SetSizeAndGrowNoLock grows the cache to cover size; the caller holds LockAll.
+// It does not touch count — PreloadNoLock counts the slots it actually fills.
 func (s *shardedLockCache[T]) SetSizeAndGrowNoLock(size uint64) {
-	atomic.StoreInt64(&s.count, int64(size))
-
 	if size < uint64(len(s.cache)) {
 		return
 	}
@@ -733,9 +768,20 @@ func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
 		return
 	}
 
-	s.cache[id] = nil
+	s.storeLocked(id, nil)
 	s.vectorDocID[id] = CacheKeys{}
-	atomic.AddInt64(&s.count, -1)
+}
+
+// storeLocked puts vec in slot id and keeps count in step with the number of
+// occupied slots: count feeds replaceIfFull, which wipes the whole cache once it
+// believes the cache is full, so every write must account for both the slot's old
+// and new state. Caller holds the stripe lock for id.
+func (s *shardedMultipleLockCache[T]) storeLocked(id uint64, vec []T) {
+	vec = emptyToNil(vec)
+	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {
+		atomic.AddInt64(&s.count, delta)
+	}
+	s.cache[id] = vec
 }
 
 func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Context, id uint64, docID uint64, relativeID uint64) ([]T, error) {
@@ -754,7 +800,8 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 				"event":  "vector_load_skipped_oom",
 				"doc_id": docID,
 				"vec_id": relativeID,
-			}).Warnf("cannot load vector into cache due to memory pressure: %v", err)
+			}).WithError(err).
+				Warnf("cannot load vector into cache due to memory pressure")
 			return nil, err
 		}
 	}
@@ -776,13 +823,7 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 
 	if len(vec) != 0 {
 		s.shardedLocks.Lock(id)
-		// count tracks occupied slots, not calls: concurrent misses on the same id
-		// would otherwise drift it above real occupancy until replaceIfFull wipes
-		// the whole cache
-		if s.cache[id] == nil {
-			atomic.AddInt64(&s.count, 1)
-		}
-		s.cache[id] = vec
+		s.storeLocked(id, vec)
 		s.shardedLocks.Unlock(id)
 	}
 
@@ -807,10 +848,9 @@ func (s *shardedMultipleLockCache[T]) Prefetch(id uint64) {
 func (s *shardedMultipleLockCache[T]) PreloadMulti(docID uint64, ids []uint64, vecs [][]T) {
 	for i, id := range ids {
 		s.shardedLocks.Lock(id)
-		if s.cache[id] == nil {
-			atomic.AddInt64(&s.count, 1)
-		}
-		s.cache[id] = vecs[i]
+		s.storeLocked(id, vecs[i])
+		// the keys are recorded even for an empty vec: they are what a later miss
+		// on this id needs to fetch it
 		s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: uint64(i)}
 		s.shardedLocks.Unlock(id)
 	}
@@ -820,18 +860,11 @@ func (s *shardedMultipleLockCache[T]) PreloadPassage(id uint64, docID uint64, re
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
-	if s.cache[id] == nil {
-		atomic.AddInt64(&s.count, 1)
-	}
-	s.cache[id] = vec
+	s.storeLocked(id, vec)
 	s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: relativeID}
 }
 
 func (s *shardedMultipleLockCache[T]) Preload(docID uint64, vec []T) {
-	panic("not implemented")
-}
-
-func (s *shardedMultipleLockCache[T]) PreloadIfAbsent(docID uint64, vec []T) bool {
 	panic("not implemented")
 }
 

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -213,8 +213,7 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 				"action": "vector_cache_miss",
 				"event":  "vector_load_skipped_oom",
 				"doc_id": id,
-			}).WithError(err).
-				Warnf("cannot load vector into cache due to memory pressure")
+			}).Warnf("cannot load vector into cache due to memory pressure: %v", err)
 			return nil, err
 		}
 	}
@@ -224,10 +223,11 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 		return nil, err
 	}
 
-	atomic.AddInt64(&s.count, 1)
-
 	if vec != nil {
 		s.shardedLocks.Lock(id)
+		if s.cache[id] == nil {
+			atomic.AddInt64(&s.count, 1)
+		}
 		s.cache[id] = vec
 		s.shardedLocks.Unlock(id)
 	}
@@ -340,8 +340,12 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 		// it here keeps the common case as cheap as before the cache became
 		// lazy: one stripe lock, no maintenanceLock traffic.
 		if int(id) < len(s.cache) {
+			// count tracks occupied slots, not calls; replaceIfFull wipes the
+			// cache when count reaches maxSize, so overwrites must not inflate it.
+			if s.cache[id] == nil {
+				atomic.AddInt64(&s.count, 1)
+			}
 			s.cache[id] = vec
-			atomic.AddInt64(&s.count, 1)
 			s.shardedLocks.Unlock(id)
 			return
 		}
@@ -350,6 +354,27 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 		// slow path: the cache doesn't cover id yet — preloaders (e.g. the
 		// HNSW insert path) don't grow the cache themselves. Grow guarantees
 		// coverage of id, so the next iteration stores.
+		s.Grow(id)
+	}
+}
+
+// PreloadIfAbsent writes vec only when the slot is empty, so it cannot clobber a
+// newer vector written concurrently. Reports whether it stored the vector.
+func (s *shardedLockCache[T]) PreloadIfAbsent(id uint64, vec []T) bool {
+	for {
+		s.shardedLocks.Lock(id)
+		if int(id) < len(s.cache) {
+			if s.cache[id] != nil {
+				s.shardedLocks.Unlock(id)
+				return false
+			}
+			atomic.AddInt64(&s.count, 1)
+			s.cache[id] = vec
+			s.shardedLocks.Unlock(id)
+			return true
+		}
+		s.shardedLocks.Unlock(id)
+
 		s.Grow(id)
 	}
 }
@@ -729,8 +754,7 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 				"event":  "vector_load_skipped_oom",
 				"doc_id": docID,
 				"vec_id": relativeID,
-			}).WithError(err).
-				Warnf("cannot load vector into cache due to memory pressure")
+			}).Warnf("cannot load vector into cache due to memory pressure: %v", err)
 			return nil, err
 		}
 	}
@@ -750,9 +774,14 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 		return nil, err
 	}
 
-	atomic.AddInt64(&s.count, 1)
 	if len(vec) != 0 {
 		s.shardedLocks.Lock(id)
+		// count tracks occupied slots, not calls: concurrent misses on the same id
+		// would otherwise drift it above real occupancy until replaceIfFull wipes
+		// the whole cache
+		if s.cache[id] == nil {
+			atomic.AddInt64(&s.count, 1)
+		}
 		s.cache[id] = vec
 		s.shardedLocks.Unlock(id)
 	}
@@ -776,9 +805,11 @@ func (s *shardedMultipleLockCache[T]) Prefetch(id uint64) {
 }
 
 func (s *shardedMultipleLockCache[T]) PreloadMulti(docID uint64, ids []uint64, vecs [][]T) {
-	atomic.AddInt64(&s.count, int64(len(ids)))
 	for i, id := range ids {
 		s.shardedLocks.Lock(id)
+		if s.cache[id] == nil {
+			atomic.AddInt64(&s.count, 1)
+		}
 		s.cache[id] = vecs[i]
 		s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: uint64(i)}
 		s.shardedLocks.Unlock(id)
@@ -789,12 +820,18 @@ func (s *shardedMultipleLockCache[T]) PreloadPassage(id uint64, docID uint64, re
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
+	if s.cache[id] == nil {
+		atomic.AddInt64(&s.count, 1)
+	}
 	s.cache[id] = vec
 	s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: relativeID}
-	atomic.AddInt64(&s.count, int64(1))
 }
 
 func (s *shardedMultipleLockCache[T]) Preload(docID uint64, vec []T) {
+	panic("not implemented")
+}
+
+func (s *shardedMultipleLockCache[T]) PreloadIfAbsent(docID uint64, vec []T) bool {
 	panic("not implemented")
 }
 

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -461,9 +461,7 @@ func countingFetcher[T float32 | byte | uint64]() (common.VectorForID[T], *int64
 	}, &calls
 }
 
-// failingFetcher fails the test if the cache falls back to a fetch. The preload
-// tests all expect the slots they wrote to still be filled, so a miss there is the
-// symptom of a store or counting regression rather than a valid path.
+// failingFetcher fails the test if the cache falls back to a fetch.
 func failingFetcher[T float32 | byte | uint64](t *testing.T) common.VectorForID[T] {
 	return func(_ context.Context, id uint64) ([]T, error) {
 		t.Errorf("unexpected cache miss for id %d", id)
@@ -471,8 +469,7 @@ func failingFetcher[T float32 | byte | uint64](t *testing.T) common.VectorForID[
 	}
 }
 
-// slotOf reads the raw backing slot, so a test can tell an empty slot from one
-// that Get would silently refill.
+// slotOf reads the raw backing slot, telling an empty slot from one Get would refill.
 func slotOf[T float32 | byte | uint64](t *testing.T, c Cache[T], id uint64) []T {
 	t.Helper()
 	s, ok := c.(*shardedLockCache[T])
@@ -480,8 +477,7 @@ func slotOf[T float32 | byte | uint64](t *testing.T, c Cache[T], id uint64) []T 
 	return s.cache[id]
 }
 
-// ifAbsentPreloader exposes PreloadIfAbsent, which lives on a narrower interface
-// than Cache[T] because the multivector cache cannot implement it.
+// ifAbsentPreloader exposes PreloadIfAbsent, which is not on Cache[T].
 func ifAbsentPreloader[T float32 | byte | uint64](t *testing.T, c Cache[T]) IfAbsentPreloader[T] {
 	t.Helper()
 	p, ok := c.(IfAbsentPreloader[T])
@@ -793,9 +789,8 @@ func TestShardedLockCache_PageSizeOnFreshCache(t *testing.T) {
 	assert.EqualValues(t, 1, c.PageSize(), "PageSize must work before the locks are allocated")
 }
 
-// TestPreloadCountsOccupiedSlotsOnly: count feeds replaceIfFull's full-cache wipe,
-// so it must equal the number of slots that actually hold a vector — across every
-// transition a write can make, in both directions.
+// count feeds replaceIfFull's full-cache wipe, so it must equal the number of slots
+// that hold a vector — across every transition a write can make, in both directions.
 func TestPreloadCountsOccupiedSlotsOnly(t *testing.T) {
 	const id = 5
 
@@ -910,10 +905,8 @@ func TestPreloadCountsOccupiedSlotsOnly(t *testing.T) {
 	}
 }
 
-// TestMultiVectorCacheCountInvariant: this cache calls a slot occupied when it
-// holds a non-empty vector — Get and Delete both test len() — so count must move
-// on exactly that transition, or replaceIfFull's full-cache wipe fires while the
-// cache isn't actually full.
+// This cache calls a slot occupied when it holds a non-empty vector — Get and Delete
+// both test len() — so count must move on exactly that transition.
 func TestMultiVectorCacheCountInvariant(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
@@ -956,8 +949,7 @@ func TestMultiVectorCacheCountInvariant(t *testing.T) {
 		c.PreloadPassage(1, 7, 0, []uint64{})
 		assert.Equal(t, int64(0), c.CountVectors(), "an empty vec leaves the slot unoccupied")
 
-		// Delete tests len(), so a slot counted while empty could never be
-		// reclaimed and the inflation would be permanent
+		// Delete tests len(), so a slot counted while empty could never be reclaimed
 		c.Delete(context.Background(), 1)
 		assert.Equal(t, int64(0), c.CountVectors())
 	})
@@ -997,9 +989,8 @@ func TestMultiVectorCacheCountInvariant(t *testing.T) {
 	})
 }
 
-// TestConcurrentMissSameID_NoDoubleCount hammers a single uncached id from many
-// goroutines that all overlap inside the fetch thunk, so every one of them observes
-// the slot as empty before any of them stores. Only one store may count.
+// Hammers a single uncached id from many goroutines that all overlap inside the
+// fetch thunk, so every one of them observes the slot as empty before any stores.
 func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 	const goroutines = 50
 
@@ -1022,8 +1013,6 @@ func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				vec, err := c.Get(context.Background(), 42)
-				// assert, not require: FailNow off the test goroutine reports
-				// without the test's stack and skips the rest of this worker
 				assert.NoError(t, err)
 				assert.Equal(t, []float32{42}, vec)
 			}()
@@ -1057,8 +1046,6 @@ func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				vec, err := c.Get(context.Background(), 42)
-				// assert, not require: FailNow off the test goroutine reports
-				// without the test's stack and skips the rest of this worker
 				assert.NoError(t, err)
 				assert.Equal(t, []uint64{42}, vec)
 			}()
@@ -1074,9 +1061,8 @@ func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 	})
 }
 
-// TestPreloadIfAbsent_ContentionWithPreload: PreloadIfAbsent can only win on an
-// empty slot, so once at least one Preload has run for an id, the final stored
-// value can never be a PreloadIfAbsent value, no matter how the two race.
+// PreloadIfAbsent can only win on an empty slot, so once at least one Preload has
+// run for an id, the final stored value can never be a PreloadIfAbsent value.
 func TestPreloadIfAbsent_ContentionWithPreload(t *testing.T) {
 	c := newLazyTestCache(t, failingFetcher[float32](t))
 	p := ifAbsentPreloader(t, c)
@@ -1113,13 +1099,12 @@ func TestPreloadIfAbsent_ContentionWithPreload(t *testing.T) {
 	}
 }
 
-// TestPreloadIfAbsent_GrowRetry covers PreloadIfAbsent's Grow-retry loop: id beyond
-// the current cache length -> unlock -> Grow -> retry.
+// Covers the Grow-retry loop: id beyond the cache length -> unlock -> Grow -> retry.
 func TestPreloadIfAbsent_GrowRetry(t *testing.T) {
 	c := newLazyTestCache(t, failingFetcher[float32](t))
 	p := ifAbsentPreloader(t, c)
 
-	c.Grow(10) // establish a small baseline cache, well short of id below
+	c.Grow(10)
 	require.Less(t, int(c.Len()), 50_000)
 
 	id := uint64(50_000)
@@ -1133,9 +1118,8 @@ func TestPreloadIfAbsent_GrowRetry(t *testing.T) {
 	assert.Equal(t, int64(1), c.CountVectors())
 }
 
-// TestPreloadIfAbsent_GrowRetryConcurrent hunts for a lost update or livelock in the
-// retry loop by forcing many goroutines through concurrent Grow calls for distinct
-// out-of-bounds ids at once.
+// Hunts for a lost update or livelock in the retry loop by forcing many goroutines
+// through concurrent Grow calls for distinct out-of-bounds ids at once.
 func TestPreloadIfAbsent_GrowRetryConcurrent(t *testing.T) {
 	c := newLazyTestCache(t, failingFetcher[float32](t))
 	p := ifAbsentPreloader(t, c)

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -764,3 +764,256 @@ func TestShardedLockCache_PageSizeOnFreshCache(t *testing.T) {
 	c := newLazyTestCache[uint64](t, fetch)
 	assert.EqualValues(t, 1, c.PageSize(), "PageSize must work before the locks are allocated")
 }
+
+// TestPreloadCountsOccupiedSlotsOnly: count feeds replaceIfFull's full-cache wipe,
+// so overwrites and if-absent no-ops must not inflate it past true occupancy — and
+// PreloadIfAbsent must never replace a present vector.
+func TestPreloadCountsOccupiedSlotsOnly(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(10)
+
+	c.Preload(5, []float32{9, 9})
+	c.Preload(5, []float32{1, 2}) // overwrite: no recount
+	assert.Equal(t, int64(1), c.CountVectors())
+
+	assert.False(t, c.PreloadIfAbsent(5, []float32{9, 9}))
+	assert.True(t, c.PreloadIfAbsent(6, []float32{3, 4}))
+	assert.Equal(t, int64(2), c.CountVectors())
+
+	got, err := c.Get(context.Background(), 5)
+	assert.NoError(t, err)
+	assert.Equal(t, []float32{1, 2}, got, "PreloadIfAbsent must not overwrite")
+
+	got, err = c.Get(context.Background(), 6)
+	assert.NoError(t, err)
+	assert.Equal(t, []float32{3, 4}, got)
+}
+
+// TestMultiVectorCacheCountInvariant regresses the shardedMultipleLockCache count
+// fix: count must track occupied slots, not calls, or replaceIfFull's full-cache
+// wipe fires while the cache isn't actually full.
+func TestMultiVectorCacheCountInvariant(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("repeated PreloadPassage on same id stays at 1", func(t *testing.T) {
+		c := NewShardedMultiUInt64LockCache(nil, 1_000_000, logger, 0, nil)
+
+		for i := 0; i < 5; i++ {
+			c.PreloadPassage(3, 7, 0, []uint64{uint64(i)})
+		}
+		assert.Equal(t, int64(1), c.CountVectors())
+
+		vec, err := c.Get(context.Background(), 3)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{4}, vec, "last PreloadPassage call wins")
+	})
+
+	t.Run("PreloadMulti with overlapping ids counts distinct slots only", func(t *testing.T) {
+		c := NewShardedMultiUInt64LockCache(nil, 1_000_000, logger, 0, nil)
+
+		c.PreloadMulti(100, []uint64{1, 2, 3}, [][]uint64{{10}, {20}, {30}})
+		c.PreloadMulti(101, []uint64{3, 4, 5}, [][]uint64{{31}, {40}, {50}})
+
+		// distinct ids touched: 1, 2, 3, 4, 5
+		assert.Equal(t, int64(5), c.CountVectors())
+	})
+
+	t.Run("miss with empty fetch result does not increment count", func(t *testing.T) {
+		emptyFetch := func(context.Context, uint64) ([]uint64, error) { return []uint64{}, nil }
+		c := NewShardedMultiUInt64LockCache(emptyFetch, 1_000_000, logger, 0, nil)
+
+		vec, err := c.Get(context.Background(), 9)
+		require.NoError(t, err)
+		assert.Empty(t, vec)
+		assert.Equal(t, int64(0), c.CountVectors())
+	})
+
+	t.Run("same id missed twice via handleMultipleCacheMiss counts once", func(t *testing.T) {
+		// simulates two goroutines that both concluded a cache miss for the same id
+		// and are now racing to store: only the first store may count.
+		fetch, _ := countingFetcher[uint64]()
+		vectorCache := NewShardedMultiUInt64LockCache(fetch, 1_000_000, logger, 0, nil)
+		c, ok := vectorCache.(*shardedMultipleLockCache[uint64])
+		require.True(t, ok)
+
+		vec1, err := c.handleMultipleCacheMiss(context.Background(), 42, 42, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, vec1)
+
+		vec2, err := c.handleMultipleCacheMiss(context.Background(), 42, 42, 0)
+		require.NoError(t, err)
+		require.NotEmpty(t, vec2)
+
+		assert.Equal(t, int64(1), c.CountVectors())
+	})
+}
+
+// TestConcurrentMissSameID_NoDoubleCount hammers a single uncached id from many
+// goroutines that all overlap inside the fetch thunk, so every one of them observes
+// the slot as empty before any of them stores. Only one store may count.
+func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
+	const goroutines = 50
+
+	t.Run("single-vector cache", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		ready := make(chan struct{}, goroutines)
+		release := make(chan struct{})
+
+		fetch := func(ctx context.Context, id uint64) ([]float32, error) {
+			ready <- struct{}{}
+			<-release
+			return []float32{float32(id)}, nil
+		}
+
+		c := NewShardedFloat32LockCache(fetch, nil, 1_000_000, 1, logger, false, 0, nil)
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				vec, err := c.Get(context.Background(), 42)
+				require.NoError(t, err)
+				assert.Equal(t, []float32{42}, vec)
+			}()
+		}
+
+		for i := 0; i < goroutines; i++ {
+			<-ready
+		}
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), c.CountVectors())
+	})
+
+	t.Run("multivector cache", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		ready := make(chan struct{}, goroutines)
+		release := make(chan struct{})
+
+		fetch := func(ctx context.Context, id uint64) ([]uint64, error) {
+			ready <- struct{}{}
+			<-release
+			return []uint64{id}, nil
+		}
+
+		c := NewShardedMultiUInt64LockCache(fetch, 1_000_000, logger, 0, nil)
+
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				vec, err := c.Get(context.Background(), 42)
+				require.NoError(t, err)
+				assert.Equal(t, []uint64{42}, vec)
+			}()
+		}
+
+		for i := 0; i < goroutines; i++ {
+			<-ready
+		}
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), c.CountVectors())
+	})
+}
+
+// TestPreloadIfAbsent_ContentionWithPreload pins the invariant the async prefill's
+// safety argument rests on: PreloadIfAbsent can only win on an empty slot, so once at
+// least one Preload has run for an id, the final stored value can never be a
+// PreloadIfAbsent value, no matter how the two race.
+func TestPreloadIfAbsent_ContentionWithPreload(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+
+	const (
+		numIDs       = 200
+		workersPerID = 8
+	)
+
+	var wg sync.WaitGroup
+	for id := uint64(0); id < numIDs; id++ {
+		for w := 0; w < workersPerID; w++ {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				c.Preload(id, []float32{1, float32(id)})
+			}()
+			go func() {
+				defer wg.Done()
+				c.PreloadIfAbsent(id, []float32{2, float32(id)})
+			}()
+		}
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(numIDs), c.CountVectors(), "count must equal exactly the number of distinct ids touched")
+
+	for id := uint64(0); id < numIDs; id++ {
+		vec, err := c.Get(context.Background(), id)
+		require.NoError(t, err)
+		require.Len(t, vec, 2)
+		assert.Equal(t, float32(1), vec[0], "id %d: a Preload ran for it, so the final value must be a Preload value", id)
+		assert.Equal(t, float32(id), vec[1])
+	}
+}
+
+// TestPreloadIfAbsent_GrowRetry covers PreloadIfAbsent's Grow-retry loop (id beyond
+// the current cache length -> unlock -> Grow -> retry), which no production caller
+// reaches: prefillFromScan skips any id beyond the pre-grown node count instead of
+// growing the cache from a scan.
+func TestPreloadIfAbsent_GrowRetry(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+
+	c.Grow(10) // establish a small baseline cache, well short of id below
+	require.Less(t, int(c.Len()), 50_000)
+
+	id := uint64(50_000)
+	ok := c.PreloadIfAbsent(id, []float32{7, 8})
+	assert.True(t, ok)
+	assert.Greater(t, c.Len(), int32(id), "PreloadIfAbsent must grow the cache to cover id")
+
+	vec, err := c.Get(context.Background(), id)
+	require.NoError(t, err)
+	assert.Equal(t, []float32{7, 8}, vec)
+	assert.Equal(t, int64(1), c.CountVectors())
+}
+
+// TestPreloadIfAbsent_GrowRetryConcurrent hunts for a lost update or livelock in the
+// retry loop by forcing many goroutines through concurrent Grow calls for distinct
+// out-of-bounds ids at once.
+func TestPreloadIfAbsent_GrowRetryConcurrent(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(10)
+
+	const (
+		goroutines = 200
+		baseID     = uint64(20_000)
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			defer wg.Done()
+			id := baseID + uint64(i)
+			ok := c.PreloadIfAbsent(id, []float32{float32(id)})
+			assert.True(t, ok)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int64(goroutines), c.CountVectors())
+	for i := 0; i < goroutines; i++ {
+		id := baseID + uint64(i)
+		vec, err := c.Get(context.Background(), id)
+		require.NoError(t, err)
+		assert.Equal(t, []float32{float32(id)}, vec)
+	}
+}

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -461,6 +461,34 @@ func countingFetcher[T float32 | byte | uint64]() (common.VectorForID[T], *int64
 	}, &calls
 }
 
+// failingFetcher fails the test if the cache falls back to a fetch. The preload
+// tests all expect the slots they wrote to still be filled, so a miss there is the
+// symptom of a store or counting regression rather than a valid path.
+func failingFetcher[T float32 | byte | uint64](t *testing.T) common.VectorForID[T] {
+	return func(_ context.Context, id uint64) ([]T, error) {
+		t.Errorf("unexpected cache miss for id %d", id)
+		return nil, errors.New("unexpected cache miss")
+	}
+}
+
+// slotOf reads the raw backing slot, so a test can tell an empty slot from one
+// that Get would silently refill.
+func slotOf[T float32 | byte | uint64](t *testing.T, c Cache[T], id uint64) []T {
+	t.Helper()
+	s, ok := c.(*shardedLockCache[T])
+	require.True(t, ok, "expected *shardedLockCache")
+	return s.cache[id]
+}
+
+// ifAbsentPreloader exposes PreloadIfAbsent, which lives on a narrower interface
+// than Cache[T] because the multivector cache cannot implement it.
+func ifAbsentPreloader[T float32 | byte | uint64](t *testing.T, c Cache[T]) IfAbsentPreloader[T] {
+	t.Helper()
+	p, ok := c.(IfAbsentPreloader[T])
+	require.True(t, ok, "expected an IfAbsentPreloader")
+	return p
+}
+
 // stripeCountOf gives white-box access to the lock stripe count of a
 // shardedLockCache so tests can assert on lazy allocation and re-striping.
 // It is 0 until the stripes are allocated on first use.
@@ -766,33 +794,126 @@ func TestShardedLockCache_PageSizeOnFreshCache(t *testing.T) {
 }
 
 // TestPreloadCountsOccupiedSlotsOnly: count feeds replaceIfFull's full-cache wipe,
-// so overwrites and if-absent no-ops must not inflate it past true occupancy — and
-// PreloadIfAbsent must never replace a present vector.
+// so it must equal the number of slots that actually hold a vector — across every
+// transition a write can make, in both directions.
 func TestPreloadCountsOccupiedSlotsOnly(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
-	c.Grow(10)
+	const id = 5
 
-	c.Preload(5, []float32{9, 9})
-	c.Preload(5, []float32{1, 2}) // overwrite: no recount
-	assert.Equal(t, int64(1), c.CountVectors())
+	tests := []struct {
+		name      string
+		write     func(t *testing.T, c Cache[float32], p IfAbsentPreloader[float32])
+		wantCount int64
+		wantSlot  []float32
+	}{
+		{
+			name: "first Preload occupies the slot",
+			write: func(_ *testing.T, c Cache[float32], _ IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{1, 2})
+			},
+			wantCount: 1,
+			wantSlot:  []float32{1, 2},
+		},
+		{
+			name: "overwrite does not recount",
+			write: func(_ *testing.T, c Cache[float32], _ IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{9, 9})
+				c.Preload(id, []float32{1, 2})
+			},
+			wantCount: 1,
+			wantSlot:  []float32{1, 2},
+		},
+		{
+			name: "Preload nil over an occupied slot frees it",
+			write: func(_ *testing.T, c Cache[float32], _ IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{1, 2})
+				c.Preload(id, nil)
+			},
+			wantCount: 0,
+			wantSlot:  nil,
+		},
+		{
+			name: "repeated Preload of nil never counts",
+			write: func(_ *testing.T, c Cache[float32], _ IfAbsentPreloader[float32]) {
+				for i := 0; i < 5; i++ {
+					c.Preload(id, nil)
+				}
+			},
+			wantCount: 0,
+			wantSlot:  nil,
+		},
+		{
+			name: "Preload of an empty non-nil vector leaves the slot empty",
+			write: func(_ *testing.T, c Cache[float32], _ IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{})
+			},
+			wantCount: 0,
+			wantSlot:  nil,
+		},
+		{
+			name: "PreloadIfAbsent fills an empty slot",
+			write: func(t *testing.T, _ Cache[float32], p IfAbsentPreloader[float32]) {
+				assert.True(t, p.PreloadIfAbsent(id, []float32{3, 4}))
+			},
+			wantCount: 1,
+			wantSlot:  []float32{3, 4},
+		},
+		{
+			name: "PreloadIfAbsent leaves an occupied slot alone",
+			write: func(t *testing.T, c Cache[float32], p IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{1, 2})
+				assert.False(t, p.PreloadIfAbsent(id, []float32{9, 9}))
+			},
+			wantCount: 1,
+			wantSlot:  []float32{1, 2},
+		},
+		{
+			name: "repeated PreloadIfAbsent of nil stores nothing and counts nothing",
+			write: func(t *testing.T, _ Cache[float32], p IfAbsentPreloader[float32]) {
+				for i := 0; i < 5; i++ {
+					assert.False(t, p.PreloadIfAbsent(id, nil))
+				}
+			},
+			wantCount: 0,
+			wantSlot:  nil,
+		},
+		{
+			name: "PreloadIfAbsent never empties an occupied slot",
+			write: func(t *testing.T, c Cache[float32], p IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{1, 2})
+				assert.False(t, p.PreloadIfAbsent(id, nil))
+			},
+			wantCount: 1,
+			wantSlot:  []float32{1, 2},
+		},
+		{
+			name: "Delete frees an occupied slot exactly once",
+			write: func(_ *testing.T, c Cache[float32], _ IfAbsentPreloader[float32]) {
+				c.Preload(id, []float32{1, 2})
+				c.Delete(context.Background(), id)
+				c.Delete(context.Background(), id)
+			},
+			wantCount: 0,
+			wantSlot:  nil,
+		},
+	}
 
-	assert.False(t, c.PreloadIfAbsent(5, []float32{9, 9}))
-	assert.True(t, c.PreloadIfAbsent(6, []float32{3, 4}))
-	assert.Equal(t, int64(2), c.CountVectors())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newLazyTestCache(t, failingFetcher[float32](t))
+			c.Grow(10)
 
-	got, err := c.Get(context.Background(), 5)
-	assert.NoError(t, err)
-	assert.Equal(t, []float32{1, 2}, got, "PreloadIfAbsent must not overwrite")
+			tt.write(t, c, ifAbsentPreloader(t, c))
 
-	got, err = c.Get(context.Background(), 6)
-	assert.NoError(t, err)
-	assert.Equal(t, []float32{3, 4}, got)
+			assert.Equal(t, tt.wantCount, c.CountVectors())
+			assert.Equal(t, tt.wantSlot, slotOf(t, c, id))
+		})
+	}
 }
 
-// TestMultiVectorCacheCountInvariant regresses the shardedMultipleLockCache count
-// fix: count must track occupied slots, not calls, or replaceIfFull's full-cache
-// wipe fires while the cache isn't actually full.
+// TestMultiVectorCacheCountInvariant: this cache calls a slot occupied when it
+// holds a non-empty vector — Get and Delete both test len() — so count must move
+// on exactly that transition, or replaceIfFull's full-cache wipe fires while the
+// cache isn't actually full.
 func TestMultiVectorCacheCountInvariant(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
@@ -826,6 +947,33 @@ func TestMultiVectorCacheCountInvariant(t *testing.T) {
 		vec, err := c.Get(context.Background(), 9)
 		require.NoError(t, err)
 		assert.Empty(t, vec)
+		assert.Equal(t, int64(0), c.CountVectors())
+	})
+
+	t.Run("an empty passage occupies nothing and stays reclaimable", func(t *testing.T) {
+		c := NewShardedMultiUInt64LockCache(nil, 1_000_000, logger, 0, nil)
+
+		c.PreloadPassage(1, 7, 0, []uint64{})
+		assert.Equal(t, int64(0), c.CountVectors(), "an empty vec leaves the slot unoccupied")
+
+		// Delete tests len(), so a slot counted while empty could never be
+		// reclaimed and the inflation would be permanent
+		c.Delete(context.Background(), 1)
+		assert.Equal(t, int64(0), c.CountVectors())
+	})
+
+	t.Run("filling a slot left empty by a preload counts it once", func(t *testing.T) {
+		fetch, _ := countingFetcher[uint64]()
+		c := NewShardedMultiUInt64LockCache(fetch, 1_000_000, logger, 0, nil)
+
+		c.PreloadPassage(2, 7, 0, nil)
+		vec, err := c.Get(context.Background(), 2)
+		require.NoError(t, err)
+		require.NotEmpty(t, vec, "an empty slot must be a miss, so Get refills it")
+
+		assert.Equal(t, int64(1), c.CountVectors())
+
+		c.Delete(context.Background(), 2)
 		assert.Equal(t, int64(0), c.CountVectors())
 	})
 
@@ -874,7 +1022,9 @@ func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				vec, err := c.Get(context.Background(), 42)
-				require.NoError(t, err)
+				// assert, not require: FailNow off the test goroutine reports
+				// without the test's stack and skips the rest of this worker
+				assert.NoError(t, err)
 				assert.Equal(t, []float32{42}, vec)
 			}()
 		}
@@ -907,7 +1057,9 @@ func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				vec, err := c.Get(context.Background(), 42)
-				require.NoError(t, err)
+				// assert, not require: FailNow off the test goroutine reports
+				// without the test's stack and skips the rest of this worker
+				assert.NoError(t, err)
 				assert.Equal(t, []uint64{42}, vec)
 			}()
 		}
@@ -922,13 +1074,12 @@ func TestConcurrentMissSameID_NoDoubleCount(t *testing.T) {
 	})
 }
 
-// TestPreloadIfAbsent_ContentionWithPreload pins the invariant the async prefill's
-// safety argument rests on: PreloadIfAbsent can only win on an empty slot, so once at
-// least one Preload has run for an id, the final stored value can never be a
-// PreloadIfAbsent value, no matter how the two race.
+// TestPreloadIfAbsent_ContentionWithPreload: PreloadIfAbsent can only win on an
+// empty slot, so once at least one Preload has run for an id, the final stored
+// value can never be a PreloadIfAbsent value, no matter how the two race.
 func TestPreloadIfAbsent_ContentionWithPreload(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c := newLazyTestCache(t, failingFetcher[float32](t))
+	p := ifAbsentPreloader(t, c)
 
 	const (
 		numIDs       = 200
@@ -945,7 +1096,7 @@ func TestPreloadIfAbsent_ContentionWithPreload(t *testing.T) {
 			}()
 			go func() {
 				defer wg.Done()
-				c.PreloadIfAbsent(id, []float32{2, float32(id)})
+				p.PreloadIfAbsent(id, []float32{2, float32(id)})
 			}()
 		}
 	}
@@ -962,19 +1113,17 @@ func TestPreloadIfAbsent_ContentionWithPreload(t *testing.T) {
 	}
 }
 
-// TestPreloadIfAbsent_GrowRetry covers PreloadIfAbsent's Grow-retry loop (id beyond
-// the current cache length -> unlock -> Grow -> retry), which no production caller
-// reaches: prefillFromScan skips any id beyond the pre-grown node count instead of
-// growing the cache from a scan.
+// TestPreloadIfAbsent_GrowRetry covers PreloadIfAbsent's Grow-retry loop: id beyond
+// the current cache length -> unlock -> Grow -> retry.
 func TestPreloadIfAbsent_GrowRetry(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c := newLazyTestCache(t, failingFetcher[float32](t))
+	p := ifAbsentPreloader(t, c)
 
 	c.Grow(10) // establish a small baseline cache, well short of id below
 	require.Less(t, int(c.Len()), 50_000)
 
 	id := uint64(50_000)
-	ok := c.PreloadIfAbsent(id, []float32{7, 8})
+	ok := p.PreloadIfAbsent(id, []float32{7, 8})
 	assert.True(t, ok)
 	assert.Greater(t, c.Len(), int32(id), "PreloadIfAbsent must grow the cache to cover id")
 
@@ -988,8 +1137,8 @@ func TestPreloadIfAbsent_GrowRetry(t *testing.T) {
 // retry loop by forcing many goroutines through concurrent Grow calls for distinct
 // out-of-bounds ids at once.
 func TestPreloadIfAbsent_GrowRetryConcurrent(t *testing.T) {
-	logger, _ := test.NewNullLogger()
-	c := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	c := newLazyTestCache(t, failingFetcher[float32](t))
+	p := ifAbsentPreloader(t, c)
 	c.Grow(10)
 
 	const (
@@ -1003,7 +1152,7 @@ func TestPreloadIfAbsent_GrowRetryConcurrent(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			id := baseID + uint64(i)
-			ok := c.PreloadIfAbsent(id, []float32{float32(id)})
+			ok := p.PreloadIfAbsent(id, []float32{float32(id)})
 			assert.True(t, ok)
 		}(i)
 	}

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -929,8 +929,7 @@ func TestMultiVectorCacheCountInvariant(t *testing.T) {
 		c.PreloadMulti(100, []uint64{1, 2, 3}, [][]uint64{{10}, {20}, {30}})
 		c.PreloadMulti(101, []uint64{3, 4, 5}, [][]uint64{{31}, {40}, {50}})
 
-		// distinct ids touched: 1, 2, 3, 4, 5
-		assert.Equal(t, int64(5), c.CountVectors())
+		assert.Equal(t, int64(5), c.CountVectors(), "distinct ids touched: 1, 2, 3, 4, 5")
 	})
 
 	t.Run("miss with empty fetch result does not increment count", func(t *testing.T) {
@@ -971,7 +970,7 @@ func TestMultiVectorCacheCountInvariant(t *testing.T) {
 
 	t.Run("same id missed twice via handleMultipleCacheMiss counts once", func(t *testing.T) {
 		// simulates two goroutines that both concluded a cache miss for the same id
-		// and are now racing to store: only the first store may count.
+		// and are now racing to store
 		fetch, _ := countingFetcher[uint64]()
 		vectorCache := NewShardedMultiUInt64LockCache(fetch, 1_000_000, logger, 0, nil)
 		c, ok := vectorCache.(*shardedMultipleLockCache[uint64])

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1034,8 +1034,8 @@ func (index *flat) PostStartup(ctx context.Context) {
 	}
 
 	// Grow cache just once. Growing before LockAll also sizes the cache's
-	// lock stripes to the actual tenant size; SetSizeAndGrowNoLock below then
-	// only records the count.
+	// lock stripes to the actual tenant size, which leaves SetSizeAndGrowNoLock
+	// below as a guard for the case where maxID outgrew that.
 	index.cache.Grow(maxID)
 	index.cache.LockAll()
 	defer index.cache.UnlockAll()

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1034,8 +1034,7 @@ func (index *flat) PostStartup(ctx context.Context) {
 	}
 
 	// Grow cache just once. Growing before LockAll also sizes the cache's
-	// lock stripes to the actual tenant size, which leaves SetSizeAndGrowNoLock
-	// below as a guard for the case where maxID outgrew that.
+	// lock stripes to the actual tenant size.
 	index.cache.Grow(maxID)
 	index.cache.LockAll()
 	defer index.cache.UnlockAll()

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -105,10 +105,6 @@ func (f *fakeCache) Delete(ctx context.Context, id uint64) {
 	panic("not implemented")
 }
 
-func (f *fakeCache) PreloadIfAbsent(id uint64, vec []float32) bool {
-	panic("not implemented")
-}
-
 func (f *fakeCache) Preload(id uint64, vec []float32) {
 	panic("not implemented")
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -105,6 +105,10 @@ func (f *fakeCache) Delete(ctx context.Context, id uint64) {
 	panic("not implemented")
 }
 
+func (f *fakeCache) PreloadIfAbsent(id uint64, vec []float32) bool {
+	panic("not implemented")
+}
+
 func (f *fakeCache) Preload(id uint64, vec []float32) {
 	panic("not implemented")
 }


### PR DESCRIPTION
Split out of #12397 so it can be read on its own — a cache-accounting bug plus the API a bulk populator needs, neither of which depends on the prefill work it was bundled with.

## The bug

`count` feeds `replaceIfFull`, which wipes the entire cache once it believes the cache is full. Every write path incremented `count` by looking only at whether the slot's *old* value was nil, so all four occupancy transitions were mis-accounted:

| write | slot before → after | `count` did | should |
|---|---|---|---|
| `Preload(id, vec)` on an occupied slot | occupied → occupied | +1 | 0 |
| `Preload(id, nil)` | empty → empty | +1 | 0 |
| `Preload(id, nil)` over a vector | occupied → empty | 0 | −1 |
| store over an empty non-nil slice (multivector) | empty → occupied | 0 | +1 |

The two over-counts have nothing to bring them back down: `Delete` returns early on an empty slot, so a slot counted while empty is never reclaimed. Both HNSW caches run with a non-zero `DefaultDeletionInterval`, so the drift ends in a full-cache wipe of a cache that was never full. `PreloadMulti` is reachable with an empty passage vector from `insert.go`, which preloads before validating `len(vector) == 0`.

## The fix

Every write goes through `storeLocked`, which normalises an empty vector to nil and moves `count` only on an empty↔occupied transition:

```go
func (s *shardedLockCache[T]) storeLocked(id uint64, vec []T) {
	vec = emptyToNil(vec)
	if delta := occupancyDelta(s.cache[id], vec); delta != 0 {
		atomic.AddInt64(&s.count, delta)
	}
	s.cache[id] = vec
}
```

A slot now holds nil or a usable vector and nothing in between, so the two spellings of the occupancy test in this file — `== nil` in the single-vector cache, `len() == 0` in the multivector one — cannot disagree, and `count` cannot drift from what `Delete` and `Get` consider filled.

`PreloadNoLock` counts what it fills and `SetSizeAndGrowNoLock` no longer stores the requested size as the count. Previously flat's `PostStartup` left `count == maxID` regardless of how many slots its iterator filled, and the `atomic.Store` discarded any count from concurrent writers. Harmless only because the flat and compressed caches pass `deletionInterval == 0`; it became a wipe the moment any of them got a non-zero interval.

## PreloadIfAbsent

Same invariant from the other side: a caller populating the cache in bulk needs to fill empty slots *without* overwriting what a concurrent insert just wrote, and whether it occupied a slot is what decides whether it counted. It returns whether it stored, and refuses an empty vector rather than reporting a store it did not make.

It lives on a narrow `IfAbsentPreloader[T]` rather than on `Cache[T]`, because a multivector slot is addressed by `(docID, relativeID)` and has no single-id write. Consumers type-assert; #12397 does this and falls back to the serial prefill path when the assertion fails, instead of reaching a `panic("not implemented")` guarded only by a gate elsewhere.

## Tests

`TestPreloadCountsOccupiedSlotsOnly` is table-driven over every transition in both directions, asserting `count` and the raw slot so an empty slot is distinguishable from one `Get` would silently refill. `TestMultiVectorCacheCountInvariant` covers the same for the multivector cache, including a slot left empty by a preload and later filled, and the empty-passage slot that `Delete` could not reclaim. The concurrency tests cover contention between `Preload` and `PreloadIfAbsent`, concurrent misses on one id, and the grow-retry loop. Every new case fails against the previous accounting.

## Not addressed here

`count` is now smaller than before for update-heavy workloads, which retunes two consumers: `AlreadyIndexed()` gates the automatic PQ/BQ/SQ upgrade, and `cacheSize()` feeds the ACORN filter ratio. Both now see true occupancy rather than a call count. That is the correct number, but when compression kicks in shifts, so it is called out rather than silently pinned by a test.

`VectorCompressor` has no `PreloadIfAbsent`. Compressed indexes prefill through `PrefillCache`, which scans the compressor's own compressed bucket, and #12397's object scan stops on `h.compressed.Load()` — so no compressed path needs an if-absent write.
