### PR TITLE
fix(storobj): bound vector reads by their declared segment

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -416,7 +416,7 @@ func (s *Shard) readMultiVectorByIndexIDIntoSlice(ctx context.Context, indexID u
 	}
 
 	container.Buff = newBuff
-	vecs, err := storobj.MultiVectorFromBinary(bytes, container.Slice, targetVector)
+	vecs, err := storobj.MultiVectorFromBinary(bytes, targetVector)
 	if err != nil {
 		var eTV storobj.ErrTargetVectorNotFound
 		if stderrors.As(err, &eTV) {
@@ -483,7 +483,7 @@ func (s *Shard) readMultiVectorByIndexIDIntoSliceWithView(ctx context.Context, i
 	}
 
 	container.Buff = newBuff
-	vecs, err := storobj.MultiVectorFromBinary(bytes, container.Slice, targetVector)
+	vecs, err := storobj.MultiVectorFromBinary(bytes, targetVector)
 	if err != nil {
 		var eTV storobj.ErrTargetVectorNotFound
 		if stderrors.As(err, &eTV) {

--- a/entities/storobj/export.go
+++ b/entities/storobj/export.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/google/uuid"
-	"github.com/vmihailenco/msgpack/v5"
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
@@ -56,6 +55,10 @@ func ExportFieldsFromBinary(data []byte) (ExportFields, error) {
 		return ExportFields{}, fmt.Errorf("unsupported binary marshaller version %d", version)
 	}
 
+	if len(data) < marshallerV1HeaderLen {
+		return ExportFields{}, fmt.Errorf("object of %d bytes is too short to hold a header", len(data))
+	}
+
 	rw := byteops.NewReadWriter(data)
 	rw.Position = 1
 
@@ -74,25 +77,35 @@ func ExportFieldsFromBinary(data []byte) (ExportFields, error) {
 	updateTime := int64(rw.ReadUint64())
 
 	// Primary vector: copy raw LE float32 bytes directly (no []float32 intermediate)
-	vectorLength := rw.ReadUint16()
-	vectorByteLen := uint64(vectorLength) * byteops.Uint32Len
+	vectorLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("read vector length: %w", err)
+	}
 	var vectorBytes []byte
 	if vectorLength > 0 {
-		vectorBytes, err = rw.CopyBytesFromBuffer(vectorByteLen, nil)
+		vectorBytes, err = rw.CopyBytesFromBufferChecked(uint64(vectorLength)*byteops.Uint32Len, nil)
 		if err != nil {
 			return ExportFields{}, fmt.Errorf("copy vector bytes: %w", err)
 		}
 	}
 
 	// Skip class name (already known from shard context, stored as file-level metadata)
-	classNameLen := rw.ReadUint16()
-	rw.MoveBufferPositionForward(uint64(classNameLen))
+	classNameLen, err := rw.ReadUint16Checked()
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("read class name length: %w", err)
+	}
+	if err := rw.SkipChecked(uint64(classNameLen)); err != nil {
+		return ExportFields{}, fmt.Errorf("skip class name: %w", err)
+	}
 
 	// Properties: copy raw JSON bytes directly (no unmarshal/enrichSchemaTypes/remarshal)
-	propsLength := rw.ReadUint32()
+	propsLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("read properties length: %w", err)
+	}
 	var properties []byte
 	if propsLength > 0 {
-		propsCopy, copyErr := rw.CopyBytesFromBuffer(uint64(propsLength), nil)
+		propsCopy, copyErr := rw.CopyBytesFromBufferChecked(uint64(propsLength), nil)
 		if copyErr != nil {
 			return ExportFields{}, fmt.Errorf("copy properties bytes: %w", copyErr)
 		}
@@ -104,29 +117,33 @@ func ExportFieldsFromBinary(data []byte) (ExportFields, error) {
 	}
 
 	// Skip meta (not exported)
-	metaLength := rw.ReadUint32()
-	rw.MoveBufferPositionForward(uint64(metaLength))
+	metaLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("read meta length: %w", err)
+	}
+	if err := rw.SkipChecked(uint64(metaLength)); err != nil {
+		return ExportFields{}, fmt.Errorf("skip meta: %w", err)
+	}
 
 	// Skip vector weights (not exported)
-	vectorWeightsLength := rw.ReadUint32()
-	rw.MoveBufferPositionForward(uint64(vectorWeightsLength))
+	vectorWeightsLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("read vector weights length: %w", err)
+	}
+	if err := rw.SkipChecked(uint64(vectorWeightsLength)); err != nil {
+		return ExportFields{}, fmt.Errorf("skip vector weights: %w", err)
+	}
 
 	// Named vectors: build JSON directly from binary
-	var namedVectors []byte
-	if rw.Position < uint64(len(rw.Buffer)) {
-		namedVectors, err = targetVectorsJSONFromBinary(&rw)
-		if err != nil {
-			return ExportFields{}, fmt.Errorf("export target vectors: %w", err)
-		}
+	namedVectors, err := targetVectorsJSONFromBinary(&rw)
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("export target vectors: %w", err)
 	}
 
 	// Multi-vectors: build JSON directly from binary
-	var multiVectors []byte
-	if rw.Position < uint64(len(rw.Buffer)) {
-		multiVectors, err = multiVectorsJSONFromBinary(&rw)
-		if err != nil {
-			return ExportFields{}, fmt.Errorf("export multi vectors: %w", err)
-		}
+	multiVectors, err := multiVectorsJSONFromBinary(&rw)
+	if err != nil {
+		return ExportFields{}, fmt.Errorf("export multi vectors: %w", err)
 	}
 
 	return ExportFields{
@@ -146,21 +163,17 @@ func ExportFieldsFromBinary(data []byte) (ExportFields, error) {
 //
 // Output format: {"vecName":[1.5,2.5,3.5],"vecName2":[4.5,5.5,6.5]}
 func targetVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
-	targetVectorsOffsets := rw.ReadBytesFromBufferWithUint32LengthIndicator()
-	targetVectorsSegmentLength := rw.ReadUint32()
-	pos := rw.Position
-
-	defer rw.MoveBufferToAbsolutePosition(pos + uint64(targetVectorsSegmentLength))
-
-	if len(targetVectorsOffsets) == 0 {
-		return nil, nil
+	seg, present, err := readVectorSegment(rw, "target vectors")
+	if err != nil || !present {
+		return nil, err
 	}
 
-	var tvOffsets map[string]uint32
-	if err := msgpack.Unmarshal(targetVectorsOffsets, &tvOffsets); err != nil {
-		return nil, fmt.Errorf("unmarshal target vectors offsets: %w", err)
-	}
+	defer rw.MoveBufferToAbsolutePosition(seg.end)
 
+	tvOffsets, err := seg.decodeOffsets("target vectors")
+	if err != nil {
+		return nil, err
+	}
 	if len(tvOffsets) == 0 {
 		return nil, nil
 	}
@@ -173,7 +186,7 @@ func targetVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 	slices.Sort(names)
 
 	// Estimate ~10 bytes per float + key/bracket overhead.
-	buf := make([]byte, 0, targetVectorsSegmentLength*3)
+	buf := make([]byte, 0, (seg.end-seg.start)*3)
 	buf = append(buf, '{')
 	for i, name := range names {
 		if i > 0 {
@@ -182,11 +195,16 @@ func targetVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 
 		buf = appendJSONStringKey(buf, name)
 
-		rw.MoveBufferToAbsolutePosition(pos + uint64(tvOffsets[name]))
-		vecLen := rw.ReadUint16()
-		vecBytes := rw.ReadBytesFromBuffer(uint64(vecLen) * byteops.Uint32Len)
+		what := fmt.Sprintf("target vector %q", name)
+		if err := seekToVector(rw, seg, what, tvOffsets[name], byteops.Uint16Len); err != nil {
+			return nil, err
+		}
+		vecBytes, dims, err := readVectorBytes(rw, seg, what)
+		if err != nil {
+			return nil, err
+		}
 
-		buf = appendFloat32BytesAsJSONArray(buf, vecBytes, int(vecLen))
+		buf = appendFloat32BytesAsJSONArray(buf, vecBytes, int(dims))
 	}
 	buf = append(buf, '}')
 
@@ -199,21 +217,17 @@ func targetVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 //
 // Output format: {"vecName":[[1.5,2.5],[3.5,4.5]],"vecName2":[[5.5,6.5]]}
 func multiVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
-	multiVectorsOffsets := rw.ReadBytesFromBufferWithUint32LengthIndicator()
-	multiVectorsSegmentLength := rw.ReadUint32()
-	pos := rw.Position
-
-	defer rw.MoveBufferToAbsolutePosition(pos + uint64(multiVectorsSegmentLength))
-
-	if len(multiVectorsOffsets) == 0 {
-		return nil, nil
+	seg, present, err := readVectorSegment(rw, "multi vectors")
+	if err != nil || !present {
+		return nil, err
 	}
 
-	var mvOffsets map[string]uint32
-	if err := msgpack.Unmarshal(multiVectorsOffsets, &mvOffsets); err != nil {
-		return nil, fmt.Errorf("unmarshal multi vectors offsets: %w", err)
-	}
+	defer rw.MoveBufferToAbsolutePosition(seg.end)
 
+	mvOffsets, err := seg.decodeOffsets("multi vectors")
+	if err != nil {
+		return nil, err
+	}
 	if len(mvOffsets) == 0 {
 		return nil, nil
 	}
@@ -225,7 +239,7 @@ func multiVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 	}
 	slices.Sort(names)
 
-	buf := make([]byte, 0, multiVectorsSegmentLength*3)
+	buf := make([]byte, 0, (seg.end-seg.start)*3)
 	buf = append(buf, '{')
 	for i, name := range names {
 		if i > 0 {
@@ -234,17 +248,26 @@ func multiVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 
 		buf = appendJSONStringKey(buf, name)
 
-		rw.MoveBufferToAbsolutePosition(pos + uint64(mvOffsets[name]))
-		numVecs := rw.ReadUint32()
+		what := fmt.Sprintf("multi vector %q", name)
+		if err := seekToVector(rw, seg, what, mvOffsets[name], byteops.Uint32Len); err != nil {
+			return nil, err
+		}
+		numVecs := uint64(rw.ReadUint32())
+		if maxVecs := (seg.end - rw.Position) / byteops.Uint16Len; numVecs > maxVecs {
+			return nil, fmt.Errorf("%s truncated at document count: declares %d documents, segment holds at most %d",
+				what, numVecs, maxVecs)
+		}
 
 		buf = append(buf, '[')
-		for j := range int(numVecs) {
+		for j := uint64(0); j < numVecs; j++ {
 			if j > 0 {
 				buf = append(buf, ',')
 			}
-			vecLen := rw.ReadUint16()
-			vecBytes := rw.ReadBytesFromBuffer(uint64(vecLen) * byteops.Uint32Len)
-			buf = appendFloat32BytesAsJSONArray(buf, vecBytes, int(vecLen))
+			vecBytes, dims, err := readVectorBytes(rw, seg, fmt.Sprintf("%s document %d", what, j))
+			if err != nil {
+				return nil, err
+			}
+			buf = appendFloat32BytesAsJSONArray(buf, vecBytes, int(dims))
 		}
 		buf = append(buf, ']')
 	}

--- a/entities/storobj/export.go
+++ b/entities/storobj/export.go
@@ -195,13 +195,12 @@ func targetVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 
 		buf = appendJSONStringKey(buf, name)
 
-		what := fmt.Sprintf("target vector %q", name)
-		if err := seekToVector(rw, seg, what, tvOffsets[name], byteops.Uint16Len); err != nil {
-			return nil, err
+		if err := seekToVector(rw, seg, tvOffsets[name], byteops.Uint16Len); err != nil {
+			return nil, fmt.Errorf("target vector %q %w", name, err)
 		}
-		vecBytes, dims, err := readVectorBytes(rw, seg, what)
+		vecBytes, dims, err := readVectorBytes(rw, seg)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("target vector %q %w", name, err)
 		}
 
 		buf = appendFloat32BytesAsJSONArray(buf, vecBytes, int(dims))
@@ -248,14 +247,13 @@ func multiVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 
 		buf = appendJSONStringKey(buf, name)
 
-		what := fmt.Sprintf("multi vector %q", name)
-		if err := seekToVector(rw, seg, what, mvOffsets[name], byteops.Uint32Len); err != nil {
-			return nil, err
+		if err := seekToVector(rw, seg, mvOffsets[name], byteops.Uint32Len); err != nil {
+			return nil, fmt.Errorf("multi vector %q %w", name, err)
 		}
 		numVecs := uint64(rw.ReadUint32())
 		if maxVecs := (seg.end - rw.Position) / byteops.Uint16Len; numVecs > maxVecs {
-			return nil, fmt.Errorf("%s truncated at document count: declares %d documents, segment holds at most %d",
-				what, numVecs, maxVecs)
+			return nil, fmt.Errorf("multi vector %q truncated at document count: declares %d documents, segment holds at most %d",
+				name, numVecs, maxVecs)
 		}
 
 		buf = append(buf, '[')
@@ -263,9 +261,9 @@ func multiVectorsJSONFromBinary(rw *byteops.ReadWriter) ([]byte, error) {
 			if j > 0 {
 				buf = append(buf, ',')
 			}
-			vecBytes, dims, err := readVectorBytes(rw, seg, fmt.Sprintf("%s document %d", what, j))
+			vecBytes, dims, err := readVectorBytes(rw, seg)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("multi vector %q document %d %w", name, j, err)
 			}
 			buf = appendFloat32BytesAsJSONArray(buf, vecBytes, int(dims))
 		}

--- a/entities/storobj/legacy_vector_bounds_test.go
+++ b/entities/storobj/legacy_vector_bounds_test.go
@@ -1,0 +1,171 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// distinctiveVector returns a vector whose values are cheap to eyeball and
+// unlikely to collide with zero-filled or garbage output.
+func distinctiveVector(dims int) []float32 {
+	vec := make([]float32, dims)
+	for i := range vec {
+		vec[i] = float32(i%100) + 0.5
+	}
+	return vec
+}
+
+func legacyVectorTestObject(docID uint64, vec []float32) *Object {
+	obj := New(docID)
+	obj.Object = models.Object{
+		ID:         strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168247"),
+		Class:      "LegacyVectorBoundsClass",
+		Properties: map[string]interface{}{"name": "x"},
+	}
+	obj.Vector = vec
+	return obj
+}
+
+// TestLegacyVectorRoundTrip covers the dimension counts that straddle the uint16
+// scaling boundary: the on-disk length field is a uint16 and the writer permits up to
+// maxVectorLength (65535) dims, so scaling it to bytes without widening first wraps
+// from 16384 dims upwards — 16384 wraps to zero (all-zero vector), higher counts wrap
+// to a partial length (silently truncated vector), both without an error.
+func TestLegacyVectorRoundTrip(t *testing.T) {
+	dimsList := []int{1, 1000, 16383, 16384, 20000, 65535}
+
+	for _, dims := range dimsList {
+		t.Run(fmt.Sprintf("%d dims", dims), func(t *testing.T) {
+			vec := distinctiveVector(dims)
+			obj := legacyVectorTestObject(1, vec)
+
+			data, err := obj.MarshalBinary()
+			require.NoError(t, err)
+
+			t.Run("VectorFromBinary", func(t *testing.T) {
+				got, err := VectorFromBinary(data, nil, "")
+				require.NoError(t, err)
+				require.Equal(t, vec, got)
+			})
+
+			t.Run("full object decode", func(t *testing.T) {
+				full, err := FromBinaryDisk(data, "LegacyVectorBoundsClass")
+				require.NoError(t, err)
+				require.Equal(t, vec, full.Vector)
+			})
+		})
+	}
+}
+
+// TestMultiVectorFromBinaryPastOversizedLegacyVector pins the same overflow in
+// MultiVectorFromBinary, which uses the legacy vector's end offset as the start
+// of a pos-cursor walk (classNameLength, schemaLength, ...) to reach the
+// multivector segment. A wrong vecEnd misaligns that whole walk, not just the
+// legacy vector itself.
+func TestMultiVectorFromBinaryPastOversizedLegacyVector(t *testing.T) {
+	dimsList := []int{16383, 16384, 20000, 65535}
+	multiVec := [][]float32{{1, 2, 3}, {4, 5, 6}}
+
+	for _, dims := range dimsList {
+		t.Run(fmt.Sprintf("%d dims", dims), func(t *testing.T) {
+			vec := distinctiveVector(dims)
+			obj := legacyVectorTestObject(1, vec)
+			obj.MultiVectors = map[string][][]float32{"mv": multiVec}
+
+			data, err := obj.MarshalBinary()
+			require.NoError(t, err)
+
+			// Assert the multivector decode independently of VectorFromBinary (already
+			// pinned in TestLegacyVectorRoundTrip) so a wrong pos-cursor walk here isn't
+			// masked by the legacy vector's own bounds bug.
+			gotMV, err := MultiVectorFromBinary(data, nil, "mv")
+			require.NoError(t, err)
+			require.Equal(t, multiVec, gotMV)
+		})
+	}
+}
+
+// TestVectorFromBinaryTruncatedInputErrors builds truncated views of a valid
+// object as subslices of a larger backing array whose tail is filled with a
+// 0xAA sentinel, mirroring how a value returned from an mmapped LSM segment
+// can have capacity well past its declared length. Pre-fix, in[44:44+n] was an
+// unchecked slice: Go's two-index slice bound check is against cap, not len, so
+// the read silently succeeded and copied the sentinel (standing in for a
+// neighbouring object's bytes) into the returned vector instead of erroring.
+func TestVectorFromBinaryTruncatedInputErrors(t *testing.T) {
+	const dims = 500
+	vec := distinctiveVector(dims)
+	obj := legacyVectorTestObject(1, vec)
+
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+
+	vecStart := marshallerV1HeaderLen + 2
+	vecEnd := vecStart + dims*4
+	require.Less(t, vecEnd, len(data), "test object must have data trailing the vector")
+
+	cases := []struct {
+		name         string
+		truncatedLen int
+	}{
+		{"single byte", 1},
+		{"mid docID", 5},
+		{"exactly header, no length field", marshallerV1HeaderLen},
+		{"one byte into length field", marshallerV1HeaderLen + 1},
+		{"length field present, zero vector bytes", vecStart},
+		{"half the vector present", vecStart + dims*4/2},
+		{"one byte short of full vector", vecEnd - 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			backing := make([]byte, len(data)+70_000)
+			copy(backing, data[:tc.truncatedLen])
+			for i := tc.truncatedLen; i < len(backing); i++ {
+				backing[i] = 0xAA
+			}
+			in := backing[:tc.truncatedLen]
+
+			_, err := VectorFromBinary(in, nil, "")
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestZeroLengthNamedVectorDecodesNonNil pins readTargetVectorAt: a nil buffer
+// must allocate even for a zero-length vector, because nil[:0] is nil and a
+// caller holding the result in a map would see an absent vector rather than an
+// explicitly empty one.
+func TestZeroLengthNamedVectorDecodesNonNil(t *testing.T) {
+	obj := legacyVectorTestObject(1, nil)
+	obj.Vectors = map[string][]float32{
+		"empty": {},
+		"full":  {1, 2},
+	}
+
+	data, err := obj.MarshalBinary()
+	require.NoError(t, err)
+
+	full, err := FromBinaryDisk(data, "LegacyVectorBoundsClass")
+	require.NoError(t, err)
+
+	require.Contains(t, full.Vectors, "empty")
+	require.NotNil(t, full.Vectors["empty"])
+	require.Len(t, full.Vectors["empty"], 0)
+	require.Equal(t, []float32{1, 2}, full.Vectors["full"])
+}

--- a/entities/storobj/legacy_vector_bounds_test.go
+++ b/entities/storobj/legacy_vector_bounds_test.go
@@ -44,10 +44,8 @@ func legacyVectorTestObject(docID uint64, vec []float32) *Object {
 }
 
 // TestLegacyVectorRoundTrip covers the dimension counts that straddle the uint16
-// scaling boundary: the on-disk length field is a uint16 and the writer permits up to
-// maxVectorLength (65535) dims, so scaling it to bytes without widening first wraps
-// from 16384 dims upwards — 16384 wraps to zero (all-zero vector), higher counts wrap
-// to a partial length (silently truncated vector), both without an error.
+// scaling boundary: unwidened, 16384 dims scale to zero bytes and higher counts to
+// a partial length, so the vector comes back empty or truncated without an error.
 func TestLegacyVectorRoundTrip(t *testing.T) {
 	dimsList := []int{1, 1000, 16383, 16384, 20000, 65535}
 
@@ -74,11 +72,10 @@ func TestLegacyVectorRoundTrip(t *testing.T) {
 	}
 }
 
-// TestMultiVectorFromBinaryPastOversizedLegacyVector pins the same overflow in
-// MultiVectorFromBinary, which uses the legacy vector's end offset as the start
-// of a pos-cursor walk (classNameLength, schemaLength, ...) to reach the
-// multivector segment. A wrong vecEnd misaligns that whole walk, not just the
-// legacy vector itself.
+// TestMultiVectorFromBinaryPastOversizedLegacyVector pins the same widening in
+// skipToVectorSections, which skips the legacy vector to reach the sections
+// behind it. A wrong vector length misaligns every field after it, not just the
+// vector.
 func TestMultiVectorFromBinaryPastOversizedLegacyVector(t *testing.T) {
 	dimsList := []int{16383, 16384, 20000, 65535}
 	multiVec := [][]float32{{1, 2, 3}, {4, 5, 6}}
@@ -92,9 +89,8 @@ func TestMultiVectorFromBinaryPastOversizedLegacyVector(t *testing.T) {
 			data, err := obj.MarshalBinary()
 			require.NoError(t, err)
 
-			// Assert the multivector decode independently of VectorFromBinary (already
-			// pinned in TestLegacyVectorRoundTrip) so a wrong pos-cursor walk here isn't
-			// masked by the legacy vector's own bounds bug.
+			// asserted independently of VectorFromBinary, which walks to the sections
+			// by a different route
 			gotMV, err := MultiVectorFromBinary(data, "mv")
 			require.NoError(t, err)
 			require.Equal(t, multiVec, gotMV)
@@ -102,11 +98,10 @@ func TestMultiVectorFromBinaryPastOversizedLegacyVector(t *testing.T) {
 	}
 }
 
-// truncatedView returns data cut to n bytes but backed by a larger array whose
-// tail holds a 0xAA sentinel. A value handed back by an mmapped LSM segment has
-// capacity well past its length, and Go bounds a two-index slice against
-// capacity, so an unchecked read past the value's end yields the sentinel —
-// standing in here for a neighbouring object's bytes — rather than panicking.
+// truncatedView cuts data to n bytes but backs it with a larger array whose tail
+// holds a 0xAA sentinel, the way an mmapped LSM segment hands back a value with
+// capacity past its length. An unchecked read then yields the sentinel — standing
+// in for a neighbouring object's bytes — rather than panicking.
 func truncatedView(data []byte, n int) []byte {
 	backing := make([]byte, len(data)+70_000)
 	copy(backing, data[:n])
@@ -117,9 +112,8 @@ func truncatedView(data []byte, n int) []byte {
 }
 
 // TestTruncatedObjectDecodersError runs every decoder that reads a vector out of
-// an object value over the same truncation matrix. Each entry point reaches the
-// vector sections by its own walk over the length-prefixed fields, so each needs
-// its own coverage: a bound on one of them says nothing about the others.
+// an object value over one truncation matrix. Each reaches the vector sections by
+// its own walk, so a bound on one says nothing about the others.
 func TestTruncatedObjectDecodersError(t *testing.T) {
 	const (
 		dims      = 500
@@ -203,9 +197,7 @@ func TestTruncatedObjectDecodersError(t *testing.T) {
 
 // TestZeroLengthNamedVectorDecodesNonNil pins readVectorInto: a nil buffer must
 // allocate even for a zero-length vector, because nil[:0] is nil and a caller
-// holding the result in a map would see an absent vector rather than an
-// explicitly empty one. The single-vector path takes the nil buffer, so it has
-// to be exercised directly — the full-object decode never reaches it.
+// holding the result in a map would see an absent vector rather than an empty one.
 func TestZeroLengthNamedVectorDecodesNonNil(t *testing.T) {
 	obj := legacyVectorTestObject(1, nil)
 	obj.Vectors = map[string][]float32{

--- a/entities/storobj/legacy_vector_bounds_test.go
+++ b/entities/storobj/legacy_vector_bounds_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -93,24 +95,40 @@ func TestMultiVectorFromBinaryPastOversizedLegacyVector(t *testing.T) {
 			// Assert the multivector decode independently of VectorFromBinary (already
 			// pinned in TestLegacyVectorRoundTrip) so a wrong pos-cursor walk here isn't
 			// masked by the legacy vector's own bounds bug.
-			gotMV, err := MultiVectorFromBinary(data, nil, "mv")
+			gotMV, err := MultiVectorFromBinary(data, "mv")
 			require.NoError(t, err)
 			require.Equal(t, multiVec, gotMV)
 		})
 	}
 }
 
-// TestVectorFromBinaryTruncatedInputErrors builds truncated views of a valid
-// object as subslices of a larger backing array whose tail is filled with a
-// 0xAA sentinel, mirroring how a value returned from an mmapped LSM segment
-// can have capacity well past its declared length. Pre-fix, in[44:44+n] was an
-// unchecked slice: Go's two-index slice bound check is against cap, not len, so
-// the read silently succeeded and copied the sentinel (standing in for a
-// neighbouring object's bytes) into the returned vector instead of erroring.
-func TestVectorFromBinaryTruncatedInputErrors(t *testing.T) {
-	const dims = 500
+// truncatedView returns data cut to n bytes but backed by a larger array whose
+// tail holds a 0xAA sentinel. A value handed back by an mmapped LSM segment has
+// capacity well past its length, and Go bounds a two-index slice against
+// capacity, so an unchecked read past the value's end yields the sentinel —
+// standing in here for a neighbouring object's bytes — rather than panicking.
+func truncatedView(data []byte, n int) []byte {
+	backing := make([]byte, len(data)+70_000)
+	copy(backing, data[:n])
+	for i := n; i < len(backing); i++ {
+		backing[i] = 0xAA
+	}
+	return backing[:n]
+}
+
+// TestTruncatedObjectDecodersError runs every decoder that reads a vector out of
+// an object value over the same truncation matrix. Each entry point reaches the
+// vector sections by its own walk over the length-prefixed fields, so each needs
+// its own coverage: a bound on one of them says nothing about the others.
+func TestTruncatedObjectDecodersError(t *testing.T) {
+	const (
+		dims      = 500
+		className = "LegacyVectorBoundsClass"
+	)
 	vec := distinctiveVector(dims)
 	obj := legacyVectorTestObject(1, vec)
+	obj.Vectors = map[string][]float32{"nv": {1, 2, 3}}
+	obj.MultiVectors = map[string][][]float32{"mv": {{1, 2}, {3, 4}}}
 
 	data, err := obj.MarshalBinary()
 	require.NoError(t, err)
@@ -119,9 +137,28 @@ func TestVectorFromBinaryTruncatedInputErrors(t *testing.T) {
 	vecEnd := vecStart + dims*4
 	require.Less(t, vecEnd, len(data), "test object must have data trailing the vector")
 
-	cases := []struct {
-		name         string
-		truncatedLen int
+	decoders := []struct {
+		name   string
+		decode func([]byte) (any, error)
+	}{
+		{"VectorFromBinary legacy", func(in []byte) (any, error) { return VectorFromBinary(in, nil, "") }},
+		{"VectorFromBinary named", func(in []byte) (any, error) { return VectorFromBinary(in, nil, "nv") }},
+		{"MultiVectorFromBinary", func(in []byte) (any, error) { return MultiVectorFromBinary(in, "mv") }},
+		{"FromBinaryDisk", func(in []byte) (any, error) { return FromBinaryDisk(in, className) }},
+		{"FromBinaryOptionalDisk", func(in []byte) (any, error) {
+			return FromBinaryOptionalDisk(in, className,
+				additional.Properties{Vector: true, Vectors: []string{"nv", "mv"}}, nil)
+		}},
+		{"UnmarshalBinaryDisk", func(in []byte) (any, error) {
+			decoded := &Object{}
+			return decoded, decoded.UnmarshalBinaryDisk(in, className)
+		}},
+		{"ExportFieldsFromBinary", func(in []byte) (any, error) { return ExportFieldsFromBinary(in) }},
+	}
+
+	lengths := []struct {
+		name string
+		n    int
 	}{
 		{"single byte", 1},
 		{"mid docID", 5},
@@ -130,27 +167,45 @@ func TestVectorFromBinaryTruncatedInputErrors(t *testing.T) {
 		{"length field present, zero vector bytes", vecStart},
 		{"half the vector present", vecStart + dims*4/2},
 		{"one byte short of full vector", vecEnd - 1},
+		{"vector complete, nothing after", vecEnd},
+		{"into the class name", vecEnd + 3},
+		{"into the vector sections", vecEnd + (len(data)-vecEnd)/2},
+		{"one byte short of complete", len(data) - 1},
 	}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			backing := make([]byte, len(data)+70_000)
-			copy(backing, data[:tc.truncatedLen])
-			for i := tc.truncatedLen; i < len(backing); i++ {
-				backing[i] = 0xAA
-			}
-			in := backing[:tc.truncatedLen]
+	for _, dec := range decoders {
+		t.Run(dec.name, func(t *testing.T) {
+			want, err := dec.decode(data)
+			require.NoError(t, err, "the complete object must decode")
 
-			_, err := VectorFromBinary(in, nil, "")
-			require.Error(t, err)
+			for _, tc := range lengths {
+				t.Run(tc.name, func(t *testing.T) {
+					got, err := dec.decode(truncatedView(data, tc.n))
+
+					// Truncations below the legacy vector's end cut a field every
+					// decoder reads, so none of them can legitimately succeed.
+					if tc.n < vecEnd {
+						require.Error(t, err)
+						return
+					}
+
+					// Past that point a decoder may stop before the truncation. What
+					// it must never do is reconstruct a plausible-looking answer out
+					// of the bytes that follow the value.
+					if err == nil {
+						require.Equal(t, want, got)
+					}
+				})
+			}
 		})
 	}
 }
 
-// TestZeroLengthNamedVectorDecodesNonNil pins readTargetVectorAt: a nil buffer
-// must allocate even for a zero-length vector, because nil[:0] is nil and a
-// caller holding the result in a map would see an absent vector rather than an
-// explicitly empty one.
+// TestZeroLengthNamedVectorDecodesNonNil pins readVectorInto: a nil buffer must
+// allocate even for a zero-length vector, because nil[:0] is nil and a caller
+// holding the result in a map would see an absent vector rather than an
+// explicitly empty one. The single-vector path takes the nil buffer, so it has
+// to be exercised directly — the full-object decode never reaches it.
 func TestZeroLengthNamedVectorDecodesNonNil(t *testing.T) {
 	obj := legacyVectorTestObject(1, nil)
 	obj.Vectors = map[string][]float32{
@@ -161,11 +216,24 @@ func TestZeroLengthNamedVectorDecodesNonNil(t *testing.T) {
 	data, err := obj.MarshalBinary()
 	require.NoError(t, err)
 
-	full, err := FromBinaryDisk(data, "LegacyVectorBoundsClass")
-	require.NoError(t, err)
+	t.Run("VectorFromBinary", func(t *testing.T) {
+		empty, err := VectorFromBinary(data, nil, "empty")
+		require.NoError(t, err)
+		require.NotNil(t, empty)
+		require.Len(t, empty, 0)
 
-	require.Contains(t, full.Vectors, "empty")
-	require.NotNil(t, full.Vectors["empty"])
-	require.Len(t, full.Vectors["empty"], 0)
-	require.Equal(t, []float32{1, 2}, full.Vectors["full"])
+		full, err := VectorFromBinary(data, nil, "full")
+		require.NoError(t, err)
+		require.Equal(t, []float32{1, 2}, full)
+	})
+
+	t.Run("full object decode", func(t *testing.T) {
+		full, err := FromBinaryDisk(data, "LegacyVectorBoundsClass")
+		require.NoError(t, err)
+
+		require.Contains(t, full.Vectors, "empty")
+		require.NotNil(t, full.Vectors["empty"])
+		require.Len(t, full.Vectors["empty"], 0)
+		require.Equal(t, []float32{1, 2}, full.Vectors["full"])
+	})
 }

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -223,8 +223,8 @@ func fromBinaryOptionalInternal(data []byte, className string,
 		return nil, errors.Errorf("unsupported binary marshaller version %d", ko.MarshallerVersion)
 	}
 
-	// the fixed-width header is read unchecked below; everything after it is
-	// length-prefixed by the data itself and goes through the checked readers
+	// only the fixed-width header may be read unchecked; every length past it
+	// comes from the data itself
 	if len(data) < marshallerV1HeaderLen {
 		return nil, errors.Errorf("object of %d bytes is too short to hold a header", len(data))
 	}
@@ -1427,8 +1427,8 @@ func (ko *Object) unmarshalInternal(data []byte, className string, properties *P
 	}
 	ko.MarshallerVersion = version
 
-	// the fixed-width header is read unchecked below; everything after it is
-	// length-prefixed by the data itself and goes through the checked readers
+	// only the fixed-width header may be read unchecked; every length past it
+	// comes from the data itself
 	if len(data) < marshallerV1HeaderLen {
 		return errors.Errorf("object of %d bytes is too short to hold a header", len(data))
 	}
@@ -1533,22 +1533,19 @@ func (ko *Object) unmarshalInternal(data []byte, className string, properties *P
 // sections: a msgpack name->offset map, then a run of vectors whose declared
 // length delimits the section. Offsets are relative to start.
 //
-// Reads inside a section are bounded by end rather than by the buffer. That is
-// the tighter limit and the only one that distinguishes a corrupt offset from a
-// vector that legitimately runs up to the end of the value.
+// Reads are bounded by end, not by the buffer. It is the tighter limit, and the
+// only one that tells a corrupt offset apart from a vector that legitimately
+// runs to the end of the value.
 type vectorSegment struct {
 	offsetsBlob []byte
 	start, end  uint64
 }
 
-// readVectorSegment reads a section's framing and validates that the section
-// fits in the buffer, leaving the cursor at start.
-//
-// present is false when there is nothing to decode: either the value ends
-// before the section — objects written before this vector kind existed have no
-// section at all — or the section declares no offsets. In the latter case the
-// cursor is advanced past the declared section, so that whatever follows is
-// parsed from the right place.
+// readVectorSegment leaves the cursor at start. present is false when there is
+// nothing to decode — the value ends before the section, as it does for objects
+// written before this vector kind existed, or the section declares no offsets —
+// and the cursor is left past the declared section so the next one starts in the
+// right place.
 func readVectorSegment(rw *byteops.ReadWriter, kind string) (vectorSegment, bool, error) {
 	if rw.Remaining() == 0 {
 		return vectorSegment{}, false, nil
@@ -1588,7 +1585,6 @@ func (seg vectorSegment) decodeOffsets(kind string) (map[string]uint32, error) {
 	return offsets, nil
 }
 
-// skipVectorSegment advances past a section without decoding its offsets.
 func skipVectorSegment(rw *byteops.ReadWriter, kind string) error {
 	seg, present, err := readVectorSegment(rw, kind)
 	if err != nil {
@@ -1600,14 +1596,13 @@ func skipVectorSegment(rw *byteops.ReadWriter, kind string) error {
 	return nil
 }
 
-// These readers name no vector in their errors: they sit under the multi-vector
-// loop, where formatting a label per document would allocate on every successful
-// passage. Callers hold the names and wrap.
+// The three readers below name no vector in their errors: they run per document
+// inside the multi-vector loop, where building a label would allocate on every
+// successful passage. Callers hold the names and wrap.
 
-// seekToVector positions the cursor at the vector stored at seg.start+offset,
-// requiring room for its headerLen-byte count prefix. Offsets are read out of
-// the value itself, so one that lands outside the section must fail here rather
-// than decode the neighbouring section's bytes as a vector.
+// seekToVector requires room for the vector's headerLen-byte count prefix.
+// Offsets are read out of the value itself, so one landing outside the section
+// must fail here rather than decode the neighbouring section as a vector.
 func seekToVector(rw *byteops.ReadWriter, seg vectorSegment, offset uint32, headerLen uint64) error {
 	start := seg.start + uint64(offset)
 	if start+headerLen > seg.end {
@@ -1617,10 +1612,9 @@ func seekToVector(rw *byteops.ReadWriter, seg vectorSegment, offset uint32, head
 	return nil
 }
 
-// readVectorBytes decodes the uint16-length-prefixed vector at the cursor and
-// returns its raw little-endian float32 bytes. dims is widened before scaling:
-// the on-disk field is a uint16 and the writer permits maxVectorLength
-// dimensions, so a uint16 multiplication wraps from 16384 dimensions upwards.
+// readVectorBytes widens dims before scaling it to bytes: the on-disk field is a
+// uint16 and the writer permits maxVectorLength dimensions, so a uint16
+// multiplication wraps from 16384 dimensions upwards.
 func readVectorBytes(rw *byteops.ReadWriter, seg vectorSegment) ([]byte, uint64, error) {
 	if rw.Position+byteops.Uint16Len > seg.end {
 		return nil, 0, errors.New("truncated at segment end")
@@ -1632,10 +1626,9 @@ func readVectorBytes(rw *byteops.ReadWriter, seg vectorSegment) ([]byte, uint64,
 	return rw.ReadBytesFromBuffer(dims * byteops.Uint32Len), dims, nil
 }
 
-// readVectorInto decodes the vector at the cursor, reusing buffer when it has
-// the capacity. A nil buffer always allocates, even for a zero-length vector:
-// nil[:0] is nil, which a caller holding the result in a map cannot tell apart
-// from an absent vector.
+// readVectorInto reuses buffer when it has the capacity. A nil buffer always
+// allocates, even for a zero-length vector: nil[:0] is nil, which a caller
+// holding the result in a map cannot tell apart from an absent vector.
 func readVectorInto(rw *byteops.ReadWriter, seg vectorSegment, buffer []float32) ([]float32, error) {
 	vecBytes, dims, err := readVectorBytes(rw, seg)
 	if err != nil {
@@ -1806,10 +1799,9 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 	return out, nil
 }
 
-// legacyVectorBounds locates the legacy vector's byte range and dimension count.
-// dims is widened before scaling: the on-disk field is a uint16 and the writer
-// permits maxVectorLength dimensions, so a uint16 multiplication wraps from
-// 16384 dimensions upwards.
+// legacyVectorBounds widens dims before scaling it to bytes: the on-disk field
+// is a uint16 and the writer permits maxVectorLength dimensions, so a uint16
+// multiplication wraps from 16384 dimensions upwards.
 func legacyVectorBounds(in []byte) (start, end, dims int, err error) {
 	if len(in) < marshallerV1HeaderLen+2 {
 		return 0, 0, 0, fmt.Errorf("object of %d bytes is too short to hold a vector length", len(in))
@@ -1826,9 +1818,8 @@ func legacyVectorBounds(in []byte) (start, end, dims int, err error) {
 	return start, end, dims, nil
 }
 
-// skipToVectorSections advances the cursor from the end of the fixed header to
-// the start of the target-vector section, over the five length-prefixed fields
-// that sit in between.
+// skipToVectorSections walks the five length-prefixed fields between the fixed
+// header and the target-vector section.
 func skipToVectorSections(rw *byteops.ReadWriter) error {
 	vectorLength, err := rw.ReadUint16Checked()
 	if err != nil {

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -211,6 +211,10 @@ func FromBinaryOptionalDisk(data []byte, className string,
 func fromBinaryOptionalInternal(data []byte, className string,
 	addProp additional.Properties, properties *PropertyExtraction,
 ) (*Object, error) {
+	if len(data) == 0 {
+		return nil, errors.New("cannot decode an empty object")
+	}
+
 	ko := &Object{}
 
 	rw := byteops.NewReadWriter(data)
@@ -218,6 +222,13 @@ func fromBinaryOptionalInternal(data []byte, className string,
 	if ko.MarshallerVersion != 1 {
 		return nil, errors.Errorf("unsupported binary marshaller version %d", ko.MarshallerVersion)
 	}
+
+	// the fixed-width header is read unchecked below; everything after it is
+	// length-prefixed by the data itself and goes through the checked readers
+	if len(data) < marshallerV1HeaderLen {
+		return nil, errors.Errorf("object of %d bytes is too short to hold a header", len(data))
+	}
+
 	ko.DocID = rw.ReadUint64()
 	rw.MoveBufferPositionForward(1) // ignore kind-byte
 	uuidObj, err := uuid.FromBytes(rw.ReadBytesFromBuffer(16))
@@ -228,14 +239,25 @@ func fromBinaryOptionalInternal(data []byte, className string,
 
 	createTime := int64(rw.ReadUint64())
 	updateTime := int64(rw.ReadUint64())
-	vectorLength := rw.ReadUint16()
+
+	vectorLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return nil, fmt.Errorf("read vector length: %w", err)
+	}
 	// The vector length should always be returned (for usage metrics purposes) even if the vector itself is skipped
 	ko.VectorLen = int(vectorLength)
+	vectorByteLen := uint64(vectorLength) * byteops.Uint32Len
 	if addProp.Vector {
+		vectorBytes, err := rw.ReadBytesFromBufferChecked(vectorByteLen)
+		if err != nil {
+			return nil, fmt.Errorf("read vector: %w", err)
+		}
 		ko.Object.Vector = make([]float32, vectorLength)
-		byteops.CopyBytesToSlice(ko.Object.Vector, rw.ReadBytesFromBuffer(uint64(vectorLength)*byteops.Uint32Len))
+		byteops.CopyBytesToSlice(ko.Object.Vector, vectorBytes)
 	} else {
-		rw.MoveBufferPositionForward(uint64(vectorLength) * 4)
+		if err := rw.SkipChecked(vectorByteLen); err != nil {
+			return nil, fmt.Errorf("skip vector: %w", err)
+		}
 		ko.Object.Vector = nil
 	}
 	ko.Vector = ko.Object.Vector
@@ -245,34 +267,57 @@ func fromBinaryOptionalInternal(data []byte, className string,
 	// falls back to the on-disk value. If both are empty there is no class
 	// to attach to the decoded object — return an error rather than produce
 	// a silent empty Class.
-	classNameLength := uint64(rw.ReadUint16())
+	classNameLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return nil, fmt.Errorf("read class name length: %w", err)
+	}
 	if className == "" {
 		if classNameLength == 0 {
 			return nil, errors.New("storobj: cannot decode object with empty className: caller supplied no className and on-disk class-name field is empty")
 		}
-		className = string(rw.ReadBytesFromBuffer(classNameLength))
-	} else {
-		rw.MoveBufferPositionForward(classNameLength)
+		classNameBytes, err := rw.ReadBytesFromBufferChecked(uint64(classNameLength))
+		if err != nil {
+			return nil, fmt.Errorf("read class name: %w", err)
+		}
+		className = string(classNameBytes)
+	} else if err := rw.SkipChecked(uint64(classNameLength)); err != nil {
+		return nil, fmt.Errorf("skip class name: %w", err)
 	}
 
-	propLength := rw.ReadUint32()
+	propLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return nil, fmt.Errorf("read properties length: %w", err)
+	}
 	var props []byte
 	if addProp.NoProps {
-		rw.MoveBufferPositionForward(uint64(propLength))
-	} else {
-		props = rw.ReadBytesFromBuffer(uint64(propLength))
+		if err := rw.SkipChecked(uint64(propLength)); err != nil {
+			return nil, fmt.Errorf("skip properties: %w", err)
+		}
+	} else if props, err = rw.ReadBytesFromBufferChecked(uint64(propLength)); err != nil {
+		return nil, fmt.Errorf("read properties: %w", err)
 	}
 
+	metaLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return nil, fmt.Errorf("read meta length: %w", err)
+	}
 	var meta []byte
-	metaLength := rw.ReadUint32()
 	if addProp.Classification || len(addProp.ModuleParams) > 0 {
-		meta = rw.ReadBytesFromBuffer(uint64(metaLength))
-	} else {
-		rw.MoveBufferPositionForward(uint64(metaLength))
+		if meta, err = rw.ReadBytesFromBufferChecked(uint64(metaLength)); err != nil {
+			return nil, fmt.Errorf("read meta: %w", err)
+		}
+	} else if err := rw.SkipChecked(uint64(metaLength)); err != nil {
+		return nil, fmt.Errorf("skip meta: %w", err)
 	}
 
-	vectorWeightsLength := rw.ReadUint32()
-	vectorWeights := rw.ReadBytesFromBuffer(uint64(vectorWeightsLength))
+	vectorWeightsLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return nil, fmt.Errorf("read vector weights length: %w", err)
+	}
+	vectorWeights, err := rw.ReadBytesFromBufferChecked(uint64(vectorWeightsLength))
+	if err != nil {
+		return nil, fmt.Errorf("read vector weights: %w", err)
+	}
 
 	if len(addProp.Vectors) > 0 {
 		vectors, err := unmarshalTargetVectors(&rw)
@@ -289,13 +334,8 @@ func fromBinaryOptionalInternal(data []byte, className string,
 				ko.Object.Vectors[vecName] = vec
 			}
 		}
-	} else {
-		if rw.Position < uint64(len(rw.Buffer)) {
-			_ = rw.ReadBytesFromBufferWithUint32LengthIndicator()
-			targetVectorsSegmentLength := rw.ReadUint32()
-			pos := rw.Position
-			rw.MoveBufferToAbsolutePosition(pos + uint64(targetVectorsSegmentLength))
-		}
+	} else if err := skipVectorSegment(&rw, "target vectors"); err != nil {
+		return nil, err
 	}
 
 	if rw.Position < uint64(len(rw.Buffer)) && len(addProp.Vectors) > 0 {
@@ -1377,59 +1417,91 @@ func (ko *Object) UnmarshalBinaryDiskWithProps(data []byte, className string, pr
 // UnmarshalBinaryNetwork. A non-empty className stamps Object.Class; an empty
 // className falls back to the on-disk value.
 func (ko *Object) unmarshalInternal(data []byte, className string, properties *PropertyExtraction) error {
+	if len(data) == 0 {
+		return errors.New("cannot decode an empty object")
+	}
+
 	version := data[0]
 	if version != 1 {
 		return errors.Errorf("unsupported binary marshaller version %d", version)
 	}
 	ko.MarshallerVersion = version
 
+	// the fixed-width header is read unchecked below; everything after it is
+	// length-prefixed by the data itself and goes through the checked readers
+	if len(data) < marshallerV1HeaderLen {
+		return errors.Errorf("object of %d bytes is too short to hold a header", len(data))
+	}
+
 	rw := byteops.NewReadWriterWithOps(data, byteops.WithPosition(1))
 	ko.DocID = rw.ReadUint64()
 	rw.MoveBufferPositionForward(1) // kind-byte
 
-	uuidParsed, err := uuid.FromBytes(data[rw.Position : rw.Position+16])
+	uuidParsed, err := uuid.FromBytes(rw.ReadBytesFromBuffer(16))
 	if err != nil {
 		return err
 	}
-	rw.MoveBufferPositionForward(16)
 
 	createTime := int64(rw.ReadUint64())
 	updateTime := int64(rw.ReadUint64())
 
-	vectorLength := rw.ReadUint16()
+	vectorLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return errors.Wrap(err, "read vector length")
+	}
+	vectorBytes, err := rw.ReadBytesFromBufferChecked(uint64(vectorLength) * byteops.Uint32Len)
+	if err != nil {
+		return errors.Wrap(err, "read vector")
+	}
 	ko.VectorLen = int(vectorLength)
 	ko.Vector = make([]float32, vectorLength)
-	byteops.CopyBytesToSlice(ko.Vector, rw.ReadBytesFromBuffer(uint64(vectorLength)*byteops.Uint32Len))
+	byteops.CopyBytesToSlice(ko.Vector, vectorBytes)
 
 	// className precedence: a non-empty caller-supplied className wins and
 	// the on-disk class-name bytes are skipped. An empty caller className
 	// falls back to the on-disk value (the UnmarshalBinaryNetwork path). If
 	// both are empty there is no class to attach to the decoded object —
 	// return an error rather than produce a silent empty Class.
-	classNameLength := uint64(rw.ReadUint16())
+	classNameLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return errors.Wrap(err, "read class name length")
+	}
 	if className == "" {
 		if classNameLength == 0 {
 			return errors.New("storobj: cannot decode object with empty className: caller supplied no className and on-disk class-name field is empty")
 		}
-		className = string(rw.ReadBytesFromBuffer(classNameLength))
-	} else {
-		rw.MoveBufferPositionForward(classNameLength)
+		classNameBytes, err := rw.ReadBytesFromBufferChecked(uint64(classNameLength))
+		if err != nil {
+			return errors.Wrap(err, "read class name")
+		}
+		className = string(classNameBytes)
+	} else if err := rw.SkipChecked(uint64(classNameLength)); err != nil {
+		return errors.Wrap(err, "skip class name")
 	}
 
-	schemaLength := uint64(rw.ReadUint32())
-	schema, err := rw.CopyBytesFromBuffer(schemaLength, nil)
+	schemaLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return errors.Wrap(err, "read schema length")
+	}
+	schema, err := rw.CopyBytesFromBufferChecked(uint64(schemaLength), nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy schema")
 	}
 
-	metaLength := uint64(rw.ReadUint32())
-	meta, err := rw.CopyBytesFromBuffer(metaLength, nil)
+	metaLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return errors.Wrap(err, "read meta length")
+	}
+	meta, err := rw.CopyBytesFromBufferChecked(uint64(metaLength), nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy meta")
 	}
 
-	vectorWeightsLength := uint64(rw.ReadUint32())
-	vectorWeights, err := rw.CopyBytesFromBuffer(vectorWeightsLength, nil)
+	vectorWeightsLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return errors.Wrap(err, "read vector weights length")
+	}
+	vectorWeights, err := rw.CopyBytesFromBufferChecked(uint64(vectorWeightsLength), nil)
 	if err != nil {
 		return errors.Wrap(err, "Could not copy vectorWeights")
 	}
@@ -1457,109 +1529,183 @@ func (ko *Object) unmarshalInternal(data []byte, className string, properties *P
 	)
 }
 
-func unmarshalTargetVectors(rw *byteops.ReadWriter) (map[string][]float32, error) {
-	// This check prevents from panic when somebody is upgrading from version that
-	// didn't have multiple target vector support. This check is needed bc with named vectors
-	// feature storage object can have vectors data appended at the end of the file
-	if rw.Position < uint64(len(rw.Buffer)) {
-		targetVectorsOffsets := rw.ReadBytesFromBufferWithUint32LengthIndicator()
-		targetVectorsSegmentLength := rw.ReadUint32()
-		pos := rw.Position
+// vectorSegment is the framing shared by the target-vector and multi-vector
+// sections: a msgpack name->offset map, then a run of vectors whose declared
+// length delimits the section. Offsets are relative to start.
+//
+// Reads inside a section are bounded by end rather than by the buffer. That is
+// the tighter limit and the only one that distinguishes a corrupt offset from a
+// vector that legitimately runs up to the end of the value.
+type vectorSegment struct {
+	offsetsBlob []byte
+	start, end  uint64
+}
 
-		if len(targetVectorsOffsets) > 0 {
-			var tvOffsets map[string]uint32
-			if err := msgpack.Unmarshal(targetVectorsOffsets, &tvOffsets); err != nil {
-				return nil, fmt.Errorf("could not unmarshal target vectors offset: %w", err)
-			}
-
-			segEnd := pos + uint64(targetVectorsSegmentLength)
-			if segEnd > uint64(len(rw.Buffer)) {
-				return nil, fmt.Errorf("target vectors segment length %d exceeds buffer", targetVectorsSegmentLength)
-			}
-
-			targetVectors := map[string][]float32{}
-			for name, offset := range tvOffsets {
-				vec, err := readTargetVectorAt(rw, pos, segEnd, name, offset, nil)
-				if err != nil {
-					return nil, err
-				}
-				targetVectors[name] = vec
-			}
-
-			rw.MoveBufferToAbsolutePosition(segEnd)
-			return targetVectors, nil
-		}
+// readVectorSegment reads a section's framing and validates that the section
+// fits in the buffer, leaving the cursor at start.
+//
+// present is false when there is nothing to decode: either the value ends
+// before the section — objects written before this vector kind existed have no
+// section at all — or the section declares no offsets. In the latter case the
+// cursor is advanced past the declared section, so that whatever follows is
+// parsed from the right place.
+func readVectorSegment(rw *byteops.ReadWriter, kind string) (vectorSegment, bool, error) {
+	if rw.Remaining() == 0 {
+		return vectorSegment{}, false, nil
 	}
-	return nil, nil
+
+	offsetsBlob, err := rw.ReadBytesFromBufferWithUint32LengthIndicatorChecked()
+	if err != nil {
+		return vectorSegment{}, false, fmt.Errorf("%s offsets: %w", kind, err)
+	}
+
+	segmentLength, err := rw.ReadUint32Checked()
+	if err != nil {
+		return vectorSegment{}, false, fmt.Errorf("%s segment length: %w", kind, err)
+	}
+
+	seg := vectorSegment{
+		offsetsBlob: offsetsBlob,
+		start:       rw.Position,
+		end:         rw.Position + uint64(segmentLength),
+	}
+	if seg.end > uint64(len(rw.Buffer)) {
+		return vectorSegment{}, false, fmt.Errorf("%s segment length %d exceeds buffer", kind, segmentLength)
+	}
+
+	if len(offsetsBlob) == 0 {
+		rw.MoveBufferToAbsolutePosition(seg.end)
+		return seg, false, nil
+	}
+	return seg, true, nil
+}
+
+func (seg vectorSegment) decodeOffsets(kind string) (map[string]uint32, error) {
+	var offsets map[string]uint32
+	if err := msgpack.Unmarshal(seg.offsetsBlob, &offsets); err != nil {
+		return nil, fmt.Errorf("could not unmarshal %s offset: %w", kind, err)
+	}
+	return offsets, nil
+}
+
+// skipVectorSegment advances past a section without decoding its offsets.
+func skipVectorSegment(rw *byteops.ReadWriter, kind string) error {
+	seg, present, err := readVectorSegment(rw, kind)
+	if err != nil {
+		return err
+	}
+	if present {
+		rw.MoveBufferToAbsolutePosition(seg.end)
+	}
+	return nil
+}
+
+// seekToVector positions the cursor at the vector stored at seg.start+offset,
+// requiring room for its headerLen-byte count prefix. Offsets are read out of
+// the value itself, so one that lands outside the section must fail here rather
+// than decode the neighbouring section's bytes as a vector.
+func seekToVector(rw *byteops.ReadWriter, seg vectorSegment, what string, offset uint32, headerLen uint64) error {
+	start := seg.start + uint64(offset)
+	if start+headerLen > seg.end {
+		return fmt.Errorf("%s offset %d out of segment bounds", what, offset)
+	}
+	rw.MoveBufferToAbsolutePosition(start)
+	return nil
+}
+
+// readVectorBytes decodes the uint16-length-prefixed vector at the cursor and
+// returns its raw little-endian float32 bytes. dims is widened before scaling:
+// the on-disk field is a uint16 and the writer permits maxVectorLength
+// dimensions, so a uint16 multiplication wraps from 16384 dimensions upwards.
+func readVectorBytes(rw *byteops.ReadWriter, seg vectorSegment, what string) ([]byte, uint64, error) {
+	if rw.Position+byteops.Uint16Len > seg.end {
+		return nil, 0, fmt.Errorf("%s truncated at segment end", what)
+	}
+	dims := uint64(rw.ReadUint16())
+	if rw.Position+dims*byteops.Uint32Len > seg.end {
+		return nil, 0, fmt.Errorf("%s length %d exceeds segment", what, dims)
+	}
+	return rw.ReadBytesFromBuffer(dims * byteops.Uint32Len), dims, nil
+}
+
+// readVectorInto decodes the vector at the cursor, reusing buffer when it has
+// the capacity. A nil buffer always allocates, even for a zero-length vector:
+// nil[:0] is nil, which a caller holding the result in a map cannot tell apart
+// from an absent vector.
+func readVectorInto(rw *byteops.ReadWriter, seg vectorSegment, what string, buffer []float32) ([]float32, error) {
+	vecBytes, dims, err := readVectorBytes(rw, seg, what)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []float32
+	if buffer != nil && uint64(cap(buffer)) >= dims {
+		out = buffer[:dims]
+	} else {
+		out = make([]float32, dims)
+	}
+	byteops.CopyBytesToSlice(out, vecBytes)
+	return out, nil
+}
+
+func unmarshalTargetVectors(rw *byteops.ReadWriter) (map[string][]float32, error) {
+	seg, present, err := readVectorSegment(rw, "target vectors")
+	if err != nil || !present {
+		return nil, err
+	}
+
+	offsets, err := seg.decodeOffsets("target vectors")
+	if err != nil {
+		return nil, err
+	}
+
+	targetVectors := make(map[string][]float32, len(offsets))
+	for name, offset := range offsets {
+		what := fmt.Sprintf("target vector %q", name)
+		if err := seekToVector(rw, seg, what, offset, byteops.Uint16Len); err != nil {
+			return nil, err
+		}
+		vec, err := readVectorInto(rw, seg, what, nil)
+		if err != nil {
+			return nil, err
+		}
+		targetVectors[name] = vec
+	}
+
+	rw.MoveBufferToAbsolutePosition(seg.end)
+	return targetVectors, nil
 }
 
 // unmarshalSingleTargetVector unmarshals only the requested target vector, reusing the
 // provided buffer if it has sufficient capacity. This avoids allocating memory for all
 // target vectors when only one is needed (e.g., during HNSW rescoring).
 func unmarshalSingleTargetVector(rw *byteops.ReadWriter, targetVector string, buffer []float32) ([]float32, error) {
-	if rw.Position >= uint64(len(rw.Buffer)) {
-		return nil, nil
+	seg, present, err := readVectorSegment(rw, "target vectors")
+	if err != nil || !present {
+		return nil, err
 	}
 
-	targetVectorsOffsets := rw.ReadBytesFromBufferWithUint32LengthIndicator()
-	targetVectorsSegmentLength := rw.ReadUint32()
-	pos := rw.Position
-
-	if len(targetVectorsOffsets) == 0 {
-		return nil, nil
-	}
-
-	var tvOffsets map[string]uint32
-	if err := msgpack.Unmarshal(targetVectorsOffsets, &tvOffsets); err != nil {
-		return nil, fmt.Errorf("could not unmarshal target vectors offset: %w", err)
-	}
-
-	segEnd := pos + uint64(targetVectorsSegmentLength)
-	if segEnd > uint64(len(rw.Buffer)) {
-		return nil, fmt.Errorf("target vectors segment length %d exceeds buffer", targetVectorsSegmentLength)
-	}
-
-	offset, ok := tvOffsets[targetVector]
-	if !ok {
-		rw.MoveBufferToAbsolutePosition(segEnd)
-		return nil, ErrTargetVectorNotFound{TargetVector: targetVector}
-	}
-
-	out, err := readTargetVectorAt(rw, pos, segEnd, targetVector, offset, buffer)
+	offsets, err := seg.decodeOffsets("target vectors")
 	if err != nil {
 		return nil, err
 	}
 
-	rw.MoveBufferToAbsolutePosition(segEnd)
-	return out, nil
-}
-
-// readTargetVectorAt decodes the length-prefixed vector at pos+offset, bounding
-// every read by segEnd. Offsets come from the on-disk offsets map: a corrupt
-// entry must fail here rather than decode bytes of a neighbouring section as a
-// vector, or slice past the buffer.
-func readTargetVectorAt(rw *byteops.ReadWriter, pos, segEnd uint64, name string, offset uint32, buffer []float32) ([]float32, error) {
-	vecStart := pos + uint64(offset)
-	if vecStart+byteops.Uint16Len > segEnd {
-		return nil, fmt.Errorf("target vector %q offset %d out of segment bounds", name, offset)
-	}
-	rw.MoveBufferToAbsolutePosition(vecStart)
-	vecLen := uint64(rw.ReadUint16())
-	if vecStart+byteops.Uint16Len+vecLen*byteops.Uint32Len > segEnd {
-		return nil, fmt.Errorf("target vector %q length %d exceeds segment", name, vecLen)
+	offset, ok := offsets[targetVector]
+	if !ok {
+		rw.MoveBufferToAbsolutePosition(seg.end)
+		return nil, ErrTargetVectorNotFound{TargetVector: targetVector}
 	}
 
-	var out []float32
-	// a nil buffer must allocate even for a zero-length vector: buffer[:0] on nil
-	// yields nil, which callers holding the result in a map would see as an absent
-	// vector rather than an empty one
-	if buffer != nil && cap(buffer) >= int(vecLen) {
-		out = buffer[:vecLen]
-	} else {
-		out = make([]float32, vecLen)
+	what := fmt.Sprintf("target vector %q", targetVector)
+	if err := seekToVector(rw, seg, what, offset, byteops.Uint16Len); err != nil {
+		return nil, err
+	}
+	out, err := readVectorInto(rw, seg, what, buffer)
+	if err != nil {
+		return nil, err
 	}
 
-	byteops.CopyBytesToSlice(out, rw.ReadBytesFromBuffer(vecLen*byteops.Uint32Len))
+	rw.MoveBufferToAbsolutePosition(seg.end)
 	return out, nil
 }
 
@@ -1569,65 +1715,56 @@ func unmarshalMultiVectors(
 	rw *byteops.ReadWriter,
 	onlyUnmarshalNames map[string]interface{},
 ) (map[string][][]float32, error) {
-	// This check prevents from panic when somebody is upgrading from version that
-	// didn't have multi vector support. This check is needed bc with the multi vectors
-	// feature the storage object can have vectors data appended at the end of the file
-	if rw.Position < uint64(len(rw.Buffer)) {
-		multiVectorsOffsets := rw.ReadBytesFromBufferWithUint32LengthIndicator()
-		multiVectorsSegmentLength := rw.ReadUint32()
-		pos := rw.Position
-
-		if len(multiVectorsOffsets) > 0 {
-			var mvOffsets map[string]uint32
-			if err := msgpack.Unmarshal(multiVectorsOffsets, &mvOffsets); err != nil {
-				return nil, fmt.Errorf("could not unmarshal multi vectors offset: %w", err)
-			}
-
-			segEnd := pos + uint64(multiVectorsSegmentLength)
-			if segEnd > uint64(len(rw.Buffer)) {
-				return nil, fmt.Errorf("multi vectors segment length %d exceeds buffer", multiVectorsSegmentLength)
-			}
-
-			// NOTE if you sort mvOffsets by offset, you may be able to speed this up via
-			// sequential reads, haven't tried this yet
-			multiVectors := map[string][][]float32{}
-			for name, offset := range mvOffsets {
-				// if onlyUnmarshalNames is not nil and non-empty, only unmarshal the vectors
-				// for the names in the map
-				if len(onlyUnmarshalNames) > 0 {
-					if _, ok := onlyUnmarshalNames[name]; !ok {
-						continue
-					}
-				}
-				// bound every read by segEnd: a corrupt offsets entry must fail
-				// instead of decoding a neighbouring section or slicing past the buffer
-				vecStart := pos + uint64(offset)
-				if vecStart+byteops.Uint32Len > segEnd {
-					return nil, fmt.Errorf("multi vector %q offset %d out of segment bounds", name, offset)
-				}
-				rw.MoveBufferToAbsolutePosition(vecStart)
-				numVecs := rw.ReadUint32()
-				vecs := make([][]float32, 0)
-				for i := 0; i < int(numVecs); i++ {
-					if rw.Position+byteops.Uint16Len > segEnd {
-						return nil, fmt.Errorf("multi vector %q truncated at document %d", name, i)
-					}
-					vecLen := uint64(rw.ReadUint16())
-					if rw.Position+vecLen*byteops.Uint32Len > segEnd {
-						return nil, fmt.Errorf("multi vector %q document %d length %d exceeds segment", name, i, vecLen)
-					}
-					vec := make([]float32, vecLen)
-					byteops.CopyBytesToSlice(vec, rw.ReadBytesFromBuffer(vecLen*byteops.Uint32Len))
-					vecs = append(vecs, vec)
-				}
-				multiVectors[name] = vecs
-			}
-
-			rw.MoveBufferToAbsolutePosition(segEnd)
-			return multiVectors, nil
-		}
+	seg, present, err := readVectorSegment(rw, "multi vectors")
+	if err != nil || !present {
+		return nil, err
 	}
-	return nil, nil
+
+	offsets, err := seg.decodeOffsets("multi vectors")
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE if you sort offsets by offset, you may be able to speed this up via
+	// sequential reads, haven't tried this yet
+	multiVectors := make(map[string][][]float32, len(offsets))
+	for name, offset := range offsets {
+		// if onlyUnmarshalNames is not nil and non-empty, only unmarshal the vectors
+		// for the names in the map
+		if len(onlyUnmarshalNames) > 0 {
+			if _, ok := onlyUnmarshalNames[name]; !ok {
+				continue
+			}
+		}
+
+		what := fmt.Sprintf("multi vector %q", name)
+		if err := seekToVector(rw, seg, what, offset, byteops.Uint32Len); err != nil {
+			return nil, err
+		}
+		numVecs := uint64(rw.ReadUint32())
+
+		// every document carries at least a length prefix, so the remaining segment
+		// caps the count. Without this the allocation below is sized by a uint32
+		// read straight out of the data.
+		maxVecs := (seg.end - rw.Position) / byteops.Uint16Len
+		if numVecs > maxVecs {
+			return nil, fmt.Errorf("%s truncated at document count: declares %d documents, segment holds at most %d",
+				what, numVecs, maxVecs)
+		}
+
+		vecs := make([][]float32, 0, numVecs)
+		for i := uint64(0); i < numVecs; i++ {
+			vec, err := readVectorInto(rw, seg, fmt.Sprintf("%s document %d", what, i), nil)
+			if err != nil {
+				return nil, err
+			}
+			vecs = append(vecs, vec)
+		}
+		multiVectors[name] = vecs
+	}
+
+	rw.MoveBufferToAbsolutePosition(seg.end)
+	return multiVectors, nil
 }
 
 func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float32, error) {
@@ -1641,24 +1778,10 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 	}
 
 	if targetVector != "" {
-		startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
-		rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(startPos))
-
-		vectorLength := uint64(rw.ReadUint16())
-		rw.MoveBufferPositionForward(vectorLength * 4)
-
-		classnameLength := uint64(rw.ReadUint16())
-		rw.MoveBufferPositionForward(classnameLength)
-
-		schemaLength := uint64(rw.ReadUint32())
-		rw.MoveBufferPositionForward(schemaLength)
-
-		metaLength := uint64(rw.ReadUint32())
-		rw.MoveBufferPositionForward(metaLength)
-
-		vectorWeightsLength := uint64(rw.ReadUint32())
-		rw.MoveBufferPositionForward(vectorWeightsLength)
-
+		rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(marshallerV1HeaderLen))
+		if err := skipToVectorSections(&rw); err != nil {
+			return nil, err
+		}
 		return unmarshalSingleTargetVector(&rw, targetVector, buffer)
 	}
 
@@ -1683,11 +1806,9 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 }
 
 // legacyVectorBounds locates the legacy vector's byte range and dimension count.
-// The dimension count is widened before scaling: the on-disk field is a uint16 and
-// the writer permits maxVectorLength (65535) dimensions, so a uint16 multiplication
-// wraps from 16384 dimensions upwards. in is also frequently a subslice of an
-// mmapped segment whose capacity runs past the value, so an unchecked end reads the
-// neighbouring object's bytes rather than panicking.
+// dims is widened before scaling: the on-disk field is a uint16 and the writer
+// permits maxVectorLength dimensions, so a uint16 multiplication wraps from
+// 16384 dimensions upwards.
 func legacyVectorBounds(in []byte) (start, end, dims int, err error) {
 	if len(in) < marshallerV1HeaderLen+2 {
 		return 0, 0, 0, fmt.Errorf("object of %d bytes is too short to hold a vector length", len(in))
@@ -1704,23 +1825,39 @@ func legacyVectorBounds(in []byte) (start, end, dims int, err error) {
 	return start, end, dims, nil
 }
 
-func incrementPos(in []byte, pos int, size int) int {
-	b := in[pos : pos+size]
-	if size == 2 {
-		length := binary.LittleEndian.Uint16(b)
-		pos += size + int(length)
-	} else if size == 4 {
-		length := binary.LittleEndian.Uint32(b)
-		pos += size + int(length)
-		return pos
-	} else if size == 8 {
-		length := binary.LittleEndian.Uint64(b)
-		pos += size + int(length)
+// skipToVectorSections advances the cursor from the end of the fixed header to
+// the start of the target-vector section, over the five length-prefixed fields
+// that sit in between.
+func skipToVectorSections(rw *byteops.ReadWriter) error {
+	vectorLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return fmt.Errorf("vector length: %w", err)
 	}
-	return pos
+	if err := rw.SkipChecked(uint64(vectorLength) * byteops.Uint32Len); err != nil {
+		return fmt.Errorf("vector: %w", err)
+	}
+
+	classNameLength, err := rw.ReadUint16Checked()
+	if err != nil {
+		return fmt.Errorf("class name length: %w", err)
+	}
+	if err := rw.SkipChecked(uint64(classNameLength)); err != nil {
+		return fmt.Errorf("class name: %w", err)
+	}
+
+	for _, field := range []string{"schema", "meta", "vector weights"} {
+		length, err := rw.ReadUint32Checked()
+		if err != nil {
+			return fmt.Errorf("%s length: %w", field, err)
+		}
+		if err := rw.SkipChecked(uint64(length)); err != nil {
+			return fmt.Errorf("%s: %w", field, err)
+		}
+	}
+	return nil
 }
 
-func MultiVectorFromBinary(in []byte, buffer []float32, targetVector string) ([][]float32, error) {
+func MultiVectorFromBinary(in []byte, targetVector string) ([][]float32, error) {
 	if len(in) == 0 {
 		return nil, nil
 	}
@@ -1730,47 +1867,24 @@ func MultiVectorFromBinary(in []byte, buffer []float32, targetVector string) ([]
 		return nil, errors.Errorf("unsupported marshaller version %d", version)
 	}
 
-	vecStart, vecEnd, vecLen, err := legacyVectorBounds(in)
-	if err != nil {
+	rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(marshallerV1HeaderLen))
+	if err := skipToVectorSections(&rw); err != nil {
+		return nil, err
+	}
+	if err := skipVectorSegment(&rw, "target vectors"); err != nil {
 		return nil, err
 	}
 
-	var out []float32
-	if vecLen > 0 {
-		if cap(buffer) >= vecLen {
-			out = buffer[:vecLen]
-		} else {
-			out = make([]float32, vecLen)
-		}
-		byteops.CopyBytesToSlice(out, in[vecStart:vecEnd])
+	multiVectors, err := unmarshalMultiVectors(&rw, map[string]interface{}{targetVector: nil})
+	if err != nil {
+		return nil, fmt.Errorf("unmarshal multivector for target vector %q: %w", targetVector, err)
 	}
 
-	pos := vecEnd
-
-	pos = incrementPos(in, pos, 2) // classNameLength
-	pos = incrementPos(in, pos, 4) // schemaLength
-	pos = incrementPos(in, pos, 4) // metaLength
-	pos = incrementPos(in, pos, 4) // vectorWeightsLength
-	pos = incrementPos(in, pos, 4) // bufLen
-	pos = incrementPos(in, pos, 4) // targetVectorsSegmentLength
-
-	// multivector
-	var multiVectors map[string][][]float32
-
-	if len(in) > pos {
-		rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(uint64(pos)))
-		mv, err := unmarshalMultiVectors(&rw, map[string]interface{}{targetVector: nil})
-		if err != nil {
-			return nil, errors.Errorf("unable to unmarshal multivector for target vector: %s", targetVector)
-		}
-		multiVectors = mv
-	}
-
-	mvout, ok := multiVectors[targetVector]
+	out, ok := multiVectors[targetVector]
 	if !ok {
 		return nil, errors.Errorf("vector not found for target vector: %s", targetVector)
 	}
-	return mvout, nil
+	return out, nil
 }
 
 func (ko *Object) parseObject(uuid strfmt.UUID, create, update int64, className string,

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1472,16 +1472,21 @@ func unmarshalTargetVectors(rw *byteops.ReadWriter) (map[string][]float32, error
 				return nil, fmt.Errorf("could not unmarshal target vectors offset: %w", err)
 			}
 
+			segEnd := pos + uint64(targetVectorsSegmentLength)
+			if segEnd > uint64(len(rw.Buffer)) {
+				return nil, fmt.Errorf("target vectors segment length %d exceeds buffer", targetVectorsSegmentLength)
+			}
+
 			targetVectors := map[string][]float32{}
 			for name, offset := range tvOffsets {
-				rw.MoveBufferToAbsolutePosition(pos + uint64(offset))
-				vecLen := rw.ReadUint16()
-				vec := make([]float32, vecLen)
-				byteops.CopyBytesToSlice(vec, rw.ReadBytesFromBuffer(uint64(vecLen)*byteops.Uint32Len))
+				vec, err := readTargetVectorAt(rw, pos, segEnd, name, offset, nil)
+				if err != nil {
+					return nil, err
+				}
 				targetVectors[name] = vec
 			}
 
-			rw.MoveBufferToAbsolutePosition(pos + uint64(targetVectorsSegmentLength))
+			rw.MoveBufferToAbsolutePosition(segEnd)
 			return targetVectors, nil
 		}
 	}
@@ -1509,25 +1514,52 @@ func unmarshalSingleTargetVector(rw *byteops.ReadWriter, targetVector string, bu
 		return nil, fmt.Errorf("could not unmarshal target vectors offset: %w", err)
 	}
 
+	segEnd := pos + uint64(targetVectorsSegmentLength)
+	if segEnd > uint64(len(rw.Buffer)) {
+		return nil, fmt.Errorf("target vectors segment length %d exceeds buffer", targetVectorsSegmentLength)
+	}
+
 	offset, ok := tvOffsets[targetVector]
 	if !ok {
-		rw.MoveBufferToAbsolutePosition(pos + uint64(targetVectorsSegmentLength))
+		rw.MoveBufferToAbsolutePosition(segEnd)
 		return nil, ErrTargetVectorNotFound{TargetVector: targetVector}
 	}
 
-	rw.MoveBufferToAbsolutePosition(pos + uint64(offset))
-	vecLen := rw.ReadUint16()
+	out, err := readTargetVectorAt(rw, pos, segEnd, targetVector, offset, buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	rw.MoveBufferToAbsolutePosition(segEnd)
+	return out, nil
+}
+
+// readTargetVectorAt decodes the length-prefixed vector at pos+offset, bounding
+// every read by segEnd. Offsets come from the on-disk offsets map: a corrupt
+// entry must fail here rather than decode bytes of a neighbouring section as a
+// vector, or slice past the buffer.
+func readTargetVectorAt(rw *byteops.ReadWriter, pos, segEnd uint64, name string, offset uint32, buffer []float32) ([]float32, error) {
+	vecStart := pos + uint64(offset)
+	if vecStart+byteops.Uint16Len > segEnd {
+		return nil, fmt.Errorf("target vector %q offset %d out of segment bounds", name, offset)
+	}
+	rw.MoveBufferToAbsolutePosition(vecStart)
+	vecLen := uint64(rw.ReadUint16())
+	if vecStart+byteops.Uint16Len+vecLen*byteops.Uint32Len > segEnd {
+		return nil, fmt.Errorf("target vector %q length %d exceeds segment", name, vecLen)
+	}
 
 	var out []float32
-	if cap(buffer) >= int(vecLen) {
+	// a nil buffer must allocate even for a zero-length vector: buffer[:0] on nil
+	// yields nil, which callers holding the result in a map would see as an absent
+	// vector rather than an empty one
+	if buffer != nil && cap(buffer) >= int(vecLen) {
 		out = buffer[:vecLen]
 	} else {
 		out = make([]float32, vecLen)
 	}
 
-	byteops.CopyBytesToSlice(out, rw.ReadBytesFromBuffer(uint64(vecLen)*byteops.Uint32Len))
-
-	rw.MoveBufferToAbsolutePosition(pos + uint64(targetVectorsSegmentLength))
+	byteops.CopyBytesToSlice(out, rw.ReadBytesFromBuffer(vecLen*byteops.Uint32Len))
 	return out, nil
 }
 
@@ -1551,6 +1583,11 @@ func unmarshalMultiVectors(
 				return nil, fmt.Errorf("could not unmarshal multi vectors offset: %w", err)
 			}
 
+			segEnd := pos + uint64(multiVectorsSegmentLength)
+			if segEnd > uint64(len(rw.Buffer)) {
+				return nil, fmt.Errorf("multi vectors segment length %d exceeds buffer", multiVectorsSegmentLength)
+			}
+
 			// NOTE if you sort mvOffsets by offset, you may be able to speed this up via
 			// sequential reads, haven't tried this yet
 			multiVectors := map[string][][]float32{}
@@ -1562,19 +1599,31 @@ func unmarshalMultiVectors(
 						continue
 					}
 				}
-				rw.MoveBufferToAbsolutePosition(pos + uint64(offset))
+				// bound every read by segEnd: a corrupt offsets entry must fail
+				// instead of decoding a neighbouring section or slicing past the buffer
+				vecStart := pos + uint64(offset)
+				if vecStart+byteops.Uint32Len > segEnd {
+					return nil, fmt.Errorf("multi vector %q offset %d out of segment bounds", name, offset)
+				}
+				rw.MoveBufferToAbsolutePosition(vecStart)
 				numVecs := rw.ReadUint32()
 				vecs := make([][]float32, 0)
 				for i := 0; i < int(numVecs); i++ {
-					vecLen := rw.ReadUint16()
+					if rw.Position+byteops.Uint16Len > segEnd {
+						return nil, fmt.Errorf("multi vector %q truncated at document %d", name, i)
+					}
+					vecLen := uint64(rw.ReadUint16())
+					if rw.Position+vecLen*byteops.Uint32Len > segEnd {
+						return nil, fmt.Errorf("multi vector %q document %d length %d exceeds segment", name, i, vecLen)
+					}
 					vec := make([]float32, vecLen)
-					byteops.CopyBytesToSlice(vec, rw.ReadBytesFromBuffer(uint64(vecLen)*byteops.Uint32Len))
+					byteops.CopyBytesToSlice(vec, rw.ReadBytesFromBuffer(vecLen*byteops.Uint32Len))
 					vecs = append(vecs, vec)
 				}
 				multiVectors[name] = vecs
 			}
 
-			rw.MoveBufferToAbsolutePosition(pos + uint64(multiVectorsSegmentLength))
+			rw.MoveBufferToAbsolutePosition(segEnd)
 			return multiVectors, nil
 		}
 	}
@@ -1613,27 +1662,46 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 		return unmarshalSingleTargetVector(&rw, targetVector, buffer)
 	}
 
-	// since we know the version and know that the blob is not len(0), we can
-	// assume that we can directly access the vector length field. The only
-	// situation where this is not accessible would be on corrupted data - where
-	// it would be acceptable to panic
-	vecLen := binary.LittleEndian.Uint16(in[marshallerV1HeaderLen : marshallerV1HeaderLen+2])
+	vecStart, vecEnd, vecLen, err := legacyVectorBounds(in)
+	if err != nil {
+		return nil, err
+	}
 	if vecLen == 0 {
 		return nil, fmt.Errorf("vector length is 0")
 	}
 
 	var out []float32
-	if cap(buffer) >= int(vecLen) {
+	if cap(buffer) >= vecLen {
 		out = buffer[:vecLen]
 	} else {
 		out = make([]float32, vecLen)
 	}
-	vecStart := 44
-	vecEnd := vecStart + int(vecLen*4)
 
 	byteops.CopyBytesToSlice(out, in[vecStart:vecEnd])
 
 	return out, nil
+}
+
+// legacyVectorBounds locates the legacy vector's byte range and dimension count.
+// The dimension count is widened before scaling: the on-disk field is a uint16 and
+// the writer permits maxVectorLength (65535) dimensions, so a uint16 multiplication
+// wraps from 16384 dimensions upwards. in is also frequently a subslice of an
+// mmapped segment whose capacity runs past the value, so an unchecked end reads the
+// neighbouring object's bytes rather than panicking.
+func legacyVectorBounds(in []byte) (start, end, dims int, err error) {
+	if len(in) < marshallerV1HeaderLen+2 {
+		return 0, 0, 0, fmt.Errorf("object of %d bytes is too short to hold a vector length", len(in))
+	}
+
+	dims = int(binary.LittleEndian.Uint16(in[marshallerV1HeaderLen : marshallerV1HeaderLen+2]))
+	start = marshallerV1HeaderLen + 2
+	end = start + dims*byteops.Uint32Len
+
+	if end > len(in) {
+		return 0, 0, 0, fmt.Errorf("legacy vector of %d dimensions exceeds the %d byte object",
+			dims, len(in))
+	}
+	return start, end, dims, nil
 }
 
 func incrementPos(in []byte, pos int, size int) int {
@@ -1662,18 +1730,14 @@ func MultiVectorFromBinary(in []byte, buffer []float32, targetVector string) ([]
 		return nil, errors.Errorf("unsupported marshaller version %d", version)
 	}
 
-	// since we know the version and know that the blob is not len(0), we can
-	// assume that we can directly access the vector length field. The only
-	// situation where this is not accessible would be on corrupted data - where
-	// it would be acceptable to panic
-	vecLen := binary.LittleEndian.Uint16(in[marshallerV1HeaderLen : marshallerV1HeaderLen+2])
+	vecStart, vecEnd, vecLen, err := legacyVectorBounds(in)
+	if err != nil {
+		return nil, err
+	}
 
 	var out []float32
-	vecStart := 44
-	vecEnd := vecStart + int(vecLen*4)
-
 	if vecLen > 0 {
-		if cap(buffer) >= int(vecLen) {
+		if cap(buffer) >= vecLen {
 			out = buffer[:vecLen]
 		} else {
 			out = make([]float32, vecLen)

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1600,14 +1600,18 @@ func skipVectorSegment(rw *byteops.ReadWriter, kind string) error {
 	return nil
 }
 
+// These readers name no vector in their errors: they sit under the multi-vector
+// loop, where formatting a label per document would allocate on every successful
+// passage. Callers hold the names and wrap.
+
 // seekToVector positions the cursor at the vector stored at seg.start+offset,
 // requiring room for its headerLen-byte count prefix. Offsets are read out of
 // the value itself, so one that lands outside the section must fail here rather
 // than decode the neighbouring section's bytes as a vector.
-func seekToVector(rw *byteops.ReadWriter, seg vectorSegment, what string, offset uint32, headerLen uint64) error {
+func seekToVector(rw *byteops.ReadWriter, seg vectorSegment, offset uint32, headerLen uint64) error {
 	start := seg.start + uint64(offset)
 	if start+headerLen > seg.end {
-		return fmt.Errorf("%s offset %d out of segment bounds", what, offset)
+		return fmt.Errorf("offset %d out of segment bounds", offset)
 	}
 	rw.MoveBufferToAbsolutePosition(start)
 	return nil
@@ -1617,13 +1621,13 @@ func seekToVector(rw *byteops.ReadWriter, seg vectorSegment, what string, offset
 // returns its raw little-endian float32 bytes. dims is widened before scaling:
 // the on-disk field is a uint16 and the writer permits maxVectorLength
 // dimensions, so a uint16 multiplication wraps from 16384 dimensions upwards.
-func readVectorBytes(rw *byteops.ReadWriter, seg vectorSegment, what string) ([]byte, uint64, error) {
+func readVectorBytes(rw *byteops.ReadWriter, seg vectorSegment) ([]byte, uint64, error) {
 	if rw.Position+byteops.Uint16Len > seg.end {
-		return nil, 0, fmt.Errorf("%s truncated at segment end", what)
+		return nil, 0, errors.New("truncated at segment end")
 	}
 	dims := uint64(rw.ReadUint16())
 	if rw.Position+dims*byteops.Uint32Len > seg.end {
-		return nil, 0, fmt.Errorf("%s length %d exceeds segment", what, dims)
+		return nil, 0, fmt.Errorf("length %d exceeds segment", dims)
 	}
 	return rw.ReadBytesFromBuffer(dims * byteops.Uint32Len), dims, nil
 }
@@ -1632,8 +1636,8 @@ func readVectorBytes(rw *byteops.ReadWriter, seg vectorSegment, what string) ([]
 // the capacity. A nil buffer always allocates, even for a zero-length vector:
 // nil[:0] is nil, which a caller holding the result in a map cannot tell apart
 // from an absent vector.
-func readVectorInto(rw *byteops.ReadWriter, seg vectorSegment, what string, buffer []float32) ([]float32, error) {
-	vecBytes, dims, err := readVectorBytes(rw, seg, what)
+func readVectorInto(rw *byteops.ReadWriter, seg vectorSegment, buffer []float32) ([]float32, error) {
+	vecBytes, dims, err := readVectorBytes(rw, seg)
 	if err != nil {
 		return nil, err
 	}
@@ -1661,13 +1665,12 @@ func unmarshalTargetVectors(rw *byteops.ReadWriter) (map[string][]float32, error
 
 	targetVectors := make(map[string][]float32, len(offsets))
 	for name, offset := range offsets {
-		what := fmt.Sprintf("target vector %q", name)
-		if err := seekToVector(rw, seg, what, offset, byteops.Uint16Len); err != nil {
-			return nil, err
+		if err := seekToVector(rw, seg, offset, byteops.Uint16Len); err != nil {
+			return nil, fmt.Errorf("target vector %q %w", name, err)
 		}
-		vec, err := readVectorInto(rw, seg, what, nil)
+		vec, err := readVectorInto(rw, seg, nil)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("target vector %q %w", name, err)
 		}
 		targetVectors[name] = vec
 	}
@@ -1696,13 +1699,12 @@ func unmarshalSingleTargetVector(rw *byteops.ReadWriter, targetVector string, bu
 		return nil, ErrTargetVectorNotFound{TargetVector: targetVector}
 	}
 
-	what := fmt.Sprintf("target vector %q", targetVector)
-	if err := seekToVector(rw, seg, what, offset, byteops.Uint16Len); err != nil {
-		return nil, err
+	if err := seekToVector(rw, seg, offset, byteops.Uint16Len); err != nil {
+		return nil, fmt.Errorf("target vector %q %w", targetVector, err)
 	}
-	out, err := readVectorInto(rw, seg, what, buffer)
+	out, err := readVectorInto(rw, seg, buffer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("target vector %q %w", targetVector, err)
 	}
 
 	rw.MoveBufferToAbsolutePosition(seg.end)
@@ -1737,9 +1739,8 @@ func unmarshalMultiVectors(
 			}
 		}
 
-		what := fmt.Sprintf("multi vector %q", name)
-		if err := seekToVector(rw, seg, what, offset, byteops.Uint32Len); err != nil {
-			return nil, err
+		if err := seekToVector(rw, seg, offset, byteops.Uint32Len); err != nil {
+			return nil, fmt.Errorf("multi vector %q %w", name, err)
 		}
 		numVecs := uint64(rw.ReadUint32())
 
@@ -1748,15 +1749,15 @@ func unmarshalMultiVectors(
 		// read straight out of the data.
 		maxVecs := (seg.end - rw.Position) / byteops.Uint16Len
 		if numVecs > maxVecs {
-			return nil, fmt.Errorf("%s truncated at document count: declares %d documents, segment holds at most %d",
-				what, numVecs, maxVecs)
+			return nil, fmt.Errorf("multi vector %q truncated at document count: declares %d documents, segment holds at most %d",
+				name, numVecs, maxVecs)
 		}
 
 		vecs := make([][]float32, 0, numVecs)
 		for i := uint64(0); i < numVecs; i++ {
-			vec, err := readVectorInto(rw, seg, fmt.Sprintf("%s document %d", what, i), nil)
+			vec, err := readVectorInto(rw, seg, nil)
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("multi vector %q document %d %w", name, i, err)
 			}
 			vecs = append(vecs, vec)
 		}

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -1239,15 +1239,15 @@ func TestMultiVectorFromBinary(t *testing.T) {
 	asBinary, err := before.MarshalBinary()
 	require.Nil(t, err)
 
-	outVector1, err := MultiVectorFromBinary(asBinary, nil, "vector1")
+	outVector1, err := MultiVectorFromBinary(asBinary, "vector1")
 	require.Nil(t, err)
 	assert.Equal(t, vector1, outVector1)
 
-	outVector2, err := MultiVectorFromBinary(asBinary, nil, "vector2")
+	outVector2, err := MultiVectorFromBinary(asBinary, "vector2")
 	require.Nil(t, err)
 	assert.Equal(t, vector2, outVector2)
 
-	outVector3, err := MultiVectorFromBinary(asBinary, nil, "vector3")
+	outVector3, err := MultiVectorFromBinary(asBinary, "vector3")
 	require.Nil(t, err)
 	assert.Equal(t, vector3, outVector3)
 

--- a/entities/storobj/target_vector_corruption_test.go
+++ b/entities/storobj/target_vector_corruption_test.go
@@ -1,0 +1,236 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package storobj
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+func encodeTargetVec(vals ...float32) []byte {
+	b := make([]byte, 2+len(vals)*4)
+	binary.LittleEndian.PutUint16(b, uint16(len(vals)))
+	for i, v := range vals {
+		binary.LittleEndian.PutUint32(b[2+i*4:], math.Float32bits(v))
+	}
+	return b
+}
+
+func encodeMultiVec(vecs ...[]float32) []byte {
+	b := binary.LittleEndian.AppendUint32(nil, uint32(len(vecs)))
+	for _, v := range vecs {
+		b = append(b, encodeTargetVec(v...)...)
+	}
+	return b
+}
+
+// buildVectorSection serializes one vector wire section
+// ([uint32 offsetsLen][msgpack offsets][uint32 segLen][segment][trailing]);
+// segLen is explicit so tests can declare a length that disagrees with the
+// actual segment bytes.
+func buildVectorSection(t *testing.T, offsets map[string]uint32, segLen uint32, segment, trailing []byte) []byte {
+	t.Helper()
+	blob, err := msgpack.Marshal(offsets)
+	require.NoError(t, err)
+	buf := binary.LittleEndian.AppendUint32(nil, uint32(len(blob)))
+	buf = append(buf, blob...)
+	buf = binary.LittleEndian.AppendUint32(buf, segLen)
+	buf = append(buf, segment...)
+	buf = append(buf, trailing...)
+	return buf
+}
+
+// TestUnmarshalTargetVectorsCorruptOffsets pins that a corrupt offsets map or
+// segment length fails with an error on both target-vector parsers, instead of
+// silently decoding bytes of the following section (or panicking past the
+// buffer, as unmarshalTargetVectors previously did).
+func TestUnmarshalTargetVectorsCorruptOffsets(t *testing.T) {
+	vecA := encodeTargetVec(1, 2, 3) // 14 bytes at offset 0
+	vecB := encodeTargetVec(4, 5)    // 10 bytes at offset 14
+	validSegment := append(append([]byte{}, vecA...), vecB...)
+	// stands in for the multi-vector section that follows on disk: well-formed
+	// vector bytes that a corrupt offset would decode cleanly
+	trailing := encodeTargetVec(9, 9, 9, 9)
+
+	// vecLen declares 10 floats but the segment ends after the prefix
+	truncatedSegment := append(append([]byte{}, vecA...), 0x0A, 0x00)
+
+	cases := []struct {
+		name    string
+		offsets map[string]uint32
+		segLen  uint32
+		segment []byte
+		lookup  string
+		want    []float32
+		errLike string
+	}{
+		{
+			name:    "valid",
+			offsets: map[string]uint32{"vecA": 0, "vecB": 14},
+			segLen:  uint32(len(validSegment)),
+			segment: validSegment,
+			lookup:  "vecB",
+			want:    []float32{4, 5},
+		},
+		{
+			name:    "offset into next section",
+			offsets: map[string]uint32{"vecA": 0, "evil": uint32(len(validSegment))},
+			segLen:  uint32(len(validSegment)),
+			segment: validSegment,
+			lookup:  "evil",
+			errLike: "out of segment bounds",
+		},
+		{
+			name:    "vector length crosses segment end",
+			offsets: map[string]uint32{"vecA": 0, "evil": 14},
+			segLen:  uint32(len(truncatedSegment)),
+			segment: truncatedSegment,
+			lookup:  "evil",
+			errLike: "exceeds segment",
+		},
+		{
+			name:    "segment length exceeds buffer",
+			offsets: map[string]uint32{"vecA": 0},
+			segLen:  10_000,
+			segment: validSegment,
+			lookup:  "vecA",
+			errLike: "exceeds buffer",
+		},
+		{
+			name:    "offset beyond buffer",
+			offsets: map[string]uint32{"evil": 60_000},
+			segLen:  uint32(len(validSegment)),
+			segment: validSegment,
+			lookup:  "evil",
+			errLike: "out of segment bounds",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := buildVectorSection(t, tc.offsets, tc.segLen, tc.segment, trailing)
+
+			rw := byteops.NewReadWriter(buf)
+			all, err := unmarshalTargetVectors(&rw)
+			rw2 := byteops.NewReadWriter(buf)
+			single, serr := unmarshalSingleTargetVector(&rw2, tc.lookup, nil)
+
+			if tc.errLike != "" {
+				require.ErrorContains(t, err, tc.errLike)
+				require.ErrorContains(t, serr, tc.errLike)
+				return
+			}
+			require.NoError(t, err)
+			require.NoError(t, serr)
+			require.Equal(t, tc.want, single)
+			require.Equal(t, tc.want, all[tc.lookup])
+		})
+	}
+
+	t.Run("missing name still reports not-found", func(t *testing.T) {
+		buf := buildVectorSection(t, map[string]uint32{"vecA": 0, "vecB": 14},
+			uint32(len(validSegment)), validSegment, trailing)
+		rw := byteops.NewReadWriter(buf)
+		_, err := unmarshalSingleTargetVector(&rw, "missing", nil)
+		require.ErrorAs(t, err, &ErrTargetVectorNotFound{})
+	})
+}
+
+// TestUnmarshalMultiVectorsCorruptOffsets: same guarantees for the multi-vector
+// parser, whose per-document inner reads must also stay inside the declared
+// segment.
+func TestUnmarshalMultiVectorsCorruptOffsets(t *testing.T) {
+	validSegment := encodeMultiVec([]float32{1, 2}, []float32{3, 4}) // 24 bytes
+	trailing := encodeTargetVec(9, 9, 9, 9)
+
+	// declares 1000 documents but holds one
+	runawaySegment := binary.LittleEndian.AppendUint32(nil, 1000)
+	runawaySegment = append(runawaySegment, encodeTargetVec(1, 2)...)
+
+	// single document whose vector length reaches past the segment
+	oversizedSegment := binary.LittleEndian.AppendUint32(nil, 1)
+	oversizedSegment = append(oversizedSegment, 0x32, 0x00) // vecLen=50, no data
+
+	cases := []struct {
+		name    string
+		offsets map[string]uint32
+		segLen  uint32
+		segment []byte
+		want    [][]float32
+		errLike string
+	}{
+		{
+			name:    "valid",
+			offsets: map[string]uint32{"colbert": 0},
+			segLen:  uint32(len(validSegment)),
+			segment: validSegment,
+			want:    [][]float32{{1, 2}, {3, 4}},
+		},
+		{
+			name:    "offset into next section",
+			offsets: map[string]uint32{"colbert": uint32(len(validSegment))},
+			segLen:  uint32(len(validSegment)),
+			segment: validSegment,
+			errLike: "out of segment bounds",
+		},
+		{
+			name:    "document count crosses segment end",
+			offsets: map[string]uint32{"colbert": 0},
+			segLen:  uint32(len(runawaySegment)),
+			segment: runawaySegment,
+			errLike: "truncated at document",
+		},
+		{
+			name:    "document length crosses segment end",
+			offsets: map[string]uint32{"colbert": 0},
+			segLen:  uint32(len(oversizedSegment)),
+			segment: oversizedSegment,
+			errLike: "exceeds segment",
+		},
+		{
+			name:    "segment length exceeds buffer",
+			offsets: map[string]uint32{"colbert": 0},
+			segLen:  10_000,
+			segment: validSegment,
+			errLike: "exceeds buffer",
+		},
+		{
+			name:    "offset beyond buffer",
+			offsets: map[string]uint32{"colbert": 60_000},
+			segLen:  uint32(len(validSegment)),
+			segment: validSegment,
+			errLike: "out of segment bounds",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := buildVectorSection(t, tc.offsets, tc.segLen, tc.segment, trailing)
+
+			rw := byteops.NewReadWriter(buf)
+			got, err := unmarshalMultiVectors(&rw, nil)
+
+			if tc.errLike != "" {
+				require.ErrorContains(t, err, tc.errLike)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got["colbert"])
+		})
+	}
+}

--- a/entities/storobj/target_vector_corruption_test.go
+++ b/entities/storobj/target_vector_corruption_test.go
@@ -151,6 +151,127 @@ func TestUnmarshalTargetVectorsCorruptOffsets(t *testing.T) {
 	})
 }
 
+// TestVectorSectionFramingCorrupt pins the two fields that frame a section — the
+// offsets blob length and the segment length. Both are read out of the value
+// itself, one field earlier than any segment bound can apply, so they need their
+// own check: a corrupt offsets length is as reachable as a corrupt offset.
+func TestVectorSectionFramingCorrupt(t *testing.T) {
+	cases := []struct {
+		name string
+		buf  []byte
+	}{
+		{"offsets length past buffer", binary.LittleEndian.AppendUint32(nil, 0xFFFFFFF0)},
+		{"one byte, no offsets length", []byte{0x01}},
+		{"offsets read, segment length truncated", append(binary.LittleEndian.AppendUint32(nil, 0), 0x00)},
+		{"offsets blob truncated", binary.LittleEndian.AppendUint32(nil, 32)},
+	}
+
+	parsers := []struct {
+		name  string
+		parse func(*byteops.ReadWriter) error
+	}{
+		{"unmarshalTargetVectors", func(rw *byteops.ReadWriter) error { _, err := unmarshalTargetVectors(rw); return err }},
+		{"unmarshalSingleTargetVector", func(rw *byteops.ReadWriter) error {
+			_, err := unmarshalSingleTargetVector(rw, "any", nil)
+			return err
+		}},
+		{"unmarshalMultiVectors", func(rw *byteops.ReadWriter) error { _, err := unmarshalMultiVectors(rw, nil); return err }},
+		{"targetVectorsJSONFromBinary", func(rw *byteops.ReadWriter) error { _, err := targetVectorsJSONFromBinary(rw); return err }},
+		{"multiVectorsJSONFromBinary", func(rw *byteops.ReadWriter) error { _, err := multiVectorsJSONFromBinary(rw); return err }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// backed by a larger array, so an unchecked read finds bytes to slice
+			backing := make([]byte, len(tc.buf)+70_000)
+			copy(backing, tc.buf)
+			for i := len(tc.buf); i < len(backing); i++ {
+				backing[i] = 0xAA
+			}
+			in := backing[:len(tc.buf)]
+
+			for _, p := range parsers {
+				t.Run(p.name, func(t *testing.T) {
+					rw := byteops.NewReadWriter(in)
+					require.Error(t, p.parse(&rw))
+				})
+			}
+		})
+	}
+}
+
+// TestEmptyOffsetsSegment pins the cursor hand-off between the two sections. A
+// section that declares no offsets still declares a length, and the multi-vector
+// parser starts wherever the target-vector parser stopped — so stopping at the
+// segment start makes it read target-vector payload as multi-vector framing.
+func TestEmptyOffsetsSegment(t *testing.T) {
+	t.Run("advances past the declared segment", func(t *testing.T) {
+		mvSegment := encodeMultiVec([]float32{7, 8})
+
+		buf := binary.LittleEndian.AppendUint32(nil, 0) // no target vector offsets
+		buf = binary.LittleEndian.AppendUint32(buf, 6)  // but six declared bytes
+		buf = append(buf, 0xDE, 0xAD, 0xBE, 0xEF, 0xBA, 0xAD)
+		buf = append(buf, buildVectorSection(t, map[string]uint32{"colbert": 0},
+			uint32(len(mvSegment)), mvSegment, nil)...)
+
+		rw := byteops.NewReadWriter(buf)
+		tv, err := unmarshalTargetVectors(&rw)
+		require.NoError(t, err)
+		require.Nil(t, tv)
+
+		mv, err := unmarshalMultiVectors(&rw, nil)
+		require.NoError(t, err)
+		require.Equal(t, [][]float32{{7, 8}}, mv["colbert"])
+	})
+
+	t.Run("corrupt segment length still errors", func(t *testing.T) {
+		buf := binary.LittleEndian.AppendUint32(nil, 0)
+		buf = binary.LittleEndian.AppendUint32(buf, 10_000)
+		buf = append(buf, 0xDE, 0xAD)
+
+		rw := byteops.NewReadWriter(buf)
+		_, err := unmarshalTargetVectors(&rw)
+		require.ErrorContains(t, err, "exceeds buffer")
+	})
+}
+
+// TestExportVectorJSONCorruptOffsets: the export path decodes the same two
+// sections straight to JSON, so it needs the same bounds as the object decoders.
+func TestExportVectorJSONCorruptOffsets(t *testing.T) {
+	trailing := encodeTargetVec(9, 9, 9, 9)
+
+	t.Run("target vectors", func(t *testing.T) {
+		segment := encodeTargetVec(1, 2, 3)
+		buf := buildVectorSection(t, map[string]uint32{"evil": uint32(len(segment))},
+			uint32(len(segment)), segment, trailing)
+
+		rw := byteops.NewReadWriter(buf)
+		_, err := targetVectorsJSONFromBinary(&rw)
+		require.ErrorContains(t, err, "out of segment bounds")
+	})
+
+	t.Run("multi vectors", func(t *testing.T) {
+		segment := encodeMultiVec([]float32{1, 2})
+		buf := buildVectorSection(t, map[string]uint32{"evil": uint32(len(segment))},
+			uint32(len(segment)), segment, trailing)
+
+		rw := byteops.NewReadWriter(buf)
+		_, err := multiVectorsJSONFromBinary(&rw)
+		require.ErrorContains(t, err, "out of segment bounds")
+	})
+
+	t.Run("multi vector document count", func(t *testing.T) {
+		segment := binary.LittleEndian.AppendUint32(nil, 1000)
+		segment = append(segment, encodeTargetVec(1, 2)...)
+		buf := buildVectorSection(t, map[string]uint32{"colbert": 0},
+			uint32(len(segment)), segment, trailing)
+
+		rw := byteops.NewReadWriter(buf)
+		_, err := multiVectorsJSONFromBinary(&rw)
+		require.ErrorContains(t, err, "truncated at document")
+	})
+}
+
 // TestUnmarshalMultiVectorsCorruptOffsets: same guarantees for the multi-vector
 // parser, whose per-document inner reads must also stay inside the declared
 // segment.

--- a/entities/storobj/target_vector_corruption_test.go
+++ b/entities/storobj/target_vector_corruption_test.go
@@ -56,9 +56,8 @@ func buildVectorSection(t *testing.T, offsets map[string]uint32, segLen uint32, 
 }
 
 // TestUnmarshalTargetVectorsCorruptOffsets pins that a corrupt offsets map or
-// segment length fails with an error on both target-vector parsers, instead of
-// silently decoding bytes of the following section (or panicking past the
-// buffer, as unmarshalTargetVectors previously did).
+// segment length errors on both target-vector parsers, rather than decoding the
+// following section's bytes or slicing past the buffer.
 func TestUnmarshalTargetVectorsCorruptOffsets(t *testing.T) {
 	vecA := encodeTargetVec(1, 2, 3) // 14 bytes at offset 0
 	vecB := encodeTargetVec(4, 5)    // 10 bytes at offset 14
@@ -152,9 +151,8 @@ func TestUnmarshalTargetVectorsCorruptOffsets(t *testing.T) {
 }
 
 // TestVectorSectionFramingCorrupt pins the two fields that frame a section — the
-// offsets blob length and the segment length. Both are read out of the value
-// itself, one field earlier than any segment bound can apply, so they need their
-// own check: a corrupt offsets length is as reachable as a corrupt offset.
+// offsets blob length and the segment length. Both are read out of the value one
+// field earlier than any segment bound can apply, so they need their own check.
 func TestVectorSectionFramingCorrupt(t *testing.T) {
 	cases := []struct {
 		name string
@@ -200,10 +198,10 @@ func TestVectorSectionFramingCorrupt(t *testing.T) {
 	}
 }
 
-// TestEmptyOffsetsSegment pins the cursor hand-off between the two sections. A
-// section that declares no offsets still declares a length, and the multi-vector
-// parser starts wherever the target-vector parser stopped — so stopping at the
-// segment start makes it read target-vector payload as multi-vector framing.
+// TestEmptyOffsetsSegment pins the cursor hand-off between the sections. A
+// section with no offsets still declares a length, and the multi-vector parser
+// starts wherever the target-vector parser stopped: stopping at the segment start
+// makes it read target-vector payload as multi-vector framing.
 func TestEmptyOffsetsSegment(t *testing.T) {
 	t.Run("advances past the declared segment", func(t *testing.T) {
 		mvSegment := encodeMultiVec([]float32{7, 8})
@@ -235,8 +233,8 @@ func TestEmptyOffsetsSegment(t *testing.T) {
 	})
 }
 
-// TestExportVectorJSONCorruptOffsets: the export path decodes the same two
-// sections straight to JSON, so it needs the same bounds as the object decoders.
+// TestExportVectorJSONCorruptOffsets: the export path decodes the same sections
+// straight to JSON, so it needs the same bounds as the object decoders.
 func TestExportVectorJSONCorruptOffsets(t *testing.T) {
 	trailing := encodeTargetVec(9, 9, 9, 9)
 
@@ -273,8 +271,7 @@ func TestExportVectorJSONCorruptOffsets(t *testing.T) {
 }
 
 // TestUnmarshalMultiVectorsCorruptOffsets: same guarantees for the multi-vector
-// parser, whose per-document inner reads must also stay inside the declared
-// segment.
+// parser, whose per-document reads must also stay inside the declared segment.
 func TestUnmarshalMultiVectorsCorruptOffsets(t *testing.T) {
 	validSegment := encodeMultiVec([]float32{1, 2}, []float32{3, 4}) // 24 bytes
 	trailing := encodeTargetVec(9, 9, 9, 9)

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -15,7 +15,6 @@ package byteops
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 	"math"
 )
@@ -149,56 +148,41 @@ func (bo *ReadWriter) Remaining() uint64 {
 	return length - bo.Position
 }
 
-func (bo *ReadWriter) checkRead(length uint64) error {
-	// the cursor needs its own test because Remaining() saturates: past the end
-	// it reports 0, which a zero-length read would satisfy before slicing at the
-	// invalid position. Position == len(Buffer) is the legitimate end-of-value
-	// cursor and still admits a zero-length read.
-	if bo.Position > uint64(len(bo.Buffer)) || length > bo.Remaining() {
-		return fmt.Errorf("%w: %d bytes at offset %d of a %d byte buffer",
-			ErrBufferOverrun, length, bo.Position, len(bo.Buffer))
-	}
-	return nil
-}
-
-func (bo *ReadWriter) ReadUint8Checked() (uint8, error) {
-	if err := bo.checkRead(Uint8Len); err != nil {
-		return 0, err
-	}
-	return bo.ReadUint8(), nil
+// canRead carries no error formatting, which keeps it and its callers under the
+// inline budget: the checked readers cost a compare and a branch on the hot path,
+// and callers name the field that failed. The cursor needs a test of its own,
+// because a zero-length read would otherwise be satisfied past the end of the
+// buffer and then slice at the invalid position; Position == len(Buffer) is the
+// legitimate end-of-value cursor and still admits a zero-length read.
+func (bo *ReadWriter) canRead(length uint64) bool {
+	pos, size := bo.Position, uint64(len(bo.Buffer))
+	return pos <= size && length <= size-pos
 }
 
 func (bo *ReadWriter) ReadUint16Checked() (uint16, error) {
-	if err := bo.checkRead(Uint16Len); err != nil {
-		return 0, err
+	if !bo.canRead(Uint16Len) {
+		return 0, ErrBufferOverrun
 	}
 	return bo.ReadUint16(), nil
 }
 
 func (bo *ReadWriter) ReadUint32Checked() (uint32, error) {
-	if err := bo.checkRead(Uint32Len); err != nil {
-		return 0, err
+	if !bo.canRead(Uint32Len) {
+		return 0, ErrBufferOverrun
 	}
 	return bo.ReadUint32(), nil
 }
 
-func (bo *ReadWriter) ReadUint64Checked() (uint64, error) {
-	if err := bo.checkRead(Uint64Len); err != nil {
-		return 0, err
-	}
-	return bo.ReadUint64(), nil
-}
-
 func (bo *ReadWriter) ReadBytesFromBufferChecked(length uint64) ([]byte, error) {
-	if err := bo.checkRead(length); err != nil {
-		return nil, err
+	if !bo.canRead(length) {
+		return nil, ErrBufferOverrun
 	}
 	return bo.ReadBytesFromBuffer(length), nil
 }
 
 func (bo *ReadWriter) CopyBytesFromBufferChecked(length uint64, out []byte) ([]byte, error) {
-	if err := bo.checkRead(length); err != nil {
-		return nil, err
+	if !bo.canRead(length) {
+		return nil, ErrBufferOverrun
 	}
 	return bo.CopyBytesFromBuffer(length, out)
 }
@@ -211,31 +195,13 @@ func (bo *ReadWriter) ReadBytesFromBufferWithUint32LengthIndicatorChecked() ([]b
 	return bo.ReadBytesFromBufferChecked(uint64(length))
 }
 
-func (bo *ReadWriter) ReadBytesFromBufferWithUint64LengthIndicatorChecked() ([]byte, error) {
-	length, err := bo.ReadUint64Checked()
-	if err != nil {
-		return nil, err
-	}
-	return bo.ReadBytesFromBufferChecked(length)
-}
-
 // SkipChecked bounds MoveBufferPositionForward, so a length read out of the data
 // cannot park the cursor past the buffer.
 func (bo *ReadWriter) SkipChecked(length uint64) error {
-	if err := bo.checkRead(length); err != nil {
-		return err
+	if !bo.canRead(length) {
+		return ErrBufferOverrun
 	}
 	bo.Position += length
-	return nil
-}
-
-// SeekChecked bounds MoveBufferToAbsolutePosition. Seeking to exactly
-// len(Buffer) is allowed: every sequential decoder finishes there.
-func (bo *ReadWriter) SeekChecked(pos uint64) error {
-	if pos > uint64(len(bo.Buffer)) {
-		return fmt.Errorf("%w: offset %d of a %d byte buffer", ErrBufferOverrun, pos, len(bo.Buffer))
-	}
-	bo.Position = pos
 	return nil
 }
 

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -132,16 +132,15 @@ func (bo *ReadWriter) DiscardBytesFromBufferWithUint32LengthIndicator() uint32 {
 // ErrBufferOverrun signals that a length or offset decoded out of a buffer runs
 // past that buffer's end.
 //
-// The unchecked readers above slice as Buffer[Position : Position+n], and Go
-// bounds a two-index slice against capacity rather than length. Buffers here are
-// routinely subslices of a larger allocation — an mmapped segment, a pooled
-// read buffer — so an overrun that stays within capacity does not panic: it
-// yields whatever bytes follow the value. Any decoder whose lengths come from
-// the data it is decoding must use the checked readers.
+// The unchecked readers above slice as Buffer[Position : Position+n], which Go
+// bounds against capacity rather than length. A buffer here is routinely a
+// subslice of a larger allocation — an mmapped segment, a pooled read buffer —
+// so an overrun that stays within capacity does not panic: it yields whatever
+// bytes follow the value. Any decoder whose lengths come from the data it is
+// decoding must use the checked readers.
 var ErrBufferOverrun = errors.New("read exceeds buffer")
 
-// Remaining reports the number of readable bytes left after Position, and 0 once
-// Position has run past the end of the buffer.
+// Remaining saturates at 0 once Position has run past the end of the buffer.
 func (bo *ReadWriter) Remaining() uint64 {
 	length := uint64(len(bo.Buffer))
 	if bo.Position >= length {
@@ -151,10 +150,10 @@ func (bo *ReadWriter) Remaining() uint64 {
 }
 
 func (bo *ReadWriter) checkRead(length uint64) error {
-	// a cursor already past the end has to be rejected on its own: Remaining()
-	// saturates at 0, which a zero-length read would otherwise satisfy before
-	// slicing at the invalid position. Position == len(Buffer) is the legitimate
-	// end-of-value cursor and still admits a zero-length read.
+	// the cursor needs its own test because Remaining() saturates: past the end
+	// it reports 0, which a zero-length read would satisfy before slicing at the
+	// invalid position. Position == len(Buffer) is the legitimate end-of-value
+	// cursor and still admits a zero-length read.
 	if bo.Position > uint64(len(bo.Buffer)) || length > bo.Remaining() {
 		return fmt.Errorf("%w: %d bytes at offset %d of a %d byte buffer",
 			ErrBufferOverrun, length, bo.Position, len(bo.Buffer))
@@ -220,8 +219,8 @@ func (bo *ReadWriter) ReadBytesFromBufferWithUint64LengthIndicatorChecked() ([]b
 	return bo.ReadBytesFromBufferChecked(length)
 }
 
-// SkipChecked is MoveBufferPositionForward bounded by the end of the buffer, so
-// that a length read out of the data cannot park the cursor past it.
+// SkipChecked bounds MoveBufferPositionForward, so a length read out of the data
+// cannot park the cursor past the buffer.
 func (bo *ReadWriter) SkipChecked(length uint64) error {
 	if err := bo.checkRead(length); err != nil {
 		return err
@@ -230,9 +229,8 @@ func (bo *ReadWriter) SkipChecked(length uint64) error {
 	return nil
 }
 
-// SeekChecked is MoveBufferToAbsolutePosition bounded by the end of the buffer.
-// Seeking to exactly len(Buffer) is allowed: that is the end-of-value position
-// every sequential decoder finishes at.
+// SeekChecked bounds MoveBufferToAbsolutePosition. Seeking to exactly
+// len(Buffer) is allowed: every sequential decoder finishes there.
 func (bo *ReadWriter) SeekChecked(pos uint64) error {
 	if pos > uint64(len(bo.Buffer)) {
 		return fmt.Errorf("%w: offset %d of a %d byte buffer", ErrBufferOverrun, pos, len(bo.Buffer))

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -15,6 +15,7 @@ package byteops
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 )
@@ -126,6 +127,114 @@ func (bo *ReadWriter) DiscardBytesFromBufferWithUint32LengthIndicator() uint32 {
 
 	bo.Position += uint64(bufLen)
 	return bufLen
+}
+
+// ErrBufferOverrun signals that a length or offset decoded out of a buffer runs
+// past that buffer's end.
+//
+// The unchecked readers above slice as Buffer[Position : Position+n], and Go
+// bounds a two-index slice against capacity rather than length. Buffers here are
+// routinely subslices of a larger allocation — an mmapped segment, a pooled
+// read buffer — so an overrun that stays within capacity does not panic: it
+// yields whatever bytes follow the value. Any decoder whose lengths come from
+// the data it is decoding must use the checked readers.
+var ErrBufferOverrun = errors.New("read exceeds buffer")
+
+// Remaining reports the number of readable bytes left after Position, and 0 once
+// Position has run past the end of the buffer.
+func (bo *ReadWriter) Remaining() uint64 {
+	length := uint64(len(bo.Buffer))
+	if bo.Position >= length {
+		return 0
+	}
+	return length - bo.Position
+}
+
+func (bo *ReadWriter) checkRead(length uint64) error {
+	if length > bo.Remaining() {
+		return fmt.Errorf("%w: %d bytes at offset %d of a %d byte buffer",
+			ErrBufferOverrun, length, bo.Position, len(bo.Buffer))
+	}
+	return nil
+}
+
+func (bo *ReadWriter) ReadUint8Checked() (uint8, error) {
+	if err := bo.checkRead(Uint8Len); err != nil {
+		return 0, err
+	}
+	return bo.ReadUint8(), nil
+}
+
+func (bo *ReadWriter) ReadUint16Checked() (uint16, error) {
+	if err := bo.checkRead(Uint16Len); err != nil {
+		return 0, err
+	}
+	return bo.ReadUint16(), nil
+}
+
+func (bo *ReadWriter) ReadUint32Checked() (uint32, error) {
+	if err := bo.checkRead(Uint32Len); err != nil {
+		return 0, err
+	}
+	return bo.ReadUint32(), nil
+}
+
+func (bo *ReadWriter) ReadUint64Checked() (uint64, error) {
+	if err := bo.checkRead(Uint64Len); err != nil {
+		return 0, err
+	}
+	return bo.ReadUint64(), nil
+}
+
+func (bo *ReadWriter) ReadBytesFromBufferChecked(length uint64) ([]byte, error) {
+	if err := bo.checkRead(length); err != nil {
+		return nil, err
+	}
+	return bo.ReadBytesFromBuffer(length), nil
+}
+
+func (bo *ReadWriter) CopyBytesFromBufferChecked(length uint64, out []byte) ([]byte, error) {
+	if err := bo.checkRead(length); err != nil {
+		return nil, err
+	}
+	return bo.CopyBytesFromBuffer(length, out)
+}
+
+func (bo *ReadWriter) ReadBytesFromBufferWithUint32LengthIndicatorChecked() ([]byte, error) {
+	length, err := bo.ReadUint32Checked()
+	if err != nil {
+		return nil, err
+	}
+	return bo.ReadBytesFromBufferChecked(uint64(length))
+}
+
+func (bo *ReadWriter) ReadBytesFromBufferWithUint64LengthIndicatorChecked() ([]byte, error) {
+	length, err := bo.ReadUint64Checked()
+	if err != nil {
+		return nil, err
+	}
+	return bo.ReadBytesFromBufferChecked(length)
+}
+
+// SkipChecked is MoveBufferPositionForward bounded by the end of the buffer, so
+// that a length read out of the data cannot park the cursor past it.
+func (bo *ReadWriter) SkipChecked(length uint64) error {
+	if err := bo.checkRead(length); err != nil {
+		return err
+	}
+	bo.Position += length
+	return nil
+}
+
+// SeekChecked is MoveBufferToAbsolutePosition bounded by the end of the buffer.
+// Seeking to exactly len(Buffer) is allowed: that is the end-of-value position
+// every sequential decoder finishes at.
+func (bo *ReadWriter) SeekChecked(pos uint64) error {
+	if pos > uint64(len(bo.Buffer)) {
+		return fmt.Errorf("%w: offset %d of a %d byte buffer", ErrBufferOverrun, pos, len(bo.Buffer))
+	}
+	bo.Position = pos
+	return nil
 }
 
 func (bo *ReadWriter) WriteUint64(value uint64) {

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -151,7 +151,11 @@ func (bo *ReadWriter) Remaining() uint64 {
 }
 
 func (bo *ReadWriter) checkRead(length uint64) error {
-	if length > bo.Remaining() {
+	// a cursor already past the end has to be rejected on its own: Remaining()
+	// saturates at 0, which a zero-length read would otherwise satisfy before
+	// slicing at the invalid position. Position == len(Buffer) is the legitimate
+	// end-of-value cursor and still admits a zero-length read.
+	if bo.Position > uint64(len(bo.Buffer)) || length > bo.Remaining() {
 		return fmt.Errorf("%w: %d bytes at offset %d of a %d byte buffer",
 			ErrBufferOverrun, length, bo.Position, len(bo.Buffer))
 	}

--- a/usecases/byteops/checked_test.go
+++ b/usecases/byteops/checked_test.go
@@ -18,11 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// shortView returns a buffer of n readable bytes backed by a much larger array.
-// This is the shape the checked readers exist for: the unchecked ones slice as
-// Buffer[Position:Position+n], which Go bounds against capacity, so an overrun
-// that stays inside the backing array returns the following bytes instead of
-// panicking.
+// shortView returns a buffer of n readable bytes backed by a much larger array —
+// the shape the checked readers exist for, where an overrun that stays inside the
+// backing array returns the following bytes instead of panicking.
 func shortView(n int) []byte {
 	backing := make([]byte, n+1024)
 	for i := range backing {
@@ -82,9 +80,8 @@ func TestCheckedReadsRejectOverrun(t *testing.T) {
 }
 
 // TestZeroLengthReadsRespectCursor pins the one case a Remaining()-only bound
-// misses: Remaining() saturates at 0, so a zero-length read past the end looks
-// satisfiable and then slices at the invalid position. A checked reader must
-// report, never panic, whatever the cursor holds.
+// misses: it saturates at 0, so a zero-length read past the end looks satisfiable
+// and then slices at the invalid position.
 func TestZeroLengthReadsRespectCursor(t *testing.T) {
 	zeroLengthReads := []struct {
 		name string

--- a/usecases/byteops/checked_test.go
+++ b/usecases/byteops/checked_test.go
@@ -35,10 +35,8 @@ func TestCheckedReadsRejectOverrun(t *testing.T) {
 		need uint64
 		read func(*ReadWriter) error
 	}{
-		{"ReadUint8Checked", Uint8Len, func(rw *ReadWriter) error { _, err := rw.ReadUint8Checked(); return err }},
 		{"ReadUint16Checked", Uint16Len, func(rw *ReadWriter) error { _, err := rw.ReadUint16Checked(); return err }},
 		{"ReadUint32Checked", Uint32Len, func(rw *ReadWriter) error { _, err := rw.ReadUint32Checked(); return err }},
-		{"ReadUint64Checked", Uint64Len, func(rw *ReadWriter) error { _, err := rw.ReadUint64Checked(); return err }},
 		{"ReadBytesFromBufferChecked", 16, func(rw *ReadWriter) error {
 			_, err := rw.ReadBytesFromBufferChecked(16)
 			return err
@@ -126,15 +124,6 @@ func TestLengthIndicatorReadsRejectCorruptLength(t *testing.T) {
 		require.ErrorIs(t, err, ErrBufferOverrun)
 	})
 
-	t.Run("uint64 length past the buffer", func(t *testing.T) {
-		buf := shortView(64)
-		binary.LittleEndian.PutUint64(buf, 1<<40)
-
-		rw := NewReadWriter(buf)
-		_, err := rw.ReadBytesFromBufferWithUint64LengthIndicatorChecked()
-		require.ErrorIs(t, err, ErrBufferOverrun)
-	})
-
 	t.Run("length indicator itself truncated", func(t *testing.T) {
 		rw := NewReadWriter(shortView(2))
 		_, err := rw.ReadBytesFromBufferWithUint32LengthIndicatorChecked()
@@ -152,20 +141,6 @@ func TestLengthIndicatorReadsRejectCorruptLength(t *testing.T) {
 		require.Equal(t, payload, got)
 		require.Equal(t, uint64(len(buf)), rw.Position)
 	})
-}
-
-func TestSeekChecked(t *testing.T) {
-	rw := NewReadWriter(shortView(32))
-
-	require.NoError(t, rw.SeekChecked(16))
-	require.Equal(t, uint64(16), rw.Position)
-
-	// the end-of-value position every sequential decoder finishes at
-	require.NoError(t, rw.SeekChecked(32))
-	require.Equal(t, uint64(32), rw.Position)
-
-	require.ErrorIs(t, rw.SeekChecked(33), ErrBufferOverrun)
-	require.Equal(t, uint64(32), rw.Position, "a rejected seek must not move the cursor")
 }
 
 func TestRemaining(t *testing.T) {

--- a/usecases/byteops/checked_test.go
+++ b/usecases/byteops/checked_test.go
@@ -1,0 +1,148 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package byteops
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// shortView returns a buffer of n readable bytes backed by a much larger array.
+// This is the shape the checked readers exist for: the unchecked ones slice as
+// Buffer[Position:Position+n], which Go bounds against capacity, so an overrun
+// that stays inside the backing array returns the following bytes instead of
+// panicking.
+func shortView(n int) []byte {
+	backing := make([]byte, n+1024)
+	for i := range backing {
+		backing[i] = 0xAA
+	}
+	return backing[:n]
+}
+
+func TestCheckedReadsRejectOverrun(t *testing.T) {
+	reads := []struct {
+		name string
+		need uint64
+		read func(*ReadWriter) error
+	}{
+		{"ReadUint8Checked", Uint8Len, func(rw *ReadWriter) error { _, err := rw.ReadUint8Checked(); return err }},
+		{"ReadUint16Checked", Uint16Len, func(rw *ReadWriter) error { _, err := rw.ReadUint16Checked(); return err }},
+		{"ReadUint32Checked", Uint32Len, func(rw *ReadWriter) error { _, err := rw.ReadUint32Checked(); return err }},
+		{"ReadUint64Checked", Uint64Len, func(rw *ReadWriter) error { _, err := rw.ReadUint64Checked(); return err }},
+		{"ReadBytesFromBufferChecked", 16, func(rw *ReadWriter) error {
+			_, err := rw.ReadBytesFromBufferChecked(16)
+			return err
+		}},
+		{"CopyBytesFromBufferChecked", 16, func(rw *ReadWriter) error {
+			_, err := rw.CopyBytesFromBufferChecked(16, nil)
+			return err
+		}},
+		{"SkipChecked", 16, func(rw *ReadWriter) error { return rw.SkipChecked(16) }},
+	}
+
+	for _, tc := range reads {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("exactly enough", func(t *testing.T) {
+				rw := NewReadWriter(shortView(int(tc.need)))
+				require.NoError(t, tc.read(&rw))
+				require.Equal(t, tc.need, rw.Position)
+			})
+
+			t.Run("one byte short", func(t *testing.T) {
+				rw := NewReadWriter(shortView(int(tc.need) - 1))
+				err := tc.read(&rw)
+				require.ErrorIs(t, err, ErrBufferOverrun)
+				require.Zero(t, rw.Position, "a rejected read must not advance the cursor")
+			})
+
+			t.Run("empty buffer", func(t *testing.T) {
+				rw := NewReadWriter(shortView(0))
+				require.ErrorIs(t, tc.read(&rw), ErrBufferOverrun)
+			})
+
+			t.Run("cursor already past the end", func(t *testing.T) {
+				rw := NewReadWriter(shortView(int(tc.need)))
+				rw.Position = tc.need + 8
+				require.ErrorIs(t, tc.read(&rw), ErrBufferOverrun)
+			})
+		})
+	}
+}
+
+func TestLengthIndicatorReadsRejectCorruptLength(t *testing.T) {
+	t.Run("uint32 length past the buffer", func(t *testing.T) {
+		buf := shortView(64)
+		binary.LittleEndian.PutUint32(buf, 0xFFFFFFF0)
+
+		rw := NewReadWriter(buf)
+		_, err := rw.ReadBytesFromBufferWithUint32LengthIndicatorChecked()
+		require.ErrorIs(t, err, ErrBufferOverrun)
+	})
+
+	t.Run("uint64 length past the buffer", func(t *testing.T) {
+		buf := shortView(64)
+		binary.LittleEndian.PutUint64(buf, 1<<40)
+
+		rw := NewReadWriter(buf)
+		_, err := rw.ReadBytesFromBufferWithUint64LengthIndicatorChecked()
+		require.ErrorIs(t, err, ErrBufferOverrun)
+	})
+
+	t.Run("length indicator itself truncated", func(t *testing.T) {
+		rw := NewReadWriter(shortView(2))
+		_, err := rw.ReadBytesFromBufferWithUint32LengthIndicatorChecked()
+		require.ErrorIs(t, err, ErrBufferOverrun)
+	})
+
+	t.Run("well-formed payload round-trips", func(t *testing.T) {
+		payload := []byte("weaviate")
+		buf := binary.LittleEndian.AppendUint32(nil, uint32(len(payload)))
+		buf = append(buf, payload...)
+
+		rw := NewReadWriter(buf)
+		got, err := rw.ReadBytesFromBufferWithUint32LengthIndicatorChecked()
+		require.NoError(t, err)
+		require.Equal(t, payload, got)
+		require.Equal(t, uint64(len(buf)), rw.Position)
+	})
+}
+
+func TestSeekChecked(t *testing.T) {
+	rw := NewReadWriter(shortView(32))
+
+	require.NoError(t, rw.SeekChecked(16))
+	require.Equal(t, uint64(16), rw.Position)
+
+	// the end-of-value position every sequential decoder finishes at
+	require.NoError(t, rw.SeekChecked(32))
+	require.Equal(t, uint64(32), rw.Position)
+
+	require.ErrorIs(t, rw.SeekChecked(33), ErrBufferOverrun)
+	require.Equal(t, uint64(32), rw.Position, "a rejected seek must not move the cursor")
+}
+
+func TestRemaining(t *testing.T) {
+	rw := NewReadWriter(shortView(8))
+	require.Equal(t, uint64(8), rw.Remaining())
+
+	rw.Position = 3
+	require.Equal(t, uint64(5), rw.Remaining())
+
+	rw.Position = 8
+	require.Zero(t, rw.Remaining())
+
+	rw.Position = 99
+	require.Zero(t, rw.Remaining(), "a cursor past the end must not underflow")
+}

--- a/usecases/byteops/checked_test.go
+++ b/usecases/byteops/checked_test.go
@@ -81,6 +81,44 @@ func TestCheckedReadsRejectOverrun(t *testing.T) {
 	}
 }
 
+// TestZeroLengthReadsRespectCursor pins the one case a Remaining()-only bound
+// misses: Remaining() saturates at 0, so a zero-length read past the end looks
+// satisfiable and then slices at the invalid position. A checked reader must
+// report, never panic, whatever the cursor holds.
+func TestZeroLengthReadsRespectCursor(t *testing.T) {
+	zeroLengthReads := []struct {
+		name string
+		read func(*ReadWriter) error
+	}{
+		{"ReadBytesFromBufferChecked", func(rw *ReadWriter) error { _, err := rw.ReadBytesFromBufferChecked(0); return err }},
+		{"CopyBytesFromBufferChecked", func(rw *ReadWriter) error { _, err := rw.CopyBytesFromBufferChecked(0, nil); return err }},
+		{"SkipChecked", func(rw *ReadWriter) error { return rw.SkipChecked(0) }},
+	}
+
+	for _, tc := range zeroLengthReads {
+		t.Run(tc.name, func(t *testing.T) {
+			// the end-of-value cursor: a zero-length read here is legitimate
+			t.Run("at the end", func(t *testing.T) {
+				rw := NewReadWriter(shortView(8))
+				rw.Position = 8
+				require.NoError(t, tc.read(&rw))
+			})
+
+			t.Run("past the end, within capacity", func(t *testing.T) {
+				rw := NewReadWriter(shortView(8))
+				rw.Position = 32
+				require.ErrorIs(t, tc.read(&rw), ErrBufferOverrun)
+			})
+
+			t.Run("past the backing array", func(t *testing.T) {
+				rw := NewReadWriter(shortView(8))
+				rw.Position = 1 << 20
+				require.ErrorIs(t, tc.read(&rw), ErrBufferOverrun)
+			})
+		})
+	}
+}
+
 func TestLengthIndicatorReadsRejectCorruptLength(t *testing.T) {
 	t.Run("uint32 length past the buffer", func(t *testing.T) {
 		buf := shortView(64)


### PR DESCRIPTION
Split out of #12397 so it can be reviewed on its own. These are decoder bounds fixes; they need none of the prefill work they were bundled with.

## The problem

Every decoder that reads a vector out of an object value reaches it through lengths and offsets stored in that same value, and sliced with them unchecked. `byteops`' readers slice as `Buffer[Position : Position+n]`, and Go bounds a two-index slice against **capacity**, not length. A value handed back by an mmapped LSM segment has capacity well past its length, so a corrupt offset, a truncated row, or a length field that outlived its data does not reliably panic — it returns the neighbouring object's bytes as a vector, and nothing reports it.

## The change

**Checked readers in `byteops`.** `ReadUint{8,16,32,64}Checked`, `ReadBytesFromBufferChecked`, `CopyBytesFromBufferChecked`, the two length-indicator variants, `SkipChecked` and `SeekChecked`, all returning `ErrBufferOverrun`. The existing unchecked readers are untouched, so nothing outside this diff changes behaviour. Any decoder whose lengths come from the data it is decoding now uses the checked ones.

**Bounds by segment, not by buffer.** Inside a vector section, reads are bounded by the length that section declares. That is the tighter limit and the only one that tells a corrupt offset apart from a vector that legitimately runs to the end of the value. `readVectorSegment` holds the framing rule and `readVectorBytes` the per-vector rule, both shared by the object decoders and the export JSON builders instead of being restated per call site.

Covered by the bound now: the named-vector branch of `VectorFromBinary`; `MultiVectorFromBinary`'s walk to the multi-vector section; `unmarshalInternal` and `fromBinaryOptionalInternal`; `targetVectorsJSONFromBinary` and `multiVectorsJSONFromBinary` on the export path; and the two fields that frame a section — the offsets blob length and the segment length — which are read one field earlier than any segment bound can apply.

**Three further defects the bound alone did not close:**

- A section declaring no offsets left the cursor at the segment start, so the multi-vector parser read target-vector payload as its own framing. It now advances past the declared length.
- A multi-vector document count is a `uint32` read straight out of the data and used to size an allocation. It is now bounded by the segment first.
- Vector lengths are widened before being scaled to bytes, so a large `uint16` cannot wrap the multiplication into an end offset that looks in-bounds.

`MultiVectorFromBinary` no longer takes a buffer: it decoded the legacy vector into the caller's pooled slice and never read the result.

## Tests

`legacy_vector_bounds_test.go` runs all seven entry points that read a vector out of a value over one truncation matrix, backing each truncated view with a sentinel-filled array so an unchecked read finds bytes to slice. Against the first commit alone, six of the seven panic — only the legacy branch of `VectorFromBinary` survives.

`target_vector_corruption_test.go` covers offsets past the segment, lengths past the segment, corrupt section framing, the empty-offsets cursor hand-off, and the export path. `checked_test.go` covers the `byteops` primitives, including a zero-length read with the cursor already past the end, which `Remaining()` alone reports as satisfiable.