### PR TITLE
perf(hnsw): parallel prefill for the muvera vector cache

### DIFF
--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -38,6 +38,12 @@ func GetCompressedBucketName(targetVector string) string {
 	return VectorsCompressedBucketLSM
 }
 
+// GetMuveraBucketName names the per-index bucket of encoded muvera vectors: an
+// 8-byte big-endian doc id key, raw float32s as the value.
+func GetMuveraBucketName(indexID string) string {
+	return indexID + "_muvera_vectors"
+}
+
 func GetVectorsBucketName(targetVector string) string {
 	if targetVector != "" {
 		return fmt.Sprintf("%s_%s", VectorsBucketLSM, targetVector)

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -952,7 +952,7 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 		if h.muvera.Load() {
 			idBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(idBytes, id)
-			if err := h.store.Bucket(h.id + "_muvera_vectors").Delete(idBytes); err != nil {
+			if err := h.store.Bucket(helpers.GetMuveraBucketName(h.id)).Delete(idBytes); err != nil {
 				h.logger.WithFields(logrus.Fields{
 					"action": "muvera_delete",
 					"id":     id,

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -315,14 +315,14 @@ func New(cfg Config, uc ent.UserConfig,
 			muveraEncoder = multivector.NewMuveraEncoder(uc.Multivector.MuveraConfig, store)
 			err := store.CreateOrLoadBucket(
 				context.Background(),
-				cfg.ID+"_muvera_vectors",
+				helpers.GetMuveraBucketName(cfg.ID),
 				cfg.MakeBucketOptions(lsmkv.StrategyReplace)...,
 			)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Create or load bucket (muvera store)")
 			}
 			muveraVectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
-				return muveraEncoder.GetMuveraVectorForID(id, cfg.ID+"_muvera_vectors")
+				return muveraEncoder.GetMuveraVectorForID(id, helpers.GetMuveraBucketName(cfg.ID))
 			}
 			vectorCache = cache.NewShardedFloat32LockCache(
 				muveraVectorForID, cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects, 1, cfg.Logger,

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -293,14 +293,15 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			h.Unlock()
 		})
 		// Process all vectors
+		muveraBucket := helpers.GetMuveraBucketName(h.id)
 		processedVectors := make([][]float32, len(vectors))
 		for i, v := range vectors {
 			processedVectors[i] = h.muveraEncoder.EncodeDoc(v)
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docIDs[i])
 			muveraBytes := multivector.MuveraBytesFromFloat32(processedVectors[i])
-			if err := h.store.Bucket(h.id+"_muvera_vectors").Put(docIDBytes, muveraBytes); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("failed to put %s_muvera_vectors into the bucket", h.id))
+			if err := h.store.Bucket(muveraBucket).Put(docIDBytes, muveraBytes); err != nil {
+				return errors.Wrapf(err, "failed to put into the %s bucket", muveraBucket)
 			}
 		}
 		// Replace original vectors with processed ones

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -566,12 +566,17 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 			} else {
 				h.compressor.PrefillMultiCache(prefillCtx, h.docIDVectors)
 			}
-		} else if h.useParallelPrefill() {
-			// Unbounded uncompressed cache: scan the objects bucket with a parallel
-			// cursor instead of looking up every vector by id (disk-seek bound).
-			err = h.prefillCacheParallel(prefillCtx)
 		} else {
-			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(prefillCtx, limit)
+			// Unbounded uncompressed cache: scan the bucket backing it with a parallel
+			// cursor instead of looking up every vector by id (disk-seek bound).
+			switch h.parallelPrefillSource() {
+			case prefillScanMuvera:
+				err = h.prefillMuveraCacheParallel(prefillCtx)
+			case prefillScanObjects:
+				err = h.prefillCacheParallel(prefillCtx)
+			default:
+				err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(prefillCtx, limit)
+			}
 		}
 
 		if err != nil {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_lifecycle_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_lifecycle_test.go
@@ -106,7 +106,7 @@ func TestStopPrefillWaitsForInFlightScan(t *testing.T) {
 	h.store = store
 	h.waitForCachePrefill = false
 
-	require.True(t, h.useParallelPrefill(), "test must exercise the scan path")
+	require.Equal(t, prefillScanObjects, h.parallelPrefillSource(), "test must exercise the scan path")
 	h.prefillCache(context.Background())
 
 	waitFor(t, blocking.entered, 10*time.Second, "no scan worker reached the cache")
@@ -171,7 +171,7 @@ func TestStopPrefillCancelsBlockedPrefill(t *testing.T) {
 	// no store: routing falls through to the serial by-id prefiller
 	h := newLifecycleTestIndex(t, c, n)
 	h.waitForCachePrefill = false
-	require.False(t, h.useParallelPrefill())
+	require.Equal(t, prefillScanNone, h.parallelPrefillSource())
 
 	h.prefillCache(context.Background())
 	waitFor(t, started, 10*time.Second, "prefill never started")
@@ -248,7 +248,7 @@ func TestPrefillRefusedAfterStop(t *testing.T) {
 	h := newLifecycleTestIndex(t, c, n)
 	h.store = store
 	h.waitForCachePrefill = true // a started prefill would run to completion inline
-	require.True(t, h.useParallelPrefill(), "test must exercise the scan path")
+	require.Equal(t, prefillScanObjects, h.parallelPrefillSource(), "test must exercise the scan path")
 
 	h.stopPrefill() // stands in for Drop, which does not cancel shutdownCtx
 	h.prefillCache(context.Background())

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -14,6 +14,7 @@ package hnsw
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"runtime"
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/multivector"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -39,16 +41,47 @@ var (
 	errPrefillCompressionActive = errors.New("vector cache prefill aborted: compression activated")
 )
 
-// useParallelPrefill reports whether the cache can be filled by scanning the objects
-// bucket instead of the serial by-id prefiller. Multivector, muvera and hfresh
-// centroid caches are sourced from their own buckets, not from objects — the last
-// of those despite sharing the shard's store.
-func (h *hnsw) useParallelPrefill() bool {
-	if h.store == nil || h.store.Bucket(helpers.ObjectsBucketLSM) == nil || h.hfreshMode {
-		return false
+// prefillScanSource names the bucket backing the cache. One gate decides it, so no
+// second copy can drift on which index types are objects-sourced.
+type prefillScanSource int
+
+const (
+	prefillScanNone prefillScanSource = iota
+	prefillScanObjects
+	prefillScanMuvera
+)
+
+func (s prefillScanSource) String() string {
+	switch s {
+	case prefillScanObjects:
+		return "objects"
+	case prefillScanMuvera:
+		return "muvera"
+	default:
+		return "none"
+	}
+}
+
+func (h *hnsw) prefillBucketName(src prefillScanSource) string {
+	if src == prefillScanMuvera {
+		return helpers.GetMuveraBucketName(h.id)
+	}
+	return helpers.ObjectsBucketLSM
+}
+
+// parallelPrefillSource reports which bucket, if any, can fill the cache by a cursor
+// scan instead of the serial by-id prefiller. The hfresh centroid cache is sourced
+// from neither, despite sharing the shard's store.
+func (h *hnsw) parallelPrefillSource() prefillScanSource {
+	if h.store == nil || h.hfreshMode {
+		return prefillScanNone
 	}
 
-	return parallelPrefillEligible(h.parallelPrefillInputs())
+	src := parallelPrefillSource(h.parallelPrefillInputs())
+	if src == prefillScanNone || h.store.Bucket(h.prefillBucketName(src)) == nil {
+		return prefillScanNone
+	}
+	return src
 }
 
 func (h *hnsw) parallelPrefillInputs() parallelPrefillInputs {
@@ -75,18 +108,26 @@ type parallelPrefillInputs struct {
 	nodeCount    int64
 }
 
-// parallelPrefillEligible is useParallelPrefill's decision core, split out so the
-// combinations can be tested directly.
-func parallelPrefillEligible(in parallelPrefillInputs) bool {
-	if in.multivector || in.muvera {
-		return false
-	}
+// parallelPrefillSource is the gate's decision core, split out so the combinations
+// can be tested directly.
+func parallelPrefillSource(in parallelPrefillInputs) prefillScanSource {
 	// running alongside live writes is only safe if the scan can fill empty slots
 	// without overwriting: its cursor holds a snapshot that may already be stale
-	if !in.ifAbsent {
-		return false
+	if !in.ifAbsent || !cacheFitsNodes(in) {
+		return prefillScanNone
 	}
-	return cacheFitsNodes(in)
+	switch {
+	case in.multivector && in.muvera:
+		return prefillScanMuvera
+	case in.multivector || in.muvera:
+		// a per-passage multivector cache is not objects-sourced. muvera without
+		// multivector is reachable (parseMultivectorMap accepts the pair
+		// independently) and nothing writes its bucket, so a scan there would report
+		// a successful prefill of nothing.
+		return prefillScanNone
+	default:
+		return prefillScanObjects
+	}
 }
 
 // cacheFitsNodes requires headroom beyond the node count rather than an exact fit:
@@ -107,12 +148,25 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 
 	targetVector := h.getTargetVector()
 	if h.useTargetedPrefillScan(bucket) {
-		return h.prefillFromScan(ctx, func(ctx context.Context, onVector prefillOnVector) error {
+		return h.prefillFromScan(ctx, prefillScanObjects, func(ctx context.Context, onVector prefillOnVector) error {
 			return h.scanObjectVectorsTargeted(ctx, bucket, targetVector, onVector)
 		})
 	}
-	return h.prefillFromScan(ctx, func(ctx context.Context, onVector prefillOnVector) error {
+	return h.prefillFromScan(ctx, prefillScanObjects, func(ctx context.Context, onVector prefillOnVector) error {
 		return scanBucketVectorsParallel(ctx, bucket, objectsRowDecoder(targetVector, h.logger), onVector, h.logger)
+	})
+}
+
+// prefillMuveraCacheParallel fills the cache by scanning the muvera vectors bucket.
+func (h *hnsw) prefillMuveraCacheParallel(ctx context.Context) error {
+	name := helpers.GetMuveraBucketName(h.id)
+	bucket := h.store.Bucket(name)
+	if bucket == nil {
+		return fmt.Errorf("prefill cache: muvera bucket %q not found", name)
+	}
+
+	return h.prefillFromScan(ctx, prefillScanMuvera, func(ctx context.Context, onVector prefillOnVector) error {
+		return scanBucketVectorsParallel(ctx, bucket, muveraRowDecoder(h.logger), onVector, h.logger)
 	})
 }
 
@@ -120,7 +174,7 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 // snapshot cursor can repopulate its slot with the pre-delete value — bounded waste,
 // the node itself stays tombstoned. Memory pressure and a full cache abort with a nil
 // error; the vectors left behind load on demand through cache.Get.
-func (h *hnsw) prefillFromScan(ctx context.Context,
+func (h *hnsw) prefillFromScan(ctx context.Context, src prefillScanSource,
 	scan func(context.Context, prefillOnVector) error,
 ) error {
 	before := time.Now()
@@ -164,6 +218,7 @@ func (h *hnsw) prefillFromScan(ctx context.Context,
 	entry := h.logger.WithFields(logrus.Fields{
 		"action":   "hnsw_vector_cache_prefill",
 		"index_id": h.id,
+		"source":   src.String(),
 	})
 
 	if err := scan(ctx, onVector); err != nil {
@@ -211,11 +266,12 @@ func (h *hnsw) nodeAlive(id uint64) bool {
 type prefillOnVector func(id uint64, vec []float32) error
 
 // prefillRowDecoder extracts (docID, vector) from one bucket entry; ok=false skips
-// the row. The returned vec must not alias v — cursor buffers are reused.
-type prefillRowDecoder func(v []byte) (id uint64, vec []float32, ok bool)
+// the row. It takes both halves because the id lives in the value for objects and in
+// the key for muvera. The returned vec must not alias v — cursor buffers are reused.
+type prefillRowDecoder func(k, v []byte) (id uint64, vec []float32, ok bool)
 
 func objectsRowDecoder(targetVector string, logger logrus.FieldLogger) prefillRowDecoder {
-	return func(v []byte) (uint64, []float32, bool) {
+	return func(_, v []byte) (uint64, []float32, bool) {
 		id, err := storobj.DocIDFromBinary(v)
 		if err != nil {
 			logger.WithField("action", "hnsw_vector_cache_prefill").
@@ -236,6 +292,26 @@ func objectsRowDecoder(targetVector string, logger logrus.FieldLogger) prefillRo
 			return 0, nil, false
 		}
 		return id, vec, true
+	}
+}
+
+func muveraRowDecoder(logger logrus.FieldLogger) prefillRowDecoder {
+	return func(k, v []byte) (uint64, []float32, bool) {
+		if len(k) != 8 {
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping muvera entry with %d-byte key", len(k))
+			return 0, nil, false
+		}
+		// MuveraFromBytes sizes the vector as len(v)/4, so a torn row would reach the
+		// distancer silently truncated rather than fail here.
+		if len(v)%4 != 0 {
+			logger.WithField("action", "hnsw_vector_cache_prefill").
+				Debugf("skipping muvera entry with %d-byte value", len(v))
+			return 0, nil, false
+		}
+		// MuveraFromBytes allocates a fresh slice, so the value never aliases the
+		// cursor buffer.
+		return binary.BigEndian.Uint64(k), multivector.MuveraFromBytes(v), true
 	}
 }
 
@@ -334,7 +410,7 @@ func scanBucketVectorsRange(ctx context.Context, bucket *lsmkv.Bucket, start, en
 			continue
 		}
 
-		id, vec, ok := decode(v)
+		id, vec, ok := decode(k, v)
 		if !ok || len(vec) == 0 {
 			continue
 		}

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_bench_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_bench_test.go
@@ -25,9 +25,11 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/multivector"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 // prefillBenchConfig shapes the slow-prefill dataset: named target vectors, a
@@ -167,7 +169,7 @@ func runTargetedPrefill(tb testing.TB, store *lsmkv.Store, cfg prefillBenchConfi
 	h := newPrefillBenchIndex(store, c, cfg.n)
 	bucket := store.Bucket(helpers.ObjectsBucketLSM)
 
-	require.NoError(tb, h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+	require.NoError(tb, h.prefillFromScan(context.Background(), prefillScanObjects, func(ctx context.Context, onVector prefillOnVector) error {
 		return h.scanObjectVectorsTargeted(ctx, bucket, prefillBenchTarget, onVector)
 	}))
 	require.Equal(tb, int64(cfg.n), c.CountVectors())
@@ -243,7 +245,7 @@ func BenchmarkPrefillNamedVectorsChurned(b *testing.B) {
 	b.Run("pread/parallel-scan", func(b *testing.B) {
 		benchRuns(b, cfg.n, func(tb testing.TB) {
 			run(tb, func(h *hnsw) error {
-				return h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+				return h.prefillFromScan(context.Background(), prefillScanObjects, func(ctx context.Context, onVector prefillOnVector) error {
 					return scanBucketVectorsParallel(ctx, bucket, objectsRowDecoder(prefillBenchTarget, h.logger), onVector, h.logger)
 				})
 			})
@@ -252,10 +254,114 @@ func BenchmarkPrefillNamedVectorsChurned(b *testing.B) {
 	b.Run("pread/targeted-scan", func(b *testing.B) {
 		benchRuns(b, cfg.n, func(tb testing.TB) {
 			run(tb, func(h *hnsw) error {
-				return h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+				return h.prefillFromScan(context.Background(), prefillScanObjects, func(ctx context.Context, onVector prefillOnVector) error {
 					return h.scanObjectVectorsTargeted(ctx, bucket, prefillBenchTarget, onVector)
 				})
 			})
 		})
+	})
+}
+
+// muveraBenchDims is the encoded width the default config produces:
+// 2^ksim * dprojections * repetitions, so a ~10KB value per doc.
+const muveraBenchDims = (1 << ent.DefaultMultivectorKSim) *
+	ent.DefaultMultivectorDProjections * ent.DefaultMultivectorRepetitions
+
+const muveraBenchIndexID = "muvera_bench"
+
+func buildMuveraBenchStore(tb testing.TB, cfg prefillBenchConfig, opts ...lsmkv.BucketOption) *lsmkv.Store {
+	tb.Helper()
+	dir := tb.TempDir()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroup("objects", logger, 1),
+		cyclemanager.NewCallbackGroup("nonObjects", logger, 1),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(tb, err)
+	tb.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	name := helpers.GetMuveraBucketName(muveraBenchIndexID)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), name,
+		append([]lsmkv.BucketOption{lsmkv.WithStrategy(lsmkv.StrategyReplace)}, opts...)...))
+	bucket := store.Bucket(name)
+
+	perSegment := (cfg.n + cfg.segments - 1) / cfg.segments
+	for i := 0; i < cfg.n; i++ {
+		// fresh key per Put: the memtable keeps the slice it is handed
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, uint64(i))
+		require.NoError(tb, bucket.Put(key, multivector.MuveraBytesFromFloat32(benchVector(i, cfg.dims, 0))))
+		if (i+1)%perSegment == 0 {
+			require.NoError(tb, bucket.FlushAndSwitch())
+		}
+	}
+	require.NoError(tb, bucket.FlushAndSwitch())
+	return store
+}
+
+func newMuveraBenchIndex(store *lsmkv.Store, c cache.Cache[float32], n int) *hnsw {
+	logger, _ := test.NewNullLogger()
+	return newPrefillTestIndex(muveraBenchIndexID, store, c, n, distancer.NewDotProductProvider(), logger)
+}
+
+// runMuveraSerialPrefill measures what muvera did before this change: one
+// GetMuveraVectorForID per node, which is a bucket.Get keyed by the 8-byte doc id.
+func runMuveraSerialPrefill(tb testing.TB, store *lsmkv.Store, cfg prefillBenchConfig) {
+	tb.Helper()
+	bucket := store.Bucket(helpers.GetMuveraBucketName(muveraBenchIndexID))
+	logger, _ := test.NewNullLogger()
+
+	byID := func(ctx context.Context, id uint64) ([]float32, error) {
+		key := make([]byte, 8)
+		binary.BigEndian.PutUint64(key, id)
+		v, err := bucket.Get(key)
+		if err != nil {
+			return nil, err
+		}
+		if len(v) == 0 {
+			return nil, fmt.Errorf("doc id %d not found", id)
+		}
+		return multivector.MuveraFromBytes(v), nil
+	}
+	c := cache.NewShardedFloat32LockCache(byID, nil, 1_000_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(cfg.n))
+	h := newMuveraBenchIndex(store, c, cfg.n)
+
+	require.NoError(tb, newVectorCachePrefiller(c, h, logger).Prefill(context.Background(), int(c.CopyMaxSize())))
+	require.Equal(tb, int64(cfg.n), c.CountVectors())
+}
+
+func runMuveraParallelPrefill(tb testing.TB, store *lsmkv.Store, cfg prefillBenchConfig) {
+	tb.Helper()
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000_000, 1, logger, false, 0, nil)
+	c.Grow(uint64(cfg.n))
+	h := newMuveraBenchIndex(store, c, cfg.n)
+
+	require.NoError(tb, h.prefillMuveraCacheParallel(context.Background()))
+	require.Equal(tb, int64(cfg.n), c.CountVectors())
+}
+
+// BenchmarkPrefillMuveraVectors compares the by-id path muvera used to take against
+// the bucket scan. There is no read amplification to recover here — the value is the
+// vector — so this measures seek-per-vector against a cursor plus parallel decode.
+// Page-cache hot, so it understates the network-storage case the scan exists for.
+func BenchmarkPrefillMuveraVectors(b *testing.B) {
+	cfg := prefillBenchConfig{n: 5_000, dims: muveraBenchDims, segments: 4}
+
+	store := buildMuveraBenchStore(b, cfg)
+	b.Run("serial-by-id", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runMuveraSerialPrefill(tb, store, cfg) })
+	})
+	b.Run("parallel-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runMuveraParallelPrefill(tb, store, cfg) })
+	})
+
+	preadStore := buildMuveraBenchStore(b, cfg, lsmkv.WithPread(true), lsmkv.WithMinMMapSize(0))
+	b.Run("pread/serial-by-id", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runMuveraSerialPrefill(tb, preadStore, cfg) })
+	})
+	b.Run("pread/parallel-scan", func(b *testing.B) {
+		benchRuns(b, cfg.n, func(tb testing.TB) { runMuveraParallelPrefill(tb, preadStore, cfg) })
 	})
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_integration_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
-// storeWithObjectsBucket gives the index a real objects bucket so useParallelPrefill
-// gets past its bucket-presence check and actually evaluates the eligibility gate —
-// otherwise every index would fall back to serial for the wrong reason.
+// storeWithObjectsBucket gives the index a real objects bucket so the gate gets past
+// its bucket-presence check and actually evaluates eligibility — otherwise every
+// index would fall back to serial for the wrong reason.
 func storeWithObjectsBucket(t *testing.T) *lsmkv.Store {
 	store := testinghelpers.NewDummyStore(t)
 	require.NoError(t, store.CreateOrLoadBucket(context.Background(), helpers.ObjectsBucketLSM,
@@ -39,7 +39,9 @@ func storeWithObjectsBucket(t *testing.T) *lsmkv.Store {
 	return store
 }
 
-func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *lsmkv.Store) *hnsw {
+func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *lsmkv.Store,
+	docs [][][]float32,
+) *hnsw {
 	idx, err := New(Config{
 		RootPath:              t.TempDir(),
 		ID:                    id,
@@ -49,7 +51,7 @@ func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *l
 			return []float32{0.1, 0.2, 0.3}, nil
 		},
 		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
-			return multiVectors[id], nil
+			return docs[id], nil
 		},
 		MakeBucketOptions:   lsmkv.MakeNoopBucketOptions,
 		AllocChecker:        memwatch.NewDummyMonitor(),
@@ -57,14 +59,10 @@ func newPrefillRoutingIndex(t *testing.T, id string, uc ent.UserConfig, store *l
 		WaitForCachePrefill: true,
 	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, idx.Shutdown(context.Background())) })
 	return idx
 }
 
-// TestUseParallelPrefillRoutingRealIndex builds real indexes (objects bucket present,
-// sync prefill, unbounded cache) and confirms the config→atomic→gate wiring routes
-// each index type to the right prefill path: only a plain single-vector index takes
-// the parallel objects-bucket scan; multivector and muvera stay on the serial path
-// because their caches are not sourced from the objects bucket.
 // prefillRoutingUserConfig is the baseline single-vector config that satisfies the
 // parallel-prefill gate (unbounded cache); tests layer Multivector/Muvera on top to
 // flip the expected routing.
@@ -81,63 +79,173 @@ func muveraUserConfig() ent.UserConfig {
 	return uc
 }
 
+// TestUseParallelPrefillRoutingRealIndex builds real indexes (objects bucket present,
+// sync prefill, unbounded cache) and confirms the config→atomic→gate wiring routes
+// each index type to the right prefill source.
 func TestUseParallelPrefillRoutingRealIndex(t *testing.T) {
-	t.Run("single-vector uncompressed is eligible", func(t *testing.T) {
-		idx := newPrefillRoutingIndex(t, "single", prefillRoutingUserConfig(), storeWithObjectsBucket(t))
-		require.True(t, idx.useParallelPrefill())
-	})
-
-	t.Run("true multivector keeps serial path", func(t *testing.T) {
-		uc := prefillRoutingUserConfig()
-		uc.Multivector = ent.MultivectorConfig{Enabled: true}
-		idx := newPrefillRoutingIndex(t, "multivector", uc, storeWithObjectsBucket(t))
-		require.False(t, idx.useParallelPrefill())
-	})
-
-	t.Run("muvera keeps serial path", func(t *testing.T) {
-		idx := newPrefillRoutingIndex(t, "muvera", muveraUserConfig(), storeWithObjectsBucket(t))
-		require.False(t, idx.useParallelPrefill())
-	})
+	tests := []struct {
+		name string
+		uc   func() ent.UserConfig
+		want prefillScanSource
+	}{
+		{"single-vector uncompressed scans objects", prefillRoutingUserConfig, prefillScanObjects},
+		{"true multivector keeps serial path", func() ent.UserConfig {
+			uc := prefillRoutingUserConfig()
+			uc.Multivector = ent.MultivectorConfig{Enabled: true}
+			return uc
+		}, prefillScanNone},
+		{"muvera scans the muvera bucket", muveraUserConfig, prefillScanMuvera},
+		// reachable through the schema, and New builds the muvera bucket for it; see
+		// parallelPrefillSource
+		{"muvera without multivector keeps serial path", func() ent.UserConfig {
+			uc := prefillRoutingUserConfig()
+			uc.Multivector = ent.MultivectorConfig{
+				MuveraConfig: ent.MuveraConfig{Enabled: true, KSim: 2, DProjections: 3, Repetitions: 5},
+			}
+			return uc
+		}, prefillScanNone},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := newPrefillRoutingIndex(t, "routing", tt.uc(), storeWithObjectsBucket(t), multiVectors)
+			require.Equal(t, tt.want, idx.parallelPrefillSource())
+		})
+	}
 }
 
-// TestMuveraSerialPrefillPopulatesCacheRealIndex is the end-to-end guard for the bug
-// the parallel path introduced: a muvera index's float32 cache is loaded from the
-// dedicated _muvera_vectors bucket, not the objects bucket. After clearing the cache
-// (cold-restart shape), the serial prefiller muvera routes to must repopulate it
-// fully with the correct muvera-encoded vectors — the parallel path would have left
-// it empty while marking it prefilled.
-func TestMuveraSerialPrefillPopulatesCacheRealIndex(t *testing.T) {
-	ctx := context.Background()
-	logger, _ := test.NewNullLogger()
-	store := storeWithObjectsBucket(t)
+// muveraPrefillDocs must be large enough that the flushed bucket yields quantile
+// seeds; below that the scan collapses to one full-range cursor and never exercises
+// the seed arithmetic. requireParallelRanges asserts that rather than trust the number.
+const muveraPrefillDocs = 3000
 
-	idx := newPrefillRoutingIndex(t, "muvera-prefill", muveraUserConfig(), store)
-
-	for i, vec := range multiVectors {
-		require.NoError(t, idx.AddMulti(ctx, uint64(i), vec))
+// generateMultiVectors stands in for the multiVectors fixture, which at 3 docs is too
+// small to flush into a segment.
+func generateMultiVectors(n int) [][][]float32 {
+	docs := make([][][]float32, n)
+	for i := range docs {
+		passages := make([][]float32, 2+i%3)
+		for p := range passages {
+			f := float32(i*10 + p)
+			passages[p] = []float32{f, f + 0.5, f - 0.5}
+		}
+		docs[i] = passages
 	}
+	return docs
+}
 
-	require.False(t, idx.useParallelPrefill(),
-		"muvera must route to the serial prefiller, not the objects-bucket scan")
+// newFlushedMuveraIndex populates a muvera index and flushes its vectors bucket, which
+// QuantileKeys needs to seed anything.
+func newFlushedMuveraIndex(t *testing.T, id string, docs [][][]float32) *hnsw {
+	ctx := context.Background()
+	store := storeWithObjectsBucket(t)
+	idx := newPrefillRoutingIndex(t, id, muveraUserConfig(), store, docs)
 
-	expected := make(map[uint64][]float32, len(multiVectors))
-	for i := range multiVectors {
-		v, err := idx.muveraEncoder.GetMuveraVectorForID(uint64(i), idx.id+"_muvera_vectors")
+	ids := make([]uint64, len(docs))
+	for i := range docs {
+		ids[i] = uint64(i)
+	}
+	require.NoError(t, idx.AddMultiBatch(ctx, ids, docs))
+	require.NoError(t, store.Bucket(helpers.GetMuveraBucketName(id)).FlushAndSwitch())
+	return idx
+}
+
+// muveraPrefillGroundTruth reads the expectation straight from the encoder/bucket, so
+// a prefill that loads the wrong vectors fails rather than agreeing with itself.
+func muveraPrefillGroundTruth(t *testing.T, idx *hnsw, docs int) map[uint64][]float32 {
+	t.Helper()
+	expected := make(map[uint64][]float32, docs)
+	for i := 0; i < docs; i++ {
+		v, err := idx.muveraEncoder.GetMuveraVectorForID(uint64(i), helpers.GetMuveraBucketName(idx.id))
 		require.NoError(t, err)
 		expected[uint64(i)] = v
 	}
+	return expected
+}
 
-	// Cold-restart shape: drop the cache, then run the serial prefiller muvera is
-	// routed to and confirm full, correct repopulation.
-	idx.cache.Drop()
-	require.Equal(t, int64(0), idx.cache.CountVectors())
-
-	require.NoError(t, newVectorCachePrefiller(idx.cache, idx, logger).Prefill(ctx, int(idx.cache.CopyMaxSize())))
-
-	require.Equal(t, int64(len(multiVectors)), idx.cache.CountVectors())
+func requireMuveraCacheMatches(t *testing.T, idx *hnsw, expected map[uint64][]float32) {
+	t.Helper()
+	require.Equal(t, int64(len(expected)), idx.cache.CountVectors())
 	for id, want := range expected {
-		got, err := idx.cache.Get(ctx, id)
+		got, err := idx.cache.Get(context.Background(), id)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
 	}
+}
+
+// evictCachedVectors empties the cache the way a cold start would leave it. Not
+// cache.Drop(): Drop notifies a deletion watcher that exits on the first notification,
+// so the deferred Shutdown — the first call through releaseVectorsOnce — would then
+// block forever on its own Drop.
+func evictCachedVectors(t *testing.T, idx *hnsw, docs int) {
+	t.Helper()
+	for id := 0; id < docs; id++ {
+		idx.cache.Delete(context.Background(), uint64(id))
+	}
+	require.Equal(t, int64(0), idx.cache.CountVectors())
+}
+
+// requireParallelRanges fails unless the bucket seeds more than one cursor range: a
+// fixture that shrinks below the segment threshold would silently stop testing the
+// parallel scan.
+func requireParallelRanges(t *testing.T, idx *hnsw) {
+	t.Helper()
+	seeds := idx.store.Bucket(helpers.GetMuveraBucketName(idx.id)).QuantileKeys(prefillScanParallelism() - 1)
+	require.NotEmpty(t, seeds, "muvera bucket yields no quantile seeds: the scan would run as one range")
+}
+
+// TestMuveraParallelPrefillPopulatesCacheRealIndex: cold-restart shape against a real
+// muvera index — the scan must repopulate the float32 cache across several ranges.
+func TestMuveraParallelPrefillPopulatesCacheRealIndex(t *testing.T) {
+	ctx := context.Background()
+	docs := generateMultiVectors(muveraPrefillDocs)
+	idx := newFlushedMuveraIndex(t, "muvera-prefill-parallel", docs)
+
+	require.Equal(t, prefillScanMuvera, idx.parallelPrefillSource())
+	requireParallelRanges(t, idx)
+	expected := muveraPrefillGroundTruth(t, idx, len(docs))
+
+	evictCachedVectors(t, idx, len(docs))
+
+	require.NoError(t, idx.prefillMuveraCacheParallel(ctx))
+	requireMuveraCacheMatches(t, idx, expected)
+}
+
+// TestMuveraPrefillCacheRoutesToParallelScan drives the shipping entry point rather
+// than the scan directly: prefillCache must pick the muvera arm and run it.
+func TestMuveraPrefillCacheRoutesToParallelScan(t *testing.T) {
+	ctx := context.Background()
+	docs := generateMultiVectors(muveraPrefillDocs)
+	idx := newFlushedMuveraIndex(t, "muvera-prefill-cache", docs)
+
+	requireParallelRanges(t, idx)
+	expected := muveraPrefillGroundTruth(t, idx, len(docs))
+
+	evictCachedVectors(t, idx, len(docs))
+	// the noop commit logger restores no state, so init() took restoreFromDisk's
+	// fresh-index shortcut and already marked the cache prefilled
+	idx.cachePrefilled.Store(false)
+
+	idx.prefillCache(ctx)
+
+	require.True(t, idx.cachePrefilled.Load())
+	requireMuveraCacheMatches(t, idx, expected)
+}
+
+// TestMuveraSerialPrefillPopulatesCacheRealIndex guards the serial by-id fallback
+// muvera still uses when the parallel gate fails (e.g. bounded cache): it must load
+// from the dedicated muvera bucket, not the objects bucket.
+func TestMuveraSerialPrefillPopulatesCacheRealIndex(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	idx := newFlushedMuveraIndex(t, "muvera-prefill-serial", multiVectors)
+
+	require.NotEqual(t, prefillScanObjects, idx.parallelPrefillSource(),
+		"muvera must never take the objects-bucket scan")
+
+	expected := muveraPrefillGroundTruth(t, idx, len(multiVectors))
+
+	evictCachedVectors(t, idx, len(multiVectors))
+
+	require.NoError(t, newVectorCachePrefiller(idx.cache, idx, logger).Prefill(ctx, int(idx.cache.CopyMaxSize())))
+	requireMuveraCacheMatches(t, idx, expected)
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel_test.go
@@ -13,6 +13,7 @@ package hnsw
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -29,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/multivector"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -234,7 +236,9 @@ func TestScanObjectVectorsParallel(t *testing.T) {
 	})
 }
 
-func TestParallelPrefillEligible(t *testing.T) {
+// TestParallelPrefillSource pins the gate every prefill caller routes through. One
+// table, so the objects and muvera answers cannot drift apart.
+func TestParallelPrefillSource(t *testing.T) {
 	base := parallelPrefillInputs{
 		multivector:  false,
 		muvera:       false,
@@ -246,28 +250,38 @@ func TestParallelPrefillEligible(t *testing.T) {
 	tests := []struct {
 		name string
 		mod  func(*parallelPrefillInputs)
-		want bool
+		want prefillScanSource
 	}{
-		{"unbounded single-vector is eligible", func(*parallelPrefillInputs) {}, true},
-		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = false }, false},
-		// muvera's float32 cache is sourced from the _muvera_vectors bucket, not the
-		// objects bucket this scan reads — it takes the muvera scan instead.
-		{"muvera does not take the objects scan", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, false},
-		{"muvera without multivector flag does not take the objects scan", func(in *parallelPrefillInputs) { in.multivector = false; in.muvera = true }, false},
-		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, false},
+		{"unbounded single-vector scans objects", func(*parallelPrefillInputs) {}, prefillScanObjects},
+		{"true multivector keeps serial path", func(in *parallelPrefillInputs) { in.multivector = true }, prefillScanNone},
+		{"muvera scans its own bucket", func(in *parallelPrefillInputs) { in.multivector = true; in.muvera = true }, prefillScanMuvera},
+		// reachable through the schema; see parallelPrefillSource
+		{"muvera without multivector keeps serial path", func(in *parallelPrefillInputs) { in.muvera = true }, prefillScanNone},
+		{"bounded cache (max < nodes) keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 500; in.nodeCount = 1000 }, prefillScanNone},
+		{"bounded muvera cache keeps serial path", func(in *parallelPrefillInputs) {
+			in.multivector = true
+			in.muvera = true
+			in.cacheMaxSize = 500
+			in.nodeCount = 1000
+		}, prefillScanNone},
 		// an exact fit would leave count == maxSize, which replaceIfFull wipes
-		{"cache exactly fits nodes keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, false},
-		{"cache one slot larger than nodes is eligible", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1001; in.nodeCount = 1000 }, true},
-		{"empty index (0 nodes) is eligible", func(in *parallelPrefillInputs) { in.nodeCount = 0 }, true},
+		{"cache exactly fits nodes keeps serial path", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1000; in.nodeCount = 1000 }, prefillScanNone},
+		{"cache one slot larger than nodes scans objects", func(in *parallelPrefillInputs) { in.cacheMaxSize = 1001; in.nodeCount = 1000 }, prefillScanObjects},
+		{"empty index (0 nodes) scans objects", func(in *parallelPrefillInputs) { in.nodeCount = 0 }, prefillScanObjects},
 		// the scan runs alongside live writes, so an overwriting Preload is not enough:
 		// without if-absent semantics it could clobber a newer inserted vector
-		{"cache without PreloadIfAbsent keeps serial path", func(in *parallelPrefillInputs) { in.ifAbsent = false }, false},
+		{"cache without PreloadIfAbsent keeps serial path", func(in *parallelPrefillInputs) { in.ifAbsent = false }, prefillScanNone},
+		{"muvera cache without PreloadIfAbsent keeps serial path", func(in *parallelPrefillInputs) {
+			in.multivector = true
+			in.muvera = true
+			in.ifAbsent = false
+		}, prefillScanNone},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			in := base
 			tt.mod(&in)
-			assert.Equal(t, tt.want, parallelPrefillEligible(in))
+			assert.Equal(t, tt.want, parallelPrefillSource(in))
 		})
 	}
 }
@@ -603,17 +617,143 @@ func TestPrefillCacheParallelStopsBelowCacheFull(t *testing.T) {
 }
 
 // TestUseParallelPrefillExcludesHFresh: the hfresh centroid index shares the shard's
-// store (objects bucket present) but its cache holds centroid vectors, so the
-// objects scan must never run for it.
+// store (objects bucket present) but its cache holds centroid vectors, so no bucket
+// scan may run for it — including the muvera one, should the centroid config ever
+// gain a multivector path.
 func TestUseParallelPrefillExcludesHFresh(t *testing.T) {
 	store := newTestObjectsStore(t)
 	logger, _ := test.NewNullLogger()
 	c := cache.NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(),
+		helpers.GetMuveraBucketName("main_centroids"), lsmkv.WithStrategy(lsmkv.StrategyReplace)))
 
 	h := newPrefillTestIndex("main_centroids", store, c, 0, distancer.NewDotProductProvider(), logger)
 	h.hfreshMode = true
-	require.False(t, h.useParallelPrefill())
+	require.Equal(t, prefillScanNone, h.parallelPrefillSource())
+
+	h.multivector.Store(true)
+	h.muvera.Store(true)
+	require.Equal(t, prefillScanNone, h.parallelPrefillSource())
 
 	h.hfreshMode = false
-	require.True(t, h.useParallelPrefill())
+	require.Equal(t, prefillScanMuvera, h.parallelPrefillSource(),
+		"the guard must be hfreshMode, not the absence of a muvera config")
+
+	h.multivector.Store(false)
+	h.muvera.Store(false)
+	require.Equal(t, prefillScanObjects, h.parallelPrefillSource())
+}
+
+func putMuveraVector(t *testing.T, bucket *lsmkv.Bucket, id uint64, vec []float32) {
+	t.Helper()
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, id)
+	require.NoError(t, bucket.Put(key, multivector.MuveraBytesFromFloat32(vec)))
+}
+
+// newMuveraBucketStore fills an index's muvera vectors bucket and flushes it, so the
+// scan seeds real parallel ranges.
+func newMuveraBucketStore(t *testing.T, id string, n uint64) (*lsmkv.Store, map[uint64][]float32) {
+	t.Helper()
+	store := newTestObjectsStore(t)
+	name := helpers.GetMuveraBucketName(id)
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(), name,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace)))
+	bucket := store.Bucket(name)
+
+	exp := make(map[uint64][]float32, n)
+	for i := uint64(0); i < n; i++ {
+		vec := []float32{float32(i) + 0.5, float32(i) - 0.5, float32(i)}
+		putMuveraVector(t, bucket, i, vec)
+		exp[i] = vec
+	}
+	require.NoError(t, bucket.FlushAndSwitch())
+	return store, exp
+}
+
+// TestPrefillMuveraCacheParallelEndToEnd scans a real muvera vectors bucket into the
+// cache, across flushed segments and with a deleted entry that must not resurface.
+func TestPrefillMuveraCacheParallelEndToEnd(t *testing.T) {
+	const n = 300
+	store, exp := newMuveraBucketStore(t, "m", n)
+	bucket := store.Bucket(helpers.GetMuveraBucketName("m"))
+
+	key := make([]byte, 8)
+	binary.BigEndian.PutUint64(key, 42)
+	require.NoError(t, bucket.Delete(key))
+	require.NoError(t, bucket.FlushAndSwitch())
+	delete(exp, 42)
+
+	require.NotEmpty(t, bucket.QuantileKeys(prefillScanParallelism()-1),
+		"fixture must seed more than one cursor range")
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(n)
+
+	h := newPrefillTestIndex("m", store, c, n, distancer.NewDotProductProvider(), logger)
+	require.NoError(t, h.prefillMuveraCacheParallel(context.Background()))
+	requireCacheContains(t, c, exp)
+}
+
+// TestPrefillMuveraCacheParallelSkipsDeadNodes: cleanUpTombstonedNodes only warn-logs
+// a failed muvera row delete, so a row can outlive its node. The scan is keyed off
+// rows, so without prefillEligible those ids would be cached for a node no search can
+// reach.
+func TestPrefillMuveraCacheParallelSkipsDeadNodes(t *testing.T) {
+	const n = 300
+	store, exp := newMuveraBucketStore(t, "m", n)
+
+	logger, _ := test.NewNullLogger()
+	c := cache.NewShardedFloat32LockCache(errOnCacheMiss, nil, 1_000_000, 1, logger, false, 0, nil)
+	c.Grow(n)
+
+	h := newPrefillTestIndex("m", store, c, n, distancer.NewDotProductProvider(), logger)
+	for _, id := range []uint64{7, 42, 199} {
+		h.nodes[id] = nil
+		delete(exp, id)
+	}
+	h.tombstones[11] = struct{}{}
+	delete(exp, 11)
+
+	require.NoError(t, h.prefillMuveraCacheParallel(context.Background()))
+	requireCacheContains(t, c, exp)
+}
+
+// TestMuveraRowDecoder: a torn or foreign row must be skipped rather than yield a
+// garbage id or a silently truncated vector.
+func TestMuveraRowDecoder(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	decode := muveraRowDecoder(logger)
+
+	key := func(id uint64) []byte {
+		k := make([]byte, 8)
+		binary.BigEndian.PutUint64(k, id)
+		return k
+	}
+
+	tests := []struct {
+		name string
+		k, v []byte
+		want []float32
+	}{
+		{"well-formed row", key(7), multivector.MuveraBytesFromFloat32([]float32{1, 2, 3}), []float32{1, 2, 3}},
+		{"short key", key(7)[:6], multivector.MuveraBytesFromFloat32([]float32{1, 2, 3}), nil},
+		{"long key", append(key(7), 0), multivector.MuveraBytesFromFloat32([]float32{1}), nil},
+		{"value not a whole number of float32s", key(7), []byte{1, 2, 3, 4, 5, 6}, nil},
+		{"empty value", key(7), []byte{}, []float32{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, vec, ok := decode(tt.k, tt.v)
+			if tt.want == nil {
+				assert.False(t, ok)
+				assert.Nil(t, vec)
+				return
+			}
+			require.True(t, ok)
+			assert.Equal(t, uint64(7), id)
+			assert.Equal(t, tt.want, vec)
+		})
+	}
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted_corruption_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted_corruption_test.go
@@ -144,7 +144,7 @@ func TestPrefillTargetedSkipsTruncatedRows(t *testing.T) {
 			c.Grow(healthy + 1)
 			h := newTargetedTestIndex(store, c, id, live, healthy+1)
 
-			require.NoError(t, h.prefillFromScan(context.Background(),
+			require.NoError(t, h.prefillFromScan(context.Background(), prefillScanObjects,
 				func(ctx context.Context, onVector prefillOnVector) error {
 					return h.scanObjectVectorsTargeted(ctx, bucket, tc.target, onVector)
 				}))
@@ -191,7 +191,7 @@ func TestPrefillTargetedSkipsRowUnderForeignKey(t *testing.T) {
 	c.Grow(healthy + 1)
 	h := newTargetedTestIndex(store, c, "main", live, healthy+1)
 
-	require.NoError(t, h.prefillFromScan(context.Background(),
+	require.NoError(t, h.prefillFromScan(context.Background(), prefillScanObjects,
 		func(ctx context.Context, onVector prefillOnVector) error {
 			return h.scanObjectVectorsTargeted(ctx, bucket, "", onVector)
 		}))

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_targeted_test.go
@@ -67,7 +67,7 @@ func newTargetedTestIndex(store *lsmkv.Store, c cache.Cache[float32], id string,
 func prefillTargeted(t *testing.T, h *hnsw, target string) error {
 	t.Helper()
 	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
-	return h.prefillFromScan(context.Background(), func(ctx context.Context, onVector prefillOnVector) error {
+	return h.prefillFromScan(context.Background(), prefillScanObjects, func(ctx context.Context, onVector prefillOnVector) error {
 		return h.scanObjectVectorsTargeted(ctx, bucket, target, onVector)
 	})
 }


### PR DESCRIPTION
Stacked on #12397. Split out of it so the objects-bucket prefill can be reviewed without this, and this without that.

Muvera's float32 cache is sourced from the muvera vectors bucket rather than from objects, so the objects scan deliberately skips it and it fell back to per-id lookups. That bucket holds nothing but id and vector, which makes it the easy case: a decoder that reads both straight off the row, plugged into the parallel scan #12397 already builds.

## Numbers

`BenchmarkPrefillMuveraVectors`, 5000 docs at the default muvera width (ksim 4, dprojections 16, repetitions 10 → 2560 floats, ~10KB per row), 4 flushed segments. M3 Max, `-benchtime 10x -count 6`, medians via benchstat.

| | serial by-id | parallel scan | |
|---|---|---|---|
| mmap | 13.43ms ± 4% | **3.32ms** ± 6% | 4.0x |
| pread | 20.19ms ± 3% | **13.20ms** ± 1% | 1.53x |

Both cases are page-cache hot, so this measures syscalls, copies and decode — not the disk latency the scan actually exists to hide. On network storage the by-id path pays a round trip per vector; here it only pays a bucket `Get` per vector. Treat 1.5–4x as the floor, not the expected win.

The muvera bucket has no read amplification to recover — the value *is* the vector — so unlike the objects case there is no targeted-scan variant here, and the whole gain is seek-per-vector versus one cursor plus parallel decode.

Widening `prefillRowDecoder` to take the key touches #12397's hot path, so I checked it against the base rather than assuming. Every scan variant of `BenchmarkPrefillNamedVectors` is statistically unchanged (parallel-scan ~, targeted-scan ~, both pread variants ~, churned ~, p > 0.05, n=6). The one significant delta, `serial-by-id` at +4%, is on a path this PR does not touch at all — it never reaches the decoder — so that is run-to-run drift.

## One gate, not two

The first cut of this added a second eligibility rule beside the objects one, and the two had already drifted before review. They fold into `parallelPrefillSource`, which returns the bucket backing the cache — `none`, `objects`, or `muvera` — and `prefillCache` switches on it once instead of walking an else-if chain that evaluated `parallelPrefillInputs()` twice.

Two things that only a single gate gets right:

- **muvera implies multivector.** `parseMultivectorMap` sets `muvera.enabled` independently of `multivector.enabled` and `Validate` only bounds `ksim`, so `{"multivector": {"muvera": {"enabled": true}}}` is reachable through the schema. `New` builds the muvera bucket for it, but `AddMultiBatch` — its only writer — rejects a non-multivector index, so the bucket stays empty forever. A gate keyed on `muvera` alone would scan it, log a successful prefill of nothing, and leave every later `Get` to miss.
- **`hfreshMode` applies to both.** The centroid cache holds centroids, not stored vectors. The objects gate excluded it; a separate muvera gate had no reason to, and nothing but the hfresh config not currently enabling multivector kept that from mattering.

`prefillRowDecoder` takes the key as well as the value now: the id lives in the value for objects and in the key for muvera. The decoder rejects a value that is not a whole number of float32s rather than letting `MuveraFromBytes` size it as `len(v)/4` and hand the distancer a silently truncated vector. `prefillFromScan` labels its completion log with the source it scanned, so an operator can tell the muvera scan from the objects one.

`prefillEligible` (from #12397) does the rest of the work here: the scan is keyed off bucket rows rather than nodes, and `cleanUpTombstonedNodes` only warn-logs a failed muvera row delete, so a leaked row can outlive its node. Filtering per row keeps those ids out of the cache.

The bucket name moves behind `helpers.GetMuveraBucketName`, replacing six inline `"_muvera_vectors"` concatenations across four files — a miss there produced a nil `Bucket()` and a panic in `GetMuveraVectorForID` rather than a compile error.

## Tests

One eligibility table over the single gate, including the half-configured row and the bounded-cache and no-`PreloadIfAbsent` rows for muvera. Decoder negative cases for a short key, a long key, and a value that is not a whole number of float32s. Dead-node and tombstone filtering against a scan keyed off rows.

The integration coverage builds a real muvera index over 3000 docs, flushes the bucket, and asserts the bucket actually seeds more than one cursor range — the 3-doc memtable-only fixture collapsed the scan to a single full-range cursor, so the seed arithmetic this PR exists for was never running. One test drives `prefillCache` itself rather than the scan directly, so the routing arm that ships is covered. The tests shut the index down instead of calling `cache.Drop()` outside `releaseVectorsOnce`, which kills the deletion watcher and deadlocks the next `Drop`.
