### PR TITLE
Gate background lazy shard warmup on an object-count threshold

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -473,7 +473,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		EnableLazyLoadShards:                appState.ServerConfig.Config.EnableLazyLoadShards,
 		LazyLoadShardCountThreshold:         appState.ServerConfig.Config.LazyLoadShardCountThreshold,
 		LazyLoadShardSizeThresholdGB:        appState.ServerConfig.Config.LazyLoadShardSizeThresholdGB,
-		LazyLoadShardWarmupDisabled:         appState.ServerConfig.Config.LazyLoadShardWarmupDisabled,
+		LazyLoadShardWarmupMinObjects:       appState.ServerConfig.Config.LazyLoadShardWarmupMinObjects,
 		ForceFullReplicasSearch:             appState.ServerConfig.Config.ForceFullReplicasSearch,
 		TransferInactivityTimeout:           appState.ServerConfig.Config.TransferInactivityTimeout,
 		HaltForTransferTimeout:              appState.ServerConfig.Config.HaltForTransferTimeout,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -473,6 +473,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		EnableLazyLoadShards:                appState.ServerConfig.Config.EnableLazyLoadShards,
 		LazyLoadShardCountThreshold:         appState.ServerConfig.Config.LazyLoadShardCountThreshold,
 		LazyLoadShardSizeThresholdGB:        appState.ServerConfig.Config.LazyLoadShardSizeThresholdGB,
+		LazyLoadShardWarmupDisabled:         appState.ServerConfig.Config.LazyLoadShardWarmupDisabled,
 		ForceFullReplicasSearch:             appState.ServerConfig.Config.ForceFullReplicasSearch,
 		TransferInactivityTimeout:           appState.ServerConfig.Config.TransferInactivityTimeout,
 		HaltForTransferTimeout:              appState.ServerConfig.Config.HaltForTransferTimeout,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -687,7 +687,11 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		}
 
 		now := time.Now()
-		var loaded, skipped, failed int
+		tally := map[monitoring.WarmupOutcome]int{}
+		recordOutcome := func(outcome monitoring.WarmupOutcome) {
+			tally[outcome]++
+			promMetrics.RecordWarmupOutcome(outcome)
+		}
 
 		for _, shardName := range hotShardNames {
 			if abortIfClosing() {
@@ -697,8 +701,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 			// The decision comes before the tick so only shards that will load wait a
 			// second. At a positive threshold each skip still costs one directory
 			// listing, unpaced.
-			if !i.warmupCandidate(shardName) {
-				skipped++
+			if shouldWarm, outcome := i.warmupCandidate(shardName); !shouldWarm {
+				recordOutcome(outcome)
 				continue
 			}
 
@@ -714,24 +718,26 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				// The memory guard a load fails on is node-wide and transient, so it
 				// says nothing about the shards behind this one. The sweep runs once
 				// per index lifetime, and nothing retries what it walks past.
-				failed++
+				recordOutcome(monitoring.WarmupFailed)
 				i.logger.
 					WithField("action", "load_shard").
 					WithField("shard_name", shardName).
 					Errorf("failed to load shard, warming the rest anyway: %v", err)
 				continue
 			}
-			loaded++
+			recordOutcome(monitoring.WarmupLoaded)
 		}
 
 		i.logger.
 			WithFields(logrus.Fields{
-				"action":  "load_all_shards",
-				"class":   i.Config.ClassName.String(),
-				"took":    time.Since(now).String(),
-				"loaded":  loaded,
-				"skipped": skipped,
-				"failed":  failed,
+				"action":                  "load_all_shards",
+				"class":                   i.Config.ClassName.String(),
+				"took":                    time.Since(now).String(),
+				"loaded":                  tally[monitoring.WarmupLoaded],
+				"failed":                  tally[monitoring.WarmupFailed],
+				"skipped_not_cold":        tally[monitoring.WarmupSkippedNotCold],
+				"skipped_empty":           tally[monitoring.WarmupSkippedEmpty],
+				"skipped_below_threshold": tally[monitoring.WarmupSkippedBelowThreshold],
 			}).
 			Debug("finished loading all shards")
 	}
@@ -752,29 +758,30 @@ func (i *Index) unloadedShardIsEmpty(shardName string) bool {
 }
 
 // warmupCandidate reports whether the startup sweep should load this shard, and
-// is asked before the sweep spends a tick on it. A count it cannot read answers
-// true: a shard is loaded rather than left cold on a number nobody could take.
-func (i *Index) warmupCandidate(shardName string) bool {
+// where it should not, the outcome naming why. It is asked before the sweep
+// spends a tick on the shard. A count it cannot read answers true: a shard is
+// loaded rather than left cold on a number nobody could take.
+func (i *Index) warmupCandidate(shardName string) (bool, monitoring.WarmupOutcome) {
 	i.shardCreateLocks.Lock(shardName)
 	defer i.shardCreateLocks.Unlock(shardName)
 
 	shard := i.shards.Load(shardName)
 	if shard == nil {
-		return false
+		return false, monitoring.WarmupSkippedNotCold
 	}
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if !ok || lazyShard.isLoaded() {
-		return false
+		return false, monitoring.WarmupSkippedNotCold
 	}
 
 	// avoid footprint of empty shards
 	if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
-		return false
+		return false, monitoring.WarmupSkippedEmpty
 	}
 
 	minObjects := i.Config.LazyLoadShardWarmupMinObjects
 	if minObjects == 0 {
-		return true
+		return true, ""
 	}
 
 	count, err := lazyShard.ObjectCountAsync(i.closingCtx)
@@ -787,10 +794,10 @@ func (i *Index) warmupCandidate(shardName string) bool {
 		} else {
 			entry.Warnf("failed to count objects of unloaded shard, warming it up anyway: %v", err)
 		}
-		return true
+		return true, ""
 	}
 	if count > minObjects {
-		return true
+		return true, ""
 	}
 
 	// The persisted doc-id counter would see the writes the sidecars miss, but it
@@ -805,7 +812,7 @@ func (i *Index) warmupCandidate(shardName string) bool {
 		"object_count":       count,
 		"warmup_min_objects": minObjects,
 	}).Debug("shard holds too few objects to warm up; it loads on first access")
-	return false
+	return false, monitoring.WarmupSkippedBelowThreshold
 }
 
 func (i *Index) loadLocalShardIfActive(shardName string) error {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -672,38 +673,61 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 
+		// abortIfClosing reports whether the index is closing and logs that the
+		// sweep stopped; the caller is the one that returns.
+		abortIfClosing := func() bool {
+			err := i.closingCtx.Err()
+			if err == nil {
+				return false
+			}
+			i.logger.
+				WithField("action", "load_all_shards").
+				Errorf("failed to load all shards: %v", err)
+			return true
+		}
+
 		now := time.Now()
+		var loaded, skipped int
 
 		for _, shardName := range hotShardNames {
+			if abortIfClosing() {
+				return
+			}
+
+			// The decision comes before the tick so only shards that will load wait a
+			// second. At a positive threshold each skip still costs one directory
+			// listing, unpaced.
+			if !i.warmupCandidate(shardName) {
+				skipped++
+				continue
+			}
+
 			select {
 			case <-i.closingCtx.Done():
-				i.logger.
-					WithField("action", "load_all_shards").
-					Errorf("failed to load all shards: %v", i.closingCtx.Err())
-				return
 			case <-ticker.C:
-				select {
-				case <-i.closingCtx.Done():
-					i.logger.
-						WithField("action", "load_all_shards").
-						Errorf("failed to load all shards: %v", i.closingCtx.Err())
-					return
-				default:
-					err := i.loadLocalShardIfActive(shardName)
-					if err != nil {
-						i.logger.
-							WithField("action", "load_shard").
-							WithField("shard_name", shardName).
-							Errorf("failed to load shard: %v", err)
-						return
-					}
-				}
 			}
+			if abortIfClosing() {
+				return
+			}
+
+			if err := i.loadLocalShardIfActive(shardName); err != nil {
+				i.logger.
+					WithField("action", "load_shard").
+					WithField("shard_name", shardName).
+					Errorf("failed to load shard: %v", err)
+				return
+			}
+			loaded++
 		}
 
 		i.logger.
-			WithField("action", "load_all_shards").
-			WithField("took", time.Since(now).String()).
+			WithFields(logrus.Fields{
+				"action":  "load_all_shards",
+				"class":   i.Config.ClassName.String(),
+				"took":    time.Since(now).String(),
+				"loaded":  loaded,
+				"skipped": skipped,
+			}).
 			Debug("finished loading all shards")
 	}
 
@@ -720,6 +744,67 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 func (i *Index) unloadedShardIsEmpty(shardName string) bool {
 	count, err := indexcounter.Read(shardPath(i.path(), shardName))
 	return err == nil && count == 0
+}
+
+// warmupCandidate reports whether the startup sweep should load this shard, and
+// is asked before the sweep spends a tick on it. A count it cannot read answers
+// true: a shard is loaded rather than left cold on a number nobody could take.
+func (i *Index) warmupCandidate(shardName string) bool {
+	i.shardCreateLocks.Lock(shardName)
+	defer i.shardCreateLocks.Unlock(shardName)
+
+	shard := i.shards.Load(shardName)
+	if shard == nil {
+		return false
+	}
+	lazyShard, ok := shard.(*LazyLoadShard)
+	if !ok || lazyShard.isLoaded() {
+		return false
+	}
+
+	// avoid footprint of empty shards
+	if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+		return false
+	}
+
+	minObjects := i.Config.LazyLoadShardWarmupMinObjects
+	if minObjects == 0 {
+		return true
+	}
+
+	count, err := lazyShard.ObjectCountAsync(i.closingCtx)
+	if err != nil {
+		entry := i.logger.
+			WithField("action", "load_shard").
+			WithField("shard_name", shardName)
+		if stderrors.Is(err, fs.ErrNotExist) {
+			entry.Debugf("unloaded shard has no objects bucket yet, warming it up: %v", err)
+		} else {
+			entry.Warnf("failed to count objects of unloaded shard, warming it up anyway: %v", err)
+		}
+		return true
+	}
+	if count > minObjects {
+		return true
+	}
+
+	// Segment sidecars miss the segment a shutdown flush writes and everything
+	// still in a write-ahead log, so they can read zero for a large shard that was
+	// merely restarted. The persisted doc-id counter sees both, and a shard left
+	// cold never gets its sidecars derived, so the skip has to convince both.
+	if written, err := indexcounter.Read(shardPath(i.path(), shardName)); err == nil &&
+		int64(written) > minObjects {
+		return true
+	}
+
+	i.logger.WithFields(logrus.Fields{
+		"action":             "skip_shard_warmup",
+		"class":              i.Config.ClassName.String(),
+		"shard_name":         shardName,
+		"object_count":       count,
+		"warmup_min_objects": minObjects,
+	}).Debug("shard holds too few objects to warm up; it loads on first access")
+	return false
 }
 
 func (i *Index) loadLocalShardIfActive(shardName string) error {
@@ -1225,7 +1310,7 @@ type IndexConfig struct {
 	AsyncReplicationScheduler           *AsyncReplicationScheduler
 	AvoidMMap                           bool
 	EnableLazyLoadShards                bool
-	LazyLoadShardWarmupDisabled         bool // read only when EnableLazyLoadShards is true
+	LazyLoadShardWarmupMinObjects       int64 // read only when EnableLazyLoadShards is true
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration
@@ -1270,10 +1355,11 @@ type IndexConfig struct {
 }
 
 // backgroundWarmupEnabled reports whether the startup sweep loads cold shards.
-// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupDisabled
-// has nothing to switch off while EnableLazyLoadShards is false.
+// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupMinObjects
+// has nothing to gate while EnableLazyLoadShards is false. A negative value turns
+// the sweep off; which shards a non-negative one loads is warmupCandidate's call.
 func (c IndexConfig) backgroundWarmupEnabled() bool {
-	return c.EnableLazyLoadShards && !c.LazyLoadShardWarmupDisabled
+	return c.EnableLazyLoadShards && c.LazyLoadShardWarmupMinObjects >= 0
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -650,6 +650,19 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return nil
 	}
 
+	if i.Config.LazyLoadShardWarmupDisabled {
+		// Nothing else sets allShardsReady once the sweep is skipped, and
+		// observeObjectCount publishes no node-wide object count while any index
+		// reports false. Cold shards answer it from disk via ObjectCountAsync.
+		i.allShardsReady.Store(true)
+		i.logger.WithFields(logrus.Fields{
+			"action":     "skip_load_all_shards",
+			"class":      i.Config.ClassName.String(),
+			"hot_shards": len(hotShardNames),
+		}).Debug("background warmup disabled; lazy shards will load on first access")
+		return nil
+	}
+
 	// NOTE(dyma):
 	// 1. So "lazy-loaded" shards are actually loaded "half-eagerly"?
 	// 2. If <-ctx.Done or we fail to load a shard, should allShardsReady still report true?
@@ -1212,6 +1225,7 @@ type IndexConfig struct {
 	AsyncReplicationScheduler           *AsyncReplicationScheduler
 	AvoidMMap                           bool
 	EnableLazyLoadShards                bool
+	LazyLoadShardWarmupDisabled         bool // read only when EnableLazyLoadShards is true
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -650,7 +650,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return nil
 	}
 
-	if i.Config.LazyLoadShardWarmupDisabled {
+	if !i.Config.backgroundWarmupEnabled() {
 		// Nothing else sets allShardsReady once the sweep is skipped, and
 		// observeObjectCount publishes no node-wide object count while any index
 		// reports false. Cold shards answer it from disk via ObjectCountAsync.
@@ -1267,6 +1267,13 @@ type IndexConfig struct {
 	AutoTenantActivation bool
 
 	DisableDimensionMetrics *configRuntime.DynamicValue[bool]
+}
+
+// backgroundWarmupEnabled reports whether the startup sweep loads cold shards.
+// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupDisabled
+// has nothing to switch off while EnableLazyLoadShards is false.
+func (c IndexConfig) backgroundWarmupEnabled() bool {
+	return c.EnableLazyLoadShards && !c.LazyLoadShardWarmupDisabled
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -788,14 +788,10 @@ func (i *Index) warmupCandidate(shardName string) bool {
 		return true
 	}
 
-	// Segment sidecars miss the segment a shutdown flush writes and everything
-	// still in a write-ahead log, so they can read zero for a large shard that was
-	// merely restarted. The persisted doc-id counter sees both, and a shard left
-	// cold never gets its sidecars derived, so the skip has to convince both.
-	if written, err := indexcounter.Read(shardPath(i.path(), shardName)); err == nil &&
-		int64(written) > minObjects {
-		return true
-	}
+	// The persisted doc-id counter would see the writes the sidecars miss, but it
+	// counts allocations rather than objects: deletes never lower it, and an update
+	// that changes a vector raises it. A shard that churned its way down to nothing
+	// would read large forever, so the sweep stays with the count that reads short.
 
 	i.logger.WithFields(logrus.Fields{
 		"action":             "skip_shard_warmup",

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -687,7 +687,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		}
 
 		now := time.Now()
-		var loaded, skipped int
+		var loaded, skipped, failed int
 
 		for _, shardName := range hotShardNames {
 			if abortIfClosing() {
@@ -711,11 +711,15 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 			}
 
 			if err := i.loadLocalShardIfActive(shardName); err != nil {
+				// The memory guard a load fails on is node-wide and transient, so it
+				// says nothing about the shards behind this one. The sweep runs once
+				// per index lifetime, and nothing retries what it walks past.
+				failed++
 				i.logger.
 					WithField("action", "load_shard").
 					WithField("shard_name", shardName).
-					Errorf("failed to load shard: %v", err)
-				return
+					Errorf("failed to load shard, warming the rest anyway: %v", err)
+				continue
 			}
 			loaded++
 		}
@@ -727,6 +731,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				"took":    time.Since(now).String(),
 				"loaded":  loaded,
 				"skipped": skipped,
+				"failed":  failed,
 			}).
 			Debug("finished loading all shards")
 	}

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -226,15 +226,21 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 		return nil, fmt.Errorf("tenant exists: %w", err)
 	}
 	if !exists {
-		return emptyShardUsageWithNameAndActivity(shardName, localStatus), nil
+		// no numbers to read from disk, but an active tenant whose lazy shard is not
+		// in memory is marked here the same way a computed one is
+		lazyShard, isLazy := shard.(*LazyLoadShard)
+		return emptyShardUsageWithNameAndActivity(shardName, localStatus, isLazy && !lazyShard.isLoaded()), nil
 	}
 
 	var err2 error
 	var shardUsage *types.ShardUsage
+	// true when the usage below was read from disk because the lazy shard is not loaded
+	var unloadedLazy bool
 	switch localStatus {
 	case models.TenantActivityStatusACTIVE, models.TenantActivityStatusHOT:
 		// active tenants can be either fully loaded or lazy loaded. Lazy shards should _not_ be loaded just for
-		// usage calculation and are treated like inactive shards
+		// usage calculation, so their usage is read from disk like an inactive shard's — they still report an
+		// active status, marked as unloaded
 		lazyShard, isLazy := shard.(*LazyLoadShard)
 		if isLazy {
 			// distinguish between loaded and unloaded lazy shards - make sure that the shard is not loaded
@@ -243,6 +249,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 				release := lazyShard.blockLoading()
 				defer release()
 
+				unloadedLazy = !lazyShard.loaded
 				if lazyShard.loaded {
 					shardUsage, err2 = i.calculateLoadedShardUsage(ctx, lazyShard.shard, exactObjectCount)
 					if err2 != nil {
@@ -285,10 +292,15 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 				"class": i.Config.ClassName.String(),
 				"shard": shardName,
 			}).Warnf("shard files missing during usage calculation, likely deleted concurrently; recording empty usage: %v", err2)
-			return emptyShardUsageWithNameAndActivity(shardName, localStatus), nil
+			return emptyShardUsageWithNameAndActivity(shardName, localStatus, unloadedLazy), nil
 		}
 		return nil, err2
 	}
+	// both fields describe the tenant now, not its files, so neither is left to the
+	// calculations above: one of them saves its result to disk, and a tenant
+	// deactivated later would keep serving whatever was saved with it
+	shardUsage.Status = strings.ToLower(localStatus)
+	shardUsage.LazyUnloaded = unloadedLazy
 	return shardUsage, nil
 }
 
@@ -338,7 +350,6 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 
 	shardUsage := &types.ShardUsage{
 		Name:                  shard.Name(),
-		Status:                strings.ToLower(models.TenantActivityStatusACTIVE),
 		ObjectsCount:          objectCount,
 		ObjectsStorageBytes:   objectsWithoutVectors,
 		VectorStorageBytes:    uint64(vectorStorageSize) + vectorsInObjects + vectorCommitLogsStorageSize, // lsm/vectors + objects vectors + commit.log folders
@@ -489,7 +500,9 @@ func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
 
 // calculateUnloadedShardUsage computes usage for a cold shard from disk. vectorConfigs must
 // contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig —
-// and vectorConfigsFingerprint must be their [shardusage.VectorConfigsFingerprint].
+// and vectorConfigsFingerprint must be their [shardusage.VectorConfigsFingerprint]. The result
+// carries no tenant status: it is saved to disk and served again later, when the tenant may
+// have a different one.
 func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig, vectorConfigsFingerprint string) (*types.ShardUsage, error) {
 	if shardusage.ComputedUsageDataExists(i.path(), shardName) {
 		// usage has been pre-calculated and can be read from disk
@@ -575,7 +588,6 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	shardUsage := &types.ShardUsage{
 		Name:                  shardName,
 		ObjectsCount:          objectUsage.Count,
-		Status:                strings.ToLower(models.TenantActivityStatusINACTIVE),
 		ObjectsStorageBytes:   objectsWithoutVectors,
 		VectorStorageBytes:    uint64(vectorMetrics.StorageBytes) + vectorsInObjects + vectorCommitLogsStorageSize,
 		IndexStorageBytes:     indexUsage,
@@ -605,12 +617,14 @@ func (i *Index) splitObjectsBucketSize(shardName string, objectsBucketSize, unco
 }
 
 // emptyShardUsageWithNameAndActivity reports zero usage for a shard with no data on disk. Callers
-// pass the schema's upper-case activity constants, while the report spells the status in lower case
-// like the computed paths do.
-func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.ShardUsage {
+// pass the schema's upper-case activity constants, while the report spells the status in lower
+// case. lazyUnloaded marks an active shard that is not in memory, the same way a computed one is
+// marked.
+func emptyShardUsageWithNameAndActivity(shardName, activity string, lazyUnloaded bool) *types.ShardUsage {
 	return &types.ShardUsage{
 		Name:                shardName,
 		Status:              strings.ToLower(activity),
+		LazyUnloaded:        lazyUnloaded,
 		ObjectsCount:        0,
 		ObjectsStorageBytes: 0,
 		VectorStorageBytes:  0,

--- a/adapters/repos/db/index_usage_cache_test.go
+++ b/adapters/repos/db/index_usage_cache_test.go
@@ -227,9 +227,8 @@ func writeSavedShardUsage(t *testing.T, indexPath, shardName string, saved *type
 	require.NoError(t, os.WriteFile(savedShardUsagePath(indexPath, shardName), data, 0o600))
 }
 
-// markSavedShardUsage stamps savedObjectsCount on the usage a report saved, leaving
-// everything the cache validates untouched.
-func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
+// readSavedShardUsage reads back the file a report saved for a cold shard.
+func readSavedShardUsage(t *testing.T, indexPath, shardName string) *types.UsageDisk {
 	t.Helper()
 
 	data, err := os.ReadFile(savedShardUsagePath(indexPath, shardName))
@@ -237,6 +236,15 @@ func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
 	saved := &types.UsageDisk{}
 	require.NoError(t, json.Unmarshal(data, saved))
 	require.NotNil(t, saved.ShardUsage, "the first report must have saved usage")
+	return saved
+}
+
+// markSavedShardUsage stamps savedObjectsCount on the usage a report saved, leaving
+// everything the cache validates untouched.
+func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
+	t.Helper()
+
+	saved := readSavedShardUsage(t, indexPath, shardName)
 	saved.ShardUsage.ObjectsCount = savedObjectsCount
 	writeSavedShardUsage(t, indexPath, shardName, saved)
 }

--- a/adapters/repos/db/index_usage_hot_cold_test.go
+++ b/adapters/repos/db/index_usage_hot_cold_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"maps"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,6 +134,70 @@ func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, recomputed.Shards, 1)
 			assert.Equal(t, loaded.Shards[0].FullShardStorageBytes, recomputed.Shards[0].FullShardStorageBytes)
+		})
+	}
+}
+
+// TestIndex_UsageForCollection_LazyUnloadedShard pins how a hot tenant is reported
+// while its lazy shard sits unloaded: it bills like a loaded one, and only the mark
+// says its numbers came from disk. Without the mark a node that leaves hot tenants
+// unloaded cannot be told apart from one serving them all from memory.
+func TestIndex_UsageForCollection_LazyUnloadedShard(t *testing.T) {
+	active := strings.ToLower(models.TenantActivityStatusACTIVE)
+
+	tests := []struct {
+		name string
+		// load asks for the shard before the report runs, so the lazy shard is loaded
+		load             bool
+		wantLazyUnloaded bool
+	}{
+		{
+			name: "hot tenant whose shard is loaded",
+			load: true,
+		},
+		{
+			name:             "hot tenant whose shard stays unloaded",
+			wantLazyUnloaded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tenantName := "test-tenant"
+
+			index, vectorConfigs := setupPopulatedLazyIndex(ctx, t, usageIndexParams{})
+			t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+			release := func() {}
+			if tt.load {
+				var err error
+				_, release, err = index.GetShard(ctx, tenantName)
+				require.NoError(t, err)
+			}
+			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(1), true, vectorConfigs)
+			release()
+			require.NoError(t, err)
+			require.Len(t, usage.Shards, 1)
+			assert.Equal(t, active, usage.Shards[0].Status, "a hot tenant reports an active shard either way")
+			assert.Equal(t, tt.wantLazyUnloaded, usage.Shards[0].LazyUnloaded)
+			assert.Equal(t, populatedObjectsCount, usage.Shards[0].ObjectsCount)
+
+			if !tt.wantLazyUnloaded {
+				return
+			}
+			// status and mark describe the tenant now, so neither may travel with the
+			// numbers the cold path saved: it may be deactivated before the next report
+			saved := readSavedShardUsage(t, index.path(), tenantName)
+			assert.Empty(t, saved.ShardUsage.Status, "the saved usage must carry no status")
+			assert.False(t, saved.ShardUsage.LazyUnloaded, "the saved usage must not carry the mark")
+
+			// the second report is served from that file and still has to describe the tenant
+			cached, err := index.usageForCollection(ctx, semaphore.NewWeighted(1), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, cached.Shards, 1)
+			assert.Equal(t, active, cached.Shards[0].Status, "usage served from disk must report the tenant active")
+			assert.True(t, cached.Shards[0].LazyUnloaded, "usage served from disk must carry the mark")
 		})
 	}
 }

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -129,12 +129,15 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			assert.Equal(t, int64(0), shardUsage.ObjectsCount, "missing shard must be recorded as empty")
 			assert.Equal(t, uint64(0), shardUsage.ObjectsStorageBytes)
 
-			// an empty shard must spell its status the same way a computed one does
+			// an empty shard must spell its status, and mark that it is not in memory,
+			// the same way a computed one does
 			wantStatus := strings.ToLower(models.TenantActivityStatusACTIVE)
 			if tt.loadAndDelete {
 				wantStatus = strings.ToLower(models.TenantActivityStatusINACTIVE)
 			}
 			assert.Equal(t, wantStatus, shardUsage.Status)
+			assert.Equal(t, !tt.loadAndDelete, shardUsage.LazyUnloaded,
+				"an unloaded lazy shard is marked, an inactive one is not")
 		})
 	}
 }

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -234,7 +234,7 @@ func (db *DB) init(ctx context.Context) error {
 				"action":                  "lazy_shard_auto_detection",
 				"class":                   class.Class,
 				"enable_lazy_load_shards": lazyLoadShardEnabled,
-				"background_warmup":       !db.config.LazyLoadShardWarmupDisabled,
+				"background_warmup":       idx.Config.backgroundWarmupEnabled(),
 				"local_shard_count":       localActiveShardsCount,
 				"total_shard_size_bytes":  totalShardSizeBytes,
 				"count_threshold":         db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -173,7 +173,7 @@ func (db *DB) init(ctx context.Context) error {
 					)
 					return lazyLoadShardEnabled
 				}(),
-				LazyLoadShardWarmupDisabled:                  db.config.LazyLoadShardWarmupDisabled,
+				LazyLoadShardWarmupMinObjects:                db.config.LazyLoadShardWarmupMinObjects,
 				ForceFullReplicasSearch:                      db.config.ForceFullReplicasSearch,
 				TransferInactivityTimeout:                    db.config.TransferInactivityTimeout,
 				HaltForTransferTimeout:                       db.config.HaltForTransferTimeout,
@@ -235,6 +235,7 @@ func (db *DB) init(ctx context.Context) error {
 				"class":                   class.Class,
 				"enable_lazy_load_shards": lazyLoadShardEnabled,
 				"background_warmup":       idx.Config.backgroundWarmupEnabled(),
+				"warmup_min_objects":      db.config.LazyLoadShardWarmupMinObjects,
 				"local_shard_count":       localActiveShardsCount,
 				"total_shard_size_bytes":  totalShardSizeBytes,
 				"count_threshold":         db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -173,6 +173,7 @@ func (db *DB) init(ctx context.Context) error {
 					)
 					return lazyLoadShardEnabled
 				}(),
+				LazyLoadShardWarmupDisabled:                  db.config.LazyLoadShardWarmupDisabled,
 				ForceFullReplicasSearch:                      db.config.ForceFullReplicasSearch,
 				TransferInactivityTimeout:                    db.config.TransferInactivityTimeout,
 				HaltForTransferTimeout:                       db.config.HaltForTransferTimeout,
@@ -233,6 +234,7 @@ func (db *DB) init(ctx context.Context) error {
 				"action":                  "lazy_shard_auto_detection",
 				"class":                   class.Class,
 				"enable_lazy_load_shards": lazyLoadShardEnabled,
+				"background_warmup":       !db.config.LazyLoadShardWarmupDisabled,
 				"local_shard_count":       localActiveShardsCount,
 				"total_shard_size_bytes":  totalShardSizeBytes,
 				"count_threshold":         db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -1,0 +1,165 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestLazyShardBackgroundWarmup pins both LazyLoadShardWarmupDisabled branches:
+// the sweep loads a HOT tenant a second after init, and disabling it leaves the
+// tenant cold with allShardsReady already published.
+func TestLazyShardBackgroundWarmup(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		className = "TestWarmupClass"
+		nodeName  = "test-node"
+		tenant    = "busy-tenant"
+	)
+
+	tests := []struct {
+		name           string
+		warmupDisabled bool
+	}{
+		{name: "warmup materializes the shard in the background", warmupDisabled: false},
+		{name: "disabled warmup leaves the shard cold", warmupDisabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			dirName := t.TempDir()
+
+			class := &models.Class{
+				Class:               className,
+				InvertedIndexConfig: &models.InvertedIndexConfig{},
+				MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+				ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+			}
+			fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+			shardState := &sharding.State{
+				Physical: map[string]sharding.Physical{
+					tenant: {
+						Name:           tenant,
+						BelongsToNodes: []string{nodeName},
+						Status:         models.TenantActivityStatusHOT,
+					},
+				},
+				PartitioningEnabled: true,
+			}
+			shardState.SetLocalName(nodeName)
+
+			// Write a non-zero indexcount so Index.unloadedShardIsEmpty reports false:
+			// the sweep skips empty tenants, which would make both cases look identical.
+			shardDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant)
+			require.NoError(t, os.MkdirAll(shardDir, os.ModePerm))
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], 10)
+			require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
+
+			scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+			mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+				func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
+					return readerFunc(class, shardState)
+				}).Maybe()
+			mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
+
+			mockSchema := schemaUC.NewMockSchemaGetter(t)
+			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+			mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
+			mockSchema.EXPECT().NodeName().Maybe().Return(nodeName)
+			mockSchema.EXPECT().TenantsShards(ctx, className, tenant).Maybe().
+				Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil)
+
+			mockRouter := types.NewMockRouter(t)
+			mockRouter.EXPECT().GetWriteReplicasLocation(className, mock.Anything, tenant).
+				Return(types.WriteReplicaSet{
+					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
+				}, nil).Maybe()
+			mockRouter.EXPECT().GetReadReplicasLocation(className, tenant, tenant).
+				Return(types.ReadReplicaSet{
+					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
+				}, nil).Maybe()
+
+			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
+			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
+
+			index, err := NewIndex(ctx, IndexConfig{
+				RootPath:                    dirName,
+				ClassName:                   schema.ClassName(className),
+				ReplicationFactor:           1,
+				ShardLoadLimiter:            loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+				EnableLazyLoadShards:        true,
+				LazyLoadShardWarmupDisabled: tt.warmupDisabled,
+			}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+				enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
+				mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+				class, nil, scheduler, nil, nil,
+				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+			require.NoError(t, err)
+			defer index.Shutdown(ctx)
+
+			stored := index.shards.Load(tenant)
+			require.NotNil(t, stored, "shard must be registered after init")
+			lazy, isLazy := stored.(*LazyLoadShard)
+			require.True(t, isLazy, "lazy mode should store a wrapper, got %T", stored)
+			require.False(t, lazy.isLoaded(), "shard must not be loaded during init in lazy mode")
+
+			if !tt.warmupDisabled {
+				// The sweep ticks once per second, so allow generous slack.
+				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
+					"background warmup should materialize the shard")
+				require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
+					"allShardsReady should be published once the sweep completes")
+				return
+			}
+
+			require.True(t, index.allShardsReady.Load(),
+				"allShardsReady must be published immediately when warmup is disabled")
+			require.Never(t, lazy.isLoaded, 3*time.Second, 100*time.Millisecond,
+				"no background sweep should run when warmup is disabled")
+
+			// Disabling the sweep must leave the shard loadable on demand.
+			require.NoError(t, lazy.Load(ctx))
+			require.True(t, lazy.isLoaded())
+		})
+	}
+}

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -122,7 +122,7 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
 			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
 
-			index, err := NewIndex(ctx, IndexConfig{
+			index, err := NewIndex(ctx, nil, IndexConfig{
 				RootPath:                    dirName,
 				ClassName:                   schema.ClassName(className),
 				ReplicationFactor:           1,

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -50,13 +51,15 @@ const (
 
 // newWarmupIndex opens a multi-tenant index over dirName, one lazy shard per
 // tenant, with the startup sweep gated at minObjects. A nil allocChecker gives
-// every load the dummy monitor, which allows all of them.
+// every load the dummy monitor, which allows all of them. The returned hook
+// holds the sweep's own log, which reports what it did with every shard.
 func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
 	allocChecker memwatch.AllocChecker, tenants ...string,
-) *Index {
+) (*Index, *test.Hook) {
 	t.Helper()
 	ctx := context.Background()
-	logger, _ := test.NewNullLogger()
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
 
 	class := newClassWithWarmProp(warmupClassName)
 	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
@@ -120,12 +123,45 @@ func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
 		LazyLoadShardWarmupMinObjects: minObjects,
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
-		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{},
+		monitoring.GetMetrics(),
 		class, nil, scheduler, nil, allocChecker,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
 
-	return index
+	return index, hook
+}
+
+// sweepDoneMessage is what the startup sweep logs once it has walked every shard.
+const sweepDoneMessage = "finished loading all shards"
+
+// requireSweepTally asserts how many shards the startup sweep reported under
+// each outcome, waiting for it to finish. An outcome absent from want must have
+// counted nothing.
+func requireSweepTally(t *testing.T, hook *test.Hook, want map[monitoring.WarmupOutcome]int) {
+	t.Helper()
+
+	var tally logrus.Fields
+	require.Eventually(t, func() bool {
+		for _, entry := range hook.AllEntries() {
+			if entry.Message != sweepDoneMessage {
+				continue
+			}
+			tally = entry.Data
+			return true
+		}
+		return false
+	}, 30*time.Second, 50*time.Millisecond, "the sweep should log what it did with every shard")
+
+	for _, outcome := range []monitoring.WarmupOutcome{
+		monitoring.WarmupLoaded,
+		monitoring.WarmupFailed,
+		monitoring.WarmupSkippedNotCold,
+		monitoring.WarmupSkippedEmpty,
+		monitoring.WarmupSkippedBelowThreshold,
+	} {
+		require.Equal(t, want[outcome], tally[string(outcome)], "shards reported as %q", outcome)
+	}
 }
 
 // coldWarmupShard returns a tenant's shard, asserting it is an unloaded lazy one.
@@ -158,7 +194,7 @@ func seedWarmupTenants(t *testing.T, dirName string, seeds map[string]warmupSeed
 		tenants = append(tenants, tenant)
 	}
 
-	index := newWarmupIndex(t, dirName, -1, nil, tenants...)
+	index, _ := newWarmupIndex(t, dirName, -1, nil, tenants...)
 	for tenant, seed := range seeds {
 		writeCountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.counted)
 		if seed.uncounted > 0 {
@@ -185,20 +221,36 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 		// unreadableCount removes the shard's objects bucket directory, so
 		// LazyLoadShard.ObjectCountAsync fails instead of returning a count.
 		unreadableCount bool
-		wantLoaded      bool
+		// wantOutcome is what the sweep should report for the shard. It is empty
+		// where a negative threshold means no sweep runs.
+		wantOutcome monitoring.WarmupOutcome
 	}{
 		{name: "a negative threshold warms nothing", seed: warmupSeed{counted: 3}, minObjects: -1},
-		{name: "the default warms a non-empty shard", seed: warmupSeed{counted: 3}, minObjects: 0, wantLoaded: true},
-		{name: "the default skips an empty shard", minObjects: 0},
-		{name: "a threshold above the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 5},
-		{name: "a threshold at the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 3},
+		{
+			name: "the default warms a non-empty shard",
+			seed: warmupSeed{counted: 3}, minObjects: 0, wantOutcome: monitoring.WarmupLoaded,
+		},
+		{
+			name:       "the default skips an empty shard",
+			minObjects: 0, wantOutcome: monitoring.WarmupSkippedEmpty,
+		},
+		{
+			name: "a threshold above the object count skips the shard",
+			seed: warmupSeed{counted: 3}, minObjects: 5,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
+		},
+		{
+			name: "a threshold at the object count skips the shard",
+			seed: warmupSeed{counted: 3}, minObjects: 3,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
+		},
 		{
 			name: "a threshold below the object count warms the shard",
-			seed: warmupSeed{counted: 3}, minObjects: 2, wantLoaded: true,
+			seed: warmupSeed{counted: 3}, minObjects: 2, wantOutcome: monitoring.WarmupLoaded,
 		},
 		{
 			name: "an unreadable object count warms the shard", seed: warmupSeed{counted: 3}, minObjects: 5,
-			unreadableCount: true, wantLoaded: true,
+			unreadableCount: true, wantOutcome: monitoring.WarmupLoaded,
 		},
 		// Segments a shutdown flush wrote carry no count sidecar, and a shard left
 		// cold never gets one derived, so the sweep weighs a shard by what was
@@ -206,14 +258,16 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 		{
 			name: "unflushed objects do not count towards the threshold",
 			seed: warmupSeed{uncounted: 5}, minObjects: 3,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
 		},
 		{
 			name: "a threshold above the flushed count alone skips the shard",
 			seed: warmupSeed{counted: 2, uncounted: 4}, minObjects: 5,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
 		},
 		{
 			name: "a threshold below the flushed count alone warms the shard",
-			seed: warmupSeed{counted: 6, uncounted: 4}, minObjects: 5, wantLoaded: true,
+			seed: warmupSeed{counted: 6, uncounted: 4}, minObjects: 5, wantOutcome: monitoring.WarmupLoaded,
 		},
 	}
 
@@ -227,17 +281,18 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 					path.Join(shardPathLSM(indexPath, tenant), helpers.ObjectsBucketLSM)))
 			}
 
-			index := newWarmupIndex(t, dirName, tt.minObjects, nil, tenant)
+			index, hook := newWarmupIndex(t, dirName, tt.minObjects, nil, tenant)
 			defer index.Shutdown(ctx)
 
 			lazy := coldWarmupShard(t, index, tenant)
 
-			if tt.wantLoaded {
+			if tt.wantOutcome == monitoring.WarmupLoaded {
 				// The sweep ticks once per second, so allow generous slack.
 				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
 					"background warmup should materialize the shard")
 				require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
 					"allShardsReady should be published once the sweep completes")
+				requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{tt.wantOutcome: 1})
 				return
 			}
 
@@ -246,12 +301,17 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 					"allShardsReady must be published immediately when no sweep runs")
 				require.Never(t, lazy.isLoaded, 2*time.Second, 100*time.Millisecond,
 					"no sweep should run at all")
+				for _, entry := range hook.AllEntries() {
+					require.NotEqual(t, sweepDoneMessage, entry.Message,
+						"a sweep that never runs must report no tally")
+				}
 			} else {
 				require.Eventually(t, index.allShardsReady.Load, 10*time.Second, 50*time.Millisecond,
 					"allShardsReady should be published once the sweep has skipped every shard")
 				// allShardsReady is published from the sweep goroutine's last deferred
 				// call, so it implies the sweep is over and no later load is possible.
 				require.False(t, lazy.isLoaded(), "a shard the sweep leaves out must stay cold")
+				requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{tt.wantOutcome: 1})
 			}
 
 			// Leaving a shard out of the sweep must keep it loadable on demand.
@@ -282,7 +342,7 @@ func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
 	dirName := t.TempDir()
 	tenants := seedWarmupTenants(t, dirName, seeds)
 
-	index := newWarmupIndex(t, dirName, minObjects, nil, tenants...)
+	index, _ := newWarmupIndex(t, dirName, minObjects, nil, tenants...)
 	defer index.Shutdown(ctx)
 
 	// The green path is one tick, so the budget only separates it from a tick per
@@ -407,7 +467,7 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 			tenants := seedWarmupTenants(t, dirName, seeds)
 
 			checker := newRefusingAllocChecker(tt.refuse)
-			index := newWarmupIndex(t, dirName, tt.minObjects, checker, tenants...)
+			index, hook := newWarmupIndex(t, dirName, tt.minObjects, checker, tenants...)
 			defer index.Shutdown(ctx)
 
 			// Published from the sweep goroutine's last deferred call, so it means
@@ -431,6 +491,51 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 				"the sweep must attempt every candidate shard, whatever the ones before it did")
 			require.Equal(t, tt.wantLoaded, loaded,
 				"every candidate the guard allowed must end up loaded")
+			requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{
+				monitoring.WarmupLoaded:                tt.wantLoaded,
+				monitoring.WarmupFailed:                len(tt.refuse),
+				monitoring.WarmupSkippedBelowThreshold: tt.cold,
+			})
+		})
+	}
+}
+
+// TestLazyShardWarmupSkipsShardNoLongerCold pins what the sweep reports for a
+// shard it listed at startup but found nothing to warm: a request loaded it
+// first, or the tenant is gone. A negative threshold keeps the sweep from
+// running, so the decision is read without one racing it.
+func TestLazyShardWarmupSkipsShardNoLongerCold(t *testing.T) {
+	ctx := context.Background()
+
+	const tenant = "busy-tenant"
+
+	tests := []struct {
+		name string
+		// asked is the shard name the sweep would ask about.
+		asked string
+		// loadFirst materializes the tenant's shard before the decision is read.
+		loadFirst bool
+	}{
+		{name: "a shard a request loaded first", asked: tenant, loadFirst: true},
+		{name: "a name the index no longer holds", asked: "vanished-tenant"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			seedWarmupTenants(t, dirName, map[string]warmupSeed{tenant: {counted: 3}})
+
+			index, _ := newWarmupIndex(t, dirName, -1, nil, tenant)
+			defer index.Shutdown(ctx)
+
+			if tt.loadFirst {
+				require.NoError(t, coldWarmupShard(t, index, tenant).Load(ctx))
+			}
+
+			shouldWarm, outcome := index.warmupCandidate(tt.asked)
+
+			require.False(t, shouldWarm, "a shard with nothing left to warm is no candidate")
+			require.Equal(t, monitoring.WarmupSkippedNotCold, outcome)
 		})
 	}
 }

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -47,8 +49,11 @@ const (
 )
 
 // newWarmupIndex opens a multi-tenant index over dirName, one lazy shard per
-// tenant, with the startup sweep gated at minObjects.
-func newWarmupIndex(t *testing.T, dirName string, minObjects int64, tenants ...string) *Index {
+// tenant, with the startup sweep gated at minObjects. A nil allocChecker gives
+// every load the dummy monitor, which allows all of them.
+func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
+	allocChecker memwatch.AllocChecker, tenants ...string,
+) *Index {
 	t.Helper()
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
@@ -116,7 +121,7 @@ func newWarmupIndex(t *testing.T, dirName string, minObjects int64, tenants ...s
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
 		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
-		class, nil, scheduler, nil, nil,
+		class, nil, scheduler, nil, allocChecker,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
 
@@ -153,7 +158,7 @@ func seedWarmupTenants(t *testing.T, dirName string, seeds map[string]warmupSeed
 		tenants = append(tenants, tenant)
 	}
 
-	index := newWarmupIndex(t, dirName, -1, tenants...)
+	index := newWarmupIndex(t, dirName, -1, nil, tenants...)
 	for tenant, seed := range seeds {
 		writeCountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.counted)
 		if seed.uncounted > 0 {
@@ -222,7 +227,7 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 					path.Join(shardPathLSM(indexPath, tenant), helpers.ObjectsBucketLSM)))
 			}
 
-			index := newWarmupIndex(t, dirName, tt.minObjects, tenant)
+			index := newWarmupIndex(t, dirName, tt.minObjects, nil, tenant)
 			defer index.Shutdown(ctx)
 
 			lazy := coldWarmupShard(t, index, tenant)
@@ -277,7 +282,7 @@ func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
 	dirName := t.TempDir()
 	tenants := seedWarmupTenants(t, dirName, seeds)
 
-	index := newWarmupIndex(t, dirName, minObjects, tenants...)
+	index := newWarmupIndex(t, dirName, minObjects, nil, tenants...)
 	defer index.Shutdown(ctx)
 
 	// The green path is one tick, so the budget only separates it from a tick per
@@ -293,5 +298,139 @@ func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
 		require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
 		require.Equal(t, tenant == bigTenant, lazy.isLoaded(),
 			"only the tenant above the threshold should be warmed, checked %q", tenant)
+	}
+}
+
+// refusingAllocChecker refuses the load attempts named in refuse, counted from
+// one, and allows every other. LazyLoadShard.Load asks it before it materializes
+// a shard, so refusing is how a test fails one load without touching its files.
+type refusingAllocChecker struct {
+	mu     sync.Mutex
+	refuse map[int]bool
+	calls  int
+}
+
+func newRefusingAllocChecker(refuse []int) *refusingAllocChecker {
+	refused := make(map[int]bool, len(refuse))
+	for _, call := range refuse {
+		refused[call] = true
+	}
+	return &refusingAllocChecker{refuse: refused}
+}
+
+func (c *refusingAllocChecker) CheckAlloc(int64) error { return nil }
+
+func (c *refusingAllocChecker) CheckMappingAndReserve(int64, int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.calls++
+	if c.refuse[c.calls] {
+		return fmt.Errorf("no mappings left for load attempt %d", c.calls)
+	}
+	return nil
+}
+
+func (c *refusingAllocChecker) Refresh(bool) {}
+
+// attempts reports how many shards the sweep tried to load.
+func (c *refusingAllocChecker) attempts() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.calls
+}
+
+// TestLazyShardBackgroundWarmupContinuesAfterFailedLoad pins that one shard
+// failing to load leaves the rest of the sweep intact. The guard a load fails on
+// is node-wide and transient, so it says nothing about the shards behind that
+// one. The sweep runs once, and nothing retries what it walks past.
+func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
+	ctx := context.Background()
+
+	// Seeded either side of the threshold the skip case uses, so warm tenants are
+	// swept and cold ones are passed over before a load is ever attempted.
+	const (
+		warmObjects = 5
+		coldObjects = 1
+		skipAtFour  = 4
+	)
+
+	tests := []struct {
+		name string
+		// warm tenants sit above the threshold and are load candidates; cold ones
+		// sit below it and the sweep skips them without attempting a load.
+		warm       int
+		cold       int
+		minObjects int64
+		// refuse names the load attempts the memory guard fails, counted from one.
+		// The sweep walks shards in map order, so a case can fix which attempt
+		// fails, never which tenant.
+		refuse       []int
+		wantLoaded   int
+		wantAttempts int
+	}{
+		{
+			name: "a failure on the first shard leaves the rest to load",
+			warm: 3, refuse: []int{1}, wantLoaded: 2, wantAttempts: 3,
+		},
+		{
+			name: "a failure in the middle leaves the rest to load",
+			warm: 3, refuse: []int{2}, wantLoaded: 2, wantAttempts: 3,
+		},
+		{
+			name: "every shard failing still leaves every shard attempted",
+			warm: 3, refuse: []int{1, 2, 3}, wantLoaded: 0, wantAttempts: 3,
+		},
+		{
+			name: "no failure loads every shard",
+			warm: 3, wantLoaded: 3, wantAttempts: 3,
+		},
+		{
+			name: "a failure leaves the shards below the threshold skipped, not attempted",
+			warm: 2, cold: 1, minObjects: skipAtFour, refuse: []int{1},
+			wantLoaded: 1, wantAttempts: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seeds := map[string]warmupSeed{}
+			for i := range tt.warm {
+				seeds[fmt.Sprintf("warm-tenant-%d", i)] = warmupSeed{counted: warmObjects}
+			}
+			for i := range tt.cold {
+				seeds[fmt.Sprintf("cold-tenant-%d", i)] = warmupSeed{counted: coldObjects}
+			}
+
+			dirName := t.TempDir()
+			tenants := seedWarmupTenants(t, dirName, seeds)
+
+			checker := newRefusingAllocChecker(tt.refuse)
+			index := newWarmupIndex(t, dirName, tt.minObjects, checker, tenants...)
+			defer index.Shutdown(ctx)
+
+			// Published from the sweep goroutine's last deferred call, so it means
+			// the sweep is over however it ended — including the abandoning return
+			// this test exists to catch.
+			require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
+				"allShardsReady should be published once the sweep is over")
+
+			loaded := 0
+			for _, tenant := range tenants {
+				stored := index.shards.Load(tenant)
+				require.NotNil(t, stored, "shard of tenant %q must be registered", tenant)
+				lazy, ok := stored.(*LazyLoadShard)
+				require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
+				if lazy.isLoaded() {
+					loaded++
+				}
+			}
+
+			require.Equal(t, tt.wantAttempts, checker.attempts(),
+				"the sweep must attempt every candidate shard, whatever the ones before it did")
+			require.Equal(t, tt.wantLoaded, loaded,
+				"every candidate the guard allowed must end up loaded")
+		})
 	}
 }

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -195,15 +195,20 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 			name: "an unreadable object count warms the shard", seed: warmupSeed{counted: 3}, minObjects: 5,
 			unreadableCount: true, wantLoaded: true,
 		},
-		// Segments a shutdown flush wrote carry no count sidecar, so the cold count
-		// reads zero for them and only the doc-id counter sees the objects.
+		// Segments a shutdown flush wrote carry no count sidecar, and a shard left
+		// cold never gets one derived, so the sweep weighs a shard by what was
+		// flushed while it last ran and nothing else.
 		{
-			name: "a threshold below the unflushed object count warms the shard",
-			seed: warmupSeed{uncounted: 5}, minObjects: 3, wantLoaded: true,
+			name: "unflushed objects do not count towards the threshold",
+			seed: warmupSeed{uncounted: 5}, minObjects: 3,
 		},
 		{
-			name: "a threshold above the unflushed object count skips the shard",
-			seed: warmupSeed{uncounted: 2}, minObjects: 3,
+			name: "a threshold above the flushed count alone skips the shard",
+			seed: warmupSeed{counted: 2, uncounted: 4}, minObjects: 5,
+		},
+		{
+			name: "a threshold below the flushed count alone warms the shard",
+			seed: warmupSeed{counted: 6, uncounted: 4}, minObjects: 5, wantLoaded: true,
 		},
 	}
 

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -15,9 +15,9 @@ package db
 
 import (
 	"context"
-	"encoding/binary"
+	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"testing"
 	"time"
 
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -40,110 +41,188 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-// TestLazyShardBackgroundWarmup pins both LazyLoadShardWarmupDisabled branches:
-// the sweep loads a HOT tenant a second after init, and disabling it leaves the
-// tenant cold with allShardsReady already published.
+const (
+	warmupClassName = "TestWarmupClass"
+	warmupNodeName  = "test-node"
+)
+
+// newWarmupIndex opens a multi-tenant index over dirName, one lazy shard per
+// tenant, with the startup sweep gated at minObjects.
+func newWarmupIndex(t *testing.T, dirName string, minObjects int64, tenants ...string) *Index {
+	t.Helper()
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	class := newClassWithWarmProp(warmupClassName)
+	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+	class.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+	fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+	shardState := &sharding.State{
+		Physical:            map[string]sharding.Physical{},
+		PartitioningEnabled: true,
+	}
+	tenantStatus := map[string]string{}
+	for _, tenant := range tenants {
+		shardState.Physical[tenant] = sharding.Physical{
+			Name:           tenant,
+			BelongsToNodes: []string{warmupNodeName},
+			Status:         models.TenantActivityStatusHOT,
+		}
+		tenantStatus[tenant] = models.TenantActivityStatusHOT
+	}
+	shardState.SetLocalName(warmupNodeName)
+
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
+			return readerFunc(class, shardState)
+		}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
+
+	mockSchema := schemaUC.NewMockSchemaGetter(t)
+	mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+	mockSchema.EXPECT().ReadOnlyClass(warmupClassName).Maybe().Return(class)
+	mockSchema.EXPECT().NodeName().Maybe().Return(warmupNodeName)
+	mockSchema.EXPECT().TenantsShards(mock.Anything, warmupClassName, mock.Anything).Maybe().
+		Return(tenantStatus, nil)
+
+	mockRouter := types.NewMockRouter(t)
+	mockRouter.EXPECT().GetWriteReplicasLocation(warmupClassName, mock.Anything, mock.Anything).
+		RunAndReturn(func(_, _, shard string) (types.WriteReplicaSet, error) {
+			return types.WriteReplicaSet{Replicas: []types.Replica{
+				{NodeName: warmupNodeName, ShardName: shard, HostAddr: "10.0.0.1"},
+			}}, nil
+		}).Maybe()
+	mockRouter.EXPECT().GetReadReplicasLocation(warmupClassName, mock.Anything, mock.Anything).
+		RunAndReturn(func(_, _, shard string) (types.ReadReplicaSet, error) {
+			return types.ReadReplicaSet{Replicas: []types.Replica{
+				{NodeName: warmupNodeName, ShardName: shard, HostAddr: "10.0.0.1"},
+			}}, nil
+		}).Maybe()
+
+	schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
+	shardResolver := resolver.NewShardResolver(warmupClassName, true, schemaGetter)
+
+	index, err := NewIndex(ctx, nil, IndexConfig{
+		RootPath:                      dirName,
+		ClassName:                     schema.ClassName(warmupClassName),
+		ReplicationFactor:             1,
+		ShardLoadLimiter:              loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+		EnableLazyLoadShards:          true,
+		LazyLoadShardWarmupMinObjects: minObjects,
+	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
+		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+		class, nil, scheduler, nil, nil,
+		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+	require.NoError(t, err)
+
+	return index
+}
+
+// coldWarmupShard returns a tenant's shard, asserting it is an unloaded lazy one.
+func coldWarmupShard(t *testing.T, index *Index, tenant string) *LazyLoadShard {
+	t.Helper()
+	stored := index.shards.Load(tenant)
+	require.NotNil(t, stored, "shard of tenant %q must be registered after init", tenant)
+	lazy, ok := stored.(*LazyLoadShard)
+	require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
+	require.False(t, lazy.isLoaded(), "shard of tenant %q must not be loaded during init", tenant)
+	return lazy
+}
+
+// warmupSeed is what a tenant holds on disk before the sweep runs.
+type warmupSeed struct {
+	// counted objects sit in a segment with a count sidecar, which
+	// LazyLoadShard.ObjectCountAsync reads without loading the shard.
+	counted int
+	// uncounted objects sit in a segment whose sidecar only the next load writes,
+	// which is what an ordinary shutdown leaves behind.
+	uncounted int
+}
+
+// seedWarmupTenants gives each tenant the objects the map asks for and leaves
+// every shard cold, so a later index sweeps over what is really on disk.
+func seedWarmupTenants(t *testing.T, dirName string, seeds map[string]warmupSeed) []string {
+	t.Helper()
+	tenants := make([]string, 0, len(seeds))
+	for tenant := range seeds {
+		tenants = append(tenants, tenant)
+	}
+
+	index := newWarmupIndex(t, dirName, -1, tenants...)
+	for tenant, seed := range seeds {
+		writeCountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.counted)
+		if seed.uncounted > 0 {
+			writeUncountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.uncounted)
+		}
+	}
+	require.NoError(t, index.Shutdown(context.Background()))
+
+	return tenants
+}
+
+// TestLazyShardBackgroundWarmup pins which shards the startup sweep materializes
+// for each range of LazyLoadShardWarmupMinObjects, and that a shard it leaves out
+// still loads on demand.
 func TestLazyShardBackgroundWarmup(t *testing.T) {
 	ctx := context.Background()
 
-	const (
-		className = "TestWarmupClass"
-		nodeName  = "test-node"
-		tenant    = "busy-tenant"
-	)
+	const tenant = "busy-tenant"
 
 	tests := []struct {
-		name           string
-		warmupDisabled bool
+		name       string
+		seed       warmupSeed
+		minObjects int64
+		// unreadableCount removes the shard's objects bucket directory, so
+		// LazyLoadShard.ObjectCountAsync fails instead of returning a count.
+		unreadableCount bool
+		wantLoaded      bool
 	}{
-		{name: "warmup materializes the shard in the background", warmupDisabled: false},
-		{name: "disabled warmup leaves the shard cold", warmupDisabled: true},
+		{name: "a negative threshold warms nothing", seed: warmupSeed{counted: 3}, minObjects: -1},
+		{name: "the default warms a non-empty shard", seed: warmupSeed{counted: 3}, minObjects: 0, wantLoaded: true},
+		{name: "the default skips an empty shard", minObjects: 0},
+		{name: "a threshold above the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 5},
+		{name: "a threshold at the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 3},
+		{
+			name: "a threshold below the object count warms the shard",
+			seed: warmupSeed{counted: 3}, minObjects: 2, wantLoaded: true,
+		},
+		{
+			name: "an unreadable object count warms the shard", seed: warmupSeed{counted: 3}, minObjects: 5,
+			unreadableCount: true, wantLoaded: true,
+		},
+		// Segments a shutdown flush wrote carry no count sidecar, so the cold count
+		// reads zero for them and only the doc-id counter sees the objects.
+		{
+			name: "a threshold below the unflushed object count warms the shard",
+			seed: warmupSeed{uncounted: 5}, minObjects: 3, wantLoaded: true,
+		},
+		{
+			name: "a threshold above the unflushed object count skips the shard",
+			seed: warmupSeed{uncounted: 2}, minObjects: 3,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := test.NewNullLogger()
 			dirName := t.TempDir()
-
-			class := &models.Class{
-				Class:               className,
-				InvertedIndexConfig: &models.InvertedIndexConfig{},
-				MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
-				ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+			seedWarmupTenants(t, dirName, map[string]warmupSeed{tenant: tt.seed})
+			if tt.unreadableCount {
+				indexPath := path.Join(dirName, indexID(schema.ClassName(warmupClassName)))
+				require.NoError(t, os.RemoveAll(
+					path.Join(shardPathLSM(indexPath, tenant), helpers.ObjectsBucketLSM)))
 			}
-			fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
 
-			shardState := &sharding.State{
-				Physical: map[string]sharding.Physical{
-					tenant: {
-						Name:           tenant,
-						BelongsToNodes: []string{nodeName},
-						Status:         models.TenantActivityStatusHOT,
-					},
-				},
-				PartitioningEnabled: true,
-			}
-			shardState.SetLocalName(nodeName)
-
-			// Write a non-zero indexcount so Index.unloadedShardIsEmpty reports false:
-			// the sweep skips empty tenants, which would make both cases look identical.
-			shardDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant)
-			require.NoError(t, os.MkdirAll(shardDir, os.ModePerm))
-			var buf [8]byte
-			binary.LittleEndian.PutUint64(buf[:], 10)
-			require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
-
-			scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
-
-			mockSchemaReader := schemaUC.NewMockSchemaReader(t)
-			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-				func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
-					return readerFunc(class, shardState)
-				}).Maybe()
-			mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
-
-			mockSchema := schemaUC.NewMockSchemaGetter(t)
-			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
-			mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
-			mockSchema.EXPECT().NodeName().Maybe().Return(nodeName)
-			mockSchema.EXPECT().TenantsShards(ctx, className, tenant).Maybe().
-				Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil)
-
-			mockRouter := types.NewMockRouter(t)
-			mockRouter.EXPECT().GetWriteReplicasLocation(className, mock.Anything, tenant).
-				Return(types.WriteReplicaSet{
-					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
-				}, nil).Maybe()
-			mockRouter.EXPECT().GetReadReplicasLocation(className, tenant, tenant).
-				Return(types.ReadReplicaSet{
-					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
-				}, nil).Maybe()
-
-			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
-			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
-
-			index, err := NewIndex(ctx, nil, IndexConfig{
-				RootPath:                    dirName,
-				ClassName:                   schema.ClassName(className),
-				ReplicationFactor:           1,
-				ShardLoadLimiter:            loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
-				EnableLazyLoadShards:        true,
-				LazyLoadShardWarmupDisabled: tt.warmupDisabled,
-			}, inverted.ConfigFromModel(class.InvertedIndexConfig),
-				enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
-				mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
-				class, nil, scheduler, nil, nil,
-				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
-			require.NoError(t, err)
+			index := newWarmupIndex(t, dirName, tt.minObjects, tenant)
 			defer index.Shutdown(ctx)
 
-			stored := index.shards.Load(tenant)
-			require.NotNil(t, stored, "shard must be registered after init")
-			lazy, isLazy := stored.(*LazyLoadShard)
-			require.True(t, isLazy, "lazy mode should store a wrapper, got %T", stored)
-			require.False(t, lazy.isLoaded(), "shard must not be loaded during init in lazy mode")
+			lazy := coldWarmupShard(t, index, tenant)
 
-			if !tt.warmupDisabled {
+			if tt.wantLoaded {
 				// The sweep ticks once per second, so allow generous slack.
 				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
 					"background warmup should materialize the shard")
@@ -152,14 +231,62 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 				return
 			}
 
-			require.True(t, index.allShardsReady.Load(),
-				"allShardsReady must be published immediately when warmup is disabled")
-			require.Never(t, lazy.isLoaded, 3*time.Second, 100*time.Millisecond,
-				"no background sweep should run when warmup is disabled")
+			if tt.minObjects < 0 {
+				require.True(t, index.allShardsReady.Load(),
+					"allShardsReady must be published immediately when no sweep runs")
+				require.Never(t, lazy.isLoaded, 2*time.Second, 100*time.Millisecond,
+					"no sweep should run at all")
+			} else {
+				require.Eventually(t, index.allShardsReady.Load, 10*time.Second, 50*time.Millisecond,
+					"allShardsReady should be published once the sweep has skipped every shard")
+				// allShardsReady is published from the sweep goroutine's last deferred
+				// call, so it implies the sweep is over and no later load is possible.
+				require.False(t, lazy.isLoaded(), "a shard the sweep leaves out must stay cold")
+			}
 
-			// Disabling the sweep must leave the shard loadable on demand.
+			// Leaving a shard out of the sweep must keep it loadable on demand.
 			require.NoError(t, lazy.Load(ctx))
 			require.True(t, lazy.isLoaded())
 		})
+	}
+}
+
+// The sweep paces itself at one shard per second, and decides whether to warm a
+// shard before spending that second. With a single shard above the threshold
+// among many below it, the sweep finishes in about a second — spending the tick
+// before the decision would take a second per tenant instead.
+func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		smallTenantCount = 7
+		bigTenant        = "big-tenant"
+		minObjects       = 3
+	)
+
+	seeds := map[string]warmupSeed{bigTenant: {counted: minObjects + 1}}
+	for i := range smallTenantCount {
+		seeds[fmt.Sprintf("small-tenant-%d", i)] = warmupSeed{counted: 1}
+	}
+
+	dirName := t.TempDir()
+	tenants := seedWarmupTenants(t, dirName, seeds)
+
+	index := newWarmupIndex(t, dirName, minObjects, tenants...)
+	defer index.Shutdown(ctx)
+
+	// The green path is one tick, so the budget only separates it from a tick per
+	// shard while there are at least three tenants.
+	sweepBudget := time.Duration(len(tenants)) * time.Second / 2
+	require.Eventually(t, index.allShardsReady.Load, sweepBudget, 50*time.Millisecond,
+		"the sweep must not spend its per-shard tick on the shards it skips")
+
+	for tenant := range seeds {
+		stored := index.shards.Load(tenant)
+		require.NotNil(t, stored)
+		lazy, ok := stored.(*LazyLoadShard)
+		require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
+		require.Equal(t, tenant == bigTenant, lazy.isLoaded(),
+			"only the tenant above the threshold should be warmed, checked %q", tenant)
 	}
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -197,6 +197,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 				)
 				return lazyLoadShardEnabled
 			}(),
+			LazyLoadShardWarmupDisabled:                  m.db.config.LazyLoadShardWarmupDisabled,
 			ForceFullReplicasSearch:                      m.db.config.ForceFullReplicasSearch,
 			TransferInactivityTimeout:                    m.db.config.TransferInactivityTimeout,
 			HaltForTransferTimeout:                       m.db.config.HaltForTransferTimeout,
@@ -288,6 +289,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"action":                  "lazy_shard_auto_detection",
 		"class":                   class.Class,
 		"enable_lazy_load_shards": lazyLoadShardEnabled,
+		"background_warmup":       !m.db.config.LazyLoadShardWarmupDisabled,
 		"local_shard_count":       localActiveShardsCount,
 		"total_shard_size_bytes":  totalShardSizeBytes,
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -289,7 +289,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"action":                  "lazy_shard_auto_detection",
 		"class":                   class.Class,
 		"enable_lazy_load_shards": lazyLoadShardEnabled,
-		"background_warmup":       !m.db.config.LazyLoadShardWarmupDisabled,
+		"background_warmup":       idx.Config.backgroundWarmupEnabled(),
 		"local_shard_count":       localActiveShardsCount,
 		"total_shard_size_bytes":  totalShardSizeBytes,
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -197,7 +197,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 				)
 				return lazyLoadShardEnabled
 			}(),
-			LazyLoadShardWarmupDisabled:                  m.db.config.LazyLoadShardWarmupDisabled,
+			LazyLoadShardWarmupMinObjects:                m.db.config.LazyLoadShardWarmupMinObjects,
 			ForceFullReplicasSearch:                      m.db.config.ForceFullReplicasSearch,
 			TransferInactivityTimeout:                    m.db.config.TransferInactivityTimeout,
 			HaltForTransferTimeout:                       m.db.config.HaltForTransferTimeout,
@@ -290,6 +290,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"class":                   class.Class,
 		"enable_lazy_load_shards": lazyLoadShardEnabled,
 		"background_warmup":       idx.Config.backgroundWarmupEnabled(),
+		"warmup_min_objects":      m.db.config.LazyLoadShardWarmupMinObjects,
 		"local_shard_count":       localActiveShardsCount,
 		"total_shard_size_bytes":  totalShardSizeBytes,
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -422,6 +422,7 @@ type Config struct {
 	EnableLazyLoadShards                *bool
 	LazyLoadShardCountThreshold         int
 	LazyLoadShardSizeThresholdGB        float64
+	LazyLoadShardWarmupDisabled         bool
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -422,7 +422,7 @@ type Config struct {
 	EnableLazyLoadShards                *bool
 	LazyLoadShardCountThreshold         int
 	LazyLoadShardSizeThresholdGB        float64
-	LazyLoadShardWarmupDisabled         bool
+	LazyLoadShardWarmupMinObjects       int64
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -57,9 +57,13 @@ import (
 )
 
 type LazyLoadShard struct {
-	shardOpts        *deferredShardOpts
-	shard            *Shard
-	loaded           bool
+	shardOpts *deferredShardOpts
+	shard     *Shard
+	loaded    bool
+	// unloadedCount caches the object count read off disk while the shard is
+	// cold, which a cold shard cannot change without loading first. nil means
+	// not read yet; Load clears it.
+	unloadedCount    *int64
 	mutex            sync.Mutex
 	memMonitor       memwatch.AllocChecker
 	shardLoadLimiter *loadlimiter.LoadLimiter
@@ -158,6 +162,8 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 
 	l.shard = shard
 	l.loaded = true
+	// The loaded shard owns the object count from here, and writes move it.
+	l.unloadedCount = nil
 
 	return nil
 }
@@ -254,12 +260,29 @@ func (l *LazyLoadShard) ObjectCountAsync(ctx context.Context) (int64, error) {
 		l.mutex.Unlock()
 		return l.shard.ObjectCountAsync(ctx)
 	}
+	if l.unloadedCount != nil {
+		count := *l.unloadedCount
+		l.mutex.Unlock()
+		return count, nil
+	}
 	l.mutex.Unlock()
+
+	// Read outside the lock: this lists the objects directory and reads a sidecar
+	// per segment, and Load needs the same lock to make progress.
 	idx := l.shardOpts.index
 	objectUsage, err := shardusage.CalculateUnloadedObjectsMetrics(idx.logger, idx.path(), l.shardOpts.name, true)
 	if err != nil {
 		return 0, fmt.Errorf("error while getting object count for shard %s: %w", l.shardOpts.name, err)
 	}
+
+	l.mutex.Lock()
+	if !l.loaded {
+		// Caching a count read before a concurrent load would outlive its accuracy.
+		count := objectUsage.Count
+		l.unloadedCount = &count
+	}
+	l.mutex.Unlock()
+
 	return objectUsage.Count, nil
 }
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -146,6 +146,11 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 		class = l.shardOpts.class
 	}
 
+	// NewShard writes the segment sidecars a cold count reads and recovers the
+	// write-ahead log into segments, so the cached cold count is stale from here
+	// on — including when the load fails partway and leaves the shard cold.
+	l.unloadedCount = nil
+
 	shard, err := NewShard(ctx, l.shardOpts.promMetrics, l.shardOpts.name, l.shardOpts.index,
 		class, l.shardOpts.jobQueueCh, l.shardOpts.scheduler,
 		l.shardOpts.indexCheckpoints, l.shardOpts.shardReindexer, l.lazyLoadSegments,
@@ -162,8 +167,6 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 
 	l.shard = shard
 	l.loaded = true
-	// The loaded shard owns the object count from here, and writes move it.
-	l.unloadedCount = nil
 
 	return nil
 }
@@ -256,34 +259,30 @@ func (l *LazyLoadShard) ObjectCount(ctx context.Context) (int, error) {
 
 func (l *LazyLoadShard) ObjectCountAsync(ctx context.Context) (int64, error) {
 	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	if l.loaded {
-		l.mutex.Unlock()
 		return l.shard.ObjectCountAsync(ctx)
 	}
 	if l.unloadedCount != nil {
-		count := *l.unloadedCount
-		l.mutex.Unlock()
-		return count, nil
+		return *l.unloadedCount, nil
 	}
-	l.mutex.Unlock()
 
-	// Read outside the lock: this lists the objects directory and reads a sidecar
-	// per segment, and Load needs the same lock to make progress.
+	// The disk read stays under the lock: a load writes segment sidecars and
+	// recovers the write-ahead log, so a read overlapping one can sum a mix of
+	// old and new segments and then cache the result. Everything else on this
+	// shard waits for one directory listing, and only until the first read
+	// fills the cache.
 	idx := l.shardOpts.index
 	objectUsage, err := shardusage.CalculateUnloadedObjectsMetrics(idx.logger, idx.path(), l.shardOpts.name, true)
 	if err != nil {
 		return 0, fmt.Errorf("error while getting object count for shard %s: %w", l.shardOpts.name, err)
 	}
 
-	l.mutex.Lock()
-	if !l.loaded {
-		// Caching a count read before a concurrent load would outlive its accuracy.
-		count := objectUsage.Count
-		l.unloadedCount = &count
-	}
-	l.mutex.Unlock()
+	count := objectUsage.Count
+	l.unloadedCount = &count
 
-	return objectUsage.Count, nil
+	return count, nil
 }
 
 func (l *LazyLoadShard) GetPropertyLengthTracker() *inverted.JsonShardMetaData {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -271,8 +271,8 @@ func (l *LazyLoadShard) ObjectCountAsync(ctx context.Context) (int64, error) {
 	// The disk read stays under the lock: a load writes segment sidecars and
 	// recovers the write-ahead log, so a read overlapping one can sum a mix of
 	// old and new segments and then cache the result. Everything else on this
-	// shard waits for one directory listing, and only until the first read
-	// fills the cache.
+	// shard waits for one directory listing. A failed read caches nothing, so a
+	// shard whose sidecars stay unreadable repeats that listing on every call.
 	idx := l.shardOpts.index
 	objectUsage, err := shardusage.CalculateUnloadedObjectsMetrics(idx.logger, idx.path(), l.shardOpts.name, true)
 	if err != nil {

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -14,6 +14,8 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -348,6 +350,52 @@ func TestGetOrInitShard_InitFailureNamesShard(t *testing.T) {
 	require.ErrorContains(t, err, `init local shard "uninitialized-shard"`)
 	require.ErrorContains(t, err, f.index.ID())
 	require.ErrorContains(t, err, "memory pressure")
+}
+
+// A cold shard answers ObjectCountAsync by listing its objects directory and
+// reading a sidecar per segment. nodeWideMetricsObserver asks every shard every
+// 30 seconds, and a cold shard cannot move that number without loading first,
+// so the answer is cached.
+func TestLazyLoadShard_ObjectCountAsyncCachesColdCount(t *testing.T) {
+	ctx := testCtx()
+	f := newAddPropertyLazyFixture(t, "ColdObjectCount", singleShardState())
+
+	for name, shard := range f.coldShards(t) {
+		// Load once so the shard has real segments on disk, then go cold again.
+		require.NoError(t, shard.Load(ctx))
+		require.NoError(t, shard.Shutdown(ctx))
+		require.False(t, shard.isLoaded(), "shard %q should be cold again", name)
+
+		first, err := shard.ObjectCountAsync(ctx)
+		require.NoError(t, err)
+
+		// A second disk read cannot succeed once the objects directory is gone, so
+		// any answer at all proves the count came from the cache.
+		require.NoError(t, os.RemoveAll(path.Join(shard.pathLSM(), helpers.ObjectsBucketLSM)))
+
+		second, err := shard.ObjectCountAsync(ctx)
+		require.NoError(t, err, "shard %q re-read the objects directory", name)
+		require.Equal(t, first, second)
+	}
+}
+
+// Loading drops the cached cold count, because from then on the loaded shard
+// owns the number and writes move it.
+func TestLazyLoadShard_LoadDropsCachedColdCount(t *testing.T) {
+	ctx := testCtx()
+	f := newAddPropertyLazyFixture(t, "ColdObjectCountInvalidation", singleShardState())
+
+	for name, shard := range f.coldShards(t) {
+		require.NoError(t, shard.Load(ctx))
+		require.NoError(t, shard.Shutdown(ctx))
+
+		_, err := shard.ObjectCountAsync(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, shard.unloadedCount, "cold read should populate the cache for %q", name)
+
+		require.NoError(t, shard.Load(ctx))
+		require.Nil(t, shard.unloadedCount, "load should drop the cached cold count for %q", name)
+	}
 }
 
 // Resuming maintenance cycles after a backup must not force-load cold shards:

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -18,6 +18,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -26,6 +28,7 @@ import (
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -58,12 +61,23 @@ type addPropertyLazyFixture struct {
 	schemaClass *models.Class
 }
 
-// newLazyLoadRepo wires a lazy-load-enabled repo whose shards start cold.
+// newLazyLoadRepo wires a lazy-load-enabled repo whose shards start cold and
+// stay cold, so a test decides when each one loads.
 // It registers no Shutdown cleanup — callers own the repo's lifecycle.
 func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, *fakeSchemaGetter) {
 	t.Helper()
+	repo, migrator, schemaGetter, _ := newLazyLoadRepoWithConfig(t, shardState, true, true)
+	return repo, migrator, schemaGetter
+}
+
+// newLazyLoadRepoWithConfig wires a repo with the two lazy-shard knobs set as
+// given, returning the log hook so a test can read what startup logged.
+func newLazyLoadRepoWithConfig(t *testing.T, shardState *sharding.State,
+	lazyLoad, warmupDisabled bool,
+) (*DB, *Migrator, *fakeSchemaGetter, *test.Hook) {
+	t.Helper()
 	ctx := testCtx()
-	logger, _ := test.NewNullLogger()
+	logger, hook := test.NewNullLogger()
 
 	baseMetrics := monitoring.GetMetrics()
 	metricsCopy := *baseMetrics
@@ -90,10 +104,11 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
-		RootPath:                  t.TempDir(),
-		QueryMaximumResults:       10000,
-		MaxImportGoroutinesFactor: 1,
-		EnableLazyLoadShards:      boolPtr(true),
+		RootPath:                    t.TempDir(),
+		QueryMaximumResults:         10000,
+		MaxImportGoroutinesFactor:   1,
+		EnableLazyLoadShards:        boolPtr(lazyLoad),
+		LazyLoadShardWarmupDisabled: warmupDisabled,
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
@@ -107,7 +122,7 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	require.NoError(t, repo.init(ctx))
 	repo.startupComplete.Store(true)
 
-	return repo, NewMigrator(repo, logger, "node1"), schemaGetter
+	return repo, NewMigrator(repo, logger, "node1"), schemaGetter, hook
 }
 
 func newAddPropertyLazyFixture(t *testing.T, className string, shardState *sharding.State) *addPropertyLazyFixture {
@@ -352,49 +367,214 @@ func TestGetOrInitShard_InitFailureNamesShard(t *testing.T) {
 	require.ErrorContains(t, err, "memory pressure")
 }
 
+// coldTestObject builds an object for the class newClassWithWarmProp defines.
+func coldTestObject(className string) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      className,
+			Properties: map[string]interface{}{"warm": "object count fixture"},
+		},
+	}
+}
+
+// writeCountedObjects writes n objects and returns the shard cold with them in a
+// segment a cold count can read: flushing while the shard runs writes each new
+// segment's sidecar, and the count comes from those sidecars.
+func writeCountedObjects(t *testing.T, shard *LazyLoadShard, className string, n int) {
+	t.Helper()
+	ctx := testCtx()
+	require.NoError(t, shard.Load(ctx))
+	for range n {
+		require.NoError(t, shard.PutObject(ctx, coldTestObject(className)))
+	}
+	require.NoError(t, shard.Store().FlushMemtables(ctx))
+	require.NoError(t, shard.Shutdown(ctx))
+	require.False(t, shard.isLoaded(), "shard %q should be cold again", shard.Name())
+}
+
+// writeUncountedObjects writes n objects and returns the shard cold with them in
+// a segment a cold count cannot read: the shutdown flush writes the segment but
+// not the sidecar holding its object count, which the next load derives.
+func writeUncountedObjects(t *testing.T, shard *LazyLoadShard, className string, n int) {
+	t.Helper()
+	ctx := testCtx()
+	require.NoError(t, shard.Load(ctx))
+	for range n {
+		require.NoError(t, shard.PutObject(ctx, coldTestObject(className)))
+	}
+	require.NoError(t, shard.Shutdown(ctx))
+	require.False(t, shard.isLoaded(), "shard %q should be cold again", shard.Name())
+}
+
 // A cold shard answers ObjectCountAsync by listing its objects directory and
 // reading a sidecar per segment. nodeWideMetricsObserver asks every shard every
 // 30 seconds, and a cold shard cannot move that number without loading first,
 // so the answer is cached.
 func TestLazyLoadShard_ObjectCountAsyncCachesColdCount(t *testing.T) {
 	ctx := testCtx()
-	f := newAddPropertyLazyFixture(t, "ColdObjectCount", singleShardState())
+	const className = "ColdObjectCount"
 
-	for name, shard := range f.coldShards(t) {
-		// Load once so the shard has real segments on disk, then go cold again.
-		require.NoError(t, shard.Load(ctx))
-		require.NoError(t, shard.Shutdown(ctx))
-		require.False(t, shard.isLoaded(), "shard %q should be cold again", name)
+	cases := []struct {
+		name    string
+		objects int
+	}{
+		{name: "empty shard"},
+		{name: "single object", objects: 1},
+		{name: "many objects", objects: 7},
+	}
 
-		first, err := shard.ObjectCountAsync(ctx)
-		require.NoError(t, err)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAddPropertyLazyFixture(t, className, singleShardState())
 
-		// A second disk read cannot succeed once the objects directory is gone, so
-		// any answer at all proves the count came from the cache.
-		require.NoError(t, os.RemoveAll(path.Join(shard.pathLSM(), helpers.ObjectsBucketLSM)))
+			for name, shard := range f.coldShards(t) {
+				writeCountedObjects(t, shard, className, tc.objects)
 
-		second, err := shard.ObjectCountAsync(ctx)
-		require.NoError(t, err, "shard %q re-read the objects directory", name)
-		require.Equal(t, first, second)
+				first, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err)
+				require.EqualValues(t, tc.objects, first, "cold read must count what shard %q has on disk", name)
+
+				// A second disk read cannot succeed once the objects directory is gone, so
+				// any answer at all proves the count came from the cache.
+				require.NoError(t, os.RemoveAll(path.Join(shard.pathLSM(), helpers.ObjectsBucketLSM)))
+
+				second, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err, "shard %q re-read the objects directory", name)
+				require.EqualValues(t, tc.objects, second)
+			}
+		})
 	}
 }
 
-// Loading drops the cached cold count, because from then on the loaded shard
-// owns the number and writes move it.
-func TestLazyLoadShard_LoadDropsCachedColdCount(t *testing.T) {
+// breakProplenTracker makes the shard's next load fail after NewShard has
+// already opened the objects bucket and written its segment sidecars, by
+// putting a directory where initProplenTracker expects a file.
+func breakProplenTracker(t *testing.T, shard *LazyLoadShard) {
+	t.Helper()
+	plPath := path.Join(path.Dir(shard.pathLSM()), "proplengths")
+	require.NoError(t, os.RemoveAll(plPath))
+	require.NoError(t, os.Mkdir(plPath, os.ModePerm))
+}
+
+// A load writes the segment sidecars a cold count reads, so the count cached
+// before it is stale — even when the load fails partway and leaves the shard
+// cold. A load that fails before reaching NewShard has touched nothing, so the
+// cache still holds.
+func TestLazyLoadShard_LoadInvalidatesCachedColdCount(t *testing.T) {
 	ctx := testCtx()
-	f := newAddPropertyLazyFixture(t, "ColdObjectCountInvalidation", singleShardState())
+	const (
+		className = "ColdObjectCountInvalidation"
+		counted   = 5 // objects a cold read counts, because their segment has its sidecar
+		uncounted = 3 // objects whose segment gets its sidecar only at the next load
+	)
 
-	for name, shard := range f.coldShards(t) {
-		require.NoError(t, shard.Load(ctx))
-		require.NoError(t, shard.Shutdown(ctx))
+	cases := []struct {
+		name      string
+		breakLoad func(t *testing.T, shard *LazyLoadShard)
+		wantErr   bool
+		// wantCached asserts the answer came from the cache, not from disk.
+		wantCached bool
+		wantCount  int64
+	}{
+		{
+			name:      "load succeeds",
+			breakLoad: func(*testing.T, *LazyLoadShard) {},
+			wantCount: counted + uncounted,
+		},
+		{
+			name:      "load fails after touching disk",
+			breakLoad: breakProplenTracker,
+			wantErr:   true,
+			wantCount: counted + uncounted,
+		},
+		{
+			name: "load fails before touching disk",
+			breakLoad: func(_ *testing.T, shard *LazyLoadShard) {
+				shard.memMonitor = failingAllocChecker{}
+			},
+			wantErr:    true,
+			wantCached: true,
+			wantCount:  counted,
+		},
+	}
 
-		_, err := shard.ObjectCountAsync(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, shard.unloadedCount, "cold read should populate the cache for %q", name)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAddPropertyLazyFixture(t, className, singleShardState())
 
-		require.NoError(t, shard.Load(ctx))
-		require.Nil(t, shard.unloadedCount, "load should drop the cached cold count for %q", name)
+			for name, shard := range f.coldShards(t) {
+				writeCountedObjects(t, shard, className, counted)
+				writeUncountedObjects(t, shard, className, uncounted)
+
+				cold, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err)
+				require.EqualValues(t, counted, cold,
+					"shard %q counts the segments whose sidecar is on disk", name)
+
+				tc.breakLoad(t, shard)
+				loadErr := shard.Load(ctx)
+				if tc.wantErr {
+					require.Error(t, loadErr)
+				} else {
+					require.NoError(t, loadErr)
+				}
+
+				// Go cold again, so the next count comes from the cold path rather than
+				// from the loaded shard.
+				require.NoError(t, shard.Shutdown(ctx))
+
+				if tc.wantCached {
+					// A disk read cannot succeed once the objects directory is gone, so
+					// any answer at all proves the cache survived the failed load.
+					require.NoError(t, os.RemoveAll(path.Join(shard.pathLSM(), helpers.ObjectsBucketLSM)))
+				}
+
+				count, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err)
+				require.EqualValues(t, tc.wantCount, count,
+					"cold count for shard %q after the load attempt", name)
+			}
+		})
+	}
+}
+
+// background_warmup tells an operator whether this collection's cold shards get
+// loaded by the startup sweep. An eagerly loaded collection has no such sweep,
+// whatever LazyLoadShardWarmupDisabled is set to.
+func TestMigratorAddClass_LogsBackgroundWarmup(t *testing.T) {
+	ctx := testCtx()
+
+	cases := []struct {
+		name           string
+		lazyLoad       bool
+		warmupDisabled bool
+		want           bool
+	}{
+		{name: "lazy loading with warmup", lazyLoad: true, want: true},
+		{name: "lazy loading with warmup disabled", lazyLoad: true, warmupDisabled: true},
+		{name: "eager loading with warmup"},
+		{name: "eager loading with warmup disabled", warmupDisabled: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, migrator, _, hook := newLazyLoadRepoWithConfig(t, singleShardState(), tc.lazyLoad, tc.warmupDisabled)
+			t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+			require.NoError(t, migrator.AddClass(ctx, newClassWithWarmProp("WarmupLogging")))
+
+			// Warnings on the same action carry no background_warmup field.
+			var logged []interface{}
+			for _, entry := range hook.AllEntries() {
+				warmup, ok := entry.Data["background_warmup"]
+				if ok && entry.Data["action"] == "lazy_shard_auto_detection" {
+					logged = append(logged, warmup)
+				}
+			}
+			require.Equal(t, []interface{}{tc.want}, logged)
+		})
 	}
 }
 

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -66,14 +66,15 @@ type addPropertyLazyFixture struct {
 // It registers no Shutdown cleanup — callers own the repo's lifecycle.
 func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, *fakeSchemaGetter) {
 	t.Helper()
-	repo, migrator, schemaGetter, _ := newLazyLoadRepoWithConfig(t, shardState, true, true)
+	repo, migrator, schemaGetter, _ := newLazyLoadRepoWithConfig(t, shardState, true, -1)
 	return repo, migrator, schemaGetter
 }
 
-// newLazyLoadRepoWithConfig wires a repo with the two lazy-shard knobs set as
-// given, returning the log hook so a test can read what startup logged.
+// newLazyLoadRepoWithConfig wires a repo with EnableLazyLoadShards and
+// LazyLoadShardWarmupMinObjects set as given, returning the log hook so a test
+// can read what startup logged.
 func newLazyLoadRepoWithConfig(t *testing.T, shardState *sharding.State,
-	lazyLoad, warmupDisabled bool,
+	lazyLoad bool, warmupMinObjects int64,
 ) (*DB, *Migrator, *fakeSchemaGetter, *test.Hook) {
 	t.Helper()
 	ctx := testCtx()
@@ -104,11 +105,11 @@ func newLazyLoadRepoWithConfig(t *testing.T, shardState *sharding.State,
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
-		RootPath:                    t.TempDir(),
-		QueryMaximumResults:         10000,
-		MaxImportGoroutinesFactor:   1,
-		EnableLazyLoadShards:        boolPtr(lazyLoad),
-		LazyLoadShardWarmupDisabled: warmupDisabled,
+		RootPath:                      t.TempDir(),
+		QueryMaximumResults:           10000,
+		MaxImportGoroutinesFactor:     1,
+		EnableLazyLoadShards:          boolPtr(lazyLoad),
+		LazyLoadShardWarmupMinObjects: warmupMinObjects,
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
@@ -540,27 +541,29 @@ func TestLazyLoadShard_LoadInvalidatesCachedColdCount(t *testing.T) {
 	}
 }
 
-// background_warmup tells an operator whether this collection's cold shards get
-// loaded by the startup sweep. An eagerly loaded collection has no such sweep,
-// whatever LazyLoadShardWarmupDisabled is set to.
+// background_warmup tells an operator whether this collection runs the startup
+// sweep at all; warmup_min_objects says which shards it then loads. An eagerly
+// loaded collection has no such sweep, whatever LazyLoadShardWarmupMinObjects
+// is set to.
 func TestMigratorAddClass_LogsBackgroundWarmup(t *testing.T) {
 	ctx := testCtx()
 
 	cases := []struct {
-		name           string
-		lazyLoad       bool
-		warmupDisabled bool
-		want           bool
+		name             string
+		lazyLoad         bool
+		warmupMinObjects int64
+		want             bool
 	}{
 		{name: "lazy loading with warmup", lazyLoad: true, want: true},
-		{name: "lazy loading with warmup disabled", lazyLoad: true, warmupDisabled: true},
+		{name: "lazy loading with a threshold", lazyLoad: true, warmupMinObjects: 1000, want: true},
+		{name: "lazy loading with warmup turned off", lazyLoad: true, warmupMinObjects: -1},
 		{name: "eager loading with warmup"},
-		{name: "eager loading with warmup disabled", warmupDisabled: true},
+		{name: "eager loading with warmup turned off", warmupMinObjects: -1},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			repo, migrator, _, hook := newLazyLoadRepoWithConfig(t, singleShardState(), tc.lazyLoad, tc.warmupDisabled)
+			repo, migrator, _, hook := newLazyLoadRepoWithConfig(t, singleShardState(), tc.lazyLoad, tc.warmupMinObjects)
 			t.Cleanup(func() { repo.Shutdown(context.Background()) })
 
 			require.NoError(t, migrator.AddClass(ctx, newClassWithWarmProp("WarmupLogging")))

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -265,12 +265,14 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	assert.Equal(t, int64(2), hotShard.ObjectsCount)
 	assert.Equal(t, uint64(612), hotShard.ObjectsStorageBytes)
 	assert.Equal(t, strings.ToLower(models.TenantActivityStatusACTIVE), hotShard.Status)
+	assert.False(t, hotShard.LazyUnloaded, "a loaded shard is not marked as unloaded")
 	assert.Len(t, hotShard.NamedVectors, 1)
 
 	require.NotNil(t, coldShard)
 	assert.Equal(t, int64(0), coldShard.ObjectsCount)
 	assert.Equal(t, uint64(0), coldShard.ObjectsStorageBytes)
 	assert.Equal(t, strings.ToLower(models.TenantActivityStatusINACTIVE), coldShard.Status)
+	assert.False(t, coldShard.LazyUnloaded, "an inactive shard is never loaded, so it carries no mark")
 	assert.Len(t, coldShard.NamedVectors, 1)
 
 	vector := hotShard.NamedVectors[0]

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -73,6 +73,13 @@ type ShardUsage struct {
 	// The status of the shard (ACTIVE, INACTIVE)
 	Status string `json:"status,omitempty"`
 
+	// LazyUnloaded marks an active shard that was not loaded into memory when the
+	// report ran, so everything above was read from disk like a cold shard's. It
+	// separates a lazy shard sitting cold from one serving requests; both are hot
+	// tenants and report the same status. An inactive shard is never loaded, so it
+	// does not carry the mark.
+	LazyUnloaded bool `json:"lazy_unloaded,omitempty"`
+
 	// The number of objects in the shard
 	ObjectsCount int64 `json:"objects_count"`
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -144,6 +144,11 @@ This document is the single source of truth for Prometheus metrics exposed by We
 | `weaviate_<module>_operation_latency_seconds` | Latency of usage operations in seconds | `Histogram` | `operation` | - Low 
 | `weaviate_<module>_uploaded_file_size_bytes` | Size of the last uploaded usage file in bytes | `Gauge` | `-` | - Low 
 
+#### Shard Loading Metrics
+| Name | Description | Type | Labels | High Cardinality |
+|---|---|---|---|---|
+| `weaviate_lazy_shard_warmup_decisions_total` | Number of shards the startup warmup sweep considered, by what it did with each: `loaded`, `failed`, `skipped_not_cold`, `skipped_empty`, `skipped_below_threshold` | `Counter` | `outcome` | - Low 
+
 #### Shard Load Limiter Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -533,11 +533,11 @@ func TestRestart(t *testing.T) {
 		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
 		WithWeaviateEnv(entcfg.EnvNestedFilteringPreview, "true").
 		// a count threshold of 0 lazy-loads every multi-tenant collection the node
-		// finds on startup, and the warmup knob leaves those shards unloaded until
-		// something asks for them, so the report after the restart has to measure hot
-		// tenants from disk
+		// finds on startup, and a negative warmup minimum leaves those shards
+		// unloaded until something asks for them, so the report after the restart
+		// has to measure hot tenants from disk
 		WithWeaviateEnv("LAZY_LOAD_SHARD_COUNT_THRESHOLD", "0").
-		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "true").
+		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", "-1").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -532,6 +532,12 @@ func TestRestart(t *testing.T) {
 		WithWeaviateWithDebugPort().
 		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
 		WithWeaviateEnv(entcfg.EnvNestedFilteringPreview, "true").
+		// a count threshold of 0 lazy-loads every multi-tenant collection the node
+		// finds on startup, and the warmup knob leaves those shards unloaded until
+		// something asks for them, so the report after the restart has to measure hot
+		// tenants from disk
+		WithWeaviateEnv("LAZY_LOAD_SHARD_COUNT_THRESHOLD", "0").
+		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "true").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -587,8 +593,9 @@ func TestRestart(t *testing.T) {
 
 	// add some data. Only even tenants get nested values, leaving the odd ones as
 	// a baseline with the same schema and object count.
+	const objectsPerTenant = 10
 	for i, tenant := range tenants {
-		objs := make([]*models.Object, 10)
+		objs := make([]*models.Object, objectsPerTenant)
 		for j := range objs {
 			vector := make([]float32, 128)
 			for k := range vector {
@@ -617,44 +624,100 @@ func TestRestart(t *testing.T) {
 		}
 	}
 
-	loaded := strings.ToLower(models.TenantActivityStatusACTIVE)
-	fromDisk := strings.ToLower(models.TenantActivityStatusINACTIVE)
+	hotStatus := strings.ToLower(models.TenantActivityStatusACTIVE)
+	coldStatus := strings.ToLower(models.TenantActivityStatusINACTIVE)
 
 	// collect with concurrent shard readers, compare with the default report after restart
 	usage, err := getDebugUsageWithPort(debug, 4)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
-	assertNestedIndexStorageCounted(t, usage, className, loaded)
+	// writing the objects loaded every shard
+	assertNestedIndexStorageCounted(t, usage, className, hotStatus, false)
 
 	require.NoError(t, compose.Stop(ctx, compose.GetWeaviate().Name(), nil))
 
 	err = compose.Start(ctx, compose.GetWeaviate().Name())
 	require.NoError(t, err)
 
-	usage2, err := getDebugUsageWithPort(compose.GetWeaviate().DebugURI())
+	// the restart gave the container a new mapped port
+	debug = compose.GetWeaviate().DebugURI()
+	c, err = client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
 	require.NoError(t, err)
-	require.NotNil(t, usage2)
-	require.NoError(t, ReportsDifference(usage, usage2))
-	assertNestedIndexStorageCounted(t, usage2, className, loaded)
+
+	// nothing has touched the tenants since the restart and the sweep that would load
+	// them is off, so they stay hot without being in memory. The sweep materializes one
+	// shard per second, so a window this wide fails if the knob stops taking effect.
+	require.Never(t, func() bool {
+		report, err := getDebugUsageWithPort(debug)
+		if err != nil {
+			return false
+		}
+		for _, shard := range shardsForCollection(report, className) {
+			if !shard.LazyUnloaded {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 3*time.Second, "no shard may load while the warmup is disabled")
+
+	unloadedUsage, err := getDebugUsageWithPort(debug)
+	require.NoError(t, err)
+	require.NotNil(t, unloadedUsage)
+	assertNestedIndexStorageCounted(t, unloadedUsage, className, hotStatus, true)
+
+	// reading one tenant loads its shard, and only its shard. Nothing else makes an
+	// unloaded shard observable from outside, so without the mark a node parked in
+	// this mode looks like one serving every tenant from memory.
+	first := tenants[0].Name
+	_, err = c.Data().ObjectsGetter().WithClassName(className).WithTenant(first).Do(ctx)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		report, err := getDebugUsageWithPort(debug)
+		require.NoError(ct, err)
+		shards := shardsForCollection(report, className)
+		require.Len(ct, shards, len(tenants))
+		for _, shard := range shards {
+			if shard.Name == first {
+				assert.False(ct, shard.LazyUnloaded, "the tenant that was read is loaded now")
+				assert.Equal(ct, int64(objectsPerTenant), shard.ObjectsCount)
+				continue
+			}
+			assert.True(ct, shard.LazyUnloaded, "shard %s stays unloaded", shard.Name)
+		}
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// reading the rest brings every shard back into memory, and the report is the one
+	// taken before the restart again
+	for _, tenant := range tenants[1:] {
+		_, err = c.Data().ObjectsGetter().WithClassName(className).WithTenant(tenant.Name).Do(ctx)
+		require.NoError(t, err)
+	}
+
+	var usage2 *usagetypes.Report
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		usage2, err = getDebugUsageWithPort(debug)
+		require.NoError(ct, err)
+		require.NoError(ct, ReportsDifference(usage, usage2))
+	}, 60*time.Second, time.Second)
+	assertNestedIndexStorageCounted(t, usage2, className, hotStatus, false)
 
 	// cold tenants are measured from the bucket directories instead of the shard
 	cold := make([]models.Tenant, len(tenants))
 	for i := range tenants {
 		cold[i] = models.Tenant{Name: tenants[i].Name, ActivityStatus: models.TenantActivityStatusCOLD}
 	}
-	// the restart gave the container a new mapped port
-	c, err = client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
-	require.NoError(t, err)
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).WithTenants(cold...).Do(ctx))
 
-	usage3, err := getDebugUsageWithPort(compose.GetWeaviate().DebugURI())
+	usage3, err := getDebugUsageWithPort(debug)
 	require.NoError(t, err)
 	require.NotNil(t, usage3)
-	assertNestedIndexStorageCounted(t, usage3, className, fromDisk)
+	// an inactive shard is never loaded, so it carries no mark
+	assertNestedIndexStorageCounted(t, usage3, className, coldStatus, false)
 
 	// shares this container instead of starting its own
 	t.Run("muvera usage", func(t *testing.T) {
-		testUsageMuvera(t, c, compose.GetWeaviate().DebugURI())
+		testUsageMuvera(t, c, debug)
 	})
 }
 
@@ -674,26 +737,37 @@ func nestedCars(tenant, object int) []any {
 func collectionShards(t *testing.T, report *usagetypes.Report, className string) usagetypes.ShardsUsage {
 	t.Helper()
 
+	shards := shardsForCollection(report, className)
+	if shards == nil {
+		require.FailNow(t, "collection missing from usage report: "+className)
+	}
+	return shards
+}
+
+// shardsForCollection returns nil for a collection the report does not carry, so a
+// polling condition can retry instead of failing off the test goroutine.
+func shardsForCollection(report *usagetypes.Report, className string) usagetypes.ShardsUsage {
 	for _, col := range report.Collections {
 		if col != nil && col.Name == className {
 			return col.Shards
 		}
 	}
-	require.FailNow(t, "collection missing from usage report: "+className)
 	return nil
 }
 
 // assertNestedIndexStorageCounted checks that tenants with nested values report more
 // than double the index storage of those without — nested data lives only in the
 // property.nested_ / property.nestedmeta_ buckets, so skipping those makes the two
-// groups equal. wantStatus is active for a loaded shard, inactive for one from disk.
-func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, className, wantStatus string) {
+// groups equal. wantStatus is active for a hot tenant, inactive for a cold one, and
+// wantLazyUnloaded says whether the hot ones were measured from disk.
+func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, className, wantStatus string, wantLazyUnloaded bool) {
 	t.Helper()
 
 	// per shard rather than summed, so one shard reporting nothing cannot hide
 	var smallestNested, largestBaseline uint64
 	for _, shard := range collectionShards(t, report, className) {
 		require.Equal(t, wantStatus, shard.Status, "shard %s", shard.Name)
+		require.Equal(t, wantLazyUnloaded, shard.LazyUnloaded, "shard %s", shard.Name)
 		require.GreaterOrEqual(t, shard.FullShardStorageBytes, shard.IndexStorageBytes,
 			"shard %s full storage must contain its index storage", shard.Name)
 
@@ -1759,7 +1833,8 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	}
 	testAllObjectsIndexed(t, c, className)
 
-	// the status pins which path served the report: active = loaded, inactive = read from disk
+	// the status pins the tenant, not the path: active covers a loaded shard and a lazy
+	// one read from disk, which lazy_unloaded tells apart. inactive means a cold tenant
 	assertUsage := func(t require.TestingT, expectedStatus string) {
 		colUsage, err := getDebugUsageWithPortAndCollection(debug, className)
 		require.NoError(t, err)

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -199,9 +199,21 @@ type Config struct {
 	// EnableLazyLoadShards controls lazy shard loading.
 	// nil = auto-detect based on thresholds, true = always lazy-load, false = always eager-load.
 	// DISABLE_LAZY_LOAD_SHARDS=true sets this to false for backward compatibility.
-	EnableLazyLoadShards                *bool                          `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
-	LazyLoadShardCountThreshold         int                            `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
-	LazyLoadShardSizeThresholdGB        float64                        `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
+	EnableLazyLoadShards         *bool   `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
+	LazyLoadShardCountThreshold  int     `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
+	LazyLoadShardSizeThresholdGB float64 `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
+	// LazyLoadShardWarmupDisabled turns off the background sweep that
+	// materializes lazy shards after startup, one shard per second. The zero
+	// value keeps the sweep running. It only takes effect on collections where
+	// lazy loading is active; eager collections never run the sweep.
+	//
+	// A HOT tenant nobody touches then stays unloaded indefinitely, and every
+	// path that reads only loaded shards under-reports or skips it. The two that
+	// change behaviour rather than a number: the TTL sweep does not delete its
+	// expired objects, and async replication does not repair a stale replica of
+	// it. The list is not exhaustive — treat any loaded-shards-only reader as
+	// affected.
+	LazyLoadShardWarmupDisabled         bool                           `json:"lazy_load_shard_warmup_disabled" yaml:"lazy_load_shard_warmup_disabled"`
 	ForceFullReplicasSearch             bool                           `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	TransferInactivityTimeout           time.Duration                  `json:"transfer_inactivity_timeout" yaml:"transfer_inactivity_timeout"`
 	HaltForTransferTimeout              time.Duration                  `json:"halt_for_transfer_timeout" yaml:"halt_for_transfer_timeout"`

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -202,18 +202,23 @@ type Config struct {
 	EnableLazyLoadShards         *bool   `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
 	LazyLoadShardCountThreshold  int     `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
 	LazyLoadShardSizeThresholdGB float64 `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
-	// LazyLoadShardWarmupDisabled turns off the background sweep that
-	// materializes lazy shards after startup, one shard per second. The zero
-	// value keeps the sweep running. It only takes effect on collections where
-	// lazy loading is active; eager collections never run the sweep.
+	// LazyLoadShardWarmupMinObjects gates the background sweep that materializes
+	// lazy shards after startup, one shard per second. A negative value sweeps
+	// nothing. The zero value sweeps every shard that has ever been written to,
+	// minus the empty tenant shards of a multi-tenant collection. A positive value
+	// sweeps only shards holding strictly more than that many objects, counted from
+	// flushed segments — so a shard whose writes are still unflushed reads small and
+	// can be left cold. It only takes effect on collections where lazy loading is
+	// active; eager collections never run the sweep.
 	//
-	// A HOT tenant nobody touches then stays unloaded indefinitely, and every
-	// path that reads only loaded shards under-reports or skips it. The two that
-	// change behaviour rather than a number: the TTL sweep does not delete its
-	// expired objects, and async replication does not repair a stale replica of
-	// it. The list is not exhaustive — treat any loaded-shards-only reader as
-	// affected.
-	LazyLoadShardWarmupDisabled         bool                           `json:"lazy_load_shard_warmup_disabled" yaml:"lazy_load_shard_warmup_disabled"`
+	// A HOT tenant the sweep leaves out and nobody touches stays unloaded
+	// indefinitely, and every path that reads only loaded shards under-reports or
+	// skips it. The two that change behaviour rather than a number: the TTL sweep
+	// does not delete its expired objects, and async replication does not repair a
+	// stale replica of it. MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so a
+	// node admits writes past its cap. The list is not exhaustive — treat any
+	// loaded-shards-only reader as affected.
+	LazyLoadShardWarmupMinObjects       int64                          `json:"lazy_load_shard_warmup_min_objects" yaml:"lazy_load_shard_warmup_min_objects"`
 	ForceFullReplicasSearch             bool                           `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	TransferInactivityTimeout           time.Duration                  `json:"transfer_inactivity_timeout" yaml:"transfer_inactivity_timeout"`
 	HaltForTransferTimeout              time.Duration                  `json:"halt_for_transfer_timeout" yaml:"halt_for_transfer_timeout"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -175,12 +175,15 @@ func FromEnv(config *Config) error {
 	// collection later, so a nil setting still warns.
 	if minObjects := config.LazyLoadShardWarmupMinObjects; minObjects != 0 &&
 		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
-		left := fmt.Sprintf("only shards holding more than %d objects are warmed up", minObjects)
+		left := fmt.Sprintf("only shards holding more than %d objects are warmed up, counted "+
+			"from flushed segments — so a shard restarted mid-write reads lower than it "+
+			"holds and can be left out", minObjects)
 		if minObjects < 0 {
 			left = "no shard is warmed up"
 		}
-		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so %s; every other shard stays unloaded "+
-			"until first access. "+
+		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so on a collection using lazy loading %s. "+
+			"Whatever is left out stays unloaded until first access, and an eager collection ignores "+
+			"the setting and loads all of its shards. "+
 			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. "+
 			"Async replication also skips it, so a stale replica is not repaired until something loads it. "+
 			"MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so this node admits writes past its cap.",

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -163,17 +163,28 @@ func FromEnv(config *Config) error {
 
 	// Written only when the variable is set, so a value from the config file
 	// survives.
-	if v := os.Getenv("LAZY_LOAD_SHARD_WARMUP_DISABLED"); v != "" {
-		config.LazyLoadShardWarmupDisabled = entcfg.Enabled(v)
+	if v := os.Getenv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS"); v != "" {
+		asInt, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS as int: %w", err)
+		}
+		config.LazyLoadShardWarmupMinObjects = asInt
 	}
 	// Eager loading ignores the knob entirely, so warning there would describe a
 	// state no collection on this node is in. Auto-detection is resolved per
 	// collection later, so a nil setting still warns.
-	if config.LazyLoadShardWarmupDisabled &&
+	if minObjects := config.LazyLoadShardWarmupMinObjects; minObjects != 0 &&
 		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
-		logrus.Warn("lazy shard background warmup is disabled; shards stay unloaded until first access. " +
-			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. " +
-			"Async replication also skips it, so a stale replica is not repaired until something loads it.")
+		left := fmt.Sprintf("only shards holding more than %d objects are warmed up", minObjects)
+		if minObjects < 0 {
+			left = "no shard is warmed up"
+		}
+		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so %s; every other shard stays unloaded "+
+			"until first access. "+
+			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. "+
+			"Async replication also skips it, so a stale replica is not repaired until something loads it. "+
+			"MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so this node admits writes past its cap.",
+			minObjects, left)
 	}
 
 	// Lazy load shard size threshold for auto-detection (in GB)

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -161,6 +161,21 @@ func FromEnv(config *Config) error {
 		config.LazyLoadShardCountThreshold = DefaultLazyLoadShardCountThreshold
 	}
 
+	// Written only when the variable is set, so a value from the config file
+	// survives.
+	if v := os.Getenv("LAZY_LOAD_SHARD_WARMUP_DISABLED"); v != "" {
+		config.LazyLoadShardWarmupDisabled = entcfg.Enabled(v)
+	}
+	// Eager loading ignores the knob entirely, so warning there would describe a
+	// state no collection on this node is in. Auto-detection is resolved per
+	// collection later, so a nil setting still warns.
+	if config.LazyLoadShardWarmupDisabled &&
+		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
+		logrus.Warn("lazy shard background warmup is disabled; shards stay unloaded until first access. " +
+			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. " +
+			"Async replication also skips it, so a stale replica is not repaired until something loads it.")
+	}
+
 	// Lazy load shard size threshold for auto-detection (in GB)
 	// Determines at what total shard size auto-detection enables lazy loading
 	if v := os.Getenv("LAZY_LOAD_SHARD_SIZE_THRESHOLD_GB"); v != "" {

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -624,6 +624,42 @@ func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {
 	}
 }
 
+func TestEnvironmentLazyLoadShardWarmupDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		// preset mirrors a value coming from the config file, which is parsed
+		// before FromEnv runs.
+		preset   bool
+		value    string
+		expected bool
+	}{
+		{name: "unset keeps warmup running", value: "", expected: false},
+		{name: "true disables", value: "true", expected: true},
+		{name: "on disables", value: "on", expected: true},
+		{name: "1 disables", value: "1", expected: true},
+		{name: "false keeps warmup running", value: "false", expected: false},
+		{name: "unparsable value keeps warmup running", value: "not-a-bool", expected: false},
+		{name: "config file value survives an unset env var", preset: true, value: "", expected: true},
+		{name: "env var overrides the config file", preset: true, value: "false", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Ensure hermetic behavior regardless of outer environment
+			t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "")
+
+			if tt.value != "" {
+				t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", tt.value)
+			}
+
+			conf := Config{LazyLoadShardWarmupDisabled: tt.preset}
+			require.NoError(t, FromEnv(&conf))
+
+			assert.Equal(t, tt.expected, conf.LazyLoadShardWarmupDisabled)
+		})
+	}
+}
+
 func TestEnvironmentHaltForTransferTimeout(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -624,38 +624,44 @@ func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {
 	}
 }
 
-func TestEnvironmentLazyLoadShardWarmupDisabled(t *testing.T) {
+func TestEnvironmentLazyLoadShardWarmupMinObjects(t *testing.T) {
 	tests := []struct {
 		name string
 		// preset mirrors a value coming from the config file, which is parsed
 		// before FromEnv runs.
-		preset   bool
-		value    string
-		expected bool
+		preset      int64
+		value       string
+		expected    int64
+		expectedErr bool
 	}{
-		{name: "unset keeps warmup running", value: "", expected: false},
-		{name: "true disables", value: "true", expected: true},
-		{name: "on disables", value: "on", expected: true},
-		{name: "1 disables", value: "1", expected: true},
-		{name: "false keeps warmup running", value: "false", expected: false},
-		{name: "unparsable value keeps warmup running", value: "not-a-bool", expected: false},
-		{name: "config file value survives an unset env var", preset: true, value: "", expected: true},
-		{name: "env var overrides the config file", preset: true, value: "false", expected: false},
+		{name: "unset keeps the zero value", value: "", expected: 0},
+		{name: "negative turns the sweep off", value: "-1", expected: -1},
+		{name: "zero sweeps every non-empty shard", value: "0", expected: 0},
+		{name: "positive sets a threshold", value: "1000", expected: 1000},
+		{name: "unparsable value is rejected", value: "not-an-int", expectedErr: true},
+		{name: "config file value survives an unset env var", preset: 500, value: "", expected: 500},
+		{name: "env var overrides the config file", preset: 500, value: "-1", expected: -1},
+		{name: "zero overrides a config-file threshold", preset: 500, value: "0", expected: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Ensure hermetic behavior regardless of outer environment
-			t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "")
+			t.Setenv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", "")
 
 			if tt.value != "" {
-				t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", tt.value)
+				t.Setenv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", tt.value)
 			}
 
-			conf := Config{LazyLoadShardWarmupDisabled: tt.preset}
-			require.NoError(t, FromEnv(&conf))
+			conf := Config{LazyLoadShardWarmupMinObjects: tt.preset}
+			err := FromEnv(&conf)
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
 
-			assert.Equal(t, tt.expected, conf.LazyLoadShardWarmupDisabled)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, conf.LazyLoadShardWarmupMinObjects)
 		})
 	}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -132,6 +132,8 @@ type PrometheusMetrics struct {
 	ShardsLoading   prometheus.Gauge
 	ShardsUnloading prometheus.Gauge
 
+	LazyShardWarmupDecisions *prometheus.CounterVec
+
 	// ShardHaltForTransferForceResume: non-zero means a transfer was
 	// force-resumed mid-stream — compaction may have raced the transfer.
 	ShardHaltForTransferForceResume *prometheus.CounterVec
@@ -794,6 +796,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "shards_unloading",
 			Help: "Number of shards in process of unloading",
 		}),
+		LazyShardWarmupDecisions: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "weaviate_lazy_shard_warmup_decisions_total",
+			Help: "Number of shards the startup warmup sweep considered, by what it did with each",
+		}, []string{"outcome"}),
 
 		ShardHaltForTransferForceResume: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "shard_halt_for_transfer_force_resume_total",

--- a/usecases/monitoring/shards.go
+++ b/usecases/monitoring/shards.go
@@ -11,6 +11,35 @@
 
 package monitoring
 
+// WarmupOutcome is the value of the closed `outcome` label on
+// weaviate_lazy_shard_warmup_decisions_total: what the startup sweep that loads
+// lazy shards did with one of them.
+type WarmupOutcome string
+
+const (
+	// WarmupLoaded: the sweep loaded the shard.
+	WarmupLoaded WarmupOutcome = "loaded"
+	// WarmupFailed: the sweep attempted the load and it failed.
+	WarmupFailed WarmupOutcome = "failed"
+	// WarmupSkippedNotCold: no cold shard was left to warm, the shard having
+	// loaded or been deleted since the sweep listed it.
+	WarmupSkippedNotCold WarmupOutcome = "skipped_not_cold"
+	// WarmupSkippedEmpty: the shard has never held an object.
+	WarmupSkippedEmpty WarmupOutcome = "skipped_empty"
+	// WarmupSkippedBelowThreshold: the shard holds too few objects for
+	// LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS.
+	WarmupSkippedBelowThreshold WarmupOutcome = "skipped_below_threshold"
+)
+
+// RecordWarmupOutcome records what the startup warmup sweep did with one shard.
+func (pm *PrometheusMetrics) RecordWarmupOutcome(outcome WarmupOutcome) {
+	if pm == nil {
+		return
+	}
+
+	pm.LazyShardWarmupDecisions.WithLabelValues(string(outcome)).Inc()
+}
+
 // Move the shard from unloaded to in progress
 func (pm *PrometheusMetrics) StartLoadingShard() {
 	if pm == nil {

--- a/usecases/monitoring/shards_test.go
+++ b/usecases/monitoring/shards_test.go
@@ -181,4 +181,51 @@ func TestShards(t *testing.T) {
 
 		assert.Equal(t, float64(1), unloadedCount) // dec
 	})
+
+	t.Run("record_warmup_outcome", func(t *testing.T) {
+		// invariant: each outcome counts on its own series and on no other.
+		outcomes := []WarmupOutcome{
+			WarmupLoaded,
+			WarmupFailed,
+			WarmupSkippedNotCold,
+			WarmupSkippedEmpty,
+			WarmupSkippedBelowThreshold,
+		}
+
+		readAll := func() map[WarmupOutcome]float64 {
+			counts := make(map[WarmupOutcome]float64, len(outcomes))
+			for _, outcome := range outcomes {
+				counts[outcome] = testutil.ToFloat64(
+					m.LazyShardWarmupDecisions.WithLabelValues(string(outcome)))
+			}
+			return counts
+		}
+
+		for _, recorded := range outcomes {
+			t.Run(string(recorded), func(t *testing.T) {
+				before := readAll()
+
+				m.RecordWarmupOutcome(recorded)
+
+				after := readAll()
+				for _, outcome := range outcomes {
+					want := before[outcome]
+					if outcome == recorded {
+						want++
+					}
+					assert.Equal(t, want, after[outcome], "outcome %q", outcome)
+				}
+			})
+		}
+	})
+
+	t.Run("nil_metrics_record_nothing", func(t *testing.T) {
+		// An index built without monitoring passes nil here, so every helper has
+		// to tolerate it.
+		var nilMetrics *PrometheusMetrics
+
+		assert.NotPanics(t, func() {
+			nilMetrics.RecordWarmupOutcome(WarmupLoaded)
+		})
+	})
 }


### PR DESCRIPTION
### What's being changed:

Adds `LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS` as an optional env var gating the background sweep that loads lazy shards one-per-second after startup. A negative value sweeps nothing, the zero default sweeps every shard that has been written to, and a positive value sweeps only the shards whose flushed object count is above it. Whatever is left out loads on first access instead. Should especially help on big MT collections. No effect unless lazy loading is active — eager collections never run the sweep.

The decision now comes before the tick, so only shards that will load wait a second. That also helps at the default, where the empty tenant shards an MT collection skips no longer cost a tick each.

### The trade-off

A HOT tenant the sweep leaves out and nobody touches stays unloaded indefinitely, and every path that only reads loaded shards under-reports or skips it. The three that change behaviour rather than a number:

- the TTL sweep doesn't delete its expired objects
- async replication doesn't repair a stale replica of it
- `MAXIMUM_ALLOWED_OBJECTS_COUNT` stops counting it, so the node admits writes past its cap

Not exhaustive — treat any loaded-shards-only reader as affected. There's a startup warning saying so, emitted only when the knob is non-zero and lazy loading isn't already ruled out.

The threshold is not exact either. The count comes from the segment sidecars, which only cover what was flushed while the shard last ran — a shutdown flush writes no sidecar, and a shard left cold never derives one. A shard restarted mid-write reads lower than it holds, so one that is genuinely above the threshold can still be left out. Fixing it at the source is tracked separately.

### Telling a cold HOT tenant apart

Nothing else makes an unloaded shard observable from outside, so a node parked in this mode looked like one serving every tenant from memory. `ShardUsage.LazyUnloaded` marks an active shard whose numbers were read from disk instead; an inactive shard is never loaded, so it doesn't carry the mark. Getting there moved `Status` out of the two calculation paths and into `usageForShard` — both fields describe the tenant, not its files, and `calculateUnloadedShardUsage` saves its result to disk and serves it again later, when the tenant may have been deactivated since.

### Four supporting changes

- `allShardsReady` is now set directly at init when the sweep is skipped. Nothing else would ever flip it, and it gates the node-wide object-count metric. It now means "done loading what this node intends to", not "everything is loaded".
- The cold object count is cached in `LazyLoadShard` — `nodeWideMetricsObserver` asks every shard every 30s, and a cold shard can't move that number. Invalidated on every load *attempt*, before `NewShard`: a failed load still writes sidecars and recovers the WAL, so the cached count is stale either way.
- `observeObjectCount` no longer holds `indexLock` across the whole walk. Now that cold shards are the norm that walk reads from disk, and it was blocking every index lookup on the node for the duration. It copies the index map once instead — one copy for both loops, so an index created in between can't be summed without its `allShardsReady` being checked — and takes `dropIndex`/`closeLock` per index. A walk stopped by a drop counts zero; stopped by anything else the gauge keeps its previous value rather than publishing a partial sum.
- `CalculateUnloadedObjectsMetrics` now skips a sidecar that vanished between the directory listing and the read (load or compaction retiring the segment) instead of failing the whole count. Any other read error still surfaces. This one also affects usage reporting.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

