### PR TITLE
test(lsmkv): bound the count of slow ops in TestLSMKV_ReplaceBucket, not the single worst one

### DIFF
--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -148,7 +148,10 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 // on every 50,000th put raised slow puts from 4 to 230 and the worst put from
 // 124ms to 202ms, which is still 0.005% of operations — a share-based limit
 // stays green through that, a count does not.
-const maxSlowOps = 50
+// TEMPORARY, REVERTED IN THE NEXT COMMIT: 0 forces the assertion to fail so CI
+// prints the real counts. A passing package prints nothing without -v, so the
+// error message is the only way to read these numbers off a CI runner.
+const maxSlowOps = 0
 
 type result struct {
 	workerID        int

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -33,21 +33,41 @@ import (
 // every stall delays one operation in each of the other workers
 // (weaviate/0-weaviate-issues#525), and a run flushes tens of times.
 //
-// At 4 workers that puts the limit at 100. Healthy runs reach 30 slow ops per
-// category on a CI runner and 26 on a loaded developer machine, and a 200ms
-// stall on every 50,000th put produces 193 to 236 slow puts. So the usable
-// window is [30, 193]: 100 sits 3.3x above the noise and 1.9x below the
-// regression the gate has to catch.
+// At 4 workers the limit is 100. Measured over 15 healthy and 11 regressed runs
+// alternated on one machine so both arms saw the same background load, where
+// the regression is a 200ms stall inside that lock on every 50,000th put:
 //
-// A count, not a share of all operations. A run performs millions of them and a
-// stall only delays the few in flight, so any share stays vanishingly small no
-// matter how often it happens.
+//	          slow puts   slow gets
+//	healthy      0 - 33      0 - 77
+//	regressed  173 - 218    61 - 107
+//
+// Only the put counts separate: 100 sits 3.0x above the worst healthy run and
+// 1.7x below the weakest regressed one. The get counts overlap, so no limit
+// separates them there. The get arm is not a second detector for a write-side
+// stall; it is the gate for a read-side regression, which this one is not.
+//
+// The margin protecting a green run is therefore 1.3x, not 3.0x: both arms are
+// checked against this same constant and either one failing fails the run, so
+// 100 has to clear 77. Counts recorded before this file started reporting them
+// are not comparable, because the older instrumentation drained per-worker
+// worst-10 heaps and so could not express more than 40 per category.
+//
+// The healthy column tracks how contended the host is, not the code under test:
+// with three competing fsync writers a healthy run reached 283 slow puts. Below
+// 4 workers the signal shrinks faster than the limit does, so the gate gets less
+// sensitive rather than more: at 2 workers the same regression produced 66 to 84
+// slow puts against a limit of 50. Both are reasons to suspect the machine
+// before the code when this goes red, not reasons to move the number.
+//
+// A count, not a share of all operations. A share separates these two arms just
+// as well, but it moves with throughput: a faster machine inflates the
+// denominator and loosens the gate without anyone editing it.
 const maxSlowOpsPerWorker = 25
 
 // maxSingleOpStall fails a run on one catastrophically slow operation. A hang
 // delays too few operations to reach maxSlowOps, so the count gate alone would
 // pass it. The limit sits two orders of magnitude above the latency threshold
-// because the worst healthy operation observed so far is 914ms, and scheduling
+// because the worst healthy operation measured here is 806ms, and scheduling
 // noise on a shared runner must not be able to reach it.
 const maxSingleOpStall = 10 * time.Second
 

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -27,6 +27,30 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
+// maxSlowOpsPerWorker bounds how many puts, and separately how many gets, may
+// exceed the latency threshold in one run. It is a per-worker budget because a
+// put holds the memtable's exclusive lock while it writes the commit log, so
+// every stall delays one operation in each of the other workers
+// (weaviate/0-weaviate-issues#525), and a run flushes tens of times.
+//
+// At 4 workers that puts the limit at 100. Healthy runs reach 30 slow ops per
+// category on a CI runner and 26 on a loaded developer machine, and a 200ms
+// stall on every 50,000th put produces 193 to 236 slow puts. So the usable
+// window is [30, 193]: 100 sits 3.3x above the noise and 1.9x below the
+// regression the gate has to catch.
+//
+// A count, not a share of all operations. A run performs millions of them and a
+// stall only delays the few in flight, so any share stays vanishingly small no
+// matter how often it happens.
+const maxSlowOpsPerWorker = 25
+
+// maxSingleOpStall fails a run on one catastrophically slow operation. A hang
+// delays too few operations to reach maxSlowOps, so the count gate alone would
+// pass it. The limit sits two orders of magnitude above the latency threshold
+// because the worst healthy operation observed so far is 914ms, and scheduling
+// noise on a shared runner must not be able to reach it.
+const maxSingleOpStall = 10 * time.Second
+
 func TestLSMKV_ReplaceBucket(t *testing.T) {
 	putThreshold := 100 * time.Millisecond
 	getThreshold := 100 * time.Millisecond
@@ -44,6 +68,7 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 		workers = n
 		logger.Infof("reducing workers to %d", workers)
 	}
+	maxSlowOps := maxSlowOpsPerWorker * workers
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", logger, 1)
 	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
@@ -79,15 +104,15 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 
 	totalIngested := 0
 	totalSpotChecks := 0
-	slowPuts := 0
-	slowGets := 0
+	totalSlowPuts := 0
+	totalSlowGets := 0
 	var worstPutMs, worstGetMs float32
 
 	for _, r := range results {
 		totalIngested += r.ingested
 		totalSpotChecks += r.getSpotChecks
-		slowPuts += r.slowPuts
-		slowGets += r.slowGets
+		totalSlowPuts += r.slowPuts
+		totalSlowGets += r.slowGets
 
 		for r.worstPutQueries.Len() > 0 {
 			if tookMs := r.worstPutQueries.Pop().Dist * 1000; tookMs > worstPutMs {
@@ -102,20 +127,28 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 		}
 	}
 
-	logger.Infof("worst put took %.2fms, worst get took %.2fms", worstPutMs, worstGetMs)
+	// The two lines below are what a future maintainer recalibrates maxSlowOps
+	// from, so they are logged on every run and not only when the gate trips.
+	// test/run.sh passes -v for this package because `go test` throws the test
+	// binary's output away otherwise.
+	logger.Infof("puts: %d of %d outside threshold (%s), limit %d, worst %.2fms",
+		totalSlowPuts, totalIngested, putThreshold, maxSlowOps, worstPutMs)
+	logger.Infof("gets: %d of %d outside threshold (%s), limit %d, worst %.2fms",
+		totalSlowGets, totalSpotChecks, getThreshold, maxSlowOps, worstGetMs)
 
-	if slowPuts > maxSlowOps {
+	if totalSlowPuts > maxSlowOps {
 		t.Errorf("%d puts were outside threshold (%s), limit is %d; %d puts total, worst %.2fms",
-			slowPuts, putThreshold, maxSlowOps, totalIngested, worstPutMs)
-	} else {
-		logger.Infof("%d of %d puts were outside threshold (%s)", slowPuts, totalIngested, putThreshold)
+			totalSlowPuts, putThreshold, maxSlowOps, totalIngested, worstPutMs)
 	}
 
-	if slowGets > maxSlowOps {
+	if totalSlowGets > maxSlowOps {
 		t.Errorf("%d gets were outside threshold (%s), limit is %d; %d gets total, worst %.2fms",
-			slowGets, getThreshold, maxSlowOps, totalSpotChecks, worstGetMs)
-	} else {
-		logger.Infof("%d of %d gets were outside threshold (%s)", slowGets, totalSpotChecks, getThreshold)
+			totalSlowGets, getThreshold, maxSlowOps, totalSpotChecks, worstGetMs)
+	}
+
+	if maxStallMs := float32(maxSingleOpStall.Milliseconds()); worstPutMs > maxStallMs || worstGetMs > maxStallMs {
+		t.Errorf("worst put took %.2fms and worst get took %.2fms, a single operation may not exceed %s",
+			worstPutMs, worstGetMs, maxSingleOpStall)
 	}
 
 	// This a sanity check to make sure the test actually ran. The expected total
@@ -132,23 +165,6 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 		logger.Infof("performed %d spot checks", totalSpotChecks)
 	}
 }
-
-// maxSlowOps is how many puts, and separately how many gets, may exceed the
-// latency threshold in one run. It is not zero because a put holds the
-// memtable's exclusive lock while it writes the commit log, so whenever that
-// buffered write reaches the disk, every concurrent put and get on the bucket
-// waits for it (weaviate/0-weaviate-issues#525). A run flushes on the order of
-// tens of times, so a handful of operations land above the threshold even when
-// the bucket is healthy: at most 8 puts and 4 gets on a CI runner, and at most
-// 9 puts and 20 gets on a developer machine with other work competing.
-//
-// A count rather than a share of all operations. A run performs millions of
-// operations, and a stall only delays the handful in flight at that moment, so
-// any share is vanishing however often it happens. Holding the lock for 200ms
-// on every 50,000th put raised slow puts from 4 to 230 and the worst put from
-// 124ms to 202ms, which is still 0.005% of operations — a share-based limit
-// stays green through that, a count does not.
-const maxSlowOps = 50
 
 type result struct {
 	workerID        int
@@ -173,12 +189,35 @@ func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int,
 	totalAsserted := 0
 	slowPuts := 0
 	slowGets := 0
+
+	// deferred so that a worker returning early still reports what it measured.
+	// The caller sums every entry of results and calls Len() on the two queues,
+	// which panics on the zero value. Registered after wg.Done() so it runs
+	// before it.
+	defer func() {
+		results[workerID] = result{
+			workerID:        workerID,
+			worstPutQueries: worstPutQueries,
+			worstGetQueries: worstGetQueries,
+			ingested:        i,
+			getSpotChecks:   totalAsserted,
+			slowPuts:        slowPuts,
+			slowGets:        slowGets,
+		}
+
+		logger.WithField("imported", i).WithField("get_spot_checks", totalAsserted).Infof("completed worker")
+	}()
+
 	for {
 		if ctx.Err() != nil {
 			break
 		}
 		before := time.Now()
-		bucket.Put([]byte(fmt.Sprintf("worker-%d-key-%d", workerID, i)), []byte(fmt.Sprintf("value-%d", i)))
+		if err := bucket.Put([]byte(fmt.Sprintf("worker-%d-key-%d", workerID, i)),
+			[]byte(fmt.Sprintf("value-%d", i))); err != nil {
+			t.Errorf("failed to put key-%d: %s", i, err)
+			return
+		}
 		took := time.Since(before)
 		trackWorstQuery(worstPutQueries, i, took, trackWorstQueries)
 		if took > putThreshold {
@@ -220,18 +259,6 @@ func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int,
 
 		i++
 	}
-
-	results[workerID] = result{
-		workerID:        workerID,
-		worstPutQueries: worstPutQueries,
-		worstGetQueries: worstGetQueries,
-		ingested:        i,
-		getSpotChecks:   totalAsserted,
-		slowPuts:        slowPuts,
-		slowGets:        slowGets,
-	}
-
-	logger.WithField("imported", i).WithField("get_spot_checks", totalAsserted).Infof("completed worker")
 }
 
 func trackWorstQuery(heap *priorityqueue.Queue[float32], i int, took time.Duration, trackWorstQueries int) {

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -77,41 +77,45 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 	wg.Wait()
 	logger.WithField("concurrency", workers).Infof("%d workers completed", workers)
 
-	var putOutsideThreshold []float32
-	var getOutsideThreshold []float32
-
 	totalIngested := 0
 	totalSpotChecks := 0
+	slowPuts := 0
+	slowGets := 0
+	var worstPutMs, worstGetMs float32
 
 	for _, r := range results {
 		totalIngested += r.ingested
 		totalSpotChecks += r.getSpotChecks
+		slowPuts += r.slowPuts
+		slowGets += r.slowGets
 
 		for r.worstPutQueries.Len() > 0 {
-			tookMs := r.worstPutQueries.Pop().Dist * 1000
-			if tookMs > float32(putThreshold.Milliseconds()) {
-				putOutsideThreshold = append(putOutsideThreshold, tookMs)
+			if tookMs := r.worstPutQueries.Pop().Dist * 1000; tookMs > worstPutMs {
+				worstPutMs = tookMs
 			}
 		}
 
 		for r.worstGetQueries.Len() > 0 {
-			tookMs := r.worstGetQueries.Pop().Dist * 1000
-			if tookMs > float32(getThreshold.Milliseconds()) {
-				getOutsideThreshold = append(getOutsideThreshold, tookMs)
+			if tookMs := r.worstGetQueries.Pop().Dist * 1000; tookMs > worstGetMs {
+				worstGetMs = tookMs
 			}
 		}
 	}
 
-	if len(putOutsideThreshold) > 0 {
-		t.Errorf("%d put queries outside threshold (%s): %v", len(putOutsideThreshold), putThreshold, putOutsideThreshold)
+	logger.Infof("worst put took %.2fms, worst get took %.2fms", worstPutMs, worstGetMs)
+
+	if slowPuts > maxSlowOps {
+		t.Errorf("%d puts were outside threshold (%s), limit is %d; %d puts total, worst %.2fms",
+			slowPuts, putThreshold, maxSlowOps, totalIngested, worstPutMs)
 	} else {
-		logger.Infof("all put queries were within threshold (%s)", putThreshold)
+		logger.Infof("%d of %d puts were outside threshold (%s)", slowPuts, totalIngested, putThreshold)
 	}
 
-	if len(getOutsideThreshold) > 0 {
-		t.Errorf("%d get queries outside threshold (%s) : %v", len(getOutsideThreshold), getThreshold, getOutsideThreshold)
+	if slowGets > maxSlowOps {
+		t.Errorf("%d gets were outside threshold (%s), limit is %d; %d gets total, worst %.2fms",
+			slowGets, getThreshold, maxSlowOps, totalSpotChecks, worstGetMs)
 	} else {
-		logger.Infof("all get queries were within threshold (%s)", getThreshold)
+		logger.Infof("%d of %d gets were outside threshold (%s)", slowGets, totalSpotChecks, getThreshold)
 	}
 
 	// This a sanity check to make sure the test actually ran. The expected total
@@ -129,12 +133,31 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 	}
 }
 
+// maxSlowOps is how many puts, and separately how many gets, may exceed the
+// latency threshold in one run. It is not zero because a put holds the
+// memtable's exclusive lock while it writes the commit log, so whenever that
+// buffered write reaches the disk, every concurrent put and get on the bucket
+// waits for it (weaviate/0-weaviate-issues#525). A run flushes on the order of
+// tens of times, so a handful of operations land above the threshold even when
+// the bucket is healthy: measured on stable/v1.38, at most 9 puts and 20 gets
+// across four runs.
+//
+// A count rather than a share of all operations. A run performs millions of
+// operations, and a stall only delays the handful in flight at that moment, so
+// any share is vanishing however often it happens. Holding the lock for 200ms
+// on every 50,000th put raised slow puts from 4 to 230 and the worst put from
+// 124ms to 202ms, which is still 0.005% of operations — a share-based limit
+// stays green through that, a count does not.
+const maxSlowOps = 50
+
 type result struct {
 	workerID        int
 	worstPutQueries *priorityqueue.Queue[float32]
 	worstGetQueries *priorityqueue.Queue[float32]
 	ingested        int
 	getSpotChecks   int
+	slowPuts        int
+	slowGets        int
 }
 
 func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int, bucket *lsmkv.Bucket, logger logrus.FieldLogger,
@@ -148,6 +171,8 @@ func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int,
 
 	i := 0
 	totalAsserted := 0
+	slowPuts := 0
+	slowGets := 0
 	for {
 		if ctx.Err() != nil {
 			break
@@ -157,7 +182,8 @@ func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int,
 		took := time.Since(before)
 		trackWorstQuery(worstPutQueries, i, took, trackWorstQueries)
 		if took > putThreshold {
-			logger.Warnf("put took too long: %s", time.Since(before))
+			slowPuts++
+			logger.Warnf("put took too long: %s", took)
 		}
 
 		// perform spot checks every 10000 iterations
@@ -173,7 +199,8 @@ func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int,
 				}
 				took := time.Since(before)
 				if took > getThreshold {
-					logger.Warnf("get took too long: %s", time.Since(before))
+					slowGets++
+					logger.Warnf("get took too long: %s", took)
 				}
 
 				if string(val) != fmt.Sprintf("value-%d", j) {
@@ -200,6 +227,8 @@ func worker(ctx context.Context, t *testing.T, wg *sync.WaitGroup, workerID int,
 		worstGetQueries: worstGetQueries,
 		ingested:        i,
 		getSpotChecks:   totalAsserted,
+		slowPuts:        slowPuts,
+		slowGets:        slowGets,
 	}
 
 	logger.WithField("imported", i).WithField("get_spot_checks", totalAsserted).Infof("completed worker")

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -139,8 +139,8 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 // buffered write reaches the disk, every concurrent put and get on the bucket
 // waits for it (weaviate/0-weaviate-issues#525). A run flushes on the order of
 // tens of times, so a handful of operations land above the threshold even when
-// the bucket is healthy: measured on stable/v1.38, at most 9 puts and 20 gets
-// across four runs.
+// the bucket is healthy: at most 8 puts and 4 gets on a CI runner, and at most
+// 9 puts and 20 gets on a developer machine with other work competing.
 //
 // A count rather than a share of all operations. A run performs millions of
 // operations, and a stall only delays the handful in flight at that moment, so
@@ -148,10 +148,7 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 // on every 50,000th put raised slow puts from 4 to 230 and the worst put from
 // 124ms to 202ms, which is still 0.005% of operations — a share-based limit
 // stays green through that, a count does not.
-// TEMPORARY, REVERTED IN THE NEXT COMMIT: 0 forces the assertion to fail so CI
-// prints the real counts. A passing package prints nothing without -v, so the
-// error message is the only way to read these numbers off a CI runner.
-const maxSlowOps = 0
+const maxSlowOps = 50
 
 type result struct {
 	workerID        int

--- a/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
@@ -228,14 +228,35 @@ func worker(ctx context.Context, t *testing.T, mode *mode, wg *sync.WaitGroup, w
 
 	i := 0
 	totalAsserted := 0
+
+	// deferred so that a worker returning early still reports what it measured.
+	// The caller sums every entry of results and calls Len() on the two queues,
+	// which panics on the zero value. Registered after wg.Done() so it runs
+	// before it.
+	defer func() {
+		results[workerID] = result{
+			workerID:        workerID,
+			worstPutQueries: worstPutQueries,
+			worstGetQueries: worstGetQueries,
+			ingested:        i,
+			getSpotChecks:   totalAsserted,
+		}
+
+		logger.WithField("imported", i).WithField("get_spot_checks", totalAsserted).Infof("completed worker")
+	}()
+
 	for ctx.Err() == nil {
 		if mode.isWrite() {
 			before := time.Now()
-			bucket.Put([]byte(fmt.Sprintf("worker-%d-key-%d", workerID, i)), []byte(fmt.Sprintf("value-%d", i)))
+			if err := bucket.Put([]byte(fmt.Sprintf("worker-%d-key-%d", workerID, i)),
+				[]byte(fmt.Sprintf("value-%d", i))); err != nil {
+				t.Errorf("failed to put key-%d: %s", i, err)
+				return
+			}
 			took := time.Since(before)
 			trackWorstQuery(worstPutQueries, i, took, trackWorstQueries)
 			if took > putThreshold {
-				logger.Warnf("put took too long: %s", time.Since(before))
+				logger.Warnf("put took too long: %s", took)
 			}
 
 			if i%100_000 == 0 {
@@ -261,7 +282,7 @@ func worker(ctx context.Context, t *testing.T, mode *mode, wg *sync.WaitGroup, w
 			}
 			took := time.Since(before)
 			if took > getThreshold {
-				logger.Warnf("get took too long: %s", time.Since(before))
+				logger.Warnf("get took too long: %s", took)
 			}
 
 			if string(val) != fmt.Sprintf("value-%d", j) {
@@ -275,16 +296,6 @@ func worker(ctx context.Context, t *testing.T, mode *mode, wg *sync.WaitGroup, w
 		}
 
 	}
-
-	results[workerID] = result{
-		workerID:        workerID,
-		worstPutQueries: worstPutQueries,
-		worstGetQueries: worstGetQueries,
-		ingested:        i,
-		getSpotChecks:   totalAsserted,
-	}
-
-	logger.WithField("imported", i).WithField("get_spot_checks", totalAsserted).Infof("completed worker")
 }
 
 func trackWorstQuery(heap *priorityqueue.Queue[float32], i int, took time.Duration, trackWorstQueries int) {

--- a/test/run.sh
+++ b/test/run.sh
@@ -483,9 +483,13 @@ function run_integration_tests() {
 
 function run_acceptance_lsmkv() {
     echo "This test runs without the race detector because it asserts performance"
+    # -v because these tests report the latency distribution they measured, and
+    # `go test` throws a passing binary's output away when it is given a package
+    # path. Without it the numbers the thresholds are calibrated from are only
+    # ever visible on a red run.
     cd 'test/acceptance_lsmkv'
     for pkg in $(go list ./...); do
-      if ! go test -timeout=15m -count 1 "$pkg"; then
+      if ! go test -v -timeout=15m -count 1 "$pkg"; then
         echo "Test for $pkg failed" >&2
         return 1
       fi


### PR DESCRIPTION
SuperClaude here.

> **Base branch: `stable/v1.38`** — this PR does **not** target `main`.

`TestLSMKV_ReplaceBucket` asserts that the single worst tracked operation stays under 100ms. That assertion goes red on healthy trees: across 173 `acceptance large (lsmkv)` jobs (2026-07-15 to 2026-08-11, every job log scanned) **16.9% of attempts failed** (33/195) and **6.4% of jobs went red** (11/173). The `retry_max_attempts=2` hid roughly as many failures as it let through: **another 11 green jobs concealed a failed first attempt**.

The red is not lying about the system. A put holds the memtable's exclusive lock while it writes the commit log, so whenever that buffered write reaches the disk, every concurrent put and get on the bucket waits for it. A 60s run flushes on the order of tens of times, so a handful of operations land above 100ms on a perfectly healthy bucket. That defect is filed separately as weaviate/etienne-claude-issues#231 and is **not** fixed here. This PR only stops the test lying in both directions.

The 11 red jobs span **8 branches, none of whose diffs touch a single lsmkv file**, and 3 of them are pushes to `stable/v1.38` itself. So the failures are not tracking anything the author of the branch did.

## What changes

1. **Count every operation that exceeds the threshold**, instead of only the ones that happen to be among the 40 tracked worst, and fail when more than `25 × workers` puts, or that many gets, exceed it. On the 4-core runner that is **100** per category.
2. **Fail on a single operation over 10s.** Replacing a worst-op bound with a count would otherwise let a hard hang through: one stall delays too few operations to reach the count limit. 10s is two orders of magnitude above the 100ms threshold and an order of magnitude above the slowest healthy operation measured for this PR, 806ms on a deliberately starved host.
3. **Report the measured distribution on every run, including green ones.** See "Making the numbers visible" below.
4. Three measurement defects fixed, listed under "Defects fixed along the way".

## Why not a share of operations, which is the obvious fix

The first version of this change allowed a small *share* of operations to exceed the threshold, gated at 0.1%. It was rejected. The measured reason is narrower than the one given at the time, so here it is stated properly.

A deliberate regression was injected at the same lock, a 200ms sleep inside the critical section on every 50,000th put. Both arms alternated on one machine so they saw the same background load:

| | healthy (15 runs) | regressed (11 runs) |
|---|---|---|
| puts in the run | 3.2M to 4.7M | 2.9M to 3.8M |
| puts >100ms | 0 to 33 | **173 to 218** |
| the same, as a share | 0% to 0.0010% | **0.0054% to 0.0070%** |
| 0.1% share gate | pass | **pass** |
| count gate in this PR | pass | **fail, all 11** |

**0.1% is far too loose.** At these volumes it allows roughly 3,600 slow puts per run, and the worst regressed run produced 218. It sits 14x above the highest share the regression ever reached, 0.0070%.

**But the share formulation is not itself blind, which is what the earlier version of this section claimed.** Run-to-run put volume only varies about 1.5x, so share and count separate the two arms by the same 5.2x. A share gate set near 0.003% would go red on this regression.

The count is still the better metric, for a duller reason than "structurally blind": it does not move with throughput. A faster machine inflates the denominator and quietly loosens a share gate, and a raw count can be compared against the number in the log without arithmetic.

## The threshold, and how it was calibrated

The budget is **25 slow ops per worker per category**, which is 100 on the 4-core runner. It is expressed per worker because each stall parks one in-flight operation in every *other* worker, so the count scales with the worker count. That keeps the limit moving in the right direction if `DB-ubuntu-24.04-4-cores` is ever repointed at a machine with a different core count. It does *not* hold the sensitivity fixed, which an earlier version of this section claimed: see "Fewer than 4 cores" below for what was measured.

**A note on the numbers below.** Everything in this section was re-measured for this description. The earlier version of it quoted a healthy floor of **30 slow gets** taken from a CI job. That number could not be right: it came from the old instrumentation, which drained the per-worker worst-10 heaps and so could not report more than 10 × 4 = **40** per category. It was a lower bound presented as a measurement. Any count recorded before this branch started reporting the real totals should be read the same way.

**The measurement.** 4 workers, no race detector, `GOMAXPROCS=4`, `t.TempDir()`, arms alternated one after the other on the same machine so both saw the same background load. 15 healthy runs and 11 regressed, where the regression is the 200ms stall on every 50,000th put:

| | slow puts | slow gets | worst single op | verdict |
|---|---|---|---|---|
| healthy, 15 runs | 0 to 33 | 0 to 77 | 45 to 224ms | 15 PASS |
| regressed, 11 runs | **173 to 218** | 61 to 107 | 213 to 325ms | **11 FAIL** |

**Only the put counts separate.** 100 sits **3.0x** above the worst healthy run and **1.7x** below the weakest regressed one. The get counts overlap outright: healthy reaches 77 and the regression starts at 61, so no limit on that axis separates the two. That answers a question the earlier text left open, which is what the get arm is for. It is not a second detector for a write-side stall. It is the gate for a read-side regression, which this one is not.

**The margin that protects a green run is 1.3x, not 3.0x.** Both arms are checked against the same constant and either one failing fails the run, so the number 100 has to clear is 77, the worst healthy count across both categories. The uncensored instrument reporting 77 is also the direct evidence that the old floor was censored: the old one could not have printed it.

**So is 100 still the right constant?** On the evidence above, yes, with a weakness worth stating rather than smoothing over. The put arm is what catches the regression and it has a real margin on both sides. The get arm contributes no detection and 1.3x of headroom, so it is the arm a flake will come from. Splitting the two limits would be the obvious follow-up, and it should be argued from a distribution rather than from this one machine.

### What this gate does not catch

The regression it was validated against is deliberately blatant. Weakening it, same machine and setup:

| stall rate | runs | slow puts | verdict |
|---|---|---|---|
| 1 per 50,000 puts | 11 | 173 to 218 | **FAIL** |
| 1 per 75,000 puts | 3 | 135 to 150 | **FAIL** |
| 1 per 125,000 puts | 3 | 78 to 92 | PASS |
| 1 per 350,000 puts | 2 | 27 to 31 | PASS |

The boundary sits between 1-in-75,000 and 1-in-125,000. Below that the gate is blind, and at 1-in-350,000 it is not a threshold problem at all: 27 to 31 slow puts falls inside the healthy range of 0 to 33, so the regression and healthy noise are the same number and no limit separates them.

That is a deliberate trade rather than an oversight. A gate has to be flake-free before it can be anything else, and this one was going red on branches that never touched lsmkv. The tables above are the evidence a future tightening should be argued against, so a sharper gate can be proposed from them rather than re-derived.

### Two conditions that break the separation

Both are properties of the machine, not of the code under test, and both are worth knowing before reading a red run as a regression.

**A contended host.** Healthy counts track how starved the machine is. Under 12 CPU spinners a healthy run reached 92 slow puts and 178 slow gets; adding three continuous fsync writers on the same disk took healthy runs to 283 and 301 slow puts. Those are above the limit and above the regressed range. The gate assumes a runner that is not itself I/O-starved.

**Fewer than 4 cores.** The limit scales with the worker count, but the signal shrinks faster than the limit does, so a smaller machine gets a *less* sensitive gate rather than a tighter one. At `GOMAXPROCS=2` the limit is 50 and the same 1-in-50,000 regression produced only 66 to 84 slow puts, clearing it by 1.3x to 1.7x instead of the 1.7x to 2.2x seen at 4 workers. One healthy run in that set produced 94 slow gets and went red on its own.

If this constant needs adjusting more than once, the metric is wrong rather than the threshold, and that should be treated as a signal to revisit rather than to keep nudging the number.

## Making the numbers visible

`test/run.sh` invokes this package **by import path**, and in package-list mode `go test` discards a passing test binary's stdout *and* stderr. On a green run the job log contained only the `ok` line: 64 bytes. `t.Log` and `fmt.Printf` are suppressed identically, so neither is a workaround.

That is why one commit on this branch set the limit to `0` to force a failure, read the real numbers out of CI, and reverted. A single forced failure is also all the earlier calibration had to work with, which is how a censored count ended up standing in for a distribution.

**`test/run.sh` now passes `-v` for this package.** Verified by running the real entry point:

```
$ ./test/run.sh --acceptance-lsmkv        # before: 64 bytes, exit 0
ok  	github.com/weaviate/weaviate/test/acceptance_lsmkv	60.501s

$ ./test/run.sh --acceptance-lsmkv        # after: 51,565 bytes, exit 0
...
level=info msg="puts: 0 of 4230883 outside threshold (100ms), limit 100, worst 87.85ms"
level=info msg="gets: 0 of 4539643 outside threshold (100ms), limit 100, worst 78.49ms"
level=info msg="ingested 4230883 entries"
level=info msg="performed 4539643 spot checks"
--- PASS: TestLSMKV_ReplaceBucket (60.48s)
```

The counts are logged before the assertions rather than inside them, so they appear on green and red runs alike, and they carry the limit alongside the observation so the margin is readable without opening the source. Total added output is about 50KB per run.

## Defects fixed along the way

- **`bucket.Put`'s error was discarded on the line whose latency was being measured.** A Put that started failing fast read as a *fast* Put: `slowPuts` stayed 0, `i++` was unconditional so `totalIngested` still passed its sanity check, and the only thing that noticed was the value comparison in the spot-check block every 10,000th iteration.
- **A worker returning early left its `results` entry at the zero value**, and the aggregation loop calls `Len()` on the two queues. That is a nil dereference. The result is now written from a `defer`.

  Forcing the early return on `stable/v1.38` and on this branch, same injected `bucket.Get` failure in one worker, no `-v`:

  ```
  # stable/v1.38
  --- FAIL: TestLSMKV_ReplaceBucket (60.46s)
      replace_bucket_acceptance_test.go:174: failed to get key-566: injected read failure
  panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
  ... 18 lines of runtime stack ...

  # this branch
  level=info msg="puts: 1 of 3770003 outside threshold (100ms), limit 100, worst 145.60ms"
  level=info msg="gets: 7 of 4797332 outside threshold (100ms), limit 100, worst 172.84ms"
  level=info msg="ingested 3770003 entries"
  level=info msg="performed 4797332 spot checks"
  --- FAIL: TestLSMKV_ReplaceBucket (60.69s)
      replace_bucket_acceptance_test.go:259: failed to get key-571: injected read failure
  ```

  The `t.Errorf` is **not** lost on the base. Go flushes a test's accumulated output under `--- FAIL` before repanicking, so the real cause prints, one line above the crash. What the panic costs is everything after it: it fires on the first queue in the aggregation loop, before the ingest totals are summed and before any of the four assertions run, so the run reports a segfault and a runtime stack where it should report the measured distribution and which limits were crossed. It also turns a test-harness bug into something that reads like an lsmkv crash.
- **The "took too long" log lines re-measured after the comparison**, so they reported a strictly longer duration than the one actually tested. Now they log the measured value.

## The long-running sibling

`test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go` is a fork of this file with the same old assertion. Nothing in CI runs it (`test/run.sh` excludes it by the `test/acceptance_lsmkv` prefix and no workflow references it).

The three defects above are fixed there too, since they need no calibration. **The count-based gate is deliberately not ported**: a 10-minute run with alternating read/write modes has a completely different operation volume, and picking a limit for it without data would repeat the mistake this PR is correcting.

## Risk

Test-only; no production code is touched.

One capability is traded rather than added: the old gate bounded the worst single operation at 100ms, and that bound is gone. It is partly replaced by the 10s hard-hang guard. Between 100ms and 10s, a single slow operation now passes as long as fewer than 101 operations cross 100ms. That is deliberate, because the worst single operation does not separate the two arms. Across the runs above, healthy peaks at 45 to 224ms and regressed at 213 to 325ms, which overlap; under a contended host a healthy run reached 806ms, higher than any regressed run measured. The value is still logged on every run, so the signal is demoted from assertion to observation rather than lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXUXUbrkRmHCC7bL6jKNz5

— SuperClaude

