### PR TITLE
fix(distributedtask): Manager.Restore must replace, not merge, snapshot state (backport to v1.38)

### DIFF
--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -1001,6 +1001,10 @@ func (m *Manager) Restore(bytes []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// The FSM contract (see Store.Restore) requires discarding all previous
+	// state: merging would resurrect tasks the snapshot's producer deleted,
+	// and this node alone would then refuse applies its peers accept.
+	m.tasks = make(map[string]map[string]*Task, len(s.Tasks))
 	for namespace, tasks := range s.Tasks {
 		for _, task := range tasks {
 			if _, ok := m.tasks[namespace]; !ok {

--- a/cluster/distributedtask/structural_invariants_test.go
+++ b/cluster/distributedtask/structural_invariants_test.go
@@ -148,13 +148,9 @@ func structuralInvariantClockHasWaiter(
 // (b) unrelated namespace, (c) intersection (correctly overwritten —
 // positive control).
 //
-// Supplementary to PR #11416's canonical fix
+// Pins the replace-not-merge fix in Manager.Restore
 // (`m.tasks = make(...)` before populating).
-// weaviate/0-weaviate-issues#245.
 func TestStructuralInvariant_ManagerRestore_ReplacesExistingState(t *testing.T) {
-	t.Skip("KNOWN-RED until PR #11416 lands — Manager.Restore merges instead of " +
-		"replaces. See test docstring + weaviate/0-weaviate-issues#245. Un-skip when " +
-		"#11416 merges and this branch rebases past it.")
 	now := time.Now().Truncate(time.Millisecond)
 
 	nullLogger, _ := logrustest.NewNullLogger()


### PR DESCRIPTION
SuperClaude here.

This is a backport to `stable/v1.38` of a fix that already exists on `main`.

## What breaks for a user

When a node falls behind the rest of the cluster, it catches up by loading a snapshot of the current state from the leader. Loading that snapshot was supposed to throw away whatever the node had before and adopt the leader's state exactly. Instead, it kept its own entries and added the leader's on top.

So any background task the node knew about, but the snapshot did not mention, survived. That includes tasks the leader had already finished and cleaned up.

The stale node does not go on to run that leftover task by itself. A node's task list comes from `Raft.ListDistributedTasks`, which goes through `Raft.Query`, and `Raft.Query` only answers from local state when this node *is* the leader; otherwise it forwards the read to the leader (`cluster/raft_query_endpoints.go`). What happens instead is worse than one node acting alone:

- **The node's state machine diverges from its peers, permanently.** Submitting a task with the same namespace and ID as the leftover one is accepted by every peer and rejected only here, with `task <ns>/<id> is already running with version <n>` (`cluster/distributedtask/manager.go:288`). Nobody notices: the caller only ever sees the leader's answer, and the sole trace is an apply-failure log line and metric on the diverged node. The two state machines can never agree again after that.
- **If that node is ever elected leader, the whole cluster gets the ghost task.** On the leader, `Raft.Query` is served from local state, so every node's scheduler starts working on a task the previous leader had already finished and deleted.

## The fix

`Manager.Restore` now empties the task list before filling it from the snapshot, so the node ends up with exactly what the snapshot contains and nothing else.

## Where the fix comes from

It was written by @antas-marcin on 2026-07-23 in commit [`faf239b86d`](https://github.com/weaviate/weaviate/commit/faf239b86db2cab5f7ea744df2bb02123223089f), which landed on `main` as part of [weaviate/weaviate#12295](https://github.com/weaviate/weaviate/pull/12295) (merged 2026-08-03).

Verified before writing any code:

| Ref | Has the fix |
| --- | --- |
| `origin/main` | ✅ yes |
| `v1.39.0` | ✅ yes |
| `origin/stable/v1.38` | ❌ no |
| `v1.38.9` | ❌ no |

## Why it cannot arrive on its own

Merges flow `stable/v1.37 → stable/v1.38 → main`, one direction only. A fix that landed on `main` never travels back down, so v1.38 would keep the defect indefinitely without a deliberate backport.

## Why this is not a cherry-pick

The original commit `faf239b86d` bundles a lot of unrelated work: it touches 16 files across the drop-vector-index feature, config handling, and acceptance tests. Only the `Manager.Restore` change is relevant here, so this PR ports that hunk alone.

One deliberate difference from `main`: the explanatory comment on `main` cites "records purged on a drop-vector marker introduction" as an example. That purge path does not exist on v1.38, so the example is dropped rather than left pointing at code this branch does not have. The code change itself is identical.

## Test

`cluster/distributedtask/structural_invariants_test.go` already carried `TestStructuralInvariant_ManagerRestore_ReplacesExistingState` on this branch, but skipped, with a note saying it stays red until the fix lands. The fix has now landed here, so the skip is removed. The test is identical to the un-skipped version on `main`.

## Mutation receipt

Proof the test actually pins this defect, run from the committed state:

| Step | Result |
| --- | --- |
| Remove the one-line fix, run the named test | ❌ FAIL — `should not contain "ns-orphan"` ("keeping ns-orphan means the FSM merged instead of replaced") |
| Put the line back | ✅ PASS |
| `git diff --quiet` | ✅ exit 0, tree matches the commit |

The failure names the exact symptom: a task namespace absent from the snapshot survived the restore.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | ✅ exit 0 |
| `go vet ./...` | exit 1, but all 5 findings are pre-existing and in unrelated packages (hnsw asm, byteops, mmap, replica, a db test helper). Zero on `cluster/distributedtask`. |
| `gofumpt -l` / `goimports -l` on touched files | ✅ clean |
| `./tools/linter_go_routines.sh` | ✅ exit 0 |
| `tools/linter_error_groups.sh` | ✅ exit 0 |
| `tools/linter_waitgroups_done.sh` | ✅ exit 0 |
| `go test -race -count 1 ./cluster/distributedtask/...` | ✅ exit 0 |

All three custom linters were run separately, so the two that normally sit behind the first one's fast-fail are genuinely verified.

— SuperClaude

