### PR TITLE
fix(api): declare the reindex cap's 429 in the OpenAPI spec

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5848,6 +5848,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "429": {
+            "description": "The collection is already at its concurrent-reindex cap. Wait for one of the in-flight tasks to finish before submitting another; the message names the collection, how many tasks are in flight, and the cap.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred.",
             "schema": {
@@ -17400,6 +17406,12 @@ func init() {
           },
           "409": {
             "description": "Conflicting reindex task already running.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "429": {
+            "description": "The collection is already at its concurrent-reindex cap. Wait for one of the in-flight tasks to finish before submitting another; the message names the collection, how many tasks are in flight, and the cap.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -1389,9 +1389,14 @@ func reindexCapExceededResponder(principal *models.Principal, collection string,
 }
 
 // reindexCapRefusal returns the 429 refusal when the collection is already at
-// the per-collection cap, or nil when the submit may proceed. Admitting while
-// strictly fewer than the cap are in flight makes the cap itself the maximum
-// number that can run at once.
+// the per-collection cap, or nil when the submit may proceed. It admits at
+// cap-1 tasks in flight and refuses at cap, so a submit it admits brings the
+// count to the cap at most.
+//
+// That bound is per check, not per collection. The submit lock is keyed on
+// (collection, property), so two PUTs on different properties of the same
+// collection can both count in-flight tasks before either has added its own,
+// and both admit at cap-1, leaving cap+1 running.
 func reindexCapRefusal(principal *models.Principal, collection string, tasks []*distributedtask.Task) middleware.Responder {
 	inflight := countStartedTasksForCollection(collection, tasks)
 	if inflight >= maxConcurrentReindexPerCollection {

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -568,8 +568,8 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 			// is unavailable". Returning 503 here misled callers and
 			// monitoring into thinking the cluster was unhealthy rather than
 			// rate-limiting them.
-			if inflight := countStartedTasksForCollection(collection, tasks[db.ReindexNamespace]); inflight >= maxConcurrentReindexPerCollection {
-				return reindexCapExceededResponder(principal, collection, inflight, maxConcurrentReindexPerCollection)
+			if refusal := reindexCapRefusal(principal, collection, tasks[db.ReindexNamespace]); refusal != nil {
+				return refusal
 			}
 		}
 	}
@@ -1371,8 +1371,8 @@ func normalizeSearchableAlgorithm(s string) string {
 // fan-out from a script that loops over hundreds of properties. The
 // original value of 4 was too restrictive: it rejected legitimate batch
 // migrations against modest-sized collections and broke the
-// reindex_concurrent acceptance test which exercises 15 simultaneous
-// non-conflicting submits.
+// reindex_concurrent acceptance test, which keeps 15 non-conflicting tasks
+// in flight at once.
 const maxConcurrentReindexPerCollection = 32
 
 // reindexCapExceededResponder returns the 429 Too Many Requests refusal for
@@ -1386,6 +1386,18 @@ func reindexCapExceededResponder(principal *models.Principal, collection string,
 	return schema.NewSchemaObjectsIndexesUpdateTooManyRequests().WithPayload(errorResponse(principal, fmt.Sprintf(
 		"collection %q already has %d concurrent reindex tasks (max %d); wait for one to finish before submitting another",
 		collection, inflight, capLimit)))
+}
+
+// reindexCapRefusal returns the 429 refusal when the collection is already at
+// the per-collection cap, or nil when the submit may proceed. Admitting while
+// strictly fewer than the cap are in flight makes the cap itself the maximum
+// number that can run at once.
+func reindexCapRefusal(principal *models.Principal, collection string, tasks []*distributedtask.Task) middleware.Responder {
+	inflight := countStartedTasksForCollection(collection, tasks)
+	if inflight >= maxConcurrentReindexPerCollection {
+		return reindexCapExceededResponder(principal, collection, inflight, maxConcurrentReindexPerCollection)
+	}
+	return nil
 }
 
 // countStartedTasksForCollection counts in-flight reindex tasks for a

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -1382,9 +1382,6 @@ const maxConcurrentReindexPerCollection = 32
 // a concurrency limit specific to this caller's collection, not by the
 // cluster being unavailable. Returning 503 made monitoring read a capped
 // collection as an unhealthy cluster.
-//
-// The cap is covered by unit tests only. Nothing in test/ drives a real
-// server to a 429 on this route.
 func reindexCapExceededResponder(principal *models.Principal, collection string, inflight, capLimit int) middleware.Responder {
 	return schema.NewSchemaObjectsIndexesUpdateTooManyRequests().WithPayload(errorResponse(principal, fmt.Sprintf(
 		"collection %q already has %d concurrent reindex tasks (max %d); wait for one to finish before submitting another",

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -1380,9 +1380,13 @@ const maxConcurrentReindexPerCollection = 32
 //
 // The status is intentionally 429 and not 503: the rejection is driven by
 // a concurrency limit specific to this caller's collection, not by the
-// cluster being unavailable. Returning 503 misled monitoring (and the
-// reindex_concurrent acceptance test asserts the cap is reached, not that
-// the service went unhealthy).
+// cluster being unavailable. Returning 503 made monitoring read a capped
+// collection as an unhealthy cluster.
+//
+// TestReindexCapExceededResponder_StatusAndBody is the only guard on this.
+// No acceptance test ever reaches the cap: every submit in
+// reindex_concurrent goes through a helper that requires 202, so a 429
+// there would fail the suite rather than assert the cap.
 func reindexCapExceededResponder(principal *models.Principal, collection string, inflight, capLimit int) middleware.Responder {
 	return schema.NewSchemaObjectsIndexesUpdateTooManyRequests().WithPayload(errorResponse(principal, fmt.Sprintf(
 		"collection %q already has %d concurrent reindex tasks (max %d); wait for one to finish before submitting another",

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -1383,10 +1383,8 @@ const maxConcurrentReindexPerCollection = 32
 // cluster being unavailable. Returning 503 made monitoring read a capped
 // collection as an unhealthy cluster.
 //
-// TestReindexCapExceededResponder_StatusAndBody is the only guard on this.
-// No acceptance test ever reaches the cap: every submit in
-// reindex_concurrent goes through a helper that requires 202, so a 429
-// there would fail the suite rather than assert the cap.
+// The cap is covered by unit tests only. Nothing in test/ drives a real
+// server to a 429 on this route.
 func reindexCapExceededResponder(principal *models.Principal, collection string, inflight, capLimit int) middleware.Responder {
 	return schema.NewSchemaObjectsIndexesUpdateTooManyRequests().WithPayload(errorResponse(principal, fmt.Sprintf(
 		"collection %q already has %d concurrent reindex tasks (max %d); wait for one to finish before submitting another",

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -18,13 +18,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"slices"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
@@ -1377,11 +1375,8 @@ func normalizeSearchableAlgorithm(s string) string {
 // non-conflicting submits.
 const maxConcurrentReindexPerCollection = 32
 
-// reindexCapExceededResponder returns a 429 Too Many Requests response with
-// the standard ErrorResponse body shape. The swagger spec for
-// PUT /v1/schema/{class}/indexes/{prop} does not declare a 429 response —
-// it predates the per-collection cap — so we hand-roll the responder
-// instead of adding to the generated code.
+// reindexCapExceededResponder returns the 429 Too Many Requests refusal for
+// the per-collection cap.
 //
 // The status is intentionally 429 and not 503: the rejection is driven by
 // a concurrency limit specific to this caller's collection, not by the
@@ -1389,17 +1384,9 @@ const maxConcurrentReindexPerCollection = 32
 // reindex_concurrent acceptance test asserts the cap is reached, not that
 // the service went unhealthy).
 func reindexCapExceededResponder(principal *models.Principal, collection string, inflight, capLimit int) middleware.Responder {
-	body := errorResponse(principal, fmt.Sprintf(
+	return schema.NewSchemaObjectsIndexesUpdateTooManyRequests().WithPayload(errorResponse(principal, fmt.Sprintf(
 		"collection %q already has %d concurrent reindex tasks (max %d); wait for one to finish before submitting another",
-		collection, inflight, capLimit))
-	return middleware.ResponderFunc(func(w http.ResponseWriter, producer runtime.Producer) {
-		w.WriteHeader(http.StatusTooManyRequests)
-		if err := producer.Produce(w, body); err != nil {
-			// Match the generated swagger responders' behaviour for body
-			// write failures; the recovery middleware logs and returns 500.
-			panic(err)
-		}
-	})
+		collection, inflight, capLimit)))
 }
 
 // countStartedTasksForCollection counts in-flight reindex tasks for a

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -1173,48 +1173,65 @@ func TestCountStartedTasksForCollection_FiltersByStatusAndCollection(t *testing.
 	}
 }
 
-// Pins the boundary of the cap comparison: a submit is rejected only when
-// the inflight count is greater than or equal to the cap. With the current
-// `inflight >= max` predicate, this means:
-//   - inflight == max-1 → admit (caller becomes the max-th simultaneously
-//     running task)
-//   - inflight == max → reject (admitting would push us above the cap)
+// Pins the boundary of the cap by calling the production decision itself:
+// a submit is admitted while strictly fewer than the cap are in flight and
+// refused from the cap upward, so the number that can run at once equals the
+// cap constant (not cap-1 and not cap+1).
 //
-// If the comparison were ever flipped to `inflight > max`, the cap would
-// silently grow by one (max+1 simultaneous). If it were `inflight+1 >= max`
-// the cap would silently shrink to max-1. Both have caused outages of this
-// kind before — the test pins the exact arithmetic so a future refactor
-// can't drift the semantics.
-func TestConcurrentReindexCap_RejectionBoundary(t *testing.T) {
-	mkStarted := func(id, coll string) *distributedtask.Task {
-		return buildTask(t, id, distributedtask.TaskStatusStarted,
-			db.ReindexTaskPayload{
-				MigrationType: db.ReindexTypeChangeTokenization,
-				Collection:    coll,
-				Properties:    []string{"p_" + id},
-			}, nil)
-	}
-
+// The assertions deliberately never restate `inflight >= cap`. A test that
+// recomputes the comparison in its own body passes whichever way the
+// production one points, which is exactly how an off-by-one on this cap sat
+// unguarded here before.
+func TestReindexCapRefusal_Boundary(t *testing.T) {
 	const collection = "C"
-	cap := maxConcurrentReindexPerCollection
+	capLimit := maxConcurrentReindexPerCollection
 
-	// At the cap minus one, a submit must be admitted.
-	tasksAtCapMinusOne := make([]*distributedtask.Task, 0, cap-1)
-	for i := 0; i < cap-1; i++ {
-		tasksAtCapMinusOne = append(tasksAtCapMinusOne,
-			mkStarted(fmtTaskID(i), collection))
+	startedTasks := func(n int) []*distributedtask.Task {
+		tasks := make([]*distributedtask.Task, 0, n)
+		for i := 0; i < n; i++ {
+			id := fmtTaskID(i)
+			tasks = append(tasks, buildTask(t, id, distributedtask.TaskStatusStarted,
+				db.ReindexTaskPayload{
+					MigrationType: db.ReindexTypeChangeTokenization,
+					Collection:    collection,
+					Properties:    []string{"p_" + id},
+				}, nil))
+		}
+		return tasks
 	}
-	got := countStartedTasksForCollection(collection, tasksAtCapMinusOne)
-	require.Equal(t, cap-1, got)
-	require.False(t, got >= cap,
-		"with %d inflight (cap=%d) the submit must be admitted", got, cap)
 
-	// At exactly the cap, a submit must be rejected.
-	tasksAtCap := append(tasksAtCapMinusOne, mkStarted(fmtTaskID(cap-1), collection))
-	got = countStartedTasksForCollection(collection, tasksAtCap)
-	require.Equal(t, cap, got)
-	require.True(t, got >= cap,
-		"with %d inflight (cap=%d) the submit must be rejected", got, cap)
+	cases := []struct {
+		name     string
+		inflight int
+		refuse   bool
+	}{
+		{name: "nothing in flight", inflight: 0, refuse: false},
+		{name: "one below the cap", inflight: capLimit - 1, refuse: false},
+		{name: "exactly at the cap", inflight: capLimit, refuse: true},
+		{name: "above the cap", inflight: capLimit + 1, refuse: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tasks := startedTasks(tc.inflight)
+			require.Equal(t, tc.inflight, countStartedTasksForCollection(collection, tasks),
+				"fixture must put the intended number of tasks in flight")
+
+			refusal := reindexCapRefusal(nil, collection, tasks)
+			if !tc.refuse {
+				require.Nil(t, refusal,
+					"with %d in flight (cap %d) the submit must be admitted", tc.inflight, capLimit)
+				return
+			}
+			require.NotNil(t, refusal,
+				"with %d in flight (cap %d) the submit must be refused", tc.inflight, capLimit)
+
+			rec := httptest.NewRecorder()
+			refusal.WriteResponse(rec, runtime.JSONProducer())
+			require.Equal(t, http.StatusTooManyRequests, rec.Code,
+				"the refusal must be the 429, not some other responder")
+		})
+	}
 }
 
 func fmtTaskID(i int) string {

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -28,6 +28,7 @@ package rest
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -37,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db"
+	clientschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -1244,6 +1246,39 @@ func TestReindexCapExceededResponder_StatusAndBody(t *testing.T) {
 		"error message must name the offending collection")
 	assert.Contains(t, body.Error[0].Message, "32",
 		"error message must surface the cap and inflight count for operator triage")
+}
+
+// stubClientResponse is the generated reader's view of an HTTP response.
+type stubClientResponse struct {
+	code int
+	body io.Reader
+}
+
+func (s stubClientResponse) Code() int                  { return s.code }
+func (s stubClientResponse) Message() string            { return http.StatusText(s.code) }
+func (s stubClientResponse) GetHeader(string) string    { return "" }
+func (s stubClientResponse) GetHeaders(string) []string { return nil }
+func (s stubClientResponse) Body() io.ReadCloser        { return io.NopCloser(s.body) }
+
+// The cap's 429 body carries the only text that tells a caller what to do
+// about the refusal. A status the spec does not declare lands in the reader's
+// default arm, which keeps the code and throws the body away. Pins that the
+// generated client reads the refusal as a typed 429 with its payload intact.
+func TestGeneratedClientParsesTheCapRefusal(t *testing.T) {
+	rec := httptest.NewRecorder()
+	reindexCapExceededResponder(&models.Principal{Username: "u1"}, "MyCollection", 32, 32).
+		WriteResponse(rec, runtime.JSONProducer())
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+
+	reader := &clientschema.SchemaObjectsIndexesUpdateReader{}
+	_, err := reader.ReadResponse(stubClientResponse{code: rec.Code, body: rec.Body}, runtime.JSONConsumer())
+
+	var capped *clientschema.SchemaObjectsIndexesUpdateTooManyRequests
+	require.ErrorAs(t, err, &capped,
+		"the client must recognize 429, not fall through to the default arm")
+	require.Len(t, capped.Payload.Error, 1)
+	require.Contains(t, capped.Payload.Error[0].Message, "wait for one to finish",
+		"the actionable half of the refusal has to survive the round trip")
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/handlers/rest/operations/schema/schema_objects_indexes_update_responses.go
+++ b/adapters/handlers/rest/operations/schema/schema_objects_indexes_update_responses.go
@@ -274,6 +274,51 @@ func (o *SchemaObjectsIndexesUpdateConflict) WriteResponse(rw http.ResponseWrite
 	}
 }
 
+// SchemaObjectsIndexesUpdateTooManyRequestsCode is the HTTP code returned for type SchemaObjectsIndexesUpdateTooManyRequests
+const SchemaObjectsIndexesUpdateTooManyRequestsCode int = 429
+
+/*
+SchemaObjectsIndexesUpdateTooManyRequests The collection is already at its concurrent-reindex cap. Wait for one of the in-flight tasks to finish before submitting another; the message names the collection, how many tasks are in flight, and the cap.
+
+swagger:response schemaObjectsIndexesUpdateTooManyRequests
+*/
+type SchemaObjectsIndexesUpdateTooManyRequests struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewSchemaObjectsIndexesUpdateTooManyRequests creates SchemaObjectsIndexesUpdateTooManyRequests with default headers values
+func NewSchemaObjectsIndexesUpdateTooManyRequests() *SchemaObjectsIndexesUpdateTooManyRequests {
+
+	return &SchemaObjectsIndexesUpdateTooManyRequests{}
+}
+
+// WithPayload adds the payload to the schema objects indexes update too many requests response
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) WithPayload(payload *models.ErrorResponse) *SchemaObjectsIndexesUpdateTooManyRequests {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the schema objects indexes update too many requests response
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(429)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // SchemaObjectsIndexesUpdateInternalServerErrorCode is the HTTP code returned for type SchemaObjectsIndexesUpdateInternalServerError
 const SchemaObjectsIndexesUpdateInternalServerErrorCode int = 500
 

--- a/client/schema/schema_objects_indexes_update_responses.go
+++ b/client/schema/schema_objects_indexes_update_responses.go
@@ -70,6 +70,12 @@ func (o *SchemaObjectsIndexesUpdateReader) ReadResponse(response runtime.ClientR
 			return nil, err
 		}
 		return nil, result
+	case 429:
+		result := NewSchemaObjectsIndexesUpdateTooManyRequests()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewSchemaObjectsIndexesUpdateInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -472,6 +478,74 @@ func (o *SchemaObjectsIndexesUpdateConflict) GetPayload() *models.ErrorResponse 
 }
 
 func (o *SchemaObjectsIndexesUpdateConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewSchemaObjectsIndexesUpdateTooManyRequests creates a SchemaObjectsIndexesUpdateTooManyRequests with default headers values
+func NewSchemaObjectsIndexesUpdateTooManyRequests() *SchemaObjectsIndexesUpdateTooManyRequests {
+	return &SchemaObjectsIndexesUpdateTooManyRequests{}
+}
+
+/*
+SchemaObjectsIndexesUpdateTooManyRequests describes a response with status code 429, with default header values.
+
+The collection is already at its concurrent-reindex cap. Wait for one of the in-flight tasks to finish before submitting another; the message names the collection, how many tasks are in flight, and the cap.
+*/
+type SchemaObjectsIndexesUpdateTooManyRequests struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this schema objects indexes update too many requests response has a 2xx status code
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this schema objects indexes update too many requests response has a 3xx status code
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this schema objects indexes update too many requests response has a 4xx status code
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this schema objects indexes update too many requests response has a 5xx status code
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this schema objects indexes update too many requests response a status code equal to that given
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) IsCode(code int) bool {
+	return code == 429
+}
+
+// Code gets the status code for the schema objects indexes update too many requests response
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) Code() int {
+	return 429
+}
+
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) Error() string {
+	return fmt.Sprintf("[PUT /schema/{className}/indexes/{propertyName}][%d] schemaObjectsIndexesUpdateTooManyRequests  %+v", 429, o.Payload)
+}
+
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) String() string {
+	return fmt.Sprintf("[PUT /schema/{className}/indexes/{propertyName}][%d] schemaObjectsIndexesUpdateTooManyRequests  %+v", 429, o.Payload)
+}
+
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *SchemaObjectsIndexesUpdateTooManyRequests) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -8943,6 +8943,12 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "429": {
+            "description": "The collection is already at its concurrent-reindex cap. Wait for one of the in-flight tasks to finish before submitting another; the message names the collection, how many tasks are in flight, and the cap.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred.",
             "schema": {


### PR DESCRIPTION
SuperClaude here.

Extracted from [weaviate/weaviate#12582](https://github.com/weaviate/weaviate/issues/12582), which is too large for GitHub to render a diff for. This piece is a shipped API defect on `stable/v1.38` that has nothing to do with backups or reindexing internals, so it is reviewable on its own.

## What a caller sees today

`PUT /v1/schema/{className}/indexes/{propertyName}` refuses a submit with **429 Too Many Requests** once a collection is already at its concurrent-reindex cap. The refusal body carries the only text that tells the caller what to do:

```
collection "MyCollection" already has 32 concurrent reindex tasks (max 32);
wait for one to finish before submitting another
```

A caller using any generated client gets the status code and an empty body:

```
response status code does not match any response statuses defined for this
endpoint in the swagger spec (status 429): {}
```

## Why

The spec never declared 429 for that operation. `openapi-specs/schema.json` lists `202, 400, 401, 403, 404, 409, 500, 503` and nothing else. go-swagger builds the client's `ReadResponse` as a switch over exactly the declared statuses, so an undeclared 429 falls into the `default:` arm, which returns a generic `runtime.APIError` carrying the code and discarding the body. The server side knew this and worked around it — `reindexCapExceededResponder` hand-rolled a `middleware.ResponderFunc` and wrote the status directly, with a comment saying the spec "predates the per-collection cap".

Working around it on the server does not help the client. The declaration is what generates the client's `case 429:` arm.

## What changes

- `openapi-specs/schema.json` declares 429 with the standard `ErrorResponse` schema for that one operation.
- The generated server responder, generated client reader, and `embedded_spec.go` pick it up.
- `reindexCapExceededResponder` returns the generated `NewSchemaObjectsIndexesUpdateTooManyRequests().WithPayload(...)` instead of writing the status by hand.

The wire behavior is unchanged: same 429, same body. What changes is that a generated client can now read it.

## Are there others?

One, and it is not fixed here. All three `/v1/mcp` methods declare only `200` in the spec, and when MCP is disabled the handler writes a 503 with a JSON body straight to the `ResponseWriter` (`adapters/handlers/rest/handlers_mcp.go:42`). Each generated reader in `client/mcp/` has exactly `case 200:` and `default:`, so the actionable text ("set `MCP_SERVER_ENABLED=true`...") is discarded exactly the same way. Tracked separately; this PR stays one operation wide.

Nothing else on the generated surface has it. Every 429 returned by a hand-written REST handler already goes through a generated responder (objects create, objects class put, batch create, near-text search, schema create, tenants create), which is only possible where the operation declares the status. The reindex 429 was the last one that did not.

## Generated code

Produced by `./tools/gen-code-from-swagger.sh`, not hand-edited. Reverting the spec hunk and re-running the generator reproduces the base versions of all three generated files byte-for-byte.

## Test

`TestGeneratedClientParsesTheCapRefusal` feeds the handler's real 429 response into the generated client's reader and asserts it comes back as a typed `SchemaObjectsIndexesUpdateTooManyRequests` with the message intact, rather than an opaque error. Without the declaration the generated type does not exist and the test does not compile; with the client's 429 arm reverted on its own, the `ErrorAs` assertion fails: the reader hands back an untyped `runtime.APIError` instead of the typed 429, so the body assertion below it never runs.

The two description edits to 409 and 503 that ride along in the original commit stay behind in [weaviate/weaviate#12582](https://github.com/weaviate/weaviate/pull/12582). The 409 clause names a refusal arm that only exists on that branch. The 503 clause is a closer call: `handlers_indexes.go` already returns 503 here for an in-flight task with an unparseable payload, so that description would be accurate today — it is left out only to keep this PR to the single undeclared status code.

## A cap boundary test that tested nothing

An earlier revision of this description cited `TestConcurrentReindexCap_RejectionBoundary` as coverage of the cap's arithmetic. It was not. The test recomputed `got >= cap` in its own body, so the production comparison never ran: flipping `>=` to `>` in `handlers_indexes.go` left the entire package green, leaving an off-by-one on a production cap with no guard at all.

The comparison was inline in a 400-line handler, inside a branch that needs a real `*db.DB` and a leader-elected RAFT node to reach, so no test could call it. It now sits in `reindexCapRefusal`, alongside the two helpers already extracted from that same handler (`countStartedTasksForCollection`, `reindexCapExceededResponder`). It returns the 429 responder or nil, the handler calls it on its one real path, and it adds no field, interface, or knob.

`TestReindexCapRefusal_Boundary` replaces the old test and drives that decision at 0, cap-1, cap and cap+1 tasks in flight without restating the predicate. Both mutations go red on the named test and on nothing else: `>=` → `>` fails `exactly_at_the_cap`, `>=` → `!=` fails `nothing_in_flight`, `one_below_the_cap` and `exactly_at_the_cap`.

## The cap has no end-to-end coverage

Worth knowing before review. Coverage of the cap is unit-level: the count helper (`TestCountStartedTasksForCollection_FiltersByStatusAndCollection`), the boundary (`TestReindexCapRefusal_Boundary`), the responder's status and body (`TestReindexCapExceededResponder_StatusAndBody`), and the client parse added here. The handler branch that returns the responder (`adapters/handlers/rest/handlers_indexes.go:571`) is reached by no test at all — a `panic()` inserted there leaves `go test ./adapters/handlers/rest/...` green.

No test under `test/` drives a real server to a 429 on this route: the cap is the only thing on that route that returns one, and the largest fan-out in any suite is `TestConcurrentReindex`. It submits its 15 tasks from two plain `for` loops, one after the other — the submits are sequential; what is concurrent is the 15 tasks then in flight, against a cap of 32.

Closing that gap needs an acceptance test that drives a collection to 32 in-flight tasks. That is separate work; this PR stays a spec declaration.

— SuperClaude

