### PR TITLE
reindex: acceptance suites, CI shard split and docs for the backup guard (follow-up to #12582)

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -767,6 +767,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Each entry here is one required status check, named
+        # `reindex (<name>)`. Branch protection lives in GitHub's repo
+        # settings, not in this repo, so nothing in CI can see it:
+        # test/ciguard proves an entry exists and that its budget fits the
+        # window, and stops there. Adding or renaming an entry is therefore a
+        # manual step at merge time — whoever merges has to add the new name
+        # to the required checks and drop the old one. Miss the add and the
+        # shard runs on every PR while a red run blocks nothing, which is
+        # silent; miss the drop and the stale name blocks every PR, which is
+        # not. Neither is detectable from inside the repo.
         include:
           - name: "multinode"
             test: "--acceptance-reindex-multinode"

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -790,8 +790,14 @@ jobs:
             test: "--acceptance-reindex-concurrent"
           - name: "mt"
             test: "--acceptance-reindex-mt"
-          - name: "backup"
-            test: "--acceptance-reindex-backup"
+          - name: "backup-suite"
+            test: "--acceptance-reindex-backup-suite"
+          - name: "backup-a"
+            test: "--acceptance-reindex-backup-a"
+          - name: "backup-b"
+            test: "--acceptance-reindex-backup-b"
+          - name: "backup-cluster"
+            test: "--acceptance-reindex-backup-cluster"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Set up Go
@@ -809,6 +815,9 @@ jobs:
           # multi-node testcontainer suites that occasionally need the full
           # window. Avoids the per-test if-chain Acceptance-Tests-4-cores
           # carried before the split.
+          #
+          # Ceiling for test/run.sh's AOF_GROUP_TIMEOUT budgets (minus ~5m
+          # image build); TestCIGroupTimeoutFitsTheJobWindow enforces it.
           timeout_minutes: 45
           max_attempts: 1
           command: ./test/run.sh ${{ matrix.test }}

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -1652,9 +1652,30 @@ with the modern testcontainer style.
 - `reindex_mt_test` — `?tenants=` filtering, per-tenant repair,
   FROZEN-tenant resume, per-tenant `OnGroupCompleted` barrier.
 
-**Acceptance — backup gate** ([`test/acceptance/reindex_backup/`](../test/acceptance/reindex_backup/)):
+**Acceptance — backup and restore gates** ([`test/acceptance/reindex_backup/`](../test/acceptance/reindex_backup/)):
 
-- `suite_test` — backup refused while a reindex is live on the shard.
+- `suite_test` — nine subtests on one node: the backup refusal and its
+  422 body, the same backup id succeeding once the migration drains,
+  the post-restart orphan audit, the mutation guard, cancel cleanup,
+  and a subtest that submits a reindex for as long as a slow backup is
+  capturing and asserts the two excluded each other.
+- `reindex_guard_singlenode_test` — the reindex side: a submission
+  refused with 409 while a backup runs, accepted once it finishes, and
+  the block clearing on its own after the node is killed mid-backup.
+- `reindex_guard_restore_test` — the same refusal with a restore, not a
+  backup, as the blocking operation.
+- `restore_guard_singlenode_test` — the restore side: a restore naming
+  the migrating collection is refused 422, one naming any other
+  collection is admitted, which is what pins the scoping.
+- `reindex_guard_cluster_test` — 3-node: a node holding no shard of the
+  backed-up collection still refuses, so the fan-out and not a
+  node-local check is what answers.
+- `reindex_guard_helpers_test` — the shared probe loop and the
+  assertions it is judged by.
+
+The package is split over four CI groups; `test/ciguard` fails when a
+test in it is named by no group, or when a group's budget does not
+cover the deadlines its tests wait on.
 
 **Acceptance — rangeable** ([`test/acceptance/reindex_rangeable/`](../test/acceptance/reindex_rangeable/)):
 
@@ -1671,8 +1692,8 @@ HTTP-level helpers (`SubmitIndexUpdate`, `AwaitReindexFinished`,
 `GetIndexes`, `AwaitReindexViaIndexes`, `BoolPtr`, `IdsMatchUnordered`)
 with `WithTenants` / `WithTimeout` functional options. Plus the
 fixture API: `SetupClass`, `SetupClassWithConfig`, `ImportObjects`,
-`WithEnv` — consolidated from prior duplicated copies across the four
-test packages.
+`WithEnv`, `WithReindexEnv` — consolidated from prior duplicated copies
+across the four test packages.
 
 **Unit tests of interest**
 

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -1317,16 +1317,146 @@ catches that gap.
    sidecar dirs for the dropped index type, plus the tracker dir.
 4. Subsequent re-enable starts from clean state.
 
-## 13. Out of scope (broken; tracked follow-up)
+## 13. Backup, restore, and the reindex guard
 
-Backups and migrations across runtime-reindex state are intentionally
-left broken on this branch and will not be fixed in the v1.38 Preview
-merge. The fixes live on `backup-runtime-reindex-fixes` and will
-land as a follow-up PR. Tracking: weaviate/0-weaviate-issues#215.
+Backup, restore and reindex all rewrite the same on-disk buckets, so
+each refuses to start while another is running:
 
-Operators should not rely on backup/restore or schema migration
-interacting cleanly with an in-flight or recently-completed reindex
-while running v1.38 Preview.
+| Submitted | Refused when | Where |
+| --- | --- | --- |
+| Backup | A live DTM reindex task targets the shard, or a cancelled task is still removing its sidecars | `Index.refuseIfReindexInFlight` |
+| Restore | A reindex task is live on one of the collections being restored, or a cancelled one is still removing that collection's sidecars on the node | `DB.RefuseIfAnyReindexInFlight`, reached through the two `Scheduler.refuseRestoreDuringReindex` calls in `Scheduler.Restore` and again in each participant's `OnCanCommit` |
+| Reindex | Any node reports a backup or restore slot held | `indexesHandlers.probeBackupActivity`, over `GET /backups/node-activity` |
+
+These rows describe behavior with `RUNTIME_REINDEX_ENABLED=true`. The flag is
+off by default, and with it off these gates return before checking anything —
+see "Where each gate fails open" below, whose third window is that default.
+
+**Where each gate fails closed.** Once its lookup is installed, every
+gate treats an uncertain answer as a blocking one. The backup gate
+refuses every backup while the cluster task manager cannot be listed.
+A live task whose payload cannot be read is the same uncertainty in a
+smaller shape, and the refusal is scoped to how much of the payload
+survives (`db.DecodeReindexTaskPayload`, consulted by
+`newShardReindexActivityBuilder` in `configure_api.go`):
+
+| What survives | What is refused |
+| --- | --- |
+| The collection, but not the shards (a field a newer node retyped) | Every backup of that one collection, and every restore that includes it |
+| Nothing — no collection either (unparseable, or a collection field a newer node renamed) | Every backup and every restore in the cluster |
+
+A payload that names no collection is unreadable even when it decodes
+without error: a renamed field leaves an empty collection behind, and
+nothing then says which shards the task holds. The cancel endpoint
+accepts such a task from any collection, which is the operator's remedy
+for the cluster-wide case. Because that cancel reaches a migration on a
+collection the URL does not name, it requires `UPDATE` on every
+collection, not just the one in the URL; a caller without that gets the
+same `NO_OP` it would get if no such task existed.
+
+The commit-time overlap check draws the same two lines through the same
+decoder, so admission and commit cannot disagree about what unreadable
+means. It also does not waive an unreadable task that already finished:
+the teardown is addressed by the shards the payload names, so nothing
+tore it down, and the refusal stands until the completed-task TTL drops
+the task. The restore gate refuses the restore on the same failure. The
+reindex gate answers 503 for a node that does not respond to the probe.
+An `Index` built without a back-reference to `DB` refuses the backup
+outright.
+
+**Where each gate fails open.** Three windows are deliberately left
+open. Two are logged; the third is silent by design and is the default
+configuration:
+
+- *Lookup not yet installed.* The lookups are wired from a
+  post-bootstrap goroutine in `configure_api.go`. Until it runs, the
+  backup gate, the restore gate, the commit-time overlap check
+  (`DB.RefuseIfReindexOverlapped`) and the reindex gate each allow the
+  operation and emit a WARN, rate-limited to one line per hour so a
+  persistent misconfiguration stays visible to whoever reads the log
+  next. This window is reachable from outside: a request that arrives
+  early enough in startup is answered before the goroutine installs the
+  lookups, and has been observed doing so. So a WARN here is a real
+  signal — it names an operation that ran without its gate — and not
+  evidence that the wiring is broken.
+  The cleanup half of both gates is narrower than this: it reads only
+  this node's own provider, so `configure_api.go` installs it
+  synchronously before that goroutine is even started, and it is never
+  nil while the goroutine waits. A submission that is sweeping sidecars
+  right now therefore refuses a concurrent backup and restore for the
+  whole of that window. It is skipped without a WARN when only the
+  activity lookup is installed, which is the shape module-test fixtures
+  use.
+- *Old node during a rolling upgrade.* A node that predates
+  `GET /backups/node-activity` answers 404. The reindex gate counts that
+  node as free of backups and admits the submission, with a WARN naming
+  the node. So a backup running only on not-yet-upgraded nodes is
+  invisible to the reindex gate. The commit-time overlap check is the
+  backstop on the backup side: a backup whose capture window overlapped
+  a reindex fails at commit rather than being stored as good.
+  A restore refused by such a node also loses its status code. The
+  coordinator maps a refusal to 422 from the `err_kind` field on the
+  canCommit response, and a participant that predates
+  `restore_blocked_by_reindex` sends a kind the coordinator does not
+  recognize, so the refusal falls through to 500. The refusal itself is
+  correct and the message still says a migration is running; only the
+  code pages the on-call. It clears when every node is upgraded. A restore
+  the coordinator's own cluster-wide check catches is unaffected: that one
+  runs before any participant is asked.
+- *`RUNTIME_REINDEX_ENABLED=false`, the default.* Every gate returns
+  before it looks at anything, so no gate refuses and none of them logs:
+  this window is silent by design, and it is the shipped default. It is
+  wider than "no reindex can start" implies — a task already running when
+  the flag went off keeps running, a node that BOOTS with the flag off
+  resumes a `STARTED` task from DTM, and cancel stays allowed so a
+  teardown can still be in flight. With the gates off a backup can span
+  any of the three, and no commit-time backstop catches it either, since
+  that check is off too. What the flag lifts is exactly the backup and
+  restore refusals (and the commit-time backstop with them), so it cannot
+  itself fail backups. It is not an escape hatch for the whole feature:
+  the schema gates that block `DeleteClass`, property updates and tenant
+  mutations while a task is in flight sit on the RAFT apply path and never
+  read this flag, so they keep refusing until the task reaches a terminal
+  state.
+
+**The commit-time backstop compares two clocks.** `RefuseIfReindexOverlapped`
+clears a task when its `FinishedAt` is before the backup's start time. Those two
+stamps come from different machines: the start time from the node capturing the
+backup, `FinishedAt` from whichever node proposed the task to RAFT. If the
+proposer's clock runs far enough behind, a migration that really did finish
+inside the backup window reads as having finished before it, and the backup is
+published as clean while it is torn.
+
+This is accepted, not a bug to be worked around here. Backup state is not
+tracked in RAFT, so there is no cluster-wide consistent answer to "when did this
+backup start" to order task state against — every timestamp comparison
+downstream of that inherits the same window. Two attempts to close it locally
+(a fixed skew allowance, then a task-set snapshot taken at backup start and
+re-read at commit) were reverted for that reason: both were workarounds for a
+limitation in the backup subsystem, placed in the reindex code. Closing it means
+putting backup state in RAFT.
+
+Refusals are retryable, never terminal:
+
+- A reindex refused because of a backup gets 409; if a node cannot be
+  reached it gets 503, since an unanswered node cannot be assumed idle.
+- A restore refused because of a reindex gets 422.
+- A restore of a backup id that does not exist gets that same 422 rather
+  than a 404 while a migration is running, because the gate answers
+  before existence does. This is deliberate: a caller who cannot restore
+  right now should be told that, not sent to fix an id that was never the
+  problem. A caller that named its collections is only gated on those, so
+  a mistyped id still gets its 404 unless a migration is live on one of
+  them.
+- Nothing needs operator action to clear. A backup or restore slot is
+  held in process memory only, so it dies with the process. Participant
+  slots expire on their own within 20s of an abandoned operation; a
+  coordinator slot can be held until its node-down timeout
+  (`_TimeoutNodeDown`, 7 minutes), which delays reindex submissions but
+  never blocks a backup.
+
+Schema migration against an in-flight reindex is still unguarded.
+Tracking: weaviate/0-weaviate-issues#215.
 
 ## 14. Files of interest
 

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -90,10 +90,11 @@ type IndexUpdateErrorResponse struct {
 	Body       string
 }
 
-// SubmitIndexUpdateExpect4xx submits a PUT /indexes request expected to
-// fail at validation and returns the response status and body. The caller
-// asserts the exact status code.
-func SubmitIndexUpdateExpect4xx(t *testing.T, restURI, collection, property, jsonBody string, opts ...Option) IndexUpdateErrorResponse {
+// SubmitIndexUpdateExpectRefusal submits a PUT /indexes request and returns
+// the response status and body. Despite the name, 202 also passes — gate-probing
+// callers poll until the refusal window opens; only a 5xx fails here, so every
+// caller must assert the exact status it expects.
+func SubmitIndexUpdateExpectRefusal(t *testing.T, restURI, collection, property, jsonBody string, opts ...Option) IndexUpdateErrorResponse {
 	t.Helper()
 	o := applyOptions(opts)
 
@@ -109,6 +110,12 @@ func SubmitIndexUpdateExpect4xx(t *testing.T, restURI, collection, property, jso
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	t.Logf("index update response (status=%d): %s", resp.StatusCode, string(body))
+	if resp.StatusCode != http.StatusAccepted {
+		require.GreaterOrEqualf(t, resp.StatusCode, 400,
+			"expected a refusal or an admission, got %d: %s", resp.StatusCode, string(body))
+		require.Lessf(t, resp.StatusCode, 500,
+			"expected a refusal, got a server error %d: %s", resp.StatusCode, string(body))
+	}
 	return IndexUpdateErrorResponse{StatusCode: resp.StatusCode, Body: string(body)}
 }
 
@@ -487,17 +494,25 @@ func WithEnv(
 	body()
 }
 
-// SingleNodeCompose is the single-node configuration the runtime-reindex
-// suites share: the feature flag on (the server default is off, so a suite
-// that bypasses this silently tests nothing), the legacy searchable path
-// off, and a 1s scheduler tick so task transitions land inside test
-// timeouts. Callers needing extra env keep chaining before Start.
-func SingleNodeCompose() *docker.Compose {
-	return docker.New().
-		WithWeaviate().
+// WithReindexEnv applies the env every runtime-reindex suite needs, whatever
+// topology or backend it builds on: the feature flag on (the server default is
+// off, so a suite that bypasses this silently tests nothing), the legacy
+// searchable path off, and a 1s scheduler tick so task transitions land inside
+// test timeouts.
+//
+// Take this rather than repeating the three lines: a suite that composes its own
+// cluster and pastes only two of them still starts, and then tests nothing while
+// looking green. Callers keep chaining their own env before Start.
+func WithReindexEnv(c *docker.Compose) *docker.Compose {
+	return c.
 		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
 		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1")
+}
+
+// SingleNodeCompose is [WithReindexEnv] on a single-node cluster.
+func SingleNodeCompose() *docker.Compose {
+	return WithReindexEnv(docker.New().WithWeaviate())
 }
 
 // StartSingleNode starts [SingleNodeCompose] with no further tuning.

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -90,11 +90,19 @@ type IndexUpdateErrorResponse struct {
 	Body       string
 }
 
-// SubmitIndexUpdateExpectRefusal submits a PUT /indexes request and returns
-// the response status and body. Despite the name, 202 also passes — gate-probing
-// callers poll until the refusal window opens; only a 5xx fails here, so every
-// caller must assert the exact status it expects.
-func SubmitIndexUpdateExpectRefusal(t *testing.T, restURI, collection, property, jsonBody string, opts ...Option) IndexUpdateErrorResponse {
+// SubmitIndexUpdateExpectRefusalOrAdmission submits a PUT /indexes request and
+// returns the response status and body. It asserts only that the endpoint
+// reached a verdict: admitted (202), or refused with a client error (4xx).
+// Anything else, a 5xx above all, fails here.
+//
+// Both outcomes pass because a gate-probing caller submits on a loop and cannot
+// say in advance which side of the window it lands on. Deciding which of the two
+// this call had to get is therefore the caller's job, and every caller does
+// assert its exact status.
+//
+// Use [SubmitIndexUpdate] instead when the submission must be admitted: it
+// requires the 202 and hands back the task id.
+func SubmitIndexUpdateExpectRefusalOrAdmission(t *testing.T, restURI, collection, property, jsonBody string, opts ...Option) IndexUpdateErrorResponse {
 	t.Helper()
 	o := applyOptions(opts)
 

--- a/test/acceptance/reindex_backup/reindex_guard_cluster_test.go
+++ b/test/acceptance/reindex_backup/reindex_guard_cluster_test.go
@@ -1,0 +1,200 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_backup_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// maxPlacementAttempts bounds the search for the two placements the test needs.
+const maxPlacementAttempts = 16
+
+// probeDataset sizes the reindex-target class; it only needs to exist.
+const probeDataset = 500
+
+// guardTopology is a backup living entirely on one node, and a reindex target owned by another.
+type guardTopology struct {
+	backupClass  string
+	reindexClass string
+	probe        clusterNode
+	placements   []string
+}
+
+// TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp pins that a node holding
+// no stake in a running backup still refuses reindex via the cluster-wide fan-out.
+func TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		propName  = "body"
+		backupID  = "reindex-guard-remote-backup"
+		bucket    = "reindex-guard-bucket"
+		backend   = "s3"
+		nodeCount = 3
+		// A 2+ node cluster refuses the filesystem backend, so the backup goes through MinIO.
+		region = "us-east-1"
+	)
+
+	compose, err := reindexhelpers.WithReindexEnv(
+		docker.New().
+			With3NodeCluster().
+			WithBackendS3(bucket, region),
+	).
+		WithWeaviateEnv("DISABLE_LAZY_LOAD_SHARDS", "true").
+		WithWeaviateEnv("MEMBERLIST_FAST_FAILURE_DETECTION", "false").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	nodes := clusterNodes(compose, nodeCount)
+	defer func() {
+		for i := 1; i <= nodeCount; i++ {
+			dumpWeaviateLogs(ctx, t, compose.GetWeaviateNode(i).Container(), nodes[i-1].name)
+		}
+	}()
+
+	helper.SetupClient(nodes[0].uri)
+	defer helper.ResetClient()
+
+	leader := raftLeaderName(t, nodes[0].uri, 60*time.Second)
+	awaitClusterMembers(t, nodes[0].uri, nodeNames(nodes), 60*time.Second)
+	topo := resolveGuardTopology(t, nodes, leader, propName)
+	coordinator := nodeByName(t, nodes, leader)
+	t.Logf("topology: leader %q owns backup class %q, probe %q owns reindex class %q; placements sampled: %v",
+		leader, topo.backupClass, topo.probe.name, topo.reindexClass, topo.placements)
+
+	// Confirm against the API, not just resolveGuardTopology's bookkeeping,
+	// that the probe node holds no stake in the backup.
+	require.NotEqual(t, leader, topo.probe.name,
+		"the probe node must not be the node that runs the backup, or the 409 proves nothing cluster-wide")
+	backupOwners, ok := shardOwners(nodes[0].uri, topo.backupClass)
+	require.True(t, ok, "could not read shard ownership of backup class %q", topo.backupClass)
+	require.NotContains(t, backupOwners, topo.probe.name,
+		"the probe node holds a shard of the backup class %q, so a node-local check would also answer 409",
+		topo.backupClass)
+
+	awaitClassVisible(t, coordinator.uri, topo.backupClass, coordinator.name)
+	awaitClassVisible(t, topo.probe.uri, topo.reindexClass, topo.probe.name)
+
+	importBodies(t, topo.backupClass, guardDataset)
+	importBodies(t, topo.reindexClass, probeDataset)
+
+	require.Equal(t, leader, raftLeaderName(t, nodes[0].uri, 60*time.Second),
+		"the RAFT leader changed during setup; the resolved topology no longer holds")
+	require.NoError(t, startS3Backup(coordinator.uri, topo.backupClass, backupID, bucket))
+
+	statusOf := nodeBackupStatus(coordinator.uri, backend, backupID)
+	run := probeReindexDuringBackup(t, topo.probe.uri, topo.reindexClass, propName, "whitespace",
+		statusOf, 10*time.Minute)
+	blocked := assertReindexBlocked(t, run, backupID)
+
+	t.Logf("probe node %q refused while only leader %q held backup %s: %s",
+		topo.probe.name, leader, backupID, blocked.body)
+
+	// The route only requires update_collections on one collection; node
+	// names and other collections' names need grants it doesn't have.
+	message := guardMessage(blocked.body)
+	for _, node := range nodes {
+		assert.NotContainsf(t, message, node.name,
+			"the 409 body leaked node %q", node.name)
+	}
+	assert.NotContainsf(t, message, topo.backupClass,
+		"the 409 body leaked the backed-up collection %q; the caller was only granted the one it is migrating",
+		topo.backupClass)
+	for _, placement := range topo.placements {
+		className, _, _ := strings.Cut(placement, "=")
+		if className == topo.reindexClass {
+			continue
+		}
+		assert.NotContainsf(t, message, className,
+			"the 409 body leaked collection %q, which the caller has no grant on", className)
+	}
+
+	// The block has to lift on a node that never took part in the backup.
+	awaitBackupSuccess(t, statusOf, backupID, 10*time.Minute)
+	taskID := awaitReindexAccepted(t, topo.probe.uri, topo.reindexClass, propName, "whitespace", 60*time.Second)
+	t.Logf("reindex accepted on probe node %q after backup %s finished: task %s",
+		topo.probe.name, backupID, taskID)
+}
+
+// resolveGuardTopology creates single-shard, RF=1 classes until one lands on
+// the RAFT leader and another elsewhere; placement can't be requested directly.
+func resolveGuardTopology(t *testing.T, nodes []clusterNode, leader, propName string) guardTopology {
+	t.Helper()
+
+	var topo guardTopology
+	var spares []string
+	for attempt := 0; attempt < maxPlacementAttempts; attempt++ {
+		// Zero-padded so no sampled name is a prefix of another (redaction
+		// assertions below are substring checks).
+		className := fmt.Sprintf("ReindexGuard_RemoteBackup_%02d", attempt)
+		helper.CreateClass(t, &models.Class{
+			Class: className,
+			Properties: []*models.Property{
+				{Name: propName, DataType: []string{"text"}, Tokenization: "word"},
+			},
+			Vectorizer: "none",
+			// One shard at RF=1 puts the whole class on a single node.
+			ShardingConfig:    map[string]interface{}{"desiredCount": 1},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		})
+		owner := awaitSingleShardOwner(t, nodes[0].uri, className, 60*time.Second)
+		topo.placements = append(topo.placements, fmt.Sprintf("%s=%s", className, owner))
+
+		switch {
+		case owner == leader && topo.backupClass == "":
+			topo.backupClass = className
+		case owner != leader && topo.reindexClass == "":
+			topo.reindexClass = className
+			topo.probe = nodeByName(t, nodes, owner)
+		default:
+			spares = append(spares, className)
+		}
+		if topo.backupClass != "" && topo.reindexClass != "" {
+			break
+		}
+	}
+
+	// Drop the losing samples so only the two topology classes remain.
+	for _, className := range spares {
+		helper.DeleteClass(t, className)
+	}
+
+	if topo.backupClass == "" || topo.reindexClass == "" {
+		t.Fatalf("could not resolve the placement the test needs within %d attempts: it needs one "+
+			"class owned by RAFT leader %q and one owned by another node of %v; ownership seen: %v",
+			maxPlacementAttempts, leader, nodeNames(nodes), topo.placements)
+	}
+	return topo
+}
+
+// awaitClassVisible blocks until the node's own schema view serves the class
+// (what the submission handler checks).
+func awaitClassVisible(t *testing.T, restURI, className, nodeName string) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		_, ok := reindexhelpers.FetchClass(restURI, className, true)
+		return ok
+	}, 60*time.Second, 100*time.Millisecond,
+		"class %s must be locally visible on %s before the test drives it", className, nodeName)
+}

--- a/test/acceptance/reindex_backup/reindex_guard_helpers_test.go
+++ b/test/acceptance/reindex_backup/reindex_guard_helpers_test.go
@@ -113,7 +113,7 @@ func probeReindexDuringBackup(
 			break
 		}
 
-		resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, probeURI, collection, property, requestBody)
+		resp := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, probeURI, collection, property, requestBody)
 		run.probes = append(run.probes, reindexProbe{
 			backupStatus: status,
 			httpStatus:   resp.StatusCode,
@@ -345,7 +345,7 @@ func awaitBackupSuccess(t *testing.T, statusOf func() (string, bool), backupID s
 }
 
 // tryReindexSubmit tolerates transport errors (e.g. node still booting) as a
-// retryable observation, unlike reindexhelpers.SubmitIndexUpdateExpectRefusal.
+// retryable observation, unlike reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission.
 func tryReindexSubmit(restURI, collection, property, requestBody string) (int, string, bool) {
 	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
 	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(requestBody))

--- a/test/acceptance/reindex_backup/reindex_guard_helpers_test.go
+++ b/test/acceptance/reindex_backup/reindex_guard_helpers_test.go
@@ -1,0 +1,625 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_backup_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// maxReindexProbes caps the loop; only the leading probe decides the verdict,
+// the rest just add diagnostic detail.
+const maxReindexProbes = 10
+
+// slowBackupConfig widens the observable in-flight window: CPUPercentage 1
+// serializes the zip and BestCompression raises the per-byte CPU cost.
+func slowBackupConfig() *models.BackupConfig {
+	return &models.BackupConfig{
+		CompressionLevel: models.BackupConfigCompressionLevelBestCompression,
+		CPUPercentage:    1,
+	}
+}
+
+// createBodyClass creates an unvectorized class with a single word-tokenized
+// text property, the shape every single-node guard test migrates.
+func createBodyClass(t *testing.T, className, propName string) {
+	t.Helper()
+	helper.CreateClass(t, &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: propName, DataType: []string{"text"}, Tokenization: "word"},
+		},
+		Vectorizer: "none",
+	})
+}
+
+// backupTerminal reports whether a backup status can no longer change.
+func backupTerminal(status string) bool {
+	switch backup.Status(status) {
+	case backup.Success, backup.Failed, backup.Cancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+// reindexProbe is one reindex submission taken while the backup was still in flight.
+type reindexProbe struct {
+	backupStatus string
+	httpStatus   int
+	body         string
+}
+
+// probeRun tracks failed status reads too, so a zero-probe run can be told
+// apart from a broken status endpoint.
+type probeRun struct {
+	probes       []reindexProbe
+	statusReads  int
+	statusErrors int
+	lastStatus   string
+}
+
+// probeReindexDuringBackup submits reindex until the first 409 or the backup goes terminal.
+func probeReindexDuringBackup(
+	t *testing.T,
+	probeURI, collection, property, targetTokenization string,
+	statusOf func() (string, bool),
+	deadline time.Duration,
+) probeRun {
+	t.Helper()
+
+	requestBody := fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, targetTokenization)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	run := probeRun{lastStatus: "(no successful status read)"}
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		status, ok := statusOf()
+		run.statusReads++
+		if !ok {
+			run.statusErrors++
+			<-ticker.C
+			continue
+		}
+		run.lastStatus = status
+		if backupTerminal(status) {
+			break
+		}
+
+		resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, probeURI, collection, property, requestBody)
+		run.probes = append(run.probes, reindexProbe{
+			backupStatus: status,
+			httpStatus:   resp.StatusCode,
+			body:         resp.Body,
+		})
+		if resp.StatusCode == http.StatusConflict || len(run.probes) >= maxReindexProbes {
+			break
+		}
+		<-ticker.C
+	}
+	return run
+}
+
+// assertReindexBlocked judges a probe run against the guard contract: only
+// the first probe must be 409. It lands microseconds after the create call
+// returns, when every participant already holds a slot; later probes can 202
+// legitimately once a participant's slot expires.
+func assertReindexBlocked(t *testing.T, run probeRun, backupID string) reindexProbe {
+	t.Helper()
+
+	if len(run.probes) == 0 {
+		t.Fatalf("vacuous run: backup %q read as %q before a single reindex submission could be "+
+			"probed against it (%d status reads, %d of them failed) — grow the imported dataset "+
+			"until the backup stays in flight for several seconds",
+			backupID, run.lastStatus, run.statusReads, run.statusErrors)
+	}
+
+	first := run.probes[0]
+	if first.httpStatus != http.StatusConflict {
+		t.Fatalf("reindex submission returned %d while backup %q was %s; the guard must answer 409:\n%s",
+			first.httpStatus, backupID, first.backupStatus, formatProbes(run.probes))
+	}
+
+	message := guardMessage(first.body)
+	require.Containsf(t, message, "reindex blocked",
+		"409 body must name the blocking condition; got: %s", first.body)
+	require.Containsf(t, message, "is running in the cluster",
+		"409 body must say what is blocking; got: %s", first.body)
+	require.NotContainsf(t, message, backupID,
+		"409 body leaked backup id %q; got: %s", backupID, first.body)
+	return first
+}
+
+// guardMessage flattens the error payload to plain message text, dropping JSON escaping.
+func guardMessage(body string) string {
+	var payload models.ErrorResponse
+	if json.Unmarshal([]byte(body), &payload) == nil {
+		if message := errorResponseMessage(&payload); message != "" {
+			return message
+		}
+	}
+	return strings.ReplaceAll(body, `\"`, `"`)
+}
+
+func formatProbes(probes []reindexProbe) string {
+	lines := make([]string, 0, len(probes))
+	for i, p := range probes {
+		lines = append(lines, fmt.Sprintf("  probe %d: backup=%s http=%d body=%s",
+			i, p.backupStatus, p.httpStatus, strings.TrimSpace(p.body)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// backupSnapshot is the whole status payload, not just the status string. The
+// whole-window guard needs the server-stamped capture window and the failure
+// reason to tell a migration admitted inside the window from one admitted
+// after it closed.
+type backupSnapshot struct {
+	status      string
+	startedAt   time.Time
+	completedAt time.Time
+	errMessage  string
+}
+
+func (s backupSnapshot) terminal() bool { return backupTerminal(s.status) }
+
+// localBackupStatus reads status via the process-global client (the single node
+// under test).
+func localBackupStatus(t *testing.T, backend, backupID string) func() (string, bool) {
+	snapshotOf := localBackupSnapshot(t, backend, backupID)
+	return func() (string, bool) {
+		snap, ok := snapshotOf()
+		return snap.status, ok
+	}
+}
+
+// localBackupSnapshot reads the whole status payload off the same endpoint.
+func localBackupSnapshot(t *testing.T, backend, backupID string) func() (backupSnapshot, bool) {
+	return func() (backupSnapshot, bool) {
+		resp, err := helper.CreateBackupStatus(t, backend, backupID, "", "")
+		if err != nil || resp == nil || resp.Payload == nil || resp.Payload.Status == nil {
+			return backupSnapshot{}, false
+		}
+		payload := resp.Payload
+		return backupSnapshot{
+			status:      *payload.Status,
+			startedAt:   time.Time(payload.StartedAt),
+			completedAt: time.Time(payload.CompletedAt),
+			errMessage:  payload.Error,
+		}, true
+	}
+}
+
+// awaitBackupTerminal polls until the backup can no longer change AND the node
+// has released its slot, returning the last snapshot read either way. Both are
+// needed: while the slot is held, status is served from memory with no
+// completion time or failure reason.
+func awaitBackupTerminal(snapshotOf func() (backupSnapshot, bool), last backupSnapshot, deadline time.Duration) backupSnapshot {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if snap, ok := snapshotOf(); ok {
+			last = snap
+			if snap.terminal() && !snap.completedAt.IsZero() {
+				return snap
+			}
+		}
+		<-ticker.C
+	}
+	return last
+}
+
+// reindexTaskStartedAt reads a task's DTM start time. Stamped by the same node
+// that stamps the backup's capture window, so the two order exactly against
+// each other with no clock skew to reason about.
+func reindexTaskStartedAt(t *testing.T, restURI, taskID string) time.Time {
+	t.Helper()
+
+	var started time.Time
+	found := assert.Eventually(t, func() bool {
+		tasks, ok := reindexhelpers.TryFetchTasks(restURI)
+		if !ok {
+			return false
+		}
+		for _, task := range tasks["reindex"] {
+			if task.ID == taskID {
+				started = time.Time(task.StartedAt)
+				return !started.IsZero()
+			}
+		}
+		return false
+	}, 30*time.Second, 250*time.Millisecond)
+	if !found {
+		t.Fatalf("the admitted reindex task %q never appeared in GET /v1/tasks with a start time, "+
+			"so it cannot be ordered against the backup's capture window", taskID)
+	}
+	return started
+}
+
+// cancelReindexAndDrain cancels a task the test admitted and waits for it to go
+// terminal, so the deferred DeleteClass is not refused by the mutation guard.
+func cancelReindexAndDrain(t *testing.T, restURI, className, propName, taskID string) {
+	t.Helper()
+
+	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, className, propName)
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(`{"searchable":{"cancel":true}}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	t.Logf("cancel of admitted reindex task %s answered %d: %s",
+		taskID, resp.StatusCode, strings.TrimSpace(string(body)))
+
+	last := "(task not seen)"
+	drained := assert.Eventually(t, func() bool {
+		tasks, ok := reindexhelpers.TryFetchTasks(restURI)
+		if !ok {
+			return false
+		}
+		for _, task := range tasks["reindex"] {
+			if task.ID != taskID {
+				continue
+			}
+			last = task.Status
+			return slices.Contains([]string{"CANCELLED", "FAILED", "FINISHED"}, task.Status)
+		}
+		return false
+	}, 90*time.Second, 500*time.Millisecond)
+	if !drained {
+		t.Logf("admitted reindex task %s did not go terminal after cancel; last status %q", taskID, last)
+	}
+}
+
+// nodeBackupStatus reads status straight off one node, since the shared client only targets one host.
+func nodeBackupStatus(restURI, backend, backupID string) func() (string, bool) {
+	url := fmt.Sprintf("http://%s/v1/backups/%s/%s", restURI, backend, backupID)
+	return func() (string, bool) {
+		// Pointer, like the generated payload localBackupStatus reads: status is
+		// omitempty, so a body without it decodes cleanly into the zero value.
+		// Returning that as a successful read makes the backup look live
+		// forever, and makes every failed read count as a good one in the
+		// vacuity check.
+		var parsed struct {
+			Status *string `json:"status"`
+		}
+		if !getJSON(url, &parsed) || parsed.Status == nil || *parsed.Status == "" {
+			return "", false
+		}
+		return *parsed.Status, true
+	}
+}
+
+// awaitBackupSuccess blocks until the backup reports SUCCESS, failing on any other terminal status.
+func awaitBackupSuccess(t *testing.T, statusOf func() (string, bool), backupID string, deadline time.Duration) {
+	t.Helper()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	last := "(no successful status read)"
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		if status, ok := statusOf(); ok {
+			last = status
+			if status == string(backup.Success) {
+				return
+			}
+			if backupTerminal(status) {
+				t.Fatalf("backup %q reached terminal status %q instead of SUCCESS", backupID, status)
+			}
+		}
+		<-ticker.C
+	}
+	t.Fatalf("backup %q did not reach SUCCESS within %s; last status: %q", backupID, deadline, last)
+}
+
+// tryReindexSubmit tolerates transport errors (e.g. node still booting) as a
+// retryable observation, unlike reindexhelpers.SubmitIndexUpdateExpectRefusal.
+func tryReindexSubmit(restURI, collection, property, requestBody string) (int, string, bool) {
+	url := fmt.Sprintf("http://%s/v1/schema/%s/indexes/%s", restURI, collection, property)
+	req, err := http.NewRequest(http.MethodPut, url, strings.NewReader(requestBody))
+	if err != nil {
+		return 0, "", false
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, "", false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, "", false
+	}
+	return resp.StatusCode, string(body), true
+}
+
+// awaitReindexAccepted polls until the submission is accepted and returns the task id.
+func awaitReindexAccepted(
+	t *testing.T, restURI, collection, property, targetTokenization string, deadline time.Duration,
+) string {
+	t.Helper()
+	requestBody := fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, targetTokenization)
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	last := "(no response yet)"
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		status, body, ok := tryReindexSubmit(restURI, collection, property, requestBody)
+		switch {
+		case !ok:
+			last = "transport error"
+		case status == http.StatusAccepted:
+			var parsed struct {
+				TaskID string `json:"taskId"`
+			}
+			require.NoErrorf(t, json.Unmarshal([]byte(body), &parsed),
+				"202 response is not an IndexUpdateResponse: %s", body)
+			require.NotEmptyf(t, parsed.TaskID, "202 response is missing taskId: %s", body)
+			return parsed.TaskID
+		default:
+			last = fmt.Sprintf("http=%d body=%s", status, strings.TrimSpace(body))
+		}
+		<-ticker.C
+	}
+	t.Fatalf("reindex submission on %s was never accepted within %s; last response: %s",
+		restURI, deadline, last)
+	return ""
+}
+
+// awaitNodeServing blocks until the node serves the class again, so a
+// post-restart deadline measures the block lifting, not boot time.
+func awaitNodeServing(t *testing.T, restURI, className string, deadline time.Duration) {
+	t.Helper()
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		// consistency:false reads the node's own schema view, matching what the
+		// submission handler checks.
+		if _, ok := reindexhelpers.FetchClass(restURI, className, true); ok {
+			return
+		}
+		<-ticker.C
+	}
+	t.Fatalf("node %s did not serve class %s again within %s", restURI, className, deadline)
+}
+
+// clusterNode pairs a Weaviate node name with the URI the test reaches it on.
+type clusterNode struct {
+	name string
+	uri  string
+}
+
+// clusterNodes lists the cluster 1-indexed, matching docker.GetWeaviateNode.
+func clusterNodes(compose *docker.DockerCompose, size int) []clusterNode {
+	nodes := make([]clusterNode, 0, size)
+	for i := 1; i <= size; i++ {
+		container := compose.GetWeaviateNode(i)
+		nodes = append(nodes, clusterNode{name: container.Name(), uri: container.URI()})
+	}
+	return nodes
+}
+
+func nodeNames(nodes []clusterNode) []string {
+	names := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		names = append(names, n.name)
+	}
+	return names
+}
+
+func nodeByName(t *testing.T, nodes []clusterNode, name string) clusterNode {
+	t.Helper()
+	for _, n := range nodes {
+		if n.name == name {
+			return n
+		}
+	}
+	t.Fatalf("node %q is not part of the cluster %v", name, nodeNames(nodes))
+	return clusterNode{}
+}
+
+// shardOwners returns the node names holding at least one shard of the class.
+func shardOwners(restURI, className string) ([]string, bool) {
+	var parsed struct {
+		Nodes []struct {
+			Name   string `json:"name"`
+			Shards []struct {
+				Class string `json:"class"`
+			} `json:"shards"`
+		} `json:"nodes"`
+	}
+	if !getJSON(fmt.Sprintf("http://%s/v1/nodes?output=verbose", restURI), &parsed) {
+		return nil, false
+	}
+
+	var owners []string
+	for _, node := range parsed.Nodes {
+		for _, shard := range node.Shards {
+			if shard.Class == className {
+				owners = append(owners, node.Name)
+				break
+			}
+		}
+	}
+	return owners, true
+}
+
+// awaitSingleShardOwner blocks until exactly one node reports a shard of the class.
+func awaitSingleShardOwner(t *testing.T, restURI, className string, deadline time.Duration) string {
+	t.Helper()
+	var owner string
+	var last []string
+	// Uses assert.Eventually + explicit Fatalf: require.Eventually captures its
+	// message before the first poll, so it can't report what ownership was seen.
+	resolved := assert.Eventually(t, func() bool {
+		owners, ok := shardOwners(restURI, className)
+		if !ok {
+			return false
+		}
+		last = owners
+		if len(owners) != 1 {
+			return false
+		}
+		owner = owners[0]
+		return true
+	}, deadline, 250*time.Millisecond)
+	if !resolved {
+		t.Fatalf("class %s must be owned by exactly one node for the probe node to exist; "+
+			"last ownership seen: %v", className, last)
+	}
+	return owner
+}
+
+// awaitClusterMembers blocks until every node appears in the cluster's own
+// view. A single-shard class created before that lands on whichever node is
+// already there, so resolveGuardTopology draws the same owner every time and
+// exhausts its attempts.
+func awaitClusterMembers(t *testing.T, restURI string, want []string, deadline time.Duration) {
+	t.Helper()
+	var last []string
+	resolved := assert.Eventually(t, func() bool {
+		var parsed struct {
+			Nodes []struct {
+				Name string `json:"name"`
+			} `json:"nodes"`
+		}
+		if !getJSON(fmt.Sprintf("http://%s/v1/nodes", restURI), &parsed) {
+			return false
+		}
+		last = last[:0]
+		for _, node := range parsed.Nodes {
+			last = append(last, node.Name)
+		}
+		for _, name := range want {
+			if !slices.Contains(last, name) {
+				return false
+			}
+		}
+		return true
+	}, deadline, 250*time.Millisecond)
+	if !resolved {
+		t.Fatalf("cluster did not report all of %v within %s; last seen: %v", want, deadline, last)
+	}
+}
+
+// raftLeaderName resolves the current RAFT leader, always enrolled as a
+// backup participant regardless of shard ownership.
+func raftLeaderName(t *testing.T, restURI string, deadline time.Duration) string {
+	t.Helper()
+	var leader string
+	resolved := assert.Eventually(t, func() bool {
+		var stats models.ClusterStatisticsResponse
+		if !getJSON(fmt.Sprintf("http://%s/v1/cluster/statistics", restURI), &stats) {
+			return false
+		}
+		for _, s := range stats.Statistics {
+			if name, ok := s.LeaderID.(string); ok && name != "" {
+				leader = name
+				return true
+			}
+		}
+		return false
+	}, deadline, 250*time.Millisecond)
+	if !resolved {
+		t.Fatalf("/v1/cluster/statistics on %s did not report a leader within %s", restURI, deadline)
+	}
+	return leader
+}
+
+// startS3Backup fires the create call and returns once accepted, leaving the transfer in flight.
+func startS3Backup(restURI, className, backupID, bucket string) error {
+	payload := map[string]interface{}{
+		"id":      backupID,
+		"include": []string{className},
+		"config": map[string]interface{}{
+			"Bucket":           bucket,
+			"CPUPercentage":    1,
+			"CompressionLevel": models.BackupConfigCompressionLevelBestCompression,
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Post(fmt.Sprintf("http://%s/v1/backups/s3", restURI),
+		"application/json", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("backup create returned %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// getJSON GETs url into out, returning false on any failed step (composes in polling loops).
+func getJSON(url string, out any) bool {
+	resp, err := http.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return false
+	}
+	return json.Unmarshal(body, out) == nil
+}
+
+// dumpWeaviateLogs prints the container's last 200 log lines on test failure.
+func dumpWeaviateLogs(ctx context.Context, t *testing.T, container testcontainers.Container, label string) {
+	if !t.Failed() {
+		return
+	}
+	reader, err := container.Logs(ctx)
+	if err != nil {
+		t.Logf("failed to read %s logs: %v", label, err)
+		return
+	}
+	defer reader.Close()
+	logs, _ := io.ReadAll(reader)
+	lines := strings.Split(string(logs), "\n")
+	if len(lines) > 200 {
+		lines = lines[len(lines)-200:]
+	}
+	t.Logf("=== %s logs (last 200 lines) ===\n%s", label, strings.Join(lines, "\n"))
+}

--- a/test/acceptance/reindex_backup/reindex_guard_restore_test.go
+++ b/test/acceptance/reindex_backup/reindex_guard_restore_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_backup_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestReindexRefusedWhileRestoreRuns is the restore half of the guard's
+// contract: a migration must not start while this node is part of a backup
+// OR a restore. Migrates a different collection than the one being
+// restored, since a restoring collection doesn't exist in the schema yet
+// and would 404 before any gate runs — the guard is node-scoped.
+func TestReindexRefusedWhileRestoreRuns(t *testing.T) {
+	ctx := context.Background()
+
+	compose := startGuardNode(ctx, t)
+	t.Cleanup(func() { require.NoError(t, compose.Terminate(ctx)) })
+	t.Cleanup(func() { dumpWeaviateLogs(ctx, t, compose.GetWeaviate().Container(), "weaviate") })
+
+	restURI := compose.GetWeaviate().URI()
+	helper.SetupClient(restURI)
+	t.Cleanup(helper.ResetClient)
+
+	const (
+		restoredClass  = "ReindexGuard_Restored"
+		migratingClass = "ReindexGuard_MigratedDuringRestore"
+		propName       = "body"
+		backend        = "filesystem"
+		backupID       = "reindex-guard-restore-running"
+	)
+
+	// 50k objects so the restore stays in flight for seconds, the same sizing
+	// the backup-side guard tests use.
+	createBodyClass(t, restoredClass, propName)
+	importBodies(t, restoredClass, guardDataset)
+
+	// The collection the migration targets. It is not in the backup, so the
+	// restore cannot touch it and the two are only ever coupled by the node.
+	createBodyClass(t, migratingClass, propName)
+	importBodies(t, migratingClass, 200)
+
+	_, err := helper.CreateBackup(t, slowBackupConfig(), restoredClass, backend, backupID)
+	require.NoError(t, err, "backup create must be accepted with no reindex in flight")
+	helper.ExpectBackupEventuallyCreated(t, backupID, backend, nil,
+		helper.WithDeadline(5*time.Minute))
+
+	// Restoring over a live class is refused for its own reasons; drop it so the
+	// restore under test is otherwise valid.
+	helper.DeleteClass(t, restoredClass)
+
+	_, err = helper.RestoreBackup(t, helper.DefaultRestoreConfig(), restoredClass, backend, backupID, nil, false)
+	require.NoError(t, err, "restore must be accepted: nothing is migrating yet")
+
+	run := probeReindexDuringBackup(t, restURI, migratingClass, propName, "whitespace",
+		localRestoreStatus(t, backend, backupID), 5*time.Minute)
+	blocked := assertReindexBlocked(t, run, backupID)
+	require.Containsf(t, guardMessage(blocked.body), "a restore is running in the cluster",
+		"the refusal must name the restore that caused it, not a backup; got: %s", blocked.body)
+	t.Logf("reindex refused while restore %s was %s: %s",
+		backupID, blocked.backupStatus, blocked.body)
+
+	helper.ExpectBackupEventuallyRestored(t, backupID, backend, nil,
+		helper.WithDeadline(5*time.Minute))
+	_, exists := reindexhelpers.FetchClass(restURI, restoredClass, true)
+	require.Truef(t, exists, "the restore must bring %s back", restoredClass)
+
+	// The refusal is transient: the same submission has to be admitted once the
+	// restore releases the node's slot.
+	successAt := time.Now()
+	taskID := awaitReindexAccepted(t, restURI, migratingClass, propName, "whitespace", 60*time.Second)
+	t.Logf("reindex accepted %s after restore %s finished: task %s",
+		time.Since(successAt).Round(time.Millisecond), backupID, taskID)
+	reindexhelpers.AwaitReindexLive(t, restURI, taskID, reindexhelpers.WithTimeout(60*time.Second))
+	reindexhelpers.AwaitReindexViaIndexes(t, restURI, migratingClass, propName,
+		"searchable", reindexhelpers.WithTimeout(180*time.Second))
+}
+
+// localRestoreStatus reads restore status via the process-global client, the
+// restore-side twin of localBackupStatus.
+func localRestoreStatus(t *testing.T, backend, backupID string) func() (string, bool) {
+	return func() (string, bool) {
+		resp, err := helper.RestoreBackupStatus(t, backend, backupID, "", "")
+		if err != nil || resp == nil || resp.Payload == nil || resp.Payload.Status == nil {
+			return "", false
+		}
+		return *resp.Payload.Status, true
+	}
+}

--- a/test/acceptance/reindex_backup/reindex_guard_singlenode_test.go
+++ b/test/acceptance/reindex_backup/reindex_guard_singlenode_test.go
@@ -1,0 +1,174 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_backup_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// guardDataset sizes the corpus so the backup stays in flight for seconds,
+// not milliseconds; matches the 50k precedent used elsewhere in this package.
+const guardDataset = 50_000
+
+// startGuardNode boots a single node with a filesystem backend.
+// USE_INVERTED_SEARCHABLE=false forces the legacy Map strategy so the
+// tokenization change has real work to do.
+func startGuardNode(ctx context.Context, t *testing.T) *docker.DockerCompose {
+	t.Helper()
+	compose, err := reindexhelpers.WithReindexEnv(
+		docker.New().
+			WithBackendFilesystem().
+			WithWeaviate(),
+	).Start(ctx)
+	require.NoError(t, err)
+	return compose
+}
+
+// guardedBackup is the state both single-node tests continue from once the
+// guard has answered 409.
+type guardedBackup struct {
+	compose   *docker.DockerCompose
+	restURI   string
+	className string
+	propName  string
+	backupID  string
+	backend   string
+	blocked   reindexProbe
+}
+
+// proveReindexBlockedDuringBackup shares single-node guard setup for both
+// tests below. The backup may already be done by return; only the guard
+// probe is guaranteed to have run while it was live.
+func proveReindexBlockedDuringBackup(
+	ctx context.Context, t *testing.T, className, backupID string,
+) guardedBackup {
+	t.Helper()
+
+	const (
+		propName = "body"
+		backend  = "filesystem"
+	)
+
+	compose := startGuardNode(ctx, t)
+	t.Cleanup(func() { require.NoError(t, compose.Terminate(ctx)) })
+	// t.Cleanup runs last-registered-first, so the dump registered here still
+	// reaches a live container.
+	t.Cleanup(func() { dumpWeaviateLogs(ctx, t, compose.GetWeaviate().Container(), "weaviate") })
+
+	restURI := compose.GetWeaviate().URI()
+	helper.SetupClient(restURI)
+	t.Cleanup(helper.ResetClient)
+
+	createBodyClass(t, className, propName)
+	importBodies(t, className, guardDataset)
+
+	_, err := helper.CreateBackup(t, slowBackupConfig(), className, backend, backupID)
+	require.NoError(t, err, "backup create must be accepted with no reindex in flight")
+
+	statusOf := localBackupStatus(t, backend, backupID)
+	run := probeReindexDuringBackup(t, restURI, className, propName, "whitespace",
+		statusOf, 5*time.Minute)
+
+	return guardedBackup{
+		compose:   compose,
+		restURI:   restURI,
+		className: className,
+		propName:  propName,
+		backupID:  backupID,
+		backend:   backend,
+		blocked:   assertReindexBlocked(t, run, backupID),
+	}
+}
+
+// TestReindexRefusedWhileBackupRuns asserts a reindex submission is refused
+// with a 409 naming the running backup, then accepted once it finishes.
+func TestReindexRefusedWhileBackupRuns(t *testing.T) {
+	guarded := proveReindexBlockedDuringBackup(context.Background(), t,
+		"ReindexGuard_BackupRunning", "reindex-guard-backup-running")
+	t.Logf("reindex refused while backup %s was %s: %s",
+		guarded.backupID, guarded.blocked.backupStatus, guarded.blocked.body)
+
+	helper.ExpectBackupEventuallyCreated(t, guarded.backupID, guarded.backend, nil,
+		helper.WithDeadline(5*time.Minute))
+
+	// The refusal is transient: the same submission must succeed once the backup
+	// finishes. Acceptance is polled since the slot releases just after SUCCESS.
+	successAt := time.Now()
+	taskID := awaitReindexAccepted(t, guarded.restURI, guarded.className, guarded.propName,
+		"whitespace", 30*time.Second)
+	t.Logf("reindex accepted %s after backup %s reported SUCCESS: task %s",
+		time.Since(successAt).Round(time.Millisecond), guarded.backupID, taskID)
+	reindexhelpers.AwaitReindexLive(t, guarded.restURI, taskID,
+		reindexhelpers.WithTimeout(60*time.Second))
+	reindexhelpers.AwaitReindexViaIndexes(t, guarded.restURI, guarded.className, guarded.propName,
+		"searchable", reindexhelpers.WithTimeout(180*time.Second))
+}
+
+// TestReindexBlockClearsAfterNodeCrash asserts the block lives in process
+// memory only: killing the node mid-backup releases it with no operator
+// action. A single node makes this deterministic (one restart clears both
+// the coordinator and the participant slot).
+func TestReindexBlockClearsAfterNodeCrash(t *testing.T) {
+	ctx := context.Background()
+
+	guarded := proveReindexBlockedDuringBackup(ctx, t,
+		"ReindexGuard_CrashClearsBlock", "reindex-guard-crash-clears")
+	t.Logf("guard engaged before the crash: %s", guarded.blocked.body)
+
+	// A graceful shutdown gets to run Weaviate's own teardown, which could
+	// release the slot deliberately, the opposite of what this test claims.
+	// The zero timeout gives Docker no grace between SIGTERM and SIGKILL, so
+	// the process dies before teardown can do anything; see the timeout
+	// contract on DockerCompose.RestartAt.
+	kill := time.Duration(0)
+	require.NoError(t, guarded.compose.StopAt(ctx, 0, &kill))
+	require.NoError(t, guarded.compose.StartAt(ctx, 0))
+
+	// The dynamic port rebinds on restart, so the URI must be re-resolved before use.
+	restURI := guarded.compose.GetWeaviate().URI()
+	helper.SetupClient(restURI)
+
+	awaitNodeServing(t, restURI, guarded.className, 120*time.Second)
+	servingAt := time.Now()
+
+	taskID := awaitReindexAccepted(t, restURI, guarded.className, guarded.propName,
+		"whitespace", 60*time.Second)
+	t.Logf("reindex accepted %s after the node started serving again, with no operator action: task %s",
+		time.Since(servingAt).Round(time.Millisecond), taskID)
+
+	reindexhelpers.AwaitReindexLive(t, restURI, taskID,
+		reindexhelpers.WithTimeout(60*time.Second))
+	reindexhelpers.AwaitReindexViaIndexes(t, restURI, guarded.className, guarded.propName,
+		"searchable", reindexhelpers.WithTimeout(180*time.Second))
+
+	// The 202 above on its own is not proof the block cleared: probeBackupActivity
+	// fails open when the activity prober is missing or the node list is empty,
+	// which is exactly the state a booting node passes through, so a gate that
+	// never re-wired answers 202 too. Make it refuse again, on the restarted
+	// process, to tell the two apart.
+	const rearmedBackupID = "reindex-guard-crash-rearmed"
+	_, err := helper.CreateBackup(t, slowBackupConfig(), guarded.className, guarded.backend, rearmedBackupID)
+	require.NoError(t, err, "backup create must be accepted once the reindex has finished")
+
+	rearmed := probeReindexDuringBackup(t, restURI, guarded.className, guarded.propName, "word",
+		localBackupStatus(t, guarded.backend, rearmedBackupID), 5*time.Minute)
+	blocked := assertReindexBlocked(t, rearmed, rearmedBackupID)
+	t.Logf("the restarted node's guard refuses again while backup %s is %s: %s",
+		rearmedBackupID, blocked.backupStatus, blocked.body)
+}

--- a/test/acceptance/reindex_backup/restore_guard_singlenode_test.go
+++ b/test/acceptance/reindex_backup/restore_guard_singlenode_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	clientbackups "github.com/weaviate/weaviate/client/backups"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/helper"
@@ -166,12 +167,16 @@ func reindexTaskStatus(t *testing.T, restURI, taskID string) string {
 	return ""
 }
 
-// liveReindexStatus mirrors db.IsLiveReindexTaskStatus for wire status strings.
+// liveReindexStatus reports whether a wire status names a DTM status that this
+// build declares and that production counts as in flight. It asks the
+// production predicates rather than listing the statuses again, so a status
+// added there is classified here the same way and the two cannot drift.
+//
+// A string no declared status matches reads as not live, which is the opposite
+// of what [distributedtask.TaskStatus.IsActive] answers on its own. The only
+// caller checks a claim that the migration was still running, so a status this
+// build cannot name has to fail that claim rather than satisfy it.
 func liveReindexStatus(status string) bool {
-	switch status {
-	case "STARTED", "PREPARING", "SWAPPING":
-		return true
-	default:
-		return false
-	}
+	s := distributedtask.TaskStatus(status)
+	return s.IsRecognized() && s.IsActive()
 }

--- a/test/acceptance/reindex_backup/restore_guard_singlenode_test.go
+++ b/test/acceptance/reindex_backup/restore_guard_singlenode_test.go
@@ -1,0 +1,177 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_backup_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	clientbackups "github.com/weaviate/weaviate/client/backups"
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestRestoreRefusedDuringInFlightReindex pins both halves of the restore
+// gate's contract while a migration is live: a restore that INCLUDES the
+// migrating collection is refused synchronously with 422, while a restore of
+// any OTHER collection is admitted and completes — the cluster-wide check
+// must stay scoped by collection. A third arm (undecodable payload refuses
+// every restore) is covered at the unit tier instead; it needs a payload no
+// API can write.
+func TestRestoreRefusedDuringInFlightReindex(t *testing.T) {
+	ctx := context.Background()
+
+	compose := startGuardNode(ctx, t)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	restURI := compose.GetWeaviate().URI()
+	helper.SetupClient(restURI)
+	defer helper.ResetClient()
+	defer dumpWeaviateLogs(ctx, t, compose.GetWeaviate().Container(), "weaviate")
+
+	const (
+		unrelatedClass = "RestoreGuard_Payload"
+		reindexClass   = "RestoreGuard_Migrating"
+		backend        = "filesystem"
+		backupID       = "restore-guard-refuse"
+	)
+
+	createBodyClass(t, unrelatedClass, "body")
+	importBodies(t, unrelatedClass, 200)
+
+	// 50k objects keep the tokenization change live for several seconds, long
+	// enough for both restore calls below to land inside the window.
+	createBodyClass(t, reindexClass, "body")
+	// Not deleted on the way out: the migration is still live at that point and
+	// the mutation guard rejects the delete. The container goes away regardless.
+	importBodies(t, reindexClass, 50_000)
+
+	// One backup holding both, so each arm below names a backup that really
+	// contains what it asks to restore.
+	createBackupOf(t, backend, backupID, unrelatedClass, reindexClass)
+	// Deleted after the backup so the cross-collection restore is otherwise
+	// valid. The migrating class has to stay: it is what the reindex runs on.
+	helper.DeleteClass(t, unrelatedClass)
+
+	taskID := submitChangeTokenization(t, restURI, reindexClass, "body", "lowercase")
+	t.Logf("change-tokenization task submitted: %s", taskID)
+	reindexhelpers.AwaitReindexLive(t, restURI, taskID,
+		reindexhelpers.WithTimeout(30*time.Second))
+
+	statusBefore := reindexTaskStatus(t, restURI, taskID)
+	sameCollectionErr := restoreClasses(t, backend, backupID, unrelatedClass, reindexClass)
+	crossCollectionErr := restoreClasses(t, backend, backupID, unrelatedClass)
+	statusAfter := reindexTaskStatus(t, restURI, taskID)
+
+	// Judge the window before judging the verdicts: a migration that drained
+	// early would make any outcome below meaningless.
+	require.Truef(t, liveReindexStatus(statusBefore) && liveReindexStatus(statusAfter),
+		"reindex task %s must still be live on both sides of the restore attempts "+
+			"(before=%q after=%q); grow the imported corpus until the migration "+
+			"outlives both restore calls", taskID, statusBefore, statusAfter)
+
+	// Arm 1: the restore names the migrating collection, so it is refused.
+	require.Error(t, sameCollectionErr,
+		"a restore including the migrating collection must be refused synchronously")
+	var refusal *clientbackups.BackupsRestoreUnprocessableEntity
+	require.ErrorAsf(t, sameCollectionErr, &refusal,
+		"expected 422 BackupsRestoreUnprocessableEntity, got %T: %v", sameCollectionErr, sameCollectionErr)
+	require.NotNil(t, refusal.Payload, "422 payload must not be nil")
+
+	errMsg := errorResponseMessage(refusal.Payload)
+	require.Contains(t, errMsg, "restore blocked: runtime-reindex in flight in the cluster",
+		"error body must name the refused operation and the blocking condition; got: %s", errMsg)
+	require.Contains(t, errMsg, "retry after the migration finishes",
+		"error body must include an actionable next step; got: %s", errMsg)
+	// "backup blocked" is the per-shard backup gate's own prefix
+	// (ErrBackupBlockedByInFlightReindex); seeing it here means the two gates'
+	// errors got crossed.
+	require.NotContains(t, errMsg, "backup blocked",
+		"a restore refusal must not be worded as a backup refusal; got: %s", errMsg)
+
+	// A refused restore may not partially land.
+	_, exists := reindexhelpers.FetchClass(restURI, unrelatedClass, true)
+	require.Falsef(t, exists, "a refused restore must not create %s", unrelatedClass)
+
+	// Arm 2: same migration, same moment, a collection it does not name. This
+	// is what pins the scoping — it passes the coordinator's gate AND every
+	// participant's, since the restore's class list reaches both.
+	require.NoErrorf(t, crossCollectionErr,
+		"a restore of %s must be admitted while the migration on %s is live; "+
+			"refusing it is the cluster-wide gate this scoping removed",
+		unrelatedClass, reindexClass)
+	helper.ExpectBackupEventuallyRestored(t, backupID, backend, nil,
+		helper.WithDeadline(2*time.Minute))
+	_, exists = reindexhelpers.FetchClass(restURI, unrelatedClass, true)
+	require.Truef(t, exists, "the admitted restore must bring %s back", unrelatedClass)
+}
+
+// createBackupOf backs up several classes into one backup and waits for it to
+// report SUCCESS. helper.CreateBackup only takes a single class.
+func createBackupOf(t *testing.T, backend, backupID string, classes ...string) {
+	t.Helper()
+	params := clientbackups.NewBackupsCreateParams().
+		WithBackend(backend).
+		WithBody(&models.BackupCreateRequest{
+			ID:      backupID,
+			Include: classes,
+			Config:  helper.DefaultBackupConfig(),
+		})
+	_, err := helper.Client(t).Backups.BackupsCreate(params, nil)
+	require.NoError(t, err)
+	helper.ExpectBackupEventuallyCreated(t, backupID, backend, nil,
+		helper.WithDeadline(3*time.Minute))
+}
+
+// restoreClasses issues one restore naming several classes and returns the
+// synchronous outcome. helper.RestoreBackup only takes a single class.
+func restoreClasses(t *testing.T, backend, backupID string, classes ...string) error {
+	t.Helper()
+	params := clientbackups.NewBackupsRestoreParams().
+		WithBackend(backend).
+		WithID(backupID).
+		WithBody(&models.BackupRestoreRequest{
+			Include: classes,
+			Config:  helper.DefaultRestoreConfig(),
+		})
+	_, err := helper.Client(t).Backups.BackupsRestore(params, nil)
+	return err
+}
+
+// reindexTaskStatus reads one reindex task's DTM status.
+func reindexTaskStatus(t *testing.T, restURI, taskID string) string {
+	t.Helper()
+	tasks, ok := reindexhelpers.TryFetchTasks(restURI)
+	require.Truef(t, ok, "GET /v1/tasks failed while probing task %s", taskID)
+	for _, task := range tasks["reindex"] {
+		if task.ID == taskID {
+			return task.Status
+		}
+	}
+	t.Fatalf("reindex task %s is not listed by GET /v1/tasks", taskID)
+	return ""
+}
+
+// liveReindexStatus mirrors db.IsLiveReindexTaskStatus for wire status strings.
+func liveReindexStatus(status string) bool {
+	switch status {
+	case "STARTED", "PREPARING", "SWAPPING":
+		return true
+	default:
+		return false
+	}
+}

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	clientbackups "github.com/weaviate/weaviate/client/backups"
 	"github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/docker"
@@ -46,16 +47,14 @@ import (
 func TestBackupVsReindexSuite(t *testing.T) {
 	ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateEnv("RUNTIME_REINDEX_ENABLED", "true").
-		WithBackendFilesystem().
-		WithWeaviate().
-		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
-		// USE_INVERTED_SEARCHABLE=false forces new classes to start with
-		// the legacy Map (WAND) strategy so the rebuild:true verb has
-		// actual Map→Blockmax migration work to do.
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		Start(ctx)
+	// USE_INVERTED_SEARCHABLE=false, from the shared env, forces new classes to
+	// start with the legacy Map (WAND) strategy so the rebuild:true verb has
+	// actual Map→Blockmax migration work to do.
+	compose, err := reindexhelpers.WithReindexEnv(
+		docker.New().
+			WithBackendFilesystem().
+			WithWeaviate(),
+	).Start(ctx)
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, compose.Terminate(ctx))
@@ -118,6 +117,190 @@ func TestBackupVsReindexSuite(t *testing.T) {
 	t.Run("CancelClearsTrackerDirsViaOnTaskCompleted", func(t *testing.T) {
 		testCancelClearsTrackerDirsViaOnTaskCompleted(t, ctx, compose, compose.GetWeaviate().URI())
 	})
+
+	t.Run("ReindexRefusedForTheWholeCaptureWindow", func(t *testing.T) {
+		testReindexRefusedForTheWholeCaptureWindow(t, compose.GetWeaviate().URI())
+	})
+}
+
+// testReindexRefusedForTheWholeCaptureWindow submits a reindex over and over
+// for as long as a slow backup is capturing, and asserts the property under
+// test — mutual exclusion, not "every submission is refused" — since a
+// submission and a capture can tie and either side may lose the race.
+// Asserts:
+//
+//   - Every refusal is the backup gate's own 409.
+//   - If nothing was admitted, the whole window was covered.
+//   - If a submission was admitted, the backup must not be published spanning
+//     it: either FAILED naming the migration, or admitted only after the
+//     capture window closed (per the server's own timestamps).
+func testReindexRefusedForTheWholeCaptureWindow(t *testing.T, restURI string) {
+	const (
+		className = "ReindexBackup_WholeWindowGuard"
+		propName  = "body"
+		backend   = "filesystem"
+		backupID  = "reindex-backup-whole-window"
+	)
+
+	createBodyClass(t, className, propName)
+	defer helper.DeleteClass(t, className)
+
+	// Same corpus the single-node guard tests use, sized so a BestCompression
+	// backup pinned to one CPU stays in flight long enough to probe repeatedly.
+	importBodies(t, className, guardDataset)
+
+	_, err := helper.CreateBackup(t, slowBackupConfig(), className, backend, backupID)
+	require.NoError(t, err, "backup create must be accepted with no reindex in flight")
+
+	snapshotOf := localBackupSnapshot(t, backend, backupID)
+	requestBody := `{"searchable":{"tokenization":"whitespace"}}`
+
+	var probes []reindexProbe
+	var statusReads, statusErrors int
+	var admittedTask string
+	last := backupSnapshot{status: "(no successful status read)"}
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.Now().Add(5 * time.Minute)
+
+	for time.Now().Before(deadline) {
+		snap, ok := snapshotOf()
+		statusReads++
+		if !ok {
+			statusErrors++
+			<-ticker.C
+			continue
+		}
+		last = snap
+		if snap.terminal() {
+			break
+		}
+
+		resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, propName, requestBody)
+		probes = append(probes, reindexProbe{
+			backupStatus: snap.status,
+			httpStatus:   resp.StatusCode,
+			body:         resp.Body,
+		})
+		if resp.StatusCode == http.StatusAccepted {
+			// Probing past an admission would only measure the reindex gate
+			// refusing on its own account, which is a different test.
+			admittedTask = admittedTaskID(t, resp.Body)
+			break
+		}
+		<-ticker.C
+	}
+
+	// A migration this test let in has to be taken back out, or the deferred
+	// DeleteClass runs into the mutation guard.
+	if admittedTask != "" {
+		defer cancelReindexAndDrain(t, restURI, className, propName, admittedTask)
+	}
+
+	// The loop stops at the first terminal read, which the node can still serve
+	// out of memory without a completion time or a failure reason. Settle on the
+	// snapshot that has both before judging anything against them.
+	last = awaitBackupTerminal(snapshotOf, last, 5*time.Minute)
+
+	for i, p := range probes {
+		if p.httpStatus == http.StatusAccepted {
+			continue
+		}
+		require.Equalf(t, http.StatusConflict, p.httpStatus,
+			"probe %d was answered %d while the backup was %s; a submission during a capture is "+
+				"either refused with the gate's 409 or admitted, never anything else. All probes:\n%s",
+			i, p.httpStatus, p.backupStatus, formatProbes(probes))
+
+		// The refusal must be the backup guard's, not some unrelated 409.
+		message := guardMessage(p.body)
+		require.Containsf(t, message, "reindex blocked",
+			"probe %d's refusal must name the blocking condition; got: %s", i, message)
+		require.Containsf(t, message, "is running in the cluster",
+			"probe %d's refusal must say what is blocking; got: %s", i, message)
+	}
+
+	if admittedTask == "" {
+		// Without this the whole loop could have been skipped and every
+		// assertion above would hold vacuously.
+		require.GreaterOrEqualf(t, len(probes), 3,
+			"backup %q read as %q after only %d probes (%d status reads, %d failed): the backup has "+
+				"to stay in flight long enough to probe the window repeatedly, otherwise this test "+
+				"proves nothing about the window",
+			backupID, last.status, len(probes), statusReads, statusErrors)
+
+		requireBackupPublishedOrBlamedTheMigration(t, backupID, last, probes)
+		t.Logf("the reindex gate refused all %d submissions spanning backup %q, which ended %s",
+			len(probes), backupID, last.status)
+		return
+	}
+
+	require.Truef(t, last.terminal(),
+		"reindex task %s was admitted during backup %q, but the backup never reached a terminal "+
+			"status (last read %q), so it cannot be shown that the two did not both complete. "+
+			"All probes:\n%s", admittedTask, backupID, last.status, formatProbes(probes))
+
+	if last.status != string(backup.Success) {
+		// The backup lost the tie. That is the safe direction, as long as it
+		// lost to the migration and not to something unrelated.
+		require.Containsf(t, last.errMessage, "runtime-reindex",
+			"backup %q ended %s while reindex task %s was admitted, but its reason does not name the "+
+				"migration, so the two did not exclude each other — something else failed the backup. "+
+				"Reason: %q. All probes:\n%s",
+			backupID, last.status, admittedTask, last.errMessage, formatProbes(probes))
+		t.Logf("exact tie: reindex task %s was admitted and backup %q ended %s naming the migration (%s)",
+			admittedTask, backupID, last.status, last.errMessage)
+		return
+	}
+
+	// The backup was published, so it must not span the migration.
+	require.Falsef(t, last.completedAt.IsZero(),
+		"backup %q reports SUCCESS with no completedAt, so the capture window has no end to order "+
+			"reindex task %s against", backupID, admittedTask)
+
+	taskStartedAt := reindexTaskStartedAt(t, restURI, admittedTask)
+	require.Falsef(t, taskStartedAt.Before(last.completedAt),
+		"backup %q was PUBLISHED spanning reindex task %s: the capture ran %s..%s and the migration "+
+			"started at %s, inside it. A published capture may not span an admitted migration — one "+
+			"of the two has to lose. All probes:\n%s",
+		backupID, admittedTask,
+		last.startedAt.Format(time.RFC3339Nano), last.completedAt.Format(time.RFC3339Nano),
+		taskStartedAt.Format(time.RFC3339Nano), formatProbes(probes))
+
+	t.Logf("reindex task %s was admitted only after backup %q had closed its capture window at %s "+
+		"(task started %s)", admittedTask, backupID,
+		last.completedAt.Format(time.RFC3339Nano), taskStartedAt.Format(time.RFC3339Nano))
+}
+
+// requireBackupPublishedOrBlamedTheMigration covers the run in which no
+// submission was admitted. The backup is normally published, but a submission
+// can also lose the tie after its own hold has already failed the backup, so a
+// failure is legitimate as long as it names the migration.
+func requireBackupPublishedOrBlamedTheMigration(t *testing.T, backupID string, last backupSnapshot, probes []reindexProbe) {
+	t.Helper()
+
+	if last.status == string(backup.Success) {
+		return
+	}
+	require.Containsf(t, last.errMessage, "runtime-reindex",
+		"backup %q ended %s with every submission refused; only a migration may end it that way, "+
+			"and this reason names none. Reason: %q. All probes:\n%s",
+		backupID, last.status, last.errMessage, formatProbes(probes))
+	t.Logf("both sides refused: every submission was answered 409 and backup %q still ended %s "+
+		"naming the migration (%s)", backupID, last.status, last.errMessage)
+}
+
+// admittedTaskID pulls the task id out of a 202 the probe loop did not expect.
+func admittedTaskID(t *testing.T, body string) string {
+	t.Helper()
+
+	var parsed struct {
+		TaskID string `json:"taskId"`
+	}
+	require.NoErrorf(t, json.Unmarshal([]byte(body), &parsed),
+		"a 202 from the reindex endpoint must decode as an IndexUpdateResponse: %s", body)
+	require.NotEmptyf(t, parsed.TaskID, "a 202 from the reindex endpoint must carry a taskId: %s", body)
+	return parsed.TaskID
 }
 
 // testBaselineBackupRoundTrip backs up, deletes, and restores a class

--- a/test/acceptance/reindex_backup/suite_test.go
+++ b/test/acceptance/reindex_backup/suite_test.go
@@ -177,7 +177,7 @@ func testReindexRefusedForTheWholeCaptureWindow(t *testing.T, restURI string) {
 			break
 		}
 
-		resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, propName, requestBody)
+		resp := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, className, propName, requestBody)
 		probes = append(probes, reindexProbe{
 			backupStatus: snap.status,
 			httpStatus:   resp.StatusCode,

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -404,7 +404,7 @@ func testValidation(t *testing.T, restURI string) {
 	}
 
 	t.Run("NonMT_with_tenants", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, nonMTClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, nonMTClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"t1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"non-MT class with tenants should reject as 400: %s", got.Body)
@@ -426,21 +426,21 @@ func testValidation(t *testing.T, restURI string) {
 	}
 
 	t.Run("ChangeTokenization_with_tenants", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, mtClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, mtClass, "text",
 			`{"searchable":{"tokenization":"field"}}`, reindexhelpers.WithTenants([]string{"active1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"MT class with tenants on change-tokenization should reject as 400: %s", got.Body)
 	})
 
 	t.Run("ChangeAlgorithm_with_tenants", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, mtClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, mtClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"active1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"MT class with tenants on change-algorithm should reject as 400: %s", got.Body)
 	})
 
 	t.Run("Nonexistent_tenant", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, mtClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, mtClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"does_not_exist"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"non-existent tenant should reject as 400: %s", got.Body)

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -404,7 +404,7 @@ func testValidation(t *testing.T, restURI string) {
 	}
 
 	t.Run("NonMT_with_tenants", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, nonMTClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, nonMTClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"t1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"non-MT class with tenants should reject as 400: %s", got.Body)
@@ -426,21 +426,21 @@ func testValidation(t *testing.T, restURI string) {
 	}
 
 	t.Run("ChangeTokenization_with_tenants", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, mtClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, mtClass, "text",
 			`{"searchable":{"tokenization":"field"}}`, reindexhelpers.WithTenants([]string{"active1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"MT class with tenants on change-tokenization should reject as 400: %s", got.Body)
 	})
 
 	t.Run("ChangeAlgorithm_with_tenants", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, mtClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, mtClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"active1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"MT class with tenants on change-algorithm should reject as 400: %s", got.Body)
 	})
 
 	t.Run("Nonexistent_tenant", func(t *testing.T) {
-		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, mtClass, "text",
+		got := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, mtClass, "text",
 			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"does_not_exist"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"non-existent tenant should reject as 400: %s", got.Body)

--- a/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
+++ b/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
@@ -137,7 +137,7 @@ func testSearchableTokenizationOnFilterableOnlyRejected(t *testing.T, restURI st
 	})
 	defer helper.DeleteClass(t, className)
 
-	resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, "name",
+	resp := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, className, "name",
 		`{"searchable":{"tokenization":"word"}}`)
 	require.Equal(t, 400, resp.StatusCode,
 		"PUT {searchable:{tokenization:X}} on filterable-only must 400, not 5xx or 202")
@@ -164,7 +164,7 @@ func testFilterableTokenizationOnSearchableOnlyRejected(t *testing.T, restURI st
 	})
 	defer helper.DeleteClass(t, className)
 
-	resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, "body",
+	resp := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, className, "body",
 		`{"filterable":{"tokenization":"field"}}`)
 	require.Equal(t, 400, resp.StatusCode,
 		"PUT {filterable:{tokenization:X}} on searchable-only must 400")
@@ -228,7 +228,7 @@ func testFilterableTokenizationOnNonText(t *testing.T, restURI string) {
 	})
 	defer helper.DeleteClass(t, className)
 
-	resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, "score",
+	resp := reindexhelpers.SubmitIndexUpdateExpectRefusalOrAdmission(t, restURI, className, "score",
 		`{"filterable":{"tokenization":"word"}}`)
 	require.Equal(t, 400, resp.StatusCode,
 		"PUT {filterable:{tokenization:X}} on a non-text property must 400")

--- a/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
+++ b/test/acceptance/reindex_singlenode/change_tokenization_filterable_test.go
@@ -137,7 +137,7 @@ func testSearchableTokenizationOnFilterableOnlyRejected(t *testing.T, restURI st
 	})
 	defer helper.DeleteClass(t, className)
 
-	resp := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, className, "name",
+	resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, "name",
 		`{"searchable":{"tokenization":"word"}}`)
 	require.Equal(t, 400, resp.StatusCode,
 		"PUT {searchable:{tokenization:X}} on filterable-only must 400, not 5xx or 202")
@@ -164,7 +164,7 @@ func testFilterableTokenizationOnSearchableOnlyRejected(t *testing.T, restURI st
 	})
 	defer helper.DeleteClass(t, className)
 
-	resp := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, className, "body",
+	resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, "body",
 		`{"filterable":{"tokenization":"field"}}`)
 	require.Equal(t, 400, resp.StatusCode,
 		"PUT {filterable:{tokenization:X}} on searchable-only must 400")
@@ -228,7 +228,7 @@ func testFilterableTokenizationOnNonText(t *testing.T, restURI string) {
 	})
 	defer helper.DeleteClass(t, className)
 
-	resp := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, className, "score",
+	resp := reindexhelpers.SubmitIndexUpdateExpectRefusal(t, restURI, className, "score",
 		`{"filterable":{"tokenization":"word"}}`)
 	require.Equal(t, 400, resp.StatusCode,
 		"PUT {filterable:{tokenization:X}} on a non-text property must 400")

--- a/test/ciguard/reindex_backup_shards_test.go
+++ b/test/ciguard/reindex_backup_shards_test.go
@@ -29,9 +29,15 @@ import (
 
 const guardedPackagePath = "test/acceptance/reindex_backup"
 
-// imageBuildAllowanceMinutes is the observed slice of the job window spent
-// building the test image before go test starts; it must fit alongside the
-// go-test budget inside the workflow's timeout_minutes.
+// imageBuildAllowanceMinutes is how much of the job window this guard reserves
+// for building the test image before go test starts, so the build and the
+// go-test budget together still fit inside the workflow's timeout_minutes.
+//
+// An allowance, not a measurement: nothing in the repo reports how long the
+// build actually takes. A build that overruns it eats the same number of
+// minutes off the end of the run instead, and the group is runner-killed at
+// timeout_minutes rather than panicking with stacks — the outcome this
+// arithmetic exists to prevent. Raise it if that starts happening.
 const imageBuildAllowanceMinutes = 5
 
 var (
@@ -44,11 +50,13 @@ var (
 	// Fuzz targets are declared like tests but no group's exact-name -run
 	// alternation can select one, so they must be visible to the guards rather
 	// than filtered out before they are counted.
-	declaredTestRe  = regexp.MustCompile(`^func ((?:Test|Fuzz)[A-Za-z0-9_]*)\(`)
-	testNameRe      = regexp.MustCompile(`^(?:Test|Fuzz)[A-Za-z0-9_]*$`)
-	runShFunctionRe = regexp.MustCompile(`^function (run_acceptance_[A-Za-z0-9_]+)\(\)`)
-	runShFlagRe     = regexp.MustCompile(`^\s*(--[a-z0-9-]+)[|)]`)
-	wholeMinutesRe  = regexp.MustCompile(`^([0-9]+)m$`)
+	declaredTestRe     = regexp.MustCompile(`^func ((?:Test|Fuzz)[A-Za-z0-9_]*)\(`)
+	testNameRe         = regexp.MustCompile(`^(?:Test|Fuzz)[A-Za-z0-9_]*$`)
+	runShFunctionRe    = regexp.MustCompile(`^function (run_acceptance_[A-Za-z0-9_]+)\(\)`)
+	runShAnyFunctionRe = regexp.MustCompile(`^function ([A-Za-z0-9_]+)\(\)`)
+	runShFlagRe        = regexp.MustCompile(`^\s*(--[a-z0-9-]+)[|)]`)
+	grepExcludeRe      = regexp.MustCompile(`grep -v[A-Za-z]* '([^']*)'`)
+	wholeMinutesRe     = regexp.MustCompile(`^([0-9]+)m$`)
 	// Matches the package path only as a whole path segment, so a future
 	// sibling such as test/acceptance/reindex_backup_mt is not read as this
 	// package and does not silently widen what these guards claim to cover.
@@ -157,6 +165,69 @@ func TestCIGroupTimeoutFitsTheJobWindow(t *testing.T) {
 				group.name, budget, floor, strings.Join(group.tests, ", "))
 		})
 	}
+}
+
+// TestCIGuardRunsInTheUnitJob pins the placement every other guard here rests
+// on. They only bind because the unit job runs this package, and it only runs it
+// because the package sits outside the trees run_unit_tests filters out. Move it
+// into one of those and it leaves CI entirely, while every assertion in this
+// file still reads as passing.
+func TestCIGuardRunsInTheUnitJob(t *testing.T) {
+	root := repoRoot(t)
+	self := selfPackagePath(t, root)
+
+	for _, pattern := range unitJobExclusions(t, readRunSh(t, root)) {
+		require.NotRegexpf(t, pattern, self,
+			"run_unit_tests in test/run.sh drops every package matching %q, and this guard's own "+
+				"package %s now matches it. Nothing then runs this file, and the shard split it "+
+				"guards goes unchecked while CI reports green. Move the guard back out of that tree.",
+			pattern, self)
+	}
+	// Below that filter run.sh splits what is left over two shards with a grep
+	// and its own -v over one shared expression, so a package that survives
+	// here is run by exactly one of them.
+}
+
+// selfPackagePath is this guard's own directory relative to the checkout root.
+// Read off the working directory rather than written down, so it follows the
+// package instead of having to be kept in step with it.
+func selfPackagePath(t *testing.T, root string) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	rel, err := filepath.Rel(root, dir)
+	require.NoError(t, err)
+	return filepath.ToSlash(rel)
+}
+
+// unitJobExclusions returns the patterns run_unit_tests drops from the package
+// list both unit shards start from.
+func unitJobExclusions(t *testing.T, runSh string) []string {
+	t.Helper()
+
+	var inUnitTests bool
+	for _, line := range strings.Split(runSh, "\n") {
+		if m := runShAnyFunctionRe.FindStringSubmatch(line); m != nil {
+			inUnitTests = m[1] == "run_unit_tests"
+			continue
+		}
+		if !inUnitTests || !strings.Contains(line, "go list ./...") {
+			continue
+		}
+		var patterns []string
+		for _, m := range grepExcludeRe.FindAllStringSubmatch(line, -1) {
+			patterns = append(patterns, m[1])
+		}
+		require.NotEmptyf(t, patterns,
+			"run_unit_tests builds its package list with %q, which this guard cannot read any "+
+				"exclusion out of; either the pipeline changed shape or this guard's parsing "+
+				"broke, and reading zero exclusions would pass every placement", strings.TrimSpace(line))
+		return patterns
+	}
+	t.Fatal("test/run.sh has no `go list ./...` line inside run_unit_tests, so this guard cannot " +
+		"tell which packages the unit job runs")
+	return nil
 }
 
 // TestCIGuardParsers pins the two readers whose failure mode is a silent pass:

--- a/test/ciguard/reindex_backup_shards_test.go
+++ b/test/ciguard/reindex_backup_shards_test.go
@@ -1,0 +1,629 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package ciguard pins the full chain that runs test/acceptance/reindex_backup
+// in CI (test -> allowlist -> run.sh function -> workflow matrix entry). It
+// lives outside the guarded package so a matrix edit that disables the shard
+// cannot also disable its own guard.
+package ciguard
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const guardedPackagePath = "test/acceptance/reindex_backup"
+
+// imageBuildAllowanceMinutes is the observed slice of the job window spent
+// building the test image before go test starts; it must fit alongside the
+// go-test budget inside the workflow's timeout_minutes.
+const imageBuildAllowanceMinutes = 5
+
+var (
+	aofGroupRunRe = regexp.MustCompile(`AOF_GROUP_RUN='([^']*)'`)
+	// Captures whatever a group sets its budget to, not only the readable
+	// shapes, so an unreadable one is rejected rather than skipped.
+	aofGroupTimeoutRe        = regexp.MustCompile(`AOF_GROUP_TIMEOUT=([^\s\\]*)`)
+	aofGroupTimeoutDefaultRe = regexp.MustCompile(`AOF_GROUP_TIMEOUT:-([^\s}]*)`)
+	aofTestBudgetRe          = regexp.MustCompile(`AOF_TEST_BUDGET (Test[A-Za-z0-9_]+) ([0-9]+)m`)
+	// Fuzz targets are declared like tests but no group's exact-name -run
+	// alternation can select one, so they must be visible to the guards rather
+	// than filtered out before they are counted.
+	declaredTestRe  = regexp.MustCompile(`^func ((?:Test|Fuzz)[A-Za-z0-9_]*)\(`)
+	testNameRe      = regexp.MustCompile(`^(?:Test|Fuzz)[A-Za-z0-9_]*$`)
+	runShFunctionRe = regexp.MustCompile(`^function (run_acceptance_[A-Za-z0-9_]+)\(\)`)
+	runShFlagRe     = regexp.MustCompile(`^\s*(--[a-z0-9-]+)[|)]`)
+	wholeMinutesRe  = regexp.MustCompile(`^([0-9]+)m$`)
+	// Matches the package path only as a whole path segment, so a future
+	// sibling such as test/acceptance/reindex_backup_mt is not read as this
+	// package and does not silently widen what these guards claim to cover.
+	guardedPackageRe = regexp.MustCompile(regexp.QuoteMeta(guardedPackagePath) + `(?:[^\w.-]|$)`)
+)
+
+// TestCIAllowlistCoversEveryTestInThisPackage fails when a test in the guarded
+// package is missing from run.sh's -run allowlists, which would leave it never
+// executed while CI stays green. It also fails the other way round, on a
+// filter or a budget line naming a test that no longer exists.
+func TestCIAllowlistCoversEveryTestInThisPackage(t *testing.T) {
+	root := repoRoot(t)
+	runSh := readRunSh(t, root)
+
+	allowed := allowlistedTests(t, runSh)
+	declared := declaredTests(t, root)
+
+	var missing []string
+	for _, name := range declared {
+		if _, ok := allowed[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	require.Emptyf(t, missing,
+		"these tests in %s are in NO run.sh allowlist, so CI never runs them while reporting green: %s\n"+
+			"Add each to an AOF_GROUP_RUN filter in test/run.sh (run_acceptance_reindex_backup_suite, "+
+			"_a or _b for single-node, run_acceptance_reindex_backup_cluster for multi-node), "+
+			"picking the group whose budget still covers its worst case.",
+		guardedPackagePath, strings.Join(missing, ", "))
+
+	declaredSet := map[string]struct{}{}
+	for _, name := range declared {
+		declaredSet[name] = struct{}{}
+	}
+	var stale []string
+	for name, group := range allowed {
+		if _, ok := declaredSet[name]; !ok {
+			stale = append(stale, name+" (in "+group+")")
+		}
+	}
+	require.Emptyf(t, stale,
+		"these names in run.sh's allowlists match no test in %s, so that filter silently runs "+
+			"fewer tests than it reads as covering: %s",
+		guardedPackagePath, strings.Join(stale, ", "))
+
+	var staleBudgets []string
+	for name := range testWorstCases(t, runSh) {
+		if _, ok := declaredSet[name]; !ok {
+			staleBudgets = append(staleBudgets, name)
+		}
+	}
+	require.Emptyf(t, staleBudgets,
+		"these AOF_TEST_BUDGET lines in run.sh name no test in %s, so a group budget is being "+
+			"read against a worst case nothing spends: %s",
+		guardedPackagePath, strings.Join(staleBudgets, ", "))
+}
+
+// TestCIGroupTimeoutFitsTheJobWindow checks each group's go-test budget against
+// the deadlines its own tests wait on and the timeout_minutes the workflow
+// gives the job, so a hang panics with stacks instead of being runner-killed.
+func TestCIGroupTimeoutFitsTheJobWindow(t *testing.T) {
+	root := repoRoot(t)
+	runSh := readRunSh(t, root)
+
+	groups := groupsRunningThisPackage(t, runSh)
+	windows := workflowRunShWindows(t, root)
+	worstCases := testWorstCases(t, runSh)
+
+	for _, group := range groups {
+		t.Run(group.name, func(t *testing.T) {
+			budget := groupTimeoutMinutes(t, runSh, group.name)
+			requireDispatched(t, runSh, group.name)
+			flag := flagArming(t, runSh, group.name)
+
+			// Zero covers both ways the window goes missing: no PR job passes
+			// this flag, or one does with an unreadable timeout_minutes.
+			window := windows[flag]
+			require.NotZerof(t, window,
+				"no pull-request-triggered workflow job in .github/workflows passes %q to "+
+					"test/run.sh under a readable timeout_minutes, so nothing bounds the job "+
+					"%s runs in — and if no job passes it at all, that group and every test it "+
+					"owns silently left PR CI",
+				flag, group.name)
+
+			require.LessOrEqualf(t, budget+imageBuildAllowanceMinutes, window,
+				"%s gets a %dm go-test budget and the image build takes about %dm, which "+
+					"together exceed the %dm the workflow step passing %q allows. The runner "+
+					"kills the job before go test can panic with stacks. Lower the budget, "+
+					"raise timeout_minutes, or split the group.",
+				group.name, budget, imageBuildAllowanceMinutes, window, flag)
+
+			var floor int
+			for _, name := range group.tests {
+				minutes, declared := worstCases[name]
+				require.Truef(t, declared,
+					"%s runs %s but run.sh declares no AOF_TEST_BUDGET line for it, so nothing says "+
+						"how much of the %dm budget it needs; add one next to the others",
+					group.name, name, budget)
+				floor += minutes
+			}
+			require.GreaterOrEqualf(t, budget, floor,
+				"%s gets a %dm go-test budget but its tests wait on %dm of deadlines (%s). go test "+
+					"is killed before the slowest one reaches its own assertion, and the failure "+
+					"reads as a product hang rather than a budget that is too small. Raise the "+
+					"budget, or move a test to another group.",
+				group.name, budget, floor, strings.Join(group.tests, ", "))
+		})
+	}
+}
+
+// TestCIGuardParsers pins the two readers whose failure mode is a silent pass:
+// a budget shape this guard rounds instead of rejecting would validate a group
+// against a number the group does not use, and a package match on a substring
+// would read a future sibling package as this one.
+func TestCIGuardParsers(t *testing.T) {
+	t.Run("only whole minutes are readable", func(t *testing.T) {
+		// The rejected shapes are all shapes go test itself accepts.
+		tests := []struct {
+			value string
+			want  int
+			ok    bool
+		}{
+			{value: "20m", want: 20, ok: true},
+			{value: "90s"},
+			{value: "18m30s"},
+			{value: "20"},
+			{value: ""},
+		}
+		for _, tc := range tests {
+			t.Run(tc.value, func(t *testing.T) {
+				minutes, ok := wholeMinutes(tc.value)
+				require.Equal(t, tc.ok, ok)
+				require.Equal(t, tc.want, minutes)
+			})
+		}
+	})
+
+	t.Run("the package path matches whole segments only", func(t *testing.T) {
+		tests := []struct {
+			scope string
+			want  bool
+		}{
+			{scope: `run_aof_group "reindex-backup-a" test/acceptance/reindex_backup`, want: true},
+			{scope: `run_aof_group "x" test/acceptance/reindex_backup someArg`, want: true},
+			{scope: `run_aof_group "x" test/acceptance/reindex_backup_mt`},
+			{scope: `run_aof_group "x" test/acceptance/reindex_backup-legacy`},
+		}
+		for _, tc := range tests {
+			t.Run(tc.scope, func(t *testing.T) {
+				require.Equal(t, tc.want, guardedPackageRe.MatchString(tc.scope))
+			})
+		}
+	})
+}
+
+// repoRoot walks up from the working directory to the checkout root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "test", "run.sh")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		require.NotEqual(t, dir, parent, "walked to the filesystem root without finding test/run.sh")
+		dir = parent
+	}
+}
+
+func readRunSh(t *testing.T, root string) string {
+	t.Helper()
+	body, err := os.ReadFile(filepath.Join(root, "test", "run.sh"))
+	require.NoError(t, err)
+	return string(body)
+}
+
+// declaredTests reads the guarded package's sources for top-level test
+// functions. A source scan, not `go test -list`: it needs no toolchain and no
+// compile of an acceptance package, and it still sees a test hidden behind a
+// build tag, which `go test -list` without -tags does not.
+//
+// The one escape left open: the read is non-recursive, so tests in a
+// subpackage of the guarded package are not covered by these guards.
+func declaredTests(t *testing.T, root string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(root, guardedPackagePath))
+	require.NoError(t, err)
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(root, guardedPackagePath, entry.Name()))
+		require.NoError(t, err)
+		for _, line := range strings.Split(string(body), "\n") {
+			m := declaredTestRe.FindStringSubmatch(line)
+			// TestMain is the package's own entry point, never selectable by a
+			// -run filter, so it is not something an allowlist can cover.
+			if m == nil || m[1] == "TestMain" {
+				continue
+			}
+			names = append(names, m[1])
+		}
+	}
+	require.NotEmptyf(t, names,
+		"%s declares no tests; either the package moved or this guard's parsing broke, and a "+
+			"silent pass here would defeat every guard in this file", guardedPackagePath)
+	return names
+}
+
+// allowlistedTests maps each allowlisted test name to the one group that runs
+// it. Being in two groups is rejected, not merged: each group's budget is
+// derived on the assumption a test runs once.
+func allowlistedTests(t *testing.T, runSh string) map[string]string {
+	t.Helper()
+
+	allowed := map[string]string{}
+	for _, group := range groupsRunningThisPackage(t, runSh) {
+		for _, name := range group.tests {
+			other, duplicate := allowed[name]
+			require.Falsef(t, duplicate,
+				"%s is in the AOF_GROUP_RUN filter of both %s and %s, so it runs twice while each "+
+					"group's budget is derived on the assumption it runs once; delete the stale entry",
+				name, other, group.name)
+			allowed[name] = group.name
+		}
+	}
+	return allowed
+}
+
+// testWorstCases reads run.sh's per-test AOF_TEST_BUDGET lines, which are the
+// sums the group budgets are derived from. They live in run.sh so the
+// derivation and the budget it produces cannot drift apart in separate files.
+func testWorstCases(t *testing.T, runSh string) map[string]int {
+	t.Helper()
+
+	worst := map[string]int{}
+	for _, m := range aofTestBudgetRe.FindAllStringSubmatch(runSh, -1) {
+		_, duplicate := worst[m[1]]
+		require.Falsef(t, duplicate, "run.sh declares two AOF_TEST_BUDGET lines for %s", m[1])
+		minutes, err := strconv.Atoi(m[2])
+		require.NoError(t, err)
+		worst[m[1]] = minutes
+	}
+	require.NotEmpty(t, worst,
+		"run.sh declares no AOF_TEST_BUDGET lines, so nothing says what each group's budget "+
+			"has to cover; either they were removed or this guard's parsing broke")
+	return worst
+}
+
+// packageGroup is one run_acceptance_* function running the guarded package,
+// with the exact test names its AOF_GROUP_RUN filter selects.
+type packageGroup struct {
+	name  string
+	tests []string
+}
+
+// groupsRunningThisPackage returns, in run.sh order, the run_acceptance_*
+// functions that carry an AOF_GROUP_RUN filter for the guarded package.
+func groupsRunningThisPackage(t *testing.T, runSh string) []packageGroup {
+	t.Helper()
+
+	lines := strings.Split(runSh, "\n")
+	var (
+		current string
+		groups  []packageGroup
+		at      = map[string]int{}
+	)
+	for i, line := range lines {
+		if m := runShFunctionRe.FindStringSubmatch(line); m != nil {
+			current = m[1]
+			continue
+		}
+		m := aofGroupRunRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		scope := strings.Join(lines[i:min(i+4, len(lines))], "\n")
+		if !guardedPackageRe.MatchString(scope) {
+			continue
+		}
+		require.NotEmptyf(t, current,
+			"an AOF_GROUP_RUN filter for %s sits outside any run_acceptance_* function "+
+				"(test/run.sh line %d); this guard cannot trace it to a CI flag",
+			guardedPackagePath, i+1)
+		idx, seen := at[current]
+		if !seen {
+			idx = len(groups)
+			at[current] = idx
+			groups = append(groups, packageGroup{name: current})
+		}
+		groups[idx].tests = append(groups[idx].tests, parseExactNameAlternation(t, m[1])...)
+	}
+	require.NotEmptyf(t, groups,
+		"test/run.sh holds no AOF_GROUP_RUN filter for %s; the whole shard split is gone "+
+			"or this guard's parsing broke", guardedPackagePath)
+	return groups
+}
+
+// parseExactNameAlternation turns `^(A|B)$` or `^A$` into its names, and fails
+// on anything else: a pattern this cannot read exactly is one whose coverage
+// this guard cannot vouch for.
+func parseExactNameAlternation(t *testing.T, pattern string) []string {
+	t.Helper()
+
+	require.True(t, strings.HasPrefix(pattern, "^") && strings.HasSuffix(pattern, "$"),
+		"AOF_GROUP_RUN %q is not anchored; this guard only understands exact-name allowlists", pattern)
+	body := strings.TrimSuffix(strings.TrimPrefix(pattern, "^"), "$")
+	if strings.HasPrefix(body, "(") && strings.HasSuffix(body, ")") {
+		body = strings.TrimSuffix(strings.TrimPrefix(body, "("), ")")
+	}
+
+	names := strings.Split(body, "|")
+	for _, name := range names {
+		require.Regexp(t, testNameRe, name,
+			"AOF_GROUP_RUN %q contains %q, which is not a plain test name; this guard only "+
+				"understands exact-name allowlists", pattern, name)
+	}
+	return names
+}
+
+// groupTimeoutMinutes reads the go-test budget a group sets, falling back to
+// run_aof_group's default when it sets none. A budget in any other shape than
+// whole minutes fails here rather than falling through to the default.
+func groupTimeoutMinutes(t *testing.T, runSh, group string) int {
+	t.Helper()
+
+	var inGroup bool
+	for _, line := range strings.Split(runSh, "\n") {
+		if m := runShFunctionRe.FindStringSubmatch(line); m != nil {
+			inGroup = m[1] == group
+			continue
+		}
+		if !inGroup {
+			continue
+		}
+		if m := aofGroupTimeoutRe.FindStringSubmatch(line); m != nil {
+			return requireWholeMinutes(t, m[1], group+" sets AOF_GROUP_TIMEOUT")
+		}
+	}
+
+	m := aofGroupTimeoutDefaultRe.FindStringSubmatch(runSh)
+	require.NotNilf(t, m, "%s sets no AOF_GROUP_TIMEOUT and run_aof_group's default "+
+		"is not in the shape this guard reads", group)
+	return requireWholeMinutes(t, m[1], "run_aof_group's default AOF_GROUP_TIMEOUT")
+}
+
+// wholeMinutes reads an Nm duration. Every other shape go test accepts —
+// 1h, 90s, 18m30s — reports false rather than a number, because rounding one
+// silently is the same defect as reading the wrong value.
+func wholeMinutes(value string) (int, bool) {
+	m := wholeMinutesRe.FindStringSubmatch(value)
+	if m == nil {
+		return 0, false
+	}
+	minutes, err := strconv.Atoi(m[1])
+	if err != nil {
+		return 0, false
+	}
+	return minutes, true
+}
+
+// requireWholeMinutes is wholeMinutes with the failure spelled out for whoever
+// wrote the unreadable value.
+func requireWholeMinutes(t *testing.T, value, what string) int {
+	t.Helper()
+
+	minutes, ok := wholeMinutes(value)
+	require.Truef(t, ok,
+		"%s to %q, which is not the whole-minutes shape this guard reads, so it cannot say "+
+			"whether the group's tests fit inside it; write the budget as Nm",
+		what, value)
+	return minutes
+}
+
+// requireDispatched pins the hop between run.sh's flag variable and the call:
+// a flag that arms a variable nobody reads runs nothing.
+func requireDispatched(t *testing.T, runSh, group string) {
+	t.Helper()
+
+	lines := strings.Split(runSh, "\n")
+	for i, line := range lines {
+		if !strings.Contains(line, "if $"+group+"; then") {
+			continue
+		}
+		scope := strings.Join(lines[i:min(i+4, len(lines))], "\n")
+		require.Containsf(t, scope, "\n    "+group+"\n",
+			"test/run.sh guards on $%s but does not call %s underneath it", group, group)
+		return
+	}
+	t.Fatalf("test/run.sh never reads $%s, so no flag can reach %s", group, group)
+}
+
+// flagArming returns the long CLI flag whose arg-parse arm sets this group's
+// variable.
+func flagArming(t *testing.T, runSh, group string) string {
+	t.Helper()
+
+	for _, line := range strings.Split(runSh, "\n") {
+		if !strings.Contains(line, group+"=true") {
+			continue
+		}
+		m := runShFlagRe.FindStringSubmatch(line)
+		require.NotNilf(t, m, "test/run.sh line %q sets %s=true but starts with no --flag", line, group)
+		return m[1]
+	}
+	t.Fatalf("no test/run.sh argument sets %s=true, so nothing on a CI command line can select it", group)
+	return ""
+}
+
+// workflowFile is the slice of a workflow this guard reads: what triggers it,
+// and which jobs it has.
+type workflowFile struct {
+	On   yaml.Node              `yaml:"on"`
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	If       string `yaml:"if"`
+	Strategy struct {
+		Matrix struct {
+			Include []map[string]yaml.Node `yaml:"include"`
+		} `yaml:"matrix"`
+	} `yaml:"strategy"`
+	Steps []workflowStep `yaml:"steps"`
+}
+
+type workflowStep struct {
+	If   string               `yaml:"if"`
+	Run  string               `yaml:"run"`
+	With map[string]yaml.Node `yaml:"with"`
+}
+
+// workflowRunShWindows maps every test/run.sh flag a pull request can reach to
+// the smallest timeout_minutes bounding a step that runs it; an absent key
+// means the group left PR CI, a zero one means its budget can't be checked.
+func workflowRunShWindows(t *testing.T, root string) map[string]int {
+	t.Helper()
+
+	dir := filepath.Join(root, ".github", "workflows")
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	windows := map[string]int{}
+	var parsed int
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), "ml") {
+			continue
+		}
+		body, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		require.NoError(t, err)
+
+		var wf workflowFile
+		require.NoErrorf(t, yaml.Unmarshal(body, &wf),
+			"%s does not parse as YAML; this guard cannot tell what it runs", entry.Name())
+		parsed++
+
+		if !triggersOnPullRequest(&wf.On) {
+			continue
+		}
+		for _, job := range wf.Jobs {
+			if notProvenTrue(job.If) {
+				continue
+			}
+			collectRunShWindows(job, windows)
+		}
+	}
+	require.NotZero(t, parsed, "no workflow files found under %s", dir)
+	return windows
+}
+
+// collectRunShWindows records the window bounding every flag one job's run.sh
+// steps can be handed, including the ones its matrix interpolates in.
+func collectRunShWindows(job workflowJob, windows map[string]int) {
+	var matrixFlags []string
+	for _, entry := range job.Strategy.Matrix.Include {
+		for _, v := range entry {
+			matrixFlags = append(matrixFlags, flagsIn(scalar(&v))...)
+		}
+	}
+
+	for _, step := range job.Steps {
+		if notProvenTrue(step.If) {
+			continue
+		}
+		commands := []string{step.Run}
+		for _, v := range step.With {
+			commands = append(commands, scalar(&v))
+		}
+
+		var runsRunSh bool
+		// Cloned: appending to the matrix flags in place would leak this step's
+		// flags into every later step's list.
+		stepFlags := append([]string(nil), matrixFlags...)
+		for _, c := range commands {
+			if strings.Contains(c, "run.sh") {
+				runsRunSh = true
+			}
+			stepFlags = append(stepFlags, flagsIn(c)...)
+		}
+		if !runsRunSh {
+			continue
+		}
+
+		// A timeout_minutes written as a `${{ }}` expression is a window this
+		// guard cannot read. Recording zero makes the group it covers fail as
+		// "no window found" rather than pass on an unread number.
+		var minutes int
+		if raw, ok := step.With["timeout_minutes"]; ok {
+			minutes, _ = strconv.Atoi(scalar(&raw))
+		}
+		for _, flag := range stepFlags {
+			existing, seen := windows[flag]
+			if !seen {
+				windows[flag] = minutes
+				continue
+			}
+			if minutes > 0 && (existing == 0 || minutes < existing) {
+				windows[flag] = minutes
+			}
+		}
+	}
+}
+
+func flagsIn(command string) []string {
+	var flags []string
+	for _, w := range strings.Fields(command) {
+		if strings.HasPrefix(w, "--") {
+			flags = append(flags, w)
+		}
+	}
+	return flags
+}
+
+// triggersOnPullRequest reads the `on:` key in each of its three legal shapes.
+func triggersOnPullRequest(on *yaml.Node) bool {
+	switch on.Kind {
+	case yaml.ScalarNode:
+		return on.Value == "pull_request"
+	case yaml.SequenceNode:
+		for _, item := range on.Content {
+			if item.Value == "pull_request" {
+				return true
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i < len(on.Content); i += 2 {
+			if on.Content[i].Value == "pull_request" {
+				return true
+			}
+		}
+	case yaml.DocumentNode, yaml.AliasNode:
+		// not a legal shape for an `on:` value; treat as not triggered
+	}
+	return false
+}
+
+// notProvenTrue reports whether an if: might not hold on a pull request.
+// Anything other than an absent or literally-true condition counts, since e.g.
+// github.event_name == 'schedule' takes the group out of every PR run too.
+func notProvenTrue(expr string) bool {
+	e := strings.TrimSpace(expr)
+	if e == "" {
+		return false
+	}
+	e = strings.TrimSuffix(strings.TrimPrefix(e, "${{"), "}}")
+	return !strings.EqualFold(strings.TrimSpace(e), "true")
+}
+
+func scalar(n *yaml.Node) string {
+	if n.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return n.Value
+}

--- a/test/run.sh
+++ b/test/run.sh
@@ -58,7 +58,10 @@ function main() {
   run_acceptance_reindex_singlenode_b=false
   run_acceptance_reindex_concurrent=false
   run_acceptance_reindex_mt=false
-  run_acceptance_reindex_backup=false
+  run_acceptance_reindex_backup_suite=false
+  run_acceptance_reindex_backup_a=false
+  run_acceptance_reindex_backup_b=false
+  run_acceptance_reindex_backup_cluster=false
   run_acceptance_backups=false
 
   while [[ "$#" -gt 0 ]]; do
@@ -117,7 +120,10 @@ function main() {
           --acceptance-reindex-singlenode-b|-arsb) run_all_tests=false; run_acceptance_reindex_singlenode_b=true;;
           --acceptance-reindex-concurrent|-arc) run_all_tests=false; run_acceptance_reindex_concurrent=true;;
           --acceptance-reindex-mt|-armt) run_all_tests=false; run_acceptance_reindex_mt=true;;
-          --acceptance-reindex-backup|-arb) run_all_tests=false; run_acceptance_reindex_backup=true;;
+          --acceptance-reindex-backup-suite|-arbs) run_all_tests=false; run_acceptance_reindex_backup_suite=true;;
+          --acceptance-reindex-backup-a|-arba) run_all_tests=false; run_acceptance_reindex_backup_a=true;;
+          --acceptance-reindex-backup-b|-arbb) run_all_tests=false; run_acceptance_reindex_backup_b=true;;
+          --acceptance-reindex-backup-cluster|-arbc) run_all_tests=false; run_acceptance_reindex_backup_cluster=true;;
           --acceptance-backups|-ab) run_all_tests=false; run_acceptance_backups=true;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
           --cleanup) run_all_tests=false; run_cleanup=true;;
@@ -166,7 +172,10 @@ function main() {
               "--acceptance-reindex-singlenode-b | -arsb"\
               "--acceptance-reindex-concurrent | -arc"\
               "--acceptance-reindex-mt | -armt"\
-              "--acceptance-reindex-backup | -arb"\
+              "--acceptance-reindex-backup-suite | -arbs"\
+              "--acceptance-reindex-backup-a | -arba"\
+              "--acceptance-reindex-backup-b | -arbb"\
+              "--acceptance-reindex-backup-cluster | -arbc"\
               "--acceptance-backups | -ab"\
               "--only-acceptance-{packageName}"
               "--only-module-{moduleName}"
@@ -396,7 +405,7 @@ function main() {
   fi
 
   if $run_acceptance_reindex_singlenode_b; then
-    echo "running reindex singlenode acceptance tests — sub-shard B (PropertyStateMigrationMatrix + PostRestartFinalize)"
+    echo "running reindex singlenode acceptance tests — sub-shard B (PropertyStateMigrationMatrix only)"
     run_acceptance_reindex_singlenode_b
   fi
 
@@ -410,9 +419,24 @@ function main() {
     run_acceptance_reindex_mt
   fi
 
-  if $run_acceptance_reindex_backup; then
-    echo "running backup × runtime-reindex acceptance tests"
-    run_acceptance_reindex_backup
+  if $run_acceptance_reindex_backup_suite; then
+    echo "running backup × runtime-reindex acceptance tests (single-node suite)"
+    run_acceptance_reindex_backup_suite
+  fi
+
+  if $run_acceptance_reindex_backup_a; then
+    echo "running backup × runtime-reindex acceptance tests (single-node guards A)"
+    run_acceptance_reindex_backup_a
+  fi
+
+  if $run_acceptance_reindex_backup_b; then
+    echo "running backup × runtime-reindex acceptance tests (single-node guards B)"
+    run_acceptance_reindex_backup_b
+  fi
+
+  if $run_acceptance_reindex_backup_cluster; then
+    echo "running backup × runtime-reindex acceptance tests (multi-node)"
+    run_acceptance_reindex_backup_cluster
   fi
 
   if $run_acceptance_backups; then
@@ -617,9 +641,11 @@ function get_fast_acceptance_packages() {
 #   $@: package_paths - list of package paths to run
 #
 # Optional env vars (read by this function):
-#   AOF_GROUP_RUN  - if non-empty, passed as `-run "$AOF_GROUP_RUN"` to go test
-#   AOF_GROUP_SKIP - if non-empty, passed as `-skip "$AOF_GROUP_SKIP"` to go test
-# Use these to shard a heavy test package across multiple CI jobs.
+#   AOF_GROUP_RUN     - if non-empty, passed as `-run "$AOF_GROUP_RUN"` to go test
+#   AOF_GROUP_SKIP    - if non-empty, passed as `-skip "$AOF_GROUP_SKIP"` to go test
+#   AOF_GROUP_TIMEOUT - per-package `-timeout`, default 20m
+# Use the first two to shard a heavy test package across multiple CI jobs, and
+# the third when a group legitimately runs longer than the default.
 #
 # Stress tests automatically get different flags (no timeout, no race detector).
 # Returns 1 if any test fails, 0 if all succeed.
@@ -644,6 +670,10 @@ function run_aof_group() {
     extra_flags+=(-skip "$AOF_GROUP_SKIP")
   fi
 
+  # Go's per-package timeout fires as a hard panic, so a group whose tests can
+  # legitimately run longer than the default needs its own budget.
+  local group_timeout="${AOF_GROUP_TIMEOUT:-20m}"
+
   local testFailed=0
   for path in "${package_paths[@]}"; do
     for pkg in $(go list "./$path" 2>/dev/null || true); do
@@ -656,7 +686,7 @@ function run_aof_group() {
           testFailed=1
         fi
       else
-        if ! go test -count 1 -timeout=20m -race "${extra_flags[@]}" "$pkg"; then
+        if ! go test -count 1 -timeout="$group_timeout" -race "${extra_flags[@]}" "$pkg"; then
           echo "Test for $pkg failed" >&2
           testFailed=1
         fi
@@ -1019,11 +1049,81 @@ function run_acceptance_reindex_mt() {
     test/acceptance/reindex_mt
 }
 
-function run_acceptance_reindex_backup() {
+# test/acceptance/reindex_backup is spread over the four groups below (three
+# single-node, one multi-node). Every filter matches by exact name; a typo runs
+# zero tests and still reports green, which is what
+# TestCIAllowlistCoversEveryTestInThisPackage exists to catch. It lives in
+# test/ciguard, which the plain unit-test job runs: a guard shipped inside the
+# shard it guards is disabled by the same matrix edit it exists to catch.
+#
+# Each group's budget is the sum of the deadlines its own tests wait on, which
+# is why they differ. A budget below that sum has go test killed by the runner
+# before it can panic with stacks, so TestCIGroupTimeoutFitsTheJobWindow reads
+# the per-test worst cases below and holds every budget to their sum. Keep the
+# AOF_TEST_BUDGET lines next to the derivation; the guard fails on a test that
+# has none.
+#
+#   AOF_TEST_BUDGET TestBackupVsReindexSuite 35m   9 sequential subtests
+#   AOF_TEST_BUDGET TestReindexRefusedWhileRestoreRuns 20m   three 5m waits + 60s + 60s + 180s
+#   AOF_TEST_BUDGET TestReindexBlockClearsAfterNodeCrash 17m   two 5m probes + 120s + 60s + 60s + 180s
+#   AOF_TEST_BUDGET TestReindexRefusedWhileBackupRuns 15m   two 5m waits + 30s + 60s + 180s, rounded up from 14.5m
+#   AOF_TEST_BUDGET TestRestoreRefusedDuringInFlightReindex 6m   3m backup + 2m restore + 30s
+#   AOF_TEST_BUDGET TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp 26m   two 10m backup waits + six 60s waits
+#
+# That sum is a floor, not a target. reindex-backup-suite and reindex-backup-b
+# are budgeted at exactly theirs, on the assumption their tests finish well
+# inside their own deadlines. Container startup and the -race build sit outside
+# every per-test deadline, so they come out of that slack rather than out of a
+# separate allowance. In practice each group finishes in under 5 minutes,
+# because the deadlines are ceilings a healthy run never approaches. If that
+# stops holding, these two groups go red first.
+#
+# Those sum to ~119m against a 45m job window that also has to fit the ~5m
+# image build, which is why the package is split over four entries rather than
+# run under one budget. 40m is therefore the ceiling for any single budget
+# below; TestCIGroupTimeoutFitsTheJobWindow enforces it.
+
+function run_acceptance_reindex_backup_suite() {
   build_weaviate_test_image
-  echo_green "acceptance — reindex-backup"
-  run_aof_group "reindex-backup" \
-    test/acceptance/reindex_backup
+  echo_green "acceptance — reindex-backup-suite (single-node, TestBackupVsReindexSuite)"
+  # One test, so it gets the entry to itself.
+  AOF_GROUP_TIMEOUT=35m \
+    AOF_GROUP_RUN='^TestBackupVsReindexSuite$' \
+    run_aof_group "reindex-backup-suite" test/acceptance/reindex_backup
+}
+
+function run_acceptance_reindex_backup_a() {
+  build_weaviate_test_image
+  echo_green "acceptance — reindex-backup-a (single-node restore guards)"
+  # Both restore-side guards, so a change to that side lands in one group
+  # rather than two. 2m over the 26m floor for container startup and the -race
+  # build, which sit outside every per-test deadline.
+  AOF_GROUP_TIMEOUT=28m \
+    AOF_GROUP_RUN='^(TestReindexRefusedWhileRestoreRuns|TestRestoreRefusedDuringInFlightReindex)$' \
+    run_aof_group "reindex-backup-a" test/acceptance/reindex_backup
+}
+
+function run_acceptance_reindex_backup_b() {
+  build_weaviate_test_image
+  echo_green "acceptance — reindex-backup-b (single-node backup guards)"
+  # Both tests are backup-side guards, so a change to that side lands in one
+  # group rather than two.
+  AOF_GROUP_TIMEOUT=32m \
+    AOF_GROUP_RUN='^(TestReindexBlockClearsAfterNodeCrash|TestReindexRefusedWhileBackupRuns)$' \
+    run_aof_group "reindex-backup-b" test/acceptance/reindex_backup
+}
+
+function run_acceptance_reindex_backup_cluster() {
+  build_weaviate_test_image
+  echo_green "acceptance — reindex-backup-cluster (multi-node)"
+  # TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp only. The 9m over its
+  # floor buys padding for the multi-node cluster, the slowest of the four
+  # groups to come up. The floor is a healthy-path ceiling; a placement-retry
+  # loop could theoretically exceed it, and this budget — but that fails loudly
+  # as a go-test panic, not silently.
+  AOF_GROUP_TIMEOUT=35m \
+    AOF_GROUP_RUN='^TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp$' \
+    run_aof_group "reindex-backup-cluster" test/acceptance/reindex_backup
 }
 
 function run_acceptance_backups() {

--- a/test/run.sh
+++ b/test/run.sh
@@ -1056,29 +1056,47 @@ function run_acceptance_reindex_mt() {
 # test/ciguard, which the plain unit-test job runs: a guard shipped inside the
 # shard it guards is disabled by the same matrix edit it exists to catch.
 #
-# Each group's budget is the sum of the deadlines its own tests wait on, which
-# is why they differ. A budget below that sum has go test killed by the runner
-# before it can panic with stacks, so TestCIGroupTimeoutFitsTheJobWindow reads
-# the per-test worst cases below and holds every budget to their sum. Keep the
-# AOF_TEST_BUDGET lines next to the derivation; the guard fails on a test that
-# has none.
+# Every AOF_TEST_BUDGET below is a sum of deadlines read off the test's own
+# code, never an observed runtime, so a budget can be checked against something
+# other than itself. A budget below its group's sum has go test killed by the
+# runner before it can panic with stacks, so TestCIGroupTimeoutFitsTheJobWindow
+# reads the per-test sums below and holds every budget at or above theirs. Keep
+# the AOF_TEST_BUDGET lines next to the derivation; the guard fails on a test
+# that has none.
 #
-#   AOF_TEST_BUDGET TestBackupVsReindexSuite 35m   9 sequential subtests
+#   AOF_TEST_BUDGET TestBackupVsReindexSuite 33m   its nine subtests' own waits,
+#     rounded up from 32m40s:
+#       BaselineBackupRoundTrip                           4m      2m create + 2m restore
+#       BackupRefusedDuringInFlightMigration              4m40s   30s live + 10s staging dir + 120s indexes + 2m create
+#       BackupSucceedsAfterMigrationFinishes              5m      60s indexes + 2m create + 2m restore
+#       PostRestartOrphanAuditClearsTracker               2m      60s tracker dir + 60s sidecar dir
+#       CancelOnNoInFlightReturns202NoOp                  0       waits on nothing
+#       AlgorithmVerbRefusesOnAlreadyBlockmaxRejectsWAND  1m      60s finished
+#       MutationGuardBlocksDeleteClassDuringInFlight      2m30s   30s indexing + 120s finished
+#       CancelClearsTrackerDirsViaOnTaskCompleted         1m30s   30s indexing + 30s drain + 30s class dir
+#       ReindexRefusedForTheWholeCaptureWindow           12m      5m probe window + 5m terminal + 30s task start + 90s cancel drain
 #   AOF_TEST_BUDGET TestReindexRefusedWhileRestoreRuns 20m   three 5m waits + 60s + 60s + 180s
 #   AOF_TEST_BUDGET TestReindexBlockClearsAfterNodeCrash 17m   two 5m probes + 120s + 60s + 60s + 180s
 #   AOF_TEST_BUDGET TestReindexRefusedWhileBackupRuns 15m   two 5m waits + 30s + 60s + 180s, rounded up from 14.5m
 #   AOF_TEST_BUDGET TestRestoreRefusedDuringInFlightReindex 6m   3m backup + 2m restore + 30s
-#   AOF_TEST_BUDGET TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp 26m   two 10m backup waits + six 60s waits
+#   AOF_TEST_BUDGET TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp 26m   two 10m backup
+#     waits + six 60s waits. It leaves out resolveGuardTopology's placement loop,
+#     which can ask for single-shard ownership up to 16 times at 60s each. That
+#     60s is how long ownership may take to resolve, not what an attempt costs:
+#     a healthy run spends about a second per attempt. Sixteen attempts each
+#     taking the full minute means the cluster is not placing shards at all, and
+#     the answer to that is the 35m budget panicking with stacks well inside the
+#     45m window, which is what it does.
 #
-# That sum is a floor, not a target. reindex-backup-suite and reindex-backup-b
-# are budgeted at exactly theirs, on the assumption their tests finish well
-# inside their own deadlines. Container startup and the -race build sit outside
-# every per-test deadline, so they come out of that slack rather than out of a
-# separate allowance. In practice each group finishes in under 5 minutes,
-# because the deadlines are ceilings a healthy run never approaches. If that
-# stops holding, these two groups go red first.
+# Those sums are floors, not targets. reindex-backup-b is budgeted at exactly
+# its own, on the assumption its tests finish well inside their own deadlines.
+# Container startup and the -race build sit outside every per-test deadline, so
+# they come out of the slack rather than out of a separate allowance. In
+# practice each group finishes in under 5 minutes, because the deadlines are
+# ceilings a healthy run never approaches. If that stops holding,
+# reindex-backup-b goes red first.
 #
-# Those sum to ~119m against a 45m job window that also has to fit the ~5m
+# Those sum to ~117m against a 45m job window that also has to fit the ~5m
 # image build, which is why the package is split over four entries rather than
 # run under one budget. 40m is therefore the ceiling for any single budget
 # below; TestCIGroupTimeoutFitsTheJobWindow enforces it.
@@ -1086,7 +1104,9 @@ function run_acceptance_reindex_mt() {
 function run_acceptance_reindex_backup_suite() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-backup-suite (single-node, TestBackupVsReindexSuite)"
-  # One test, so it gets the entry to itself.
+  # One test, so it gets the entry to itself. 2m over its 33m floor for
+  # container startup, the -race build and three 50k imports, none of which sit
+  # inside a per-subtest deadline.
   AOF_GROUP_TIMEOUT=35m \
     AOF_GROUP_RUN='^TestBackupVsReindexSuite$' \
     run_aof_group "reindex-backup-suite" test/acceptance/reindex_backup
@@ -1118,9 +1138,7 @@ function run_acceptance_reindex_backup_cluster() {
   echo_green "acceptance — reindex-backup-cluster (multi-node)"
   # TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp only. The 9m over its
   # floor buys padding for the multi-node cluster, the slowest of the four
-  # groups to come up. The floor is a healthy-path ceiling; a placement-retry
-  # loop could theoretically exceed it, and this budget — but that fails loudly
-  # as a go-test panic, not silently.
+  # groups to come up, and for the placement loop the floor leaves out.
   AOF_GROUP_TIMEOUT=35m \
     AOF_GROUP_RUN='^TestMultiNodeReindexRefusedWhileRemoteNodeBacksUp$' \
     run_aof_group "reindex-backup-cluster" test/acceptance/reindex_backup


### PR DESCRIPTION
## What this is

The end-to-end proof for [weaviate/weaviate#12582](https://github.com/weaviate/weaviate/issues/12582), plus the CI plumbing that runs it.

**This must merge after #12582.** These are black-box HTTP tests: they compile against 12582's base and would *fail* there, because the behavior they exercise does not exist until 12582 lands. That is why they stack above rather than below.

## Why it is a separate PR

12582's diff was 22,936 lines of rendered diff output across 115 files, past GitHub's 20,000-line ceiling. The diff API answers `406`, which means `protolint` and `hidden unicode characters` fail on the fetch alone — there is no `.proto` file in that branch at all, so protolint has nothing to complain about; it simply cannot read the patch. Moving this block out is part of getting 12582 under the ceiling and reviewable.

Nothing in 12582's production code references these files, so this is a pure move: no rebase, no code change.

## Contents

| Block | What it covers |
|---|---|
| `test/acceptance/reindex_backup/` | Five guard suites plus the whole-capture-window subtest: the submit gate, the restore gate, the block clearing after a node crash, and the multi-node case where a remote node is the one backing up. |
| `test/run.sh`, `.github/workflows/pull_requests.yaml` | The `reindex_backup` CI shard split into four groups, each with its own timeout budget derived from the deadlines its own tests wait on. |
| `test/ciguard/` | Holds those budgets to the 45-minute job window and fails when a test in the package is named by no group's allowlist — a typo in a `-run` filter otherwise runs zero tests and still reports green. It lives outside the shard it guards, so the matrix edit it exists to catch cannot disable it. |
| `docs/runtime-reindex.md` | The section describing the finished behavior. |
| `test/acceptance/helpers/reindex/helpers.go` | The shared helper rename the suites call (`SubmitIndexUpdateExpect4xx` → `SubmitIndexUpdateExpectRefusalOrAdmission`, plus the `WithReindexEnv` extraction), and its two call sites. |

## ⚠️ Admin step at merge time — nothing in CI can check this

The required status check `reindex (backup)` is replaced by **four** names:

- `reindex (backup-suite)`
- `reindex (backup-a)`
- `reindex (backup-b)`
- `reindex (backup-cluster)`

Whoever merges has to **add all four** to branch protection and **drop the old one**. Branch protection lives in GitHub's repo settings, not in this repository, so no test can see it — `test/ciguard` proves each shard exists, is dispatched by a PR job, and fits its window, and stops there.

The two directions fail differently:

| Miss | Symptom | Loud? |
|---|---|---|
| Forget to **drop** `reindex (backup)` | The stale name is never reported, so every PR blocks forever | 🔊 Loud — noticed within one PR |
| Forget to **add** the four | The shards run on every PR, but a red shard blocks nothing | 🔇 **Silent** — indistinguishable from green |

The silent direction is the one that matters, and nothing in-repo can detect it. It is a genuine gap, closed only by a human at merge time. The same note now sits on the workflow matrix itself (`.github/workflows/pull_requests.yaml`), so the next person who adds or renames a shard reads it where they are already editing.

## Review focus

- The per-group timeout budgets in `test/run.sh`. Each is the sum of deadlines read off its tests' own code, never an observed runtime, so `TestCIGroupTimeoutFitsTheJobWindow` checks a budget against something other than itself. It enforces both the derivation and the 40-minute ceiling.
- `TestCIAllowlistCoversEveryTestInThisPackage` is the guard that matters most — it is what makes a mistyped filter loud instead of green.
- `TestCIGuardRunsInTheUnitJob` closes the last loop: it holds the guard's own package path against the exclusions `run_unit_tests` applies, so moving this package under `test/acceptance/` fails instead of quietly taking the guard off CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXUXUbrkRmHCC7bL6jKNz5
