### PR TITLE
fix(objects): wait for auto-schema version before single-object write

### DIFF
--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -106,6 +106,15 @@ func (m *Manager) addObjectToConnectorAndSchema(ctx context.Context, principal *
 	}
 	maxSchemaVersion = max(maxSchemaVersion, autoTenantSchemaVersion)
 
+	// The caller already waited, but only for the version known before
+	// auto-schema ran. When auto-schema creates the class the index is
+	// materialised inside the raft apply, so a node that has not yet applied
+	// that entry resolves no index and the write fails with "import into
+	// non-existing index". Wait again on the post-auto-schema version.
+	if err := m.schemaManager.WaitForUpdate(ctx, maxSchemaVersion); err != nil {
+		return nil, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", maxSchemaVersion, err)
+	}
+
 	class := fetchedClasses[object.Class].Class
 
 	err = m.validateObjectAndNormalizeNames(ctx, principal, repl, object, nil, fetchedClasses)

--- a/usecases/objects/add_test.go
+++ b/usecases/objects/add_test.go
@@ -582,3 +582,76 @@ func Test_AddObjectWithUUIDProps(t *testing.T) {
 	assert.Equal(t, expectedID, addedObject.Properties.(map[string]interface{})["my_id"])
 	assert.Equal(t, expectedIDz, addedObject.Properties.(map[string]interface{})["my_idz"])
 }
+
+// Test_Add_Object_Waits_For_AutoSchema_Version_Before_Write pins the contract
+// that a write is never issued at a schema version the local node has not
+// waited for. Auto-schema materialises the index inside the raft apply, so
+// writing at an unawaited version lets a node that has not applied that entry
+// resolve no index and fail with "import into non-existing index".
+func Test_Add_Object_Waits_For_AutoSchema_Version_Before_Write(t *testing.T) {
+	const autoSchemaVersion uint64 = 41
+
+	existingClass := &models.Class{
+		Class: "FooExisting", Vectorizer: config.VectorizerModuleNone,
+		VectorIndexConfig: hnsw.UserConfig{},
+	}
+
+	tests := []struct {
+		name   string
+		schema schema.Schema
+		object *models.Object
+	}{
+		{
+			name:   "auto-schema creates the collection",
+			schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{}}},
+			object: &models.Object{Class: "FooBrandNew", Properties: map[string]any{"title": "a"}},
+		},
+		{
+			name:   "auto-schema adds a property to an existing collection",
+			schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{existingClass}}},
+			object: &models.Object{Class: "FooExisting", Properties: map[string]any{"title": "a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaManager := &fakeSchemaManager{
+				GetSchemaResponse: tt.schema,
+				AutoSchemaVersion: autoSchemaVersion,
+			}
+			vectorRepo := &fakeVectorRepo{}
+
+			// Sampled inside the write so the assertion sees what had been
+			// waited for at that moment. Comparing the end-state maxima
+			// instead would pass even if the wait ran after the write.
+			var (
+				maxWaitedAtWrite uint64
+				waitedAtWrite    []uint64
+			)
+			vectorRepo.On("PutObject", mock.Anything, mock.Anything).
+				Run(func(mock.Arguments) {
+					maxWaitedAtWrite = schemaManager.MaxWaitedSchemaVersion
+					waitedAtWrite = append([]uint64(nil), schemaManager.WaitedVersions...)
+				}).
+				Return(nil).Once()
+			cfg := &config.WeaviateConfig{Config: config.Config{
+				AutoSchema: config.AutoSchema{Enabled: runtime.NewDynamicValue(true)},
+			}}
+			logger, _ := test.NewNullLogger()
+			modulesProvider := getFakeModulesProvider()
+			modulesProvider.On("UpdateVector", mock.Anything, mock.AnythingOfType(FindObjectFn)).Return(nil, nil)
+			manager := NewManager(schemaManager, cfg, logger, mocks.NewMockAuthorizer(), vectorRepo,
+				modulesProvider, &fakeMetrics{}, nil,
+				NewAutoSchemaManager(schemaManager, vectorRepo, cfg, logger, prometheus.NewPedanticRegistry()))
+
+			_, err := manager.AddObject(context.Background(), nil, tt.object, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, autoSchemaVersion, vectorRepo.CapturedSchemaVersion,
+				"the write must carry the version auto-schema produced")
+			assert.GreaterOrEqual(t, maxWaitedAtWrite, vectorRepo.CapturedSchemaVersion,
+				"must wait for the schema version it then writes at, before the write; versions waited for by then were %v",
+				waitedAtWrite)
+		})
+	}
+}


### PR DESCRIPTION
## What

A single-object insert that lets auto-schema create the collection can fail with a 500 on any node that has not yet applied the RAFT entry:

```
put object: import into non-existing index for AutoCreated
```

`AddObject` waits for the schema version known *before* auto-schema runs, then lets auto-schema create the class and writes at the resulting version without waiting again. Auto-schema materializes the index inside the RAFT apply (`ADD_CLASS` → `Migrator.AddClass` → `db.indices[...]`), so a node that has not applied that entry resolves no index and the write fails.

The fix waits on the post-auto-schema version before the write, in `addObjectToConnectorAndSchema`.

## Why this is a separate PR

This extracts the nine-line production fix, with its test, out of #12230 so it can be reviewed and merged on its own. #12230 bundles it with a GitHub Actions workflow change and a 145-line container-file-capture helper for reindex CI forensics. Those need a different reviewer and a different kind of scrutiny, and the correctness fix has been queued behind them since 2026-07-17.

Nothing else from #12230 is included here. That branch keeps the CI-forensics and test-legibility work.

## Why the usecase layer is the right place

`Index.putObject` already waits on the same version, but that wait sits *behind* the nil-index check in `adapters/repos/db/crud.go` — the lower-layer wait can never fire for a class that does not exist locally yet. The caller-side wait is load-bearing for exactly one thing: index existence.

The sibling paths already get this right. `batch_add.go` waits after `validateObjectsConcurrently` returns the post-auto-schema version, and `autoTenants` waits inside `addTenants`. Single-object add was the outlier.

## Cost

Negligible. `WaitForUpdate` is an atomic load plus an integer compare on the fast path; the context and ticker are only built after a miss. When auto-schema did not run, the version here is identical to the one already waited for earlier in `AddObject`, so the call is free. On the leader it never blocks.

## Test

`Test_Add_Object_Waits_For_AutoSchema_Version_Before_Write` is table-driven over collection creation and property addition. It samples the waited version *inside* the `PutObject` call rather than comparing end-state maxima, which makes it order-sensitive:

| Production code | Test |
|---|---|
| fix applied | 🟢 pass |
| fix removed (`stable/v1.38` as-is) | 🔴 `"0" is not greater than or equal to "41"` |
| wait moved to *after* `PutObject` | 🔴 same failure |

The third row is the one that matters: comparing two independently accumulated maxima would have passed there, and would have let a future reordering of these statements reintroduce the bug with a green suite.

## Gates

`go build ./...`, `go vet ./usecases/objects/...`, `gofumpt`/`goimports` on both files, all four `tools/linter_*.sh`, `golangci-lint run ./usecases/objects/...`, and `go test -race -count 1 ./usecases/objects/...` all exit 0. `go vet ./...` reports 5 findings, all pre-existing and none in a file this PR touches.
