### PR TITLE
fix(tokenizer): make optional tokenizer init idempotent and restorable

### DIFF
--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -639,6 +639,9 @@ func TestAnalyzeFoldAndTokenize(t *testing.T) {
 }
 
 func TestHandleGenericTokenizeGSE(t *testing.T) {
+	// InitOptionalTokenizers below leaves the tokenizer enabled for every
+	// test that runs after this one in the same process.
+	t.Cleanup(tokenizer.SaveOptionalTokenizerState())
 	t.Setenv("USE_GSE", "true")
 	t.Setenv("ENABLE_TOKENIZER_GSE_CH", "true")
 	tokenizer.InitOptionalTokenizers()
@@ -679,6 +682,9 @@ func TestHandleGenericTokenizeGSE(t *testing.T) {
 }
 
 func TestHandleGenericTokenizeKagome(t *testing.T) {
+	// InitOptionalTokenizers below leaves the tokenizer enabled for every
+	// test that runs after this one in the same process.
+	t.Cleanup(tokenizer.SaveOptionalTokenizerState())
 	t.Setenv("ENABLE_TOKENIZER_KAGOME_KR", "true")
 	t.Setenv("ENABLE_TOKENIZER_KAGOME_JA", "true")
 	tokenizer.InitOptionalTokenizers()

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -2038,6 +2038,13 @@ func Test_DeleteTombstoneMetrics(t *testing.T) {
 
 	metrics := monitoring.GetMetrics()
 
+	// The metrics registry is a process-wide singleton, so this gauge still
+	// holds whatever an earlier test -- or an earlier iteration under
+	// -count=2 -- left in it, and the assertions below compare against an
+	// absolute value. Start from a known state and leave one behind.
+	metrics.VectorIndexTombstones.DeleteLabelValues("", "")
+	t.Cleanup(func() { metrics.VectorIndexTombstones.DeleteLabelValues("", "") })
+
 	t.Run("import the test vectors", func(t *testing.T) {
 		index, err := New(Config{
 			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -119,7 +119,7 @@ func InitOptionalTokenizers() {
 			if err != nil {
 				return err
 			}
-			Tokenizations = append(Tokenizations, models.PropertyTokenizationKagomeKr)
+			enableTokenization(models.PropertyTokenizationKagomeKr)
 			return nil
 		}(); err != nil {
 			logger.WithField("tokenizer", "kagome_kr").Error(err)
@@ -134,12 +134,23 @@ func InitOptionalTokenizers() {
 			if err != nil {
 				return err
 			}
-			Tokenizations = append(Tokenizations, models.PropertyTokenizationKagomeJa)
+			enableTokenization(models.PropertyTokenizationKagomeJa)
 			return nil
 		}(); err != nil {
 			logger.WithField("tokenizer", "kagome_ja").Error(err)
 		}
 	}
+}
+
+// enableTokenization records a tokenization as available. It is idempotent:
+// initialization skips its work when the dictionary is already loaded, so an
+// append guarded by that check ran once per process and could not put the
+// entry back after a test restored the list.
+func enableTokenization(name string) {
+	if slices.Contains(Tokenizations, name) {
+		return
+	}
+	Tokenizations = append(Tokenizations, name)
 }
 
 func init_gse() error {
@@ -152,10 +163,14 @@ func init_gse() error {
 			return fmt.Errorf("load ja dictionary: %w", err)
 		}
 		gseTokenizer = &seg
-		UseGse = true
-		Tokenizations = append(Tokenizations, models.PropertyTokenizationGse)
 		monitoring.GetMetrics().TokenizerInitializeDuration.WithLabelValues(models.PropertyTokenizationGse).Observe(time.Since(startTime).Seconds())
 	}
+	// Outside the guard: the flag says the tokenizer is usable, which is true
+	// whenever the dictionary is loaded, not only on the call that loaded it.
+	// Setting it inside meant a second init found the segmenter already there,
+	// skipped the block, and left the flag off.
+	UseGse = true
+	enableTokenization(models.PropertyTokenizationGse)
 	return nil
 }
 
@@ -169,10 +184,10 @@ func init_gse_ch() error {
 			return fmt.Errorf("load zh dictionary: %w", err)
 		}
 		gseTokenizerCh = &seg
-		UseGseCh = true
-		Tokenizations = append(Tokenizations, models.PropertyTokenizationGseCh)
 		monitoring.GetMetrics().TokenizerInitializeDuration.WithLabelValues(models.PropertyTokenizationGseCh).Observe(time.Since(startTime).Seconds())
 	}
+	UseGseCh = true
+	enableTokenization(models.PropertyTokenizationGseCh)
 	return nil
 }
 
@@ -528,4 +543,24 @@ func TokenizeAndCountDuplicatesForClass(tokenization string, in string, class st
 	}
 
 	return unique, boosts
+}
+
+// SaveOptionalTokenizerState captures the process-global state that
+// InitOptionalTokenizers mutates and returns a function restoring it.
+//
+// t.Setenv puts the environment back but not the state derived from it: the
+// UseGse flags, the Kagome tokenizers and the Tokenizations list all outlive
+// the test that enabled them, so a later test asking whether an optional
+// tokenizer is disabled sees it enabled. Tests that call
+// InitOptionalTokenizers should register this with t.Cleanup.
+func SaveOptionalTokenizerState() func() {
+	useGse, useGseCh := UseGse, UseGseCh
+	savedKagome := tokenizers
+	savedTokenizations := append([]string(nil), Tokenizations...)
+
+	return func() {
+		UseGse, UseGseCh = useGse, useGseCh
+		tokenizers = savedKagome
+		Tokenizations = savedTokenizations
+	}
 }


### PR DESCRIPTION
Fixes #12573

Both tests named in the issue fail on the second run because they leave process-global state behind.

### The tokenizer one has a deeper cause than a missing cleanup

`InitOptionalTokenizers` set `UseGse`/`UseGseCh` **and** appended to `Tokenizations` *inside* the "dictionary not loaded yet" guard, so those writes happened exactly once per process. `t.Setenv` restores the environment, but nothing restored the state derived from it — so once `TestHandleGenericTokenizeGSE` had run, gse stayed enabled and `TestHandleGenericTokenize/disabled_tokenizer_returns_bad_request` saw an OK where it required a rejection.

Restoring the globals in the test alone is not enough: a second `Init` call finds the segmenter already loaded, skips the guard, and never puts the flag or the list entry back. That just moves the failure onto the GSE test.

So the flag and the list entry move out of the guard. They say the tokenizer is *usable*, which is true whenever the dictionary is loaded rather than only on the call that loaded it. `enableTokenization` keeps the list free of duplicates, and `SaveOptionalTokenizerState` lets a test capture and restore the whole set — registered with `t.Cleanup` by the two tests that enable a tokenizer.

### The metrics one

`Test_DeleteTombstoneMetrics` compares an absolute gauge value read from the process-wide metrics singleton, so a second run saw 90 where it expected 45. It now clears the label pair before it starts and again on cleanup.

### Verification

- `adapters/handlers/rest` and `adapters/repos/db/vector/hnsw` both pass at `-count=2` and `-count=3`
- revert-checked: with the change stashed, both fail again at `-count=2` exactly as reported
- `go vet` clean; `gofmt` clean on LF-normalized content
- the `TestBackup_*` / `TestCommitLog*` failures in the hnsw package are pre-existing on Windows and fail the same way on a clean tree
