### PR TITLE
test(namespace): surface server errors and node logs on failure

### DIFF
--- a/test/acceptance/namespace/auto_schema_test.go
+++ b/test/acceptance/namespace/auto_schema_test.go
@@ -44,7 +44,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 			Class:      class,
 			Properties: map[string]any{"title": "Inception"},
 		}, user1Key)
-		require.NoError(t, err)
+		require.NoError(t, err, "auto-create %s in %s: %s", class, ns1, helper.ErrorDetail(err))
 
 		// Namespaced principal sees the short class on read-back (response stripping).
 		got, err := helper.GetObjectAuth(t, class, id, user1Key)
@@ -62,7 +62,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 			Class:      class,
 			Properties: map[string]any{"title": "Memento"},
 		}, user2Key)
-		require.NoError(t, err)
+		require.NoError(t, err, "auto-create %s in %s: %s", class, ns2, helper.ErrorDetail(err))
 		t.Cleanup(func() { helper.DeleteClassAuth(t, ns2+":"+class, adminKey) })
 
 		gotClass2 := helper.GetClassAuth(t, ns2+":"+class, adminKey)

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -85,7 +85,6 @@ var sharedCompose *docker.DockerCompose
 
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
-	defer cancel()
 
 	// offload-s3 needs AWS creds in the process env before Start so each
 	// node can authenticate against the MinIO sidecar.
@@ -116,6 +115,9 @@ func TestMain(m *testing.M) {
 		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithWeaviateClusterWithGRPC().
 		Start(ctx)
+	// Start is this context's only consumer, and a deferred cancel would not run
+	// under the os.Exit below.
+	cancel()
 	if err != nil {
 		panic(errors.Wrap(err, "failed to start shared compose"))
 	}

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -125,6 +125,17 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 
+	// On failure, dump every node's logs so the leader side is visible. Without
+	// this the only record of a server-side 500 is the client's rendering of
+	// models.ErrorResponse, which prints the message slice as pointers.
+	// A fresh context, because the suite may have used up the one above and an
+	// expired context turns the dump into "logs unavailable" on every node.
+	if code != 0 {
+		dumpCtx, cancelDump := context.WithTimeout(context.Background(), time.Minute)
+		sharedCompose.DumpWeaviateLogs(dumpCtx, os.Stderr, 300)
+		cancelDump()
+	}
+
 	if err := sharedCompose.Terminate(ctx); err != nil {
 		panic(errors.Wrap(err, "failed to terminate shared compose"))
 	}

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -136,7 +136,12 @@ func TestMain(m *testing.M) {
 		cancelDump()
 	}
 
-	if err := sharedCompose.Terminate(ctx); err != nil {
+	// Teardown gets its own context for the same reason. Terminate passes it to
+	// docker; on an expired one it fails and the panic below replaces the test
+	// failure the run was about.
+	termCtx, cancelTerm := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancelTerm()
+	if err := sharedCompose.Terminate(termCtx); err != nil {
 		panic(errors.Wrap(err, "failed to terminate shared compose"))
 	}
 	os.Exit(code)

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -140,9 +140,10 @@ func TestMain(m *testing.M) {
 	// docker; on an expired one it fails and the panic below replaces the test
 	// failure the run was about.
 	termCtx, cancelTerm := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer cancelTerm()
-	if err := sharedCompose.Terminate(termCtx); err != nil {
-		panic(errors.Wrap(err, "failed to terminate shared compose"))
+	termErr := sharedCompose.Terminate(termCtx)
+	cancelTerm()
+	if termErr != nil {
+		panic(errors.Wrap(termErr, "failed to terminate shared compose"))
 	}
 	os.Exit(code)
 }

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -316,8 +316,13 @@ func ErrorDetail(err error) string {
 }
 
 // serverMessages returns the message list carried by err's payload, or nil if
-// err carries neither payload shape. A type has at most one GetPayload method,
-// so the two cases cannot both match.
+// err carries neither payload shape.
+//
+// errors.As stops at the first match in err's tree, so only one payload is ever
+// read even when err carries several. An error joining both shapes reports the
+// ErrorResponse one, since that case comes first; one joining two of the same
+// shape reports the earlier one. No error here carries more than one payload,
+// and reading them all would mean walking the tree by hand.
 func serverMessages(err error) []string {
 	var plain interface {
 		GetPayload() *models.ErrorResponse
@@ -344,6 +349,10 @@ func serverMessages(err error) []string {
 
 // itemMessages reads a message off every non-nil item, substituting "<empty>"
 // for an item that carries none so it stays visible in the joined output.
+//
+// T is unconstrained because nothing here reads a field off it. Which payload
+// shapes get unpacked is decided in serverMessages, and no caller reaches this
+// without writing an extractor for its own item type.
 func itemMessages[T any](items []*T, message func(*T) string) []string {
 	msgs := make([]string, 0, len(items))
 	for _, item := range items {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -286,35 +286,77 @@ func CreateObjectWithResponse(t *testing.T, object *models.Object) (*models.Obje
 	return resp.Payload, nil
 }
 
-// ErrorDetail renders the server-side message carried by a swagger client
-// error. The generated error types format models.ErrorResponse with %+v, and
-// because its Error field is a slice of pointers that renders as
+// ErrorDetail renders the server-side messages carried by a swagger client
+// error. The generated error types format their payload with %+v, and the
+// payload's message list is a slice of pointers, so it renders as
 // "&{Error:[0xc000acd5a0]}" -- the address, not the reason the server rejected
 // the request. Use it in assertion messages so a failure is diagnosable from
-// the test log alone. When there is no message to add it returns err.Error()
-// unchanged, so the output never ends in a bare separator.
+// the test log alone.
+//
+// It returns the messages on their own, because testify already prints
+// err.Error() on a line of its own. With no messages to show it falls back to
+// err.Error(), and for a nil error it returns the literal "<nil>". An item that
+// carries no message renders as "<empty>" rather than disappearing, since an
+// empty message is itself an anomaly worth seeing.
+//
+// Two payload shapes carry a message list: models.ErrorResponse and the schema
+// routes' models.RestrictionViolationResponse. Others, such as the 429
+// models.UsageLimitExceededResponse, take the err.Error() fallback -- which
+// stays readable there because every field they carry is a scalar that %+v
+// prints in full.
 func ErrorDetail(err error) string {
 	if err == nil {
 		return "<nil>"
 	}
-	var carrier interface{ GetPayload() *models.ErrorResponse }
-	if !errors.As(err, &carrier) {
-		return err.Error()
-	}
-	payload := carrier.GetPayload()
-	if payload == nil {
-		return err.Error()
-	}
-	msgs := make([]string, 0, len(payload.Error))
-	for _, item := range payload.Error {
-		if item != nil && item.Message != "" {
-			msgs = append(msgs, item.Message)
-		}
-	}
+	msgs := serverMessages(err)
 	if len(msgs) == 0 {
 		return err.Error()
 	}
-	return fmt.Sprintf("%s: %s", err.Error(), strings.Join(msgs, "; "))
+	return strings.Join(msgs, "; ")
+}
+
+// serverMessages returns the message list carried by err's payload, or nil if
+// err carries neither payload shape. A type has at most one GetPayload method,
+// so the two cases cannot both match.
+func serverMessages(err error) []string {
+	var plain interface {
+		GetPayload() *models.ErrorResponse
+	}
+	var restricted interface {
+		GetPayload() *models.RestrictionViolationResponse
+	}
+	switch {
+	case errors.As(err, &plain):
+		if payload := plain.GetPayload(); payload != nil {
+			return itemMessages(payload.Error, func(item *models.ErrorResponseErrorItems0) string {
+				return item.Message
+			})
+		}
+	case errors.As(err, &restricted):
+		if payload := restricted.GetPayload(); payload != nil {
+			return itemMessages(payload.Error, func(item *models.RestrictionViolationResponseErrorItems0) string {
+				return item.Message
+			})
+		}
+	}
+	return nil
+}
+
+// itemMessages reads a message off every non-nil item, substituting "<empty>"
+// for an item that carries none so it stays visible in the joined output.
+func itemMessages[T any](items []*T, message func(*T) string) []string {
+	msgs := make([]string, 0, len(items))
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		msg := message(item)
+		if msg == "" {
+			msg = "<empty>"
+		}
+		msgs = append(msgs, msg)
+	}
+	return msgs
 }
 
 func CreateObjectWithResponseAuth(t *testing.T, object *models.Object, key string) (*models.Object, error) {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -291,7 +291,8 @@ func CreateObjectWithResponse(t *testing.T, object *models.Object) (*models.Obje
 // because its Error field is a slice of pointers that renders as
 // "&{Error:[0xc000acd5a0]}" -- the address, not the reason the server rejected
 // the request. Use it in assertion messages so a failure is diagnosable from
-// the test log alone.
+// the test log alone. When there is no message to add it returns err.Error()
+// unchanged, so the output never ends in a bare separator.
 func ErrorDetail(err error) string {
 	if err == nil {
 		return "<nil>"
@@ -306,7 +307,7 @@ func ErrorDetail(err error) string {
 	}
 	msgs := make([]string, 0, len(payload.Error))
 	for _, item := range payload.Error {
-		if item != nil {
+		if item != nil && item.Message != "" {
 			msgs = append(msgs, item.Message)
 		}
 	}

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -286,6 +286,36 @@ func CreateObjectWithResponse(t *testing.T, object *models.Object) (*models.Obje
 	return resp.Payload, nil
 }
 
+// ErrorDetail renders the server-side message carried by a swagger client
+// error. The generated error types format models.ErrorResponse with %+v, and
+// because its Error field is a slice of pointers that renders as
+// "&{Error:[0xc000acd5a0]}" -- the address, not the reason the server rejected
+// the request. Use it in assertion messages so a failure is diagnosable from
+// the test log alone.
+func ErrorDetail(err error) string {
+	if err == nil {
+		return "<nil>"
+	}
+	var carrier interface{ GetPayload() *models.ErrorResponse }
+	if !errors.As(err, &carrier) {
+		return err.Error()
+	}
+	payload := carrier.GetPayload()
+	if payload == nil {
+		return err.Error()
+	}
+	msgs := make([]string, 0, len(payload.Error))
+	for _, item := range payload.Error {
+		if item != nil {
+			msgs = append(msgs, item.Message)
+		}
+	}
+	if len(msgs) == 0 {
+		return err.Error()
+	}
+	return fmt.Sprintf("%s: %s", err.Error(), strings.Join(msgs, "; "))
+}
+
 func CreateObjectWithResponseAuth(t *testing.T, object *models.Object, key string) (*models.Object, error) {
 	t.Helper()
 	params := objects.NewObjectsCreateParams().WithBody(object)

--- a/test/helper/objects_test.go
+++ b/test/helper/objects_test.go
@@ -155,19 +155,61 @@ func TestErrorDetail(t *testing.T) {
 
 // The payload shapes without a message list take the err.Error() fallback. That
 // is acceptable because every field they carry is a scalar, which %+v prints in
-// full -- unlike the pointer slice ErrorDetail exists to unpack.
+// full -- unlike the pointer slice ErrorDetail exists to unpack. Each payload
+// below sets every field it has, and each of those values is asserted.
 func TestErrorDetailFallbackKeepsScalarPayloadsReadable(t *testing.T) {
 	restrictionStructured := &schema.SchemaObjectsCreateUnprocessableEntity{
 		Payload: &models.RestrictionViolationResponse{
-			Message: "vector index type flat is not allowed",
+			Allowed:     []string{"hnsw", "flat"},
+			ErrorCode:   "CONFIG_NOT_ALLOWED",
+			Message:     "vector index type dynamic is not allowed",
+			Restriction: "vector_index_type",
+			Value:       "dynamic",
 		},
 	}
 	usageLimit := &objects.ObjectsCreateTooManyRequests{
 		Payload: &models.UsageLimitExceededResponse{
-			Message: "object limit of 1000 exceeded",
+			ErrorCode: "USAGE_LIMIT_EXCEEDED",
+			Limit:     "objects",
+			Message:   "object limit of 1000 exceeded",
+			Value:     1000,
 		},
 	}
 
-	assert.Contains(t, ErrorDetail(restrictionStructured), "vector index type flat is not allowed")
-	assert.Contains(t, ErrorDetail(usageLimit), "object limit of 1000 exceeded")
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "schema 422 structured fields",
+			err:  restrictionStructured,
+			want: []string{
+				"Allowed:[hnsw flat]",
+				"ErrorCode:CONFIG_NOT_ALLOWED",
+				"Message:vector index type dynamic is not allowed",
+				"Restriction:vector_index_type",
+				"Value:dynamic",
+			},
+		},
+		{
+			name: "429 usage limit",
+			err:  usageLimit,
+			want: []string{
+				"ErrorCode:USAGE_LIMIT_EXCEEDED",
+				"Limit:objects",
+				"Message:object limit of 1000 exceeded",
+				"Value:1000",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ErrorDetail(tt.err)
+			for _, want := range tt.want {
+				assert.Contains(t, got, want)
+			}
+		})
+	}
 }

--- a/test/helper/objects_test.go
+++ b/test/helper/objects_test.go
@@ -34,9 +34,11 @@ func TestErrorDetail(t *testing.T) {
 	nilPayload := &objects.ObjectsCreateInternalServerError{}
 	noItems := carrier()
 	onlyNilItems := carrier(nil, nil)
+	onlyEmptyItems := carrier(item(""), item(""))
 	single := carrier(item("import into non-existing index for AutoCreated"))
 	multiple := carrier(item("first"), item("second"))
 	nilAmongItems := carrier(nil, item("second"), nil)
+	emptyAmongItems := carrier(item(""), item("second"), item(""))
 	wrapped := fmt.Errorf("put object: %w", single)
 
 	tests := []struct {
@@ -70,6 +72,11 @@ func TestErrorDetail(t *testing.T) {
 			want: onlyNilItems.Error(),
 		},
 		{
+			name: "carrier whose items all carry an empty message falls back to the error string",
+			err:  onlyEmptyItems,
+			want: onlyEmptyItems.Error(),
+		},
+		{
 			name: "single server message is appended",
 			err:  single,
 			want: single.Error() + ": import into non-existing index for AutoCreated",
@@ -83,6 +90,11 @@ func TestErrorDetail(t *testing.T) {
 			name: "nil items are skipped, real ones kept",
 			err:  nilAmongItems,
 			want: nilAmongItems.Error() + ": second",
+		},
+		{
+			name: "empty messages are skipped, real ones kept",
+			err:  emptyAmongItems,
+			want: emptyAmongItems.Error() + ": second",
 		},
 		{
 			name: "carrier reached through a wrapped error",

--- a/test/helper/objects_test.go
+++ b/test/helper/objects_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/client/objects"
+	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -40,6 +41,28 @@ func TestErrorDetail(t *testing.T) {
 	nilAmongItems := carrier(nil, item("second"), nil)
 	emptyAmongItems := carrier(item(""), item("second"), item(""))
 	wrapped := fmt.Errorf("put object: %w", single)
+
+	restrictionList := &schema.SchemaObjectsCreateUnprocessableEntity{
+		Payload: &models.RestrictionViolationResponse{
+			Error: []*models.RestrictionViolationResponseErrorItems0{
+				{Message: "class name ns1:Movie already exists"},
+			},
+		},
+	}
+	restrictionStructured := &schema.SchemaObjectsCreateUnprocessableEntity{
+		Payload: &models.RestrictionViolationResponse{
+			ErrorCode: "CONFIG_NOT_ALLOWED", Restriction: "vector_index_type",
+			Value: "flat", Allowed: []string{"hnsw"},
+			Message: "vector index type flat is not allowed",
+		},
+	}
+	restrictionNilPayload := &schema.SchemaObjectsCreateUnprocessableEntity{}
+	usageLimit := &objects.ObjectsCreateTooManyRequests{
+		Payload: &models.UsageLimitExceededResponse{
+			ErrorCode: "USAGE_LIMIT_EXCEEDED", Limit: "objects", Value: 1000,
+			Message: "object limit of 1000 exceeded",
+		},
+	}
 
 	tests := []struct {
 		name string
@@ -72,34 +95,54 @@ func TestErrorDetail(t *testing.T) {
 			want: onlyNilItems.Error(),
 		},
 		{
-			name: "carrier whose items all carry an empty message falls back to the error string",
-			err:  onlyEmptyItems,
-			want: onlyEmptyItems.Error(),
-		},
-		{
-			name: "single server message is appended",
+			name: "single server message replaces the error string",
 			err:  single,
-			want: single.Error() + ": import into non-existing index for AutoCreated",
+			want: "import into non-existing index for AutoCreated",
 		},
 		{
 			name: "multiple server messages are joined",
 			err:  multiple,
-			want: multiple.Error() + ": first; second",
+			want: "first; second",
 		},
 		{
 			name: "nil items are skipped, real ones kept",
 			err:  nilAmongItems,
-			want: nilAmongItems.Error() + ": second",
+			want: "second",
 		},
 		{
-			name: "empty messages are skipped, real ones kept",
+			name: "an empty message stays visible as a placeholder",
 			err:  emptyAmongItems,
-			want: emptyAmongItems.Error() + ": second",
+			want: "<empty>; second; <empty>",
+		},
+		{
+			name: "items that all carry an empty message render as placeholders",
+			err:  onlyEmptyItems,
+			want: "<empty>; <empty>",
 		},
 		{
 			name: "carrier reached through a wrapped error",
 			err:  wrapped,
-			want: wrapped.Error() + ": import into non-existing index for AutoCreated",
+			want: "import into non-existing index for AutoCreated",
+		},
+		{
+			name: "schema 422 message list is unpacked like the plain one",
+			err:  restrictionList,
+			want: "class name ns1:Movie already exists",
+		},
+		{
+			name: "schema 422 without a message list falls back to the error string",
+			err:  restrictionStructured,
+			want: restrictionStructured.Error(),
+		},
+		{
+			name: "schema 422 with a nil payload falls back to the error string",
+			err:  restrictionNilPayload,
+			want: restrictionNilPayload.Error(),
+		},
+		{
+			name: "429 payload has no message list, so it falls back",
+			err:  usageLimit,
+			want: usageLimit.Error(),
 		},
 	}
 
@@ -108,4 +151,23 @@ func TestErrorDetail(t *testing.T) {
 			assert.Equal(t, tt.want, ErrorDetail(tt.err))
 		})
 	}
+}
+
+// The payload shapes without a message list take the err.Error() fallback. That
+// is acceptable because every field they carry is a scalar, which %+v prints in
+// full -- unlike the pointer slice ErrorDetail exists to unpack.
+func TestErrorDetailFallbackKeepsScalarPayloadsReadable(t *testing.T) {
+	restrictionStructured := &schema.SchemaObjectsCreateUnprocessableEntity{
+		Payload: &models.RestrictionViolationResponse{
+			Message: "vector index type flat is not allowed",
+		},
+	}
+	usageLimit := &objects.ObjectsCreateTooManyRequests{
+		Payload: &models.UsageLimitExceededResponse{
+			Message: "object limit of 1000 exceeded",
+		},
+	}
+
+	assert.Contains(t, ErrorDetail(restrictionStructured), "vector index type flat is not allowed")
+	assert.Contains(t, ErrorDetail(usageLimit), "object limit of 1000 exceeded")
 }

--- a/test/helper/objects_test.go
+++ b/test/helper/objects_test.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package helper
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/client/objects"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestErrorDetail(t *testing.T) {
+	item := func(msg string) *models.ErrorResponseErrorItems0 {
+		return &models.ErrorResponseErrorItems0{Message: msg}
+	}
+	carrier := func(items ...*models.ErrorResponseErrorItems0) *objects.ObjectsCreateInternalServerError {
+		return &objects.ObjectsCreateInternalServerError{
+			Payload: &models.ErrorResponse{Error: items},
+		}
+	}
+
+	nilPayload := &objects.ObjectsCreateInternalServerError{}
+	noItems := carrier()
+	onlyNilItems := carrier(nil, nil)
+	single := carrier(item("import into non-existing index for AutoCreated"))
+	multiple := carrier(item("first"), item("second"))
+	nilAmongItems := carrier(nil, item("second"), nil)
+	wrapped := fmt.Errorf("put object: %w", single)
+
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: "<nil>",
+		},
+		{
+			name: "plain error carries no payload, so it renders unchanged",
+			err:  errors.New("boom"),
+			want: "boom",
+		},
+		{
+			name: "carrier with a nil payload falls back to the error string",
+			err:  nilPayload,
+			want: nilPayload.Error(),
+		},
+		{
+			name: "carrier with no message items falls back to the error string",
+			err:  noItems,
+			want: noItems.Error(),
+		},
+		{
+			name: "carrier whose items are all nil falls back to the error string",
+			err:  onlyNilItems,
+			want: onlyNilItems.Error(),
+		},
+		{
+			name: "single server message is appended",
+			err:  single,
+			want: single.Error() + ": import into non-existing index for AutoCreated",
+		},
+		{
+			name: "multiple server messages are joined",
+			err:  multiple,
+			want: multiple.Error() + ": first; second",
+		},
+		{
+			name: "nil items are skipped, real ones kept",
+			err:  nilAmongItems,
+			want: nilAmongItems.Error() + ": second",
+		},
+		{
+			name: "carrier reached through a wrapped error",
+			err:  wrapped,
+			want: wrapped.Error() + ": import into non-existing index for AutoCreated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ErrorDetail(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
SuperClaude here.

This is one of three PRs that replace weaviate/weaviate#12230. That PR bundled a production fix with two unrelated bodies of test tooling, and the fix sat unmerged for 25 days behind a review queue meant for CI scaffolding. The production fix is already out on its own as weaviate/weaviate#12607. This PR is the namespace-test diagnostics part.

## What you get

When a namespace acceptance test fails on a server-side error, the test log now tells you what the server said. Today it does not:

    [POST /objects][500] objectsCreateInternalServerError &{Error:[0xc000acd5a0]}

The generated swagger client formats its payload with `%+v`, and the payload's message list is a slice of pointers, so the reason the server rejected the request renders as an address. The package also terminated its compose without dumping container logs, so the leader-side record was gone too. Between them, a 500 left nothing to debug from.

Here is a real testify failure from a forced failure in `test/helper`. BEFORE is this branch's own earlier form, which printed the error twice; at the merge base there is no `Messages:` line at all, only the `Error:` line at the top.

```
BEFORE
  Error:      [POST /objects][500] objectsCreateInternalServerError  &{Error:[0x7d638c36a820]}
  Messages:   auto-create Movie in ns1: [POST /objects][500] objectsCreateInternalServerError  &{Error:[0x7d638c36a820]}: import into non-existing index for AutoCreated

AFTER
  Error:      [POST /objects][500] objectsCreateInternalServerError  &{Error:[0x42fad4a0d890]}
  Messages:   auto-create Movie in ns1: import into non-existing index for AutoCreated
```

## What changes

**`helper.ErrorDetail(err)`** unwraps a swagger client error and returns the payload's messages, joined with `"; "`. It returns the messages on their own rather than `err.Error()` plus the messages, because testify already prints the error on its own line; the earlier form printed it twice, as the BEFORE block above shows. With no messages to show it falls back to `err.Error()`, and `ErrorDetail(nil)` is the literal `"<nil>"`.

**Two payload shapes carry a message list, and both are read.** `models.ErrorResponse`, and the schema routes' `models.RestrictionViolationResponse` (HTTP 422, `client/schema/schema_objects_create_responses.go`). Only a list needs unpacking, since a list is where the pointers are. Payloads without one take the `err.Error()` fallback, which stays readable because every field they carry is a scalar that `%+v` prints in full. Probed against all three shapes:

```
schema 422, legacy message list   BEFORE  ... &{Allowed:[] Error:[0xc04fa4e25d0] ErrorCode: Message: Restriction: Value:}
                                  AFTER   class name ns1:Movie already exists

schema 422, structured fields     ... &{Allowed:[hnsw] Error:[] ErrorCode:CONFIG_NOT_ALLOWED Message:vector index type flat is not allowed ...}
429 UsageLimitExceededResponse    ... &{ErrorCode:USAGE_LIMIT_EXCEEDED Limit:objects Message:object limit of 1000 exceeded Value:1000}
```

The bottom two are the fallback, and they are why the fallback is acceptable rather than a hole: the reader still gets the message. Only the first one was losing information. Both fallbacks are pinned by tests so the next caller learns the boundary from a table row rather than from an address in a log.

Only one payload is ever read, because `errors.As` stops at the first match in the error's tree. An error joining both shapes reports the `ErrorResponse` one, since that case comes first; one joining two of the same shape reports the earlier one. Nothing here joins swagger errors, so this is a documented property rather than a live loss, and the doc comment on `serverMessages` says so.

**An item whose `Message` is empty renders as `<empty>`** rather than being dropped. Dropping it kept the joined output from ending in a bare separator, but it also erased the anomaly, which is the same failure mode this helper exists to remove one level down. Both behaviors are defensive: `ErrorResponseErrorItems0` has `Message` as its only field and it is `omitempty`, so an item with no message is representable on the wire, but no server path here is known to emit one. In particular the namespace prefix strip does not produce one — `strings.ReplaceAll("ns1:Movie", "ns1:", "")` is `"Movie"` (`usecases/schema/namespacing/resolver.go:426`, separator at `entities/schema/validation.go:114`).

A payload that carried both a message list and structured fields would render as its messages alone. That costs nothing in the intended usage, because testify prints `err.Error()` on the line above, and that line still carries the route, the status and every scalar field.

**Two assertions in `auto_schema_test.go`** that were dropping the server message now pass it through.

**`TestMain` dumps every node's logs when the package fails.** The dump gets its own one-minute context rather than reusing `TestMain`'s. `TestMain`'s context is sized for cluster startup and its deadline is absolute, so a suite that outlives it would turn the dump into `logs unavailable` on every node, on precisely the run you needed it for.

Teardown gets a fresh context for the same reason, and because the dump can spend a minute of whatever is left before it. `DockerCompose.Terminate` hands its context to `testcontainers.StopContext` and to `network.Remove`, so an expired one fails the terminate and the `panic` that follows replaces the test failure the run was about. All three cancels are called explicitly rather than deferred, because `TestMain` ends in `os.Exit`, which skips deferred functions. The startup context is released as soon as `Start` returns, its only consumer.

The same context shape is already used in `test/acceptance/replication/replica_replication/fast/endpoints_test.go`, which roots its dump context (1 minute) and its teardown context (10 minutes) in `context.Background()`. That file has no `TestMain`; the equivalent code lives in its testify `TearDownSuite` and in the `down` closure that closes over the compose.

## Evidence

`ErrorDetail` is covered by a fifteen-row table test plus a second test that pins the fallback, both in `test/helper/objects_test.go`. They run in the ordinary unit job, since `test/helper` is not excluded from that job's package list (`test/run.sh:457` filters only `test/acceptance` and `test/modules`).

Mutation receipt. Each mutation applied alone, mutant confirmed to build, the named test confirmed red, file restored, worktree confirmed clean (`git diff --quiet`) after each. Every one of the fifteen rows and the second test is killed by at least one mutant, so no assertion here is unfalsifiable.

| Mutation | Red rows | Kill |
|---|---|---|
| Drop the `<empty>` placeholder | `an empty message stays visible…`, `items that all carry an empty message…` | value |
| Drop the nil-item guard | `carrier whose items are all nil…` | panic |
| Drop the `RestrictionViolationResponse` branch | `schema 422 message list is unpacked…` | value |
| Drop the nil-payload guard, `ErrorResponse` branch | `carrier with a nil payload…` | panic |
| Drop the nil-payload guard, `RestrictionViolationResponse` branch | `schema 422 with a nil payload…` | panic |
| Drop the no-messages fallback | 7 rows plus both rows of the second test | value |
| Drop the nil-error guard | `nil error` | panic |
| Replace `errors.As` with a direct type assertion | `carrier reached through a wrapped error` | value |
| Change the join separator `"; "` → `", "` | `multiple server messages are joined` + 2 | value |
| Restore the `err.Error()` prefix | 7 rows | value |
| `"<nil>"` → `""` | `nil error` | value |
| `"<empty>"` → `"<blank>"` | 2 rows | value |

Four of the twelve go red by panic rather than by a value mismatch, which is a weaker signal: a panic aborts the binary before the row's assertion runs, so it kills the mutant without showing that the assertion discriminates. Each of those four rows is also killed by a value mismatch under a different mutant — dropping the no-messages fallback covers three of them, and `"<nil>"` → `""` covers `nil error`. So all fifteen rows are value-discriminating.

Base-green, both directions:

- At the merge base the test file does not compile: two references to `undefined: ErrorDetail`, `[build failed]`. So this is new coverage rather than a test that already passed.
- At the previous head of this branch, `a205579ec5`, none of the 15 rows are red: the head commit changes no behavior, its only edit to `test/helper/objects.go` being the doc comments on `serverMessages` and `itemMessages`. The 7-of-15 figure belongs to the two commits before it, `f914d4eb75` and `e4fc02118d`; the 8 that pass there are the ones pinning behavior that did not change, including the three that pin the fallback deliberately.

The log dump was checked against a real three-node cluster by forcing `TestNamespaces_AutoSchema` to fail: three `--- weaviate-N ... status=running exitCode=0 oomKilled=false` headers, zero `logs unavailable` lines. The teardown-context change is not covered by that run and has no unit-level receipt; reaching it needs a three-node cluster whose suite context has actually expired.

Gates, from a clean worktree off `stable/v1.38`: `go build ./...` 0 · `go vet ./...` 5 findings (baseline, none in a touched file, one of them in an assembly file) · `go vet -tags integrationTest ./...` 17 (baseline, tag run separately, none in a touched file) · `gofmt`/`gofumpt`/`goimports -l` empty on all four touched files · all four `tools/linter_*.sh` 0 · `golangci-lint` on both touched trees `0 issues.` · `go test -race -count 2 ./test/helper/` 0 · `go test -race -c ./test/acceptance/namespace/` 0.

## Deliberately left behind

- **The sibling `namespace_limits` suite has the same context bug.** `test/acceptance/namespace_limits/setup_test.go` reuses its suite context for both `DumpWeaviateLogs` and `Terminate`, exactly what this PR fixes here. It is a different package and shares no file with this change, so it is separable and is being tracked on its own rather than widening this diff.
- **`ErrorDetail` covers 2 of the 19 error assertions in `auto_schema_test.go`.** That is 18 `require.NoError` plus one `require.Error`; the file has no bare `if err != nil` handling, and 41 testify assertions in total. The other 17 all take an error straight from the swagger client, so they still render the payload as pointers whenever the server sends one. Broadening it is mechanical, but none of the others were load-bearing for the failure that motivated this, and a file-wide sweep would bury the part worth reading.
- **`DumpWeaviateLogs` can be very loud.** `dumpWindowStart` in `test/docker/docker.go` widens the window to a 6000-line ceiling whenever any node log contains `panic:`, `fatal error:` or `WARNING: DATA RACE`. When the log runs more than 6000 lines past that marker the ceiling clamps the window to start after it, so the widened dump excludes the line that triggered it; a marker inside the last 6000 lines is kept. A per-package dump on any failure inherits both behaviors. That is pre-existing, belongs to `test/docker`, is shared by three suites, and is tracked separately, so it is not touched here.
- **The dump is a 300-line tail, taken once, after the whole suite.** `test/docker/weaviate.go:86` pins `LOG_LEVEL=debug` for test containers and this suite runs up to 15 minutes across three nodes, so those 300 lines are the end of the run and not necessarily the moment of the failure. The marker-widening above does not help here either: it fires on panics and races, not on the 500 that motivated this PR. 300 is the value both other callers use (`test/acceptance/namespace_limits/setup_test.go:82`, `test/acceptance/replication/replica_replication/fast/endpoints_test.go:73`), so it stays. Making the window actually span the failure needs a per-test dump or a marker for server-side 500s, and both are larger than this change.
- **The reindex CI forensics** from weaviate/weaviate#12230 are in the sibling PR below, not here. They share no file with this change.

## Chain

- weaviate/weaviate#12230 — the original, which should close in favor of the three below. Nothing in it is dropped: each of its eight files lands in exactly one successor, and the three successors share no file. Its own 268 added lines divide 69 / 39 / 160 between weaviate/weaviate#12607, this PR, and weaviate/weaviate#12610. Each successor then adds more on top of the share it inherited.
- weaviate/weaviate#12607 — the production fix. It has passed two consecutive clean internal cold-review rounds, which is our own gate, not a sign-off: GitHub still reports `REVIEW_REQUIRED` on it, and its only two reviews are from bots.
- **This PR** — namespace test diagnostics.
- weaviate/weaviate#12610 — reindex CI forensics.

— SuperClaude
