### PR TITLE
test(reindex): capture shard LSM data dirs as a CI artifact on range-count failure

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -764,6 +764,10 @@ jobs:
   Acceptance-Reindex-Tests:
     name: reindex (${{ matrix.name }})
     runs-on: ubicloud-standard-4-ubuntu-2404
+    env:
+      # Where reindex acceptance tests write failure-only forensic dumps,
+      # uploaded by the "Upload reindex forensic artifacts" step below.
+      REINDEX_FORENSICS_DIR: ${{ github.workspace }}/reindex-forensics
     strategy:
       fail-fast: false
       matrix:
@@ -813,6 +817,14 @@ jobs:
           max_attempts: 1
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup
+      - name: Upload reindex forensic artifacts
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: reindex-forensics-${{ matrix.name }}
+          path: ${{ github.workspace }}/reindex-forensics
+          if-no-files-found: ignore
+          retention-days: 14
   Acceptance-Tests-github-4-cores:
     name: acceptance large (${{ matrix.name }})
     runs-on: DB-ubuntu-24.04-4-cores

--- a/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
+++ b/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
@@ -374,6 +374,9 @@ func assertRangeCountAllNodes(t *testing.T, compose *docker.DockerCompose, class
 		"%s: every replica must serve all %d updated objects over the sentinel band", phase, want)
 	if !ok {
 		t.Errorf("%s rangeable counts per node = %v, want %d on every node (silent rangeable write-loss)", phase, last, want)
+		// weaviate/0-weaviate-issues#335: capture on-disk state before a
+		// possible restart mutates it.
+		captureRangeableDataDirsOnFailure(t, compose, className, propName, phase)
 	}
 }
 

--- a/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
+++ b/test/acceptance/reindex_multinode/enable_rangeable_concurrent_updates_test.go
@@ -351,6 +351,12 @@ func fetchObjectDateInt(restURI, className, id string) (int, bool) {
 	return int(obj.Properties.DateInt), true
 }
 
+// rangeCountConvergenceWindow is how long a replica gets to agree before the
+// count is called wrong. A forensic capture runs after it expires, so it is
+// also how much newer the captured on-disk state can be than the first bad
+// count, which the capture's own record states.
+const rangeCountConvergenceWindow = 30 * time.Second
+
 // assertRangeCountAllNodes requires that every replica serves exactly want
 // objects over [lo, hi] on propName within the convergence window. A durable
 // loss never converges and fails the poll; a transient replication lag
@@ -370,7 +376,7 @@ func assertRangeCountAllNodes(t *testing.T, compose *docker.DockerCompose, class
 			}
 		}
 		return true
-	}, 30*time.Second, 500*time.Millisecond,
+	}, rangeCountConvergenceWindow, 500*time.Millisecond,
 		"%s: every replica must serve all %d updated objects over the sentinel band", phase, want)
 	if !ok {
 		t.Errorf("%s rangeable counts per node = %v, want %d on every node (silent rangeable write-loss)", phase, last, want)

--- a/test/acceptance/reindex_multinode/forensic_capture_bounds_test.go
+++ b/test/acceptance/reindex_multinode/forensic_capture_bounds_test.go
@@ -256,7 +256,7 @@ func (f *fakeContainer) Exec(_ context.Context, cmd []string, _ ...tcexec.Proces
 func newTestCapture(t *testing.T) *forensicCapture {
 	t.Helper()
 	return &forensicCapture{
-		log:         &captureLog{t: t, phase: "probe", prefix: "range-count forensic capture [probe]"},
+		log:         &captureLog{t: t, prefix: "range-count forensic capture [probe]"},
 		root:        t.TempDir(),
 		dataDir:     "/data",
 		classDir:    "things",
@@ -385,6 +385,80 @@ func TestCopyFilesMarksFilesThatAreNotFaithfulCopies(t *testing.T) {
 	}
 }
 
+// The rename is the one place the marking can fail open: the copy is already
+// short, and a file that keeps its .db name is byte-indistinguishable from a
+// whole segment. The manifest is then the only thing standing between an
+// investigator and reading a cut capture as product corruption.
+func TestCopyFilesKeepsTheOriginalNameWhenTheMarkerCannotBeApplied(t *testing.T) {
+	c := newTestCapture(t)
+	// A non-empty directory sitting on the .PARTIAL name: os.Rename cannot
+	// replace it, on any unix.
+	blocked := filepath.Join(c.root, "node1", "things", "s", "lsm", "b", "seg.db"+partialSuffix)
+	require.NoError(t, os.MkdirAll(blocked, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(blocked, "occupied"), []byte("x"), 0o644))
+
+	container := &fakeContainer{open: func(string) (io.ReadCloser, error) {
+		return io.NopCloser(&errReader{payload: []byte("cut"), err: errors.New("stream reset")}), nil
+	}}
+
+	c.copyFiles(context.Background(), container, 1, "/data/things/s/lsm/b/seg.db")
+	c.log.writeTo(c.root)
+
+	files := artifactFiles(t, c.root)
+	assert.Equal(t, "cut", files["node1/things/s/lsm/b/seg.db"],
+		"the incomplete copy stays in the artifact under its original name")
+
+	manifest := files[captureManifestName]
+	assert.Contains(t, manifest, "could not mark node1/things/s/lsm/b/seg.db as "+partialSuffix,
+		"the manifest is the only remaining signal that this file is not whole")
+	assert.Contains(t, manifest, "it stays in the artifact under its original name")
+	// The copy line must name the file as it actually is on disk, not as the
+	// rename meant to leave it.
+	assert.Contains(t, manifest, "kept as node1/things/s/lsm/b/seg.db:")
+	assert.NotContains(t, manifest, "kept as node1/things/s/lsm/b/seg.db"+partialSuffix)
+}
+
+func TestCopyFilesRecordsWhatEachNodeContributed(t *testing.T) {
+	tests := []struct {
+		name        string
+		alreadyUsed int64
+		body        string
+		paths       string
+		want        string
+	}{
+		{
+			name:  "a node that listed nothing says so",
+			paths: "",
+			want:  "node 1: listed 0 files, attempted 0, copied 0 whole, 0 bytes",
+		},
+		{
+			name:  "a node that copied cleanly says how much",
+			body:  "segment-bytes",
+			paths: "/data/things/s/lsm/b/a.db\n/data/things/s/lsm/b/b.db",
+			want:  "node 1: listed 2 files, attempted 2, copied 2 whole, 26 bytes",
+		},
+		{
+			name:        "a truncated file is not counted as copied whole",
+			alreadyUsed: forensicCaptureByteBudget - 5,
+			body:        "whole-segment",
+			paths:       "/data/things/s/lsm/b/a.db",
+			want:        "node 1: listed 1 files, attempted 1, copied 0 whole, 5 bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCapture(t)
+			c.copied = tt.alreadyUsed
+			container := &fakeContainer{open: readerFor(tt.body)}
+
+			c.copyFiles(context.Background(), container, 1, tt.paths)
+
+			assert.Contains(t, strings.Join(c.log.lines, "\n"), tt.want)
+		})
+	}
+}
+
 func TestCaptureManifestNamesEveryIncompleteFile(t *testing.T) {
 	c := newTestCapture(t)
 	container := &fakeContainer{open: func(path string) (io.ReadCloser, error) {
@@ -442,6 +516,45 @@ func TestCopyFilesRecordsAFileItCouldNotOpen(t *testing.T) {
 		"copy /data/things/s/lsm/b/gone.db failed, no file written: no such file or directory")
 }
 
+// A destination the capture cannot write is a path that appears in no artifact
+// file, so the record has to be what names it.
+func TestCopyFilesRecordsAFileItCouldNotWrite(t *testing.T) {
+	tests := []struct {
+		name    string
+		blocker func(t *testing.T, root string)
+	}{
+		{
+			name: "a file where the destination directory has to go",
+			blocker: func(t *testing.T, root string) {
+				require.NoError(t, os.MkdirAll(filepath.Join(root, "node1", "things", "s", "lsm"), 0o755))
+				require.NoError(t, os.WriteFile(filepath.Join(root, "node1", "things", "s", "lsm", "b"),
+					[]byte("x"), 0o644))
+			},
+		},
+		{
+			name: "a directory where the destination file has to go",
+			blocker: func(t *testing.T, root string) {
+				require.NoError(t, os.MkdirAll(
+					filepath.Join(root, "node1", "things", "s", "lsm", "b", "seg.db"), 0o755))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCapture(t)
+			tt.blocker(t, c.root)
+			container := &fakeContainer{open: readerFor("segment-bytes")}
+
+			c.copyFiles(context.Background(), container, 1, "/data/things/s/lsm/b/seg.db")
+
+			assert.Zero(t, c.copied, "nothing reached the disk, so nothing may be charged")
+			assert.Contains(t, strings.Join(c.log.lines, "\n"),
+				"node 1 copy /data/things/s/lsm/b/seg.db failed, no file written:")
+		})
+	}
+}
+
 // fakeNode answers the two commands collectNode runs, dispatching on which one
 // it was handed. Only the manifest script sets a shell variable first.
 func fakeNode(manifest string, manifestCode int, fileList string, fileListCode int) func([]string) (int, io.Reader, error) {
@@ -483,6 +596,161 @@ func TestCollectNodeSaysSoWhenTheCollectorItselfBroke(t *testing.T) {
 	assert.Contains(t, record, "partial output")
 	assert.Contains(t, record, "node 1 file list command failed (exit code 1)")
 	assert.Empty(t, container.opened)
+}
+
+func TestCollectNodeReportsTheCapEvenWhenTheCommandAlsoFailed(t *testing.T) {
+	// One line short of the cap, then enough to run past it.
+	longManifest := strings.Repeat("### /data/things/s/lsm\n", forensicExecOutputCap/23+10)
+
+	tests := []struct {
+		name     string
+		manifest string
+		code     int
+		fileList string
+		wantHas  []string
+		wantMiss []string
+	}{
+		{
+			name:     "a command that failed and was cut reports both",
+			manifest: longManifest,
+			code:     2,
+			wantHas: []string{
+				"node 1 manifest command failed (exit code 2)",
+				"node 1 manifest output was cut at 1048576 bytes",
+			},
+		},
+		{
+			name:     "a cut that kept no whole line says nothing of it is shown",
+			manifest: strings.Repeat("a", forensicExecOutputCap+1),
+			code:     0,
+			wantHas: []string{
+				"node 1 manifest output was cut at 1048576 bytes; no whole line survived the cut",
+			},
+		},
+		{
+			name:     "a cut file list says how much of it reached the copy",
+			manifest: "### /data/things/s/lsm\n",
+			code:     0,
+			fileList: strings.Repeat("a", forensicExecOutputCap+1),
+			wantHas: []string{
+				"node 1 file list was cut at 1048576 bytes",
+				"the files past the cut were never offered to the copy; no whole line survived the cut",
+				"node 1: listed 0 files",
+			},
+		},
+		{
+			name:     "output inside the cap is not reported as cut",
+			manifest: "### /data/things/s/lsm\n",
+			code:     0,
+			wantMiss: []string{"was cut at"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCapture(t)
+			container := &fakeContainer{
+				exec: fakeNode(tt.manifest, tt.code, tt.fileList, 0),
+				open: readerFor("never read"),
+			}
+
+			c.collectNode(context.Background(), container, 1)
+
+			record := strings.Join(c.log.lines, "\n")
+			for _, want := range tt.wantHas {
+				assert.Contains(t, record, want)
+			}
+			for _, miss := range tt.wantMiss {
+				assert.NotContains(t, record, miss)
+			}
+		})
+	}
+}
+
+// Every other way a captured file can be wrong is marked on the file. A copy
+// taken from running nodes is not, so the record has to say it.
+func TestCollectAllSaysTheCopyWasTakenFromRunningNodes(t *testing.T) {
+	c := newTestCapture(t)
+	node := &fakeContainer{
+		exec: fakeNode("### /data/things/shardA/lsm\n", 0, "", 0),
+		open: readerFor("never read"),
+	}
+
+	c.collectAll(context.Background(), []testcontainers.Container{node, node})
+	c.log.writeTo(c.root)
+
+	manifest := artifactFiles(t, c.root)[captureManifestName]
+	assert.Contains(t, manifest, "not a point-in-time snapshot")
+	assert.Contains(t, manifest, "a .wal can have a torn tail")
+	assert.Contains(t, manifest, "keep their original names")
+	assert.Contains(t, manifest, "polled for "+rangeCountConvergenceWindow.String()+" before this ran")
+	assert.Contains(t, manifest, "artifact root = "+c.root)
+	assert.Contains(t, manifest, "copied ~0 bytes from 2 of 2 nodes")
+}
+
+func TestCollectAllTellsAnEmptyClusterApartFromAClosedWindow(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodes    int
+		closed   bool
+		wantHas  []string
+		wantMiss []string
+	}{
+		{
+			name:    "a compose with no weaviate nodes says so",
+			nodes:   0,
+			wantHas: []string{"no weaviate containers found", "copied ~0 bytes from 0 of 0 nodes"},
+		},
+		{
+			name:     "a window that closed first is not reported as an empty cluster",
+			nodes:    3,
+			closed:   true,
+			wantHas:  []string{"capture window closed", "after 0 of 3 nodes"},
+			wantMiss: []string{"no weaviate containers found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.closed {
+				cancel()
+			}
+			c := newTestCapture(t)
+			var nodes []testcontainers.Container
+			for i := 0; i < tt.nodes; i++ {
+				nodes = append(nodes, &fakeContainer{
+					exec: fakeNode("", 0, "", 0),
+					open: readerFor("never read"),
+				})
+			}
+
+			c.collectAll(ctx, nodes)
+
+			record := strings.Join(c.log.lines, "\n")
+			for _, want := range tt.wantHas {
+				assert.Contains(t, record, want)
+			}
+			for _, miss := range tt.wantMiss {
+				assert.NotContains(t, record, miss)
+			}
+		})
+	}
+}
+
+// A capture that cannot create its artifact dir must stop before it touches a
+// container, or it logs one failure per file for every node.
+func TestCaptureStopsBeforeItTouchesAnyContainer(t *testing.T) {
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+	t.Setenv("REINDEX_FORENSICS_DIR", blocked)
+
+	// A nil compose panics on the first node lookup, so returning at all is the
+	// proof that no lookup happened.
+	assert.NotPanics(t, func() {
+		captureRangeableDataDirsOnFailure(t, nil, "Things", "dateInt", "pre-restart")
+	})
 }
 
 func execReturning(code int, out string, err error) func([]string) (int, io.Reader, error) {
@@ -691,6 +959,28 @@ func TestManifestScriptExplainsEveryEmptyCase(t *testing.T) {
 	}
 }
 
+// A search that could not read a directory and a search that found nothing are
+// the same empty result. Only the exit status tells them apart, and the script
+// prints its "nothing found" sentence off that result.
+func TestManifestScriptSaysWhenTheSearchItselfFailed(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root reads unreadable directories, so find cannot be made to fail this way")
+	}
+	dataDir := t.TempDir()
+	unreadable := filepath.Join(dataDir, "things", "shardA", "lsm", "blocked")
+	require.NoError(t, os.MkdirAll(unreadable, 0o755))
+	require.NoError(t, os.Chmod(unreadable, 0o000))
+	// t.TempDir cleanup cannot descend into a 000 dir.
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0o755) })
+
+	out := runManifestScript(t, dataDir)
+
+	assert.Contains(t, out, "exited 1; what it listed may be incomplete")
+	assert.NotContains(t, out, "no property_dateInt_rangeable* bucket dirs found",
+		"a search that broke must not be reported as a search that found nothing")
+	assert.Contains(t, out, "blocked", "the listing that follows must still be there")
+}
+
 func TestForensicArtifactRootHonorsTheCIEnvAndIsUniquePerCapture(t *testing.T) {
 	base := t.TempDir()
 	t.Setenv("REINDEX_FORENSICS_DIR", base)
@@ -707,6 +997,25 @@ func TestForensicArtifactRootHonorsTheCIEnvAndIsUniquePerCapture(t *testing.T) {
 		assert.DirExists(t, root)
 	}
 	assert.NotEqual(t, first, second, "two captures in one run must not overwrite each other")
+}
+
+// Off CI nothing sets the env var, and a capture that landed nowhere would be
+// a local run with no way to see what it found.
+func TestForensicArtifactRootFallsBackToATempDir(t *testing.T) {
+	t.Setenv("REINDEX_FORENSICS_DIR", "")
+	fallback := filepath.Join(os.TempDir(), "reindex-forensics")
+
+	root, err := forensicArtifactRoot(t, "Things", "pre-restart")
+
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(root)
+		// Only succeeds while no other capture is using it.
+		_ = os.Remove(fallback)
+	})
+	assert.True(t, strings.HasPrefix(root, fallback+string(filepath.Separator)),
+		"%s must be under %s", root, fallback)
+	assert.DirExists(t, root)
 }
 
 func TestForensicArtifactRootReportsAnUnusableBase(t *testing.T) {
@@ -772,9 +1081,25 @@ func TestSplitPaths(t *testing.T) {
 // captureLog writes into the artifact, so its own failure to write must not be
 // what stops a capture.
 func TestCaptureLogSurvivesAnUnwritableRoot(t *testing.T) {
-	c := &captureLog{t: t, phase: "probe", prefix: "probe"}
+	c := &captureLog{t: t, prefix: "probe"}
 	c.recordf("something happened")
 
 	assert.NotPanics(t, func() { c.writeTo(filepath.Join(t.TempDir(), "missing", "deeper")) })
 	assert.Equal(t, []string{"something happened"}, c.lines)
+}
+
+// A manifest that the write cut short keeps the bytes it managed to write, so
+// without a terminator it reads exactly like a complete one.
+func TestCaptureManifestEndsWithATerminator(t *testing.T) {
+	c := &captureLog{t: t, prefix: "probe"}
+	c.recordf("first")
+	c.recordf("second")
+	root := t.TempDir()
+
+	c.writeTo(root)
+
+	body := artifactFiles(t, root)[captureManifestName]
+	require.NotEmpty(t, body)
+	assert.True(t, strings.HasSuffix(body, "=== END OF CAPTURE MANIFEST, 2 records ===\n"),
+		"a cut manifest must be tellable from a complete one, got:\n%s", body)
 }

--- a/test/acceptance/reindex_multinode/forensic_capture_bounds_test.go
+++ b/test/acceptance/reindex_multinode/forensic_capture_bounds_test.go
@@ -1,0 +1,245 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllowNextFile(t *testing.T) {
+	const budget = int64(forensicCaptureByteBudget)
+
+	tests := []struct {
+		name          string
+		copiedTotal   int64
+		filesThisNode int
+		wantStop      bool
+		wantLimit     int64
+		wantReason    string
+	}{
+		{
+			name:          "a fresh capture may use the whole budget",
+			copiedTotal:   0,
+			filesThisNode: 0,
+			wantStop:      false,
+			wantLimit:     budget,
+		},
+		{
+			name:          "a partly used budget offers only the remainder",
+			copiedTotal:   budget - 100,
+			filesThisNode: 1,
+			wantStop:      false,
+			wantLimit:     100,
+		},
+		{
+			name:          "the last byte of budget is still offered",
+			copiedTotal:   budget - 1,
+			filesThisNode: 1,
+			wantStop:      false,
+			wantLimit:     1,
+		},
+		{
+			name:          "an exactly exhausted budget stops the capture",
+			copiedTotal:   budget,
+			filesThisNode: 1,
+			wantStop:      true,
+			wantReason:    "byte budget",
+		},
+		{
+			name:          "an overshot budget stops the capture",
+			copiedTotal:   budget + 4096,
+			filesThisNode: 1,
+			wantStop:      true,
+			wantReason:    "byte budget",
+		},
+		{
+			name:          "one file below the per-node cap is still allowed",
+			copiedTotal:   0,
+			filesThisNode: forensicFilesPerNodeCap - 1,
+			wantStop:      false,
+			wantLimit:     budget,
+		},
+		{
+			name:          "reaching the per-node cap stops the capture",
+			copiedTotal:   0,
+			filesThisNode: forensicFilesPerNodeCap,
+			wantStop:      true,
+			wantReason:    "per-node file cap",
+		},
+		{
+			name:          "exceeding the per-node cap stops the capture",
+			copiedTotal:   0,
+			filesThisNode: forensicFilesPerNodeCap + 1,
+			wantStop:      true,
+			wantReason:    "per-node file cap",
+		},
+		{
+			name:          "the file cap is reported when both bounds are hit",
+			copiedTotal:   budget,
+			filesThisNode: forensicFilesPerNodeCap,
+			wantStop:      true,
+			wantReason:    "per-node file cap",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := allowNextFile(tt.copiedTotal, tt.filesThisNode)
+
+			assert.Equal(t, tt.wantStop, got.stop)
+			if tt.wantStop {
+				assert.Contains(t, got.reason, tt.wantReason)
+				return
+			}
+			assert.Empty(t, got.reason)
+			assert.Equal(t, tt.wantLimit, got.limit)
+			// A non-stopping allowance feeds io.CopyN directly, and a limit of
+			// zero there would silently write an empty file forever.
+			assert.Positive(t, got.limit)
+		})
+	}
+}
+
+// errReader fails after handing out its payload, standing in for a container
+// stream that breaks mid-copy.
+type errReader struct {
+	payload []byte
+	err     error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if len(r.payload) > 0 {
+		n := copy(p, r.payload)
+		r.payload = r.payload[n:]
+		return n, nil
+	}
+	return 0, r.err
+}
+
+func TestCopyBounded(t *testing.T) {
+	tests := []struct {
+		name          string
+		src           string
+		limit         int64
+		wantWritten   string
+		wantTruncated bool
+	}{
+		{
+			name:          "a file smaller than the limit is copied whole",
+			src:           "segment",
+			limit:         64,
+			wantWritten:   "segment",
+			wantTruncated: false,
+		},
+		{
+			name:          "a file exactly at the limit is not reported truncated",
+			src:           "seg",
+			limit:         3,
+			wantWritten:   "seg",
+			wantTruncated: false,
+		},
+		{
+			name:          "a file larger than the limit is cut and reported",
+			src:           "segment-and-more",
+			limit:         7,
+			wantWritten:   "segment",
+			wantTruncated: true,
+		},
+		{
+			name:          "one byte over the limit still counts as truncated",
+			src:           "abcd",
+			limit:         3,
+			wantWritten:   "abc",
+			wantTruncated: true,
+		},
+		{
+			name:          "an empty file copies nothing and is not truncated",
+			src:           "",
+			limit:         64,
+			wantWritten:   "",
+			wantTruncated: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dst bytes.Buffer
+
+			written, truncated, err := copyBounded(&dst, strings.NewReader(tt.src), tt.limit)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantWritten, dst.String())
+			assert.Equal(t, int64(len(tt.wantWritten)), written)
+			assert.Equal(t, tt.wantTruncated, truncated)
+		})
+	}
+}
+
+func TestCopyBoundedSurfacesReadErrors(t *testing.T) {
+	t.Run("a stream that breaks before the limit surfaces the error", func(t *testing.T) {
+		var dst bytes.Buffer
+		broken := &errReader{payload: []byte("par"), err: errors.New("stream reset")}
+
+		written, truncated, err := copyBounded(&dst, broken, 64)
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "stream reset")
+		assert.False(t, truncated)
+		assert.Equal(t, int64(3), written)
+	})
+
+	t.Run("a stream that breaks exactly at the limit surfaces the error", func(t *testing.T) {
+		var dst bytes.Buffer
+		broken := &errReader{payload: []byte("par"), err: errors.New("stream reset")}
+
+		written, truncated, err := copyBounded(&dst, broken, 3)
+
+		require.Error(t, err)
+		assert.EqualError(t, err, "stream reset")
+		assert.False(t, truncated)
+		assert.Equal(t, int64(3), written)
+		assert.Equal(t, "par", dst.String())
+	})
+
+	t.Run("io.EOF at the limit means the file simply ended", func(t *testing.T) {
+		var dst bytes.Buffer
+		exact := &errReader{payload: []byte("par"), err: io.EOF}
+
+		written, truncated, err := copyBounded(&dst, exact, 3)
+
+		require.NoError(t, err)
+		assert.False(t, truncated)
+		assert.Equal(t, int64(3), written)
+	})
+}
+
+func TestCopyContainerFilesStopsWhenCaptureWindowClosed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Once the window is closed every copy would fail instantly, one log line
+	// per remaining path. A nil container is safe here precisely because the
+	// loop must stop before it reaches the first copy; if it does not, this
+	// panics rather than quietly logging thousands of failures.
+	copied := copyContainerFiles(ctx, t, nil, t.TempDir(), 1,
+		"/data/foo/shard/lsm/a.db\n/data/foo/shard/lsm/b.db\n/data/foo/shard/lsm/c.db", 0, "probe")
+
+	assert.Zero(t, copied)
+}

--- a/test/acceptance/reindex_multinode/forensic_capture_bounds_test.go
+++ b/test/acceptance/reindex_multinode/forensic_capture_bounds_test.go
@@ -16,11 +16,17 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
 )
 
 func TestAllowNextFile(t *testing.T) {
@@ -110,9 +116,6 @@ func TestAllowNextFile(t *testing.T) {
 			}
 			assert.Empty(t, got.reason)
 			assert.Equal(t, tt.wantLimit, got.limit)
-			// A non-stopping allowance feeds io.CopyN directly, and a limit of
-			// zero there would silently write an empty file forever.
-			assert.Positive(t, got.limit)
 		})
 	}
 }
@@ -230,16 +233,548 @@ func TestCopyBoundedSurfacesReadErrors(t *testing.T) {
 	})
 }
 
-func TestCopyContainerFilesStopsWhenCaptureWindowClosed(t *testing.T) {
+// fakeContainer stands in for a weaviate container. Only the two methods the
+// capture calls are implemented; the embedded nil interface panics loudly if
+// the capture ever reaches for anything else.
+type fakeContainer struct {
+	testcontainers.Container
+	opened []string
+	open   func(path string) (io.ReadCloser, error)
+	exec   func(cmd []string) (int, io.Reader, error)
+}
+
+func (f *fakeContainer) CopyFileFromContainer(_ context.Context, path string) (io.ReadCloser, error) {
+	f.opened = append(f.opened, path)
+	return f.open(path)
+}
+
+func (f *fakeContainer) Exec(_ context.Context, cmd []string, _ ...tcexec.ProcessOption) (int, io.Reader, error) {
+	return f.exec(cmd)
+}
+
+// newTestCapture builds a capture writing into a fresh temp dir.
+func newTestCapture(t *testing.T) *forensicCapture {
+	t.Helper()
+	return &forensicCapture{
+		log:         &captureLog{t: t, phase: "probe", prefix: "range-count forensic capture [probe]"},
+		root:        t.TempDir(),
+		dataDir:     "/data",
+		classDir:    "things",
+		bucketMatch: "property_dateInt_rangeable",
+	}
+}
+
+// artifactFiles lists every file under root, by its path inside root, so a test
+// can assert on exactly what an investigator would see after unzipping.
+func artifactFiles(t *testing.T, root string) map[string]string {
+	t.Helper()
+	found := map[string]string{}
+	require.NoError(t, filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		body, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		found[filepath.ToSlash(rel)] = string(body)
+		return nil
+	}))
+	return found
+}
+
+func readerFor(s string) func(string) (io.ReadCloser, error) {
+	return func(string) (io.ReadCloser, error) { return io.NopCloser(strings.NewReader(s)), nil }
+}
+
+func TestCopyFilesMirrorsContainerPaths(t *testing.T) {
+	c := newTestCapture(t)
+	container := &fakeContainer{open: readerFor("segment-bytes")}
+
+	c.copyFiles(context.Background(), container, 2,
+		"/data/things/shardA/lsm/property_dateInt_rangeable/segment.db\n"+
+			"/data/things/shardA/lsm/property_dateInt_rangeable/segment.wal\n")
+
+	assert.Equal(t, map[string]string{
+		"node2/things/shardA/lsm/property_dateInt_rangeable/segment.db":  "segment-bytes",
+		"node2/things/shardA/lsm/property_dateInt_rangeable/segment.wal": "segment-bytes",
+	}, artifactFiles(t, c.root))
+	assert.Equal(t, int64(2*len("segment-bytes")), c.copied)
+}
+
+func TestCopyFilesCountsBytesLeftOnDiskByABrokenCopy(t *testing.T) {
+	c := newTestCapture(t)
+	// Three streams that hand out 20 bytes each and then break, which is what
+	// a container stream that resets mid-file looks like.
+	container := &fakeContainer{open: func(string) (io.ReadCloser, error) {
+		return io.NopCloser(&errReader{
+			payload: []byte(strings.Repeat("x", 20)),
+			err:     errors.New("stream reset"),
+		}), nil
+	}}
+
+	c.copyFiles(context.Background(), container, 1,
+		"/data/things/s/lsm/b/a.db\n/data/things/s/lsm/b/b.db\n/data/things/s/lsm/b/c.db")
+
+	var onDisk int
+	for _, body := range artifactFiles(t, c.root) {
+		onDisk += len(body)
+	}
+	assert.Equal(t, 60, onDisk, "the broken copies left 60 bytes on disk")
+	assert.Equal(t, int64(60), c.copied, "bytes on disk must be charged to the byte budget")
+}
+
+func TestCopyFilesMarksFilesThatAreNotFaithfulCopies(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		readErr   error
+		limit     int64
+		wantName  string
+		wantBody  string
+		wantNotes []string
+	}{
+		{
+			name:     "a complete copy keeps its name",
+			body:     "whole-segment",
+			limit:    forensicCaptureByteBudget,
+			wantName: "node1/things/s/lsm/b/seg.db",
+			wantBody: "whole-segment",
+		},
+		{
+			name:      "a copy cut by the budget is marked TRUNCATED",
+			body:      "whole-segment",
+			limit:     5,
+			wantName:  "node1/things/s/lsm/b/seg.db" + truncatedSuffix,
+			wantBody:  "whole",
+			wantNotes: []string{"truncated /data/things/s/lsm/b/seg.db at 5 bytes"},
+		},
+		{
+			name:      "a copy broken mid-stream is marked PARTIAL",
+			body:      "whole",
+			readErr:   errors.New("stream reset"),
+			limit:     forensicCaptureByteBudget,
+			wantName:  "node1/things/s/lsm/b/seg.db" + partialSuffix,
+			wantBody:  "whole",
+			wantNotes: []string{"broke after 5 bytes", "stream reset"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestCapture(t)
+			container := &fakeContainer{open: func(string) (io.ReadCloser, error) {
+				if tt.readErr != nil {
+					return io.NopCloser(&errReader{payload: []byte(tt.body), err: tt.readErr}), nil
+				}
+				return io.NopCloser(strings.NewReader(tt.body)), nil
+			}}
+			c.copied = forensicCaptureByteBudget - tt.limit
+
+			c.copyFiles(context.Background(), container, 1, "/data/things/s/lsm/b/seg.db")
+
+			assert.Equal(t, map[string]string{tt.wantName: tt.wantBody}, artifactFiles(t, c.root))
+			for _, note := range tt.wantNotes {
+				assert.Contains(t, strings.Join(c.log.lines, "\n"), note)
+			}
+		})
+	}
+}
+
+func TestCaptureManifestNamesEveryIncompleteFile(t *testing.T) {
+	c := newTestCapture(t)
+	container := &fakeContainer{open: func(path string) (io.ReadCloser, error) {
+		if strings.HasSuffix(path, "broken.db") {
+			return io.NopCloser(&errReader{payload: []byte("ab"), err: errors.New("stream reset")}), nil
+		}
+		return io.NopCloser(strings.NewReader("ok")), nil
+	}}
+
+	c.copyFiles(context.Background(), container, 1, "/data/things/s/lsm/b/good.db\n/data/things/s/lsm/b/broken.db")
+	c.log.writeTo(c.root)
+
+	manifest := artifactFiles(t, c.root)[captureManifestName]
+	require.NotEmpty(t, manifest, "the artifact must carry its own record of what the capture did")
+	assert.Contains(t, manifest, "broken.db"+partialSuffix)
+	assert.Contains(t, manifest, "stream reset")
+	assert.NotContains(t, manifest, "good.db"+partialSuffix)
+}
+
+func TestCopyFilesStopsWhenCaptureWindowClosed(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	c := newTestCapture(t)
+	container := &fakeContainer{open: readerFor("never read")}
 
-	// Once the window is closed every copy would fail instantly, one log line
-	// per remaining path. A nil container is safe here precisely because the
-	// loop must stop before it reaches the first copy; if it does not, this
-	// panics rather than quietly logging thousands of failures.
-	copied := copyContainerFiles(ctx, t, nil, t.TempDir(), 1,
-		"/data/foo/shard/lsm/a.db\n/data/foo/shard/lsm/b.db\n/data/foo/shard/lsm/c.db", 0, "probe")
+	c.copyFiles(ctx, container, 1, "/data/things/s/lsm/b/a.db\n/data/things/s/lsm/b/b.db\n/data/things/s/lsm/b/c.db")
 
-	assert.Zero(t, copied)
+	assert.Empty(t, container.opened, "a closed window must stop the loop before the first copy")
+	assert.Zero(t, c.copied)
+	assert.Contains(t, strings.Join(c.log.lines, "\n"), "3 of 3 files not attempted")
+}
+
+func TestCopyFilesStopsWhenTheByteBudgetIsSpent(t *testing.T) {
+	c := newTestCapture(t)
+	c.copied = forensicCaptureByteBudget
+	container := &fakeContainer{open: readerFor("never read")}
+
+	c.copyFiles(context.Background(), container, 1, "/data/things/s/lsm/b/a.db\n/data/things/s/lsm/b/b.db")
+
+	assert.Empty(t, container.opened)
+	assert.Contains(t, strings.Join(c.log.lines, "\n"), "2 of 2 files not attempted")
+}
+
+func TestCopyFilesRecordsAFileItCouldNotOpen(t *testing.T) {
+	c := newTestCapture(t)
+	container := &fakeContainer{open: func(string) (io.ReadCloser, error) {
+		return nil, errors.New("no such file or directory")
+	}}
+
+	c.copyFiles(context.Background(), container, 1, "/data/things/s/lsm/b/gone.db")
+
+	assert.Empty(t, artifactFiles(t, c.root))
+	assert.Zero(t, c.copied)
+	assert.Contains(t, strings.Join(c.log.lines, "\n"),
+		"copy /data/things/s/lsm/b/gone.db failed, no file written: no such file or directory")
+}
+
+// fakeNode answers the two commands collectNode runs, dispatching on which one
+// it was handed. Only the manifest script sets a shell variable first.
+func fakeNode(manifest string, manifestCode int, fileList string, fileListCode int) func([]string) (int, io.Reader, error) {
+	return func(cmd []string) (int, io.Reader, error) {
+		if script := cmd[len(cmd)-1]; strings.HasPrefix(script, "d=") {
+			return manifestCode, strings.NewReader(manifest), nil
+		}
+		return fileListCode, strings.NewReader(fileList), nil
+	}
+}
+
+func TestCollectNodeRecordsTheManifestAndCopiesTheFilesItNames(t *testing.T) {
+	c := newTestCapture(t)
+	container := &fakeContainer{
+		exec: fakeNode("### /data/things/shardA/lsm\n", 0, "/data/things/shardA/lsm/b/seg.db\n", 0),
+		open: readerFor("segment-bytes"),
+	}
+
+	c.collectNode(context.Background(), container, 3)
+
+	assert.Contains(t, strings.Join(c.log.lines, "\n"), "node 3 rangeable bucket manifest:\n### /data/things/shardA/lsm")
+	assert.Equal(t, map[string]string{"node3/things/shardA/lsm/b/seg.db": "segment-bytes"},
+		artifactFiles(t, c.root))
+}
+
+func TestCollectNodeSaysSoWhenTheCollectorItselfBroke(t *testing.T) {
+	c := newTestCapture(t)
+	container := &fakeContainer{
+		exec: fakeNode("partial output", 2, "", 1),
+		open: readerFor("never read"),
+	}
+
+	c.collectNode(context.Background(), container, 1)
+
+	record := strings.Join(c.log.lines, "\n")
+	// A broken collector and a node with genuinely no rangeable data must not
+	// leave the same record behind.
+	assert.Contains(t, record, "node 1 manifest command failed (exit code 2)")
+	assert.Contains(t, record, "partial output")
+	assert.Contains(t, record, "node 1 file list command failed (exit code 1)")
+	assert.Empty(t, container.opened)
+}
+
+func execReturning(code int, out string, err error) func([]string) (int, io.Reader, error) {
+	return func([]string) (int, io.Reader, error) { return code, strings.NewReader(out), err }
+}
+
+func TestExecCollectSurfacesFailures(t *testing.T) {
+	tests := []struct {
+		name       string
+		exec       func([]string) (int, io.Reader, error)
+		wantOut    string
+		wantCut    bool
+		wantErr    string
+		wantNoErr  bool
+		wantOutHas string
+	}{
+		{
+			name:      "a command that succeeds returns its output and no error",
+			exec:      execReturning(0, "### /data/things/s/lsm\n", nil),
+			wantOut:   "### /data/things/s/lsm\n",
+			wantNoErr: true,
+		},
+		{
+			name:    "a non-zero exit code is surfaced, not swallowed",
+			exec:    execReturning(2, "find: permission denied\n", nil),
+			wantOut: "find: permission denied\n",
+			wantErr: "exit code 2",
+		},
+		{
+			name: "an unreadable stream is surfaced, not reported as no output",
+			exec: func([]string) (int, io.Reader, error) {
+				return 0, &errReader{payload: []byte("half"), err: errors.New("stdcopy broke")}, nil
+			},
+			wantOut: "half",
+			wantErr: "stdcopy broke",
+		},
+		{
+			name:    "a container that refuses the exec is surfaced",
+			exec:    execReturning(0, "", errors.New("container exec attach: no such container")),
+			wantErr: "no such container",
+		},
+		{
+			name: "output past the cap is cut at a line boundary and reported",
+			exec: execReturning(0,
+				strings.Repeat("/data/things/s/lsm/b/x.db\n", forensicExecOutputCap/26+10), nil),
+			wantCut:    true,
+			wantErr:    "",
+			wantNoErr:  true,
+			wantOutHas: "/data/things/s/lsm/b/x.db\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, cut, err := execCollect(context.Background(), &fakeContainer{exec: tt.exec}, []string{"sh", "-c", "true"})
+
+			if tt.wantNoErr {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+			assert.Equal(t, tt.wantCut, cut)
+			if tt.wantOutHas != "" {
+				assert.True(t, strings.HasSuffix(out, tt.wantOutHas), "a cut list must end on a whole path")
+				assert.LessOrEqual(t, len(out), forensicExecOutputCap)
+			} else {
+				assert.Equal(t, tt.wantOut, out)
+			}
+		})
+	}
+}
+
+func TestExecCollectReturnsWhenTheContainerNeverDoes(t *testing.T) {
+	// A wedged container blocks inside Exec with nothing closing the connection
+	// the context was supposed to bound.
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+	wedged := &fakeContainer{exec: func([]string) (int, io.Reader, error) {
+		<-release
+		return 0, strings.NewReader(""), nil
+	}}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+
+	out, cut, err := execCollect(ctx, wedged, []string{"sh", "-c", "sleep forever"})
+
+	assert.Less(t, time.Since(start), 5*time.Second, "capture must not wait on a wedged container")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not return inside the capture window")
+	assert.Empty(t, out)
+	assert.False(t, cut)
+}
+
+func TestCapExecOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		in       string
+		want     string
+		wantCut  bool
+		wantSize int
+	}{
+		{
+			name: "output below the cap is untouched",
+			in:   "a\nb\n",
+			want: "a\nb\n",
+		},
+		{
+			name: "output exactly at the cap is untouched",
+			in:   strings.Repeat("a", forensicExecOutputCap),
+			want: strings.Repeat("a", forensicExecOutputCap),
+		},
+		{
+			name:     "output past the cap is cut back to the last whole line",
+			in:       strings.Repeat("ab\n", forensicExecOutputCap),
+			wantCut:  true,
+			wantSize: forensicExecOutputCap / 3 * 3,
+		},
+		{
+			name:    "output past the cap with no line break keeps nothing",
+			in:      strings.Repeat("a", forensicExecOutputCap+1),
+			want:    "",
+			wantCut: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, cut := capExecOutput(tt.in)
+
+			assert.Equal(t, tt.wantCut, cut)
+			if tt.wantSize > 0 {
+				assert.Len(t, got, tt.wantSize)
+				assert.True(t, strings.HasSuffix(got, "\n"))
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+// runManifestScript runs the real script against a real shell, so what is
+// asserted is the script's behavior rather than its text.
+func runManifestScript(t *testing.T, dataDir string) string {
+	t.Helper()
+	c := &forensicCapture{dataDir: dataDir, classDir: "things", bucketMatch: "property_dateInt_rangeable"}
+	out, err := exec.Command("sh", "-c", c.manifestScript()).CombinedOutput()
+	require.NoError(t, err, "manifest script must exit cleanly: %s", out)
+	return string(out)
+}
+
+func TestManifestScriptExplainsEveryEmptyCase(t *testing.T) {
+	tests := []struct {
+		name     string
+		dirs     []string
+		files    []string
+		wantHas  []string
+		wantMiss []string
+	}{
+		{
+			name:    "a missing class dir says so and lists what is there instead",
+			dirs:    []string{"somethingelse"},
+			wantHas: []string{"no ", "/things dir", "somethingelse"},
+		},
+		{
+			name:    "a class dir with no lsm dirs says so and lists what is there",
+			dirs:    []string{"things/shardA"},
+			wantHas: []string{"no */lsm dirs under", "shardA"},
+		},
+		{
+			name:    "an lsm dir with no matching bucket falls back to a full listing",
+			dirs:    []string{"things/shardA/lsm/property_other_rangeable"},
+			wantHas: []string{"### ", "no property_dateInt_rangeable* bucket dirs found", "property_other_rangeable"},
+		},
+		{
+			name:     "a matching bucket is listed",
+			dirs:     []string{"things/shardA/lsm/property_dateInt_rangeable__rangeable_ingest_1"},
+			files:    []string{"things/shardA/lsm/property_dateInt_rangeable__rangeable_ingest_1/segment.db"},
+			wantHas:  []string{"### ", "property_dateInt_rangeable__rangeable_ingest_1", "segment.db"},
+			wantMiss: []string{"no property_dateInt_rangeable* bucket dirs found"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dataDir := t.TempDir()
+			for _, d := range tt.dirs {
+				require.NoError(t, os.MkdirAll(filepath.Join(dataDir, d), 0o755))
+			}
+			for _, f := range tt.files {
+				require.NoError(t, os.WriteFile(filepath.Join(dataDir, f), []byte("x"), 0o644))
+			}
+
+			out := runManifestScript(t, dataDir)
+
+			assert.NotEmpty(t, strings.TrimSpace(out), "an empty manifest cannot be told apart from no data")
+			for _, want := range tt.wantHas {
+				assert.Contains(t, out, want)
+			}
+			for _, miss := range tt.wantMiss {
+				assert.NotContains(t, out, miss)
+			}
+		})
+	}
+}
+
+func TestForensicArtifactRootHonorsTheCIEnvAndIsUniquePerCapture(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("REINDEX_FORENSICS_DIR", base)
+
+	first, err := forensicArtifactRoot(t, "Things", "pre-restart")
+	require.NoError(t, err)
+	second, err := forensicArtifactRoot(t, "Things", "post-restart")
+	require.NoError(t, err)
+
+	// The workflow uploads REINDEX_FORENSICS_DIR, so a root outside it is a
+	// capture CI would silently drop.
+	for _, root := range []string{first, second} {
+		assert.True(t, strings.HasPrefix(root, base), "%s must be under %s", root, base)
+		assert.DirExists(t, root)
+	}
+	assert.NotEqual(t, first, second, "two captures in one run must not overwrite each other")
+}
+
+func TestForensicArtifactRootReportsAnUnusableBase(t *testing.T) {
+	// A regular file where the base dir should be: MkdirAll cannot succeed, and
+	// a capture that carried on would log one failure per file instead.
+	blocked := filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(blocked, []byte("x"), 0o644))
+	t.Setenv("REINDEX_FORENSICS_DIR", blocked)
+
+	root, err := forensicArtifactRoot(t, "Things", "pre-restart")
+
+	require.Error(t, err)
+	assert.Empty(t, root)
+}
+
+func TestIncompleteSuffix(t *testing.T) {
+	tests := []struct {
+		name      string
+		truncated bool
+		err       error
+		want      string
+	}{
+		{name: "a faithful copy is not marked", want: ""},
+		{name: "a truncated copy is marked", truncated: true, want: truncatedSuffix},
+		{name: "a broken copy is marked", err: errors.New("boom"), want: partialSuffix},
+		{
+			name:      "a copy that was both broken and cut reports the break",
+			truncated: true,
+			err:       errors.New("boom"),
+			want:      partialSuffix,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, incompleteSuffix(tt.truncated, tt.err))
+		})
+	}
+}
+
+func TestSplitPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{name: "no output yields no paths", in: "", want: nil},
+		{name: "only whitespace yields no paths", in: "\n  \n\n", want: nil},
+		{
+			name: "blank and padded lines are dropped",
+			in:   "  /data/a.db  \n\n/data/b.db\n",
+			want: []string{"/data/a.db", "/data/b.db"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, splitPaths(tt.in))
+		})
+	}
+}
+
+// captureLog writes into the artifact, so its own failure to write must not be
+// what stops a capture.
+func TestCaptureLogSurvivesAnUnwritableRoot(t *testing.T) {
+	c := &captureLog{t: t, phase: "probe", prefix: "probe"}
+	c.recordf("something happened")
+
+	assert.NotPanics(t, func() { c.writeTo(filepath.Join(t.TempDir(), "missing", "deeper")) })
+	assert.Equal(t, []string{"something happened"}, c.lines)
 }

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -15,9 +15,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -26,6 +29,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
 	"github.com/weaviate/weaviate/test/docker"
@@ -696,6 +701,222 @@ func dumpStartupLogs(ctx context.Context, t *testing.T, compose *docker.DockerCo
 		}
 		t.Logf("=== Node %d logs (%d migration/reindex lines) ===\n%s", i, len(filtered), strings.Join(filtered, "\n"))
 	}
+}
+
+// forensicCaptureByteBudget caps the bytes one capture may write, so a
+// pathological on-disk state cannot fill the CI runner's disk. It is shared by
+// every node in the capture, not per node.
+const forensicCaptureByteBudget = 512 << 20 // 512 MiB
+
+// forensicFilesPerNodeCap caps how many files a single node contributes, so one
+// node with a runaway directory cannot consume the whole byte budget.
+const forensicFilesPerNodeCap = 4000
+
+// captureAllowance is the decision for one candidate file: whether the capture
+// should stop, and if not, the most bytes that file may consume.
+type captureAllowance struct {
+	stop   bool
+	reason string
+	limit  int64
+}
+
+// allowNextFile applies both bounds before a file is copied. copiedTotal is the
+// running cross-node byte total and filesThisNode the count already taken from
+// the current node, so the byte budget is global while the file cap is per node.
+// A non-stopping allowance always carries a limit above zero, which is what lets
+// the caller pass it straight to io.CopyN.
+func allowNextFile(copiedTotal int64, filesThisNode int) captureAllowance {
+	if filesThisNode >= forensicFilesPerNodeCap {
+		return captureAllowance{
+			stop:   true,
+			reason: fmt.Sprintf("per-node file cap (%d) reached", forensicFilesPerNodeCap),
+		}
+	}
+	remaining := int64(forensicCaptureByteBudget) - copiedTotal
+	if remaining <= 0 {
+		return captureAllowance{
+			stop:   true,
+			reason: fmt.Sprintf("byte budget (%d) exhausted", forensicCaptureByteBudget),
+		}
+	}
+	return captureAllowance{limit: remaining}
+}
+
+// captureRangeableDataDirsOnFailure is a best-effort dump of the rangeable
+// bucket's on-disk state (weaviate/0-weaviate-issues#335), for offline
+// post-mortem on a range-count failure. Capture errors are logged, never fatal.
+func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompose, className, propName, phase string) {
+	t.Helper()
+	// Independent of the test's ctx (which may be cancelling) and bounded, so
+	// capture can never hang CI.
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	root := forensicArtifactRoot(t, className, phase)
+	t.Logf("range-count forensic capture [%s]: artifact root = %s", phase, root)
+
+	classDirLower := strings.ToLower(className)
+	// Prefix shared by the canonical bucket dir and all its sidecar generations.
+	bucketMatch := fmt.Sprintf("property_%s_rangeable", propName)
+
+	var copiedBytes int64
+	nodesVisited := 0
+	// Walk until the compose runs out of nodes rather than assuming three, so a
+	// larger cluster cannot be captured only in part.
+	for nodeIdx := 1; ; nodeIdx++ {
+		node := compose.GetWeaviateNode(nodeIdx)
+		if node == nil {
+			break
+		}
+		nodesVisited++
+		container := node.Container()
+
+		// Manifest into the test log so it survives even without the artifact
+		// download; fall back to a full listing if nothing matches.
+		manifestScript := fmt.Sprintf(
+			`for lsm in /data/%s/*/lsm; do [ -d "$lsm" ] || continue; echo "### $lsm"; `+
+				`m=$(find "$lsm" -path "*%s*" 2>/dev/null); `+
+				`if [ -n "$m" ]; then echo "$m" | while IFS= read -r p; do ls -ld "$p"; done; `+
+				`else echo "(no %s* bucket dirs found; full lsm listing:)"; ls -la "$lsm"; fi; done`,
+			classDirLower, bucketMatch, bucketMatch)
+		manifest := execCollect(ctx, container, []string{"sh", "-c", manifestScript})
+		t.Logf("range-count forensic capture [%s]: node %d rangeable bucket manifest:\n%s",
+			phase, nodeIdx, strings.TrimSpace(manifest))
+
+		fileList := execCollect(ctx, container, []string{"sh", "-c", fmt.Sprintf(
+			`find /data/%s -path "*%s*" -type f 2>/dev/null`, classDirLower, bucketMatch)})
+		copiedBytes += copyContainerFiles(ctx, t, container, root, nodeIdx, fileList, copiedBytes, phase)
+	}
+	if nodesVisited == 0 {
+		t.Logf("range-count forensic capture [%s]: no weaviate containers found, nothing captured", phase)
+	}
+	t.Logf("range-count forensic capture [%s]: copied ~%d bytes from %d nodes into %s",
+		phase, copiedBytes, nodesVisited, root)
+}
+
+// forensicArtifactRoot returns a unique host dir for one capture: under
+// REINDEX_FORENSICS_DIR in CI, an OS temp dir locally. Unique per
+// test+phase+timestamp so repeated captures in the same run don't collide.
+func forensicArtifactRoot(t *testing.T, className, phase string) string {
+	t.Helper()
+	base := os.Getenv("REINDEX_FORENSICS_DIR")
+	if base == "" {
+		base = filepath.Join(os.TempDir(), "reindex-forensics")
+	}
+	name := strings.ReplaceAll(t.Name(), "/", "_")
+	root := filepath.Join(base, fmt.Sprintf("%s_%s_%s_%d", name, className, phase, time.Now().UnixNano()))
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Logf("range-count forensic capture [%s]: mkdir %s failed: %v", phase, root, err)
+	}
+	return root
+}
+
+// execCollect runs cmd in the container and returns combined stdout+stderr.
+// tcexec.Multiplexed strips Docker's stream-framing headers so the output is
+// plain text. Best effort: exec errors are returned as a note, not an error.
+func execCollect(ctx context.Context, container testcontainers.Container, cmd []string) string {
+	_, reader, err := container.Exec(ctx, cmd, tcexec.Multiplexed())
+	if err != nil {
+		return fmt.Sprintf("(exec error: %v)", err)
+	}
+	buf := new(strings.Builder)
+	if reader != nil {
+		_, _ = io.Copy(buf, reader)
+	}
+	return buf.String()
+}
+
+// copyContainerFiles copies each container path to disk. alreadyCopied is the
+// running cross-node total, so the shared byte budget applies across nodes.
+func copyContainerFiles(
+	ctx context.Context, t *testing.T, container testcontainers.Container,
+	root string, nodeIdx int, newlineSeparatedPaths string, alreadyCopied int64, phase string,
+) int64 {
+	t.Helper()
+	var nodeCopied int64
+	files := 0
+	for _, p := range strings.Split(strings.TrimSpace(newlineSeparatedPaths), "\n") {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		// Once the capture window closes every remaining copy fails instantly,
+		// which would otherwise emit one log line per remaining path.
+		if err := ctx.Err(); err != nil {
+			t.Logf("range-count forensic capture [%s]: node %d capture window closed (%v); remaining files skipped",
+				phase, nodeIdx, err)
+			break
+		}
+		allowance := allowNextFile(alreadyCopied+nodeCopied, files)
+		if allowance.stop {
+			t.Logf("range-count forensic capture [%s]: node %d %s; remaining files skipped",
+				phase, nodeIdx, allowance.reason)
+			break
+		}
+		files++
+		n, truncated, err := copyOneContainerFile(ctx, container, root, nodeIdx, p, allowance.limit)
+		if err != nil {
+			t.Logf("range-count forensic capture [%s]: node %d copy %s failed: %v", phase, nodeIdx, p, err)
+			continue
+		}
+		nodeCopied += n
+		if truncated {
+			t.Logf("range-count forensic capture [%s]: node %d truncated %s at %d bytes to stay inside the budget",
+				phase, nodeIdx, p, n)
+		}
+	}
+	return nodeCopied
+}
+
+// copyOneContainerFile mirrors containerPath's /data-relative path under
+// <root>/node<nodeIdx>/, writing at most limit bytes. It reports how much it
+// wrote and whether the file was cut short by that limit.
+func copyOneContainerFile(
+	ctx context.Context, container testcontainers.Container, root string, nodeIdx int,
+	containerPath string, limit int64,
+) (written int64, truncated bool, err error) {
+	rc, err := container.CopyFileFromContainer(ctx, containerPath)
+	if err != nil {
+		return 0, false, err
+	}
+	defer rc.Close()
+	rel := strings.TrimPrefix(containerPath, "/data/")
+	dest := filepath.Join(root, fmt.Sprintf("node%d", nodeIdx), filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return 0, false, err
+	}
+	f, err := os.Create(dest)
+	if err != nil {
+		return 0, false, err
+	}
+	defer f.Close()
+	return copyBounded(f, rc, limit)
+}
+
+// copyBounded writes at most limit bytes from src to dst, reporting how much it
+// wrote and whether src still had data left at that point. Bounded rather than
+// io.Copy because the byte budget is only checked between files, so one
+// pathological segment would otherwise carry the capture past it.
+func copyBounded(dst io.Writer, src io.Reader, limit int64) (written int64, truncated bool, err error) {
+	written, err = io.CopyN(dst, src, limit)
+	if errors.Is(err, io.EOF) {
+		return written, false, nil
+	}
+	if err != nil {
+		return written, false, err
+	}
+	// CopyN stops at limit without reading beyond it, so a file of exactly
+	// limit bytes looks the same as a larger one. Probe for one more byte
+	// rather than reporting a truncation that did not happen.
+	var probe [1]byte
+	n, probeErr := src.Read(probe[:])
+	if n > 0 {
+		return written, true, nil
+	}
+	if probeErr != nil && !errors.Is(probeErr, io.EOF) {
+		return written, false, probeErr
+	}
+	return written, false, nil
 }
 
 // probeSample is one observation of a probe function against a node.

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -705,12 +705,35 @@ func dumpStartupLogs(ctx context.Context, t *testing.T, compose *docker.DockerCo
 
 // forensicCaptureByteBudget caps the bytes one capture may write, so a
 // pathological on-disk state cannot fill the CI runner's disk. It is shared by
-// every node in the capture, not per node.
+// every node in one capture, but each capture gets a fresh one: a test that
+// asserts at several phases can spend it once per failing assert.
 const forensicCaptureByteBudget = 512 << 20 // 512 MiB
 
 // forensicFilesPerNodeCap caps how many files a single node contributes, so one
 // node with a runaway directory cannot consume the whole byte budget.
 const forensicFilesPerNodeCap = 4000
+
+// forensicExecOutputCap caps how much of one in-container command's output is
+// read into memory. The byte budget and the file cap only apply once the file
+// list exists, so without this a runaway directory is read whole first.
+const forensicExecOutputCap = 1 << 20 // 1 MiB
+
+// forensicCaptureWindow bounds how long a capture may take. It does not reach
+// into container.Exec; see execCollect for what bounds that.
+const forensicCaptureWindow = 90 * time.Second
+
+// captureManifestName is the record of what the capture did, written inside the
+// artifact. The artifact zip and the CI job log are separate downloads, so
+// anything that explains a missing or short file has to be in both.
+const captureManifestName = "CAPTURE-MANIFEST.txt"
+
+// Suffixes for a captured file that is not a faithful copy of the container's.
+// They also take the file out of its original extension, so a tool pointed at
+// the artifact cannot parse a cut segment as if it were whole.
+const (
+	truncatedSuffix = ".TRUNCATED"
+	partialSuffix   = ".PARTIAL"
+)
 
 // captureAllowance is the decision for one candidate file: whether the capture
 // should stop, and if not, the most bytes that file may consume.
@@ -742,62 +765,231 @@ func allowNextFile(copiedTotal int64, filesThisNode int) captureAllowance {
 	return captureAllowance{limit: remaining}
 }
 
+// captureLog records what a capture did, to the test log and to a file inside
+// the artifact. Both matter: whoever downloads the zip may not have the job log
+// open, and a line that explains a missing or short file is useless in the one
+// place the reader is not looking.
+type captureLog struct {
+	t      *testing.T
+	phase  string
+	lines  []string
+	prefix string
+}
+
+func (c *captureLog) recordf(format string, args ...any) {
+	line := fmt.Sprintf(format, args...)
+	c.lines = append(c.lines, line)
+	c.t.Logf("%s: %s", c.prefix, line)
+}
+
+// writeTo drops the record into the artifact root under captureManifestName.
+func (c *captureLog) writeTo(root string) {
+	dest := filepath.Join(root, captureManifestName)
+	body := strings.Join(c.lines, "\n") + "\n"
+	if err := os.WriteFile(dest, []byte(body), 0o644); err != nil {
+		// Recording this through recordf would write it into the file that just
+		// failed to be written.
+		c.t.Logf("%s: writing %s failed, the artifact carries no manifest: %v", c.prefix, dest, err)
+	}
+}
+
+// forensicCapture is one capture in progress: where files land, how much of the
+// shared byte budget is spent, and the record being built. dataDir is the
+// container path the class dirs live under, which is what PERSISTENCE_DATA_PATH
+// sets on the node.
+type forensicCapture struct {
+	log         *captureLog
+	root        string
+	dataDir     string
+	classDir    string
+	bucketMatch string
+	copied      int64
+}
+
 // captureRangeableDataDirsOnFailure is a best-effort dump of the rangeable
 // bucket's on-disk state (weaviate/0-weaviate-issues#335), for offline
 // post-mortem on a range-count failure. Capture errors are logged, never fatal.
 func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompose, className, propName, phase string) {
 	t.Helper()
-	// Independent of the test's ctx (which may be cancelling) and bounded, so
-	// capture can never hang CI.
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	// The test's own ctx may already be cancelling, so capture gets its own.
+	ctx, cancel := context.WithTimeout(context.Background(), forensicCaptureWindow)
 	defer cancel()
 
-	root := forensicArtifactRoot(t, className, phase)
-	t.Logf("range-count forensic capture [%s]: artifact root = %s", phase, root)
+	log := &captureLog{t: t, phase: phase, prefix: fmt.Sprintf("range-count forensic capture [%s]", phase)}
+	root, err := forensicArtifactRoot(t, className, phase)
+	if err != nil {
+		// Without a root every copy below would fail, one log line per file.
+		t.Logf("%s: no artifact dir (%v); nothing captured", log.prefix, err)
+		return
+	}
 
-	classDirLower := strings.ToLower(className)
-	// Prefix shared by the canonical bucket dir and all its sidecar generations.
-	bucketMatch := fmt.Sprintf("property_%s_rangeable", propName)
+	c := &forensicCapture{
+		log:      log,
+		root:     root,
+		dataDir:  "/data",
+		classDir: strings.ToLower(className),
+		// Prefix shared by the canonical bucket dir and all its sidecar generations.
+		bucketMatch: fmt.Sprintf("property_%s_rangeable", propName),
+	}
+	c.log.recordf("artifact root = %s", root)
+	defer c.log.writeTo(root)
 
-	var copiedBytes int64
 	nodesVisited := 0
-	// Walk until the compose runs out of nodes rather than assuming three, so a
-	// larger cluster cannot be captured only in part.
+	// Walk until the compose runs out of nodes rather than assuming three.
 	for nodeIdx := 1; ; nodeIdx++ {
 		node := compose.GetWeaviateNode(nodeIdx)
 		if node == nil {
 			break
 		}
+		if err := ctx.Err(); err != nil {
+			c.log.recordf("capture window closed (%v) after %d nodes; the remaining nodes were not visited",
+				err, nodesVisited)
+			break
+		}
 		nodesVisited++
-		container := node.Container()
-
-		// Manifest into the test log so it survives even without the artifact
-		// download; fall back to a full listing if nothing matches.
-		manifestScript := fmt.Sprintf(
-			`for lsm in /data/%s/*/lsm; do [ -d "$lsm" ] || continue; echo "### $lsm"; `+
-				`m=$(find "$lsm" -path "*%s*" 2>/dev/null); `+
-				`if [ -n "$m" ]; then echo "$m" | while IFS= read -r p; do ls -ld "$p"; done; `+
-				`else echo "(no %s* bucket dirs found; full lsm listing:)"; ls -la "$lsm"; fi; done`,
-			classDirLower, bucketMatch, bucketMatch)
-		manifest := execCollect(ctx, container, []string{"sh", "-c", manifestScript})
-		t.Logf("range-count forensic capture [%s]: node %d rangeable bucket manifest:\n%s",
-			phase, nodeIdx, strings.TrimSpace(manifest))
-
-		fileList := execCollect(ctx, container, []string{"sh", "-c", fmt.Sprintf(
-			`find /data/%s -path "*%s*" -type f 2>/dev/null`, classDirLower, bucketMatch)})
-		copiedBytes += copyContainerFiles(ctx, t, container, root, nodeIdx, fileList, copiedBytes, phase)
+		c.collectNode(ctx, node.Container(), nodeIdx)
 	}
 	if nodesVisited == 0 {
-		t.Logf("range-count forensic capture [%s]: no weaviate containers found, nothing captured", phase)
+		c.log.recordf("no weaviate containers found, nothing captured")
 	}
-	t.Logf("range-count forensic capture [%s]: copied ~%d bytes from %d nodes into %s",
-		phase, copiedBytes, nodesVisited, root)
+	c.log.recordf("copied ~%d bytes from %d nodes into %s", c.copied, nodesVisited, root)
 }
 
-// forensicArtifactRoot returns a unique host dir for one capture: under
+// collectNode records one node's rangeable bucket manifest and copies the
+// matching files under <root>/node<nodeIdx>/.
+func (c *forensicCapture) collectNode(ctx context.Context, container testcontainers.Container, nodeIdx int) {
+	manifest, cut, err := execCollect(ctx, container, []string{"sh", "-c", c.manifestScript()})
+	switch {
+	case err != nil:
+		c.log.recordf("node %d manifest command failed (%v); output so far:\n%s",
+			nodeIdx, err, strings.TrimSpace(manifest))
+	case cut:
+		c.log.recordf("node %d rangeable bucket manifest, cut at %d bytes:\n%s",
+			nodeIdx, forensicExecOutputCap, strings.TrimSpace(manifest))
+	default:
+		c.log.recordf("node %d rangeable bucket manifest:\n%s", nodeIdx, strings.TrimSpace(manifest))
+	}
+
+	fileList, cut, err := execCollect(ctx, container, []string{"sh", "-c", c.fileListScript()})
+	if err != nil {
+		// Whatever paths did arrive are still worth copying, so this reports
+		// rather than returns.
+		c.log.recordf("node %d file list command failed (%v); copying what it did list", nodeIdx, err)
+	}
+	if cut {
+		c.log.recordf("node %d file list was cut at %d bytes; the files past the cut were never offered to the copy",
+			nodeIdx, forensicExecOutputCap)
+	}
+	c.copyFiles(ctx, container, nodeIdx, fileList)
+}
+
+// manifestScript lists the rangeable bucket dirs on one node. Every branch
+// prints something: an empty manifest reads the same whether the data is
+// genuinely absent, the path is wrong, or the collector broke.
+func (c *forensicCapture) manifestScript() string {
+	return fmt.Sprintf(
+		`d="%[1]s/%[2]s"; `+
+			`if [ ! -d "$d" ]; then echo "(no $d dir; %[1]s listing:)"; ls -la "%[1]s"; exit 0; fi; `+
+			`found=0; `+
+			`for lsm in "$d"/*/lsm; do [ -d "$lsm" ] || continue; found=1; echo "### $lsm"; `+
+			`m=$(find "$lsm" -path "*%[3]s*" 2>/dev/null); `+
+			`if [ -n "$m" ]; then echo "$m" | while IFS= read -r p; do ls -ld "$p"; done; `+
+			`else echo "(no %[3]s* bucket dirs found; full lsm listing:)"; ls -la "$lsm"; fi; done; `+
+			`[ "$found" = 1 ] || { echo "(no */lsm dirs under $d; listing:)"; ls -la "$d"; }`,
+		c.dataDir, c.classDir, c.bucketMatch)
+}
+
+func (c *forensicCapture) fileListScript() string {
+	return fmt.Sprintf(`find "%s/%s" -path "*%s*" -type f 2>/dev/null`, c.dataDir, c.classDir, c.bucketMatch)
+}
+
+// copyFiles copies each listed container path under <root>/node<nodeIdx>/,
+// stopping at the first bound that trips.
+func (c *forensicCapture) copyFiles(
+	ctx context.Context, container testcontainers.Container, nodeIdx int, newlineSeparatedPaths string,
+) {
+	paths := splitPaths(newlineSeparatedPaths)
+	files := 0
+	for i, p := range paths {
+		// Once the capture window closes every remaining copy fails instantly,
+		// which would otherwise emit one log line per remaining path.
+		if err := ctx.Err(); err != nil {
+			c.log.recordf("node %d capture window closed (%v); %d of %d files not attempted",
+				nodeIdx, err, len(paths)-i, len(paths))
+			return
+		}
+		allowance := allowNextFile(c.copied, files)
+		if allowance.stop {
+			c.log.recordf("node %d %s; %d of %d files not attempted",
+				nodeIdx, allowance.reason, len(paths)-i, len(paths))
+			return
+		}
+		files++
+		res := c.copyOneFile(ctx, container, nodeIdx, p, allowance.limit)
+		// A copy that broke mid-stream still left its bytes on disk, so they
+		// count against the budget the same as a copy that finished.
+		c.copied += res.written
+		c.recordCopy(nodeIdx, p, c.markIncomplete(nodeIdx, res))
+	}
+}
+
+// markIncomplete renames a file that is not a faithful copy, and reports the
+// result with rel pointing at whatever name the file ended up under.
+func (c *forensicCapture) markIncomplete(nodeIdx int, res copyResult) copyResult {
+	suffix := incompleteSuffix(res.truncated, res.err)
+	if suffix == "" || res.rel == "" {
+		return res
+	}
+	if err := os.Rename(filepath.Join(c.root, res.rel), filepath.Join(c.root, res.rel+suffix)); err != nil {
+		c.log.recordf("node %d could not mark %s as %s; it stays in the artifact under its original name: %v",
+			nodeIdx, res.rel, suffix, err)
+		return res
+	}
+	res.rel += suffix
+	return res
+}
+
+func (c *forensicCapture) recordCopy(nodeIdx int, containerPath string, res copyResult) {
+	switch {
+	case res.err != nil && res.rel == "":
+		c.log.recordf("node %d copy %s failed, no file written: %v", nodeIdx, containerPath, res.err)
+	case res.err != nil:
+		c.log.recordf("node %d copy %s broke after %d bytes; kept as %s: %v",
+			nodeIdx, containerPath, res.written, res.rel, res.err)
+	case res.truncated:
+		c.log.recordf("node %d truncated %s at %d bytes to stay inside the budget; kept as %s",
+			nodeIdx, containerPath, res.written, res.rel)
+	}
+}
+
+// incompleteSuffix names what is wrong with a captured file, or "" when the
+// file is a faithful copy.
+func incompleteSuffix(truncated bool, err error) string {
+	switch {
+	case err != nil:
+		return partialSuffix
+	case truncated:
+		return truncatedSuffix
+	default:
+		return ""
+	}
+}
+
+// splitPaths turns a find(1) listing into the paths it names.
+func splitPaths(newlineSeparated string) []string {
+	var paths []string
+	for _, p := range strings.Split(newlineSeparated, "\n") {
+		if p = strings.TrimSpace(p); p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
+}
+
+// forensicArtifactRoot creates a unique host dir for one capture: under
 // REINDEX_FORENSICS_DIR in CI, an OS temp dir locally. Unique per
 // test+phase+timestamp so repeated captures in the same run don't collide.
-func forensicArtifactRoot(t *testing.T, className, phase string) string {
+func forensicArtifactRoot(t *testing.T, className, phase string) (string, error) {
 	t.Helper()
 	base := os.Getenv("REINDEX_FORENSICS_DIR")
 	if base == "" {
@@ -806,91 +998,112 @@ func forensicArtifactRoot(t *testing.T, className, phase string) string {
 	name := strings.ReplaceAll(t.Name(), "/", "_")
 	root := filepath.Join(base, fmt.Sprintf("%s_%s_%s_%d", name, className, phase, time.Now().UnixNano()))
 	if err := os.MkdirAll(root, 0o755); err != nil {
-		t.Logf("range-count forensic capture [%s]: mkdir %s failed: %v", phase, root, err)
+		return "", err
 	}
-	return root
+	return root, nil
 }
 
-// execCollect runs cmd in the container and returns combined stdout+stderr.
-// tcexec.Multiplexed strips Docker's stream-framing headers so the output is
-// plain text. Best effort: exec errors are returned as a note, not an error.
-func execCollect(ctx context.Context, container testcontainers.Container, cmd []string) string {
-	_, reader, err := container.Exec(ctx, cmd, tcexec.Multiplexed())
+// execCollect runs cmd in the container and returns its combined stdout+stderr,
+// whether that output was cut at forensicExecOutputCap, and what went wrong.
+//
+// ctx does not bound container.Exec. With tcexec.Multiplexed it blocks draining
+// a hijacked connection that nothing closes when ctx expires, so a wedged
+// container — the state this code exists for — would block until the go test
+// timeout fires and buries the real failure. Handing the call its own goroutine
+// is what actually bounds the caller's wait. A wedged exec parks that goroutine
+// until the test binary exits; it only ever writes to a buffered channel, never
+// to t, so it cannot log after the test has finished.
+func execCollect(ctx context.Context, container testcontainers.Container, cmd []string) (string, bool, error) {
+	type collected struct {
+		out string
+		err error
+	}
+	done := make(chan collected, 1)
+	go func() {
+		out, err := execCollectBlocking(ctx, container, cmd)
+		done <- collected{out: out, err: err}
+	}()
+
+	select {
+	case r := <-done:
+		out, cut := capExecOutput(r.out)
+		return out, cut, r.err
+	case <-ctx.Done():
+		return "", false, fmt.Errorf("command did not return inside the capture window: %w", ctx.Err())
+	}
+}
+
+// execCollectBlocking is the part that can hang. tcexec.Multiplexed strips
+// Docker's stream-framing headers so the output is plain text.
+func execCollectBlocking(ctx context.Context, container testcontainers.Container, cmd []string) (string, error) {
+	code, reader, err := container.Exec(ctx, cmd, tcexec.Multiplexed())
 	if err != nil {
-		return fmt.Sprintf("(exec error: %v)", err)
+		return "", err
 	}
 	buf := new(strings.Builder)
 	if reader != nil {
-		_, _ = io.Copy(buf, reader)
-	}
-	return buf.String()
-}
-
-// copyContainerFiles copies each container path to disk. alreadyCopied is the
-// running cross-node total, so the shared byte budget applies across nodes.
-func copyContainerFiles(
-	ctx context.Context, t *testing.T, container testcontainers.Container,
-	root string, nodeIdx int, newlineSeparatedPaths string, alreadyCopied int64, phase string,
-) int64 {
-	t.Helper()
-	var nodeCopied int64
-	files := 0
-	for _, p := range strings.Split(strings.TrimSpace(newlineSeparatedPaths), "\n") {
-		p = strings.TrimSpace(p)
-		if p == "" {
-			continue
-		}
-		// Once the capture window closes every remaining copy fails instantly,
-		// which would otherwise emit one log line per remaining path.
-		if err := ctx.Err(); err != nil {
-			t.Logf("range-count forensic capture [%s]: node %d capture window closed (%v); remaining files skipped",
-				phase, nodeIdx, err)
-			break
-		}
-		allowance := allowNextFile(alreadyCopied+nodeCopied, files)
-		if allowance.stop {
-			t.Logf("range-count forensic capture [%s]: node %d %s; remaining files skipped",
-				phase, nodeIdx, allowance.reason)
-			break
-		}
-		files++
-		n, truncated, err := copyOneContainerFile(ctx, container, root, nodeIdx, p, allowance.limit)
-		if err != nil {
-			t.Logf("range-count forensic capture [%s]: node %d copy %s failed: %v", phase, nodeIdx, p, err)
-			continue
-		}
-		nodeCopied += n
-		if truncated {
-			t.Logf("range-count forensic capture [%s]: node %d truncated %s at %d bytes to stay inside the budget",
-				phase, nodeIdx, p, n)
+		// One byte past the cap is enough for capExecOutput to see it was cut.
+		if _, err := io.Copy(buf, io.LimitReader(reader, forensicExecOutputCap+1)); err != nil {
+			return buf.String(), fmt.Errorf("reading output: %w", err)
 		}
 	}
-	return nodeCopied
+	if code != 0 {
+		return buf.String(), fmt.Errorf("exit code %d", code)
+	}
+	return buf.String(), nil
 }
 
-// copyOneContainerFile mirrors containerPath's /data-relative path under
-// <root>/node<nodeIdx>/, writing at most limit bytes. It reports how much it
-// wrote and whether the file was cut short by that limit.
-func copyOneContainerFile(
-	ctx context.Context, container testcontainers.Container, root string, nodeIdx int,
+// capExecOutput cuts s to forensicExecOutputCap at a line boundary, so a cut
+// list of paths never ends in half a path, and reports whether it cut anything.
+func capExecOutput(s string) (string, bool) {
+	if len(s) <= forensicExecOutputCap {
+		return s, false
+	}
+	s = s[:forensicExecOutputCap]
+	// No newline at all means no whole line survived the cut.
+	i := strings.LastIndexByte(s, '\n')
+	if i < 0 {
+		return "", true
+	}
+	return s[:i+1], true
+}
+
+// copyResult is what one file copy left behind. rel is the file's path inside
+// the artifact root, empty when no file was created.
+type copyResult struct {
+	rel       string
+	written   int64
+	truncated bool
+	err       error
+}
+
+// copyOneFile mirrors containerPath's dataDir-relative path under
+// <root>/node<nodeIdx>/, writing at most limit bytes.
+func (c *forensicCapture) copyOneFile(
+	ctx context.Context, container testcontainers.Container, nodeIdx int,
 	containerPath string, limit int64,
-) (written int64, truncated bool, err error) {
+) copyResult {
 	rc, err := container.CopyFileFromContainer(ctx, containerPath)
 	if err != nil {
-		return 0, false, err
+		return copyResult{err: err}
 	}
 	defer rc.Close()
-	rel := strings.TrimPrefix(containerPath, "/data/")
-	dest := filepath.Join(root, fmt.Sprintf("node%d", nodeIdx), filepath.FromSlash(rel))
+	rel := filepath.Join(fmt.Sprintf("node%d", nodeIdx),
+		filepath.FromSlash(strings.TrimPrefix(containerPath, c.dataDir+"/")))
+	dest := filepath.Join(c.root, rel)
 	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return 0, false, err
+		return copyResult{err: err}
 	}
 	f, err := os.Create(dest)
 	if err != nil {
-		return 0, false, err
+		return copyResult{err: err}
 	}
-	defer f.Close()
-	return copyBounded(f, rc, limit)
+	written, truncated, err := copyBounded(f, rc, limit)
+	// A close-time write error leaves behind another silently short file.
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	return copyResult{rel: rel, written: written, truncated: truncated, err: err}
 }
 
 // copyBounded writes at most limit bytes from src to dst, reporting how much it

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -771,7 +771,6 @@ func allowNextFile(copiedTotal int64, filesThisNode int) captureAllowance {
 // place the reader is not looking.
 type captureLog struct {
 	t      *testing.T
-	phase  string
 	lines  []string
 	prefix string
 }
@@ -782,14 +781,23 @@ func (c *captureLog) recordf(format string, args ...any) {
 	c.t.Logf("%s: %s", c.prefix, line)
 }
 
+// captureManifestTerminator ends a complete manifest. os.WriteFile leaves the
+// bytes it managed to write behind when it fails, so without a terminator a
+// manifest cut short by a full disk reads exactly like a complete one.
+const captureManifestTerminator = "=== END OF CAPTURE MANIFEST, %d records ==="
+
 // writeTo drops the record into the artifact root under captureManifestName.
+// A capture whose manifest cannot be written is still a valid artifact, so this
+// reports and returns rather than failing the capture.
 func (c *captureLog) writeTo(root string) {
 	dest := filepath.Join(root, captureManifestName)
-	body := strings.Join(c.lines, "\n") + "\n"
+	body := strings.Join(c.lines, "\n") + "\n" +
+		fmt.Sprintf(captureManifestTerminator, len(c.lines)) + "\n"
 	if err := os.WriteFile(dest, []byte(body), 0o644); err != nil {
 		// Recording this through recordf would write it into the file that just
 		// failed to be written.
-		c.t.Logf("%s: writing %s failed, the artifact carries no manifest: %v", c.prefix, dest, err)
+		c.t.Logf("%s: writing %s failed, so the artifact carries no manifest or a cut one: %v",
+			c.prefix, dest, err)
 	}
 }
 
@@ -815,7 +823,7 @@ func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompo
 	ctx, cancel := context.WithTimeout(context.Background(), forensicCaptureWindow)
 	defer cancel()
 
-	log := &captureLog{t: t, phase: phase, prefix: fmt.Sprintf("range-count forensic capture [%s]", phase)}
+	log := &captureLog{t: t, prefix: fmt.Sprintf("range-count forensic capture [%s]", phase)}
 	root, err := forensicArtifactRoot(t, className, phase)
 	if err != nil {
 		// Without a root every copy below would fail, one log line per file.
@@ -831,44 +839,75 @@ func captureRangeableDataDirsOnFailure(t *testing.T, compose *docker.DockerCompo
 		// Prefix shared by the canonical bucket dir and all its sidecar generations.
 		bucketMatch: fmt.Sprintf("property_%s_rangeable", propName),
 	}
-	c.log.recordf("artifact root = %s", root)
 	defer c.log.writeTo(root)
+	c.collectAll(ctx, weaviateContainers(compose))
+}
 
-	nodesVisited := 0
-	// Walk until the compose runs out of nodes rather than assuming three.
+// weaviateContainers lists the compose's weaviate nodes in node order, walking
+// until the compose runs out of nodes rather than assuming three. The lookup is
+// an in-memory scan, so listing them all up front costs nothing.
+func weaviateContainers(compose *docker.DockerCompose) []testcontainers.Container {
+	var containers []testcontainers.Container
 	for nodeIdx := 1; ; nodeIdx++ {
 		node := compose.GetWeaviateNode(nodeIdx)
 		if node == nil {
-			break
+			return containers
 		}
-		if err := ctx.Err(); err != nil {
-			c.log.recordf("capture window closed (%v) after %d nodes; the remaining nodes were not visited",
-				err, nodesVisited)
-			break
-		}
-		nodesVisited++
-		c.collectNode(ctx, node.Container(), nodeIdx)
+		containers = append(containers, node.Container())
 	}
-	if nodesVisited == 0 {
+}
+
+// collectAll captures every node in turn, opening the record with what the
+// artifact is and what it is not.
+func (c *forensicCapture) collectAll(ctx context.Context, containers []testcontainers.Container) {
+	c.log.recordf("artifact root = %s", c.root)
+	c.recordHowToRead()
+	if len(containers) == 0 {
 		c.log.recordf("no weaviate containers found, nothing captured")
 	}
-	c.log.recordf("copied ~%d bytes from %d nodes into %s", c.copied, nodesVisited, root)
+
+	visited := 0
+	for i, container := range containers {
+		if err := ctx.Err(); err != nil {
+			c.log.recordf("capture window closed (%v) after %d of %d nodes; the rest were not visited",
+				err, visited, len(containers))
+			break
+		}
+		visited++
+		c.collectNode(ctx, container, i+1)
+	}
+	c.log.recordf("copied ~%d bytes from %d of %d nodes into %s",
+		c.copied, visited, len(containers), c.root)
+}
+
+// recordHowToRead states the one thing a file name cannot: the copy was taken
+// from a live cluster. Every other way a file here can be wrong is either
+// marked on the file or named in this record, so without this line an
+// investigator reads mutually inconsistent segments as product corruption.
+func (c *forensicCapture) recordHowToRead() {
+	c.log.recordf("how to read this artifact:\n"+
+		"  the nodes were running and serving while these files were copied, so this is not a point-in-time snapshot\n"+
+		"  each file is copied on its own: two segments here can be from different instants, and a .wal can have a torn tail\n"+
+		"  files in that state keep their original names, because from the copier's side nothing went wrong\n"+
+		"  the assertion had already polled for %s before this ran, so what is on disk here can be that much newer than the first bad count",
+		rangeCountConvergenceWindow)
 }
 
 // collectNode records one node's rangeable bucket manifest and copies the
 // matching files under <root>/node<nodeIdx>/.
 func (c *forensicCapture) collectNode(ctx context.Context, container testcontainers.Container, nodeIdx int) {
+	// A command that failed and a command whose output was cut are separate
+	// facts. Reported as one choice, a manifest that hit both says only that
+	// the command failed and never mentions the cap.
 	manifest, cut, err := execCollect(ctx, container, []string{"sh", "-c", c.manifestScript()})
-	switch {
-	case err != nil:
-		c.log.recordf("node %d manifest command failed (%v); output so far:\n%s",
-			nodeIdx, err, strings.TrimSpace(manifest))
-	case cut:
-		c.log.recordf("node %d rangeable bucket manifest, cut at %d bytes:\n%s",
-			nodeIdx, forensicExecOutputCap, strings.TrimSpace(manifest))
-	default:
-		c.log.recordf("node %d rangeable bucket manifest:\n%s", nodeIdx, strings.TrimSpace(manifest))
+	if err != nil {
+		c.log.recordf("node %d manifest command failed (%v); what it printed before that is below", nodeIdx, err)
 	}
+	if cut {
+		c.log.recordf("node %d manifest output was cut at %d bytes%s",
+			nodeIdx, forensicExecOutputCap, nothingSurvivedNote(manifest))
+	}
+	c.log.recordf("node %d rangeable bucket manifest:\n%s", nodeIdx, strings.TrimSpace(manifest))
 
 	fileList, cut, err := execCollect(ctx, container, []string{"sh", "-c", c.fileListScript()})
 	if err != nil {
@@ -877,24 +916,38 @@ func (c *forensicCapture) collectNode(ctx context.Context, container testcontain
 		c.log.recordf("node %d file list command failed (%v); copying what it did list", nodeIdx, err)
 	}
 	if cut {
-		c.log.recordf("node %d file list was cut at %d bytes; the files past the cut were never offered to the copy",
-			nodeIdx, forensicExecOutputCap)
+		c.log.recordf("node %d file list was cut at %d bytes; the files past the cut were never offered to the copy%s",
+			nodeIdx, forensicExecOutputCap, nothingSurvivedNote(fileList))
 	}
 	c.copyFiles(ctx, container, nodeIdx, fileList)
 }
 
+// nothingSurvivedNote explains output that the cap left empty. capExecOutput
+// keeps whole lines only, so a cut that found no line break keeps nothing, and
+// the bare word "cut" would otherwise read as if something was shown.
+func nothingSurvivedNote(out string) string {
+	if strings.TrimSpace(out) != "" {
+		return ""
+	}
+	return "; no whole line survived the cut, so none of it is shown"
+}
+
 // manifestScript lists the rangeable bucket dirs on one node. Every branch
 // prints something: an empty manifest reads the same whether the data is
-// genuinely absent, the path is wrong, or the collector broke.
+// genuinely absent, the path is wrong, or the collector broke. The find keeps
+// its stderr and its exit status for the same reason, so a search that could
+// not read a directory is not reported as a search that found nothing.
 func (c *forensicCapture) manifestScript() string {
 	return fmt.Sprintf(
 		`d="%[1]s/%[2]s"; `+
 			`if [ ! -d "$d" ]; then echo "(no $d dir; %[1]s listing:)"; ls -la "%[1]s"; exit 0; fi; `+
 			`found=0; `+
 			`for lsm in "$d"/*/lsm; do [ -d "$lsm" ] || continue; found=1; echo "### $lsm"; `+
-			`m=$(find "$lsm" -path "*%[3]s*" 2>/dev/null); `+
+			`m=$(find "$lsm" -path "*%[3]s*"); rc=$?; `+
+			`[ "$rc" = 0 ] || echo "(find under $lsm exited $rc; what it listed may be incomplete)"; `+
 			`if [ -n "$m" ]; then echo "$m" | while IFS= read -r p; do ls -ld "$p"; done; `+
-			`else echo "(no %[3]s* bucket dirs found; full lsm listing:)"; ls -la "$lsm"; fi; done; `+
+			`elif [ "$rc" = 0 ]; then echo "(no %[3]s* bucket dirs found; full lsm listing:)"; ls -la "$lsm"; `+
+			`else ls -la "$lsm"; fi; done; `+
 			`[ "$found" = 1 ] || { echo "(no */lsm dirs under $d; listing:)"; ls -la "$d"; }`,
 		c.dataDir, c.classDir, c.bucketMatch)
 }
@@ -909,7 +962,13 @@ func (c *forensicCapture) copyFiles(
 	ctx context.Context, container testcontainers.Container, nodeIdx int, newlineSeparatedPaths string,
 ) {
 	paths := splitPaths(newlineSeparatedPaths)
-	files := 0
+	files, whole, bytesBefore := 0, 0, c.copied
+	// Without this, a node that listed nothing and a node that copied everything
+	// cleanly leave the same trace: none.
+	defer func() {
+		c.log.recordf("node %d: listed %d files, attempted %d, copied %d whole, %d bytes",
+			nodeIdx, len(paths), files, whole, c.copied-bytesBefore)
+	}()
 	for i, p := range paths {
 		// Once the capture window closes every remaining copy fails instantly,
 		// which would otherwise emit one log line per remaining path.
@@ -929,6 +988,9 @@ func (c *forensicCapture) copyFiles(
 		// A copy that broke mid-stream still left its bytes on disk, so they
 		// count against the budget the same as a copy that finished.
 		c.copied += res.written
+		if res.err == nil && !res.truncated {
+			whole++
+		}
 		c.recordCopy(nodeIdx, p, c.markIncomplete(nodeIdx, res))
 	}
 }


### PR DESCRIPTION
SuperClaude here.

This is one of the three PRs that replace weaviate/weaviate#12230. That PR bundled a production fix with two unrelated bodies of test tooling, and the fix sat unmerged for 25 days behind a review queue meant for CI scaffolding. The production fix is out on its own as weaviate/weaviate#12607. This PR is the reindex forensics half, and it is the part that actually needs a reindex/LSM reviewer.

## What you get

`TestMultiNode_EnableRangeable_ConcurrentUpdatesNoLossNoPanic` fails intermittently on its range-count assertion (weaviate/etienne-claude-issues#67), and the on-disk state that would explain it is gone by the time anyone looks. The test restarts nodes immediately afterward, and CI kept no copy of the shard directories. Every occurrence so far has been diagnosed from counts alone.

After this, a failing run leaves behind the rangeable bucket's actual segments and WALs, per node, as a downloadable CI artifact, plus a manifest in the test log for when nobody wants to download anything.

## What changes

- **On failure only**, `assertRangeCountAllNodes` dumps each node's rangeable bucket manifest into the test log and copies the matching files off every container into `REINDEX_FORENSICS_DIR`.
- **The reindex job uploads that directory** when it fails, with `if-no-files-found: ignore` since 11 of the 12 matrix entries never reach the test that writes it.

A green run captures nothing and writes nothing.

## The artifact says what it is

A forensic dump exists to tell "the data was missing" apart from "the collector was." A short file that keeps its `.db` name defeats that: it is byte-indistinguishable from a complete segment, so an investigator reads a cut capture as product corruption. Three things inside the artifact prevent that, and none depends on having the job log open.

- **A file that is not a faithful copy is renamed.** `.PARTIAL` when the stream broke mid-copy, `.TRUNCATED` when the byte budget cut it. The suffix also takes the file out of its original extension, so a tool pointed at the tree cannot parse it as whole.
- **`CAPTURE-MANIFEST.txt` carries the same lines the test log gets.** This is the only place a *skipped* file can be reported at all, since a skip leaves no file behind to rename. It is also the backstop for the one path where the renaming fails open, below. Writing it can itself fail, which is reported to the job log and nowhere else, so the file ends in `=== END OF CAPTURE MANIFEST, N records ===`: an absent or short manifest is then tellable from a complete one rather than being read as the whole story.
- **The record opens by saying what the artifact is not.** The copies come off running nodes, so two segments can be from different instants and a `.wal` can have a torn tail, and those files carry their original names because from the copier's side nothing went wrong. That is the one way a captured file can be wrong that no file name can express, so the manifest states it, along with how long the assertion had already polled before the capture ran.

### The one path where the marking fails open

`markIncomplete` renames the file. If the rename itself fails, the incomplete copy keeps its `.db` name and the manifest line is all that is left:

```
node1/things/s/lsm/b/seg.db                   (3 bytes)   ← incomplete, original name
CAPTURE-MANIFEST.txt:
  node 1 could not mark node1/things/s/lsm/b/seg.db as .PARTIAL; it stays in the
  artifact under its original name: … file exists
  node 1 copy /data/things/s/lsm/b/seg.db broke after 3 bytes; kept as
  node1/things/s/lsm/b/seg.db: stream reset
```

`TestCopyFilesKeepsTheOriginalNameWhenTheMarkerCannotBeApplied` forces it (a non-empty directory on the `.PARTIAL` name, which `os.Rename` cannot replace on any unix) and pins both the byte-for-byte artifact and the two manifest lines, including that the copy line names the file as it actually is on disk rather than as the rename meant to leave it.

## Why the bounds are the interesting part

Capture runs on a CI runner during a failure, which is the worst moment to start an unbounded copy. Five bounds:

- **A byte budget shared across all nodes** (512 MiB), not per node. Bytes are charged to it whether or not the copy that wrote them finished, so a stream that breaks mid-file cannot leak past it. Each capture gets a fresh budget, so a test that asserts at several phases can spend it once per failing assert.
- **A per-node file cap** (4000), so one runaway directory cannot consume the whole budget.
- **A copy that stops at the remaining budget.** This is `io.CopyN`, not `io.Copy`. The budget is only checked *between* files, so an unbounded copy would let a single pathological segment carry the capture well past it.
- **A cap on how much of one in-container command's output is read** (1 MiB), cut back to the last whole line so a truncated file list never ends in half a path. The file cap and the byte budget only apply once the list exists.
- **A 90-second window**, after which the loop stops instead of emitting one failure line per remaining path.

**The window does not reach into `container.Exec`, and this is worth knowing.** With `tcexec.Multiplexed`, `Exec` blocks on `stdcopy.StdCopy` draining a hijacked raw connection, and nothing closes that connection when the context expires (`docker/client/hijack.go` hands back a bare `net.Conn`; the TCP keepalive does not apply to the unix socket CI uses). A wedged container is exactly the state this code is written for, so on an earlier revision it would have turned a clean assertion failure into a `go test` timeout panic that buries the real failure under every goroutine stack in the process. The exec now runs on its own goroutine and the caller stops waiting at the window. A wedged exec parks that goroutine until the test binary exits; it only ever writes to a buffered channel, never to `t`, so it cannot log after the test finishes.

The node walk follows the compose until it runs out of nodes rather than assuming three. Note that the caller it currently serves asserts over a hardcoded three nodes, so the walk is what generalizes, not the test around it.

## Every way the capture can mislead its reader

| Path | What you get now |
|---|---|
| Copy breaks mid-stream | file renamed `.PARTIAL`, bytes charged to the budget, named in the manifest |
| File hits the byte budget | file renamed `.TRUNCATED`, named in the manifest |
| **That rename itself fails** | file keeps its original name, and the manifest says so under that name |
| **Copies taken from running nodes** | the manifest opens by saying this is not a point-in-time snapshot, that a `.wal` can have a torn tail, and that such files keep their original names |
| **The manifest write fails or is cut short** | the terminator line is missing, so a short manifest is not read as the whole story |
| A bound or the window stops the loop | manifest says how many files of how many were not attempted |
| **A node contributed nothing** | per-node line: how many files were listed, attempted, copied whole, and how many bytes. A node that listed zero files and a node that copied 40 cleanly no longer leave the same trace |
| **The window closes before the first node** | reported as a closed window, not as "no weaviate containers found" |
| `/data/<class>` missing | script prints the reason and lists `/data`, instead of printing nothing |
| `/data/<class>` exists but has no `*/lsm` | script says so and lists the class dir |
| **`find` fails inside the container** | its stderr and its exit status are kept, so a search that could not read a directory is not reported as a search that found nothing |
| exec refused by the container | reported as an error, never fed back into the copy loop as a path |
| exec stream unreadable | `io.Copy` error surfaced instead of yielding an empty manifest |
| Non-zero exec exit code | surfaced instead of discarded |
| **An exec that both failed and hit the 1 MiB cap** | two separate lines. Reported as one choice, the cap went unmentioned |
| **A cap that landed with no line break in 1 MiB** | says no whole line survived, so the reader is not left looking for output that was never shown |
| `MkdirAll(root)` fails | capture stops with one line, instead of up to 4000 "copy failed" lines per node |

Bold rows are new in the latest revision.

### Two things this deliberately does not do

- **`capExecOutput` still returns nothing when 1 MiB of output contains no line break.** The same function feeds the file list to the copy loop, so keeping the raw prefix would hand `splitPaths` a truncated container path and produce a "copy failed" line for a file that never existed. Whole lines only is the safe contract; the fix went into the report instead.
- **A destination file that could not be created leaves an empty directory behind.** `copyOneFile` creates the parent before it creates the file. The manifest records it as "no file written", so the tree is untidy rather than misleading.

## Evidence

`test/acceptance/reindex_multinode/forensic_capture_bounds_test.go` runs **31 test functions / 51 subtests, no containers, 2.0s** under `-race`.

Mutation receipt, 32 guards. Each applied alone, mutant confirmed to build (`go vet`), named test run, then restored with `git diff --quiet` verified clean. **18 of them were re-run on this revision:** the 11 new ones, plus the 7 older ones whose code this revision touched (marked ↻), since a refactor is exactly what quietly weakens an existing guard.

| Mutation | Named test |
|---|---|
| `io.CopyN` back to `io.Copy` (restores the unbounded copy) | 🔴 `TestCopyBounded` |
| Drop the exact-size probe, always claim truncation | 🔴 `TestCopyBounded` |
| Drop the byte-budget stop | 🔴 `TestAllowNextFile` |
| Drop the per-node file cap stop | 🔴 `TestAllowNextFile` |
| Swap guard precedence, budget before file cap | 🔴 `TestAllowNextFile` |
| ↻ Drop the closed-capture-window check | 🔴 `TestCopyFilesStopsWhenCaptureWindowClosed` |
| ↻ Drop the budget/file-cap stop from the copy loop | 🔴 `TestCopyFilesStopsWhenTheByteBudgetIsSpent` |
| ↻ Skip bytes left on disk by a failed copy | 🔴 `TestCopyFilesCountsBytesLeftOnDiskByABrokenCopy` |
| Leave incomplete files under their original name | 🔴 `TestCopyFilesMarksFilesThatAreNotFaithfulCopies` |
| **Stop recording a rename that could not be applied** | 🔴 `TestCopyFilesKeepsTheOriginalNameWhenTheMarkerCannotBeApplied` |
| ↻ Never write the manifest into the artifact | 🔴 `TestCaptureManifestNamesEveryIncompleteFile` |
| **Drop the manifest terminator** | 🔴 `TestCaptureManifestEndsWithATerminator` |
| **Drop the line saying the copy came from running nodes** | 🔴 `TestCollectAllSaysTheCopyWasTakenFromRunningNodes` |
| **Swallow the cut flag when the command also failed** | 🔴 `TestCollectNodeReportsTheCapEvenWhenTheCommandAlsoFailed` |
| **Stop saying that no whole line survived a cut** | 🔴 `TestCollectNodeReportsTheCapEvenWhenTheCommandAlsoFailed` |
| **Hide the in-container `find`'s error and exit status** | 🔴 `TestManifestScriptSaysWhenTheSearchItselfFailed` |
| **Drop the per-node summary line** | 🔴 `TestCopyFilesRecordsWhatEachNodeContributed` |
| **Report a closed window as an empty cluster** | 🔴 `TestCollectAllTellsAnEmptyClusterApartFromAClosedWindow` |
| **Let the capture continue past an artifact dir it could not create** | 🔴 `TestCaptureStopsBeforeItTouchesAnyContainer` |
| **Report a destination that could not be created as a file that exists** | 🔴 `TestCopyFilesRecordsAFileItCouldNotWrite` |
| **Scatter local captures across the bare temp dir** | 🔴 `TestForensicArtifactRootFallsBackToATempDir` |
| Flatten the container path instead of mirroring it | 🔴 `TestCopyFilesMirrorsContainerPaths` |
| Report a file that could not be opened as if bytes were written | 🔴 `TestCopyFilesRecordsAFileItCouldNotOpen` |
| Call `Exec` on the caller's goroutine (no wall-clock bound) | 🔴 `TestExecCollectReturnsWhenTheContainerNeverDoes` |
| Discard the exec exit code | 🔴 `TestExecCollectSurfacesFailures` |
| Discard the exec stream read error | 🔴 `TestExecCollectSurfacesFailures` |
| Read exec output unbounded | 🔴 `TestCapExecOutput` |
| Cut exec output without honoring the line boundary | 🔴 `TestCapExecOutput` |
| ↻ Drop the missing-class-dir guard from the manifest script | 🔴 `TestManifestScriptExplainsEveryEmptyCase` |
| ↻ Drop the no-lsm-dirs fallback from the manifest script | 🔴 `TestManifestScriptExplainsEveryEmptyCase` |
| Carry on with an artifact root that could not be created | 🔴 `TestForensicArtifactRootReportsAnUnusableBase` |
| ↻ Swallow a collector that broke | 🔴 `TestCollectNodeSaysSoWhenTheCollectorItselfBroke` |

Bold rows are new in the latest revision; ↻ marks an older guard re-verified on it.

The exec-bound mutant is worth calling out: without the bound the named test does not merely fail, it hangs, and `go test` dies with `panic: test timed out` whose stack points at `execCollect`. That is the CI failure mode the bound exists to prevent, reproduced.

At the merge base the whole test file fails to compile (**17** distinct `undefined` symbols across 56 errors, built with `-gcflags=-e` to defeat the 10-error cap), so **none of the 31 tests was already green** and all of them count as new coverage.

The in-container manifest script is shell, and shell is easy to get subtly wrong. `TestManifestScriptExplainsEveryEmptyCase` and `TestManifestScriptSaysWhenTheSearchItselfFailed` run the real script through a real `sh` against a real directory tree rather than asserting on its text. Those tests use the host's `sh`, so the script was also dumped straight out of Go and run under `alpine:3.24` (BusyBox v1.37.0, which is what the runtime image ships) across eight scenarios: missing `/data`, missing class dir, no `*/lsm`, no matching bucket, a match, two shards with one match, a `find` that hits an unreadable directory and finds nothing, and one that hits it and still finds a match. All eight explain themselves and exit 0.

End-to-end against a real three-node `-race` cluster (measured two revisions ago; the copy path it exercised is unchanged, the record around it has grown):

- **Green run:** test passes in 75s, **0** captures, **0** capture log lines. Failure-scoping holds.
- **Forced failure** on the pre-restart assert: capture fires at `pre-restart` only and not at the passing `post-restart` assert; `copied ~1374789 bytes from 3 nodes`; **18 files, 1.37 MB** under `REINDEX_FORENSICS_DIR` in the expected `node<N>/<class>/<shard>/lsm/property_dateInt_rangeable__rangeable_ingest_1/...` layout, with both the `.l0.s4.db` segment and the `.wal`.

Gates: `go build ./...` 0 · `go vet ./...` 5 findings (baseline, none in a touched file) · `go vet -tags integrationTest ./...` 17 (baseline, none in a touched file) · `gofumpt`/`goimports -l` empty · all four `tools/linter_*.sh` 0 · `golangci-lint` on the touched tree `0 issues.` · `-race` on the touched package 0 races. `tools/linter_go_routines.sh` filters `_test.go` out of its file list, so its silence about the bare `go func()` in `execCollect` is by design and not evidence.

Every Go line this PR adds is in a `_test.go` file, so no production code carries a test seam.

## What is still not covered, and why

**18 lines / 9 of 161 statements (94.4% of statements covered).** Coverage of `_test.go` files is not instrumented, so this was measured by lifting the forensic block verbatim into a scratch package next to the unmodified test file and running it under `-race` with a coverage profile. An earlier revision of this description claimed 45 lines from a hand count of one function; measured properly that revision was at **61 lines / 31 of 147 statements**, and 16 of those lines sat outside the function named, reachable with the existing fake. That claim was wrong and this is the correction.

What is left is two functions, and both are blocked for the same reason: they take a `*docker.DockerCompose`, a concrete struct whose `GetWeaviateNode(int)` returns another concrete struct, with no interface to stand in for either.

| Region | Lines | Stmts |
|---|---|---|
| `captureRangeableDataDirsOnFailure`, after the artifact dir exists | 10 | 3 |
| `weaviateContainers`, the node enumeration | 8 | 6 |

The per-node capture the walk delegates to is now `collectAll`, which takes a slice of `testcontainers.Container` and is fully covered by the 13-line fake, as is everything below it: the node collection, the per-file path mapping, budget accumulation across files, truncation, the broken-stream path, the file-cap and window stops, the marker and its failure, the destination that could not be created, and the record itself. The error path of `captureRangeableDataDirsOnFailure` is covered too, by passing a `nil` compose: a nil pointer panics on the first node lookup, so returning at all is the proof that no container was touched.

**Read those 18 lines as a limitation, not a guarantee:** their only proof is the forced-failure run quoted above.

## Please review deliberately

The workflow change touches `Acceptance-Reindex-Tests` only, but it is a workflow change: a job-level `env`, and one `if: failure()` upload step.

**CI artifact size** is worth a conscious decision, since it lands in org-wide storage. Worst case per matrix entry is 2 captures × 512 MiB = 1 GiB at `retention-days: 14`. The budget is per capture, not per run, and `assertRangeCountAllNodes` has two call sites. The exposure is bounded to the one shard that claims this test (`multinode-scale`).

## Known, not introduced here

`assertRangeCountAllNodes` has a data race on its `last [3]int`: `assert.Eventuallyf` returns on its `waitFor` timer while the last `condition()` goroutine may still be writing, and the `t.Errorf` on the failure path then reads it. Identical at the merge base, so this PR neither introduces nor widens it, and it is left alone here.

## Chain

- weaviate/weaviate#12230 — the original, which should close in favor of the three below. Nothing in it is dropped: its 268 added lines are 69 (fix) + 39 (namespace diagnostics) + 160 (this PR), and each lands in exactly one of them.
- weaviate/weaviate#12607 — the production fix, on its own.
- weaviate/weaviate#12609 — namespace test diagnostics.
- **This PR** — reindex CI forensics.

One framing worth stating plainly: of the ~1620 lines here, 160 came from #12230 and the rest is hardening added during review, two thirds of it the bounds test file. So "the split-out third of #12230" undersells what a reviewer is being asked to read.

— SuperClaude
