### PR TITLE
fix(config): restore the environment after tests clear it

### DIFF
--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -104,7 +104,7 @@ func TestEnvironmentSetFlushAfter_AllNames(t *testing.T) {
 func TestEnvironmentFlushConflictingValues(t *testing.T) {
 	// if all 3 variable names are used, the newest variable name
 	// should be taken into consideration
-	os.Clearenv()
+	clearEnv(t)
 	t.Setenv("PERSISTENCE_FLUSH_IDLE_MEMTABLES_AFTER", "16")
 	t.Setenv("PERSISTENCE_MEMTABLES_FLUSH_IDLE_AFTER_SECONDS", "17")
 	t.Setenv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "18")
@@ -738,14 +738,14 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 
 func TestEnvironmentSetDefaultVectorDistanceMetric(t *testing.T) {
 	t.Run("DefaultVectorDistanceMetricIsEmpty", func(t *testing.T) {
-		os.Clearenv()
+		clearEnv(t)
 		conf := Config{}
 		FromEnv(&conf)
 		require.Equal(t, "", conf.DefaultVectorDistanceMetric)
 	})
 
 	t.Run("NonEmptyDefaultVectorDistanceMetric", func(t *testing.T) {
-		os.Clearenv()
+		clearEnv(t)
 		t.Setenv("DEFAULT_VECTOR_DISTANCE_METRIC", "l2-squared")
 		conf := Config{}
 		FromEnv(&conf)
@@ -772,7 +772,7 @@ func TestEnvironmentDebugEndpointsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
+			clearEnv(t)
 			if tt.envSet {
 				t.Setenv("DEBUG_ENDPOINTS_ENABLED", tt.envValue)
 			}
@@ -826,7 +826,7 @@ func TestEnvironmentCORS_Origin(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
+			clearEnv(t)
 			if len(tt.value) == 1 {
 				os.Setenv("CORS_ALLOW_ORIGIN", tt.value[0])
 			}
@@ -918,7 +918,7 @@ func TestEnvironmentCORS_Methods(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
+			clearEnv(t)
 			if len(tt.value) == 1 {
 				os.Setenv("CORS_ALLOW_METHODS", tt.value[0])
 			}
@@ -1011,7 +1011,7 @@ func TestEnvironmentCORS_Headers(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
+			clearEnv(t)
 			if len(tt.value) == 1 {
 				os.Setenv("CORS_ALLOW_HEADERS", tt.value[0])
 			}
@@ -1319,7 +1319,7 @@ func TestEnvironmentHNSWWaitForPrefill(t *testing.T) {
 	}
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
+			clearEnv(t)
 			if len(tt.value) == 1 {
 				t.Setenv("HNSW_STARTUP_WAIT_FOR_VECTOR_CACHE", tt.value[0])
 			}
@@ -2072,7 +2072,7 @@ func TestEnvironmentRuntimeReindexEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Clearenv()
+			clearEnv(t)
 			if len(tt.envValue) == 1 {
 				t.Setenv("RUNTIME_REINDEX_ENABLED", tt.envValue[0])
 			}

--- a/usecases/config/helpers_for_test.go
+++ b/usecases/config/helpers_for_test.go
@@ -11,7 +11,38 @@
 
 package config
 
-import "github.com/pkg/errors"
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+)
+
+// clearEnv empties the process environment for the duration of the test and
+// puts it back afterwards.
+//
+// os.Clearenv on its own removes TMP/TEMP too, and os.TempDir falls back to
+// C:\Windows on Windows and /tmp elsewhere -- so every later t.TempDir in the
+// package either fails outright or silently writes somewhere unintended. The
+// fallback being writable on Linux is why this only shows up on Windows and
+// under -count>1, where a test that clears the environment runs before one
+// that needs a temporary directory.
+func clearEnv(t *testing.T) {
+	t.Helper()
+
+	saved := os.Environ()
+	t.Cleanup(func() {
+		os.Clearenv()
+		for _, entry := range saved {
+			if key, value, ok := strings.Cut(entry, "="); ok {
+				os.Setenv(key, value)
+			}
+		}
+	})
+
+	os.Clearenv()
+}
 
 type fakeModuleProvider struct {
 	valid []string


### PR DESCRIPTION
Found while scanning for more of the class in #12573: packages that pass at `-count=1` and fail at `-count=2`.

`usecases/config` is one. Nine tests call `os.Clearenv()`, which removes `TMP` and `TEMP` along with everything else, and `os.TempDir()` then falls back to `C:\Windows` on Windows and `/tmp` elsewhere. Every later `t.TempDir()` in the package inherits that: on Windows it fails with `Access is denied`, and on Linux it quietly writes outside the directory the test runner would have cleaned up.

Proven rather than inferred:

```
BEFORE: TMP="C:\Users\...\AppData\Local\Temp"  os.TempDir()="C:\Users\...\AppData\Local\Temp"
AFTER : TMP=""                                  os.TempDir()="C:\Windows"
        TempDir: mkdir C:\Windows\...: Access is denied.
```

The Linux fallback being writable is why this stayed invisible in CI.

### The change

`clearEnv` keeps the intent — an empty environment for the duration of a test — and puts the old one back with `t.Cleanup`. All nine call sites use it.

### Verification

- `go test ./usecases/config/ -count=2` and `-count=3`: green
- revert-checked: putting `os.Clearenv()` back fails `TestConfigModules` and `TestConfigParsing` at `-count=2` again
- `go vet` clean, `gofmt` clean on LF-normalized content

Happy to fold this into #12608 instead if you would rather keep the non-idempotency work in one place — it is a different package and a different root cause, so I kept it separate.
