### PR TITLE
fix(hfresh): hold the posting lock during version map warmup

### DIFF
--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -354,39 +354,46 @@ func (h *HFresh) ListQueues(ctx context.Context, basePath string) ([]string, err
 
 func (h *HFresh) PostStartup(ctx context.Context) {
 	// Warm the version map in the background
+	enterrors.GoWrapper(h.warmVersionMap, h.logger)
+
+	h.Centroids.hnsw.PostStartup(ctx)
+}
+
+func (h *HFresh) warmVersionMap() {
 	before := time.Now()
-	enterrors.GoWrapper(func() {
-		count, err := h.VersionMap.Warmup(h.ctx)
-		if err != nil {
-			h.logger.Warnf("version map warmup interrupted after %d entries: %v", count, err)
+	count, err := h.VersionMap.Warmup(h.ctx)
+	if err != nil {
+		h.logger.Warnf("version map warmup interrupted after %d entries: %v", count, err)
+		return
+	}
+
+	// the store only holds updated or deleted vectors: fill the implicit
+	// first version for every remaining vector known to the posting map,
+	// so never-updated vectors skip the lazy fault path too
+	var defaults int
+	for postingID, metadata := range h.PostingMap.Iter() {
+		if h.ctx.Err() != nil {
+			h.logger.Warnf("version map warmup interrupted after %d entries: %v", count+defaults, h.ctx.Err())
 			return
 		}
 
-		// the store only holds updated or deleted vectors: fill the implicit
-		// first version for every remaining vector known to the posting map,
-		// so never-updated vectors skip the lazy fault path too
-		var defaults int
-		for _, metadata := range h.PostingMap.Iter() {
-			if h.ctx.Err() != nil {
-				h.logger.Warnf("version map warmup interrupted after %d entries: %v", count+defaults, h.ctx.Err())
-				return
-			}
-			for vectorID := range metadata.Iter() {
-				if h.VersionMap.EnsureDefault(vectorID) {
-					defaults++
-				}
+		// concurrent inserts mutate the metadata in place: hold the posting
+		// lock while reading it
+		h.PostingMap.RLock(postingID)
+		for vectorID := range metadata.Iter() {
+			if h.VersionMap.EnsureDefault(vectorID) {
+				defaults++
 			}
 		}
+		h.PostingMap.RUnlock(postingID)
+	}
 
-		h.logger.WithFields(logrus.Fields{
-			"action":   "hfresh_version_map_warmup",
-			"count":    count,
-			"defaults": defaults,
-			"took":     time.Since(before).String(),
-		}).Info("version map warmed up")
-	}, h.logger)
-
-	h.Centroids.hnsw.PostStartup(ctx)
+	h.logger.WithFields(logrus.Fields{
+		"action":   "hfresh_version_map_warmup",
+		"count":    count,
+		"defaults": defaults,
+		"took":     time.Since(before).String(),
+	}).Info("version map warmed up")
 }
 
 func (h *HFresh) Compressed() bool {

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -379,13 +379,16 @@ func (h *HFresh) warmVersionMap() {
 
 		// concurrent inserts mutate the metadata in place: hold the posting
 		// lock while reading it
-		h.PostingMap.RLock(postingID)
-		for vectorID := range metadata.Iter() {
-			if h.VersionMap.EnsureDefault(vectorID) {
-				defaults++
+		func() {
+			h.PostingMap.RLock(postingID)
+			defer h.PostingMap.RUnlock(postingID)
+
+			for vectorID := range metadata.Iter() {
+				if h.VersionMap.EnsureDefault(vectorID) {
+					defaults++
+				}
 			}
-		}
-		h.PostingMap.RUnlock(postingID)
+		}()
 	}
 
 	h.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/vector/hfresh/version_map_test.go
+++ b/adapters/repos/db/vector/hfresh/version_map_test.go
@@ -16,9 +16,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
 
 func makeVersionMap(t *testing.T) *VersionMap {
@@ -378,6 +381,50 @@ func TestVersionMapWarmup(t *testing.T) {
 	count, err = m.Warmup(ctx)
 	require.NoError(t, err)
 	require.Zero(t, count)
+}
+
+// TestVersionMapWarmupConcurrentWithInserts pins that the posting-map pass
+// of the warmup holds the per-posting lock: inserts mutate posting metadata
+// in place, so an unlocked read is a data race (caught by -race).
+func TestVersionMapWarmupConcurrentWithInserts(t *testing.T) {
+	const preload, total = 200, 400
+	vectors, _ := testinghelpers.RandomVecs(total, 1, 32)
+
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+	logger, _ := test.NewNullLogger()
+	cfg.Logger = logger
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector,
+		func(ctx context.Context, id uint64, _ string) ([]float32, error) {
+			return vectors[id], nil
+		})
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+
+	ctx := t.Context()
+	for i := range preload {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	enterrors.GoWrapper(func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				index.warmVersionMap()
+			}
+		}
+	}, logger)
+
+	for i := preload; i < total; i++ {
+		require.NoError(t, index.Add(ctx, uint64(i), vectors[i]))
+	}
+	close(stop)
+	wg.Wait()
 }
 
 func TestVersionMapEnsureDefault(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Fixes a data race in the HFresh version map warmup introduced by #12504, seen flaking CI on unrelated PRs (e.g. [this run](https://github.com/weaviate/weaviate/actions/runs/31360397888/job/93368005653)).

The warmup's second pass iterates the in-memory posting map and reads each posting's packed metadata without holding the per-posting lock. Concurrent inserts (`FastAddVectorID`) mutate that same `PostingMetadata` in place under the write lock — not copy-on-write — so the unlocked read races: torn slice headers, a count that doesn't match the buffer, and potentially reading a buffer already recycled through the buffer pool.

The fix takes `PostingMap.RLock(postingID)` around each posting's metadata read, the same pattern the allow list read path uses (`containsPosting`). The lock is per-posting (512-way sharded, read lock), held for microseconds per posting, and released between postings, so inserts never wait behind the whole pass.

Also extracts the warmup goroutine body into `warmVersionMap()` so the new test can drive it deterministically: the test races the warmup loop against concurrent `Add`s and fails under `-race` without the fix.

The same race exists on every branch carrying the warmup pass; this needs forward-porting to `stable/v1.38` and `main`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)