### PR TITLE
inverted: hold the batched Contains keys as a sorted slab

### DIFF
--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -172,10 +172,10 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 	require.NoError(tb, dateBucket.RoaringSetAddList(sharedDateKey, containsFamilySharedDocIDs))
 	require.NoError(tb, dateBucket.FlushAndSwitch())
 
-	// Booleans have only two distinct keys however many values a filter names,
-	// so it is the family where a batch is most likely to repeat one. Even docs
-	// are false and odd ones true; the shared docs hold both, so ContainsAll
-	// over true and false is non-empty.
+	// Booleans have only two distinct keys however many values a filter
+	// names, which is the family where a batch is most likely to hold
+	// duplicates. Even docs are false and odd ones true; the shared docs hold
+	// both, so ContainsAll over true and false is non-empty.
 	boolBucketName := helpers.BucketFromPropNameLSM(benchBoolPropName)
 	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), boolBucketName,
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
@@ -789,8 +789,8 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 				leafValues:  []interface{}{benchDateValue(1), containsSharedDateValue()},
 				contains:    []uint64{2, 3}, notContains: []uint64{1, 7, 9},
 			},
-			// Booleans draw on two distinct keys however many values a filter
-			// names, and the rows below name more than two.
+			// Booleans collapse the most: at most two keys survive however many
+			// values a filter names, and the rows below name more than two.
 			{
 				name: "bool ContainsAny, duplicate values", prop: benchBoolPropName, dt: schema.DataTypeBoolean,
 				op:          filters.ContainsAny,

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -140,6 +140,54 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 	require.NoError(tb, uuidBucket.RoaringSetAddList(sharedUUID[:], containsFamilySharedDocIDs))
 	require.NoError(tb, uuidBucket.FlushAndSwitch())
 
+	numberBucketName := helpers.BucketFromPropNameLSM(benchNumberPropName)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), numberBucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(bufPool),
+	))
+	numberBucket := store.Bucket(numberBucketName)
+	for i := 0; i < containsFamilyDocs; i++ {
+		key := make([]byte, 8)
+		entinverted.PutLexicographicallySortableFloat64(key, benchNumberValue(i))
+		require.NoError(tb, numberBucket.RoaringSetAddList(key, []uint64{uint64(i)}))
+	}
+	sharedNumberKey := make([]byte, 8)
+	entinverted.PutLexicographicallySortableFloat64(sharedNumberKey, containsSharedNumber)
+	require.NoError(tb, numberBucket.RoaringSetAddList(sharedNumberKey, containsFamilySharedDocIDs))
+	require.NoError(tb, numberBucket.FlushAndSwitch())
+
+	dateBucketName := helpers.BucketFromPropNameLSM(benchDatePropName)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), dateBucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(bufPool),
+	))
+	dateBucket := store.Bucket(dateBucketName)
+	for i := 0; i < containsFamilyDocs; i++ {
+		key := make([]byte, 8)
+		entinverted.PutLexicographicallySortableInt64(key, benchDateTime(i).UnixNano())
+		require.NoError(tb, dateBucket.RoaringSetAddList(key, []uint64{uint64(i)}))
+	}
+	sharedDateKey := make([]byte, 8)
+	entinverted.PutLexicographicallySortableInt64(sharedDateKey, containsSharedDateTime().UnixNano())
+	require.NoError(tb, dateBucket.RoaringSetAddList(sharedDateKey, containsFamilySharedDocIDs))
+	require.NoError(tb, dateBucket.FlushAndSwitch())
+
+	// Booleans have only two distinct keys however many values a filter names,
+	// so it is the family where a batch is most likely to repeat one. Even docs
+	// are false and odd ones true; the shared docs hold both, so ContainsAll
+	// over true and false is non-empty.
+	boolBucketName := helpers.BucketFromPropNameLSM(benchBoolPropName)
+	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), boolBucketName,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
+		lsmkv.WithBitmapBufPool(bufPool),
+	))
+	boolBucket := store.Bucket(boolBucketName)
+	for i := 0; i < containsFamilyDocs; i++ {
+		require.NoError(tb, boolBucket.RoaringSetAddList([]byte{byte(i % 2)}, []uint64{uint64(i)}))
+	}
+	require.NoError(tb, boolBucket.RoaringSetAddList([]byte{0}, containsFamilySharedDocIDs))
+	require.NoError(tb, boolBucket.FlushAndSwitch())
+
 	maxDocID := uint64(numDocs + 1)
 	bitmapFactory := roaringset.NewBitmapFactory(bufPool, newFakeMaxIDGetter(maxDocID))
 	searcher := NewSearcher(logger, store, createSchema().GetClass, nil, nil,
@@ -163,12 +211,16 @@ const (
 	containsPaddedDocID = uint64(23)
 )
 
-// int and uuid corpora for the family end-to-end rows.
+// Per-family corpora for the end-to-end rows.
 const (
-	benchIntPropName   = "inverted-without-frequency-roaringset"
-	benchUUIDPropName  = "inverted-uuid-roaringset"
-	containsFamilyDocs = 50
-	containsSharedInt  = 1000
+	benchIntPropName     = "inverted-without-frequency-roaringset"
+	benchUUIDPropName    = "inverted-uuid-roaringset"
+	benchNumberPropName  = "inverted-number-roaringset"
+	benchBoolPropName    = "inverted-bool-roaringset"
+	benchDatePropName    = "inverted-date-roaringset"
+	containsFamilyDocs   = 50
+	containsSharedInt    = 1000
+	containsSharedNumber = 1000.5
 )
 
 var (
@@ -179,6 +231,20 @@ var (
 func benchUUIDValue(i int) string {
 	return fmt.Sprintf("00000000-0000-0000-0000-%012d", i)
 }
+
+// benchNumberValue keeps a fraction so the keys exercise the sign-and-mantissa
+// flip the float encoding does rather than reading as small integers.
+func benchNumberValue(i int) float64 { return float64(i) + 0.5 }
+
+func benchDateTime(i int) time.Time {
+	return time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, i)
+}
+
+func benchDateValue(i int) string { return benchDateTime(i).Format(time.RFC3339) }
+
+func containsSharedDateTime() time.Time { return benchDateTime(9_999) }
+
+func containsSharedDateValue() string { return containsSharedDateTime().Format(time.RFC3339) }
 
 // sampleValues picks `size` values spread evenly across the corpus (strided),
 // so the selection touches the whole keyspace. Deterministic and identical
@@ -409,6 +475,63 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 	// write unflushed so the active memtable is non-empty, the one shape where
 	// the two paths could diverge: the batch reader must probe it per key like
 	// the desugared path does.
+	// The corpus rows above are all small or uniform-width, so they reach only
+	// three of the sort's branches. These two are sized and shaped to reach the
+	// two-word radix and the variable-width radix with its collision repair,
+	// which unit tests cover but nothing had exercised through a real bucket.
+	//
+	// Each list mixes present values with absent ones: the absent values set the
+	// branch, the present ones keep the result non-empty so the two paths are
+	// compared on something.
+	t.Run("large batches reach the radix branches", func(t *testing.T) {
+		// 250 uuids with no shared prefix, past the two-word cutoff.
+		uuids := make([]interface{}, 0, 250)
+		for i := 0; i < containsFamilyDocs; i++ {
+			uuids = append(uuids, benchUUIDValue(i))
+		}
+		for i := 0; len(uuids) < 250; i++ {
+			uuids = append(uuids, fmt.Sprintf("%08x-0000-0000-0000-%012d", uint32(i)*2654435761, i))
+		}
+
+		// 100 text values of differing lengths sharing a prefix longer than the
+		// packed word, so the first pass cannot separate them and the repair
+		// has to run.
+		texts := make([]interface{}, 0, 100)
+		for i := 0; i < 20; i++ {
+			texts = append(texts, benchValue(i))
+		}
+		for i := 0; len(texts) < 100; i++ {
+			group := "user_profile_settings_"
+			if i%2 == 1 {
+				group = "user_profile_avatars_"
+			}
+			texts = append(texts, fmt.Sprintf("%s%d", group, i*7919))
+		}
+
+		for _, tc := range []struct {
+			name   string
+			prop   string
+			dt     schema.DataType
+			values []interface{}
+		}{
+			{"uuid, two-word radix", benchUUIDPropName, schema.DataTypeText, uuids},
+			{"text, variable radix with collision repair", benchPropName, schema.DataTypeText, texts},
+		} {
+			for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
+				t.Run(tc.name+"/"+op.Name(), func(t *testing.T) {
+					batched := f.resolveDocIDs(t, ctx, containsFilterOn(op, tc.prop, tc.dt, tc.values))
+					desugared := f.resolveDocIDs(t, ctx, equalCompoundFilterOn(op, tc.prop, tc.dt, tc.values))
+					require.Equal(t, desugared, batched,
+						"batched Contains must resolve the same doc IDs as the desugared Equal compound")
+					if op == filters.ContainsAny {
+						require.NotEmpty(t, batched,
+							"the present values must keep the comparison non-vacuous")
+					}
+				})
+			}
+		}
+	})
+
 	t.Run("unflushed write in the active memtable", func(t *testing.T) {
 		g := newContainsFixture(t, 200)
 		bucket := g.store.Bucket(helpers.BucketFromPropNameLSM(benchPropName))
@@ -554,7 +677,11 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 	// exact-docs assertions matter here: both query paths share one encoder
 	// per family, so differential equality alone would survive an encoding
 	// bug that breaks lookups on both sides.
-	t.Run("int and uuid families end-to-end", func(t *testing.T) {
+	//
+	// Every family that classifies as batchable appears, because each reaches a
+	// different sorting arm — one word for int, number and date, two for uuid,
+	// a counting pass for bool.
+	t.Run("every family end-to-end", func(t *testing.T) {
 		ints := func(vs ...int) []interface{} {
 			out := make([]interface{}, len(vs))
 			for i, v := range vs {
@@ -615,6 +742,82 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 				filterValue: []interface{}{benchUUIDValue(1), containsSharedUUIDValue},
 				leafValues:  []interface{}{benchUUIDValue(1), containsSharedUUIDValue},
 				contains:    []uint64{2, 3}, notContains: []uint64{1, 7, 9},
+			},
+			{
+				name: "number ContainsAny", prop: benchNumberPropName, dt: schema.DataTypeNumber,
+				op:          filters.ContainsAny,
+				filterValue: []float64{benchNumberValue(1), benchNumberValue(2), containsSharedNumber},
+				leafValues: []interface{}{
+					benchNumberValue(1), benchNumberValue(2), containsSharedNumber,
+				},
+				exact: []uint64{1, 2, 7, 9},
+			},
+			{
+				name: "number ContainsAll", prop: benchNumberPropName, dt: schema.DataTypeNumber,
+				op:          filters.ContainsAll,
+				filterValue: []float64{containsSharedNumber, benchNumberValue(7)},
+				leafValues:  []interface{}{containsSharedNumber, benchNumberValue(7)},
+				exact:       []uint64{7},
+			},
+			{
+				name: "number ContainsNone", prop: benchNumberPropName, dt: schema.DataTypeNumber,
+				op:          filters.ContainsNone,
+				filterValue: []float64{benchNumberValue(1), containsSharedNumber},
+				leafValues:  []interface{}{benchNumberValue(1), containsSharedNumber},
+				contains:    []uint64{2, 3}, notContains: []uint64{1, 7, 9},
+			},
+			{
+				name: "date ContainsAny", prop: benchDatePropName, dt: schema.DataTypeDate,
+				op:          filters.ContainsAny,
+				filterValue: []string{benchDateValue(1), benchDateValue(2), containsSharedDateValue()},
+				leafValues: []interface{}{
+					benchDateValue(1), benchDateValue(2), containsSharedDateValue(),
+				},
+				exact: []uint64{1, 2, 7, 9},
+			},
+			{
+				name: "date ContainsAll", prop: benchDatePropName, dt: schema.DataTypeDate,
+				op:          filters.ContainsAll,
+				filterValue: []string{containsSharedDateValue(), benchDateValue(7)},
+				leafValues:  []interface{}{containsSharedDateValue(), benchDateValue(7)},
+				exact:       []uint64{7},
+			},
+			{
+				name: "date ContainsNone", prop: benchDatePropName, dt: schema.DataTypeDate,
+				op:          filters.ContainsNone,
+				filterValue: []string{benchDateValue(1), containsSharedDateValue()},
+				leafValues:  []interface{}{benchDateValue(1), containsSharedDateValue()},
+				contains:    []uint64{2, 3}, notContains: []uint64{1, 7, 9},
+			},
+			// Booleans draw on two distinct keys however many values a filter
+			// names, and the rows below name more than two.
+			{
+				name: "bool ContainsAny, duplicate values", prop: benchBoolPropName, dt: schema.DataTypeBoolean,
+				op:          filters.ContainsAny,
+				filterValue: []bool{true, false, true, false},
+				leafValues:  []interface{}{true, false, true, false},
+				contains:    []uint64{0, 1, 2, 7, 9},
+			},
+			{
+				name: "bool ContainsAny, one value repeated", prop: benchBoolPropName, dt: schema.DataTypeBoolean,
+				op:          filters.ContainsAny,
+				filterValue: []bool{true, true, true},
+				leafValues:  []interface{}{true, true, true},
+				contains:    []uint64{1, 3, 7, 9}, notContains: []uint64{0, 2, 4},
+			},
+			{
+				name: "bool ContainsAll", prop: benchBoolPropName, dt: schema.DataTypeBoolean,
+				op:          filters.ContainsAll,
+				filterValue: []bool{true, false, true},
+				leafValues:  []interface{}{true, false, true},
+				exact:       []uint64{7, 9},
+			},
+			{
+				name: "bool ContainsNone", prop: benchBoolPropName, dt: schema.DataTypeBoolean,
+				op:          filters.ContainsNone,
+				filterValue: []bool{true, true},
+				leafValues:  []interface{}{true, true},
+				contains:    []uint64{0, 2, 4}, notContains: []uint64{1, 3, 7, 9},
 			},
 		}
 

--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -172,10 +172,9 @@ func newContainsFixture(tb testing.TB, numDocs int) *containsFixture {
 	require.NoError(tb, dateBucket.RoaringSetAddList(sharedDateKey, containsFamilySharedDocIDs))
 	require.NoError(tb, dateBucket.FlushAndSwitch())
 
-	// Booleans have only two distinct keys however many values a filter
-	// names, which is the family where a batch is most likely to hold
-	// duplicates. Even docs are false and odd ones true; the shared docs hold
-	// both, so ContainsAll over true and false is non-empty.
+	// Booleans have only two distinct keys, the family most likely to hold
+	// duplicates in a batch; even docs are false and odd ones true, so
+	// ContainsAll over true and false is non-empty via the shared docs.
 	boolBucketName := helpers.BucketFromPropNameLSM(benchBoolPropName)
 	require.NoError(tb, store.CreateOrLoadBucket(context.Background(), boolBucketName,
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
@@ -469,20 +468,12 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 		}
 	}
 
-	// Every case above runs against a fully flushed corpus, which is exactly
-	// the shape where the batch reader skips the active memtable — so batched
-	// and desugared can agree by both reading only disk. This case leaves a
-	// write unflushed so the active memtable is non-empty, the one shape where
-	// the two paths could diverge: the batch reader must probe it per key like
-	// the desugared path does.
-	// The corpus rows above are all small or uniform-width, so they reach only
-	// three of the sort's branches. These two are sized and shaped to reach the
-	// two-word radix and the variable-width radix with its collision repair,
-	// which unit tests cover but nothing had exercised through a real bucket.
-	//
-	// Each list mixes present values with absent ones: the absent values set the
-	// branch, the present ones keep the result non-empty so the two paths are
-	// compared on something.
+	// The corpus rows above are small or uniform-width, reaching only three of
+	// the sort's branches. These two are sized to reach the two-word radix and
+	// the variable-width radix with its collision repair — covered by unit
+	// tests but never exercised through a real bucket. Each list mixes present
+	// values with absent ones so the two paths are compared on a non-empty
+	// result.
 	t.Run("large batches reach the radix branches", func(t *testing.T) {
 		// 250 uuids with no shared prefix, past the two-word cutoff.
 		uuids := make([]interface{}, 0, 250)
@@ -532,6 +523,10 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 		}
 	})
 
+	// Every case above runs against a fully flushed corpus, where the batch
+	// reader skips the active memtable entirely. This leaves a write unflushed
+	// so the batch reader must probe the memtable per key like the desugared
+	// path does, the one shape where the two could otherwise diverge.
 	t.Run("unflushed write in the active memtable", func(t *testing.T) {
 		g := newContainsFixture(t, 200)
 		bucket := g.store.Bucket(helpers.BucketFromPropNameLSM(benchPropName))

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -1320,6 +1320,27 @@ func createSchema() *schema.Schema {
 							IndexRangeFilters: &vFalse,
 						},
 						{
+							Name:              "inverted-number-roaringset",
+							DataType:          schema.DataTypeNumber.PropString(),
+							IndexFilterable:   &vTrue,
+							IndexSearchable:   &vFalse,
+							IndexRangeFilters: &vFalse,
+						},
+						{
+							Name:              "inverted-bool-roaringset",
+							DataType:          schema.DataTypeBoolean.PropString(),
+							IndexFilterable:   &vTrue,
+							IndexSearchable:   &vFalse,
+							IndexRangeFilters: &vFalse,
+						},
+						{
+							Name:              "inverted-date-roaringset",
+							DataType:          schema.DataTypeDate.PropString(),
+							IndexFilterable:   &vTrue,
+							IndexSearchable:   &vFalse,
+							IndexRangeFilters: &vFalse,
+						},
+						{
 							Name:              "inverted-roaringsetrange-on-disk",
 							DataType:          schema.DataTypeInt.PropString(),
 							IndexFilterable:   &vFalse,

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -47,15 +47,14 @@ type propValuePair struct {
 	nested             nestedInfo
 	Class              *models.Class // The schema
 
-	// containsValues holds pre-encoded on-disk keys for a flat, single-property
+	// containsKeys holds pre-encoded on-disk keys for a flat, single-property
 	// Contains(Any|All|None) filter. When it holds any, resolveDocIDs routes to
 	// fetchContainsBatch instead of the children-based dispatch below.
 	//
-	// The count is what routes: an empty list and an unset field are the same
-	// value, so nothing else distinguishes a batched leaf.
-	// newBatchedContainsPair rejects a leaf holding no keys, so the two
-	// cannot diverge.
-	containsValues entsInverted.SortedKeys
+	// The key count is what routes — an empty list and an unset field look the
+	// same — and newBatchedContainsPair guarantees a batched leaf never holds
+	// zero keys, so the two states can't be confused.
+	containsKeys entsInverted.SortedKeys
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
@@ -70,12 +69,12 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return nil, err
 	}
 
-	if pv.containsValues.Len() > 0 {
-		if !pv.operator.IsContains() {
-			return nil, fmt.Errorf("%w: pre-encoded contains keys with non-contains operator %q",
-				entsInverted.ErrInternal, pv.operator.Name())
+	if pv.containsKeys.Len() > 0 {
+		dbm, err := pv.fetchContainsBatch(ctx, s)
+		if err != nil {
+			s.logContainsFault(pv.prop, err)
 		}
-		return pv.fetchContainsBatch(ctx, s)
+		return dbm, err
 	}
 
 	// Correlated nested AND created during extraction: all children target the
@@ -364,26 +363,28 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 }
 
 // fetchContainsBatch resolves a batched Contains(Any|All|None) filter whose keys
-// were already encoded into pv.containsValues, folding every key's bitmap
+// were already encoded into pv.containsKeys, folding every key's bitmap
 // through docBitmapContainsBatch under a single consistent view.
 //
 // The annotation's window starts before the reader is opened, so a filter that
 // stalls waiting out an in-flight flush shows that time rather than hiding it.
 func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_ *docBitmap, err error) {
+	// Both hold on the pair, not the store, so they answer before it is opened:
+	// keys are attached only on a Contains operator, and dedup can shrink a
+	// batch but not empty it. Either here is a pair assembled wrong.
+	if !pv.operator.IsContains() {
+		return nil, fmt.Errorf("%w: pre-encoded contains keys with non-contains operator %q",
+			entsInverted.ErrInternal, pv.operator.Name())
+	}
+	if pv.containsKeys.Len() == 0 {
+		return nil, fmt.Errorf("%w: contains filter on prop %q carries no keys",
+			entsInverted.ErrInternal, pv.prop)
+	}
+
 	bucketName := pv.getBucketName()
 	b := s.store.Bucket(bucketName)
 	if b == nil {
 		return nil, errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
-	}
-
-	// A batched Contains carries at least one key. Extraction does not batch
-	// below two values, but the builders drop duplicates, so the key count can
-	// be lower than the value count. Zero is a caller bug: answering it would
-	// mean inventing a result for each operator, and the fold refuses it for
-	// the same reason.
-	if pv.containsValues.Len() == 0 {
-		return nil, fmt.Errorf("%w: contains filter on prop %q carries no keys",
-			entsInverted.ErrInternal, pv.prop)
 	}
 
 	before := time.Now()
@@ -400,10 +401,9 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 				"count":       dbm.count(),
 				"failed":      err != nil,
 				"strategy":    b.Strategy(),
-				// Distinct keys, not filter values: the builders drop
-				// duplicates, so a boolean filter over any number of values
-				// reports at most two.
-				"batched_keys": pv.containsValues.Len(),
+				// Distinct keys, not filter values: dedup means a boolean
+				// filter reports at most two regardless of value count.
+				"batched_keys": pv.containsKeys.Len(),
 			}
 		})
 	}()

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -17,6 +17,8 @@ import (
 	"strings"
 	"time"
 
+	entsInverted "github.com/weaviate/weaviate/entities/inverted"
+
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -46,9 +48,14 @@ type propValuePair struct {
 	Class              *models.Class // The schema
 
 	// containsValues holds pre-encoded on-disk keys for a flat, single-property
-	// Contains(Any|All|None) filter. When non-nil, resolveDocIDs routes to
+	// Contains(Any|All|None) filter. When it holds any, resolveDocIDs routes to
 	// fetchContainsBatch instead of the children-based dispatch below.
-	containsValues [][]byte
+	//
+	// The count is what routes: an empty list and an unset field are the same
+	// value, so nothing else distinguishes a batched leaf.
+	// newBatchedContainsPair rejects a leaf holding no keys, so the two
+	// cannot diverge.
+	containsValues entsInverted.SortedKeys
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
@@ -63,9 +70,10 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return nil, err
 	}
 
-	if pv.containsValues != nil {
+	if pv.containsValues.Len() > 0 {
 		if !pv.operator.IsContains() {
-			return nil, fmt.Errorf("pre-encoded contains keys with non-contains operator %q", pv.operator.Name())
+			return nil, fmt.Errorf("%w: pre-encoded contains keys with non-contains operator %q",
+				entsInverted.ErrInternal, pv.operator.Name())
 		}
 		return pv.fetchContainsBatch(ctx, s)
 	}
@@ -368,12 +376,12 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 		return nil, errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
 	}
 
-	// A batched Contains always carries at least two keys — extraction does not
-	// batch below that, and every path errors rather than dropping a value. Zero
-	// keys is therefore a caller bug, and answering it here would mean inventing
-	// a result for each operator; the fold rejects it for the same reason.
-	if len(pv.containsValues) == 0 {
-		return nil, fmt.Errorf("contains filter on prop %q carries no keys", pv.prop)
+	// A batched Contains carries at least one key — extraction does not batch
+	// below two values. Zero is a caller bug: answering it would mean inventing
+	// a result for each operator, and the fold refuses it for the same reason.
+	if pv.containsValues.Len() == 0 {
+		return nil, fmt.Errorf("%w: contains filter on prop %q carries no keys",
+			entsInverted.ErrInternal, pv.prop)
 	}
 
 	before := time.Now()
@@ -390,7 +398,7 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 				"count":          dbm.count(),
 				"failed":         err != nil,
 				"strategy":       b.Strategy(),
-				"batched_values": len(pv.containsValues),
+				"batched_values": pv.containsValues.Len(),
 			}
 		})
 	}()

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -376,9 +376,11 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 		return nil, errors.Errorf("bucket for prop %s not found - is it indexed?", pv.prop)
 	}
 
-	// A batched Contains carries at least one key — extraction does not batch
-	// below two values. Zero is a caller bug: answering it would mean inventing
-	// a result for each operator, and the fold refuses it for the same reason.
+	// A batched Contains carries at least one key. Extraction does not batch
+	// below two values, but the builders drop duplicates, so the key count can
+	// be lower than the value count. Zero is a caller bug: answering it would
+	// mean inventing a result for each operator, and the fold refuses it for
+	// the same reason.
 	if pv.containsValues.Len() == 0 {
 		return nil, fmt.Errorf("%w: contains filter on prop %q carries no keys",
 			entsInverted.ErrInternal, pv.prop)
@@ -391,14 +393,17 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 		took := time.Since(before)
 		helpers.AnnotateSlowQueryLogAppendFunc(ctx, "build_allow_list_doc_bitmap", func() map[string]any {
 			return map[string]any{
-				"prop":           pv.prop,
-				"operator":       pv.operator.Name(),
-				"took":           took,
-				"took_string":    took.String(),
-				"count":          dbm.count(),
-				"failed":         err != nil,
-				"strategy":       b.Strategy(),
-				"batched_values": pv.containsValues.Len(),
+				"prop":        pv.prop,
+				"operator":    pv.operator.Name(),
+				"took":        took,
+				"took_string": took.String(),
+				"count":       dbm.count(),
+				"failed":      err != nil,
+				"strategy":    b.Strategy(),
+				// Distinct keys, not filter values: the builders drop
+				// duplicates, so a boolean filter over any number of values
+				// reports at most two.
+				"batched_keys": pv.containsValues.Len(),
 			}
 		})
 	}()

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -338,7 +338,9 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	}
 
 	beforeResolve := time.Now()
-	// Children on the desugared path, keys on the batched one.
+	// Children on the desugared path, distinct keys on the batched one — the
+	// latter can be fewer than the values the filter named, since the builders
+	// drop duplicates.
 	n := len(pv.children)
 	if ln := pv.containsValues.Len(); ln > 0 {
 		n = ln
@@ -1139,6 +1141,11 @@ func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.Dat
 // filled, and the fixed-width encoders sort theirs in place, where a key's
 // position is its rank. The fold that consumes them walks the bucket once in
 // key order.
+//
+// The key count is at least one. extractContains only reaches a batched arm at
+// len(values) >= 2 and every arm turns one value into one key, but the builders
+// drop duplicates, so a filter repeating a value — or a boolean one, which has
+// only two distinct keys — arrives with fewer keys than values.
 //
 // A leaf must hold at least one key, and that is checked here because the
 // routing predicate downstream is a key count rather than a presence test: a

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -338,9 +338,10 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	}
 
 	beforeResolve := time.Now()
+	// Children on the desugared path, keys on the batched one.
 	n := len(pv.children)
-	if pv.containsValues != nil {
-		n = len(pv.containsValues)
+	if ln := pv.containsValues.Len(); ln > 0 {
+		n = ln
 	}
 	helpers.AnnotateSlowQueryLog(ctx, "build_allow_list_resolve_len", n)
 	dbm, err := pv.resolveDocIDs(ctx, s, limit)
@@ -1132,9 +1133,24 @@ func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.Dat
 }
 
 // newBatchedContainsPair builds the batched Contains leaf from pre-encoded keys.
+//
+// The keys arrive ascending, ordered by whichever producer built them, because
+// that is where ordering is cheapest: the text path sorts the slab it has just
+// filled, and the fixed-width encoders sort theirs in place, where a key's
+// position is its rank. The fold that consumes them walks the bucket once in
+// key order.
+//
+// A leaf must hold at least one key, and that is checked here because the
+// routing predicate downstream is a key count rather than a presence test: a
+// batched leaf holding none would not look like one at all, and would resolve
+// through the children dispatch with no children to resolve.
 func newBatchedContainsPair(property *models.Property, operator filters.Operator,
-	class *models.Class, keys [][]byte,
+	class *models.Class, keys inverted.SortedKeys,
 ) (*propValuePair, error) {
+	if keys.Len() == 0 {
+		return nil, fmt.Errorf("%w: batched contains leaf for property %q has no keys",
+			inverted.ErrInternal, property.Name)
+	}
 	pv, err := newPropValuePair(class)
 	if err != nil {
 		return nil, err
@@ -1144,6 +1160,20 @@ func newBatchedContainsPair(property *models.Property, operator filters.Operator
 	pv.hasFilterableIndex = true
 	pv.containsValues = keys
 	return pv, nil
+}
+
+// wrapExtractErr reports what a batched arm could not encode.
+//
+// An internal fault is logged as well as returned. It reaches the API through
+// the same channel as a value the user got wrong — and under the same prefix —
+// so without this a broken sort or a misused builder arrives looking like a
+// malformed filter, with nothing on the server saying otherwise.
+func (s *Searcher) wrapExtractErr(prop string, err error) error {
+	if errors.Is(err, inverted.ErrInternal) {
+		s.logger.WithField("prop", prop).
+			Errorf("batched contains could not encode its keys: %v", err)
+	}
+	return fmt.Errorf("extract contains values: %w", err)
 }
 
 // batchedContainsUUID builds the batched leaf for string values on a UUID
@@ -1156,7 +1186,7 @@ func (s *Searcher) batchedContainsUUID(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeUUIDKeys(values)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1172,24 +1202,25 @@ func (s *Searcher) batchedContainsTextField(property *models.Property, operator 
 	prepared := tokenizer.NewPreparedAnalyzer(property.TextAnalyzer)
 	batch, err := tokenizer.AnalyzeBatch(values, models.PropertyTokenizationField, class.Class, prepared, nil)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
-	total := 0
-	for i, valueTokens := range batch.All() {
-		if len(valueTokens) != 1 {
-			return nil, fmt.Errorf("extract contains values: value %d: FIELD tokenization produced %d tokens, want exactly 1", i, len(valueTokens))
-		}
-		total += len(valueTokens[0])
+	// FIELD gives one token per value, and the key is that token's bytes.
+	total, err := batch.SingleTokenBytes()
+	if err != nil {
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
-	// all keys share one backing slab; the three-index sub-slices cap each
-	// key's capacity at its own end, so an append to one key cannot clobber
-	// the next
-	keys := make([][]byte, batch.Len())
-	slab := make([]byte, 0, total)
-	for i, valueTokens := range batch.All() {
-		start := len(slab)
-		slab = append(slab, valueTokens[0]...)
-		keys[i] = slab[start:len(slab):len(slab)]
+
+	// Fill first, order in Build — the same shape the fixed-width encoders use.
+	// Ordering the tokens here instead would mean a comparison sort over string
+	// headers, which dereferences into the tokenizer's backing array;
+	// ordering the slab lets equal-width keys go through a radix.
+	kb := inverted.NewVarKeyBuilder(batch.Len(), total)
+	for _, valueTokens := range batch.All() {
+		kb.AppendString(valueTokens[0])
+	}
+	keys, err := kb.Build()
+	if err != nil {
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1199,7 +1230,7 @@ func (s *Searcher) batchedContainsInt(property *models.Property, operator filter
 ) (*propValuePair, error) {
 	keys, err := encodeIntKeys(values)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1209,7 +1240,7 @@ func (s *Searcher) batchedContainsNumber(property *models.Property, operator fil
 ) (*propValuePair, error) {
 	keys, err := encodeNumberKeys(values)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1219,7 +1250,7 @@ func (s *Searcher) batchedContainsBool(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeBoolKeys(values)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1229,7 +1260,7 @@ func (s *Searcher) batchedContainsDate(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeDateKeys(values)
 	if err != nil {
-		return nil, fmt.Errorf("extract contains values: %w", err)
+		return nil, s.wrapExtractErr(property.Name, err)
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -342,7 +342,7 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	// latter can be fewer than the values the filter named, since the builders
 	// drop duplicates.
 	n := len(pv.children)
-	if ln := pv.containsValues.Len(); ln > 0 {
+	if ln := pv.containsKeys.Len(); ln > 0 {
 		n = ln
 	}
 	helpers.AnnotateSlowQueryLog(ctx, "build_allow_list_resolve_len", n)
@@ -503,7 +503,13 @@ func (s *Searcher) buildPropValuePair(
 
 	switch filter.Operator {
 	case filters.ContainsAll, filters.ContainsAny, filters.ContainsNone:
-		return s.extractContains(ctx, filter.On, filter.Value.Type, filter.Value.Value, filter.Operator, class)
+		pv, err := s.extractContains(ctx, filter.On, filter.Value.Type,
+			filter.Value.Value, filter.Operator, class)
+		if err != nil {
+			s.logContainsFault(string(filter.On.Property), err)
+			return nil, fmt.Errorf("extract contains values: %w", err)
+		}
+		return pv, nil
 	default:
 		// proceed
 	}
@@ -1134,23 +1140,15 @@ func (s *Searcher) classifyContainsBatch(path *filters.Path, propType schema.Dat
 	}
 }
 
-// newBatchedContainsPair builds the batched Contains leaf from pre-encoded keys.
+// newBatchedContainsPair builds the batched Contains leaf from pre-encoded
+// keys, which arrive already ascending — each producer sorts its own slab or
+// encodes directly into rank order — so the fold can walk the bucket once.
 //
-// The keys arrive ascending, ordered by whichever producer built them, because
-// that is where ordering is cheapest: the text path sorts the slab it has just
-// filled, and the fixed-width encoders sort theirs in place, where a key's
-// position is its rank. The fold that consumes them walks the bucket once in
-// key order.
-//
-// The key count is at least one. extractContains only reaches a batched arm at
-// len(values) >= 2 and every arm turns one value into one key, but the builders
-// drop duplicates, so a filter repeating a value — or a boolean one, which has
-// only two distinct keys — arrives with fewer keys than values.
-//
-// A leaf must hold at least one key, and that is checked here because the
-// routing predicate downstream is a key count rather than a presence test: a
-// batched leaf holding none would not look like one at all, and would resolve
-// through the children dispatch with no children to resolve.
+// At least one key is required and checked here: the downstream routing
+// predicate is a key count, not a presence test, so a leaf holding none would
+// fall through to the children dispatch with no children to resolve. The
+// count can be lower than the filter's value count, since the builders drop
+// duplicates.
 func newBatchedContainsPair(property *models.Property, operator filters.Operator,
 	class *models.Class, keys inverted.SortedKeys,
 ) (*propValuePair, error) {
@@ -1165,22 +1163,19 @@ func newBatchedContainsPair(property *models.Property, operator filters.Operator
 	pv.prop = property.Name
 	pv.operator = operator
 	pv.hasFilterableIndex = true
-	pv.containsValues = keys
+	pv.containsKeys = keys
 	return pv, nil
 }
 
-// wrapExtractErr reports what a batched arm could not encode.
-//
-// An internal fault is logged as well as returned. It reaches the API through
-// the same channel as a value the user got wrong — and under the same prefix —
-// so without this a broken sort or a misused builder arrives looking like a
-// malformed filter, with nothing on the server saying otherwise.
-func (s *Searcher) wrapExtractErr(prop string, err error) error {
+// logContainsFault reports an assertion from either Contains path. A fault
+// returns through the same channel and prefix as a value the user got wrong,
+// so without this it arrives looking like a malformed filter, and the gRPC
+// path records nothing else.
+func (s *Searcher) logContainsFault(prop string, err error) {
 	if errors.Is(err, inverted.ErrInternal) {
 		s.logger.WithField("prop", prop).
-			Errorf("batched contains could not encode its keys: %v", err)
+			Errorf("contains hit an internal fault: %v", err)
 	}
-	return fmt.Errorf("extract contains values: %w", err)
 }
 
 // batchedContainsUUID builds the batched leaf for string values on a UUID
@@ -1193,7 +1188,7 @@ func (s *Searcher) batchedContainsUUID(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeUUIDKeys(values)
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1209,25 +1204,24 @@ func (s *Searcher) batchedContainsTextField(property *models.Property, operator 
 	prepared := tokenizer.NewPreparedAnalyzer(property.TextAnalyzer)
 	batch, err := tokenizer.AnalyzeBatch(values, models.PropertyTokenizationField, class.Class, prepared, nil)
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	// FIELD gives one token per value, and the key is that token's bytes.
 	total, err := batch.SingleTokenBytes()
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 
-	// Fill first, order in Build — the same shape the fixed-width encoders use.
-	// Ordering the tokens here instead would mean a comparison sort over string
-	// headers, which dereferences into the tokenizer's backing array;
-	// ordering the slab lets equal-width keys go through a radix.
+	// Fill first, order in Build: ordering the tokens here instead would mean a
+	// comparison sort dereferencing string headers into the tokenizer's backing
+	// array, where ordering the slab lets equal-width keys go through a radix.
 	kb := inverted.NewVarKeyBuilder(batch.Len(), total)
 	for _, valueTokens := range batch.All() {
 		kb.AppendString(valueTokens[0])
 	}
 	keys, err := kb.Build()
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1237,7 +1231,7 @@ func (s *Searcher) batchedContainsInt(property *models.Property, operator filter
 ) (*propValuePair, error) {
 	keys, err := encodeIntKeys(values)
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1247,7 +1241,7 @@ func (s *Searcher) batchedContainsNumber(property *models.Property, operator fil
 ) (*propValuePair, error) {
 	keys, err := encodeNumberKeys(values)
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1257,7 +1251,7 @@ func (s *Searcher) batchedContainsBool(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeBoolKeys(values)
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }
@@ -1267,7 +1261,7 @@ func (s *Searcher) batchedContainsDate(property *models.Property, operator filte
 ) (*propValuePair, error) {
 	keys, err := encodeDateKeys(values)
 	if err != nil {
-		return nil, s.wrapExtractErr(property.Name, err)
+		return nil, err
 	}
 	return newBatchedContainsPair(property, operator, class, keys)
 }

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -12,8 +12,12 @@
 package inverted
 
 import (
+	"bytes"
 	"context"
+	"slices"
 	"testing"
+
+	entsInverted "github.com/weaviate/weaviate/entities/inverted"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -147,6 +151,20 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 		require.NoError(t, err)
 		return want
 	}
+	// Value lists that repeat, so wantKey is asked for every value the filter
+	// named and the expectation has to be compacted like the builders do.
+	boolDupValues := []bool{true, false, true, false}
+	boolDupKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractBoolValue(boolDupValues[i])
+		require.NoError(t, err)
+		return want
+	}
+	intDupValues := []int{2, 2, 2}
+	intDupKey := func(t *testing.T, i int) []byte {
+		want, err := s.extractIntValue(intDupValues[i])
+		require.NoError(t, err)
+		return want
+	}
 	dateValues := []string{"2021-01-01T00:00:00Z", "2022-02-02T00:00:00Z", "2023-03-03T00:00:00Z"}
 	dateKey := func(t *testing.T, i int) []byte {
 		want, err := s.extractDateValue(dateValues[i])
@@ -161,8 +179,9 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 		operator filters.Operator
 		// value is what the filter layer hands over: typed slices from
 		// internal callers, []interface{} from the GraphQL/gRPC layer
-		value   interface{}
-		numVals int
+		value interface{}
+		// numKeys is how many values wantKey can be asked for.
+		numKeys int
 		wantKey func(t *testing.T, i int) []byte
 	}{
 		{"uuid", "prop-uuid", schema.DataTypeText, filters.ContainsAny, uuidValues, 3, uuidKey},
@@ -180,6 +199,8 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 		{"bool []interface{}", "prop-bool", schema.DataTypeBoolean, filters.ContainsAny, []interface{}{true, false}, 2, boolKey},
 		{"date", "prop-date", schema.DataTypeDate, filters.ContainsAny, dateValues, 3, dateKey},
 		{"date []interface{}", "prop-date", schema.DataTypeDate, filters.ContainsAny, []interface{}{dateValues[0], dateValues[1], dateValues[2]}, 3, dateKey},
+		{"bool, values repeated", "prop-bool", schema.DataTypeBoolean, filters.ContainsAny, boolDupValues, len(boolDupValues), boolDupKey},
+		{"int, values repeated", "prop-int", schema.DataTypeInt, filters.ContainsAny, intDupValues, len(intDupValues), intDupKey},
 	}
 
 	for _, tt := range tests {
@@ -195,10 +216,17 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 			require.Equal(t, tt.operator, pv.operator)
 			require.Equal(t, tt.prop, pv.prop)
 			require.True(t, pv.hasFilterableIndex)
-			require.Len(t, pv.containsValues, tt.numVals)
-			for i := 0; i < tt.numVals; i++ {
-				require.Equal(t, tt.wantKey(t, i), pv.containsValues[i], "key %d", i)
+			// The keys come back ascending, not in the order the filter listed
+			// them, so the expectation is built from every value and then
+			// ordered the same way. The bool rows are where the two differ.
+			want := make([][]byte, tt.numKeys)
+			for i := range want {
+				want[i] = tt.wantKey(t, i)
 			}
+			slices.SortFunc(want, bytes.Compare)
+			require.Equal(t, len(want), pv.containsValues.Len(),
+				"one key per value")
+			require.Equal(t, want, collectKeys(pv.containsValues))
 		})
 	}
 }
@@ -369,7 +397,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, pv)
-			require.Nil(t, pv.containsValues, "shape must not resolve through the batched path")
+			require.Zero(t, pv.containsValues.Len(), "shape must not resolve through the batched path")
 		})
 	}
 }
@@ -421,7 +449,7 @@ func TestExtractContains_FallsThroughToPerValuePath(t *testing.T) {
 	pv, err := s.extractContains(ctx, path, schema.DataTypeText, []string{"hello world", "goodbye"},
 		filters.ContainsAny, f.class)
 	require.NoError(t, err)
-	require.Nil(t, pv.containsValues)
+	require.Zero(t, pv.containsValues.Len())
 	require.NotEmpty(t, pv.children)
 }
 
@@ -438,7 +466,38 @@ func TestExtractContains_UsesBatchedPathWhenEligible(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pv)
 	require.Nil(t, pv.children)
-	require.Len(t, pv.containsValues, 3)
+	require.Equal(t, 3, pv.containsValues.Len())
+}
+
+// TestNewBatchedContainsPair_RejectsNoKeys pins the invariant resolveDocIDs
+// routes on.
+//
+// Routing asks how many keys the leaf holds, not whether it has any, because a
+// key list has no absent value to test for — its zero value is an empty list. A
+// leaf built with none would therefore route as if it were not a batched
+// Contains at all, and reach the children dispatch holding no children. The
+// value-count gate in extractContains keeps that unreachable; this keeps the
+// two from drifting apart if the gate ever moves.
+func TestNewBatchedContainsPair_RejectsNoKeys(t *testing.T) {
+	f := newContainsBatchGateFixture(t)
+	prop := &models.Property{Name: "prop-int"}
+
+	_, err := newBatchedContainsPair(prop, filters.ContainsAny, f.class, entsInverted.SortedKeys{})
+	require.ErrorContains(t, err, "no keys")
+
+	for _, tc := range []struct {
+		name string
+		keys entsInverted.SortedKeys
+	}{
+		{name: "one key", keys: keysFrom(t, []byte("a"))},
+		{name: "two keys", keys: keysFrom(t, []byte("a"), []byte("b"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pv, err := newBatchedContainsPair(prop, filters.ContainsAny, f.class, tc.keys)
+			require.NoError(t, err)
+			require.Equal(t, tc.keys.Len(), pv.containsValues.Len())
+		})
+	}
 }
 
 // TestExtractContainsBatch_OptInGate pins that the batched resolution is
@@ -460,7 +519,7 @@ func TestExtractContainsBatch_OptInGate(t *testing.T) {
 		ctx := helpers.InitSlowQueryDetails(context.Background())
 		pv, err := extract(ctx)
 		require.NoError(t, err)
-		require.Nil(t, pv.containsValues)
+		require.Zero(t, pv.containsValues.Len())
 		require.NotEmpty(t, pv.children, "with the gate unwired, Contains must desugar per value")
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 	})
@@ -472,20 +531,20 @@ func TestExtractContainsBatch_OptInGate(t *testing.T) {
 		ctx := helpers.InitSlowQueryDetails(context.Background())
 		pv, err := extract(ctx)
 		require.NoError(t, err)
-		require.Nil(t, pv.containsValues)
+		require.Zero(t, pv.containsValues.Len())
 		require.NotEmpty(t, pv.children, "with the gate off, Contains must desugar per value")
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 
 		require.NoError(t, gate.SetValue(true))
 		pv, err = extract(context.Background())
 		require.NoError(t, err)
-		require.Len(t, pv.containsValues, 3, "gate flipped on at runtime must batch")
+		require.Equal(t, 3, pv.containsValues.Len(), "gate flipped on at runtime must batch")
 
 		require.NoError(t, gate.SetValue(false))
 		ctx = helpers.InitSlowQueryDetails(context.Background())
 		pv, err = extract(ctx)
 		require.NoError(t, err)
-		require.Nil(t, pv.containsValues, "gate flipped off at runtime must desugar again")
+		require.Zero(t, pv.containsValues.Len(), "gate flipped off at runtime must desugar again")
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 	})
 }
@@ -504,7 +563,7 @@ func TestFetchContainsBatch_EmptyKeySet(t *testing.T) {
 			pv := &propValuePair{
 				prop:               "prop-int",
 				operator:           op,
-				containsValues:     [][]byte{},
+				containsValues:     keysFrom(t),
 				hasFilterableIndex: true,
 				Class:              f.class,
 			}
@@ -537,7 +596,7 @@ func TestFetchContainsBatch_BucketErrors(t *testing.T) {
 			pv := &propValuePair{
 				prop:               tc.prop,
 				operator:           filters.ContainsAny,
-				containsValues:     [][]byte{[]byte("a")},
+				containsValues:     keysFrom(t, []byte("a")),
 				hasFilterableIndex: true,
 				Class:              f.class,
 			}
@@ -578,13 +637,13 @@ func TestFetchContainsBatch_ReadsRows(t *testing.T) {
 	tests := []struct {
 		name         string
 		operator     filters.Operator
-		keys         [][]byte
+		keys         entsInverted.SortedKeys
 		wantDocIDs   []uint64
 		wantDenyList bool
 	}{
-		{"ContainsAny reaches the rows", filters.ContainsAny, [][]byte{[]byte("a"), []byte("b")}, []uint64{1, 2, 3, 4}, false},
+		{"ContainsAny reaches the rows", filters.ContainsAny, keysFrom(t, []byte("a"), []byte("b")), []uint64{1, 2, 3, 4}, false},
 		// ContainsNone additionally proves the fold's deny flag reaches the caller
-		{"ContainsNone denies", filters.ContainsNone, [][]byte{[]byte("a"), []byte("b")}, []uint64{1, 2, 3, 4}, true},
+		{"ContainsNone denies", filters.ContainsNone, keysFrom(t, []byte("a"), []byte("b")), []uint64{1, 2, 3, 4}, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -616,7 +675,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 	f := newContainsBatchGateFixture(t)
 	writeContainsRows(t, f, "prop-int", map[string][]uint64{"a": {1, 2}, "b": {2, 3}})
 
-	newPV := func(keys [][]byte) *propValuePair {
+	newPV := func(keys entsInverted.SortedKeys) *propValuePair {
 		return &propValuePair{
 			prop:               "prop-int",
 			operator:           filters.ContainsAny,
@@ -628,7 +687,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 
 	t.Run("a batched read is annotated", func(t *testing.T) {
 		ctx := helpers.InitSlowQueryDetails(context.Background())
-		dbm, err := newPV([][]byte{[]byte("a"), []byte("b")}).fetchContainsBatch(ctx, f.searcher)
+		dbm, err := newPV(keysFrom(t, []byte("a"), []byte("b"))).fetchContainsBatch(ctx, f.searcher)
 		require.NoError(t, err)
 		defer dbm.release()
 
@@ -650,7 +709,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		pv := &propValuePair{
 			prop:               "prop-nonroaringset",
 			operator:           filters.ContainsAny,
-			containsValues:     [][]byte{[]byte("a"), []byte("b")},
+			containsValues:     keysFrom(t, []byte("a"), []byte("b")),
 			hasFilterableIndex: true,
 			Class:              f.class,
 		}
@@ -673,7 +732,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		ctx, cancel := context.WithCancel(helpers.InitSlowQueryDetails(context.Background()))
 		cancel()
 
-		_, err := newPV([][]byte{[]byte("a"), []byte("b")}).fetchContainsBatch(ctx, f.searcher)
+		_, err := newPV(keysFrom(t, []byte("a"), []byte("b"))).fetchContainsBatch(ctx, f.searcher)
 		require.ErrorIs(t, err, context.Canceled)
 
 		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
@@ -689,10 +748,10 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 	for _, tc := range []struct {
 		name string
 		prop string
-		keys [][]byte
+		keys entsInverted.SortedKeys
 	}{
-		{name: "an empty key set is not annotated", prop: "prop-int", keys: nil},
-		{name: "a missing bucket is not annotated", prop: "prop-no-bucket", keys: [][]byte{[]byte("a")}},
+		{name: "an empty key set is not annotated", prop: "prop-int"},
+		{name: "a missing bucket is not annotated", prop: "prop-no-bucket", keys: keysFrom(t, []byte("a"))},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := helpers.InitSlowQueryDetails(context.Background())

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -180,7 +180,9 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 		// value is what the filter layer hands over: typed slices from
 		// internal callers, []interface{} from the GraphQL/gRPC layer
 		value interface{}
-		// numKeys is how many values wantKey can be asked for.
+		// numKeys is how many values wantKey can be asked for; the distinct
+		// count is derived from the keys it returns, since the builders drop
+		// duplicates.
 		numKeys int
 		wantKey func(t *testing.T, i int) []byte
 	}{
@@ -199,6 +201,9 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 		{"bool []interface{}", "prop-bool", schema.DataTypeBoolean, filters.ContainsAny, []interface{}{true, false}, 2, boolKey},
 		{"date", "prop-date", schema.DataTypeDate, filters.ContainsAny, dateValues, 3, dateKey},
 		{"date []interface{}", "prop-date", schema.DataTypeDate, filters.ContainsAny, []interface{}{dateValues[0], dateValues[1], dateValues[2]}, 3, dateKey},
+		// Four values, two distinct keys. Every other row has one key per
+		// value, so without this the gate's >= 2 values and the leaf's >= 1 key
+		// are never seen to disagree.
 		{"bool, values repeated", "prop-bool", schema.DataTypeBoolean, filters.ContainsAny, boolDupValues, len(boolDupValues), boolDupKey},
 		{"int, values repeated", "prop-int", schema.DataTypeInt, filters.ContainsAny, intDupValues, len(intDupValues), intDupKey},
 	}
@@ -217,15 +222,17 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 			require.Equal(t, tt.prop, pv.prop)
 			require.True(t, pv.hasFilterableIndex)
 			// The keys come back ascending, not in the order the filter listed
-			// them, so the expectation is built from every value and then
-			// ordered the same way. The bool rows are where the two differ.
+			// them, and duplicates are gone — so the expectation is built from
+			// every value and then ordered and compacted the same way. The bool
+			// rows are where the two orders differ.
 			want := make([][]byte, tt.numKeys)
 			for i := range want {
 				want[i] = tt.wantKey(t, i)
 			}
 			slices.SortFunc(want, bytes.Compare)
+			want = slices.CompactFunc(want, bytes.Equal)
 			require.Equal(t, len(want), pv.containsValues.Len(),
-				"one key per value")
+				"one key per distinct value")
 			require.Equal(t, want, collectKeys(pv.containsValues))
 		})
 	}
@@ -478,6 +485,10 @@ func TestExtractContains_UsesBatchedPathWhenEligible(t *testing.T) {
 // Contains at all, and reach the children dispatch holding no children. The
 // value-count gate in extractContains keeps that unreachable; this keeps the
 // two from drifting apart if the gate ever moves.
+//
+// One key is accepted: the builders drop duplicate values, so a filter naming
+// the same value twice — or any boolean filter, which has two distinct keys to
+// draw on however many values it names — legitimately arrives with one.
 func TestNewBatchedContainsPair_RejectsNoKeys(t *testing.T) {
 	f := newContainsBatchGateFixture(t)
 	prop := &models.Property{Name: "prop-int"}
@@ -699,9 +710,30 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Equal(t, filters.ContainsAny.Name(), entries[0]["operator"])
 		require.Equal(t, 3, entries[0]["count"])
 		require.Equal(t, false, entries[0]["failed"])
-		require.Equal(t, 2, entries[0]["batched_values"])
+		require.Equal(t, 2, entries[0]["batched_keys"])
 		require.Contains(t, entries[0], "took")
 		require.Contains(t, entries[0], "took_string")
+	})
+
+	// The annotation counts keys, not the values the filter named, and the two
+	// stop agreeing the moment a filter repeats a value. Asserted on a shape
+	// where they differ, since a fixture with distinct values reports the same
+	// number either way and would not notice the field changing meaning.
+	t.Run("the annotation counts distinct keys, not values", func(t *testing.T) {
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		keys, err := encodeBoolKeys([]bool{true, false, true, false})
+		require.NoError(t, err)
+		require.Equal(t, 2, keys.Len(), "four values, two distinct boolean keys")
+
+		pv := newPV(keys)
+		pv.prop = "prop-bool"
+		writeContainsRows(t, f, "prop-bool", map[string][]uint64{"\x00": {1}, "\x01": {2}})
+		dbm, err := pv.fetchContainsBatch(ctx, f.searcher)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		entries := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.Equal(t, 2, entries[0]["batched_keys"], "four values must report two keys")
 	})
 
 	t.Run("a bucket rejected at open is still annotated", func(t *testing.T) {

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -231,9 +231,9 @@ func TestExtractContainsBatch_EligibleFamilies(t *testing.T) {
 			}
 			slices.SortFunc(want, bytes.Compare)
 			want = slices.CompactFunc(want, bytes.Equal)
-			require.Equal(t, len(want), pv.containsValues.Len(),
+			require.Equal(t, len(want), pv.containsKeys.Len(),
 				"one key per distinct value")
-			require.Equal(t, want, collectKeys(pv.containsValues))
+			require.Equal(t, want, collectKeys(pv.containsKeys))
 		})
 	}
 }
@@ -247,7 +247,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 	// its decline reason in the slow-query details. Rows with wantErr expect
 	// the desugared continuation to fail on its own terms (which also proves
 	// the gate declined: a wrongly-accepted shape would have succeeded with
-	// containsValues instead of erroring); the annotation is written before
+	// containsKeys instead of erroring); the annotation is written before
 	// the failure, so the reason is asserted on those rows too.
 	tests := []struct {
 		name       string
@@ -404,7 +404,7 @@ func TestExtractContainsBatch_Ineligible(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.NotNil(t, pv)
-			require.Zero(t, pv.containsValues.Len(), "shape must not resolve through the batched path")
+			require.Zero(t, pv.containsKeys.Len(), "shape must not resolve through the batched path")
 		})
 	}
 }
@@ -439,14 +439,14 @@ func TestExtractContainsBatch_EncodingErrorIsEligibleButFails(t *testing.T) {
 	pv, err := s.extractContains(ctx, containsPath("prop-uuid"),
 		schema.DataTypeText, values, filters.ContainsAny, f.class)
 	require.Error(t, err)
-	require.ErrorContains(t, err, "extract contains values",
+	require.ErrorContains(t, err, "parse uuid filter value",
 		"the matched shape must fail in the gate, not fall through to desugar")
 	require.Nil(t, pv)
 }
 
 // TestExtractContains_FallsThroughToPerValuePath proves that once the gate
 // declines a shape, extractContains's existing per-value dispatch still
-// runs unchanged, producing children (not containsValues).
+// runs unchanged, producing children (not containsKeys).
 func TestExtractContains_FallsThroughToPerValuePath(t *testing.T) {
 	f := newContainsBatchGateFixture(t)
 	s := f.searcher
@@ -456,7 +456,7 @@ func TestExtractContains_FallsThroughToPerValuePath(t *testing.T) {
 	pv, err := s.extractContains(ctx, path, schema.DataTypeText, []string{"hello world", "goodbye"},
 		filters.ContainsAny, f.class)
 	require.NoError(t, err)
-	require.Zero(t, pv.containsValues.Len())
+	require.Zero(t, pv.containsKeys.Len())
 	require.NotEmpty(t, pv.children)
 }
 
@@ -473,22 +473,16 @@ func TestExtractContains_UsesBatchedPathWhenEligible(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, pv)
 	require.Nil(t, pv.children)
-	require.Equal(t, 3, pv.containsValues.Len())
+	require.Equal(t, 3, pv.containsKeys.Len())
 }
 
 // TestNewBatchedContainsPair_RejectsNoKeys pins the invariant resolveDocIDs
-// routes on.
+// routes on: a key count, not a presence test, since a key list's zero value
+// is itself an empty list. A leaf built with none would route as if it were
+// not batched at all, reaching the children dispatch with none to resolve.
 //
-// Routing asks how many keys the leaf holds, not whether it has any, because a
-// key list has no absent value to test for — its zero value is an empty list. A
-// leaf built with none would therefore route as if it were not a batched
-// Contains at all, and reach the children dispatch holding no children. The
-// value-count gate in extractContains keeps that unreachable; this keeps the
-// two from drifting apart if the gate ever moves.
-//
-// One key is accepted: the builders drop duplicate values, so a filter naming
-// the same value twice — or any boolean filter, which has two distinct keys to
-// draw on however many values it names — legitimately arrives with one.
+// One key is accepted: dedup can legitimately shrink a filter — a repeated
+// value, or any boolean filter — down to one distinct key.
 func TestNewBatchedContainsPair_RejectsNoKeys(t *testing.T) {
 	f := newContainsBatchGateFixture(t)
 	prop := &models.Property{Name: "prop-int"}
@@ -506,7 +500,7 @@ func TestNewBatchedContainsPair_RejectsNoKeys(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pv, err := newBatchedContainsPair(prop, filters.ContainsAny, f.class, tc.keys)
 			require.NoError(t, err)
-			require.Equal(t, tc.keys.Len(), pv.containsValues.Len())
+			require.Equal(t, tc.keys.Len(), pv.containsKeys.Len())
 		})
 	}
 }
@@ -530,7 +524,7 @@ func TestExtractContainsBatch_OptInGate(t *testing.T) {
 		ctx := helpers.InitSlowQueryDetails(context.Background())
 		pv, err := extract(ctx)
 		require.NoError(t, err)
-		require.Zero(t, pv.containsValues.Len())
+		require.Zero(t, pv.containsKeys.Len())
 		require.NotEmpty(t, pv.children, "with the gate unwired, Contains must desugar per value")
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 	})
@@ -542,20 +536,20 @@ func TestExtractContainsBatch_OptInGate(t *testing.T) {
 		ctx := helpers.InitSlowQueryDetails(context.Background())
 		pv, err := extract(ctx)
 		require.NoError(t, err)
-		require.Zero(t, pv.containsValues.Len())
+		require.Zero(t, pv.containsKeys.Len())
 		require.NotEmpty(t, pv.children, "with the gate off, Contains must desugar per value")
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 
 		require.NoError(t, gate.SetValue(true))
 		pv, err = extract(context.Background())
 		require.NoError(t, err)
-		require.Equal(t, 3, pv.containsValues.Len(), "gate flipped on at runtime must batch")
+		require.Equal(t, 3, pv.containsKeys.Len(), "gate flipped on at runtime must batch")
 
 		require.NoError(t, gate.SetValue(false))
 		ctx = helpers.InitSlowQueryDetails(context.Background())
 		pv, err = extract(ctx)
 		require.NoError(t, err)
-		require.Zero(t, pv.containsValues.Len(), "gate flipped off at runtime must desugar again")
+		require.Zero(t, pv.containsKeys.Len(), "gate flipped off at runtime must desugar again")
 		require.Equal(t, containsDeclineNotEnabled, extractContainsDesugaredReason(t, ctx))
 	})
 }
@@ -574,7 +568,7 @@ func TestFetchContainsBatch_EmptyKeySet(t *testing.T) {
 			pv := &propValuePair{
 				prop:               "prop-int",
 				operator:           op,
-				containsValues:     keysFrom(t),
+				containsKeys:       keysFrom(t),
 				hasFilterableIndex: true,
 				Class:              f.class,
 			}
@@ -607,7 +601,7 @@ func TestFetchContainsBatch_BucketErrors(t *testing.T) {
 			pv := &propValuePair{
 				prop:               tc.prop,
 				operator:           filters.ContainsAny,
-				containsValues:     keysFrom(t, []byte("a")),
+				containsKeys:       keysFrom(t, []byte("a")),
 				hasFilterableIndex: true,
 				Class:              f.class,
 			}
@@ -661,7 +655,7 @@ func TestFetchContainsBatch_ReadsRows(t *testing.T) {
 			pv := &propValuePair{
 				prop:               "prop-int",
 				operator:           tc.operator,
-				containsValues:     tc.keys,
+				containsKeys:       tc.keys,
 				hasFilterableIndex: true,
 				Class:              f.class,
 			}
@@ -690,7 +684,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		return &propValuePair{
 			prop:               "prop-int",
 			operator:           filters.ContainsAny,
-			containsValues:     keys,
+			containsKeys:       keys,
 			hasFilterableIndex: true,
 			Class:              f.class,
 		}
@@ -741,7 +735,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		pv := &propValuePair{
 			prop:               "prop-nonroaringset",
 			operator:           filters.ContainsAny,
-			containsValues:     keysFrom(t, []byte("a"), []byte("b")),
+			containsKeys:       keysFrom(t, []byte("a"), []byte("b")),
 			hasFilterableIndex: true,
 			Class:              f.class,
 		}
@@ -790,7 +784,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 			pv := &propValuePair{
 				prop:               tc.prop,
 				operator:           filters.ContainsAny,
-				containsValues:     tc.keys,
+				containsKeys:       tc.keys,
 				hasFilterableIndex: true,
 				Class:              f.class,
 			}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"time"
 
+	entsInverted "github.com/weaviate/weaviate/entities/inverted"
+
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
@@ -275,10 +277,11 @@ var containsAnyAccumulatorMinKeys = 256
 func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBatchReader,
 	pv *propValuePair,
 ) (docBitmap, error) {
-	if len(pv.containsValues) == 0 {
+	if pv.containsValues.Len() == 0 {
 		// defensive: the folds adopt their first row as the accumulator, so zero
 		// keys yields a nil bitmap rather than an empty one
-		return docBitmap{}, fmt.Errorf("contains fold on prop %q carries no keys", pv.prop)
+		return docBitmap{}, fmt.Errorf("%w: contains fold on prop %q carries no keys",
+			entsInverted.ErrInternal, pv.prop)
 	}
 
 	isDenyList := pv.operator == filters.ContainsNone
@@ -295,7 +298,7 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 		// applied to the result, not the fold. Below
 		// containsAnyAccumulatorMinKeys keys the Accumulator's staging setup
 		// and finalize scan are not worth it — union incrementally instead.
-		if len(pv.containsValues) < containsAnyAccumulatorMinKeys {
+		if pv.containsValues.Len() < containsAnyAccumulatorMinKeys {
 			acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsValues, filters.ContainsAny, mergeConc)
 		} else {
 			acc, accRelease, err = foldContainsAnyAccumulator(ctx, reader, pv.containsValues,
@@ -304,7 +307,8 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 	default:
 		// defensive: a non-Contains operator must never pick a fold — a
 		// silent union here would return plausible but wrong results
-		return docBitmap{}, fmt.Errorf("unsupported operator %q for batched contains", pv.operator.Name())
+		return docBitmap{}, fmt.Errorf("%w: unsupported operator %q for batched contains",
+			entsInverted.ErrInternal, pv.operator.Name())
 	}
 	if err != nil {
 		return docBitmap{}, err
@@ -322,13 +326,13 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 // staging blocks (proportional to the doc-ID spread of the result, not to
 // the number of keys) plus a single row in flight.
 func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
-	keys [][]byte, pool roaringset.BitmapBufPool, mergeConc int,
+	keys entsInverted.SortedKeys, pool roaringset.BitmapBufPool, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
 	// TODO aliszka:gh12242 wire mergeConc into the accumulator's Or once sroar
 	// supports concurrent deposits; today it bounds only the per-row disk merge
 	// and the deposits themselves are single-threaded.
 	acc := sroar.NewAccumulator()
-	for _, key := range keys {
+	for _, key := range keys.All() {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
@@ -358,11 +362,11 @@ func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
 // batch-read grouping can beat — hence ContainsAll deliberately has no
 // accumulator path.
 func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
-	keys [][]byte, op filters.Operator, mergeConc int,
+	keys entsInverted.SortedKeys, op filters.Operator, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
 	var acc *sroar.Bitmap
 	accRelease := noopRelease
-	for _, key := range keys {
+	for _, key := range keys.All() {
 		if err := ctx.Err(); err != nil {
 			accRelease()
 			return nil, nil, err

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -259,7 +259,7 @@ func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 // for sit far above it either way.
 var containsAnyAccumulatorMinKeys = 256
 
-// docBitmapContainsBatch folds every key in pv.containsValues into a single
+// docBitmapContainsBatch folds every key in pv.containsKeys into a single
 // docBitmap under reader's held view: a dense Accumulator fold for
 // ContainsAny and ContainsNone, an incremental intersection with empty-result
 // early exit for ContainsAll. Every per-key fetch is an OperatorEqual read on
@@ -277,7 +277,7 @@ var containsAnyAccumulatorMinKeys = 256
 func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBatchReader,
 	pv *propValuePair,
 ) (docBitmap, error) {
-	if pv.containsValues.Len() == 0 {
+	if pv.containsKeys.Len() == 0 {
 		// defensive: the folds adopt their first row as the accumulator, so zero
 		// keys yields a nil bitmap rather than an empty one
 		return docBitmap{}, fmt.Errorf("%w: contains fold on prop %q carries no keys",
@@ -292,16 +292,16 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 	var err error
 	switch pv.operator {
 	case filters.ContainsAll:
-		acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsValues, filters.ContainsAll, mergeConc)
+		acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsKeys, filters.ContainsAll, mergeConc)
 	case filters.ContainsAny, filters.ContainsNone:
 		// ContainsNone folds the same union as ContainsAny; the deny flag is
 		// applied to the result, not the fold. Below
 		// containsAnyAccumulatorMinKeys keys the Accumulator's staging setup
 		// and finalize scan are not worth it — union incrementally instead.
-		if pv.containsValues.Len() < containsAnyAccumulatorMinKeys {
-			acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsValues, filters.ContainsAny, mergeConc)
+		if pv.containsKeys.Len() < containsAnyAccumulatorMinKeys {
+			acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsKeys, filters.ContainsAny, mergeConc)
 		} else {
-			acc, accRelease, err = foldContainsAnyAccumulator(ctx, reader, pv.containsValues,
+			acc, accRelease, err = foldContainsAnyAccumulator(ctx, reader, pv.containsKeys,
 				s.bitmapFactory.BufPool(), mergeConc)
 		}
 	default:

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -511,8 +511,9 @@ func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
 }
 
 // keysFrom builds a [entsInverted.SortedKeys] from literal keys so tests can
-// state the keys they mean without mirroring a builder. Build orders them, so
-// the result is ascending whatever order they are given in.
+// state the keys they mean without mirroring a builder. Build orders them and
+// drops duplicates, so the result is the distinct keys in ascending order
+// whatever order they are given in.
 func keysFrom(tb testing.TB, keys ...[]byte) entsInverted.SortedKeys {
 	tb.Helper()
 	total := 0

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
+	entsInverted "github.com/weaviate/weaviate/entities/inverted"
 )
 
 // containsBatchFixture owns a real roaringset *lsmkv.Bucket and the
@@ -124,7 +125,7 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 
 	pv := &propValuePair{
 		operator:       filters.ContainsAny,
-		containsValues: [][]byte{[]byte("present-a"), []byte("missing"), []byte("present-b")},
+		containsValues: keysFrom(t, []byte("present-a"), []byte("missing"), []byte("present-b")),
 	}
 
 	s := &Searcher{}
@@ -134,8 +135,8 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 
 	require.Equal(t, []uint64{1, 2, 3, 4, 5}, dbm.docIDs.ToArray())
 	require.False(t, dbm.IsDenyList())
-	require.Equal(t, []string{"present-a", "missing", "present-b"}, fixture.reads,
-		"every key must be read for ContainsAny, absent key included")
+	require.Equal(t, []string{"missing", "present-a", "present-b"}, fixture.reads,
+		"every key must be read for ContainsAny, absent key included, in key order")
 }
 
 // TestDocBitmapContainsBatch_UnsupportedOperator pins the defensive default
@@ -152,7 +153,7 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 
 	pv := &propValuePair{
 		operator:       filters.OperatorEqual,
-		containsValues: [][]byte{[]byte("present-a"), []byte("present-b")},
+		containsValues: keysFrom(t, []byte("present-a"), []byte("present-b")),
 	}
 
 	s := &Searcher{}
@@ -175,7 +176,7 @@ func TestDocBitmapContainsBatch_NoKeys(t *testing.T) {
 		t.Run(op.Name(), func(t *testing.T) {
 			s := &Searcher{}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
-				&propValuePair{prop: "some-prop", operator: op, containsValues: [][]byte{}})
+				&propValuePair{prop: "some-prop", operator: op, containsValues: keysFrom(t)})
 			require.ErrorContains(t, err, "carries no keys")
 			require.ErrorContains(t, err, `"some-prop"`, "the error must name the property")
 			require.Nil(t, dbm.docIDs)
@@ -219,25 +220,26 @@ func TestDocBitmapContainsBatch_ReadError(t *testing.T) {
 			ctx := context.Background()
 			fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 				"a": {1, 2, 3},
-				"c": {7, 8},
+				"z": {7, 8},
 			})
 
 			pool := roaringset.NewBitmapBufPoolTrackingForTests()
 			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
 
-			// "a" is read and accumulated, "poison" fails, "c" must never be read
+			// "a" is read and accumulated, "poison" fails, "z" must never be
+			// reached — the keys arrive ascending, so "poison" sits between them
 			dbm, err := s.docBitmapContainsBatch(ctx,
 				&failingContainsBatchReader{containsBatchReader: fixture.reader(t), failKey: "poison"},
 				&propValuePair{
 					operator:       filters.ContainsAny,
-					containsValues: [][]byte{[]byte("a"), []byte("poison"), []byte("c")},
+					containsValues: keysFrom(t, []byte("a"), []byte("poison"), []byte("z")),
 				})
 			require.ErrorContains(t, err, "read row")
 			require.ErrorContains(t, err, "injected read failure")
 			require.Equal(t, docBitmap{}, dbm, "a failed read must not yield a partial result")
 
 			// the poisoned key is answered by the wrapper, so it never reaches
-			// the fixture; "c" missing is what proves the fold stopped
+			// the fixture; "z" missing is what proves the fold stopped
 			require.Equal(t, []string{"a"}, fixture.reads, "no key after the failure may be read")
 			require.Equal(t, len(fixture.reads), fixture.releaseCalls,
 				"every row the fold received must be released")
@@ -259,7 +261,7 @@ func TestResolveDocIDs_ContainsKeysRequireContainsOperator(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pv := &propValuePair{
 				operator:       tc.operator,
-				containsValues: [][]byte{[]byte("a"), []byte("b")},
+				containsValues: keysFrom(t, []byte("a"), []byte("b")),
 			}
 			_, err := pv.resolveDocIDs(context.Background(), &Searcher{}, 0)
 			require.ErrorContains(t, err, "non-contains operator")
@@ -280,7 +282,7 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 
 	pv := &propValuePair{
 		operator:       filters.ContainsNone,
-		containsValues: [][]byte{[]byte("present-a"), []byte("missing"), []byte("present-b")},
+		containsValues: keysFrom(t, []byte("present-a"), []byte("missing"), []byte("present-b")),
 	}
 
 	s := &Searcher{}
@@ -291,7 +293,7 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 	require.Equal(t, []uint64{1, 2, 3, 4, 5}, dbm.docIDs.ToArray(),
 		"ContainsNone folds the same union as ContainsAny")
 	require.True(t, dbm.IsDenyList())
-	require.Equal(t, []string{"present-a", "missing", "present-b"}, fixture.reads)
+	require.Equal(t, []string{"missing", "present-a", "present-b"}, fixture.reads)
 }
 
 // Same folds as above but forced through the Accumulator path, which the
@@ -313,9 +315,9 @@ func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
 		"present-c": {70_000, 200_000},
 	}
 
-	keys := [][]byte{
+	keys := keysFrom(t,
 		[]byte("present-a"), []byte("missing"), []byte("present-b"), []byte("present-c"),
-	}
+	)
 	for _, tc := range []struct {
 		operator     filters.Operator
 		wantDenyList bool
@@ -334,8 +336,8 @@ func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
 
 			require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
 			require.Equal(t, tc.wantDenyList, dbm.IsDenyList())
-			require.Equal(t, []string{"present-a", "missing", "present-b", "present-c"}, fixture.reads,
-				"every key must be read, absent key included")
+			require.Equal(t, []string{"missing", "present-a", "present-b", "present-c"}, fixture.reads,
+				"every key must be read, absent key included, in key order")
 
 			dbm.release()
 			require.Zero(t, pool.Outstanding(),
@@ -357,11 +359,17 @@ func TestDocBitmapContainsBatch_SingleKey(t *testing.T) {
 		operator filters.Operator
 		key      string
 		want     []uint64
+		wantDeny bool
 	}{
 		{operator: filters.ContainsAny, key: "a", want: []uint64{1, 2, 3}},
 		{operator: filters.ContainsAll, key: "a", want: []uint64{1, 2, 3}},
 		{operator: filters.ContainsAny, key: "missing", want: []uint64{}},
 		{operator: filters.ContainsAll, key: "missing", want: []uint64{}},
+		// ContainsNone is the only operator that marks the result a deny list,
+		// and one key is newly reachable for it: a two-value filter naming the
+		// same value twice arrives here with one.
+		{operator: filters.ContainsNone, key: "a", want: []uint64{1, 2, 3}, wantDeny: true},
+		{operator: filters.ContainsNone, key: "missing", want: []uint64{}, wantDeny: true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.operator.Name()+"/"+tc.key, func(t *testing.T) {
@@ -370,13 +378,15 @@ func TestDocBitmapContainsBatch_SingleKey(t *testing.T) {
 			s := &Searcher{}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
 				operator:       tc.operator,
-				containsValues: [][]byte{[]byte(tc.key)},
+				containsValues: keysFrom(t, []byte(tc.key)),
 			})
 			require.NoError(t, err)
 			defer dbm.release()
 
 			require.NotNil(t, dbm.docIDs, "a fold must never return a nil bitmap")
 			require.Equal(t, tc.want, dbm.docIDs.ToArray())
+			require.Equal(t, tc.wantDeny, dbm.IsDenyList(),
+				"the deny flag is set on the result, not folded into it")
 			require.Equal(t, []string{tc.key}, fixture.reads)
 		})
 	}
@@ -394,7 +404,7 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 
 		pv := &propValuePair{
 			operator:       filters.ContainsAll,
-			containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			containsValues: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
 		}
 
 		s := &Searcher{}
@@ -415,7 +425,7 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 
 		pv := &propValuePair{
 			operator:       filters.ContainsAll,
-			containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+			containsValues: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
 		}
 
 		s := &Searcher{}
@@ -431,12 +441,13 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 	t.Run("absent key empties the intersection and stops reading", func(t *testing.T) {
 		fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
 			"a": {1, 2, 3},
-			"c": {1, 2, 3}, // must never be read: the absent key already emptied the AND
+			"z": {1, 2, 3}, // must never be read: the absent key already emptied the AND
 		})
 
+		// keys arrive ascending, so "missing" sits between the two present ones
 		pv := &propValuePair{
 			operator:       filters.ContainsAll,
-			containsValues: [][]byte{[]byte("a"), []byte("missing"), []byte("c")},
+			containsValues: keysFrom(t, []byte("a"), []byte("missing"), []byte("z")),
 		}
 
 		s := &Searcher{}
@@ -446,7 +457,7 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 
 		require.Empty(t, dbm.docIDs.ToArray())
 		require.Equal(t, []string{"a", "missing"}, fixture.reads,
-			"key c must not be read once the absent key emptied the accumulator")
+			"key z must not be read once the absent key emptied the accumulator")
 	})
 }
 
@@ -487,7 +498,7 @@ func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
 			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(fixture.pool, func() uint64 { return 300_000 })}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
 				operator:       filters.ContainsAny,
-				containsValues: [][]byte{[]byte("a"), []byte("b"), []byte("c")},
+				containsValues: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
 			})
 			require.ErrorIs(t, err, context.Canceled)
 			require.Equal(t, docBitmap{}, dbm)
@@ -497,4 +508,33 @@ func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
 			require.Zero(t, fixture.pool.Outstanding(), "no row buffer may outlive the cancelled fold")
 		})
 	}
+}
+
+// keysFrom builds a [entsInverted.SortedKeys] from literal keys so tests can
+// state the keys they mean without mirroring a builder. Build orders them, so
+// the result is ascending whatever order they are given in.
+func keysFrom(tb testing.TB, keys ...[]byte) entsInverted.SortedKeys {
+	tb.Helper()
+	total := 0
+	for _, k := range keys {
+		total += len(k)
+	}
+	kb := entsInverted.NewVarKeyBuilder(len(keys), total)
+	for _, k := range keys {
+		kb.AppendString(string(k))
+	}
+	built, err := kb.Build()
+	require.NoError(tb, err)
+	return built
+}
+
+// collectKeys materializes a [entsInverted.SortedKeys] as a [][]byte, so tests
+// can compare against the keys they expect without asserting through an
+// accessor.
+func collectKeys(keys entsInverted.SortedKeys) [][]byte {
+	out := make([][]byte, 0, keys.Len())
+	for _, k := range keys.All() {
+		out = append(out, k)
+	}
+	return out
 }

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
@@ -124,8 +125,8 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 	})
 
 	pv := &propValuePair{
-		operator:       filters.ContainsAny,
-		containsValues: keysFrom(t, []byte("present-a"), []byte("missing"), []byte("present-b")),
+		operator:     filters.ContainsAny,
+		containsKeys: keysFrom(t, []byte("present-a"), []byte("missing"), []byte("present-b")),
 	}
 
 	s := &Searcher{}
@@ -152,8 +153,8 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 	})
 
 	pv := &propValuePair{
-		operator:       filters.OperatorEqual,
-		containsValues: keysFrom(t, []byte("present-a"), []byte("present-b")),
+		operator:     filters.OperatorEqual,
+		containsKeys: keysFrom(t, []byte("present-a"), []byte("present-b")),
 	}
 
 	s := &Searcher{}
@@ -176,7 +177,7 @@ func TestDocBitmapContainsBatch_NoKeys(t *testing.T) {
 		t.Run(op.Name(), func(t *testing.T) {
 			s := &Searcher{}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
-				&propValuePair{prop: "some-prop", operator: op, containsValues: keysFrom(t)})
+				&propValuePair{prop: "some-prop", operator: op, containsKeys: keysFrom(t)})
 			require.ErrorContains(t, err, "carries no keys")
 			require.ErrorContains(t, err, `"some-prop"`, "the error must name the property")
 			require.Nil(t, dbm.docIDs)
@@ -231,8 +232,8 @@ func TestDocBitmapContainsBatch_ReadError(t *testing.T) {
 			dbm, err := s.docBitmapContainsBatch(ctx,
 				&failingContainsBatchReader{containsBatchReader: fixture.reader(t), failKey: "poison"},
 				&propValuePair{
-					operator:       filters.ContainsAny,
-					containsValues: keysFrom(t, []byte("a"), []byte("poison"), []byte("z")),
+					operator:     filters.ContainsAny,
+					containsKeys: keysFrom(t, []byte("a"), []byte("poison"), []byte("z")),
 				})
 			require.ErrorContains(t, err, "read row")
 			require.ErrorContains(t, err, "injected read failure")
@@ -260,11 +261,17 @@ func TestResolveDocIDs_ContainsKeysRequireContainsOperator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			pv := &propValuePair{
-				operator:       tc.operator,
-				containsValues: keysFrom(t, []byte("a"), []byte("b")),
+				operator:     tc.operator,
+				containsKeys: keysFrom(t, []byte("a"), []byte("b")),
 			}
-			_, err := pv.resolveDocIDs(context.Background(), &Searcher{}, 0)
+			logger, hook := test.NewNullLogger()
+			_, err := pv.resolveDocIDs(context.Background(), &Searcher{logger: logger}, 0)
 			require.ErrorContains(t, err, "non-contains operator")
+
+			// Reported nowhere else: the caller's wrap gives no hint it was ours.
+			require.Len(t, hook.Entries, 1)
+			require.Equal(t, logrus.ErrorLevel, hook.LastEntry().Level)
+			require.Contains(t, hook.LastEntry().Message, "internal fault")
 		})
 	}
 }
@@ -281,8 +288,8 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 	})
 
 	pv := &propValuePair{
-		operator:       filters.ContainsNone,
-		containsValues: keysFrom(t, []byte("present-a"), []byte("missing"), []byte("present-b")),
+		operator:     filters.ContainsNone,
+		containsKeys: keysFrom(t, []byte("present-a"), []byte("missing"), []byte("present-b")),
 	}
 
 	s := &Searcher{}
@@ -331,7 +338,7 @@ func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
 			pool := roaringset.NewBitmapBufPoolTrackingForTests()
 			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
-				&propValuePair{operator: tc.operator, containsValues: keys})
+				&propValuePair{operator: tc.operator, containsKeys: keys})
 			require.NoError(t, err)
 
 			require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
@@ -377,8 +384,8 @@ func TestDocBitmapContainsBatch_SingleKey(t *testing.T) {
 
 			s := &Searcher{}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
-				operator:       tc.operator,
-				containsValues: keysFrom(t, []byte(tc.key)),
+				operator:     tc.operator,
+				containsKeys: keysFrom(t, []byte(tc.key)),
 			})
 			require.NoError(t, err)
 			defer dbm.release()
@@ -403,8 +410,8 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		})
 
 		pv := &propValuePair{
-			operator:       filters.ContainsAll,
-			containsValues: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
+			operator:     filters.ContainsAll,
+			containsKeys: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
 		}
 
 		s := &Searcher{}
@@ -424,8 +431,8 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		})
 
 		pv := &propValuePair{
-			operator:       filters.ContainsAll,
-			containsValues: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
+			operator:     filters.ContainsAll,
+			containsKeys: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
 		}
 
 		s := &Searcher{}
@@ -446,8 +453,8 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 
 		// keys arrive ascending, so "missing" sits between the two present ones
 		pv := &propValuePair{
-			operator:       filters.ContainsAll,
-			containsValues: keysFrom(t, []byte("a"), []byte("missing"), []byte("z")),
+			operator:     filters.ContainsAll,
+			containsKeys: keysFrom(t, []byte("a"), []byte("missing"), []byte("z")),
 		}
 
 		s := &Searcher{}
@@ -497,8 +504,8 @@ func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
 
 			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(fixture.pool, func() uint64 { return 300_000 })}
 			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
-				operator:       filters.ContainsAny,
-				containsValues: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
+				operator:     filters.ContainsAny,
+				containsKeys: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
 			})
 			require.ErrorIs(t, err, context.Canceled)
 			require.Equal(t, docBitmap{}, dbm)

--- a/adapters/repos/db/inverted/searcher_value_extractors.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors.go
@@ -75,7 +75,8 @@ func putUUIDKey(dst []byte, v string) error {
 
 // encodeFixedWidthKeys encodes every already-typed value into its fixed-width
 // slot of one shared slab, wrapping the first failure with its position so the
-// caller can report which element was malformed.
+// caller can report which element was malformed. Build orders the result and
+// drops duplicate keys, so it can be shorter than values.
 func encodeFixedWidthKeys[T any](values []T, keyLen int, encode func(dst []byte, v T) error) (ent.SortedKeys, error) {
 	kb := ent.NewFixedKeyBuilder(len(values), keyLen)
 	for i := range values {

--- a/adapters/repos/db/inverted/searcher_value_extractors.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors.go
@@ -75,53 +75,57 @@ func putUUIDKey(dst []byte, v string) error {
 
 // encodeFixedWidthKeys encodes every already-typed value into its fixed-width
 // slot of one shared slab, wrapping the first failure with its position so the
-// caller can report which element was malformed. The three-index sub-slices
-// cap each key's capacity at its own end, so an append to one key cannot
-// clobber the next.
-func encodeFixedWidthKeys[T any](values []T, keyLen int, encode func(dst []byte, v T) error) ([][]byte, error) {
-	keys := make([][]byte, len(values))
-	slab := make([]byte, len(values)*keyLen)
+// caller can report which element was malformed.
+func encodeFixedWidthKeys[T any](values []T, keyLen int, encode func(dst []byte, v T) error) (ent.SortedKeys, error) {
+	kb := ent.NewFixedKeyBuilder(len(values), keyLen)
 	for i := range values {
-		dst := slab[i*keyLen : (i+1)*keyLen : (i+1)*keyLen]
-		if err := encode(dst, values[i]); err != nil {
-			return nil, fmt.Errorf("value %d: %w", i, err)
+		if err := encode(kb.AppendBuf(), values[i]); err != nil {
+			return ent.SortedKeys{}, fmt.Errorf("value %d: %w", i, err)
 		}
-		keys[i] = dst
 	}
-	return keys, nil
+	// Build orders the encoded keys rather than the values: every fixed-width
+	// encoding here is order-preserving, but only for its own type, and a
+	// string-valued date or uuid does not sort as its encoding does. Sorting
+	// the slab is uniform across all of them and moves only bytes, not slice
+	// headers.
+	//
+	// Every error it can return is [ent.ErrInternal] — the encoders have already
+	// run, so no filter value reaches it — which is what lets the caller report
+	// an internal fault as one.
+	return kb.Build()
 }
 
 // encode*Keys below are the slice counterparts of the extract*Value
 // methods: one key per value, all keys backed by one shared slab.
 
-func encodeIntKeys(values []int) ([][]byte, error) {
+func encodeIntKeys(values []int) (ent.SortedKeys, error) {
 	return encodeFixedWidthKeys(values, 8, func(dst []byte, v int) error {
 		putIntKey(dst, v)
 		return nil
 	})
 }
 
-func encodeNumberKeys(values []float64) ([][]byte, error) {
+func encodeNumberKeys(values []float64) (ent.SortedKeys, error) {
 	return encodeFixedWidthKeys(values, 8, func(dst []byte, v float64) error {
 		putNumberKey(dst, v)
 		return nil
 	})
 }
 
-func encodeBoolKeys(values []bool) ([][]byte, error) {
+func encodeBoolKeys(values []bool) (ent.SortedKeys, error) {
 	return encodeFixedWidthKeys(values, 1, func(dst []byte, v bool) error {
 		putBoolKey(dst, v)
 		return nil
 	})
 }
 
-func encodeDateKeys(values []string) ([][]byte, error) {
+func encodeDateKeys(values []string) (ent.SortedKeys, error) {
 	return encodeFixedWidthKeys(values, 8, func(dst []byte, v string) error {
 		return putDateKey(dst, v)
 	})
 }
 
-func encodeUUIDKeys(values []string) ([][]byte, error) {
+func encodeUUIDKeys(values []string) (ent.SortedKeys, error) {
 	return encodeFixedWidthKeys(values, 16, func(dst []byte, v string) error {
 		return putUUIDKey(dst, v)
 	})

--- a/adapters/repos/db/inverted/searcher_value_extractors.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors.go
@@ -84,15 +84,13 @@ func encodeFixedWidthKeys[T any](values []T, keyLen int, encode func(dst []byte,
 			return ent.SortedKeys{}, fmt.Errorf("value %d: %w", i, err)
 		}
 	}
-	// Build orders the encoded keys rather than the values: every fixed-width
-	// encoding here is order-preserving, but only for its own type, and a
-	// string-valued date or uuid does not sort as its encoding does. Sorting
-	// the slab is uniform across all of them and moves only bytes, not slice
-	// headers.
+	// Build orders by the encoded key, not the value: each fixed-width encoding
+	// is order-preserving only for its own type (a string-valued date or uuid
+	// doesn't sort as its encoding does), so sorting the slab is what stays
+	// uniform across all of them.
 	//
-	// Every error it can return is [ent.ErrInternal] — the encoders have already
-	// run, so no filter value reaches it — which is what lets the caller report
-	// an internal fault as one.
+	// Every error here is [ent.ErrInternal] — the encoders already ran, so no
+	// filter value reaches this point — letting the caller report it as such.
 	return kb.Build()
 }
 

--- a/adapters/repos/db/inverted/searcher_value_extractors_test.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors_test.go
@@ -62,10 +62,11 @@ func TestEncodeKeys(t *testing.T) {
 	// and that each key's capacity is capped to keyLen, so appending to one
 	// cannot reach the next.
 	//
-	// The expectation is built from every input value and then ordered the way
-	// the builders do, and its length is asserted. Sizing it from keys.Len()
-	// instead would make it agree with whatever the encoder produced —
-	// including nothing at all, since the range body would simply not run.
+	// The expectation is built from every input value and then ordered and
+	// deduplicated the way the builders do, and its length is asserted. Sizing
+	// it from keys.Len() instead would make it agree with whatever the encoder
+	// produced — including nothing at all, since the range body would simply
+	// not run.
 	assertKeysMatch := func(t *testing.T, keys ent.SortedKeys, keyLen, numValues int, want func(i int) []byte) {
 		t.Helper()
 		expected := make([][]byte, numValues)
@@ -73,8 +74,9 @@ func TestEncodeKeys(t *testing.T) {
 			expected[i] = want(i)
 		}
 		slices.SortFunc(expected, bytes.Compare)
+		expected = slices.CompactFunc(expected, bytes.Equal)
 
-		require.Equal(t, len(expected), keys.Len(), "one key per value")
+		require.Equal(t, len(expected), keys.Len(), "one key per distinct value")
 		for i, key := range keys.All() {
 			assert.Equalf(t, expected[i], key, "key %d bytes", i)
 			assert.Equalf(t, keyLen, cap(key), "key %d capacity must be capped to its own %d-byte end", i, keyLen)
@@ -106,6 +108,7 @@ func TestEncodeKeys(t *testing.T) {
 	})
 
 	t.Run("bool", func(t *testing.T) {
+		// Three values, two distinct keys: the shape where dedup shrinks the list.
 		values := []bool{true, false, true}
 		keys, err := encodeBoolKeys(values)
 		require.NoError(t, err)

--- a/adapters/repos/db/inverted/searcher_value_extractors_test.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors_test.go
@@ -12,11 +12,14 @@
 package inverted
 
 import (
+	"bytes"
 	"math"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	ent "github.com/weaviate/weaviate/entities/inverted"
 )
 
 // TestExtractBoolValue pins the filter-side bool encoding byte-for-byte and
@@ -55,21 +58,36 @@ func TestExtractBoolValue(t *testing.T) {
 func TestEncodeKeys(t *testing.T) {
 	s := &Searcher{}
 
-	// assertKeysMatch checks each slab key against the single-value encoder and
-	// that its capacity is capped to keyLen (the three-index sub-slice).
-	assertKeysMatch := func(t *testing.T, keys [][]byte, keyLen int, want func(i int) []byte) {
+	// assertKeysMatch checks the encoded keys against the single-value encoder
+	// and that each key's capacity is capped to keyLen, so appending to one
+	// cannot reach the next.
+	//
+	// The expectation is built from every input value and then ordered the way
+	// the builders do, and its length is asserted. Sizing it from keys.Len()
+	// instead would make it agree with whatever the encoder produced —
+	// including nothing at all, since the range body would simply not run.
+	assertKeysMatch := func(t *testing.T, keys ent.SortedKeys, keyLen, numValues int, want func(i int) []byte) {
 		t.Helper()
-		for i := range keys {
-			assert.Equalf(t, want(i), keys[i], "key %d bytes", i)
-			assert.Equalf(t, keyLen, cap(keys[i]), "key %d capacity must be capped to its own %d-byte end", i, keyLen)
+		expected := make([][]byte, numValues)
+		for i := range expected {
+			expected[i] = want(i)
+		}
+		slices.SortFunc(expected, bytes.Compare)
+
+		require.Equal(t, len(expected), keys.Len(), "one key per value")
+		for i, key := range keys.All() {
+			assert.Equalf(t, expected[i], key, "key %d bytes", i)
+			assert.Equalf(t, keyLen, cap(key), "key %d capacity must be capped to its own %d-byte end", i, keyLen)
 		}
 	}
 
 	t.Run("int", func(t *testing.T) {
-		values := []int{-1_000_000, -1, 0, 1, 42}
+		// Deliberately not in ascending order: a fixture that is already sorted
+		// passes whether or not the encoder orders anything.
+		values := []int{0, 42, -1_000_000, 1, -1}
 		keys, err := encodeIntKeys(values)
 		require.NoError(t, err)
-		assertKeysMatch(t, keys, 8, func(i int) []byte {
+		assertKeysMatch(t, keys, 8, len(values), func(i int) []byte {
 			b, err := s.extractIntValue(values[i])
 			require.NoError(t, err)
 			return b
@@ -77,10 +95,10 @@ func TestEncodeKeys(t *testing.T) {
 	})
 
 	t.Run("number", func(t *testing.T) {
-		values := []float64{-math.Pi, 0, 0.5, math.MaxFloat64}
+		values := []float64{0.5, math.MaxFloat64, -math.Pi, 0}
 		keys, err := encodeNumberKeys(values)
 		require.NoError(t, err)
-		assertKeysMatch(t, keys, 8, func(i int) []byte {
+		assertKeysMatch(t, keys, 8, len(values), func(i int) []byte {
 			b, err := s.extractNumberValue(values[i])
 			require.NoError(t, err)
 			return b
@@ -91,7 +109,7 @@ func TestEncodeKeys(t *testing.T) {
 		values := []bool{true, false, true}
 		keys, err := encodeBoolKeys(values)
 		require.NoError(t, err)
-		assertKeysMatch(t, keys, 1, func(i int) []byte {
+		assertKeysMatch(t, keys, 1, len(values), func(i int) []byte {
 			b, err := s.extractBoolValue(values[i])
 			require.NoError(t, err)
 			return b
@@ -99,10 +117,13 @@ func TestEncodeKeys(t *testing.T) {
 	})
 
 	t.Run("date", func(t *testing.T) {
-		values := []string{"2020-01-02T03:04:05Z", "1999-12-31T23:59:59Z"}
+		// The second value is the earlier instant (19:00Z the previous day) but
+		// the later string, so a sort over the values rather than their encodings
+		// would order these the other way round.
+		values := []string{"2020-12-31T23:00:00Z", "2021-01-01T00:00:00+05:00"}
 		keys, err := encodeDateKeys(values)
 		require.NoError(t, err)
-		assertKeysMatch(t, keys, 8, func(i int) []byte {
+		assertKeysMatch(t, keys, 8, len(values), func(i int) []byte {
 			b, err := s.extractDateValue(values[i])
 			require.NoError(t, err)
 			return b
@@ -111,12 +132,12 @@ func TestEncodeKeys(t *testing.T) {
 
 	t.Run("uuid", func(t *testing.T) {
 		values := []string{
-			"00000000-0000-0000-0000-000000000001",
 			"ffffffff-ffff-ffff-ffff-ffffffffffff",
+			"00000000-0000-0000-0000-000000000001",
 		}
 		keys, err := encodeUUIDKeys(values)
 		require.NoError(t, err)
-		assertKeysMatch(t, keys, 16, func(i int) []byte {
+		assertKeysMatch(t, keys, 16, len(values), func(i int) []byte {
 			b, err := s.extractUUIDValue(values[i])
 			require.NoError(t, err)
 			return b
@@ -126,21 +147,21 @@ func TestEncodeKeys(t *testing.T) {
 	t.Run("keys are independent", func(t *testing.T) {
 		keys, err := encodeIntKeys([]int{1, 2, 3})
 		require.NoError(t, err)
-		neighbor := append([]byte(nil), keys[1]...)
-		// no spare capacity, so this reallocates and cannot reach keys[1]
-		grown := append(keys[0], 0xff, 0xff, 0xff, 0xff)
-		require.Len(t, grown, len(keys[0])+4)
-		assert.Equal(t, neighbor, keys[1], "append to one key must not clobber the next")
+		neighbor := append([]byte(nil), keys.At(1)...)
+		// no spare capacity, so this reallocates and cannot reach key 1
+		grown := append(keys.At(0), 0xff, 0xff, 0xff, 0xff)
+		require.Len(t, grown, len(keys.At(0))+4)
+		assert.Equal(t, neighbor, keys.At(1), "append to one key must not clobber the next")
 	})
 
 	t.Run("empty and single", func(t *testing.T) {
 		empty, err := encodeIntKeys(nil)
 		require.NoError(t, err)
-		assert.Empty(t, empty)
+		assert.Zero(t, empty.Len())
 
 		one, err := encodeIntKeys([]int{7})
 		require.NoError(t, err)
-		require.Len(t, one, 1)
+		require.Equal(t, 1, one.Len())
 	})
 
 	t.Run("encode error reports the failing index", func(t *testing.T) {

--- a/adapters/repos/db/inverted/searcher_value_extractors_test.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors_test.go
@@ -58,15 +58,12 @@ func TestExtractBoolValue(t *testing.T) {
 func TestEncodeKeys(t *testing.T) {
 	s := &Searcher{}
 
-	// assertKeysMatch checks the encoded keys against the single-value encoder
-	// and that each key's capacity is capped to keyLen, so appending to one
-	// cannot reach the next.
+	// assertKeysMatch checks the encoded keys against the single-value encoder,
+	// each key's capacity capped to keyLen so appending can't reach the next.
 	//
-	// The expectation is built from every input value and then ordered and
-	// deduplicated the way the builders do, and its length is asserted. Sizing
-	// it from keys.Len() instead would make it agree with whatever the encoder
-	// produced — including nothing at all, since the range body would simply
-	// not run.
+	// The expectation is ordered and deduplicated the way the builders do, and
+	// its length is asserted rather than derived from keys.Len() — which would
+	// trivially agree with whatever the encoder produced, including nothing.
 	assertKeysMatch := func(t *testing.T, keys ent.SortedKeys, keyLen, numValues int, want func(i int) []byte) {
 		t.Helper()
 		expected := make([][]byte, numValues)

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -24,7 +24,9 @@ import (
 // carry the width instead of offsets, since key i then starts at i*w.
 //
 // Only a builder's Build returns one, so the order cannot be lost downstream
-// and no consumer re-checks it. Build verifies it instead.
+// and no consumer re-checks it. Build verifies it instead, while dropping
+// duplicates — so a list holds distinct keys, and can be shorter than the
+// values a filter named.
 //
 // The zero value is a valid empty list.
 type SortedKeys struct {
@@ -187,10 +189,14 @@ func (b *VarKeyBuilder) AppendString(key string) {
 	b.n++
 }
 
-// Build orders the keys and returns the finished list, consuming the builder.
+// Build orders the keys, drops duplicates, and returns the finished list,
+// consuming the builder.
 //
 // Ordering here, rather than in a Sort the producer has to remember to call,
-// leaves no way to skip the invariant [SortedKeys] is named for.
+// leaves no way to skip the invariant [SortedKeys] is named for. Dropping
+// duplicates is then a linear pass over the same comparisons — see [dedupFixed]
+// and [dedupVariable] — so the list can be shorter than the appends that filled
+// it, and a caller needing its own count must not take this one for it.
 //
 // Keys that share a width come back in the layout carrying no offsets. The sort
 // scans them to choose its method regardless, so the layout costs nothing to
@@ -226,9 +232,22 @@ func (b *VarKeyBuilder) Build() (SortedKeys, error) {
 	}
 	slab, offs, w := sortKeys(b.slab, b.offs)
 	if w > 0 {
-		return SortedKeys{slab: slab, w: w}, nil
+		n, err := dedupFixed(slab, w, b.n)
+		if err != nil {
+			return SortedKeys{}, err
+		}
+		// Capped at the last surviving key so an index past Len cannot reach the
+		// deduped tail, and copied down when that tail is most of the array.
+		return SortedKeys{slab: shrinkKeys(slab, n*w), w: w}, nil
 	}
-	return SortedKeys{slab: slab, offs: offs}, nil
+	n, err := dedupVariable(slab, offs, b.n)
+	if err != nil {
+		return SortedKeys{}, err
+	}
+	return SortedKeys{
+		slab: shrinkKeys(slab, int(offs[n])),
+		offs: shrinkOffs(offs, n+1),
+	}, nil
 }
 
 // FixedKeyBuilder fills a [SortedKeys] whose keys are all one width. It records
@@ -245,7 +264,7 @@ type FixedKeyBuilder struct {
 // keyWidth is the width of one key, not the batch's total — the neighbouring
 // [NewVarKeyBuilder] takes a total, and the two are otherwise identical in
 // shape. Passing a total here is accepted by the compiler and produces keys of
-// the wrong width that sort normally, so it is refused at the point
+// the wrong width that sort and dedup normally, so it is refused at the point
 // the mistake is made: a width past the widest key any family encodes is
 // rejected here rather than diagnosed inside an encoder writing into a buffer
 // of the wrong size.
@@ -297,8 +316,49 @@ func (b *FixedKeyBuilder) AppendBuf() []byte {
 // not just the bound — AppendBuf extends the slab from it and sizes nothing.
 var zeroKey [16]byte
 
-// Build orders the keys in place and returns the finished list, consuming the
-// builder, for the reasons given on [VarKeyBuilder.Build].
+// shrinkFloor is the array size below which reclaiming a deduped tail is not
+// worth a copy. Small batches are the common ones and would pay the copy for
+// bytes nobody misses.
+const shrinkFloor = 4 << 10
+
+// shrinkKeys ends the slab at the last surviving key, and copies it onto its
+// own array when what is left behind is most of it.
+//
+// An aliased result is capped at that key so an index past it cannot reach the
+// dropped tail. A copied one may carry spare capacity, which append rounds up
+// to a size class — but those bytes are a fresh allocation, not the tail.
+//
+// Dedup can leave a handful of keys inside an allocation sized for the whole
+// batch — a boolean filter over 100,000 values keeps two — and the finished
+// list is held for as long as the query runs, so the dead tail is held with it.
+// Capping alone does not release it, and hides it: the returned slice reports
+// the small capacity while the whole array stays reachable. So the decision is
+// made from the array the keys came in, before it is capped.
+//
+// The ratio keeps a batch that dropped nothing from copying at all, and leaves
+// a worst case of three quarters wasted: a batch dedupping 100,000 keys to
+// 26,000 holds 800KB for 208KB of keys rather than pay the copy.
+func shrinkKeys(slab []byte, end int) []byte {
+	if cap(slab) < shrinkFloor || cap(slab) <= 4*end {
+		return slab[:end:end]
+	}
+	return append([]byte(nil), slab[:end]...)
+}
+
+// shrinkOffs is shrinkKeys for the offsets, which are sized to the pre-dedup key
+// count and go dead in the same proportion. Its floor is the same number of
+// bytes, not of entries, so the two decide independently: 4095 offsets are worth
+// reclaiming where 4095 bytes are not.
+func shrinkOffs(offs []uint32, end int) []uint32 {
+	if 4*cap(offs) < shrinkFloor || cap(offs) <= 4*end {
+		return offs[:end:end]
+	}
+	return append([]uint32(nil), offs[:end]...)
+}
+
+// Build orders the keys in place, drops duplicates, and returns the finished
+// list, consuming the builder. Both happen here for the reasons given on
+// [VarKeyBuilder.Build].
 //
 // At one width key i sits at offset i*w, so ordering moves only the slab and
 // there are no offsets to reorder alongside it. That is also what lets these
@@ -312,5 +372,11 @@ func (b *FixedKeyBuilder) Build() (SortedKeys, error) {
 			"NewFixedKeyBuilder was not used", ErrInternal, b.w)
 	}
 	sortFixedWidth(b.slab, b.w)
-	return SortedKeys{slab: b.slab, w: b.w}, nil
+	n, err := dedupFixed(b.slab, b.w, len(b.slab)/b.w)
+	if err != nil {
+		return SortedKeys{}, err
+	}
+	// Capped at the last surviving key so an index past Len cannot reach the
+	// deduped tail, and copied down when that tail is most of the array.
+	return SortedKeys{slab: shrinkKeys(b.slab, n*b.w), w: b.w}, nil
 }

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -63,43 +63,36 @@ func (k SortedKeys) Len() int {
 	return len(k.slab) / k.w
 }
 
+// errUnbuiltKeys is built once rather than formatted per panic: formatting is a
+// call, and a call is what At cannot afford — see below.
+var errUnbuiltKeys = fmt.Errorf("%w: keys were not made by a builder", ErrInternal)
+
 // At returns key i, aliasing the slab. Callers must not modify it. Its capacity
 // stops at its own end, so appending to it reallocates rather than writing over
 // the next key.
 //
-// Use [SortedKeys.All] to walk the list. The range check is what makes At too
-// large to inline — its cost is 271 against a budget of 80, and 45 without the
-// two panic paths — so a loop driven by At pays a call per key, which
-// BenchmarkIterate measures at about four times the cost of iterating. That is
-// the price of the check, and All is how the query path avoids paying it.
+// An index the list cannot answer panics, on the bounds check the compiler
+// generates for the slice expression. Which panic that is depends on the layout
+// — the offsets arm fails on its own index, in key terms, the width arm on the
+// slice bounds, in byte terms — and the wording belongs to the runtime rather
+// than to this package. That is deliberate. A check here could name the index
+// and the count instead, but it costs At its inlining, 271 against a budget of
+// 80 where this is 53, and At is what a reader that needs keys out of order
+// calls per key. [SortedKeys.All] reads the slab directly and never paid
+// either way; a binary search cannot use it.
 //
-// The range is checked here rather than left to the two layouts, which disagree
-// about it: the offsets arm would panic on its own index, the width arm reads
-// slab[0:0:0] for every index when the width is zero, and a zero value has no
-// width at all. One check makes all three refuse the same way.
+// One index the generated check cannot refuse: any index into a list of zero
+// width, where i*0 slices to [0:0:0] and is legal against any slab. An unbuilt
+// SortedKeys would then answer every index with an empty key rather than
+// failing, so that one is refused here.
 func (k SortedKeys) At(i int) []byte {
 	if k.offs == nil {
-		// Multiplied rather than dividing to derive the count, which would be a
-		// division per key. An index large enough to overflow the product still
-		// panics, on the slice expression rather than here, so the cost is the
-		// message and not safety.
-		if i < 0 || k.w <= 0 || (i+1)*k.w > len(k.slab) {
-			panic(outOfRange(i, k.Len()))
+		if k.w <= 0 {
+			panic(errUnbuiltKeys)
 		}
 		return k.slab[i*k.w : (i+1)*k.w : (i+1)*k.w]
 	}
-	if i < 0 || i+1 >= len(k.offs) {
-		panic(outOfRange(i, k.Len()))
-	}
 	return k.slab[k.offs[i]:k.offs[i+1]:k.offs[i+1]]
-}
-
-// outOfRange builds the value At panics with. It carries [ErrInternal] like the
-// returned faults do: if the recovery interceptor whose absence sends Build's
-// errors back through the return ever arrives, a recovered panic should be
-// classifiable the same way rather than arriving as an opaque string.
-func outOfRange(i, n int) error {
-	return fmt.Errorf("%w: key %d requested from a list of %d", ErrInternal, i, n)
 }
 
 // All iterates the keys in order, yielding each key's position and bytes, which

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -1,0 +1,316 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"bytes"
+	"fmt"
+	"iter"
+	"math"
+)
+
+// SortedKeys is an ascending, immutable list of encoded index keys, held as one
+// slab plus per-key offsets rather than as a [][]byte whose 24-byte headers
+// would outweigh the 8-to-16-byte keys they describe. Keys that share a width
+// carry the width instead of offsets, since key i then starts at i*w.
+//
+// Only a builder's Build returns one, so the order cannot be lost downstream
+// and no consumer re-checks it. Build verifies it instead.
+//
+// The zero value is a valid empty list.
+type SortedKeys struct {
+	slab []byte
+	// offs has one entry per key plus a terminator, and is nil when the keys
+	// share a width.
+	offs []uint32
+	// w is the shared key width, read only when offs is nil.
+	w int
+}
+
+// Len returns the number of keys.
+//
+// Derived rather than stored. Each layout already carries the count — one
+// offset per key plus a terminator, or a slab that is exactly n keys wide — and
+// a stored count would be a third place for them to disagree. Routing reads
+// this, so a count out of step with the arrays would send a filter down the
+// wrong path rather than merely iterate wrong.
+func (k SortedKeys) Len() int {
+	if k.offs != nil {
+		// An offsets array with no terminator is not a shape the builders
+		// produce. Reporting -1 for it would pass every "no keys" guard, which
+		// all test for zero, and then fail the "has keys" test that routes to
+		// the batched fold — so the leaf would fall through to the per-value
+		// path with no value set, and answer from the wrong bucket.
+		if len(k.offs) == 0 {
+			return 0
+		}
+		return len(k.offs) - 1
+	}
+	if k.w <= 0 {
+		return 0
+	}
+	return len(k.slab) / k.w
+}
+
+// At returns key i, aliasing the slab. Callers must not modify it. Its capacity
+// stops at its own end, so appending to it reallocates rather than writing over
+// the next key.
+//
+// Use [SortedKeys.All] to walk the list. The range check is what makes At too
+// large to inline — its cost is 271 against a budget of 80, and 45 without the
+// two panic paths — so a loop driven by At pays a call per key, which
+// BenchmarkIterate measures at about four times the cost of iterating. That is
+// the price of the check, and All is how the query path avoids paying it.
+//
+// The range is checked here rather than left to the two layouts, which disagree
+// about it: the offsets arm would panic on its own index, the width arm reads
+// slab[0:0:0] for every index when the width is zero, and a zero value has no
+// width at all. One check makes all three refuse the same way.
+func (k SortedKeys) At(i int) []byte {
+	if k.offs == nil {
+		// Multiplied rather than dividing to derive the count, which would be a
+		// division per key. An index large enough to overflow the product still
+		// panics, on the slice expression rather than here, so the cost is the
+		// message and not safety.
+		if i < 0 || k.w <= 0 || (i+1)*k.w > len(k.slab) {
+			panic(outOfRange(i, k.Len()))
+		}
+		return k.slab[i*k.w : (i+1)*k.w : (i+1)*k.w]
+	}
+	if i < 0 || i+1 >= len(k.offs) {
+		panic(outOfRange(i, k.Len()))
+	}
+	return k.slab[k.offs[i]:k.offs[i+1]:k.offs[i+1]]
+}
+
+// outOfRange builds the value At panics with. It carries [ErrInternal] like the
+// returned faults do: if the recovery interceptor whose absence sends Build's
+// errors back through the return ever arrives, a recovered panic should be
+// classifiable the same way rather than arriving as an opaque string.
+func outOfRange(i, n int) error {
+	return fmt.Errorf("%w: key %d requested from a list of %d", ErrInternal, i, n)
+}
+
+// All iterates the keys in order, yielding each key's position and bytes, which
+// alias the slab.
+//
+// One func literal covers both layouts. With one per layout the compiler cannot
+// tell which iterator a caller received, so it cannot devirtualize the yield and
+// heap-allocates the caller's loop body instead.
+//
+// The layout is branched on once, outside the loop, and the keys are sliced
+// here rather than through At, which would pay both the branch and a range
+// check per key to re-prove what the loop condition already guarantees.
+// BenchmarkIterate measures the two: 38us against 159us over 100,000 keys.
+func (k SortedKeys) All() iter.Seq2[int, []byte] {
+	return func(yield func(int, []byte) bool) {
+		if k.offs == nil {
+			if k.w <= 0 {
+				return
+			}
+			for i := 0; (i+1)*k.w <= len(k.slab); i++ {
+				if !yield(i, k.slab[i*k.w:(i+1)*k.w:(i+1)*k.w]) {
+					return
+				}
+			}
+			return
+		}
+		for i := 0; i+1 < len(k.offs); i++ {
+			if !yield(i, k.slab[k.offs[i]:k.offs[i+1]:k.offs[i+1]]) {
+				return
+			}
+		}
+	}
+}
+
+// isAscending reports whether the keys are ordered. Off the query path — it
+// exists so tests can pin the invariant each producer promises.
+func (k SortedKeys) isAscending() bool {
+	for i := 1; i < k.Len(); i++ {
+		if bytes.Compare(k.At(i-1), k.At(i)) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// VarKeyBuilder fills a [SortedKeys] whose keys vary in length. Keys may be
+// appended in any order; because a key's offset then depends on the lengths
+// before it, ordering them means sorting a permutation and rebuilding the slab
+// in that order, both of which happen in [VarKeyBuilder.Build].
+//
+// The builder a producer picks is what chooses the layout. Deciding it here
+// instead — watching the lengths appended — costs a per-key test that pushes
+// AppendString past Go's inlining budget.
+type VarKeyBuilder struct {
+	slab []byte
+	offs []uint32
+	// n counts the appends, duplicating len(offs)-1 so the two disagree exactly
+	// when the constructor was skipped. Build refuses that.
+	n int
+}
+
+// NewVarKeyBuilder sizes both arrays up front so neither grows: a producer knows
+// its key count and total byte length before it starts. It panics on negative
+// arguments.
+//
+// totalBytes is the batch's total, not a per-key width — the opposite of the
+// neighbouring [NewFixedKeyBuilder], which the arguments cannot distinguish.
+func NewVarKeyBuilder(numKeys, totalBytes int) *VarKeyBuilder {
+	// Refused here rather than left to make: a negative count sizes offs to
+	// numKeys+1 == 0 and hands back a builder that works while quietly growing,
+	// which is the one promise this constructor exists to make.
+	if numKeys < 0 || totalBytes < 0 {
+		panic(fmt.Errorf("%w: key count %d and total bytes %d must not be negative",
+			ErrInternal, numKeys, totalBytes))
+	}
+	return &VarKeyBuilder{
+		slab: make([]byte, 0, totalBytes),
+		offs: append(make([]uint32, 0, numKeys+1), 0),
+	}
+}
+
+// AppendString copies a key onto the slab without materializing a []byte for
+// the conversion.
+func (b *VarKeyBuilder) AppendString(key string) {
+	b.slab = append(b.slab, key...)
+	b.offs = append(b.offs, uint32(len(b.slab)))
+	b.n++
+}
+
+// Build orders the keys and returns the finished list, consuming the builder.
+//
+// Ordering here, rather than in a Sort the producer has to remember to call,
+// leaves no way to skip the invariant [SortedKeys] is named for.
+//
+// Keys that share a width come back in the layout carrying no offsets. The sort
+// scans them to choose its method regardless, so the layout costs nothing to
+// learn and saves four bytes per key for the query's lifetime.
+//
+// Scratch is sized to the batch. Its rebuilt slab and offsets become the
+// returned list; the rest dies with the sort. Pooling measured no faster at any
+// batch size and would hold a large batch's buffers for the process's lifetime.
+func (b *VarKeyBuilder) Build() (SortedKeys, error) {
+	// offs carries a leading zero, so a filled builder holds one more offset
+	// than keys. Without it every key reads a position over and the last is
+	// lost, narrowing a filter result with nothing to report it. Reachable from
+	// outside the package: an empty composite literal needs no exported field.
+	if len(b.offs) != b.n+1 {
+		return SortedKeys{}, fmt.Errorf("%w: VarKeyBuilder holds %d keys against %d "+
+			"offsets; NewVarKeyBuilder was not used", ErrInternal, b.n, len(b.offs))
+	}
+	// Offsets are uint32 and AppendString cannot afford a bound per key, but
+	// len(slab) is still an honest int here, so the ceiling is checked once
+	// after the fact. Past it the offsets have wrapped and stopped ascending,
+	// which reads as wrong keys rather than as a failure.
+	// Deliberately not an [ErrInternal]: a batch this large is what the filter
+	// asked for, not this package being wrong, and an operator reading it as an
+	// internal fault would look in the wrong place. Not covered by any test —
+	// reaching it needs 4GiB of keys in one filter — and unreachable for the
+	// only production caller, which bounds the same total through
+	// [tokenizer.AnalyzedBatch.SingleTokenBytes] before sizing this builder —
+	// AnalyzeBatch bounds the token count, which is a different quantity. It is
+	// kept because the builder is exported and the next producer may not.
+	if uint64(len(b.slab)) > math.MaxUint32 {
+		return SortedKeys{}, fmt.Errorf("inverted: batch holds %d bytes of keys, "+
+			"above the uint32 offset ceiling of %d", len(b.slab), uint32(math.MaxUint32))
+	}
+	slab, offs, w := sortKeys(b.slab, b.offs)
+	if w > 0 {
+		return SortedKeys{slab: slab, w: w}, nil
+	}
+	return SortedKeys{slab: slab, offs: offs}, nil
+}
+
+// FixedKeyBuilder fills a [SortedKeys] whose keys are all one width. It records
+// no offsets, since key i is at i*w, and the type is what keeps that true:
+// nothing can append a key of another length to it.
+type FixedKeyBuilder struct {
+	slab []byte
+	w    int
+}
+
+// NewFixedKeyBuilder sizes the slab for numKeys keys of keyWidth bytes each. It
+// panics on arguments it cannot build from.
+//
+// keyWidth is the width of one key, not the batch's total — the neighbouring
+// [NewVarKeyBuilder] takes a total, and the two are otherwise identical in
+// shape. Passing a total here is accepted by the compiler and produces keys of
+// the wrong width that sort normally, so it is refused at the point
+// the mistake is made: a width past the widest key any family encodes is
+// rejected here rather than diagnosed inside an encoder writing into a buffer
+// of the wrong size.
+func NewFixedKeyBuilder(numKeys, keyWidth int) *FixedKeyBuilder {
+	if keyWidth <= 0 || keyWidth > maxKeyWidth {
+		panic(fmt.Errorf("%w: key width %d is not in 1..%d; NewFixedKeyBuilder "+
+			"takes the width of one key, not the batch total",
+			ErrInternal, keyWidth, maxKeyWidth))
+	}
+	if numKeys < 0 {
+		panic(fmt.Errorf("%w: key count %d is negative", ErrInternal, numKeys))
+	}
+	return &FixedKeyBuilder{slab: make([]byte, 0, numKeys*keyWidth), w: keyWidth}
+}
+
+// maxKeyWidth is the widest key any fixed-width family encodes — a uuid, at 16.
+// Bounding the width here is what makes a batch total passed as a width fail at
+// the call rather than silently produce keys of the wrong shape, and it is what
+// lets AppendBuf extend the slab from zeroKey without ever sizing a buffer.
+const maxKeyWidth = len(zeroKey)
+
+// AppendBuf appends a key and returns its bytes, zeroed, for the encoder to
+// write into — cheaper than encoding into a temporary and copying it in. The
+// returned slice is capped at its own end, so writing through it cannot reach
+// the next key.
+//
+// It is valid until the next append or Build, whichever comes first. The slab
+// is sized for the key count the constructor was given, so it does not grow in
+// practice; a buffer held across a growth would alias the old array and lose
+// what was written through it, and one held across Build would land on whatever
+// key the sort moved into that slot.
+func (b *FixedKeyBuilder) AppendBuf() []byte {
+	// A zero width would hand back an empty buffer and leave the encoder to
+	// die writing into it, several frames from the mistake and with nothing
+	// but an index-out-of-range to go on. Build's guard cannot reach that: the
+	// encoder runs first. Panics rather than returning because there is no
+	// error to return through, and the width came from a constructor argument.
+	if b.w <= 0 {
+		panic(fmt.Errorf("%w: FixedKeyBuilder has a key width of %d; "+
+			"NewFixedKeyBuilder was not used", ErrInternal, b.w))
+	}
+	start := len(b.slab)
+	b.slab = append(b.slab, zeroKey[:b.w]...)
+	return b.slab[start : start+b.w : start+b.w]
+}
+
+// zeroKey backs AppendBuf's extension, and its length is the width bound every
+// builder is checked against. A family wider than this has to grow the array,
+// not just the bound — AppendBuf extends the slab from it and sizes nothing.
+var zeroKey [16]byte
+
+// Build orders the keys in place and returns the finished list, consuming the
+// builder, for the reasons given on [VarKeyBuilder.Build].
+//
+// At one width key i sits at offset i*w, so ordering moves only the slab and
+// there are no offsets to reorder alongside it. That is also what lets these
+// keys be radix sorted rather than compared.
+func (b *FixedKeyBuilder) Build() (SortedKeys, error) {
+	// A width is a constant of the family being encoded, so a non-positive one
+	// is a builder that skipped its constructor. Refused rather than returned as
+	// an empty list, which reads downstream as a filter that matched nothing.
+	if b.w <= 0 {
+		return SortedKeys{}, fmt.Errorf("%w: FixedKeyBuilder has a key width of %d; "+
+			"NewFixedKeyBuilder was not used", ErrInternal, b.w)
+	}
+	sortFixedWidth(b.slab, b.w)
+	return SortedKeys{slab: b.slab, w: b.w}, nil
+}

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -85,6 +85,11 @@ var errUnbuiltKeys = fmt.Errorf("%w: keys were not made by a builder", ErrIntern
 // width, where i*0 slices to [0:0:0] and is legal against any slab. An unbuilt
 // SortedKeys would then answer every index with an empty key rather than
 // failing, so that one is refused here.
+//
+// One it cannot refuse and this does not either: an index near maxint, where
+// i*k.w wraps to a legal range and answers with the wrong key. No caller can
+// hold one — Len bounds every index a reader derives — and guarding it slows
+// the width arm of [BenchmarkIterate], so it is stated rather than checked.
 func (k SortedKeys) At(i int) []byte {
 	if k.offs == nil {
 		if k.w <= 0 {

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -18,17 +18,14 @@ import (
 	"math"
 )
 
-// SortedKeys is an ascending, immutable list of encoded index keys, held as one
-// slab plus per-key offsets rather than as a [][]byte whose 24-byte headers
-// would outweigh the 8-to-16-byte keys they describe. Keys that share a width
-// carry the width instead of offsets, since key i then starts at i*w.
+// SortedKeys is an ascending, immutable list of encoded index keys, held as
+// one slab plus per-key offsets — or a shared width, when keys are all one
+// size — rather than a [][]byte, whose 24-byte headers would outweigh the
+// 8-to-16-byte keys they describe.
 //
-// Only a builder's Build returns one, so the order cannot be lost downstream
-// and no consumer re-checks it. Build verifies it instead, while dropping
-// duplicates — so a list holds distinct keys, and can be shorter than the
-// values a filter named.
-//
-// The zero value is a valid empty list.
+// Only a builder's Build returns one, so callers can trust the order and the
+// absence of duplicates without re-checking. The zero value is a valid empty
+// list.
 type SortedKeys struct {
 	slab []byte
 	// offs has one entry per key plus a terminator, and is nil when the keys
@@ -40,18 +37,12 @@ type SortedKeys struct {
 
 // Len returns the number of keys.
 //
-// Derived rather than stored. Each layout already carries the count — one
-// offset per key plus a terminator, or a slab that is exactly n keys wide — and
-// a stored count would be a third place for them to disagree. Routing reads
-// this, so a count out of step with the arrays would send a filter down the
-// wrong path rather than merely iterate wrong.
+// Derived from the backing arrays rather than stored, so it can't drift out of
+// sync with them — callers route on this count.
 func (k SortedKeys) Len() int {
 	if k.offs != nil {
-		// An offsets array with no terminator is not a shape the builders
-		// produce. Reporting -1 for it would pass every "no keys" guard, which
-		// all test for zero, and then fail the "has keys" test that routes to
-		// the batched fold — so the leaf would fall through to the per-value
-		// path with no value set, and answer from the wrong bucket.
+		// A builder never leaves offs without a terminator; treat that shape
+		// as empty rather than reporting a count that could misroute callers.
 		if len(k.offs) == 0 {
 			return 0
 		}
@@ -67,29 +58,24 @@ func (k SortedKeys) Len() int {
 // call, and a call is what At cannot afford — see below.
 var errUnbuiltKeys = fmt.Errorf("%w: keys were not made by a builder", ErrInternal)
 
-// At returns key i, aliasing the slab. Callers must not modify it. Its capacity
-// stops at its own end, so appending to it reallocates rather than writing over
-// the next key.
+// At returns key i, aliasing the slab; callers must not modify it. The
+// result's capacity ends at the key itself, so append reallocates rather than
+// overwriting the next key.
 //
-// An index the list cannot answer panics, on the bounds check the compiler
-// generates for the slice expression. Which panic that is depends on the layout
-// — the offsets arm fails on its own index, in key terms, the width arm on the
-// slice bounds, in byte terms — and the wording belongs to the runtime rather
-// than to this package. That is deliberate. A check here could name the index
-// and the count instead, but it costs At its inlining, 271 against a budget of
-// 80 where this is 53, and At is what a reader that needs keys out of order
-// calls per key. [SortedKeys.All] reads the slab directly and never paid
-// either way; a binary search cannot use it.
+// Out-of-range panics via the compiler's generated bounds check rather than an
+// explicit one: naming the index and count here costs At its inlining — 271
+// against an 80 budget, versus 53 without — and At is called per key by
+// readers that need keys out of order. [SortedKeys.All] reads the slab
+// directly and pays neither cost.
 //
-// One index the generated check cannot refuse: any index into a list of zero
-// width, where i*0 slices to [0:0:0] and is legal against any slab. An unbuilt
-// SortedKeys would then answer every index with an empty key rather than
-// failing, so that one is refused here.
+// One case the generated check misses: a zero width, where i*0 legally slices
+// to [0:0:0] against any slab. Refused explicitly in the body, or an unbuilt
+// SortedKeys would answer every index with an empty key instead of panicking.
 //
-// One it cannot refuse and this does not either: an index near maxint, where
-// i*k.w wraps to a legal range and answers with the wrong key. No caller can
-// hold one — Len bounds every index a reader derives — and guarding it slows
-// the width arm of [BenchmarkIterate], so it is stated rather than checked.
+// One case neither checks: an index near maxint can wrap i*k.w into a legal
+// range and return the wrong key. No caller holds one — Len bounds every
+// derived index — and guarding it slows [BenchmarkIterate]'s width arm, so
+// this is documented rather than enforced.
 func (k SortedKeys) At(i int) []byte {
 	if k.offs == nil {
 		if k.w <= 0 {
@@ -100,17 +86,15 @@ func (k SortedKeys) At(i int) []byte {
 	return k.slab[k.offs[i]:k.offs[i+1]:k.offs[i+1]]
 }
 
-// All iterates the keys in order, yielding each key's position and bytes, which
-// alias the slab.
+// All iterates the keys in order, yielding each key's position and bytes,
+// aliasing the slab.
 //
-// One func literal covers both layouts. With one per layout the compiler cannot
-// tell which iterator a caller received, so it cannot devirtualize the yield and
-// heap-allocates the caller's loop body instead.
+// One func literal covers both layouts: separate ones would keep the compiler
+// from devirtualizing the yield, heap-allocating the caller's loop body.
 //
-// The layout is branched on once, outside the loop, and the keys are sliced
-// here rather than through At, which would pay both the branch and a range
-// check per key to re-prove what the loop condition already guarantees.
-// BenchmarkIterate measures the two: 38us against 159us over 100,000 keys.
+// The layout is branched on once, outside the loop, and keys are sliced
+// directly rather than via At, which would add a branch and a redundant range
+// check per key. BenchmarkIterate: 38us vs 159us over 100,000 keys.
 func (k SortedKeys) All() iter.Seq2[int, []byte] {
 	return func(yield func(int, []byte) bool) {
 		if k.offs == nil {
@@ -143,32 +127,28 @@ func (k SortedKeys) isAscending() bool {
 	return true
 }
 
-// VarKeyBuilder fills a [SortedKeys] whose keys vary in length. Keys may be
-// appended in any order; because a key's offset then depends on the lengths
-// before it, ordering them means sorting a permutation and rebuilding the slab
-// in that order, both of which happen in [VarKeyBuilder.Build].
+// VarKeyBuilder fills a [SortedKeys] whose keys vary in length, appended in
+// any order; [VarKeyBuilder.Build] sorts them and rebuilds the slab to match.
 //
-// The builder a producer picks is what chooses the layout. Deciding it here
-// instead — watching the lengths appended — costs a per-key test that pushes
-// AppendString past Go's inlining budget.
+// The layout isn't chosen by watching appended lengths here — that per-key
+// test would push AppendString past Go's inlining budget.
 type VarKeyBuilder struct {
 	slab []byte
 	offs []uint32
-	// n counts the appends, duplicating len(offs)-1 so the two disagree exactly
-	// when the constructor was skipped. Build refuses that.
+	// n duplicates len(offs)-1, so the two disagree exactly when the
+	// constructor was skipped; Build refuses that.
 	n int
 }
 
-// NewVarKeyBuilder sizes both arrays up front so neither grows: a producer knows
-// its key count and total byte length before it starts. It panics on negative
-// arguments.
+// NewVarKeyBuilder sizes both arrays up front so neither grows, since a
+// producer knows its key count and total byte length before it starts. It
+// panics on negative arguments.
 //
-// totalBytes is the batch's total, not a per-key width — the opposite of the
-// neighbouring [NewFixedKeyBuilder], which the arguments cannot distinguish.
+// totalBytes is the batch total, not a per-key width — the reverse of
+// [NewFixedKeyBuilder]'s argument, and the compiler can't catch the swap.
 func NewVarKeyBuilder(numKeys, totalBytes int) *VarKeyBuilder {
-	// Refused here rather than left to make: a negative count sizes offs to
-	// numKeys+1 == 0 and hands back a builder that works while quietly growing,
-	// which is the one promise this constructor exists to make.
+	// A negative count would size offs to numKeys+1 == 0 and hand back a
+	// builder that quietly grows instead of staying pre-sized.
 	if numKeys < 0 || totalBytes < 0 {
 		panic(fmt.Errorf("%w: key count %d and total bytes %d must not be negative",
 			ErrInternal, numKeys, totalBytes))
@@ -188,42 +168,29 @@ func (b *VarKeyBuilder) AppendString(key string) {
 }
 
 // Build orders the keys, drops duplicates, and returns the finished list,
-// consuming the builder.
+// consuming the builder. Ordering happens here rather than in a separate Sort
+// call, so the invariant [SortedKeys] promises can't be skipped.
 //
-// Ordering here, rather than in a Sort the producer has to remember to call,
-// leaves no way to skip the invariant [SortedKeys] is named for. Dropping
-// duplicates is then a linear pass over the same comparisons — see [dedupFixed]
-// and [dedupVariable] — so the list can be shorter than the appends that filled
-// it, and a caller needing its own count must not take this one for it.
+// The result can be shorter than the number of appends — duplicates are
+// dropped (see [dedupFixed], [dedupVariable]) — so a caller needing its own
+// count must not substitute this one. Keys that share a width come back
+// without offsets; the sort already scans for that, so it costs nothing extra.
 //
-// Keys that share a width come back in the layout carrying no offsets. The sort
-// scans them to choose its method regardless, so the layout costs nothing to
-// learn and saves four bytes per key for the query's lifetime.
-//
-// Scratch is sized to the batch. Its rebuilt slab and offsets become the
-// returned list; the rest dies with the sort. Pooling measured no faster at any
-// batch size and would hold a large batch's buffers for the process's lifetime.
+// Scratch isn't pooled: measured no faster at any batch size, and pooling
+// would hold a large batch's buffers for the process's lifetime.
 func (b *VarKeyBuilder) Build() (SortedKeys, error) {
 	// offs carries a leading zero, so a filled builder holds one more offset
-	// than keys. Without it every key reads a position over and the last is
-	// lost, narrowing a filter result with nothing to report it. Reachable from
-	// outside the package: an empty composite literal needs no exported field.
+	// than keys; a mismatch means the constructor was skipped (reachable via
+	// an exported zero-value composite literal).
 	if len(b.offs) != b.n+1 {
 		return SortedKeys{}, fmt.Errorf("%w: VarKeyBuilder holds %d keys against %d "+
 			"offsets; NewVarKeyBuilder was not used", ErrInternal, b.n, len(b.offs))
 	}
-	// Offsets are uint32 and AppendString cannot afford a bound per key, but
-	// len(slab) is still an honest int here, so the ceiling is checked once
-	// after the fact. Past it the offsets have wrapped and stopped ascending,
-	// which reads as wrong keys rather than as a failure.
-	// Deliberately not an [ErrInternal]: a batch this large is what the filter
-	// asked for, not this package being wrong, and an operator reading it as an
-	// internal fault would look in the wrong place. Not covered by any test —
-	// reaching it needs 4GiB of keys in one filter — and unreachable for the
-	// only production caller, which bounds the same total through
-	// [tokenizer.AnalyzedBatch.SingleTokenBytes] before sizing this builder —
-	// AnalyzeBatch bounds the token count, which is a different quantity. It is
-	// kept because the builder is exported and the next producer may not.
+	// Checked once here rather than per key: offsets are uint32 and
+	// AppendString can't afford a bound per append, but len(slab) is still an
+	// honest int after the fact. Not an [ErrInternal] — a batch this large is
+	// what the caller asked for — and kept despite being unreachable for the
+	// current production caller, since the builder is exported.
 	if uint64(len(b.slab)) > math.MaxUint32 {
 		return SortedKeys{}, fmt.Errorf("inverted: batch holds %d bytes of keys, "+
 			"above the uint32 offset ceiling of %d", len(b.slab), uint32(math.MaxUint32))
@@ -256,16 +223,13 @@ type FixedKeyBuilder struct {
 	w    int
 }
 
-// NewFixedKeyBuilder sizes the slab for numKeys keys of keyWidth bytes each. It
-// panics on arguments it cannot build from.
+// NewFixedKeyBuilder sizes the slab for numKeys keys of keyWidth bytes each,
+// and panics on invalid arguments.
 //
-// keyWidth is the width of one key, not the batch's total — the neighbouring
-// [NewVarKeyBuilder] takes a total, and the two are otherwise identical in
-// shape. Passing a total here is accepted by the compiler and produces keys of
-// the wrong width that sort and dedup normally, so it is refused at the point
-// the mistake is made: a width past the widest key any family encodes is
-// rejected here rather than diagnosed inside an encoder writing into a buffer
-// of the wrong size.
+// keyWidth is one key's width, not the batch total — the reverse of
+// [NewVarKeyBuilder]'s argument, and the compiler can't catch the swap. A
+// width above the widest key any family encodes is rejected here, before it
+// silently produces wrong-width keys that would sort and dedup normally.
 func NewFixedKeyBuilder(numKeys, keyWidth int) *FixedKeyBuilder {
 	if keyWidth <= 0 || keyWidth > maxKeyWidth {
 		panic(fmt.Errorf("%w: key width %d is not in 1..%d; NewFixedKeyBuilder "+
@@ -278,28 +242,22 @@ func NewFixedKeyBuilder(numKeys, keyWidth int) *FixedKeyBuilder {
 	return &FixedKeyBuilder{slab: make([]byte, 0, numKeys*keyWidth), w: keyWidth}
 }
 
-// maxKeyWidth is the widest key any fixed-width family encodes — a uuid, at 16.
-// Bounding the width here is what makes a batch total passed as a width fail at
-// the call rather than silently produce keys of the wrong shape, and it is what
-// lets AppendBuf extend the slab from zeroKey without ever sizing a buffer.
+// maxKeyWidth is the widest key any fixed-width family encodes — a uuid, at
+// 16. It also lets AppendBuf extend the slab from zeroKey without sizing a
+// buffer.
 const maxKeyWidth = len(zeroKey)
 
-// AppendBuf appends a key and returns its bytes, zeroed, for the encoder to
-// write into — cheaper than encoding into a temporary and copying it in. The
-// returned slice is capped at its own end, so writing through it cannot reach
-// the next key.
+// AppendBuf appends a key and returns its zeroed bytes for the encoder to
+// write into directly. The slice is capped at its own end, so writing through
+// it cannot reach the next key.
 //
-// It is valid until the next append or Build, whichever comes first. The slab
-// is sized for the key count the constructor was given, so it does not grow in
-// practice; a buffer held across a growth would alias the old array and lose
-// what was written through it, and one held across Build would land on whatever
-// key the sort moved into that slot.
+// Valid only until the next append or Build: a buffer held across a slab
+// growth would alias the stale array, and one held across Build would land on
+// whatever key the sort moved into that slot.
 func (b *FixedKeyBuilder) AppendBuf() []byte {
-	// A zero width would hand back an empty buffer and leave the encoder to
-	// die writing into it, several frames from the mistake and with nothing
-	// but an index-out-of-range to go on. Build's guard cannot reach that: the
-	// encoder runs first. Panics rather than returning because there is no
-	// error to return through, and the width came from a constructor argument.
+	// A zero width would hand back an empty buffer and let the encoder die
+	// several frames away with an unhelpful index-out-of-range. Panics rather
+	// than returning an error since none can be returned through here.
 	if b.w <= 0 {
 		panic(fmt.Errorf("%w: FixedKeyBuilder has a key width of %d; "+
 			"NewFixedKeyBuilder was not used", ErrInternal, b.w))
@@ -322,25 +280,26 @@ const shrinkFloor = 4 << 10
 // shrinkKeys ends the slab at the last surviving key, and copies it onto its
 // own array when what is left behind is most of it.
 //
-// An aliased result is capped at that key so an index past it cannot reach the
-// dropped tail. A copied one may carry spare capacity, which append rounds up
-// to a size class — but those bytes are a fresh allocation, not the tail.
+// Both results are capped at that key: an aliased one so an index past it
+// cannot reach the dropped tail, a copied one because append rounds up to a
+// size class and At bounds against capacity, which would otherwise answer an
+// index past the last key with a zero one instead of panicking.
 //
 // Dedup can leave a handful of keys inside an allocation sized for the whole
-// batch — a boolean filter over 100,000 values keeps two — and the finished
-// list is held for as long as the query runs, so the dead tail is held with it.
-// Capping alone does not release it, and hides it: the returned slice reports
-// the small capacity while the whole array stays reachable. So the decision is
-// made from the array the keys came in, before it is capped.
+// batch — a boolean filter over 100,000 values keeps two — and the list is
+// held for the query's lifetime, keeping the dead tail alive with it. Capping
+// alone hides that rather than releasing it, so the copy decision is made from
+// the pre-cap array size.
 //
-// The ratio keeps a batch that dropped nothing from copying at all, and leaves
-// a worst case of three quarters wasted: a batch dedupping 100,000 keys to
-// 26,000 holds 800KB for 208KB of keys rather than pay the copy.
+// The ratio lets a batch that dropped nothing skip the copy, at a worst case
+// of three quarters wasted: dedupping 100,000 keys to 26,000 holds 800KB for
+// 208KB of live keys.
 func shrinkKeys(slab []byte, end int) []byte {
 	if cap(slab) < shrinkFloor || cap(slab) <= 4*end {
 		return slab[:end:end]
 	}
-	return append([]byte(nil), slab[:end]...)
+	out := append([]byte(nil), slab[:end]...)
+	return out[:end:end]
 }
 
 // shrinkOffs is shrinkKeys for the offsets, which are sized to the pre-dedup key
@@ -351,16 +310,16 @@ func shrinkOffs(offs []uint32, end int) []uint32 {
 	if 4*cap(offs) < shrinkFloor || cap(offs) <= 4*end {
 		return offs[:end:end]
 	}
-	return append([]uint32(nil), offs[:end]...)
+	out := append([]uint32(nil), offs[:end]...)
+	return out[:end:end]
 }
 
 // Build orders the keys in place, drops duplicates, and returns the finished
-// list, consuming the builder. Both happen here for the reasons given on
-// [VarKeyBuilder.Build].
+// list, consuming the builder — see [VarKeyBuilder.Build] for why.
 //
-// At one width key i sits at offset i*w, so ordering moves only the slab and
-// there are no offsets to reorder alongside it. That is also what lets these
-// keys be radix sorted rather than compared.
+// At one width, key i sits at offset i*w, so ordering moves only the slab and
+// there are no offsets to reorder alongside it — and what lets these keys be
+// radix sorted rather than compared.
 func (b *FixedKeyBuilder) Build() (SortedKeys, error) {
 	// A width is a constant of the family being encoded, so a non-positive one
 	// is a builder that skipped its constructor. Refused rather than returned as

--- a/entities/inverted/keys_sort.go
+++ b/entities/inverted/keys_sort.go
@@ -747,10 +747,13 @@ func sortVariableWidth(slab []byte, offs []uint32, n int, sc *sortScratch) ([]by
 // depth advances 8 bytes per level here rather than one, but key length still
 // comes from a filter value. The work stack is bounded the same way.
 //
-// What terminates it is the depth check, not the splitting. A level that
-// separates nothing still pushes the run 8 bytes deeper, and keys shorter than
-// that depth pack to zero forever, so the run ends in a comparison once the
-// depth passes its longest key.
+// What terminates it is the depth check, not the splitting: a level that
+// separates nothing still pushes the run 8 bytes deeper. The check is against
+// the run's shortest key, since packSuffix pads an ended key with zero exactly
+// as it packs a key still running through NULs — so past that depth no level
+// can separate them, while each one re-packs the whole run. A FIELD-tokenized
+// filter keeps NUL bytes verbatim, so waiting for the longest key instead lets
+// one long value hold a whole batch in the loop.
 func repairCollisions(slab []byte, offs []uint32, n, lcp int, sc *sortScratch) {
 	keys, idx := sc.keys, sc.idx
 	pending := appendTiedRuns(make([]keyRange, 0, 64), keys, 0, n, lcp+8)
@@ -760,7 +763,7 @@ func repairCollisions(slab []byte, offs []uint32, n, lcp int, sc *sortScratch) {
 		pending = pending[:len(pending)-1]
 
 		run := idx[r.off : r.off+r.n]
-		if r.n < repairRunCutoff || r.d >= longestKeyIn(offs, run) {
+		if r.n < repairRunCutoff || r.d >= shortestKeyIn(offs, run) {
 			sortRunByBytes(slab, offs, run, lcp)
 			continue
 		}
@@ -789,14 +792,16 @@ func appendTiedRuns(dst []keyRange, keys []uint64, off, n, d int) []keyRange {
 	return dst
 }
 
-func longestKeyIn(offs []uint32, run []uint32) int {
-	longest := 0
-	for _, e := range run {
-		if l := int(offs[e+1] - offs[e]); l > longest {
-			longest = l
+// shortestKeyIn is the length of the run's shortest key, which is the depth
+// past which the packing stops telling its keys apart. See repairCollisions.
+func shortestKeyIn(offs []uint32, run []uint32) int {
+	shortest := int(offs[run[0]+1] - offs[run[0]])
+	for _, e := range run[1:] {
+		if l := int(offs[e+1] - offs[e]); l < shortest {
+			shortest = l
 		}
 	}
-	return longest
+	return shortest
 }
 
 // sortRunByBytes is the terminal comparison, and it starts at the batch's

--- a/entities/inverted/keys_sort.go
+++ b/entities/inverted/keys_sort.go
@@ -16,6 +16,7 @@ import (
 	"cmp"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"slices"
 	"sort"
 )
@@ -579,6 +580,94 @@ func insertionSortFixed(slab []byte, w, d int, swap []byte) {
 			copy(b, swap)
 		}
 	}
+}
+
+// dedupFixed collapses runs of equal keys in a sorted fixed-width slab and
+// reports how many distinct keys remain.
+//
+// Duplicates are free to drop because every consumer treats the list as a set —
+// visiting a key twice changes nothing observable. What is not free is keeping
+// them: each duplicate is another key a lookup has to visit. Booleans are the
+// clearest case, with at most two distinct keys however many values arrive.
+//
+// The pass doubles as the only runtime check that the sort worked. It already
+// compares each key against the one before it, so asking for the sign rather
+// than for equality costs nothing and turns an out-of-order key — which no
+// consumer can detect, and which narrows a filter's result silently — into an
+// error the query can report.
+//
+// An inversion is returned rather than panicked because the condition depends
+// on the filter's values: a shape that reaches it would take the process down
+// on every replay of the query, where an error fails just that query.
+//
+// TestDedupRejectsAnInversion drives this by hand, since a correct sort never
+// produces one.
+func dedupFixed(slab []byte, w, n int) (int, error) {
+	if n < 2 {
+		return n, nil
+	}
+	out := 1
+	for i := 1; i < n; i++ {
+		cur := slab[i*w : i*w+w]
+		switch c := bytes.Compare(slab[(out-1)*w:out*w], cur); {
+		case c == 0:
+			continue
+		case c > 0:
+			return 0, fmt.Errorf("%w: key %d of %d sorts before its predecessor "+
+				"(%x after %x) in the %d-byte fixed-width branch",
+				ErrInternal, i, n, headOf(cur), headOf(slab[(out-1)*w:out*w]), w)
+		}
+		if out != i {
+			copy(slab[out*w:], cur)
+		}
+		out++
+	}
+	return out, nil
+}
+
+// headOf trims a key for an error message. The batch is gone by the time anyone
+// reads the log, so the two keys that disagreed are the only evidence of which
+// encoding broke.
+func headOf(key []byte) []byte {
+	const most = 16
+	if len(key) > most {
+		return key[:most]
+	}
+	return key
+}
+
+// dedupVariable is dedupFixed for keys of differing lengths, packing the
+// survivors back down the slab and rewriting their offsets as it goes.
+func dedupVariable(slab []byte, offs []uint32, n int) (int, error) {
+	if n < 2 {
+		return n, nil
+	}
+	out := 1
+	pos := offs[1]
+	for i := 1; i < n; i++ {
+		cur := slab[offs[i]:offs[i+1]]
+		prev := slab[offs[out-1]:pos]
+		switch c := bytes.Compare(prev, cur); {
+		case c == 0:
+			continue
+		case c > 0:
+			return 0, fmt.Errorf("%w: key %d of %d sorts before its predecessor "+
+				"(%x after %x) in the variable-width branch",
+				ErrInternal, i, n, headOf(cur), headOf(prev))
+		}
+		// Survivors only ever move towards the front of the slab, so the write
+		// cursor trails the key being read and cannot overwrite it. Skipped
+		// when nothing has been dropped yet, which is the whole batch when the
+		// filter had no duplicates.
+		if pos != offs[i] {
+			copy(slab[pos:], cur)
+		}
+		offs[out] = pos
+		pos += uint32(len(cur))
+		offs[out+1] = pos
+		out++
+	}
+	return out, nil
 }
 
 // countingSort1 is the boolean path: one pass to count, one to write back.

--- a/entities/inverted/keys_sort.go
+++ b/entities/inverted/keys_sort.go
@@ -1,0 +1,899 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"bytes"
+	"cmp"
+	"encoding/binary"
+	"errors"
+	"slices"
+	"sort"
+)
+
+// Ordering for [SortedKeys], reached only through the builders' Build methods.
+// The branches are in dispatchFixedWidth and sortVariableWidth; each one
+// documents the shape it covers.
+//
+// The branch is picked from key width and shared prefix, never from the
+// caller's type: the lexicographic encoders already make byte order equal value
+// order — it is why LexicographicallySortableFloat64 flips the sign bit — so
+// int, number, date, boolean, uuid and text keys all sort correctly by bytes.
+//
+// A shared prefix leaves fewer discriminating bytes, so it can move a batch to
+// a narrower branch: 14-byte ids need two words, the same ids under a 6-byte
+// shared prefix need one.
+
+// sortScratch holds one sort's working buffers, gathered so that what a sort
+// costs in memory can be read in one place. A scratch is made per sort and is
+// not pooled — see [VarKeyBuilder.Build] for why — so every buffer here is
+// allocated at most once and dies with the sort, except bytes and offs, which
+// the variable-width arm hands back for the caller to adopt as the finished
+// list.
+type sortScratch struct {
+	// keys and keysAlt are always the same length — the radix alternates
+	// between them — so they come from one allocation sliced in two rather
+	// than two of half the size.
+	keysBacking   []uint64
+	keys, keysAlt []uint64
+	hi, hiAlt     []uint64
+	idx, idxAlt   []uint32
+	bytes         []byte
+	offs          []uint32
+	// swapBuf holds a key-sized working buffer inline, sized to cover the cases
+	// that reach here without an allocation: fixed keys are at most 16 bytes,
+	// and uniform text keys are short in practice. A key longer than that is
+	// allocated on the heap by ensureSwap.
+	swapBuf [64]byte
+}
+
+// ensureKeys backs the packed keys. The radix alternates between two halves of
+// one allocation, so they are sliced from a single backing array.
+func (s *sortScratch) ensureKeys(n int) {
+	s.keysBacking = make([]uint64, 2*n)
+	s.keys = s.keysBacking[:n]
+	s.keysAlt = s.keysBacking[n : 2*n]
+}
+
+// ensureIdx backs the permutation alone. The comparison branch of the
+// variable-width arm sorts indices and reads nothing else, so it must not pay
+// for the packed keys or the second index array — the same reasoning ensureWide
+// applies one order of magnitude up.
+func (s *sortScratch) ensureIdx(n int) []uint32 {
+	s.idx = make([]uint32, n)
+	return s.idx
+}
+
+// ensureIndexed backs a radix that carries indices alongside the packed keys,
+// because the key it packed is not the whole key and cannot be written back on
+// its own.
+func (s *sortScratch) ensureIndexed(n int) {
+	s.ensureKeys(n)
+	s.ensureIdx(n)
+	s.idxAlt = make([]uint32, n)
+}
+
+// ensureWide adds the second key word, which only the 128-bit arm reads. It is
+// separate because the variable-width arm needs everything else here and none
+// of this: asking for it too would allocate 1.6MB on a 100,000-key filter and
+// never touch it, and that is per concurrent query.
+func (s *sortScratch) ensureWide(n int) {
+	s.ensureIndexed(n)
+	s.hi = make([]uint64, n)
+	s.hiAlt = make([]uint64, n)
+}
+
+func (s *sortScratch) ensureBytes(n int) []byte {
+	s.bytes = make([]byte, n)
+	return s.bytes
+}
+
+// ensureOffs backs the rebuilt offset array. Variable-width keys are permuted,
+// so new offsets cannot be written over the old ones: the loop still has to
+// read offs[e] for indices it has not reached yet.
+func (s *sortScratch) ensureOffs(n int) []uint32 {
+	s.offs = make([]uint32, n)
+	return s.offs
+}
+
+// ensureSwap hands out n bytes that do not alias the slab, which is what
+// americanFlagSort holds a whole key in while it swaps two of them.
+func (s *sortScratch) ensureSwap(n int) []byte {
+	if n <= len(s.swapBuf) {
+		return s.swapBuf[:n]
+	}
+	return make([]byte, n)
+}
+
+// radixCutoff is the batch size at which the packed arms hand over to a radix
+// pass, and it is set by the stack array those arms sort in rather than by
+// where the two cross: [radixCutoff]uint64 is 512 bytes, and the two-word arm
+// holds twice that.
+//
+// The handover is early: BenchmarkFixedArmsSmall measures the packed branch
+// still ahead of the radix pass at n=63, on both widths. Moving the boundary
+// out means a larger stack array or an allocation on a path whose whole point
+// is having neither, and being early costs under a microsecond.
+//
+// It is deliberately not tuned per machine. The crossover moves with the branch
+// predictor and the memory bandwidth, but a low gate stays cheap where a high
+// one would not: the comparison sort this replaced runs 8.4ms at n=65536 where
+// the radix pass runs 0.67ms.
+const radixCutoff = 64
+
+// wideRadixCutoff is where the two-word arm takes over, and it is much later
+// than radixCutoff because that arm pays for a second radix pass, an index
+// array and a permutation buffer — costs the one-word arm does not have.
+//
+// Between the two constants a two-word batch is sorted by comparison. That is
+// the band the packed arm cannot reach, its stack array being sized to
+// radixCutoff, and it is where BenchmarkFixedArmsLarge measures the radix pass
+// behind. Uuid filters of a few dozen to a few hundred ids sit in it.
+//
+// It is rounded rather than measured to a crossover, which moves between runs
+// and machines: repeated benchmarks put it anywhere from 160 to 200, so a
+// precise-looking number here would be noise fixed in place. Being off by a few
+// dozen keys costs a few percent — the two branches are within about 5% of each
+// other through that band, and only pull apart well past it.
+const wideRadixCutoff = 192
+
+// ErrInternal reports that a list could not be built because this package, or
+// its caller, is wrong — not because a filter value was.
+//
+// The distinction is the point. Everything else a builder rejects is a value
+// the user supplied, and both reach the API through the same return, so without
+// a sentinel a broken sort arrives looking like a malformed query. A searcher
+// can tell them apart and log an internal fault as one.
+//
+// These conditions are returned rather than panicked because they would
+// otherwise take the node down: the gRPC search path installs no recovery
+// interceptor, so a panic there ends the process, and a shape that reaches one
+// would do it again on every replay of the query. Failing the query loses less.
+var ErrInternal = errors.New("inverted: internal fault")
+
+// varRadixCutoff is where the variable-width branch hands over. It is later
+// than radixCutoff because that branch pays for more than the fixed ones do: a
+// permutation to carry, a prefix scan over offsets rather than a stride, and
+// the collision repair the packed word cannot separate.
+//
+// BenchmarkVariableArms measures the two against each other. At n=64 the
+// comparison sort is still 28% ahead and allocates a third as much; they meet
+// near here. Sharing radixCutoff sent everything from 64 up to the slower one.
+//
+// Written out rather than derived from radixCutoff: that constant is bounded by
+// the stack arrays the packed branches sort in, and this one is a measured
+// crossover. Tying them would move this whenever those arrays were resized,
+// with nothing measured behind the new value.
+const varRadixCutoff = 128
+
+// repairRunCutoff is the run size below which the collision repair stops
+// re-packing and compares instead. It shares a value with radixCutoff and
+// nothing else: a run is a stretch of an existing permutation rather than a
+// batch, so what makes a radix pass worth its histogram there is its own
+// question, unmeasured so far.
+const repairRunCutoff = radixCutoff
+
+// keyRange is a stretch of keys plus the byte depth at which they are still
+// equal. Both radix traversals that carry their own work stack use it — one
+// over records in a slab, one over indices into a permutation.
+type keyRange struct{ off, n, d int }
+
+// sortKeys orders a variable-width key list — slab plus n+1 ascending offsets —
+// and reports the width every key shares, or 0 if they differ.
+//
+// The returned slab and offsets need not be the ones passed in: keys of
+// differing lengths are rebuilt into fresh arrays, and handing those back lets
+// the caller adopt them instead of copying the batch back where it started.
+//
+// Uniform width is a property of the data rather than of the builder, and one
+// scan of the offsets says whether it holds — a fraction of the sort it
+// redirects, and nothing at all on the append path.
+func sortKeys(slab []byte, offs []uint32) ([]byte, []uint32, int) {
+	n := len(offs) - 1
+	w := uniformWidthOf(offs)
+	if n < 2 {
+		return slab, offs, w
+	}
+	// One scratch for whichever arm runs, so the uniform-width path does not
+	// build a second set of buffers it has no use for.
+	var sc sortScratch
+	if w > 0 {
+		dispatchFixedWidth(slab, w, &sc)
+		return slab, offs, w
+	}
+	slab, offs = sortVariableWidth(slab, offs, n, &sc)
+	return slab, offs, 0
+}
+
+// uniformWidthOf reports the width every key shares, or 0 if they differ.
+// offs[i] is cumulative, so uniform width w means offs[i] == i*w.
+func uniformWidthOf(offs []uint32) int {
+	if len(offs) < 2 {
+		return 0
+	}
+	w := offs[1] - offs[0]
+	if w == 0 {
+		return 0
+	}
+	for i := 1; i < len(offs); i++ {
+		if offs[i] != uint32(i)*w {
+			return 0
+		}
+	}
+	return int(w)
+}
+
+// sortFixedWidth orders a slab whose keys are all w bytes.
+func sortFixedWidth(slab []byte, w int) {
+	var sc sortScratch
+	dispatchFixedWidth(slab, w, &sc)
+}
+
+// dispatchFixedWidth is the shared body: sortKeys reaches it with a scratch it is
+// already holding for the variable-width arm.
+func dispatchFixedWidth(slab []byte, w int, sc *sortScratch) {
+	// w == 0 would divide by zero below. Both entry points refuse a
+	// non-positive width before reaching here — the builder in its constructor,
+	// sortKeys through uniformWidthOf — so this only orders the check ahead of
+	// the division it guards.
+	if w <= 0 {
+		return
+	}
+	n := len(slab) / w
+	if n < 2 {
+		return
+	}
+	if w == 1 {
+		countingSort1(slab)
+		return
+	}
+	// The prefix scan comes before the batch-size gate because it decides how a
+	// key is represented, where the gate only decides whether a radix pass can
+	// amortise. A key that fits a word packs into one whatever the batch size,
+	// and small batches are exactly where the fixed cost of not packing — a
+	// sort.Interface allocation and an indirect call per comparison and per
+	// swap — is largest relative to the work. The scan itself is O(n*w) and
+	// stops at the first key that shares nothing.
+	lcp := commonPrefixFixed(slab, w, n)
+	d := w - lcp
+	small := n < radixCutoff
+	switch {
+	case d <= 8 && small:
+		packedSmall(slab, w, lcp, n)
+	case d <= 8:
+		packedRadix(slab, w, lcp, n, sc)
+	case d <= 16 && small:
+		widePackedSmall(slab, w, lcp, n)
+	case d <= 16 && n < wideRadixCutoff:
+		sortSlabComparison(slab, w, n, sc.ensureSwap(w))
+	case d <= 16:
+		widePackedRadix(slab, w, lcp, n, sc)
+	case small:
+		sortSlabComparison(slab, w, n, sc.ensureSwap(w))
+	default:
+		americanFlagSort(slab, w, lcp, sc.ensureSwap(w))
+	}
+}
+
+// packedSmall orders a batch below the radix cutoff whose keys fit one word
+// after the shared prefix — every int, number and date filter, and any uuid or
+// text batch whose keys share enough of a prefix.
+//
+// The packed keys live in a stack array, so this allocates nothing where the
+// comparison fallback allocates twice, and it compares words directly where
+// that one calls through sort.Interface for every comparison and every swap.
+// As in packedRadix the packed value IS the key, so the sorted slab is written
+// back from it with nothing permuted alongside.
+func packedSmall(slab []byte, w, lcp, n int) {
+	var buf [radixCutoff]uint64
+	keys := buf[:n]
+	d := w - lcp
+	shiftUp := uint(8 * (8 - d))
+	for i := range keys {
+		keys[i] = loadBE(slab[i*w+lcp:], d) << shiftUp
+	}
+	slices.Sort(keys)
+	for i, v := range keys {
+		storeBE(slab[i*w+lcp:], v>>shiftUp, d)
+	}
+}
+
+// widePackedSmall is packedSmall for the keys that need two words — uuids, and
+// anything else up to 16 discriminating bytes. Comparing the pair high word
+// first is the same ordering the two stable radix passes of widePackedRadix produce.
+//
+// Between them the two cover every fixed-width family below radixCutoff.
+// sortSlabComparison still takes two-word keys in the band up to
+// wideRadixCutoff, which the stack array cannot reach, and keys wider than 16
+// discriminating bytes at any size.
+func widePackedSmall(slab []byte, w, lcp, n int) {
+	var buf [radixCutoff][2]uint64
+	keys := buf[:n]
+	lowBytes := w - lcp - 8
+	lowShift := uint(8 * (8 - lowBytes))
+	for i := range keys {
+		keys[i][0] = binary.BigEndian.Uint64(slab[i*w+lcp:])
+		keys[i][1] = loadBE(slab[i*w+lcp+8:], lowBytes) << lowShift
+	}
+	slices.SortFunc(keys, func(a, b [2]uint64) int {
+		if c := cmp.Compare(a[0], b[0]); c != 0 {
+			return c
+		}
+		return cmp.Compare(a[1], b[1])
+	})
+	for i, v := range keys {
+		binary.BigEndian.PutUint64(slab[i*w+lcp:], v[0])
+		storeBE(slab[i*w+lcp+8:], v[1]>>lowShift, lowBytes)
+	}
+}
+
+func commonPrefixFixed(slab []byte, w, n int) int {
+	lcp := w
+	first := slab[:w]
+	for i := 1; i < n && lcp > 0; i++ {
+		k := slab[i*w : i*w+w]
+		j := 0
+		for j < lcp && k[j] == first[j] {
+			j++
+		}
+		lcp = j
+	}
+	return lcp
+}
+
+// packedRadix applies when the bytes after the shared prefix fit in a word.
+// The packed value then holds the whole key, so the sorted slab is written
+// back from it — no index array, and no second slab to permute into.
+func packedRadix(slab []byte, w, lcp, n int, sc *sortScratch) {
+	sc.ensureKeys(n)
+	keys := sc.keys
+	d := w - lcp
+	shiftUp := uint(8 * (8 - d))
+	if d == 8 && lcp == 0 {
+		// Every int, number and date key. Worth its own arm: loadBE walks the
+		// key a byte at a time to stay correct at any width, and that loop
+		// costs more than the radix it feeds.
+		for i := 0; i < n; i++ {
+			keys[i] = binary.BigEndian.Uint64(slab[i*w:])
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			keys[i] = loadBE(slab[i*w+lcp:], d) << shiftUp
+		}
+	}
+	radixU64(keys, sc.keysAlt)
+
+	// Only the discriminating bytes are written back. The prefix is shared by
+	// every key by definition, so whatever key a slot ends up holding, the
+	// bytes already sitting in front of it are the ones it wants.
+	for i, v := range keys {
+		storeBE(slab[i*w+lcp:], v>>shiftUp, d)
+	}
+}
+
+// widePackedRadix handles uuid-shaped keys: too wide for one word, narrow enough for
+// two. The low word is sorted first so the high word's stable pass preserves
+// its ordering, which is what makes the pair a correct 128-bit sort.
+func widePackedRadix(slab []byte, w, lcp, n int, sc *sortScratch) {
+	sc.ensureWide(n)
+	hi, lo, idx := sc.hi, sc.keys, sc.idx
+	d := w - lcp
+	lowBytes := d - 8
+	lowShift := uint(8 * (8 - lowBytes))
+	for i := 0; i < n; i++ {
+		hi[i] = binary.BigEndian.Uint64(slab[i*w+lcp:])
+		lo[i] = loadBE(slab[i*w+lcp+8:], lowBytes) << lowShift
+		idx[i] = uint32(i)
+	}
+	radixU64Keyed(lo, sc.keysAlt, idx, sc.idxAlt)
+	for i, e := range idx {
+		sc.hiAlt[i] = hi[e]
+	}
+	copy(hi, sc.hiAlt)
+	radixU64Keyed(hi, sc.hiAlt, idx, sc.idxAlt)
+
+	permuteFixed(slab, w, idx, sc.ensureSwap(w))
+}
+
+// permuteFixed rearranges equal-width records so that record i ends up holding
+// what idx[i] pointed at, working inside the slab rather than through a second
+// copy of it.
+//
+// A permutation is a set of disjoint cycles, so following each one moves every
+// record exactly once and needs room for a single key. Permuting into a scratch
+// slab instead would allocate another len(slab) bytes — the largest buffer this
+// sort would hold — and pass over the batch twice.
+//
+// The trade is a dependent load chain, not write locality. A scratch slab is
+// filled by gathering: every source index is known up front, so those reads
+// overlap. A cycle instead finds its next address in idx at the address it just
+// visited, so each hop waits a full memory latency. Measured on uuid-shaped
+// keys, BenchmarkPermute has the cycle behind at every size: by a third to a
+// half from n=64 through n=2048, level within noise around n=4096, and 2.4x at
+// n=65536. So this is chosen for memory, not speed: it removes the
+// second slab, which is 16 of widePackedRadix's 56 bytes per key. What it costs
+// is a fifth of that branch at its largest size and a few percent at the sizes
+// a uuid filter actually reaches. Streaming stores would not close the gap;
+// fewer dependent loads would.
+//
+// idx must be a permutation of 0..n-1. Anything else — a repeat, an index
+// outside the range — leaves a cycle that never returns to its start, and this
+// loops forever where filling a scratch slab would have terminated with the
+// wrong answer. A hang in a query goroutine cannot be cancelled, so a future
+// caller must not hand it a partial or unvalidated ordering.
+//
+// idx is left as the identity, which is how each cycle marks what it has
+// already moved. Nothing reads it afterwards.
+func permuteFixed(slab []byte, w int, idx []uint32, tmp []byte) {
+	for i := range idx {
+		if int(idx[i]) == i {
+			continue
+		}
+		copy(tmp, slab[i*w:i*w+w])
+		j := i
+		for int(idx[j]) != i {
+			src := int(idx[j])
+			copy(slab[j*w:j*w+w], slab[src*w:src*w+w])
+			idx[j] = uint32(j)
+			j = src
+		}
+		copy(slab[j*w:j*w+w], tmp)
+		idx[j] = uint32(j)
+	}
+}
+
+// americanFlagSort orders equal-width keys with an in-place MSD radix. Once a
+// byte is bucketed elements never leave their bucket, so the permutation can be
+// cycled within the slab and needs no second copy of it — only the caller's
+// swap buffer and the ranges still to visit. d is where to start, letting a
+// caller that knows the shared prefix skip the levels that bucket every key
+// together.
+//
+// The traversal must stay iterative. Recursion carries three 256-entry arrays
+// per frame, about 6KB, at a depth equal to the key width — which comes from
+// a filter value, so a wide key exhausts the goroutine stack. That is fatal:
+// recover cannot catch it and the process dies.
+//
+// Pending ranges are bounded by the key count rather than the key width: each
+// is a disjoint subset holding at least two keys, so at most n/2 can wait.
+func americanFlagSort(slab []byte, w, d int, swap []byte) {
+	// Headroom in the allocation the initial range needs anyway, which also
+	// keeps it off the heap. Not sized to the n/2 bound, which the stack comes
+	// nowhere near — a wide 65,536-key batch peaks around 330 — and not to a
+	// level either, since one partition can push a range per bucket.
+	pending := make([]keyRange, 1, 64)
+	pending[0] = keyRange{off: 0, n: len(slab) / w, d: d}
+	var b bucketing
+	for len(pending) > 0 {
+		s := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+
+		// Advancing over bytes every key agrees on is a loop, not a call: this
+		// is the depth that must not become one frame per byte of key width.
+		for s.n >= 2 && s.d < w {
+			if s.n < msdInsertionCutoff {
+				insertionSortFixed(slab[s.off*w:(s.off+s.n)*w], w, s.d, swap)
+				break
+			}
+			if !b.partition(slab, w, s, swap) {
+				s.d++
+				continue
+			}
+			pending = b.appendSubRanges(pending, s)
+			break
+		}
+	}
+}
+
+// bucketing holds one level's histogram and cursors.
+//
+// count is shared: partition builds it and appendSubRanges reads it. head and
+// tail are partition's own, hoisted here only to keep 4KB off a per-range
+// frame — which is what recursion would have cost per level.
+type bucketing struct {
+	count      [256]int
+	head, tail [256]int
+}
+
+// partition groups the range by the byte at depth s.d, moving records within
+// the slab, and reports whether the byte separated anything. A byte every key
+// shares leaves the range untouched for the caller to retry one byte deeper.
+func (b *bucketing) partition(slab []byte, w int, s keyRange, swap []byte) bool {
+	clear(b.count[:])
+	for i := s.off; i < s.off+s.n; i++ {
+		b.count[slab[i*w+s.d]]++
+	}
+	if b.count[slab[s.off*w+s.d]] == s.n {
+		return false
+	}
+
+	sum := s.off
+	for v := 0; v < 256; v++ {
+		b.head[v] = sum
+		sum += b.count[v]
+		b.tail[v] = sum
+	}
+	// Records are cycled into place rather than copied out and back: once a
+	// byte is bucketed nothing leaves its bucket, so every record can be swapped
+	// directly to where it belongs.
+	for v := 0; v < 256; v++ {
+		for b.head[v] < b.tail[v] {
+			rec := slab[b.head[v]*w : b.head[v]*w+w]
+			target := rec[s.d]
+			if target == byte(v) {
+				b.head[v]++
+				continue
+			}
+			dst := slab[b.head[target]*w : b.head[target]*w+w]
+			copy(swap, rec)
+			copy(rec, dst)
+			copy(dst, swap)
+			b.head[target]++
+		}
+	}
+	return true
+}
+
+// appendSubRanges queues every bucket still holding more than one key, to be
+// separated one byte deeper.
+func (b *bucketing) appendSubRanges(pending []keyRange, s keyRange) []keyRange {
+	start := s.off
+	for v := 0; v < 256; v++ {
+		if b.count[v] > 1 {
+			pending = append(pending, keyRange{off: start, n: b.count[v], d: s.d + 1})
+		}
+		start += b.count[v]
+	}
+	return pending
+}
+
+// msdInsertionCutoff is where bucketing a range costs more than comparing it:
+// a pass builds a 256-entry histogram whatever the range holds.
+const msdInsertionCutoff = 24
+
+// insertionSortFixed orders a short range of equal-width keys, comparing from
+// depth d. swap holds one key while two exchange places: a key here is wide by
+// construction — this is only reached below americanFlagSort, which handles the
+// keys too wide to pack — so exchanging them a byte at a time costs several
+// times what one buffered copy does.
+func insertionSortFixed(slab []byte, w, d int, swap []byte) {
+	n := len(slab) / w
+	for i := 1; i < n; i++ {
+		for j := i; j > 0; j-- {
+			a := slab[j*w : j*w+w]
+			b := slab[(j-1)*w : (j-1)*w+w]
+			if bytes.Compare(a[d:], b[d:]) >= 0 {
+				break
+			}
+			copy(swap, a)
+			copy(a, b)
+			copy(b, swap)
+		}
+	}
+}
+
+// countingSort1 is the boolean path: one pass to count, one to write back.
+func countingSort1(slab []byte) {
+	var counts [256]int
+	for _, b := range slab {
+		counts[b]++
+	}
+	pos := 0
+	for v, c := range counts {
+		for ; c > 0; c-- {
+			slab[pos] = byte(v)
+			pos++
+		}
+	}
+}
+
+// sortVariableWidth is the general case: keys of differing lengths, so a key's
+// position is not its rank and both slab and offsets have to be rebuilt. The
+// rebuilt arrays are returned for the caller to adopt — copying them back over
+// the originals would move the whole batch twice for no one's benefit.
+//
+// The rebuild is unavoidable either way, so only the ordering itself is worth
+// gating, and it gates later than the fixed branches do — see varRadixCutoff.
+// BenchmarkVariableArms measures the two against each other at a shared size,
+// which is where that constant comes from.
+func sortVariableWidth(slab []byte, offs []uint32, n int, sc *sortScratch) ([]byte, []uint32) {
+	small := n < varRadixCutoff
+	var idx []uint32
+	if small {
+		idx = sc.ensureIdx(n)
+	} else {
+		sc.ensureIndexed(n)
+		idx = sc.idx
+	}
+	for i := 0; i < n; i++ {
+		idx[i] = uint32(i)
+	}
+	if small {
+		sortRunByBytes(slab, offs, idx, 0)
+	} else {
+		lcp := commonPrefixVariable(slab, offs, n)
+		keys := sc.keys
+		for i := 0; i < n; i++ {
+			keys[i] = packSuffix(slab[offs[i]:offs[i+1]], lcp)
+		}
+		radixU64Keyed(keys, sc.keysAlt, idx, sc.idxAlt)
+		repairCollisions(slab, offs, n, lcp, sc)
+	}
+
+	out := sc.ensureBytes(len(slab))
+	newOffs := sc.ensureOffs(n + 1)
+	pos := uint32(0)
+	for i, e := range idx {
+		k := slab[offs[e]:offs[e+1]]
+		copy(out[pos:], k)
+		newOffs[i] = pos
+		pos += uint32(len(k))
+	}
+	newOffs[n] = pos
+	return out, newOffs
+}
+
+// repairCollisions orders the keys the packed word could not separate.
+//
+// A key with more than 8 discriminating bytes packs to the same word as its
+// neighbours, and radix is stable, so such a run comes out in the order it went
+// in, which is not sorted. Without this pass the result is silently wrong for any keys
+// agreeing on their first 8 discriminating bytes.
+//
+// A run is repaired the way the whole batch was: re-pack it 8 bytes deeper and
+// radix again. Comparison is what this shape costs most on, since a run is by
+// definition keys sharing a long prefix, so every comparison re-walks bytes
+// already known equal.
+//
+// The traversal stays iterative for the reason given on [americanFlagSort];
+// depth advances 8 bytes per level here rather than one, but key length still
+// comes from a filter value. The work stack is bounded the same way.
+//
+// What terminates it is the depth check, not the splitting. A level that
+// separates nothing still pushes the run 8 bytes deeper, and keys shorter than
+// that depth pack to zero forever, so the run ends in a comparison once the
+// depth passes its longest key.
+func repairCollisions(slab []byte, offs []uint32, n, lcp int, sc *sortScratch) {
+	keys, idx := sc.keys, sc.idx
+	pending := appendTiedRuns(make([]keyRange, 0, 64), keys, 0, n, lcp+8)
+
+	for len(pending) > 0 {
+		r := pending[len(pending)-1]
+		pending = pending[:len(pending)-1]
+
+		run := idx[r.off : r.off+r.n]
+		if r.n < repairRunCutoff || r.d >= longestKeyIn(offs, run) {
+			sortRunByBytes(slab, offs, run, lcp)
+			continue
+		}
+		for i := r.off; i < r.off+r.n; i++ {
+			keys[i] = packSuffix(slab[offs[idx[i]]:offs[idx[i]+1]], r.d)
+		}
+		radixU64Keyed(keys[r.off:r.off+r.n], sc.keysAlt[r.off:r.off+r.n],
+			run, sc.idxAlt[r.off:r.off+r.n])
+		pending = appendTiedRuns(pending, keys, r.off, r.n, r.d+8)
+	}
+}
+
+// appendTiedRuns records every stretch of two or more keys the last pass left
+// tied, to be separated at depth d.
+func appendTiedRuns(dst []keyRange, keys []uint64, off, n, d int) []keyRange {
+	for i := off; i < off+n; {
+		j := i + 1
+		for j < off+n && keys[j] == keys[i] {
+			j++
+		}
+		if j-i > 1 {
+			dst = append(dst, keyRange{off: i, n: j - i, d: d})
+		}
+		i = j
+	}
+	return dst
+}
+
+func longestKeyIn(offs []uint32, run []uint32) int {
+	longest := 0
+	for _, e := range run {
+		if l := int(offs[e+1] - offs[e]); l > longest {
+			longest = l
+		}
+	}
+	return longest
+}
+
+// sortRunByBytes is the terminal comparison, and it starts at the batch's
+// shared prefix rather than at the run's own depth.
+//
+// Skipping the bytes the pack matched is not safe: packSuffix
+// pads a short key with zeros, so "ab" and "ab\x00" pack alike without agreeing
+// on 8 bytes. Comparing their tails past that point compares nothing against
+// nothing and reports them equal, which leaves them in input order. lcp is the
+// deepest offset every key is guaranteed to reach.
+func sortRunByBytes(slab []byte, offs []uint32, run []uint32, lcp int) {
+	slices.SortFunc(run, func(a, b uint32) int {
+		return bytes.Compare(slab[offs[a]+uint32(lcp):offs[a+1]],
+			slab[offs[b]+uint32(lcp):offs[b+1]])
+	})
+}
+
+func commonPrefixVariable(slab []byte, offs []uint32, n int) int {
+	first := slab[offs[0]:offs[1]]
+	lcp := len(first)
+	for i := 1; i < n && lcp > 0; i++ {
+		k := slab[offs[i]:offs[i+1]]
+		if len(k) < lcp {
+			lcp = len(k)
+		}
+		j := 0
+		for j < lcp && k[j] == first[j] {
+			j++
+		}
+		lcp = j
+	}
+	return lcp
+}
+
+// radixU64 is an LSD radix that skips passes whose byte every key agrees on.
+// Which passes those are comes from the OR and the AND of every key, folded in
+// one arithmetic pass with no memory traffic: a zero byte in (or ^ and) is a
+// byte all keys agree on. Narrow value ranges — small ints, dates in one era —
+// make that common rather than exceptional.
+//
+// Kept separate from radixU64Keyed rather than carrying a nil index: the
+// scatter loop below is the hot one, and a branch or a second indexed store in
+// it costs more than the duplicated body.
+func radixU64(a, scratch []uint64) {
+	// Both loops below index element 0, and varyingBytes reports every byte as
+	// varying for an empty slice. Callers are gated well above this today, but
+	// the gate is a tunable constant.
+	if len(a) < 2 {
+		return
+	}
+	varying := varyingBytes(a)
+	var counts [256]int
+	src, dst := a, scratch
+	for p := 0; p < 8; p++ {
+		shift := uint(8 * p)
+		if (varying>>shift)&0xff == 0 {
+			continue
+		}
+		clear(counts[:])
+		for _, v := range src {
+			counts[(v>>shift)&0xff]++
+		}
+		sum := 0
+		for i := range counts {
+			counts[i], sum = sum, sum+counts[i]
+		}
+		for _, v := range src {
+			b := (v >> shift) & 0xff
+			dst[counts[b]] = v
+			counts[b]++
+		}
+		src, dst = dst, src
+	}
+	if &src[0] != &a[0] {
+		copy(a, src)
+	}
+}
+
+// radixU64Keyed sorts keys while carrying idx alongside, stably.
+func radixU64Keyed(keys, keyScratch []uint64, idx, idxScratch []uint32) {
+	if len(keys) < 2 {
+		return
+	}
+	varying := varyingBytes(keys)
+	var counts [256]int
+	ks, kd, is, id := keys, keyScratch, idx, idxScratch
+	for p := 0; p < 8; p++ {
+		shift := uint(8 * p)
+		if (varying>>shift)&0xff == 0 {
+			continue
+		}
+		clear(counts[:])
+		for _, v := range ks {
+			counts[(v>>shift)&0xff]++
+		}
+		sum := 0
+		for i := range counts {
+			counts[i], sum = sum, sum+counts[i]
+		}
+		for i, v := range ks {
+			b := (v >> shift) & 0xff
+			kd[counts[b]], id[counts[b]] = v, is[i]
+			counts[b]++
+		}
+		ks, kd, is, id = kd, ks, id, is
+	}
+	if &ks[0] != &keys[0] {
+		copy(keys, ks)
+		copy(idx, is)
+	}
+}
+
+// varyingBytes returns a mask whose byte p is non-zero exactly when the keys
+// disagree somewhere in byte p.
+func varyingBytes(a []uint64) uint64 {
+	var or uint64
+	and := ^uint64(0)
+	for _, v := range a {
+		or |= v
+		and &= v
+	}
+	return or ^ and
+}
+
+// packSuffix folds up to 8 bytes after the shared prefix into a word,
+// big-endian so integer order matches byte order. Short keys pad with zero,
+// which is correct because a prefix sorts before any extension of it.
+func packSuffix(k []byte, lcp int) uint64 {
+	if lcp < len(k) {
+		k = k[lcp:]
+	} else {
+		k = nil
+	}
+	var v uint64
+	for i := 0; i < 8; i++ {
+		v <<= 8
+		if i < len(k) {
+			v |= uint64(k[i])
+		}
+	}
+	return v
+}
+
+func loadBE(b []byte, w int) uint64 {
+	var v uint64
+	for i := 0; i < w; i++ {
+		v = v<<8 | uint64(b[i])
+	}
+	return v
+}
+
+func storeBE(b []byte, v uint64, w int) {
+	for i := w - 1; i >= 0; i-- {
+		b[i] = byte(v)
+		v >>= 8
+	}
+}
+
+// fixedWidthKeys sorts a slab of equal-width keys in place through
+// sort.Interface, which costs a call per comparison and per swap. It is the
+// fallback for keys too wide to pack into words — see dispatchFixedWidth.
+type fixedWidthKeys struct {
+	slab    []byte
+	w, n    int
+	scratch []byte
+}
+
+func (f *fixedWidthKeys) Len() int { return f.n }
+
+func (f *fixedWidthKeys) Less(i, j int) bool {
+	return bytes.Compare(f.at(i), f.at(j)) < 0
+}
+
+func (f *fixedWidthKeys) Swap(i, j int) {
+	a, b := f.at(i), f.at(j)
+	copy(f.scratch, a)
+	copy(a, b)
+	copy(b, f.scratch)
+}
+
+func (f *fixedWidthKeys) at(i int) []byte { return f.slab[i*f.w : (i+1)*f.w] }
+
+// sortSlabComparison is the small-batch fallback: pdqsort through
+// sort.Interface, which costs a call per comparison and per swap. The swap
+// buffer comes from the caller's scratch rather than a fresh allocation, since
+// every call site is already holding one.
+func sortSlabComparison(slab []byte, w, n int, swap []byte) {
+	sort.Sort(&fixedWidthKeys{slab: slab, w: w, n: n, scratch: swap})
+}

--- a/entities/inverted/keys_sort.go
+++ b/entities/inverted/keys_sort.go
@@ -22,24 +22,20 @@ import (
 )
 
 // Ordering for [SortedKeys], reached only through the builders' Build methods.
-// The branches are in dispatchFixedWidth and sortVariableWidth; each one
-// documents the shape it covers.
+// dispatchFixedWidth and sortVariableWidth each document the shape they cover.
 //
 // The branch is picked from key width and shared prefix, never from the
-// caller's type: the lexicographic encoders already make byte order equal value
-// order — it is why LexicographicallySortableFloat64 flips the sign bit — so
-// int, number, date, boolean, uuid and text keys all sort correctly by bytes.
-//
-// A shared prefix leaves fewer discriminating bytes, so it can move a batch to
-// a narrower branch: 14-byte ids need two words, the same ids under a 6-byte
-// shared prefix need one.
+// caller's type: the lexicographic encoders already make byte order equal
+// value order — it is why LexicographicallySortableFloat64 flips the sign bit
+// — so int, number, date, boolean, uuid and text keys all sort correctly by
+// bytes. A shared prefix leaves fewer discriminating bytes, so it can move a
+// batch to a narrower branch: 14-byte ids need two words, the same ids under a
+// 6-byte shared prefix need one.
 
-// sortScratch holds one sort's working buffers, gathered so that what a sort
-// costs in memory can be read in one place. A scratch is made per sort and is
-// not pooled — see [VarKeyBuilder.Build] for why — so every buffer here is
-// allocated at most once and dies with the sort, except bytes and offs, which
-// the variable-width arm hands back for the caller to adopt as the finished
-// list.
+// sortScratch gathers one sort's working buffers, so what a sort costs in
+// memory can be read in one place. Made per sort, not pooled (see
+// [VarKeyBuilder.Build]); every buffer here dies with the sort except bytes
+// and offs, which the variable-width arm hands back as the finished list.
 type sortScratch struct {
 	// keys and keysAlt are always the same length — the radix alternates
 	// between them — so they come from one allocation sliced in two rather
@@ -50,11 +46,10 @@ type sortScratch struct {
 	idx, idxAlt   []uint32
 	bytes         []byte
 	offs          []uint32
-	// swapBuf holds a key-sized working buffer inline, sized to cover the cases
-	// that reach here without an allocation: fixed keys are at most 16 bytes,
-	// and uniform text keys are short in practice. A key longer than that is
-	// allocated on the heap by ensureSwap.
-	swapBuf [64]byte
+	// The key-sized buffer americanFlagSort swaps through is deliberately not
+	// a field here. It reaches sort.Interface, so handing out a pointer into
+	// this struct would move the whole struct to the heap on every path —
+	// including the packed arms, which never ask for one.
 }
 
 // ensureKeys backs the packed keys. The radix alternates between two halves of
@@ -65,10 +60,9 @@ func (s *sortScratch) ensureKeys(n int) {
 	s.keysAlt = s.keysBacking[n : 2*n]
 }
 
-// ensureIdx backs the permutation alone. The comparison branch of the
-// variable-width arm sorts indices and reads nothing else, so it must not pay
-// for the packed keys or the second index array — the same reasoning ensureWide
-// applies one order of magnitude up.
+// ensureIdx backs the permutation alone, for the comparison branch of the
+// variable-width arm, which sorts indices and must not pay for the packed
+// keys or the second index array.
 func (s *sortScratch) ensureIdx(n int) []uint32 {
 	s.idx = make([]uint32, n)
 	return s.idx
@@ -106,74 +100,58 @@ func (s *sortScratch) ensureOffs(n int) []uint32 {
 	return s.offs
 }
 
-// ensureSwap hands out n bytes that do not alias the slab, which is what
-// americanFlagSort holds a whole key in while it swaps two of them.
-func (s *sortScratch) ensureSwap(n int) []byte {
-	if n <= len(s.swapBuf) {
-		return s.swapBuf[:n]
-	}
-	return make([]byte, n)
-}
-
 // radixCutoff is the batch size at which the packed arms hand over to a radix
-// pass, and it is set by the stack array those arms sort in rather than by
-// where the two cross: [radixCutoff]uint64 is 512 bytes, and the two-word arm
-// holds twice that.
+// pass. Set by the stack array those arms sort in — [radixCutoff]uint64 is 512
+// bytes, the two-word arm holds twice that — rather than by the measured
+// crossover.
 //
-// The handover is early: BenchmarkFixedArmsSmall measures the packed branch
-// still ahead of the radix pass at n=63, on both widths. Moving the boundary
-// out means a larger stack array or an allocation on a path whose whole point
-// is having neither, and being early costs under a microsecond.
+// The handover is early: BenchmarkFixedArmsSmall still has the packed branch
+// ahead of the radix pass at n=63, on both widths, and being early costs under
+// a microsecond. Moving the boundary out would mean a larger stack array or an
+// allocation on a path whose whole point is having neither.
 //
-// It is deliberately not tuned per machine. The crossover moves with the branch
-// predictor and the memory bandwidth, but a low gate stays cheap where a high
-// one would not: the comparison sort this replaced runs 8.4ms at n=65536 where
+// Deliberately not tuned per machine: the crossover moves with the branch
+// predictor and memory bandwidth, but a low gate stays cheap where a high one
+// would not — the comparison sort this replaced runs 8.4ms at n=65536 where
 // the radix pass runs 0.67ms.
 const radixCutoff = 64
 
-// wideRadixCutoff is where the two-word arm takes over, and it is much later
-// than radixCutoff because that arm pays for a second radix pass, an index
-// array and a permutation buffer — costs the one-word arm does not have.
+// wideRadixCutoff is where the two-word arm takes over, much later than
+// radixCutoff because that arm pays for a second radix pass, an index array
+// and a permutation buffer.
 //
-// Between the two constants a two-word batch is sorted by comparison. That is
-// the band the packed arm cannot reach, its stack array being sized to
-// radixCutoff, and it is where BenchmarkFixedArmsLarge measures the radix pass
-// behind. Uuid filters of a few dozen to a few hundred ids sit in it.
+// Between the two constants a two-word batch is sorted by comparison instead
+// — the band the packed arm's radixCutoff-sized stack array can't reach, where
+// BenchmarkFixedArmsLarge measures the radix pass behind. Uuid filters of a
+// few dozen to a few hundred ids sit in it.
 //
-// It is rounded rather than measured to a crossover, which moves between runs
-// and machines: repeated benchmarks put it anywhere from 160 to 200, so a
-// precise-looking number here would be noise fixed in place. Being off by a few
-// dozen keys costs a few percent — the two branches are within about 5% of each
-// other through that band, and only pull apart well past it.
+// Rounded rather than measured to an exact crossover, which moves between runs
+// and machines — repeated benchmarks put it anywhere from 160 to 200. Being off
+// by a few dozen keys costs little: the two branches are within about 5% of
+// each other through that band, and only pull apart well past it.
 const wideRadixCutoff = 192
 
 // ErrInternal reports that a list could not be built because this package, or
-// its caller, is wrong — not because a filter value was.
+// its caller, is wrong — not because a filter value was. A builder's other
+// rejections and this one reach the API through the same return, so without a
+// sentinel a broken sort would look like a malformed query; a searcher can
+// tell them apart and log an internal fault as one.
 //
-// The distinction is the point. Everything else a builder rejects is a value
-// the user supplied, and both reach the API through the same return, so without
-// a sentinel a broken sort arrives looking like a malformed query. A searcher
-// can tell them apart and log an internal fault as one.
-//
-// These conditions are returned rather than panicked because they would
-// otherwise take the node down: the gRPC search path installs no recovery
-// interceptor, so a panic there ends the process, and a shape that reaches one
-// would do it again on every replay of the query. Failing the query loses less.
+// Returned rather than panicked: the gRPC search path installs no recovery
+// interceptor, so a panic here ends the process, and would do so again on
+// every replay of the query.
 var ErrInternal = errors.New("inverted: internal fault")
 
-// varRadixCutoff is where the variable-width branch hands over. It is later
-// than radixCutoff because that branch pays for more than the fixed ones do: a
-// permutation to carry, a prefix scan over offsets rather than a stride, and
-// the collision repair the packed word cannot separate.
+// varRadixCutoff is where the variable-width branch hands over, later than
+// radixCutoff because that branch also pays for a permutation, a prefix scan
+// over offsets, and collision repair for keys the packed word can't separate.
 //
-// BenchmarkVariableArms measures the two against each other. At n=64 the
-// comparison sort is still 28% ahead and allocates a third as much; they meet
-// near here. Sharing radixCutoff sent everything from 64 up to the slower one.
+// BenchmarkVariableArms: at n=64 the comparison sort is still 28% ahead and
+// allocates a third as much; the two meet near here.
 //
-// Written out rather than derived from radixCutoff: that constant is bounded by
-// the stack arrays the packed branches sort in, and this one is a measured
-// crossover. Tying them would move this whenever those arrays were resized,
-// with nothing measured behind the new value.
+// A separate constant rather than radixCutoff itself, since that one is
+// bounded by the packed branches' stack arrays, not by a measured crossover —
+// tying them would move this value with no benchmark behind the change.
 const varRadixCutoff = 128
 
 // repairRunCutoff is the run size below which the collision repair stops
@@ -191,13 +169,12 @@ type keyRange struct{ off, n, d int }
 // sortKeys orders a variable-width key list — slab plus n+1 ascending offsets —
 // and reports the width every key shares, or 0 if they differ.
 //
-// The returned slab and offsets need not be the ones passed in: keys of
-// differing lengths are rebuilt into fresh arrays, and handing those back lets
-// the caller adopt them instead of copying the batch back where it started.
+// The returned slab and offsets need not be the ones passed in: differing-
+// length keys are rebuilt into fresh arrays, which the caller adopts instead
+// of being copied back where they started.
 //
-// Uniform width is a property of the data rather than of the builder, and one
-// scan of the offsets says whether it holds — a fraction of the sort it
-// redirects, and nothing at all on the append path.
+// Uniform width is a property of the data, not the builder, so it's detected
+// with one scan of the offsets rather than tracked on the append path.
 func sortKeys(slab []byte, offs []uint32) ([]byte, []uint32, int) {
 	n := len(offs) - 1
 	w := uniformWidthOf(offs)
@@ -242,10 +219,8 @@ func sortFixedWidth(slab []byte, w int) {
 // dispatchFixedWidth is the shared body: sortKeys reaches it with a scratch it is
 // already holding for the variable-width arm.
 func dispatchFixedWidth(slab []byte, w int, sc *sortScratch) {
-	// w == 0 would divide by zero below. Both entry points refuse a
-	// non-positive width before reaching here — the builder in its constructor,
-	// sortKeys through uniformWidthOf — so this only orders the check ahead of
-	// the division it guards.
+	// w == 0 would divide by zero below; both entry points already refuse a
+	// non-positive width, so this is belt and suspenders.
 	if w <= 0 {
 		return
 	}
@@ -257,13 +232,11 @@ func dispatchFixedWidth(slab []byte, w int, sc *sortScratch) {
 		countingSort1(slab)
 		return
 	}
-	// The prefix scan comes before the batch-size gate because it decides how a
-	// key is represented, where the gate only decides whether a radix pass can
-	// amortise. A key that fits a word packs into one whatever the batch size,
-	// and small batches are exactly where the fixed cost of not packing — a
-	// sort.Interface allocation and an indirect call per comparison and per
-	// swap — is largest relative to the work. The scan itself is O(n*w) and
-	// stops at the first key that shares nothing.
+	// The prefix scan runs before the batch-size gate because it decides how a
+	// key is represented, not just whether a radix pass amortises: a key that
+	// fits a word packs into one whatever the batch size, and small batches are
+	// where the fixed cost of not packing — a sort.Interface allocation and an
+	// indirect call per comparison and swap — hurts most.
 	lcp := commonPrefixFixed(slab, w, n)
 	d := w - lcp
 	small := n < radixCutoff
@@ -275,13 +248,13 @@ func dispatchFixedWidth(slab []byte, w int, sc *sortScratch) {
 	case d <= 16 && small:
 		widePackedSmall(slab, w, lcp, n)
 	case d <= 16 && n < wideRadixCutoff:
-		sortSlabComparison(slab, w, n, sc.ensureSwap(w))
+		sortSlabComparison(slab, w, n, make([]byte, w))
 	case d <= 16:
 		widePackedRadix(slab, w, lcp, n, sc)
 	case small:
-		sortSlabComparison(slab, w, n, sc.ensureSwap(w))
+		sortSlabComparison(slab, w, n, make([]byte, w))
 	default:
-		americanFlagSort(slab, w, lcp, sc.ensureSwap(w))
+		americanFlagSort(slab, w, lcp, make([]byte, w))
 	}
 }
 
@@ -289,11 +262,10 @@ func dispatchFixedWidth(slab []byte, w int, sc *sortScratch) {
 // after the shared prefix — every int, number and date filter, and any uuid or
 // text batch whose keys share enough of a prefix.
 //
-// The packed keys live in a stack array, so this allocates nothing where the
-// comparison fallback allocates twice, and it compares words directly where
-// that one calls through sort.Interface for every comparison and every swap.
-// As in packedRadix the packed value IS the key, so the sorted slab is written
-// back from it with nothing permuted alongside.
+// The packed keys live in a stack array rather than the comparison fallback's
+// two allocations, and compare as words rather than through sort.Interface. As
+// in packedRadix, the packed value IS the key, so the slab is written back
+// from it directly.
 func packedSmall(slab []byte, w, lcp, n int) {
 	var buf [radixCutoff]uint64
 	keys := buf[:n]
@@ -309,13 +281,8 @@ func packedSmall(slab []byte, w, lcp, n int) {
 }
 
 // widePackedSmall is packedSmall for the keys that need two words — uuids, and
-// anything else up to 16 discriminating bytes. Comparing the pair high word
-// first is the same ordering the two stable radix passes of widePackedRadix produce.
-//
-// Between them the two cover every fixed-width family below radixCutoff.
-// sortSlabComparison still takes two-word keys in the band up to
-// wideRadixCutoff, which the stack array cannot reach, and keys wider than 16
-// discriminating bytes at any size.
+// anything else up to 16 discriminating bytes. Comparing high word first
+// matches the ordering widePackedRadix's two stable radix passes produce.
 func widePackedSmall(slab []byte, w, lcp, n int) {
 	var buf [radixCutoff][2]uint64
 	keys := buf[:n]
@@ -402,38 +369,25 @@ func widePackedRadix(slab []byte, w, lcp, n int, sc *sortScratch) {
 	copy(hi, sc.hiAlt)
 	radixU64Keyed(hi, sc.hiAlt, idx, sc.idxAlt)
 
-	permuteFixed(slab, w, idx, sc.ensureSwap(w))
+	permuteFixed(slab, w, idx, make([]byte, w))
 }
 
-// permuteFixed rearranges equal-width records so that record i ends up holding
-// what idx[i] pointed at, working inside the slab rather than through a second
-// copy of it.
+// permuteFixed rearranges equal-width records in place — record i ends up
+// holding what idx[i] pointed at — by following each cycle of the permutation,
+// which needs room for one key rather than a second copy of the slab.
 //
-// A permutation is a set of disjoint cycles, so following each one moves every
-// record exactly once and needs room for a single key. Permuting into a scratch
-// slab instead would allocate another len(slab) bytes — the largest buffer this
-// sort would hold — and pass over the batch twice.
+// Chosen for memory, not speed: it saves widePackedRadix's second slab (16 of
+// 56 bytes per key) at the cost of a dependent load chain in place of a
+// gather's overlapping reads. BenchmarkPermute, on uuid-shaped keys: the cycle
+// trails a scratch-slab gather by a third to a half up to n=2048, ties near
+// n=4096, and is 2.4x slower at n=65536 — a few percent at the sizes a uuid
+// filter actually reaches.
 //
-// The trade is a dependent load chain, not write locality. A scratch slab is
-// filled by gathering: every source index is known up front, so those reads
-// overlap. A cycle instead finds its next address in idx at the address it just
-// visited, so each hop waits a full memory latency. Measured on uuid-shaped
-// keys, BenchmarkPermute has the cycle behind at every size: by a third to a
-// half from n=64 through n=2048, level within noise around n=4096, and 2.4x at
-// n=65536. So this is chosen for memory, not speed: it removes the
-// second slab, which is 16 of widePackedRadix's 56 bytes per key. What it costs
-// is a fifth of that branch at its largest size and a few percent at the sizes
-// a uuid filter actually reaches. Streaming stores would not close the gap;
-// fewer dependent loads would.
-//
-// idx must be a permutation of 0..n-1. Anything else — a repeat, an index
-// outside the range — leaves a cycle that never returns to its start, and this
-// loops forever where filling a scratch slab would have terminated with the
-// wrong answer. A hang in a query goroutine cannot be cancelled, so a future
-// caller must not hand it a partial or unvalidated ordering.
-//
-// idx is left as the identity, which is how each cycle marks what it has
-// already moved. Nothing reads it afterwards.
+// idx must be a permutation of 0..n-1: a repeat or an out-of-range index
+// leaves a cycle that never returns to its start, hanging the goroutine
+// forever — uncancellable, unlike a wrong answer. idx is left as the identity
+// when done, which is how each cycle marks what it moved; nothing reads it
+// after.
 func permuteFixed(slab []byte, w int, idx []uint32, tmp []byte) {
 	for i := range idx {
 		if int(idx[i]) == i {
@@ -452,12 +406,12 @@ func permuteFixed(slab []byte, w int, idx []uint32, tmp []byte) {
 	}
 }
 
-// americanFlagSort orders equal-width keys with an in-place MSD radix. Once a
-// byte is bucketed elements never leave their bucket, so the permutation can be
-// cycled within the slab and needs no second copy of it — only the caller's
-// swap buffer and the ranges still to visit. d is where to start, letting a
-// caller that knows the shared prefix skip the levels that bucket every key
-// together.
+// americanFlagSort orders equal-width keys with an in-place most-significant-
+// digit radix: it buckets on the leading byte first. Once a byte is bucketed
+// elements never leave their bucket, so the permutation can be cycled within
+// the slab and needs no second copy of it — only the caller's swap buffer and
+// the ranges still to visit. d is where to start, letting a caller that knows
+// the shared prefix skip the levels that bucket every key together.
 //
 // The traversal must stay iterative. Recursion carries three 256-entry arrays
 // per frame, about 6KB, at a depth equal to the key width — which comes from
@@ -467,10 +421,8 @@ func permuteFixed(slab []byte, w int, idx []uint32, tmp []byte) {
 // Pending ranges are bounded by the key count rather than the key width: each
 // is a disjoint subset holding at least two keys, so at most n/2 can wait.
 func americanFlagSort(slab []byte, w, d int, swap []byte) {
-	// Headroom in the allocation the initial range needs anyway, which also
-	// keeps it off the heap. Not sized to the n/2 bound, which the stack comes
-	// nowhere near — a wide 65,536-key batch peaks around 330 — and not to a
-	// level either, since one partition can push a range per bucket.
+	// 64 keeps the initial allocation off the heap without reaching for the n/2
+	// bound: a wide 65,536-key batch peaks around 330 pending ranges in practice.
 	pending := make([]keyRange, 1, 64)
 	pending[0] = keyRange{off: 0, n: len(slab) / w, d: d}
 	var b bucketing
@@ -585,22 +537,12 @@ func insertionSortFixed(slab []byte, w, d int, swap []byte) {
 // dedupFixed collapses runs of equal keys in a sorted fixed-width slab and
 // reports how many distinct keys remain.
 //
-// Duplicates are free to drop because every consumer treats the list as a set —
-// visiting a key twice changes nothing observable. What is not free is keeping
-// them: each duplicate is another key a lookup has to visit. Booleans are the
-// clearest case, with at most two distinct keys however many values arrive.
+// The pass also re-validates the sort for free: it already compares each key
+// to its predecessor, so checking the sign catches an out-of-order key that no
+// consumer could otherwise detect. Returned as an error rather than panicked,
+// since a panic here would kill the process on every replay of the query.
 //
-// The pass doubles as the only runtime check that the sort worked. It already
-// compares each key against the one before it, so asking for the sign rather
-// than for equality costs nothing and turns an out-of-order key — which no
-// consumer can detect, and which narrows a filter's result silently — into an
-// error the query can report.
-//
-// An inversion is returned rather than panicked because the condition depends
-// on the filter's values: a shape that reaches it would take the process down
-// on every replay of the query, where an error fails just that query.
-//
-// TestDedupRejectsAnInversion drives this by hand, since a correct sort never
+// TestDedupRejectsAnInversion drives this by hand; a correct sort never
 // produces one.
 func dedupFixed(slab []byte, w, n int) (int, error) {
 	if n < 2 {
@@ -655,10 +597,8 @@ func dedupVariable(slab []byte, offs []uint32, n int) (int, error) {
 				"(%x after %x) in the variable-width branch",
 				ErrInternal, i, n, headOf(cur), headOf(prev))
 		}
-		// Survivors only ever move towards the front of the slab, so the write
-		// cursor trails the key being read and cannot overwrite it. Skipped
-		// when nothing has been dropped yet, which is the whole batch when the
-		// filter had no duplicates.
+		// The write cursor trails the read position, so this cannot overwrite a
+		// key not yet read; skipped while nothing has been dropped yet.
 		if pos != offs[i] {
 			copy(slab[pos:], cur)
 		}
@@ -686,14 +626,12 @@ func countingSort1(slab []byte) {
 }
 
 // sortVariableWidth is the general case: keys of differing lengths, so a key's
-// position is not its rank and both slab and offsets have to be rebuilt. The
-// rebuilt arrays are returned for the caller to adopt — copying them back over
-// the originals would move the whole batch twice for no one's benefit.
+// position isn't its rank and both slab and offsets must be rebuilt. The
+// rebuilt arrays are returned for the caller to adopt, rather than copied back
+// over the originals.
 //
-// The rebuild is unavoidable either way, so only the ordering itself is worth
-// gating, and it gates later than the fixed branches do — see varRadixCutoff.
-// BenchmarkVariableArms measures the two against each other at a shared size,
-// which is where that constant comes from.
+// The rebuild is unavoidable either way, so only the ordering is worth gating
+// — see varRadixCutoff.
 func sortVariableWidth(slab []byte, offs []uint32, n int, sc *sortScratch) ([]byte, []uint32) {
 	small := n < varRadixCutoff
 	var idx []uint32
@@ -734,26 +672,20 @@ func sortVariableWidth(slab []byte, offs []uint32, n int, sc *sortScratch) ([]by
 // repairCollisions orders the keys the packed word could not separate.
 //
 // A key with more than 8 discriminating bytes packs to the same word as its
-// neighbours, and radix is stable, so such a run comes out in the order it went
-// in, which is not sorted. Without this pass the result is silently wrong for any keys
-// agreeing on their first 8 discriminating bytes.
+// neighbours; since radix is stable, such a run comes out in input order,
+// which is silently wrong unless repaired here — re-packed 8 bytes deeper and
+// radixed again, since a comparison sort would re-walk their shared prefix on
+// every call.
 //
-// A run is repaired the way the whole batch was: re-pack it 8 bytes deeper and
-// radix again. Comparison is what this shape costs most on, since a run is by
-// definition keys sharing a long prefix, so every comparison re-walks bytes
-// already known equal.
+// Stays iterative for the reason given on [americanFlagSort], advancing 8
+// bytes per level instead of one.
 //
-// The traversal stays iterative for the reason given on [americanFlagSort];
-// depth advances 8 bytes per level here rather than one, but key length still
-// comes from a filter value. The work stack is bounded the same way.
-//
-// What terminates it is the depth check, not the splitting: a level that
-// separates nothing still pushes the run 8 bytes deeper. The check is against
-// the run's shortest key, since packSuffix pads an ended key with zero exactly
-// as it packs a key still running through NULs — so past that depth no level
-// can separate them, while each one re-packs the whole run. A FIELD-tokenized
-// filter keeps NUL bytes verbatim, so waiting for the longest key instead lets
-// one long value hold a whole batch in the loop.
+// Terminates on the run's shortest key, not on whether a level separates
+// anything: packSuffix pads an ended key with zero exactly as it pads a
+// still-running one, so past that depth no level can tell them apart. Gating
+// on the longest key instead would let one long value hold the whole batch in
+// the loop, since FIELD tokenization keeps NUL bytes verbatim and so cannot be
+// used to detect where a shorter key ended.
 func repairCollisions(slab []byte, offs []uint32, n, lcp int, sc *sortScratch) {
 	keys, idx := sc.keys, sc.idx
 	pending := appendTiedRuns(make([]keyRange, 0, 64), keys, 0, n, lcp+8)
@@ -804,14 +736,10 @@ func shortestKeyIn(offs []uint32, run []uint32) int {
 	return shortest
 }
 
-// sortRunByBytes is the terminal comparison, and it starts at the batch's
-// shared prefix rather than at the run's own depth.
-//
-// Skipping the bytes the pack matched is not safe: packSuffix
-// pads a short key with zeros, so "ab" and "ab\x00" pack alike without agreeing
-// on 8 bytes. Comparing their tails past that point compares nothing against
-// nothing and reports them equal, which leaves them in input order. lcp is the
-// deepest offset every key is guaranteed to reach.
+// sortRunByBytes is the terminal comparison, starting at the batch's shared
+// prefix (lcp) rather than the run's own depth: packSuffix zero-pads short
+// keys, so "ab" and "ab\x00" pack alike without agreeing on 8 real bytes, and
+// comparing only past that point would report them equal.
 func sortRunByBytes(slab []byte, offs []uint32, run []uint32, lcp int) {
 	slices.SortFunc(run, func(a, b uint32) int {
 		return bytes.Compare(slab[offs[a]+uint32(lcp):offs[a+1]],
@@ -836,19 +764,19 @@ func commonPrefixVariable(slab []byte, offs []uint32, n int) int {
 	return lcp
 }
 
-// radixU64 is an LSD radix that skips passes whose byte every key agrees on.
-// Which passes those are comes from the OR and the AND of every key, folded in
-// one arithmetic pass with no memory traffic: a zero byte in (or ^ and) is a
-// byte all keys agree on. Narrow value ranges — small ints, dates in one era —
-// make that common rather than exceptional.
+// radixU64 is a least-significant-digit radix — it passes over the trailing
+// byte first — and skips passes whose byte every key agrees on. Which passes
+// those are comes from the OR and the AND of every key, folded in one
+// arithmetic pass with no memory traffic: a zero byte in (or ^ and) is a byte
+// all keys agree on. Narrow value ranges — small ints, dates in one era — make
+// that common rather than exceptional.
 //
 // Kept separate from radixU64Keyed rather than carrying a nil index: the
 // scatter loop below is the hot one, and a branch or a second indexed store in
 // it costs more than the duplicated body.
 func radixU64(a, scratch []uint64) {
-	// Both loops below index element 0, and varyingBytes reports every byte as
-	// varying for an empty slice. Callers are gated well above this today, but
-	// the gate is a tunable constant.
+	// Guards element-0 indexing below; callers are gated well above this today,
+	// but the gate is a tunable constant.
 	if len(a) < 2 {
 		return
 	}

--- a/entities/inverted/keys_sort_bench_test.go
+++ b/entities/inverted/keys_sort_bench_test.go
@@ -1,0 +1,316 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+// benchArms runs one shape through every arm that can order it, so the numbers
+// the dispatch is built on can be re-derived rather than taken on trust.
+//
+// Each arm is handed a fresh copy of the same slab. The copy is inside the timed
+// region because an arm that sorts an already-sorted slab measures nothing, and
+// subtracting it would compare arms on different inputs.
+func benchArms(b *testing.B, src []byte, w int, arms map[string]func(slab []byte, n int)) {
+	n := len(src) / w
+	buf := make([]byte, len(src))
+	for name, arm := range arms {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				copy(buf, src)
+				arm(buf, n)
+			}
+		})
+	}
+}
+
+// BenchmarkFixedArmsSmall is the measurement radixCutoff rests on for batches
+// below it: the packed branches against both the branch the cutoff hands over
+// to and the sort.Interface fallback, which is still live for wider keys.
+//
+// All three run at the same sizes so the boundary can be read here rather than
+// across two benchmarks. The packed branches' stack array is sized to
+// radixCutoff, so this cannot run past it.
+func BenchmarkFixedArmsSmall(b *testing.B) {
+	for _, w := range []int{8, 16} {
+		for _, n := range []int{4, 8, 16, 32, 63} {
+			src := randomFixedSlab(b, n, w)
+			b.Run(fmt.Sprintf("w=%d/n=%d", w, n), func(b *testing.B) {
+				benchArms(b, src, w, map[string]func([]byte, int){
+					"packed": func(slab []byte, n int) {
+						if w <= 8 {
+							packedSmall(slab, w, 0, n)
+						} else {
+							widePackedSmall(slab, w, 0, n)
+						}
+					},
+					"radix": func(slab []byte, n int) {
+						var sc sortScratch
+						if w <= 8 {
+							packedRadix(slab, w, 0, n, &sc)
+						} else {
+							widePackedRadix(slab, w, 0, n, &sc)
+						}
+					},
+					"interface": func(slab []byte, n int) { sortSlabComparison(slab, w, n, make([]byte, w)) },
+				})
+			})
+		}
+	}
+}
+
+// BenchmarkFixedArmsLarge is the other half: the radix arms against the
+// comparison sort, across the sizes radixCutoff sits between. The comparison
+// arm is unbounded, so this can run well past the constant.
+func BenchmarkFixedArmsLarge(b *testing.B) {
+	for _, w := range []int{8, 16} {
+		for _, n := range []int{32, 64, 128, 256, 4096, 65536} {
+			src := randomFixedSlab(b, n, w)
+			b.Run(fmt.Sprintf("w=%d/n=%d", w, n), func(b *testing.B) {
+				benchArms(b, src, w, map[string]func([]byte, int){
+					"radix": func(slab []byte, n int) {
+						var sc sortScratch
+						if w <= 8 {
+							packedRadix(slab, w, 0, n, &sc)
+						} else {
+							widePackedRadix(slab, w, 0, n, &sc)
+						}
+					},
+					"interface": func(slab []byte, n int) { sortSlabComparison(slab, w, n, make([]byte, w)) },
+				})
+			})
+		}
+	}
+}
+
+// BenchmarkSortVariableWidth measures the arm that rebuilds slab and offsets,
+// across the cutoff its own dispatch uses.
+func BenchmarkSortVariableWidth(b *testing.B) {
+	rng := rand.New(rand.NewSource(9))
+	for _, n := range []int{8, 63, 64, 4096, 65536} {
+		keys := shapeKeys(n, func(i int) string {
+			return fmt.Sprintf("item_%d", rng.Intn(1<<40))
+		})
+		srcSlab, srcOffs := buildVar(keys)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			slab := make([]byte, len(srcSlab))
+			offs := make([]uint32, len(srcOffs))
+			for i := 0; i < b.N; i++ {
+				copy(slab, srcSlab)
+				copy(offs, srcOffs)
+				var sc sortScratch
+				sortVariableWidth(slab, offs, n, &sc)
+			}
+		})
+	}
+}
+
+// BenchmarkBuild is the end-to-end cost a query pays, per family shape: fill a
+// builder and take the finished list. Allocation counts here are what the
+// batched path adds to a filter.
+func BenchmarkBuild(b *testing.B) {
+	rng := rand.New(rand.NewSource(5))
+	for _, n := range []int{8, 64, 10_000, 100_000} {
+		for _, w := range []int{8, 16} {
+			src := randomFixedSlab(b, n, w)
+			b.Run(fmt.Sprintf("fixed/w=%d/n=%d", w, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					kb := NewFixedKeyBuilder(n, w)
+					for j := 0; j < n; j++ {
+						copy(kb.AppendBuf(), src[j*w:])
+					}
+					built, err := kb.Build()
+					if err != nil {
+						b.Fatal(err)
+					}
+					if built.Len() == 0 && n > 0 {
+						b.Fatal("empty")
+					}
+				}
+			})
+		}
+
+		for _, shape := range []struct {
+			name string
+			gen  func(i int) string
+		}{
+			{"uniform", func(i int) string { return fmt.Sprintf("%012d", rng.Intn(1_000_000_000_000)) }},
+			{"variable", func(i int) string { return fmt.Sprintf("item_%d", rng.Intn(1<<40)) }},
+		} {
+			keys := shapeKeys(n, shape.gen)
+			total := 0
+			for _, k := range keys {
+				total += len(k)
+			}
+			b.Run(fmt.Sprintf("text-%s/n=%d", shape.name, n), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					kb := NewVarKeyBuilder(n, total)
+					for _, k := range keys {
+						kb.AppendString(k)
+					}
+					built, err := kb.Build()
+					if err != nil {
+						b.Fatal(err)
+					}
+					if built.Len() == 0 && n > 0 {
+						b.Fatal("empty")
+					}
+				}
+			})
+		}
+	}
+}
+
+// permuteScratch is the permutation widePackedRadix used before permuteFixed:
+// gather into a second slab, then copy it back. Kept as the baseline the
+// in-place cycle is measured against, since the trade it makes — one array
+// instead of two, against a dependent load chain instead of independent reads —
+// is only readable as a comparison.
+func permuteScratch(slab []byte, w int, idx []uint32, out []byte) {
+	for i, e := range idx {
+		copy(out[i*w:], slab[int(e)*w:int(e)*w+w])
+	}
+	copy(slab, out)
+}
+
+// BenchmarkPermute measures the two ways of applying the sorted order to the
+// slab, which is what the paragraph on permuteFixed rests on.
+//
+// Both arms restore the slab and the permutation inside the timed region, since
+// each consumes both — permuteFixed leaves idx as the identity. That charges
+// roughly 15% of the gather arm and 5% of the cycle's at the largest size, so
+// the gap between them is wider than the raw figures show.
+func BenchmarkPermute(b *testing.B) {
+	const w = 16
+	rng := rand.New(rand.NewSource(3))
+	for _, n := range []int{64, 256, 2048, 4096, 65536} {
+		src := randomFixedSlab(b, n, w)
+		perm := make([]uint32, n)
+		for i, v := range rng.Perm(n) {
+			perm[i] = uint32(v)
+		}
+		b.Run(fmt.Sprintf("n=%d/cycle", n), func(b *testing.B) {
+			b.ReportAllocs()
+			slab, idx, tmp := make([]byte, len(src)), make([]uint32, n), make([]byte, w)
+			for i := 0; i < b.N; i++ {
+				copy(slab, src)
+				copy(idx, perm)
+				permuteFixed(slab, w, idx, tmp)
+			}
+		})
+		b.Run(fmt.Sprintf("n=%d/scratch", n), func(b *testing.B) {
+			b.ReportAllocs()
+			slab, idx, out := make([]byte, len(src)), make([]uint32, n), make([]byte, len(src))
+			for i := 0; i < b.N; i++ {
+				copy(slab, src)
+				copy(idx, perm)
+				permuteScratch(slab, w, idx, out)
+			}
+		})
+	}
+}
+
+// BenchmarkIterate measures walking the finished keys the way the fold does,
+// against the same walk driven by At. It is the number All's godoc quotes for
+// branching on the layout once rather than per key.
+func BenchmarkIterate(b *testing.B) {
+	const w = 12
+	for _, n := range []int{64, 100_000} {
+		slab := randomFixedSlab(b, n, w)
+		offs := make([]uint32, n+1)
+		for i := range offs {
+			offs[i] = uint32(i * w)
+		}
+		for name, keys := range map[string]SortedKeys{
+			"offsets": {slab: slab, offs: offs},
+			"width":   {slab: slab, w: w},
+		} {
+			b.Run(fmt.Sprintf("n=%d/%s/All", n, name), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					var total int
+					for _, k := range keys.All() {
+						total += len(k)
+					}
+					if total != n*w {
+						b.Fatal("bad")
+					}
+				}
+			})
+			b.Run(fmt.Sprintf("n=%d/%s/At", n, name), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					var total int
+					for j, end := 0, keys.Len(); j < end; j++ {
+						total += len(keys.At(j))
+					}
+					if total != n*w {
+						b.Fatal("bad")
+					}
+				}
+			})
+		}
+	}
+}
+
+// BenchmarkVariableArms measures the variable-width branches against each other
+// at a shared size, which sortVariableWidth's own benchmark cannot do — it runs
+// whichever branch the dispatch picks.
+func BenchmarkVariableArms(b *testing.B) {
+	rng := rand.New(rand.NewSource(9))
+	for _, n := range []int{2, 63, 64, 96, 128, 160, 256, 1024, 10_000} {
+		keys := shapeKeys(n, func(i int) string {
+			return fmt.Sprintf("item_%d", rng.Intn(1<<40))
+		})
+		srcSlab, srcOffs := buildVar(keys)
+		for name, arm := range map[string]func([]byte, []uint32, *sortScratch){
+			"comparison": func(slab []byte, offs []uint32, sc *sortScratch) {
+				idx := sc.ensureIdx(n)
+				for j := range idx {
+					idx[j] = uint32(j)
+				}
+				sortRunByBytes(slab, offs, idx, 0)
+			},
+			"radix": func(slab []byte, offs []uint32, sc *sortScratch) {
+				sc.ensureIndexed(n)
+				idx := sc.idx
+				for j := range idx {
+					idx[j] = uint32(j)
+				}
+				lcp := commonPrefixVariable(slab, offs, n)
+				for j := 0; j < n; j++ {
+					sc.keys[j] = packSuffix(slab[offs[j]:offs[j+1]], lcp)
+				}
+				radixU64Keyed(sc.keys, sc.keysAlt, idx, sc.idxAlt)
+				repairCollisions(slab, offs, n, lcp, sc)
+			},
+		} {
+			// Neither arm writes to the slab or the offsets — both order a
+			// permutation and read through it — so unlike benchArms there is
+			// nothing to reset between iterations.
+			b.Run(fmt.Sprintf("n=%d/%s", n, name), func(b *testing.B) {
+				b.ReportAllocs()
+				for i := 0; i < b.N; i++ {
+					var sc sortScratch
+					arm(srcSlab, srcOffs, &sc)
+				}
+			})
+		}
+	}
+}

--- a/entities/inverted/keys_sort_test.go
+++ b/entities/inverted/keys_sort_test.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -638,4 +639,53 @@ func TestCutoffsAreBracketed(t *testing.T) {
 		assert.Contains(t, matchesInterfaceSizes, cutoff, "no size at cutoff %d", cutoff)
 		assert.Contains(t, matchesInterfaceSizes, cutoff+1, "no size above cutoff %d", cutoff)
 	}
+}
+
+// Ended keys tied with one long all-NUL key must fall back to comparison, not
+// re-pack the run once per 8 bytes of that key.
+func TestRepairCollisionsEndedKeysFallBack(t *testing.T) {
+	t.Parallel()
+
+	// distinct, since every length differs, yet tied at every depth
+	const (
+		n       = 4_000
+		longKey = 16 << 20
+	)
+	values := make([]string, 0, n+1)
+	total := 0
+	for i := 1; i <= n; i++ {
+		values = append(values, strings.Repeat("\x00", i))
+		total += i
+	}
+	values = append(values, strings.Repeat("\x00", longKey))
+	total += longKey
+
+	b := NewVarKeyBuilder(len(values), total)
+	for _, v := range values {
+		b.AppendString(v)
+	}
+
+	done := make(chan SortedKeys, 1)
+	go func() {
+		keys, err := b.Build()
+		require.NoError(t, err)
+		done <- keys
+	}()
+
+	var keys SortedKeys
+	select {
+	case keys = <-done:
+	// two orders of magnitude above a run that falls back and below one that
+	// does not — both ends measured against this fixture
+	case <-time.After(10 * time.Second):
+		t.Fatal("Build did not finish: the repair is walking the longest key rather than falling back")
+	}
+
+	// and still a sort: each NUL string is a prefix of the next
+	require.Equal(t, len(values), keys.Len(), "no key may be dropped")
+	require.True(t, keys.isAscending())
+	for i := 0; i < n; i++ {
+		require.Equalf(t, i+1, len(keys.At(i)), "key %d", i)
+	}
+	require.Len(t, keys.At(n), longKey, "the long key sorts last, being every other key's extension")
 }

--- a/entities/inverted/keys_sort_test.go
+++ b/entities/inverted/keys_sort_test.go
@@ -516,6 +516,80 @@ func TestSortFixedWidthAllIdentical(t *testing.T) {
 	}
 }
 
+// TestDedupRejectsAnInversion covers the check that stands in for verifying the
+// sort.
+//
+// It is dead under the rest of the suite by construction — a correct sort never
+// produces an inversion — so the only way to show it fires, and names the pair
+// it found, is to hand it a slab the sort could not have produced. Without this
+// the branch could be deleted, or made to drop the smaller key silently, with
+// everything still green.
+func TestDedupRejectsAnInversion(t *testing.T) {
+	t.Run("fixed width", func(t *testing.T) {
+		tests := []struct {
+			name string
+			keys []string
+			want string
+		}{
+			{"adjacent pair swapped", []string{"bb", "aa"}, "key 1 of 2"},
+			{"inversion after a duplicate run", []string{"bb", "bb", "aa"}, "key 2 of 3"},
+			{"inversion in the middle", []string{"aa", "cc", "bb", "dd"}, "key 2 of 4"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				slab := []byte(strings.Join(tt.keys, ""))
+				n, err := dedupFixed(slab, 2, len(tt.keys))
+				require.ErrorIs(t, err, ErrInternal,
+					"a caller must be able to tell this from a bad filter value")
+				assert.Zero(t, n, "a rejected batch must not report a count")
+				assert.Contains(t, err.Error(), tt.want)
+				assert.Contains(t, err.Error(), "sorts before its predecessor")
+				assert.Contains(t, err.Error(), "2-byte fixed-width")
+			})
+		}
+
+		// The two keys that disagreed are the only evidence of which encoding
+		// broke, so the message must carry both.
+		_, err := dedupFixed([]byte("bbaa"), 2, 2)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "6161 after 6262")
+	})
+
+	t.Run("variable width", func(t *testing.T) {
+		tests := []struct {
+			name string
+			keys []string
+			want string
+		}{
+			{"adjacent pair swapped", []string{"bbb", "a"}, "key 1 of 2"},
+			{"a prefix sorting after its extension", []string{"abc", "ab"}, "key 1 of 2"},
+			{"inversion after a dropped duplicate", []string{"bb", "bb", "a"}, "key 2 of 3"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				slab, offs := buildVar(tt.keys)
+				n, err := dedupVariable(slab, offs, len(tt.keys))
+				require.ErrorIs(t, err, ErrInternal)
+				assert.Zero(t, n)
+				assert.Contains(t, err.Error(), tt.want)
+				assert.Contains(t, err.Error(), "variable-width branch")
+			})
+		}
+
+		_, err := dedupVariable(buildVarSlab(t, "bbb", "a"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "61 after 626262")
+	})
+}
+
+// buildVarSlab is buildVar plus the key count, shaped for dedupVariable's
+// signature.
+func buildVarSlab(tb testing.TB, keys ...string) ([]byte, []uint32, int) {
+	tb.Helper()
+	slab, offs := buildVar(keys)
+	return slab, offs, len(keys)
+}
+
 // TestSortFixedWidthWidthZeroWritesNothing covers d == 0, where every key is its
 // own shared prefix.
 //

--- a/entities/inverted/keys_sort_test.go
+++ b/entities/inverted/keys_sort_test.go
@@ -1,0 +1,567 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Keys here must be shuffled, never strided. An ascending fixture puts pdqsort
+// on its already-sorted fast path and reports a cost no production batch pays.
+
+// sortSlabInterface is the oracle every arm is checked against.
+//
+// It shares no code with production, which is the point: an oracle built on the
+// comparison sort would leave every case that dispatches to that branch —
+// d > 16 below the cutoff — asserting only that the branch agrees with itself.
+// Materializing the keys and sorting the slice is slower and obviously correct,
+// which is the trade an oracle wants.
+func sortSlabInterface(slab []byte, w int) {
+	n := len(slab) / w
+	if n < 2 {
+		return
+	}
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = bytes.Clone(slab[i*w : (i+1)*w])
+	}
+	slices.SortFunc(keys, bytes.Compare)
+	for i, k := range keys {
+		copy(slab[i*w:], k)
+	}
+}
+
+func randomFixedSlab(tb testing.TB, n, w int) []byte {
+	tb.Helper()
+	slab := make([]byte, n*w)
+	rng := rand.New(rand.NewSource(20260807))
+	for i := 0; i < n; i++ {
+		key := slab[i*w : (i+1)*w]
+		if w == 8 {
+			binary.BigEndian.PutUint64(key, rng.Uint64())
+			continue
+		}
+		for j := range key {
+			key[j] = byte(rng.Intn(256))
+		}
+	}
+	return slab
+}
+
+func narrowSlab(n, span int) []byte {
+	slab := make([]byte, n*8)
+	rng := rand.New(rand.NewSource(11))
+	for i := 0; i < n; i++ {
+		binary.BigEndian.PutUint64(slab[i*8:], uint64(rng.Intn(span)))
+	}
+	return slab
+}
+
+func shapeKeys(n int, f func(i int) string) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = f(i)
+	}
+	rng := rand.New(rand.NewSource(9))
+	rng.Shuffle(n, func(a, b int) { out[a], out[b] = out[b], out[a] })
+	return out
+}
+
+// fixedShapeKeys is shapeKeys for a fixture that claims one width, and fails if
+// the keys do not have it.
+//
+// %0Nd pads to a MINIMUM width, so a fixture written with it stops being
+// fixed-width the moment a value needs more digits. uniformWidthOf then routes
+// the case to sortVariableWidth, and it passes while exercising an arm other
+// than the one its name claims. Checking the width here is what keeps a case
+// honest about which arm it covers.
+func fixedShapeKeys(tb testing.TB, n, w int, f func(i int) string) []string {
+	tb.Helper()
+	keys := shapeKeys(n, f)
+	for _, k := range keys {
+		if len(k) != w {
+			tb.Fatalf("fixture claims %d-byte keys, got %q (%d bytes)", w, k, len(k))
+		}
+	}
+	return keys
+}
+
+// randHex draws n hex digits, every one of them significant — unlike %0Nx of an
+// integer, whose leading zeros become a shared prefix and shrink d.
+func randHex(rng *rand.Rand, n int) string {
+	const hex = "0123456789abcdef"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = hex[rng.Intn(16)]
+	}
+	return string(b)
+}
+
+func buildVar(keys []string) ([]byte, []uint32) {
+	offs := make([]uint32, len(keys)+1)
+	var slab []byte
+	for i, k := range keys {
+		slab = append(slab, k...)
+		offs[i+1] = uint32(len(slab))
+	}
+	return slab, offs
+}
+
+func keysOf(slab []byte, offs []uint32) []string {
+	out := make([]string, len(offs)-1)
+	for i := range out {
+		out[i] = string(slab[offs[i]:offs[i+1]])
+	}
+	return out
+}
+
+func requireSlabEqual(tb testing.TB, got, want []byte, w int) {
+	tb.Helper()
+	if bytes.Equal(got, want) {
+		return
+	}
+	for i := 0; i < len(want)/w; i++ {
+		g, e := got[i*w:(i+1)*w], want[i*w:(i+1)*w]
+		if !bytes.Equal(g, e) {
+			tb.Fatalf("slab differs at key %d: got %x want %x", i, g, e)
+		}
+	}
+	tb.Fatal("slabs differ")
+}
+
+// matchesInterfaceSizes straddles both cutoffs, so every arm is exercised on
+// each side of the constant that gates it. TestCutoffsAreBracketed pins that
+// it still does: a list that stops covering a cutoff keeps passing while
+// testing only one side of it.
+var matchesInterfaceSizes = []int{0, 1, 2, 3, 63, 64, 65, 127, 128, 129, 191, 192, 193, 255, 256, 10_000}
+
+// TestSortFixedWidthMatchesInterface checks every fixed-width arm against a
+// plain comparison sort over materialized keys.
+func TestSortFixedWidthMatchesInterface(t *testing.T) {
+	widths := []int{1, 8, 14, 16, 20}
+	// Sizes straddle radixCutoff so both the packed and radix arms are
+	// exercised. They must be updated with the constant: sizes that no longer
+	// bracket it still pass, while covering only one side.
+	sizes := matchesInterfaceSizes
+	for _, w := range widths {
+		for _, n := range sizes {
+			slab := randomFixedSlab(t, n, w)
+			want := bytes.Clone(slab)
+			sortSlabInterface(want, w)
+			got := bytes.Clone(slab)
+			sortFixedWidth(got, w)
+			requireSlabEqual(t, got, want, w)
+		}
+	}
+	// Narrow ranges drive radixU64's skip-constant-byte path; span 2 is the
+	// boolean-like extreme where all but one byte is constant.
+	for _, span := range []int{2, 1_000, 1_000_000} {
+		slab := narrowSlab(50_000, span)
+		want := bytes.Clone(slab)
+		sortSlabInterface(want, 8)
+		got := bytes.Clone(slab)
+		sortFixedWidth(got, 8)
+		requireSlabEqual(t, got, want, 8)
+	}
+}
+
+// TestSortKeysAcrossShapes walks the dispatch: shared prefix or not, narrow or
+// wide, fixed or variable length.
+func TestSortKeysAcrossShapes(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	shapes := []struct {
+		name string
+		keys []string
+	}{
+		// Each fixed case names the arm it is here for. d is the width minus
+		// the prefix every key shares, and it — not the width — picks the arm.
+		{ // d=8 -> packedRadix, with a prefix
+			"fixed 14B, 6-byte prefix",
+			fixedShapeKeys(t, 5000, 14, func(i int) string { return fmt.Sprintf("hotel_%08d", i) }),
+		},
+		{ // d=8 -> packedRadix, no prefix
+			"fixed 8B, no shared prefix",
+			fixedShapeKeys(t, 5000, 8, func(i int) string { return fmt.Sprintf("%08d", rng.Intn(99999999)) }),
+		},
+		{ // d=16 -> widePackedRadix, no prefix
+			"fixed 16B, uuid-shaped",
+			fixedShapeKeys(t, 5000, 16, func(i int) string { return fmt.Sprintf("%016x", rng.Int63()) }),
+		},
+		{ // d=12 -> widePackedRadix WITH a prefix, which nothing else reaches
+			"fixed 16B, 4-byte prefix",
+			fixedShapeKeys(t, 5000, 16, func(i int) string { return fmt.Sprintf("pre_%012x", rng.Int63n(1<<48)) }),
+		},
+		{ // d=19 -> americanFlagSort; %020d cannot fill 20 digits from an
+			// Int63, so every key shares the leading zero
+			"fixed 20B, one-byte prefix",
+			fixedShapeKeys(t, 5000, 20, func(i int) string { return fmt.Sprintf("%020d", rng.Int63()) }),
+		},
+		{ // d=20 -> americanFlagSort with a prefix worth skipping. The suffix
+			// is drawn byte by byte because %020x of an int63 can only fill 16
+			// digits and pads the rest, which drops d back to 16.
+			"fixed 27B, 7-byte prefix",
+			fixedShapeKeys(t, 5000, 27, func(i int) string { return "prefix_" + randHex(rng, 20) }),
+		},
+		{"variable length, shared prefix", shapeKeys(5000, func(i int) string { return fmt.Sprintf("item_%d", i) })},
+		{"variable length, no shared prefix", shapeKeys(5000, func(i int) string { return fmt.Sprintf("%c%d", rune('a'+i%26), i) })},
+		{"variable, one key prefixes another", []string{"ab", "abc", "a", "abcd", "zz"}},
+		{"all identical", shapeKeys(500, func(i int) string { return "same" })},
+		{"below the radix cutoff", shapeKeys(radixCutoff-1, func(i int) string { return fmt.Sprintf("k%04d", i) })},
+		{"at the radix cutoff", shapeKeys(radixCutoff, func(i int) string { return fmt.Sprintf("k%04d", i) })},
+		{"two keys", []string{"b", "a"}},
+	}
+	for _, sh := range shapes {
+		t.Run(sh.name, func(t *testing.T) {
+			want := slices.Clone(sh.keys)
+			slices.Sort(want)
+
+			slab, offs := buildVar(sh.keys)
+			slab, offs, _ = sortKeys(slab, offs)
+			got := keysOf(slab, offs)
+
+			if !slices.Equal(got, want) {
+				for i := range want {
+					if got[i] != want[i] {
+						t.Fatalf("first mismatch at %d: got %q want %q", i, got[i], want[i])
+					}
+				}
+				t.Fatal("mismatch")
+			}
+		})
+	}
+}
+
+// TestSortKeysCollisionRepair covers the keys the packed word cannot separate.
+//
+// The variable-width arm packs 8 bytes past the prefix EVERY key shares, so a
+// prefix shared by only a subset survives into the packed word and that subset
+// arrives from the stable radix in input order. These shapes all produce such a
+// run; a repair that no-ops, or that resumes comparing past the packed bytes,
+// returns them unsorted.
+func TestSortKeysCollisionRepair(t *testing.T) {
+	rng := rand.New(rand.NewSource(31))
+	// Keys must differ in length or uniformWidthOf diverts them to the fixed
+	// arm, which is not the code under test here.
+	repeatTo := func(keys []string, n int) []string {
+		out := make([]string, 0, n)
+		for len(out) < n {
+			out = append(out, keys...)
+		}
+		return out
+	}
+	cases := []struct {
+		name string
+		keys []string
+	}{
+		{"two prefix groups, shuffled", shapeKeys(5000, func(i int) string {
+			if i%2 == 0 {
+				return fmt.Sprintf("user_profile_settings_%d", i)
+			}
+			return fmt.Sprintf("user_profile_avatars_%d", i)
+		})},
+		{"group prefix outlives several packed words", shapeKeys(2000, func(i int) string {
+			return fmt.Sprintf("shared_%s_%d",
+				[]string{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab"}[i%2], i)
+		})},
+		{"many groups, few keys each", shapeKeys(5000, func(i int) string {
+			return fmt.Sprintf("g%03d_aaaaaaaa_%d", i%500, i)
+		})},
+		{"random, no group structure", shapeKeys(5000, func(i int) string {
+			return fmt.Sprintf("%08d_%d", rng.Intn(99999999), i)
+		})},
+		// packSuffix pads a short key with zeros, so these pack alike without
+		// agreeing on 8 bytes. A repair that resumes comparing past the packed
+		// word sees nil against nil, calls them equal, and leaves them as they
+		// came in.
+		{"zero padding against a short key", repeatTo(
+			[]string{"ab", "ab\x00", "ab\x00\x00", "a", "ab\x00b", "ab\x00a"}, 6)},
+		{"zero padding, run past the radix cutoff", repeatTo(
+			[]string{"ab", "ab\x00", "ab\x00\x00", "a", "ab\x00b", "ab\x00a"}, 4*radixCutoff)},
+		{"one key is a prefix of a long run", append(
+			shapeKeys(200, func(i int) string { return "pfx" + strings.Repeat("z", 40) }),
+			"pfx", "pfx"+strings.Repeat("z", 41))},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			want := slices.Clone(tc.keys)
+			slices.Sort(want)
+
+			slab, offs := buildVar(tc.keys)
+			slab, offs, _ = sortKeys(slab, offs)
+			got := keysOf(slab, offs)
+
+			// Checked before the per-key loop, which would otherwise ignore a
+			// rebuild that duplicated keys rather than dropping them.
+			require.Equal(t, len(want), len(got), "sortKeys must neither drop nor add keys")
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("first mismatch at %d: got %q want %q", i, got[i], want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestUniformWidthOf(t *testing.T) {
+	cases := []struct {
+		name string
+		offs []uint32
+		want int
+	}{
+		{"uniform 14", []uint32{0, 14, 28, 42}, 14},
+		{"varying", []uint32{0, 2, 5, 6}, 0},
+		{"empty keys", []uint32{0, 0, 0}, 0},
+		{"single key", []uint32{0, 7}, 7},
+		{"too short", []uint32{0}, 0},
+		{"uniform then not", []uint32{0, 4, 8, 11}, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := uniformWidthOf(tc.offs); got != tc.want {
+				t.Fatalf("uniformWidthOf(%v) = %d, want %d", tc.offs, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAmericanFlagSortDeepAgreement pins a stack overflow.
+//
+// The MSD arm advances one byte at a time whenever every key agrees on that
+// byte, and must do so iteratively. One frame per byte carries three 256-entry
+// arrays, about 6.2KB, so a key wide enough to hold a long agreement run would
+// exhaust the goroutine stack — a fatal error, not a panic: recover cannot
+// catch it and the process dies.
+//
+// It is reachable from a filter value. Only the text path produces keys wider
+// than 16 discriminating bytes, tokenizeField trims whitespace and passes the
+// value through as the key, and nothing caps its length.
+//
+// The shape: 64 keys (radixCutoff) of one width, all but one sharing byte 0,
+// the rest zero. The global prefix is empty so the dispatch picks this arm,
+// and the large bucket then agrees on every remaining byte.
+func TestAmericanFlagSortDeepAgreement(t *testing.T) {
+	for _, w := range []int{1_000, 20_000, 200_000} {
+		n := radixCutoff
+		slab := make([]byte, n*w)
+		for i := 0; i < n; i++ {
+			slab[i*w] = 'A'
+		}
+		slab[(n-1)*w] = 'B'
+
+		want := bytes.Clone(slab)
+		sortSlabInterface(want, w)
+		got := bytes.Clone(slab)
+		sortFixedWidth(got, w)
+		requireSlabEqual(t, got, want, w)
+	}
+}
+
+// prefixedSlab builds n keys of width w that all share their first lcp bytes,
+// drawing the rest from a three-symbol alphabet so ties, equal keys and runs the
+// pack cannot separate all occur.
+func prefixedSlab(rng *rand.Rand, n, w, lcp int) []byte {
+	prefix := make([]byte, lcp)
+	rng.Read(prefix)
+	slab := make([]byte, n*w)
+	for i := 0; i < n; i++ {
+		copy(slab[i*w:], prefix)
+		for j := lcp; j < w; j++ {
+			slab[i*w+j] = byte(rng.Intn(3))
+		}
+	}
+	return slab
+}
+
+// TestSortFixedWidthSharedPrefix covers every arm with a prefix each key shares.
+//
+// The random slabs the other tests use leave the shared prefix empty almost
+// always, so on their own they exercise each arm only at lcp == 0 — where the
+// pack has nothing to skip and the discriminating width is the whole key. A
+// prefix moves a batch to a different arm, and the small-batch arms in
+// particular are only reachable with one for widths above 8.
+func TestSortFixedWidthSharedPrefix(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	for _, w := range []int{2, 5, 8, 9, 12, 14, 16, 17, 20, 24} {
+		for _, lcp := range []int{0, 1, 3, 7, 8, 15} {
+			if lcp >= w {
+				continue
+			}
+			for _, n := range []int{0, 1, 2, 3, 5, 23, 24, 25, 63, 64, 65, 127, 128, 129, 191, 192, 193, 300} {
+				slab := prefixedSlab(rng, n, w, lcp)
+				want := bytes.Clone(slab)
+				sortSlabInterface(want, w)
+				got := bytes.Clone(slab)
+				sortFixedWidth(got, w)
+				if !bytes.Equal(got, want) {
+					t.Fatalf("w=%d lcp=%d n=%d: got %x want %x", w, lcp, n, got, want)
+				}
+			}
+		}
+	}
+}
+
+// TestCountingSort1 covers the boolean arm directly. It is the one arm that
+// compares nothing, so an error in it cannot show up as a mis-ordered
+// comparison — only as the wrong number of each value.
+func TestCountingSort1(t *testing.T) {
+	tests := []struct {
+		name string
+		slab []byte
+	}{
+		{"empty", nil},
+		{"one", []byte{7}},
+		{"already ordered", []byte{0, 1}},
+		{"reversed", []byte{1, 0}},
+		{"booleans as encoded", []byte{1, 0, 1, 1, 0}},
+		{"every byte value", func() []byte {
+			s := make([]byte, 256)
+			for i := range s {
+				s[i] = byte(255 - i)
+			}
+			return s
+		}()},
+		{"all equal", bytes.Repeat([]byte{42}, 100)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want := bytes.Clone(tt.slab)
+			slices.Sort(want)
+			got := bytes.Clone(tt.slab)
+			countingSort1(got)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+// TestInsertionSortFixed covers the arm americanFlagSort drops into for short
+// ranges, including that it starts comparing at d rather than at the key start.
+func TestInsertionSortFixed(t *testing.T) {
+	const w = 4
+	tests := []struct {
+		name string
+		keys []string
+		d    int
+		want []string
+	}{
+		{"empty", nil, 0, nil},
+		{"one key", []string{"abcd"}, 0, []string{"abcd"}},
+		{
+			"reversed",
+			[]string{"dddd", "cccc", "bbbb", "aaaa"},
+			0,
+			[]string{"aaaa", "bbbb", "cccc", "dddd"},
+		},
+		{
+			"equal keys hold",
+			[]string{"bbbb", "aaaa", "bbbb"},
+			0,
+			[]string{"aaaa", "bbbb", "bbbb"},
+		},
+		{
+			"ordered from d, not from 0",
+			[]string{"zzab", "aazz"},
+			2,
+			[]string{"zzab", "aazz"},
+		},
+		{
+			"depth equal to width leaves order alone",
+			[]string{"bbbb", "aaaa"},
+			w,
+			[]string{"bbbb", "aaaa"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slab := []byte(strings.Join(tt.keys, ""))
+			insertionSortFixed(slab, w, tt.d, make([]byte, w))
+			assert.Equal(t, strings.Join(tt.want, ""), string(slab))
+		})
+	}
+}
+
+// TestSortFixedWidthAllIdentical pins d == 0, where every key is its own shared
+// prefix so the pack shifts by 64 and Go's defined behaviour for an over-wide
+// shift is the only thing making it a no-op.
+//
+// It is a case of its own because the other fixtures reach it by chance: the
+// random slabs never do, and the small-alphabet ones only when a draw happens
+// to come out uniform, so reordering a fixture list can silently stop covering
+// it.
+func TestSortFixedWidthAllIdentical(t *testing.T) {
+	for _, w := range []int{1, 2, 8, 9, 16, 17, 20} {
+		for _, n := range []int{2, 3, 63, 64, 65, 300} {
+			slab := bytes.Repeat([]byte(strings.Repeat("k", w)), n)
+			want := bytes.Clone(slab)
+			sortFixedWidth(slab, w)
+			requireSlabEqual(t, slab, want, w)
+		}
+	}
+}
+
+// TestSortFixedWidthWidthZeroWritesNothing covers d == 0, where every key is its
+// own shared prefix.
+//
+// A sort over identical keys cannot observe this: any permutation of equal keys
+// is byte-identical whatever the pack computed. So the pack's behaviour at zero
+// width is asserted directly, and the slab is bracketed with sentinels to catch
+// a write landing outside it.
+//
+// The shift itself is beyond reach: at d == 0 loadBE reads no bytes, so the
+// value shifted is zero and Go's over-wide shift and the hardware's masked one
+// agree. What is pinned here is that nothing is read, written, or written
+// outside the slab.
+func TestSortFixedWidthWidthZeroWritesNothing(t *testing.T) {
+	assert.Zero(t, loadBE([]byte("kk"), 0), "a zero-width load reads nothing")
+	assert.Zero(t, packSuffix([]byte("kk"), 2), "a key with no bytes past the prefix packs to zero")
+
+	dst := []byte{0xAA}
+	storeBE(dst, ^uint64(0), 0)
+	assert.Equal(t, []byte{0xAA}, dst, "a zero-width store writes nothing")
+
+	for _, w := range []int{1, 2, 8, 9, 16, 17, 20} {
+		for _, n := range []int{2, 3, 63, 64, 65, 300} {
+			buf := bytes.Repeat([]byte{0xAA}, w+n*w+w)
+			slab := buf[w : w+n*w]
+			copy(slab, bytes.Repeat([]byte(strings.Repeat("k", w)), n))
+			want := bytes.Clone(slab)
+
+			sortFixedWidth(slab, w)
+
+			requireSlabEqual(t, slab, want, w)
+			// Only the trailing sentinel can catch anything: the slab has spare
+			// capacity behind it, so a write can land there without touching a
+			// key. Nothing can address bytes before the slab's start.
+			assert.Equal(t, bytes.Repeat([]byte{0xAA}, w), buf[w+n*w:],
+				"w=%d n=%d: wrote past the slab", w, n)
+		}
+	}
+}
+
+// TestCutoffsAreBracketed pins that the size lists either side of each cutoff
+// still straddle it. They are not decorative: raising a cutoff past every size
+// tested drops the arm it gates to zero coverage while the suite stays green.
+func TestCutoffsAreBracketed(t *testing.T) {
+	for _, cutoff := range []int{radixCutoff, wideRadixCutoff, varRadixCutoff} {
+		assert.Contains(t, matchesInterfaceSizes, cutoff-1, "no size below cutoff %d", cutoff)
+		assert.Contains(t, matchesInterfaceSizes, cutoff, "no size at cutoff %d", cutoff)
+		assert.Contains(t, matchesInterfaceSizes, cutoff+1, "no size above cutoff %d", cutoff)
+	}
+}

--- a/entities/inverted/keys_sort_test.go
+++ b/entities/inverted/keys_sort_test.go
@@ -28,13 +28,9 @@ import (
 // Keys here must be shuffled, never strided. An ascending fixture puts pdqsort
 // on its already-sorted fast path and reports a cost no production batch pays.
 
-// sortSlabInterface is the oracle every arm is checked against.
-//
-// It shares no code with production, which is the point: an oracle built on the
-// comparison sort would leave every case that dispatches to that branch —
-// d > 16 below the cutoff — asserting only that the branch agrees with itself.
-// Materializing the keys and sorting the slice is slower and obviously correct,
-// which is the trade an oracle wants.
+// sortSlabInterface is the oracle every arm is checked against. It shares no
+// code with production — an oracle built on the comparison sort would leave
+// cases dispatching to that branch asserting only that it agrees with itself.
 func sortSlabInterface(slab []byte, w int) {
 	n := len(slab) / w
 	if n < 2 {
@@ -86,14 +82,10 @@ func shapeKeys(n int, f func(i int) string) []string {
 	return out
 }
 
-// fixedShapeKeys is shapeKeys for a fixture that claims one width, and fails if
-// the keys do not have it.
-//
-// %0Nd pads to a MINIMUM width, so a fixture written with it stops being
-// fixed-width the moment a value needs more digits. uniformWidthOf then routes
-// the case to sortVariableWidth, and it passes while exercising an arm other
-// than the one its name claims. Checking the width here is what keeps a case
-// honest about which arm it covers.
+// fixedShapeKeys is shapeKeys for a fixture that claims width w, and fails if
+// a key doesn't have it: %0Nd only pads to a minimum, so a value needing more
+// digits would silently move the case to sortVariableWidth instead of the
+// fixed arm its name claims.
 func fixedShapeKeys(tb testing.TB, n, w int, f func(i int) string) []string {
 	tb.Helper()
 	keys := shapeKeys(n, f)
@@ -158,9 +150,6 @@ var matchesInterfaceSizes = []int{0, 1, 2, 3, 63, 64, 65, 127, 128, 129, 191, 19
 // plain comparison sort over materialized keys.
 func TestSortFixedWidthMatchesInterface(t *testing.T) {
 	widths := []int{1, 8, 14, 16, 20}
-	// Sizes straddle radixCutoff so both the packed and radix arms are
-	// exercised. They must be updated with the constant: sizes that no longer
-	// bracket it still pass, while covering only one side.
 	sizes := matchesInterfaceSizes
 	for _, w := range widths {
 		for _, n := range sizes {
@@ -250,13 +239,10 @@ func TestSortKeysAcrossShapes(t *testing.T) {
 	}
 }
 
-// TestSortKeysCollisionRepair covers the keys the packed word cannot separate.
-//
-// The variable-width arm packs 8 bytes past the prefix EVERY key shares, so a
-// prefix shared by only a subset survives into the packed word and that subset
-// arrives from the stable radix in input order. These shapes all produce such a
-// run; a repair that no-ops, or that resumes comparing past the packed bytes,
-// returns them unsorted.
+// TestSortKeysCollisionRepair covers keys the packed word can't separate: a
+// prefix shared by only a subset of keys survives into the packed word, so a
+// repair that no-ops, or resumes comparing past the packed bytes, would leave
+// that subset in input order instead of sorted.
 func TestSortKeysCollisionRepair(t *testing.T) {
 	rng := rand.New(rand.NewSource(31))
 	// Keys must differ in length or uniformWidthOf diverts them to the fixed
@@ -288,10 +274,9 @@ func TestSortKeysCollisionRepair(t *testing.T) {
 		{"random, no group structure", shapeKeys(5000, func(i int) string {
 			return fmt.Sprintf("%08d_%d", rng.Intn(99999999), i)
 		})},
-		// packSuffix pads a short key with zeros, so these pack alike without
-		// agreeing on 8 bytes. A repair that resumes comparing past the packed
-		// word sees nil against nil, calls them equal, and leaves them as they
-		// came in.
+		// packSuffix zero-pads these alike without agreeing on 8 real bytes; a
+		// repair resuming past the packed word would compare nil to nil, call
+		// them equal, and leave them as they came in.
 		{"zero padding against a short key", repeatTo(
 			[]string{"ab", "ab\x00", "ab\x00\x00", "a", "ab\x00b", "ab\x00a"}, 6)},
 		{"zero padding, run past the radix cutoff", repeatTo(
@@ -343,21 +328,13 @@ func TestUniformWidthOf(t *testing.T) {
 	}
 }
 
-// TestAmericanFlagSortDeepAgreement pins a stack overflow.
+// TestAmericanFlagSortDeepAgreement pins a stack overflow: recursion at one
+// frame per matching byte would carry ~6.2KB per frame and blow the goroutine
+// stack on a long agreement run — a fatal, uncatchable crash, not a panic.
+// Reachable from a filter value, since nothing caps a text key's length.
 //
-// The MSD arm advances one byte at a time whenever every key agrees on that
-// byte, and must do so iteratively. One frame per byte carries three 256-entry
-// arrays, about 6.2KB, so a key wide enough to hold a long agreement run would
-// exhaust the goroutine stack — a fatal error, not a panic: recover cannot
-// catch it and the process dies.
-//
-// It is reachable from a filter value. Only the text path produces keys wider
-// than 16 discriminating bytes, tokenizeField trims whitespace and passes the
-// value through as the key, and nothing caps its length.
-//
-// The shape: 64 keys (radixCutoff) of one width, all but one sharing byte 0,
-// the rest zero. The global prefix is empty so the dispatch picks this arm,
-// and the large bucket then agrees on every remaining byte.
+// Shape: radixCutoff keys of one width, all but one sharing byte 0, so the
+// large bucket agrees on every remaining byte.
 func TestAmericanFlagSortDeepAgreement(t *testing.T) {
 	for _, w := range []int{1_000, 20_000, 200_000} {
 		n := radixCutoff
@@ -391,13 +368,9 @@ func prefixedSlab(rng *rand.Rand, n, w, lcp int) []byte {
 	return slab
 }
 
-// TestSortFixedWidthSharedPrefix covers every arm with a prefix each key shares.
-//
-// The random slabs the other tests use leave the shared prefix empty almost
-// always, so on their own they exercise each arm only at lcp == 0 — where the
-// pack has nothing to skip and the discriminating width is the whole key. A
-// prefix moves a batch to a different arm, and the small-batch arms in
-// particular are only reachable with one for widths above 8.
+// TestSortFixedWidthSharedPrefix covers every arm with a shared prefix: the
+// other tests' random slabs leave lcp == 0 almost always, so the small-batch
+// arms above width 8 are otherwise unreachable.
 func TestSortFixedWidthSharedPrefix(t *testing.T) {
 	rng := rand.New(rand.NewSource(7))
 	for _, w := range []int{2, 5, 8, 9, 12, 14, 16, 17, 20, 24} {
@@ -498,33 +471,9 @@ func TestInsertionSortFixed(t *testing.T) {
 	}
 }
 
-// TestSortFixedWidthAllIdentical pins d == 0, where every key is its own shared
-// prefix so the pack shifts by 64 and Go's defined behaviour for an over-wide
-// shift is the only thing making it a no-op.
-//
-// It is a case of its own because the other fixtures reach it by chance: the
-// random slabs never do, and the small-alphabet ones only when a draw happens
-// to come out uniform, so reordering a fixture list can silently stop covering
-// it.
-func TestSortFixedWidthAllIdentical(t *testing.T) {
-	for _, w := range []int{1, 2, 8, 9, 16, 17, 20} {
-		for _, n := range []int{2, 3, 63, 64, 65, 300} {
-			slab := bytes.Repeat([]byte(strings.Repeat("k", w)), n)
-			want := bytes.Clone(slab)
-			sortFixedWidth(slab, w)
-			requireSlabEqual(t, slab, want, w)
-		}
-	}
-}
-
-// TestDedupRejectsAnInversion covers the check that stands in for verifying the
-// sort.
-//
-// It is dead under the rest of the suite by construction — a correct sort never
-// produces an inversion — so the only way to show it fires, and names the pair
-// it found, is to hand it a slab the sort could not have produced. Without this
-// the branch could be deleted, or made to drop the smaller key silently, with
-// everything still green.
+// TestDedupRejectsAnInversion drives the check that stands in for verifying
+// the sort: a correct sort never triggers it, so this hand-builds an inverted
+// slab to confirm it fires and names the offending pair.
 func TestDedupRejectsAnInversion(t *testing.T) {
 	t.Run("fixed width", func(t *testing.T) {
 		tests := []struct {
@@ -592,7 +541,9 @@ func buildVarSlab(tb testing.TB, keys ...string) ([]byte, []uint32, int) {
 }
 
 // TestSortFixedWidthWidthZeroWritesNothing covers d == 0, where every key is its
-// own shared prefix.
+// own shared prefix. The fixture is identical keys deliberately: the other
+// fixtures reach this only by chance — the random slabs never do, the
+// small-alphabet ones only on a uniform draw — so nothing else pins it.
 //
 // A sort over identical keys cannot observe this: any permutation of equal keys
 // is byte-identical whatever the pack computed. So the pack's behaviour at zero

--- a/entities/inverted/keys_test.go
+++ b/entities/inverted/keys_test.go
@@ -12,6 +12,10 @@
 package inverted
 
 import (
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -238,9 +242,9 @@ func TestFixedKeyBuilderBuild(t *testing.T) {
 		assert.Equal(t, []string{"zz"}, collect(buildFixed(t, 2)([]string{"zz"})))
 	})
 
-	t.Run("equal keys keep their run", func(t *testing.T) {
+	t.Run("equal keys collapse", func(t *testing.T) {
 		keys := buildFixed(t, 2)([]string{"bb", "aa", "bb"})
-		assert.Equal(t, []string{"aa", "bb", "bb"}, collect(keys))
+		assert.Equal(t, []string{"aa", "bb"}, collect(keys))
 	})
 }
 
@@ -361,6 +365,96 @@ func TestVarKeyBuilderBuild(t *testing.T) {
 	}
 }
 
+// TestBuildDropsDuplicates covers the pass Build runs after ordering.
+//
+// Both layouts compact in place, and the variable one rewrites offsets as it
+// goes, so a survivor that moves must take its own offsets with it. Duplicates
+// are seeded at the front, the back and throughout because the compaction reads
+// ahead of the cursor it writes to.
+func TestBuildDropsDuplicates(t *testing.T) {
+	tests := []struct {
+		name string
+		keys []string
+		want []string
+	}{
+		{"none to drop", []string{"cc", "aa", "bb"}, []string{"aa", "bb", "cc"}},
+		{"one adjacent pair", []string{"bb", "aa", "bb"}, []string{"aa", "bb"}},
+		{"every key equal", []string{"aa", "aa", "aa", "aa"}, []string{"aa"}},
+		{"duplicates at the front", []string{"aa", "aa", "bb", "cc"}, []string{"aa", "bb", "cc"}},
+		{"duplicates at the back", []string{"aa", "bb", "cc", "cc"}, []string{"aa", "bb", "cc"}},
+		{"runs throughout", []string{"bb", "aa", "cc", "bb", "aa", "cc", "bb"}, []string{"aa", "bb", "cc"}},
+		{"two keys, both equal", []string{"zz", "zz"}, []string{"zz"}},
+		{"one key", []string{"qq"}, []string{"qq"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Run("fixed", func(t *testing.T) {
+				keys := buildFixed(t, 2)(tt.keys)
+				assert.Equal(t, tt.want, collect(keys))
+				assert.Equal(t, len(tt.want), keys.Len())
+			})
+			t.Run("variable", func(t *testing.T) {
+				// Widen one key per case so the list cannot take the
+				// fixed-width layout and the offset-rewriting arm is the one
+				// under test.
+				keys := append([]string{"aaa"}, tt.keys...)
+				want := append([]string{"aaa"}, tt.want...)
+				slices.Sort(want)
+				got := buildVariable(t, keys)
+				assert.Equal(t, want, collect(got))
+				assert.NotNil(t, got.offs, "the widened list must keep its offsets")
+			})
+		})
+	}
+}
+
+// TestBuildDropsDuplicatesAcrossShapes checks the compaction against
+// slices.Compact over alphabets narrow enough to collide constantly, at sizes
+// either side of every arm boundary.
+func TestBuildDropsDuplicatesAcrossShapes(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	for _, alphabet := range []int{1, 2, 3, 8} {
+		for _, maxLen := range []int{1, 2, 5, 12} {
+			for _, n := range []int{0, 1, 2, 3, 5, 63, 64, 65, 500} {
+				keys := make([]string, n)
+				fixed := make([]string, n)
+				for i := range keys {
+					b := make([]byte, 1+rng.Intn(maxLen))
+					for j := range b {
+						b[j] = byte('a' + rng.Intn(alphabet))
+					}
+					keys[i] = string(b)
+					fixed[i] = fmt.Sprintf("%-*s", maxLen, b)
+				}
+				for name, got := range map[string][]string{
+					"variable": collect(buildVariable(t, keys)),
+					"fixed":    collect(buildFixed(t, maxLen)(fixed)),
+				} {
+					src := keys
+					if name == "fixed" {
+						src = fixed
+					}
+					want := slices.Clone(src)
+					slices.Sort(want)
+					want = slices.Compact(want)
+					if len(got) != len(want) {
+						t.Fatalf("%s alphabet=%d maxLen=%d n=%d: got %d keys, want %d",
+							name, alphabet, maxLen, n, len(got), len(want))
+					}
+					for i := range want {
+						if got[i] != want[i] {
+							t.Fatalf("%s alphabet=%d maxLen=%d n=%d: key %d is %q, want %q",
+								name, alphabet, maxLen, n, i, got[i], want[i])
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// fixedBuilder adapts buildFixed to the table's build signature, which takes the
+// TB so a builder error fails the case rather than being dropped.
 func fixedBuilder(width int) func(tb testing.TB, keys []string) SortedKeys {
 	return func(tb testing.TB, keys []string) SortedKeys {
 		return buildFixed(tb, width)(keys)
@@ -438,4 +532,108 @@ func TestSortedKeysAtRefusesOutOfRange(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestShrinkKeysReleasesTheDedupedTail covers the copy that returns a deduped
+// batch's array to the collector.
+//
+// Asserted on the array identity, not on cap(): the returned slice is capped at
+// the last surviving key either way, so cap() reads the same whether the tail
+// was released or is merely hidden behind it. That is the trap the shrink code
+// itself first fell into, and a test reading cap() falls into it too.
+func TestShrinkKeysReleasesTheDedupedTail(t *testing.T) {
+	sameArray := func(a, b []byte) bool { return &a[:1][0] == &b[:1][0] }
+
+	tests := []struct {
+		name       string
+		cap, end   int
+		wantCopied bool
+	}{
+		{"most of a large array is dead", 100_000, 8, true},
+		{"exactly at the ratio", 4096, 1024, false},
+		{"just inside the ratio", 4096, 1025, false},
+		{"below the floor, however dead", 4095, 1, false},
+		{"nothing was dropped", 4096, 4096, false},
+		// Either side of 4*end == cap on a large array, so loosening the ratio
+		// as well as tightening it changes an answer.
+		{"exactly at the ratio, large array", 100_000, 25_000, false},
+		{"one key past the ratio", 100_000, 24_999, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := make([]byte, tt.cap)
+			for i := range src {
+				src[i] = byte(i)
+			}
+			got := shrinkKeys(src, tt.end)
+
+			require.Len(t, got, tt.end)
+			assert.Equal(t, src[:tt.end], got, "shrinking must not alter a key")
+			if tt.wantCopied {
+				// append rounds to a size class, so the spare bytes are fresh
+				// zeros rather than the tail that was dropped.
+				assert.GreaterOrEqual(t, cap(got), tt.end)
+			} else {
+				assert.Equal(t, tt.end, cap(got), "an aliased result must stop at the last key")
+			}
+			assert.Equal(t, tt.wantCopied, !sameArray(src, got),
+				"copied-vs-aliased decides whether the array is released")
+		})
+	}
+
+	// Compared as a bool, not with NotEqual on the two pointers: testify would
+	// dereference them and find both elements zero.
+	t.Run("offsets shrink on the same rule", func(t *testing.T) {
+		aliased := func(a, b []uint32) bool { return &a[:1][0] == &b[:1][0] }
+
+		src := make([]uint32, 25_000)
+		assert.False(t, aliased(src, shrinkOffs(src, 3)), "a dead offset array must be released")
+		assert.True(t, aliased(src, shrinkOffs(src, 6_250)), "at the ratio, nothing is reclaimed")
+		assert.False(t, aliased(src, shrinkOffs(src, 6_249)), "one entry past it, the copy is worth it")
+
+		// The floor is counted in bytes, not entries, so these two straddle it
+		// at a quarter of the element count shrinkKeys would need.
+		atFloor := make([]uint32, 1024)
+		assert.False(t, aliased(atFloor, shrinkOffs(atFloor, 1)), "1024 offsets is 4096 bytes")
+		belowFloor := make([]uint32, 1023)
+		assert.True(t, aliased(belowFloor, shrinkOffs(belowFloor, 1)), "1023 offsets is below it")
+	})
+
+	// The helpers above are only reached through Build, and nothing else pins
+	// that Build still calls them: every call site could go back to a plain
+	// three-index slice with the rest of the suite green.
+	t.Run("Build hands the batch array back", func(t *testing.T) {
+		const n = 100_000
+
+		t.Run("fixed layout", func(t *testing.T) {
+			b := NewFixedKeyBuilder(n, 8)
+			for i := 0; i < n; i++ {
+				binary.BigEndian.PutUint64(b.AppendBuf(), uint64(i%2))
+			}
+			raw := b.slab
+			built, err := b.Build()
+			require.NoError(t, err)
+			require.Equal(t, 2, built.Len())
+			assert.False(t, &raw[:1][0] == &built.slab[:1][0],
+				"a batch that dedups to two keys must not keep the array it filled")
+		})
+
+		t.Run("offsets layout", func(t *testing.T) {
+			b := NewVarKeyBuilder(n, 3*n)
+			for i := 0; i < n; i++ {
+				if i%2 == 0 {
+					b.AppendString("aa")
+				} else {
+					b.AppendString("bbb")
+				}
+			}
+			rawSlab, rawOffs := b.slab, b.offs
+			built, err := b.Build()
+			require.NoError(t, err)
+			require.Equal(t, 2, built.Len())
+			require.NotNil(t, built.offs, "mixed widths must keep the offsets layout")
+			assert.False(t, &rawSlab[:1][0] == &built.slab[:1][0], "the slab must be released")
+			assert.False(t, &rawOffs[:1][0] == &built.offs[:1][0], "the offsets must be released")
+		})
+	})
 }

--- a/entities/inverted/keys_test.go
+++ b/entities/inverted/keys_test.go
@@ -1,0 +1,441 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSortedKeysLayouts reads both layouts back through every accessor. They
+// are built by different types and share no code, so what a key reads back as
+// must not depend on which one produced it.
+func TestSortedKeysLayouts(t *testing.T) {
+	tests := []struct {
+		name      string
+		keys      []string
+		build     func(tb testing.TB, keys []string) SortedKeys
+		wantFixed bool
+	}{
+		{
+			name:  "variable width",
+			keys:  []string{"a", "bb", "ccc"},
+			build: buildVariable,
+		},
+		{
+			// One key is trivially of one width, so the variable builder hands
+			// back the layout that carries no offsets.
+			name:      "variable width, one key",
+			keys:      []string{"only"},
+			build:     buildVariable,
+			wantFixed: true,
+		},
+		{
+			name:  "variable width, empty key among real ones",
+			keys:  []string{"", "b"},
+			build: buildVariable,
+		},
+		{
+			name:      "fixed width",
+			keys:      []string{"aa", "bb", "cc"},
+			build:     fixedBuilder(2),
+			wantFixed: true,
+		},
+		{
+			name:      "fixed width, one key",
+			keys:      []string{"xyz"},
+			build:     fixedBuilder(3),
+			wantFixed: true,
+		},
+		{
+			name:      "fixed width of one byte",
+			keys:      []string{"a", "b"},
+			build:     fixedBuilder(1),
+			wantFixed: true,
+		},
+		{
+			name:      "fixed width of sixteen, the widest key there is",
+			keys:      []string{"0123456789abcdef", "fedcba9876543210"},
+			build:     fixedBuilder(16),
+			wantFixed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys := tt.build(t, tt.keys)
+
+			require.Equal(t, tt.wantFixed, keys.offs == nil, "layout")
+			require.Equal(t, len(tt.keys), keys.Len())
+
+			for i, want := range tt.keys {
+				assert.Equalf(t, want, string(keys.At(i)), "At(%d)", i)
+				assert.Equalf(t, len(want), cap(keys.At(i)),
+					"key %d capacity must stop at its own end", i)
+			}
+
+			var iterated []string
+			for i, k := range keys.All() {
+				require.Equal(t, len(iterated), i, "All must yield positions in order")
+				iterated = append(iterated, string(k))
+			}
+			assert.Equal(t, tt.keys, iterated, "All must agree with At")
+		})
+	}
+}
+
+// TestSortedKeysAllStopsEarly pins that a consumer can abandon the iteration.
+//
+// All hands out one func literal for both layouts so the compiler can keep the
+// caller's loop body on the stack, and the literal has to honour a false from
+// yield. Nothing on the query path breaks out today — the fold visits every key
+// — so without this the early return is only reachable through a caller that
+// does not exist yet.
+func TestSortedKeysAllStopsEarly(t *testing.T) {
+	for name, keys := range map[string]SortedKeys{
+		"variable width": buildVariable(t, []string{"a", "bb", "ccc", "dddd"}),
+		"fixed width":    buildFixed(t, 2)([]string{"aa", "bb", "cc", "dd"}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var seen int
+			for range keys.All() {
+				seen++
+				if seen == 2 {
+					break
+				}
+			}
+			assert.Equal(t, 2, seen, "All must stop where the consumer stopped")
+		})
+	}
+}
+
+// TestSortedKeysEmpty covers the lists that hold no keys: one from each builder,
+// and the zero value a leaf carries when it is not a batched Contains.
+func TestSortedKeysEmpty(t *testing.T) {
+	for name, keys := range map[string]SortedKeys{
+		"variable builder, nothing appended": mustBuildVar(t, NewVarKeyBuilder(4, 16)),
+		"fixed builder, nothing appended":    mustBuildFixed(t, NewFixedKeyBuilder(4, 8)),
+		"zero value":                         {},
+		// No builder produces this — offsets always carry their leading zero —
+		// but deriving the count from len(offs)-1 would report -1 for it, which
+		// passes every guard that tests for zero.
+		"offsets array with no terminator": {offs: []uint32{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Zero(t, keys.Len())
+			assert.True(t, keys.isAscending())
+			for range keys.All() {
+				t.Fatal("an empty list must yield nothing")
+			}
+		})
+	}
+}
+
+// TestSortedKeysDegenerate covers the builders reached without a usable width or
+// without their constructor. Each refuses, because the alternative is a list
+// that reads as a legitimate one: a fixed builder with no width would report no
+// keys, and a variable builder with no leading offset reads every key one
+// position over and loses the last — a narrower filter result that nothing
+// reports.
+//
+// The constructors panic and Build returns: a constructor can see the mistake
+// in the arguments it was handed, where Build only sees it in state that has
+// already accumulated, on a path where a panic would take the node down.
+func TestSortedKeysDegenerate(t *testing.T) {
+	cases := map[string]struct {
+		build func()
+		// wantPanic is matched against the recovered value. Asserting only that
+		// something panicked is satisfied by the incidental panics these inputs
+		// cause anyway — a nil offsets slice, a division by a zero width — so
+		// the guard could be deleted with the test still green.
+		wantPanic string
+	}{
+		"fixed builder, zero width": {
+			build:     func() { NewFixedKeyBuilder(0, 0) },
+			wantPanic: "key width 0 is not in 1..",
+		},
+		"fixed builder, width given as a batch total": {
+			build:     func() { NewFixedKeyBuilder(3, 3*8) },
+			wantPanic: "width of one key, not the batch total",
+		},
+		"variable builder, negative key count": {
+			build:     func() { NewVarKeyBuilder(-1, 10) },
+			wantPanic: "must not be negative",
+		},
+		// Without this the encoder dies writing into an empty buffer, several
+		// frames from the mistake, and Build's guard is never reached.
+		"append to a builder with no width": {
+			build:     func() { (&FixedKeyBuilder{}).AppendBuf() },
+			wantPanic: "NewFixedKeyBuilder was not used",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			recovered := func() (r any) {
+				defer func() { r = recover() }()
+				tc.build()
+				return nil
+			}()
+			require.NotNil(t, recovered, "a misused constructor must refuse, not hand back a builder")
+			err, ok := recovered.(error)
+			require.True(t, ok, "a panic must carry an error so a recovered one can be classified")
+			assert.ErrorIs(t, err, ErrInternal)
+			assert.Contains(t, err.Error(), tc.wantPanic,
+				"the panic must name the mistake, not just fail somewhere downstream")
+		})
+	}
+
+	// Build is handed accumulated state rather than a constant, and sits where a
+	// panic would end the process, so it reports the same class of mistake as an
+	// error a caller can distinguish from a bad filter value.
+	t.Run("build refuses a builder that skipped its constructor", func(t *testing.T) {
+		for name, build := range map[string]func() (SortedKeys, error){
+			"variable, nothing appended": (&VarKeyBuilder{}).Build,
+			"variable, filled": func() (SortedKeys, error) {
+				b := &VarKeyBuilder{}
+				b.AppendString("alpha")
+				b.AppendString("be")
+				return b.Build()
+			},
+			"fixed, no width": (&FixedKeyBuilder{}).Build,
+		} {
+			t.Run(name, func(t *testing.T) {
+				got, err := build()
+				require.ErrorIs(t, err, ErrInternal,
+					"a caller must be able to tell this from a bad filter value")
+				assert.Contains(t, err.Error(), "was not used")
+				assert.Zero(t, got.Len(), "a refused build must not hand back keys")
+			})
+		}
+	})
+
+	// A zero width reaching the sort directly must not divide by zero.
+	assert.NotPanics(t, func() { sortFixedWidth(nil, 0) })
+	assert.NotPanics(t, func() { sortFixedWidth([]byte("abc"), 0) })
+}
+
+// TestFixedKeyBuilderBuild pins that ordering happens in the slab itself — the
+// keys move, and nothing indexes them that would have to move too.
+func TestFixedKeyBuilderBuild(t *testing.T) {
+	t.Run("orders the keys", func(t *testing.T) {
+		keys := buildFixed(t, 2)([]string{"dd", "bb", "cc", "aa"})
+		require.True(t, keys.isAscending())
+		assert.Equal(t, []string{"aa", "bb", "cc", "dd"}, collect(keys))
+	})
+
+	t.Run("a single key needs no ordering", func(t *testing.T) {
+		assert.Equal(t, []string{"zz"}, collect(buildFixed(t, 2)([]string{"zz"})))
+	})
+
+	t.Run("equal keys keep their run", func(t *testing.T) {
+		keys := buildFixed(t, 2)([]string{"bb", "aa", "bb"})
+		assert.Equal(t, []string{"aa", "bb", "bb"}, collect(keys))
+	})
+}
+
+func TestIsAscending(t *testing.T) {
+	cases := []struct {
+		name string
+		keys []string
+		want bool
+	}{
+		{"ascending", []string{"aa", "bb", "cc"}, true},
+		{"descending", []string{"bb", "aa"}, false},
+		{"equal keys are ordered", []string{"aa", "aa"}, true},
+		{"shorter is not smaller", []string{"b", "aaa"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, inOrderGiven(tc.keys).isAscending())
+		})
+	}
+}
+
+// inOrderGiven assembles a list in the order it is given, bypassing the
+// builders — which order what they are handed, so a list out of order cannot be
+// produced through them at all.
+func inOrderGiven(keys []string) SortedKeys {
+	var slab []byte
+	offs := []uint32{0}
+	for _, k := range keys {
+		slab = append(slab, k...)
+		offs = append(offs, uint32(len(slab)))
+	}
+	return SortedKeys{slab: slab, offs: offs}
+}
+
+func buildVariable(tb testing.TB, keys []string) SortedKeys {
+	tb.Helper()
+	total := 0
+	for _, k := range keys {
+		total += len(k)
+	}
+	b := NewVarKeyBuilder(len(keys), total)
+	for _, k := range keys {
+		b.AppendString(k)
+	}
+	built, err := b.Build()
+	require.NoError(tb, err)
+	return built
+}
+
+// buildFixed appends through the encoder-shaped path — write into the buffer the
+// builder hands out — as the fixed-width encoders do.
+func buildFixed(tb testing.TB, width int) func(keys []string) SortedKeys {
+	return func(keys []string) SortedKeys {
+		tb.Helper()
+		b := NewFixedKeyBuilder(len(keys), width)
+		for _, k := range keys {
+			copy(b.AppendBuf(), k)
+		}
+		built, err := b.Build()
+		require.NoError(tb, err)
+		return built
+	}
+}
+
+func collect(keys SortedKeys) []string {
+	out := make([]string, 0, keys.Len())
+	for _, k := range keys.All() {
+		out = append(out, string(k))
+	}
+	return out
+}
+
+// TestVarKeyBuilderBuild is the variable-width counterpart to
+// [TestFixedKeyBuilderBuild]: ordering happens in Build, and which layout comes
+// back is decided by the widths that were appended rather than by the builder.
+func TestVarKeyBuilderBuild(t *testing.T) {
+	tests := []struct {
+		name      string
+		keys      []string
+		want      []string
+		wantFixed bool
+	}{
+		{
+			name: "orders mixed widths",
+			keys: []string{"ccc", "a", "bb"},
+			want: []string{"a", "bb", "ccc"},
+		},
+		{
+			name:      "one width drops the offsets",
+			keys:      []string{"dd", "bb", "cc", "aa"},
+			want:      []string{"aa", "bb", "cc", "dd"},
+			wantFixed: true,
+		},
+		{
+			name: "a prefix sorts before its extension",
+			keys: []string{"abc", "ab", "abcd", "a"},
+			want: []string{"a", "ab", "abc", "abcd"},
+		},
+		{
+			name: "an empty key sorts first",
+			keys: []string{"b", "", "a"},
+			want: []string{"", "a", "b"},
+		},
+		{
+			name:      "a single key needs no ordering",
+			keys:      []string{"zz"},
+			want:      []string{"zz"},
+			wantFixed: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys := buildVariable(t, tt.keys)
+			assert.Equal(t, tt.want, collect(keys))
+			assert.True(t, keys.isAscending())
+			assert.Equal(t, tt.wantFixed, keys.offs == nil, "layout")
+		})
+	}
+}
+
+func fixedBuilder(width int) func(tb testing.TB, keys []string) SortedKeys {
+	return func(tb testing.TB, keys []string) SortedKeys {
+		return buildFixed(tb, width)(keys)
+	}
+}
+
+func mustBuildVar(tb testing.TB, b *VarKeyBuilder) SortedKeys {
+	tb.Helper()
+	built, err := b.Build()
+	require.NoError(tb, err)
+	return built
+}
+
+func mustBuildFixed(tb testing.TB, b *FixedKeyBuilder) SortedKeys {
+	tb.Helper()
+	built, err := b.Build()
+	require.NoError(tb, err)
+	return built
+}
+
+// TestSortedKeysAllDoesNotAllocate pins the claim All's godoc rests on: one func
+// literal covers both layouts, so the compiler can tell which iterator a caller
+// received, devirtualize the yield, and keep the caller's loop body on the
+// stack. Splitting All per layout would put an allocation in every fold with
+// nothing else to notice.
+func TestSortedKeysAllDoesNotAllocate(t *testing.T) {
+	for name, keys := range map[string]SortedKeys{
+		"offsets layout": buildVariable(t, []string{"a", "bb", "ccc"}),
+		"width layout":   buildFixed(t, 2)([]string{"aa", "bb", "cc"}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var sink int
+			allocs := testing.AllocsPerRun(100, func() {
+				for _, k := range keys.All() {
+					sink += len(k)
+				}
+			})
+			assert.Zero(t, allocs, "iterating the keys must not allocate")
+			require.NotZero(t, sink, "the loop body must have run")
+		})
+	}
+}
+
+// TestSortedKeysAtRefusesOutOfRange covers the range check At makes.
+//
+// The message is asserted, not merely the panic: an out-of-range index panics
+// somewhere in every layout — on the offsets index, or on the slice bounds — so
+// asserting only that something blew up would be satisfied with the check
+// deleted. What the check buys is that all three layouts refuse the SAME way.
+//
+// One case spells the message out rather than building it from outOfRange,
+// which would mutate both sides together and pin nothing about the wording.
+func TestSortedKeysAtRefusesOutOfRange(t *testing.T) {
+	t.Run("the message names the index and the count", func(t *testing.T) {
+		keys := buildFixed(t, 2)([]string{"aa", "bb"})
+		assert.PanicsWithError(t,
+			"inverted: internal fault: key 2 requested from a list of 2",
+			func() { keys.At(2) })
+	})
+
+	for name, keys := range map[string]SortedKeys{
+		"offsets layout": buildVariable(t, []string{"a", "bb"}),
+		"width layout":   buildFixed(t, 2)([]string{"aa", "bb"}),
+		"zero value":     {},
+		"empty, width":   mustBuildFixed(t, NewFixedKeyBuilder(4, 8)),
+		"empty, offsets": mustBuildVar(t, NewVarKeyBuilder(4, 16)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			n := keys.Len()
+			assert.PanicsWithError(t, outOfRange(n, n).Error(), func() { keys.At(n) })
+			assert.PanicsWithError(t, outOfRange(n+1, n).Error(), func() { keys.At(n + 1) })
+			assert.PanicsWithError(t, outOfRange(-1, n).Error(), func() { keys.At(-1) })
+			if n > 0 {
+				assert.NotPanics(t, func() { keys.At(n - 1) }, "the last key must be readable")
+			}
+		})
+	}
+}

--- a/entities/inverted/keys_test.go
+++ b/entities/inverted/keys_test.go
@@ -498,40 +498,47 @@ func TestSortedKeysAllDoesNotAllocate(t *testing.T) {
 	}
 }
 
-// TestSortedKeysAtRefusesOutOfRange covers the range check At makes.
+// TestSortedKeysAtRefusesOutOfRange covers what At does with an index the list
+// cannot answer: refuse it, rather than answer with an empty key or with one
+// belonging to another position.
 //
-// The message is asserted, not merely the panic: an out-of-range index panics
-// somewhere in every layout — on the offsets index, or on the slice bounds — so
-// asserting only that something blew up would be satisfied with the check
-// deleted. What the check buys is that all three layouts refuse the SAME way.
+// The refusal is asserted, not its wording. Most of it is the bounds check the
+// compiler generates, so what each layout panics with differs — an offsets
+// index or a slice bound, in key terms or in byte terms — and the message is
+// the runtime's, free to change with it. A check of this package's own would
+// make all the layouts refuse alike, and cost At its inlining; [SortedKeys.At]
+// carries that argument.
 //
-// One case spells the message out rather than building it from outOfRange,
-// which would mutate both sides together and pin nothing about the wording.
+// The zero value is the exception and the reason any check survives: a width of
+// zero makes every slice expression legal and empty, so nothing would panic and
+// every index would answer "". That message this package owns, so it is pinned.
 func TestSortedKeysAtRefusesOutOfRange(t *testing.T) {
-	t.Run("the message names the index and the count", func(t *testing.T) {
-		keys := buildFixed(t, 2)([]string{"aa", "bb"})
-		assert.PanicsWithError(t,
-			"inverted: internal fault: key 2 requested from a list of 2",
-			func() { keys.At(2) })
-	})
-
 	for name, keys := range map[string]SortedKeys{
 		"offsets layout": buildVariable(t, []string{"a", "bb"}),
 		"width layout":   buildFixed(t, 2)([]string{"aa", "bb"}),
-		"zero value":     {},
 		"empty, width":   mustBuildFixed(t, NewFixedKeyBuilder(4, 8)),
 		"empty, offsets": mustBuildVar(t, NewVarKeyBuilder(4, 16)),
 	} {
 		t.Run(name, func(t *testing.T) {
 			n := keys.Len()
-			assert.PanicsWithError(t, outOfRange(n, n).Error(), func() { keys.At(n) })
-			assert.PanicsWithError(t, outOfRange(n+1, n).Error(), func() { keys.At(n + 1) })
-			assert.PanicsWithError(t, outOfRange(-1, n).Error(), func() { keys.At(-1) })
+			assert.Panics(t, func() { keys.At(n) }, "one past the last key")
+			assert.Panics(t, func() { keys.At(n + 1) }, "well past the last key")
+			assert.Panics(t, func() { keys.At(-1) }, "before the first key")
 			if n > 0 {
 				assert.NotPanics(t, func() { keys.At(n - 1) }, "the last key must be readable")
 			}
 		})
 	}
+
+	t.Run("zero value", func(t *testing.T) {
+		var keys SortedKeys
+		for _, i := range []int{0, 1, -1} {
+			assert.PanicsWithError(t,
+				"inverted: internal fault: keys were not made by a builder",
+				func() { keys.At(i) },
+				"index %d into a list that was never built", i)
+		}
+	})
 }
 
 // TestShrinkKeysReleasesTheDedupedTail covers the copy that returns a deduped

--- a/entities/inverted/keys_test.go
+++ b/entities/inverted/keys_test.go
@@ -22,9 +22,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSortedKeysLayouts reads both layouts back through every accessor. They
-// are built by different types and share no code, so what a key reads back as
-// must not depend on which one produced it.
+// TestSortedKeysLayouts pins that both layouts, built by different types
+// sharing no code, answer identically through every accessor.
 func TestSortedKeysLayouts(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -99,13 +98,9 @@ func TestSortedKeysLayouts(t *testing.T) {
 	}
 }
 
-// TestSortedKeysAllStopsEarly pins that a consumer can abandon the iteration.
-//
-// All hands out one func literal for both layouts so the compiler can keep the
-// caller's loop body on the stack, and the literal has to honour a false from
-// yield. Nothing on the query path breaks out today — the fold visits every key
-// — so without this the early return is only reachable through a caller that
-// does not exist yet.
+// TestSortedKeysAllStopsEarly pins that a consumer can abandon the iteration
+// by returning false from yield, even though nothing on the query path does
+// so today.
 func TestSortedKeysAllStopsEarly(t *testing.T) {
 	for name, keys := range map[string]SortedKeys{
 		"variable width": buildVariable(t, []string{"a", "bb", "ccc", "dddd"}),
@@ -131,9 +126,7 @@ func TestSortedKeysEmpty(t *testing.T) {
 		"variable builder, nothing appended": mustBuildVar(t, NewVarKeyBuilder(4, 16)),
 		"fixed builder, nothing appended":    mustBuildFixed(t, NewFixedKeyBuilder(4, 8)),
 		"zero value":                         {},
-		// No builder produces this — offsets always carry their leading zero —
-		// but deriving the count from len(offs)-1 would report -1 for it, which
-		// passes every guard that tests for zero.
+		// Not a shape a builder produces; Len must not report -1 for it.
 		"offsets array with no terminator": {offs: []uint32{}},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -146,23 +139,14 @@ func TestSortedKeysEmpty(t *testing.T) {
 	}
 }
 
-// TestSortedKeysDegenerate covers the builders reached without a usable width or
-// without their constructor. Each refuses, because the alternative is a list
-// that reads as a legitimate one: a fixed builder with no width would report no
-// keys, and a variable builder with no leading offset reads every key one
-// position over and loses the last — a narrower filter result that nothing
-// reports.
-//
-// The constructors panic and Build returns: a constructor can see the mistake
-// in the arguments it was handed, where Build only sees it in state that has
-// already accumulated, on a path where a panic would take the node down.
+// TestSortedKeysDegenerate covers builders reached without a usable width or
+// without their constructor — each refuses, rather than quietly returning a
+// list that reads as a legitimate one.
 func TestSortedKeysDegenerate(t *testing.T) {
 	cases := map[string]struct {
 		build func()
-		// wantPanic is matched against the recovered value. Asserting only that
-		// something panicked is satisfied by the incidental panics these inputs
-		// cause anyway — a nil offsets slice, a division by a zero width — so
-		// the guard could be deleted with the test still green.
+		// Matched against the panic's text, not just its presence: these inputs
+		// panic incidentally anyway (nil slice, zero-width division).
 		wantPanic string
 	}{
 		"fixed builder, zero width": {
@@ -200,9 +184,6 @@ func TestSortedKeysDegenerate(t *testing.T) {
 		})
 	}
 
-	// Build is handed accumulated state rather than a constant, and sits where a
-	// panic would end the process, so it reports the same class of mistake as an
-	// error a caller can distinguish from a bad filter value.
 	t.Run("build refuses a builder that skipped its constructor", func(t *testing.T) {
 		for name, build := range map[string]func() (SortedKeys, error){
 			"variable, nothing appended": (&VarKeyBuilder{}).Build,
@@ -365,12 +346,8 @@ func TestVarKeyBuilderBuild(t *testing.T) {
 	}
 }
 
-// TestBuildDropsDuplicates covers the pass Build runs after ordering.
-//
-// Both layouts compact in place, and the variable one rewrites offsets as it
-// goes, so a survivor that moves must take its own offsets with it. Duplicates
-// are seeded at the front, the back and throughout because the compaction reads
-// ahead of the cursor it writes to.
+// TestBuildDropsDuplicates covers the dedup pass Build runs after ordering,
+// with duplicates seeded at the front, the back, and throughout.
 func TestBuildDropsDuplicates(t *testing.T) {
 	tests := []struct {
 		name string
@@ -394,9 +371,7 @@ func TestBuildDropsDuplicates(t *testing.T) {
 				assert.Equal(t, len(tt.want), keys.Len())
 			})
 			t.Run("variable", func(t *testing.T) {
-				// Widen one key per case so the list cannot take the
-				// fixed-width layout and the offset-rewriting arm is the one
-				// under test.
+				// Widened so the list keeps offsets, exercising that arm.
 				keys := append([]string{"aaa"}, tt.keys...)
 				want := append([]string{"aaa"}, tt.want...)
 				slices.Sort(want)
@@ -475,11 +450,8 @@ func mustBuildFixed(tb testing.TB, b *FixedKeyBuilder) SortedKeys {
 	return built
 }
 
-// TestSortedKeysAllDoesNotAllocate pins the claim All's godoc rests on: one func
-// literal covers both layouts, so the compiler can tell which iterator a caller
-// received, devirtualize the yield, and keep the caller's loop body on the
-// stack. Splitting All per layout would put an allocation in every fold with
-// nothing else to notice.
+// TestSortedKeysAllDoesNotAllocate pins the escape-analysis claim
+// [SortedKeys.All]'s godoc rests on.
 func TestSortedKeysAllDoesNotAllocate(t *testing.T) {
 	for name, keys := range map[string]SortedKeys{
 		"offsets layout": buildVariable(t, []string{"a", "bb", "ccc"}),
@@ -498,26 +470,25 @@ func TestSortedKeysAllDoesNotAllocate(t *testing.T) {
 	}
 }
 
-// TestSortedKeysAtRefusesOutOfRange covers what At does with an index the list
-// cannot answer: refuse it, rather than answer with an empty key or with one
-// belonging to another position.
-//
-// The refusal is asserted, not its wording. Most of it is the bounds check the
-// compiler generates, so what each layout panics with differs — an offsets
-// index or a slice bound, in key terms or in byte terms — and the message is
-// the runtime's, free to change with it. A check of this package's own would
-// make all the layouts refuse alike, and cost At its inlining; [SortedKeys.At]
-// carries that argument.
-//
-// The zero value is the exception and the reason any check survives: a width of
-// zero makes every slice expression legal and empty, so nothing would panic and
-// every index would answer "". That message this package owns, so it is pinned.
+// TestSortedKeysAtRefusesOutOfRange pins that every layout panics on an
+// out-of-range index, asserted by occurrence rather than message (see
+// [SortedKeys.At] for why) — except the zero value, whose message this
+// package owns and does pin.
 func TestSortedKeysAtRefusesOutOfRange(t *testing.T) {
+	// Enough duplicates to force Build's copy path: append rounds the
+	// allocation up, and an uncapped copy would answer past-the-end indices
+	// with a zero key instead of panicking.
+	dupes := make([]string, 40_000)
+	for i := range dupes {
+		dupes[i] = fmt.Sprintf("%08d", i%251)
+	}
+
 	for name, keys := range map[string]SortedKeys{
-		"offsets layout": buildVariable(t, []string{"a", "bb"}),
-		"width layout":   buildFixed(t, 2)([]string{"aa", "bb"}),
-		"empty, width":   mustBuildFixed(t, NewFixedKeyBuilder(4, 8)),
-		"empty, offsets": mustBuildVar(t, NewVarKeyBuilder(4, 16)),
+		"offsets layout":       buildVariable(t, []string{"a", "bb"}),
+		"width layout":         buildFixed(t, 2)([]string{"aa", "bb"}),
+		"width layout, copied": buildFixed(t, 8)(dupes),
+		"empty, width":         mustBuildFixed(t, NewFixedKeyBuilder(4, 8)),
+		"empty, offsets":       mustBuildVar(t, NewVarKeyBuilder(4, 16)),
 	} {
 		t.Run(name, func(t *testing.T) {
 			n := keys.Len()
@@ -541,13 +512,9 @@ func TestSortedKeysAtRefusesOutOfRange(t *testing.T) {
 	})
 }
 
-// TestShrinkKeysReleasesTheDedupedTail covers the copy that returns a deduped
-// batch's array to the collector.
-//
-// Asserted on the array identity, not on cap(): the returned slice is capped at
-// the last surviving key either way, so cap() reads the same whether the tail
-// was released or is merely hidden behind it. That is the trap the shrink code
-// itself first fell into, and a test reading cap() falls into it too.
+// TestShrinkKeysReleasesTheDedupedTail asserts on array identity, not cap():
+// cap() reads the same whether the dead tail was released or merely hidden
+// behind it.
 func TestShrinkKeysReleasesTheDedupedTail(t *testing.T) {
 	sameArray := func(a, b []byte) bool { return &a[:1][0] == &b[:1][0] }
 
@@ -576,13 +543,7 @@ func TestShrinkKeysReleasesTheDedupedTail(t *testing.T) {
 
 			require.Len(t, got, tt.end)
 			assert.Equal(t, src[:tt.end], got, "shrinking must not alter a key")
-			if tt.wantCopied {
-				// append rounds to a size class, so the spare bytes are fresh
-				// zeros rather than the tail that was dropped.
-				assert.GreaterOrEqual(t, cap(got), tt.end)
-			} else {
-				assert.Equal(t, tt.end, cap(got), "an aliased result must stop at the last key")
-			}
+			assert.Equal(t, tt.end, cap(got), "a result must stop at the last key")
 			assert.Equal(t, tt.wantCopied, !sameArray(src, got),
 				"copied-vs-aliased decides whether the array is released")
 		})
@@ -606,9 +567,8 @@ func TestShrinkKeysReleasesTheDedupedTail(t *testing.T) {
 		assert.True(t, aliased(belowFloor, shrinkOffs(belowFloor, 1)), "1023 offsets is below it")
 	})
 
-	// The helpers above are only reached through Build, and nothing else pins
-	// that Build still calls them: every call site could go back to a plain
-	// three-index slice with the rest of the suite green.
+	// Pins that Build still calls shrinkKeys/shrinkOffs, since nothing else
+	// would notice a regression to a plain three-index slice.
 	t.Run("Build hands the batch array back", func(t *testing.T) {
 		const n = 100_000
 

--- a/entities/tokenizer/analyze.go
+++ b/entities/tokenizer/analyze.go
@@ -136,6 +136,36 @@ func (b *AnalyzedBatch) All() iter.Seq2[int, []string] {
 	}
 }
 
+// SingleTokenBytes checks that every value produced exactly one token and
+// reports the tokens' total byte length.
+//
+// A caller building one key per value has no key to stand for a value that
+// tokenized into none or several, so the precondition is checked rather than
+// assumed. FIELD tokenization gives one token per value, but these are query
+// tokens: a stopword detector can empty a value.
+//
+// The total is bounded like [AnalyzeBatch] bounds the token count, since a
+// caller indexing with uint32 offsets needs a byte limit and a token limit does
+// not imply one.
+func (b *AnalyzedBatch) SingleTokenBytes() (int, error) {
+	var total uint64
+	start := uint32(0)
+	for i, end := range b.ends {
+		if end-start != 1 {
+			return 0, fmt.Errorf("value %d produced %d tokens, want exactly 1", i, end-start)
+		}
+		// One token per value, so flat[start] is value i's, and counting it
+		// here saves a second walk of the whole batch.
+		total += uint64(len(b.flat[start]))
+		start = end
+	}
+	if total > math.MaxUint32 {
+		return 0, fmt.Errorf("batch produced %d bytes of tokens, above the uint32 offset limit %d",
+			total, uint32(math.MaxUint32))
+	}
+	return int(total), nil
+}
+
 // AnalyzeBatch analyzes each value independently — the batch equivalent of
 // calling Analyze per value and collecting each result's Query — but reuses
 // buffers across values and records tokenizer metrics once for the whole

--- a/entities/tokenizer/analyze.go
+++ b/entities/tokenizer/analyze.go
@@ -136,17 +136,11 @@ func (b *AnalyzedBatch) All() iter.Seq2[int, []string] {
 	}
 }
 
-// SingleTokenBytes checks that every value produced exactly one token and
-// reports the tokens' total byte length.
-//
-// A caller building one key per value has no key to stand for a value that
-// tokenized into none or several, so the precondition is checked rather than
-// assumed. FIELD tokenization gives one token per value, but these are query
-// tokens: a stopword detector can empty a value.
-//
-// The total is bounded like [AnalyzeBatch] bounds the token count, since a
-// caller indexing with uint32 offsets needs a byte limit and a token limit does
-// not imply one.
+// SingleTokenBytes checks that every value produced exactly one token — a
+// caller building one key per value has none to stand for a value that
+// tokenized into none or several, which a stopword detector can still do
+// under FIELD tokenization — and reports the tokens' total byte length,
+// bounded like [AnalyzeBatch] bounds the token count.
 func (b *AnalyzedBatch) SingleTokenBytes() (int, error) {
 	var total uint64
 	start := uint32(0)

--- a/entities/tokenizer/analyze_batch_test.go
+++ b/entities/tokenizer/analyze_batch_test.go
@@ -263,3 +263,99 @@ func TestAnalyzedBatchAccessors(t *testing.T) {
 			"full-slice-capped views must force append to reallocate")
 	})
 }
+
+// TestSingleTokenBytes covers the precondition the batched key builder depends
+// on: one token per value, and their total byte length.
+//
+// The caller builds one key per value from that value's single token, so a
+// value that tokenized into none or several has no key to stand for it — and
+// the total sizes the slab those keys are written into. Both are checked here
+// rather than through the caller, which cannot reach the failing shapes: it
+// passes FIELD tokenization and no stopword detector, under which every value
+// yields exactly one token.
+func TestSingleTokenBytes(t *testing.T) {
+	tests := []struct {
+		name         string
+		values       []string
+		tokenization string
+		stopwords    StopwordDetector
+		wantBytes    int
+		wantErr      string
+	}{
+		{
+			name: "no values", values: nil,
+			tokenization: models.PropertyTokenizationField,
+		},
+		{
+			name: "one token each", values: []string{"alpha", "be"},
+			tokenization: models.PropertyTokenizationField,
+			wantBytes:    7,
+		},
+		{
+			name: "field trims to one token", values: []string{"  padded value  "},
+			tokenization: models.PropertyTokenizationField,
+			wantBytes:    len("padded value"),
+		},
+		{
+			// FIELD keeps an empty token for an empty value, so this is one
+			// key of zero bytes rather than a missing key.
+			name: "empty value is one empty token", values: []string{""},
+			tokenization: models.PropertyTokenizationField,
+			wantBytes:    0,
+		},
+		{
+			name: "a value producing several tokens", values: []string{"alpha", "two words"},
+			tokenization: models.PropertyTokenizationWord,
+			wantErr:      "value 1 produced 2 tokens",
+		},
+		{
+			name: "the first offending value is the one reported", values: []string{"a b c", "d e"},
+			tokenization: models.PropertyTokenizationWord,
+			wantErr:      "value 0 produced 3 tokens",
+		},
+		{
+			// Stopword filtering happens before this runs, so a value whose
+			// only token is a stopword arrives with none.
+			name: "a value producing no tokens", values: []string{"keep", "the"},
+			tokenization: models.PropertyTokenizationWord,
+			stopwords:    fakeStopwords{"the": {}},
+			wantErr:      "value 1 produced 0 tokens",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch, err := AnalyzeBatch(tt.values, tt.tokenization, "Class",
+				NewPreparedAnalyzer(nil), tt.stopwords)
+			require.NoError(t, err)
+
+			total, err := batch.SingleTokenBytes()
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Zero(t, total, "a rejected batch must not report a size")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantBytes, total)
+		})
+	}
+}
+
+// TestSingleTokenBytesCountsEveryToken pins that the total covers all values
+// rather than stopping at the first, which a walk that returned early would
+// still satisfy for a single-value batch.
+func TestSingleTokenBytesCountsEveryToken(t *testing.T) {
+	values := make([]string, 50)
+	want := 0
+	for i := range values {
+		values[i] = fmt.Sprintf("%0*d", i+1, 0)
+		want += i + 1
+	}
+	batch, err := AnalyzeBatch(values, models.PropertyTokenizationField, "Class",
+		NewPreparedAnalyzer(nil), nil)
+	require.NoError(t, err)
+
+	total, err := batch.SingleTokenBytes()
+	require.NoError(t, err)
+	assert.Equal(t, want, total)
+}

--- a/entities/tokenizer/analyze_batch_test.go
+++ b/entities/tokenizer/analyze_batch_test.go
@@ -264,16 +264,18 @@ func TestAnalyzedBatchAccessors(t *testing.T) {
 	})
 }
 
-// TestSingleTokenBytes covers the precondition the batched key builder depends
-// on: one token per value, and their total byte length.
-//
-// The caller builds one key per value from that value's single token, so a
-// value that tokenized into none or several has no key to stand for it — and
-// the total sizes the slab those keys are written into. Both are checked here
-// rather than through the caller, which cannot reach the failing shapes: it
-// passes FIELD tokenization and no stopword detector, under which every value
-// yields exactly one token.
+// TestSingleTokenBytes covers the precondition SingleTokenBytes checks — one
+// token per value — and the byte total it reports.
 func TestSingleTokenBytes(t *testing.T) {
+	// Enough values that a walk stopping short of the last one is visible in
+	// the total, each a different length so no two can cancel out.
+	manyValues := make([]string, 50)
+	manyBytes := 0
+	for i := range manyValues {
+		manyValues[i] = fmt.Sprintf("%0*d", i+1, 0)
+		manyBytes += i + 1
+	}
+
 	tests := []struct {
 		name         string
 		values       []string
@@ -290,6 +292,11 @@ func TestSingleTokenBytes(t *testing.T) {
 			name: "one token each", values: []string{"alpha", "be"},
 			tokenization: models.PropertyTokenizationField,
 			wantBytes:    7,
+		},
+		{
+			name: "many values", values: manyValues,
+			tokenization: models.PropertyTokenizationField,
+			wantBytes:    manyBytes,
 		},
 		{
 			name: "field trims to one token", values: []string{"  padded value  "},
@@ -339,23 +346,4 @@ func TestSingleTokenBytes(t *testing.T) {
 			assert.Equal(t, tt.wantBytes, total)
 		})
 	}
-}
-
-// TestSingleTokenBytesCountsEveryToken pins that the total covers all values
-// rather than stopping at the first, which a walk that returned early would
-// still satisfy for a single-value batch.
-func TestSingleTokenBytesCountsEveryToken(t *testing.T) {
-	values := make([]string, 50)
-	want := 0
-	for i := range values {
-		values[i] = fmt.Sprintf("%0*d", i+1, 0)
-		want += i + 1
-	}
-	batch, err := AnalyzeBatch(values, models.PropertyTokenizationField, "Class",
-		NewPreparedAnalyzer(nil), nil)
-	require.NoError(t, err)
-
-	total, err := batch.SingleTokenBytes()
-	require.NoError(t, err)
-	assert.Equal(t, want, total)
 }


### PR DESCRIPTION
## Motivation

Part 9 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242). The batched path held one key per filter value as a `[][]byte` — a 24-byte header per 8 to 16 bytes of key — and ordered them by comparison sort over those headers: 9-13ms at 100K keys, **36% of a `ContainsAny` query** by CPU profile, roughly 8x the row reads the ordering exists to make sequential.

## Approach

- **`entities/inverted.SortedKeys`** holds one slab plus offsets — or, when every key shares a width, the slab and that width with no index at all. **Only `Build` hands one out**, so there is no separate `Sort` to forget.
- **The ordering arm comes from the key's shape, never the caller's type**, which the lexicographic encoders make sound by giving byte order equal value order. Writing `d` for the discriminating bytes (width minus the shared prefix): `d <= 8` packs into a word, `d <= 16` into two, wider falls to an in-place MSD radix, differing lengths rebuild slab and offsets together. Below each cutoff the packed branches sort in a stack array, allocating nothing.
- **Duplicates are dropped where the order is confirmed** — `Build` already compares each key with its predecessor, so collapsing equal runs is the same pass.
- **`At` defers to the compiler's bounds check**: the hand-written one cost 271 against an inlining budget of 80. `At` is 53 now, and inlines.

## Behaviour change

- **Visible in the slow-query log**: `batched_values` becomes **`batched_keys`** — a 100,000-value boolean filter now reports 2. Results are unchanged; every Contains operator is idempotent in a repeated key.
- A batched leaf can hold **one** key where extraction required two values, so `newBatchedContainsPair` floors on keys rather than the gate's value count.
- **`Build` errors rather than panicking** on anything driven by filter values — a batch past the `uint32` offset ceiling, an ordering inversion the sort detects in itself. A panic on the gRPC search path takes the process down (no recovery interceptor) and would on every replay. Programmer errors still panic; both carry `ErrInternal`.

## Risks and testing

- **A wrong order is silent** — the fold's merge-scan advances one cursor, so unsorted keys return *fewer documents* rather than failing. Every arm is checked against the comparison sort it replaces across widths 1 to 20, sizes straddling every cutoff, and the shapes that break a naive packed sort; the sort also detects an inversion in its own output, naming both keys. Fixed-width fixtures go through a helper that fails if the keys are not the width the case name claims, since `%0Nd` pads to a *minimum* — which is how the 128-bit arm went untested behind a case claiming to cover it.
- **Key width comes from a filter value and nothing caps it**, so `americanFlagSort` and `repairCollisions` iterate rather than recurse: recursion put an attacker-chosen bound on the stack, and a stack overflow is fatal rather than recoverable. A 200,000-byte key killed it; 5,000,000 is fine now.

`go test -race` on `inverted`, `lsmkv`, `roaringset`, `tokenizer`; `-tags integrationTest -race` on the db packages; linters clean. No on-disk or API change. Seven benchmarks ship with it.

## Numbers

300K-object reproduction corpus, this PR vs PR 8; 3 round-robin rounds, 60s per cell, distinct id-sets per request:

| workers | PR 8 | this PR | Δ throughput | Δ p99 |
|---|---|---|---|---|
| 16 | 169.2 q/s | **303.7 q/s** | **+79.6%** | −42.4% |
| 32 | 167.9 | **304.2** | +81.2% | −41.3% |
| 64 | 169.5 | **306.3** | +80.7% | −35.8% |
| 100 | 170.5 | **299.4** | +75.6% | −35.7% |
| 100 (10K ids) | 787.0 | **836.1** | +6.2% | — |

Unlike PR 8, **this is a single-query win too**: sequential p50 61.68ms → **32.01ms** at 100K ids (−48.1%), 8.11 → 6.38 at 10K (−21.4%), unchanged below. Per sort at 100K keys — int/date/number 12.9ms → **1.0**, uuid 12.4 → **2.1**, boolean 6.5 → **0.05**, text 9.1 → **1.4**; iterating them 93µs → 41µs.

Allocations, `BenchmarkDocIDs_ContainsAny` over the whole `DocIDs` path:

| keys | PR 8 | this PR | Δ bytes | allocs |
|---|---|---|---|---|
| 100 | 13,434 B | 13,370 B | −0.5% | 104 → 107 |
| 1,000 | 103,472 | 99,797 | −3.6% | 42 → 45 |
| 10,000 | 640,048 | 599,504 | −6.3% | 42 → 45 |
| 100,000 | 5,703,496 | **5,310,373** | **−6.9%** | 51 → 51 |

The headers removed (~2.4MB at 100K keys) outweigh the scratch added (~2MB), and object count stays flat because that scratch is two large slices. Total allocated is not peak live: **peak is 2-4x the key bytes**, freed when `Build` returns, per concurrent query. That benchmark's *timings* are omitted — `sampleValues` strides upward, so its keys arrive sorted and pdqsort exits after one scan; allocation is order-independent, so the table stands.

### The win depends on the memtable being skippable

PR 8's reader drops an active memtable that is empty when the view is taken, so today a filter's keys never touch it — production cannot rely on that. Measured at 100K/16 with the skip removed:

| | memtable skipped | memtable read | cost |
|---|---|---|---|
| PR 8 | 169.2 q/s | 82.0 | −51.5% |
| this PR | **303.7** | **76.5** | **−74.8%** |

**The advantage is conditional, and inverts when the condition fails** — 76.5 against PR 8's 82.0. Both hit the floor set by 100,000 lock acquisitions per query; a profile puts the memtable's `RWMutex` atomic at 64% of samples here against 40% for PR 8, the faster fold keeping its workers inside the lock region longer. Nothing regresses what ships today — the skip is in place, and the left column is production. **PR 10 addresses it** by reading the memtable a window of the batch at a time rather than per key: 0.993 of the skipped-memtable rate, against 0.252 here.

The 10K cell is the noisiest here and has produced results that did not reproduce; read +6.2% as "no worse", not a measurement. Throughput is requests / wall — a ratio between branches, not an absolute rate.