### PR TITLE
Fix Geo property bugs

### DIFF
--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
@@ -47,7 +48,8 @@ type Aggregator struct {
 	store                   *lsmkv.Store
 	params                  aggregation.Params
 	getSchema               schemaUC.SchemaGetter
-	classSearcher           inverted.ClassSearcher // to support ref-filters
+	propIndices             propertyspecific.Indices // to support geo-filters
+	classSearcher           inverted.ClassSearcher   // to support ref-filters
 	vectorIndex             vectorIndex
 	stopwordProvider        *stopwords.Provider
 	shardVersion            uint16
@@ -92,7 +94,8 @@ func (a *Aggregator) WithBatchedContainsEnabled(v *runtime.DynamicValue[bool]) *
 }
 
 func New(store *lsmkv.Store, params aggregation.Params,
-	getSchema schemaUC.SchemaGetter, classSearcher inverted.ClassSearcher,
+	getSchema schemaUC.SchemaGetter, propIndices propertyspecific.Indices,
+	classSearcher inverted.ClassSearcher,
 	stopwordProvider *stopwords.Provider, shardVersion uint16,
 	vectorIndex vectorIndex, logger logrus.FieldLogger,
 	propLenTracker *inverted.JsonShardMetaData,
@@ -108,6 +111,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 		store:                   store,
 		params:                  params,
 		getSchema:               getSchema,
+		propIndices:             propIndices,
 		classSearcher:           classSearcher,
 		stopwordProvider:        stopwordProvider,
 		shardVersion:            shardVersion,

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/docid"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
-	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -142,7 +141,7 @@ func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.
 	kw.ChooseSearchableProperties(class)
 
 	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, fa.getSchema.ReadOnlyClass,
-		propertyspecific.Indices{}, fa.classSearcher, fa.stopwordProvider,
+		fa.classSearcher, fa.stopwordProvider,
 		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,
 	).WithTokenizationResolver(fa.tokResolver).
 		WithSearchableBucketPinningResolver(fa.bucketPinResolver).

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -18,7 +18,6 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
-	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
@@ -55,7 +54,7 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 	kw.ChooseSearchableProperties(class)
 
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, a.getSchema.ReadOnlyClass,
-		propertyspecific.Indices{}, a.classSearcher, a.stopwordProvider,
+		a.classSearcher, a.stopwordProvider,
 		a.GetPropertyLengthTracker(), a.logger, a.shardVersion,
 	).WithTokenizationResolver(a.tokResolver).
 		WithSearchableBucketPinningResolver(a.bucketPinResolver).

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -94,7 +94,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 	)
 
 	if a.params.Filters != nil {
-		allow, err = inverted.NewSearcher(a.logger, a.store, a.getSchema.ReadOnlyClass, nil,
+		allow, err = inverted.NewSearcher(a.logger, a.store, a.getSchema.ReadOnlyClass, a.propIndices,
 			a.classSearcher, a.stopwordProvider, a.shardVersion, a.isFallbackToSearchable,
 			a.isRangeableLocallyReady, a.tenant, a.nestedCrossRefLimit, a.bitmapFactory).
 			WithTokenizationResolver(a.tokResolver).

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -16,6 +16,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -1187,6 +1188,123 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 		// notice the opposite order
 		assert.Equal(t, ids[1], res[0].ID)
 	})
+}
+
+// AddProperty writes the shard's property indices while a geo filter reads
+// them, so the searcher must not be handed the live map.
+func TestGeoFilterDuringConcurrentAddProperty(t *testing.T) {
+	dirName := t.TempDir()
+
+	logger, _ := test.NewNullLogger()
+	shardState := singleShardState()
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: shardState,
+	}
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+		class := &models.Class{Class: className}
+		return readFunc(class, shardState)
+	}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().HasActiveReplicationForShard(mock.Anything, mock.Anything).Return(false).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
+	repo, err := New(logger, "node1", Config{
+		MemtablesFlushDirtyAfter:  60,
+		RootPath:                  dirName,
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
+		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader, nil)
+	require.Nil(t, err)
+	repo.SetSchemaGetter(schemaGetter)
+	require.Nil(t, repo.WaitForStartup(testCtx()))
+	defer repo.Shutdown(context.Background())
+
+	migrator := NewMigrator(repo, logger, "node1")
+	className := "GeoConcurrentTestClass"
+
+	class := &models.Class{
+		Class:               className,
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		Properties: []*models.Property{
+			{
+				Name:     "location",
+				DataType: []string{string(schema.DataTypeGeoCoordinates)},
+			},
+		},
+	}
+	require.Nil(t, migrator.AddClass(context.Background(), class))
+	schemaGetter.schema.Objects = &models.Schema{Classes: []*models.Class{class}}
+
+	lat, lon := float32(7), float32(1)
+	require.Nil(t, repo.PutObject(context.Background(), &models.Object{
+		Class: className,
+		ID:    "4002609e-ee57-4404-a0ad-798af7da0004",
+		Properties: map[string]interface{}{
+			"location": &models.GeoCoordinates{Latitude: &lat, Longitude: &lon},
+		},
+	}, []float32{0.5}, nil, nil, nil, 0))
+
+	searchQuery := filters.GeoRange{
+		GeoCoordinates: &models.GeoCoordinates{
+			Latitude:  ptFloat32(6.0),
+			Longitude: ptFloat32(-2.0),
+		},
+		Distance: 400000,
+	}
+
+	const rounds = 25
+	var (
+		wg       sync.WaitGroup
+		errsLock sync.Mutex
+		errs     []error
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			err := migrator.AddProperty(context.Background(), className, &models.Property{
+				Name:     fmt.Sprintf("location%d", i),
+				DataType: []string{string(schema.DataTypeGeoCoordinates)},
+			})
+			if err != nil {
+				errsLock.Lock()
+				errs = append(errs, err)
+				errsLock.Unlock()
+			}
+		}
+	}()
+
+	for reader := 0; reader < 4; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				_, err := repo.Search(context.Background(),
+					getParamsWithFilter(className, buildFilter(
+						"location", searchQuery, wgr, schema.DataTypeGeoCoordinates,
+					)))
+				if err != nil {
+					errsLock.Lock()
+					errs = append(errs, err)
+					errsLock.Unlock()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	require.Empty(t, errs)
 }
 
 // This test prevents a regression on

--- a/adapters/repos/db/filters_integration_test.go
+++ b/adapters/repos/db/filters_integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -37,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/objects"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -1067,8 +1069,10 @@ var carVectors = [][]float32{
 	{0, 0, 0, 0, 1.1},
 }
 
-func TestGeoPropUpdateJourney(t *testing.T) {
-	dirName := t.TempDir()
+// newGeoTestRepo starts a repo holding className with a single geo property
+// named "location".
+func newGeoTestRepo(t *testing.T, className string) (*DB, *Migrator) {
+	t.Helper()
 
 	logger, _ := test.NewNullLogger()
 	shardState := singleShardState()
@@ -1093,36 +1097,55 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 	repo, err := New(logger, "node1", Config{
 		MemtablesFlushDirtyAfter:  60,
-		RootPath:                  dirName,
+		RootPath:                  t.TempDir(),
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
 	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
 		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	repo.SetSchemaGetter(schemaGetter)
-	require.Nil(t, repo.WaitForStartup(testCtx()))
-	defer repo.Shutdown(context.Background())
+	require.NoError(t, repo.WaitForStartup(testCtx()))
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
 
 	migrator := NewMigrator(repo, logger, "node1")
-
-	t.Run("import schema", func(t *testing.T) {
-		class := &models.Class{
-			Class:               "GeoUpdateTestClass",
-			VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
-			InvertedIndexConfig: invertedConfig(),
-			Properties: []*models.Property{
-				{
-					Name:     "location",
-					DataType: []string{string(schema.DataTypeGeoCoordinates)},
-				},
+	class := &models.Class{
+		Class:               className,
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		Properties: []*models.Property{
+			{
+				Name:     "location",
+				DataType: []string{string(schema.DataTypeGeoCoordinates)},
 			},
-		}
+			{
+				Name:     "name",
+				DataType: []string{string(schema.DataTypeText)},
+			},
+		},
+	}
+	require.NoError(t, migrator.AddClass(context.Background(), class))
+	schemaGetter.schema.Objects = &models.Schema{Classes: []*models.Class{class}}
 
-		migrator.AddClass(context.Background(), class)
-		schemaGetter.schema.Objects = &models.Schema{
-			Classes: []*models.Class{class},
-		}
-	})
+	return repo, migrator
+}
+
+func putGeoObject(t *testing.T, repo *DB, className, name string, id strfmt.UUID, lat, lon float32) {
+	t.Helper()
+
+	require.NoError(t, repo.PutObject(context.Background(), &models.Object{
+		Class: className,
+		ID:    id,
+		Properties: map[string]interface{}{
+			"location": &models.GeoCoordinates{Latitude: &lat, Longitude: &lon},
+			"name":     name,
+		},
+	}, []float32{0.5}, nil, nil, nil, 0))
+}
+
+func TestGeoPropUpdateJourney(t *testing.T) {
+	const className = "GeoUpdateTestClass"
+
+	repo, _ := newGeoTestRepo(t, className)
 
 	ids := []strfmt.UUID{
 		"4002609e-ee57-4404-a0ad-798af7da0004",
@@ -1141,7 +1164,7 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 		return func(t *testing.T) {
 			for i, id := range ids {
 				repo.PutObject(context.Background(), &models.Object{
-					Class: "GeoUpdateTestClass",
+					Class: className,
 					ID:    id,
 					Properties: map[string]interface{}{
 						"location": &models.GeoCoordinates{
@@ -1161,7 +1184,7 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 
 	t.Run("verify 1st object found", func(t *testing.T) {
 		res, err := repo.Search(context.Background(),
-			getParamsWithFilter("GeoUpdateTestClass", buildFilter(
+			getParamsWithFilter(className, buildFilter(
 				"location", searchQuery, wgr, schema.DataTypeGeoCoordinates,
 			)))
 
@@ -1178,7 +1201,7 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 
 	t.Run("verify 2nd object found", func(t *testing.T) {
 		res, err := repo.Search(context.Background(),
-			getParamsWithFilter("GeoUpdateTestClass", buildFilter(
+			getParamsWithFilter(className, buildFilter(
 				"location", searchQuery, wgr, schema.DataTypeGeoCoordinates,
 			)))
 
@@ -1193,66 +1216,10 @@ func TestGeoPropUpdateJourney(t *testing.T) {
 // AddProperty writes the shard's property indices while a geo filter reads
 // them, so the searcher must not be handed the live map.
 func TestGeoFilterDuringConcurrentAddProperty(t *testing.T) {
-	dirName := t.TempDir()
-
-	logger, _ := test.NewNullLogger()
-	shardState := singleShardState()
-	schemaGetter := &fakeSchemaGetter{
-		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
-		shardState: shardState,
-	}
-	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
-	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardState.AllPhysicalShards(), nil).Maybe()
-	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
-		class := &models.Class{Class: className}
-		return readFunc(class, shardState)
-	}).Maybe()
-	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
-	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
-	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
-	mockReplicationFSMReader.EXPECT().HasActiveReplicationForShard(mock.Anything, mock.Anything).Return(false).Maybe()
-	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
-	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
-	mockNodeSelector := cluster.NewMockNodeSelector(t)
-	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
-	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
-	repo, err := New(logger, "node1", Config{
-		MemtablesFlushDirtyAfter:  60,
-		RootPath:                  dirName,
-		QueryMaximumResults:       10000,
-		MaxImportGoroutinesFactor: 1,
-	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
-		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader, nil)
-	require.Nil(t, err)
-	repo.SetSchemaGetter(schemaGetter)
-	require.Nil(t, repo.WaitForStartup(testCtx()))
-	defer repo.Shutdown(context.Background())
-
-	migrator := NewMigrator(repo, logger, "node1")
 	className := "GeoConcurrentTestClass"
+	repo, migrator := newGeoTestRepo(t, className)
 
-	class := &models.Class{
-		Class:               className,
-		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
-		InvertedIndexConfig: invertedConfig(),
-		Properties: []*models.Property{
-			{
-				Name:     "location",
-				DataType: []string{string(schema.DataTypeGeoCoordinates)},
-			},
-		},
-	}
-	require.Nil(t, migrator.AddClass(context.Background(), class))
-	schemaGetter.schema.Objects = &models.Schema{Classes: []*models.Class{class}}
-
-	lat, lon := float32(7), float32(1)
-	require.Nil(t, repo.PutObject(context.Background(), &models.Object{
-		Class: className,
-		ID:    "4002609e-ee57-4404-a0ad-798af7da0004",
-		Properties: map[string]interface{}{
-			"location": &models.GeoCoordinates{Latitude: &lat, Longitude: &lon},
-		},
-	}, []float32{0.5}, nil, nil, nil, 0))
+	putGeoObject(t, repo, className, "location", "4002609e-ee57-4404-a0ad-798af7da0004", 7, 1)
 
 	searchQuery := filters.GeoRange{
 		GeoCoordinates: &models.GeoCoordinates{
@@ -1305,6 +1272,159 @@ func TestGeoFilterDuringConcurrentAddProperty(t *testing.T) {
 
 	wg.Wait()
 	require.Empty(t, errs)
+}
+
+// A geo filter resolves against the shard's geo index, so a path that reaches
+// the searcher without those indices matches nothing instead of failing.
+func TestGeoFilterOnFilteredPaths(t *testing.T) {
+	const (
+		nearAID = strfmt.UUID("4002609e-ee57-4404-a0ad-798af7da0004")
+		nearBID = strfmt.UUID("1477aed8-f677-4131-a3ad-4deef6176066")
+		farID   = strfmt.UUID("6b0d9bbb-3b3d-4f3f-8f47-4b1e0e3fbb02")
+	)
+
+	near := filters.GeoRange{
+		GeoCoordinates: &models.GeoCoordinates{
+			Latitude:  ptFloat32(6.0),
+			Longitude: ptFloat32(-2.0),
+		},
+		Distance: 400000,
+	}
+	// no object sits this close to the query point
+	none := filters.GeoRange{GeoCoordinates: near.GeoCoordinates, Distance: 1}
+
+	tests := []struct {
+		name  string
+		geo   filters.GeoRange
+		check func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter)
+	}{
+		{
+			name: "aggregate counts only the objects in range",
+			geo:  near,
+			check: func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter) {
+				res, err := repo.Aggregate(context.Background(), aggregation.Params{
+					ClassName:        schema.ClassName(className),
+					Filters:          filter,
+					IncludeMetaCount: true,
+				}, nil)
+
+				require.NoError(t, err)
+				require.Len(t, res.Groups, 1)
+				assert.Equal(t, 2, res.Groups[0].Count)
+			},
+		},
+		{
+			name: "aggregate counts nothing when the range is empty",
+			geo:  none,
+			check: func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter) {
+				res, err := repo.Aggregate(context.Background(), aggregation.Params{
+					ClassName:        schema.ClassName(className),
+					Filters:          filter,
+					IncludeMetaCount: true,
+				}, nil)
+
+				require.NoError(t, err)
+				require.Len(t, res.Groups, 1)
+				assert.Equal(t, 0, res.Groups[0].Count)
+			},
+		},
+		{
+			name: "grouped aggregate groups only the objects in range",
+			geo:  near,
+			check: func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter) {
+				res, err := repo.Aggregate(context.Background(), aggregation.Params{
+					ClassName: schema.ClassName(className),
+					Filters:   filter,
+					GroupBy: &filters.Path{
+						Class:    schema.ClassName(className),
+						Property: schema.PropertyName("name"),
+					},
+					IncludeMetaCount: true,
+				}, nil)
+
+				require.NoError(t, err)
+				groups := make([]string, 0, len(res.Groups))
+				for _, group := range res.Groups {
+					groups = append(groups, group.GroupedBy.Value.(string))
+				}
+				assert.ElementsMatch(t, []string{"near-a", "near-b"}, groups)
+			},
+		},
+		{
+			name: "batch delete removes only the objects in range",
+			geo:  near,
+			check: func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter) {
+				res, err := repo.BatchDeleteObjects(context.Background(), objects.BatchDeleteParams{
+					ClassName: schema.ClassName(className),
+					Filters:   filter,
+					DryRun:    false,
+				}, time.Now(), nil, "", 0)
+
+				require.NoError(t, err)
+				assert.Equal(t, int64(2), res.Matches)
+				require.Len(t, res.Objects, 2)
+
+				// a wide radius enumerates everything, so the far object must still be there
+				remaining, err := repo.Search(context.Background(),
+					getParamsWithFilter(className, buildFilter("location", filters.GeoRange{
+						GeoCoordinates: near.GeoCoordinates,
+						Distance:       20000000,
+					}, wgr, schema.DataTypeGeoCoordinates)))
+				require.NoError(t, err)
+				require.Len(t, remaining, 1)
+				assert.Equal(t, farID, remaining[0].ID)
+			},
+		},
+		{
+			name: "batch delete dry run reports the matches but keeps them",
+			geo:  near,
+			check: func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter) {
+				res, err := repo.BatchDeleteObjects(context.Background(), objects.BatchDeleteParams{
+					ClassName: schema.ClassName(className),
+					Filters:   filter,
+					DryRun:    true,
+				}, time.Now(), nil, "", 0)
+
+				require.NoError(t, err)
+				assert.Equal(t, int64(2), res.Matches)
+
+				remaining, err := repo.Search(context.Background(),
+					getParamsWithFilter(className, buildFilter("location", filters.GeoRange{
+						GeoCoordinates: near.GeoCoordinates,
+						Distance:       20000000,
+					}, wgr, schema.DataTypeGeoCoordinates)))
+				require.NoError(t, err)
+				require.Len(t, remaining, 3)
+			},
+		},
+		{
+			name: "batch delete removes nothing when the range is empty",
+			geo:  none,
+			check: func(t *testing.T, repo *DB, className string, filter *filters.LocalFilter) {
+				res, err := repo.BatchDeleteObjects(context.Background(), objects.BatchDeleteParams{
+					ClassName: schema.ClassName(className),
+					Filters:   filter,
+					DryRun:    false,
+				}, time.Now(), nil, "", 0)
+
+				require.NoError(t, err)
+				assert.Equal(t, int64(0), res.Matches)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			className := "GeoFilteredPathsTestClass"
+			repo, _ := newGeoTestRepo(t, className)
+			putGeoObject(t, repo, className, "near-a", nearAID, 6.5, -1)
+			putGeoObject(t, repo, className, "near-b", nearBID, 6.4, -1.1)
+			putGeoObject(t, repo, className, "far", farID, 45, 40)
+
+			test.check(t, repo, className, buildFilter(
+				"location", test.geo, wgr, schema.DataTypeGeoCoordinates))
+		})
+	}
 }
 
 // This test prevents a regression on

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -35,7 +35,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/terms"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
-	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -49,7 +48,6 @@ type BM25Searcher struct {
 	store            *lsmkv.Store
 	getClass         func(string) *models.Class
 	classSearcher    ClassSearcher // to allow recursive searches on ref-props
-	propIndices      propertyspecific.Indices
 	propLenTracker   propLengthRetriever
 	logger           logrus.FieldLogger
 	shardVersion     uint16
@@ -119,7 +117,7 @@ type termListRequest struct {
 }
 
 func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store,
-	getClass func(string) *models.Class, propIndices propertyspecific.Indices,
+	getClass func(string) *models.Class,
 	classSearcher ClassSearcher, stopwordProvider *stopwords.Provider, propLenTracker propLengthRetriever,
 	logger logrus.FieldLogger, shardVersion uint16,
 ) *BM25Searcher {
@@ -127,7 +125,6 @@ func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store,
 		config:           config,
 		store:            store,
 		getClass:         getClass,
-		propIndices:      propIndices,
 		classSearcher:    classSearcher,
 		propLenTracker:   propLenTracker,
 		logger:           logger.WithField("action", "bm25_search"),

--- a/adapters/repos/db/inverted_reindex_pin_bucket_drain_test.go
+++ b/adapters/repos/db/inverted_reindex_pin_bucket_drain_test.go
@@ -113,7 +113,7 @@ func runPinBucketDrainProof(t *testing.T, forceRefetch bool) pinBucketDrainResul
 	}
 
 	bm25 := inverted.NewBM25Searcher(bm25Config, shard.store,
-		idx.getSchema.ReadOnlyClass, shard.propertyIndices, idx.classSearcher,
+		idx.getSchema.ReadOnlyClass, idx.classSearcher,
 		idx.getStopwordProvider(), shard.GetPropertyLengthTracker(), logger,
 		shard.versioner.Version())
 

--- a/adapters/repos/db/propertyspecific/index.go
+++ b/adapters/repos/db/propertyspecific/index.go
@@ -14,7 +14,6 @@ package propertyspecific
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -55,19 +54,23 @@ func (i Indices) ShutdownGeoIndices(ctx context.Context) error {
 }
 
 func (i Indices) DropAll(ctx context.Context, keepFiles bool) error {
+	// one failing property must not skip the teardown of the remaining ones
+	ec := errorcompounder.New()
 	for propName, index := range i {
 		if index.Type != schema.DataTypeGeoCoordinates {
-			return errors.Errorf("no implementation to delete property %s index of type %v",
+			ec.Addf("no implementation to delete property %s index of type %v",
 				propName, index.Type)
+			continue
 		}
 
 		if err := index.GeoIndex.Drop(ctx, keepFiles); err != nil {
-			return errors.Wrapf(err, "drop property %s", propName)
+			ec.AddWrapf(err, "drop property %s", propName)
+			continue
 		}
 
-		index.GeoIndex = nil
+		// Drop nils the underlying vector index, so a kept entry would panic
+		// the next ShutdownGeoIndices
 		delete(i, propName)
-
 	}
-	return nil
+	return ec.ToError()
 }

--- a/adapters/repos/db/propertyspecific/index_test.go
+++ b/adapters/repos/db/propertyspecific/index_test.go
@@ -65,25 +65,9 @@ func TestShutdownGeoIndices(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			indices := Indices{}
-			for _, propName := range test.geoProps {
-				indices[propName] = Index{
-					Name:     propName,
-					Type:     schema.DataTypeGeoCoordinates,
-					GeoIndex: newGeoIndex(t, propName),
-				}
-			}
-			if test.otherProp {
-				indices["name"] = Index{Name: "name", Type: schema.DataTypeText}
-			}
+			indices := newIndices(t, test.geoProps, test.otherProp)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			if test.cancelled {
-				cancel()
-			}
-
-			err := indices.ShutdownGeoIndices(ctx)
+			err := indices.ShutdownGeoIndices(testContext(t, test.cancelled))
 
 			if len(test.wantErrs) == 0 {
 				require.NoError(t, err)
@@ -95,6 +79,131 @@ func TestShutdownGeoIndices(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDropAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		geoProps  []string
+		otherProp bool
+		// a cancelled context makes every geo index fail to drop
+		cancelled     bool
+		repeat        int
+		wantErrs      []string
+		wantRemaining []string
+	}{
+		{
+			name: "no properties",
+		},
+		{
+			name:     "single geo property is dropped",
+			geoProps: []string{"location"},
+		},
+		{
+			name:     "every geo property is dropped",
+			geoProps: []string{"location", "home", "work"},
+		},
+		{
+			name:          "unsupported property type is reported and stays registered",
+			otherProp:     true,
+			wantErrs:      []string{"no implementation to delete property name"},
+			wantRemaining: []string{"name"},
+		},
+		{
+			// map iteration order is random, so a single run can pass even when
+			// the loop aborts at the unsupported property
+			name:          "unsupported property type does not strand the geo indices",
+			geoProps:      []string{"location", "home", "work"},
+			otherProp:     true,
+			repeat:        20,
+			wantErrs:      []string{"no implementation to delete property name"},
+			wantRemaining: []string{"name"},
+		},
+		{
+			name:          "single geo property fails and stays registered",
+			geoProps:      []string{"location"},
+			cancelled:     true,
+			wantErrs:      []string{"drop property location"},
+			wantRemaining: []string{"location"},
+		},
+		{
+			name:      "every failing geo property is reported, not just the first",
+			geoProps:  []string{"location", "home", "work"},
+			cancelled: true,
+			wantErrs: []string{
+				"drop property location",
+				"drop property home",
+				"drop property work",
+			},
+			wantRemaining: []string{"location", "home", "work"},
+		},
+		{
+			name:      "failing drops and an unsupported type are all reported",
+			geoProps:  []string{"location", "home", "work"},
+			otherProp: true,
+			cancelled: true,
+			wantErrs: []string{
+				"drop property location",
+				"drop property home",
+				"drop property work",
+				"no implementation to delete property name",
+			},
+			wantRemaining: []string{"location", "home", "work", "name"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			for i := 0; i < max(test.repeat, 1); i++ {
+				indices := newIndices(t, test.geoProps, test.otherProp)
+
+				err := indices.DropAll(testContext(t, test.cancelled), false)
+
+				if len(test.wantErrs) == 0 {
+					require.NoError(t, err)
+				} else {
+					require.Error(t, err)
+					for _, want := range test.wantErrs {
+						require.ErrorContains(t, err, want)
+					}
+				}
+
+				remaining := make([]string, 0, len(indices))
+				for propName := range indices {
+					remaining = append(remaining, propName)
+				}
+				require.ElementsMatch(t, test.wantRemaining, remaining)
+			}
+		})
+	}
+}
+
+func newIndices(t *testing.T, geoProps []string, otherProp bool) Indices {
+	t.Helper()
+
+	indices := Indices{}
+	for _, propName := range geoProps {
+		indices[propName] = Index{
+			Name:     propName,
+			Type:     schema.DataTypeGeoCoordinates,
+			GeoIndex: newGeoIndex(t, propName),
+		}
+	}
+	if otherProp {
+		indices["name"] = Index{Name: "name", Type: schema.DataTypeText}
+	}
+	return indices
+}
+
+func testContext(t *testing.T, cancelled bool) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	if cancelled {
+		cancel()
+	}
+	return ctx
 }
 
 func newGeoIndex(t *testing.T, id string) *geo.Index {

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -14,9 +14,12 @@
 package db
 
 import (
+	"maps"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -201,6 +204,20 @@ func (s *Shard) ForEachGeoIndex(f func(propName string, index *geo.Index) error)
 		}
 	}
 	return nil
+}
+
+// propertyIndicesSnapshot copies the property-specific indices for a searcher
+// to read after this returns. Handing out the live map instead would race with
+// initGeoProp and DropAll, which is fatal rather than recoverable. The copy is
+// shallow: the *geo.Index values stay shared, so a concurrent drop reaches them.
+func (s *Shard) propertyIndicesSnapshot() propertyspecific.Indices {
+	s.propertyIndicesLock.RLock()
+	defer s.propertyIndicesLock.RUnlock()
+
+	if len(s.propertyIndices) == 0 {
+		return nil
+	}
+	return maps.Clone(s.propertyIndices)
 }
 
 func (s *Shard) hasGeoIndex() bool {

--- a/adapters/repos/db/shard_accessors_test.go
+++ b/adapters/repos/db/shard_accessors_test.go
@@ -12,11 +12,15 @@
 package db
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -167,4 +171,109 @@ func TestShard_ForEachVectorIndexAndQueue(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestShard_PropertyIndicesSnapshot(t *testing.T) {
+	tests := []struct {
+		name    string
+		props   []string
+		wantNil bool
+	}{
+		{
+			name:    "uninitialized",
+			wantNil: true,
+		},
+		{
+			name:    "no properties",
+			props:   []string{},
+			wantNil: true,
+		},
+		{
+			name:  "single geo property",
+			props: []string{"location"},
+		},
+		{
+			name:  "several geo properties",
+			props: []string{"location", "home", "work"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var live propertyspecific.Indices
+			if test.props != nil {
+				live = propertyspecific.Indices{}
+				for _, propName := range test.props {
+					live[propName] = propertyspecific.Index{
+						Name: propName,
+						Type: schema.DataTypeGeoCoordinates,
+					}
+				}
+			}
+			shard := &Shard{propertyIndices: live}
+
+			snapshot := shard.propertyIndicesSnapshot()
+
+			if test.wantNil {
+				require.Nil(t, snapshot)
+			}
+
+			// a later initGeoProp / DropAll must not reach the handed-out copy
+			if live != nil {
+				shard.propertyIndicesLock.Lock()
+				for _, propName := range test.props {
+					delete(shard.propertyIndices, propName)
+				}
+				shard.propertyIndices["added"] = propertyspecific.Index{Name: "added"}
+				shard.propertyIndicesLock.Unlock()
+			}
+
+			got := make([]string, 0, len(snapshot))
+			for propName := range snapshot {
+				got = append(got, propName)
+			}
+			require.ElementsMatch(t, test.props, got)
+		})
+	}
+}
+
+// A searcher reads the indices long after it was handed them, so the snapshot
+// has to survive writers running the whole time.
+func TestShard_PropertyIndicesSnapshotDuringConcurrentWrites(t *testing.T) {
+	shard := &Shard{propertyIndices: propertyspecific.Indices{
+		"location": {Name: "location", Type: schema.DataTypeGeoCoordinates},
+	}}
+
+	const rounds = 500
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			propName := fmt.Sprintf("prop%d", i)
+			shard.propertyIndicesLock.Lock()
+			shard.propertyIndices[propName] = propertyspecific.Index{
+				Name: propName,
+				Type: schema.DataTypeGeoCoordinates,
+			}
+			delete(shard.propertyIndices, propName)
+			shard.propertyIndicesLock.Unlock()
+		}
+	}()
+
+	for reader := 0; reader < 4; reader++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				snapshot := shard.propertyIndicesSnapshot()
+				for range snapshot {
+				}
+				snapshot.ByProp("location")
+			}
+		}()
+	}
+
+	wg.Wait()
 }

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -32,7 +32,7 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params, module
 		vectorIndex = idx
 	}
 
-	return aggregator.New(s.store, params, s.index.getSchema, s.index.classSearcher,
+	return aggregator.New(s.store, params, s.index.getSchema, s.propertyIndicesSnapshot(), s.index.classSearcher,
 		s.index.getStopwordProvider(), s.versioner.Version(), vectorIndex, s.index.logger, s.GetPropertyLengthTracker(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory, modules, s.index.Config.QueryHybridMaximumResults,
 		s.TokenizationFor).

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -543,7 +543,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 
 		if filters != nil {
 			filterDocIds, err = inverted.NewSearcher(s.index.logger, s.store,
-				s.index.getSchema.ReadOnlyClass, s.propertyIndices,
+				s.index.getSchema.ReadOnlyClass, s.propertyIndicesSnapshot(),
 				s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 				s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit,
 				s.bitmapFactory).
@@ -561,7 +561,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		bm25Config := s.index.GetInvertedIndexConfig().BM25
 		logger := s.index.logger.WithFields(logrus.Fields{"class": s.index.Config.ClassName, "shard": s.name})
 		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store,
-			s.index.getSchema.ReadOnlyClass, s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(),
+			s.index.getSchema.ReadOnlyClass, s.index.classSearcher, s.index.getStopwordProvider(),
 			s.GetPropertyLengthTracker(), logger, s.versioner.Version()).
 			WithTokenizationResolver(s.TokenizationFor).
 			WithSearchableBucketPinningResolver(s.PinTokenizationAndSearchableBucket)
@@ -579,7 +579,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		return objs, nil, err
 	}
 	objs, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
-		s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
+		s.propertyIndicesSnapshot(), s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		WithTokenizationResolver(s.TokenizationFor).
 		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).
@@ -905,7 +905,7 @@ func (s *Shard) sortDocIDsAndDists(ctx context.Context, limit int, sort []filter
 
 func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter, addl additional.Properties) (helpers.AllowList, error) {
 	list, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
-		s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
+		s.propertyIndicesSnapshot(), s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		WithTokenizationResolver(s.TokenizationFor).
 		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -172,7 +172,7 @@ func (s *Shard) FindUUIDs(ctx context.Context, filters *filters.LocalFilter, lim
 	start := time.Now()
 
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
-		nil, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.version, s.isFallbackToSearchable,
+		s.propertyIndicesSnapshot(), s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.version, s.isFallbackToSearchable,
 		s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
 		WithTokenizationResolver(s.TokenizationFor).
 		WithBatchedContainsEnabled(s.index.Config.QueryBatchedContainsEnabled).


### PR DESCRIPTION
### What's being changed:

1. DropAll aborted on the first error, now continues to leave half-shutdown things around
2. Avoid races by handing out a copy of the propertyIndices to avoid concurrent map access which is fatal
3. Resolve geo filters in aggregation and batch delete

Closes: https://github.com/weaviate/dirk-claude-issues/issues/29


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
