### PR TITLE
fix(modules): don't panic when a batch has objects with no vectorizable properties

### DIFF
--- a/usecases/modulecomponents/batch/batch_simple.go
+++ b/usecases/modulecomponents/batch/batch_simple.go
@@ -167,6 +167,10 @@ func (b *BatchSimple[T]) VectorizeBatchObjects(
 				return nil
 			}
 			res, _, err := vectorize(ctx, batchOfObjects[batchIndex].objs, cfg)
+			if err == nil && len(res) != len(batchOfObjects[batchIndex].indexes) {
+				err = fmt.Errorf("vectorizer returned %d embeddings for %d objects",
+					len(res), len(batchOfObjects[batchIndex].indexes))
+			}
 			if err != nil {
 				errorLock.Lock()
 				defer errorLock.Unlock()

--- a/usecases/modulecomponents/batch/batch_simple_test.go
+++ b/usecases/modulecomponents/batch/batch_simple_test.go
@@ -13,6 +13,7 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"slices"
@@ -198,6 +199,125 @@ func TestVectorizeBatchObjects(t *testing.T) {
 				assert.Equal(t, vec, res[i])
 			}
 		})
+	}
+}
+
+// A vectorizer that hands back fewer embeddings than it was given objects used
+// to make VectorizeBatchObjects index past the end of the result slice.
+func TestVectorizeBatchObjects_shortResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		objs       int
+		batchSize  int
+		vectorizer batchObjectsVectorizer[[]float32]
+		errs       map[int]error
+	}{
+		{
+			name:       "no embeddings at all",
+			objs:       3,
+			batchSize:  10,
+			vectorizer: constantResultVectorizer(nil),
+			errs: map[int]error{
+				0: errors.New("vectorizer returned 0 embeddings for 3 objects"),
+				1: errors.New("vectorizer returned 0 embeddings for 3 objects"),
+				2: errors.New("vectorizer returned 0 embeddings for 3 objects"),
+			},
+		},
+		{
+			name:       "fewer embeddings than objects",
+			objs:       3,
+			batchSize:  10,
+			vectorizer: constantResultVectorizer([][]float32{{1, 2}}),
+			errs: map[int]error{
+				0: errors.New("vectorizer returned 1 embeddings for 3 objects"),
+				1: errors.New("vectorizer returned 1 embeddings for 3 objects"),
+				2: errors.New("vectorizer returned 1 embeddings for 3 objects"),
+			},
+		},
+		{
+			name:       "more embeddings than objects",
+			objs:       1,
+			batchSize:  10,
+			vectorizer: constantResultVectorizer([][]float32{{1, 2}, {3, 4}}),
+			errs: map[int]error{
+				0: errors.New("vectorizer returned 2 embeddings for 1 objects"),
+			},
+		},
+		{
+			name:       "short result only affects its own sub-batch",
+			objs:       4,
+			batchSize:  2,
+			vectorizer: shortOnSecondBatchVectorizer(),
+			errs: map[int]error{
+				2: errors.New("vectorizer returned 1 embeddings for 2 objects"),
+				3: errors.New("vectorizer returned 1 embeddings for 2 objects"),
+			},
+		},
+		{
+			// Real vectorizers return no embeddings next to their error, so the
+			// length check must not shadow what the provider actually said.
+			name:       "failing vectorizer keeps its own error",
+			objs:       2,
+			batchSize:  10,
+			vectorizer: failingVectorizer(errors.New("remote client vectorize: 429 rate limit exceeded")),
+			errs: map[int]error{
+				0: errors.New("remote client vectorize: 429 rate limit exceeded"),
+				1: errors.New("remote client vectorize: 429 rate limit exceeded"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l, _ := test.NewNullLogger()
+			sb := NewBatchSimple[[]float32](l, 0)
+
+			res, _, errs := sb.VectorizeBatchObjects(context.Background(),
+				generateObjects(tt.objs), generateSkipObjects(tt.objs), nil, tt.vectorizer, tt.batchSize)
+
+			require.Len(t, errs, len(tt.errs))
+			for index, want := range tt.errs {
+				err, ok := errs[index]
+				require.True(t, ok)
+				assert.EqualError(t, err, want.Error())
+				assert.Empty(t, res[index])
+			}
+			for i := range tt.objs {
+				if _, failed := tt.errs[i]; !failed {
+					assert.NotEmpty(t, res[i])
+				}
+			}
+		})
+	}
+}
+
+func constantResultVectorizer(res [][]float32) batchObjectsVectorizer[[]float32] {
+	return func(ctx context.Context, objs []*models.Object, cfg moduletools.ClassConfig,
+	) ([][]float32, models.AdditionalProperties, error) {
+		return res, nil, nil
+	}
+}
+
+func failingVectorizer(err error) batchObjectsVectorizer[[]float32] {
+	return func(ctx context.Context, objs []*models.Object, cfg moduletools.ClassConfig,
+	) ([][]float32, models.AdditionalProperties, error) {
+		return nil, nil, err
+	}
+}
+
+// Returns a full result for the batch starting at object "0" and a short one
+// for every other batch.
+func shortOnSecondBatchVectorizer() batchObjectsVectorizer[[]float32] {
+	return func(ctx context.Context, objs []*models.Object, cfg moduletools.ClassConfig,
+	) ([][]float32, models.AdditionalProperties, error) {
+		if objs[0].ID == "0" {
+			vecs := make([][]float32, len(objs))
+			for i := range vecs {
+				vecs[i] = []float32{1, 2}
+			}
+			return vecs, nil, nil
+		}
+		return [][]float32{{1, 2}}, nil, nil
 	}
 }
 

--- a/usecases/modulecomponents/vectorizer/batchclip/batch_clip_vectorizer.go
+++ b/usecases/modulecomponents/vectorizer/batchclip/batch_clip_vectorizer.go
@@ -185,14 +185,19 @@ func (v *BatchCLIPVectorizer[T]) objects(ctx context.Context, objects []*models.
 		batchObjects = append(batchObjects, batchObject)
 	}
 
-	var result []T
+	// One entry per input object, always. Objects without any vectorizable
+	// property keep a nil entry: callers map the result back positionally and
+	// panic on a short slice.
+	result := make([]T, len(batchObjects))
 	if len(texts) > 0 || len(images) > 0 {
 		res, err := v.client.Vectorize(ctx, texts, images, cfg)
 		if err != nil {
 			return nil, err
 		}
-		result = make([]T, len(batchObjects))
 		for objIndex, batchObj := range batchObjects {
+			if len(batchObj.textIndexes) == 0 && len(batchObj.imageIndexes) == 0 {
+				continue
+			}
 			vectors := []T{}
 			for _, textIndex := range batchObj.textIndexes {
 				vec, ok := v.getVector(res.TextVectors, textIndex)

--- a/usecases/modulecomponents/vectorizer/batchclip/batch_clip_vectorizer_test.go
+++ b/usecases/modulecomponents/vectorizer/batchclip/batch_clip_vectorizer_test.go
@@ -151,6 +151,122 @@ func Test_BatchCLIPVectorizer(t *testing.T) {
 	})
 }
 
+// Objects that carry none of the configured image/text fields used to make
+// Objects() return a slice shorter than the input, which the batch caller maps
+// back positionally.
+func Test_BatchCLIPVectorizer_ObjectsWithoutVectorizableProperties(t *testing.T) {
+	type testCase struct {
+		name       string
+		objects    []*models.Object
+		client     *fakeClient
+		wantVector []bool
+	}
+
+	vectorizable := map[string]any{"image": image, "text": "text"}
+	imageOnly := map[string]any{"image": image}
+	nonVectorizable := map[string]any{"number": 1.0, "description": "not configured"}
+
+	tests := []testCase{
+		{
+			name: "no object has a vectorizable property",
+			objects: []*models.Object{
+				{ID: "a", Properties: nonVectorizable},
+				{ID: "b", Properties: nonVectorizable},
+			},
+			wantVector: []bool{false, false},
+		},
+		{
+			name: "no properties at all",
+			objects: []*models.Object{
+				{ID: "a"},
+				{ID: "b"},
+			},
+			wantVector: []bool{false, false},
+		},
+		{
+			name: "first object vectorizable, second not",
+			objects: []*models.Object{
+				{ID: "a", Properties: vectorizable},
+				{ID: "b", Properties: nonVectorizable},
+			},
+			wantVector: []bool{true, false},
+		},
+		{
+			name: "non-vectorizable object between two vectorizable ones",
+			objects: []*models.Object{
+				{ID: "a", Properties: imageOnly},
+				{ID: "b", Properties: nonVectorizable},
+				{ID: "c", Properties: imageOnly},
+			},
+			client: &fakeClient{result: &modulecomponents.VectorizationCLIPResult[[]float32]{
+				ImageVectors: [][]float32{{10.0, 20.0}, {30.0, 40.0}},
+			}},
+			wantVector: []bool{true, false, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := tt.client
+			if client == nil {
+				client = &fakeClient{}
+			}
+			vectorizer := New("moduleName", client)
+			config := newConfigBuilder().
+				addSetting("imageFields", []any{"image"}).
+				addSetting("textFields", []any{"text"}).
+				build()
+
+			vectors, _, err := vectorizer.Objects(context.Background(), tt.objects, config)
+
+			require.NoError(t, err)
+			require.Len(t, vectors, len(tt.objects))
+			for i, wantVector := range tt.wantVector {
+				if wantVector {
+					assert.NotEmpty(t, vectors[i])
+				} else {
+					assert.Nil(t, vectors[i])
+				}
+			}
+		})
+	}
+}
+
+// Same as above for multi vectors, where combining an empty set of vectors used
+// to panic instead of yielding no vector.
+func Test_BatchCLIPMultiVectorizer_ObjectsWithoutVectorizableProperties(t *testing.T) {
+	vectorizer := New("moduleName", &fakeMultiVectorClient{})
+	config := newConfigBuilder().
+		addSetting("imageFields", []any{"image"}).
+		addSetting("textFields", []any{"text"}).
+		build()
+
+	objects := []*models.Object{
+		{ID: "a", Properties: map[string]any{"text": "text"}},
+		{ID: "b", Properties: map[string]any{"number": 1.0}},
+	}
+
+	vectors, _, err := vectorizer.Objects(context.Background(), objects, config)
+
+	require.NoError(t, err)
+	require.Len(t, vectors, len(objects))
+	assert.NotEmpty(t, vectors[0])
+	assert.Nil(t, vectors[1])
+}
+
+// A single object without vectorizable properties gets no vector rather than a
+// bogus "more than one embedding found" error.
+func Test_BatchCLIPVectorizer_ObjectWithoutVectorizableProperties(t *testing.T) {
+	vectorizer := New("moduleName", &fakeClient{})
+	config := newConfigBuilder().addSetting("imageFields", []any{"image"}).build()
+
+	vector, _, err := vectorizer.Object(context.Background(),
+		&models.Object{ID: "a", Properties: map[string]any{"number": 1.0}}, config)
+
+	require.NoError(t, err)
+	assert.Nil(t, vector)
+}
+
 func Test_BatchCLIPVectorizer_WithDiff(t *testing.T) {
 	type testCase struct {
 		name    string
@@ -358,6 +474,33 @@ func (c *fakeClient) Vectorize(ctx context.Context,
 	texts, images []string, cfg moduletools.ClassConfig,
 ) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
 	return c.getEmbeddings()
+}
+
+type fakeMultiVectorClient struct{}
+
+func (c *fakeMultiVectorClient) VectorizeImages(ctx context.Context,
+	images []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[][]float32], error) {
+	return c.getEmbeddings()
+}
+
+func (c *fakeMultiVectorClient) VectorizeQuery(ctx context.Context,
+	texts []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[][]float32], error) {
+	return c.getEmbeddings()
+}
+
+func (c *fakeMultiVectorClient) Vectorize(ctx context.Context,
+	texts, images []string, cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationCLIPResult[[][]float32], error) {
+	return c.getEmbeddings()
+}
+
+func (c *fakeMultiVectorClient) getEmbeddings() (*modulecomponents.VectorizationCLIPResult[[][]float32], error) {
+	return &modulecomponents.VectorizationCLIPResult[[][]float32]{
+		TextVectors:  [][][]float32{{{1.0, 2.0}, {3.0, 4.0}}},
+		ImageVectors: [][][]float32{{{10.0, 20.0}, {30.0, 40.0}}},
+	}, nil
 }
 
 func (c *fakeClient) getEmbeddings() (*modulecomponents.VectorizationCLIPResult[[]float32], error) {


### PR DESCRIPTION
### What's being changed:

This PR fixes this panic:
```
Root cause — the panic stack trace
goroutine 11313312 [running]:
runtime/debug.Stack()
    runtime/debug/stack.go:26 +0x5e
github.com/weaviate/weaviate/entities/errors.PrintStack(...)
    .../entities/errors/panics_logger.go:21
github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).setDeferFunc.func1(...)
    .../entities/errors/error_group_wrapper.go:88
panic({0x37f1500?, 0x1ffdddad578?})
    runtime/panic.go:860
github.com/weaviate/weaviate/usecases/modulecomponents/batch.(*BatchSimple[...]).VectorizeBatchObjects.func1()
    .../usecases/modulecomponents/batch/batch_simple.go:178
github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).Go.func1()
    .../entities/errors/error_group_wrapper.go:106

The panic originated in BatchSimple.VectorizeBatchObjects — the batch vectorization code path in usecases/modulecomponents/batch/batch_simple.go:178
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
