### PR TITLE
fix(db): pin shards against teardown during class-wide schema work

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -835,13 +835,40 @@ func (i *Index) IterateShards(ctx context.Context, cb func(index *Index, shard S
 	})
 }
 
+// pinLoadedShard takes a shutdown refcount so bucket work scheduled onto an
+// error group outlives the shard walk. A cold lazy shard has no store to
+// refcount; its file surgery holds shardCreateLocks in shard_lazyloader.go.
+func pinLoadedShard(shard ShardLike) (release func(), ok bool) {
+	if lazy, isLazy := shard.(*LazyLoadShard); isLazy && !lazy.isLoaded() {
+		return func() {}, true
+	}
+
+	release, err := shard.preventShutdown()
+	if err != nil {
+		return func() {}, false
+	}
+	return release, true
+}
+
 func (i *Index) addProperty(ctx context.Context, props ...*models.Property) error {
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU)
 
+	var releases []func()
+	defer func() {
+		for _, release := range releases {
+			release()
+		}
+	}()
+
 	// Skip cold shards: they'd only be force-loaded to create empty buckets,
 	// which they build from the refreshed class at their next load anyway.
 	i.ForEachLoadedShard(func(key string, shard ShardLike) error {
+		release, ok := pinLoadedShard(shard)
+		if !ok {
+			return nil
+		}
+		releases = append(releases, release)
 		shard.initPropertyBuckets(ctx, eg, false, props...)
 		return nil
 	})
@@ -856,7 +883,19 @@ func (i *Index) updateProperty(ctx context.Context, property *models.Property) e
 	eg := enterrors.NewErrorGroupWrapper(i.logger)
 	eg.SetLimit(_NUMCPU)
 
+	var releases []func()
+	defer func() {
+		for _, release := range releases {
+			release()
+		}
+	}()
+
 	i.ForEachShard(func(key string, shard ShardLike) error {
+		release, ok := pinLoadedShard(shard)
+		if !ok {
+			return nil
+		}
+		releases = append(releases, release)
 		shard.updatePropertyBuckets(ctx, eg, property)
 		return nil
 	})
@@ -873,6 +912,12 @@ func (i *Index) updateVectorIndexConfig(ctx context.Context,
 ) error {
 	// an updated is not specific to one shard, but rather all
 	err := i.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		release, ok := pinLoadedShard(shard)
+		if !ok {
+			return nil
+		}
+		defer release()
+
 		// At the moment, we don't do anything in an update that could fail, but
 		// technically this should be part of some sort of a two-phase commit  or
 		// have another way to rollback if we have updates that could potentially
@@ -897,6 +942,12 @@ func (i *Index) updateVectorIndexConfigs(ctx context.Context,
 	updated map[string]schemaConfig.VectorIndexConfig,
 ) error {
 	err := i.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		release, ok := pinLoadedShard(shard)
+		if !ok {
+			return nil
+		}
+		defer release()
+
 		if err := shard.UpdateVectorIndexConfigs(ctx, updated); err != nil {
 			return fmt.Errorf("shard %q: %w", name, err)
 		}
@@ -926,6 +977,12 @@ func (i *Index) dropVectorIndex(ctx context.Context, targetVector string) error 
 	}()
 
 	if err := i.ForEachShardConcurrently(func(name string, shard ShardLike) error {
+		release, ok := pinLoadedShard(shard)
+		if !ok {
+			return nil
+		}
+		defer release()
+
 		if err := shard.DropVectorIndex(ctx, targetVector); err != nil {
 			return fmt.Errorf("shard %q: %w", name, err)
 		}

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"maps"
@@ -23,14 +24,19 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/clients"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/aggregation"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	esync "github.com/weaviate/weaviate/entities/sync"
 	"github.com/weaviate/weaviate/usecases/cluster"
@@ -416,4 +422,88 @@ func TestIndexDropLocalShard(t *testing.T) {
 		}
 		require.True(t, sawNamedDropLog, "expected a drop_shard error log naming the shard")
 	})
+}
+
+// addProperty and updateProperty only schedule the bucket work onto an error
+// group, so the pins must outlive the walk and drop after eg.Wait().
+//
+// Two shards because shardMap.Range is sequential: the second callback firing
+// proves the first returned, which is when a per-shard release would happen.
+func TestPropertyWorkPinsShardAgainstTeardown(t *testing.T) {
+	prop := &models.Property{
+		Name:         "pinned",
+		DataType:     schema.DataTypeText.PropString(),
+		Tokenization: models.PropertyTokenizationWord,
+	}
+
+	const shardCount = 2
+
+	tests := []struct {
+		name   string
+		expect func(shard *MockShardLike, schedule func(*enterrors.ErrorGroupWrapper))
+		run    func(idx *Index) error
+	}{
+		{
+			name: "addProperty",
+			expect: func(shard *MockShardLike, schedule func(*enterrors.ErrorGroupWrapper)) {
+				shard.EXPECT().initPropertyBuckets(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Run(func(_ context.Context, eg *enterrors.ErrorGroupWrapper, _ bool, _ ...*models.Property) {
+						schedule(eg)
+					})
+			},
+			run: func(idx *Index) error { return idx.addProperty(context.Background(), prop) },
+		},
+		{
+			name: "updateProperty",
+			expect: func(shard *MockShardLike, schedule func(*enterrors.ErrorGroupWrapper)) {
+				shard.EXPECT().updatePropertyBuckets(mock.Anything, mock.Anything, mock.Anything).
+					Run(func(_ context.Context, eg *enterrors.ErrorGroupWrapper, _ *models.Property) {
+						schedule(eg)
+					})
+			},
+			run: func(idx *Index) error { return idx.updateProperty(context.Background(), prop) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx, _ := newDropTestIndex(t)
+
+			var (
+				activePins atomic.Int32
+				remaining  atomic.Int32
+				allWalked  = make(chan struct{})
+			)
+			remaining.Store(shardCount)
+
+			schedule := func(eg *enterrors.ErrorGroupWrapper) {
+				eg.Go(func() error {
+					<-allWalked
+					if pins := activePins.Load(); pins != shardCount {
+						return fmt.Errorf("%d of %d pins released before the scheduled bucket work ran",
+							shardCount-pins, shardCount)
+					}
+					return nil
+				})
+			}
+
+			for i := range shardCount {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().preventShutdown().RunAndReturn(func() (func(), error) {
+					activePins.Add(1)
+					return func() { activePins.Add(-1) }, nil
+				})
+				tt.expect(shard, func(eg *enterrors.ErrorGroupWrapper) {
+					schedule(eg)
+					if remaining.Add(-1) == 0 {
+						close(allWalked)
+					}
+				})
+				idx.shards.Store(fmt.Sprintf("t%d", i), shard)
+			}
+
+			require.NoError(t, tt.run(idx))
+			require.Zero(t, activePins.Load(), "%s leaked a pin", tt.name)
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:
Class-wide property and vector-config walks now pin each shard, so a concurrent teardown can't close the store or delete files under work that outlives the walk.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
