### PR TITLE
Hybrid Aggregation: Apply the filter to the BM25 search

### DIFF
--- a/adapters/repos/db/aggregations_hybrid_filter_integration_test.go
+++ b/adapters/repos/db/aggregations_hybrid_filter_integration_test.go
@@ -1,0 +1,265 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
+	"github.com/weaviate/weaviate/entities/aggregation"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/searchparams"
+)
+
+func titleEqualsClause(token string) filters.Clause {
+	return filters.Clause{
+		Operator: filters.OperatorEqual,
+		On: &filters.Path{
+			Class:    schema.ClassName("MyClass"),
+			Property: schema.PropertyName("title"),
+		},
+		Value: &filters.Value{
+			Value: token,
+			Type:  schema.DataTypeText,
+		},
+	}
+}
+
+// titleEquals matches the objects whose word-tokenized title contains any of
+// the given tokens.
+func titleEquals(tokens ...string) *filters.LocalFilter {
+	if len(tokens) == 1 {
+		clause := titleEqualsClause(tokens[0])
+		return &filters.LocalFilter{Root: &clause}
+	}
+
+	operands := make([]filters.Clause, len(tokens))
+	for i, token := range tokens {
+		operands[i] = titleEqualsClause(token)
+	}
+	return &filters.LocalFilter{
+		Root: &filters.Clause{Operator: filters.OperatorOr, Operands: operands},
+	}
+}
+
+// TestAggregateHybridAppliesFilter pins that both hybrid legs honor the filter.
+// Fusion unions the sparse and dense result sets, so a leg that skips the filter
+// puts non-matching objects into the counts.
+func TestAggregateHybridAppliesFilter(t *testing.T) {
+	_, repo, schemaGetter := createRepo(t)
+	defer repo.Shutdown(context.Background())
+
+	logger, _ := test.NewNullLogger()
+	SetupFusionClass(t, repo, schemaGetter, logger, 1.2, 0.75)
+
+	// "BM25F" appears in the title and description of "Our journey to BM25F" and
+	// "Our peanuts to BM25F", but not in "Elephant Parade".
+	const query = "BM25F"
+
+	titlePath := &filters.Path{
+		Class:    schema.ClassName("MyClass"),
+		Property: schema.PropertyName("title"),
+	}
+	objectLimit := 10
+	topOccurrencesLimit := 10
+
+	tests := []struct {
+		name            string
+		alpha           float64
+		filter          *filters.LocalFilter
+		groupBy         *filters.Path
+		fusionAlgorithm int
+		omitObjectLimit bool
+		expectedCount   int
+		expectedTitles  []string
+	}{
+		{
+			name:           "sparse only, filter keeps one of the two keyword hits",
+			alpha:          0,
+			filter:         titleEquals("journey"),
+			expectedCount:  1,
+			expectedTitles: []string{"Our journey to BM25F"},
+		},
+		{
+			name:           "sparse and dense, filter keeps one of the two keyword hits",
+			alpha:          0.5,
+			filter:         titleEquals("journey"),
+			expectedCount:  1,
+			expectedTitles: []string{"Our journey to BM25F"},
+		},
+		{
+			name:            "sparse and dense, relative score fusion",
+			alpha:           0.5,
+			filter:          titleEquals("journey"),
+			fusionAlgorithm: common_filters.HybridRelativeScoreFusion,
+			expectedCount:   1,
+			expectedTitles:  []string{"Our journey to BM25F"},
+		},
+		{
+			name:           "sparse only, filter keeps both keyword hits",
+			alpha:          0,
+			filter:         titleEquals("journey", "peanuts"),
+			expectedCount:  2,
+			expectedTitles: []string{"Our journey to BM25F", "Our peanuts to BM25F"},
+		},
+		{
+			name:          "sparse only, filter excludes every keyword hit",
+			alpha:         0,
+			filter:        titleEquals("elephant"),
+			expectedCount: 0,
+		},
+		{
+			name:           "sparse and dense, filter excludes every keyword hit",
+			alpha:          0.5,
+			filter:         titleEquals("elephant"),
+			expectedCount:  1,
+			expectedTitles: []string{"Elephant Parade"},
+		},
+		{
+			name:          "sparse only, filter matches nothing",
+			alpha:         0,
+			filter:        titleEquals("zebra"),
+			expectedCount: 0,
+		},
+		{
+			name:          "sparse and dense, filter matches nothing",
+			alpha:         0.5,
+			filter:        titleEquals("zebra"),
+			expectedCount: 0,
+		},
+		{
+			name:           "dense only, filter keeps one object",
+			alpha:          1,
+			filter:         titleEquals("journey"),
+			expectedCount:  1,
+			expectedTitles: []string{"Our journey to BM25F"},
+		},
+		{
+			name:            "dense only, no object limit",
+			alpha:           1,
+			filter:          titleEquals("journey"),
+			omitObjectLimit: true,
+			expectedCount:   1,
+			expectedTitles:  []string{"Our journey to BM25F"},
+		},
+		{
+			name:           "sparse only, no filter",
+			alpha:          0,
+			expectedCount:  2,
+			expectedTitles: []string{"Our journey to BM25F", "Our peanuts to BM25F"},
+		},
+		{
+			name:           "sparse and dense, no filter",
+			alpha:          0.5,
+			expectedCount:  3,
+			expectedTitles: []string{"Our journey to BM25F", "Our peanuts to BM25F", "Elephant Parade"},
+		},
+		{
+			name:           "grouped, sparse only, filter keeps one of the two keyword hits",
+			alpha:          0,
+			filter:         titleEquals("journey"),
+			groupBy:        titlePath,
+			expectedCount:  1,
+			expectedTitles: []string{"Our journey to BM25F"},
+		},
+		{
+			name:           "grouped, sparse and dense, filter keeps one of the two keyword hits",
+			alpha:          0.5,
+			filter:         titleEquals("journey"),
+			groupBy:        titlePath,
+			expectedCount:  1,
+			expectedTitles: []string{"Our journey to BM25F"},
+		},
+		{
+			name:           "grouped, sparse only, filter keeps both keyword hits",
+			alpha:          0,
+			filter:         titleEquals("journey", "peanuts"),
+			groupBy:        titlePath,
+			expectedCount:  2,
+			expectedTitles: []string{"Our journey to BM25F", "Our peanuts to BM25F"},
+		},
+		{
+			name:          "grouped, sparse only, filter excludes every keyword hit",
+			alpha:         0,
+			filter:        titleEquals("elephant"),
+			groupBy:       titlePath,
+			expectedCount: 0,
+		},
+		{
+			name:           "grouped, sparse and dense, filter excludes every keyword hit",
+			alpha:          0.5,
+			filter:         titleEquals("elephant"),
+			groupBy:        titlePath,
+			expectedCount:  1,
+			expectedTitles: []string{"Elephant Parade"},
+		},
+		{
+			name:          "grouped, sparse only, filter matches nothing",
+			alpha:         0,
+			filter:        titleEquals("zebra"),
+			groupBy:       titlePath,
+			expectedCount: 0,
+		},
+		{
+			name:           "grouped, sparse only, no filter",
+			alpha:          0,
+			groupBy:        titlePath,
+			expectedCount:  2,
+			expectedTitles: []string{"Our journey to BM25F", "Our peanuts to BM25F"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := aggregation.Params{
+				ClassName:        schema.ClassName("MyClass"),
+				Filters:          tc.filter,
+				GroupBy:          tc.groupBy,
+				IncludeMetaCount: true,
+				Properties: []aggregation.ParamProperty{{
+					Name:        schema.PropertyName("title"),
+					Aggregators: []aggregation.Aggregator{aggregation.NewTopOccurrencesAggregator(&topOccurrencesLimit)},
+				}},
+				Hybrid: &searchparams.HybridSearch{
+					Query:           query,
+					Alpha:           tc.alpha,
+					Vector:          JourneyVector(),
+					FusionAlgorithm: tc.fusionAlgorithm,
+				},
+			}
+			if !tc.omitObjectLimit {
+				params.ObjectLimit = &objectLimit
+			}
+
+			res, err := repo.Aggregate(context.Background(), params, nil)
+			require.NoError(t, err)
+
+			var count int
+			var titles []string
+			for _, group := range res.Groups {
+				count += group.Count
+				for _, occ := range group.Properties["title"].TextAggregation.Items {
+					titles = append(titles, occ.Value)
+				}
+			}
+			require.Equal(t, tc.expectedCount, count)
+			require.ElementsMatch(t, tc.expectedTitles, titles)
+		})
+	}
+}

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -15,16 +15,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/docid"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/traverser"
 	"github.com/weaviate/weaviate/usecases/traverser/hybrid"
@@ -38,10 +35,6 @@ func newFilteredAggregator(agg *Aggregator) *filteredAggregator {
 	return &filteredAggregator{Aggregator: agg}
 }
 
-func (fa *filteredAggregator) GetPropertyLengthTracker() *inverted.JsonShardMetaData {
-	return fa.propLenTracker
-}
-
 func (fa *filteredAggregator) Do(ctx context.Context) (*aggregation.Result, error) {
 	if fa.params.Hybrid != nil {
 		return fa.hybrid(ctx)
@@ -51,18 +44,26 @@ func (fa *filteredAggregator) Do(ctx context.Context) (*aggregation.Result, erro
 }
 
 func (fa *filteredAggregator) hybrid(ctx context.Context) (*aggregation.Result, error) {
+	// Both legs need the allow list: fusion unions their results without
+	// intersecting them, so an unfiltered leg contributes objects the filter
+	// excludes.
+	allowList, err := fa.buildAllowList(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if allowList != nil {
+		defer allowList.Close()
+	}
+
+	fa.setDefaultObjectLimit()
+
 	sparseSearch := func() ([]*storobj.Object, []float32, error) {
 		kw, err := fa.buildHybridKeywordRanking()
 		if err != nil {
 			return nil, nil, fmt.Errorf("build hybrid keyword ranking: %w", err)
 		}
 
-		if fa.params.ObjectLimit == nil {
-			limit := int(fa.defaultLimit)
-			fa.params.ObjectLimit = &limit
-		}
-
-		sparse, scores, err := fa.bm25Objects(ctx, kw)
+		sparse, scores, err := fa.bm25Objects(ctx, kw, allowList)
 		if err != nil {
 			return nil, nil, fmt.Errorf("aggregate sparse search: %w", err)
 		}
@@ -71,14 +72,6 @@ func (fa *filteredAggregator) hybrid(ctx context.Context) (*aggregation.Result, 
 	}
 
 	denseSearch := func(vec models.Vector) ([]*storobj.Object, []float32, error) {
-		allowList, err := fa.buildAllowList(ctx)
-		if err != nil {
-			return nil, nil, err
-		}
-		if allowList != nil {
-			defer allowList.Close()
-		}
-
 		res, dists, err := fa.objectVectorSearch(ctx, vec, allowList)
 		if err != nil {
 			return nil, nil, fmt.Errorf("aggregate dense search: %w", err)
@@ -129,27 +122,6 @@ func (fa *filteredAggregator) filtered(ctx context.Context) (*aggregation.Result
 	}
 
 	return fa.prepareResult(ctx, foundIDs)
-}
-
-func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
-	class := fa.getSchema.ReadOnlyClass(fa.params.ClassName.String())
-	if class == nil {
-		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", fa.params.ClassName)
-	}
-	cfg := inverted.ConfigFromModel(class.InvertedIndexConfig)
-
-	kw.ChooseSearchableProperties(class)
-
-	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, fa.getSchema.ReadOnlyClass,
-		fa.classSearcher, fa.stopwordProvider,
-		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,
-	).WithTokenizationResolver(fa.tokResolver).
-		WithSearchableBucketPinningResolver(fa.bucketPinResolver).
-		BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw, additional.Properties{})
-	if err != nil {
-		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
-	}
-	return objs, scores, nil
 }
 
 func (fa *filteredAggregator) properties(ctx context.Context,

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -124,18 +124,15 @@ func (g *grouper) fetchDocIDs(ctx context.Context) (ids []uint64, err error) {
 }
 
 func (g *grouper) hybrid(ctx context.Context, allowList helpers.AllowList, modules *modules.Provider) ([]uint64, error) {
+	g.setDefaultObjectLimit()
+
 	sparseSearch := func() ([]*storobj.Object, []float32, error) {
 		kw, err := g.buildHybridKeywordRanking()
 		if err != nil {
 			return nil, nil, fmt.Errorf("build hybrid keyword ranking: %w", err)
 		}
 
-		if g.params.ObjectLimit == nil {
-			limit := int(g.defaultLimit)
-			g.params.ObjectLimit = &limit
-		}
-
-		sparse, dists, err := g.bm25Objects(ctx, kw)
+		sparse, dists, err := g.bm25Objects(ctx, kw, allowList)
 		if err != nil {
 			return nil, nil, fmt.Errorf("aggregate sparse search: %w", err)
 		}

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/additional"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -44,7 +45,17 @@ func (a *Aggregator) buildHybridKeywordRanking() (*searchparams.KeywordRanking, 
 	return kw, nil
 }
 
-func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking) ([]*storobj.Object, []float32, error) {
+// setDefaultObjectLimit fills in the limit a hybrid request may omit. Both legs
+// read it, and either can run alone depending on alpha, so it has to be set
+// before the search rather than inside one leg.
+func (a *Aggregator) setDefaultObjectLimit() {
+	if a.params.ObjectLimit == nil {
+		limit := int(a.defaultLimit)
+		a.params.ObjectLimit = &limit
+	}
+}
+
+func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRanking, allowList helpers.AllowList) ([]*storobj.Object, []float32, error) {
 	class := a.getSchema.ReadOnlyClass(a.params.ClassName.String())
 	if class == nil {
 		return nil, nil, fmt.Errorf("bm25 objects: could not find class %s in schema", a.params.ClassName)
@@ -58,7 +69,7 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 		a.GetPropertyLengthTracker(), a.logger, a.shardVersion,
 	).WithTokenizationResolver(a.tokResolver).
 		WithSearchableBucketPinningResolver(a.bucketPinResolver).
-		BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw, additional.Properties{})
+		BM25F(ctx, allowList, a.params.ClassName, *a.params.ObjectLimit, *kw, additional.Properties{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
 	}

--- a/adapters/repos/db/crud_null_objects_integration_test.go
+++ b/adapters/repos/db/crud_null_objects_integration_test.go
@@ -174,6 +174,7 @@ func createRepo(t *testing.T) (*Migrator, *DB, *fakeSchemaGetter) {
 		MemtablesFlushDirtyAfter:  60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10,
+		QueryHybridMaximumResults: config.DefaultQueryHybridMaximumResults,
 		MaxImportGoroutinesFactor: 1,
 	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil, memwatch.NewDummyMonitor(),
 		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader, nil)

--- a/test/acceptance_with_python/test_aggregate.py
+++ b/test/acceptance_with_python/test_aggregate.py
@@ -50,3 +50,75 @@ def test_aggregate_max_vector_distance_named(collection_factory: CollectionFacto
         target_vector="default",
     )
     assert res.total_count == 2
+
+
+def _fruit_and_veg_collection(collection_factory: CollectionFactory):
+    collection = collection_factory(
+        properties=[
+            Property(name="name", data_type=DataType.TEXT),
+            Property(name="category", data_type=DataType.TEXT),
+        ],
+        vectorizer_config=Configure.Vectorizer.none(),
+    )
+    collection.data.insert({"name": "banana one", "category": "fruit"}, vector=[1, 0, 0, 0])
+    collection.data.insert({"name": "banana two", "category": "fruit"}, vector=[0, 1, 0, 0])
+    collection.data.insert({"name": "banana three", "category": "veg"}, vector=[0, 1, 0, 0])
+    collection.data.insert({"name": "banana four", "category": "veg"}, vector=[1, 0, 0, 0])
+    return collection
+
+
+# "banana" matches all four objects, so a leg that ignores the filter doubles
+# every count below. alpha 0 runs the keyword leg alone, which is what a client
+# gets by leaving alpha unset over gRPC.
+@pytest.mark.parametrize(
+    "alpha,object_limit,expected_count",
+    [
+        (0, 10, 2),
+        (0, None, 2),
+        (0.5, 10, 2),
+        (1, None, 2),
+    ],
+)
+def test_aggregate_hybrid_applies_filter(
+    collection_factory: CollectionFactory,
+    alpha: float,
+    object_limit: int,
+    expected_count: int,
+) -> None:
+    collection = _fruit_and_veg_collection(collection_factory)
+
+    res = collection.aggregate.hybrid(
+        "banana",
+        alpha=alpha,
+        vector=[1, 0, 0, 0],
+        object_limit=object_limit,
+        filters=wvc.query.Filter.by_property("category").equal("fruit"),
+        return_metrics=[wvc.aggregate.Metrics("name").text(top_occurrences_value=True)],
+    )
+    assert res.total_count == expected_count
+    assert sorted(occ.value for occ in res.properties["name"].top_occurrences) == [
+        "banana one",
+        "banana two",
+    ]
+
+
+def test_aggregate_hybrid_without_filter(collection_factory: CollectionFactory) -> None:
+    collection = _fruit_and_veg_collection(collection_factory)
+
+    res = collection.aggregate.hybrid("banana", alpha=0, object_limit=10)
+    assert res.total_count == 4
+
+
+def test_aggregate_hybrid_group_by_applies_filter(collection_factory: CollectionFactory) -> None:
+    collection = _fruit_and_veg_collection(collection_factory)
+
+    res = collection.aggregate.hybrid(
+        "banana",
+        alpha=0,
+        object_limit=10,
+        filters=wvc.query.Filter.by_property("category").equal("fruit"),
+        group_by=wvc.aggregate.GroupByAggregate(prop="category"),
+    )
+    assert len(res.groups) == 1
+    assert res.groups[0].grouped_by.value == "fruit"
+    assert res.groups[0].total_count == 2

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -71,7 +71,9 @@ type targetVectorParamHelper interface {
 	GetTargetVectorOrDefault(getClass func(string) *models.Class, className string, targetVector []string) ([]string, error)
 }
 
-// Search executes sparse and dense searches and combines the result sets using Reciprocal Rank Fusion
+// Search executes sparse and dense searches and combines the result sets using Reciprocal Rank Fusion.
+// The two sets are unioned, never intersected, and alpha can skip either one, so each search func must
+// apply the query's filter itself.
 func Search(ctx context.Context, params *Params, logger logrus.FieldLogger, sparseSearch sparseSearchFunc, denseSearch denseSearchFunc, postProc postProcFunc, modules modulesProvider, schemaGetter uc.SchemaGetter, targetVectorParamHelper targetVectorParamHelper) ([]search.Result, error) {
 	var (
 		found   [][]*search.Result


### PR DESCRIPTION
### What's being changed:

 Hybrid aggregation passed a nil allow list to BM25F, so objects excluded by the filter were counted in meta.count and the property aggregations. At alpha 0 the dense leg never ran, so nothing was filtered at all.Both aggregation paths now build the allow list before the search and give it to both legs. 

Additional Bugs:
-  ObjectLimit's default now also applies to both legs.
- at alpha 0 a where clause that fails to resolve now returns an error instead of silently aggregating unfiltered.

Closes: https://github.com/weaviate/dirk-claude-issues/issues/90

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
