### PR TITLE
fix: publish the raft node atomically to close a boot-time data race

### DIFF
--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -127,10 +127,11 @@ func (s *Raft) WaitForUpdate(ctx context.Context, schemaVersion uint64) error {
 }
 
 func (s *Raft) ReplicationAllPeersAtLeast(opID uint64, target cmd.ShardReplicationState) (bool, error) {
-	if s.store.raft == nil {
+	rn := s.store.raft.Load()
+	if rn == nil {
 		return false, nil
 	}
-	cfg := s.store.raft.GetConfiguration()
+	cfg := rn.GetConfiguration()
 	if err := cfg.Error(); err != nil {
 		return false, fmt.Errorf("get raft configuration: %w", err)
 	}

--- a/cluster/raft_cluster_endpoints.go
+++ b/cluster/raft_cluster_endpoints.go
@@ -35,7 +35,8 @@ func (s *Raft) LeaderWithID() (string, string) {
 // StorageCandidates return the nodes in the raft configuration or memberlist storage nodes
 // based on the current configuration of the cluster if it does have  MetadataVoterOnly nodes.
 func (s *Raft) StorageCandidates() []string {
-	if s.store.raft == nil {
+	rn := s.store.raft.Load()
+	if rn == nil {
 		// get candidates from memberlist
 		return s.nodeSelector.StorageCandidates()
 	}
@@ -47,7 +48,7 @@ func (s *Raft) StorageCandidates() []string {
 		nonStorageCandidates  = s.nodeSelector.NonStorageNodes()
 	)
 
-	for _, server := range s.store.raft.GetConfiguration().Configuration().Servers {
+	for _, server := range rn.GetConfiguration().Configuration().Servers {
 		existedRaftCandidates = append(existedRaftCandidates, string(server.ID))
 	}
 

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -73,8 +73,8 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	assert.Equal(t, "S0", getTenantStatus(t, schemaReader, cls.Class, "T0"))
 
 	// Create a snapshot here with the class and the tenant existing
-	assert.Nil(t, srv.store.raft.Barrier(2*time.Second).Error())
-	assert.Nil(t, srv.store.raft.Snapshot().Error())
+	assert.Nil(t, srv.store.raft.Load().Barrier(2*time.Second).Error())
+	assert.Nil(t, srv.store.raft.Load().Snapshot().Error())
 
 	m.indexer.On("DeleteTenants", Anything, Anything).Return(nil)
 	m.replicationFSM.On("DeleteReplicationsByTenants", Anything, Anything).Return(nil)
@@ -150,8 +150,8 @@ func TestSnapshotRestoreReloadsDBBeforeWaitToRestoreDB(t *testing.T) {
 	_, err := srv.AddClass(ctx, cls, ss)
 	require.NoError(t, err)
 
-	require.NoError(t, srv.store.raft.Barrier(2*time.Second).Error())
-	require.NoError(t, srv.store.raft.Snapshot().Error())
+	require.NoError(t, srv.store.raft.Load().Barrier(2*time.Second).Error())
+	require.NoError(t, srv.store.raft.Load().Snapshot().Error())
 
 	m.indexer.On("Close", Anything).Return(nil)
 	require.NoError(t, srv.Close(ctx))

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -322,8 +322,8 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Equal(t, m.store.cfg.NodeID, leaderID)
 
 	// create snapshot
-	assert.Nil(t, srv.store.raft.Barrier(2*time.Second).Error())
-	assert.Nil(t, srv.store.raft.Snapshot().Error())
+	assert.Nil(t, srv.store.raft.Load().Barrier(2*time.Second).Error())
+	assert.Nil(t, srv.store.raft.Load().Snapshot().Error())
 
 	// restore from snapshot
 	assert.Nil(t, srv.Close(ctx))

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -231,7 +231,8 @@ type Store struct {
 	dbLoaded atomic.Bool
 
 	// raft implementation from external library
-	raft          *raft.Raft
+	// raft is atomically published: Open assigns it while concurrently-served RPCs (JoinPeer/Leader) read it.
+	raft          atomic.Pointer[raft.Raft]
 	raftResolver  types.RaftResolver
 	raftTransport *raft.NetworkTransport
 
@@ -456,8 +457,8 @@ func (st *Store) RegisterDistributedTaskCollectionExtractor(namespace string, ex
 // this method work as a protection from applying anything was applied to the db
 // by checking either raft or max(snapshot, log store) instead the db will catchup
 func (st *Store) lastIndex() uint64 {
-	if st.raft != nil {
-		return st.raft.AppliedIndex()
+	if r := st.raft.Load(); r != nil {
+		return r.AppliedIndex()
 	}
 
 	l, err := st.LastAppliedCommand()
@@ -491,10 +492,11 @@ func (st *Store) Open(ctx context.Context) (err error) {
 		"name":                 st.cfg.NodeID,
 		"metadata_only_voters": st.cfg.MetadataOnlyVoters,
 	}).Info("construct a new raft node")
-	st.raft, err = raft.NewRaft(st.raftConfig(), st, st.logCache, st.logStore, st.snapshotStore, st.raftTransport)
+	rn, err := raft.NewRaft(st.raftConfig(), st, st.logCache, st.logStore, st.snapshotStore, st.raftTransport)
 	if err != nil {
 		return fmt.Errorf("raft.NewRaft %v %w", st.raftTransport.LocalAddr(), err)
 	}
+	st.raft.Store(rn)
 
 	// Only if node recovery is enabled will we check if we are either forcing it or automating the detection of a one
 	// node cluster
@@ -510,11 +512,11 @@ func (st *Store) Open(ctx context.Context) (err error) {
 		st.dbLoaded.Store(true)
 	}
 
-	st.lastAppliedIndex.Store(st.raft.AppliedIndex())
+	st.lastAppliedIndex.Store(rn.AppliedIndex())
 
 	st.log.WithFields(logrus.Fields{
-		"raft_applied_index":                st.raft.AppliedIndex(),
-		"raft_last_index":                   st.raft.LastIndex(),
+		"raft_applied_index":                rn.AppliedIndex(),
+		"raft_last_index":                   rn.LastIndex(),
 		"last_store_applied_index_on_start": st.lastAppliedIndexToDB.Load(),
 		"last_snapshot_index":               snapIndex,
 	}).Info("raft node constructed")
@@ -607,9 +609,10 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 			if err != nil {
 				return fmt.Errorf("create snapshot: %w", err)
 			}
-			b.Index = st.raft.LastIndex()
+			rn := st.raft.Load()
+			b.Index = rn.LastIndex()
 			b.Term = 1
-			if err := st.raft.Restore(b, c, timeout); err != nil {
+			if err := rn.Restore(b, c, timeout); err != nil {
 				return fmt.Errorf("raft restore: %w", err)
 			}
 			return nil
@@ -639,9 +642,9 @@ func (st *Store) Close(ctx context.Context) error {
 
 	// transfer leadership: it stops accepting client requests, ensures
 	// the target server is up to date and initiates the transfer
-	if st.IsLeader() && len(st.raft.GetConfiguration().Configuration().Servers) > 1 {
+	if rn := st.raft.Load(); st.IsLeader() && len(rn.GetConfiguration().Configuration().Servers) > 1 {
 		st.log.Info("transferring leadership to another server")
-		if err := st.raft.LeadershipTransfer().Error(); err != nil {
+		if err := rn.LeadershipTransfer().Error(); err != nil {
 			st.log.WithError(err).Error("transferring leadership")
 		} else {
 			st.log.Info("successfully transferred leadership to another server")
@@ -662,7 +665,7 @@ func (st *Store) Close(ctx context.Context) error {
 
 	// shutdown raft after transport is closed to ensure clean termination
 	st.log.Info("shutting down raft ...")
-	if err := st.raft.Shutdown().Error(); err != nil {
+	if err := st.raft.Load().Shutdown().Error(); err != nil {
 		st.log.WithError(err).Warn("raft shutdown failed")
 	}
 
@@ -810,7 +813,8 @@ func (st *Store) WaitForAppliedIndex(ctx context.Context, period time.Duration, 
 
 // IsLeader returns whether this node is the leader of the cluster
 func (st *Store) IsLeader() bool {
-	return st.raft != nil && st.raft.State() == raft.Leader
+	r := st.raft.Load()
+	return r != nil && r.State() == raft.Leader
 }
 
 // SchemaReader returns a SchemaReader from the underlying schema manager using a wait function that will make it wait
@@ -873,11 +877,11 @@ func (st *Store) Stats() map[string]any {
 	stats["db_loaded"] = st.dbLoaded.Load()
 
 	// If the raft stats exist, add them as a nested map
-	if st.raft != nil {
-		stats["raft"] = st.raft.Stats()
+	if rn := st.raft.Load(); rn != nil {
+		stats["raft"] = rn.Stats()
 		// add the servers information
 		var servers []map[string]any
-		if cf := st.raft.GetConfiguration(); cf.Error() == nil {
+		if cf := rn.GetConfiguration(); cf.Error() == nil {
 			servers = make([]map[string]any, len(cf.Configuration().Servers))
 			for i, server := range cf.Configuration().Servers {
 				servers[i] = map[string]any{
@@ -896,18 +900,20 @@ func (st *Store) Stats() map[string]any {
 // Leader is used to return the current leader address.
 // It may return empty strings if there is no current leader or the leader is unknown.
 func (st *Store) Leader() string {
-	if st.raft == nil {
+	rn := st.raft.Load()
+	if rn == nil {
 		return ""
 	}
-	add, _ := st.raft.LeaderWithID()
+	add, _ := rn.LeaderWithID()
 	return string(add)
 }
 
 func (st *Store) LeaderWithID() (raft.ServerAddress, raft.ServerID) {
-	if st.raft == nil {
+	rn := st.raft.Load()
+	if rn == nil {
 		return "", ""
 	}
-	return st.raft.LeaderWithID()
+	return rn.LeaderWithID()
 }
 
 func (st *Store) assertFuture(fut raft.IndexFuture) error {
@@ -1008,7 +1014,7 @@ func (st *Store) reloadDBFromSchema() {
 
 	// in this path it means it was called from Apply()
 	// or forced Restore()
-	if st.raft != nil {
+	if st.raft.Load() != nil {
 		// we don't update lastAppliedIndexToDB if not a restore
 		return
 	}
@@ -1064,7 +1070,7 @@ func (st *Store) recoverSingleNode(force bool) error {
 		return fmt.Errorf("bootstrap expect %v, candidates %v, "+
 			"can't perform auto recovery in multi node cluster", st.cfg.BootstrapExpect, st.candidates)
 	}
-	servers := st.raft.GetConfiguration().Configuration().Servers
+	servers := st.raft.Load().GetConfiguration().Configuration().Servers
 	// nothing to do here, wasn't a single node
 	if !force && len(servers) != 1 {
 		st.log.WithFields(logrus.Fields{
@@ -1092,7 +1098,7 @@ func (st *Store) recoverSingleNode(force bool) error {
 		"new_single_cluster_node":     newNode,
 	}).Info("perform cluster recovery")
 
-	fut := st.raft.Shutdown()
+	fut := st.raft.Load().Shutdown()
 	if err := fut.Error(); err != nil {
 		return err
 	}
@@ -1115,11 +1121,11 @@ func (st *Store) recoverSingleNode(force bool) error {
 		return err
 	}
 
-	var err error
-	st.raft, err = raft.NewRaft(st.raftConfig(), st, st.logCache, st.logStore, st.snapshotStore, st.raftTransport)
+	rn, err := raft.NewRaft(st.raftConfig(), st, st.logCache, st.logStore, st.snapshotStore, st.raftTransport)
 	if err != nil {
 		return fmt.Errorf("raft.NewRaft %v %w", st.raftTransport.LocalAddr(), err)
 	}
+	st.raft.Store(rn)
 
 	if exNode.ID == newNode.ID {
 		// no node name change needed in the state

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -54,7 +54,7 @@ func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 	}
 
 	// The change is validated, we can apply it in RAFT
-	fut := st.raft.Apply(cmdBytes, st.applyTimeout)
+	fut := st.raft.Load().Apply(cmdBytes, st.applyTimeout)
 
 	// Always call Error first otherwise the response can't  be read from the future
 	if err := fut.Error(); err != nil {
@@ -142,8 +142,8 @@ func (st *Store) Apply(l *raft.Log) any {
 			st.metrics.applyFailures.Inc()
 			_, leaderID := st.LeaderWithID()
 			nodeState := ""
-			if st.raft != nil {
-				nodeState = st.raft.State().String()
+			if rn := st.raft.Load(); rn != nil {
+				nodeState = rn.State().String()
 			}
 			st.log.WithFields(logrus.Fields{
 				"log_type":        l.Type,

--- a/cluster/store_cluster_rpc.go
+++ b/cluster/store_cluster_rpc.go
@@ -31,16 +31,17 @@ func (st *Store) Join(id, addr string, voter bool) error {
 	if !st.open.Load() {
 		return types.ErrNotOpen
 	}
-	if st.raft.State() != raft.Leader {
+	rn := st.raft.Load()
+	if rn == nil || rn.State() != raft.Leader {
 		return types.ErrNotLeader
 	}
 
 	rID, rAddr := raft.ServerID(id), raft.ServerAddress(addr)
 
 	if !voter {
-		return st.assertFuture(st.raft.AddNonvoter(rID, rAddr, 0, 0))
+		return st.assertFuture(rn.AddNonvoter(rID, rAddr, 0, 0))
 	}
-	return st.assertFuture(st.raft.AddVoter(rID, rAddr, 0, 0))
+	return st.assertFuture(rn.AddVoter(rID, rAddr, 0, 0))
 }
 
 // Remove removes this peer from the cluster
@@ -48,7 +49,8 @@ func (st *Store) Remove(id string) error {
 	if !st.open.Load() {
 		return types.ErrNotOpen
 	}
-	if st.raft.State() != raft.Leader {
+	rn := st.raft.Load()
+	if rn == nil || rn.State() != raft.Leader {
 		return types.ErrNotLeader
 	}
 	// A namespace can only place shards on its home_node, so losing that node
@@ -62,7 +64,7 @@ func (st *Store) Remove(id string) error {
 		return fmt.Errorf("cannot remove node %q: it is the home_node of namespace(s) %s",
 			id, strings.Join(pinned, ", "))
 	}
-	return st.assertFuture(st.raft.RemoveServer(raft.ServerID(id), 0, 0))
+	return st.assertFuture(rn.RemoveServer(raft.ServerID(id), 0, 0))
 }
 
 // namespacesWithHomeNode returns the names of the namespaces whose home_node is
@@ -118,7 +120,7 @@ func (st *Store) Notify(id, addr string) (err error) {
 		"candidates": candidates,
 	}).Info("starting cluster bootstrapping")
 
-	fut := st.raft.BootstrapCluster(raft.Configuration{Servers: candidates})
+	fut := st.raft.Load().BootstrapCluster(raft.Configuration{Servers: candidates})
 	if err := fut.Error(); err != nil {
 		if !errors.Is(err, raft.ErrCantBootstrap) {
 			st.log.WithField("action", "bootstrap").WithError(err).Error("could not bootstrapping cluster")

--- a/cluster/store_raft_field_race_test.go
+++ b/cluster/store_raft_field_race_test.go
@@ -1,0 +1,38 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestStoreLeaderConcurrentWithRaftAssignment races Open's raft-field publication against an RPC-served Leader read.
+func TestStoreLeaderConcurrentWithRaftAssignment(t *testing.T) {
+	st := &Store{}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = st.Leader()
+			_, _ = st.LeaderWithID()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			st.raft.Store(nil)
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
## Motivation

The race detector flagged an unsynchronized publication of the raft node during cluster bootstrap: `Store.Open` assigns the `raft` field while concurrently served RPCs read it (`JoinPeer` → `Leader()` → `st.raft`). A peer's join request arriving in the boot window reads the pointer with no happens-before edge to `NewRaft`'s internal writes. This is the third member of the bootstrap-concurrency family fixed in #12533 (candidates map) and #12534 (memberlist node mutation) — found the same way, with a race-enabled binary running a live 3-node cluster.

## Approach

Convert the field to `atomic.Pointer[raft.Raft]`. Every reader loads once and uses the local copy (`rn := st.raft.Load()`), so nil-check-then-use stays consistent within a call. The two assignment sites (`Open` and single-node recovery) publish via `Store` after `NewRaft` returns. `Join`/`Remove` now also tolerate a nil raft (return `ErrNotLeader`, i.e. retry) instead of relying on the `open` flag alone.

No behavioral change outside the race: same nil semantics, same call sites, load-once locals only.

## Key review areas

- `cluster/store.go` `Open`: the raft node is published after `NewRaft` succeeds; the boot-log fields read the local `rn`, not the field.
- `cluster/store_cluster_rpc.go` `Join`/`Remove`: the added `rn == nil` arm maps to `ErrNotLeader` — a joiner retries against the eventual leader, matching the existing not-leader flow.
- Leadership-transfer path in `Close`: `rn` is loaded before the `IsLeader()` short-circuit; the nil case cannot reach the dereference because `IsLeader()` is false then.

## Testing

- `TestStoreLeaderConcurrentWithRaftAssignment` pins the race: red (DATA RACE) against the plain field, green after the conversion.
- Full `cluster` package with `-race`, plus `golangci-lint`: clean.
- Live validation: a race-enabled 3-node cluster rebuilt with this fix boots with concurrent peer joins and no detector reports (the same setup fired the race reliably before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
