### PR TITLE
fix(metrics): release shard gauges when a shard goes away

### DIFF
--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -596,6 +596,16 @@ func NewMetrics(
 	return m, nil
 }
 
+// UpdateShardStatus moves one shard between the buckets of the per-status shard
+// gauge. The empty string is not a status but the absence of one, at either end:
+// `old == ""` registers a shard that was not counted yet, and `new == ""`
+// removes one for good. Without that second case the gauge only ever transitions
+// and never releases, so every shard torn down leaks its bucket until the
+// process restarts.
+//
+// Both labels must be the ones this shard is actually counted under. Callers
+// should go through Shard.setCountedStatus rather than passing a status read
+// from the shard, which can drift from the gauge (see Shard.countedStatus).
 func (m *Metrics) UpdateShardStatus(old, new string) {
 	if m.shardsCount == nil {
 		return
@@ -605,7 +615,9 @@ func (m *Metrics) UpdateShardStatus(old, new string) {
 		m.shardsCount.WithLabelValues(old).Dec()
 	}
 
-	m.shardsCount.WithLabelValues(new).Inc()
+	if new != "" {
+		m.shardsCount.WithLabelValues(new).Inc()
+	}
 }
 
 func (m *Metrics) ObserveUpdateShardStatus(status string, duration time.Duration) {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -358,7 +358,15 @@ type Shard struct {
 	haltForTransferCount     atomic.Int64
 	haltForTransferCtxCancel context.CancelFunc
 
-	status              ShardStatus
+	status ShardStatus
+	// countedStatus is the label this shard is currently counted under in the
+	// per-status shard gauge, or "" once it has been released. It is deliberately
+	// NOT derived from status on the fly: GetStatus recomputes READY/INDEXING from
+	// the vector queues and writes it back without touching the gauge, so the two
+	// drift apart in normal operation. Decrementing the bucket a drifted status
+	// names would corrupt a bucket this shard was never counted in, so every gauge
+	// mutation reads and writes this field instead. Guarded by statusLock.
+	countedStatus       string
 	statusLock          sync.RWMutex
 	propertyIndicesLock sync.RWMutex
 	// geoInitLock serializes initGeoProp so a prop never has two indexes under
@@ -513,6 +521,11 @@ type Shard struct {
 	// (e.g., NewLoadedShard or FinishLoadingShard was called). This prevents double-counting
 	// or incorrect metric updates during partial initialization cleanup.
 	metricsRegistered atomic.Bool
+
+	// metricsUnloaded records that performShutdown already moved this shard from
+	// the loaded to the unloaded bucket of the shard-lifecycle gauges. A drop
+	// that follows must then release the unloaded bucket, not the loaded one.
+	metricsUnloaded atomic.Bool
 
 	// tornStoreReported keeps reportTornStoreAccess to one line per shard
 	tornStoreReported atomic.Bool

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -46,6 +46,12 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 
 	s.shutCtxCancel(fmt.Errorf("drop %q", s.ID()))
 
+	// Release both shard gauges up front, on every exit. The teardown below
+	// early-returns on a dozen different failures, and a shard that failed to
+	// drop is still gone from the shard map, so accounting for it only on the
+	// happy path strands its count until the process restarts.
+	defer s.releaseShardMetrics()
+
 	s.metrics.DeleteShardLabels(s.index.Config.ClassName.String(), s.name)
 	s.replicationMap.clear()
 
@@ -177,11 +183,6 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 		}
 	}
 
-	// Only update metrics if the shard was properly registered
-	if s.metricsRegistered.Load() {
-		s.metrics.baseMetrics.DeleteLoadedShard()
-	}
-
 	s.index.logger.WithFields(logrus.Fields{
 		"action": "drop_shard",
 		"class":  s.class.Class,
@@ -189,4 +190,25 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 	}).Debug("shard successfully dropped")
 
 	return nil
+}
+
+// releaseShardMetrics removes this shard from every gauge that counts live
+// shards: the lifecycle pair (shards_loaded / shards_unloaded) and the
+// per-status gauge. It runs exactly once — metricsRegistered is swapped rather
+// than read, and setCountedStatus is idempotent — so a drop that follows a
+// completed shutdown does not decrement a second time.
+//
+// Which lifecycle bucket to release depends on whether a shutdown already moved
+// the shard: unregistered shards were never counted at all (partial init), and
+// a shut-down shard sits in unloaded, not loaded.
+func (s *Shard) releaseShardMetrics() {
+	if s.metricsRegistered.CompareAndSwap(true, false) {
+		if s.metricsUnloaded.Load() {
+			s.metrics.baseMetrics.DeleteUnloadedShard()
+		} else {
+			s.metrics.baseMetrics.DeleteLoadedShard()
+		}
+	}
+
+	s.setCountedStatus("")
 }

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -96,7 +96,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		lazySegmentLoadingEnabled:       lazyLoadSegments,
 	}
 
-	index.metrics.UpdateShardStatus("", storagestate.StatusLoading.String())
+	s.setCountedStatus(storagestate.StatusLoading.String())
 
 	defer func() {
 		p := recover()
@@ -211,6 +211,11 @@ func (s *Shard) cleanupPartialInit(ctx context.Context) {
 	if err := s.Shutdown(ctx); err != nil {
 		log.WithError(err).Error("failed to shutdown store")
 	}
+
+	// A shard that never finished initializing is still counted from the
+	// LOADING registration above, and a Shutdown that failed may not have
+	// reached the release. Idempotent, so the common path double-calls for free.
+	s.setCountedStatus("")
 
 	log.Debug("successfully cleaned up partially initialized shard")
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -57,13 +57,50 @@ import (
 )
 
 type LazyLoadShard struct {
-	shardOpts        *deferredShardOpts
-	shard            *Shard
-	loaded           bool
+	shardOpts *deferredShardOpts
+	shard     *Shard
+	loaded    bool
+	// metricsReleased records that the unloaded count NewLazyLoadShard
+	// registered has already been given back, so the two paths that can release
+	// it (drop and leaving the shard map) cannot both decrement. Guarded by mutex.
+	metricsReleased  bool
 	mutex            sync.Mutex
 	memMonitor       memwatch.AllocChecker
 	shardLoadLimiter *loadlimiter.LoadLimiter
 	lazyLoadSegments bool
+}
+
+// releaseShardMetrics removes this shard from the lifecycle gauges once it has
+// left the shard map for good.
+//
+// A wrapper that never loaded still holds the unloaded count NewLazyLoadShard
+// registered, and nothing else releases it: LazyLoadShard.Shutdown is a no-op
+// while !loaded, so a deactivated cold tenant would keep its +1 in
+// shards_unloaded for the life of the process. A wrapper that did load hands off
+// to the inner shard, which tracks whether it currently sits in the loaded or
+// the unloaded bucket. Idempotent.
+func (l *LazyLoadShard) releaseShardMetrics() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	l.releaseShardMetricsLocked()
+}
+
+// releaseShardMetricsLocked is releaseShardMetrics for callers already holding
+// mutex.
+func (l *LazyLoadShard) releaseShardMetricsLocked() {
+	// Not `loaded`: Shutdown clears that flag but leaves the inner shard, which
+	// keeps owning the accounting once StartLoadingShard consumed the wrapper's
+	// unloaded count.
+	if l.shard != nil {
+		l.shard.releaseShardMetrics()
+		return
+	}
+
+	if !l.metricsReleased {
+		l.metricsReleased = true
+		l.shardOpts.promMetrics.DeleteUnloadedShard()
+	}
 }
 
 func NewLazyLoadShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
@@ -524,7 +561,7 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 		}
 
 		// decrement unloaded shard count since this shard is being deleted
-		l.shardOpts.promMetrics.DeleteUnloadedShard()
+		l.releaseShardMetricsLocked()
 
 		return nil
 	}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -524,6 +524,12 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 		className := idx.Config.ClassName.String()
 		shardName := l.shardOpts.name
 
+		// Release up front, on every exit, mirroring Shard.drop: the steps below
+		// early-return on failure, and the caller removed this wrapper from the
+		// shard map before calling, so a failed drop would strand its unloaded
+		// count until the process restarts.
+		defer l.releaseShardMetricsLocked()
+
 		// cleanup metrics
 		metrics, err := NewMetrics(idx.logger, l.shardOpts.promMetrics, className, shardName)
 		if err != nil {
@@ -559,9 +565,6 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 				spawnAsyncDelete(deleted, idx.logger)
 			}
 		}
-
-		// decrement unloaded shard count since this shard is being deleted
-		l.releaseShardMetricsLocked()
 
 		return nil
 	}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -170,12 +170,24 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 // every one of them that forgot would leak a shard in shards_unloaded until the
 // process restarted.
 func shutdownOrRestoreShard(ctx context.Context, shards *shardMap, name string, shard ShardLike, logger logrus.FieldLogger) error {
+	// Deferred rather than called on each outcome so a panic in Shutdown is
+	// covered too: the caller has already removed the shard from the map, and a
+	// panic means the restore below never ran, so the shard is evicted for good.
+	// Callers run inside error-group wrappers that recover, so the process
+	// carries on and the stranded count would outlive the shard.
+	restored := false
+	defer func() {
+		if !restored {
+			releaseShardLifecycleMetrics(shard)
+		}
+	}()
+
 	err := shard.Shutdown(ctx)
 	if err == nil || errors.Is(err, errAlreadyShutdown) {
-		releaseShardLifecycleMetrics(shard)
 		return err
 	}
 	if restoreShardIfStillAlive(shards, name, shard) {
+		restored = true
 		if terr := shardTeardownError(shard); terr != nil {
 			logger.WithField("action", "shard_shutdown").
 				WithField("shard", name).
@@ -193,7 +205,6 @@ func shutdownOrRestoreShard(ctx context.Context, shards *shardMap, name string, 
 	// outcome the caller asked for happened. Report it as the benign
 	// already-shut case, not a failure (a cold-tenant batch would otherwise
 	// fail whole on one racy tenant).
-	releaseShardLifecycleMetrics(shard)
 	return errAlreadyShutdown
 }
 
@@ -292,6 +303,16 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	// teardown that panics or grows an early return later must still not strand
 	// this shard's bucket. Deferred after the point of no return, so the
 	// still-in-use rejection above (which leaves the shard live) never reaches it.
+	//
+	// This releases on shutdown rather than on eviction, so a shard that is
+	// restored to the map by shutdownOrRestoreShard — a torn one holding its
+	// leaked handles, or one whose deferred ref-drain completed it in place —
+	// stops being counted while it is technically still in the map. That is
+	// deliberate: the gauge counts shards this node can serve, and a shut shard
+	// serves nothing but errAlreadyShutdown / errTeardownFailed. Tying the
+	// release to eviction instead would mean repeating it at every site that
+	// evicts a known-shut entry (both re-init paths, each drop path), which is
+	// the scattered bookkeeping that leaked in the first place.
 	defer s.setCountedStatus("")
 
 	start := time.Now()

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -101,6 +101,25 @@ func shardStillAlive(s ShardLike) bool {
 	}
 }
 
+// releaseShardLifecycleMetrics gives back the shard-lifecycle count of a shard
+// that has left the shard map for good. Shutting a shard down only moves it from
+// the loaded to the unloaded bucket — that is the right bookkeeping for a shard
+// still on this node, but a shard evicted from the map is on it no longer, and
+// nothing downstream would ever take it back out of unloaded.
+//
+// Call it only once the shard is known to have stayed out of the map: a failed
+// shutdown puts live and torn shards back (see restoreShardIfStillAlive), and
+// those are still counted. Idempotent for both shard kinds, so a later drop of
+// the same instance does not double-decrement.
+func releaseShardLifecycleMetrics(s ShardLike) {
+	switch sh := s.(type) {
+	case *Shard:
+		sh.releaseShardMetrics()
+	case *LazyLoadShard:
+		sh.releaseShardMetrics()
+	}
+}
+
 func (s *Shard) Shutdown(ctx context.Context) (err error) {
 	s.shutdownRequested.Store(true)
 	var lastAttemptErr error
@@ -143,9 +162,17 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 // leaving a live instance out of the map lets a later (re)load double-open
 // the directory. Callers hold the shard's create lock and classify
 // errAlreadyShutdown themselves (terminal, not a failure).
+//
+// It is also where a shard that stays evicted gives back its shard-lifecycle
+// count, because this is the only place that knows which way that went. Doing it
+// here rather than in each caller is deliberate: the eviction sites are spread
+// across tenant deactivation, replica teardown and index reconciliation, and
+// every one of them that forgot would leak a shard in shards_unloaded until the
+// process restarted.
 func shutdownOrRestoreShard(ctx context.Context, shards *shardMap, name string, shard ShardLike, logger logrus.FieldLogger) error {
 	err := shard.Shutdown(ctx)
 	if err == nil || errors.Is(err, errAlreadyShutdown) {
+		releaseShardLifecycleMetrics(shard)
 		return err
 	}
 	if restoreShardIfStillAlive(shards, name, shard) {
@@ -166,6 +193,7 @@ func shutdownOrRestoreShard(ctx context.Context, shards *shardMap, name string, 
 	// outcome the caller asked for happened. Report it as the benign
 	// already-shut case, not a failure (a cold-tenant batch would otherwise
 	// fail whole on one racy tenant).
+	releaseShardLifecycleMetrics(shard)
 	return errAlreadyShutdown
 }
 
@@ -247,7 +275,24 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	// during partial initialization cleanup)
 	if s.metricsRegistered.Load() {
 		s.metrics.baseMetrics.StartUnloadingShard()
+		// Deferred, not tail-called: the teardown below routes its failures into
+		// an error compounder rather than returning, but a panic in any of the
+		// closes would unwind past a plain statement and pin shards_unloading at
+		// +1 with shards_loaded already decremented.
+		defer func() {
+			s.metrics.baseMetrics.FinishUnloadingShard()
+			// The shard now sits in the unloaded bucket, so a drop that follows
+			// must release that one rather than decrementing loaded a second time.
+			s.metricsUnloaded.Store(true)
+		}()
 	}
+
+	// Release the per-status gauge from here on out, not at the end: everything
+	// below reports through the error compounder rather than returning, but a
+	// teardown that panics or grows an early return later must still not strand
+	// this shard's bucket. Deferred after the point of no return, so the
+	// still-in-use rejection above (which leaves the shard live) never reaches it.
+	defer s.setCountedStatus("")
 
 	start := time.Now()
 	defer func() {
@@ -347,11 +392,6 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	if s.dynamicVectorIndexDB != nil {
 		err = s.dynamicVectorIndexDB.Close()
 		ec.AddWrapf(err, "stop dynamic vector index db")
-	}
-
-	// Track shard unloaded: unloading -> unloaded
-	if s.metricsRegistered.Load() {
-		s.metrics.baseMetrics.FinishUnloadingShard()
 	}
 
 	return ec.ToError()

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -36,6 +36,29 @@ type ShardStatus struct {
 	Reason string
 }
 
+// setCountedStatus moves this shard's entry in the per-status shard gauge to
+// next, or releases it entirely when next is "". It is idempotent: re-releasing
+// an already-released shard is a no-op, which is what lets both teardown paths
+// (shutdown and drop, in either order, plus the partial-init cleanup) call it
+// unconditionally without double-decrementing.
+func (s *Shard) setCountedStatus(next string) {
+	s.statusLock.Lock()
+	defer s.statusLock.Unlock()
+
+	s.setCountedStatusLocked(next)
+}
+
+// setCountedStatusLocked is setCountedStatus for callers already holding
+// statusLock.
+func (s *Shard) setCountedStatusLocked(next string) {
+	if s.countedStatus == next {
+		return
+	}
+
+	s.index.metrics.UpdateShardStatus(s.countedStatus, next)
+	s.countedStatus = next
+}
+
 func (s *Shard) GetStatus() storagestate.Status {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
@@ -117,7 +140,7 @@ func (s *Shard) updateStatusUnlocked(in, reason string) error {
 		return err
 	}
 
-	s.index.metrics.UpdateShardStatus(oldStatus.String(), targetStatus.String())
+	s.setCountedStatusLocked(targetStatus.String())
 
 	lvl := logrus.DebugLevel
 	if targetStatus == storagestate.StatusReadOnly {

--- a/adapters/repos/db/shard_status_metrics_test.go
+++ b/adapters/repos/db/shard_status_metrics_test.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -372,6 +373,48 @@ func TestShardLifecycleMetricReleasedOnTenantDeactivation(t *testing.T) {
 			h.requireNoLiveShards(t, "after deactivating the tenant")
 		})
 	}
+}
+
+// TestShardLifecycleMetricReleasedOnFailedLazyDrop covers the unloaded drop path
+// failing part way. The caller has already removed the wrapper from the shard
+// map by then, so releasing only on the success tail would strand the count for
+// the life of the process — the same reason Shard.drop releases from a defer.
+func TestShardLifecycleMetricReleasedOnFailedLazyDrop(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("runs as root, which ignores the directory permissions this test relies on")
+	}
+
+	const tenant = "tenant-0"
+	h := newStatusMetricsHarnessWithState(t, false, tenantState(tenant))
+
+	idx := h.addClassWith(t, &models.Class{
+		Class:               "StatusMetricFailedDrop",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+	})
+
+	lazy, ok := idx.shards.Load(tenant).(*LazyLoadShard)
+	require.True(t, ok, "a multi-tenant class registers its tenant shards lazily")
+	require.Equal(t, float64(1), h.unloaded(t))
+
+	// A never-loaded shard has no directory yet, and the drop skips the rename
+	// entirely when there is nothing to rename. Create it so the drop has real
+	// work to fail at.
+	indexPath := idx.path()
+	require.NoError(t, os.MkdirAll(shardPath(indexPath, tenant), 0o755))
+
+	// Make the index directory read-only so the drop fails somewhere in the
+	// middle — which step exactly does not matter, only that it returns early.
+	info, err := os.Stat(indexPath)
+	require.NoError(t, err)
+	require.NoError(t, os.Chmod(indexPath, 0o555))
+	t.Cleanup(func() { _ = os.Chmod(indexPath, info.Mode()) })
+
+	require.Error(t, lazy.drop(false), "the drop should fail with the index directory read-only")
+
+	require.Equal(t, float64(0), h.unloaded(t),
+		"a shard whose drop failed is still gone from the shard map and must not stay counted")
 }
 
 // TestShardStatusMetricFollowsCountedLabel guards the subtler desync: GetStatus

--- a/adapters/repos/db/shard_status_metrics_test.go
+++ b/adapters/repos/db/shard_status_metrics_test.go
@@ -1,0 +1,414 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// The gauges below are process-global in production but per-instance here
+// (NoopRegisterer skips the AlreadyRegistered dedup), so each test gets a clean
+// slate as long as it reads them through the helpers in this file.
+
+// statusMetricsHarness bundles a repo and the two shard gauges under test.
+type statusMetricsHarness struct {
+	repo     *DB
+	migrator *Migrator
+	base     *monitoring.PrometheusMetrics
+	// shardsCount is captured up front: it lives on the Index, which is gone by
+	// the time a drop test wants to assert on it.
+	shardsCount *prometheus.GaugeVec
+}
+
+// status reads the bucket a status label currently holds. Reading through
+// WithLabelValues materializes the series at 0, which is exactly the assertion
+// "this bucket holds nothing".
+func (h *statusMetricsHarness) status(t *testing.T, status storagestate.Status) float64 {
+	t.Helper()
+	require.NotNil(t, h.shardsCount, "index metrics were never captured")
+	return testutil.ToFloat64(h.shardsCount.WithLabelValues(status.String()))
+}
+
+func (h *statusMetricsHarness) loaded(t *testing.T) float64 {
+	t.Helper()
+	return testutil.ToFloat64(h.base.ShardsLoaded)
+}
+
+func (h *statusMetricsHarness) unloaded(t *testing.T) float64 {
+	t.Helper()
+	return testutil.ToFloat64(h.base.ShardsUnloaded)
+}
+
+// requireNoLiveShards asserts that nothing is counted anywhere: every status
+// bucket empty and both lifecycle gauges at zero. Buckets are checked for
+// exactly 0 rather than "not positive" on purpose — a double release drives a
+// gauge negative, which is just as wrong as a leak and much easier to miss.
+func (h *statusMetricsHarness) requireNoLiveShards(t *testing.T, msg string) {
+	t.Helper()
+	for _, s := range []storagestate.Status{
+		storagestate.StatusReady,
+		storagestate.StatusLoading,
+		storagestate.StatusReadOnly,
+		storagestate.StatusIndexing,
+		storagestate.StatusShutdown,
+	} {
+		require.Equal(t, float64(0), h.status(t, s),
+			"%s: status bucket %q should hold no shards", msg, s)
+	}
+	require.Equal(t, float64(0), h.loaded(t), "%s: shards_loaded should be 0", msg)
+	require.Equal(t, float64(0), h.unloaded(t), "%s: shards_unloaded should be 0", msg)
+}
+
+// tenantState returns a partitioned single-tenant state, so the migrator's
+// tenant-activation paths are exercised rather than the plain sharding ones.
+func tenantState(tenant string) *sharding.State {
+	s := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			tenant: {
+				Name:           tenant,
+				BelongsToNodes: []string{"node1"},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+		PartitioningEnabled: true,
+	}
+	s.SetLocalName("node1")
+	return s
+}
+
+func newStatusMetricsHarness(t *testing.T, lazyLoad bool) *statusMetricsHarness {
+	t.Helper()
+	return newStatusMetricsHarnessWithState(t, lazyLoad, singleShardState())
+}
+
+func newStatusMetricsHarnessWithState(t *testing.T, lazyLoad bool, shardState *sharding.State) *statusMetricsHarness {
+	t.Helper()
+
+	logger, _ := test.NewNullLogger()
+
+	baseMetrics := monitoring.GetMetrics()
+	metricsCopy := *baseMetrics
+	metricsCopy.Registerer = monitoring.NoopRegisterer
+	metrics := &metricsCopy
+
+	metrics.ShardsLoaded.Set(0)
+	metrics.ShardsLoading.Set(0)
+	metrics.ShardsUnloaded.Set(0)
+	metrics.ShardsUnloading.Set(0)
+
+	schemaGetter := &fakeSchemaGetter{
+		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
+		shardState: shardState,
+	}
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+			return readFunc(&models.Class{Class: className}, shardState)
+		}).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
+	// Consulted only for multi-tenant classes, when the migrator picks eager vs
+	// lazy shard loading.
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).
+		Return(len(shardState.Physical), nil).Maybe()
+
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().HasActiveReplicationForShard(mock.Anything, mock.Anything).Return(false).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
+
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
+
+	repo, err := New(logger, "node1", Config{
+		RootPath:                  t.TempDir(),
+		QueryMaximumResults:       10000,
+		MaxImportGoroutinesFactor: 1,
+		EnableLazyLoadShards:      boolPtr(lazyLoad),
+	},
+		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
+		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
+		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader, nil,
+	)
+	require.NoError(t, err)
+
+	repo.SetSchemaGetter(schemaGetter)
+	require.NoError(t, repo.WaitForStartup(testCtx()))
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	return &statusMetricsHarness{
+		repo:     repo,
+		migrator: NewMigrator(repo, logger, "node1"),
+		base:     metrics,
+	}
+}
+
+// addClass creates the collection and captures the per-status gauge off its index.
+func (h *statusMetricsHarness) addClass(t *testing.T, className string) *Index {
+	t.Helper()
+	return h.addClassWith(t, &models.Class{
+		Class:               className,
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+	})
+}
+
+func (h *statusMetricsHarness) addClassWith(t *testing.T, class *models.Class) *Index {
+	t.Helper()
+
+	className := class.Class
+	require.NoError(t, h.migrator.AddClass(context.Background(), class))
+
+	idx := h.repo.GetIndex(schema.ClassName(className))
+	require.NotNil(t, idx)
+	h.shardsCount = idx.metrics.shardsCount
+	require.NotNil(t, h.shardsCount)
+
+	return idx
+}
+
+func onlyShardName(t *testing.T, idx *Index) string {
+	t.Helper()
+
+	var name string
+	require.NoError(t, idx.ForEachShard(func(shardName string, _ ShardLike) error {
+		name = shardName
+		return nil
+	}))
+	require.NotEmpty(t, name)
+
+	return name
+}
+
+// TestShardStatusMetricReleasedOnDrop pins the reported bug: dropping a shard
+// decremented shards_loaded but left its per-status bucket behind, so a
+// collection that was created and deleted kept inflating READY until restart.
+func TestShardStatusMetricReleasedOnDrop(t *testing.T) {
+	ctx := testCtx()
+	h := newStatusMetricsHarness(t, false)
+
+	className := "StatusMetricDrop"
+	h.addClass(t, className)
+
+	require.Equal(t, float64(1), h.status(t, storagestate.StatusReady),
+		"a freshly created shard should be counted as READY")
+	require.Equal(t, float64(1), h.loaded(t))
+
+	require.NoError(t, h.migrator.DropClass(ctx, className, false))
+
+	h.requireNoLiveShards(t, "after dropping the collection")
+}
+
+// TestShardStatusMetricReleasedRepeatedly is the drift the dashboards showed:
+// the leak was one shard per create/drop cycle, so a single round would not have
+// caught it drifting.
+func TestShardStatusMetricReleasedRepeatedly(t *testing.T) {
+	ctx := testCtx()
+	h := newStatusMetricsHarness(t, false)
+
+	for i := 0; i < 3; i++ {
+		className := "StatusMetricCycle"
+		h.addClass(t, className)
+		require.Equal(t, float64(1), h.status(t, storagestate.StatusReady),
+			"round %d: exactly one shard should be counted while the collection exists", i)
+
+		require.NoError(t, h.migrator.DropClass(ctx, className, false))
+		h.requireNoLiveShards(t, "after round "+string(rune('0'+i)))
+	}
+}
+
+// TestShardMetricsNotDoubleReleasedOnShutdownThenDrop covers the other half:
+// shutdown already moved the shard from loaded to unloaded, so the drop that
+// follows must release the unloaded bucket. Releasing loaded a second time drove
+// shards_loaded negative.
+func TestShardMetricsNotDoubleReleasedOnShutdownThenDrop(t *testing.T) {
+	ctx := testCtx()
+	h := newStatusMetricsHarness(t, false)
+
+	className := "StatusMetricShutdownDrop"
+	idx := h.addClass(t, className)
+	shardName := onlyShardName(t, idx)
+
+	shard := idx.shards.Load(shardName)
+	require.NotNil(t, shard)
+	concrete, ok := shard.(*Shard)
+	require.True(t, ok, "lazy loading is off, so the map should hold a concrete shard")
+
+	require.NoError(t, concrete.Shutdown(ctx))
+
+	require.Equal(t, float64(0), h.loaded(t), "shutdown moves the shard out of loaded")
+	require.Equal(t, float64(1), h.unloaded(t), "shutdown moves the shard into unloaded")
+	require.Equal(t, float64(0), h.status(t, storagestate.StatusReady),
+		"a shut-down shard should not be counted as READY")
+	require.Equal(t, float64(0), h.status(t, storagestate.StatusShutdown),
+		"the SHUTDOWN bucket must not strand shards that left the shard map")
+
+	require.NoError(t, h.migrator.DropClass(ctx, className, false))
+
+	h.requireNoLiveShards(t, "after shutdown followed by drop")
+}
+
+// TestShardLifecycleMetricReleasedOnUnloadLocalShard covers tenant deactivation:
+// UnloadLocalShard evicts the shard from the map, so its unloaded count has to
+// go with it. A never-loaded lazy shard is the sharper case — its Shutdown is a
+// no-op, so nothing else would ever release the count NewLazyLoadShard took.
+func TestShardLifecycleMetricReleasedOnUnloadLocalShard(t *testing.T) {
+	ctx := testCtx()
+
+	for _, tc := range []struct {
+		name string
+		load bool
+	}{
+		{name: "never loaded", load: false},
+		{name: "loaded first", load: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newStatusMetricsHarness(t, true)
+
+			className := "StatusMetricUnload"
+			idx := h.addClass(t, className)
+			shardName := onlyShardName(t, idx)
+
+			require.Equal(t, float64(1), h.unloaded(t),
+				"a lazy shard is registered as unloaded on creation")
+
+			if tc.load {
+				shard := idx.shards.Load(shardName)
+				require.NotNil(t, shard)
+				lazy, ok := shard.(*LazyLoadShard)
+				require.True(t, ok)
+				require.NoError(t, lazy.Load(ctx))
+
+				require.Equal(t, float64(1), h.loaded(t))
+				require.Equal(t, float64(0), h.unloaded(t))
+			}
+
+			require.NoError(t, idx.UnloadLocalShard(ctx, shardName))
+
+			h.requireNoLiveShards(t, "after unloading the shard")
+		})
+	}
+}
+
+// TestShardLifecycleMetricReleasedOnTenantDeactivation drives the real
+// deactivation path. Migrator.UpdateTenants does its own LoadAndDelete rather
+// than going through UnloadLocalShard, which is why the release belongs in
+// shutdownOrRestoreShard where every eviction site converges: a fix applied per
+// caller would have missed this one, and this is the path that actually runs on
+// a multi-tenant cluster.
+func TestShardLifecycleMetricReleasedOnTenantDeactivation(t *testing.T) {
+	ctx := testCtx()
+
+	const tenant = "tenant-0"
+
+	class := &models.Class{
+		Class:               "StatusMetricDeactivate",
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+		MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+	}
+	for _, tc := range []struct {
+		name string
+		load bool
+	}{
+		// The never-loaded case is the sharper one: LazyLoadShard.Shutdown is a
+		// no-op while !loaded, so nothing but this release ever gives back the
+		// count NewLazyLoadShard took.
+		{name: "never loaded", load: false},
+		{name: "loaded first", load: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newStatusMetricsHarnessWithState(t, false, tenantState(tenant))
+			idx := h.addClassWith(t, class)
+
+			// A multi-tenant class registers its tenant shards lazily, so the
+			// shard starts out counted as unloaded rather than READY.
+			require.Equal(t, float64(1), h.unloaded(t),
+				"the tenant's shard should be registered as unloaded on creation")
+
+			if tc.load {
+				lazy, ok := idx.shards.Load(tenant).(*LazyLoadShard)
+				require.True(t, ok)
+				require.NoError(t, lazy.Load(ctx))
+				require.Equal(t, float64(1), h.loaded(t))
+				require.Equal(t, float64(1), h.status(t, storagestate.StatusReady))
+			}
+
+			require.NoError(t, h.migrator.UpdateTenants(ctx, class,
+				[]*schemaUC.UpdateTenantPayload{{Name: tenant, Status: models.TenantActivityStatusCOLD}}, false))
+
+			require.Nil(t, idx.shards.Load(tenant),
+				"deactivation should have evicted the shard from the shard map")
+			h.requireNoLiveShards(t, "after deactivating the tenant")
+		})
+	}
+}
+
+// TestShardStatusMetricFollowsCountedLabel guards the subtler desync: GetStatus
+// recomputes READY/INDEXING and writes it back to the shard without touching the
+// gauge, so the shard's own status drifts from the bucket it is counted in.
+// Trusting the drifted status on the next transition decremented a bucket the
+// shard was never counted in, driving it negative and stranding the real one.
+func TestShardStatusMetricFollowsCountedLabel(t *testing.T) {
+	ctx := testCtx()
+	h := newStatusMetricsHarness(t, false)
+
+	className := "StatusMetricDrift"
+	idx := h.addClass(t, className)
+	shardName := onlyShardName(t, idx)
+
+	shard := idx.shards.Load(shardName)
+	require.NotNil(t, shard)
+	concrete, ok := shard.(*Shard)
+	require.True(t, ok)
+
+	require.Equal(t, float64(1), h.status(t, storagestate.StatusReady))
+
+	// Reproduce GetStatus's write-back without going through the vector queues,
+	// which cannot be driven deterministically from here.
+	concrete.statusLock.Lock()
+	concrete.status.Status = storagestate.StatusIndexing
+	concrete.statusLock.Unlock()
+
+	require.NoError(t, concrete.UpdateStatus(storagestate.StatusReadOnly.String(), "test"))
+
+	require.Equal(t, float64(1), h.status(t, storagestate.StatusReadOnly),
+		"the shard should now be counted as READONLY")
+	require.Equal(t, float64(0), h.status(t, storagestate.StatusReady),
+		"the bucket the shard was actually counted in should have been released")
+	require.Equal(t, float64(0), h.status(t, storagestate.StatusIndexing),
+		"INDEXING was never incremented, so it must not be decremented")
+
+	require.NoError(t, h.migrator.DropClass(ctx, className, false))
+	h.requireNoLiveShards(t, "after dropping a shard that drifted status")
+}


### PR DESCRIPTION
## What

`weaviate_index_shards_total` over-reports how many shards a node holds, and only a process restart brings it back in line. The sibling `shards_loaded` / `shards_unloaded` / `shards_unloading` gauges drift on adjacent paths for the same reason. All of it is fixed here.

## Reproduce

```bash
docker run -d --name wvdrift -p 8080:8080 -p 2112:2112 \
  -e AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
  -e PROMETHEUS_MONITORING_ENABLED=true \
  cr.weaviate.io/semitechnologies/weaviate:1.39.0 \
  --host 0.0.0.0 --port 8080 --scheme http
sleep 18

# create a collection with 8 shards, delete it, repeat
for i in 1 2 3; do
  curl -s -X POST localhost:8080/v1/schema -H 'Content-Type: application/json' \
    -d '{"class":"Drift","vectorizer":"none","shardingConfig":{"desiredCount":8}}' >/dev/null
  sleep 2
  curl -s -X DELETE localhost:8080/v1/schema/Drift >/dev/null
  sleep 3
  echo "round $i:"
  curl -s localhost:2112/metrics | grep '^weaviate_index_shards_total'
  curl -s 'localhost:8080/v1/nodes?output=verbose' \
    | python3 -c 'import json,sys; print("  actual shards:", sum(len(n.get("shards") or []) for n in json.load(sys.stdin)["nodes"]))'
done
```

Before this PR — the gauge climbs by the number of shards dropped while the node actually holds none:

```
round 1:  weaviate_index_shards_total{status="READY"} 8      actual shards: 0
round 2:  weaviate_index_shards_total{status="READY"} 16     actual shards: 0
round 3:  weaviate_index_shards_total{status="READY"} 24     actual shards: 0
```

After: `READY` is `0` on every round, matching `/v1/nodes`.

Tenant churn drifts the same way — deactivating and reactivating tenants strands a shard in `status="SHUTDOWN"` and another in `shards_unloaded` on every cycle:

```bash
curl -s -X POST localhost:8080/v1/schema -H 'Content-Type: application/json' \
  -d '{"class":"MT","vectorizer":"none","multiTenancyConfig":{"enabled":true}}'
curl -s -X POST localhost:8080/v1/schema/MT/tenants -H 'Content-Type: application/json' \
  -d '[{"name":"t1","activityStatus":"HOT"},{"name":"t2","activityStatus":"HOT"}]'
# ...then flip them COLD and back to HOT a few times, watching the two metrics
```

## Why it happens

`weaviate_index_shards_total` is a `GaugeVec` keyed by shard status, and the only thing that moves it is `Metrics.UpdateShardStatus(old, new)` — `old.Dec()` then `new.Inc()`. That is a *transition*. Nothing ever removes a shard from the gauge, so:

- **Drop.** `Shard.drop()` decremented `shards_loaded` but never touched the status gauge. `DeleteShardLabels` can't cover it — the gauge is labelled by *status*, not by class/shard. Every dropped shard keeps its bucket for the life of the process.
- **SHUTDOWN never drains.** Deactivating moves `READY → SHUTDOWN`, but reactivation builds a *new* `Shard` starting at `"" → LOADING → READY`. The old count is stranded.
- **Failed init.** A shard that dies before its store exists keeps its `LOADING` bucket, because the `SHUTDOWN` transition that would have moved it sits behind `if s.store != nil`.

There is a second, quieter bug in the same gauge: `GetStatus()` recomputes `READY`/`INDEXING` from the vector queues and writes the result back to the shard **without touching the gauge**. So the shard's own status and the bucket it is counted in drift apart during normal operation, and the next transition decremented a bucket the shard was never counted in — pushing that series negative while leaving the real one behind.

## The fix

`""` already meant "not counted yet" on the `old` side of `UpdateShardStatus`; it now means the same on the `new` side, so a shard can be removed and not just moved.

`Shard.countedStatus` records the label a shard is actually counted under, and every gauge mutation reads and writes that field instead of the shard's status. That is what makes the release correct in the face of the `GetStatus` drift above, and it makes releasing idempotent for free — which is what lets shutdown, drop and the partial-init cleanup all call it unconditionally without double-decrementing.

The release is **deferred** from each teardown path rather than tail-called, because `Shard.drop()` early-returns on a dozen different failures and the shard is gone from the shard map either way.

Same-shaped bugs in the lifecycle gauges, fixed alongside since they live on the paths this PR already touches:

| Path | Before |
|---|---|
| drop after a completed shutdown | `shards_loaded` decremented twice (`metricsRegistered` was never cleared) — could go negative, while the shard's `shards_unloaded` entry stayed |
| drop whose teardown failed | `shards_loaded` never decremented at all |
| panic mid-teardown | `FinishUnloadingShard` was a plain statement, so `shards_unloading` stayed pinned |
| shard evicted from the shard map | still counted in `shards_unloaded` forever; a never-loaded `LazyLoadShard` is the sharp case, since its `Shutdown` is a no-op |

That last one is why the release lives in `shutdownOrRestoreShard` rather than in each caller: it is the one place that knows whether the shard stayed evicted or was restored, and every eviction site converges there. Tenant deactivation in particular reaches it through `Migrator.UpdateTenants`, which does its own `LoadAndDelete` instead of going through `UnloadLocalShard` — a per-caller fix would have missed the single most common path.

## Impact

No behavioural change outside metrics.

A shard stops being counted the moment it shuts down, not when it is evicted from the shard map. So a shard that shutdown restores to the map — a torn one holding its leaked handles, or one whose deferred ref-drain completed it in place — is no longer counted even though the map still holds it, and `status="SHUTDOWN"` becomes rare rather than a steady-state bucket. That is deliberate: the gauge counts shards the node can *serve*, and a shut shard serves nothing but `errAlreadyShutdown` / `errTeardownFailed`. Tying the release to eviction instead would mean repeating it at every site that evicts a known-shut entry (both re-init paths, each drop path) — the scattered bookkeeping that leaked in the first place.

Dashboards that stack the status buckets will stop counting shards the node no longer has.

## Review notes

- `adapters/repos/db/shard_status.go` — `setCountedStatus` / `countedStatus` are the core of it; everything else calls into them.
- `adapters/repos/db/shard_shutdown.go` — the release in `shutdownOrRestoreShard` is the part with the widest blast radius (5 callers).
- The deferred release in `performShutdown` sits **after** the point of no return, so the still-in-use rejection (which leaves the shard live and in the map) never reaches it.

## Tests

`adapters/repos/db/shard_status_metrics_test.go` — create/drop, repeated create/drop cycles, shutdown-then-drop, `UnloadLocalShard`, tenant deactivation via `Migrator.UpdateTenants` (loaded and never-loaded), a lazy drop that fails part way, and the `GetStatus` drift case. Every one of them fails on `main` and passes here. Assertions check for exactly `0` rather than "not positive", so a double release is caught as well as a leak.

Verified end-to-end against a build of this branch: the repro above reports `0` on every round, and three deactivate/reactivate cycles leave every gauge matching `/v1/nodes` exactly.

## Follow-up (not in this PR)

Shard counts could be recomputed periodically in `nodeWideMetricsObserver`, the same way `observeObjectCount` works, so this class of drift self-heals instead of depending on every teardown path remembering to decrement.

A wider audit turned up the same incremental-gauge pattern outside the shard lifecycle — `weaviate_lsm_bucket_segment_total` leaks on two error paths and has no shard label to clean up, and `t2v_concurrent_batches` can strand its decrement behind a blocking channel send. Both are worth separate issues.
