### PR TITLE
fix(tools): don't let SIGPIPE break the gh escape-sequence feature check

### DIFF
--- a/tools/dev/qa_pr.sh
+++ b/tools/dev/qa_pr.sh
@@ -248,8 +248,12 @@ log "Extracting docker image tags from job logs..."
 # Use gh api (works even when logs are large / job just completed).
 # gh >= 2.97 refuses to print responses containing terminal escape sequences
 # unless --allow-escape-sequences is passed; older versions lack the flag.
+# Capture the help text first: piping it into `grep -q` makes grep close the pipe
+# on the first match, which kills gh with SIGPIPE (141) and — under `set -o
+# pipefail` — makes the feature check look like "flag not supported".
 ALLOW_ESC_FLAG=""
-if gh api --help 2>&1 | grep -q -- '--allow-escape-sequences'; then
+GH_API_HELP=$(gh api --help 2>&1 || true)
+if grep -q -- '--allow-escape-sequences' <<<"$GH_API_HELP"; then
   ALLOW_ESC_FLAG="--allow-escape-sequences"
 fi
 TAGS=$(gh api $ALLOW_ESC_FLAG "repos/$WEAVIATE_REPO/actions/jobs/$JOB_ID/logs" 2>&1 \


### PR DESCRIPTION
### What's being changed:

This PR fixes qa_pr.sh script.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
