### PR TITLE
Fix three crashes and data corruptions in cluster state handling

### DIFF
--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -383,14 +383,7 @@ func (s *ShardReplicationFSM) ForceDeleteByCollection(collection string) error {
 		return nil // nothing to do
 	}
 
-	for _, op := range ops {
-		err := s.removeReplicationOp(op.ID)
-		if err != nil {
-			return fmt.Errorf("could not remove op %d: %w", op.ID, err)
-		}
-	}
-
-	return nil
+	return s.removeReplicationOps(ops)
 }
 
 func (s *ShardReplicationFSM) ForceDeleteByCollectionAndShard(collection, shard string) error {
@@ -407,14 +400,7 @@ func (s *ShardReplicationFSM) ForceDeleteByCollectionAndShard(collection, shard 
 		return nil // nothing to do
 	}
 
-	for _, op := range shardOps {
-		err := s.removeReplicationOp(op.ID)
-		if err != nil {
-			return fmt.Errorf("could not remove op %d: %w", op.ID, err)
-		}
-	}
-
-	return nil
+	return s.removeReplicationOps(shardOps)
 }
 
 func (s *ShardReplicationFSM) ForceDeleteByTargetNode(node string) error {
@@ -426,14 +412,7 @@ func (s *ShardReplicationFSM) ForceDeleteByTargetNode(node string) error {
 		return nil // nothing to do
 	}
 
-	for _, op := range ops {
-		err := s.removeReplicationOp(op.ID)
-		if err != nil {
-			return fmt.Errorf("could not remove op %d: %w", op.ID, err)
-		}
-	}
-
-	return nil
+	return s.removeReplicationOps(ops)
 }
 
 func (s *ShardReplicationFSM) ForceDeleteByUuid(uuid strfmt.UUID) error {
@@ -447,6 +426,25 @@ func (s *ShardReplicationFSM) ForceDeleteByUuid(uuid strfmt.UUID) error {
 
 	if err := s.removeReplicationOp(id); err != nil {
 		return fmt.Errorf("could not remove op %d: %w", id, err)
+	}
+
+	return nil
+}
+
+// removeReplicationOps deletes every op in ops. It reads the ids up front
+// because removeReplicationOp compacts the very slices ops points into: ranging
+// over ops directly skips entries and then revisits ids it already deleted,
+// which fails the whole delete and leaves the skipped ops behind.
+func (s *ShardReplicationFSM) removeReplicationOps(ops []ShardReplicationOp) error {
+	ids := make([]uint64, len(ops))
+	for i, op := range ops {
+		ids[i] = op.ID
+	}
+
+	for _, id := range ids {
+		if err := s.removeReplicationOp(id); err != nil {
+			return fmt.Errorf("could not remove op %d: %w", id, err)
+		}
 	}
 
 	return nil

--- a/cluster/replication/shard_replication_apply_test.go
+++ b/cluster/replication/shard_replication_apply_test.go
@@ -492,3 +492,74 @@ func TestShardReplicationFSM_SetUnCancellable(t *testing.T) {
 		require.ErrorIs(t, err, types.ErrReplicationOperationNotFound)
 	})
 }
+
+// Every force delete walks an index slice that removeReplicationOp compacts in
+// place, so ranging over that slice directly skips ops and then fails on an id
+// it already deleted. Three ops is the smallest set that shows it.
+func TestShardReplicationFSM_ForceDelete(t *testing.T) {
+	const (
+		coll   = "TestClass"
+		shard  = "shard-0"
+		target = "node2"
+	)
+
+	// Ops that share a target need distinct shards, and ops that share a shard
+	// need distinct targets, or admission rejects them.
+	seedPerShard := func(t *testing.T, fsm *replication.ShardReplicationFSM, n int) {
+		for i := range n {
+			seedOpFull(t, fsm, uint64(i+1), "node1", target, coll, fmt.Sprintf("shard-%d", i), api.COPY)
+		}
+	}
+
+	tests := []struct {
+		name        string
+		seed        func(t *testing.T, fsm *replication.ShardReplicationFSM, n int)
+		forceDelete func(fsm *replication.ShardReplicationFSM) error
+	}{
+		{
+			name: "by collection",
+			seed: seedPerShard,
+			forceDelete: func(fsm *replication.ShardReplicationFSM) error {
+				return fsm.ForceDeleteByCollection(coll)
+			},
+		},
+		{
+			name: "by collection and shard",
+			seed: func(t *testing.T, fsm *replication.ShardReplicationFSM, n int) {
+				for i := range n {
+					seedOpFull(t, fsm, uint64(i+1), "node1", fmt.Sprintf("node-%d", i), coll, shard, api.COPY)
+				}
+			},
+			forceDelete: func(fsm *replication.ShardReplicationFSM) error {
+				return fsm.ForceDeleteByCollectionAndShard(coll, shard)
+			},
+		},
+		{
+			name: "by target node",
+			seed: seedPerShard,
+			forceDelete: func(fsm *replication.ShardReplicationFSM) error {
+				return fsm.ForceDeleteByTargetNode(target)
+			},
+		},
+		{
+			name: "all",
+			seed: seedPerShard,
+			forceDelete: func(fsm *replication.ShardReplicationFSM) error {
+				return fsm.ForceDeleteAll()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		for _, ops := range []int{1, 2, 3, 4, 5} {
+			t.Run(fmt.Sprintf("%s/%d ops", test.name, ops), func(t *testing.T) {
+				fsm := replication.NewShardReplicationFSM(prometheus.NewRegistry())
+				test.seed(t, fsm, ops)
+				require.Len(t, fsm.GetStatusByOps(), ops)
+
+				require.NoError(t, test.forceDelete(fsm))
+				require.Empty(t, fsm.GetStatusByOps(), "force delete leaves no op behind")
+			})
+		}
+	}
+}

--- a/cluster/replication/shard_replication_fsm.go
+++ b/cluster/replication/shard_replication_fsm.go
@@ -14,6 +14,7 @@ package replication
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sync"
 
 	"github.com/go-openapi/strfmt"
@@ -109,19 +110,29 @@ type snapshot struct {
 }
 
 func (s *ShardReplicationFSM) Snapshot() ([]byte, error) {
+	ops, err := s.snapshotOps()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(&snapshot{Ops: ops})
+}
+
+// snapshotOps copies the ops under the read lock so Snapshot can encode them
+// without holding it. Raft runs Persist concurrently with Apply, so the copies
+// must not alias state the apply path still writes.
+func (s *ShardReplicationFSM) snapshotOps() (map[ShardReplicationOp]ShardReplicationOpStatus, error) {
 	s.opsLock.RLock()
+	defer s.opsLock.RUnlock()
+
 	ops := make(map[ShardReplicationOp]ShardReplicationOpStatus, len(s.statusById))
 	for id, status := range s.statusById {
 		op, ok := s.opsById[id]
 		if !ok {
-			s.opsLock.RUnlock()
-			return nil, fmt.Errorf("op %d not found in opsById", op.ID)
+			return nil, fmt.Errorf("op %d not found in opsById", id)
 		}
-		ops[op] = status
+		ops[op] = status.clone()
 	}
-	s.opsLock.RUnlock()
-
-	return json.Marshal(&snapshot{Ops: ops})
+	return ops, nil
 }
 
 func (s *ShardReplicationFSM) Restore(bytes []byte) error {
@@ -192,10 +203,12 @@ func (s *ShardReplicationFSM) GetOpById(id uint64) (ShardReplicationOpAndStatus,
 	return NewShardReplicationOpAndStatus(op, status), true
 }
 
+// GetOpsForTarget returns a copy: removeReplicationOp compacts the stored slice
+// in place, which would shift entries under a caller still ranging over it.
 func (s *ShardReplicationFSM) GetOpsForTarget(node string) []ShardReplicationOp {
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
-	return s.opsByTarget[node]
+	return slices.Clone(s.opsByTarget[node])
 }
 
 func (s *ShardReplicationFSM) GetOpsForCollection(collection string) ([]ShardReplicationOpAndStatus, bool) {
@@ -307,7 +320,7 @@ func (s *ShardReplicationFSM) GetStatusByOps() map[ShardReplicationOp]ShardRepli
 		if !ok {
 			continue
 		}
-		opsStatus[op] = status
+		opsStatus[op] = status.clone()
 	}
 	return opsStatus
 }
@@ -332,7 +345,10 @@ func (s *ShardReplicationFSM) GetOpState(op ShardReplicationOp) (ShardReplicatio
 	s.opsLock.RLock()
 	defer s.opsLock.RUnlock()
 	v, ok := s.statusById[op.ID]
-	return v, ok
+	if !ok {
+		return ShardReplicationOpStatus{}, false
+	}
+	return v.clone(), true
 }
 
 func (s *ShardReplicationFSM) FilterOneShardReplicasRead(collection string, shard string, shardReplicasLocation []string) []string {

--- a/cluster/replication/shard_replication_fsm_test.go
+++ b/cluster/replication/shard_replication_fsm_test.go
@@ -526,6 +526,188 @@ func TestShardReplicationFSM_HasActiveTargetReplicationForShardConcurrent(t *tes
 	assert.True(t, fsm.HasActiveTargetReplicationForShard(coll, pinnedShard, "node2"))
 }
 
+// Snapshot encodes the op statuses after it releases opsLock, so it must not
+// hand the encoder a PerNodeState map that NodeReachedState still writes to.
+// Raft runs Persist concurrently with Apply, so both are live at once whenever
+// a replication op is in flight.
+func TestShardReplicationFSM_SnapshotConcurrentWithNodeReachedState(t *testing.T) {
+	const (
+		coll       = "TestClass"
+		opID       = uint64(1)
+		peers      = 8
+		iterations = 200
+	)
+	fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+	seedOpFull(t, fsm, opID, "node1", "node2", coll, "shard-0", api.COPY)
+	driveToState(t, fsm, opID, api.HYDRATING)
+
+	var eg errgroup.Group
+	for p := range peers {
+		eg.Go(func() error {
+			// A fresh node id per iteration keeps the map growing; repeating one
+			// id would write only once, since the FSM records peer state
+			// monotonically.
+			for i := range iterations {
+				if err := fsm.NodeReachedState(&api.ReplicationNodeReachedStateRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Id:      opID,
+					NodeId:  fmt.Sprintf("node-%d-%d", p, i),
+					State:   api.HYDRATING,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	for range peers {
+		eg.Go(func() error {
+			for range iterations {
+				if _, err := fsm.Snapshot(); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+	require.NoError(t, eg.Wait())
+
+	// Every peer, not a sample: a Snapshot that pruned or rewrote the map it
+	// hands out would still satisfy a spot check.
+	peerIDs := make([]string, 0, peers*iterations)
+	for p := range peers {
+		for i := range iterations {
+			peerIDs = append(peerIDs, fmt.Sprintf("node-%d-%d", p, i))
+		}
+	}
+	require.True(t, fsm.AllPeersAtLeast(opID, api.HYDRATING, peerIDs))
+
+	snap, err := fsm.Snapshot()
+	require.NoError(t, err)
+	restored := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+	require.NoError(t, restored.Restore(snap))
+	require.True(t, restored.AllPeersAtLeast(opID, api.HYDRATING, peerIDs),
+		"snapshot carries the per-peer state")
+}
+
+// The FSM keeps mutating the maps and slices inside its ops, so a caller that
+// reads one after the lock is released must be holding a copy. The consumer does
+// exactly that: it polls a status, transitions its own copy, and the producer
+// ranges a target's ops across per-op lock acquisitions.
+func TestShardReplicationFSM_HandsOutDetachedState(t *testing.T) {
+	const (
+		coll   = "TestClass"
+		target = "node2"
+		opID   = uint64(1)
+	)
+
+	tests := []struct {
+		name string
+		test func(t *testing.T, fsm *replication.ShardReplicationFSM)
+	}{
+		{
+			name: "a stale consumer transition leaves the fsm history alone",
+			test: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, opID, "node1", target, coll, "shard-0", api.COPY)
+				for _, state := range []api.ShardReplicationState{api.HYDRATING, api.FINALIZING, api.INTEGRATING} {
+					driveToState(t, fsm, opID, state)
+				}
+
+				// The consumer polls the op, then keeps working while the FSM
+				// applies further commands, so its copy goes stale.
+				polled, ok := fsm.GetOpById(opID)
+				require.True(t, ok)
+				require.NoError(t, fsm.RegisterError(&api.ReplicationRegisterErrorRequest{
+					Version:    api.ReplicationCommandVersionV0,
+					Id:         opID,
+					Error:      "hydration failed",
+					TimeUnixMs: 1,
+				}))
+				driveToState(t, fsm, opID, api.READY)
+
+				// Transitioning the stale copy archives a state the FSM has
+				// already archived itself, at the same history index.
+				polled.Status.ChangeState(api.READY)
+
+				current, ok := fsm.GetOpById(opID)
+				require.True(t, ok)
+				history := current.Status.GetHistory()
+				require.Len(t, history, 4)
+				assert.Equal(t, api.INTEGRATING, history[3].State)
+				assert.Len(t, history[3].Errors, 1, "the archived state keeps the error registered before it")
+			},
+		},
+		{
+			name: "per-node state from GetStatusByOps is not the fsm's map",
+			test: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, opID, "node1", target, coll, "shard-0", api.COPY)
+				driveToState(t, fsm, opID, api.HYDRATING)
+				require.NoError(t, fsm.NodeReachedState(&api.ReplicationNodeReachedStateRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Id:      opID,
+					NodeId:  "node1",
+					State:   api.HYDRATING,
+				}))
+
+				for _, status := range fsm.GetStatusByOps() {
+					status.PerNodeState["injected"] = api.READY
+				}
+
+				assert.False(t, fsm.AllPeersAtLeast(opID, api.HYDRATING, []string{"injected"}))
+			},
+		},
+		{
+			name: "per-node state from GetOpState is not the fsm's map",
+			test: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				seedOpFull(t, fsm, opID, "node1", target, coll, "shard-0", api.COPY)
+				driveToState(t, fsm, opID, api.HYDRATING)
+				require.NoError(t, fsm.NodeReachedState(&api.ReplicationNodeReachedStateRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Id:      opID,
+					NodeId:  "node1",
+					State:   api.HYDRATING,
+				}))
+
+				op, ok := fsm.GetOpById(opID)
+				require.True(t, ok)
+				status, ok := fsm.GetOpState(op.Op)
+				require.True(t, ok)
+				status.PerNodeState["injected"] = api.READY
+
+				assert.False(t, fsm.AllPeersAtLeast(opID, api.HYDRATING, []string{"injected"}))
+			},
+		},
+		{
+			name: "target ops survive a removal mid-iteration",
+			test: func(t *testing.T, fsm *replication.ShardReplicationFSM) {
+				for i := range 3 {
+					seedOpFull(t, fsm, uint64(i+1), "node1", target, coll, fmt.Sprintf("shard-%d", i), api.COPY)
+				}
+				ops := fsm.GetOpsForTarget(target)
+				require.Len(t, ops, 3)
+
+				// Removing the middle op compacts the FSM's own slice in place.
+				require.NoError(t, fsm.RemoveReplicationOp(&api.ReplicationRemoveOpRequest{
+					Version: api.ReplicationCommandVersionV0,
+					Id:      2,
+				}))
+
+				ids := make([]uint64, len(ops))
+				for i, op := range ops {
+					ids[i] = op.ID
+				}
+				assert.Equal(t, []uint64{1, 2, 3}, ids)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.test(t, replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry()))
+		})
+	}
+}
+
 func BenchmarkHasActiveTargetReplicationForShard(b *testing.B) {
 	const (
 		coll   = "TestClass"

--- a/cluster/replication/shard_replication_fsm_test.go
+++ b/cluster/replication/shard_replication_fsm_test.go
@@ -708,6 +708,108 @@ func TestShardReplicationFSM_HandsOutDetachedState(t *testing.T) {
 	}
 }
 
+// Cloning the History slice copies the State entries but not the Errors slice
+// inside each one, so an archived error stays shared with the FSM. Every exit
+// point that hands out a status is covered: a caller reaching one of them holds
+// the same aliased memory as a caller reaching any other.
+func TestShardReplicationFSM_HandsOutDetachedHistoryErrors(t *testing.T) {
+	const (
+		coll   = "TestClass"
+		source = "node1"
+		target = "node2"
+		shard  = "shard-0"
+		opID   = uint64(1)
+		errMsg = "hydration failed"
+	)
+
+	tests := []struct {
+		name    string
+		handOut func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus
+	}{
+		{
+			name: "GetOpById",
+			handOut: func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus {
+				op, ok := fsm.GetOpById(opID)
+				require.True(t, ok)
+				return op.Status
+			},
+		},
+		{
+			name: "GetOpState",
+			handOut: func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus {
+				op, ok := fsm.GetOpById(opID)
+				require.True(t, ok)
+				status, ok := fsm.GetOpState(op.Op)
+				require.True(t, ok)
+				return status
+			},
+		},
+		{
+			name: "GetStatusByOps",
+			handOut: func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus {
+				statuses := fsm.GetStatusByOps()
+				require.Len(t, statuses, 1)
+				for _, status := range statuses {
+					return status
+				}
+				return replication.ShardReplicationOpStatus{}
+			},
+		},
+		{
+			name: "GetOpsForCollection",
+			handOut: func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus {
+				ops, ok := fsm.GetOpsForCollection(coll)
+				require.True(t, ok)
+				require.Len(t, ops, 1)
+				return ops[0].Status
+			},
+		},
+		{
+			name: "GetOpsForCollectionAndShard",
+			handOut: func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus {
+				ops, ok := fsm.GetOpsForCollectionAndShard(coll, shard)
+				require.True(t, ok)
+				require.Len(t, ops, 1)
+				return ops[0].Status
+			},
+		},
+		{
+			name: "GetOpsForTargetNode",
+			handOut: func(t *testing.T, fsm *replication.ShardReplicationFSM) replication.ShardReplicationOpStatus {
+				ops, ok := fsm.GetOpsForTargetNode(target)
+				require.True(t, ok)
+				require.Len(t, ops, 1)
+				return ops[0].Status
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fsm := replication.NewShardReplicationFSM(prometheus.NewPedanticRegistry())
+			seedOpFull(t, fsm, opID, source, target, coll, shard, api.COPY)
+			require.NoError(t, fsm.RegisterError(&api.ReplicationRegisterErrorRequest{
+				Version:    api.ReplicationCommandVersionV0,
+				Id:         opID,
+				Error:      errMsg,
+				TimeUnixMs: 1,
+			}))
+			// Moves the error out of Current and into History.
+			driveToState(t, fsm, opID, api.HYDRATING)
+
+			status := test.handOut(t, fsm)
+			history := status.GetHistory()
+			require.Len(t, history, 1)
+			require.Len(t, history[0].Errors, 1)
+			history[0].Errors[0].Message = "overwritten by the caller"
+
+			current, ok := fsm.GetOpById(opID)
+			require.True(t, ok)
+			assert.Equal(t, errMsg, current.Status.GetHistory()[0].Errors[0].Message)
+		})
+	}
+}
+
 func BenchmarkHasActiveTargetReplicationForShard(b *testing.B) {
 	const (
 		coll   = "TestClass"

--- a/cluster/replication/shard_replication_op_state.go
+++ b/cluster/replication/shard_replication_op_state.go
@@ -15,6 +15,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"time"
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
@@ -120,6 +122,20 @@ func NewShardReplicationStatus(state api.ShardReplicationState) ShardReplication
 	}
 }
 
+// clone returns a status that shares no memory with the FSM's own. Anything the
+// FSM hands out needs one: a plain value copy still points at the map and slices
+// the apply path keeps writing to, and the caller reads them after opsLock is
+// released.
+//
+// The Errors slices already archived in History need no copy. ChangeState puts a
+// fresh slice in Current, so nothing appends to an archived one again.
+func (s ShardReplicationOpStatus) clone() ShardReplicationOpStatus {
+	s.PerNodeState = maps.Clone(s.PerNodeState)
+	s.History = slices.Clone(s.History)
+	s.Current.Errors = slices.Clone(s.Current.Errors)
+	return s
+}
+
 // AddError adds an error to the current state of the shard replication operation
 func (s *ShardReplicationOpStatus) AddError(error string, timeUnixMs int64) error {
 	if len(s.Current.Errors) >= MaxErrors {
@@ -207,10 +223,12 @@ type ShardReplicationOpAndStatus struct {
 	Status ShardReplicationOpStatus
 }
 
-// NewShardReplicationOpAndStatus creates a new ShardReplicationOpAndStatus from op and status
+// NewShardReplicationOpAndStatus creates a new ShardReplicationOpAndStatus from op and status.
+// The status is cloned, so the caller may read and mutate it without holding the
+// FSM's lock.
 func NewShardReplicationOpAndStatus(op ShardReplicationOp, status ShardReplicationOpStatus) ShardReplicationOpAndStatus {
 	return ShardReplicationOpAndStatus{
 		Op:     op,
-		Status: status,
+		Status: status.clone(),
 	}
 }

--- a/cluster/replication/shard_replication_op_state.go
+++ b/cluster/replication/shard_replication_op_state.go
@@ -127,11 +127,14 @@ func NewShardReplicationStatus(state api.ShardReplicationState) ShardReplication
 // the apply path keeps writing to, and the caller reads them after opsLock is
 // released.
 //
-// The Errors slices already archived in History need no copy. ChangeState puts a
-// fresh slice in Current, so nothing appends to an archived one again.
+// Cloning the History slice alone is not enough, because each entry keeps its own
+// Errors slice pointing back into the FSM.
 func (s ShardReplicationOpStatus) clone() ShardReplicationOpStatus {
 	s.PerNodeState = maps.Clone(s.PerNodeState)
 	s.History = slices.Clone(s.History)
+	for i := range s.History {
+		s.History[i].Errors = slices.Clone(s.History[i].Errors)
+	}
 	s.Current.Errors = slices.Clone(s.Current.Errors)
 	return s
 }

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -216,7 +216,7 @@ func (s *SchemaManager) AliasSnapshot() ([]byte, error) {
 
 	// Raft runs Persist concurrently with Apply, so the alias map must be
 	// copied under the schema read lock.
-	err := json.NewEncoder(&buf).Encode(s.schema.getAliases("", ""))
+	err := json.NewEncoder(&buf).Encode(s.schema.cloneAliases())
 	return buf.Bytes(), err
 }
 

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -214,7 +214,9 @@ func (s *SchemaManager) SchemaSnapshot() ([]byte, error) {
 func (s *SchemaManager) AliasSnapshot() ([]byte, error) {
 	var buf bytes.Buffer
 
-	err := json.NewEncoder(&buf).Encode(s.schema.aliases)
+	// Raft runs Persist concurrently with Apply, so the alias map must be
+	// copied under the schema read lock.
+	err := json.NewEncoder(&buf).Encode(s.schema.getAliases("", ""))
 	return buf.Bytes(), err
 }
 

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -835,6 +835,14 @@ func (s *schema) getAliases(alias, class string) map[string]string {
 	return nil
 }
 
+// cloneAliases returns a copy of the whole alias map, safe to hand to callers
+// that read it while the FSM keeps applying alias commands.
+func (s *schema) cloneAliases() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return maps.Clone(s.aliases)
+}
+
 func (s *schema) ResolveAlias(alias string) string {
 	alias = s.canonicalAlias(alias)
 	s.mu.RLock()

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -81,7 +81,7 @@ type schema struct {
 	nodeID      string
 	shardReader shardReader
 
-	// mu protects the `classes`
+	// mu protects `classes` and `aliases`
 	mu      sync.RWMutex
 	classes map[string]*metaClass
 	aliases map[string]string // key: canonical form all in TitleCase.

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -12,6 +12,7 @@
 package schema
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -76,6 +77,10 @@ func TestConcurrentSchemaAccess(t *testing.T) {
 		{
 			name: "concurrent sharding state operations",
 			test: testConcurrentShardingStateOperations,
+		},
+		{
+			name: "concurrent alias snapshot and alias writes",
+			test: testConcurrentAliasSnapshot,
 		},
 	}
 
@@ -742,6 +747,66 @@ func testConcurrentShardingStateOperations(t *testing.T, s *schema) {
 					assert.NotEmpty(t, status)
 				}
 				time.Sleep(time.Microsecond)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+// AliasSnapshot runs while raft applies alias commands. Reading the alias map
+// without the lock is a concurrent map iteration and write, which crashes the
+// process. RestoreAlias is covered too: it replaces the map rather than
+// mutating it in place.
+func testConcurrentAliasSnapshot(t *testing.T, s *schema) {
+	class := &models.Class{Class: "TestClass"}
+	require.NoError(t, s.addClass(class, &sharding.State{}, 1))
+
+	sm := &SchemaManager{schema: s}
+
+	const numGoroutines = 10
+	const iterations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 3)
+
+	// Test concurrent AliasSnapshot calls
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				data, err := sm.AliasSnapshot()
+				if !assert.NoError(t, err) {
+					continue
+				}
+				var aliases map[string]string
+				if !assert.NoError(t, json.Unmarshal(data, &aliases)) {
+					continue
+				}
+				for alias, className := range aliases {
+					assert.Equal(t, "TestClass", className, "alias %q resolves to its class", alias)
+				}
+			}
+		}()
+	}
+
+	// Test concurrent alias creation while snapshotting
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				assert.NoError(t, s.createAlias("TestClass", fmt.Sprintf("Alias%d_%d", id, j)))
+			}
+		}(i)
+	}
+
+	// Test concurrent alias restores while snapshotting
+	restored := []byte(`{"RestoredAlias":"TestClass"}`)
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				assert.NoError(t, s.RestoreAlias(restored))
 			}
 		}()
 	}


### PR DESCRIPTION
### What's being changed:

Three crashes and corruptions in cluster bookkeeping, all caused by reading data while something else was changing it. Each is reachable in normal operation and comes with a test that fails without its fix.

- cluster/schema: copy the alias map under the lock in AliasSnapshot — saving cluster state to disk read the alias list while another alias was being created. Go kills the whole node when that happens, and the usual panic handler can't stop it. Fixes https://github.com/weaviate/dirk-claude-issues/issues/18.
- cluster/replication: stop handing out state the FSM still writes to: handing out a replication operation's status gave callers a shallow copy that still pointed back at the original, so saving state could crash the node, and a worker finishing a step could quietly overwrite a completed step's record, losing the errors attached to it. What gets written to disk is unchanged, so upgrades are unaffected.
- cluster/replication: force delete no longer skips ops — force-delete walked a list while deleting from that same list. With three or more operations it skipped some, then failed on one it had already removed, so the caller got an error and the leftovers stayed behind.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
