### PR TITLE
Usage: Make cold tenants report the same data as hot tenants

### DIFF
--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -14,12 +14,8 @@ package helpers
 import (
 	"fmt"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
-	"github.com/weaviate/weaviate/entities/vectorindex/flat"
-	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 var (
@@ -178,41 +174,4 @@ func BucketSearchableFromPropertyLSM(prop *models.Property) string {
 // a property at its currently-active generation. See [BucketFromPropertyLSM].
 func BucketRangeableFromPropertyLSM(prop *models.Property) string {
 	return BucketRangeableFromPropNameLSMAtGen(prop.Name, prop.BucketGeneration)
-}
-
-// CompressionRatioFromConfig calculates the compression ratio from vector index config
-// This is used for inactive tenants where we don't have access to the actual vector index
-func CompressionRatioFromConfig(config schemaConfig.VectorIndexConfig, dimensions int) float64 {
-	// Check for different compression types in config by type asserting
-	if hnswConfig, ok := config.(hnsw.UserConfig); ok {
-		// Check for different compression types in HNSW config
-		if hnswConfig.PQ.Enabled {
-			// PQ compression ratio depends on segments
-			segments := hnswConfig.PQ.Segments
-			if segments == 0 {
-				segments = common.CalculateOptimalSegments(dimensions)
-			}
-			return float64(dimensions*4) / float64(segments)
-		} else if hnswConfig.BQ.Enabled {
-			// BQ compression ratio is approximately 32x
-			return 32
-		} else if hnswConfig.SQ.Enabled {
-			// SQ compression ratio is approximately 4x
-			return 4
-		}
-	} else if flatConfig, ok := config.(flat.UserConfig); ok {
-		// Check for different compression types in Flat config
-		if flatConfig.BQ.Enabled {
-			// BQ compression ratio is approximately 32x
-			return 32
-		} else if flatConfig.PQ.Enabled {
-			// PQ compression ratio depends on segments (not supported in flat but handle gracefully)
-		} else if flatConfig.SQ.Enabled {
-			// SQ compression ratio is approximately 4x
-			return 4
-		}
-	}
-
-	// Default to no compression
-	return 1
 }

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -432,8 +432,16 @@ func (i *Index) unloadedVectorState(shardName, lsmPath, targetVector string,
 
 	state := unloadedVectorState{quantizedVectorsExist: quantized}
 	if vectorConfig.VectorIndexType == common.IndexTypeDynamic {
-		state.dynamicUpgraded = dynamic.UpgradedOnDisk(shardPath(i.path(), shardName),
+		upgraded, err := dynamic.UpgradedOnDisk(shardPath(i.path(), shardName),
 			vectorIndexID(targetVector), targetVector)
+		if err != nil {
+			i.logger.WithFields(logrus.Fields{
+				"class":         i.Config.ClassName.String(),
+				"shard":         shardName,
+				"target_vector": targetVector,
+			}).Warnf("cannot read dynamic upgrade state, reporting it as not upgraded: %v", err)
+		}
+		state.dynamicUpgraded = upgraded
 	}
 	return state, nil
 }

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -422,15 +422,14 @@ type unloadedVectorState struct {
 }
 
 // unloadedVectorState reads the state of one target vector of an unloaded shard.
-func (i *Index) unloadedVectorState(shardName, lsmPath, targetVector string,
-	vectorConfig models.VectorConfig,
-) (unloadedVectorState, error) {
-	quantized, err := shardusage.QuantizedVectorsExist(lsmPath, targetVector)
-	if err != nil {
-		return unloadedVectorState{}, fmt.Errorf("quantized vectors of %q: %w", targetVector, err)
+// Whether quantized vectors exist is taken from the vector metrics rather than read
+// again, as the walk that produced them already sized the compressed bucket.
+func (i *Index) unloadedVectorState(shardName, targetVector string,
+	vectorConfig models.VectorConfig, vectorMetrics shardusage.VectorsMetrics,
+) unloadedVectorState {
+	state := unloadedVectorState{
+		quantizedVectorsExist: vectorMetrics.QuantizedVectorsExist(targetVector),
 	}
-
-	state := unloadedVectorState{quantizedVectorsExist: quantized}
 	if vectorConfig.VectorIndexType == common.IndexTypeDynamic {
 		upgraded, err := dynamic.UpgradedOnDisk(shardPath(i.path(), shardName),
 			vectorIndexID(targetVector), targetVector)
@@ -443,7 +442,7 @@ func (i *Index) unloadedVectorState(shardName, lsmPath, targetVector string,
 		}
 		state.dynamicUpgraded = upgraded
 	}
-	return state, nil
+	return state
 }
 
 // unloadedVectorUsage builds the usage entry of one target vector of an unloaded
@@ -509,7 +508,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		return nil, err
 	}
 
-	vectorStorageSize, err := shardusage.CalculateUnloadedVectorsMetrics(lsmPath, directories)
+	vectorMetrics, err := shardusage.CalculateUnloadedVectorsMetrics(lsmPath, directories)
 	if err != nil {
 		return nil, err
 	}
@@ -541,10 +540,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		dimensionality := dimensionalitiesAll[targetVector]
 		uncompressedVectorSize += uint64(dimensionality.Count) * uint64(dimensionality.Dimensions) * 4
 
-		state, err := i.unloadedVectorState(shardName, lsmPath, targetVector, vectorConfig)
-		if err != nil {
-			return nil, err
-		}
+		state := i.unloadedVectorState(shardName, targetVector, vectorConfig, vectorMetrics)
 		vectorUsage, err := unloadedVectorUsage(targetVector, vectorConfig, dimensionality, state)
 		if err != nil {
 			return nil, err
@@ -562,9 +558,9 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		ObjectsCount:          objectUsage.Count,
 		Status:                strings.ToLower(models.TenantActivityStatusINACTIVE),
 		ObjectsStorageBytes:   objectsWithoutVectors,
-		VectorStorageBytes:    uint64(vectorStorageSize) + vectorsInObjects + vectorCommitLogsStorageSize,
+		VectorStorageBytes:    uint64(vectorMetrics.StorageBytes) + vectorsInObjects + vectorCommitLogsStorageSize,
 		IndexStorageBytes:     indexUsage,
-		FullShardStorageBytes: vectorCommitLogsStorageSize + otherNonLSMFoldersStorageSize + indexUsage + uint64(objectUsage.StorageBytes) + uint64(vectorStorageSize),
+		FullShardStorageBytes: vectorCommitLogsStorageSize + otherNonLSMFoldersStorageSize + indexUsage + uint64(objectUsage.StorageBytes) + uint64(vectorMetrics.StorageBytes),
 		NamedVectors:          namedVectors,
 	}
 	if err := shardusage.SaveComputedUsageData(i.path(), shardName, shardUsage); err != nil {

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -413,6 +413,63 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 	return usages, nil
 }
 
+// unloadedVectorState is what a shard's files say about one target vector that
+// its schema config cannot: whether a configured quantizer has actually run, and
+// which index a dynamic vector settled on.
+type unloadedVectorState struct {
+	quantizedVectorsExist bool
+	dynamicUpgraded       bool
+}
+
+// unloadedVectorState reads the state of one target vector of an unloaded shard.
+func (i *Index) unloadedVectorState(shardName, lsmPath, targetVector string,
+	vectorConfig models.VectorConfig,
+) (unloadedVectorState, error) {
+	quantized, err := shardusage.QuantizedVectorsExist(lsmPath, targetVector)
+	if err != nil {
+		return unloadedVectorState{}, fmt.Errorf("quantized vectors of %q: %w", targetVector, err)
+	}
+
+	state := unloadedVectorState{quantizedVectorsExist: quantized}
+	if vectorConfig.VectorIndexType == common.IndexTypeDynamic {
+		state.dynamicUpgraded = dynamic.UpgradedOnDisk(shardPath(i.path(), shardName),
+			vectorIndexID(targetVector), targetVector)
+	}
+	return state, nil
+}
+
+// unloadedVectorUsage builds the usage entry of one target vector of an unloaded
+// shard from its schema config, the dimensions read off disk, and what the shard's
+// files say about the index the config asks for.
+func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
+	dimensionality types.Dimensionality, state unloadedVectorState,
+) (*types.VectorUsage, error) {
+	vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
+	if !ok {
+		return nil, fmt.Errorf("vector index config for %q is not of expected type", targetVector)
+	}
+
+	dimInfo := GetDimensionCategory(vectorIndexConfig, state.dynamicUpgraded)
+	vectorUsage := &types.VectorUsage{
+		Name:                   targetVector,
+		Compression:            dimInfo.category.String(),
+		Bits:                   dimInfo.bits,
+		VectorCompressionRatio: dimInfo.compressionRatio(dimensionality.Dimensions, state.quantizedVectorsExist),
+		VectorIndexType:        vectorIndexConfig.IndexType(),
+		IsDynamic:              vectorConfig.VectorIndexType == common.IndexTypeDynamic,
+		Dimensionalities:       []*types.Dimensionality{&dimensionality},
+		MultiVectorConfig:      multiVectorConfigFromConfig(vectorIndexConfig),
+	}
+	if vectorUsage.IsDynamic {
+		// name the index that holds the vectors, as the loaded path does
+		vectorUsage.VectorIndexType = common.IndexTypeFlat
+		if state.dynamicUpgraded {
+			vectorUsage.VectorIndexType = common.IndexTypeHNSW
+		}
+	}
+	return vectorUsage, nil
+}
+
 // calculateUnloadedShardUsage computes usage for a cold shard from disk. vectorConfigs must
 // contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig.
 func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig) (*types.ShardUsage, error) {
@@ -420,8 +477,13 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		// usage has been pre-calculated and can be read from disk
 		shardUsage, err := shardusage.LoadComputedUsageData(i.path(), shardName)
 		if err != nil {
-			// in case of error just log an information and proceed with computation
-			i.logger.Errorf("failed to load pre-calculated usage data for shard %s: %v", shardName, err)
+			// the computation below overwrites the unusable file, so a stale
+			// version is routine; anything else is worth an operator's attention
+			if errors.Is(err, shardusage.ErrUsageVersionMismatch) {
+				i.logger.Debugf("recomputing usage data for shard %s: %v", shardName, err)
+			} else {
+				i.logger.Warnf("failed to load pre-calculated usage data for shard %s: %v", shardName, err)
+			}
 		} else {
 			return shardUsage, nil
 		}
@@ -468,28 +530,17 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	var namedVectors types.VectorsUsage
 	uncompressedVectorSize := uint64(0) // calculate total uncompressed vector size for all vectors
 	for targetVector, vectorConfig := range vectorConfigs {
-		vectorUsage := &types.VectorUsage{
-			Name:                   targetVector,
-			VectorCompressionRatio: 1.0, // Default ratio for cold shards
-		}
+		dimensionality := dimensionalitiesAll[targetVector]
+		uncompressedVectorSize += uint64(dimensionality.Count) * uint64(dimensionality.Dimensions) * 4
 
-		vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
-		if !ok {
-			return nil, fmt.Errorf("vector index config for %q is not of expected type", targetVector)
+		state, err := i.unloadedVectorState(shardName, lsmPath, targetVector, vectorConfig)
+		if err != nil {
+			return nil, err
 		}
-
-		vectorUsage.IsDynamic = vectorConfig.VectorIndexType == common.IndexTypeDynamic
-		if !vectorUsage.IsDynamic {
-			// for cold tenants we cannot distinguish know if dynamic has been upgraded or not. Do not include wrong data
-			dimInfo := GetDimensionCategory(vectorIndexConfig, false)
-			vectorUsage.Compression = dimInfo.category.String()
-			vectorUsage.VectorIndexType = vectorIndexConfig.IndexType()
+		vectorUsage, err := unloadedVectorUsage(targetVector, vectorConfig, dimensionality, state)
+		if err != nil {
+			return nil, err
 		}
-
-		dimensionalities := dimensionalitiesAll[targetVector]
-		uncompressedVectorSize += uint64(dimensionalities.Count) * uint64(dimensionalities.Dimensions) * 4
-		vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &dimensionalities)
-		vectorUsage.MultiVectorConfig = multiVectorConfigFromConfig(vectorIndexConfig)
 		namedVectors = append(namedVectors, vectorUsage)
 	}
 

--- a/adapters/repos/db/index_usage_cache_test.go
+++ b/adapters/repos/db/index_usage_cache_test.go
@@ -1,0 +1,85 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/weaviate/weaviate/cluster/usage/types"
+)
+
+// TestUnloadedShardUsageSavedToDisk pins which saved usage a cold shard serves.
+// Nothing deletes the file of a shard that stays cold, so a UsageDiskVersion bump
+// only reaches those shards if a version it does not know makes them recompute.
+func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
+	// distinguishable from the 20 objects the shard actually holds
+	const savedObjectsCount = int64(7)
+
+	tests := []struct {
+		name             string
+		savedVersion     int
+		wantObjectsCount int64
+	}{
+		{
+			name:             "usage of the current version is served",
+			savedVersion:     types.UsageDiskVersion,
+			wantObjectsCount: savedObjectsCount,
+		},
+		{
+			name:             "usage of an older version is recomputed",
+			savedVersion:     types.UsageDiskVersion - 1,
+			wantObjectsCount: 20,
+		},
+		{
+			name:             "usage of a newer version is recomputed",
+			savedVersion:     types.UsageDiskVersion + 1,
+			wantObjectsCount: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tenantName := "test-tenant"
+
+			index := setupPopulatedLazyIndex(ctx, t)
+			t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+			writeSavedShardUsage(t, index.path(), tenantName, tt.savedVersion,
+				&types.ShardUsage{Name: tenantName, ObjectsCount: savedObjectsCount})
+
+			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(1), true, nil)
+			require.NoError(t, err)
+			require.Len(t, usage.Shards, 1)
+			assert.Equal(t, tt.wantObjectsCount, usage.Shards[0].ObjectsCount)
+		})
+	}
+}
+
+// writeSavedShardUsage writes the file [shardusage.SaveComputedUsageData] writes,
+// at an arbitrary version. It repeats that file's name because the package keeps
+// it private and stamps the current version on everything it saves.
+func writeSavedShardUsage(t *testing.T, indexPath, shardName string, version int, usage *types.ShardUsage) {
+	t.Helper()
+
+	data, err := json.Marshal(&types.UsageDisk{Version: version, ShardUsage: usage})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(indexPath, shardName, "usage.json.tmp"), data, 0o600))
+}

--- a/adapters/repos/db/index_usage_compression_ratio_test.go
+++ b/adapters/repos/db/index_usage_compression_ratio_test.go
@@ -1,0 +1,328 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/entities/models"
+	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	hfreshent "github.com/weaviate/weaviate/entities/vectorindex/hfresh"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+func TestDimensionInfoCompressionRatio(t *testing.T) {
+	tests := []struct {
+		name string
+		// quantizedVectorsExist defaults to false, so every case that expects a
+		// compressed ratio has to say the quantizer already ran
+		quantizedVectorsExist bool
+		dimInfo               DimensionInfo
+		dimensions            int
+		wantRatio             float64
+	}{
+		{
+			name:       "standard",
+			dimInfo:    DimensionInfo{category: DimensionCategoryStandard},
+			dimensions: 64,
+			wantRatio:  1,
+		},
+		{
+			name:       "auto quantizes like rq on 1 bit, without its own bucket",
+			dimInfo:    DimensionInfo{category: DimensionCategoryAuto},
+			dimensions: 64,
+			wantRatio:  16,
+		},
+		{
+			name:                  "bq stores one bit per dimension",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryBQ},
+			dimensions:            64,
+			wantRatio:             32,
+		},
+		{
+			name:                  "sq",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategorySQ},
+			dimensions:            64,
+			wantRatio:             4,
+		},
+		{
+			name:                  "pq with configured segments",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryPQ, segments: 16},
+			dimensions:            64,
+			wantRatio:             16, // 64 * 4 bytes / 16 codes
+		},
+		{
+			name:                  "pq with unset segments uses the optimal count",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryPQ},
+			dimensions:            64,
+			wantRatio:             8, // optimal is 64/2 segments
+		},
+		{
+			name:                  "pq with unset segments on a six-divisible dimension count",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryPQ},
+			dimensions:            768,
+			wantRatio:             24, // optimal is 768/6 segments
+		},
+		{
+			name:                  "pq with unset segments on an odd dimension count",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryPQ},
+			dimensions:            1,
+			wantRatio:             4, // optimal is one segment per dimension
+		},
+		{
+			name:                  "rq with 8 bits",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryRQ, bits: 8},
+			dimensions:            64,
+			wantRatio:             3.2, // 64 * 4 bytes / (16 metadata + 64 codes)
+		},
+		{
+			name:                  "rq with unset bits reports the 8 bit ratio",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryRQ},
+			dimensions:            64,
+			wantRatio:             3.2,
+		},
+		{
+			name:                  "rq with 1 bit",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryRQ, bits: 1},
+			dimensions:            64,
+			wantRatio:             16, // 64 * 4 bytes / (8 metadata + 8 packed bytes)
+		},
+		{
+			name:       "pq that has not reached its training limit",
+			dimInfo:    DimensionInfo{category: DimensionCategoryPQ, segments: 16},
+			dimensions: 64,
+			wantRatio:  1,
+		},
+		{
+			name:       "bq on a shard that never built its index",
+			dimInfo:    DimensionInfo{category: DimensionCategoryBQ},
+			dimensions: 64,
+			wantRatio:  1,
+		},
+		{
+			name:                  "pq without tracked dimensions",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryPQ},
+			dimensions:            0,
+			wantRatio:             1,
+		},
+		{
+			name:                  "rq without tracked dimensions",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryRQ, bits: 8},
+			dimensions:            0,
+			wantRatio:             1,
+		},
+		{
+			name:                  "bq without tracked dimensions",
+			quantizedVectorsExist: true,
+			dimInfo:               DimensionInfo{category: DimensionCategoryBQ},
+			dimensions:            0,
+			wantRatio:             1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.InDelta(t, tt.wantRatio,
+				tt.dimInfo.compressionRatio(tt.dimensions, tt.quantizedVectorsExist), 1e-9)
+		})
+	}
+}
+
+func TestUnloadedVectorUsage(t *testing.T) {
+	dimensionality := types.Dimensionality{Dimensions: 64, Count: 10}
+
+	tests := []struct {
+		name            string
+		vectorConfig    models.VectorConfig
+		state           unloadedVectorState
+		wantRatio       float64
+		wantCompression string
+		wantIndexType   string
+		wantBits        int16
+		wantDynamic     bool
+		wantErr         bool
+	}{
+		{
+			name: "hnsw without compression",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: enthnsw.UserConfig{},
+			},
+			wantRatio:       1,
+			wantCompression: "standard",
+			wantIndexType:   common.IndexTypeHNSW,
+		},
+		{
+			name: "hnsw with bq",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: enthnsw.UserConfig{BQ: enthnsw.BQConfig{Enabled: true}},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       32,
+			wantCompression: "bq",
+			wantIndexType:   common.IndexTypeHNSW,
+		},
+		{
+			name: "hnsw with sq",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: enthnsw.UserConfig{SQ: enthnsw.SQConfig{Enabled: true}},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       4,
+			wantCompression: "sq",
+			wantIndexType:   common.IndexTypeHNSW,
+		},
+		{
+			name: "hnsw with pq on unset segments",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: enthnsw.UserConfig{PQ: enthnsw.PQConfig{Enabled: true}},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       8,
+			wantCompression: "pq",
+			wantIndexType:   common.IndexTypeHNSW,
+		},
+		{
+			name: "hnsw with rq on 1 bit",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: enthnsw.UserConfig{RQ: enthnsw.RQConfig{Enabled: true, Bits: 1}},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       16,
+			wantCompression: "rq",
+			wantIndexType:   common.IndexTypeHNSW,
+			wantBits:        1,
+		},
+		{
+			name: "flat with bq",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeFlat,
+				VectorIndexConfig: flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       32,
+			wantCompression: "bq",
+			wantIndexType:   common.IndexTypeFlat,
+		},
+		{
+			name: "flat with rq on 8 bits",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeFlat,
+				VectorIndexConfig: flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true, Bits: 8}},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       3.2,
+			wantCompression: "rq",
+			wantIndexType:   common.IndexTypeFlat,
+			wantBits:        8,
+		},
+		{
+			name: "hfresh",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHFresh,
+				VectorIndexConfig: hfreshent.NewDefaultUserConfig(),
+			},
+			wantRatio:       16, // hfresh always quantizes with rq on 1 bit
+			wantCompression: "auto",
+			wantIndexType:   common.IndexTypeHFresh,
+		},
+		{
+			name: "hnsw with pq that has not reached its training limit",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: enthnsw.UserConfig{PQ: enthnsw.PQConfig{Enabled: true}},
+			},
+			wantRatio:       1,
+			wantCompression: "pq",
+			wantIndexType:   common.IndexTypeHNSW,
+		},
+		{
+			name: "dynamic still on flat",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType: common.IndexTypeDynamic,
+				VectorIndexConfig: dynamicent.UserConfig{
+					HnswUC: enthnsw.UserConfig{PQ: enthnsw.PQConfig{Enabled: true}},
+					FlatUC: flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}},
+				},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true},
+			wantRatio:       32,
+			wantCompression: "bq",
+			wantIndexType:   common.IndexTypeFlat,
+			wantDynamic:     true,
+		},
+		{
+			name: "dynamic upgraded to hnsw",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType: common.IndexTypeDynamic,
+				VectorIndexConfig: dynamicent.UserConfig{
+					HnswUC: enthnsw.UserConfig{PQ: enthnsw.PQConfig{Enabled: true}},
+					FlatUC: flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}},
+				},
+			},
+			state:           unloadedVectorState{quantizedVectorsExist: true, dynamicUpgraded: true},
+			wantRatio:       8, // pq on the optimal 64/2 segments
+			wantCompression: "pq",
+			wantIndexType:   common.IndexTypeHNSW,
+			wantDynamic:     true,
+		},
+		{
+			name: "unparsed config",
+			vectorConfig: models.VectorConfig{
+				VectorIndexType:   common.IndexTypeHNSW,
+				VectorIndexConfig: map[string]any{"bq": map[string]any{"enabled": true}},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage, err := unloadedVectorUsage("vec", tt.vectorConfig, dimensionality, tt.state)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			assert.Equal(t, "vec", usage.Name)
+			assert.InDelta(t, tt.wantRatio, usage.VectorCompressionRatio, 1e-9)
+			assert.Equal(t, tt.wantCompression, usage.Compression)
+			assert.Equal(t, tt.wantIndexType, usage.VectorIndexType)
+			assert.Equal(t, tt.wantBits, usage.Bits)
+			assert.Equal(t, tt.wantDynamic, usage.IsDynamic)
+			require.Len(t, usage.Dimensionalities, 1)
+			assert.Equal(t, dimensionality, *usage.Dimensionalities[0])
+		})
+	}
+}

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -302,7 +302,14 @@ func (db *DB) totalShardSizeBytes(className schema.ClassName, shardNames []strin
 		// and already contains the full shard storage size.
 		if shardusage.ComputedUsageDataExists(indexPath, shardName) {
 			shardUsage, err := shardusage.LoadComputedUsageData(indexPath, shardName)
-			if err != nil {
+			if errors.Is(err, shardusage.ErrUsageVersionMismatch) {
+				// a version bump leaves this behind on every shard that stayed
+				// cold across it; the on-disk size below is exact anyway
+				db.logger.WithField("action", "lazy_shard_auto_detection").
+					WithField("class", className).
+					WithField("shard", shardName).
+					Debugf("pre-calculated shard usage unusable; falling back to on-disk size: %v", err)
+			} else if err != nil {
 				db.logger.WithField("action", "lazy_shard_auto_detection").
 					WithField("class", className).
 					WithField("shard", shardName).

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -672,7 +672,7 @@ func (s *Shard) ObjectStorageSize(ctx context.Context) (int64, error) {
 // VectorStorageUsage calculates the total storage size of all vector indexes in the shard. It also
 // returns every target vector's dimensionality, so callers need not re-read the dimensions bucket.
 func (s *Shard) VectorStorageUsage(ctx context.Context, lsmPath string, directories []string) (int64, int64, map[string]usagetypes.Dimensionality, error) {
-	vectorSize, err := shardusage.CalculateUnloadedVectorsMetrics(lsmPath, directories)
+	vectorMetrics, err := shardusage.CalculateUnloadedVectorsMetrics(lsmPath, directories)
 	if err != nil {
 		return 0, 0, nil, err
 	}
@@ -696,7 +696,7 @@ func (s *Shard) VectorStorageUsage(ctx context.Context, lsmPath string, director
 		return 0, 0, nil, err
 	}
 
-	return vectorSize, uncompressedSize, dimensionalities, nil
+	return vectorMetrics.StorageBytes, uncompressedSize, dimensionalities, nil
 }
 
 func (s *Shard) isFallbackToSearchable() bool {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -538,6 +538,12 @@ func (s *Shard) pathHashTree() string {
 }
 
 func (s *Shard) vectorIndexID(targetVector string) string {
+	return vectorIndexID(targetVector)
+}
+
+// vectorIndexID names the files a target vector's index owns inside the shard
+// directory. Unloaded shards need it too, so it does not hang off [Shard].
+func vectorIndexID(targetVector string) string {
 	if targetVector != "" {
 		return fmt.Sprintf("%s_%s", helpers.VectorsBucketLSM, targetVector)
 	}

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
@@ -224,6 +225,47 @@ func getDynamicCompression(config dynamicent.UserConfig, dynamicUpgraded bool) D
 		return getHNSWCompression(config.HnswUC)
 	} else {
 		return getFlatCompression(config.FlatUC)
+	}
+}
+
+// compressionRatio reports how many times smaller a compressed vector is than
+// its float32 form, by asking the quantizer the configuration selects. Each
+// quantizer derives the ratio from the dimensions alone, so an unloaded shard
+// can report it without its index.
+//
+// quantizedVectorsExist says whether the shard's quantized vectors bucket holds
+// anything, which the configuration does not settle: PQ and SQ wait for their
+// training limit before compressing anything, and until then the vectors on disk
+// are float32. hfresh is exempt — it keeps its codes in its own postings.
+func (di DimensionInfo) compressionRatio(dimensions int, quantizedVectorsExist bool) float64 {
+	// with nothing tracked there is nothing to compress, and PQ's optimal
+	// segment count would collapse to zero and divide by it
+	if dimensions <= 0 {
+		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
+	}
+
+	if !quantizedVectorsExist && di.category != DimensionCategoryAuto {
+		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
+	}
+
+	switch di.category {
+	case DimensionCategoryPQ:
+		return compressionhelpers.PQStats{M: correctEmptySegments(di.segments, dimensions)}.CompressionRatio(dimensions)
+	case DimensionCategoryBQ:
+		return compressionhelpers.BQStats{}.CompressionRatio(dimensions)
+	case DimensionCategorySQ:
+		return compressionhelpers.SQStats{}.CompressionRatio(dimensions)
+	case DimensionCategoryRQ:
+		if di.bits == 1 {
+			return compressionhelpers.BinaryRQStats{}.CompressionRatio(dimensions)
+		}
+		return compressionhelpers.RQStats{Bits: uint32(di.bits)}.CompressionRatio(dimensions)
+	case DimensionCategoryAuto:
+		// hfresh quantizes with RQ on 1 bit; its config validation rejects
+		// disabling it or asking for another bit count
+		return compressionhelpers.BinaryRQStats{}.CompressionRatio(dimensions)
+	default:
+		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
 	}
 }
 

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -79,6 +79,11 @@ func SaveComputedUsageData(indexPath, shardName string, shardUsage *types.ShardU
 	return nil
 }
 
+// ErrUsageVersionMismatch reports usage written by another version of the format.
+// Every caller recomputes, so it is the expected outcome of a version bump for
+// each shard that stayed cold across it — routine, unlike an unreadable file.
+var ErrUsageVersionMismatch = errors.New("usage data saved to disk version mismatch")
+
 // LoadComputedUsageData loads pre-calculated shard usage data, checks version of saved data before returning
 func LoadComputedUsageData(indexPath, shardName string) (*types.ShardUsage, error) {
 	// usage has been pre-calculated and can be read from disk
@@ -91,8 +96,8 @@ func LoadComputedUsageData(indexPath, shardName string) (*types.ShardUsage, erro
 		return nil, fmt.Errorf("unmarshal pre-calculated usage from disk: %w", err)
 	}
 	if usageDisk.Version != types.UsageDiskVersion {
-		return nil, fmt.Errorf("usage data saved to disk version mismatch, currently supported version is %d but got %d",
-			types.UsageDiskVersion, usageDisk.Version)
+		return nil, fmt.Errorf("%w, currently supported version is %d but got %d",
+			ErrUsageVersionMismatch, types.UsageDiskVersion, usageDisk.Version)
 	}
 	return usageDisk.ShardUsage, nil
 }
@@ -201,6 +206,17 @@ func CalculateUnloadedVectorsMetrics(lsmPath string, directories []string) (int6
 		totalSize += int64(size)
 	}
 	return totalSize, nil
+}
+
+// QuantizedVectorsExist reports whether a shard holds quantized vectors for a
+// target vector. The bucket directory alone is no proof: it is created empty as
+// soon as the schema enables quantization, so that a downgrade finds it in place.
+func QuantizedVectorsExist(lsmPath, targetVector string) (bool, error) {
+	size, err := bucketSize(filepath.Join(lsmPath, helpers.GetCompressedBucketName(targetVector)))
+	if err != nil {
+		return false, err
+	}
+	return size > 0, nil
 }
 
 // bucketSize sums the sizes of the files in a bucket directory. A bucket that was deleted

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -185,9 +185,27 @@ func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	return dimensionalities, nil
 }
 
+// VectorsMetrics is what a single walk over a shard's vector buckets yields: their
+// total size, and the size of each compressed bucket on its own. The per-bucket
+// sizes are a by-product of the same walk, so asking whether a target vector holds
+// quantized vectors costs no further disk reads.
+type VectorsMetrics struct {
+	// StorageBytes is the size of all vector buckets together.
+	StorageBytes int64
+	// compressedBytes is keyed by compressed bucket directory name.
+	compressedBytes map[string]uint64
+}
+
+// QuantizedVectorsExist reports whether a shard holds quantized vectors for a
+// target vector. The bucket directory alone is no proof: it is created empty as
+// soon as the schema enables quantization, so that a downgrade finds it in place.
+func (m VectorsMetrics) QuantizedVectorsExist(targetVector string) bool {
+	return m.compressedBytes[helpers.GetCompressedBucketName(targetVector)] > 0
+}
+
 // CalculateUnloadedVectorsMetrics calculates vector storage size from disk
-func CalculateUnloadedVectorsMetrics(lsmPath string, directories []string) (int64, error) {
-	totalSize := int64(0)
+func CalculateUnloadedVectorsMetrics(lsmPath string, directories []string) (VectorsMetrics, error) {
+	metrics := VectorsMetrics{}
 
 	// vector storage consists of:
 	// 1) size of vector folder - these are:
@@ -201,22 +219,18 @@ func CalculateUnloadedVectorsMetrics(lsmPath string, directories []string) (int6
 		}
 		size, err := bucketSize(filepath.Join(lsmPath, directory))
 		if err != nil {
-			return 0, err
+			return VectorsMetrics{}, err
 		}
-		totalSize += int64(size)
-	}
-	return totalSize, nil
-}
+		metrics.StorageBytes += int64(size)
 
-// QuantizedVectorsExist reports whether a shard holds quantized vectors for a
-// target vector. The bucket directory alone is no proof: it is created empty as
-// soon as the schema enables quantization, so that a downgrade finds it in place.
-func QuantizedVectorsExist(lsmPath, targetVector string) (bool, error) {
-	size, err := bucketSize(filepath.Join(lsmPath, helpers.GetCompressedBucketName(targetVector)))
-	if err != nil {
-		return false, err
+		if strings.HasPrefix(directory, helpers.VectorsCompressedBucketLSM) {
+			if metrics.compressedBytes == nil {
+				metrics.compressedBytes = make(map[string]uint64)
+			}
+			metrics.compressedBytes[directory] = size
+		}
 	}
-	return size > 0, nil
+	return metrics, nil
 }
 
 // bucketSize sums the sizes of the files in a bucket directory. A bucket that was deleted

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -244,7 +244,8 @@ func TestLoadComputedUsageDataVersion(t *testing.T) {
 
 			usage, err := LoadComputedUsageData(dirName, "shard1")
 			if tt.wantError {
-				require.Error(t, err)
+				require.ErrorIs(t, err, ErrUsageVersionMismatch,
+					"callers tell a stale version from an unreadable file by this error")
 				return
 			}
 			require.NoError(t, err)
@@ -325,6 +326,67 @@ func TestStorageCalculation(t *testing.T) {
 	vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, err := CalculateNonLSMStorage(dirName, "shard1")
 	require.NoError(t, err)
 	require.Equal(t, expectedTotal, vectorCommitLogsStorageSize+otherNonLSMFoldersStorageSize+indexBytes+uint64(objectsBytes.StorageBytes)+uint64(vectorBytes))
+}
+
+func TestQuantizedVectorsExist(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetVector string
+		// bucket is created when named, and holds a file when fileSize > 0
+		bucket   string
+		fileSize int
+		want     bool
+	}{
+		{
+			name:   "no bucket at all",
+			bucket: "",
+		},
+		{
+			name:   "bucket created empty for a downgrade",
+			bucket: "vectors_compressed_named",
+		},
+		{
+			name:     "bucket holding quantized vectors",
+			bucket:   "vectors_compressed_named",
+			fileSize: 1,
+			want:     true,
+		},
+		{
+			name:     "another target vector's bucket does not count",
+			bucket:   "vectors_compressed_other",
+			fileSize: 100,
+		},
+		{
+			name:     "legacy unnamed vector",
+			bucket:   "vectors_compressed",
+			fileSize: 100,
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetVector := "named"
+			if tt.bucket == "vectors_compressed" {
+				targetVector = ""
+			}
+
+			lsmPath := filepath.Join(t.TempDir(), "lsm")
+			require.NoError(t, os.MkdirAll(lsmPath, 0o777))
+			if tt.bucket != "" {
+				bucketPath := filepath.Join(lsmPath, tt.bucket)
+				require.NoError(t, os.MkdirAll(bucketPath, 0o777))
+				if tt.fileSize > 0 {
+					require.NoError(t, os.WriteFile(filepath.Join(bucketPath, "segment.db"),
+						make([]byte, tt.fileSize), 0o600))
+				}
+			}
+
+			got, err := QuantizedVectorsExist(lsmPath, targetVector)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func BenchmarkStorageCalculation(b *testing.B) {

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -311,9 +311,10 @@ func TestStorageCalculation(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, sizeTracker[helpers.ObjectsBucketLSM], uint64(objectsBytes.StorageBytes))
 
-	vectorBytes, err := CalculateUnloadedVectorsMetrics(lsmFolder, buckets)
+	vectorMetrics, err := CalculateUnloadedVectorsMetrics(lsmFolder, buckets)
 	require.NoError(t, err)
-	require.Equal(t, sizeTracker["vectors"]+sizeTracker["vectors_compressed"]+sizeTracker["vectors_compressed_named_vector"], uint64(vectorBytes))
+	vectorBytes := uint64(vectorMetrics.StorageBytes)
+	require.Equal(t, sizeTracker["vectors"]+sizeTracker["vectors_compressed"]+sizeTracker["vectors_compressed_named_vector"], vectorBytes)
 
 	indexBytes, err := CalculateUnloadedIndicesSize(lsmFolder, buckets)
 	require.NoError(t, err)
@@ -325,13 +326,12 @@ func TestStorageCalculation(t *testing.T) {
 
 	vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, err := CalculateNonLSMStorage(dirName, "shard1")
 	require.NoError(t, err)
-	require.Equal(t, expectedTotal, vectorCommitLogsStorageSize+otherNonLSMFoldersStorageSize+indexBytes+uint64(objectsBytes.StorageBytes)+uint64(vectorBytes))
+	require.Equal(t, expectedTotal, vectorCommitLogsStorageSize+otherNonLSMFoldersStorageSize+indexBytes+uint64(objectsBytes.StorageBytes)+vectorBytes)
 }
 
 func TestQuantizedVectorsExist(t *testing.T) {
 	tests := []struct {
-		name         string
-		targetVector string
+		name string
 		// bucket is created when named, and holds a file when fileSize > 0
 		bucket   string
 		fileSize int
@@ -357,6 +357,11 @@ func TestQuantizedVectorsExist(t *testing.T) {
 			fileSize: 100,
 		},
 		{
+			name:     "the target vector's uncompressed bucket does not count",
+			bucket:   "vectors_named",
+			fileSize: 100,
+		},
+		{
 			name:     "legacy unnamed vector",
 			bucket:   "vectors_compressed",
 			fileSize: 100,
@@ -373,18 +378,20 @@ func TestQuantizedVectorsExist(t *testing.T) {
 
 			lsmPath := filepath.Join(t.TempDir(), "lsm")
 			require.NoError(t, os.MkdirAll(lsmPath, 0o777))
+			var directories []string
 			if tt.bucket != "" {
 				bucketPath := filepath.Join(lsmPath, tt.bucket)
 				require.NoError(t, os.MkdirAll(bucketPath, 0o777))
+				directories = append(directories, tt.bucket)
 				if tt.fileSize > 0 {
 					require.NoError(t, os.WriteFile(filepath.Join(bucketPath, "segment.db"),
 						make([]byte, tt.fileSize), 0o600))
 				}
 			}
 
-			got, err := QuantizedVectorsExist(lsmPath, targetVector)
+			metrics, err := CalculateUnloadedVectorsMetrics(lsmPath, directories)
 			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.want, metrics.QuantizedVectorsExist(targetVector))
 		})
 	}
 }
@@ -433,9 +440,10 @@ func BenchmarkStorageCalculation(b *testing.B) {
 		require.NoError(b, err)
 		require.Equal(b, sizeTracker[helpers.ObjectsBucketLSM], uint64(objectsBytes.StorageBytes))
 
-		vectorBytes, err := CalculateUnloadedVectorsMetrics(lsmFolder, buckets)
+		vectorMetrics, err := CalculateUnloadedVectorsMetrics(lsmFolder, buckets)
 		require.NoError(b, err)
-		require.Equal(b, sizeTracker["vectors"]+sizeTracker["vectors_compressed"]+sizeTracker["vectors_compressed_named_vector"], uint64(vectorBytes))
+		vectorBytes := uint64(vectorMetrics.StorageBytes)
+		require.Equal(b, sizeTracker["vectors"]+sizeTracker["vectors_compressed"]+sizeTracker["vectors_compressed_named_vector"], vectorBytes)
 
 		indexBytes, err := CalculateUnloadedIndicesSize(lsmFolder, buckets)
 		require.NoError(b, err)
@@ -443,7 +451,7 @@ func BenchmarkStorageCalculation(b *testing.B) {
 
 		vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, err := CalculateNonLSMStorage(dirName, "shard1")
 		require.NoError(b, err)
-		require.Equal(b, expectedTotal, vectorCommitLogsStorageSize+otherNonLSMFoldersStorageSize+indexBytes+uint64(objectsBytes.StorageBytes)+uint64(vectorBytes))
+		require.Equal(b, expectedTotal, vectorCommitLogsStorageSize+otherNonLSMFoldersStorageSize+indexBytes+uint64(objectsBytes.StorageBytes)+vectorBytes)
 
 	}
 }

--- a/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
+++ b/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
@@ -106,6 +106,6 @@ func TestUnloadedSizesSkipVanishedBucket(t *testing.T) {
 
 // vectorsSize adapts CalculateUnloadedVectorsMetrics to the table's uint64 signature.
 func vectorsSize(lsmPath string, directories []string) (uint64, error) {
-	size, err := CalculateUnloadedVectorsMetrics(lsmPath, directories)
-	return uint64(size), err
+	metrics, err := CalculateUnloadedVectorsMetrics(lsmPath, directories)
+	return uint64(metrics.StorageBytes), err
 }

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -305,10 +305,11 @@ func dbKey(targetVector string) []byte {
 // switched to hnsw, reading the same state the shard's own load reads: the
 // shared state DB, falling back for a named vector to the hnsw commit log
 // directory. An unnamed vector gets no such fallback, because its load reads a
-// missing key as not upgraded and then deletes that directory. Unreadable state
-// counts as not upgraded, so the caller never claims hnsw's behaviour for a shard
-// that may still be flat.
-func UpgradedOnDisk(rootPath, id, targetVector string) bool {
+// missing key as not upgraded and then deletes that directory.
+//
+// State that could not be read returns false along with the error, so a caller
+// can tell that answer apart from a shard positively known to be flat.
+func UpgradedOnDisk(rootPath, id, targetVector string) (bool, error) {
 	upgradedWithoutStateKey := false
 	if targetVector != "" {
 		_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
@@ -321,9 +322,9 @@ func UpgradedOnDisk(rootPath, id, targetVector string) bool {
 		// only a shard that never wrote state may fall back to the directory; a
 		// locked or damaged DB is state we failed to read
 		if os.IsNotExist(err) {
-			return upgradedWithoutStateKey
+			return upgradedWithoutStateKey, nil
 		}
-		return false
+		return false, fmt.Errorf("open dynamic state db: %w", err)
 	}
 	defer db.Close()
 
@@ -338,9 +339,9 @@ func UpgradedOnDisk(rootPath, id, targetVector string) bool {
 		}
 		return nil
 	}); err != nil {
-		return false
+		return false, fmt.Errorf("read dynamic state db: %w", err)
 	}
-	return upgraded
+	return upgraded, nil
 }
 
 func (dynamic *dynamic) getBucketName() string {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -45,6 +46,11 @@ const (
 	composerUpgradedKey = "upgraded"
 	batchSize           = 500
 	StateDBFileName     = "index.db"
+
+	// stateDBOpenTimeout bounds the wait for the state DB's file lock. Only a
+	// loaded shard holds it, and [UpgradedOnDisk] reads unloaded ones, so waiting
+	// is a sign the caller raced a load rather than something to sit out.
+	stateDBOpenTimeout = time.Second
 )
 
 var dynamicBucket = []byte("dynamic")
@@ -280,17 +286,50 @@ func (dynamic *dynamic) Type() common.IndexType {
 }
 
 func (dynamic *dynamic) dbKey() []byte {
-	var key []byte
-	if dynamic.targetVector != "" {
-		key = make([]byte, 0, len(composerUpgradedKey)+len(dynamic.targetVector)+1)
-		key = append(key, composerUpgradedKey...)
-		key = append(key, '_')
-		key = append(key, dynamic.targetVector...)
-	} else {
-		key = []byte(composerUpgradedKey)
+	return dbKey(dynamic.targetVector)
+}
+
+func dbKey(targetVector string) []byte {
+	if targetVector == "" {
+		return []byte(composerUpgradedKey)
 	}
 
+	key := make([]byte, 0, len(composerUpgradedKey)+len(targetVector)+1)
+	key = append(key, composerUpgradedKey...)
+	key = append(key, '_')
+	key = append(key, targetVector...)
 	return key
+}
+
+// UpgradedOnDisk reports whether the dynamic index of an unloaded shard already
+// switched to hnsw, reading the state its own startup reads: the shared state DB,
+// falling back to the hnsw commit log directory for an index written before the
+// state key existed. Unreadable state counts as not upgraded, so the caller never
+// claims hnsw's behaviour for a shard that may still be flat.
+func UpgradedOnDisk(rootPath, id, targetVector string) bool {
+	_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
+	hnswDirExists := err == nil
+
+	db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600,
+		&bbolt.Options{ReadOnly: true, Timeout: stateDBOpenTimeout})
+	if err != nil {
+		return hnswDirExists
+	}
+	defer db.Close()
+
+	upgraded := hnswDirExists
+	//nolint:errcheck // the fallback above stands in for an unreadable state
+	db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(dynamicBucket)
+		if b == nil {
+			return nil
+		}
+		if v := b.Get(dbKey(targetVector)); len(v) > 0 {
+			upgraded = v[0] != 0
+		}
+		return nil
+	})
+	return upgraded
 }
 
 func (dynamic *dynamic) getBucketName() string {
@@ -863,16 +902,19 @@ func (dynamic *dynamic) Stats() (*hnsw.HnswStats, error) {
 	return h.Stats()
 }
 
+type compressionStatsReporter interface {
+	CompressionStats() compressionhelpers.CompressionStats
+}
+
 func (dynamic *dynamic) CompressionStats() compressionhelpers.CompressionStats {
 	dynamic.RLock()
 	defer dynamic.RUnlock()
 
-	// Delegate to the underlying index (flat or hnsw)
-	if vectorIndex, ok := dynamic.index.(compressionhelpers.CompressionStats); ok {
-		return vectorIndex
+	// the stats belong to whichever index is active, flat or hnsw
+	if index, ok := dynamic.index.(compressionStatsReporter); ok {
+		return index.CompressionStats()
 	}
 
-	// Fallback: return uncompressed stats if the underlying index doesn't support CompressionStats
 	return compressionhelpers.UncompressedStats{}
 }
 

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -302,24 +302,33 @@ func dbKey(targetVector string) []byte {
 }
 
 // UpgradedOnDisk reports whether the dynamic index of an unloaded shard already
-// switched to hnsw, reading the state its own startup reads: the shared state DB,
-// falling back to the hnsw commit log directory for an index written before the
-// state key existed. Unreadable state counts as not upgraded, so the caller never
-// claims hnsw's behaviour for a shard that may still be flat.
+// switched to hnsw, reading the same state the shard's own load reads: the
+// shared state DB, falling back for a named vector to the hnsw commit log
+// directory. An unnamed vector gets no such fallback, because its load reads a
+// missing key as not upgraded and then deletes that directory. Unreadable state
+// counts as not upgraded, so the caller never claims hnsw's behaviour for a shard
+// that may still be flat.
 func UpgradedOnDisk(rootPath, id, targetVector string) bool {
-	_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
-	hnswDirExists := err == nil
+	upgradedWithoutStateKey := false
+	if targetVector != "" {
+		_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
+		upgradedWithoutStateKey = err == nil
+	}
 
 	db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600,
 		&bbolt.Options{ReadOnly: true, Timeout: stateDBOpenTimeout})
 	if err != nil {
-		return hnswDirExists
+		// only a shard that never wrote state may fall back to the directory; a
+		// locked or damaged DB is state we failed to read
+		if os.IsNotExist(err) {
+			return upgradedWithoutStateKey
+		}
+		return false
 	}
 	defer db.Close()
 
-	upgraded := hnswDirExists
-	//nolint:errcheck // the fallback above stands in for an unreadable state
-	db.View(func(tx *bbolt.Tx) error {
+	upgraded := upgradedWithoutStateKey
+	if err := db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(dynamicBucket)
 		if b == nil {
 			return nil
@@ -328,7 +337,9 @@ func UpgradedOnDisk(rootPath, id, targetVector string) bool {
 			upgraded = v[0] != 0
 		}
 		return nil
-	})
+	}); err != nil {
+		return false
+	}
 	return upgraded
 }
 
@@ -357,8 +368,10 @@ func (dynamic *dynamic) init(cfg *Config) (bool, error) {
 		}
 
 		if cfg.TargetVector == "" {
+			// a stored empty value reads back non-nil, so length is what says
+			// whether a state was recorded
 			v := b.Get(dbKey)
-			if v == nil {
+			if len(v) == 0 {
 				return nil
 			}
 
@@ -372,7 +385,7 @@ func (dynamic *dynamic) init(cfg *Config) (bool, error) {
 
 		// first, check if there's an entry for this specific target vector
 		v := b.Get(dbKey)
-		if v != nil {
+		if len(v) > 0 {
 			upgraded = v[0] != 0
 			return nil
 		}

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -1388,6 +1388,26 @@ func TestDynamicStaleCommitLogCleanedOnInit(t *testing.T) {
 			storedState:  nil,
 			wantDirKept:  true,
 		},
+		{
+			// the unnamed vector gets no such migration, which is why a usage
+			// report may not read its commit log dir as an upgrade either
+			name:        "unnamed vector without state key: stale commit log removed",
+			storedState: nil,
+			wantDirKept: false,
+		},
+		{
+			// a stored empty value reads back non-nil, so it has to be treated
+			// as no recorded state rather than indexed into
+			name:        "unnamed vector with an empty state value: stale commit log removed",
+			storedState: []byte{},
+			wantDirKept: false,
+		},
+		{
+			name:         "target vector with an empty state value: dir kept",
+			targetVector: "vec1",
+			storedState:  []byte{},
+			wantDirKept:  true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -528,6 +528,7 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 		setupFlatConfig func(*flatent.UserConfig)
 		setupHNSWConfig func(*hnswent.UserConfig, int)
 		compressed      bool
+		compressionType string
 	}{
 		{
 			name: "BQ->Uncompressed",
@@ -539,7 +540,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 			},
 			setupHNSWConfig: func(hnswuc *hnswent.UserConfig, threshold int) {
 			},
-			compressed: false,
+			compressed:      false,
+			compressionType: "none",
 		},
 		{
 			name: "RQ->Uncompressed",
@@ -551,7 +553,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 			},
 			setupHNSWConfig: func(hnswuc *hnswent.UserConfig, threshold int) {
 			},
-			compressed: false,
+			compressed:      false,
+			compressionType: "none",
 		},
 		{
 			name: "BQ->PQ",
@@ -574,7 +577,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 					},
 				}
 			},
-			compressed: true,
+			compressed:      true,
+			compressionType: "pq",
 		},
 		{
 			name: "BQ->SQ",
@@ -589,7 +593,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 					Enabled: true,
 				}
 			},
-			compressed: true,
+			compressed:      true,
+			compressionType: "sq",
 		},
 		{
 			name: "RQ->PQ",
@@ -613,7 +618,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 					},
 				}
 			},
-			compressed: true,
+			compressed:      true,
+			compressionType: "pq",
 		},
 		{
 			name: "BQ->RQ",
@@ -629,7 +635,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 					Bits:    1,
 				}
 			},
-			compressed: true,
+			compressed:      true,
+			compressionType: "rq",
 		},
 		{
 			name: "RQ->BQ",
@@ -644,7 +651,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 					Enabled: true,
 				}
 			},
-			compressed: true,
+			compressed:      true,
+			compressionType: "bq",
 		},
 		{
 			name: "RQ1->RQ8",
@@ -661,7 +669,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 					Bits:    8,
 				}
 			},
-			compressed: true,
+			compressed:      true,
+			compressionType: "rq",
 		},
 	}
 
@@ -786,6 +795,8 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 			require.NoError(t, err)
 			dynamic.PostStartup(context.Background())
 			require.Equal(t, dynamic.Compressed(), tt.compressed)
+			assert.Equal(t, tt.compressionType, dynamic.CompressionStats().CompressionType(),
+				"the usage report bills from the active index's own stats")
 			recall2, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
 			assert.Equal(t, recall, recall2)
 		})

--- a/adapters/repos/db/vector/dynamic/upgrade_state_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_state_test.go
@@ -42,6 +42,8 @@ func TestUpgradedOnDisk(t *testing.T) {
 		storedValue   []byte
 		hnswDirExists bool
 		want          bool
+		// state we could not read is reported as an error rather than as flat
+		wantErr bool
 	}{
 		// The unnamed vector's load reads a missing key as not upgraded and then
 		// deletes the commit log, so nothing here may infer an upgrade from it.
@@ -82,6 +84,7 @@ func TestUpgradedOnDisk(t *testing.T) {
 			name:          "damaged state db",
 			db:            stateDBDamaged,
 			hnswDirExists: true,
+			wantErr:       true,
 		},
 		{
 			name:          "state db locked by a loaded shard",
@@ -89,6 +92,7 @@ func TestUpgradedOnDisk(t *testing.T) {
 			storedKey:     "upgraded",
 			storedValue:   []byte{1},
 			hnswDirExists: true,
+			wantErr:       true,
 		},
 
 		// A named vector's load migrates an upgrade recorded only as the commit
@@ -136,16 +140,18 @@ func TestUpgradedOnDisk(t *testing.T) {
 			want:          true,
 		},
 		{
-			name:          "damaged state db outranks a named vector's hnsw dir",
+			name:          "damaged state db does not fall back to a named vector's hnsw dir",
 			targetVector:  "custom",
 			db:            stateDBDamaged,
 			hnswDirExists: true,
+			wantErr:       true,
 		},
 		{
-			name:          "locked state db outranks a named vector's hnsw dir",
+			name:          "locked state db does not fall back to a named vector's hnsw dir",
 			targetVector:  "custom",
 			db:            stateDBLocked,
 			hnswDirExists: true,
+			wantErr:       true,
 		},
 	}
 
@@ -162,7 +168,13 @@ func TestUpgradedOnDisk(t *testing.T) {
 			}
 			setUpStateDB(t, rootPath, tt.db, tt.storedKey, tt.storedValue)
 
-			assert.Equal(t, tt.want, UpgradedOnDisk(rootPath, id, tt.targetVector))
+			upgraded, err := UpgradedOnDisk(rootPath, id, tt.targetVector)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, upgraded)
 		})
 	}
 }

--- a/adapters/repos/db/vector/dynamic/upgrade_state_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_state_test.go
@@ -21,50 +21,131 @@ import (
 	"go.etcd.io/bbolt"
 )
 
+// how the state DB is set up before the shard is read
+type stateDB int
+
+const (
+	stateDBMissing stateDB = iota // no state DB on disk
+	stateDBPresent                // a readable state DB, carrying storedKey when set
+	stateDBDamaged                // unparseable bytes where the state DB belongs
+	stateDBLocked                 // state DB still held open by a loaded shard
+)
+
 // TestUpgradedOnDisk pins how an unloaded shard is read, which decides whether
 // its usage report bills the flat or the hnsw side of a dynamic config.
 func TestUpgradedOnDisk(t *testing.T) {
 	tests := []struct {
-		name         string
-		targetVector string
-		// storedKey is written to the state DB when named
+		name          string
+		targetVector  string
+		db            stateDB
 		storedKey     string
-		storedValue   byte
+		storedValue   []byte
 		hnswDirExists bool
 		want          bool
 	}{
+		// The unnamed vector's load reads a missing key as not upgraded and then
+		// deletes the commit log, so nothing here may infer an upgrade from it.
 		{
 			name: "no state and no hnsw dir",
 		},
 		{
-			name:          "no state, hnsw dir left by an index older than the state key",
+			name:          "hnsw dir from a crash before the state key was written",
 			hnswDirExists: true,
-			want:          true,
 		},
 		{
 			name:        "state says upgraded",
+			db:          stateDBPresent,
 			storedKey:   "upgraded",
-			storedValue: 1,
+			storedValue: []byte{1},
 			want:        true,
 		},
 		{
 			name:          "state outranks an hnsw dir from an aborted upgrade",
+			db:            stateDBPresent,
 			storedKey:     "upgraded",
-			storedValue:   0,
+			storedValue:   []byte{0},
 			hnswDirExists: true,
+		},
+		{
+			name:          "state db carries no dynamic bucket",
+			db:            stateDBPresent,
+			hnswDirExists: true,
+		},
+		{
+			name:          "state key holds an empty value",
+			db:            stateDBPresent,
+			storedKey:     "upgraded",
+			storedValue:   []byte{},
+			hnswDirExists: true,
+		},
+		{
+			name:          "damaged state db",
+			db:            stateDBDamaged,
+			hnswDirExists: true,
+		},
+		{
+			name:          "state db locked by a loaded shard",
+			db:            stateDBLocked,
+			storedKey:     "upgraded",
+			storedValue:   []byte{1},
+			hnswDirExists: true,
+		},
+
+		// A named vector's load migrates an upgrade recorded only as the commit
+		// log directory, so the directory still answers when its key is absent.
+		{
+			name:         "named vector with no state and no hnsw dir",
+			targetVector: "custom",
+		},
+		{
+			name:          "named vector infers an upgrade from its hnsw dir",
+			targetVector:  "custom",
+			hnswDirExists: true,
+			want:          true,
 		},
 		{
 			name:         "state of a named target vector",
 			targetVector: "custom",
+			db:           stateDBPresent,
 			storedKey:    "upgraded_custom",
-			storedValue:  1,
+			storedValue:  []byte{1},
 			want:         true,
+		},
+		{
+			name:          "named state outranks an hnsw dir from an aborted upgrade",
+			targetVector:  "custom",
+			db:            stateDBPresent,
+			storedKey:     "upgraded_custom",
+			storedValue:   []byte{0},
+			hnswDirExists: true,
 		},
 		{
 			name:         "another target vector's state does not count",
 			targetVector: "custom",
+			db:           stateDBPresent,
 			storedKey:    "upgraded_other",
-			storedValue:  1,
+			storedValue:  []byte{1},
+		},
+		{
+			name:          "another target vector's state does not mask the hnsw dir",
+			targetVector:  "custom",
+			db:            stateDBPresent,
+			storedKey:     "upgraded_other",
+			storedValue:   []byte{1},
+			hnswDirExists: true,
+			want:          true,
+		},
+		{
+			name:          "damaged state db outranks a named vector's hnsw dir",
+			targetVector:  "custom",
+			db:            stateDBDamaged,
+			hnswDirExists: true,
+		},
+		{
+			name:          "locked state db outranks a named vector's hnsw dir",
+			targetVector:  "custom",
+			db:            stateDBLocked,
+			hnswDirExists: true,
 		},
 	}
 
@@ -79,26 +160,42 @@ func TestUpgradedOnDisk(t *testing.T) {
 			if tt.hnswDirExists {
 				require.NoError(t, os.MkdirAll(hnswCommitLogDirectory(rootPath, id), 0o777))
 			}
-			if tt.storedKey != "" {
-				writeUpgradedState(t, rootPath, tt.storedKey, tt.storedValue)
-			}
+			setUpStateDB(t, rootPath, tt.db, tt.storedKey, tt.storedValue)
 
 			assert.Equal(t, tt.want, UpgradedOnDisk(rootPath, id, tt.targetVector))
 		})
 	}
 }
 
-func writeUpgradedState(t *testing.T, rootPath, key string, value byte) {
+func setUpStateDB(t *testing.T, rootPath string, state stateDB, key string, value []byte) {
 	t.Helper()
 
-	db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600, nil)
+	path := filepath.Join(rootPath, StateDBFileName)
+	switch state {
+	case stateDBMissing:
+		return
+	case stateDBDamaged:
+		require.NoError(t, os.WriteFile(path, []byte("not a state db"), 0o600))
+		return
+	case stateDBPresent, stateDBLocked:
+		// both need the real db opened below
+	}
+
+	db, err := bbolt.Open(path, 0o600, nil)
 	require.NoError(t, err)
-	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
-		b, err := tx.CreateBucketIfNotExists(dynamicBucket)
-		if err != nil {
-			return err
-		}
-		return b.Put([]byte(key), []byte{value})
-	}))
+	if key != "" {
+		require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists(dynamicBucket)
+			if err != nil {
+				return err
+			}
+			return b.Put([]byte(key), value)
+		}))
+	}
+	if state == stateDBLocked {
+		// an open read-write handle is what a loaded shard holds
+		t.Cleanup(func() { db.Close() })
+		return
+	}
 	require.NoError(t, db.Close())
 }

--- a/adapters/repos/db/vector/dynamic/upgrade_state_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_state_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package dynamic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+)
+
+// TestUpgradedOnDisk pins how an unloaded shard is read, which decides whether
+// its usage report bills the flat or the hnsw side of a dynamic config.
+func TestUpgradedOnDisk(t *testing.T) {
+	tests := []struct {
+		name         string
+		targetVector string
+		// storedKey is written to the state DB when named
+		storedKey     string
+		storedValue   byte
+		hnswDirExists bool
+		want          bool
+	}{
+		{
+			name: "no state and no hnsw dir",
+		},
+		{
+			name:          "no state, hnsw dir left by an index older than the state key",
+			hnswDirExists: true,
+			want:          true,
+		},
+		{
+			name:        "state says upgraded",
+			storedKey:   "upgraded",
+			storedValue: 1,
+			want:        true,
+		},
+		{
+			name:          "state outranks an hnsw dir from an aborted upgrade",
+			storedKey:     "upgraded",
+			storedValue:   0,
+			hnswDirExists: true,
+		},
+		{
+			name:         "state of a named target vector",
+			targetVector: "custom",
+			storedKey:    "upgraded_custom",
+			storedValue:  1,
+			want:         true,
+		},
+		{
+			name:         "another target vector's state does not count",
+			targetVector: "custom",
+			storedKey:    "upgraded_other",
+			storedValue:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootPath := t.TempDir()
+			id := "main"
+			if tt.targetVector != "" {
+				id = "vectors_" + tt.targetVector
+			}
+
+			if tt.hnswDirExists {
+				require.NoError(t, os.MkdirAll(hnswCommitLogDirectory(rootPath, id), 0o777))
+			}
+			if tt.storedKey != "" {
+				writeUpgradedState(t, rootPath, tt.storedKey, tt.storedValue)
+			}
+
+			assert.Equal(t, tt.want, UpgradedOnDisk(rootPath, id, tt.targetVector))
+		})
+	}
+}
+
+func writeUpgradedState(t *testing.T, rootPath, key string, value byte) {
+	t.Helper()
+
+	db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(dynamicBucket)
+		if err != nil {
+			return err
+		}
+		return b.Put([]byte(key), []byte{value})
+	}))
+	require.NoError(t, db.Close())
+}

--- a/adapters/repos/db/vector/flat/compression_stats_test.go
+++ b/adapters/repos/db/vector/flat/compression_stats_test.go
@@ -1,0 +1,116 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+)
+
+// TestFlatCompressionStats pins what a flat index reports about its own
+// compression: the usage report bills cold and hot tenants from these numbers,
+// so an index holding quantized vectors must not report itself uncompressed.
+func TestFlatCompressionStats(t *testing.T) {
+	dimensions := 64
+
+	tests := []struct {
+		name            string
+		userConfig      flatent.UserConfig
+		wantType        string
+		wantRatio       float64
+		wantCompression bool
+	}{
+		{
+			name:       "without compression",
+			userConfig: flatent.UserConfig{},
+			wantType:   "none",
+			wantRatio:  1,
+		},
+		{
+			name: "with bq",
+			userConfig: flatent.UserConfig{
+				BQ: flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 10},
+			},
+			wantType:        "bq",
+			wantRatio:       32,
+			wantCompression: true,
+		},
+		{
+			name: "with rq on 1 bit",
+			userConfig: flatent.UserConfig{
+				RQ: flatent.RQUserConfig{Enabled: true, Bits: 1, RescoreLimit: 10},
+			},
+			wantType:        "rq",
+			wantRatio:       16, // 64 * 4 bytes / (8 metadata + 8 packed bytes)
+			wantCompression: true,
+		},
+		{
+			name: "with rq on 8 bits",
+			userConfig: flatent.UserConfig{
+				RQ: flatent.RQUserConfig{Enabled: true, Bits: 8, RescoreLimit: 10},
+			},
+			wantType:        "rq",
+			wantRatio:       3.2, // 64 * 4 bytes / (16 metadata + 64 codes)
+			wantCompression: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			index := newTestIndex(t, tt.userConfig)
+
+			// the RQ quantizer only exists once a vector fixed the dimensions
+			require.NoError(t, index.Add(ctx, 0, make([]float32, dimensions)))
+			require.Equal(t, tt.wantCompression, index.Compressed())
+
+			stats := index.CompressionStats()
+			assert.Equal(t, tt.wantType, stats.CompressionType())
+			assert.InDelta(t, tt.wantRatio, stats.CompressionRatio(dimensions), 1e-9)
+		})
+	}
+}
+
+// newTestIndex builds a flat index on a temporary store. It is not shared with
+// index_test.go: that file is excluded from race builds (//go:build !race), and
+// the tests here must run under the race detector.
+func newTestIndex(t *testing.T, userConfig flatent.UserConfig) *flat {
+	t.Helper()
+
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	index, err := New(Config{
+		ID:                "compression-stats-test",
+		RootPath:          dirName,
+		DistanceProvider:  distancer.NewL2SquaredProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, userConfig, store)
+	require.NoError(t, err)
+	t.Cleanup(func() { index.Shutdown(context.Background()) })
+	return index
+}

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1323,8 +1323,12 @@ func (index *flat) Type() common.IndexType {
 }
 
 func (index *flat) CompressionStats() compressionhelpers.CompressionStats {
-	// Flat index doesn't have detailed compression stats, return uncompressed stats
-	return compressionhelpers.UncompressedStats{}
+	// the quantizer is published before the compressed flag, so a set flag makes
+	// this lock-free read safe
+	if !index.Compressed() {
+		return compressionhelpers.UncompressedStats{}
+	}
+	return index.quantizer.Stats()
 }
 
 func (h *flat) ShouldUpgrade() (bool, int) {

--- a/adapters/repos/db/vector/flat/quantizer_test.go
+++ b/adapters/repos/db/vector/flat/quantizer_test.go
@@ -17,45 +17,21 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
-	"github.com/weaviate/weaviate/entities/cyclemanager"
 	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
 )
 
-// Helpers are self-contained rather than shared with index_test.go: that file
-// is excluded from race builds (//go:build !race), and these tests must run
-// under the race detector.
 func newRQTestIndex(t *testing.T, bits int, cache bool) *flat {
 	t.Helper()
-	logger, _ := test.NewNullLogger()
-	dirName := t.TempDir()
-	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
-		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
-	require.NoError(t, err)
-	t.Cleanup(func() { store.Shutdown(context.Background()) })
-
-	index, err := New(Config{
-		ID:                "quantizer-init-test",
-		RootPath:          dirName,
-		DistanceProvider:  distancer.NewL2SquaredProvider(),
-		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
-	}, flatent.UserConfig{
+	return newTestIndex(t, flatent.UserConfig{
 		RQ: flatent.RQUserConfig{
 			Enabled:      true,
 			Bits:         bits,
 			RescoreLimit: 10,
 			Cache:        cache,
 		},
-	}, store)
-	require.NoError(t, err)
-	t.Cleanup(func() { index.Shutdown(context.Background()) })
-	return index
+	})
 }
 
 // simulateInterruptedInit puts the index into the state a concurrent searcher

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -13,7 +13,7 @@ package types
 
 // UsageDiskVersion invalidates usage already stored on disk. Bump it when reported
 // sizes change meaning, or shards that stay cold keep serving the old numbers.
-const UsageDiskVersion int = 1
+const UsageDiskVersion int = 2
 
 // UsageDisk defines format of saved pre-computed shard usage data
 type UsageDisk struct {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -714,13 +714,26 @@ func testAllObjectsIndexed(t *testing.T, c *client.Client, className string) {
 	}, 30*time.Second, 500*time.Millisecond)
 }
 
+// namedVectors maps every named vector of a shard usage report to its usage
+// entry, requiring every wanted name to be among them.
+func namedVectors(t require.TestingT, shard *usagetypes.ShardUsage, want ...string) map[string]*usagetypes.VectorUsage {
+	vectors := make(map[string]*usagetypes.VectorUsage, len(shard.NamedVectors))
+	for _, v := range shard.NamedVectors {
+		vectors[v.Name] = v
+	}
+	for _, name := range want {
+		require.Contains(t, vectors, name)
+	}
+	return vectors
+}
+
 // namedVectorDimensionalities maps every named vector of a shard usage report to the
 // dimensionality it reports.
 func namedVectorDimensionalities(t require.TestingT, shard *usagetypes.ShardUsage) map[string]usagetypes.Dimensionality {
 	dimensionalities := make(map[string]usagetypes.Dimensionality, len(shard.NamedVectors))
-	for _, v := range shard.NamedVectors {
-		require.NotEmpty(t, v.Dimensionalities, "no dimensionality reported for vector %q", v.Name)
-		dimensionalities[v.Name] = *v.Dimensionalities[0]
+	for name, v := range namedVectors(t, shard) {
+		require.NotEmpty(t, v.Dimensionalities, "no dimensionality reported for vector %q", name)
+		dimensionalities[name] = *v.Dimensionalities[0]
 	}
 	return dimensionalities
 }
@@ -791,17 +804,24 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	dynamic1024 := "dynamic1024"
+	hnswBQ := "hnswbq"
+	hnswPQ := "hnswpq"
 	dimensions := 1024
 	flat := "flat"
 	bq := "bq"
 	hnsw := "hnsw"
 	pq := "pq"
 
+	// bq stores one bit per dimension instead of 32
+	bqCompressionRatio := float64(32)
+
 	objectCount1 := 1000
 	objectCount2 := 2000
 
 	targetVectorDimensions := map[string]int{
 		dynamic1024: dimensions,
+		hnswBQ:      dimensions,
+		hnswPQ:      dimensions,
 	}
 
 	dynamicVectorIndexConfig := map[string]any{
@@ -908,6 +928,30 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 					VectorIndexType:   "dynamic",
 					VectorIndexConfig: dynamicVectorIndexConfig,
 				},
+				hnswBQ: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: hnsw,
+					VectorIndexConfig: map[string]any{
+						bq: map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+				// pq trains at 100k objects, far above what this tenant holds,
+				// so its vectors stay uncompressed on disk
+				hnswPQ: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: hnsw,
+					VectorIndexConfig: map[string]any{
+						pq: map[string]any{
+							"enabled": true,
+						},
+					},
+				},
 			},
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 		}
@@ -919,6 +963,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 		insertObjects(t, 1000, c, className, tenantName, models.Vectors{
 			dynamic1024: generateRandomVector(targetVectorDimensions[dynamic1024]),
+			hnswBQ:      generateRandomVector(targetVectorDimensions[hnswBQ]),
+			hnswPQ:      generateRandomVector(targetVectorDimensions[hnswPQ]),
 		}, nil)
 		testAllObjectsIndexed(t, c, className)
 
@@ -929,14 +975,22 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Len(t, colHot.Shards, 1)
 		shardHot := colHot.Shards[0]
 		require.Equal(t, int64(objectCount1), shardHot.ObjectsCount)
-		require.Len(t, shardHot.NamedVectors, 1)
-		require.Equal(t, dynamic1024, shardHot.NamedVectors[0].Name)
-		require.Equal(t, flat, shardHot.NamedVectors[0].VectorIndexType)
-		require.Equal(t, bq, shardHot.NamedVectors[0].Compression)
-		require.True(t, shardHot.NamedVectors[0].IsDynamic)
-		require.NotEmpty(t, shardHot.NamedVectors[0].Dimensionalities)
-		require.Equal(t, dimensions, shardHot.NamedVectors[0].Dimensionalities[0].Dimensions)
-		require.Equal(t, objectCount1, shardHot.NamedVectors[0].Dimensionalities[0].Count)
+		require.Len(t, shardHot.NamedVectors, 3)
+		hotVectors := namedVectors(t, shardHot, dynamic1024, hnswBQ, hnswPQ)
+		require.Equal(t, flat, hotVectors[dynamic1024].VectorIndexType)
+		require.Equal(t, bq, hotVectors[dynamic1024].Compression)
+		require.True(t, hotVectors[dynamic1024].IsDynamic)
+		require.Equal(t, bqCompressionRatio, hotVectors[dynamic1024].VectorCompressionRatio)
+		require.NotEmpty(t, hotVectors[dynamic1024].Dimensionalities)
+		require.Equal(t, dimensions, hotVectors[dynamic1024].Dimensionalities[0].Dimensions)
+		require.Equal(t, objectCount1, hotVectors[dynamic1024].Dimensionalities[0].Count)
+		require.Equal(t, hnsw, hotVectors[hnswBQ].VectorIndexType)
+		require.Equal(t, bq, hotVectors[hnswBQ].Compression)
+		require.False(t, hotVectors[hnswBQ].IsDynamic)
+		require.Equal(t, bqCompressionRatio, hotVectors[hnswBQ].VectorCompressionRatio)
+		require.Equal(t, pq, hotVectors[hnswPQ].Compression)
+		require.Equal(t, float64(1), hotVectors[hnswPQ].VectorCompressionRatio,
+			"pq compresses nothing before it trains")
 
 		require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
 
@@ -946,15 +1000,32 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 		require.Len(t, colCold.Shards, 1)
 		shardCold := colCold.Shards[0]
-		require.Len(t, shardCold.NamedVectors, 1)
-		require.Equal(t, dynamic1024, shardCold.NamedVectors[0].Name)
-		// cold dynamic indices cannot easily determine the index type and compression
-		require.Empty(t, shardCold.NamedVectors[0].VectorIndexType)
-		require.Empty(t, shardCold.NamedVectors[0].Compression)
-		require.True(t, shardCold.NamedVectors[0].IsDynamic)
-		require.NotEmpty(t, shardCold.NamedVectors[0].Dimensionalities)
-		require.Equal(t, dimensions, shardCold.NamedVectors[0].Dimensionalities[0].Dimensions)
-		require.Equal(t, objectCount1, shardCold.NamedVectors[0].Dimensionalities[0].Count)
+		require.Len(t, shardCold.NamedVectors, 3)
+		coldVectors := namedVectors(t, shardCold, dynamic1024, hnswBQ, hnswPQ)
+		// a cold tenant reports what it reported while hot: the dynamic index
+		// is read as the flat one it has not upgraded away from, and both
+		// compression ratios follow from the config plus the quantized vectors
+		// the shard actually holds
+		require.Equal(t, flat, coldVectors[dynamic1024].VectorIndexType)
+		require.Equal(t, bq, coldVectors[dynamic1024].Compression)
+		require.True(t, coldVectors[dynamic1024].IsDynamic)
+		require.Equal(t, bqCompressionRatio, coldVectors[dynamic1024].VectorCompressionRatio)
+		require.NotEmpty(t, coldVectors[dynamic1024].Dimensionalities)
+		require.Equal(t, dimensions, coldVectors[dynamic1024].Dimensionalities[0].Dimensions)
+		require.Equal(t, objectCount1, coldVectors[dynamic1024].Dimensionalities[0].Count)
+		require.Equal(t, hnsw, coldVectors[hnswBQ].VectorIndexType)
+		require.Equal(t, bq, coldVectors[hnswBQ].Compression)
+		require.False(t, coldVectors[hnswBQ].IsDynamic)
+		require.Equal(t, bqCompressionRatio, coldVectors[hnswBQ].VectorCompressionRatio)
+		require.Equal(t, pq, coldVectors[hnswPQ].Compression)
+		require.Equal(t, float64(1), coldVectors[hnswPQ].VectorCompressionRatio,
+			"the config asks for pq, but no quantized vectors exist to bill for")
+
+		// the first cold report saves itself to disk, and every later one is
+		// served from that file rather than recomputed
+		colCached, err := getDebugUsageWithPortAndCollection(debug, className)
+		require.NoError(t, err)
+		require.NoError(t, CollectionUsageDifference(colCold, colCached))
 	})
 
 	t.Run("legacy vectorConfig", func(t *testing.T) {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -809,6 +809,10 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 	hnswRQ := "hnswrq"
 	hnswSQ := "hnswsq"
 	dimensions := 1024
+	// the quantizer vectors below only have to prove the ratio each quantizer
+	// reports, and no quantizer derives that from the width, so they stay narrow
+	// to keep their shared tenant cheap to insert and index
+	quantizerDimensions := 128
 	flat := "flat"
 	bq := "bq"
 	hnsw := "hnsw"
@@ -820,6 +824,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 	sqCompressionRatio := float64(4)
 	// rq on 8 bits stores one byte per dimension, plus 16 bytes of metadata
 	rq8CompressionRatio := float64(dimensions*4) / float64(16+dimensions)
+	rq8QuantizerRatio := float64(quantizerDimensions*4) / float64(16+quantizerDimensions)
 	// hfresh always quantizes with rq on 1 bit: one packed byte per 8
 	// dimensions, plus 8 bytes of metadata
 	rq1CompressionRatio := float64(dimensions*4) / float64(8+dimensions/8)
@@ -829,10 +834,10 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 	targetVectorDimensions := map[string]int{
 		dynamic1024: dimensions,
-		hnswBQ:      dimensions,
-		hnswPQ:      dimensions,
-		hnswRQ:      dimensions,
-		hnswSQ:      dimensions,
+		hnswBQ:      quantizerDimensions,
+		hnswPQ:      quantizerDimensions,
+		hnswRQ:      quantizerDimensions,
+		hnswSQ:      quantizerDimensions,
 	}
 
 	dynamicVectorIndexConfig := map[string]any{
@@ -1041,7 +1046,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 			"pq compresses nothing before it trains")
 		require.Equal(t, "rq", hotVectors[hnswRQ].Compression)
 		require.Equal(t, int16(8), hotVectors[hnswRQ].Bits)
-		require.InDelta(t, rq8CompressionRatio, hotVectors[hnswRQ].VectorCompressionRatio, 0.001)
+		require.InDelta(t, rq8QuantizerRatio, hotVectors[hnswRQ].VectorCompressionRatio, 0.001)
 		require.Equal(t, "sq", hotVectors[hnswSQ].Compression)
 		require.Equal(t, sqCompressionRatio, hotVectors[hnswSQ].VectorCompressionRatio)
 
@@ -1075,7 +1080,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 			"the config asks for pq, but no quantized vectors exist to bill for")
 		require.Equal(t, "rq", coldVectors[hnswRQ].Compression)
 		require.Equal(t, int16(8), coldVectors[hnswRQ].Bits)
-		require.InDelta(t, rq8CompressionRatio, coldVectors[hnswRQ].VectorCompressionRatio, 0.001)
+		require.InDelta(t, rq8QuantizerRatio, coldVectors[hnswRQ].VectorCompressionRatio, 0.001)
 		// sq trained while hot, so its quantized vectors are on disk to bill for
 		require.Equal(t, "sq", coldVectors[hnswSQ].Compression)
 		require.Equal(t, sqCompressionRatio, coldVectors[hnswSQ].VectorCompressionRatio)
@@ -1095,6 +1100,24 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 		defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 
+		// pq trains one centroid per cluster and needs at least as many vectors
+		// as it has centroids, 256 by default. The shared config trains on 100,
+		// too few to fit, which leaves its index uncompressed.
+		upgradingVectorIndexConfig := map[string]any{
+			"threshold": 1001,
+			hnsw: map[string]any{
+				pq: map[string]any{
+					"enabled":       true,
+					"trainingLimit": float64(512),
+				},
+			},
+			flat: map[string]any{
+				bq: map[string]any{
+					"enabled": true,
+				},
+			},
+		}
+
 		class := &models.Class{
 			Class: className,
 			VectorConfig: map[string]models.VectorConfig{
@@ -1103,7 +1126,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 						"none": map[string]any{},
 					},
 					VectorIndexType:   "dynamic",
-					VectorIndexConfig: dynamicVectorIndexConfig,
+					VectorIndexConfig: upgradingVectorIndexConfig,
 				},
 			},
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -696,8 +696,10 @@ func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, cl
 		"every tenant with nested values must report the nested property buckets on top of the baseline")
 }
 
+// testAllObjectsIndexed waits for every shard of a class to finish indexing. A
+// class with several named vectors fills one queue per vector, and a quantizer
+// trains on top of that, so the wait is far longer than a single queue needs.
 func testAllObjectsIndexed(t *testing.T, c *client.Client, className string) {
-	// wait for all of the objects to get indexed
 	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 		resp, err := c.Cluster().NodesStatusGetter().
 			WithClass(className).
@@ -711,7 +713,7 @@ func testAllObjectsIndexed(t *testing.T, c *client.Client, className string) {
 				assert.Equal(ct, "READY", s.VectorIndexingStatus)
 			}
 		}
-	}, 30*time.Second, 500*time.Millisecond)
+	}, 2*time.Minute, 500*time.Millisecond)
 }
 
 // namedVectors maps every named vector of a shard usage report to its usage

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -808,6 +808,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 	hnswPQ := "hnswpq"
 	hnswRQ := "hnswrq"
 	hnswSQ := "hnswsq"
+	flatBQ := "flatbq"
+	flatRQ := "flatrq"
 	dimensions := 1024
 	// the quantizer vectors below only have to prove the ratio each quantizer
 	// reports, and no quantizer derives that from the width, so they stay narrow
@@ -838,6 +840,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		hnswPQ:      quantizerDimensions,
 		hnswRQ:      quantizerDimensions,
 		hnswSQ:      quantizerDimensions,
+		flatBQ:      quantizerDimensions,
+		flatRQ:      quantizerDimensions,
 	}
 
 	dynamicVectorIndexConfig := map[string]any{
@@ -993,6 +997,30 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 						},
 					},
 				},
+				// a flat index reaches its quantizer through neither the hnsw
+				// nor the dynamic config, so it has to be covered on its own
+				flatBQ: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: flat,
+					VectorIndexConfig: map[string]any{
+						bq: map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+				flatRQ: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: flat,
+					VectorIndexConfig: map[string]any{
+						"rq": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
 			},
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 		}
@@ -1008,6 +1036,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 			hnswPQ:      generateRandomVector(targetVectorDimensions[hnswPQ]),
 			hnswRQ:      generateRandomVector(targetVectorDimensions[hnswRQ]),
 			hnswSQ:      generateRandomVector(targetVectorDimensions[hnswSQ]),
+			flatBQ:      generateRandomVector(targetVectorDimensions[flatBQ]),
+			flatRQ:      generateRandomVector(targetVectorDimensions[flatRQ]),
 		}, nil)
 		testAllObjectsIndexed(t, c, className)
 
@@ -1028,8 +1058,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Len(t, colHot.Shards, 1)
 		shardHot := colHot.Shards[0]
 		require.Equal(t, int64(objectCount1), shardHot.ObjectsCount)
-		require.Len(t, shardHot.NamedVectors, 5)
-		hotVectors := namedVectors(t, shardHot, dynamic1024, hnswBQ, hnswPQ, hnswRQ, hnswSQ)
+		require.Len(t, shardHot.NamedVectors, 7)
+		hotVectors := namedVectors(t, shardHot, dynamic1024, hnswBQ, hnswPQ, hnswRQ, hnswSQ, flatBQ, flatRQ)
 		require.Equal(t, flat, hotVectors[dynamic1024].VectorIndexType)
 		require.Equal(t, bq, hotVectors[dynamic1024].Compression)
 		require.True(t, hotVectors[dynamic1024].IsDynamic)
@@ -1049,6 +1079,14 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.InDelta(t, rq8QuantizerRatio, hotVectors[hnswRQ].VectorCompressionRatio, 0.001)
 		require.Equal(t, "sq", hotVectors[hnswSQ].Compression)
 		require.Equal(t, sqCompressionRatio, hotVectors[hnswSQ].VectorCompressionRatio)
+		require.Equal(t, flat, hotVectors[flatBQ].VectorIndexType)
+		require.Equal(t, bq, hotVectors[flatBQ].Compression)
+		require.False(t, hotVectors[flatBQ].IsDynamic)
+		require.Equal(t, bqCompressionRatio, hotVectors[flatBQ].VectorCompressionRatio)
+		require.Equal(t, flat, hotVectors[flatRQ].VectorIndexType)
+		require.Equal(t, "rq", hotVectors[flatRQ].Compression)
+		require.Equal(t, int16(8), hotVectors[flatRQ].Bits)
+		require.InDelta(t, rq8QuantizerRatio, hotVectors[flatRQ].VectorCompressionRatio, 0.001)
 
 		require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
 
@@ -1058,8 +1096,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 		require.Len(t, colCold.Shards, 1)
 		shardCold := colCold.Shards[0]
-		require.Len(t, shardCold.NamedVectors, 5)
-		coldVectors := namedVectors(t, shardCold, dynamic1024, hnswBQ, hnswPQ, hnswRQ, hnswSQ)
+		require.Len(t, shardCold.NamedVectors, 7)
+		coldVectors := namedVectors(t, shardCold, dynamic1024, hnswBQ, hnswPQ, hnswRQ, hnswSQ, flatBQ, flatRQ)
 		// a cold tenant reports what it reported while hot: the dynamic index
 		// is read as the flat one it has not upgraded away from, and both
 		// compression ratios follow from the config plus the quantized vectors
@@ -1084,6 +1122,14 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		// sq trained while hot, so its quantized vectors are on disk to bill for
 		require.Equal(t, "sq", coldVectors[hnswSQ].Compression)
 		require.Equal(t, sqCompressionRatio, coldVectors[hnswSQ].VectorCompressionRatio)
+		require.Equal(t, flat, coldVectors[flatBQ].VectorIndexType)
+		require.Equal(t, bq, coldVectors[flatBQ].Compression)
+		require.False(t, coldVectors[flatBQ].IsDynamic)
+		require.Equal(t, bqCompressionRatio, coldVectors[flatBQ].VectorCompressionRatio)
+		require.Equal(t, flat, coldVectors[flatRQ].VectorIndexType)
+		require.Equal(t, "rq", coldVectors[flatRQ].Compression)
+		require.Equal(t, int16(8), coldVectors[flatRQ].Bits)
+		require.InDelta(t, rq8QuantizerRatio, coldVectors[flatRQ].VectorCompressionRatio, 0.001)
 
 		// the first cold report saves itself to disk, and every later one is
 		// served from that file rather than recomputed
@@ -1530,9 +1576,9 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 		defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
 
-		flatRQ := "flat_rq"
+		singleFlatRQ := "flat_rq"
 		targetVectorDimensions := map[string]int{
-			flatRQ: 1024,
+			singleFlatRQ: 1024,
 		}
 
 		class := &models.Class{
@@ -1546,7 +1592,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 				},
 			},
 			VectorConfig: map[string]models.VectorConfig{
-				flatRQ: {
+				singleFlatRQ: {
 					Vectorizer: map[string]any{
 						"none": map[string]any{},
 					},
@@ -1563,7 +1609,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
 
 		insertObjects(t, 1000, c, className, "", models.Vectors{
-			flatRQ: generateRandomVector(targetVectorDimensions[flatRQ]),
+			singleFlatRQ: generateRandomVector(targetVectorDimensions[singleFlatRQ]),
 		}, nil)
 		testAllObjectsIndexed(t, c, className)
 
@@ -1575,7 +1621,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		shard := colUsage.Shards[0]
 		require.Equal(t, int64(objectCount1), shard.ObjectsCount)
 		require.Len(t, shard.NamedVectors, 1)
-		require.Equal(t, flatRQ, shard.NamedVectors[0].Name)
+		require.Equal(t, singleFlatRQ, shard.NamedVectors[0].Name)
 		require.Equal(t, flat, shard.NamedVectors[0].VectorIndexType)
 		require.Equal(t, "rq", shard.NamedVectors[0].Compression)
 		require.NotNil(t, shard.NamedVectors[0].Bits)

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -806,6 +806,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 	dynamic1024 := "dynamic1024"
 	hnswBQ := "hnswbq"
 	hnswPQ := "hnswpq"
+	hnswRQ := "hnswrq"
+	hnswSQ := "hnswsq"
 	dimensions := 1024
 	flat := "flat"
 	bq := "bq"
@@ -814,6 +816,13 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 	// bq stores one bit per dimension instead of 32
 	bqCompressionRatio := float64(32)
+	// sq stores one byte per dimension instead of four
+	sqCompressionRatio := float64(4)
+	// rq on 8 bits stores one byte per dimension, plus 16 bytes of metadata
+	rq8CompressionRatio := float64(dimensions*4) / float64(16+dimensions)
+	// hfresh always quantizes with rq on 1 bit: one packed byte per 8
+	// dimensions, plus 8 bytes of metadata
+	rq1CompressionRatio := float64(dimensions*4) / float64(8+dimensions/8)
 
 	objectCount1 := 1000
 	objectCount2 := 2000
@@ -822,6 +831,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		dynamic1024: dimensions,
 		hnswBQ:      dimensions,
 		hnswPQ:      dimensions,
+		hnswRQ:      dimensions,
+		hnswSQ:      dimensions,
 	}
 
 	dynamicVectorIndexConfig := map[string]any{
@@ -939,6 +950,31 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 						},
 					},
 				},
+				hnswRQ: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: hnsw,
+					VectorIndexConfig: map[string]any{
+						"rq": map[string]any{
+							"enabled": true,
+						},
+					},
+				},
+				// sq trains at 100k objects by default, which this tenant would
+				// never reach; the low limit lets it compress while indexing
+				hnswSQ: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: hnsw,
+					VectorIndexConfig: map[string]any{
+						"sq": map[string]any{
+							"enabled":       true,
+							"trainingLimit": float64(100),
+						},
+					},
+				},
 				// pq trains at 100k objects, far above what this tenant holds,
 				// so its vectors stay uncompressed on disk
 				hnswPQ: {
@@ -965,8 +1001,20 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 			dynamic1024: generateRandomVector(targetVectorDimensions[dynamic1024]),
 			hnswBQ:      generateRandomVector(targetVectorDimensions[hnswBQ]),
 			hnswPQ:      generateRandomVector(targetVectorDimensions[hnswPQ]),
+			hnswRQ:      generateRandomVector(targetVectorDimensions[hnswRQ]),
+			hnswSQ:      generateRandomVector(targetVectorDimensions[hnswSQ]),
 		}, nil)
 		testAllObjectsIndexed(t, c, className)
+
+		// sq trains off the indexing queue, so the ratio it reports lags the
+		// objects being indexed
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			colUsage, err := getDebugUsageWithPortAndCollection(debug, className)
+			require.NoError(ct, err)
+			require.Len(ct, colUsage.Shards, 1)
+			sq := namedVectors(ct, colUsage.Shards[0], hnswSQ)[hnswSQ]
+			require.Equal(ct, sqCompressionRatio, sq.VectorCompressionRatio)
+		}, 2*time.Minute, 500*time.Millisecond)
 
 		colHot, err := getDebugUsageWithPortAndCollection(debug, className)
 		require.NoError(t, err)
@@ -975,8 +1023,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Len(t, colHot.Shards, 1)
 		shardHot := colHot.Shards[0]
 		require.Equal(t, int64(objectCount1), shardHot.ObjectsCount)
-		require.Len(t, shardHot.NamedVectors, 3)
-		hotVectors := namedVectors(t, shardHot, dynamic1024, hnswBQ, hnswPQ)
+		require.Len(t, shardHot.NamedVectors, 5)
+		hotVectors := namedVectors(t, shardHot, dynamic1024, hnswBQ, hnswPQ, hnswRQ, hnswSQ)
 		require.Equal(t, flat, hotVectors[dynamic1024].VectorIndexType)
 		require.Equal(t, bq, hotVectors[dynamic1024].Compression)
 		require.True(t, hotVectors[dynamic1024].IsDynamic)
@@ -991,6 +1039,11 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Equal(t, pq, hotVectors[hnswPQ].Compression)
 		require.Equal(t, float64(1), hotVectors[hnswPQ].VectorCompressionRatio,
 			"pq compresses nothing before it trains")
+		require.Equal(t, "rq", hotVectors[hnswRQ].Compression)
+		require.Equal(t, int16(8), hotVectors[hnswRQ].Bits)
+		require.InDelta(t, rq8CompressionRatio, hotVectors[hnswRQ].VectorCompressionRatio, 0.001)
+		require.Equal(t, "sq", hotVectors[hnswSQ].Compression)
+		require.Equal(t, sqCompressionRatio, hotVectors[hnswSQ].VectorCompressionRatio)
 
 		require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
 
@@ -1000,8 +1053,8 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 
 		require.Len(t, colCold.Shards, 1)
 		shardCold := colCold.Shards[0]
-		require.Len(t, shardCold.NamedVectors, 3)
-		coldVectors := namedVectors(t, shardCold, dynamic1024, hnswBQ, hnswPQ)
+		require.Len(t, shardCold.NamedVectors, 5)
+		coldVectors := namedVectors(t, shardCold, dynamic1024, hnswBQ, hnswPQ, hnswRQ, hnswSQ)
 		// a cold tenant reports what it reported while hot: the dynamic index
 		// is read as the flat one it has not upgraded away from, and both
 		// compression ratios follow from the config plus the quantized vectors
@@ -1020,12 +1073,127 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Equal(t, pq, coldVectors[hnswPQ].Compression)
 		require.Equal(t, float64(1), coldVectors[hnswPQ].VectorCompressionRatio,
 			"the config asks for pq, but no quantized vectors exist to bill for")
+		require.Equal(t, "rq", coldVectors[hnswRQ].Compression)
+		require.Equal(t, int16(8), coldVectors[hnswRQ].Bits)
+		require.InDelta(t, rq8CompressionRatio, coldVectors[hnswRQ].VectorCompressionRatio, 0.001)
+		// sq trained while hot, so its quantized vectors are on disk to bill for
+		require.Equal(t, "sq", coldVectors[hnswSQ].Compression)
+		require.Equal(t, sqCompressionRatio, coldVectors[hnswSQ].VectorCompressionRatio)
 
 		// the first cold report saves itself to disk, and every later one is
 		// served from that file rather than recomputed
 		colCached, err := getDebugUsageWithPortAndCollection(debug, className)
 		require.NoError(t, err)
 		require.NoError(t, CollectionUsageDifference(colCold, colCached))
+	})
+
+	// A tenant that crossed the dynamic threshold before going cold: the report
+	// has to read the upgrade from disk, or it bills the flat side of the config
+	// for a tenant whose vectors hnsw now holds.
+	t.Run("multi tenant upgraded to hnsw", func(t *testing.T) {
+		className := sanitizeName("Class" + t.Name())
+		c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+		defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+		class := &models.Class{
+			Class: className,
+			VectorConfig: map[string]models.VectorConfig{
+				dynamic1024: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType:   "dynamic",
+					VectorIndexConfig: dynamicVectorIndexConfig,
+				},
+			},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		}
+		require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		tenantName := "tenant"
+		require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).
+			WithTenants(models.Tenant{Name: tenantName}).Do(ctx))
+
+		// past the threshold of 1001, so the index upgrades to hnsw and trains pq
+		insertObjects(t, objectCount2, c, className, tenantName, models.Vectors{
+			dynamic1024: generateRandomVector(targetVectorDimensions[dynamic1024]),
+		}, nil)
+		testAllObjectsIndexed(t, c, className)
+
+		var hotRatio float64
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			colHot, err := getDebugUsageWithPortAndCollection(debug, className)
+			require.NoError(ct, err)
+			require.Len(ct, colHot.Shards, 1)
+			hot := namedVectors(ct, colHot.Shards[0], dynamic1024)[dynamic1024]
+			require.Equal(ct, hnsw, hot.VectorIndexType)
+			require.Equal(ct, pq, hot.Compression)
+			hotRatio = hot.VectorCompressionRatio
+		}, 5*time.Minute, 500*time.Millisecond)
+
+		require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+			WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+
+		colCold, err := getDebugUsageWithPortAndCollection(debug, className)
+		require.NoError(t, err)
+		require.Len(t, colCold.Shards, 1)
+		cold := namedVectors(t, colCold.Shards[0], dynamic1024)[dynamic1024]
+		require.Equal(t, hnsw, cold.VectorIndexType, "reading flat here would bill the wrong side of the config")
+		require.Equal(t, pq, cold.Compression)
+		require.True(t, cold.IsDynamic)
+		// pq trains off the indexing queue, so whether this tenant compressed
+		// before its writes stopped is timing rather than contract; what has to
+		// hold is that deactivating it does not change the answer
+		require.Equal(t, hotRatio, cold.VectorCompressionRatio)
+	})
+
+	// hfresh quantizes with rq on 1 bit whatever its config says, so a cold
+	// tenant has to report that ratio without reading its index.
+	t.Run("multi tenant hfresh", func(t *testing.T) {
+		className := sanitizeName("Class" + t.Name())
+		c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+		defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+		hfreshVector := "hfreshrq"
+		class := &models.Class{
+			Class: className,
+			VectorConfig: map[string]models.VectorConfig{
+				hfreshVector: {
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+					VectorIndexType: "hfresh",
+				},
+			},
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		}
+		require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+		tenantName := "tenant"
+		require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).
+			WithTenants(models.Tenant{Name: tenantName}).Do(ctx))
+
+		insertObjects(t, objectCount1, c, className, tenantName, models.Vectors{
+			hfreshVector: generateRandomVector(dimensions),
+		}, nil)
+		testAllObjectsIndexed(t, c, className)
+
+		colHot, err := getDebugUsageWithPortAndCollection(debug, className)
+		require.NoError(t, err)
+		require.Len(t, colHot.Shards, 1)
+		hot := namedVectors(t, colHot.Shards[0], hfreshVector)[hfreshVector]
+		require.Equal(t, "auto", hot.Compression)
+		require.InDelta(t, rq1CompressionRatio, hot.VectorCompressionRatio, 0.001)
+
+		require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+			WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+
+		colCold, err := getDebugUsageWithPortAndCollection(debug, className)
+		require.NoError(t, err)
+		require.Len(t, colCold.Shards, 1)
+		cold := namedVectors(t, colCold.Shards[0], hfreshVector)[hfreshVector]
+		require.Equal(t, "auto", cold.Compression)
+		require.InDelta(t, rq1CompressionRatio, cold.VectorCompressionRatio, 0.001)
 	})
 
 	t.Run("legacy vectorConfig", func(t *testing.T) {
@@ -1388,6 +1556,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Equal(t, "rq", shard.NamedVectors[0].Compression)
 		require.NotNil(t, shard.NamedVectors[0].Bits)
 		require.Equal(t, int16(8), shard.NamedVectors[0].Bits)
+		require.InDelta(t, rq8CompressionRatio, shard.NamedVectors[0].VectorCompressionRatio, 0.001)
 		require.NotEmpty(t, shard.NamedVectors[0].Dimensionalities)
 		require.Equal(t, dimensions, shard.NamedVectors[0].Dimensionalities[0].Dimensions)
 		require.Equal(t, objectCount1, shard.NamedVectors[0].Dimensionalities[0].Count)

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -1121,13 +1121,16 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		testAllObjectsIndexed(t, c, className)
 
 		var hotRatio float64
-		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			colHot, err := getDebugUsageWithPortAndCollection(debug, className)
 			require.NoError(ct, err)
 			require.Len(ct, colHot.Shards, 1)
 			hot := namedVectors(ct, colHot.Shards[0], dynamic1024)[dynamic1024]
 			require.Equal(ct, hnsw, hot.VectorIndexType)
 			require.Equal(ct, pq, hot.Compression)
+			// Compression comes from the config, so only a ratio above 1 says pq
+			// finished training and wrote the quantized vectors a cold read bills.
+			require.Greater(ct, hot.VectorCompressionRatio, float64(1))
 			hotRatio = hot.VectorCompressionRatio
 		}, 5*time.Minute, 500*time.Millisecond)
 
@@ -1141,9 +1144,7 @@ func TestUsageWithDynamicIndex(t *testing.T) {
 		require.Equal(t, hnsw, cold.VectorIndexType, "reading flat here would bill the wrong side of the config")
 		require.Equal(t, pq, cold.Compression)
 		require.True(t, cold.IsDynamic)
-		// pq trains off the indexing queue, so whether this tenant compressed
-		// before its writes stopped is timing rather than contract; what has to
-		// hold is that deactivating it does not change the answer
+		// deactivating a tenant must not change the ratio it bills
 		require.Equal(t, hotRatio, cold.VectorCompressionRatio)
 	})
 

--- a/test/acceptance_with_python/test_usage.py
+++ b/test/acceptance_with_python/test_usage.py
@@ -657,10 +657,7 @@ def analyze_tenant(
             if isinstance(vec_index_config.quantizer, _BQConfigCreate):
                 assert named_vector.compression == _BQConfigCreate.quantizer_name()
                 if is_active:
-                    if vec_index_config.vector_index_type() == "flat":
-                        assert named_vector.vector_compression_ratio == 1  # not set for flat
-                    else:
-                        assert named_vector.vector_compression_ratio == 32
+                    assert named_vector.vector_compression_ratio == 32
             elif isinstance(vec_index_config.quantizer, _SQConfigCreate):
                 assert named_vector.compression == _SQConfigCreate.quantizer_name()
                 # SQ compression is only enabled for async indexing after training


### PR DESCRIPTION
### What's being changed:

This PR aligns the returned data from cold and hot tenants:
- Compression was always reported as "none" (ratio 1.0)
- For dynamic indexes, the index type and compression fields came back empty entirely

While fixing that, two problems on the active side turned up too:

- A flat index always reported "uncompressed", even with quantization enabled and working.
- A dynamic index never reported its real compression stats — it handed back a placeholder instead of asking whichever index (flat or HNSW) is currently holding the vectors.

Note: There are more differences but the PR already grew enough

### Where the cold ratio now comes from

A cold shard has no index to ask, so the ratio is taken from the same quantizer stats the hot path uses (`compressionhelpers.*Stats.CompressionRatio`) instead of a second, hand-maintained table. That table (`helpers.CompressionRatioFromConfig`) is deleted with this change: it hardcoded 32 for BQ and 4 for SQ, and knew nothing about RQ or hfresh, so those reported no compression whatever the config said.

Two things the schema config cannot answer are read off the shard's files instead:

- **Did the quantizer actually run?** PQ and SQ only compress once they reach their training limit; until then the vectors on disk are still float32 and 1.0 is the honest answer. The compressed bucket has to hold bytes. Its directory alone proves nothing — it is created empty as soon as the schema enables quantization.
- **Which index does a dynamic vector currently use?** The new `dynamic.UpgradedOnDisk` reads the same shared bbolt state the shard's own load reads — read-only, with a one second lock timeout — falling back to the HNSW commit log directory for named vectors. State that cannot be read is logged and reported as not upgraded, rather than passed off as a fact.

Neither costs an extra pass over the shard: `CalculateUnloadedVectorsMetrics` now returns the per-bucket compressed sizes as a by-product of the walk it already does.

### Usage cached on disk

`UsageDiskVersion` goes 1 → 2. Cold shards keep their computed usage in a file, so without the bump every shard that stayed cold across the upgrade would keep serving the old 1.0 and never pick this fix up. The first collection after the upgrade recomputes them once.

The bump also made the surrounding logging wrong: a version mismatch is the expected outcome on every such shard, and it was logged at Error on each one. It is now Debug when the version simply moved on, and Warn when the file is genuinely unreadable — in `calculateUnloadedShardUsage` and in `totalShardSizeBytes`.

### Also in here

- `dynamic.init` tested the stored upgrade state with `v != nil` and then read `v[0]`; a zero-length stored value would have panicked. It checks the length now.
- `vectorIndexID` no longer hangs off `*Shard`, since unloaded shards need to name the same files.

### What consumers will see

Cold tenants that reported `vectorCompressionRatio: 1.0` start reporting their real ratio, and cold dynamic ones start reporting a concrete index type instead of an empty field. Anything downstream that sizes or bills off these numbers will see them move for tenants that were compressed all along.

### Tests

- Unit: the cold ratio per quantizer, per index type and for a quantizer that has not trained yet; the dynamic on-disk upgrade state (no state, empty value, no bucket, aborted upgrade, another target vector's key, damaged and locked DB); flat compression stats; and the usage cache honouring the disk version.
- e2e (Go): a multi-tenant collection with HNSW + BQ/PQ/RQ/SQ and flat + BQ/RQ target vectors, asserted active, then deactivated and asserted cold; plus dynamic-upgraded-to-HNSW and hfresh tenants.
- e2e (Python): a flat BQ tenant now has to report 32 where it previously accepted 1.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
