### PR TITLE
fix(lsmkv): remove the partial segment a failed edit-op rewrite leaves behind

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -16,6 +16,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -849,16 +850,27 @@ func (c *segmentCleanerCommon) cleanPendingSegmentToTmp(segID string,
 	cleaner := newSegmentCleanerReplace(file, oldSegment.newCursor(), keyExists,
 		oldSegment.getLevel(), oldSegment.getSecondaryIndexCount(),
 		c.sg.enableChecksumValidation, transformer)
+	// Every failure past this point leaves a partial .tmp on disk. The caller
+	// gets no path back, so it cannot compensate — and the biggest reason to be
+	// here is ENOSPC, where the orphan is as large as the free space that ran
+	// out and the retry needs that space back. Remove it on the way out.
+	discardPartial := func(cause error) error {
+		if rmErr := os.Remove(tmpPath); rmErr != nil && !errors.Is(rmErr, fs.ErrNotExist) {
+			c.sg.logger.WithField("action", "lsm_cleanup_editops").WithField("path", c.sg.dir).
+				Warnf("could not remove partial cleaned segment %q after a failed rewrite: %v", tmpPath, rmErr)
+		}
+		return cause
+	}
 	if err := cleaner.do(shouldAbort); err != nil {
 		file.Close()
-		return emptyIdx, "", false, err
+		return emptyIdx, "", false, discardPartial(err)
 	}
 	if err := file.Sync(); err != nil {
 		file.Close()
-		return emptyIdx, "", false, fmt.Errorf("fsync cleaned segment file: %w", err)
+		return emptyIdx, "", false, discardPartial(fmt.Errorf("fsync cleaned segment file: %w", err))
 	}
 	if err := file.Close(); err != nil {
-		return emptyIdx, "", false, fmt.Errorf("close cleaned segment file: %w", err)
+		return emptyIdx, "", false, discardPartial(fmt.Errorf("close cleaned segment file: %w", err))
 	}
 
 	return idx, tmpPath, true, nil

--- a/adapters/repos/db/lsmkv/segment_group_cleanup_editops_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup_editops_test.go
@@ -14,6 +14,8 @@ package lsmkv
 import (
 	"context"
 	"errors"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -535,4 +537,53 @@ func TestSegmentEditOps_Recover_StaleCacheDoesNotDeleteLiveOp(t *testing.T) {
 	pending, err := s.Pending("opX")
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{"100"}, pending, "the live op stays armed")
+}
+
+// failingTransformer errors on the first value it is handed, which fails the
+// rewrite after the .tmp file exists — the shape ENOSPC produces.
+func failingTransformer(className string, ops []ActiveOp) func([]byte) ([]byte, error) {
+	return func(v []byte) ([]byte, error) { return nil, errors.New("no space left on device") }
+}
+
+// TestSegmentCleanerEditOps_FailedRewriteLeavesNoPartial pins the cleanup of the
+// .tmp file a failed rewrite leaves behind. The caller gets no path back on the
+// error paths, so it cannot compensate — and the failure most likely to put us
+// there is ENOSPC, where the orphan is as large as the space that ran out and
+// the retry needs it back.
+func TestSegmentCleanerEditOps_FailedRewriteLeavesNoPartial(t *testing.T) {
+	bucket, editOps := newReplaceBucketWithEditOps(t, failingTransformer)
+
+	require.NoError(t, bucket.Put([]byte("k1"), []byte("v1")))
+	require.NoError(t, bucket.FlushAndSwitch())
+	require.NoError(t, bucket.Put([]byte("k2"), []byte("v2")))
+	require.NoError(t, bucket.FlushAndSwitch())
+
+	require.NoError(t, editOps.RegisterOp("op1", OpDescriptor{Type: "remove_target_vectors", CreatedAt: 1}))
+	require.NoError(t, editOps.SnapshotSegments("op1", segIDsOf(bucket)))
+
+	tmpBefore := countTmpSegments(t, bucket.disk.dir)
+
+	_, err := bucket.disk.segmentCleaner.cleanupOnce(func() bool { return false })
+	require.NoError(t, err, "a failed rewrite is recorded on the row, not returned")
+
+	pending, perr := editOps.AllPending()
+	require.NoError(t, perr)
+	require.NotEmpty(t, pending, "the rewrite failed, so the segment stays owed")
+	require.Positive(t, pending[0].Attempts, "and the failure was counted against its budget")
+
+	require.Equal(t, tmpBefore, countTmpSegments(t, bucket.disk.dir),
+		"a rewrite that did not complete must not leave its partial segment behind")
+}
+
+func countTmpSegments(t *testing.T, dir string) int {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	n := 0
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			n++
+		}
+	}
+	return n
 }


### PR DESCRIPTION
### What's being changed:

An edit-op segment rewrite that fails partway left its `.tmp` file on disk. `cleanPendingSegmentToTmp` now removes it on all three failure paths (`cleaner.do`, `Sync`, `Close`).

## Why it matters

The caller can't clean up after it: the error paths return an empty path, so nothing downstream knows the file exists. It is then orphaned until the shard is dropped.

The failure most likely to get you there is **ENOSPC** — and that is also where it hurts most, because the orphan is as large as the segment being rewritten, so it consumes exactly the space the retry needs to succeed. A disk that filled up during a drop-vector cleanup stays full.

## Scope

Reachable on any shard running a drop-vector cleanup. Present since `291336f626` (2026-06-22), which introduced the edit-ops cleanup driver — so it is in `v1.39.0` and its rcs and **no older release line**. Nothing to backport; fixing it here covers everything affected.

Split out of #12059, which touches the same function for unrelated reasons.

## Testing

`TestSegmentCleanerEditOps_FailedRewriteLeavesNoPartial` drives a real rewrite with a transformer that errors — the shape ENOSPC produces — and asserts no `.tmp` survives. Red-verified: it fails without the fix.

(An abort-based test would not do: an abort returns before the file is created, so it passes either way.)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
