### PR TITLE
test(usage): wait for storage to settle instead of relaxing the assertions

### DIFF
--- a/test/acceptance_with_python/get_debug_usage.py
+++ b/test/acceptance_with_python/get_debug_usage.py
@@ -219,3 +219,36 @@ def get_debug_usage_for_collection(
         if attempt < retries - 1:
             time.sleep(delay)
     raise last_err
+
+
+def get_settled_debug_usage_for_collection(
+    collection: str, stable_reads: int = 4, delay: float = 1.0, timeout: float = 120.0
+) -> CollectionUsage:
+    """Read usage once the shard stops writing to disk in the background.
+
+    A shard that was just loaded keeps shrinking on disk: the HNSW commit log is written
+    unconsolidated during import and the compactor rewrites it shortly after the shard loads,
+    and dirty memtables are flushed on a timer. A read taken right after activating a tenant
+    therefore captures a transient value - for a 1000 object shard the report starts at ~36 MB
+    and drops to ~5.7 MB. Comparing such a read against one taken later, as the hot vs cold
+    assertions do, compares two different disk states.
+
+    Poll until `stable_reads` consecutive reports are identical, so the comparison is over a
+    disk state that is no longer moving and can be asserted exactly. The compaction was
+    measured to complete within 1.4s of activation even with every core busy, so the three
+    seconds of observed stability the defaults require leave a wide margin.
+    """
+    deadline = time.monotonic() + timeout
+    previous = None
+    identical = 0
+    while True:
+        current = get_debug_usage_for_collection(collection)
+        identical = identical + 1 if current == previous else 1
+        previous = current
+        if identical >= stable_reads:
+            return current
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"usage of collection {collection} kept changing for {timeout}s, last report: {current}"
+            )
+        time.sleep(delay)

--- a/test/acceptance_with_python/test_usage.py
+++ b/test/acceptance_with_python/test_usage.py
@@ -19,11 +19,17 @@ from weaviate.collections.classes.config_vectors import _VectorConfigCreate
 
 from . import get_debug_usage as debug_usage
 from .conftest import CollectionFactory
-from .get_debug_usage import ShardUsage, VectorUsage
+from .get_debug_usage import CollectionUsage, ShardUsage, VectorUsage
 
 vectors = wvc.config.Configure.Vectors
 vectorizers = wvc.config.Configure.Vectorizer
 quantizer = wvc.config.Configure.VectorIndex.Quantizer
+
+# These tests assert on storage sizes that only settle once background work (commit log
+# rewrites, memtable flushes, quantizer training) has run. Keeping them on a single worker
+# stops them from competing with the rest of the suite for the CPU that work needs, and stops
+# them from waiting on each other's shards through the node-wide /debug/usage report.
+pytestmark = pytest.mark.xdist_group("usage")
 
 
 def tenant_objects_count(tenant_id: int) -> int:
@@ -31,6 +37,56 @@ def tenant_objects_count(tenant_id: int) -> int:
 
 
 vector_names = ["first", "second", "third", "fourth"]
+
+
+def wait_for_compression(
+    collection_name: str, target_vector: str, compression: str, timeout: float = 60.0
+) -> VectorUsage:
+    """Poll until a named vector reports the given compression with a settled ratio.
+
+    Enabling a quantizer trains and re-encodes in the background, so both the reported
+    compression and its ratio only change some time after the schema update returns. PQ is
+    excluded from the ratio check because it keeps reporting an uncompressed ratio.
+    """
+    deadline = time.monotonic() + timeout
+    named_vector = None
+    while True:
+        usage = debug_usage.get_debug_usage_for_collection(collection_name)
+        named_vector = next(
+            (nv for nv in usage.shards[0].named_vectors if nv.name == target_vector), None
+        )
+        if named_vector is not None and named_vector.compression == compression:
+            if compression == "pq" or named_vector.vector_compression_ratio != 1:
+                return named_vector
+        if time.monotonic() >= deadline:
+            raise TimeoutError(
+                f"named vector {target_vector} did not report {compression} within {timeout}s,"
+                f" last report: {named_vector}"
+            )
+        time.sleep(0.5)
+
+
+def wait_for_shard_status(
+    collection_name: str, shard_names: List[str], status: str, timeout: float = 60.0
+) -> CollectionUsage:
+    """Poll until the given shards report the given status.
+
+    The reported status follows whether the shard is loaded locally, not what the schema says.
+    Activating and deactivating a tenant both return once the schema change is applied and
+    load or unload the shard afterwards, so the two disagree for a while.
+    """
+    deadline = time.monotonic() + timeout
+    expected = set(shard_names)
+    while True:
+        usage = debug_usage.get_debug_usage_for_collection(collection_name)
+        pending = {
+            s.name: s.status for s in usage.shards if s.name in expected and s.status != status
+        }
+        if not pending:
+            return usage
+        if time.monotonic() >= deadline:
+            raise TimeoutError(f"shards {pending} did not become {status} within {timeout}s")
+        time.sleep(0.5)
 
 
 def test_usage_adding_named_vector(collection_factory: CollectionFactory):
@@ -178,7 +234,8 @@ def test_usage_mt(
             )
 
     # test usage for HOT tenants
-    usage_collection = debug_usage.get_debug_usage_for_collection(collection.name)
+    tenants = ["tenant" + str(i) for i in range(num_tenants)]
+    usage_collection = wait_for_shard_status(collection.name, tenants, "active")
     assert usage_collection.name == collection.name
     assert len(usage_collection.shards) == num_tenants
 
@@ -186,10 +243,11 @@ def test_usage_mt(
         analyze_tenant(shard, True, num_vector_indices, vector_config, vector_index_config)
 
     # now deactivate some tenats and check usage again
-    collection.tenants.deactivate(["tenant" + str(i) for i in range(0, num_tenants, 2)])
-    usage_collection_col = debug_usage.get_debug_usage_for_collection(collection.name)
-    assert usage_collection.name == collection.name
-    assert len(usage_collection.shards) == num_tenants
+    deactivated = tenants[::2]
+    collection.tenants.deactivate(deactivated)
+    usage_collection_col = wait_for_shard_status(collection.name, deactivated, "inactive")
+    assert usage_collection_col.name == collection.name
+    assert len(usage_collection_col.shards) == num_tenants
 
     for shard in usage_collection_col.shards:
         tenant_id = int(shard.name.removeprefix("tenant"))
@@ -247,7 +305,7 @@ def test_usage_enabling_compression(
         )
     )
 
-    time.sleep(0.5)  # wait for async training to finish
+    wait_for_compression(collection.name, vector_names[0], quantizer_config.quantizer_name())
 
     usage_collection = debug_usage.get_debug_usage_for_collection(collection.name)
     assert usage_collection.name == collection.name
@@ -397,7 +455,8 @@ def test_object_storage(collection_factory: CollectionFactory):
     collection.tenants.deactivate("tenant")
     collection.tenants.activate("tenant")
 
-    usage_collection = debug_usage.get_debug_usage_for_collection(collection.name)
+    # settled, so the hot totals below describe the same bytes the cold read will see
+    usage_collection = debug_usage.get_settled_debug_usage_for_collection(collection.name)
     assert usage_collection.name == collection.name
     assert len(usage_collection.shards) == 1
     shard = usage_collection.shards[0]
@@ -466,7 +525,8 @@ def test_storage_vectors(collection_factory: CollectionFactory):
     # Moreover, the flat index does use an additional bucket to store the uncompressed vectors, resulting in an
     # additional 400000 bytes for the first vector, so total storage should be around 1328125 bytes
 
-    usage_collection = debug_usage.get_debug_usage_for_collection(collection.name)
+    # settled, so the hot totals below describe the same bytes the cold read will see
+    usage_collection = debug_usage.get_settled_debug_usage_for_collection(collection.name)
     assert usage_collection.name == collection.name
     assert len(usage_collection.shards) == 1
     shard = usage_collection.shards[0]
@@ -481,18 +541,13 @@ def test_storage_vectors(collection_factory: CollectionFactory):
     shard_cold = usage_collection_cold.shards[0]
     assert len(shard_cold.named_vectors) == 2
 
-    # On-disk LSM segments and HNSW commit-log/snapshot files are non-deterministic
-    # between a live shard (hot) and a fully-shutdown shard (cold) because the second
-    # deactivate flushes memtables and stops commit-log/compaction cycles. Allow ~1%
-    # drift between hot and cold totals instead of strict equality.
-    assert shard_cold.vector_storage_bytes == pytest.approx(shard.vector_storage_bytes, rel=0.01)
+    # hot and cold computation should result in the same value
+    assert shard_cold.vector_storage_bytes == shard.vector_storage_bytes
     # we want AT LEAST the calculated value, but it can be higher due to overhead
     assert shard_cold.vector_storage_bytes > 1328125
 
-    assert shard_cold.index_storage_bytes == pytest.approx(shard.index_storage_bytes, rel=0.01)
-    assert shard_cold.full_shard_storage_bytes == pytest.approx(
-        shard.full_shard_storage_bytes, rel=0.01
-    )
+    assert shard_cold.index_storage_bytes == shard.index_storage_bytes
+    assert shard_cold.full_shard_storage_bytes == shard.full_shard_storage_bytes
     # shard storage must be larger than sum of components
     assert (
         shard.full_shard_storage_bytes
@@ -577,7 +632,7 @@ def analyze_tenant(
     tenant_id = int(shard.name.removeprefix("tenant"))
     assert len(shard.named_vectors) == num_vector_indices
     if is_active:
-        shard.status = "active"
+        assert shard.status == "active"
         assert shard.objects_count == tenant_objects_count(
             tenant_id
         )  # inactive count is too unreliable


### PR DESCRIPTION
`test_storage_vectors` compared a hot read taken right after `activate()` against a cold
read taken later, so it compared two different disk states. On 1.39 the HNSW compactor
rewrites the commit log 0.3–1.4s after a shard loads (~36 MB → 5.7 MB), which is what
[this CI run](https://github.com/weaviate/weaviate/actions/runs/31692678672/job/94423292444?pr=12059)
hit: `assert 1830035 == 36258490 ± 3.6e+05`. The two earlier `pytest.approx(rel=0.01)`
relaxations couldn't help — the gap isn't measurement noise, it's whether a background
rewrite has run yet.

Now the hot read polls until the report stops changing, so both reads describe the same
bytes and strict equality is back. Same treatment for the other timing guesses in the file:

- `time.sleep(0.5)  # wait for async training` → poll for the expected quantizer state
- `test_usage_mt` waits for the shard status instead of reading straight after (de)activate,
  and its two asserts on the stale `usage_collection` now check `usage_collection_col`
- `analyze_tenant` had `shard.status = "active"` — an assignment, so the HOT status check
  never ran. Now asserted.
- `xdist_group("usage")` keeps all 16 on one worker so they don't fight the rest of the
  suite for the CPU the background work needs

Based on v1.37 because the file is byte-identical on v1.37/v1.38/v1.39/main. Only 1.39
fails today — I built each branch and 1.37/1.38 never rewrite the log (polled 2 min), so
they pass by luck.

Verified under 8× CPU load: baseline 2/10 failed with the CI signature, patched 0/12, and
0/6 on the full file on both 1.37 and 1.39. Settled, hot and cold match byte-for-byte.
Full file goes ~23s → ~28s.
