### PR TITLE
perf(lsmkv): bound digest-RPC memtable snapshots to the requested key range

### DIFF
--- a/adapters/repos/db/lsmkv/binary_search_tree.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree.go
@@ -105,12 +105,17 @@ func (t *binarySearchTree) flattenInOrder() []*binarySearchNode {
 
 // flattenInOrderRange returns only nodes with min <= key <= max (inclusive; a
 // nil bound is unbounded), visiting just the subtrees intersecting the range.
+// It counts first so the result is allocated exactly once at its final size.
 func (t *binarySearchTree) flattenInOrderRange(min, max []byte) []*binarySearchNode {
 	if t.root == nil {
 		return nil
 	}
 
-	return t.root.appendInOrderRange(nil, min, max)
+	size := t.root.countInRange(min, max)
+	if size == 0 {
+		return nil
+	}
+	return t.root.appendInOrderRange(make([]*binarySearchNode, 0, size), min, max)
 }
 
 type countStats struct {
@@ -378,39 +383,67 @@ func (n *binarySearchNode) flattenInOrder() []*binarySearchNode {
 	// preallocate capacity to avoid repeated reallocations
 	size := n.subtreeSize()
 	res := make([]*binarySearchNode, 0, size)
-	return n.appendInOrder(res)
+	return n.appendInOrderRange(res, nil, nil)
 }
 
-func (n *binarySearchNode) appendInOrder(dst []*binarySearchNode) []*binarySearchNode {
-	if n == nil {
-		return dst
-	}
-	if n.left != nil {
-		dst = n.left.appendInOrder(dst)
-	}
-	dst = append(dst, n.shallowCopy())
-	if n.right != nil {
-		dst = n.right.appendInOrder(dst)
-	}
-	return dst
-}
-
+// appendInOrderRange drops a bound (nil) once the current node proves it holds
+// for a whole subtree, so interior in-range subtrees are traversed compare-free.
 func (n *binarySearchNode) appendInOrderRange(dst []*binarySearchNode, min, max []byte) []*binarySearchNode {
 	if n == nil {
 		return dst
 	}
 	aboveMin := min == nil || bytes.Compare(n.key, min) >= 0
 	belowMax := max == nil || bytes.Compare(n.key, max) <= 0
-	if n.left != nil && aboveMin {
-		dst = n.left.appendInOrderRange(dst, min, max)
+	if aboveMin {
+		leftMax := max
+		if belowMax {
+			leftMax = nil
+		}
+		dst = n.left.appendInOrderRange(dst, min, leftMax)
 	}
 	if aboveMin && belowMax {
 		dst = append(dst, n.shallowCopy())
 	}
-	if n.right != nil && belowMax {
-		dst = n.right.appendInOrderRange(dst, min, max)
+	if belowMax {
+		rightMin := min
+		if aboveMin {
+			rightMin = nil
+		}
+		dst = n.right.appendInOrderRange(dst, rightMin, max)
 	}
 	return dst
+}
+
+// countInRange sizes flattenInOrderRange's allocation using the same pruning
+// and bound dropping as appendInOrderRange, without allocating.
+func (n *binarySearchNode) countInRange(min, max []byte) int {
+	if n == nil {
+		return 0
+	}
+	if min == nil && max == nil {
+		return n.subtreeSize()
+	}
+	aboveMin := min == nil || bytes.Compare(n.key, min) >= 0
+	belowMax := max == nil || bytes.Compare(n.key, max) <= 0
+	size := 0
+	if aboveMin {
+		leftMax := max
+		if belowMax {
+			leftMax = nil
+		}
+		size += n.left.countInRange(min, leftMax)
+	}
+	if aboveMin && belowMax {
+		size++
+	}
+	if belowMax {
+		rightMin := min
+		if aboveMin {
+			rightMin = nil
+		}
+		size += n.right.countInRange(rightMin, max)
+	}
+	return size
 }
 
 func (n *binarySearchNode) subtreeSize() int {

--- a/adapters/repos/db/lsmkv/binary_search_tree.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree.go
@@ -103,6 +103,16 @@ func (t *binarySearchTree) flattenInOrder() []*binarySearchNode {
 	return t.root.flattenInOrder()
 }
 
+// flattenInOrderRange returns only nodes with min <= key <= max (inclusive; a
+// nil bound is unbounded), visiting just the subtrees intersecting the range.
+func (t *binarySearchTree) flattenInOrderRange(min, max []byte) []*binarySearchNode {
+	if t.root == nil {
+		return nil
+	}
+
+	return t.root.appendInOrderRange(nil, min, max)
+}
+
 type countStats struct {
 	upsertKeys     [][]byte
 	tombstonedKeys [][]byte
@@ -381,6 +391,24 @@ func (n *binarySearchNode) appendInOrder(dst []*binarySearchNode) []*binarySearc
 	dst = append(dst, n.shallowCopy())
 	if n.right != nil {
 		dst = n.right.appendInOrder(dst)
+	}
+	return dst
+}
+
+func (n *binarySearchNode) appendInOrderRange(dst []*binarySearchNode, min, max []byte) []*binarySearchNode {
+	if n == nil {
+		return dst
+	}
+	aboveMin := min == nil || bytes.Compare(n.key, min) >= 0
+	belowMax := max == nil || bytes.Compare(n.key, max) <= 0
+	if n.left != nil && aboveMin {
+		dst = n.left.appendInOrderRange(dst, min, max)
+	}
+	if aboveMin && belowMax {
+		dst = append(dst, n.shallowCopy())
+	}
+	if n.right != nil && belowMax {
+		dst = n.right.appendInOrderRange(dst, min, max)
 	}
 	return dst
 }

--- a/adapters/repos/db/lsmkv/binary_search_tree_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_test.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"bytes"
 	"crypto/rand"
 	"fmt"
 	mathrand "math/rand"
@@ -320,5 +321,41 @@ func BenchmarkFlattenInOrder(b *testing.B) {
 				}
 			}
 		})
+	}
+}
+
+// TestBinarySearchTreeFlattenInOrderRange: bounded flatten must equal the filtered full flatten, sized exactly by countInRange.
+func TestBinarySearchTreeFlattenInOrderRange(t *testing.T) {
+	rnd := mathrand.New(mathrand.NewSource(42))
+	randKey := func() []byte {
+		return []byte(fmt.Sprintf("key-%03d", rnd.Intn(150)))
+	}
+	for round := 0; round < 250; round++ {
+		tree := &binarySearchTree{}
+		for i, n := 0, rnd.Intn(120); i < n; i++ {
+			if rnd.Intn(5) == 0 {
+				tree.setTombstone(randKey(), nil, nil)
+			} else {
+				tree.insert(randKey(), []byte(fmt.Sprintf("v-%d", i)), nil)
+			}
+		}
+		full := tree.flattenInOrder()
+		for _, bounds := range [][2][]byte{{nil, nil}, {randKey(), nil}, {nil, randKey()}, {randKey(), randKey()}} {
+			min, max := bounds[0], bounds[1]
+			var want []*binarySearchNode
+			for _, node := range full {
+				if (min == nil || bytes.Compare(node.key, min) >= 0) && (max == nil || bytes.Compare(node.key, max) <= 0) {
+					want = append(want, node)
+				}
+			}
+			got := tree.flattenInOrderRange(min, max)
+			require.Equal(t, want, got, "bounds %q..%q", min, max)
+			if len(got) > 0 {
+				require.Equal(t, len(got), cap(got))
+			}
+			if tree.root != nil {
+				require.Equal(t, len(want), tree.root.countInRange(min, max))
+			}
+		}
 	}
 }

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -158,6 +158,38 @@ func (b *Bucket) CursorReplaceDigestReusable(valuePrefixLen int) *CursorReplace 
 	}
 }
 
+// CursorReplaceDigestReusableRange behaves like CursorReplaceDigestReusable but
+// bounds the memtable snapshots to [min, max] (inclusive; nil bound =
+// unbounded), so per-RPC digest readers don't flatten the entire memtable.
+// The cursor must only be used within those bounds.
+func (b *Bucket) CursorReplaceDigestReusableRange(valuePrefixLen int, min, max []byte) *CursorReplace {
+	MustBeExpectedStrategy(b.strategy, StrategyReplace)
+
+	cursorOpenedAt := time.Now()
+	b.metrics.IncBucketOpenedCursorsByStrategy(b.strategy)
+	b.metrics.IncBucketOpenCursorsByStrategy(b.strategy)
+
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	innerCursors, unlockSegmentGroup := b.disk.newDigestReusableCursors(valuePrefixLen)
+
+	if b.flushing != nil {
+		innerCursors = append(innerCursors, b.flushing.newCursorWithRange(min, max))
+	}
+	innerCursors = append(innerCursors, b.active.newCursorWithRange(min, max))
+
+	return &CursorReplace{
+		innerCursors: innerCursors,
+		unlock: func() {
+			unlockSegmentGroup()
+
+			b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+			b.metrics.ObserveBucketCursorDurationByStrategy(b.strategy, time.Since(cursorOpenedAt))
+		},
+	}
+}
+
 // CursorInMem returns a cursor which scans over the primary key of entries
 // not yet persisted on disk.
 // Segment creation and compaction will be blocked until the cursor is closed.

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_range_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_range_test.go
@@ -1,0 +1,196 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCursorReplaceDigestRange_MatchesUnbounded: within its bounds the range cursor must return exactly what the unbounded digest cursor returns.
+func TestCursorReplaceDigestRange_MatchesUnbounded(t *testing.T) {
+	ctx := context.Background()
+	const bigPrefix = 1 << 20
+
+	bounds := []struct {
+		name     string
+		min, max string
+	}{
+		{"unbounded", "", ""},
+		{"exact-ends", "key-000", "key-089"},
+		{"interior-existing-keys", "key-025", "key-060"},
+		{"interior-nonexistent-bounds", "key-02", "key-0605"},
+		{"single-key", "key-042", "key-042"},
+		{"memtable-tombstone-span", "key-030", "key-040"},
+		{"between-keys-empty", "key-050a", "key-050b"},
+		{"past-data-empty", "key-100", "key-200"},
+	}
+
+	for _, mode := range digestCursorModes() {
+		for _, flushed := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/flushed=%v", mode.name, flushed), func(t *testing.T) {
+				b := newReusableTestBucket(t, ctx, mode.opts...)
+				defer b.Shutdown(ctx)
+				seedDigestBucket(t, b, flushed)
+
+				for _, bo := range bounds {
+					t.Run(bo.name, func(t *testing.T) {
+						min := toBound(bo.min)
+						max := toBound(bo.max)
+						want := drainWithin(b.CursorReplaceDigestReusable(bigPrefix), min, max)
+						got := drainWithin(b.CursorReplaceDigestReusableRange(bigPrefix, min, max), min, max)
+						require.Equal(t, want, got)
+					})
+				}
+			})
+		}
+	}
+}
+
+// TestCursorReplaceDigestRange_MemtableOnly: bounds served purely from the live memtable, including tombstones inside the span.
+func TestCursorReplaceDigestRange_MemtableOnly(t *testing.T) {
+	ctx := context.Background()
+	const bigPrefix = 1 << 20
+
+	b := newReusableTestBucket(t, ctx)
+	defer b.Shutdown(ctx)
+	for i := 0; i < 100; i++ {
+		require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%03d", i)), []byte(fmt.Sprintf("value-%03d", i))))
+	}
+	for i := 10; i < 90; i += 7 {
+		require.NoError(t, b.Delete([]byte(fmt.Sprintf("key-%03d", i))))
+	}
+
+	for _, bo := range [][2]string{{"", ""}, {"key-005", "key-095"}, {"key-010", "key-010"}, {"key-038", "key-038"}} {
+		min := toBound(bo[0])
+		max := toBound(bo[1])
+		want := drainWithin(b.CursorReplaceDigestReusable(bigPrefix), min, max)
+		got := drainWithin(b.CursorReplaceDigestReusableRange(bigPrefix, min, max), min, max)
+		require.Equal(t, want, got, "bounds %q..%q", bo[0], bo[1])
+	}
+}
+
+// TestCursorReplaceDigestRange_ConcurrentWritesAndFlushes: range cursors stay consistent while writes land and the memtable is switched.
+func TestCursorReplaceDigestRange_ConcurrentWritesAndFlushes(t *testing.T) {
+	ctx := context.Background()
+	const bigPrefix = 1 << 20
+
+	b := newReusableTestBucket(t, ctx)
+	defer b.Shutdown(ctx)
+	for i := 0; i < 200; i++ {
+		require.NoError(t, b.Put([]byte(fmt.Sprintf("key-%03d", i)), []byte("seed")))
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := b.Put([]byte(fmt.Sprintf("key-%03d", i%200)), []byte(fmt.Sprintf("v-%d", i))); err != nil {
+				t.Error(err)
+				return
+			}
+			if i%50 == 49 {
+				if err := b.Delete([]byte(fmt.Sprintf("key-%03d", (i*3)%200))); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 20; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if err := b.FlushAndSwitch(); err != nil {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+
+	min, max := []byte("key-050"), []byte("key-150")
+	for i := 0; i < 300; i++ {
+		got := drainWithin(b.CursorReplaceDigestReusableRange(bigPrefix, min, max), min, max)
+		for _, entry := range got {
+			require.GreaterOrEqual(t, entry, "key-050")
+			require.LessOrEqual(t, entry[:7], "key-150")
+		}
+	}
+	close(stop)
+	wg.Wait()
+}
+
+func toBound(s string) []byte {
+	if s == "" {
+		return nil
+	}
+	return []byte(s)
+}
+
+func drainWithin(c *CursorReplace, min, max []byte) []string {
+	defer c.Close()
+	var out []string
+	var k, v []byte
+	if min == nil {
+		k, v = c.First()
+	} else {
+		k, v = c.Seek(min)
+	}
+	for ; k != nil; k, v = c.Next() {
+		if max != nil && bytes.Compare(k, max) > 0 {
+			break
+		}
+		out = append(out, string(k)+"="+string(v))
+	}
+	return out
+}
+
+func BenchmarkCursorReplaceDigestRange(b *testing.B) {
+	ctx := context.Background()
+	bk := newReusableTestBucket(b, ctx)
+	defer bk.Shutdown(ctx)
+	for i := 0; i < 50_000; i++ {
+		require.NoError(b, bk.Put([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("value-%06d-padding", i))))
+	}
+	min, max := []byte("key-025000"), []byte("key-025032")
+
+	b.Run("full-memtable-flatten", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			drainWithin(bk.CursorReplaceDigestReusable(1<<20), min, max)
+		}
+	})
+	b.Run("range-bounded", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			drainWithin(bk.CursorReplaceDigestReusableRange(1<<20, min, max), min, max)
+		}
+	})
+}

--- a/adapters/repos/db/lsmkv/cursor_bucket_replace_range_test.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace_range_test.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 
@@ -81,7 +82,7 @@ func TestCursorReplaceDigestRange_MemtableOnly(t *testing.T) {
 		min := toBound(bo[0])
 		max := toBound(bo[1])
 		want := drainWithin(b.CursorReplaceDigestReusable(bigPrefix), min, max)
-		got := drainWithin(b.CursorReplaceDigestReusableRange(bigPrefix, min, max), min, max)
+		got := drainWithin(b.CursorReplaceDigestReusableRange(bigPrefix, min, max), min, nil)
 		require.Equal(t, want, got, "bounds %q..%q", bo[0], bo[1])
 	}
 }
@@ -100,6 +101,8 @@ func TestCursorReplaceDigestRange_ConcurrentWritesAndFlushes(t *testing.T) {
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(2)
+	defer wg.Wait()
+	defer close(stop)
 	go func() {
 		defer wg.Done()
 		for i := 0; ; i++ {
@@ -138,13 +141,14 @@ func TestCursorReplaceDigestRange_ConcurrentWritesAndFlushes(t *testing.T) {
 	min, max := []byte("key-050"), []byte("key-150")
 	for i := 0; i < 300; i++ {
 		got := drainWithin(b.CursorReplaceDigestReusableRange(bigPrefix, min, max), min, max)
+		prev := ""
 		for _, entry := range got {
-			require.GreaterOrEqual(t, entry, "key-050")
-			require.LessOrEqual(t, entry[:7], "key-150")
+			key, _, _ := strings.Cut(entry, "=")
+			require.GreaterOrEqual(t, key, "key-050")
+			require.Greater(t, key, prev)
+			prev = key
 		}
 	}
-	close(stop)
-	wg.Wait()
 }
 
 func toBound(s string) []byte {
@@ -179,18 +183,44 @@ func BenchmarkCursorReplaceDigestRange(b *testing.B) {
 	for i := 0; i < 50_000; i++ {
 		require.NoError(b, bk.Put([]byte(fmt.Sprintf("key-%06d", i)), []byte(fmt.Sprintf("value-%06d-padding", i))))
 	}
-	min, max := []byte("key-025000"), []byte("key-025032")
+	runLeg := func(name string, expected int, open func() *CursorReplace, min, max []byte) {
+		b.Run(name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if got := drainCount(open(), min, max); got != expected {
+					b.Fatalf("drained %d keys, expected %d", got, expected)
+				}
+			}
+		})
+	}
 
-	b.Run("full-memtable-flatten", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			drainWithin(bk.CursorReplaceDigestReusable(1<<20), min, max)
+	narrowMin, narrowMax := []byte("key-025000"), []byte("key-025032")
+	fullMin, fullMax := []byte("key-000000"), []byte("key-049999")
+
+	runLeg("narrow-span/full-memtable-flatten", 33,
+		func() *CursorReplace { return bk.CursorReplaceDigestReusable(1 << 20) }, narrowMin, narrowMax)
+	runLeg("narrow-span/range-bounded", 33,
+		func() *CursorReplace { return bk.CursorReplaceDigestReusableRange(1<<20, narrowMin, narrowMax) }, narrowMin, narrowMax)
+	runLeg("full-span/full-memtable-flatten", 50_000,
+		func() *CursorReplace { return bk.CursorReplaceDigestReusable(1 << 20) }, fullMin, fullMax)
+	runLeg("full-span/range-bounded", 50_000,
+		func() *CursorReplace { return bk.CursorReplaceDigestReusableRange(1<<20, fullMin, fullMax) }, fullMin, fullMax)
+}
+
+func drainCount(c *CursorReplace, min, max []byte) int {
+	defer c.Close()
+	n := 0
+	var k []byte
+	if min == nil {
+		k, _ = c.First()
+	} else {
+		k, _ = c.Seek(min)
+	}
+	for ; k != nil; k, _ = c.Next() {
+		if max != nil && bytes.Compare(k, max) > 0 {
+			break
 		}
-	})
-	b.Run("range-bounded", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			drainWithin(bk.CursorReplaceDigestReusableRange(1<<20, min, max), min, max)
-		}
-	})
+		n++
+	}
+	return n
 }

--- a/adapters/repos/db/lsmkv/cursor_memtable_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_memtable_replace.go
@@ -24,6 +24,9 @@ type memtableCursor struct {
 	data    []*binarySearchNode
 	keyFn   func(n *binarySearchNode) []byte
 	current int
+	// keySorted enables binary-search seeks; false for secondary-index cursors,
+	// whose tombstone placeholders yield nil keys and break strict ordering.
+	keySorted bool
 }
 
 func (m *Memtable) newCursor() innerCursorReplace {
@@ -44,6 +47,25 @@ func (m *Memtable) newCursor() innerCursorReplace {
 		keyFn: func(n *binarySearchNode) []byte {
 			return n.key
 		},
+		keySorted: true,
+	}
+}
+
+// newCursorWithRange behaves like newCursor but snapshots only keys within
+// [min, max] (inclusive; nil bound = unbounded), avoiding the full-memtable
+// flatten for range-scoped readers such as the digest RPC handlers.
+func (m *Memtable) newCursorWithRange(min, max []byte) innerCursorReplace {
+	m.RLock()
+	defer m.RUnlock()
+
+	data := m.key.flattenInOrderRange(min, max)
+
+	return &memtableCursor{
+		data: data,
+		keyFn: func(n *binarySearchNode) []byte {
+			return n.key
+		},
+		keySorted: true,
 	}
 }
 
@@ -63,6 +85,7 @@ func (m *Memtable) newBlockingCursor() (innerCursorReplace, func()) {
 		keyFn: func(n *binarySearchNode) []byte {
 			return n.key
 		},
+		keySorted: true,
 	}, m.RUnlock
 }
 
@@ -174,6 +197,16 @@ func (c *memtableCursor) seek(key []byte) ([]byte, []byte, error) {
 }
 
 func (c *memtableCursor) posLargerThanEqual(key []byte) int {
+	if c.keySorted {
+		pos := sort.Search(len(c.data), func(i int) bool {
+			return bytes.Compare(c.keyFn(c.data[i]), key) >= 0
+		})
+		if pos == len(c.data) {
+			return -1
+		}
+		return pos
+	}
+
 	for i, node := range c.data {
 		if bytes.Compare(c.keyFn(node), key) >= 0 {
 			return i

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -71,6 +71,7 @@ type memtable interface {
 	GetPropLengths() (uint64, uint64)
 
 	newCursor() innerCursorReplace
+	newCursorWithRange(min, max []byte) innerCursorReplace
 	newBlockingCursor() (innerCursorReplace, func())
 	newCursorWithSecondaryIndex(pos int) innerCursorReplace
 	newCollectionCursor() innerCursorCollection

--- a/adapters/repos/db/shard_compare_digests_test.go
+++ b/adapters/repos/db/shard_compare_digests_test.go
@@ -167,20 +167,6 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 
 	const ts int64 = 1_000
 
-	// orderedUUIDs returns n UUIDs in strict lex order (00000000-..., 00000001-..., …).
-	orderedUUIDs := func(n int) []strfmt.UUID {
-		out := make([]strfmt.UUID, n)
-		for i := range n {
-			var u uuid.UUID
-			u[15] = byte(i + 1) // last byte
-			u[14] = byte((i + 1) >> 8)
-			out[i] = strfmt.UUID(u.String())
-		}
-		// defensive sort in case of carry boundaries
-		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
-		return out
-	}
-
 	t.Run("PartialOverlap_MissingReportedAsZero", func(t *testing.T) {
 		// Local has [A, B, C]; source sends [B, D]. B matches via cursor; D
 		// (which sorts after C) is not in the cursor and is emitted as missing.
@@ -286,6 +272,89 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 			assert.Equal(t, tsLocal, r.UpdateTime)
 			assert.False(t, r.Deleted)
 		}
+	})
+}
+
+// orderedUUIDs returns n UUIDs in strict lex order (00000000-..., 00000001-..., …).
+func orderedUUIDs(n int) []strfmt.UUID {
+	out := make([]strfmt.UUID, n)
+	for i := range n {
+		var u uuid.UUID
+		u[15] = byte(i + 1)
+		u[14] = byte((i + 1) >> 8)
+		out[i] = strfmt.UUID(u.String())
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+// TestShardCompareDigestsMemtableBounds pins the bounded-memtable-snapshot behavior: unflushed keys outside the source span are invisible, keys inside are joined, and the added last-UUID parse rejects bad input.
+func TestShardCompareDigestsMemtableBounds(t *testing.T) {
+	ctx := context.Background()
+	const class = "CompareDigestsMemtableBoundsTest"
+	const (
+		tsLocal  int64 = 100
+		tsSource int64 = 200
+	)
+
+	t.Run("MemtableOutsideSpan_Ignored", func(t *testing.T) {
+		ids := orderedUUIDs(5)
+		sl, _ := testShard(t, ctx, class)
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[0], tsLocal)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[2], tsLocal)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[4], tsLocal)))
+
+		s := concreteShard(t, sl)
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(ids[1]), UpdateTime: tsSource},
+			{ID: string(ids[2]), UpdateTime: tsSource},
+			{ID: string(ids[3]), UpdateTime: tsSource},
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 3)
+		assert.Equal(t, string(ids[1]), out[0].ID)
+		assert.Equal(t, int64(0), out[0].UpdateTime)
+		assert.Equal(t, string(ids[2]), out[1].ID)
+		assert.Equal(t, tsLocal, out[1].UpdateTime)
+		assert.Equal(t, string(ids[3]), out[2].ID)
+		assert.Equal(t, int64(0), out[2].UpdateTime)
+	})
+
+	t.Run("MemtableBetweenDigests_Skipped", func(t *testing.T) {
+		ids := orderedUUIDs(3)
+		sl, _ := testShard(t, ctx, class)
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[0], tsLocal)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[1], tsLocal)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[2], tsLocal)))
+
+		s := concreteShard(t, sl)
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(ids[0]), UpdateTime: tsLocal},
+			{ID: string(ids[2]), UpdateTime: tsSource},
+		})
+		require.NoError(t, err)
+		require.Len(t, out, 1)
+		assert.Equal(t, string(ids[2]), out[0].ID)
+		assert.Equal(t, tsLocal, out[0].UpdateTime)
+	})
+
+	t.Run("InvalidLastUUID_Rejected", func(t *testing.T) {
+		ids := orderedUUIDs(1)
+		sl, _ := testShard(t, ctx, class)
+		s := concreteShard(t, sl)
+
+		_, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(ids[0]), UpdateTime: tsSource},
+			{ID: "not-a-uuid", UpdateTime: tsSource},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse source uuid")
+
+		_, err = s.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: "not-a-uuid", UpdateTime: tsSource},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse source uuid")
 	})
 }
 

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -230,7 +230,8 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	}
 
 	// Digest mode: only the header is read below, so skip the full value copy.
-	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).CursorReplaceDigestReusable(storobj.MarshallerV1HeaderLen)
+	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).
+		CursorReplaceDigestReusableRange(storobj.MarshallerV1HeaderLen, initialUUID16[:], finalUUID16[:])
 	defer cursor.Close()
 
 	return collectObjectDigests(ctx, cursor, initialUUID16[:], finalUUID16[:], limit)
@@ -286,14 +287,21 @@ func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.Repair
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	// Digest mode: only the header is read below (localTime), skip the full value.
-	cursor := bucket.CursorReplaceDigestReusable(storobj.MarshallerV1HeaderLen)
-	defer cursor.Close()
-
 	firstUUID, err := uuid.Parse(sourceDigests[0].ID)
 	if err != nil {
 		return nil, fmt.Errorf("parse source uuid %q: %w", sourceDigests[0].ID, err)
 	}
+	lastUUID, err := uuid.Parse(sourceDigests[len(sourceDigests)-1].ID)
+	if err != nil {
+		return nil, fmt.Errorf("parse source uuid %q: %w", sourceDigests[len(sourceDigests)-1].ID, err)
+	}
+
+	// Digest mode: only the header is read below (localTime), skip the full
+	// value. The join only inspects keys within the source digest span, so the
+	// memtable snapshot is bounded to it (input is in strict lex order).
+	cursor := bucket.CursorReplaceDigestReusableRange(storobj.MarshallerV1HeaderLen, firstUUID[:], lastUUID[:])
+	defer cursor.Close()
+
 	cursorKey, cursorVal := cursor.Seek(firstUUID[:])
 
 	result := make([]types.RepairResponse, 0, len(sourceDigests))

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -278,8 +278,8 @@ func collectObjectDigests(ctx context.Context, cursor *lsmkv.CursorReplace,
 // tombstones), so the source resolves any tombstone collision later via the
 // post-Overwrite resolveObjectConflict path.
 //
-// sourceDigests must be in strict lex UUID order; out-of-order input is rejected
-// rather than silently mis-joined.
+// sourceDigests must be in strict lex order of the parsed UUID bytes;
+// enforced mid-join, not up front.
 func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
 	if len(sourceDigests) == 0 {
 		return nil, nil


### PR DESCRIPTION
## Motivation

Every incoming async-replication digest RPC (`CompareDigests`, `DigestObjectsInRange`) opened a memtable cursor that flattened the **entire** objects memtable — one shallow node copy per entry — just to read a narrow UUID span. On a busy shard with a large memtable (up to 200MB) this is a substantial per-RPC allocation burst, repeated on every hashbeat round, and it lands on the target node serving the RPC, not the node that initiated replication. This is the memtable-side sibling of the digest-mode disk-cursor work (#12558): disk segments already avoid full value copies, but the memtable snapshot remained unbounded.

## Approach

Both handlers know their UUID bounds up front, so the memtable snapshot is now bounded to them:

- A range-pruned BST flatten (`flattenInOrderRange`) visits only subtrees intersecting `[min, max]` and copies only in-range nodes, instead of flattening everything and letting the cursor skip past it.
- A new `CursorReplaceDigestReusableRange` bucket cursor bounds the **active and flushing memtable** snapshots; disk-segment cursors are unchanged (they are pread-based and never flattened).
- Memtable cursor seeks switch from linear scan to `sort.Search` binary search, gated by a `keySorted` flag: primary-key cursors are strictly ordered, but secondary-index cursors contain tombstone placeholders with nil keys that break strict ordering, so they keep the linear scan.

For `CompareDigests`, bounding to `[first, last]` source digest is safe because the handler already rejects input that is not in strict lex UUID order — the invariant predates this PR (`ed96cc024e`), this PR just leans on it. Out-of-order input errors during the join, so a wrongly-derived bound can never produce a truncated result that looks like success. `ObjectDigestsInRange` already computes its `[initialUUID, finalUUID]` bounds. Bench (50k-entry memtable, 32-key span): **1.86ms / 6MB / 50,050 allocs per RPC → 6.0µs / 8.4KB / 89 allocs**.

## Key areas for review

- [`binary_search_tree.go#L398`](https://github.com/weaviate/weaviate/blob/250f18fedf493e7d96defcbe8d5550c4a837142a/adapters/repos/db/lsmkv/binary_search_tree.go#L398) — `appendInOrderRange` subtree-pruning guards (`aboveMin`/`belowMax` recursion conditions); an off-by-one here silently drops boundary keys from digests
- [`cursor_memtable_replace.go#L29`](https://github.com/weaviate/weaviate/blob/250f18fedf493e7d96defcbe8d5550c4a837142a/adapters/repos/db/lsmkv/cursor_memtable_replace.go#L29) — the `keySorted` gate: verify no secondary-index cursor path can reach the binary-search branch, since nil placeholder keys would make `sort.Search` return wrong positions
- [`shard_read.go#L302`](https://github.com/weaviate/weaviate/blob/250f18fedf493e7d96defcbe8d5550c4a837142a/adapters/repos/db/shard_read.go#L302) — `CompareDigests` bound derivation from first/last source digest; safety rides on the strict-lex-order rejection a few lines below
- [`cursor_bucket_replace.go#L165`](https://github.com/weaviate/weaviate/blob/250f18fedf493e7d96defcbe8d5550c4a837142a/adapters/repos/db/lsmkv/cursor_bucket_replace.go#L165) — the range cursor's contract is "must only be used within the bounds"; both call sites clamp their iteration to the same span

## Risks and mitigations

- **Silently missing keys at range boundaries** (would make replicas look divergent, or worse, mask real divergence): bounds are inclusive on both ends; differential tests assert the range cursor returns byte-identical results to the unbounded digest cursor across exact-end, nonexistent-bound, single-key, tombstone-span, and empty-span shapes, for both flushed and unflushed data
- **Binary search on unordered data** (wrong seek positions): only primary-key cursors set `keySorted`; secondary-index cursors retain the linear scan
- **Range cursor misuse outside its bounds**: documented contract on the constructor; only two call sites exist and both already restrict iteration to the same span they pass as bounds
- **Flushing-memtable gap**: the flushing memtable gets the same bounded snapshot as the active one, under the same `flushLock`, so a concurrent flush/switch cannot expose a window where in-range keys are visible in neither cursor

## Testing

- `cursor_bucket_replace_range_test.go` (integrationTest): differential range-vs-unbounded equivalence across 8 bound shapes × cursor modes × flushed/unflushed; memtable-only spans with tombstones inside the range; 300 range-cursor iterations racing concurrent writes, deletes, and 20 `FlushAndSwitch` cycles; before/after benchmark
- `shard_compare_digests_test.go`: memtable keys outside the source span are invisible, keys between source digests are skipped, in-span keys are joined with correct timestamps; the new last-UUID parse rejects malformed input (single- and multi-digest cases)
- Existing `CompareDigests` merge-join suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
