### PR TITLE
perf(async-repl): negotiate binary digest encoding on the gRPC HashTreeLevel RPC

### DIFF
--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -588,6 +588,12 @@ func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 	}
 
 	if resp.GetEncoding() == replica.DigestsEncodingBinary {
+		// A compliant server returns at most one digest per set discriminant bit;
+		// reject larger payloads before decoding, like the REST reader's pre-size clamp.
+		if maxLen := discriminant.SetCount() * hashtree.DigestLength; len(resp.GetDigestsData()) > maxLen {
+			return nil, fmt.Errorf("binary digests payload of %d bytes exceeds the %d bytes for the %d requested digests",
+				len(resp.GetDigestsData()), maxLen, discriminant.SetCount())
+		}
 		digests, err := hashtree.DigestsFromBinary(resp.GetDigestsData())
 		if err != nil {
 			return nil, fmt.Errorf("decode binary digests: %w", err)

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -574,10 +574,11 @@ func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 	defer cancel()
 
 	resp, err := client.HashTreeLevel(ctx, &protocol.HashTreeLevelRequest{
-		Index:        index,
-		Shard:        shard,
-		Level:        int32(level),
-		Discriminant: discData,
+		Index:          index,
+		Shard:          shard,
+		Level:          int32(level),
+		Discriminant:   discData,
+		AcceptEncoding: replica.DigestsEncodingBinary,
 	})
 	if err != nil {
 		if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
@@ -586,6 +587,15 @@ func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 		return nil, fmt.Errorf("gRPC HashTreeLevel: %w", err)
 	}
 
+	if resp.GetEncoding() == replica.DigestsEncodingBinary {
+		digests, err := hashtree.DigestsFromBinary(resp.GetDigestsData())
+		if err != nil {
+			return nil, fmt.Errorf("decode binary digests: %w", err)
+		}
+		return digests, nil
+	}
+
+	// JSON fallback: older servers ignore accept_encoding and reply encoding=0.
 	var digests []hashtree.Digest
 	if err := json.Unmarshal(resp.GetDigestsData(), &digests); err != nil {
 		return nil, fmt.Errorf("unmarshal digests: %w", err)

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -71,6 +71,10 @@ type fakeGRPCReplicationServer struct {
 	// hashTreeLevelErr/compareDigestsErr, when set, are returned verbatim.
 	hashTreeLevelErr  error
 	compareDigestsErr error
+
+	// hashTreeLevelResp, when set, is returned verbatim; the last request is captured.
+	hashTreeLevelResp    *pb.HashTreeLevelResponse
+	lastHashTreeLevelReq atomic.Pointer[pb.HashTreeLevelRequest]
 }
 
 func newFakeGRPCReplicationServer(t *testing.T) *fakeGRPCReplicationServer {
@@ -107,9 +111,13 @@ func (f *fakeGRPCReplicationServer) dispatchWrite(requestID, index, shard string
 	}
 }
 
-func (f *fakeGRPCReplicationServer) HashTreeLevel(_ context.Context, _ *pb.HashTreeLevelRequest) (*pb.HashTreeLevelResponse, error) {
+func (f *fakeGRPCReplicationServer) HashTreeLevel(_ context.Context, req *pb.HashTreeLevelRequest) (*pb.HashTreeLevelResponse, error) {
+	f.lastHashTreeLevelReq.Store(req)
 	if f.hashTreeLevelErr != nil {
 		return nil, f.hashTreeLevelErr
+	}
+	if f.hashTreeLevelResp != nil {
+		return f.hashTreeLevelResp, nil
 	}
 	return &pb.HashTreeLevelResponse{DigestsData: []byte("[]")}, nil
 }
@@ -814,6 +822,103 @@ func TestGRPCReplicationDigestObjects(t *testing.T) {
 			[]strfmt.UUID{UUID1}, 9)
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "connection")
+	})
+}
+
+func TestGRPCReplicationHashTreeLevelEncoding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	discriminant := hashtree.NewBitset(hashtree.LeavesCount(3))
+	discriminant.Set(0)
+	digests := []hashtree.Digest{{1, 2}, {3, 4}, {^uint64(0), 5}}
+
+	t.Run("BinaryFromNewServer", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{
+			DigestsData: hashtree.DigestsToBinary(digests),
+			Encoding:    replica.DigestsEncodingBinary,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		got, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.NoError(t, err)
+		assert.Equal(t, digests, got)
+		require.NotNil(t, fake.lastHashTreeLevelReq.Load())
+		assert.Equal(t, replica.DigestsEncodingBinary, fake.lastHashTreeLevelReq.Load().GetAcceptEncoding())
+	})
+
+	t.Run("JSONFromOldServer", func(t *testing.T) {
+		jsonData, err := json.Marshal(digests)
+		require.NoError(t, err)
+
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{DigestsData: jsonData}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		got, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.NoError(t, err)
+		assert.Equal(t, digests, got)
+	})
+
+	t.Run("EmptyJSONFromOldServer", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		got, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("EmptyBinary", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{Encoding: replica.DigestsEncodingBinary}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		got, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("TruncatedBinaryRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{
+			DigestsData: make([]byte, hashtree.DigestLength+1),
+			Encoding:    replica.DigestsEncodingBinary,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "decode binary digests")
+	})
+
+	t.Run("JSONBodyClaimedBinaryRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{
+			DigestsData: []byte("[]"),
+			Encoding:    replica.DigestsEncodingBinary,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.Error(t, err)
+	})
+
+	t.Run("InvalidJSONRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{DigestsData: []byte("not json")}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.Error(t, err)
 	})
 }
 

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -830,7 +830,7 @@ func TestGRPCReplicationHashTreeLevelEncoding(t *testing.T) {
 	ctx := context.Background()
 
 	discriminant := hashtree.NewBitset(hashtree.LeavesCount(3))
-	discriminant.Set(0)
+	discriminant.Set(0).Set(1).Set(2)
 	digests := []hashtree.Digest{{1, 2}, {3, 4}, {^uint64(0), 5}}
 
 	t.Run("BinaryFromNewServer", func(t *testing.T) {
@@ -896,6 +896,20 @@ func TestGRPCReplicationHashTreeLevelEncoding(t *testing.T) {
 		_, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "decode binary digests")
+	})
+
+	t.Run("OversizedBinaryRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.hashTreeLevelResp = &pb.HashTreeLevelResponse{
+			DigestsData: hashtree.DigestsToBinary(append([]hashtree.Digest{{6, 7}}, digests...)),
+			Encoding:    replica.DigestsEncodingBinary,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.HashTreeLevel(ctx, "passthrough:bufnet", "C1", "S1", 3, discriminant)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds")
 	})
 
 	t.Run("JSONBodyClaimedBinaryRejected", func(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
@@ -1933,13 +1933,17 @@ func (x *FindUUIDsResponse) GetUuids() []string {
 
 // HashTreeLevel fetches hash tree level digests.
 type HashTreeLevelRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
-	Shard         string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
-	Level         int32                  `protobuf:"varint,3,opt,name=level,proto3" json:"level,omitempty"`
-	Discriminant  []byte                 `protobuf:"bytes,4,opt,name=discriminant,proto3" json:"discriminant,omitempty"` // hashtree.Bitset.Marshal() output
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state        protoimpl.MessageState `protogen:"open.v1"`
+	Index        string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	Shard        string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
+	Level        int32                  `protobuf:"varint,3,opt,name=level,proto3" json:"level,omitempty"`
+	Discriminant []byte                 `protobuf:"bytes,4,opt,name=discriminant,proto3" json:"discriminant,omitempty"` // hashtree.Bitset.Marshal() output
+	// Encoding the sender accepts for digests_data. 0 (default, used by older
+	// senders) = JSON; 1 = fixed 16-byte big-endian records. Servers only emit
+	// 1 when asked, so rolling upgrades stay JSON until both sides are new.
+	AcceptEncoding uint32 `protobuf:"varint,5,opt,name=accept_encoding,json=acceptEncoding,proto3" json:"accept_encoding,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *HashTreeLevelRequest) Reset() {
@@ -2000,10 +2004,20 @@ func (x *HashTreeLevelRequest) GetDiscriminant() []byte {
 	return nil
 }
 
-// HashTreeLevelResponse carries digests as opaque binary (JSON-encoded []hashtree.Digest).
+func (x *HashTreeLevelRequest) GetAcceptEncoding() uint32 {
+	if x != nil {
+		return x.AcceptEncoding
+	}
+	return 0
+}
+
+// HashTreeLevelResponse carries level digests; encoding declares their format.
 type HashTreeLevelResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	DigestsData   []byte                 `protobuf:"bytes,1,opt,name=digests_data,json=digestsData,proto3" json:"digests_data,omitempty"` // JSON-encoded []hashtree.Digest
+	state       protoimpl.MessageState `protogen:"open.v1"`
+	DigestsData []byte                 `protobuf:"bytes,1,opt,name=digests_data,json=digestsData,proto3" json:"digests_data,omitempty"` // []hashtree.Digest, encoded per `encoding`
+	// 0 (default, emitted by older servers) = JSON; 1 = fixed 16-byte
+	// big-endian records (hashtree.DigestsToBinary).
+	Encoding      uint32 `protobuf:"varint,2,opt,name=encoding,proto3" json:"encoding,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2043,6 +2057,13 @@ func (x *HashTreeLevelResponse) GetDigestsData() []byte {
 		return x.DigestsData
 	}
 	return nil
+}
+
+func (x *HashTreeLevelResponse) GetEncoding() uint32 {
+	if x != nil {
+		return x.Encoding
+	}
+	return 0
 }
 
 // CompareHashTreeRoots pre-filters shards by bulk-comparing hashtree roots: the
@@ -2794,14 +2815,16 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"filterJson\x12\x14\n" +
 	"\x05limit\x18\x04 \x01(\x05R\x05limit\")\n" +
 	"\x11FindUUIDsResponse\x12\x14\n" +
-	"\x05uuids\x18\x01 \x03(\tR\x05uuids\"|\n" +
+	"\x05uuids\x18\x01 \x03(\tR\x05uuids\"\xa5\x01\n" +
 	"\x14HashTreeLevelRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x12\x14\n" +
 	"\x05level\x18\x03 \x01(\x05R\x05level\x12\"\n" +
-	"\fdiscriminant\x18\x04 \x01(\fR\fdiscriminant\":\n" +
+	"\fdiscriminant\x18\x04 \x01(\fR\fdiscriminant\x12'\n" +
+	"\x0faccept_encoding\x18\x05 \x01(\rR\x0eacceptEncoding\"V\n" +
 	"\x15HashTreeLevelResponse\x12!\n" +
-	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\"q\n" +
+	"\fdigests_data\x18\x01 \x01(\fR\vdigestsData\x12\x1a\n" +
+	"\bencoding\x18\x02 \x01(\rR\bencoding\"q\n" +
 	"\x0fShardRootDigest\x12\x14\n" +
 	"\x05shard\x18\x01 \x01(\tR\x05shard\x12$\n" +
 	"\x0eroot_hash_high\x18\x02 \x01(\x06R\frootHashHigh\x12\"\n" +

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
@@ -257,11 +257,18 @@ message HashTreeLevelRequest {
   string shard = 2;
   int32 level = 3;
   bytes discriminant = 4; // hashtree.Bitset.Marshal() output
+  // Encoding the sender accepts for digests_data. 0 (default, used by older
+  // senders) = JSON; 1 = fixed 16-byte big-endian records. Servers only emit
+  // 1 when asked, so rolling upgrades stay JSON until both sides are new.
+  uint32 accept_encoding = 5;
 }
 
-// HashTreeLevelResponse carries digests as opaque binary (JSON-encoded []hashtree.Digest).
+// HashTreeLevelResponse carries level digests; encoding declares their format.
 message HashTreeLevelResponse {
-  bytes digests_data = 1; // JSON-encoded []hashtree.Digest
+  bytes digests_data = 1; // []hashtree.Digest, encoded per `encoding`
+  // 0 (default, emitted by older servers) = JSON; 1 = fixed 16-byte
+  // big-endian records (hashtree.DigestsToBinary).
+  uint32 encoding = 2;
 }
 
 // CompareHashTreeRoots pre-filters shards by bulk-comparing hashtree roots: the

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -266,6 +266,14 @@ func (s *ReplicationService) HashTreeLevel(ctx context.Context, req *pb.HashTree
 		return nil, replicationErrorToGRPC(err)
 	}
 
+	if req.GetAcceptEncoding() == replica.DigestsEncodingBinary {
+		return &pb.HashTreeLevelResponse{
+			DigestsData: hashtree.DigestsToBinary(digests),
+			Encoding:    replica.DigestsEncodingBinary,
+		}, nil
+	}
+
+	// JSON default: older clients never set accept_encoding.
 	data, err := json.Marshal(digests)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "marshal digests: %v", err)

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -13,6 +13,7 @@ package grpc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -88,6 +89,82 @@ func TestLocalIndexNotReady(t *testing.T) {
 			},
 		}
 		assert.True(t, shared.LocalIndexNotReady(resp))
+	})
+}
+
+func TestHashTreeLevelEncodingNegotiation(t *testing.T) {
+	const index = "MyClass"
+	digests := []hashtree.Digest{{1, 2}, {3, 4}, {^uint64(0), 5}}
+
+	discriminant := hashtree.NewBitset(hashtree.LeavesCount(2))
+	discriminant.Set(0)
+	discData, err := discriminant.Marshal()
+	require.NoError(t, err)
+
+	t.Run("binary when requested", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		mockReplicator.EXPECT().
+			HashTreeLevel(mock.Anything, index, "S1", 2, mock.Anything).
+			Return(digests, nil)
+
+		resp, err := svc.HashTreeLevel(context.Background(), &pb.HashTreeLevelRequest{
+			Index:          index,
+			Shard:          "S1",
+			Level:          2,
+			Discriminant:   discData,
+			AcceptEncoding: replica.DigestsEncodingBinary,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, replica.DigestsEncodingBinary, resp.GetEncoding())
+		assert.Equal(t, hashtree.DigestsToBinary(digests), resp.GetDigestsData())
+
+		decoded, err := hashtree.DigestsFromBinary(resp.GetDigestsData())
+		require.NoError(t, err)
+		assert.Equal(t, digests, decoded)
+	})
+
+	t.Run("JSON when accept_encoding unset (old client)", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		mockReplicator.EXPECT().
+			HashTreeLevel(mock.Anything, index, "S1", 2, mock.Anything).
+			Return(digests, nil)
+
+		resp, err := svc.HashTreeLevel(context.Background(), &pb.HashTreeLevelRequest{
+			Index:        index,
+			Shard:        "S1",
+			Level:        2,
+			Discriminant: discData,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, replica.DigestsEncodingJSON, resp.GetEncoding())
+
+		var decoded []hashtree.Digest
+		require.NoError(t, json.Unmarshal(resp.GetDigestsData(), &decoded))
+		assert.Equal(t, digests, decoded)
+	})
+
+	t.Run("binary with empty result", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		mockReplicator.EXPECT().
+			HashTreeLevel(mock.Anything, index, "S1", 2, mock.Anything).
+			Return(nil, nil)
+
+		resp, err := svc.HashTreeLevel(context.Background(), &pb.HashTreeLevelRequest{
+			Index:          index,
+			Shard:          "S1",
+			Level:          2,
+			Discriminant:   discData,
+			AcceptEncoding: replica.DigestsEncodingBinary,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, replica.DigestsEncodingBinary, resp.GetEncoding())
+		assert.Empty(t, resp.GetDigestsData())
 	})
 }
 

--- a/adapters/handlers/rest/clusterapi/grpc/server_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/server_test.go
@@ -330,7 +330,7 @@ func Test_ServerReplicationService(t *testing.T) {
 				level := 1
 				// level-local discriminant: size must equal hashtree.LeavesCount(level).
 				discriminant := hashtree.NewBitset(hashtree.LeavesCount(level))
-				discriminant.Set(0)
+				discriminant.Set(0).Set(1)
 				expectedDigests := []hashtree.Digest{
 					{1, 2},
 					{3, 4},

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -625,15 +625,11 @@ func writeHashTreeLevelResponse(w http.ResponseWriter, r *http.Request, results 
 		return
 	}
 
+	body := hashtree.DigestsToBinary(results)
 	w.Header().Set("X-Response-Encoding", "binary")
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(results))*int64(hashtree.DigestLength), 10))
-	var buf [hashtree.DigestLength]byte
-	for _, d := range results {
-		binary.BigEndian.PutUint64(buf[:8], d[0])
-		binary.BigEndian.PutUint64(buf[8:], d[1])
-		w.Write(buf[:]) //nolint:errcheck
-	}
+	w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+	w.Write(body) //nolint:errcheck
 }
 
 func readRequestBodyWithOptionalCompression(

--- a/usecases/replica/hashtree/digest.go
+++ b/usecases/replica/hashtree/digest.go
@@ -68,3 +68,32 @@ func SizeDigests(buf []Digest, n int) []Digest {
 	}
 	return buf[:n]
 }
+
+// DigestsToBinary encodes digests as fixed DigestLength big-endian records —
+// the shared wire format of the REST binary response and the gRPC encoding=1
+// payload.
+func DigestsToBinary(digests []Digest) []byte {
+	out := make([]byte, 0, len(digests)*DigestLength)
+	var buf [DigestLength]byte
+	for _, d := range digests {
+		binary.BigEndian.PutUint64(buf[:8], d[0])
+		binary.BigEndian.PutUint64(buf[8:], d[1])
+		out = append(out, buf[:]...)
+	}
+	return out
+}
+
+// DigestsFromBinary decodes a DigestsToBinary payload, rejecting any length
+// that is not a whole number of records.
+func DigestsFromBinary(data []byte) ([]Digest, error) {
+	if len(data)%DigestLength != 0 {
+		return nil, fmt.Errorf("invalid digests payload length %d: not a multiple of %d", len(data), DigestLength)
+	}
+	digests := make([]Digest, len(data)/DigestLength)
+	for i := range digests {
+		off := i * DigestLength
+		digests[i][0] = binary.BigEndian.Uint64(data[off : off+8])
+		digests[i][1] = binary.BigEndian.Uint64(data[off+8 : off+DigestLength])
+	}
+	return digests, nil
+}

--- a/usecases/replica/hashtree/digest_test.go
+++ b/usecases/replica/hashtree/digest_test.go
@@ -38,3 +38,34 @@ func TestDigestMarshallingUnmarshalling(t *testing.T) {
 
 	require.Equal(t, d1, d2)
 }
+
+func TestDigestsBinaryCodec(t *testing.T) {
+	digests := []Digest{{1, 2}, {0, 0}, {^uint64(0), ^uint64(0)}, {1 << 63, 42}}
+
+	encoded := DigestsToBinary(digests)
+	require.Len(t, encoded, len(digests)*DigestLength)
+
+	for i := range digests {
+		single, err := digests[i].MarshalBinary()
+		require.NoError(t, err)
+		require.Equal(t, single, encoded[i*DigestLength:(i+1)*DigestLength])
+	}
+
+	decoded, err := DigestsFromBinary(encoded)
+	require.NoError(t, err)
+	require.Equal(t, digests, decoded)
+
+	decoded, err = DigestsFromBinary(nil)
+	require.NoError(t, err)
+	require.Empty(t, decoded)
+
+	require.Empty(t, DigestsToBinary(nil))
+
+	for _, n := range []int{1, 15, 17, 31, DigestLength + 1} {
+		_, err := DigestsFromBinary(make([]byte, n))
+		require.Error(t, err, "length %d", n)
+	}
+
+	_, err = DigestsFromBinary([]byte("[]"))
+	require.Error(t, err)
+}

--- a/usecases/replica/payload.go
+++ b/usecases/replica/payload.go
@@ -32,3 +32,11 @@ const CompareDigestsFlagDeleted byte = 0x01
 // body. The cap leaves enough headroom for the largest realistic
 // diffBatchSize × CompareDigestsRecordLength; tests guard the headroom.
 const CompareDigestsMaxBodyBytes = 4 * 1024 * 1024
+
+// Digest payload encodings negotiated on the gRPC HashTreeLevel RPC. Zero is
+// JSON so payloads from/to older nodes (which never set the field) keep
+// decoding as before; binary is only used when explicitly requested.
+const (
+	DigestsEncodingJSON   uint32 = 0
+	DigestsEncodingBinary uint32 = 1
+)


### PR DESCRIPTION
## Motivation

The gRPC `HashTreeLevel` RPC — the hashbeat descent path of async replication — marshalled level digests as JSON, base64-encoding each digest individually. A full level-16 response is ~1.7MB (vs 1.0MB binary) and ~65k allocations per call, on both the server (marshal) and client (unmarshal) side, repeated every hashbeat iteration per diverging shard. The REST transport already negotiates a fixed-record binary format for the same payload; this brings the gRPC transport to parity.

## Approach

Encoding negotiation follows the existing `OverwriteObjectsRequest.encoding` precedent rather than a proto schema change to the payload itself: the request gains `accept_encoding` and the response declares its `encoding`, with `0` = JSON as the proto3 default. That makes mixed-version behavior automatic — old servers ignore the request field and answer JSON (`encoding=0`), old clients never set `accept_encoding` so new servers answer JSON. Binary is only on the wire when both sides are new.

The binary format is the same 16-byte big-endian record the REST binary responder already emits. Encode/decode now lives in one shared, length-validated codec (`hashtree.DigestsToBinary` / `DigestsFromBinary`), and the REST writer's hand-rolled per-digest loop was replaced with the shared encoder — one wire format, one implementation. Field semantics are documented in the proto ([replication.proto](https://github.com/weaviate/weaviate/blob/482ed7632641903c48aef2fde3a8dfa313e39d2d/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto#L257-L272)).

## Key areas for review

- `usecases/replica/hashtree/digest.go` — the shared codec; `DigestsFromBinary` rejects any length that is not a whole number of records, so a torn/mismatched payload errors instead of desyncing
- `adapters/handlers/rest/clusterapi/grpc/replication_service.go:HashTreeLevel` — server emits binary only when explicitly asked
- `adapters/clients/replication_grpc.go:HashTreeLevel` — client branches on the response's declared encoding, JSON fallback preserved verbatim
- `replication.proto` — new fields use fresh numbers (request `5`, response `2`); no existing field changed

## Risks and mitigations

- **Mixed-version clusters**: proto3 zero-defaults make JSON the fallback in every old/new pairing; binary requires both sides to opt in. Covered by explicit old-client and old-server tests.
- **Corrupt or mislabeled binary payload**: length validation in `DigestsFromBinary` turns it into a decode error (tests: truncated payload, JSON body claiming binary encoding), and the client rejects payloads larger than the requested digest count (`discriminant.SetCount()` records) before decoding, mirroring the REST reader's pre-size clamp.
- **REST behavior change**: none intended — the shared encoder produces byte-identical output to the removed inline loop; `Content-Length` is now derived from the actual body.

## Testing

- Codec unit tests: round-trip (including zero, max-uint64, high-bit values), byte-compatibility with `Digest.MarshalBinary`, empty/nil payloads, rejection of every non-multiple-of-16 length.
- Client tests against a fake gRPC server: binary round-trip (and assertion that the client sends `accept_encoding=1`), JSON fallback from an old server, empty payloads in both encodings, truncated binary rejected, oversized binary rejected, invalid JSON rejected.
- Server tests: binary when requested, JSON when `accept_encoding` unset (old client), empty result under binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

