### PR TITLE
Resource scan: Dont load lazy shards and set newly loaded shards to ReadOnly too

### DIFF
--- a/adapters/repos/db/defer_empty_shard_integration_test.go
+++ b/adapters/repos/db/defer_empty_shard_integration_test.go
@@ -137,7 +137,7 @@ func TestDeferEmptyMultiTenantShardOnInit(t *testing.T) {
 			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
 			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
 
-			index, err := NewIndex(ctx, IndexConfig{
+			index, err := NewIndex(ctx, nil, IndexConfig{
 				RootPath:             dirName,
 				ClassName:            schema.ClassName(className),
 				ReplicationFactor:    1,

--- a/adapters/repos/db/drop_shards_registry_test.go
+++ b/adapters/repos/db/drop_shards_registry_test.go
@@ -72,7 +72,7 @@ func newEmptyMTIndex(t *testing.T) *Index {
 	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
 	shardResolver := resolver.NewShardResolver(class.Class, true, mockSchemaGetter)
 
-	index, err := NewIndex(context.Background(), IndexConfig{
+	index, err := NewIndex(context.Background(), nil, IndexConfig{
 		ClassName:         schema.ClassName("TestClass"),
 		RootPath:          rootPath,
 		ReplicationFactor: 1,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -403,8 +403,14 @@ func (i *Index) debugLoggingEnabled() bool {
 
 // NewIndex creates an index with the specified amount of shards, using only
 // the shards that are local to a node
+// NewIndex builds an index and every shard it owns. db is the owning DB, wired
+// in here rather than by the caller because the shards built below read state
+// off it while they come up (e.g. the resource-pressure read-only flag, see
+// [Shard.inheritResourcePressureReadOnly]) - assigning it after this returns
+// would leave those reads racing the assignment.
 func NewIndex(
 	ctx context.Context,
+	db *DB,
 	cfg IndexConfig,
 	invertedIndexConfig schema.InvertedIndexConfig,
 	vectorIndexUserConfig schemaConfig.VectorIndexConfig,
@@ -459,6 +465,7 @@ func NewIndex(
 	}
 
 	index := &Index{
+		db:                      db,
 		Config:                  cfg,
 		globalreplicationConfig: globalReplicationConfig,
 		getSchema:               sg,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -802,16 +802,27 @@ func (i *Index) ForEachShard(f func(name string, shard ShardLike) error) error {
 	return i.shards.Range(f)
 }
 
+// shardIsLoaded reports whether the shard is materialized, i.e. whether
+// touching it would force a cold shard to load.
+func shardIsLoaded(shard ShardLike) bool {
+	asLazyLoadShard, ok := shard.(*LazyLoadShard)
+	return !ok || asLazyLoadShard.isLoaded()
+}
+
 func (i *Index) ForEachLoadedShard(f func(name string, shard ShardLike) error) error {
 	return i.shards.Range(func(name string, shard ShardLike) error {
-		// Skip lazy loaded shard which are not loaded
-		if asLazyLoadShard, ok := shard.(*LazyLoadShard); ok {
-			if !asLazyLoadShard.isLoaded() {
-				return nil
-			}
+		if !shardIsLoaded(shard) {
+			return nil
 		}
 		return f(name, shard)
 	})
+}
+
+// publishShard makes the shard visible under shardName, reconciling it against
+// the resource-pressure flag it may have read before becoming visible.
+func (i *Index) publishShard(shardName string, shard ShardLike) {
+	i.shards.Store(shardName, shard)
+	i.db.reconcileShardResourcePressure(shardName, shard)
 }
 
 func (i *Index) ForEachShardConcurrently(f func(name string, shard ShardLike) error) error {
@@ -825,11 +836,8 @@ func (i *Index) ForEachShardConcurrently(f func(name string, shard ShardLike) er
 
 func (i *Index) ForEachLoadedShardConcurrently(f func(name string, shard ShardLike) error) error {
 	return i.shards.RangeConcurrently(i.logger, func(name string, shard ShardLike) error {
-		// Skip lazy loaded shard which are not loaded
-		if asLazyLoadShard, ok := shard.(*LazyLoadShard); ok {
-			if !asLazyLoadShard.isLoaded() {
-				return nil
-			}
+		if !shardIsLoaded(shard) {
+			return nil
 		}
 		return f(name, shard)
 	})
@@ -3049,7 +3057,7 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 		return err
 	}
 
-	i.shards.Store(shardName, shard)
+	i.publishShard(shardName, shard)
 
 	return nil
 }
@@ -3180,7 +3188,7 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 			if err != nil {
 				return nil, func() {}, fmt.Errorf("init local shard %q of index %s: %w", shardName, i.ID(), err)
 			}
-			i.shards.Store(shardName, shard)
+			i.publishShard(shardName, shard)
 		}
 	}
 

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -158,7 +158,7 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 		schema: fakeSchema, shardState: shardState,
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
-	index, err := NewIndex(testCtx(), IndexConfig{
+	index, err := NewIndex(testCtx(), nil, IndexConfig{
 		EnableLazyLoadShards: true,
 		RootPath:             dirName,
 		ClassName:            schema.ClassName(class.Class),
@@ -216,7 +216,7 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 	indexFilesAfterDelete, err := getIndexFilenames(dirName, class.Class)
 	require.Nil(t, err)
 	// recreate the index
-	index, err = NewIndex(testCtx(), IndexConfig{
+	index, err = NewIndex(testCtx(), nil, IndexConfig{
 		EnableLazyLoadShards: true,
 		RootPath:             dirName,
 		ClassName:            schema.ClassName(class.Class),
@@ -396,7 +396,7 @@ func TestIndex_DropReadOnlyIndexWithData(t *testing.T) {
 		schema: fakeSchema, shardState: shardState,
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
-	index, err := NewIndex(ctx, IndexConfig{
+	index, err := NewIndex(ctx, nil, IndexConfig{
 		EnableLazyLoadShards: true,
 		RootPath:             dirName,
 		ClassName:            schema.ClassName(class.Class),
@@ -495,7 +495,7 @@ func TestIndex_DropUnloadedShard(t *testing.T) {
 		schema: fakeSchema, shardState: shardState,
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
-	index, err := NewIndex(testCtx(), IndexConfig{
+	index, err := NewIndex(testCtx(), nil, IndexConfig{
 		EnableLazyLoadShards: true,
 		RootPath:             dirName,
 		ClassName:            schema.ClassName(class.Class),
@@ -593,7 +593,7 @@ func TestIndex_DropLoadedShard(t *testing.T) {
 		schema: fakeSchema, shardState: shardState,
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
-	index, err := NewIndex(testCtx(), IndexConfig{
+	index, err := NewIndex(testCtx(), nil, IndexConfig{
 		EnableLazyLoadShards: true,
 		RootPath:             dirName,
 		ClassName:            schema.ClassName(class.Class),
@@ -660,7 +660,7 @@ func emptyIdx(t *testing.T, rootDir string, class *models.Class, shardState *sha
 		shardState: shardState,
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
-	idx, err := NewIndex(testCtx(), IndexConfig{
+	idx, err := NewIndex(testCtx(), nil, IndexConfig{
 		RootPath:             rootDir,
 		ClassName:            schema.ClassName(class.Class),
 		EnableLazyLoadShards: false,

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -163,7 +163,7 @@ func TestIndex_ObjectStorageSize_Comprehensive(t *testing.T) {
 				Return(types.WriteReplicaSet{Replicas: []types.Replica{{NodeName: "test-node", ShardName: tt.shardName, HostAddr: "110.12.15.23"}}}, nil).Maybe()
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
 			// Create index
-			index, err := NewIndex(ctx, IndexConfig{
+			index, err := NewIndex(ctx, nil, IndexConfig{
 				RootPath:              dirName,
 				ClassName:             schema.ClassName(tt.className),
 				ReplicationFactor:     1,
@@ -344,7 +344,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	// loaded as a raw *Shard (not deferred as an empty tenant).
 	seedShardObjectCounter(t, dirName, className, tenantNamePopulated)
 	// Create index with lazy loading disabled to test active calculation methods
-	index, err := NewIndex(ctx, IndexConfig{
+	index, err := NewIndex(ctx, nil, IndexConfig{
 		RootPath:              dirName,
 		ClassName:             schema.ClassName(className),
 		ReplicationFactor:     1,
@@ -446,7 +446,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	require.NoError(t, index.Shutdown(ctx))
 	// Create a new index instance to test inactive calculation methods
 	// This ensures we're testing the inactive methods on a fresh index that reads from disk
-	newIndex, err := NewIndex(ctx, IndexConfig{
+	newIndex, err := NewIndex(ctx, nil, IndexConfig{
 		RootPath:              dirName,
 		ClassName:             schema.ClassName(className),
 		ReplicationFactor:     1,

--- a/adapters/repos/db/index_objects_ttl_integration_test.go
+++ b/adapters/repos/db/index_objects_ttl_integration_test.go
@@ -94,7 +94,7 @@ func TestTTLSkipsLazyUnloadedTenant(t *testing.T) {
 	schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
 	shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
 
-	index, err := NewIndex(ctx, IndexConfig{
+	index, err := NewIndex(ctx, nil, IndexConfig{
 		RootPath:             t.TempDir(),
 		ClassName:            schema.ClassName(className),
 		ReplicationFactor:    1,

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -258,7 +258,7 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T, params usageInde
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
 
 	newIndexFn := func(lazy, trackDimensions bool) *Index {
-		idx, err := NewIndex(ctx, IndexConfig{
+		idx, err := NewIndex(ctx, nil, IndexConfig{
 			RootPath:              dirName,
 			ClassName:             schema.ClassName(className),
 			ReplicationFactor:     1,

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -225,7 +225,7 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 					Replicas: []types.Replica{{NodeName: "test-node", ShardName: tt.shardName, HostAddr: "10.14.57.56"}},
 				}, nil).Maybe()
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
-			index, err := NewIndex(ctx, IndexConfig{
+			index, err := NewIndex(ctx, nil, IndexConfig{
 				RootPath:              dirName,
 				ClassName:             schema.ClassName(tt.className),
 				ReplicationFactor:     1,
@@ -543,7 +543,7 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 					Replicas: []types.Replica{{NodeName: "test-node", ShardName: tt.shardName, HostAddr: "10.14.57.56"}},
 				}, nil).Maybe()
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
-			index, err := NewIndex(ctx, IndexConfig{
+			index, err := NewIndex(ctx, nil, IndexConfig{
 				EnableLazyLoadShards:  true,
 				RootPath:              dirName,
 				ClassName:             schema.ClassName(tt.className),
@@ -763,7 +763,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	// loaded as a raw *Shard (not deferred as an empty tenant).
 	seedShardObjectCounter(t, dirName, className, tenantNamePopulated)
 	// Create index with lazy loading disabled to test active calculation methods
-	index, err := NewIndex(ctx, IndexConfig{
+	index, err := NewIndex(ctx, nil, IndexConfig{
 		RootPath:              dirName,
 		ClassName:             schema.ClassName(className),
 		ReplicationFactor:     1,
@@ -910,7 +910,7 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 
 	// Create a new index instance to test inactive calculation methods
 	// This ensures we're testing the inactive methods on a fresh index that reads from disk
-	newIndex, err := NewIndex(ctx, IndexConfig{
+	newIndex, err := NewIndex(ctx, nil, IndexConfig{
 		RootPath:              dirName,
 		ClassName:             schema.ClassName(className),
 		ReplicationFactor:     1,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -128,7 +128,7 @@ func (db *DB) init(ctx context.Context) error {
 			).Build()
 			shardResolver := resolver.NewShardResolver(collection, multitenancy.IsMultiTenant(class.MultiTenancyConfig), db.schemaGetter)
 			var lazyLoadShardEnabled bool
-			idx, err := NewIndex(ctx, IndexConfig{
+			idx, err := NewIndex(ctx, db, IndexConfig{
 				ClassName:                      schema.ClassName(class.Class),
 				RootPath:                       db.config.RootPath,
 				ResourceUsage:                  db.config.ResourceUsage,
@@ -225,7 +225,6 @@ func (db *DB) init(ctx context.Context) error {
 			}
 
 			idx.usageLimits = db.usageLimits
-			idx.db = db
 			idx.SetReplicationFSMReader(db.replicationFSM)
 			db.indexLock.Lock()
 			db.indices[idx.ID()] = idx

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -255,6 +255,9 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 	m.db.indices[idx.ID()] = idx
 	m.db.indexLock.Unlock()
 
+	// Shards built inside NewIndex pick up the read-only flag here.
+	m.db.reconcileIndexResourcePressure(idx)
+
 	// NewIndex loaded shards reading the live AsyncReplicationDisabled flag, but
 	// the index was not yet in db.indices, so a concurrent runtime flag toggle's
 	// reconcile hook could have skipped it. Re-reconcile now that it is visible

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -151,7 +151,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 	}
 
 	var lazyLoadShardEnabled bool
-	idx, err = NewIndex(ctx,
+	idx, err = NewIndex(ctx, m.db,
 		IndexConfig{
 			ClassName:                      schema.ClassName(class.Class),
 			RootPath:                       m.db.config.RootPath,
@@ -249,13 +249,15 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 	}
 
 	idx.usageLimits = m.db.usageLimits
-	idx.db = m.db
 	idx.SetReplicationFSMReader(m.db.replicationFSM)
 	m.db.indexLock.Lock()
 	m.db.indices[idx.ID()] = idx
 	m.db.indexLock.Unlock()
 
-	// Shards built inside NewIndex pick up the read-only flag here.
+	// Shards built inside NewIndex read the read-only flag as they come up, but
+	// a transition landing after that read reaches them through neither path -
+	// the sweep cannot see an index that is not in db.indices yet. Settle them
+	// against the flag now that it can.
 	m.db.reconcileIndexResourcePressure(idx)
 
 	// NewIndex loaded shards reading the live AsyncReplicationDisabled flag, but

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -106,7 +106,7 @@ func TestUpdateIndexTenants(t *testing.T) {
 				return readFunc(class, originalSS)
 			}).Maybe()
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
-			index, err := NewIndex(context.Background(), IndexConfig{
+			index, err := NewIndex(context.Background(), nil, IndexConfig{
 				ClassName:         schema.ClassName("TestClass"),
 				RootPath:          t.TempDir(),
 				ReplicationFactor: 1,
@@ -548,7 +548,7 @@ func TestUpdateIndexShards(t *testing.T) {
 
 			shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
 			// Create index with proper configuration
-			index, err := NewIndex(ctx, IndexConfig{
+			index, err := NewIndex(ctx, nil, IndexConfig{
 				ClassName:            schema.ClassName("TestClass"),
 				RootPath:             rootPath,
 				ReplicationFactor:    1,
@@ -983,7 +983,7 @@ func TestListAndGetFilesWithIntegrityChecking(t *testing.T) {
 		return readFunc(class, originalSS)
 	}).Maybe()
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
-	index, err := NewIndex(context.Background(), IndexConfig{
+	index, err := NewIndex(context.Background(), nil, IndexConfig{
 		ClassName:         schema.ClassName("TestClass"),
 		RootPath:          t.TempDir(),
 		ReplicationFactor: 1,

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -248,7 +248,7 @@ func TestLazyLoadedShards(t *testing.T) {
 		schema: fakeSchema, shardState: shardState,
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
-	index, err := NewIndex(ctx, IndexConfig{
+	index, err := NewIndex(ctx, nil, IndexConfig{
 		RootPath:             dirName,
 		ClassName:            schema.ClassName(className),
 		ReplicationFactor:    1,

--- a/adapters/repos/db/replica_snapshot_concurrent_test.go
+++ b/adapters/repos/db/replica_snapshot_concurrent_test.go
@@ -72,7 +72,7 @@ func TestIncomingCreateReplicaSnapshotConcurrent(t *testing.T) {
 
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
 
-	index, err := NewIndex(context.Background(), IndexConfig{
+	index, err := NewIndex(context.Background(), nil, IndexConfig{
 		ClassName:         schema.ClassName("TestClass"),
 		RootPath:          t.TempDir(),
 		ReplicationFactor: 1,

--- a/adapters/repos/db/replica_snapshot_fallback_timer_test.go
+++ b/adapters/repos/db/replica_snapshot_fallback_timer_test.go
@@ -82,7 +82,7 @@ func TestReplicaSnapshotFallbackInactivityTimerIsReset(t *testing.T) {
 
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
 
-	index, err := NewIndex(context.Background(), IndexConfig{
+	index, err := NewIndex(context.Background(), nil, IndexConfig{
 		ClassName:                 schema.ClassName("TestClass"),
 		RootPath:                  t.TempDir(),
 		ReplicationFactor:         1,

--- a/adapters/repos/db/replica_snapshot_shared_halt_test.go
+++ b/adapters/repos/db/replica_snapshot_shared_halt_test.go
@@ -256,7 +256,7 @@ func newSharedHaltTestShard(t *testing.T) (*Index, *Shard) {
 
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchemaGetter)
 
-	index, err := NewIndex(context.Background(), IndexConfig{
+	index, err := NewIndex(context.Background(), nil, IndexConfig{
 		ClassName:         schema.ClassName("TestClass"),
 		RootPath:          t.TempDir(),
 		ReplicationFactor: 1,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -189,6 +189,8 @@ func (db *DB) WaitForStartup(ctx context.Context) error {
 	}
 
 	db.startupComplete.Store(true)
+	// Only once init has returned: the indices it builds publish their shards
+	// without reconciling them against the read-only flag.
 	db.scanResourceUsage()
 
 	return nil

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -189,8 +189,10 @@ func (db *DB) WaitForStartup(ctx context.Context) error {
 	}
 
 	db.startupComplete.Store(true)
-	// Only once init has returned: the indices it builds publish their shards
-	// without reconciling them against the read-only flag.
+	// Only once init has returned: unlike AddClass, it does not settle the
+	// indices it builds against the read-only flag, so a transition landing
+	// while one is still being assembled would reach its shards through neither
+	// path.
 	db.scanResourceUsage()
 
 	return nil

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -14,6 +14,7 @@ package db
 import (
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -83,6 +84,11 @@ type resourceScanState struct {
 	diskWarning *interval.BackoffTimer
 	memWarning  *interval.BackoffTimer
 
+	// transition is held for write only while isReadOnly is flipped, never
+	// across a sweep - a sweep takes indexLock and the shards' own locks. A
+	// shard settling under the read lock therefore cannot straddle the flip.
+	transition sync.RWMutex
+
 	// isReadOnly reports whether the scan currently holds shards read-only.
 	// Written by the scan goroutine, read by every shard that is built: a shard
 	// created or loaded while this is set comes up READONLY instead of READY.
@@ -91,10 +97,20 @@ type resourceScanState struct {
 }
 
 // resourcePressureReadOnly reports whether the resource scan currently holds
-// shards read-only. Tolerates a nil DB and a nil scan state, both of which
-// occur in tests that build an Index without its owning DB.
+// shards read-only. Tolerates a nil DB and a nil scan state: a shard built
+// inside [NewIndex] has no owning DB to read yet, and picks the flag up from
+// [DB.reconcileIndexResourcePressure] once the index is published.
 func (db *DB) resourcePressureReadOnly() bool {
 	return db != nil && db.resourceScanState != nil && db.resourceScanState.isReadOnly.Load()
+}
+
+// setReadOnlyFlag flips the flag deciding whether a shard comes up READONLY
+// when it is built.
+func (db *DB) setReadOnlyFlag(readOnly bool) {
+	db.resourceScanState.transition.Lock()
+	defer db.resourceScanState.transition.Unlock()
+
+	db.resourceScanState.isReadOnly.Store(readOnly)
 }
 
 func newResourceScanState() *resourceScanState {
@@ -177,11 +193,11 @@ func (db *DB) memUseReadonly(mon *memwatch.Monitor) {
 }
 
 func (db *DB) setShardsReadOnly(reason string) {
-	// Raise the flag before the sweep, never after: a shard loading concurrently
-	// reads it while holding the load lock the sweep needs to see that shard as
-	// loaded, so flag-then-sweep means every shard is caught by exactly one of
-	// the two - the sweep if it was already loaded, the flag if it loads later.
-	db.resourceScanState.isReadOnly.Store(true)
+	// Raise the flag before the sweep, never after: a lazily loading shard reads
+	// it while holding the load lock the sweep needs to see that shard as loaded,
+	// so the two are mutually exclusive. An eagerly built shard holds no such
+	// lock, and reconciles against the flag when it is published instead.
+	db.setReadOnlyFlag(true)
 
 	db.indexLock.Lock()
 	defer db.indexLock.Unlock()
@@ -190,24 +206,83 @@ func (db *DB) setShardsReadOnly(reason string) {
 		// scan may be reacting to, and a failed load panics out of the scan
 		// goroutine. Cold shards inherit the flag when they load instead.
 		index.ForEachLoadedShard(func(name string, shard ShardLike) error {
-			// Don't overwrite the reason of an already read-only shard: it may be
-			// read-only for a non-resource reason (e.g. a vector-index config
-			// update), and relabeling it would let setShardsReady flip it back to
-			// READY mid-operation.
-			if shard.GetStatus() == storagestate.StatusReadOnly {
-				return nil
-			}
-			// A shard whose store closed concurrently (tenant deletion,
-			// deactivation, shutdown) is going away and takes no more writes.
-			err := shard.SetStatusReadonly(statusReasonResourcePressure)
-			if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
-				db.logger.WithField("action", "set_shard_read_only").
-					WithField("path", db.config.RootPath).
-					Errorf("failed to set to READONLY: shard %q: %v", name, err)
-			}
+			db.markShardReadOnly(name, shard)
 			return nil
 		})
 	}
+}
+
+// markShardReadOnly holds one loaded shard read-only for resource pressure.
+//
+// A shard that is already read-only keeps its reason: it may be read-only for a
+// non-resource reason (e.g. a vector-index config update), and relabeling it
+// would let the recovery pass flip it back to READY mid-operation.
+func (db *DB) markShardReadOnly(name string, shard ShardLike) {
+	if shard.GetStatus() == storagestate.StatusReadOnly {
+		return
+	}
+	// A shard whose store closed concurrently (tenant deletion, deactivation,
+	// shutdown) is going away and takes no more writes.
+	err := shard.SetStatusReadonly(statusReasonResourcePressure)
+	if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
+		db.logger.WithField("action", "set_shard_read_only").
+			WithField("path", db.config.RootPath).
+			Errorf("failed to set to READONLY: shard %q: %v", name, err)
+	}
+}
+
+// markShardReady releases one shard from resource-pressure read-only, leaving a
+// shard held read-only for any other reason alone. Reports whether the release
+// succeeded.
+func (db *DB) markShardReady(name string, shard ShardLike) bool {
+	if shard.GetStatus() != storagestate.StatusReadOnly ||
+		shard.GetStatusReason() != statusReasonResourcePressure {
+		return true
+	}
+	// A shard whose store closed concurrently (tenant deletion, deactivation,
+	// shutdown) takes no writes either way, and comes back READY if it is ever
+	// loaded again.
+	err := shard.UpdateStatus(storagestate.StatusReady.String(), statusReasonResourceRecovery)
+	if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
+		db.logger.WithField("action", "set_shard_ready").
+			WithField("path", db.config.RootPath).
+			Errorf("failed to set to READY: shard %q: %v", name, err)
+		return false
+	}
+	return true
+}
+
+// reconcileShardResourcePressure applies the current read-only flag to a shard
+// the caller has just published. Publishing first is required: it is what lets
+// a transition that wins the lock find the shard in the sweep that follows.
+//
+// A cold shard is skipped - a status change would force it to load, and it
+// reads the flag itself when it does.
+func (db *DB) reconcileShardResourcePressure(name string, shard ShardLike) {
+	if db == nil || db.resourceScanState == nil || !shardIsLoaded(shard) {
+		return
+	}
+
+	db.resourceScanState.transition.RLock()
+	defer db.resourceScanState.transition.RUnlock()
+
+	if db.resourceScanState.isReadOnly.Load() {
+		db.markShardReadOnly(name, shard)
+		return
+	}
+	db.markShardReady(name, shard)
+}
+
+// reconcileIndexResourcePressure applies the current read-only flag to the
+// loaded shards of an index the caller has just published. Shards built inside
+// [NewIndex] are out of the scan's reach - the index is not in db.indices for
+// its sweep, and they have no owning DB to read the flag from - so this is
+// where they pick it up.
+func (db *DB) reconcileIndexResourcePressure(index *Index) {
+	index.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		db.reconcileShardResourcePressure(name, shard)
+		return nil
+	})
 }
 
 // resourceUseRecovery checks whether resource usage has dropped below the
@@ -236,7 +311,7 @@ func (db *DB) setShardsReady() {
 	// would otherwise inherit READONLY after the sweep already passed it, and
 	// nothing would flip it back - this recovery pass only runs while the flag
 	// is set. It goes back up below if any shard failed to transition.
-	db.resourceScanState.isReadOnly.Store(false)
+	db.setReadOnlyFlag(false)
 
 	var failedCount atomic.Int64
 	func() {
@@ -244,18 +319,8 @@ func (db *DB) setShardsReady() {
 		defer db.indexLock.Unlock()
 		for _, index := range db.indices {
 			index.ForEachShardConcurrently(func(name string, shard ShardLike) error {
-				if shard.GetStatus() == storagestate.StatusReadOnly &&
-					shard.GetStatusReason() == statusReasonResourcePressure {
-					err := shard.UpdateStatus(storagestate.StatusReady.String(), statusReasonResourceRecovery)
-					// A shard whose store closed concurrently (tenant deletion,
-					// deactivation, shutdown) takes no writes either way, and comes
-					// back READY if it is ever loaded again.
-					if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
-						failedCount.Add(1)
-						db.logger.WithField("action", "set_shard_ready").
-							WithField("path", db.config.RootPath).
-							Errorf("failed to set to READY: shard %q: %v", name, err)
-					}
+				if !db.markShardReady(name, shard) {
+					failedCount.Add(1)
 				}
 				return nil
 			})
@@ -263,7 +328,7 @@ func (db *DB) setShardsReady() {
 	}()
 
 	if count := failedCount.Load(); count > 0 {
-		db.resourceScanState.isReadOnly.Store(true)
+		db.setReadOnlyFlag(true)
 		db.logger.WithField("action", "set_shard_ready").
 			WithField("failed_count", count).
 			Warn("Resource usage below threshold, but some shards failed to transition to READY")

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -85,7 +85,7 @@ type resourceScanState struct {
 	memWarning  *interval.BackoffTimer
 
 	// transition is held for write only while isReadOnly is flipped, never
-	// across a sweep - a sweep takes indexLock and the shards' own locks. A
+	// across a sweep - a sweep takes the indices' and the shards' own locks. A
 	// shard settling under the read lock therefore cannot straddle the flip.
 	transition sync.RWMutex
 
@@ -97,9 +97,9 @@ type resourceScanState struct {
 }
 
 // resourcePressureReadOnly reports whether the resource scan currently holds
-// shards read-only. Tolerates a nil DB and a nil scan state: a shard built
-// inside [NewIndex] has no owning DB to read yet, and picks the flag up from
-// [DB.reconcileIndexResourcePressure] once the index is published.
+// shards read-only. Every index gets its owning DB in [NewIndex], before it
+// builds a single shard, so a shard always reads the live flag; the nil
+// tolerance here covers indices assembled by hand in tests.
 func (db *DB) resourcePressureReadOnly() bool {
 	return db != nil && db.resourceScanState != nil && db.resourceScanState.isReadOnly.Load()
 }
@@ -199,9 +199,7 @@ func (db *DB) setShardsReadOnly(reason string) {
 	// lock, and reconciles against the flag when it is published instead.
 	db.setReadOnlyFlag(true)
 
-	db.indexLock.Lock()
-	defer db.indexLock.Unlock()
-	for _, index := range db.indices {
+	db.forEachIndexOutsideIndexLock(func(index *Index) {
 		// Loaded shards only: force-loading a cold shard here costs the memory the
 		// scan may be reacting to, and a failed load panics out of the scan
 		// goroutine. Cold shards inherit the flag when they load instead.
@@ -209,6 +207,48 @@ func (db *DB) setShardsReadOnly(reason string) {
 			db.markShardReadOnly(name, shard)
 			return nil
 		})
+	})
+}
+
+// forEachIndexOutsideIndexLock walks every index, holding indexLock only long
+// enough to snapshot the pointers.
+//
+// A sweep must not hold indexLock while it touches shards. Deciding whether a
+// shard is loaded blocks on that shard's load lock - which is exactly what
+// makes a sweep and a shard building itself mutually exclusive - and a shard
+// load can run for minutes. Every object read and write takes indexLock read
+// side, so holding it across a load would stall the whole node.
+//
+// The snapshot survives a concurrent DeleteIndex: the pointer stays valid, and
+// the per-index dropIndex read lock plus the closed check are the established
+// discipline for using an index outside indexLock. Taking dropIndex only after
+// releasing indexLock keeps the indexLock -> dropIndex order used everywhere
+// else. An index created after the snapshot is not missed: it reconciles
+// against the flag when it is published, see [DB.reconcileIndexResourcePressure].
+func (db *DB) forEachIndexOutsideIndexLock(f func(index *Index)) {
+	var indices []*Index
+	func() {
+		db.indexLock.RLock()
+		defer db.indexLock.RUnlock()
+
+		indices = make([]*Index, 0, len(db.indices))
+		for _, index := range db.indices {
+			indices = append(indices, index)
+		}
+	}()
+
+	for _, index := range indices {
+		func() {
+			index.dropIndex.RLock()
+			defer index.dropIndex.RUnlock()
+			index.closeLock.RLock()
+			defer index.closeLock.RUnlock()
+
+			if index.closed {
+				return // index is shutting down, its shards take no writes
+			}
+			f(index)
+		}()
 	}
 }
 
@@ -275,9 +315,8 @@ func (db *DB) reconcileShardResourcePressure(name string, shard ShardLike) {
 
 // reconcileIndexResourcePressure applies the current read-only flag to the
 // loaded shards of an index the caller has just published. Shards built inside
-// [NewIndex] are out of the scan's reach - the index is not in db.indices for
-// its sweep, and they have no owning DB to read the flag from - so this is
-// where they pick it up.
+// [NewIndex] read the flag themselves, but are out of a sweep's reach until the
+// index lands in db.indices, so a transition in between reaches them here.
 func (db *DB) reconcileIndexResourcePressure(index *Index) {
 	index.ForEachLoadedShard(func(name string, shard ShardLike) error {
 		db.reconcileShardResourcePressure(name, shard)
@@ -314,18 +353,14 @@ func (db *DB) setShardsReady() {
 	db.setReadOnlyFlag(false)
 
 	var failedCount atomic.Int64
-	func() {
-		db.indexLock.Lock()
-		defer db.indexLock.Unlock()
-		for _, index := range db.indices {
-			index.ForEachShardConcurrently(func(name string, shard ShardLike) error {
-				if !db.markShardReady(name, shard) {
-					failedCount.Add(1)
-				}
-				return nil
-			})
-		}
-	}()
+	db.forEachIndexOutsideIndexLock(func(index *Index) {
+		index.ForEachShardConcurrently(func(name string, shard ShardLike) error {
+			if !db.markShardReady(name, shard) {
+				failedCount.Add(1)
+			}
+			return nil
+		})
+	})
 
 	if count := failedCount.Load(); count > 0 {
 		db.setReadOnlyFlag(true)

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -354,7 +354,11 @@ func (db *DB) setShardsReady() {
 
 	var failedCount atomic.Int64
 	db.forEachIndexOutsideIndexLock(func(index *Index) {
-		index.ForEachShardConcurrently(func(name string, shard ShardLike) error {
+		// Loaded shards only, mirroring the read-only sweep: a cold shard has no
+		// resource-pressure status to release, and touching one would force it to
+		// load - spending the memory this pass is recovering from, on the shard
+		// least likely to need it. Cold shards come up READY on their next load.
+		index.ForEachLoadedShardConcurrently(func(name string, shard ShardLike) error {
 			if !db.markShardReady(name, shard) {
 				failedCount.Add(1)
 			}

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -12,12 +12,14 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
 
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/interval"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -69,7 +71,7 @@ func (d *DB) scanResourceUsage() {
 // memory pressure would never see the usage drop back below the threshold.
 func (db *DB) scanResourceUsageOnce(mon *memwatch.Monitor, du diskUse, updateMappings bool) {
 	mon.Refresh(updateMappings)
-	if db.resourceScanState.isReadOnly {
+	if db.resourceScanState.isReadOnly.Load() {
 		db.resourceUseRecovery(mon, du)
 	} else {
 		db.resourceUseWarn(mon, du)
@@ -80,7 +82,19 @@ func (db *DB) scanResourceUsageOnce(mon *memwatch.Monitor, du diskUse, updateMap
 type resourceScanState struct {
 	diskWarning *interval.BackoffTimer
 	memWarning  *interval.BackoffTimer
-	isReadOnly  bool
+
+	// isReadOnly reports whether the scan currently holds shards read-only.
+	// Written by the scan goroutine, read by every shard that is built: a shard
+	// created or loaded while this is set comes up READONLY instead of READY.
+	// See [Shard.inheritResourcePressureReadOnly].
+	isReadOnly atomic.Bool
+}
+
+// resourcePressureReadOnly reports whether the resource scan currently holds
+// shards read-only. Tolerates a nil DB and a nil scan state, both of which
+// occur in tests that build an Index without its owning DB.
+func (db *DB) resourcePressureReadOnly() bool {
+	return db != nil && db.resourceScanState != nil && db.resourceScanState.isReadOnly.Load()
 }
 
 func newResourceScanState() *resourceScanState {
@@ -163,9 +177,19 @@ func (db *DB) memUseReadonly(mon *memwatch.Monitor) {
 }
 
 func (db *DB) setShardsReadOnly(reason string) {
+	// Raise the flag before the sweep, never after: a shard loading concurrently
+	// reads it while holding the load lock the sweep needs to see that shard as
+	// loaded, so flag-then-sweep means every shard is caught by exactly one of
+	// the two - the sweep if it was already loaded, the flag if it loads later.
+	db.resourceScanState.isReadOnly.Store(true)
+
 	db.indexLock.Lock()
+	defer db.indexLock.Unlock()
 	for _, index := range db.indices {
-		index.ForEachShard(func(name string, shard ShardLike) error {
+		// Loaded shards only: force-loading a cold shard here costs the memory the
+		// scan may be reacting to, and a failed load panics out of the scan
+		// goroutine. Cold shards inherit the flag when they load instead.
+		index.ForEachLoadedShard(func(name string, shard ShardLike) error {
 			// Don't overwrite the reason of an already read-only shard: it may be
 			// read-only for a non-resource reason (e.g. a vector-index config
 			// update), and relabeling it would let setShardsReady flip it back to
@@ -173,17 +197,17 @@ func (db *DB) setShardsReadOnly(reason string) {
 			if shard.GetStatus() == storagestate.StatusReadOnly {
 				return nil
 			}
+			// A shard whose store closed concurrently (tenant deletion,
+			// deactivation, shutdown) is going away and takes no more writes.
 			err := shard.SetStatusReadonly(statusReasonResourcePressure)
-			if err != nil {
+			if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
 				db.logger.WithField("action", "set_shard_read_only").
 					WithField("path", db.config.RootPath).
-					Fatalf("failed to set to READONLY: shard %q: %v", name, err)
+					Errorf("failed to set to READONLY: shard %q: %v", name, err)
 			}
 			return nil
 		})
 	}
-	db.indexLock.Unlock()
-	db.resourceScanState.isReadOnly = true
 }
 
 // resourceUseRecovery checks whether resource usage has dropped below the
@@ -208,6 +232,12 @@ func (db *DB) memAboveReadonlyThreshold(mon *memwatch.Monitor) bool {
 }
 
 func (db *DB) setShardsReady() {
+	// Drop the flag before the sweep, never after: a shard loading concurrently
+	// would otherwise inherit READONLY after the sweep already passed it, and
+	// nothing would flip it back - this recovery pass only runs while the flag
+	// is set. It goes back up below if any shard failed to transition.
+	db.resourceScanState.isReadOnly.Store(false)
+
 	var failedCount atomic.Int64
 	func() {
 		db.indexLock.Lock()
@@ -217,12 +247,14 @@ func (db *DB) setShardsReady() {
 				if shard.GetStatus() == storagestate.StatusReadOnly &&
 					shard.GetStatusReason() == statusReasonResourcePressure {
 					err := shard.UpdateStatus(storagestate.StatusReady.String(), statusReasonResourceRecovery)
-					if err != nil {
+					// A shard whose store closed concurrently (tenant deletion,
+					// deactivation, shutdown) takes no writes either way, and comes
+					// back READY if it is ever loaded again.
+					if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
 						failedCount.Add(1)
 						db.logger.WithField("action", "set_shard_ready").
 							WithField("path", db.config.RootPath).
-							WithError(err).
-							Error("failed to set to READY")
+							Errorf("failed to set to READY: shard %q: %v", name, err)
 					}
 				}
 				return nil
@@ -231,12 +263,12 @@ func (db *DB) setShardsReady() {
 	}()
 
 	if count := failedCount.Load(); count > 0 {
+		db.resourceScanState.isReadOnly.Store(true)
 		db.logger.WithField("action", "set_shard_ready").
 			WithField("failed_count", count).
 			Warn("Resource usage below threshold, but some shards failed to transition to READY")
 		return
 	}
-	db.resourceScanState.isReadOnly = false
 	db.logger.WithField("action", "set_shard_ready").
 		Info("Resource usage below threshold. Set shards back to READY")
 }

--- a/adapters/repos/db/resource_use_shard_init_test.go
+++ b/adapters/repos/db/resource_use_shard_init_test.go
@@ -1,0 +1,212 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+)
+
+// resourcePressureFixture is a lazy-load repo with one cold shard, wired so the
+// resource scan can be driven by hand through the real disk-usage path.
+type resourcePressureFixture struct {
+	repo      *DB
+	migrator  *Migrator
+	index     *Index
+	class     *models.Class
+	className string
+}
+
+func newResourcePressureFixture(t *testing.T) *resourcePressureFixture {
+	t.Helper()
+	ctx := testCtx()
+	className := "ResourcePressureLoad"
+
+	repo, migrator, schemaGetter := newLazyLoadRepo(t, singleShardState())
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+	class := newClassWithWarmProp(className)
+	require.NoError(t, migrator.AddClass(ctx, class))
+	schemaGetter.schema = schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+	index := repo.GetIndex(schema.ClassName(className))
+	require.NotNil(t, index)
+
+	// The scan is a no-op unless the threshold is configured.
+	repo.config.ResourceUsage.DiskUse.ReadOnlyPercentage = 90
+
+	return &resourcePressureFixture{
+		repo: repo, migrator: migrator, index: index, class: class, className: className,
+	}
+}
+
+// coldShard returns the fixture's single shard, asserting it has not been
+// loaded yet.
+func (f *resourcePressureFixture) coldShard(t *testing.T) *LazyLoadShard {
+	t.Helper()
+	var cold *LazyLoadShard
+	f.index.shards.Range(func(name string, shard ShardLike) error {
+		lazyShard, ok := shard.(*LazyLoadShard)
+		require.True(t, ok, "shard %q should be a LazyLoadShard", name)
+		require.False(t, lazyShard.isLoaded(), "shard %q should start cold", name)
+		cold = lazyShard
+		return nil
+	})
+	require.NotNil(t, cold)
+	return cold
+}
+
+// A shard that loads while the resource scan holds the DB read-only must come
+// up READONLY. The scan sweeps loaded shards only, so without inheritance a
+// cold shard would come up READY and take the very writes the scan is stopping.
+func TestLazyLoadShard_InheritsResourcePressureOnLoad(t *testing.T) {
+	tests := []struct {
+		name         string
+		du           diskUse
+		wantStatus   storagestate.Status
+		wantReason   string
+		wantReadOnly bool
+	}{
+		{
+			name:         "disk over readonly threshold at load time",
+			du:           diskUse{total: 100, free: 5, avail: 5},
+			wantStatus:   storagestate.StatusReadOnly,
+			wantReason:   statusReasonResourcePressure,
+			wantReadOnly: true,
+		},
+		{
+			name:       "disk below readonly threshold at load time",
+			du:         diskUse{total: 100, free: 50, avail: 50},
+			wantStatus: storagestate.StatusReady,
+			wantReason: statusReasonNotifyReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testCtx()
+			f := newResourcePressureFixture(t)
+			cold := f.coldShard(t)
+
+			f.repo.diskUseReadonly(tt.du)
+			require.NoError(t, cold.Load(ctx))
+
+			assert.Equal(t, tt.wantStatus, cold.GetStatus())
+			assert.Equal(t, tt.wantReason, cold.GetStatusReason())
+
+			err := cold.PutObject(ctx, testObject(f.className))
+			if tt.wantReadOnly {
+				require.ErrorContains(t, err, "store is read-only",
+					"a shard loaded under resource pressure must reject writes")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// A tenant created while the resource scan holds the DB read-only must not come
+// up writable either. The scan only ever sweeps the shards that exist when it
+// runs, so a tenant added afterwards learns about the pressure when its shard is
+// built - cold with lazy loading on (the default), eagerly with it off.
+func TestNewTenant_InheritsResourcePressure(t *testing.T) {
+	tests := []struct {
+		name                 string
+		lazyLoadShards       bool
+		wantStatusOnCreation storagestate.Status
+	}{
+		{
+			name:                 "lazy load shards",
+			lazyLoadShards:       true,
+			wantStatusOnCreation: storagestate.StatusLazyLoading,
+		},
+		{
+			name:                 "eager shard creation",
+			lazyLoadShards:       false,
+			wantStatusOnCreation: storagestate.StatusReadOnly,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testCtx()
+			f := newResourcePressureFixture(t)
+			f.index.Config.EnableLazyLoadShards = tt.lazyLoadShards
+
+			// 95% disk usage, threshold is 90%
+			f.repo.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+
+			const tenant = "tenant_added_under_pressure"
+			require.NoError(t, f.migrator.NewTenants(ctx, f.class, []*schemaUC.CreateTenantPayload{
+				{Name: tenant, Status: models.TenantActivityStatusHOT},
+			}))
+
+			shard := f.index.shards.Load(tenant)
+			require.NotNil(t, shard)
+			assert.Equal(t, tt.wantStatusOnCreation, shard.GetStatus())
+
+			// A cold shard loads on the write, and must be read-only by the time
+			// the write reaches the shard.
+			require.ErrorContains(t, shard.PutObject(ctx, testObject(f.className)), "store is read-only",
+				"a tenant created under resource pressure must not take writes")
+			assert.Equal(t, storagestate.StatusReadOnly, shard.GetStatus())
+			assert.Equal(t, statusReasonResourcePressure, shard.GetStatusReason())
+		})
+	}
+}
+
+// The status a shard inherits when it is built must carry the reason the
+// recovery sweep looks for, or the shard would stay READONLY after the pressure
+// clears.
+func TestLazyLoadShard_InheritedReadOnlyRecovers(t *testing.T) {
+	ctx := testCtx()
+	f := newResourcePressureFixture(t)
+	cold := f.coldShard(t)
+
+	f.repo.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+	require.NoError(t, cold.Load(ctx))
+	require.Equal(t, storagestate.StatusReadOnly, cold.GetStatus())
+
+	mon := newTestMemMonitor(0, 100)
+	f.repo.resourceUseRecovery(mon, diskUse{total: 100, free: 50, avail: 50})
+
+	assert.False(t, f.repo.resourceScanState.isReadOnly.Load())
+	assert.Equal(t, storagestate.StatusReady, cold.GetStatus())
+	require.NoError(t, cold.PutObject(ctx, testObject(f.className)),
+		"a shard recovered from resource pressure must take writes again")
+}
+
+// A shard loading after the pressure cleared must come up READY: the scan drops
+// its flag before the recovery sweep, so a shard that loads at any point around
+// that sweep is either flipped by it or never marked in the first place.
+func TestLazyLoadShard_NoInheritanceAfterRecovery(t *testing.T) {
+	ctx := testCtx()
+	f := newResourcePressureFixture(t)
+	cold := f.coldShard(t)
+
+	f.repo.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+	mon := newTestMemMonitor(0, 100)
+	f.repo.resourceUseRecovery(mon, diskUse{total: 100, free: 50, avail: 50})
+
+	require.NoError(t, cold.Load(ctx))
+
+	assert.Equal(t, storagestate.StatusReady, cold.GetStatus())
+	require.NoError(t, cold.PutObject(ctx, testObject(f.className)))
+}

--- a/adapters/repos/db/resource_use_shard_init_test.go
+++ b/adapters/repos/db/resource_use_shard_init_test.go
@@ -13,11 +13,19 @@ package db
 
 import (
 	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
@@ -27,11 +35,12 @@ import (
 // resourcePressureFixture is a lazy-load repo with one cold shard, wired so the
 // resource scan can be driven by hand through the real disk-usage path.
 type resourcePressureFixture struct {
-	repo      *DB
-	migrator  *Migrator
-	index     *Index
-	class     *models.Class
-	className string
+	repo         *DB
+	migrator     *Migrator
+	schemaGetter *fakeSchemaGetter
+	index        *Index
+	class        *models.Class
+	className    string
 }
 
 func newResourcePressureFixture(t *testing.T) *resourcePressureFixture {
@@ -53,7 +62,8 @@ func newResourcePressureFixture(t *testing.T) *resourcePressureFixture {
 	repo.config.ResourceUsage.DiskUse.ReadOnlyPercentage = 90
 
 	return &resourcePressureFixture{
-		repo: repo, migrator: migrator, index: index, class: class, className: className,
+		repo: repo, migrator: migrator, schemaGetter: schemaGetter,
+		index: index, class: class, className: className,
 	}
 }
 
@@ -191,6 +201,316 @@ func TestLazyLoadShard_InheritedReadOnlyRecovers(t *testing.T) {
 	assert.Equal(t, storagestate.StatusReady, cold.GetStatus())
 	require.NoError(t, cold.PutObject(ctx, testObject(f.className)),
 		"a shard recovered from resource pressure must take writes again")
+}
+
+// testResourcePressureIndex returns a DB holding one empty index that knows its
+// owning DB, i.e. an index that has already been published.
+func testResourcePressureIndex(t *testing.T, readOnly bool) (*DB, *Index) {
+	t.Helper()
+	db := testResourceDB(t, 90, 0, nil)
+	index := db.indices["TestIndex"]
+	index.db = db
+	db.resourceScanState.isReadOnly.Store(readOnly)
+	return db, index
+}
+
+// An eagerly built shard reads the read-only flag before it reaches the shard
+// map, so a transition in between reaches it through neither path: the sweep
+// cannot see a shard that is not published yet, and neither sweep runs a second
+// time within the same pressure episode. It has to settle when it is published.
+func TestPublishShard_ReconcilesAgainstPressureTransition(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusAtBuild  ShardStatus
+		readOnlyAtPush bool
+		noOwningDB     bool
+		wantStatus     storagestate.Status
+		wantReason     string
+	}{
+		{
+			name:           "built before pressure, published after",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady},
+			readOnlyAtPush: true,
+			wantStatus:     storagestate.StatusReadOnly,
+			wantReason:     statusReasonResourcePressure,
+		},
+		{
+			name:           "built under pressure, published after recovery",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure},
+			readOnlyAtPush: false,
+			wantStatus:     storagestate.StatusReady,
+			wantReason:     statusReasonResourceRecovery,
+		},
+		{
+			name:           "built and published under pressure",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure},
+			readOnlyAtPush: true,
+			wantStatus:     storagestate.StatusReadOnly,
+			wantReason:     statusReasonResourcePressure,
+		},
+		{
+			name:           "built and published without pressure",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady},
+			readOnlyAtPush: false,
+			wantStatus:     storagestate.StatusReady,
+			wantReason:     statusReasonNotifyReady,
+		},
+		{
+			name:           "read-only for a vector index update is not recovered",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate},
+			readOnlyAtPush: false,
+			wantStatus:     storagestate.StatusReadOnly,
+			wantReason:     statusReasonVectorIndexUpdate,
+		},
+		{
+			name:           "read-only for a vector index update keeps its reason under pressure",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate},
+			readOnlyAtPush: true,
+			wantStatus:     storagestate.StatusReadOnly,
+			wantReason:     statusReasonVectorIndexUpdate,
+		},
+		{
+			name:           "index without an owning DB leaves the shard alone",
+			statusAtBuild:  ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady},
+			readOnlyAtPush: true,
+			noOwningDB:     true,
+			wantStatus:     storagestate.StatusReady,
+			wantReason:     statusReasonNotifyReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, index := testResourcePressureIndex(t, tt.readOnlyAtPush)
+			if tt.noOwningDB {
+				index.db = nil
+			}
+			shard, status, mu := newStatefulShardMock(t, tt.statusAtBuild)
+
+			index.publishShard("shard1", shard)
+
+			require.NotNil(t, index.shards.Load("shard1"), "the shard must be published")
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tt.wantStatus, status.Status)
+			assert.Equal(t, tt.wantReason, status.Reason)
+		})
+	}
+}
+
+// A shard whose store closes while it is being published takes no writes
+// either way, so the reconcile is routine there. Anything else is a real
+// failure that must be logged - and either way the shard stays published and
+// the publish path stays on its feet.
+func TestPublishShard_ReconcileFailure(t *testing.T) {
+	tests := []struct {
+		name           string
+		shardErr       error
+		wantErrorLevel bool
+	}{
+		{
+			name:     "store closed concurrently",
+			shardErr: fmt.Errorf("%w: updating buckets state in store %q", lsmkv.ErrAlreadyClosed, "/data/shard"),
+		},
+		{
+			name:           "unexpected error",
+			shardErr:       fmt.Errorf("disk I/O error"),
+			wantErrorLevel: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, index := testResourcePressureIndex(t, true)
+			hook := test.NewLocal(db.logger.(*logrus.Logger))
+
+			shard := NewMockShardLike(t)
+			shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+			shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(tt.shardErr)
+
+			assert.NotPanics(t, func() { index.publishShard("shard1", shard) })
+
+			require.NotNil(t, index.shards.Load("shard1"), "the shard must stay published")
+			errLine := firstErrorEntry(hook)
+			if tt.wantErrorLevel {
+				require.NotNil(t, errLine, "an unexpected error must be logged")
+				assert.Contains(t, errLine.Message, "shard1")
+			} else {
+				assert.Nil(t, errLine, "a shard closing concurrently is routine, not an error")
+			}
+		})
+	}
+}
+
+// Publishing a cold shard must not reconcile it: a status change would force it
+// to load, costing the very memory the scan may be reacting to. It reads the
+// flag itself when it loads.
+func TestPublishShard_LeavesColdShardUnloaded(t *testing.T) {
+	_, index := testResourcePressureIndex(t, true)
+	cold := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
+
+	assert.NotPanics(t, func() { index.publishShard("cold_shard", cold) })
+
+	assert.False(t, cold.isLoaded(), "publishing a cold shard must not load it")
+}
+
+// Shards built inside NewIndex are out of the scan's reach, so they settle when
+// the index is published - however many of them there are, and whether or not
+// some of them are still cold.
+func TestReconcileIndexResourcePressure_ShardCounts(t *testing.T) {
+	tests := []struct {
+		name        string
+		loadedCount int
+	}{
+		{name: "no loaded shards", loadedCount: 0},
+		{name: "one loaded shard", loadedCount: 1},
+		{name: "several loaded shards", loadedCount: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, index := testResourcePressureIndex(t, true)
+
+			statuses := make([]*ShardStatus, 0, tt.loadedCount)
+			locks := make([]*sync.Mutex, 0, tt.loadedCount)
+			for n := range tt.loadedCount {
+				shard, status, mu := newStatefulShardMock(t,
+					ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady})
+				index.shards.Store(fmt.Sprintf("loaded_shard_%d", n), shard)
+				statuses = append(statuses, status)
+				locks = append(locks, mu)
+			}
+			cold := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
+			index.shards.Store("cold_shard", cold)
+
+			db.reconcileIndexResourcePressure(index)
+
+			for n, status := range statuses {
+				locks[n].Lock()
+				assert.Equal(t, storagestate.StatusReadOnly, status.Status)
+				assert.Equal(t, statusReasonResourcePressure, status.Reason)
+				locks[n].Unlock()
+			}
+			assert.False(t, cold.isLoaded(), "a cold shard must not be loaded when its index is published")
+		})
+	}
+}
+
+// The flag must not flip while a shard settles against it: the shard would
+// apply the value it read before the flip, and the sweep following the flip has
+// already walked the shard map.
+func TestReconcileShardResourcePressure_HoldsOffFlagFlip(t *testing.T) {
+	db, index := testResourcePressureIndex(t, true)
+
+	settling := make(chan struct{})
+	release := make(chan struct{})
+	var flagDuringSettle atomic.Bool
+
+	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).RunAndReturn(func(string) error {
+		close(settling)
+		<-release
+		flagDuringSettle.Store(db.resourceScanState.isReadOnly.Load())
+		return nil
+	})
+
+	published := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		index.publishShard("shard1", shard)
+		close(published)
+	}, db.logger)
+	<-settling
+
+	flipped := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		db.setReadOnlyFlag(false)
+		close(flipped)
+	}, db.logger)
+
+	select {
+	case <-flipped:
+		require.Fail(t, "the read-only flag flipped while a shard was settling against it")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	<-published
+	<-flipped
+
+	assert.True(t, flagDuringSettle.Load(),
+		"a settling shard must see one flag value for the whole transition")
+}
+
+// The eager publish path must reconcile the shard it publishes against the
+// flag, not just hand it to the shard map. Holding the transition lock stalls
+// the reconcile, opening the window a real transition would land in.
+func TestLoadLocalShard_ReconcilesAfterPublishing(t *testing.T) {
+	ctx := testCtx()
+	f := newResourcePressureFixture(t)
+
+	// 95% disk usage, threshold is 90%
+	f.repo.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+
+	const shardName = "shard_published_across_recovery"
+	published := make(chan error, 1)
+	f.repo.resourceScanState.transition.Lock()
+	enterrors.GoWrapper(func() {
+		published <- f.index.LoadLocalShard(ctx, shardName, false)
+	}, f.repo.logger)
+
+	// publishShard reaches the shard map before it reconciles, so the shard is
+	// now built and READONLY, waiting to reconcile.
+	require.Eventually(t, func() bool { return f.index.shards.Load(shardName) != nil },
+		10*time.Second, time.Millisecond, "the shard was never published")
+
+	// The pressure clears while the shard sits in that window, i.e. at the point
+	// a recovery sweep would already have walked past it.
+	f.repo.resourceScanState.isReadOnly.Store(false)
+	f.repo.resourceScanState.transition.Unlock()
+	require.NoError(t, <-published)
+
+	shard := f.index.shards.Load(shardName)
+	require.NotNil(t, shard)
+	assert.Equal(t, storagestate.StatusReady, shard.GetStatus())
+	assert.Equal(t, statusReasonResourceRecovery, shard.GetStatusReason())
+	require.NoError(t, shard.PutObject(ctx, testObject(f.className)),
+		"a shard published after the pressure cleared must take writes")
+}
+
+// A collection created while the scan holds the DB read-only must not come up
+// writable. Its shards are built inside NewIndex, where the sweep cannot reach
+// them - the index is not in db.indices yet - so they reconcile when it is.
+func TestNewCollection_InheritsResourcePressure(t *testing.T) {
+	ctx := testCtx()
+	f := newResourcePressureFixture(t)
+
+	// Eager shards, the default for a collection without multi-tenancy.
+	f.repo.config.EnableLazyLoadShards = boolPtr(false)
+
+	// 95% disk usage, threshold is 90%
+	f.repo.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+
+	const className = "CollectionAddedUnderPressure"
+	class := newClassWithWarmProp(className)
+	require.NoError(t, f.migrator.AddClass(ctx, class))
+	f.schemaGetter.schema = schema.Schema{Objects: &models.Schema{
+		Classes: []*models.Class{f.class, class},
+	}}
+
+	index := f.repo.GetIndex(schema.ClassName(className))
+	require.NotNil(t, index)
+
+	eagerShards := 0
+	require.NoError(t, index.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		eagerShards++
+		assert.Equal(t, storagestate.StatusReadOnly, shard.GetStatus())
+		assert.Equal(t, statusReasonResourcePressure, shard.GetStatusReason())
+		require.ErrorContains(t, shard.PutObject(ctx, testObject(className)), "store is read-only",
+			"a collection created under resource pressure must not take writes")
+		return nil
+	}))
+	require.Positive(t, eagerShards, "the collection must have brought up at least one eager shard")
 }
 
 // A shard loading after the pressure cleared must come up READY: the scan drops

--- a/adapters/repos/db/resource_use_shard_init_test.go
+++ b/adapters/repos/db/resource_use_shard_init_test.go
@@ -513,6 +513,49 @@ func TestNewCollection_InheritsResourcePressure(t *testing.T) {
 	require.Positive(t, eagerShards, "the collection must have brought up at least one eager shard")
 }
 
+// The shards of a new collection must read the flag inside NewIndex, not only
+// when AddClass settles them afterwards: NewIndex both builds and publishes
+// them, so between the two a lazy load has no index of its own to consult.
+// Stalling the reconcile takes it out of the picture, leaving NewIndex as the
+// only thing that can have held the shard read-only.
+func TestNewCollection_InheritsResourcePressureBeforeReconcile(t *testing.T) {
+	ctx := testCtx()
+	f := newResourcePressureFixture(t)
+
+	// Eager shards, the default for a collection without multi-tenancy.
+	f.repo.config.EnableLazyLoadShards = boolPtr(false)
+
+	// 95% disk usage, threshold is 90%
+	f.repo.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+
+	const className = "CollectionBuiltUnderPressure"
+	class := newClassWithWarmProp(className)
+
+	added := make(chan error, 1)
+	f.repo.resourceScanState.transition.Lock()
+	enterrors.GoWrapper(func() { added <- f.migrator.AddClass(ctx, class) }, f.repo.logger)
+
+	// AddClass publishes the index before it reconciles, so the index is now
+	// visible with its shards built, waiting on the stalled reconcile.
+	var index *Index
+	require.Eventually(t, func() bool {
+		index = f.repo.GetIndex(schema.ClassName(className))
+		return index != nil
+	}, 10*time.Second, time.Millisecond, "the index was never published")
+
+	eagerShards := 0
+	require.NoError(t, index.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		eagerShards++
+		assert.Equal(t, storagestate.StatusReadOnly, shard.GetStatus())
+		assert.Equal(t, statusReasonResourcePressure, shard.GetStatusReason())
+		return nil
+	}))
+	require.Positive(t, eagerShards, "the collection must have brought up at least one eager shard")
+
+	f.repo.resourceScanState.transition.Unlock()
+	require.NoError(t, <-added)
+}
+
 // A shard loading after the pressure cleared must come up READY: the scan drops
 // its flag before the recovery sweep, so a shard that loads at any point around
 // that sweep is either flipped by it or never marked in the first place.

--- a/adapters/repos/db/resource_use_test.go
+++ b/adapters/repos/db/resource_use_test.go
@@ -585,6 +585,33 @@ func TestSetShardsReady_ClosedStoreDoesNotBlockRecovery(t *testing.T) {
 	assert.Nil(t, firstErrorEntry(hook), "a shard closing concurrently is routine, not an error")
 }
 
+// The recovery sweep must skip cold shards for the same reason the read-only
+// sweep does: a cold shard has no resource-pressure status to release, and
+// force-loading one spends the memory this pass is recovering from. It must
+// also not count as a failed transition, which would put the DB straight back
+// into read-only.
+func TestSetShardsReady_SkipsUnloadedShard(t *testing.T) {
+	coldShard := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
+
+	loadedShard := NewMockShardLike(t)
+	loadedShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
+	loadedShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
+	loadedShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+
+	db := testResourceDBWithShards(t, 90, 90, map[string]ShardLike{
+		"cold_shard":   coldShard,
+		"loaded_shard": loadedShard,
+	})
+	db.resourceScanState.isReadOnly.Store(true)
+
+	assert.NotPanics(t, func() { db.setShardsReady() })
+
+	assert.False(t, coldShard.isLoaded(), "a cold shard must not be loaded by the recovery sweep")
+	loadedShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.False(t, db.resourceScanState.isReadOnly.Load(),
+		"a skipped cold shard must not count as a failed transition")
+}
+
 func TestReadonlyRecoveryCycle(t *testing.T) {
 	// This test simulates the full cycle:
 	// 1. Usage goes over threshold → shards become READONLY

--- a/adapters/repos/db/resource_use_test.go
+++ b/adapters/repos/db/resource_use_test.go
@@ -19,10 +19,13 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -42,6 +45,17 @@ func newTestMemMonitor(usedMemory, limit int64) *memwatch.Monitor {
 // testResourceDB creates a minimal DB with one index containing the given mock shards.
 // The DB is configured with the given disk and memory readonly thresholds.
 func testResourceDB(t *testing.T, diskROPercent, memROPercent uint64, shards map[string]*MockShardLike) *DB {
+	t.Helper()
+	asShardLike := make(map[string]ShardLike, len(shards))
+	for name, shard := range shards {
+		asShardLike[name] = shard
+	}
+	return testResourceDBWithShards(t, diskROPercent, memROPercent, asShardLike)
+}
+
+// testResourceDBWithShards is testResourceDB for shards that are not mocks, e.g.
+// a LazyLoadShard.
+func testResourceDBWithShards(t *testing.T, diskROPercent, memROPercent uint64, shards map[string]ShardLike) *DB {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 
@@ -123,7 +137,7 @@ func TestDiskUseReadonly_OverThreshold(t *testing.T) {
 	du := diskUse{total: 100, free: 5, avail: 5}
 	db.diskUseReadonly(du)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should be true after exceeding disk threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be true after exceeding disk threshold")
 	shard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
 }
 
@@ -138,7 +152,7 @@ func TestMemUseReadonly_OverThreshold(t *testing.T) {
 	mon := newTestMemMonitor(95, 100)
 	db.memUseReadonly(mon)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should be true after exceeding memory threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be true after exceeding memory threshold")
 	shard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
 }
 
@@ -156,7 +170,7 @@ func TestResourceUseReadonly_BothOverThreshold(t *testing.T) {
 	mon := newTestMemMonitor(95, 100)
 	db.resourceUseReadonly(mon, du)
 
-	assert.True(t, db.resourceScanState.isReadOnly)
+	assert.True(t, db.resourceScanState.isReadOnly.Load())
 }
 
 func TestDiskUseReadonly_UnderThreshold(t *testing.T) {
@@ -168,7 +182,7 @@ func TestDiskUseReadonly_UnderThreshold(t *testing.T) {
 	du := diskUse{total: 100, free: 15, avail: 15}
 	db.diskUseReadonly(du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "isReadOnly should remain false when under threshold")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain false when under threshold")
 	shard.AssertNotCalled(t, "SetStatusReadonly", mock.Anything)
 }
 
@@ -180,8 +194,132 @@ func TestDiskUseReadonly_ThresholdDisabled(t *testing.T) {
 	du := diskUse{total: 100, free: 5, avail: 5}
 	db.diskUseReadonly(du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "isReadOnly should remain false when threshold is disabled")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain false when threshold is disabled")
 	shard.AssertNotCalled(t, "SetStatusReadonly", mock.Anything)
+}
+
+// A shard that fails to go READONLY must not take the process down, and must not
+// stop the scan from marking the remaining shards.
+func TestSetShardsReadOnly_ShardError(t *testing.T) {
+	tests := []struct {
+		name           string
+		shardErr       error
+		wantErrorLevel bool
+	}{
+		{
+			name:     "store closed concurrently",
+			shardErr: fmt.Errorf("%w: updating buckets state in store %q", lsmkv.ErrAlreadyClosed, "/data/shard"),
+		},
+		{
+			name:           "unexpected error",
+			shardErr:       fmt.Errorf("disk I/O error"),
+			wantErrorLevel: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failingShard := NewMockShardLike(t)
+			failingShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+			failingShard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(tt.shardErr)
+
+			healthyShard := NewMockShardLike(t)
+			healthyShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+			healthyShard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
+
+			db := testResourceDB(t, 90, 0, map[string]*MockShardLike{
+				"failing_shard": failingShard,
+				"healthy_shard": healthyShard,
+			})
+			logger := db.logger.(*logrus.Logger)
+			hook := test.NewLocal(logger)
+			exited := false
+			logger.ExitFunc = func(int) { exited = true }
+
+			// 95% disk usage, threshold is 90%
+			db.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+
+			assert.False(t, exited, "a failed shard status update must not exit the process")
+			healthyShard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
+			assert.True(t, db.resourceScanState.isReadOnly.Load())
+
+			errLine := firstErrorEntry(hook)
+			if tt.wantErrorLevel {
+				require.NotNil(t, errLine, "an unexpected error must be logged")
+				assert.Contains(t, errLine.Message, "failing_shard")
+			} else {
+				assert.Nil(t, errLine, "a shard closing concurrently is routine, not an error")
+			}
+		})
+	}
+}
+
+// A panic mid-scan must not leave the DB-wide index lock held: the scan runs in
+// a GoWrapper goroutine that recovers and exits, so a held lock would block
+// every later index operation for the life of the process.
+func TestSetShardsReadOnly_PanicReleasesIndexLock(t *testing.T) {
+	panickingShard := NewMockShardLike(t)
+	panickingShard.EXPECT().GetStatus().RunAndReturn(func() storagestate.Status {
+		panic("shard status read blew up")
+	})
+
+	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"panicking_shard": panickingShard})
+
+	assert.Panics(t, func() {
+		db.setShardsReadOnly(statusReasonResourcePressure)
+	})
+
+	require.True(t, db.indexLock.TryLock(), "index lock must be released when the scan panics")
+	db.indexLock.Unlock()
+}
+
+// The resource scanner must not force-load a cold shard: loading one costs the
+// memory the scan may be reacting to, and a failed load panics out of the scan
+// goroutine, leaving the node without resource protection.
+func TestSetShardsReadOnly_SkipsUnloadedShard(t *testing.T) {
+	coldShard := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
+
+	loadedShard := NewMockShardLike(t)
+	loadedShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+	loadedShard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
+
+	db := testResourceDBWithShards(t, 90, 0, map[string]ShardLike{
+		"cold_shard":   coldShard,
+		"loaded_shard": loadedShard,
+	})
+
+	// 95% disk usage, threshold is 90%
+	assert.NotPanics(t, func() {
+		db.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+	})
+
+	assert.False(t, coldShard.isLoaded(), "a cold shard must not be loaded by the resource scan")
+	loadedShard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
+	assert.True(t, db.resourceScanState.isReadOnly.Load())
+}
+
+// The flag must be raised before the sweep: a shard loading concurrently reads
+// it to decide whether it comes up READONLY, and the sweep can only see shards
+// that finished loading. Raising it after the sweep leaves a window in which a
+// shard is caught by neither.
+func TestSetShardsReadOnly_FlagRaisedBeforeSweep(t *testing.T) {
+	var db *DB
+	var flagDuringSweep atomic.Bool
+
+	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).RunAndReturn(func(string) error {
+		flagDuringSweep.Store(db.resourceScanState.isReadOnly.Load())
+		return nil
+	})
+
+	db = testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
+
+	// 95% disk usage, threshold is 90%
+	db.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
+
+	assert.True(t, flagDuringSweep.Load(),
+		"a shard loading while the sweep runs must already see the read-only flag")
 }
 
 func TestResourceUseRecovery_BothBelowThreshold(t *testing.T) {
@@ -191,7 +329,7 @@ func TestResourceUseRecovery_BothBelowThreshold(t *testing.T) {
 	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
 
 	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	// 50% disk and 50% memory, both below 90% threshold
 	du := diskUse{total: 100, free: 50, avail: 50}
@@ -199,7 +337,7 @@ func TestResourceUseRecovery_BothBelowThreshold(t *testing.T) {
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "isReadOnly should be false after recovery")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be false after recovery")
 	shard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 }
 
@@ -208,7 +346,7 @@ func TestResourceUseRecovery_DiskRecoveredMemoryStillOver(t *testing.T) {
 	// No status changes expected since memory is still above threshold
 
 	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	// 50% disk (below 90%), 95% memory (above 90%)
 	du := diskUse{total: 100, free: 50, avail: 50}
@@ -216,7 +354,7 @@ func TestResourceUseRecovery_DiskRecoveredMemoryStillOver(t *testing.T) {
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should remain true when memory is still over threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when memory is still over threshold")
 	shard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
 }
 
@@ -225,7 +363,7 @@ func TestResourceUseRecovery_MemoryRecoveredDiskStillOver(t *testing.T) {
 	// No status changes expected since disk is still above threshold
 
 	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	// 95% disk (above 90%), 50% memory (below 90%)
 	du := diskUse{total: 100, free: 5, avail: 5}
@@ -233,7 +371,7 @@ func TestResourceUseRecovery_MemoryRecoveredDiskStillOver(t *testing.T) {
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should remain true when disk is still over threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when disk is still over threshold")
 	shard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
 }
 
@@ -241,7 +379,7 @@ func TestResourceUseRecovery_BothStillOverThreshold(t *testing.T) {
 	shard := NewMockShardLike(t)
 
 	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	// 95% disk and 95% memory, both above 90% threshold
 	du := diskUse{total: 100, free: 5, avail: 5}
@@ -249,7 +387,7 @@ func TestResourceUseRecovery_BothStillOverThreshold(t *testing.T) {
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should remain true when both are over threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when both are over threshold")
 	shard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
 }
 
@@ -261,14 +399,14 @@ func TestResourceUseRecovery_ThresholdsDisabled(t *testing.T) {
 
 	// Both thresholds disabled (0), but isReadOnly was set somehow
 	db := testResourceDB(t, 0, 0, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	du := diskUse{total: 100, free: 5, avail: 5}
 	mon := newTestMemMonitor(95, 100)
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "isReadOnly should be false when thresholds are disabled")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be false when thresholds are disabled")
 }
 
 func TestResourceUseRecovery_OnlyDiskThresholdEnabled_BelowThreshold(t *testing.T) {
@@ -279,7 +417,7 @@ func TestResourceUseRecovery_OnlyDiskThresholdEnabled_BelowThreshold(t *testing.
 
 	// Only disk threshold enabled, memory disabled
 	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	// 50% disk (below threshold), memory high but threshold disabled
 	du := diskUse{total: 100, free: 50, avail: 50}
@@ -287,7 +425,7 @@ func TestResourceUseRecovery_OnlyDiskThresholdEnabled_BelowThreshold(t *testing.
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "should recover when only enabled threshold is below limit")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "should recover when only enabled threshold is below limit")
 }
 
 func TestResourceUseRecovery_OnlyMemThresholdEnabled_BelowThreshold(t *testing.T) {
@@ -298,7 +436,7 @@ func TestResourceUseRecovery_OnlyMemThresholdEnabled_BelowThreshold(t *testing.T
 
 	// Only memory threshold enabled, disk disabled
 	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	// Disk high but threshold disabled, 50% memory (below threshold)
 	du := diskUse{total: 100, free: 5, avail: 5}
@@ -306,7 +444,7 @@ func TestResourceUseRecovery_OnlyMemThresholdEnabled_BelowThreshold(t *testing.T
 
 	db.resourceUseRecovery(mon, du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "should recover when only enabled threshold is below limit")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "should recover when only enabled threshold is below limit")
 }
 
 func TestSetShardsReady_OnlyRecoverReadOnlyShards(t *testing.T) {
@@ -323,13 +461,60 @@ func TestSetShardsReady_OnlyRecoverReadOnlyShards(t *testing.T) {
 		"readonly_shard": readonlyShard,
 		"ready_shard":    readyShard,
 	})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
 
-	assert.False(t, db.resourceScanState.isReadOnly)
+	assert.False(t, db.resourceScanState.isReadOnly.Load())
 	readonlyShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 	readyShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
+}
+
+// The flag must be dropped before the sweep: a shard loading concurrently
+// would otherwise inherit READONLY after the sweep already passed it, and
+// nothing would flip it back - the recovery pass only runs while the flag is
+// set.
+func TestSetShardsReady_FlagDroppedBeforeSweep(t *testing.T) {
+	var db *DB
+	var flagDuringSweep atomic.Bool
+
+	shard := NewMockShardLike(t)
+	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
+	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
+	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).
+		RunAndReturn(func(status, reason string) error {
+			flagDuringSweep.Store(db.resourceScanState.isReadOnly.Load())
+			return nil
+		})
+
+	db = testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db.resourceScanState.isReadOnly.Store(true)
+
+	db.setShardsReady()
+
+	assert.False(t, flagDuringSweep.Load(),
+		"a shard loading while the recovery sweep runs must no longer see the read-only flag")
+}
+
+// A shard whose store closed concurrently (tenant deletion, deactivation,
+// shutdown) must not hold the whole DB in read-only mode: it takes no writes
+// either way, and comes back READY the next time it is loaded.
+func TestSetShardsReady_ClosedStoreDoesNotBlockRecovery(t *testing.T) {
+	closingShard := NewMockShardLike(t)
+	closingShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
+	closingShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
+	closingShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).
+		Return(fmt.Errorf("%w: updating buckets state in store %q", lsmkv.ErrAlreadyClosed, "/data/shard"))
+
+	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"closing_shard": closingShard})
+	db.resourceScanState.isReadOnly.Store(true)
+	hook := test.NewLocal(db.logger.(*logrus.Logger))
+
+	db.setShardsReady()
+
+	assert.False(t, db.resourceScanState.isReadOnly.Load(),
+		"a shard closing concurrently must not keep the DB read-only")
+	assert.Nil(t, firstErrorEntry(hook), "a shard closing concurrently is routine, not an error")
 }
 
 func TestReadonlyRecoveryCycle(t *testing.T) {
@@ -349,7 +534,7 @@ func TestReadonlyRecoveryCycle(t *testing.T) {
 	mon := newTestMemMonitor(0, 100)
 	db.resourceUseReadonly(mon, du)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "should be readonly after exceeding threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "should be readonly after exceeding threshold")
 	mu.Lock()
 	assert.Equal(t, storagestate.StatusReadOnly, status.Status)
 	assert.Equal(t, statusReasonResourcePressure, status.Reason)
@@ -359,7 +544,7 @@ func TestReadonlyRecoveryCycle(t *testing.T) {
 	du = diskUse{total: 100, free: 50, avail: 50}
 	db.resourceUseRecovery(mon, du)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "should recover after usage drops below threshold")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "should recover after usage drops below threshold")
 	mu.Lock()
 	assert.Equal(t, storagestate.StatusReady, status.Status)
 	mu.Unlock()
@@ -368,7 +553,7 @@ func TestReadonlyRecoveryCycle(t *testing.T) {
 	du = diskUse{total: 100, free: 5, avail: 5}
 	db.resourceUseReadonly(mon, du)
 
-	assert.True(t, db.resourceScanState.isReadOnly, "should be readonly again after re-exceeding threshold")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "should be readonly again after re-exceeding threshold")
 	mu.Lock()
 	assert.Equal(t, storagestate.StatusReadOnly, status.Status)
 	mu.Unlock()
@@ -415,11 +600,11 @@ func TestSetShardsReady_MultipleIndices(t *testing.T) {
 			"Index2": idx2,
 		},
 	}
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
 
-	assert.False(t, db.resourceScanState.isReadOnly)
+	assert.False(t, db.resourceScanState.isReadOnly.Load())
 	shard1.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 	shard2.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 }
@@ -442,11 +627,11 @@ func TestSetShardsReady_SkipsNonResourcePressureReadonly(t *testing.T) {
 		"config_update_shard":     configUpdateShard,
 		"resource_pressure_shard": resourcePressureShard,
 	})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
 
-	assert.False(t, db.resourceScanState.isReadOnly)
+	assert.False(t, db.resourceScanState.isReadOnly.Load())
 	configUpdateShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
 	resourcePressureShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 }
@@ -483,11 +668,11 @@ func TestSetShardsReady_SkipsUserInitiatedReadonly(t *testing.T) {
 	// UpdateStatus should NOT be called
 
 	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"user_shard": userShard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
 
-	assert.False(t, db.resourceScanState.isReadOnly)
+	assert.False(t, db.resourceScanState.isReadOnly.Load())
 	userShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
 }
 
@@ -506,11 +691,11 @@ func TestSetShardsReady_PartialFailure(t *testing.T) {
 		"success_shard": successShard,
 		"failing_shard": failingShard,
 	})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
 
-	assert.True(t, db.resourceScanState.isReadOnly, "isReadOnly should remain true when some shards fail to transition")
+	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when some shards fail to transition")
 	successShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 	failingShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 }
@@ -528,11 +713,11 @@ func TestScanResourceUsageOnce_SeesMemoryDropWhileReadOnly(t *testing.T) {
 	mon := memwatch.NewMonitor(used.Load, func(int64) int64 { return 100 }, 1.0)
 
 	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
-	db.resourceScanState.isReadOnly = true
+	db.resourceScanState.isReadOnly.Store(true)
 
 	used.Store(10)
 	db.scanResourceUsageOnce(mon, diskUse{total: 100, free: 100, avail: 100}, false)
 
-	assert.False(t, db.resourceScanState.isReadOnly, "isReadOnly should lift once memory drops")
+	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should lift once memory drops")
 	shard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
 }

--- a/adapters/repos/db/resource_use_test.go
+++ b/adapters/repos/db/resource_use_test.go
@@ -254,6 +254,74 @@ func TestSetShardsReadOnly_ShardError(t *testing.T) {
 	}
 }
 
+// A sweep must not hold the DB-wide index lock while it touches shards.
+// Deciding whether a shard is loaded blocks on that shard's load lock - which
+// is what makes a sweep and a shard building itself mutually exclusive - and a
+// shard load can run for minutes. Every object read and write takes indexLock
+// read side, so holding it across a load would stall the whole node.
+func TestResourceSweep_DoesNotHoldIndexLock(t *testing.T) {
+	tests := []struct {
+		name  string
+		shard func(t *testing.T, probe func()) *MockShardLike
+		sweep func(db *DB)
+	}{
+		{
+			name: "read-only sweep",
+			shard: func(t *testing.T, probe func()) *MockShardLike {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
+				shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).
+					RunAndReturn(func(string) error {
+						probe()
+						return nil
+					})
+				return shard
+			},
+			sweep: func(db *DB) { db.setShardsReadOnly(statusReasonResourcePressure) },
+		},
+		{
+			name: "recovery sweep",
+			shard: func(t *testing.T, probe func()) *MockShardLike {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
+				shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
+				shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).
+					RunAndReturn(func(status, reason string) error {
+						probe()
+						return nil
+					})
+				return shard
+			},
+			sweep: func(db *DB) { db.setShardsReady() },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var db *DB
+			var heldDuringSweep atomic.Bool
+
+			shard := tt.shard(t, func() {
+				// TryRLock fails while any goroutine holds the write side, and a
+				// RWMutex is not reentrant, so this reports the lock either way.
+				if db.indexLock.TryRLock() {
+					db.indexLock.RUnlock()
+					return
+				}
+				heldDuringSweep.Store(true)
+			})
+
+			db = testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+			db.resourceScanState.isReadOnly.Store(true)
+
+			tt.sweep(db)
+
+			assert.False(t, heldDuringSweep.Load(),
+				"the sweep must release indexLock before it touches shards")
+		})
+	}
+}
+
 // A panic mid-scan must not leave the DB-wide index lock held: the scan runs in
 // a GoWrapper goroutine that recovers and exits, so a held lock would block
 // every later index operation for the life of the process.

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -194,6 +194,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		enterrors.GoWrapper(f, s.index.logger)
 	}
 	s.NotifyReady()
+	s.inheritResourcePressureReadOnly()
 
 	if exists {
 		s.index.logger.Printf("Completed loading shard %s in %s", s.ID(), time.Since(start))
@@ -215,6 +216,27 @@ func (s *Shard) cleanupPartialInit(ctx context.Context) {
 	}
 
 	log.Debug("successfully cleaned up partially initialized shard")
+}
+
+// inheritResourcePressureReadOnly marks a freshly built shard READONLY while
+// the resource scan holds the DB read-only. Every shard is built here - loaded
+// lazily, loaded eagerly at startup, created for a new or activated tenant,
+// re-created for a replica - so this is the one place that state can be picked
+// up. Without it a shard that did not exist when the scan swept would come up
+// READY and take the writes the scan is trying to stop.
+//
+// The scan raises its flag before it sweeps, so a shard the sweep cannot see
+// yet (still loading, or not yet in the shard map) reads the raised flag here
+// instead. For a lazily loaded shard the two are mutually exclusive: this runs
+// under the load lock the sweep needs to see the shard as loaded.
+func (s *Shard) inheritResourcePressureReadOnly() {
+	if !s.index.db.resourcePressureReadOnly() {
+		return
+	}
+	if err := s.SetStatusReadonly(statusReasonResourcePressure); err != nil {
+		s.index.logger.WithField("action", "set_shard_read_only").
+			Errorf("failed to set to READONLY on init: shard %q: %v", s.name, err)
+	}
 }
 
 func (s *Shard) NotifyReady() {

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -219,16 +219,14 @@ func (s *Shard) cleanupPartialInit(ctx context.Context) {
 }
 
 // inheritResourcePressureReadOnly marks a freshly built shard READONLY while
-// the resource scan holds the DB read-only. Every shard is built here - loaded
-// lazily, loaded eagerly at startup, created for a new or activated tenant,
-// re-created for a replica - so this is the one place that state can be picked
-// up. Without it a shard that did not exist when the scan swept would come up
-// READY and take the writes the scan is trying to stop.
+// the resource scan holds the DB read-only, so a shard that did not exist when
+// the scan swept does not come up READY and take the writes the scan is trying
+// to stop.
 //
-// The scan raises its flag before it sweeps, so a shard the sweep cannot see
-// yet (still loading, or not yet in the shard map) reads the raised flag here
-// instead. For a lazily loaded shard the two are mutually exclusive: this runs
-// under the load lock the sweep needs to see the shard as loaded.
+// The flag is raised before the sweep, so a lazily loaded shard is caught by
+// exactly one of the two: this runs under the load lock the sweep needs to see
+// the shard as loaded. An eagerly built shard is not in the shard map yet here,
+// and reconciles against the flag when it is published instead.
 func (s *Shard) inheritResourcePressureReadOnly() {
 	if !s.index.db.resourcePressureReadOnly() {
 		return

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -99,7 +99,11 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	)
 	require.NoError(t, err)
 	repo.SetSchemaGetter(schemaGetter)
-	require.NoError(t, repo.WaitForStartup(ctx))
+	// WaitForStartup without the resource scan: the scan ticks twice a second
+	// against the real disk, so it would undo a resource transition a test makes
+	// by hand. Tests that want one drive the scan themselves.
+	require.NoError(t, repo.init(ctx))
+	repo.startupComplete.Store(true)
 
 	return repo, NewMigrator(repo, logger, "node1"), schemaGetter
 }


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/dirk-claude-issues/issues/59

The resource scanner previously would:
- load all lazy shards in case it needs to set ReadOnly (which creates even more memory pressure)
- would not set newly loaded shards (auto tenant activation for examlpe) to ReadOnly

This PR changes readOnly to be a flag on the DB so newly loaded shards can check

The sweep also does not take db.indexLock for the full scan.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
