### PR TITLE
fix: two panics in the re-vectorization comparator on JSON-shaped values

### DIFF
--- a/usecases/modules/compare.go
+++ b/usecases/modules/compare.go
@@ -133,6 +133,29 @@ func renderSourceValue(v any) string {
 	return fmt.Sprintf("%v", v)
 }
 
+// asStringSlice normalizes a text[] value to []string: it can be []any after a JSON/RAFT
+// round-trip, and nil means empty. False means the shape is not a renderable text[].
+func asStringSlice(v any) ([]string, bool) {
+	switch val := v.(type) {
+	case nil:
+		return nil, true
+	case []string:
+		return val, true
+	case []any:
+		out := make([]string, len(val))
+		for i := range val {
+			s, ok := val[i].(string)
+			if !ok {
+				return nil, false
+			}
+			out[i] = s
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
 func reVectorizeEmbeddings[T dto.Embedding](ctx context.Context,
 	cfg moduletools.ClassConfig,
 	mod modulecapabilities.Vectorizer[T],
@@ -277,20 +300,19 @@ func reVectorizeEmbeddings[T dto.Embedding](ctx context.Context,
 		}
 
 		if propStruct.IsArray {
-			// empty strings do not have type information saved with them - the new value can also come from disk if
-			// an update happens
-			if _, ok := valOld.([]any); ok && len(valOld.([]any)) == 0 {
-				valOld = []string{}
-			}
-			if _, ok := valNew.([]any); ok && len(valNew.([]any)) == 0 {
-				valNew = []string{}
-			}
-
-			if len(valOld.([]string)) != len(valNew.([]string)) {
+			// Either side can be []any after a JSON/RAFT round-trip; normalize instead
+			// of asserting []string, which panicked and surfaced as a 500.
+			oldArr, oldOK := asStringSlice(valOld)
+			newArr, newOK := asStringSlice(valNew)
+			if !oldOK || !newOK {
+				// Unknown shape: cannot prove the corpus text unchanged - re-vectorize.
 				return true, nil
 			}
-			for i, val := range valOld.([]string) {
-				if val != valNew.([]string)[i] {
+			if len(oldArr) != len(newArr) {
+				return true, nil
+			}
+			for i, val := range oldArr {
+				if val != newArr[i] {
 					return true, nil
 				}
 			}

--- a/usecases/modules/compare.go
+++ b/usecases/modules/compare.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/additional"
@@ -154,6 +155,39 @@ func asStringSlice(v any) ([]string, bool) {
 	default:
 		return nil, false
 	}
+}
+
+// hasComparableDynamicType reports whether v holds a dynamic type == compares without
+// panicking. The list is a fast path, not the correctness boundary.
+func hasComparableDynamicType(v any) bool {
+	switch v.(type) {
+	case nil, string, bool, int, int32, int64, float32, float64, json.Number, time.Time:
+		return true
+	default:
+		return false
+	}
+}
+
+// sourceValuesEqual compares scalar values without the panic a bare == raises when both
+// interfaces hold the same uncomparable type (slice/map), as object/object[] media
+// properties reaching this branch can. Tiers: type-switch fast path, reflect only when
+// both sides are slice/map-shaped, same-type uncomparable pairs by renderSourceValue key.
+func sourceValuesEqual(a, b any) bool {
+	if hasComparableDynamicType(a) || hasComparableDynamicType(b) {
+		// At least one dynamic type is comparable, so the two are either identical and
+		// comparable or simply different types: == cannot panic either way.
+		return a == b
+	}
+	// Both sides are uncomparable-suspect; == panics only when the dynamic types are
+	// identical and uncomparable, so establish that first.
+	ta, tb := reflect.TypeOf(a), reflect.TypeOf(b)
+	if ta != tb {
+		return false
+	}
+	if ta.Comparable() {
+		return a == b
+	}
+	return renderSourceValue(a) == renderSourceValue(b)
 }
 
 func reVectorizeEmbeddings[T dto.Embedding](ctx context.Context,
@@ -327,7 +361,7 @@ func reVectorizeEmbeddings[T dto.Embedding](ctx context.Context,
 					}
 				}
 			}
-			if valOld != valNew {
+			if !sourceValuesEqual(valOld, valNew) {
 				return true, nil
 			}
 		}

--- a/usecases/modules/compare_test.go
+++ b/usecases/modules/compare_test.go
@@ -430,3 +430,135 @@ func TestCompareRevectorize_TextArrayAnyForms(t *testing.T) {
 		runSourcePropCases(t, class, []string{"image", "video"}, withSourceProps)
 	})
 }
+
+// TestCompareRevectorize_ScalarUncomparableValues: the scalar branch used a bare ==, which
+// panics (a 500) when both sides hold the same uncomparable dynamic type (slice/map).
+func TestCompareRevectorize_ScalarUncomparableValues(t *testing.T) {
+	textProp := &models.Property{Name: "text", DataType: []string{schema.DataTypeText.String()}}
+
+	cases := []sourcePropCase{
+		// Same uncomparable dynamic type on both sides: these panicked before the fix.
+		{name: "[]string both sides, equal -> skip", oldProps: map[string]any{"text": []string{"a", "b"}}, newProps: map[string]any{"text": []string{"a", "b"}}, different: false},
+		{name: "[]string both sides, differing value -> re-vectorize", oldProps: map[string]any{"text": []string{"a", "b"}}, newProps: map[string]any{"text": []string{"a", "c"}}, different: true},
+		{name: "[]string both sides, differing length -> re-vectorize", oldProps: map[string]any{"text": []string{"a"}}, newProps: map[string]any{"text": []string{"a", "b"}}, different: true},
+		{name: "[]string both sides, differing order -> re-vectorize", oldProps: map[string]any{"text": []string{"a", "b"}}, newProps: map[string]any{"text": []string{"b", "a"}}, different: true},
+		{name: "nil []string both sides -> skip", oldProps: map[string]any{"text": []string(nil)}, newProps: map[string]any{"text": []string(nil)}, different: false},
+		{name: "empty []string both sides -> skip", oldProps: map[string]any{"text": []string{}}, newProps: map[string]any{"text": []string{}}, different: false},
+		{name: "map[string]any both sides, equal -> skip", oldProps: map[string]any{"text": map[string]any{"a": "b"}}, newProps: map[string]any{"text": map[string]any{"a": "b"}}, different: false},
+		{name: "map[string]any both sides, differing value -> re-vectorize", oldProps: map[string]any{"text": map[string]any{"a": "b"}}, newProps: map[string]any{"text": map[string]any{"a": "c"}}, different: true},
+		{name: "map[string]any both sides, differing key -> re-vectorize", oldProps: map[string]any{"text": map[string]any{"a": "b"}}, newProps: map[string]any{"text": map[string]any{"z": "b"}}, different: true},
+		{name: "map[string]any both sides, key order irrelevant -> skip", oldProps: map[string]any{"text": map[string]any{"a": "1", "z": "2"}}, newProps: map[string]any{"text": map[string]any{"z": "2", "a": "1"}}, different: false},
+		{name: "[]any both sides, equal -> skip", oldProps: map[string]any{"text": []any{"a", 1.0}}, newProps: map[string]any{"text": []any{"a", 1.0}}, different: false},
+		{name: "[]any both sides, differing value -> re-vectorize", oldProps: map[string]any{"text": []any{"a", 1.0}}, newProps: map[string]any{"text": []any{"a", 2.0}}, different: true},
+		{name: "[]map[string]any both sides, equal -> skip", oldProps: map[string]any{"text": []map[string]any{{"a": "b"}}}, newProps: map[string]any{"text": []map[string]any{{"a": "b"}}}, different: false},
+		{name: "[]map[string]any both sides, differing value -> re-vectorize", oldProps: map[string]any{"text": []map[string]any{{"a": "b"}}}, newProps: map[string]any{"text": []map[string]any{{"a": "c"}}}, different: true},
+
+		// Mixed dynamic types stay unequal, exactly as == had them: two shapes of the
+		// "same" text[] do not necessarily render the same corpus, so re-vectorize.
+		{name: "[]string old vs []any new -> re-vectorize", oldProps: map[string]any{"text": []string{"a"}}, newProps: map[string]any{"text": []any{"a"}}, different: true},
+		{name: "[]any old vs []string new -> re-vectorize", oldProps: map[string]any{"text": []any{"a"}}, newProps: map[string]any{"text": []string{"a"}}, different: true},
+		{name: "[]string old vs map new -> re-vectorize", oldProps: map[string]any{"text": []string{"a"}}, newProps: map[string]any{"text": map[string]any{"a": "b"}}, different: true},
+		{name: "string old vs []string new -> re-vectorize", oldProps: map[string]any{"text": "a"}, newProps: map[string]any{"text": []string{"a"}}, different: true},
+		{name: "[]string old vs string new -> re-vectorize", oldProps: map[string]any{"text": []string{"a"}}, newProps: map[string]any{"text": "a"}, different: true},
+
+		// A nil interface on one side against an uncomparable value on the other: == is
+		// safe here too, and the values are genuinely different.
+		{name: "nil old vs []string new -> re-vectorize", oldProps: map[string]any{"text": nil}, newProps: map[string]any{"text": []string{"a"}}, different: true},
+		{name: "[]string old vs nil new -> re-vectorize", oldProps: map[string]any{"text": []string{"a"}}, newProps: map[string]any{"text": nil}, different: true},
+		{name: "nil old vs map new -> re-vectorize", oldProps: map[string]any{"text": nil}, newProps: map[string]any{"text": map[string]any{"a": "b"}}, different: true},
+		{name: "nil both sides -> skip", oldProps: map[string]any{"text": nil}, newProps: map[string]any{"text": nil}, different: false},
+
+		// The ordinary string traffic this branch actually carries must be untouched.
+		{name: "string both sides, equal -> skip", oldProps: map[string]any{"text": "a"}, newProps: map[string]any{"text": "a"}, different: false},
+		{name: "string both sides, differing -> re-vectorize", oldProps: map[string]any{"text": "a"}, newProps: map[string]any{"text": "b"}, different: true},
+	}
+
+	t.Run("legacy class-level vectorizer", func(t *testing.T) {
+		class := &models.Class{
+			Class:      "MyClass",
+			Vectorizer: "my-module",
+			Properties: []*models.Property{textProp},
+		}
+		runSourcePropCases(t, class, []string{"image", "video"}, cases)
+	})
+
+	t.Run("named vector with source properties", func(t *testing.T) {
+		class := newSourcePropClass(textProp)
+		withSourceProps := make([]sourcePropCase, len(cases))
+		for i, c := range cases {
+			c.sourceProps = []string{"text"}
+			withSourceProps[i] = c
+		}
+		runSourcePropCases(t, class, []string{"image", "video"}, withSourceProps)
+	})
+}
+
+// TestCompareRevectorize_ObjectMediaPropertyUncomparable: object/object[] media properties
+// reach the scalar comparison holding a map or slice (IsArrayDataType covers neither).
+func TestCompareRevectorize_ObjectMediaPropertyUncomparable(t *testing.T) {
+	class := newSourcePropClass(
+		&models.Property{Name: "image", DataType: []string{schema.DataTypeObject.String()}},
+		&models.Property{Name: "video", DataType: []string{schema.DataTypeObjectArray.String()}},
+	)
+
+	runSourcePropCases(t, class, []string{"image", "video"}, []sourcePropCase{
+		{name: "object media prop unchanged -> skip", oldProps: map[string]any{"image": map[string]any{"a": "b"}}, newProps: map[string]any{"image": map[string]any{"a": "b"}}, different: false},
+		{name: "object media prop changed -> re-vectorize", oldProps: map[string]any{"image": map[string]any{"a": "b"}}, newProps: map[string]any{"image": map[string]any{"a": "c"}}, different: true},
+		{name: "object[] media prop unchanged -> skip", oldProps: map[string]any{"video": []any{map[string]any{"a": "b"}}}, newProps: map[string]any{"video": []any{map[string]any{"a": "b"}}}, different: false},
+		{name: "object[] media prop changed -> re-vectorize", oldProps: map[string]any{"video": []any{map[string]any{"a": "b"}}}, newProps: map[string]any{"video": []any{map[string]any{"a": "c"}}}, different: true},
+	})
+}
+
+// TestSourceValuesEqual exercises the helper directly, including shapes a class schema
+// cannot produce. Every case must return without panicking.
+func TestSourceValuesEqual(t *testing.T) {
+	cases := []struct {
+		name  string
+		a, b  any
+		equal bool
+	}{
+		// Comparable fast paths.
+		{name: "string equal", a: "x", b: "x", equal: true},
+		{name: "string differing", a: "x", b: "y", equal: false},
+		{name: "string vs nil", a: "x", b: nil, equal: false},
+		{name: "nil vs nil", a: nil, b: nil, equal: true},
+		{name: "float64 equal", a: 1.5, b: 1.5, equal: true},
+		{name: "float64 differing", a: 1.5, b: 2.5, equal: false},
+		{name: "bool equal", a: true, b: true, equal: true},
+		// A comparable type not on the fast-path list still has to work: the list is a
+		// performance hint, not the correctness boundary.
+		{name: "array type equal", a: [2]string{"a", "b"}, b: [2]string{"a", "b"}, equal: true},
+		{name: "array type differing", a: [2]string{"a", "b"}, b: [2]string{"a", "c"}, equal: false},
+		{name: "time.Time equal", a: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), b: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), equal: true},
+
+		// Same uncomparable dynamic type: bare == panics on every one of these.
+		{name: "[]string equal", a: []string{"a"}, b: []string{"a"}, equal: true},
+		{name: "[]string differing", a: []string{"a"}, b: []string{"b"}, equal: false},
+		{name: "[]string nil vs nil", a: []string(nil), b: []string(nil), equal: true},
+		// nil renders as JSON null, empty as []: unequal, but only in the wasteful
+		// direction (an extra re-vectorization), so not worth a nil-normalization.
+		{name: "[]string nil vs empty", a: []string(nil), b: []string{}, equal: false},
+		{name: "map equal", a: map[string]any{"a": "b"}, b: map[string]any{"a": "b"}, equal: true},
+		{name: "map differing", a: map[string]any{"a": "b"}, b: map[string]any{"a": "c"}, equal: false},
+		{name: "map nil vs nil", a: map[string]any(nil), b: map[string]any(nil), equal: true},
+		{name: "[]byte equal", a: []byte("ab"), b: []byte("ab"), equal: true},
+		{name: "[]byte differing", a: []byte("ab"), b: []byte("ac"), equal: false},
+		{name: "[]float32 equal", a: []float32{1, 2}, b: []float32{1, 2}, equal: true},
+		{name: "[]float32 differing", a: []float32{1, 2}, b: []float32{1, 3}, equal: false},
+
+		// Mixed dynamic types are never equal, matching what == already did.
+		{name: "[]string vs []any", a: []string{"a"}, b: []any{"a"}, equal: false},
+		{name: "[]string vs map", a: []string{"a"}, b: map[string]any{"a": "b"}, equal: false},
+		{name: "[]string vs nil interface", a: []string{"a"}, b: nil, equal: false},
+		{name: "nil interface vs map", a: nil, b: map[string]any{"a": "b"}, equal: false},
+		{name: "[]byte vs []string", a: []byte("a"), b: []string{"a"}, equal: false},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotPanics(t, func() { sourceValuesEqual(tt.a, tt.b) })
+			require.Equal(t, tt.equal, sourceValuesEqual(tt.a, tt.b))
+			require.Equal(t, tt.equal, sourceValuesEqual(tt.b, tt.a), "must be symmetric")
+		})
+	}
+}

--- a/usecases/modules/compare_test.go
+++ b/usecases/modules/compare_test.go
@@ -386,3 +386,47 @@ func TestCompareRevectorize_BlobHashMediaProperty(t *testing.T) {
 		{name: "media blobHash changed -> re-vectorize", oldProps: map[string]any{"image": hashA}, newProps: map[string]any{"image": "Qg=="}, different: true},
 	})
 }
+
+// TestCompareRevectorize_TextArrayAnyForms: a text[] can be []any after a JSON/RAFT
+// round-trip; the comparator must normalize, not assert []string (which panicked as a 500).
+func TestCompareRevectorize_TextArrayAnyForms(t *testing.T) {
+	textArrayProp := &models.Property{
+		Name:     "text_array",
+		DataType: []string{schema.DataTypeTextArray.String()},
+	}
+
+	cases := []sourcePropCase{
+		{name: "[]any old vs []string new, equal -> skip", oldProps: map[string]any{"text_array": []any{"a", "b"}}, newProps: map[string]any{"text_array": []string{"a", "b"}}, different: false},
+		{name: "[]string old vs []any new, equal -> skip", oldProps: map[string]any{"text_array": []string{"a", "b"}}, newProps: map[string]any{"text_array": []any{"a", "b"}}, different: false},
+		{name: "[]any both sides, equal -> skip", oldProps: map[string]any{"text_array": []any{"a", "b"}}, newProps: map[string]any{"text_array": []any{"a", "b"}}, different: false},
+		{name: "[]any old vs []string new, differing value -> re-vectorize", oldProps: map[string]any{"text_array": []any{"a", "b"}}, newProps: map[string]any{"text_array": []string{"a", "c"}}, different: true},
+		{name: "[]string old vs []any new, differing value -> re-vectorize", oldProps: map[string]any{"text_array": []string{"a", "b"}}, newProps: map[string]any{"text_array": []any{"a", "c"}}, different: true},
+		{name: "[]any old vs []string new, differing length -> re-vectorize", oldProps: map[string]any{"text_array": []any{"a"}}, newProps: map[string]any{"text_array": []string{"a", "b"}}, different: true},
+		{name: "empty []any vs empty []string -> skip", oldProps: map[string]any{"text_array": []any{}}, newProps: map[string]any{"text_array": []string{}}, different: false},
+		{name: "nil vs empty []string -> skip", oldProps: map[string]any{"text_array": nil}, newProps: map[string]any{"text_array": []string{}}, different: false},
+		// Not a text[] the corpus could render: we cannot prove the corpus text is
+		// unchanged, so re-vectorize rather than risk keeping a stale vector.
+		{name: "[]any holding a non-string -> re-vectorize", oldProps: map[string]any{"text_array": []any{1, 2}}, newProps: map[string]any{"text_array": []any{1, 2}}, different: true},
+		{name: "[]any holding a non-string vs []string -> re-vectorize", oldProps: map[string]any{"text_array": []any{"a", 2}}, newProps: map[string]any{"text_array": []string{"a", "2"}}, different: true},
+	}
+
+	t.Run("legacy class-level vectorizer", func(t *testing.T) {
+		class := &models.Class{
+			Class:      "MyClass",
+			Vectorizer: "my-module",
+			Properties: []*models.Property{textArrayProp},
+		}
+		// sourceProps stays nil on every case: this is the legacy, no-source-properties path.
+		runSourcePropCases(t, class, []string{"image", "video"}, cases)
+	})
+
+	t.Run("named vector with source properties", func(t *testing.T) {
+		class := newSourcePropClass(textArrayProp)
+		withSourceProps := make([]sourcePropCase, len(cases))
+		for i, c := range cases {
+			c.sourceProps = []string{"text_array"}
+			withSourceProps[i] = c
+		}
+		runSourcePropCases(t, class, []string{"image", "video"}, withSourceProps)
+	})
+}


### PR DESCRIPTION
Follow-up to #11789, stacked on its branch — retarget to `stable/v1.37` once it merges. Two pre-existing panics in the source-properties comparator, both the same class: code trusting that values carry their validated Go types when they can arrive JSON-decoded.

- **text[]**: the array branch asserted `.([]string)`, but a text[] is `[]any` after a JSON/RAFT round-trip (and a merge's "new" value can come from disk) — an ordinary PATCH panicked → 500. Now normalized via `asStringSlice`; unconvertible shapes re-vectorize instead of crashing.
- **scalar**: a bare `!=` panics when both interfaces hold the same uncomparable type (slice/map) — reachable because object/object[] media properties are routed to the scalar branch (`IsArrayDataType` covers neither). Now compared in tiers via `sourceValuesEqual`; same-type uncomparable pairs compare by the canonical `renderSourceValue` key, so equality stays exact.

On `reflect` here: aware of the earlier feedback — it is confined to a cold path that string/number traffic never reaches (a comparable-type whitelist answers the fast path), and it keeps unknown future slice types on the safe path instead of reinstating the panic. Happy to swap for a type switch over the known uncomparable shapes if preferred.

Both panics are reproduced by tests that fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxQr8cSY1FSNPeK1WpMDFn
