### PR TITLE
test(drop-vector-index): retry the write after a leader kill instead of failing on the rejoin blip

### DIFF
--- a/test/acceptance/drop_vector_index/rolling_restart_test.go
+++ b/test/acceptance/drop_vector_index/rolling_restart_test.go
@@ -197,14 +197,25 @@ func runRollingRestartSuite(t *testing.T, compose *docker.DockerCompose) {
 				}
 			}, schemaWriteTimeout, time.Second)
 
-			_, err := helper.Client(t).Objects.ObjectsCreate(
-				clobjects.NewObjectsCreateParams().WithBody(&models.Object{
-					ID:         "00000000-0000-0000-0002-000000001800",
-					Class:      className,
-					Properties: map[string]any{"name": "reborn"},
-					Vectors:    models.Vectors{dropped: randVec(16, 1)},
-				}), nil)
-			require.NoError(t, err)
+			// The write is retried for the same reason the schema update above
+			// is: the leader kill leaves nodes rejoining, and a request routed
+			// to one whose connection to the leader is still being rebuilt fails
+			// its schema query with "grpc: the client connection is closing",
+			// surfaced as a 500. Retrying cannot hide what this pins — a name
+			// that was genuinely poisoned by the replayed completion is refused
+			// on every attempt, not just the first.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				_, err := helper.Client(t).Objects.ObjectsCreate(
+					clobjects.NewObjectsCreateParams().WithBody(&models.Object{
+						ID:         "00000000-0000-0000-0002-000000001800",
+						Class:      className,
+						Properties: map[string]any{"name": "reborn"},
+						Vectors:    models.Vectors{dropped: randVec(16, 1)},
+					}), nil)
+				if err != nil {
+					assert.Fail(collect, "the re-created vector must accept writes", errorResponseText(err))
+				}
+			}, schemaWriteTimeout, time.Second)
 		})
 	})
 }


### PR DESCRIPTION
### What's being changed:

Fix for flaky `TestDropVectorIndex_RollingRestart_Cluster` test:

```
--- FAIL: TestDropVectorIndex_RollingRestart_Cluster (117.50s)
      --- FAIL: TestDropVectorIndex_RollingRestart_Cluster/leader_kill_right_after_finalize (68.51s)
          --- FAIL: TestDropVectorIndex_RollingRestart_Cluster/leader_kill_right_after_finalize/name_is_re-creatable_after_the_disruption (0.03s)
              rolling_restart_test.go:207: 
                  	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance/drop_vector_index/rolling_restart_test.go:207
                  	Error:      	Received unexpected error:
                  	            	[POST /objects][500] objectsCreateInternalServerError  &{Error:[0xc000e740c0]}
                  	Test:       	TestDropVectorIndex_RollingRestart_Cluster/leader_kill_right_after_finalize/name_is_re-creatable_after_the_disruption
  FAIL
  FAIL	github.com/weaviate/weaviate/test/acceptance/drop_vector_index	117.656s
```  
  

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
