### PR TITLE
fix(usage): skip dropped named vectors when computing cold shard usage

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/entities/diskio"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -87,6 +88,18 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 		shardReadSem = semaphore.NewWeighted(1)
 	}
 
+	// A dropped vector index keeps its schema entry but loses its VectorIndexConfig,
+	// so there is nothing to report on. Filtering here, once per collection rather
+	// than once per shard, matches the loaded path, where the shard holds no such
+	// index to enumerate.
+	activeVectorConfigs := make(map[string]models.VectorConfig, len(vectorConfig))
+	for targetVector, cfg := range vectorConfig {
+		if modelsext.IsVectorIndexDropped(cfg) {
+			continue
+		}
+		activeVectorConfigs[targetVector] = cfg
+	}
+
 	localShards := map[string]struct{}{}
 
 	// We need a consistent view of the sharding state and the locals shards. At the same time, we do not want to lock
@@ -132,7 +145,7 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 		eg.Go(func() error {
 			defer shardReadSem.Release(1)
 
-			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, vectorConfig)
+			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, activeVectorConfigs)
 			if err != nil {
 				return err
 			}
@@ -184,7 +197,7 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 // in the _local_ state (i.e. loading/unloading) for the duration of the calculation. A nil
 // *ShardUsage with a nil error means the shard should be skipped (transitional states like
 // FREEZING/OFFLOADING). Safe to call concurrently for distinct shards.
-func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, vectorConfig map[string]models.VectorConfig) (*types.ShardUsage, error) {
+func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, activeVectorConfigs map[string]models.VectorConfig) (*types.ShardUsage, error) {
 	i.shardCreateLocks.RLock(shardName)
 	defer i.shardCreateLocks.RUnlock(shardName)
 
@@ -231,7 +244,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 						err2 = fmt.Errorf("loaded lazy shard %s: %w", shardName, err2)
 					}
 				} else {
-					shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, vectorConfig)
+					shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, activeVectorConfigs)
 					if err2 != nil {
 						err2 = fmt.Errorf("unloaded lazy shard %s: %w", shardName, err2)
 					}
@@ -248,7 +261,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 			}
 		}
 	case models.TenantActivityStatusINACTIVE, models.TenantActivityStatusCOLD:
-		shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, vectorConfig)
+		shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, activeVectorConfigs)
 		if err2 != nil {
 			err2 = fmt.Errorf("inactive shard %s: %w", shardName, err2)
 		}
@@ -400,6 +413,8 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 	return usages, nil
 }
 
+// calculateUnloadedShardUsage computes usage for a cold shard from disk. vectorConfigs must
+// contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig.
 func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig) (*types.ShardUsage, error) {
 	if shardusage.ComputedUsageDataExists(i.path(), shardName) {
 		// usage has been pre-calculated and can be read from disk

--- a/adapters/repos/db/index_usage_dropped_vector_test.go
+++ b/adapters/repos/db/index_usage_dropped_vector_test.go
@@ -1,0 +1,113 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestIndex_UsageForCollection_DroppedNamedVector is a regression test for a
+// dropped named vector aborting the entire node's usage report:
+//
+//	collection X: inactive shard <id>:
+//	vector index config for "to-be-dropped" is not of expected type
+//
+// Dropping a named vector keeps its schema entry with VectorIndexType "none"
+// and drops its VectorIndexConfig, and nothing ever repopulates that config —
+// the schema parser skips dropped entries. The cold path asserted every entry
+// to a concrete config type, so the nil left behind failed the assertion, and
+// the error is not fs.ErrNotExist so usageForShard's recovery arm did not catch
+// it. It propagated all the way out of service.Usage, costing the node every
+// collection's usage, not just this one.
+//
+// The loaded path never saw this: dropVectorIndex removes the entry from
+// vectorIndexUserConfigs, so ForEachVectorIndex has no such vector to
+// enumerate. The cold path must skip it the same way.
+func TestIndex_UsageForCollection_DroppedNamedVector(t *testing.T) {
+	liveConfig := models.VectorConfig{
+		VectorIndexType:   "hnsw",
+		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+	}
+	droppedConfig := models.VectorConfig{
+		VectorIndexType: modelsext.VectorIndexTypeNone,
+	}
+
+	tests := []struct {
+		name         string
+		vectorConfig map[string]models.VectorConfig
+		wantVectors  []string
+	}{
+		{
+			name:         "no dropped vectors",
+			vectorConfig: map[string]models.VectorConfig{"one": liveConfig},
+			wantVectors:  []string{"one"},
+		},
+		{
+			name:         "dropped vector alongside a live one",
+			vectorConfig: map[string]models.VectorConfig{"one": liveConfig, "to-be-dropped": droppedConfig},
+			wantVectors:  []string{"one"},
+		},
+		{
+			name:         "every vector dropped",
+			vectorConfig: map[string]models.VectorConfig{"one": droppedConfig, "to-be-dropped": droppedConfig},
+			wantVectors:  nil,
+		},
+	}
+
+	// shardStates covers the two journeys onto the cold path: a tenant that went
+	// INACTIVE, and one still registered but never lazy-loaded (e.g. after a restart).
+	shardStates := []struct {
+		name string
+		// loadAndDelete drops the shard from the in-memory map so it is processed
+		// as INACTIVE; otherwise it stays a registered-but-unloaded lazy shard.
+		loadAndDelete bool
+	}{
+		{name: "unloaded lazy shard", loadAndDelete: false},
+		{name: "inactive shard", loadAndDelete: true},
+	}
+
+	for _, tt := range tests {
+		for _, state := range shardStates {
+			t.Run(tt.name+", "+state.name, func(t *testing.T) {
+				ctx := context.Background()
+				tenantName := "test-tenant"
+
+				index := setupPopulatedLazyIndex(ctx, t)
+				t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+				if state.loadAndDelete {
+					index.shards.LoadAndDelete(tenantName)
+				}
+
+				usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, tt.vectorConfig)
+				require.NoError(t, err, "a dropped named vector must not fail the report")
+				require.NotNil(t, usage)
+				require.Len(t, usage.Shards, 1)
+
+				var gotVectors []string
+				for _, namedVector := range usage.Shards[0].NamedVectors {
+					gotVectors = append(gotVectors, namedVector.Name)
+				}
+				assert.Equal(t, tt.wantVectors, gotVectors)
+			})
+		}
+	}
+}

--- a/test/acceptance_with_go_client/usage/dropped_vector_test.go
+++ b/test/acceptance_with_go_client/usage/dropped_vector_test.go
@@ -1,0 +1,146 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package usage
+
+import (
+	"acceptance_tests_with_client/internal/wvhost"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestUsageAfterDroppingNamedVector covers a dropped named vector aborting the
+// whole node's usage report once any tenant is cold.
+//
+// Dropping a named vector leaves its schema entry in place with VectorIndexType
+// "none" and no VectorIndexConfig. The cold path enumerates target vectors from
+// that schema and asserted every entry to a concrete config type, so the nil
+// config failed the assertion. The error is not fs.ErrNotExist, so the recovery
+// arm in usageForShard did not absorb it and it propagated out of
+// service.Usage — costing every collection's usage, not just this one.
+//
+// The loaded path is immune, which is why this only shows up once a tenant goes
+// cold: dropVectorIndex removes the entry from the index's vector configs, so a
+// loaded shard has no such vector to enumerate.
+func TestUsageAfterDroppingNamedVector(t *testing.T) {
+	ctx := context.Background()
+
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
+	require.NoError(t, err)
+
+	const (
+		keptVector    = "one"
+		droppedVector = "toBeDropped"
+		dimensions    = 8
+	)
+	className := t.Name() + "Class"
+	tenants := []models.Tenant{{Name: "tenant0"}, {Name: "tenant1"}, {Name: "tenant2"}}
+	coldTenant := tenants[0].Name
+
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+	namedVector := models.VectorConfig{
+		Vectorizer:      map[string]any{"none": map[string]any{}},
+		VectorIndexType: "hnsw",
+	}
+	require.NoError(t, c.Schema().ClassCreator().WithClass(&models.Class{
+		Class:              className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		Properties: []*models.Property{
+			{Name: "first", DataType: []string{string(schema.DataTypeText)}},
+		},
+		VectorConfig: map[string]models.VectorConfig{
+			keptVector:    namedVector,
+			droppedVector: namedVector,
+		},
+	}).Do(ctx))
+
+	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).WithTenants(tenants...).Do(ctx))
+
+	for i, tenant := range tenants {
+		_, err := c.Data().Creator().WithClassName(className).
+			WithID(uuid.NewString()).
+			WithTenant(tenant.Name).
+			WithProperties(map[string]any{"first": fmt.Sprintf("hello%d", i)}).
+			WithVectors(models.Vectors{
+				keptVector:    generateRandomVector(dimensions),
+				droppedVector: generateRandomVector(dimensions),
+			}).Do(ctx)
+		require.NoError(t, err)
+	}
+
+	// baseline: every tenant is hot and both vectors are reported
+	colUsage, err := GetDebugUsageForCollection(className)
+	require.NoError(t, err)
+	require.Len(t, colUsage.Shards, len(tenants))
+	for _, shard := range colUsage.Shards {
+		assert.Equal(t, []string{keptVector, droppedVector}, namedVectorNames(shard),
+			"shard %q should report both vectors before the drop", shard.Name)
+	}
+
+	dropVectorIndex(t, wvhost.REST(), className, droppedVector)
+
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: coldTenant, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+
+	// Without the fix the cold tenant fails the assertion on the nil config and
+	// GetDebugUsageForCollection returns the resulting HTTP 400 instead
+	// of a report — for the whole node, not just this collection.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		colUsage, err := GetDebugUsageForCollection(className)
+		require.NoError(ct, err)
+		require.Len(ct, colUsage.Shards, len(tenants))
+
+		for _, shard := range colUsage.Shards {
+			assert.Equal(ct, []string{keptVector}, namedVectorNames(shard),
+				"shard %q should report only the surviving vector", shard.Name)
+			if shard.Name == coldTenant {
+				assert.Equal(ct, "inactive", shard.Status)
+			}
+		}
+	}, 60*time.Second, 500*time.Millisecond)
+}
+
+// dropVectorIndex calls the experimental drop endpoint, which the go client does
+// not expose.
+func dropVectorIndex(t *testing.T, host, className, targetVector string) {
+	t.Helper()
+
+	url := fmt.Sprintf("http://%s/v1/schema/%s/vectors/%s/index", host, className, targetVector)
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func namedVectorNames(shard *usagetypes.ShardUsage) []string {
+	names := make([]string, 0, len(shard.NamedVectors))
+	for _, namedVector := range shard.NamedVectors {
+		names = append(names, namedVector.Name)
+	}
+	return names
+}


### PR DESCRIPTION
## What's being changed?

Dropping a named vector index keeps its schema entry (`vectorIndexType: "none"`) but leaves its `VectorIndexConfig` nil. The cold-shard usage path type-asserts every entry's config, so the nil failed the assertion and the error propagated out of `service.Usage` — the node stopped emitting usage reports entirely (all collections, not just the affected one) for as long as any tenant was INACTIVE or not yet lazy-loaded. The loaded path never sees this because a loaded shard holds no index for a dropped vector, which is why the failure only appears once tenants go cold.

The fix filters dropped vectors out of the configs once per collection in `usageForCollection`, so the cold path reports them the same way the loaded path does: not at all. This also keeps the dimensions-bucket scan from running for dropped vectors.

## Testing

- Unit: `TestIndex_UsageForCollection_DroppedNamedVector` — 3 vector-config shapes × unloaded-lazy/inactive shard states; fails on the base with the production error, passes with the fix.
- E2E: `TestUsageAfterDroppingNamedVector` — MT collection with 2 named vectors and 3 tenants; drops one vector via the experimental endpoint, deactivates a tenant, and asserts `/debug/usage` still returns a full report listing only the surviving vector. Red-verified against an image without the fix (HTTP 400, whole report lost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
