### PR TITLE
fix(usage): report legacy vector alongside named vectors in usage metrics

### DIFF
--- a/entities/schema/config/vector_index_config.go
+++ b/entities/schema/config/vector_index_config.go
@@ -25,17 +25,27 @@ type VectorIndexConfig interface {
 	IsMultiVector() bool
 }
 
+// ExtractVectorConfigs returns every vector config of the class keyed by target vector,
+// with a legacy class-level vector index under the empty key. A class can carry both —
+// named vectors added to a class created with a legacy vector — so the two sources are
+// merged rather than treated as mutually exclusive.
 func ExtractVectorConfigs(class *models.Class) (map[string]models.VectorConfig, error) {
-	if len(class.VectorConfig) == 0 && modelsext.ClassHasLegacyVectorIndex(class) {
-		vectorIndexConfig, ok := class.VectorIndexConfig.(VectorIndexConfig)
-		if !ok {
-			return nil, fmt.Errorf("class '%s' vector index: config is not schema.VectorIndexConfig: %T",
-				class.Class, class.VectorIndexConfig)
-		}
-		return map[string]models.VectorConfig{"": {Vectorizer: class.Vectorizer, VectorIndexConfig: vectorIndexConfig, VectorIndexType: class.VectorIndexType}}, nil
+	if !modelsext.ClassHasLegacyVectorIndex(class) {
+		return class.VectorConfig, nil
 	}
 
-	return class.VectorConfig, nil
+	vectorIndexConfig, ok := class.VectorIndexConfig.(VectorIndexConfig)
+	if !ok {
+		return nil, fmt.Errorf("class '%s' vector index: config is not schema.VectorIndexConfig: %T",
+			class.Class, class.VectorIndexConfig)
+	}
+
+	configs := make(map[string]models.VectorConfig, len(class.VectorConfig)+1)
+	for targetVector, cfg := range class.VectorConfig {
+		configs[targetVector] = cfg
+	}
+	configs[""] = models.VectorConfig{Vectorizer: class.Vectorizer, VectorIndexConfig: vectorIndexConfig, VectorIndexType: class.VectorIndexType}
+	return configs, nil
 }
 
 func TypeAssertVectorIndex(class *models.Class, targetVectors []string) ([]VectorIndexConfig, error) {

--- a/entities/schema/config/vector_index_config_test.go
+++ b/entities/schema/config/vector_index_config_test.go
@@ -1,0 +1,133 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestExtractVectorConfigs(t *testing.T) {
+	legacyConfig := &MockVectorIndexConfig{}
+	namedConfig := models.VectorConfig{
+		Vectorizer:        map[string]any{"none": map[string]any{}},
+		VectorIndexType:   "hnsw",
+		VectorIndexConfig: &MockVectorIndexConfig{},
+	}
+
+	tests := []struct {
+		name    string
+		class   *models.Class
+		want    map[string]models.VectorConfig
+		wantErr bool
+	}{
+		{
+			name:  "no vectors at all",
+			class: &models.Class{Class: "C"},
+			want:  nil,
+		},
+		{
+			name: "named vectors only",
+			class: &models.Class{
+				Class:        "C",
+				VectorConfig: map[string]models.VectorConfig{"named": namedConfig},
+			},
+			want: map[string]models.VectorConfig{"named": namedConfig},
+		},
+		{
+			name: "legacy vector only",
+			class: &models.Class{
+				Class:             "C",
+				Vectorizer:        "none",
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: legacyConfig,
+			},
+			want: map[string]models.VectorConfig{
+				"": {Vectorizer: "none", VectorIndexType: "hnsw", VectorIndexConfig: legacyConfig},
+			},
+		},
+		{
+			// named vectors added to a class created with a legacy vector: both
+			// must be reported, the legacy one under the empty key
+			name: "legacy and named vectors",
+			class: &models.Class{
+				Class:             "C",
+				Vectorizer:        "none",
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: legacyConfig,
+				VectorConfig:      map[string]models.VectorConfig{"named": namedConfig},
+			},
+			want: map[string]models.VectorConfig{
+				"named": namedConfig,
+				"":      {Vectorizer: "none", VectorIndexType: "hnsw", VectorIndexConfig: legacyConfig},
+			},
+		},
+		{
+			name: "legacy vector with unparsed config",
+			class: &models.Class{
+				Class:             "C",
+				Vectorizer:        "none",
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: map[string]any{"distance": "cosine"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "legacy and named vectors with unparsed legacy config",
+			class: &models.Class{
+				Class:             "C",
+				Vectorizer:        "none",
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: map[string]any{"distance": "cosine"},
+				VectorConfig:      map[string]models.VectorConfig{"named": namedConfig},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ExtractVectorConfigs(tt.class)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExtractVectorConfigs_DoesNotMutateClass(t *testing.T) {
+	class := &models.Class{
+		Class:             "C",
+		Vectorizer:        "none",
+		VectorIndexType:   "hnsw",
+		VectorIndexConfig: &MockVectorIndexConfig{},
+		VectorConfig: map[string]models.VectorConfig{
+			"named": {Vectorizer: map[string]any{"none": map[string]any{}}, VectorIndexType: "hnsw", VectorIndexConfig: &MockVectorIndexConfig{}},
+		},
+	}
+
+	_, err := ExtractVectorConfigs(class)
+	require.NoError(t, err)
+
+	// the merged result must be a copy: the class's own map, shared with the
+	// schema, must not receive the legacy entry
+	require.Len(t, class.VectorConfig, 1)
+	_, exists := class.VectorConfig[""]
+	assert.False(t, exists)
+}

--- a/test/acceptance_with_go_client/usage/mixed_vectors_test.go
+++ b/test/acceptance_with_go_client/usage/mixed_vectors_test.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+
+	"acceptance_tests_with_client/internal/wvhost"
+)
+
+// TestUsageWithLegacyAndNamedVectors covers a class carrying both a legacy
+// class-level vector and named vectors — a supported state reached by adding
+// named vectors to a class created with a legacy vector. The usage report must
+// list both, the legacy one under the empty name. ExtractVectorConfigs used to
+// treat the two as mutually exclusive, so cold shards dropped the legacy
+// vector and its storage from the report; loaded shards enumerate their
+// indexes directly and never had the gap.
+func TestUsageWithLegacyAndNamedVectors(t *testing.T) {
+	ctx := context.Background()
+
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
+	require.NoError(t, err)
+
+	const (
+		namedVector      = "named"
+		legacyDimensions = 4
+		namedDimensions  = 8
+	)
+	className := t.Name() + "Class"
+	tenants := []models.Tenant{{Name: "tenant0"}, {Name: "tenant1"}}
+	coldTenant := tenants[0].Name
+
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+	// a class with both vector kinds cannot be created in one call: create it
+	// with the legacy vector, then add the named vector through a class update
+	class := &models.Class{
+		Class:              className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		Properties: []*models.Property{
+			{Name: "name", DataType: []string{string(schema.DataTypeText)}},
+			{Name: "description", DataType: []string{string(schema.DataTypeText)}},
+		},
+		Vectorizer:      "none",
+		VectorIndexType: "hnsw",
+	}
+	require.NoError(t, c.Schema().ClassCreator().WithClass(class).Do(ctx))
+
+	class.VectorConfig = map[string]models.VectorConfig{
+		namedVector: {
+			Vectorizer:      map[string]any{"none": map[string]any{}},
+			VectorIndexType: "hnsw",
+		},
+	}
+	require.NoError(t, c.Schema().ClassUpdater().WithClass(class).Do(ctx))
+
+	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).WithTenants(tenants...).Do(ctx))
+
+	const objectCount = 5
+	for _, tenant := range tenants {
+		insertObjects(t, objectCount, c, className, tenant.Name,
+			models.Vectors{namedVector: generateRandomVector(namedDimensions)},
+			generateRandomVector(legacyDimensions))
+	}
+
+	assertBothVectorsReported := func(ct *assert.CollectT, wantShardStatus map[string]string) {
+		colUsage, err := GetDebugUsageForCollection(className)
+		require.NoError(ct, err)
+		require.Len(ct, colUsage.Shards, len(tenants))
+
+		for _, shard := range colUsage.Shards {
+			if wantStatus, ok := wantShardStatus[shard.Name]; ok {
+				require.Equal(ct, wantStatus, shard.Status)
+			}
+			names := make([]string, 0, len(shard.NamedVectors))
+			for _, vectorUsage := range shard.NamedVectors {
+				names = append(names, vectorUsage.Name)
+			}
+			require.Equal(ct, []string{"", namedVector}, names,
+				"shard %q must report the legacy vector alongside the named one", shard.Name)
+
+			for _, vectorUsage := range shard.NamedVectors {
+				wantDimensions := namedDimensions
+				if vectorUsage.Name == "" {
+					wantDimensions = legacyDimensions
+				}
+				require.Len(ct, vectorUsage.Dimensionalities, 1, "vector %q", vectorUsage.Name)
+				assert.Equal(ct, wantDimensions, vectorUsage.Dimensionalities[0].Dimensions, "vector %q", vectorUsage.Name)
+				assert.Equal(ct, objectCount, vectorUsage.Dimensionalities[0].Count, "vector %q", vectorUsage.Name)
+			}
+		}
+	}
+
+	// all tenants hot: the loaded path enumerates shard indexes directly
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assertBothVectorsReported(ct, nil)
+	}, 60*time.Second, 500*time.Millisecond)
+
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: coldTenant, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+
+	// cold tenant: the shard is reported from disk via the schema's vector
+	// configs, which must include the legacy vector
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assertBothVectorsReported(ct, map[string]string{coldTenant: "inactive"})
+	}, 60*time.Second, 500*time.Millisecond)
+}


### PR DESCRIPTION
## What's being changed?

A class can carry both a legacy class-level vector and named vectors (created legacy-first, named vectors added via class update — a supported, tested journey). `ExtractVectorConfigs` treated the two as mutually exclusive: with named vectors present it returned only those, so cold (INACTIVE / not yet lazy-loaded) shards silently dropped the legacy vector from the usage report — its dimensions, its `uncompressedVectorSize` contribution, and its report entry. Loaded shards enumerate their indexes directly and were not affected, so the report changed shape depending on tenant activity.

The fix merges the two sources: the legacy vector is returned under the empty key alongside the named configs (into a new map — the class's schema-shared map is not mutated). Named-only classes keep the previous pass-through.

`ExtractVectorConfigs` has exactly one caller (the usage service), so no other path changes behavior.

## Testing

- Unit: `TestExtractVectorConfigs` — named-only / legacy-only / mixed / malformed-config cases plus a no-mutation guard; the mixed cases fail on the base and pass with the fix.
- E2E: `TestUsageWithLegacyAndNamedVectors` — MT class with legacy (4-dim) + named (8-dim) vectors; asserts `/debug/usage` lists both per shard with the correct per-vector dimensionalities and counts, first all-hot, then with a COLD tenant. Red-verified against an image without the fix: hot passes, the cold shard reports only the named vector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
