### PR TITLE
gh-11627 auto-tune hybrid search alpha

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -120,6 +120,10 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 		return nil, nil, fmt.Errorf("alpha should be between 0.0 and 1.0")
 	}
 
+	if autoTuneAlpha, ok := source["autoTuneAlpha"]; ok {
+		args.AutoTuneAlpha = autoTuneAlpha.(bool)
+	}
+
 	vectorDistanceCutOff, ok := source["maxVectorDistance"]
 	if ok {
 		args.Distance = float32(vectorDistanceCutOff.(float64))

--- a/adapters/handlers/graphql/local/common_filters/hybrid_test.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid_test.go
@@ -49,6 +49,16 @@ func TestHybrid(t *testing.T) {
 			output:            &searchparams.HybridSearch{NearVectorParams: &searchparams.NearVector{Vectors: []models.Vector{[]float32{1, 2, 3}, []float32{1, 2}}}, TargetVectors: []string{"target1", "target2"}, SubSearches: ss, Type: "hybrid", Alpha: 0.75, FusionAlgorithm: 1},
 			outputCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: nilweights},
 		},
+		{
+			input:             map[string]interface{}{"vector": []float32{1.0, 2.0, 3.0}, "autoTuneAlpha": true},
+			output:            &searchparams.HybridSearch{Vector: []float32{1.0, 2.0, 3.0}, SubSearches: ss, Type: "hybrid", Alpha: 0.75, AutoTuneAlpha: true, FusionAlgorithm: 1},
+			outputCombination: nil,
+		},
+		{
+			input:             map[string]interface{}{"vector": []float32{1.0, 2.0, 3.0}},
+			output:            &searchparams.HybridSearch{Vector: []float32{1.0, 2.0, 3.0}, SubSearches: ss, Type: "hybrid", Alpha: 0.75, AutoTuneAlpha: false, FusionAlgorithm: 1},
+			outputCombination: nil,
+		},
 	}
 
 	for _, tt := range cases {

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -55,6 +55,10 @@ func hybridOperands(classObject *graphql.Object,
 			Description: "Search weight",
 			Type:        graphql.Float,
 		},
+		"autoTuneAlpha": &graphql.InputObjectFieldConfig{
+			Description: "Derive alpha per-query from BM25 result confidence instead of using a fixed value",
+			Type:        graphql.Boolean,
+		},
 		"maxVectorDistance": &graphql.InputObjectFieldConfig{
 			Description: "Removes all results that have a vector distance larger than the given value",
 			Type:        graphql.Float,

--- a/entities/searchparams/retrieval.go
+++ b/entities/searchparams/retrieval.go
@@ -112,6 +112,7 @@ type HybridSearch struct {
 	SubSearches          interface{}   `json:"subSearches"`
 	Type                 string        `json:"type"`
 	Alpha                float64       `json:"alpha"`
+	AutoTuneAlpha        bool          `json:"autoTuneAlpha"`
 	Query                string        `json:"query"`
 	Vector               models.Vector `json:"vector"`
 	Properties           []string      `json:"properties"`

--- a/usecases/traverser/hybrid/fusion_test.go
+++ b/usecases/traverser/hybrid/fusion_test.go
@@ -117,6 +117,98 @@ func TestFusionOrderRelative(t *testing.T) {
 	}
 }
 
+func TestComputeAdaptiveAlpha(t *testing.T) {
+	cases := []struct {
+		name          string
+		scores        []float32
+		fallbackAlpha float64
+		expectLow     bool // expect alpha pulled toward 0 (favor keyword)
+		expectHigh    bool // expect alpha pulled toward 1 (favor vector)
+		expectDefault bool // expect fallbackAlpha returned unchanged
+	}{
+		{
+			name:          "no results falls back to caller-provided alpha",
+			scores:        nil,
+			fallbackAlpha: 0.42,
+			expectDefault: true,
+		},
+		{
+			name:          "single sharp result is treated as maximally confident",
+			scores:        []float32{9.5},
+			fallbackAlpha: 0.5,
+			expectLow:     true,
+		},
+		{
+			name:          "one dominant score among many is confident, favors keyword",
+			scores:        []float32{20, 0.1, 0.1, 0.1, 0.1},
+			fallbackAlpha: 0.5,
+			expectLow:     true,
+		},
+		{
+			name:          "near-uniform scores are unconfident, favors vector",
+			scores:        []float32{1, 1.01, 0.99, 1.02, 0.98},
+			fallbackAlpha: 0.5,
+			expectHigh:    true,
+		},
+		{
+			name:          "all-zero scores treated as maximally uncertain, favors vector",
+			scores:        []float32{0, 0, 0},
+			fallbackAlpha: 0.5,
+			expectHigh:    true,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var results []*search.Result
+			for i, score := range tt.scores {
+				docId := uint64(i)
+				results = append(results, &search.Result{Score: score, DocID: &docId, ID: strfmt.UUID(fmt.Sprint(i))})
+			}
+
+			alpha := ComputeAdaptiveAlpha(results, tt.fallbackAlpha)
+
+			require.GreaterOrEqual(t, alpha, autoTuneAlphaMin)
+			require.LessOrEqual(t, alpha, autoTuneAlphaMax)
+
+			switch {
+			case tt.expectDefault:
+				assert.Equal(t, tt.fallbackAlpha, alpha)
+			case tt.expectLow:
+				assert.Less(t, alpha, 0.5)
+			case tt.expectHigh:
+				assert.Greater(t, alpha, 0.5)
+			}
+		})
+	}
+}
+
+func TestNormalizedBM25Entropy(t *testing.T) {
+	cases := []struct {
+		name     string
+		scores   []float32
+		expected float64
+	}{
+		{name: "empty", scores: nil, expected: -1},
+		{name: "single result is zero entropy", scores: []float32{5}, expected: 0},
+		{name: "uniform scores are maximum entropy", scores: []float32{2, 2, 2, 2}, expected: 1},
+		{name: "all-zero scores default to maximum entropy", scores: []float32{0, 0, 0}, expected: 1},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var results []*search.Result
+			for i, score := range tt.scores {
+				docId := uint64(i)
+				results = append(results, &search.Result{Score: score, DocID: &docId, ID: strfmt.UUID(fmt.Sprint(i))})
+			}
+
+			entropy := normalizedBM25Entropy(results)
+			assert.InDelta(t, tt.expected, entropy, 0.0001)
+		})
+	}
+}
+
 func TestFusionOrderRanked(t *testing.T) {
 	docId1 := uint64(1)
 	docId2 := uint64(2)

--- a/usecases/traverser/hybrid/hybrid_fusion.go
+++ b/usecases/traverser/hybrid/hybrid_fusion.go
@@ -13,11 +13,73 @@ package hybrid
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/entities/search"
 )
+
+const (
+	// autoTuneAlphaSteepness: sigmoid steepness around the entropy midpoint (0.5).
+	autoTuneAlphaSteepness = 2.0
+	autoTuneAlphaMin       = 0.05
+	autoTuneAlphaMax       = 0.95
+)
+
+// ComputeAdaptiveAlpha derives alpha from BM25 result confidence (falling back to fallbackAlpha).
+func ComputeAdaptiveAlpha(bm25Results []*search.Result, fallbackAlpha float64) float64 {
+	entropy := normalizedBM25Entropy(bm25Results)
+	if entropy < 0 {
+		return fallbackAlpha
+	}
+
+	z := autoTuneAlphaSteepness * (entropy - 0.5) //this equation
+	alpha := 1 / (1 + math.Exp(-z))
+	//weight that is being given to BM25 
+	return clampFloat64(alpha, autoTuneAlphaMin, autoTuneAlphaMax)
+}
+
+// normalizedBM25Entropy returns the Shannon entropy of results' scores normalized to [0, 1], or -1 if empty.
+func normalizedBM25Entropy(results []*search.Result) float64 {
+	k := len(results)
+	if k == 0 {
+		return -1
+	}
+	if k == 1 {
+		return 0
+	}
+	sum := 0.0
+	for _, r := range results {
+		if r.Score > 0 {
+			sum += float64(r.Score)
+		}
+	}
+	if sum <= 0 {
+		return 1 // no score mass to measure; treat as maximally uncertain
+	}
+
+	h := 0.0
+	for _, r := range results {
+		if r.Score <= 0 {
+			continue
+		}
+		p := float64(r.Score) / sum
+		h -= p * math.Log(p)
+	}
+
+	return h / math.Log(float64(k))
+}
+
+func clampFloat64(v, min, max float64) float64 {
+	if v < min {
+		return min
+	}
+	if v > max {
+		return max
+	}
+	return v
+}
 
 func FusionRanked(weights []float64, resultSets [][]*search.Result, setNames []string) []*search.Result {
 	combinedResults := map[strfmt.UUID]*search.Result{}

--- a/usecases/traverser/hybrid/searcher.go
+++ b/usecases/traverser/hybrid/searcher.go
@@ -88,6 +88,10 @@ func Search(ctx context.Context, params *Params, logger logrus.FieldLogger, spar
 				return nil, err
 			}
 
+			if params.AutoTuneAlpha && alpha > 0 {
+				alpha = ComputeAdaptiveAlpha(res, alpha)
+			}
+
 			found = append(found, res)
 			weights = append(weights, 1-alpha)
 			names = append(names, "keyword")


### PR DESCRIPTION
…flag that adjusts alpha per query based on BM25 confidence, favoring keyword or vector search as appropriate. Exposed via a new autoTuneAlpha field on the GraphQL hybrid search input. Closes #11627

### What's being changed:

Hybrid search currently uses one fixed alpha for every query, which doesn't fit both exact-match queries (error codes, SKUs) and conceptual queries well.

This adds an opt-in `AutoTuneAlpha` flag that derives alpha per query from BM25 result confidence (measured via normalized Shannon entropy, passed through a sigmoid): a sharp match favors keyword search, a flat/uncertain one favors vector search.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: not yet - holding off until there's real benchmark evidence.
- [ ] Chaos pipeline run or not necessary. Link to pipeline: not necessary.
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary. Not run, but should be negligible - no extra search/I/O added.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->