### PR TITLE
fix(indexcounter): close the counter's file descriptor on shard unload

### DIFF
--- a/adapters/repos/db/indexcounter/counter.go
+++ b/adapters/repos/db/indexcounter/counter.go
@@ -144,6 +144,32 @@ func (c *Counter) Drop(keepFiles bool) error {
 	return nil
 }
 
+// Close closes the counter's open file descriptor without removing the
+// underlying file, unlike Drop. Callers that unload a shard (as opposed to
+// deleting it) must call this so the fd isn't held until the *os.File
+// finalizer eventually runs it -- non-deterministic, and least likely to
+// happen promptly under the memory pressure that makes fds scarce in the
+// first place. Nothing needs flushing first: GetAndInc already does a
+// synchronous Seek+Write on every increment, so the persisted value is
+// already durable.
+//
+// Deliberately does not nil out c.f, mirroring Drop: a shard unloaded via
+// Close can still be deleted afterwards via Drop, which needs c.f.Name()
+// for the file path it removes. Closing an already-closed *os.File is a
+// harmless no-op error, same as Drop already tolerates if it's ever called
+// on a counter this has already closed.
+func (c *Counter) Close() error {
+	c.Lock()
+	defer c.Unlock()
+	if c.f == nil {
+		return nil
+	}
+	if err := c.f.Close(); err != nil {
+		return errors.Wrap(err, "close counter file")
+	}
+	return nil
+}
+
 func (c *Counter) FileName() string {
 	return c.f.Name()
 }

--- a/adapters/repos/db/indexcounter/counter_test.go
+++ b/adapters/repos/db/indexcounter/counter_test.go
@@ -67,3 +67,32 @@ func TestReadOnDisk(t *testing.T) {
 		require.Equal(t, uint64(3), count)
 	})
 }
+
+func TestClose(t *testing.T) {
+	t.Run("closes without removing the file, unlike Drop", func(t *testing.T) {
+		dir := t.TempDir()
+		c, err := New(dir)
+		require.NoError(t, err)
+		for range 3 {
+			_, err := c.GetAndInc()
+			require.NoError(t, err)
+		}
+
+		require.NoError(t, c.Close())
+
+		filename := filepath.Join(dir, "indexcount")
+		_, statErr := os.Stat(filename)
+		require.NoError(t, statErr, "Close must not remove the counter file")
+
+		// The persisted value survives the close (GetAndInc already fsyncs
+		// on every call) -- a fresh open on the same path reads it back.
+		reopened, err := New(dir)
+		require.NoError(t, err)
+		require.Equal(t, uint64(3), reopened.Get())
+	})
+
+	t.Run("does not panic on a zero-value Counter", func(t *testing.T) {
+		var c Counter
+		require.NoError(t, c.Close())
+	})
+}

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -335,6 +335,15 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 		storeDurable = err == nil
 	}
 
+	// Release the indexcounter's fd on unload same as every other per-shard
+	// resource above -- Drop (shard deletion) already closes it, but nothing
+	// closed it on a plain unload, leaving it to the *os.File finalizer
+	// (non-deterministic, least likely to run promptly under the memory
+	// pressure that makes fds scarce in the first place).
+	if s.counter != nil {
+		ec.AddWrapf(s.counter.Close(), "close indexcounter")
+	}
+
 	// Publish only after the store flushed: a crash-surviving snapshot must never over-represent the store.
 	if capturedHT != nil && storeDurable {
 		s.dumpHashTreeWithTimeout(capturedHT, hashtreeDumpTimeout)


### PR DESCRIPTION
Fixes #12523.

`Counter` opens its `indexcount` file once in `New()` and never gets a `Close()` — only `Drop(keepFiles)`, which also unlinks the file and is only called on shard **deletion**. `Shard.performShutdown`, which runs on every shard **unload**, closes the property-length tracker, the vector indexes, and the LSM store, but never touches `s.counter`. Every unload leaks one fd to the `*os.File` finalizer — non-deterministic, and least likely to run promptly under the memory pressure that makes fds scarce in the first place. Matches the reported production numbers: ~18% of all open fds on a multi-tenant deployment with ~127K loaded shards.

Added `Counter.Close()` (closes without removing, mirroring `Drop`'s close path minus `os.Remove`) and call it from `performShutdown` alongside the other per-shard resource closes. Nothing needs flushing first — `GetAndInc` already does a synchronous `Seek`+`Write` on every increment.

Deliberately doesn't nil out `Counter.f` after closing, matching `Drop`'s existing style: a shard closed via unload can still be deleted afterwards via `Drop`, which needs `f.Name()` for the path it removes — nilling `f` here would make that later `Drop` silently skip removing the file.

**Verification:** `go test ./adapters/repos/db/indexcounter/...` — new `TestClose` cases confirm the file survives close (unlike `Drop`) and the persisted value is durable across a close+reopen. Confirmed fail-before via `git stash` (build fails, `Close` undefined on unpatched code). Ran the existing shard-shutdown suite with a real shard end-to-end (`go test -tags integrationTest -race ./adapters/repos/db/ -run 'TestShardShutdownWhenIdle|TestShardShutdownWhenIdleEventually|TestShardReinitAfterDeferredShutdown|TestShutdownOrRestoreShard_ConcurrentCompletionIsNotAFailure'`) — all pass, confirming the new `s.counter.Close()` call doesn't break existing shutdown behavior. `golangci-lint run` and `tools/linter_go_routines.sh`: clean. `gofumpt -l`: clean.