### PR TITLE
gh-12536: apply Boost.Depth to hybrid leg fetch without MMR

### DIFF
--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -228,9 +228,14 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 	if params.Boost != nil && params.Boost.OriginalLimit > 0 {
 		subSearchLimit = params.Boost.OriginalLimit
 	}
-	// Under MMR, fetch deep enough to reach the [offset:offset+limit] window (and
-	// Boost.Depth deep when boost is active so it re-ranks that deep).
-	if origParams.Selection != nil && origParams.Selection.MMR != nil {
+	// Fetch deep enough to reach the [offset:offset+limit] window under MMR, and Boost.Depth
+	// deep whenever boost is active so it re-ranks that deep (bounded by QueryMaximumResults).
+	// This must also apply when boost is active without MMR; otherwise a Boost.Depth larger than
+	// QueryHybridMaximumResults would be silently truncated and candidates past that depth would
+	// never reach the boost scorer. See https://github.com/weaviate/weaviate/issues/12536
+	mmrActive := origParams.Selection != nil && origParams.Selection.MMR != nil
+	boostActive := origParams.Boost != nil && origParams.Boost.Weight > 0
+	if mmrActive || boostActive {
 		windowEnd := origParams.Pagination.Offset + params.Pagination.Limit
 		if d := e.mmrFetchDepth(origParams.Boost, windowEnd); d > subSearchLimit {
 			subSearchLimit = d

--- a/usecases/traverser/explorer_hybrid_selection_test.go
+++ b/usecases/traverser/explorer_hybrid_selection_test.go
@@ -278,4 +278,36 @@ func Test_Explorer_HybridSelection(t *testing.T) {
 		assert.GreaterOrEqual(t, legLimit, 40, "leg fetch must reach Boost.Depth")
 		assert.Equal(t, 10, diversifyInputLen, "MMR pool must be the query Limit")
 	})
+
+	// https://github.com/weaviate/weaviate/issues/12536: a Boost.Depth larger than the user
+	// limit must deepen the sub-search legs even when MMR is not used, otherwise candidates
+	// past that depth are dropped before the boost scorer runs.
+	t.Run("Boost.Depth deepens the leg fetch without MMR", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		explorer := newTestExplorer(searcher, getFakeModulesProvider())
+
+		results := makeHybridVectorResults(50)
+		for i := range results {
+			results[i].Schema.(map[string]any)["likes"] = float64(i * 100)
+		}
+		var legLimit int
+		searcher.On("VectorSearch", mock.Anything, mock.Anything).
+			Run(func(args mock.Arguments) {
+				legLimit = args.Get(0).(dto.GetParams).Pagination.Limit
+			}).
+			Return(results, nil)
+
+		params := dto.GetParams{
+			ClassName:    "TestClass",
+			Pagination:   &filters.Pagination{Offset: 0, Limit: 10},
+			HybridSearch: &searchparams.HybridSearch{Query: "foo", Alpha: 1, Vector: []float32{0.1, 0.2, 0.3}},
+			Boost:        likesBoost(1.0, 150), // Depth = 150, larger than the user limit
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, legLimit, 150,
+			"leg fetch must reach Boost.Depth even without MMR")
+	})
 }

--- a/usecases/traverser/explorer_hybrid_selection_test.go
+++ b/usecases/traverser/explorer_hybrid_selection_test.go
@@ -49,6 +49,25 @@ func makeHybridVectorResults(n int) []search.Result {
 
 // Test_Explorer_HybridSelection: MMR on a hybrid query must run as a post-fusion
 // pass on the fused pool, with the legs loading the vectors MMR needs.
+// newHybridLegProbe builds an explorer whose vector leg records the fetch limit it is invoked
+// with, so tests can assert how deep Boost.Depth / MMR make the hybrid sub-searches fetch.
+func newHybridLegProbe() (*Explorer, *fakeVectorSearcher, *int) {
+	searcher := &fakeVectorSearcher{}
+	explorer := newTestExplorer(searcher, getFakeModulesProvider())
+
+	results := makeHybridVectorResults(50)
+	for i := range results {
+		results[i].Schema.(map[string]any)["likes"] = float64(i * 100)
+	}
+	legLimit := new(int)
+	searcher.On("VectorSearch", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			*legLimit = args.Get(0).(dto.GetParams).Pagination.Limit
+		}).
+		Return(results, nil)
+	return explorer, searcher, legLimit
+}
+
 func Test_Explorer_HybridSelection(t *testing.T) {
 	t.Run("MMR selection runs post-fusion on hybrid results", func(t *testing.T) {
 		searcher := &fakeVectorSearcher{}
@@ -243,19 +262,7 @@ func Test_Explorer_HybridSelection(t *testing.T) {
 	})
 
 	t.Run("Boost.Depth deepens the leg fetch, MMR over top Limit", func(t *testing.T) {
-		searcher := &fakeVectorSearcher{}
-		explorer := newTestExplorer(searcher, getFakeModulesProvider())
-
-		results := makeHybridVectorResults(50)
-		for i := range results {
-			results[i].Schema.(map[string]any)["likes"] = float64(i * 100)
-		}
-		var legLimit int
-		searcher.On("VectorSearch", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				legLimit = args.Get(0).(dto.GetParams).Pagination.Limit
-			}).
-			Return(results, nil)
+		explorer, searcher, legLimit := newHybridLegProbe()
 
 		var diversifyInputLen int
 		searcher.diversifyFn = func(sel *searchparams.Selection, class, target string, in []search.Result) ([]search.Result, error) {
@@ -275,7 +282,7 @@ func Test_Explorer_HybridSelection(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, res, 5, "page size is MMR.Limit")
 
-		assert.GreaterOrEqual(t, legLimit, 40, "leg fetch must reach Boost.Depth")
+		assert.GreaterOrEqual(t, *legLimit, 40, "leg fetch must reach Boost.Depth")
 		assert.Equal(t, 10, diversifyInputLen, "MMR pool must be the query Limit")
 	})
 
@@ -283,19 +290,7 @@ func Test_Explorer_HybridSelection(t *testing.T) {
 	// limit must deepen the sub-search legs even when MMR is not used, otherwise candidates
 	// past that depth are dropped before the boost scorer runs.
 	t.Run("Boost.Depth deepens the leg fetch without MMR", func(t *testing.T) {
-		searcher := &fakeVectorSearcher{}
-		explorer := newTestExplorer(searcher, getFakeModulesProvider())
-
-		results := makeHybridVectorResults(50)
-		for i := range results {
-			results[i].Schema.(map[string]any)["likes"] = float64(i * 100)
-		}
-		var legLimit int
-		searcher.On("VectorSearch", mock.Anything, mock.Anything).
-			Run(func(args mock.Arguments) {
-				legLimit = args.Get(0).(dto.GetParams).Pagination.Limit
-			}).
-			Return(results, nil)
+		explorer, _, legLimit := newHybridLegProbe()
 
 		params := dto.GetParams{
 			ClassName:    "TestClass",
@@ -307,7 +302,7 @@ func Test_Explorer_HybridSelection(t *testing.T) {
 		_, err := explorer.GetClass(context.Background(), params)
 		require.NoError(t, err)
 
-		assert.GreaterOrEqual(t, legLimit, 150,
+		assert.GreaterOrEqual(t, *legLimit, 150,
 			"leg fetch must reach Boost.Depth even without MMR")
 	})
 }


### PR DESCRIPTION
Closes #12536.

## Problem

Hybrid search silently caps `boost.depth` at `QUERY_HYBRID_MAXIMUM_RESULTS` (default 100). When `boost.depth` is larger, candidates ranked past position 100 are dropped from the fused pool before boost re-scoring, so a high-boost object beyond that depth is never promoted and the top result is wrong — with no error or warning. The reproduction in #12536 sets `boost.depth=150` and the object at BM25 rank 121 is never boosted.

## Root cause

In `usecases/traverser/explorer_hybrid.go`, the sub-search leg sizing (`subSearchLimit`) is only raised to the boost-aware `mmrFetchDepth(...)` **when MMR is active**:

```go
if origParams.Selection != nil && origParams.Selection.MMR != nil {
    windowEnd := ...
    if d := e.mmrFetchDepth(origParams.Boost, windowEnd); d > subSearchLimit {
        subSearchLimit = d
    }
}
```

With boost but no MMR, the legs fetch only `max(QueryHybridMaximumResults, userLimit)`, so `Boost.Depth` never influences how deep each leg fetches.

## Fix

Apply the boost-aware fetch depth whenever boost is active, not only under MMR. `mmrFetchDepth` already bounds the depth by `QueryMaximumResults` and floors it at the requested window, so both legs now fetch deep enough for boost to re-rank the requested `Boost.Depth` candidates. Behavior for plain hybrid searches (no MMR, no boost) is unchanged.

## Testing

- Added a regression test (`Boost.Depth deepens the leg fetch without MMR`) asserting the leg fetch reaches `Boost.Depth` when boost is active without MMR. It fails on `main` (leg fetch = user limit) and passes with this change.
- Full `./usecases/traverser/` suite passes; `gofmt` and `go vet` clean.

I used AI assistance on this change; I've reviewed and verified it end-to-end and am happy to adjust the approach.
