### PR TITLE
gh-12693: tie-break property sort on doc id for deterministic multi-shard order

### DIFF
--- a/adapters/repos/db/sorter/comparator.go
+++ b/adapters/repos/db/sorter/comparator.go
@@ -31,5 +31,17 @@ func (c *comparator) compare(a, b *comparable) int {
 			return res
 		}
 	}
+	// Tie-breaker: use document ID for deterministic ordering, consistent with the
+	// other cross-shard merges (see sortByDistances, sortByScores, sortByID). Without
+	// it, objects that tie on every sort key but live on different shards get a
+	// nondeterministic order in the cross-shard merge (an unstable sort over results
+	// appended in goroutine-completion order), so a boundary object can be dropped from
+	// or duplicated across paginated (offset/limit) requests.
+	if a.docID != b.docID {
+		if a.docID < b.docID {
+			return -1
+		}
+		return 1
+	}
 	return 0
 }

--- a/adapters/repos/db/sorter/comparator_test.go
+++ b/adapters/repos/db/sorter/comparator_test.go
@@ -1,0 +1,63 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package sorter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// tiedBasicComparator always reports equality, simulating objects whose sort-key
+// values all tie so that the tie-breaker in comparator.compare is exercised.
+type tiedBasicComparator struct{}
+
+func (tiedBasicComparator) compare(a, b interface{}) int { return 0 }
+
+func TestComparatorTieBreaksOnDocID(t *testing.T) {
+	c := &comparator{comparators: []basicComparator{tiedBasicComparator{}}}
+
+	t.Run("compare falls back to ascending docID when sort keys tie", func(t *testing.T) {
+		lo := &comparable{docID: 1, values: []interface{}{"x"}}
+		hi := &comparable{docID: 2, values: []interface{}{"x"}}
+		assert.Equal(t, -1, c.compare(lo, hi))
+		assert.Equal(t, 1, c.compare(hi, lo))
+		assert.Equal(t, 0, c.compare(lo, lo))
+	})
+
+	t.Run("tied objects sort deterministically by docID regardless of input order", func(t *testing.T) {
+		// The cross-shard merge appends per-shard results in nondeterministic
+		// goroutine-completion order and then runs an unstable sort. Objects that tie on
+		// every sort key must still end up in a single deterministic order (ascending
+		// docID), otherwise a boundary object can be dropped from or duplicated across
+		// paginated (offset/limit) requests.
+		want := []uint64{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}
+		inputs := [][]uint64{
+			{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			{9, 8, 7, 6, 5, 4, 3, 2, 1, 0},
+			{5, 3, 9, 1, 7, 2, 8, 4, 6, 0},
+		}
+		for _, in := range inputs {
+			sorter := newDefaultSorter(c, len(in))
+			for _, id := range in {
+				sorter.addComparable(&comparable{docID: id, values: []interface{}{"tie"}})
+			}
+			sorted := sorter.getSorted()
+			got := make([]uint64, len(sorted))
+			for i, cmp := range sorted {
+				got[i] = cmp.docID
+			}
+			assert.Equal(t, want, got,
+				"tied objects must sort by ascending docID, input order %v", in)
+		}
+	})
+}


### PR DESCRIPTION
Closes #12693.

## Problem

Sorting by an object property in a **multi-shard** collection returns tied objects in a **nondeterministic order** between identical requests. With `offset`/`limit` pagination, a tied object on a page boundary can be dropped from every page or returned on two consecutive pages, so paging through a sorted result set can silently miss or duplicate objects. Single-shard collections are unaffected.

## Root cause

The property sort comparator returns `0` when all sort keys tie, with no tie-breaker:

```go
// adapters/repos/db/sorter/comparator.go
func (c *comparator) compare(a, b *comparable) int {
	for level, comparator := range c.comparators {
		if res := comparator.compare(a.values[level], b.values[level]); res != 0 {
			return res
		}
	}
	return 0
}
```

The cross-shard merge (`index.go`, only when `len(shards) > 1`) collects per-shard results in nondeterministic goroutine-completion order and re-sorts them with an **unstable** `sort.Sort` (`comparable_sorter.go`, `defaultSorter.getSorted`). So objects that tie on every sort key get a nondeterministic global order.

Every other cross-shard merge already tie-breaks on doc id for this exact reason — `sortByDistances` (`// Tie-breaker: use document ID for deterministic ordering`), `sortByScores`, `sortByID`, the BM25 merge, and both hybrid-fusion sorters. The property comparator is the only one missing it. A stable sort alone would not fix it because the input (append) order across shards is itself nondeterministic — the deterministic key has to be the doc id.

## Fix

Add an ascending doc-id tie-breaker to `comparator.compare`, matching the other merge paths.

## Testing

- New `comparator_test.go`: verifies `compare` falls back to ascending doc id on a full tie, and that `defaultSorter` sorts tied objects into the same deterministic doc-id order regardless of input (append) order. The test fails on `main` (both the direct `compare` assertions and the order-independence assertion) and passes with this change.
- Full `./adapters/repos/db/sorter/` package passes; `gofmt` and `go vet` clean.

I used AI assistance on this change; I've reviewed and verified it end-to-end (including that the fix is consistent with the existing tie-break convention) and am happy to adjust.
