### PR TITLE
fix(distributedtask): `FinishedAt` means finished

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9091,7 +9091,7 @@ func init() {
           "type": "string"
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated. Absent until the unit first reports progress.",
+          "description": "The time when the unit was last updated, including its transition to a terminal status. Absent for a unit that has not started yet.",
           "type": "string",
           "format": "date-time",
           "x-nullable": true
@@ -21561,7 +21561,7 @@ func init() {
           "type": "string"
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated. Absent until the unit first reports progress.",
+          "description": "The time when the unit was last updated, including its transition to a terminal status. Absent for a unit that has not started yet.",
           "type": "string",
           "format": "date-time",
           "x-nullable": true

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9015,9 +9015,10 @@ func init() {
           "x-omitempty": true
         },
         "finishedAt": {
-          "description": "The time when the task was finished.",
+          "description": "The time when the task reached a terminal status. Absent while the task is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "finishedNodes": {
           "description": "The nodes that finished the task.",
@@ -9067,9 +9068,10 @@ func init() {
           "x-omitempty": true
         },
         "finishedAt": {
-          "description": "The time when the unit finished.",
+          "description": "The time when the unit reached a terminal status. Absent while the unit is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "id": {
           "description": "The ID of the unit.",
@@ -9089,9 +9091,10 @@ func init() {
           "type": "string"
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated.",
+          "description": "The time when the unit was last updated. Absent until the unit first reports progress.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         }
       }
     },
@@ -21482,9 +21485,10 @@ func init() {
           "x-omitempty": true
         },
         "finishedAt": {
-          "description": "The time when the task was finished.",
+          "description": "The time when the task reached a terminal status. Absent while the task is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "finishedNodes": {
           "description": "The nodes that finished the task.",
@@ -21534,9 +21538,10 @@ func init() {
           "x-omitempty": true
         },
         "finishedAt": {
-          "description": "The time when the unit finished.",
+          "description": "The time when the unit reached a terminal status. Absent while the unit is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "id": {
           "description": "The ID of the unit.",
@@ -21556,9 +21561,10 @@ func init() {
           "type": "string"
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated.",
+          "description": "The time when the unit was last updated. Absent until the unit first reports progress.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         }
       }
     },

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -634,8 +634,7 @@ func (m *Manager) RecordPostCompletionAck(c *api.ApplyRequest) error {
 		AckedAt: ackedAt,
 	}
 
-	// Any failure flips the task to FAILED immediately; later acks are
-	// still recorded for forensic value.
+	// Any failure flips the task to FAILED immediately.
 	if !r.Success && task.Status == TaskStatusSwapping {
 		ackErr := fmt.Sprintf("post-completion swap failed on node %s: %s", r.NodeId, r.Error)
 		if task.Error != "" {

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -970,14 +970,10 @@ func (m *Manager) CleanUpTask(a *api.ApplyRequest) error {
 		return err
 	}
 
-	// This check is all that stands between an in-flight task and deletion:
-	// such a task never had its FinishedAt stamped, so the age check below
-	// reads it as long expired.
-	//
-	// A status this build cannot name is deliberately not refused. The
-	// scheduler's TTL sweep is the only proposer and it reads the leader's
-	// view, so a clean-up for such a task means the rest of the cluster
-	// already considers it done.
+	// Without this guard an in-flight task — never FinishedAt-stamped — would
+	// read as long expired by the check below. An unrecognized status is let
+	// through deliberately: the TTL sweep is the sole proposer and reads the
+	// leader's view, so a clean-up for it means the cluster already calls it done.
 	if task.Status.IsActive() && task.Status.IsRecognized() {
 		return fmt.Errorf("task %s/%s/%d is still running", r.Namespace, r.Id, task.Version)
 	}
@@ -1165,9 +1161,9 @@ func (m *Manager) Restore(bytes []byte) error {
 				m.tasks[namespace] = make(map[string]*Task)
 			}
 
-			// A snapshot written by an earlier build of this version line can
-			// hold a mid-coordination task with FinishedAt already stamped,
-			// which would serve a finish time for work still in flight.
+			// An older snapshot can hold a mid-coordination task with
+			// FinishedAt already stamped, which would misreport work still
+			// in flight.
 			if !task.Status.IsTerminal() {
 				task.FinishedAt = time.Time{}
 			}

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -544,18 +544,16 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 	finishedAt := time.UnixMilli(r.FinishedAtUnixMillis)
 
 	if r.Error != "" {
-		u.Status = UnitStatusFailed
+		u.markTerminal(UnitStatusFailed, finishedAt)
 		u.Error = r.Error
-		u.FinishedAt = finishedAt
 		task.Error = fmt.Sprintf("unit %s failed: %s", r.UnitId, r.Error)
 		task.markTerminal(TaskStatusFailed, finishedAt)
 		m.notifySchedulerWithLock()
 		return nil
 	}
 
-	u.Status = UnitStatusCompleted
+	u.markTerminal(UnitStatusCompleted, finishedAt)
 	u.Progress = 1.0
-	u.FinishedAt = finishedAt
 
 	if task.AllUnitsTerminal() {
 		if task.AnyUnitFailed() {

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -547,9 +547,8 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 		u.Status = UnitStatusFailed
 		u.Error = r.Error
 		u.FinishedAt = finishedAt
-		task.Status = TaskStatusFailed
 		task.Error = fmt.Sprintf("unit %s failed: %s", r.UnitId, r.Error)
-		task.FinishedAt = finishedAt
+		task.markTerminal(TaskStatusFailed, finishedAt)
 		m.notifySchedulerWithLock()
 		return nil
 	}
@@ -565,19 +564,17 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 			// (the schema flip is intentionally skipped when any
 			// unit failed; see OnTaskCompleted's early-return for
 			// FAILED tasks).
-			task.Status = TaskStatusFailed
+			task.markTerminal(TaskStatusFailed, finishedAt)
 		} else {
 			// Barrier tasks go through PREPARING; others jump to SWAPPING.
+			// Both are non-terminal, so neither stamps FinishedAt: the unit
+			// work has stopped but the cutover has not run yet.
 			if task.NeedsPreparationBarrier {
 				task.Status = TaskStatusPreparing
 			} else {
 				task.Status = TaskStatusSwapping
 			}
 		}
-		// FinishedAt = when units completed, for PREPARING and SWAPPING
-		// alike. The TTL cleanup skips both, so this cannot clean a task
-		// mid-coordination.
-		task.FinishedAt = finishedAt
 	}
 
 	// Notify on every unit completion — even when not the last one — so
@@ -630,23 +627,23 @@ func (m *Manager) RecordPostCompletionAck(c *api.ApplyRequest) error {
 		return nil
 	}
 
+	ackedAt := time.UnixMilli(r.AckedAtUnixMillis)
 	task.PostCompletionAcks[r.NodeId] = PostCompletionAck{
 		Success: r.Success,
 		Error:   r.Error,
-		AckedAt: time.UnixMilli(r.AckedAtUnixMillis),
+		AckedAt: ackedAt,
 	}
 
 	// Any failure flips the task to FAILED immediately; later acks are
-	// still recorded for forensic value. FinishedAt is not updated —
-	// "when did the work end" should remain the AllUnitsTerminal moment.
+	// still recorded for forensic value.
 	if !r.Success && task.Status == TaskStatusSwapping {
-		task.Status = TaskStatusFailed
 		ackErr := fmt.Sprintf("post-completion swap failed on node %s: %s", r.NodeId, r.Error)
 		if task.Error != "" {
 			task.Error = task.Error + "; " + ackErr
 		} else {
 			task.Error = ackErr
 		}
+		task.markTerminal(TaskStatusFailed, ackedAt)
 	}
 
 	m.notifySchedulerWithLock()
@@ -721,23 +718,23 @@ func (m *Manager) RecordPreparationCompleteAck(c *api.ApplyRequest) error {
 		return nil
 	}
 
+	ackedAt := time.UnixMilli(r.AckedAtUnixMillis)
 	task.PreparationCompletionAcks[r.NodeId] = PostCompletionAck{
 		Success: r.Success,
 		Error:   r.Error,
-		AckedAt: time.UnixMilli(r.AckedAtUnixMillis),
+		AckedAt: ackedAt,
 	}
 
 	// Failure path: the task fails immediately. No node proceeds to the
 	// atomic swap.
 	if !r.Success && task.Status == TaskStatusPreparing {
-		task.Status = TaskStatusFailed
 		ackErr := fmt.Sprintf("prep failed on node %s: %s", r.NodeId, r.Error)
 		if task.Error != "" {
 			task.Error = task.Error + "; " + ackErr
 		} else {
 			task.Error = ackErr
 		}
-		// FinishedAt was set when AllUnitsTerminal landed; keep it.
+		task.markTerminal(TaskStatusFailed, ackedAt)
 		m.notifySchedulerWithLock()
 		return nil
 	}
@@ -812,13 +809,7 @@ func (m *Manager) MarkTaskFinalized(c *api.ApplyRequest) error {
 				r.Namespace, r.Id, task.Version, task.Status))
 	}
 
-	// FinishedAt is intentionally NOT overwritten here. It was already set
-	// in [Manager.RecordUnitCompletion] when all units reached terminal
-	// state — that is the user-meaningful "when did the work finish"
-	// timestamp, and the completed-task TTL counts from there. The
-	// FinalizedAtUnixMillis on the request is left in place for forensic
-	// purposes (visible in RAFT logs) but not stored on the Task.
-	task.Status = TaskStatusFinished
+	task.markTerminal(TaskStatusFinished, time.UnixMilli(r.FinalizedAtUnixMillis))
 	m.notifySchedulerWithLock()
 	return nil
 }
@@ -830,7 +821,7 @@ func (m *Manager) MarkTaskFinalized(c *api.ApplyRequest) error {
 //
 // Idempotent at the FSM layer: the first commit wins; a later call on an
 // already-FAILED task is a no-op, and one racing a peer's FINISHED/CANCELLED
-// is refused. FinishedAt stays at the AllUnitsTerminal moment.
+// is refused.
 func (m *Manager) MarkTaskFailed(c *api.ApplyRequest) error {
 	var r api.MarkTaskFailedRequest
 	if err := json.Unmarshal(c.SubCommand, &r); err != nil {
@@ -858,7 +849,6 @@ func (m *Manager) MarkTaskFailed(c *api.ApplyRequest) error {
 				r.Namespace, r.Id, task.Version, task.Status))
 	}
 
-	task.Status = TaskStatusFailed
 	if r.Error != "" {
 		if task.Error != "" {
 			task.Error = task.Error + "; " + r.Error
@@ -866,6 +856,7 @@ func (m *Manager) MarkTaskFailed(c *api.ApplyRequest) error {
 			task.Error = r.Error
 		}
 	}
+	task.markTerminal(TaskStatusFailed, time.UnixMilli(r.FailedAtUnixMillis))
 	m.notifySchedulerWithLock()
 	return nil
 }
@@ -957,8 +948,7 @@ func (m *Manager) CancelTask(a *api.ApplyRequest) error {
 		return errTaskNotRunning(r.Namespace, r.Id, task.Version)
 	}
 
-	task.Status = TaskStatusCancelled
-	task.FinishedAt = time.UnixMilli(r.CancelledAtUnixMillis)
+	task.markTerminal(TaskStatusCancelled, time.UnixMilli(r.CancelledAtUnixMillis))
 	m.notifySchedulerWithLock()
 	return nil
 }
@@ -981,7 +971,7 @@ func (m *Manager) CleanUpTask(a *api.ApplyRequest) error {
 		return err
 	}
 
-	// This check is all that stands between a STARTED task and deletion:
+	// This check is all that stands between an in-flight task and deletion:
 	// such a task never had its FinishedAt stamped, so the age check below
 	// reads it as long expired.
 	//
@@ -1174,6 +1164,13 @@ func (m *Manager) Restore(bytes []byte) error {
 		for _, task := range tasks {
 			if _, ok := m.tasks[namespace]; !ok {
 				m.tasks[namespace] = make(map[string]*Task)
+			}
+
+			// A snapshot written by an earlier build of this version line can
+			// hold a mid-coordination task with FinishedAt already stamped,
+			// which would serve a finish time for work still in flight.
+			if !task.Status.IsTerminal() {
+				task.FinishedAt = time.Time{}
 			}
 
 			m.tasks[namespace][task.ID] = task

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -61,15 +61,21 @@ func errIfFailed(success bool) string {
 	return "boom"
 }
 
-// TestManager_FinishedAtIsStampedAtTheTerminalTransition walks every FSM path
-// that reaches a terminal status. The fake clock advances between the last
-// in-flight step and the terminal one, so a stamp taken when the units stopped
-// is distinguishable from a stamp taken when the task actually finished.
+// TestManager_FinishedAtIsStampedAtTheTerminalTransition covers the three FSM
+// paths that reach a terminal status out of a coordination phase: a failing
+// PREP ack out of PREPARING, a failing SWAP ack out of SWAPPING, and finalize
+// out of SWAPPING. The fake clock advances between the last in-flight step and
+// the terminal one, so a stamp taken when the units stopped is distinguishable
+// from a stamp taken when the task actually finished.
 //
-// The coordination phases this covers (PREPARING, SWAPPING) run per-shard prep
-// and two cluster-wide ack barriers, the second of which has no timeout — so a
-// stamp set on entry to them can be served for an unbounded time while the
-// task is still running.
+// Those phases run per-shard prep and two cluster-wide ack barriers, the
+// second of which has no timeout — so a stamp set on entry to them can be
+// served for an unbounded time while the task is still running. The other
+// three terminal paths leave STARTED directly and are pinned elsewhere: a
+// failing unit by TestTaskFailureInAnotherNode and TestTaskFailureInLocalNode,
+// cancel by TestTaskCancellation and
+// TestManager_CancelTask_AcceptsOnlyTheCancellableStatuses, and a swallowed
+// cutover failure by TestManager_MarkTaskFailed.
 func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 	// driveToSwapping walks a barrier task STARTED → PREPARING → SWAPPING.
 	driveToSwapping := func(t *testing.T, h *testHarness) {
@@ -89,32 +95,6 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 		terminal   func(t *testing.T, h *testHarness)
 		wantStatus TaskStatus
 	}{
-		{
-			name: "a failing unit fails the task",
-			inFlight: func(t *testing.T, h *testHarness) {
-				addTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1", "u-n2"})
-				completeUnit(t, h, finishedAtNS, finishedAtID, finishedAtVersion, "n1", "u-n1")
-			},
-			terminal: func(t *testing.T, h *testHarness) {
-				failUnit(t, h, finishedAtNS, finishedAtID, finishedAtVersion, "n2", "u-n2", "boom")
-			},
-			wantStatus: TaskStatusFailed,
-		},
-		{
-			name: "cancel from STARTED",
-			inFlight: func(t *testing.T, h *testHarness) {
-				addTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1"})
-			},
-			terminal: func(t *testing.T, h *testHarness) {
-				require.NoError(t, h.manager.CancelTask(toCmd(t, &cmd.CancelDistributedTaskRequest{
-					Namespace:             finishedAtNS,
-					Id:                    finishedAtID,
-					Version:               finishedAtVersion,
-					CancelledAtUnixMillis: h.clock.Now().UnixMilli(),
-				})))
-			},
-			wantStatus: TaskStatusCancelled,
-		},
 		{
 			name: "a failing PREP ack fails the task from PREPARING",
 			inFlight: func(t *testing.T, h *testHarness) {
@@ -149,20 +129,6 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 				})))
 			},
 			wantStatus: TaskStatusFinished,
-		},
-		{
-			name:     "a swallowed cutover failure fails the task from SWAPPING",
-			inFlight: driveToSwapping,
-			terminal: func(t *testing.T, h *testHarness) {
-				require.NoError(t, h.manager.MarkTaskFailed(toCmd(t, &cmd.MarkTaskFailedRequest{
-					Namespace:          finishedAtNS,
-					Id:                 finishedAtID,
-					Version:            finishedAtVersion,
-					Error:              "flip failed",
-					FailedAtUnixMillis: h.clock.Now().UnixMilli(),
-				})))
-			},
-			wantStatus: TaskStatusFailed,
 		},
 	}
 

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -21,9 +21,8 @@ import (
 )
 
 // TestManager_FinishedAtIsStampedAtTheTerminalTransition pins that FinishedAt
-// is set on the terminal transition, not when the last unit completes, so
-// retention counts from when the task actually finished. Covers three of
-// four coordination-phase exits; the fourth is TestManager_MarkTaskFailed.
+// is set on the terminal transition, not when units complete. Covers three
+// of four coordination-phase exits; the fourth is TestManager_MarkTaskFailed.
 func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 	tests := []struct {
 		name string
@@ -99,8 +98,7 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 }
 
 // TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks pins that Restore
-// clears FinishedAt from any non-terminal task in a snapshot written by an
-// earlier build of this version line.
+// clears FinishedAt from any non-terminal task in an older snapshot.
 func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
 	const (
 		ns      = "ns"

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -137,3 +137,76 @@ func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
 		})
 	}
 }
+
+// TestManager_UnitUpdatedAtIncludesTheTerminalTransition pins that a unit's
+// updatedAt covers the transition that ended it. The API omits a zero
+// timestamp, so a unit that fails before its first progress report would
+// otherwise come back with a finishedAt and no updatedAt at all.
+func TestManager_UnitUpdatedAtIncludesTheTerminalTransition(t *testing.T) {
+	const (
+		ns      = "ns"
+		id      = "task1"
+		version = uint64(10)
+		unitID  = "u-n1"
+		node    = "n1"
+	)
+
+	tests := []struct {
+		name string
+		// reportsProgress claims the unit with a progress report before it
+		// goes terminal, which is the only writer of updatedAt today.
+		reportsProgress bool
+		terminal        func(t *testing.T, h *testHarness)
+		wantStatus      UnitStatus
+	}{
+		{
+			name:       "failed, never reported progress",
+			terminal:   func(t *testing.T, h *testHarness) { failUnit(t, h, ns, id, version, node, unitID, "boom") },
+			wantStatus: UnitStatusFailed,
+		},
+		{
+			name:       "completed, never reported progress",
+			terminal:   func(t *testing.T, h *testHarness) { completeUnit(t, h, ns, id, version, node, unitID) },
+			wantStatus: UnitStatusCompleted,
+		},
+		{
+			name:            "failed after reporting progress",
+			reportsProgress: true,
+			terminal:        func(t *testing.T, h *testHarness) { failUnit(t, h, ns, id, version, node, unitID, "boom") },
+			wantStatus:      UnitStatusFailed,
+		},
+		{
+			name:            "completed after reporting progress",
+			reportsProgress: true,
+			terminal:        func(t *testing.T, h *testHarness) { completeUnit(t, h, ns, id, version, node, unitID) },
+			wantStatus:      UnitStatusCompleted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHarness(t).init(t)
+			addTaskWithUnits(t, h, ns, id, version, []string{unitID})
+
+			if tt.reportsProgress {
+				updateProgress(t, h, ns, id, version, node, unitID, 0.5)
+			}
+
+			before := h.manager.tasks[ns][id].Units[unitID]
+			require.Equal(t, tt.reportsProgress, !before.UpdatedAt.IsZero(),
+				"before going terminal a unit carries an update time iff it reported progress")
+
+			h.clock.Advance(time.Hour)
+			wantUpdatedAt := h.clock.Now()
+			tt.terminal(t, h)
+
+			got := h.manager.tasks[ns][id].Units[unitID]
+			require.Equal(t, tt.wantStatus, got.Status)
+			require.False(t, got.UpdatedAt.IsZero(),
+				"a terminal unit must report when it was last touched")
+			require.Equal(t, wantUpdatedAt.UnixMilli(), got.UpdatedAt.UnixMilli(),
+				"the terminal transition is the last touch, so it must move updatedAt")
+			require.Equal(t, wantUpdatedAt.UnixMilli(), got.FinishedAt.UnixMilli())
+		})
+	}
+}

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -20,47 +20,6 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-const (
-	finishedAtNS      = "ns"
-	finishedAtID      = "task1"
-	finishedAtVersion = uint64(10)
-)
-
-// ackPrep records one node's PREP-phase ack through the FSM.
-func ackPrep(t *testing.T, h *testHarness, node string, success bool) {
-	t.Helper()
-	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-		Namespace:         finishedAtNS,
-		Id:                finishedAtID,
-		Version:           finishedAtVersion,
-		NodeId:            node,
-		Success:           success,
-		Error:             errIfFailed(success),
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
-}
-
-// ackSwap records one node's SWAP-phase ack through the FSM.
-func ackSwap(t *testing.T, h *testHarness, node string, success bool) {
-	t.Helper()
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         finishedAtNS,
-		Id:                finishedAtID,
-		Version:           finishedAtVersion,
-		NodeId:            node,
-		Success:           success,
-		Error:             errIfFailed(success),
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
-}
-
-func errIfFailed(success bool) string {
-	if success {
-		return ""
-	}
-	return "boom"
-}
-
 // TestManager_FinishedAtIsStampedAtTheTerminalTransition covers the three FSM
 // paths that reach a terminal status out of a coordination phase: a failing
 // PREP ack out of PREPARING, a failing SWAP ack out of SWAPPING, and finalize
@@ -77,54 +36,38 @@ func errIfFailed(success bool) string {
 // TestManager_CancelTask_AcceptsOnlyTheCancellableStatuses, and a swallowed
 // cutover failure by TestManager_MarkTaskFailed.
 func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
-	// driveToSwapping walks a barrier task STARTED → PREPARING → SWAPPING.
-	driveToSwapping := func(t *testing.T, h *testHarness) {
-		addBarrierTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1"})
-		drivePreparing(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"n1"})
-		require.True(t, h.manager.tasks[finishedAtNS][finishedAtID].FinishedAt.IsZero(),
-			"a PREPARING task must not carry a finish time")
-		h.clock.Advance(time.Minute)
-		ackPrep(t, h, "n1", true)
-	}
-
 	tests := []struct {
 		name string
-		// inFlight drives the task to the last non-terminal state on this path.
-		inFlight func(t *testing.T, h *testHarness)
+		// from is the last non-terminal state on this path.
+		from TaskStatus
 		// terminal performs the single transition into a terminal status.
-		terminal   func(t *testing.T, h *testHarness)
+		terminal   func(t *testing.T, h *testHarness, ns, id string, version uint64)
 		wantStatus TaskStatus
 	}{
 		{
 			name: "a failing PREP ack fails the task from PREPARING",
-			inFlight: func(t *testing.T, h *testHarness) {
-				addBarrierTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1"})
-				drivePreparing(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"n1"})
-			},
-			terminal: func(t *testing.T, h *testHarness) {
-				ackPrep(t, h, "n1", false)
+			from: TaskStatusPreparing,
+			terminal: func(t *testing.T, h *testHarness, ns, id string, version uint64) {
+				ackPrep(t, h, ns, id, version, "n1", false)
 			},
 			wantStatus: TaskStatusFailed,
 		},
 		{
-			name:     "a failing SWAP ack fails the task from SWAPPING",
-			inFlight: driveToSwapping,
-			terminal: func(t *testing.T, h *testHarness) {
-				ackSwap(t, h, "n1", false)
+			name: "a failing SWAP ack fails the task from SWAPPING",
+			from: TaskStatusSwapping,
+			terminal: func(t *testing.T, h *testHarness, ns, id string, version uint64) {
+				ackSwap(t, h, ns, id, version, "n1", false)
 			},
 			wantStatus: TaskStatusFailed,
 		},
 		{
 			name: "finalize from SWAPPING",
-			inFlight: func(t *testing.T, h *testHarness) {
-				driveToSwapping(t, h)
-				ackSwap(t, h, "n1", true)
-			},
-			terminal: func(t *testing.T, h *testHarness) {
+			from: TaskStatusSwapping,
+			terminal: func(t *testing.T, h *testHarness, ns, id string, version uint64) {
 				require.NoError(t, h.manager.MarkTaskFinalized(toCmd(t, &cmd.MarkTaskFinalizedRequest{
-					Namespace:             finishedAtNS,
-					Id:                    finishedAtID,
-					Version:               finishedAtVersion,
+					Namespace:             ns,
+					Id:                    id,
+					Version:               version,
 					FinalizedAtUnixMillis: h.clock.Now().UnixMilli(),
 				})))
 			},
@@ -135,9 +78,9 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			h := newTestHarness(t).init(t)
-			tt.inFlight(t, h)
+			ns, id, version := fixtureInStatus(t, h, tt.from)
 
-			inFlight := h.manager.tasks[finishedAtNS][finishedAtID]
+			inFlight := h.manager.tasks[ns][id]
 			require.False(t, inFlight.Status.IsTerminal(),
 				"fixture must stop short of a terminal status, got %q", inFlight.Status)
 			require.True(t, inFlight.FinishedAt.IsZero(),
@@ -145,9 +88,9 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 
 			h.clock.Advance(time.Minute)
 			wantFinishedAt := h.clock.Now()
-			tt.terminal(t, h)
+			tt.terminal(t, h, ns, id, version)
 
-			got := h.manager.tasks[finishedAtNS][finishedAtID]
+			got := h.manager.tasks[ns][id]
 			require.Equal(t, tt.wantStatus, got.Status)
 			require.Equal(t, wantFinishedAt.UnixMilli(), got.FinishedAt.UnixMilli(),
 				"FinishedAt must be the terminal moment, not an earlier phase change")
@@ -161,6 +104,11 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 // task with a stamp already set; restoring it verbatim would serve a finish
 // time for a task that is still running.
 func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
+	const (
+		ns      = "ns"
+		id      = "task1"
+		version = uint64(10)
+	)
 	var (
 		startedAt = time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
 		stamped   = startedAt.Add(time.Hour)
@@ -175,9 +123,9 @@ func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
 			h := newTestHarness(t).init(t)
 
 			bytes, err := json.Marshal(&snapshot{Tasks: map[string][]*Task{
-				finishedAtNS: {{
-					Namespace:      finishedAtNS,
-					TaskDescriptor: TaskDescriptor{ID: finishedAtID, Version: finishedAtVersion},
+				ns: {{
+					Namespace:      ns,
+					TaskDescriptor: TaskDescriptor{ID: id, Version: version},
 					Status:         status,
 					StartedAt:      startedAt,
 					FinishedAt:     stamped,
@@ -186,7 +134,7 @@ func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, h.manager.Restore(bytes))
 
-			got := h.manager.tasks[finishedAtNS][finishedAtID]
+			got := h.manager.tasks[ns][id]
 			require.Equal(t, status, got.Status, "Restore must not change the status")
 			require.Equal(t, status.IsTerminal(), !got.FinishedAt.IsZero(),
 				"a restored task in %q carries a finish time iff it is terminal", status)

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -86,7 +86,9 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 			require.True(t, inFlight.FinishedAt.IsZero(),
 				"a task in %q must not carry a finish time", inFlight.Status)
 
-			h.clock.Advance(time.Minute)
+			// An hour, so the retention probe below has half an hour of
+			// margin on each side of the TTL boundary.
+			h.clock.Advance(time.Hour)
 			wantFinishedAt := h.clock.Now()
 			tt.terminal(t, h, ns, id, version)
 
@@ -94,6 +96,17 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 			require.Equal(t, tt.wantStatus, got.Status)
 			require.Equal(t, wantFinishedAt.UnixMilli(), got.FinishedAt.UnixMilli(),
 				"FinishedAt must be the terminal moment, not an earlier phase change")
+
+			// Retention counts from the stamp, so half an hour short of a
+			// full TTL past the terminal transition the record is still
+			// readable — even though it is half an hour past a TTL measured
+			// from the moment the units stopped.
+			h.clock.Advance(h.completedTaskTTL - 30*time.Minute)
+			require.ErrorContains(t, h.manager.CleanUpTask(toCmd(t, &cmd.CleanUpDistributedTaskRequest{
+				Namespace: ns,
+				Id:        id,
+				Version:   version,
+			})), "too fresh")
 		})
 	}
 }

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -20,21 +20,10 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-// TestManager_FinishedAtIsStampedAtTheTerminalTransition covers three of the
-// four FSM paths that reach a terminal status out of a coordination phase: a
-// failing PREP ack out of PREPARING, a failing SWAP ack out of SWAPPING, and
-// finalize out of SWAPPING. The fake clock advances between the last in-flight
-// step and the terminal one, so a stamp taken when the units stopped is
-// distinguishable from a stamp taken when the task actually finished.
-//
-// Those phases run per-shard prep and two cluster-wide ack barriers, the
-// second of which has no timeout — so a stamp set on entry to them can be
-// served for an unbounded time while the task is still running. The fourth
-// exit, SWAPPING → FAILED via MarkTaskFailed, is pinned by
-// TestManager_MarkTaskFailed. Two more terminal paths leave STARTED directly:
-// a failing unit (TestTaskFailureInAnotherNode, TestTaskFailureInLocalNode)
-// and cancel (TestTaskCancellation,
-// TestManager_CancelTask_AcceptsOnlyTheCancellableStatuses).
+// TestManager_FinishedAtIsStampedAtTheTerminalTransition pins that FinishedAt
+// is set on the terminal transition, not when the last unit completes, so
+// retention counts from when the task actually finished. Covers three of
+// four coordination-phase exits; the fourth is TestManager_MarkTaskFailed.
 func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 	tests := []struct {
 		name string
@@ -97,10 +86,8 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 			require.Equal(t, wantFinishedAt.UnixMilli(), got.FinishedAt.UnixMilli(),
 				"FinishedAt must be the terminal moment, not an earlier phase change")
 
-			// Retention counts from the stamp, so half an hour short of a
-			// full TTL past the terminal transition the record is still
-			// readable — even though it is half an hour past a TTL measured
-			// from the moment the units stopped.
+			// Retention counts from the stamp above; a stamp taken when the
+			// units stopped instead would already read as expired here.
 			h.clock.Advance(h.completedTaskTTL - 30*time.Minute)
 			require.ErrorContains(t, h.manager.CleanUpTask(toCmd(t, &cmd.CleanUpDistributedTaskRequest{
 				Namespace: ns,
@@ -111,11 +98,9 @@ func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 	}
 }
 
-// TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks covers a snapshot
-// written by an earlier build of this version line, which stamped FinishedAt
-// when the units stopped. Such a snapshot can hold a PREPARING or SWAPPING
-// task with a stamp already set; restoring it verbatim would serve a finish
-// time for a task that is still running.
+// TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks pins that Restore
+// clears FinishedAt from any non-terminal task in a snapshot written by an
+// earlier build of this version line.
 func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
 	const (
 		ns      = "ns"

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -20,21 +20,21 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-// TestManager_FinishedAtIsStampedAtTheTerminalTransition covers the three FSM
-// paths that reach a terminal status out of a coordination phase: a failing
-// PREP ack out of PREPARING, a failing SWAP ack out of SWAPPING, and finalize
-// out of SWAPPING. The fake clock advances between the last in-flight step and
-// the terminal one, so a stamp taken when the units stopped is distinguishable
-// from a stamp taken when the task actually finished.
+// TestManager_FinishedAtIsStampedAtTheTerminalTransition covers three of the
+// four FSM paths that reach a terminal status out of a coordination phase: a
+// failing PREP ack out of PREPARING, a failing SWAP ack out of SWAPPING, and
+// finalize out of SWAPPING. The fake clock advances between the last in-flight
+// step and the terminal one, so a stamp taken when the units stopped is
+// distinguishable from a stamp taken when the task actually finished.
 //
 // Those phases run per-shard prep and two cluster-wide ack barriers, the
 // second of which has no timeout — so a stamp set on entry to them can be
-// served for an unbounded time while the task is still running. The other
-// three terminal paths leave STARTED directly and are pinned elsewhere: a
-// failing unit by TestTaskFailureInAnotherNode and TestTaskFailureInLocalNode,
-// cancel by TestTaskCancellation and
-// TestManager_CancelTask_AcceptsOnlyTheCancellableStatuses, and a swallowed
-// cutover failure by TestManager_MarkTaskFailed.
+// served for an unbounded time while the task is still running. The fourth
+// exit, SWAPPING → FAILED via MarkTaskFailed, is pinned by
+// TestManager_MarkTaskFailed. Two more terminal paths leave STARTED directly:
+// a failing unit (TestTaskFailureInAnotherNode, TestTaskFailureInLocalNode)
+// and cancel (TestTaskCancellation,
+// TestManager_CancelTask_AcceptsOnlyTheCancellableStatuses).
 func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cluster/distributedtask/manager_finishedat_test.go
+++ b/cluster/distributedtask/manager_finishedat_test.go
@@ -1,0 +1,229 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package distributedtask
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+const (
+	finishedAtNS      = "ns"
+	finishedAtID      = "task1"
+	finishedAtVersion = uint64(10)
+)
+
+// ackPrep records one node's PREP-phase ack through the FSM.
+func ackPrep(t *testing.T, h *testHarness, node string, success bool) {
+	t.Helper()
+	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
+		Namespace:         finishedAtNS,
+		Id:                finishedAtID,
+		Version:           finishedAtVersion,
+		NodeId:            node,
+		Success:           success,
+		Error:             errIfFailed(success),
+		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
+	})))
+}
+
+// ackSwap records one node's SWAP-phase ack through the FSM.
+func ackSwap(t *testing.T, h *testHarness, node string, success bool) {
+	t.Helper()
+	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
+		Namespace:         finishedAtNS,
+		Id:                finishedAtID,
+		Version:           finishedAtVersion,
+		NodeId:            node,
+		Success:           success,
+		Error:             errIfFailed(success),
+		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
+	})))
+}
+
+func errIfFailed(success bool) string {
+	if success {
+		return ""
+	}
+	return "boom"
+}
+
+// TestManager_FinishedAtIsStampedAtTheTerminalTransition walks every FSM path
+// that reaches a terminal status. The fake clock advances between the last
+// in-flight step and the terminal one, so a stamp taken when the units stopped
+// is distinguishable from a stamp taken when the task actually finished.
+//
+// The coordination phases this covers (PREPARING, SWAPPING) run per-shard prep
+// and two cluster-wide ack barriers, the second of which has no timeout — so a
+// stamp set on entry to them can be served for an unbounded time while the
+// task is still running.
+func TestManager_FinishedAtIsStampedAtTheTerminalTransition(t *testing.T) {
+	// driveToSwapping walks a barrier task STARTED → PREPARING → SWAPPING.
+	driveToSwapping := func(t *testing.T, h *testHarness) {
+		addBarrierTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1"})
+		drivePreparing(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"n1"})
+		require.True(t, h.manager.tasks[finishedAtNS][finishedAtID].FinishedAt.IsZero(),
+			"a PREPARING task must not carry a finish time")
+		h.clock.Advance(time.Minute)
+		ackPrep(t, h, "n1", true)
+	}
+
+	tests := []struct {
+		name string
+		// inFlight drives the task to the last non-terminal state on this path.
+		inFlight func(t *testing.T, h *testHarness)
+		// terminal performs the single transition into a terminal status.
+		terminal   func(t *testing.T, h *testHarness)
+		wantStatus TaskStatus
+	}{
+		{
+			name: "a failing unit fails the task",
+			inFlight: func(t *testing.T, h *testHarness) {
+				addTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1", "u-n2"})
+				completeUnit(t, h, finishedAtNS, finishedAtID, finishedAtVersion, "n1", "u-n1")
+			},
+			terminal: func(t *testing.T, h *testHarness) {
+				failUnit(t, h, finishedAtNS, finishedAtID, finishedAtVersion, "n2", "u-n2", "boom")
+			},
+			wantStatus: TaskStatusFailed,
+		},
+		{
+			name: "cancel from STARTED",
+			inFlight: func(t *testing.T, h *testHarness) {
+				addTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1"})
+			},
+			terminal: func(t *testing.T, h *testHarness) {
+				require.NoError(t, h.manager.CancelTask(toCmd(t, &cmd.CancelDistributedTaskRequest{
+					Namespace:             finishedAtNS,
+					Id:                    finishedAtID,
+					Version:               finishedAtVersion,
+					CancelledAtUnixMillis: h.clock.Now().UnixMilli(),
+				})))
+			},
+			wantStatus: TaskStatusCancelled,
+		},
+		{
+			name: "a failing PREP ack fails the task from PREPARING",
+			inFlight: func(t *testing.T, h *testHarness) {
+				addBarrierTaskWithUnits(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"u-n1"})
+				drivePreparing(t, h, finishedAtNS, finishedAtID, finishedAtVersion, []string{"n1"})
+			},
+			terminal: func(t *testing.T, h *testHarness) {
+				ackPrep(t, h, "n1", false)
+			},
+			wantStatus: TaskStatusFailed,
+		},
+		{
+			name:     "a failing SWAP ack fails the task from SWAPPING",
+			inFlight: driveToSwapping,
+			terminal: func(t *testing.T, h *testHarness) {
+				ackSwap(t, h, "n1", false)
+			},
+			wantStatus: TaskStatusFailed,
+		},
+		{
+			name: "finalize from SWAPPING",
+			inFlight: func(t *testing.T, h *testHarness) {
+				driveToSwapping(t, h)
+				ackSwap(t, h, "n1", true)
+			},
+			terminal: func(t *testing.T, h *testHarness) {
+				require.NoError(t, h.manager.MarkTaskFinalized(toCmd(t, &cmd.MarkTaskFinalizedRequest{
+					Namespace:             finishedAtNS,
+					Id:                    finishedAtID,
+					Version:               finishedAtVersion,
+					FinalizedAtUnixMillis: h.clock.Now().UnixMilli(),
+				})))
+			},
+			wantStatus: TaskStatusFinished,
+		},
+		{
+			name:     "a swallowed cutover failure fails the task from SWAPPING",
+			inFlight: driveToSwapping,
+			terminal: func(t *testing.T, h *testHarness) {
+				require.NoError(t, h.manager.MarkTaskFailed(toCmd(t, &cmd.MarkTaskFailedRequest{
+					Namespace:          finishedAtNS,
+					Id:                 finishedAtID,
+					Version:            finishedAtVersion,
+					Error:              "flip failed",
+					FailedAtUnixMillis: h.clock.Now().UnixMilli(),
+				})))
+			},
+			wantStatus: TaskStatusFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestHarness(t).init(t)
+			tt.inFlight(t, h)
+
+			inFlight := h.manager.tasks[finishedAtNS][finishedAtID]
+			require.False(t, inFlight.Status.IsTerminal(),
+				"fixture must stop short of a terminal status, got %q", inFlight.Status)
+			require.True(t, inFlight.FinishedAt.IsZero(),
+				"a task in %q must not carry a finish time", inFlight.Status)
+
+			h.clock.Advance(time.Minute)
+			wantFinishedAt := h.clock.Now()
+			tt.terminal(t, h)
+
+			got := h.manager.tasks[finishedAtNS][finishedAtID]
+			require.Equal(t, tt.wantStatus, got.Status)
+			require.Equal(t, wantFinishedAt.UnixMilli(), got.FinishedAt.UnixMilli(),
+				"FinishedAt must be the terminal moment, not an earlier phase change")
+		})
+	}
+}
+
+// TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks covers a snapshot
+// written by an earlier build of this version line, which stamped FinishedAt
+// when the units stopped. Such a snapshot can hold a PREPARING or SWAPPING
+// task with a stamp already set; restoring it verbatim would serve a finish
+// time for a task that is still running.
+func TestManager_Restore_ClearsFinishedAtOnNonTerminalTasks(t *testing.T) {
+	var (
+		startedAt = time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+		stamped   = startedAt.Add(time.Hour)
+	)
+
+	for _, status := range []TaskStatus{
+		TaskStatusStarted, TaskStatusPreparing, TaskStatusSwapping,
+		TaskStatusFinished, TaskStatusFailed, TaskStatusCancelled,
+		unknownFutureStatus,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			h := newTestHarness(t).init(t)
+
+			bytes, err := json.Marshal(&snapshot{Tasks: map[string][]*Task{
+				finishedAtNS: {{
+					Namespace:      finishedAtNS,
+					TaskDescriptor: TaskDescriptor{ID: finishedAtID, Version: finishedAtVersion},
+					Status:         status,
+					StartedAt:      startedAt,
+					FinishedAt:     stamped,
+				}},
+			}})
+			require.NoError(t, err)
+			require.NoError(t, h.manager.Restore(bytes))
+
+			got := h.manager.tasks[finishedAtNS][finishedAtID]
+			require.Equal(t, status, got.Status, "Restore must not change the status")
+			require.Equal(t, status.IsTerminal(), !got.FinishedAt.IsZero(),
+				"a restored task in %q carries a finish time iff it is terminal", status)
+		})
+	}
+}

--- a/cluster/distributedtask/manager_sort_test.go
+++ b/cluster/distributedtask/manager_sort_test.go
@@ -161,15 +161,22 @@ func TestManager_ListDistributedTasks_OrderIsStable(t *testing.T) {
 	h := newTestHarness(t).init(t)
 	now := h.clock.Now().Truncate(time.Millisecond)
 
-	// Three STARTED tasks plus two terminal ones, mixed insertion order.
+	// STARTED, coordination-phase and terminal tasks, mixed insertion order.
 	// All in the same namespace to force the sort path to run.
 	for i, payload := range []*cmd.AddDistributedTaskRequest{
 		{Namespace: "ns", Id: "started-c", SubmittedAtUnixMillis: now.UnixMilli(), UnitIds: []string{"u-1"}},
 		{Namespace: "ns", Id: "started-a", SubmittedAtUnixMillis: now.Add(2 * time.Minute).UnixMilli(), UnitIds: []string{"u-1"}},
 		{Namespace: "ns", Id: "started-b", SubmittedAtUnixMillis: now.Add(time.Minute).UnixMilli(), UnitIds: []string{"u-1"}},
+		{Namespace: "ns", Id: "swap-a", SubmittedAtUnixMillis: now.Add(10 * time.Minute).UnixMilli(), UnitIds: []string{"u-1"}},
+		{Namespace: "ns", Id: "swap-b", SubmittedAtUnixMillis: now.Add(20 * time.Minute).UnixMilli(), UnitIds: []string{"u-1"}},
 	} {
 		require.NoError(t, h.manager.AddTask(toCmd(t, payload), uint64(10+i)))
 	}
+
+	// Units done, cutover still pending: SWAPPING carries no finish stamp,
+	// so these sort by submission time like any other in-flight task.
+	completeUnit(t, h, "ns", "swap-a", 13, "n1", "u-1")
+	completeUnit(t, h, "ns", "swap-b", 14, "n1", "u-1")
 
 	// Cancel two of them so we have terminal tasks too.
 	require.NoError(t, h.manager.CancelTask(toCmd(t, &cmd.CancelDistributedTaskRequest{
@@ -190,16 +197,16 @@ func TestManager_ListDistributedTasks_OrderIsStable(t *testing.T) {
 	first, err := h.manager.ListDistributedTasks(context.Background())
 	require.NoError(t, err)
 	firstIDs := ids(first["ns"])
-	require.Len(t, firstIDs, 3)
+	require.Len(t, firstIDs, 5)
 	for i := 0; i < 50; i++ {
 		next, err := h.manager.ListDistributedTasks(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, firstIDs, ids(next["ns"]), "list call %d returned different order", i)
 	}
 
-	// And confirm the order is sensible: the lone remaining STARTED
-	// (started-a) is first, then the two terminals by FinishedAt DESC.
-	require.Equal(t, []string{"started-a", "started-c", "started-b"}, firstIDs)
+	// And confirm the order is sensible: the in-flight tasks first by
+	// submission time DESC, then the two terminals by FinishedAt DESC.
+	require.Equal(t, []string{"swap-b", "swap-a", "started-a", "started-c", "started-b"}, firstIDs)
 }
 
 func ids(tasks []*Task) []string {

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -559,13 +559,8 @@ func ingestSampleTasks(t *testing.T, m *Manager, now time.Time) map[string][]*Ta
 					Version: 13,
 				},
 				Payload: []byte("test2"),
-				// Manager.RecordUnitCompletion alone takes a successful
-				// task to SWAPPING; the FINISHED transition is committed
-				// by [Manager.MarkTaskFinalized] which the [Scheduler]
-				// issues after every node's [Provider.OnTaskCompleted]
-				// returns. This helper exercises RecordUnitCompletion in
-				// isolation, so SWAPPING is the expected end state — and a
-				// SWAPPING task carries no FinishedAt.
+				// RecordUnitCompletion alone lands a successful task in
+				// SWAPPING, not FINISHED, so this fixture carries no FinishedAt.
 				Status:    TaskStatusSwapping,
 				StartedAt: now,
 				Units: map[string]*Unit{
@@ -2088,8 +2083,7 @@ func ackSwap(t *testing.T, h *testHarness, ns, id string, version uint64, node s
 	})))
 }
 
-// errIfFailed supplies the error message the FSM requires on a failing
-// ack, and the empty string a succeeding one must carry.
+// errIfFailed returns a fixed error string on failure, or empty on success.
 func errIfFailed(success bool) string {
 	if success {
 		return ""

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -560,14 +560,14 @@ func ingestSampleTasks(t *testing.T, m *Manager, now time.Time) map[string][]*Ta
 				},
 				Payload: []byte("test2"),
 				// Manager.RecordUnitCompletion alone takes a successful
-				// task to FINALIZING; the FINISHED transition is committed
+				// task to SWAPPING; the FINISHED transition is committed
 				// by [Manager.MarkTaskFinalized] which the [Scheduler]
 				// issues after every node's [Provider.OnTaskCompleted]
 				// returns. This helper exercises RecordUnitCompletion in
-				// isolation, so FINALIZING is the expected end state.
-				Status:     TaskStatusSwapping,
-				StartedAt:  now,
-				FinishedAt: now.Add(time.Minute),
+				// isolation, so SWAPPING is the expected end state — and a
+				// SWAPPING task carries no FinishedAt.
+				Status:    TaskStatusSwapping,
+				StartedAt: now,
 				Units: map[string]*Unit{
 					"su-1": {ID: "su-1", Status: UnitStatusCompleted, Progress: 1.0},
 				},
@@ -1429,16 +1429,17 @@ func TestManager_MarkTaskFailed(t *testing.T) {
 
 		tasks, _ := h.manager.ListDistributedTasks(context.Background())
 		require.Equal(t, TaskStatusSwapping, tasks["ns"][0].Status)
-		finishedAt := tasks["ns"][0].FinishedAt
 
+		h.clock.Advance(time.Minute)
+		failedAt := h.clock.Now()
 		require.NoError(t, markFailed(t, h, "ns", "task1", version, "schema flip failed at finalize"))
 
 		tasks, _ = h.manager.ListDistributedTasks(context.Background())
 		task := tasks["ns"][0]
 		require.Equal(t, TaskStatusFailed, task.Status)
 		require.Contains(t, task.Error, "schema flip failed at finalize")
-		require.Equal(t, finishedAt, task.FinishedAt,
-			"FinishedAt must stay at the AllUnitsTerminal moment, matching other FAILED paths")
+		require.Equal(t, failedAt.UnixMilli(), task.FinishedAt.UnixMilli(),
+			"FinishedAt must be the failure moment, not the earlier AllUnitsTerminal one")
 	})
 
 	t.Run("is idempotent: second call on FAILED is a no-op", func(t *testing.T) {

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -2060,6 +2060,43 @@ func drivePreparing(t *testing.T, h *testHarness, ns, id string, version uint64,
 		"barrier task with all units terminal MUST land in PREPARING (not SWAPPING)")
 }
 
+// ackPrep records one node's PREP-phase ack through the FSM.
+func ackPrep(t *testing.T, h *testHarness, ns, id string, version uint64, node string, success bool) {
+	t.Helper()
+	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
+		Namespace:         ns,
+		Id:                id,
+		Version:           version,
+		NodeId:            node,
+		Success:           success,
+		Error:             errIfFailed(success),
+		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
+	})))
+}
+
+// ackSwap records one node's SWAP-phase ack through the FSM.
+func ackSwap(t *testing.T, h *testHarness, ns, id string, version uint64, node string, success bool) {
+	t.Helper()
+	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
+		Namespace:         ns,
+		Id:                id,
+		Version:           version,
+		NodeId:            node,
+		Success:           success,
+		Error:             errIfFailed(success),
+		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
+	})))
+}
+
+// errIfFailed supplies the error message the FSM requires on a failing
+// ack, and the empty string a succeeding one must carry.
+func errIfFailed(success bool) string {
+	if success {
+		return ""
+	}
+	return "boom"
+}
+
 // TestManager_RecordPreparationCompleteAck_Success pins the core PREP barrier
 // invariant: PREPARING → SWAPPING happens only after EVERY expected
 // node ack lands with Success=true. Until the last ack arrives, the
@@ -2273,14 +2310,7 @@ func fixtureInStatus(t *testing.T, h *testHarness, status TaskStatus) (string, s
 	case TaskStatusFinished:
 		addTaskWithUnits(t, h, ns, id, version, []string{"u-n1"})
 		completeUnit(t, h, ns, id, version, "n1", "u-n1")
-		require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-			Namespace:         ns,
-			Id:                id,
-			Version:           version,
-			NodeId:            "n1",
-			Success:           true,
-			AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-		})))
+		ackSwap(t, h, ns, id, version, "n1", true)
 		require.NoError(t, h.manager.MarkTaskFinalized(toCmd(t, &cmd.MarkTaskFinalizedRequest{
 			Namespace:             ns,
 			Id:                    id,

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1211,14 +1211,7 @@ func TestManager_RecordPostCompletionAck_Success(t *testing.T) {
 	require.Equal(t, TaskStatusSwapping, tasks["ns"][0].Status)
 
 	for _, n := range []string{"node-1", "node-2", "node-3"} {
-		require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-			Namespace:         "ns",
-			Id:                "task1",
-			Version:           version,
-			NodeId:            n,
-			Success:           true,
-			AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-		})))
+		ackSwap(t, h, "ns", "task1", version, n, true)
 	}
 
 	tasks, _ = h.manager.ListDistributedTasks(context.Background())
@@ -1260,14 +1253,7 @@ func TestManager_RecordPostCompletionAck_FailureTransitionsToFailed(t *testing.T
 	}
 
 	// node-1 acks success.
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackSwap(t, h, "ns", "task1", version, "node-1", true)
 
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
 	require.Equal(t, TaskStatusSwapping, tasks["ns"][0].Status)
@@ -1314,29 +1300,14 @@ func TestManager_RecordPostCompletionAck_Idempotent(t *testing.T) {
 	})))
 
 	// First ack: success.
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackSwap(t, h, "ns", "task1", version, "node-1", true)
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
 	require.True(t, tasks["ns"][0].PostCompletionAcks["node-1"].Success)
 	require.Equal(t, TaskStatusSwapping, tasks["ns"][0].Status)
 
 	// Duplicate ack from same node with FAILURE — must be ignored, the
 	// status MUST stay FINALIZING (not flip to FAILED).
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           false,
-		Error:             "stale retry that must NOT flip success",
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackSwap(t, h, "ns", "task1", version, "node-1", false)
 	tasks, _ = h.manager.ListDistributedTasks(context.Background())
 	require.True(t, tasks["ns"][0].PostCompletionAcks["node-1"].Success,
 		"first ack wins — duplicate must not flip success to failure")
@@ -1364,14 +1335,7 @@ func TestManager_RecordPostCompletionAck_DropsAcksForTerminalStatus(t *testing.T
 	})))
 
 	// Drive the task to FINISHED via MarkTaskFinalized.
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackSwap(t, h, "ns", "task1", version, "node-1", true)
 	require.NoError(t, h.manager.MarkTaskFinalized(toCmd(t, &cmd.MarkTaskFinalizedRequest{
 		Namespace:             "ns",
 		Id:                    "task1",
@@ -1386,15 +1350,7 @@ func TestManager_RecordPostCompletionAck_DropsAcksForTerminalStatus(t *testing.T
 	// A stale retry from "node-2" arrives — there's no node-2 unit in
 	// this task, but real cluster retries can hit FINISHED tasks. The
 	// apply must silently no-op (no error returned, no map mutation).
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-2",
-		Success:           false,
-		Error:             "stale ack after FINISHED",
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackSwap(t, h, "ns", "task1", version, "node-2", false)
 
 	tasks, _ = h.manager.ListDistributedTasks(context.Background())
 	require.Equal(t, TaskStatusFinished, tasks["ns"][0].Status,
@@ -1495,14 +1451,7 @@ func TestManager_SnapshotRestore_WithPostCompletionAcks(t *testing.T) {
 			FinishedAtUnixMillis: h.clock.Now().UnixMilli(),
 		})))
 	}
-	require.NoError(t, h.manager.RecordPostCompletionAck(toCmd(t, &cmd.RecordDistributedTaskPostCompletionAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackSwap(t, h, "ns", "task1", version, "node-1", true)
 
 	snap, err := h.manager.Snapshot()
 	require.NoError(t, err)
@@ -2106,28 +2055,14 @@ func TestManager_RecordPreparationCompleteAck_Success(t *testing.T) {
 	// lifted yet (load-bearing property; the third node must NOT see
 	// SWAPPING and prematurely fire its OnSwapRequested).
 	for _, n := range nodes[:2] {
-		require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-			Namespace:         "ns",
-			Id:                "task1",
-			Version:           version,
-			NodeId:            n,
-			Success:           true,
-			AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-		})))
+		ackPrep(t, h, "ns", "task1", version, n, true)
 		tasks, _ := h.manager.ListDistributedTasks(context.Background())
 		require.Equal(t, TaskStatusPreparing, tasks["ns"][0].Status,
 			"PREPARING → SWAPPING must NOT fire until EVERY expected node has acked")
 	}
 
 	// Third ack lifts the barrier.
-	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-3",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackPrep(t, h, "ns", "task1", version, "node-3", true)
 
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
 	task := tasks["ns"][0]
@@ -2155,14 +2090,7 @@ func TestManager_RecordPreparationCompleteAck_FailureTransitionsToFailed(t *test
 	drivePreparing(t, h, "ns", "task1", version, nodes)
 
 	// node-1 acks success.
-	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackPrep(t, h, "ns", "task1", version, "node-1", true)
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
 	require.Equal(t, TaskStatusPreparing, tasks["ns"][0].Status,
 		"one success ack does not lift the barrier — both nodes still owe an ack")
@@ -2198,14 +2126,7 @@ func TestManager_RecordPreparationCompleteAck_Idempotent(t *testing.T) {
 	drivePreparing(t, h, "ns", "task1", version, []string{"node-1"})
 
 	// First ack: success → barrier lifts (single-node).
-	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           true,
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackPrep(t, h, "ns", "task1", version, "node-1", true)
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
 	require.True(t, tasks["ns"][0].PreparationCompletionAcks["node-1"].Success)
 	require.Equal(t, TaskStatusSwapping, tasks["ns"][0].Status)
@@ -2213,15 +2134,7 @@ func TestManager_RecordPreparationCompleteAck_Idempotent(t *testing.T) {
 	// Duplicate ack with Success=false: must be silently dropped.
 	// If the duplicate took effect it would flip Success→false in the
 	// recorded ack AND flip SWAPPING → FAILED, both of which are wrong.
-	require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-		Namespace:         "ns",
-		Id:                "task1",
-		Version:           version,
-		NodeId:            "node-1",
-		Success:           false,
-		Error:             "this must be ignored",
-		AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-	})))
+	ackPrep(t, h, "ns", "task1", version, "node-1", false)
 	tasks, _ = h.manager.ListDistributedTasks(context.Background())
 	require.True(t, tasks["ns"][0].PreparationCompletionAcks["node-1"].Success,
 		"duplicate ack must not flip recorded success → failure")
@@ -2249,14 +2162,7 @@ func TestManager_RecordPreparationCompleteAck_AckOrderCommutativity(t *testing.T
 			drivePreparing(t, h, "ns", "task1", version, nodes)
 
 			for _, n := range perm {
-				require.NoError(t, h.manager.RecordPreparationCompleteAck(toCmd(t, &cmd.RecordDistributedTaskPreparationCompleteAckRequest{
-					Namespace:         "ns",
-					Id:                "task1",
-					Version:           version,
-					NodeId:            n,
-					Success:           true,
-					AckedAtUnixMillis: h.clock.Now().UnixMilli(),
-				})))
+				ackPrep(t, h, "ns", "task1", version, n, true)
 			}
 
 			tasks, _ := h.manager.ListDistributedTasks(context.Background())

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -1892,10 +1892,9 @@ func TestSchedulerTick_UnrecognizedStatusWarn(t *testing.T) {
 				addTaskWithUnits(t, h, spec.namespace, spec.id, spec.version, []string{"su-" + spec.id})
 				task := h.manager.tasks[spec.namespace][spec.id]
 				task.Status = spec.status
-				// A terminal task whose FinishedAt was never stamped reads
-				// as long expired, and the TTL sweep deletes it before the
-				// assertions run. A non-terminal one must carry no stamp at
-				// all, which is also how the localTasks half above seeds.
+				// Terminal tasks need FinishedAt stamped, or the TTL sweep
+				// deletes them before assertions run; non-terminal tasks
+				// must stay unstamped, matching how localTasks seeds above.
 				if spec.status.IsTerminal() {
 					task.FinishedAt = h.clock.Now()
 				}

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -72,8 +72,10 @@ func TestHappyPathTaskLifecycleWithSingleNode(t *testing.T) {
 	h.advanceClock(h.schedulerTickInterval)
 	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
-	// advance the clock just before expected clean up time to check whether it respects it
-	h.advanceClock(h.completedTaskTTL - h.clockAdvancedSoFar - time.Minute)
+	// advance the clock just before expected clean up time to check whether it
+	// respects it. Retention counts from the FINISHED transition, which lands a
+	// tick after the units stopped, so the TTL has not elapsed here either way.
+	h.advanceClock(h.completedTaskTTL - h.clockAdvancedSoFar)
 
 	h.expectCleanUpTask(t, h.tasksNamespace, taskID, version)
 	h.advanceClock(h.schedulerTickInterval + time.Minute)
@@ -393,6 +395,10 @@ func TestRemoveCleanedUpTaskLocalStateDuringRuntime(t *testing.T) {
 	completeUnit(t, h, h.tasksNamespace, startedTask.ID, startedTask.Version, h.localNodeID, "su-1")
 
 	recvWithTimeout(t, h.provider.completedCh)
+
+	// Retention counts from the FINISHED transition, which the scheduler
+	// commits a tick after the last unit stopped.
+	h.advanceClock(h.schedulerTickInterval)
 
 	h.expectCleanUpTask(t, h.tasksNamespace, startedTask.ID, startedTask.Version)
 	h.advanceClock(h.completedTaskTTL)

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -72,9 +72,8 @@ func TestHappyPathTaskLifecycleWithSingleNode(t *testing.T) {
 	h.advanceClock(h.schedulerTickInterval)
 	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
-	// advance the clock just before expected clean up time to check whether it
-	// respects it. Retention counts from the FINISHED transition, which lands a
-	// tick after the units stopped, so the TTL has not elapsed here either way.
+	// Retention counts from the FINISHED transition, which lands a tick
+	// after the units stopped, so this still lands just short of the TTL.
 	h.advanceClock(h.completedTaskTTL - h.clockAdvancedSoFar)
 
 	h.expectCleanUpTask(t, h.tasksNamespace, taskID, version)

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -1895,8 +1895,11 @@ func TestSchedulerTick_UnrecognizedStatusWarn(t *testing.T) {
 				task.Status = spec.status
 				// A terminal task whose FinishedAt was never stamped reads
 				// as long expired, and the TTL sweep deletes it before the
-				// assertions run.
-				task.FinishedAt = h.clock.Now()
+				// assertions run. A non-terminal one must carry no stamp at
+				// all, which is also how the localTasks half above seeds.
+				if spec.status.IsTerminal() {
+					task.FinishedAt = h.clock.Now()
+				}
 			}
 
 			h.startScheduler(t)

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -562,19 +562,14 @@ type Task struct {
 	// Status is the current status of the task.
 	Status TaskStatus `json:"status"`
 
-	// StartedAt is the time that a task was submitted to the cluster.
-	// [Manager.AddTask] is its only writer and sets it from the request's
-	// SubmittedAtUnixMillis, so it is never zero on a task that exists —
-	// which is why it stays a value while its API siblings are pointers.
+	// StartedAt is set once by [Manager.AddTask] and is never zero, unlike
+	// its pointer-typed API siblings.
 	StartedAt time.Time `json:"startedAt"`
 
-	// FinishedAt is the time that task reached a terminal status, and is
-	// zero until it does. [Task.markTerminal] is the only writer that sets
-	// it; [Manager.Restore] is the only other writer at all, and only ever
-	// clears it on a restored non-terminal task. The coordination phases
-	// (PREPARING, SWAPPING) can run for minutes on a large collection, so a
-	// stamp set before them would report a finish time for work still in
-	// flight. Additionally, it is used to schedule task clean up.
+	// FinishedAt is the terminal timestamp (zero until then); [Task.markTerminal]
+	// is the sole writer, aside from Restore clearing it on non-terminal tasks.
+	// Must not be stamped during PREPARING/SWAPPING — those can run minutes on
+	// large collections — since cleanup TTL counts from this value.
 	FinishedAt time.Time `json:"finishedAt"`
 
 	// Error is an optional field to store the error which moved the task to FAILED status.
@@ -619,12 +614,10 @@ type PostCompletionAck struct {
 	// Error captures the aggregated error message when Success==false.
 	// Empty when Success==true.
 	Error string `json:"error,omitempty"`
-	// AckedAt is the wall-clock time the acking node read when it built the
-	// RAFT request (cluster/raft_distributed_tasks_apply_endpoints.go), not
-	// a clock read at apply time — so every node's apply of that entry
-	// stores the same value. Useful for forensics — the gap between the
-	// earliest and the latest AckedAt is how long the cluster spent waiting
-	// on its slowest node.
+	// AckedAt is the acking node's clock at request-build time, not the FSM
+	// apply-time clock — required so every replica's apply produces the
+	// same value. The spread between the earliest and latest AckedAt shows
+	// how long the cluster waited on its slowest node.
 	AckedAt time.Time `json:"ackedAt"`
 }
 
@@ -652,11 +645,10 @@ func (t *Task) Clone() *Task {
 	return &clone
 }
 
-// markTerminal stamps status and FinishedAt together, so a terminal
-// transition can never set one without the other. Bare Status assignments
-// elsewhere in the FSM only ever write the non-terminal PREPARING/SWAPPING.
-// at must come from the RAFT request, never a local clock, so every node's
-// apply of the same log entry produces the same timestamp.
+// markTerminal stamps status and FinishedAt together so a terminal
+// transition never sets one without the other. at must come from the RAFT
+// request, never a local clock, so every replica's apply produces the same
+// timestamp.
 func (t *Task) markTerminal(status TaskStatus, at time.Time) {
 	t.Status = status
 	t.FinishedAt = at

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -565,8 +565,12 @@ type Task struct {
 	// StartedAt is the time that a task was submitted to the cluster.
 	StartedAt time.Time `json:"startedAt"`
 
-	// FinishedAt is the time that task reached a terminal status.
-	// Additionally, it is used to schedule task clean up.
+	// FinishedAt is the time that task reached a terminal status, and is
+	// zero until it does — [Task.markTerminal] is the only writer. The
+	// coordination phases (PREPARING, SWAPPING) can run for minutes on a
+	// large collection, so a stamp set before them would report a finish
+	// time for work still in flight. Additionally, it is used to schedule
+	// task clean up.
 	FinishedAt time.Time `json:"finishedAt"`
 
 	// Error is an optional field to store the error which moved the task to FAILED status.
@@ -613,9 +617,8 @@ type PostCompletionAck struct {
 	Error string `json:"error,omitempty"`
 	// AckedAt is the wall-clock time the ack was applied on the FSM
 	// (set on the apply path, not from the scheduler). Useful for
-	// forensics — the gap between AllUnitsTerminal's FinishedAt and the
-	// last AckedAt is the SWAPPING window's wall-clock duration on this
-	// cluster.
+	// forensics — the gap between the earliest and the latest AckedAt is
+	// how long the cluster spent waiting on its slowest node.
 	AckedAt time.Time `json:"ackedAt"`
 }
 
@@ -641,6 +644,15 @@ func (t *Task) Clone() *Task {
 		}
 	}
 	return &clone
+}
+
+// markTerminal moves the task to a terminal status and stamps FinishedAt in
+// the same step, so a future transition cannot set one without the other.
+// at must come from the RAFT request, never a local clock, so every node's
+// apply of the same log entry produces the same timestamp.
+func (t *Task) markTerminal(status TaskStatus, at time.Time) {
+	t.Status = status
+	t.FinishedAt = at
 }
 
 // AllUnitsTerminal returns true if all units are in a terminal state (COMPLETED or FAILED).

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -402,6 +402,16 @@ type Unit struct {
 	FinishedAt time.Time  `json:"finishedAt,omitempty"`
 }
 
+// markTerminal stamps FinishedAt and UpdatedAt together with the status, so a
+// unit that goes terminal before its first progress report still reports when
+// it was last touched. at must come from the RAFT request, never a local
+// clock, so every replica's apply produces the same timestamp.
+func (u *Unit) markTerminal(status UnitStatus, at time.Time) {
+	u.Status = status
+	u.FinishedAt = at
+	u.UpdatedAt = at
+}
+
 // UnitSpec defines a unit with an optional group assignment. Used at task creation
 // time when units need group membership (e.g. one group per tenant for MT reindex).
 type UnitSpec struct {

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -652,10 +652,9 @@ func (t *Task) Clone() *Task {
 	return &clone
 }
 
-// markTerminal moves the task to a terminal status and stamps FinishedAt in
-// the same step, so a terminal transition cannot set one without the other.
-// The bare Status assignments left in the FSM all write PREPARING or
-// SWAPPING, which must carry no stamp at all.
+// markTerminal stamps status and FinishedAt together, so a terminal
+// transition can never set one without the other. Bare Status assignments
+// elsewhere in the FSM only ever write the non-terminal PREPARING/SWAPPING.
 // at must come from the RAFT request, never a local clock, so every node's
 // apply of the same log entry produces the same timestamp.
 func (t *Task) markTerminal(status TaskStatus, at time.Time) {

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -563,14 +563,18 @@ type Task struct {
 	Status TaskStatus `json:"status"`
 
 	// StartedAt is the time that a task was submitted to the cluster.
+	// [Manager.AddTask] is its only writer and sets it from the request's
+	// SubmittedAtUnixMillis, so it is never zero on a task that exists —
+	// which is why it stays a value while its API siblings are pointers.
 	StartedAt time.Time `json:"startedAt"`
 
 	// FinishedAt is the time that task reached a terminal status, and is
-	// zero until it does — [Task.markTerminal] is the only writer. The
-	// coordination phases (PREPARING, SWAPPING) can run for minutes on a
-	// large collection, so a stamp set before them would report a finish
-	// time for work still in flight. Additionally, it is used to schedule
-	// task clean up.
+	// zero until it does. [Task.markTerminal] is the only writer that sets
+	// it; [Manager.Restore] is the only other writer at all, and only ever
+	// clears it on a restored non-terminal task. The coordination phases
+	// (PREPARING, SWAPPING) can run for minutes on a large collection, so a
+	// stamp set before them would report a finish time for work still in
+	// flight. Additionally, it is used to schedule task clean up.
 	FinishedAt time.Time `json:"finishedAt"`
 
 	// Error is an optional field to store the error which moved the task to FAILED status.
@@ -615,10 +619,12 @@ type PostCompletionAck struct {
 	// Error captures the aggregated error message when Success==false.
 	// Empty when Success==true.
 	Error string `json:"error,omitempty"`
-	// AckedAt is the wall-clock time the ack was applied on the FSM
-	// (set on the apply path, not from the scheduler). Useful for
-	// forensics — the gap between the earliest and the latest AckedAt is
-	// how long the cluster spent waiting on its slowest node.
+	// AckedAt is the wall-clock time the acking node read when it built the
+	// RAFT request (cluster/raft_distributed_tasks_apply_endpoints.go), not
+	// a clock read at apply time — so every node's apply of that entry
+	// stores the same value. Useful for forensics — the gap between the
+	// earliest and the latest AckedAt is how long the cluster spent waiting
+	// on its slowest node.
 	AckedAt time.Time `json:"ackedAt"`
 }
 
@@ -647,7 +653,9 @@ func (t *Task) Clone() *Task {
 }
 
 // markTerminal moves the task to a terminal status and stamps FinishedAt in
-// the same step, so a future transition cannot set one without the other.
+// the same step, so a terminal transition cannot set one without the other.
+// The bare Status assignments left in the FSM all write PREPARING or
+// SWAPPING, which must carry no stamp at all.
 // at must come from the RAFT request, never a local clock, so every node's
 // apply of the same log entry produces the same timestamp.
 func (t *Task) markTerminal(status TaskStatus, at time.Time) {

--- a/entities/models/distributed_task.go
+++ b/entities/models/distributed_task.go
@@ -34,9 +34,9 @@ type DistributedTask struct {
 	// The high level reason why the task failed.
 	Error string `json:"error,omitempty"`
 
-	// The time when the task was finished.
+	// The time when the task reached a terminal status. Absent while the task is still running.
 	// Format: date-time
-	FinishedAt strfmt.DateTime `json:"finishedAt,omitempty"`
+	FinishedAt *strfmt.DateTime `json:"finishedAt,omitempty"`
 
 	// The nodes that finished the task.
 	FinishedNodes []string `json:"finishedNodes"`

--- a/entities/models/distributed_task_unit.go
+++ b/entities/models/distributed_task_unit.go
@@ -33,9 +33,9 @@ type DistributedTaskUnit struct {
 	// The error message if the unit failed.
 	Error string `json:"error,omitempty"`
 
-	// The time when the unit finished.
+	// The time when the unit reached a terminal status. Absent while the unit is still running.
 	// Format: date-time
-	FinishedAt strfmt.DateTime `json:"finishedAt,omitempty"`
+	FinishedAt *strfmt.DateTime `json:"finishedAt,omitempty"`
 
 	// The ID of the unit.
 	ID string `json:"id,omitempty"`
@@ -49,9 +49,9 @@ type DistributedTaskUnit struct {
 	// The status of the unit.
 	Status string `json:"status,omitempty"`
 
-	// The time when the unit was last updated.
+	// The time when the unit was last updated. Absent until the unit first reports progress.
 	// Format: date-time
-	UpdatedAt strfmt.DateTime `json:"updatedAt,omitempty"`
+	UpdatedAt *strfmt.DateTime `json:"updatedAt,omitempty"`
 }
 
 // Validate validates this distributed task unit

--- a/entities/models/distributed_task_unit.go
+++ b/entities/models/distributed_task_unit.go
@@ -49,7 +49,7 @@ type DistributedTaskUnit struct {
 	// The status of the unit.
 	Status string `json:"status,omitempty"`
 
-	// The time when the unit was last updated. Absent until the unit first reports progress.
+	// The time when the unit was last updated, including its transition to a terminal status. Absent for a unit that has not started yet.
 	// Format: date-time
 	UpdatedAt *strfmt.DateTime `json:"updatedAt,omitempty"`
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -2726,9 +2726,10 @@
           "format": "date-time"
         },
         "finishedAt": {
-          "description": "The time when the task was finished.",
+          "description": "The time when the task reached a terminal status. Absent while the task is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "finishedNodes": {
           "description": "The nodes that finished the task.",
@@ -2783,14 +2784,16 @@
           "x-omitempty": true
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated.",
+          "description": "The time when the unit was last updated. Absent until the unit first reports progress.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         },
         "finishedAt": {
-          "description": "The time when the unit finished.",
+          "description": "The time when the unit reached a terminal status. Absent while the unit is still running.",
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "x-nullable": true
         }
       }
     },

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -2784,7 +2784,7 @@
           "x-omitempty": true
         },
         "updatedAt": {
-          "description": "The time when the unit was last updated. Absent until the unit first reports progress.",
+          "description": "The time when the unit was last updated, including its transition to a terminal status. Absent for a unit that has not started yet.",
           "type": "string",
           "format": "date-time",
           "x-nullable": true

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -323,8 +323,7 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 			terminalErr.Store(&err)
 			return true // exit Eventually; Fatalf below on the test goroutine
 		}
-		// The coordination phases (PREPARING, SWAPPING) run after the units
-		// stop, so a task that is not terminal must report no finish time.
+		// Non-terminal tasks (PREPARING, SWAPPING) must report no finish time.
 		if task.FinishedAt != nil && !distributedtask.TaskStatus(task.Status).IsTerminal() {
 			err := fmt.Errorf("reindex task %s reports finishedAt %s while still in status %s",
 				taskID, task.FinishedAt, task.Status)

--- a/test/acceptance/helpers/reindex/helpers.go
+++ b/test/acceptance/helpers/reindex/helpers.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
@@ -321,6 +322,14 @@ func AwaitReindexFinished(t *testing.T, restURI, taskID string, opts ...Option) 
 			err := fmt.Errorf("reindex task failed: %s", task.Error)
 			terminalErr.Store(&err)
 			return true // exit Eventually; Fatalf below on the test goroutine
+		}
+		// The coordination phases (PREPARING, SWAPPING) run after the units
+		// stop, so a task that is not terminal must report no finish time.
+		if task.FinishedAt != nil && !distributedtask.TaskStatus(task.Status).IsTerminal() {
+			err := fmt.Errorf("reindex task %s reports finishedAt %s while still in status %s",
+				taskID, task.FinishedAt, task.Status)
+			terminalErr.Store(&err)
+			return true
 		}
 		return task.Status == "FINISHED"
 	}, o.timeout, 1*time.Second, "reindex task %s should reach FINISHED status", taskID)

--- a/usecases/distributedtask/handler.go
+++ b/usecases/distributedtask/handler.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
@@ -67,7 +68,7 @@ func (h *Handler) ListTasks(ctx context.Context, principal *models.Principal) (m
 				Status:     task.Status.String(),
 				Error:      task.Error,
 				StartedAt:  strfmt.DateTime(task.StartedAt),
-				FinishedAt: strfmt.DateTime(task.FinishedAt),
+				FinishedAt: optionalDateTime(task.FinishedAt),
 				Payload:    payload,
 			}
 
@@ -89,12 +90,24 @@ func mapUnits(task *distributedtask.Task) []*models.DistributedTaskUnit {
 			Status:     string(u.Status),
 			Progress:   u.Progress,
 			Error:      u.Error,
-			UpdatedAt:  strfmt.DateTime(u.UpdatedAt),
-			FinishedAt: strfmt.DateTime(u.FinishedAt),
+			UpdatedAt:  optionalDateTime(u.UpdatedAt),
+			FinishedAt: optionalDateTime(u.FinishedAt),
 		})
 	}
 	sort.Slice(units, func(i, j int) bool {
 		return units[i].ID < units[j].ID
 	})
 	return units
+}
+
+// optionalDateTime keeps an unset timestamp out of the response body
+// entirely. strfmt.DateTime is a struct, so encoding/json ignores omitempty
+// on a non-pointer field and renders the zero value as a year-1 timestamp,
+// which a client cannot tell apart from a real one.
+func optionalDateTime(t time.Time) *strfmt.DateTime {
+	if t.IsZero() {
+		return nil
+	}
+	dt := strfmt.DateTime(t)
+	return &dt
 }

--- a/usecases/distributedtask/handler.go
+++ b/usecases/distributedtask/handler.go
@@ -100,10 +100,8 @@ func mapUnits(task *distributedtask.Task) []*models.DistributedTaskUnit {
 	return units
 }
 
-// optionalDateTime keeps an unset timestamp out of the response body
-// entirely. strfmt.DateTime is a struct, so encoding/json ignores omitempty
-// on a non-pointer field and renders the zero value as a year-1 timestamp,
-// which a client cannot tell apart from a real one.
+// optionalDateTime nils out a zero time so the JSON response omits it — a
+// struct-typed strfmt.DateTime doesn't get omitempty support for free.
 func optionalDateTime(t time.Time) *strfmt.DateTime {
 	if t.IsZero() {
 		return nil

--- a/usecases/distributedtask/handler_test.go
+++ b/usecases/distributedtask/handler_test.go
@@ -41,9 +41,8 @@ func TestHandler_ListTasks(t *testing.T) {
 		name string
 		task *distributedtask.Task
 		want models.DistributedTask
-		// wantJSON is the serialized task, which is what a client actually
-		// reads: a finishedAt it does not contain cannot be misread as a
-		// finish time that has not happened.
+		// wantJSON is what a client actually reads, so an absent finishedAt
+		// can't be misread as a zero-value finish time.
 		wantJSON string
 	}{
 		{

--- a/usecases/distributedtask/handler_test.go
+++ b/usecases/distributedtask/handler_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
 
 func TestHandler_ListTasks(t *testing.T) {
@@ -40,7 +41,10 @@ func TestHandler_ListTasks(t *testing.T) {
 	tests := []struct {
 		name string
 		task *distributedtask.Task
-		want models.DistributedTask
+		// authzErr makes the authorizer refuse; the row then asserts the
+		// refusal instead of the response shape.
+		authzErr error
+		want     models.DistributedTask
 		// wantJSON pins that an absent finishedAt is never serialized as the zero value.
 		wantJSON string
 	}{
@@ -95,6 +99,20 @@ func TestHandler_ListTasks(t *testing.T) {
 			},
 			wantJSON: `{"id":"u-idle","nodeId":"n3","status":"PENDING"}`,
 		},
+		{
+			// The lister holds a task, so a refusal that logged and fell
+			// through would hand it to a caller without permission.
+			name: "a refused caller gets the error and no tasks",
+			task: &distributedtask.Task{
+				Namespace:      namespace,
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "test-task-3", Version: 12},
+				Payload:        []byte(`{}`),
+				Status:         distributedtask.TaskStatusStarted,
+				StartedAt:      anHourGo,
+			},
+			authzErr: autherrs.NewForbidden(&models.Principal{Username: "nobody"},
+				authorization.READ, authorization.Cluster()),
+		},
 	}
 
 	for _, tt := range tests {
@@ -102,12 +120,18 @@ func TestHandler_ListTasks(t *testing.T) {
 			authorizer := authorization.NewMockAuthorizer(t)
 			authorizer.EXPECT().
 				Authorize(mock.Anything, mock.Anything, authorization.READ, authorization.Cluster()).
-				Return(nil)
+				Return(tt.authzErr)
 			h := NewHandler(authorizer, taskListerStub{
 				items: map[string][]*distributedtask.Task{namespace: {tt.task}},
 			})
 
 			tasks, err := h.ListTasks(context.Background(), &models.Principal{})
+			if tt.authzErr != nil {
+				var forbidden autherrs.Forbidden
+				require.ErrorAs(t, err, &forbidden)
+				require.Nil(t, tasks)
+				return
+			}
 			require.NoError(t, err)
 			require.Equal(t, models.DistributedTasks{namespace: []models.DistributedTask{tt.want}}, tasks)
 

--- a/usecases/distributedtask/handler_test.go
+++ b/usecases/distributedtask/handler_test.go
@@ -13,6 +13,7 @@ package distributedtask
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -25,51 +26,100 @@ import (
 )
 
 func TestHandler_ListTasks(t *testing.T) {
-	var (
-		authorizer = authorization.NewMockAuthorizer(t)
-		now        = time.Now()
+	const namespace = "testNamespace"
 
-		namespace = "testNamespace"
-		lister    = taskListerStub{
-			items: map[string][]*distributedtask.Task{
-				namespace: {
-					{
-						Namespace: namespace,
-						TaskDescriptor: distributedtask.TaskDescriptor{
-							ID:      "test-task-1",
-							Version: 10,
-						},
-						Payload:    []byte(`{"hello": "world"}`),
-						Status:     distributedtask.TaskStatusFailed,
-						StartedAt:  now.Add(-time.Hour),
-						FinishedAt: now,
-						Error:      "server is on fire",
-					},
-				},
-			},
+	var (
+		now      = time.Now()
+		anHourGo = now.Add(-time.Hour)
+		dt       = func(t time.Time) *strfmt.DateTime {
+			d := strfmt.DateTime(t)
+			return &d
 		}
-		h = NewHandler(authorizer, lister)
 	)
 
-	authorizer.EXPECT().Authorize(mock.Anything, mock.Anything, authorization.READ, authorization.Cluster()).Return(nil)
-
-	tasks, err := h.ListTasks(context.Background(), &models.Principal{})
-	require.NoError(t, err)
-
-	require.Equal(t, models.DistributedTasks{
-		"testNamespace": []models.DistributedTask{
-			{
+	tests := []struct {
+		name string
+		task *distributedtask.Task
+		want models.DistributedTask
+		// wantJSON is the serialized task, which is what a client actually
+		// reads: a finishedAt it does not contain cannot be misread as a
+		// finish time that has not happened.
+		wantJSON string
+	}{
+		{
+			name: "terminal task carries finishedAt",
+			task: &distributedtask.Task{
+				Namespace:      namespace,
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "test-task-1", Version: 10},
+				Payload:        []byte(`{"hello": "world"}`),
+				Status:         distributedtask.TaskStatusFailed,
+				StartedAt:      anHourGo,
+				FinishedAt:     now,
+				Error:          "server is on fire",
+			},
+			want: models.DistributedTask{
 				ID:         "test-task-1",
 				Version:    10,
 				Status:     "FAILED",
 				Error:      "server is on fire",
-				StartedAt:  strfmt.DateTime(now.Add(-time.Hour)),
-				FinishedAt: strfmt.DateTime(now),
+				StartedAt:  strfmt.DateTime(anHourGo),
+				FinishedAt: dt(now),
 				Payload:    map[string]interface{}{"hello": "world"},
 				Units:      []*models.DistributedTaskUnit{},
 			},
+			wantJSON: `"finishedAt":"` + strfmt.DateTime(now).String() + `"`,
 		},
-	}, tasks)
+		{
+			name: "task mid-coordination omits finishedAt, and so does its unfinished unit",
+			task: &distributedtask.Task{
+				Namespace:      namespace,
+				TaskDescriptor: distributedtask.TaskDescriptor{ID: "test-task-2", Version: 11},
+				Payload:        []byte(`{}`),
+				Status:         distributedtask.TaskStatusSwapping,
+				StartedAt:      anHourGo,
+				Units: map[string]*distributedtask.Unit{
+					"u-done": {ID: "u-done", NodeID: "n1", Status: distributedtask.UnitStatusCompleted, Progress: 1, UpdatedAt: now, FinishedAt: now},
+					"u-live": {ID: "u-live", NodeID: "n2", Status: distributedtask.UnitStatusInProgress, Progress: 0.5, UpdatedAt: now},
+					"u-idle": {ID: "u-idle", NodeID: "n3", Status: distributedtask.UnitStatusPending},
+				},
+			},
+			want: models.DistributedTask{
+				ID:        "test-task-2",
+				Version:   11,
+				Status:    "SWAPPING",
+				StartedAt: strfmt.DateTime(anHourGo),
+				Payload:   map[string]interface{}{},
+				Units: []*models.DistributedTaskUnit{
+					{ID: "u-done", NodeID: "n1", Status: "COMPLETED", Progress: 1, UpdatedAt: dt(now), FinishedAt: dt(now)},
+					{ID: "u-idle", NodeID: "n3", Status: "PENDING"},
+					{ID: "u-live", NodeID: "n2", Status: "IN_PROGRESS", Progress: 0.5, UpdatedAt: dt(now)},
+				},
+			},
+			wantJSON: `{"id":"u-idle","nodeId":"n3","status":"PENDING"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := authorization.NewMockAuthorizer(t)
+			authorizer.EXPECT().
+				Authorize(mock.Anything, mock.Anything, authorization.READ, authorization.Cluster()).
+				Return(nil)
+			h := NewHandler(authorizer, taskListerStub{
+				items: map[string][]*distributedtask.Task{namespace: {tt.task}},
+			})
+
+			tasks, err := h.ListTasks(context.Background(), &models.Principal{})
+			require.NoError(t, err)
+			require.Equal(t, models.DistributedTasks{namespace: []models.DistributedTask{tt.want}}, tasks)
+
+			body, err := json.Marshal(tasks)
+			require.NoError(t, err)
+			require.Contains(t, string(body), tt.wantJSON)
+			require.NotContains(t, string(body), "0001-01-01T00:00:00.000Z",
+				"an unset timestamp must be absent, not serialized as the zero value")
+		})
+	}
 }
 
 type taskListerStub struct {

--- a/usecases/distributedtask/handler_test.go
+++ b/usecases/distributedtask/handler_test.go
@@ -41,8 +41,7 @@ func TestHandler_ListTasks(t *testing.T) {
 		name string
 		task *distributedtask.Task
 		want models.DistributedTask
-		// wantJSON is what a client actually reads, so an absent finishedAt
-		// can't be misread as a zero-value finish time.
+		// wantJSON pins that an absent finishedAt is never serialized as the zero value.
 		wantJSON string
 	}{
 		{


### PR DESCRIPTION
**The bug.** A reindex task that is still running reports a finish time. Ask for its status mid-migration and it tells you when it finished.

**Why that's wrong.** Nothing the user is waiting for has happened at that point: no index has been swapped and the property still uses its old settings. A client that reads a finish time as "done" queries next and gets the old behavior. The field's own documentation and the public API description both say it appears only once the task reaches a final state.

**The wait is not short.** After the moment the time was being stamped, the cluster still has to prepare every shard on every node, wait for all nodes twice, switch the schema, and finalize. The second wait has no timeout, so a single slow node can hold the task there indefinitely with a finish time already published. Our test collections finish in under a second, which is why this was never caught.

**A client couldn't detect it either.** An unset timestamp was sent as the year 1 (`0001-01-01T00:00:00.000Z`) instead of being left out, so "not finished" and "finished" looked identical. Two sibling fields had the same flaw, one of them on every freshly submitted task. All three now omit the value when it isn't set.

**The fix.** The timestamp is written at the same moment the task reaches its final state, in a single step, so a later change cannot set one without the other. The value comes from the cluster log rather than a local clock, so every node agrees on it. A task restored after a restart while still mid-migration has the stale value cleared.

**Behavior changes.**
1. The finish time is absent until the task is genuinely finished.
2. Retention counts from the finish rather than from the moment the units stopped, so a failed task survives long enough for an operator to read the error. The shift is not bounded — a task stuck mid-migration for days is kept that much longer.
3. Running tasks sort by submission time.

**Review notes.**
- Seven call sites reach the new helper but only six paths are reachable; one is dead on `stable/v1.39` already and is filed separately, not fixed here.
- Four paths reach a terminal state out of a coordination phase. The new test table covers three of them; the fourth is pinned by an existing test whose assertion this change had to invert, because it previously asserted the old contract. Two further paths leave the running state directly and were already covered.
- One comment on a neighbouring field was corrected even though it predates this PR. It claimed the ack timestamp is set while applying the change; it is set by the node proposing it. That distinction is exactly why the new timestamp is identical on every node, so leaving it would have contradicted this PR's own reasoning four lines away.
- A structural test pinning which functions may write the field was planned and dropped. This was the review's headline suggestion, so it is worth being explicit: the pattern it relied on would not have matched one of the two writers at all, so it would have pinned the wrong set — and it would also have pushed the diff over budget. The field's documentation now states the writer set, and nothing enforces it.

**What this lets us delete, and what it doesn't.** Other code was written to work around the wrong timestamp, and most of it is not here — the status endpoint's time window, the suppressor for the phantom entry it produced, and the tracker feeding that suppressor are removed by their own PR. What this change removes is the commentary that defended the old value. Two guards deliberately stay and in fact matter *more* now: the checks that refuse to clean up a task still in flight. They used to be a second line of defense behind an age check; now that a running task carries no timestamp at all, the age check protects nothing and those guards are the only thing left.

## Not in this PR

- A cosmetic ordering artifact: on the two failure paths the task's timestamp comes from a different node's clock than its units', so under clock skew a unit can display as finishing after the task containing it. Previously impossible by construction. No invariant depends on it.
- Two nodes can hold different finish times for the same completed task, depending on whether they rebuilt from a snapshot or replayed the log. It cannot be corrected from inside this change, and the only thing reading it is already inconsistent across nodes for a larger reason — both are recorded on the existing issue.
- The stale index-status window on `GET /v1/schema/{class}/indexes`, which reads this field. It is broken for an unrelated reason and is deleted by its own PR.
