### PR TITLE
[v1.38] fix(hnsw): drain commit-log maintenance before locking in Drop() (#12100)

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -812,15 +812,20 @@ func (l *hnswCommitLogger) logCombiningThreshold() int64 {
 }
 
 func (l *hnswCommitLogger) Drop(ctx context.Context, keepFiles bool) error {
+	// Drain before locking: Shutdown waits for an in-flight switchCommitLogs,
+	// which starts by taking l.Mutex. Holding it here deadlocks both until ctx
+	// expires. Report the drain error only after the fd is closed, or a timed-out
+	// drain leaks it.
+	shutdownErr := l.Shutdown(ctx)
+
 	l.Lock()
 	defer l.Unlock()
 	if err := l.commitLogger.Close(); err != nil {
 		return errors.Wrap(err, "close hnsw commit logger prior to delete")
 	}
 
-	// stop all goroutines
-	if err := l.Shutdown(ctx); err != nil {
-		return errors.Wrap(err, "drop commitlog")
+	if shutdownErr != nil {
+		return errors.Wrap(shutdownErr, "drop commitlog")
 	}
 
 	if keepFiles {

--- a/adapters/repos/db/vector/hnsw/commit_logger_drop_deadlock_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_drop_deadlock_test.go
@@ -1,0 +1,101 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestCommitLoggerDropDoesNotDeadlockWithMaintenanceCycle pins a deadlock: Drop
+// held l.Mutex while Shutdown -> Unregister waited for an in-flight
+// switchCommitLogs, whose first statement is l.Lock(). It unwound only when ctx
+// expired — Shard.drop's 20s, on the RAFT apply goroutine.
+//
+// gatedFile forces the interleaving rather than racing for it: it parks Drop
+// inside its critical section, so switchCommitLogs blocks on the mutex before
+// Drop starts draining.
+func TestCommitLoggerDropDoesNotDeadlockWithMaintenanceCycle(t *testing.T) {
+	// Shard.drop allows 20s; shortened so a deadlock fails fast.
+	const dropCtxBudget = 5 * time.Second
+
+	logger, _ := test.NewNullLogger()
+	ctx, cancel := context.WithTimeout(context.Background(), dropCtxBudget)
+	defer cancel()
+
+	callbacks := cyclemanager.NewCallbackGroup("maintenance", logger, 1)
+	cycle := cyclemanager.NewManager("maintenance",
+		cyclemanager.NewFixedTicker(time.Millisecond), callbacks.CycleCallback, logger)
+	cycle.Start()
+	defer cycle.StopAndWait(context.Background())
+
+	gate := &gatedFile{parked: make(chan struct{}), released: make(chan struct{})}
+	fs := common.NewTestFS()
+	fs.OnOpenFile = func(f common.File) common.File { gate.File = f; return gate }
+
+	cl, err := NewCommitLogger(t.TempDir(), "deadlock", logger, callbacks, WithFS(fs))
+	require.NoError(t, err)
+
+	// Without this there is no callback to drain and the test passes vacuously.
+	cl.InitMaintenance()
+
+	dropped := make(chan error, 1)
+	begin := time.Now()
+	go func() { dropped <- cl.Drop(ctx, false) }()
+
+	select {
+	case <-gate.parked:
+	case err := <-dropped:
+		t.Fatalf("Drop returned without reaching its critical section: %v", err)
+	}
+
+	// switchCommitLogs cannot pass l.Lock() while Drop holds it, so it parks there
+	// and the group marks it running — what Unregister waits on.
+	time.Sleep(200 * time.Millisecond)
+	close(gate.released)
+
+	select {
+	case err := <-dropped:
+		require.NoError(t, err, "Drop drained switchCommitLogs while holding l.Mutex, "+
+			"so Unregister timed out after %s", time.Since(begin))
+	case <-time.After(dropCtxBudget + time.Second):
+		t.Fatal("Drop never returned: it waits for switchCommitLogs, blocked on the " +
+			"l.Mutex that Drop holds")
+	}
+
+	require.True(t, cl.TryLock(), "Drop returned while still holding l.Mutex")
+	cl.Unlock()
+}
+
+// gatedFile parks Close() until released, holding Drop inside its critical
+// section. Drop's is the only Close here: switchCommitLogs rotates (and closes)
+// only past maxSizeIndividual, and this commit log stays empty.
+type gatedFile struct {
+	common.File
+	once     sync.Once
+	parked   chan struct{}
+	released chan struct{}
+}
+
+func (f *gatedFile) Close() error {
+	f.once.Do(func() { close(f.parked) })
+	<-f.released
+	return f.File.Close()
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -765,20 +765,15 @@ func (h *hnsw) nodeByID(id uint64) *vertex {
 	return h.nodes[id]
 }
 
+// Drop stops the index exactly as Shutdown does, then removes the commit log's
+// files. Dropping before stopping would leave the maintenance cycles and the
+// tombstone cleanup running against state being torn down underneath them.
 func (h *hnsw) Drop(ctx context.Context, keepFiles bool) error {
-	// cancel tombstone cleanup goroutine
-	if err := h.tombstoneCleanupCallbackCtrl.Unregister(ctx); err != nil {
+	if err := h.Shutdown(ctx); err != nil {
 		return errors.Wrap(err, "hnsw drop")
 	}
 
-	if err := h.releaseVectors(); err != nil {
-		return err
-	}
-
-	// cancel commit logger last, as the tombstone cleanup cycle might still
-	// write while it's still running
-	err := h.commitLog.Drop(ctx, keepFiles)
-	if err != nil {
+	if err := h.commitLog.Drop(ctx, keepFiles); err != nil {
 		return errors.Wrap(err, "commit log drop")
 	}
 

--- a/adapters/repos/db/vector/hnsw/index_drop_teardown_test.go
+++ b/adapters/repos/db/vector/hnsw/index_drop_teardown_test.go
@@ -1,0 +1,153 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// TestDropTeardown holds hnsw.Drop to Shutdown's teardown order.
+//
+// Drop used to leave shutdownCtx live, so tombstone cleanup kept walking the graph
+// (delete.go: reassignNeighborsOf) while the index it walks was being torn down. It
+// runs under Shard.drop's 20s ctx on the RAFT apply goroutine, so a wait here
+// freezes the node's schema applies.
+//
+// Both compression branches are covered: collapsing Drop into Shutdown must keep
+// each arm. A double stands in for the compressor, whose Compress() needs an
+// lsmkv.Store.
+func TestDropTeardown(t *testing.T) {
+	// Shard.drop allows 20s; shortened so a stalled Drop fails fast.
+	const dropMustFinishWithin = 5 * time.Second
+
+	tests := []struct {
+		name           string
+		compressed     bool
+		wantCompressor int32
+	}{
+		{name: "compressed index drops the compressor", compressed: true, wantCompressor: 1},
+		{name: "uncompressed index drops the cache", compressed: false, wantCompressor: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			idx := newDropTeardownIndex(t)
+
+			for i := 0; i < 10; i++ {
+				inc := float32(i)
+				require.Nil(t, idx.Add(ctx, uint64(i), []float32{inc, inc + 1, inc + 2}))
+			}
+
+			// Only the teardown path is under test, and it reaches nothing but
+			// VectorCompressor.Drop. Flip the flag after inserting: the insert path
+			// would call Preload on the embedded nil interface.
+			compressor := &countingCompressor{}
+			idx.compressor = compressor
+			idx.compressed.Store(tt.compressed)
+
+			// Let the cycles pick the callbacks up, so Drop competes with live
+			// maintenance rather than an idle index.
+			time.Sleep(50 * time.Millisecond)
+			require.NoError(t, idx.shutdownCtx.Err(), "precondition: shutdownCtx live before Drop")
+
+			dropCtx, cancel := context.WithTimeout(ctx, dropMustFinishWithin)
+			defer cancel()
+
+			dropped := make(chan error, 1)
+			begin := time.Now()
+			go func() { dropped <- idx.Drop(dropCtx, false) }()
+
+			select {
+			case err := <-dropped:
+				require.NoError(t, err, "Drop failed after %s", time.Since(begin))
+				require.Less(t, time.Since(begin), dropMustFinishWithin,
+					"Drop waited on background work it should have cancelled first")
+			case <-time.After(dropMustFinishWithin + time.Second):
+				t.Fatal("Drop never returned: it waits on a background cycle it never cancelled")
+			}
+
+			require.Error(t, idx.shutdownCtx.Err(), "Drop must cancel shutdownCtx")
+			require.Equal(t, tt.wantCompressor, compressor.drops.Load(),
+				"Drop must take the compressed=%v arm of Shutdown", tt.compressed)
+		})
+	}
+}
+
+// countingCompressor embeds the interface: Drop is the only method the teardown
+// path reaches.
+type countingCompressor struct {
+	compressionhelpers.VectorCompressor
+	drops atomic.Int32
+}
+
+func (c *countingCompressor) Drop() error {
+	c.drops.Add(1)
+	return nil
+}
+
+// newDropTeardownIndex builds an index whose maintenance cycles fire throughout,
+// as on a shard that was restored and is immediately deleted.
+func newDropTeardownIndex(t *testing.T) *hnsw {
+	t.Helper()
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+	const indexID = "drop-teardown"
+
+	commitLoggerCallbacks := cyclemanager.NewCallbackGroup("commitLogger", logger, 1)
+	commitLoggerCycle := cyclemanager.NewManager("commitLogger",
+		cyclemanager.NewFixedTicker(time.Millisecond), commitLoggerCallbacks.CycleCallback, logger)
+	commitLoggerCycle.Start()
+	t.Cleanup(func() { commitLoggerCycle.StopAndWait(ctx) })
+
+	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstoneCleanup", logger, 1)
+	tombstoneCycle := cyclemanager.NewManager("tombstoneCleanup",
+		cyclemanager.NewFixedTicker(time.Millisecond), tombstoneCallbacks.CycleCallback, logger)
+	tombstoneCycle.Start()
+	t.Cleanup(func() { tombstoneCycle.StopAndWait(ctx) })
+
+	idx, err := New(Config{
+		AllocChecker:     memwatch.NewDummyMonitor(),
+		RootPath:         dirName,
+		ID:               indexID,
+		Logger:           logger,
+		DistanceProvider: distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk: testVectorForID,
+		GetViewThunk:     func() common.BucketView { return &dropTeardownNoopBucketView{} },
+		MakeCommitLoggerThunk: func() (CommitLogger, error) {
+			return NewCommitLogger(dirName, indexID, logger, commitLoggerCallbacks)
+		},
+	}, enthnsw.NewDefaultUserConfig(), tombstoneCallbacks, nil)
+	require.Nil(t, err)
+	idx.PostStartup(ctx)
+
+	return idx
+}
+
+type dropTeardownNoopBucketView struct{}
+
+func (v *dropTeardownNoopBucketView) ReleaseView() {}


### PR DESCRIPTION
Backport of #12100 to `stable/v1.38`. Cherry-pick of 8942430e23 with conflicts resolved for this branch.

### What's being changed

Deleting a class runs `Shard.drop()` on the RAFT apply goroutine with a 20s context. `hnswCommitLogger.Drop` took `l.Mutex` and, still holding it, called `Shutdown` → `Unregister`, which waits for a running maintenance callback to finish. When that callback is `switchCommitLogs`, its first statement is `l.Lock()` on the same mutex, so both stall until the context expires. The RAFT apply goroutine is blocked for the full 20s per shard; the `hnsw commit log switch failed: … file already closed` log line is the deadlock ending, not a separate fault.

Seen on `1.38.9-99b9837` in weaviate-e2e-tests ([run 31988125624](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/31988125624/job/95266613101)): after a 100-tenant collection delete, one node applied no schema entries for ~20s and the next test's insert failed with `error waiting for local schema to catch up to version 878: got=876 want=878`. The fix is on `main` and `stable/v1.39` only.

Changes, same as the original PR:

- `commitLog.Drop` drains (`Shutdown`) before taking the mutex; the drain error is reported only after the fd is closed so a timed-out drain does not leak it.
- `hnsw.Drop` calls `hnsw.Shutdown` (cancel ctx, wait prefill, shut down commit log, unregister tombstone cleanup, release vectors) and then removes the commit-log files, instead of a partial copy of that sequence that never cancelled `shutdownCtx`.

### Cherry-pick adaptations

- `commit_logger.go:Drop`: this branch closes via `l.commitLogger.Close()` instead of `currentWriter.Flush()` + `currentFile.Close()`; the hunk moved onto that line.
- `index.go:Drop`: this branch already has `releaseVectors` (guarded by `releaseVectorsOnce`) and the `errorcompounder`-based `Shutdown`, so `Drop` reduces to `Shutdown` + `commitLog.Drop` as in the original.
- `index_drop_teardown_test.go`: `MakeCommitLogger` takes no options on this branch, so the thunk drops the `opts ...CommitlogOption` parameter.

`hnsw.Shutdown` calls `commitLog.Shutdown` and `commitLog.Drop` calls it again; `Unregister` on an absent callback is a no-op success on this branch (`cyclecallbackgroup.go:unregister`).

### Testing

Both regression tests fail on unfixed `stable/v1.38` (`TestCommitLoggerDropDoesNotDeadlockWithMaintenanceCycle` times out at the 5s budget; `TestDropTeardown` fails on "Drop must cancel shutdownCtx") and pass with this change, also under `-race`. `go test ./adapters/repos/db/vector/hnsw/` passes; `golangci-lint` clean.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
