### PR TITLE
lsmkv: read the batched Contains keys from a memtable a window at a time

### DIFF
--- a/adapters/repos/db/inverted/containsany_docids_bench_test.go
+++ b/adapters/repos/db/inverted/containsany_docids_bench_test.go
@@ -561,6 +561,96 @@ func TestDocIDs_BatchedMatchesDesugared(t *testing.T) {
 			uint64(unflushedDocID), "ContainsNone must exclude it")
 	})
 
+	// The case above reaches a memtable inside a single window. This one makes
+	// the batch wider than one window as well, which is the combination the
+	// batching exists for and which nothing else reaches through filter
+	// parsing — the windowing itself is proven a level down, against readers
+	// those tests assemble themselves.
+	t.Run("a batch spanning windows over a live memtable", func(t *testing.T) {
+		g := newContainsFixture(t, 5_000)
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+
+		// Written after the fixture's flush, so these keys exist only in the
+		// active memtable.
+		const liveValues = 64
+		bucket := g.store.Bucket(helpers.BucketFromPropNameLSM(benchPropName))
+		values := make([]string, 0, 2048+liveValues)
+		wantIDs := map[uint64]struct{}{}
+		for i := 0; i < liveValues; i++ {
+			value := fmt.Sprintf("live_%04d", i)
+			require.NoError(t, bucket.RoaringSetAddList([]byte(value), []uint64{uint64(i)}))
+			values = append(values, value)
+			wantIDs[uint64(i)] = struct{}{}
+		}
+
+		// Wide enough that one window cannot hold the batch. The assertion on
+		// window_fills below is what states that, rather than this number.
+		flushed, flushedIDs := g.sampleValues(2048)
+		values = append(values, flushed...)
+		for _, id := range flushedIDs {
+			wantIDs[id] = struct{}{}
+		}
+
+		batched := g.resolveDocIDs(t, ctx, containsFilter(filters.ContainsAny, values))
+		desugared := g.resolveDocIDs(t, context.Background(),
+			equalCompoundFilter(filters.ContainsAny, values))
+		require.Equal(t, desugared, batched,
+			"a batch spanning windows over a live memtable must resolve what the desugared compound does")
+
+		want := make([]uint64, 0, len(wantIDs))
+		for id := range wantIDs {
+			want = append(want, id)
+		}
+		sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+		require.Equal(t, want, batched)
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, entries, 1)
+		fills, ok := entries[0]["window_fills"].(int)
+		require.True(t, ok)
+		require.Greater(t, fills, 1, "the batch must refill, or this covers only the single-window case")
+		reads, ok := entries[0]["memtable_reads"].(int)
+		require.True(t, ok)
+		require.Positive(t, reads, "the keys written after the flush are only reachable through a memtable")
+	})
+
+	// ContainsAll is the one fold that stops before the end of its batch, and
+	// every ContainsAll elsewhere in this package either keeps a non-empty
+	// intersection or runs against a corpus with no live memtable at all. Here
+	// the first two keys hold disjoint documents, so the intersection empties
+	// on the second and the last two are never asked for — the shape the Fills
+	// godoc names, where a whole window is charged and part of it never served.
+	t.Run("ContainsAll whose intersection empties over a live memtable", func(t *testing.T) {
+		g := newContainsFixture(t, 200)
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+
+		bucket := g.store.Bucket(helpers.BucketFromPropNameLSM(benchPropName))
+		values := []string{"live_a", "live_b", "live_c", "live_d"}
+		// live_a and live_b share no document, so the fold empties at live_b.
+		for value, docID := range map[string]uint64{
+			"live_a": 1, "live_b": 2, "live_c": 1, "live_d": 1,
+		} {
+			require.NoError(t, bucket.RoaringSetAddList([]byte(value), []uint64{docID}))
+		}
+
+		batched := g.resolveDocIDs(t, ctx, containsFilter(filters.ContainsAll, values))
+		desugared := g.resolveDocIDs(t, context.Background(),
+			equalCompoundFilter(filters.ContainsAll, values))
+		require.Equal(t, desugared, batched,
+			"a ContainsAll that empties early over a memtable must resolve what the desugared compound does")
+		require.Empty(t, batched, "live_a and live_b share no document")
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, entries, 1)
+		require.Equal(t, 2, entries[0]["batch_keys_served"],
+			"the fold must stop at the key that empties the intersection, not walk the batch")
+		reads, ok := entries[0]["memtable_reads"].(int)
+		require.True(t, ok)
+		require.Positive(t, reads, "these keys are only reachable through a memtable")
+	})
+
 	t.Run("[]interface{} values from the API layer", func(t *testing.T) {
 		values := []string{containsSharedValues[0], containsSharedValues[1], benchValue(11)}
 		iface := make([]interface{}, len(values))

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -426,6 +426,7 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 			if reader != nil {
 				st := reader.Stats()
 				fields["window_fills"] = st.Fills
+				fields["window_narrowed_fills"] = st.NarrowedFills
 				fields["window_keys_read"] = st.KeysRead
 				fields["window_bytes_peak"] = st.BytesPeak
 				fields["window_bytes_copied"] = st.BytesCopied

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -388,12 +389,25 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 	}
 
 	before := time.Now()
-	// deferred so a filter that fails after the reader opens is still timed
 	var dbm docBitmap
+
+	// Released after the annotation below rather than before it: deferred calls
+	// run in reverse, so registering the release first leaves the annotation to
+	// read the reader and the result while the segments they came from are still
+	// mapped.
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+
+	// Named before the annotation so its closure can reach the reader, and nil
+	// until there is one — a filter rejected while opening it is timed without
+	// inventing counts for work that never happened.
+	var reader *lsmkv.RoaringSetBatchReader
+	// Deferred so a filter that fails partway is timed and reports what it did
+	// before it stopped.
 	defer func() {
 		took := time.Since(before)
 		helpers.AnnotateSlowQueryLogAppendFunc(ctx, "build_allow_list_doc_bitmap", func() map[string]any {
-			return map[string]any{
+			fields := map[string]any{
 				"prop":        pv.prop,
 				"operator":    pv.operator.Name(),
 				"took":        took,
@@ -405,14 +419,26 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 				// filter reports at most two regardless of value count.
 				"batched_keys": pv.containsKeys.Len(),
 			}
+			// What the batching itself did, so a slow batched filter can be told
+			// from a filter that was merely slow. Without these the log says the
+			// read was batched and how big the batch was, and nothing about the
+			// memtable work that is this path's own.
+			if reader != nil {
+				st := reader.Stats()
+				fields["window_fills"] = st.Fills
+				fields["window_keys_read"] = st.KeysRead
+				fields["window_bytes_peak"] = st.BytesPeak
+				fields["window_bytes_copied"] = st.BytesCopied
+				fields["memtables_read"] = st.Memtables
+			}
+			return fields
 		})
 	}()
 
-	reader, err := b.NewRoaringSetBatchReader()
+	reader, err = lsmkv.NewRoaringSetBatchReader(view, pv.containsKeys)
 	if err != nil {
 		return nil, err
 	}
-	defer reader.Release()
 
 	dbm, err = s.docBitmapContainsBatch(ctx, reader, pv)
 	if err != nil {

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -391,16 +391,11 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 	before := time.Now()
 	var dbm docBitmap
 
-	// Released after the annotation below rather than before it: deferred calls
-	// run in reverse, so registering the release first leaves the annotation to
-	// read the reader and the result while the segments they came from are still
-	// mapped.
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	// Named before the annotation so its closure can reach the reader, and nil
-	// until there is one — a filter rejected while opening it is timed without
-	// inventing counts for work that never happened.
+	// Nil until there is a reader, so a filter rejected while opening one is
+	// timed without inventing counts for work that never happened.
 	var reader *lsmkv.RoaringSetBatchReader
 	// Deferred so a filter that fails partway is timed and reports what it did
 	// before it stopped.
@@ -420,17 +415,20 @@ func (pv *propValuePair) fetchContainsBatch(ctx context.Context, s *Searcher) (_
 				"batched_keys": pv.containsKeys.Len(),
 			}
 			// What the batching itself did, so a slow batched filter can be told
-			// from a filter that was merely slow. Without these the log says the
-			// read was batched and how big the batch was, and nothing about the
-			// memtable work that is this path's own.
+			// from a filter that was merely slow.
 			if reader != nil {
 				st := reader.Stats()
 				fields["window_fills"] = st.Fills
 				fields["window_narrowed_fills"] = st.NarrowedFills
-				fields["window_keys_read"] = st.KeysRead
+				fields["batch_keys_served"] = st.KeysServed
 				fields["window_bytes_peak"] = st.BytesPeak
 				fields["window_bytes_copied"] = st.BytesCopied
-				fields["memtables_read"] = st.Memtables
+				fields["memtable_reads"] = st.MemtableReads
+				// Without this the read count cannot be normalized: reads per
+				// fill run from one to one per memtable, so a ratio of 1.0
+				// cannot be told from two memtables whose every fill skipped
+				// one.
+				fields["memtables"] = st.Memtables
 			}
 			return fields
 		})

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -684,7 +684,7 @@ func TestFetchContainsBatch_ReadsRows(t *testing.T) {
 // halves of that pair have to name the same set: listing them twice is how one
 // drifts and the guard stops being pinned.
 var readerAnnotationFields = []string{
-	"window_fills", "window_keys_read",
+	"window_fills", "window_narrowed_fills", "window_keys_read",
 	"window_bytes_peak", "window_bytes_copied", "memtables_read",
 }
 

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -617,12 +617,21 @@ func TestFetchContainsBatch_BucketErrors(t *testing.T) {
 // them to a segment, so the batch reader below reads real disk layers.
 func writeContainsRows(t *testing.T, f *containsBatchGateFixture, propName string, rows map[string][]uint64) {
 	t.Helper()
+	writeContainsRowsUnflushed(t, f, propName, rows)
+	b := f.searcher.store.Bucket(helpers.BucketFromPropNameLSM(propName))
+	require.NoError(t, b.FlushAndSwitch())
+}
+
+// writeContainsRowsUnflushed leaves the rows in the active memtable, which is
+// the only state in which the reader's window read runs at all: a flushed bucket
+// has an empty active memtable and the reader drops it from the view.
+func writeContainsRowsUnflushed(t *testing.T, f *containsBatchGateFixture, propName string, rows map[string][]uint64) {
+	t.Helper()
 	b := f.searcher.store.Bucket(helpers.BucketFromPropNameLSM(propName))
 	require.NotNil(t, b)
 	for key, docIDs := range rows {
 		require.NoError(t, b.RoaringSetAddList([]byte(key), docIDs))
 	}
-	require.NoError(t, b.FlushAndSwitch())
 }
 
 // TestFetchContainsBatch_ReadsRows pins the wiring between key extraction and
@@ -670,12 +679,21 @@ func TestFetchContainsBatch_ReadsRows(t *testing.T) {
 	}
 }
 
+// readerAnnotationFields are the slow-query fields only a reader can fill, so a
+// filter that never opened one must carry none of them. Named once because both
+// halves of that pair have to name the same set: listing them twice is how one
+// drifts and the guard stops being pinned.
+var readerAnnotationFields = []string{
+	"window_fills", "window_keys_read",
+	"window_bytes_peak", "window_bytes_copied", "memtables_read",
+}
+
 // TestFetchContainsBatch_AnnotatesSlowQueryLog pins the slow-query annotation
 // for a batched read — that it fires and carries the fields an operator reads —
 // and that an empty key set, which does no work, logs nothing. Where the timing
-// window starts is not observable from here, and neither is the view's release;
-// the refcount assertion for that lives in TestRoaringSetBatchReader_ReleaseGuard
-// (getRefs is unexported in lsmkv).
+// window starts is not observable from here. The view's release is, but only as
+// a consequence: a leaked view keeps a segment referenced and this test's bucket
+// then hangs on Shutdown.
 func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 	f := newContainsBatchGateFixture(t)
 	writeContainsRows(t, f, "prop-int", map[string][]uint64{"a": {1, 2}, "b": {2, 3}})
@@ -707,6 +725,40 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Equal(t, 2, entries[0]["batched_keys"])
 		require.Contains(t, entries[0], "took")
 		require.Contains(t, entries[0], "took_string")
+	})
+
+	// What the batching itself did, which is what separates a batched filter that
+	// went slow from one that merely ran during a slow query. On its own fixture
+	// because the shared one flushes, and a reader over a flushed bucket drops the
+	// active memtable, so the fields that count memtable work all read zero.
+	t.Run("the annotation carries the reader's work", func(t *testing.T) {
+		g := newContainsBatchGateFixture(t)
+		writeContainsRowsUnflushed(t, g, "prop-int", map[string][]uint64{"a": {1, 2}, "b": {2, 3}})
+
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		pv := &propValuePair{
+			prop:               "prop-int",
+			operator:           filters.ContainsAny,
+			containsKeys:       keysFrom(t, []byte("a"), []byte("b")),
+			hasFilterableIndex: true,
+			Class:              g.class,
+		}
+		dbm, err := pv.fetchContainsBatch(ctx, g.searcher)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, entries, 1)
+
+		require.Equal(t, 1, entries[0]["memtables_read"], "the unflushed rows must be read from the active memtable")
+		require.Equal(t, 2, entries[0]["window_keys_read"], "both keys were folded")
+		// A bound, not a count: how many windows a batch costs is pinned in
+		// TestBatchReaderStatsReportTheWork. What matters here is that the four
+		// are wired through at all, which zeros would not show.
+		require.GreaterOrEqual(t, entries[0]["window_fills"], 1)
+		require.Greater(t, entries[0]["window_bytes_peak"], 0)
+		require.Greater(t, entries[0]["window_bytes_copied"], 0)
 	})
 
 	// The annotation counts keys, not the values the filter named, and the two
@@ -750,6 +802,12 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Equal(t, 0, entries[0]["count"])
 		require.Equal(t, true, entries[0]["failed"],
 			"a zero count means nothing without this: an empty result looks identical")
+		// No reader was built, so the reader's own fields must be absent rather
+		// than present and zero — which is what the guard around them is for.
+		for _, k := range readerAnnotationFields {
+			require.NotContains(t, entries[0], k,
+				"a filter that never opened a reader must not report the reader's work")
+		}
 	})
 
 	t.Run("a fold that fails after the reader opened is still annotated", func(t *testing.T) {
@@ -767,6 +825,15 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Equal(t, "prop-int", entries[0]["prop"])
 		require.Equal(t, 0, entries[0]["count"])
 		require.Equal(t, true, entries[0]["failed"])
+		// The reader was opened, so its fields are present where the case above
+		// has them absent. That pair is what holds the guard in place, and it is
+		// the only thing proving the reader is read on the failing path at all.
+		// The values are not asserted: this fixture flushes, so what the reader
+		// found is beside the point here.
+		for _, k := range readerAnnotationFields {
+			require.Contains(t, entries[0], k,
+				"a fold that opened a reader must report its work even when it failed")
+		}
 	})
 
 	// Both returns that precede the timer: nothing has been done, so there is no

--- a/adapters/repos/db/inverted/searcher_contains_batch_test.go
+++ b/adapters/repos/db/inverted/searcher_contains_batch_test.go
@@ -14,6 +14,7 @@ package inverted
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"slices"
 	"testing"
 
@@ -679,13 +680,11 @@ func TestFetchContainsBatch_ReadsRows(t *testing.T) {
 	}
 }
 
-// readerAnnotationFields are the slow-query fields only a reader can fill, so a
-// filter that never opened one must carry none of them. Named once because both
-// halves of that pair have to name the same set: listing them twice is how one
-// drifts and the guard stops being pinned.
+// readerAnnotationFields are the slow-query fields only a reader can fill,
+// named once so both halves of the present/absent guard below use the same set.
 var readerAnnotationFields = []string{
-	"window_fills", "window_narrowed_fills", "window_keys_read",
-	"window_bytes_peak", "window_bytes_copied", "memtables_read",
+	"window_fills", "window_narrowed_fills", "batch_keys_served",
+	"window_bytes_peak", "window_bytes_copied", "memtable_reads", "memtables",
 }
 
 // TestFetchContainsBatch_AnnotatesSlowQueryLog pins the slow-query annotation
@@ -727,10 +726,8 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Contains(t, entries[0], "took_string")
 	})
 
-	// What the batching itself did, which is what separates a batched filter that
-	// went slow from one that merely ran during a slow query. On its own fixture
-	// because the shared one flushes, and a reader over a flushed bucket drops the
-	// active memtable, so the fields that count memtable work all read zero.
+	// Own fixture, unflushed: the shared one flushes, and a reader over a
+	// flushed bucket drops the active memtable, reading all memtable fields as zero.
 	t.Run("the annotation carries the reader's work", func(t *testing.T) {
 		g := newContainsBatchGateFixture(t)
 		writeContainsRowsUnflushed(t, g, "prop-int", map[string][]uint64{"a": {1, 2}, "b": {2, 3}})
@@ -751,14 +748,64 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.True(t, ok)
 		require.Len(t, entries, 1)
 
-		require.Equal(t, 1, entries[0]["memtables_read"], "the unflushed rows must be read from the active memtable")
-		require.Equal(t, 2, entries[0]["window_keys_read"], "both keys were folded")
-		// A bound, not a count: how many windows a batch costs is pinned in
-		// TestBatchReaderStatsReportTheWork. What matters here is that the four
-		// are wired through at all, which zeros would not show.
+		require.Equal(t, 1, entries[0]["memtable_reads"], "one fill of the one active memtable")
+		require.Equal(t, 2, entries[0]["batch_keys_served"], "both keys were folded")
+		// Just wired through, not pinned to a value; window-fill counting is
+		// TestBatchReaderStatsReportTheWork's job.
 		require.GreaterOrEqual(t, entries[0]["window_fills"], 1)
 		require.Greater(t, entries[0]["window_bytes_peak"], 0)
 		require.Greater(t, entries[0]["window_bytes_copied"], 0)
+		// Nothing here reaches the byte budget, so the only right answer is zero
+		// — and every other stat is non-zero, so this also catches the field
+		// being wired to one of them.
+		require.Equal(t, 0, entries[0]["window_narrowed_fills"], "no window ended on the budget")
+	})
+
+	// Wide enough to take several fills, so a wiring that reported one
+	// acquisition per batch shows up. window_fills and memtable_reads cannot
+	// diverge here: that takes a second memtable, which this package cannot
+	// reach.
+	t.Run("the annotation counts memtable acquisitions", func(t *testing.T) {
+		g := newContainsBatchGateFixture(t)
+
+		const n = 2*1024 + 50
+		rows := make(map[string][]uint64, n)
+		names := make([][]byte, n)
+		for i := range names {
+			names[i] = []byte(fmt.Sprintf("k%06d", i))
+			rows[string(names[i])] = []uint64{uint64(i)}
+		}
+		writeContainsRowsUnflushed(t, g, "prop-int", rows)
+
+		// A batch this wide takes the Accumulator fold, which the gate fixture's
+		// searcher has no factory for.
+		g.searcher.bitmapFactory = roaringset.NewBitmapFactory(
+			roaringset.NewBitmapBufPoolTrackingForTests(), func() uint64 { return 300_000 })
+
+		ctx := helpers.InitSlowQueryDetails(context.Background())
+		pv := &propValuePair{
+			prop:               "prop-int",
+			operator:           filters.ContainsAny,
+			containsKeys:       keysFrom(t, names...),
+			hasFilterableIndex: true,
+			Class:              g.class,
+		}
+		dbm, err := pv.fetchContainsBatch(ctx, g.searcher)
+		require.NoError(t, err)
+		defer dbm.release()
+
+		entries, ok := helpers.ExtractSlowQueryDetails(ctx)["build_allow_list_doc_bitmap"].([]map[string]any)
+		require.True(t, ok)
+		require.Len(t, entries, 1)
+
+		fills, ok := entries[0]["window_fills"].(int)
+		require.True(t, ok)
+		require.Greater(t, fills, 1, "the batch must span windows, or this proves nothing")
+		require.Equal(t, fills, entries[0]["memtable_reads"],
+			"the one memtable is read once per fill, not once per batch")
+		// Asserted here rather than beside a single-fill batch, where it would
+		// equal the fill count and could not be told from it.
+		require.Equal(t, 1, entries[0]["memtables"], "one memtable, and nothing flushing behind it")
 	})
 
 	// The annotation counts keys, not the values the filter named, and the two
@@ -802,8 +849,7 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Equal(t, 0, entries[0]["count"])
 		require.Equal(t, true, entries[0]["failed"],
 			"a zero count means nothing without this: an empty result looks identical")
-		// No reader was built, so the reader's own fields must be absent rather
-		// than present and zero — which is what the guard around them is for.
+		// No reader was built, so these fields must be absent, not present-and-zero.
 		for _, k := range readerAnnotationFields {
 			require.NotContains(t, entries[0], k,
 				"a filter that never opened a reader must not report the reader's work")
@@ -825,11 +871,8 @@ func TestFetchContainsBatch_AnnotatesSlowQueryLog(t *testing.T) {
 		require.Equal(t, "prop-int", entries[0]["prop"])
 		require.Equal(t, 0, entries[0]["count"])
 		require.Equal(t, true, entries[0]["failed"])
-		// The reader was opened, so its fields are present where the case above
-		// has them absent. That pair is what holds the guard in place, and it is
-		// the only thing proving the reader is read on the failing path at all.
-		// The values are not asserted: this fixture flushes, so what the reader
-		// found is beside the point here.
+		// The reader was opened, so these fields must be present (values
+		// unasserted; this fixture flushes, so what the reader found doesn't matter).
 		for _, k := range readerAnnotationFields {
 			require.Contains(t, entries[0], k,
 				"a fold that opened a reader must report its work even when it failed")

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -342,8 +342,9 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 // the number of keys) plus a single row in flight.
 //
 // The reader adds to that rather than being covered by it: a batched one caches a
-// window of cloned rows per memtable, live until the fold has walked the window. So
-// the peak here is the staging blocks plus a window, not plus a row.
+// window of cloned rows per memtable, bounded by lsmkv's window budget and live
+// until the fold has walked the window. So the peak here is the staging blocks
+// plus a window, not plus a row.
 func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
 	pool roaringset.BitmapBufPool, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -209,12 +209,24 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 }
 
 // containsBatchReader reads roaringset rows for one batched Contains fold under
-// a single held view; *lsmkv.RoaringSetBatchReader satisfies it and nothing
-// else implements it in production. It exists so tests can record which keys
-// the fold reads and inject read errors and cancellation. Releasing is absent
-// deliberately: the caller owns the reader's lifetime.
+// a single held view; *lsmkv.RoaringSetBatchReader satisfies it and nothing else
+// implements it in production. It exists so tests can inject read errors and
+// cancellation.
+//
+// Rows are read in order rather than by key so the reader can consult each
+// memtable once per window of the batch instead of once per key. The reader is
+// built around its batch, so Len is what the folds walk — they are not handed a
+// key list of their own that could disagree with it.
+//
+// Next returns a row and the release for it, or an error and neither. Where it
+// returns no error it must return a row: the folds adopt both without checking,
+// so a nil release is called rather than skipped.
+//
+// One reader serves one goroutine — the window it caches is shared mutable
+// state, and overlapping calls can hand back another key's row.
 type containsBatchReader interface {
-	Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error)
+	Len() int
+	Next(mergeConc int) (*sroar.Bitmap, func(), error)
 }
 
 // mergeAllowlistBitmaps folds b into a under op (ContainsAny -> union,
@@ -259,15 +271,15 @@ func mergeAllowlistBitmaps(op filters.Operator, maxConc int,
 // for sit far above it either way.
 var containsAnyAccumulatorMinKeys = 256
 
-// docBitmapContainsBatch folds every key in pv.containsKeys into a single
-// docBitmap under reader's held view: a dense Accumulator fold for
+// docBitmapContainsBatch folds every row of reader into a single docBitmap
+// under its held view: a dense Accumulator fold for
 // ContainsAny and ContainsNone, an incremental intersection with empty-result
 // early exit for ContainsAll. Every per-key fetch is an OperatorEqual read on
 // a roaringset bucket, so it is always an allowlist (never a denylist), which
 // is why all folds can skip mergeBitmapsAndOrWithDenyList's deny-list algebra
 // entirely. The caller owns reader (creates and releases it around this call)
-// and must pass at least one key: the folds adopt their first row as the
-// accumulator, so an empty key set has no result to return, and both this
+// and must give it at least one key: the folds adopt their first row as the
+// accumulator, so an empty batch has no result to return, and both this
 // function and fetchContainsBatch reject it rather than inventing one.
 //
 // ContainsNone is NOT(ContainsAny): it computes the same union and marks the
@@ -277,7 +289,10 @@ var containsAnyAccumulatorMinKeys = 256
 func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBatchReader,
 	pv *propValuePair,
 ) (docBitmap, error) {
-	if pv.containsKeys.Len() == 0 {
+	// Asked of the reader rather than of pv, because the reader is what the
+	// folds walk: a guard on the other one could pass while the fold runs zero
+	// iterations and returns a nil bitmap with no error.
+	if reader.Len() == 0 {
 		// defensive: the folds adopt their first row as the accumulator, so zero
 		// keys yields a nil bitmap rather than an empty one
 		return docBitmap{}, fmt.Errorf("%w: contains fold on prop %q carries no keys",
@@ -292,16 +307,16 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 	var err error
 	switch pv.operator {
 	case filters.ContainsAll:
-		acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsKeys, filters.ContainsAll, mergeConc)
+		acc, accRelease, err = foldContainsIncremental(ctx, reader, filters.ContainsAll, mergeConc)
 	case filters.ContainsAny, filters.ContainsNone:
 		// ContainsNone folds the same union as ContainsAny; the deny flag is
 		// applied to the result, not the fold. Below
 		// containsAnyAccumulatorMinKeys keys the Accumulator's staging setup
 		// and finalize scan are not worth it — union incrementally instead.
-		if pv.containsKeys.Len() < containsAnyAccumulatorMinKeys {
-			acc, accRelease, err = foldContainsIncremental(ctx, reader, pv.containsKeys, filters.ContainsAny, mergeConc)
+		if reader.Len() < containsAnyAccumulatorMinKeys {
+			acc, accRelease, err = foldContainsIncremental(ctx, reader, filters.ContainsAny, mergeConc)
 		} else {
-			acc, accRelease, err = foldContainsAnyAccumulator(ctx, reader, pv.containsKeys,
+			acc, accRelease, err = foldContainsAnyAccumulator(ctx, reader,
 				s.bitmapFactory.BufPool(), mergeConc)
 		}
 	default:
@@ -322,21 +337,25 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 // the final bitmap is assembled once, exactly sized, into a pooled buffer
 // (the returned release puts it back). This
 // replaces one structural Or per key (an O(container) memmove even for a
-// single-doc row) with O(1) bit deposits, and bounds peak memory at the
-// staging blocks (proportional to the doc-ID spread of the result, not to
+// single-doc row) with O(1) bit deposits, and bounds what the fold itself holds
+// at the staging blocks (proportional to the doc-ID spread of the result, not to
 // the number of keys) plus a single row in flight.
+//
+// The reader adds to that rather than being covered by it: a batched one caches a
+// window of cloned rows per memtable, live until the fold has walked the window. So
+// the peak here is the staging blocks plus a window, not plus a row.
 func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
-	keys entsInverted.SortedKeys, pool roaringset.BitmapBufPool, mergeConc int,
+	pool roaringset.BitmapBufPool, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
 	// TODO aliszka:gh12242 wire mergeConc into the accumulator's Or once sroar
 	// supports concurrent deposits; today it bounds only the per-row disk merge
 	// and the deposits themselves are single-threaded.
 	acc := sroar.NewAccumulator()
-	for _, key := range keys.All() {
+	for range reader.Len() {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		bm, release, err := reader.Get(key, mergeConc)
+		bm, release, err := reader.Next(mergeConc)
 		if err != nil {
 			return nil, nil, fmt.Errorf("read row: %w", err)
 		}
@@ -357,22 +376,25 @@ func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
 //
 // ContainsAll additionally stops as soon as the intersection is empty: no
 // remaining key can change an empty result (the intersection only shrinks),
-// so this only skips reads that cannot matter, never the result. On
-// disjoint-ish data the early exit reads a handful of keys, which no
-// batch-read grouping can beat — hence ContainsAll deliberately has no
-// accumulator path.
+// so this only skips reads that cannot matter, never the result. It skips the
+// reads, not their cost: the reader fills a whole window at a time, so an exit
+// on the second key has already paid for every row its memtables hold in that
+// window — and goes on holding them, since nothing drops the window here and the
+// reader stays reachable until the read that built it returns. ContainsAll has no
+// accumulator path because the exit makes staging setup unlikely to pay for
+// itself, not because the exit makes the reads cheap.
 func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
-	keys entsInverted.SortedKeys, op filters.Operator, mergeConc int,
+	op filters.Operator, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
 	var acc *sroar.Bitmap
 	accRelease := noopRelease
-	for _, key := range keys.All() {
+	for range reader.Len() {
 		if err := ctx.Err(); err != nil {
 			accRelease()
 			return nil, nil, err
 		}
 
-		bm, release, err := reader.Get(key, mergeConc)
+		bm, release, err := reader.Next(mergeConc)
 		if err != nil {
 			accRelease()
 			return nil, nil, fmt.Errorf("read row: %w", err)
@@ -391,9 +413,9 @@ func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
 			break
 		}
 	}
-	// keys is non-empty (docBitmapContainsBatch's precondition, enforced by
-	// fetchContainsBatch) and the first iteration always adopts its fetched
-	// bitmap, so acc is non-nil.
+	// The reader holds at least one key, which docBitmapContainsBatch has just
+	// checked of this same reader, and the first iteration always adopts its
+	// fetched bitmap, so acc is non-nil.
 	return acc, accRelease, nil
 }
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -208,22 +208,11 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 	return out, nil
 }
 
-// containsBatchReader reads roaringset rows for one batched Contains fold under
-// a single held view; *lsmkv.RoaringSetBatchReader satisfies it and nothing else
-// implements it in production. It exists so tests can inject read errors and
-// cancellation.
-//
-// Rows are read in order rather than by key so the reader can consult each
-// memtable once per window of the batch instead of once per key. The reader is
-// built around its batch, so Len is what the folds walk — they are not handed a
-// key list of their own that could disagree with it.
-//
-// Next returns a row and the release for it, or an error and neither. Where it
-// returns no error it must return a row: the folds adopt both without checking,
-// so a nil release is called rather than skipped.
-//
-// One reader serves one goroutine — the window it caches is shared mutable
-// state, and overlapping calls can hand back another key's row.
+// containsBatchReader reads roaringset rows for one batched Contains fold
+// under a single held view; *lsmkv.RoaringSetBatchReader satisfies it and
+// nothing else implements it in production (it exists so tests can inject
+// read errors and cancellation). Next returns either a row and its release or
+// an error and neither. One reader serves one goroutine.
 type containsBatchReader interface {
 	Len() int
 	Next(mergeConc int) (*sroar.Bitmap, func(), error)
@@ -277,10 +266,11 @@ var containsAnyAccumulatorMinKeys = 256
 // early exit for ContainsAll. Every per-key fetch is an OperatorEqual read on
 // a roaringset bucket, so it is always an allowlist (never a denylist), which
 // is why all folds can skip mergeBitmapsAndOrWithDenyList's deny-list algebra
-// entirely. The caller owns reader (creates and releases it around this call)
-// and must give it at least one key: the folds adopt their first row as the
-// accumulator, so an empty batch has no result to return, and both this
-// function and fetchContainsBatch reject it rather than inventing one.
+// entirely. The caller owns the view that reader borrows, and releases it
+// around this call. It must also give the reader at least one key:
+// foldContainsIncremental adopts its first row as the accumulator, so an empty
+// batch leaves it nil, and both this function and fetchContainsBatch reject one
+// rather than inventing a result.
 //
 // ContainsNone is NOT(ContainsAny): it computes the same union and marks the
 // result a deny list, exactly as the desugared NOT(OR(Equal...)) tree does in
@@ -289,12 +279,9 @@ var containsAnyAccumulatorMinKeys = 256
 func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBatchReader,
 	pv *propValuePair,
 ) (docBitmap, error) {
-	// Asked of the reader rather than of pv, because the reader is what the
-	// folds walk: a guard on the other one could pass while the fold runs zero
-	// iterations and returns a nil bitmap with no error.
 	if reader.Len() == 0 {
-		// defensive: the folds adopt their first row as the accumulator, so zero
-		// keys yields a nil bitmap rather than an empty one
+		// Checked on the reader because the reader is what the fold walks; pv is
+		// here for the operator and the error message.
 		return docBitmap{}, fmt.Errorf("%w: contains fold on prop %q carries no keys",
 			entsInverted.ErrInternal, pv.prop)
 	}
@@ -331,20 +318,21 @@ func (s *Searcher) docBitmapContainsBatch(ctx context.Context, reader containsBa
 	return docBitmap{docIDs: acc, release: accRelease, isDenyList: isDenyList}, nil
 }
 
+// readRowErr names the position in the batch, counting from one, since a batch
+// this size gives an operator nothing else to go on.
+func readRowErr(i, n int, err error) error {
+	return fmt.Errorf("read row %d of %d: %w", i+1, n, err)
+}
+
 // foldContainsAnyAccumulator unions the rows of all keys through a
 // sroar.Accumulator: each fetched row is deposited into the accumulator's
 // dense per-64K-range staging blocks and its buffer released immediately, and
 // the final bitmap is assembled once, exactly sized, into a pooled buffer
-// (the returned release puts it back). This
-// replaces one structural Or per key (an O(container) memmove even for a
-// single-doc row) with O(1) bit deposits, and bounds what the fold itself holds
-// at the staging blocks (proportional to the doc-ID spread of the result, not to
-// the number of keys) plus a single row in flight.
-//
-// The reader adds to that rather than being covered by it: a batched one caches a
-// window of cloned rows per memtable, bounded by lsmkv's window budget and live
-// until the fold has walked the window. So the peak here is the staging blocks
-// plus a window, not plus a row.
+// (the returned release puts it back). This replaces one structural Or per
+// key (an O(container) memmove even for a single-doc row) with O(1) bit
+// deposits, bounding memory at the staging blocks (sized to the result's
+// doc-ID spread, not the key count) plus one row in flight — plus one
+// memtable window, since a batched reader caches one per lsmkv's budget.
 func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
 	pool roaringset.BitmapBufPool, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
@@ -352,13 +340,13 @@ func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
 	// supports concurrent deposits; today it bounds only the per-row disk merge
 	// and the deposits themselves are single-threaded.
 	acc := sroar.NewAccumulator()
-	for range reader.Len() {
+	for i := range reader.Len() {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
 		bm, release, err := reader.Next(mergeConc)
 		if err != nil {
-			return nil, nil, fmt.Errorf("read row: %w", err)
+			return nil, nil, readRowErr(i, reader.Len(), err)
 		}
 		// Or never retains bm, so the row's buffer goes straight back.
 		acc.Or(bm)
@@ -377,19 +365,17 @@ func foldContainsAnyAccumulator(ctx context.Context, reader containsBatchReader,
 //
 // ContainsAll additionally stops as soon as the intersection is empty: no
 // remaining key can change an empty result (the intersection only shrinks),
-// so this only skips reads that cannot matter, never the result. It skips the
-// reads, not their cost: the reader fills a whole window at a time, so an exit
-// on the second key has already paid for every row its memtables hold in that
-// window — and goes on holding them, since nothing drops the window here and the
-// reader stays reachable until the read that built it returns. ContainsAll has no
-// accumulator path because the exit makes staging setup unlikely to pay for
-// itself, not because the exit makes the reads cheap.
+// so this only skips reads that cannot matter, never the result. It skips
+// their cost too, from the next window on: the window holding the exit was
+// filled whole, so the saving is a window's granularity, not a key's.
+// ContainsAll has no accumulator path because the early exit makes staging
+// setup not worth it, not because it makes reads cheap.
 func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
 	op filters.Operator, mergeConc int,
 ) (*sroar.Bitmap, func(), error) {
 	var acc *sroar.Bitmap
 	accRelease := noopRelease
-	for range reader.Len() {
+	for i := range reader.Len() {
 		if err := ctx.Err(); err != nil {
 			accRelease()
 			return nil, nil, err
@@ -398,7 +384,7 @@ func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
 		bm, release, err := reader.Next(mergeConc)
 		if err != nil {
 			accRelease()
-			return nil, nil, fmt.Errorf("read row: %w", err)
+			return nil, nil, readRowErr(i, reader.Len(), err)
 		}
 
 		if acc == nil {
@@ -414,9 +400,8 @@ func foldContainsIncremental(ctx context.Context, reader containsBatchReader,
 			break
 		}
 	}
-	// The reader holds at least one key, which docBitmapContainsBatch has just
-	// checked of this same reader, and the first iteration always adopts its
-	// fetched bitmap, so acc is non-nil.
+	// reader.Len() > 0 (checked in docBitmapContainsBatch), so the first
+	// iteration always runs and adopts its bitmap: acc is non-nil.
 	return acc, accRelease, nil
 }
 

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -64,18 +64,14 @@ type spyContainsBatchReader struct {
 	reader  *lsmkv.RoaringSetBatchReader
 	fixture *containsBatchFixture
 	keys    entsInverted.SortedKeys
-	// pos tracks the walk so the spy can name the key each read is for, since Next
-	// is handed no index and the fixture records by key.
-	pos int
+	pos     int // tracks the walk so Next can name the key each read is for
 }
 
 func (r *spyContainsBatchReader) Len() int { return r.keys.Len() }
 
 func (r *spyContainsBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), error) {
 	s := r.fixture
-	// A fold reading past the batch is the reader's error to report, not a
-	// panic here.
-	if r.pos < r.keys.Len() {
+	if r.pos < r.keys.Len() { // past the batch is the reader's error to report, not a panic here
 		s.reads = append(s.reads, string(r.keys.At(r.pos)))
 		if s.onRead != nil {
 			s.onRead(len(s.reads))
@@ -83,14 +79,8 @@ func (r *spyContainsBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), err
 	}
 	bm, release, err := r.reader.Next(mergeConc)
 	if err != nil {
-		// The contract the folds are written against: an error and neither a row
-		// nor a release. Wrapping the nil release would hand back a closure that
-		// panics, and a double looser than the reader it stands in for would let
-		// a fold mishandle the error path and still pass.
-		//
-		// The position stays where it is for the same reason: the reader does not
-		// advance its own on a failed read, so a double that advanced would name
-		// the following key for a read that never happened.
+		// Matches the real reader's error contract (no row, no release, position
+		// unchanged) so a fold that mishandles this path doesn't pass anyway.
 		return nil, nil, err
 	}
 	r.pos++
@@ -106,10 +96,9 @@ func newContainsBatchFixture(t *testing.T, ctx context.Context, rows map[string]
 }
 
 // newContainsBatchFixtureSplit flushes one set of rows and leaves the other in
-// the active memtable. A fully flushed bucket has an empty active memtable, the
-// reader drops it from the view, and the windowed read never runs — so the
-// unflushed half is the only way a fold here reaches the reader it was built
-// for. Passing nil for it gives the all-flushed bucket most tests want.
+// the active memtable — a fully flushed bucket drops its empty active memtable
+// from the view, so the windowed read never runs. Passing nil for unflushed
+// gives the all-flushed bucket most tests want.
 func newContainsBatchFixtureSplit(t *testing.T, ctx context.Context,
 	flushed, unflushed map[string][]uint64,
 ) *containsBatchFixture {
@@ -137,17 +126,14 @@ func newContainsBatchFixtureSplit(t *testing.T, ctx context.Context,
 }
 
 // TestDocBitmapContainsBatch_ReadsUnflushedRows folds a batch whose rows are
-// split between disk and the active memtable, over enough keys to cross several
-// windows. It is the only test that takes the fold, the reader, the windowing
-// and the memtable walk together; the rest flush first and so exercise the disk
-// path with the memtable skipped.
+// split between disk and the active memtable, the only test that exercises
+// the fold, the reader, the windowing and the memtable walk together — the
+// rest flush first and skip the memtable.
 func TestDocBitmapContainsBatch_ReadsUnflushedRows(t *testing.T) {
 	ctx := context.Background()
 
-	// Three windows at the production size of 1024, so the walk crosses two
-	// boundaries and ends on a narrower one, which is where an off-by-one in the
-	// window's end shows. The size is not reachable from here — the exported
-	// constructor picks it — so this is a key count rather than a multiple of it.
+	// Three windows at the production size of 1024, crossing two boundaries and
+	// ending on a narrower one — where an off-by-one in the window's end shows.
 	const n = 2500
 	flushed, unflushed := map[string][]uint64{}, map[string][]uint64{}
 	batch := make([][]byte, 0, n)
@@ -246,13 +232,9 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 
 // TestDocBitmapContainsBatch_NoKeys pins the fold's other defensive backstop:
 // its accumulator is the first row it reads, so zero keys has no result to
-// return. Erroring keeps that a loud caller bug rather than a docBitmap with a
-// nil bitmap flowing into the merges. fetchContainsBatch answers the empty case
-// before calling in, which TestFetchContainsBatch_EmptyKeySet pins.
-//
-// The count that decides it is the reader's, because the reader is what the
-// fold walks. Taking it off pv instead lets a reader holding nothing reach a
-// fold that runs no iterations and returns a nil bitmap with no error.
+// return, and it errors rather than let a nil bitmap flow into the merges.
+// The count that gates it is the reader's, not pv's — checked here by giving
+// pv keys while the reader stays empty.
 func TestDocBitmapContainsBatch_NoKeys(t *testing.T) {
 	ctx := context.Background()
 	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{"present-a": {1, 2, 3}})
@@ -343,7 +325,10 @@ func TestDocBitmapContainsBatch_ReadError(t *testing.T) {
 					keys:                pv.containsKeys,
 				},
 				pv)
-			require.ErrorContains(t, err, "read row")
+			// Which of the three keys failed: the fold reports a position
+			// because a six-figure batch gives an operator nothing else to go
+			// on, and "poison" sorts second of the three.
+			require.ErrorContains(t, err, "read row 2 of 3")
 			require.ErrorContains(t, err, "injected read failure")
 			require.Equal(t, docBitmap{}, dbm, "a failed read must not yield a partial result")
 
@@ -411,15 +396,10 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 	require.Equal(t, []string{"missing", "present-a", "present-b"}, fixture.reads)
 }
 
-// TestDocBitmapContainsBatch_AccumulatorGateReadsTheReader pins which count
-// picks the fold. Both the emptiness guard and the gate read the reader rather
-// than pv.containsKeys, and every other test hands the two the same length —
-// so reading the gate off pv instead would be invisible to all of them.
-//
-// The reader carries enough keys for the accumulator and pv carries fewer, so
-// the two disagree about which side of the gate the batch falls on. The result
-// has to be the union of what the reader holds either way; what would change is
-// the fold that produced it, which the read counts make visible.
+// TestDocBitmapContainsBatch_AccumulatorGateReadsTheReader pins that the
+// accumulator gate counts the reader's keys, not pv.containsKeys: it hands
+// the reader enough keys to cross the gate and pv fewer, then checks which
+// fold ran through the release-count side effect below.
 func TestDocBitmapContainsBatch_AccumulatorGateReadsTheReader(t *testing.T) {
 	oldGate := containsAnyAccumulatorMinKeys
 	containsAnyAccumulatorMinKeys = 3
@@ -444,10 +424,8 @@ func TestDocBitmapContainsBatch_AccumulatorGateReadsTheReader(t *testing.T) {
 	require.Equal(t, []string{"present-a", "present-b", "present-c"}, fixture.reads,
 		"every key of the reader's batch must be read")
 
-	// Which fold ran, stated as something observable: the accumulator deposits
-	// each row and releases it straight away, so every read is released during
-	// the fold. The incremental fold adopts its first row instead and hands that
-	// release to the caller, so one fewer.
+	// The accumulator releases every row it deposits; the incremental fold
+	// adopts its first row and hands that release to the caller instead, one fewer.
 	require.Equal(t, len(fixture.reads), fixture.releaseCalls,
 		"the reader's count puts this batch on the accumulator side of the gate")
 	dbm.release()

--- a/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap_test.go
@@ -48,12 +48,13 @@ type containsBatchFixture struct {
 // every read and every release func records into the fixture. The reader's view is
 // released once, at test end — releasing is the caller's job, so the fold never
 // does it.
-func (s *containsBatchFixture) reader(t *testing.T) *spyContainsBatchReader {
+func (s *containsBatchFixture) reader(t *testing.T, keys entsInverted.SortedKeys) *spyContainsBatchReader {
 	t.Helper()
-	rdr, err := s.NewRoaringSetBatchReader()
+	view := s.GetConsistentView()
+	t.Cleanup(view.ReleaseView)
+	rdr, err := lsmkv.NewRoaringSetBatchReader(view, keys)
 	require.NoError(t, err)
-	t.Cleanup(rdr.Release)
-	return &spyContainsBatchReader{reader: rdr, fixture: s}
+	return &spyContainsBatchReader{reader: rdr, fixture: s, keys: keys}
 }
 
 // spyContainsBatchReader is the reader the fixture hands the fold: it records
@@ -62,43 +63,122 @@ func (s *containsBatchFixture) reader(t *testing.T) *spyContainsBatchReader {
 type spyContainsBatchReader struct {
 	reader  *lsmkv.RoaringSetBatchReader
 	fixture *containsBatchFixture
+	keys    entsInverted.SortedKeys
+	// pos tracks the walk so the spy can name the key each read is for, since Next
+	// is handed no index and the fixture records by key.
+	pos int
 }
 
-func (r *spyContainsBatchReader) Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error) {
+func (r *spyContainsBatchReader) Len() int { return r.keys.Len() }
+
+func (r *spyContainsBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), error) {
 	s := r.fixture
-	s.reads = append(s.reads, string(key))
-	if s.onRead != nil {
-		s.onRead(len(s.reads))
+	// A fold reading past the batch is the reader's error to report, not a
+	// panic here.
+	if r.pos < r.keys.Len() {
+		s.reads = append(s.reads, string(r.keys.At(r.pos)))
+		if s.onRead != nil {
+			s.onRead(len(s.reads))
+		}
 	}
-	bm, release, err := r.reader.Get(key, mergeConc)
+	bm, release, err := r.reader.Next(mergeConc)
+	if err != nil {
+		// The contract the folds are written against: an error and neither a row
+		// nor a release. Wrapping the nil release would hand back a closure that
+		// panics, and a double looser than the reader it stands in for would let
+		// a fold mishandle the error path and still pass.
+		//
+		// The position stays where it is for the same reason: the reader does not
+		// advance its own on a failed read, so a double that advanced would name
+		// the following key for a read that never happened.
+		return nil, nil, err
+	}
+	r.pos++
 	return bm, func() {
 		s.releaseCalls++
 		release()
-	}, err
+	}, nil
 }
 
 func newContainsBatchFixture(t *testing.T, ctx context.Context, rows map[string][]uint64) *containsBatchFixture {
 	t.Helper()
+	return newContainsBatchFixtureSplit(t, ctx, rows, nil)
+}
+
+// newContainsBatchFixtureSplit flushes one set of rows and leaves the other in
+// the active memtable. A fully flushed bucket has an empty active memtable, the
+// reader drops it from the view, and the windowed read never runs — so the
+// unflushed half is the only way a fold here reaches the reader it was built
+// for. Passing nil for it gives the all-flushed bucket most tests want.
+func newContainsBatchFixtureSplit(t *testing.T, ctx context.Context,
+	flushed, unflushed map[string][]uint64,
+) *containsBatchFixture {
+	t.Helper()
 
 	logger, _ := test.NewNullLogger()
-	tmpDir := t.TempDir()
-
 	pool := roaringset.NewBitmapBufPoolTrackingForTests()
-	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
+	b, err := lsmkv.NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet),
 		lsmkv.WithBitmapBufPool(pool))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
-
 	b.SetMemtableThreshold(1e9) // no auto-flush; keep the fixture deterministic
 
-	for key, values := range rows {
+	for key, values := range flushed {
 		require.NoError(t, b.RoaringSetAddList([]byte(key), values))
 	}
 	require.NoError(t, b.FlushAndSwitch())
+	for key, values := range unflushed {
+		require.NoError(t, b.RoaringSetAddList([]byte(key), values))
+	}
 
 	return &containsBatchFixture{Bucket: b, pool: pool}
+}
+
+// TestDocBitmapContainsBatch_ReadsUnflushedRows folds a batch whose rows are
+// split between disk and the active memtable, over enough keys to cross several
+// windows. It is the only test that takes the fold, the reader, the windowing
+// and the memtable walk together; the rest flush first and so exercise the disk
+// path with the memtable skipped.
+func TestDocBitmapContainsBatch_ReadsUnflushedRows(t *testing.T) {
+	ctx := context.Background()
+
+	// Three windows at the production size of 1024, so the walk crosses two
+	// boundaries and ends on a narrower one, which is where an off-by-one in the
+	// window's end shows. The size is not reachable from here — the exported
+	// constructor picks it — so this is a key count rather than a multiple of it.
+	const n = 2500
+	flushed, unflushed := map[string][]uint64{}, map[string][]uint64{}
+	batch := make([][]byte, 0, n)
+	want := make([]uint64, 0, n)
+	for i := 0; i < n; i++ {
+		key := fmt.Sprintf("key_%05d", i)
+		batch = append(batch, []byte(key))
+		switch i % 3 {
+		case 0:
+			flushed[key] = []uint64{uint64(i)}
+			want = append(want, uint64(i))
+		case 1:
+			unflushed[key] = []uint64{uint64(i)}
+			want = append(want, uint64(i))
+		}
+		// i%3 == 2 is asked for and held by neither layer
+	}
+
+	fixture := newContainsBatchFixtureSplit(t, ctx, flushed, unflushed)
+	s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(fixture.pool, func() uint64 { return 300_000 })}
+
+	pv := &propValuePair{
+		prop:         "some-prop",
+		operator:     filters.ContainsAny,
+		containsKeys: keysFrom(t, batch...),
+	}
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
+	require.NoError(t, err)
+	require.Equal(t, want, dbm.docIDs.ToArray(),
+		"the fold must see the memtable's rows as well as the disk's")
+	dbm.release()
 }
 
 // TestMergeAllowlistBitmaps_UnsupportedOperator pins the defensive default
@@ -130,7 +210,7 @@ func TestDocBitmapContainsBatch_ContainsAnyFold(t *testing.T) {
 	}
 
 	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 	require.NoError(t, err)
 	defer dbm.release()
 
@@ -158,7 +238,7 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 	}
 
 	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 	require.ErrorContains(t, err, "unsupported operator")
 	require.Nil(t, dbm.docIDs)
 	require.Empty(t, fixture.reads, "no key may be read for an unsupported operator")
@@ -169,20 +249,34 @@ func TestDocBitmapContainsBatch_UnsupportedOperator(t *testing.T) {
 // return. Erroring keeps that a loud caller bug rather than a docBitmap with a
 // nil bitmap flowing into the merges. fetchContainsBatch answers the empty case
 // before calling in, which TestFetchContainsBatch_EmptyKeySet pins.
+//
+// The count that decides it is the reader's, because the reader is what the
+// fold walks. Taking it off pv instead lets a reader holding nothing reach a
+// fold that runs no iterations and returns a nil bitmap with no error.
 func TestDocBitmapContainsBatch_NoKeys(t *testing.T) {
 	ctx := context.Background()
 	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{"present-a": {1, 2, 3}})
 
-	for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
-		t.Run(op.Name(), func(t *testing.T) {
-			s := &Searcher{}
-			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
-				&propValuePair{prop: "some-prop", operator: op, containsKeys: keysFrom(t)})
-			require.ErrorContains(t, err, "carries no keys")
-			require.ErrorContains(t, err, `"some-prop"`, "the error must name the property")
-			require.Nil(t, dbm.docIDs)
-			require.Empty(t, fixture.reads, "no key may be read")
-		})
+	tests := []struct {
+		name   string
+		pvKeys entsInverted.SortedKeys
+	}{
+		{name: "pv is empty too", pvKeys: keysFrom(t)},
+		{name: "pv still carries keys", pvKeys: keysFrom(t, []byte("present-a"))},
+	}
+
+	for _, tc := range tests {
+		for _, op := range []filters.Operator{filters.ContainsAny, filters.ContainsAll, filters.ContainsNone} {
+			t.Run(tc.name+"/"+op.Name(), func(t *testing.T) {
+				s := &Searcher{}
+				pv := &propValuePair{prop: "some-prop", operator: op, containsKeys: tc.pvKeys}
+				dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, keysFrom(t)), pv)
+				require.ErrorContains(t, err, "carries no keys")
+				require.ErrorContains(t, err, `"some-prop"`, "the error must name the property")
+				require.Nil(t, dbm.docIDs)
+				require.Empty(t, fixture.reads, "no key may be read")
+			})
+		}
 	}
 }
 
@@ -191,13 +285,22 @@ func TestDocBitmapContainsBatch_NoKeys(t *testing.T) {
 type failingContainsBatchReader struct {
 	containsBatchReader
 	failKey string
+	keys    entsInverted.SortedKeys
+	pos     int
 }
 
-func (r *failingContainsBatchReader) Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error) {
-	if string(key) == r.failKey {
-		return nil, noopRelease, fmt.Errorf("injected read failure")
+func (r *failingContainsBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), error) {
+	key := ""
+	if r.pos < r.keys.Len() {
+		key = string(r.keys.At(r.pos))
 	}
-	return r.containsBatchReader.Get(key, mergeConc)
+	r.pos++
+	if key == r.failKey {
+		// The wrapped reader is left where it was, which is what a fold aborting
+		// on this error does anyway.
+		return nil, nil, fmt.Errorf("injected read failure")
+	}
+	return r.containsBatchReader.Next(mergeConc)
 }
 
 // TestDocBitmapContainsBatch_ReadError pins what a failed row read costs: the
@@ -229,12 +332,17 @@ func TestDocBitmapContainsBatch_ReadError(t *testing.T) {
 
 			// "a" is read and accumulated, "poison" fails, "z" must never be
 			// reached — the keys arrive ascending, so "poison" sits between them
+			pv := &propValuePair{
+				operator:     filters.ContainsAny,
+				containsKeys: keysFrom(t, []byte("a"), []byte("poison"), []byte("z")),
+			}
 			dbm, err := s.docBitmapContainsBatch(ctx,
-				&failingContainsBatchReader{containsBatchReader: fixture.reader(t), failKey: "poison"},
-				&propValuePair{
-					operator:     filters.ContainsAny,
-					containsKeys: keysFrom(t, []byte("a"), []byte("poison"), []byte("z")),
-				})
+				&failingContainsBatchReader{
+					containsBatchReader: fixture.reader(t, pv.containsKeys),
+					failKey:             "poison",
+					keys:                pv.containsKeys,
+				},
+				pv)
 			require.ErrorContains(t, err, "read row")
 			require.ErrorContains(t, err, "injected read failure")
 			require.Equal(t, docBitmap{}, dbm, "a failed read must not yield a partial result")
@@ -293,7 +401,7 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 	}
 
 	s := &Searcher{}
-	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 	require.NoError(t, err)
 	defer dbm.release()
 
@@ -301,6 +409,48 @@ func TestDocBitmapContainsBatch_ContainsNoneFold(t *testing.T) {
 		"ContainsNone folds the same union as ContainsAny")
 	require.True(t, dbm.IsDenyList())
 	require.Equal(t, []string{"missing", "present-a", "present-b"}, fixture.reads)
+}
+
+// TestDocBitmapContainsBatch_AccumulatorGateReadsTheReader pins which count
+// picks the fold. Both the emptiness guard and the gate read the reader rather
+// than pv.containsKeys, and every other test hands the two the same length —
+// so reading the gate off pv instead would be invisible to all of them.
+//
+// The reader carries enough keys for the accumulator and pv carries fewer, so
+// the two disagree about which side of the gate the batch falls on. The result
+// has to be the union of what the reader holds either way; what would change is
+// the fold that produced it, which the read counts make visible.
+func TestDocBitmapContainsBatch_AccumulatorGateReadsTheReader(t *testing.T) {
+	oldGate := containsAnyAccumulatorMinKeys
+	containsAnyAccumulatorMinKeys = 3
+	defer func() { containsAnyAccumulatorMinKeys = oldGate }()
+
+	ctx := context.Background()
+	fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{
+		"present-a": {1, 2}, "present-b": {3}, "present-c": {4},
+	})
+
+	readerKeys := keysFrom(t, []byte("present-a"), []byte("present-b"), []byte("present-c"))
+	pool := roaringset.NewBitmapBufPoolTrackingForTests()
+	s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
+
+	// pv is one key short of the gate, the reader is on it
+	pv := &propValuePair{operator: filters.ContainsAny, containsKeys: keysFrom(t, []byte("present-a"))}
+	dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, readerKeys), pv)
+	require.NoError(t, err)
+
+	require.Equal(t, []uint64{1, 2, 3, 4}, dbm.docIDs.ToArray(),
+		"the fold must cover every key the reader carries, not pv's shorter list")
+	require.Equal(t, []string{"present-a", "present-b", "present-c"}, fixture.reads,
+		"every key of the reader's batch must be read")
+
+	// Which fold ran, stated as something observable: the accumulator deposits
+	// each row and releases it straight away, so every read is released during
+	// the fold. The incremental fold adopts its first row instead and hands that
+	// release to the caller, so one fewer.
+	require.Equal(t, len(fixture.reads), fixture.releaseCalls,
+		"the reader's count puts this batch on the accumulator side of the gate")
+	dbm.release()
 }
 
 // Same folds as above but forced through the Accumulator path, which the
@@ -337,8 +487,8 @@ func TestDocBitmapContainsBatch_ContainsAnyAccumulatorFold(t *testing.T) {
 
 			pool := roaringset.NewBitmapBufPoolTrackingForTests()
 			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(pool, func() uint64 { return 300_000 })}
-			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t),
-				&propValuePair{operator: tc.operator, containsKeys: keys})
+			pv := &propValuePair{operator: tc.operator, containsKeys: keys}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 			require.NoError(t, err)
 
 			require.Equal(t, []uint64{1, 2, 3, 4, 5, 70_000, 200_000}, dbm.docIDs.ToArray())
@@ -383,10 +533,11 @@ func TestDocBitmapContainsBatch_SingleKey(t *testing.T) {
 			fixture := newContainsBatchFixture(t, ctx, map[string][]uint64{"a": {1, 2, 3}})
 
 			s := &Searcher{}
-			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
+			pv := &propValuePair{
 				operator:     tc.operator,
 				containsKeys: keysFrom(t, []byte(tc.key)),
-			})
+			}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 			require.NoError(t, err)
 			defer dbm.release()
 
@@ -415,7 +566,7 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		}
 
 		s := &Searcher{}
-		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
+		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 		require.NoError(t, err)
 		defer dbm.release()
 
@@ -436,7 +587,7 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		}
 
 		s := &Searcher{}
-		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
+		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 		require.NoError(t, err)
 		defer dbm.release()
 
@@ -458,7 +609,7 @@ func TestDocBitmapContainsBatch_ContainsAllFold(t *testing.T) {
 		}
 
 		s := &Searcher{}
-		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), pv)
+		dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 		require.NoError(t, err)
 		defer dbm.release()
 
@@ -503,10 +654,11 @@ func TestDocBitmapContainsBatch_ContextCancelledMidLoop(t *testing.T) {
 			}
 
 			s := &Searcher{bitmapFactory: roaringset.NewBitmapFactory(fixture.pool, func() uint64 { return 300_000 })}
-			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t), &propValuePair{
+			pv := &propValuePair{
 				operator:     filters.ContainsAny,
 				containsKeys: keysFrom(t, []byte("a"), []byte("b"), []byte("c")),
-			})
+			}
+			dbm, err := s.docBitmapContainsBatch(ctx, fixture.reader(t, pv.containsKeys), pv)
 			require.ErrorIs(t, err, context.Canceled)
 			require.Equal(t, docBitmap{}, dbm)
 

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -638,6 +638,7 @@ func (b *Bucket) SetMemtableThreshold(size uint64) {
 }
 
 type BucketConsistentView struct {
+	// Active is always set; Flushing is nil unless a flush is in flight.
 	Active   memtable
 	Flushing memtable
 	Disk     []Segment

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -638,8 +638,6 @@ func (b *Bucket) SetMemtableThreshold(size uint64) {
 }
 
 type BucketConsistentView struct {
-	// Active is nil for a bucket with no active memtable. Most reads below
-	// dereference it unguarded, so nil it only in a copy you own.
 	Active   memtable
 	Flushing memtable
 	Disk     []Segment
@@ -683,6 +681,22 @@ func viewMemtables(view BucketConsistentView) ([2]memtable, int) {
 		return [2]memtable{view.Active, view.Flushing}, 2
 	}
 	return [2]memtable{view.Active, nil}, 1
+}
+
+// viewMemtablesOldestFirst orders them the way a layer fold has to replay them:
+// flushing before active. The other way round the active memtable's re-add is
+// applied before the flushing one's deletion, and a document deleted while
+// flushing and re-added after comes back deleted — no error, just a wrong row.
+//
+// The replace paths want the opposite and take viewMemtables directly. They
+// stop at the first memtable holding the key, so newest first is what makes
+// that first hit the answer.
+func viewMemtablesOldestFirst(view BucketConsistentView) ([2]memtable, int) {
+	mts, count := viewMemtables(view)
+	if count == 2 {
+		mts[0], mts[1] = mts[1], mts[0]
+	}
+	return mts, count
 }
 
 // Get retrieves the single value for the given key.

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -210,35 +210,45 @@ type RoaringSetBatchReader struct {
 	pos              int
 	winStart, winEnd int
 	// layers[mt] is mts[mt]'s window, so they fold in the same oldest-first order
-	// the merger needs. Each is the width of the window, so key i sits at
-	// i-winStart and there is nothing to search; the allocation is reused.
+	// the merger needs. Each is as wide as the widest window the batch can need,
+	// and the window in it is the prefix [0, winEnd-winStart), so key i sits at
+	// i-winStart and there is nothing to search; one allocation serves them all.
 	//
 	// A zero BitmapLayer means the memtable contributes nothing for that key:
 	// both a key it does not hold and a row holding nothing, which the fold
 	// cannot tell apart. TestNilAndEmptyBitmapsMergeAlike pins it.
 	layers [2][]roaringset.BitmapLayer
-	// windowSize is how many keys one acquisition covers. See
-	// memtableWindowKeys for what it trades against.
-	windowSize int
+	// windowSize is how many keys one acquisition covers and windowBytes what
+	// they may cost; a window ends at whichever comes first. See
+	// memtableWindowKeys and memtableWindowBytes for what they trade against.
+	windowSize  int
+	windowBytes int
 
 	// What the reader did, for the slow-query annotation. See Stats.
-	fills       int
-	bytesPeak   int
-	bytesCopied int
+	fills         int
+	narrowedFills int
+	bytesPeak     int
+	bytesCopied   int
 }
 
 // RoaringSetBatchReaderStats is what one reader spent, for a caller annotating a
-// slow query: what the batching cost, and how far the fold got for it.
+// slow query: what the batching cost, and which of the two window limits to
+// change.
 type RoaringSetBatchReaderStats struct {
 	// Fills times Memtables is the acquisitions the windowing exists to reduce.
 	Fills int
+	// Windows the allowance ended rather than the key count, which names the limit
+	// worth raising. Keys read against fills already shows that windows were cut;
+	// this says which bound did it.
+	NarrowedFills int
 	// How far the fold got. Fills cannot say: a fold stopping after eight keys and
 	// one reading thousands both enter one window if the window is wide enough.
 	KeysRead int
 	// The most one window held, which is the memory to size against.
 	BytesPeak int
-	// Every byte copied under the memtable locks, which is the work rather than
-	// the footprint; a batch spanning many windows copies that many times its peak.
+	// Every byte copied under the memtable locks, summed over the windows, which
+	// is the work rather than the footprint. Against KeysRead it is what a row
+	// costs on this property.
 	BytesCopied int
 	// One, or two while a flush is in flight — which is why the same filter can
 	// report twice the acquisitions on consecutive runs.
@@ -249,26 +259,57 @@ type RoaringSetBatchReaderStats struct {
 // counters rather than the windows, which the fold has already emptied.
 func (r *RoaringSetBatchReader) Stats() RoaringSetBatchReaderStats {
 	return RoaringSetBatchReaderStats{
-		Fills:       r.fills,
-		KeysRead:    r.pos,
-		BytesPeak:   r.bytesPeak,
-		BytesCopied: r.bytesCopied,
-		Memtables:   r.mtCount,
+		Fills:         r.fills,
+		NarrowedFills: r.narrowedFills,
+		KeysRead:      r.pos,
+		BytesPeak:     r.bytesPeak,
+		BytesCopied:   r.bytesCopied,
+		Memtables:     r.mtCount,
 	}
 }
 
-// memtableWindowKeys is how many keys one lock acquisition covers.
+// memtableWindowKeys is how many keys one lock acquisition covers, and
+// memtableWindowBytes what those keys may cost to copy. A window ends at
+// whichever it reaches first.
 //
-// Speed does not settle it, and the two sides of the trade disagree: a bigger
-// window raises writer throughput, since readers take the lock less often, but
-// writer p99 rises with it once readers reach the core count. Memory settles it —
-// a window holds a clone of every row it matched, and nothing here bounds how big
-// a row is.
+// Speed does not settle the key count, and the two sides of the trade disagree:
+// a bigger window raises writer throughput, since readers take the lock less
+// often, but writer p99 rises with it once readers reach the core count. Memory
+// settles it, and only jointly with the budget — raising this past what the
+// budget allows buys a window the budget cuts back.
 //
 // Tune against [BenchmarkRoaringSetWindowRead] and
 // [BenchmarkRoaringSetWindowUnderWrite], reading clone-B rather than allocs/op,
-// which counts events and is flat here. Neither builds a second memtable.
+// which counts events and is flat here. clone-B is measured unbudgeted, so it is
+// what a window of this size costs, not what production holds; neither benchmark
+// builds a second memtable.
 const memtableWindowKeys = 1024
+
+// What makes a row expensive is how many containers its documents touch rather than
+// how many it holds, since a clone copies whole containers. A container spans 65,536
+// ids, so the stride between one value's documents decides the cost, and the two ends
+// are orders of magnitude apart: a thousand documents sharing one container clone to a
+// couple of kilobytes, the same thousand one per container to well over a hundred.
+// Where within a container a run starts matters too — a run that straddles a boundary
+// pays for both.
+//
+// It is a reader's whole allowance rather than each memtable's, despite the name. A
+// fill divides it between the memtables it reads, so a flush in flight halves each
+// share rather than doubling what the query holds, and the peak is this many bytes
+// per query — or one row, where a row alone exceeds a share, since a window always
+// takes its first key.
+//
+// The value trades peak against acquisitions. Halving it would leave rows that share
+// a container almost untouched and roughly halve every window that any wider row
+// produces; doubling it would widen those windows and double the peak, through a
+// fan-out nothing bounds — filter children, shards and concurrent requests all fan
+// out uncapped, and turning the feature off is the only lever over the product. This
+// sits where clustered rows are not cut at all, flush or no flush, which is the
+// property worth keeping.
+//
+// [BenchmarkRoaringSetWindowRead] sweeps both spreads; read clone-B there rather than
+// allocs/op, which counts events and is flat.
+const memtableWindowBytes = 8 << 20
 
 // NewRoaringSetBatchReader opens a reader on this view for one sorted batch,
 // which it serves in order through Next. The view stays the caller's to
@@ -287,17 +328,26 @@ func NewRoaringSetBatchReader(
 	if err := CheckStrategyRoaringSet(view.Bucket.strategy); err != nil {
 		return nil, err
 	}
-	return newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	return newRoaringSetBatchReader(view, keys, memtableWindowKeys, memtableWindowBytes)
 }
 
-// newRoaringSetBatchReader builds a reader with an explicit window size, which is
-// how a test reaches a boundary the production constant would take thousands of
-// keys to cross.
+// newRoaringSetBatchReader builds a reader with an explicit window size and byte
+// budget, both of which bound a window and only one of which a test can reach
+// cheaply: rows fat enough to spend the production budget take millions of
+// documents to build.
 func newRoaringSetBatchReader(
-	view BucketConsistentView, keys inverted.SortedKeys, window int,
+	view BucketConsistentView, keys inverted.SortedKeys, window, budget int,
 ) (*RoaringSetBatchReader, error) {
 	if window <= 0 {
 		return nil, fmt.Errorf("roaring set batch reader: window size must be positive, got %d", window)
+	}
+	// Refused rather than tolerated, because tolerating it reads as working: a
+	// budget of nothing ends every window after its always-taken first key, so a
+	// batch pays a fill per key — the per-key read the windowing replaces, with
+	// the windowing still keeping its books. The window read itself takes any
+	// budget; this is where a caller's arithmetic is checked.
+	if budget <= 0 {
+		return nil, fmt.Errorf("roaring set batch reader: byte budget must be positive, got %d", budget)
 	}
 	mts, count := viewMemtablesOldestFirst(view)
 
@@ -318,12 +368,13 @@ func newRoaringSetBatchReader(
 	}
 
 	return &RoaringSetBatchReader{
-		bucket:     view.Bucket,
-		segments:   view.Disk,
-		keys:       keys,
-		windowSize: window,
-		mts:        mts,
-		mtCount:    count,
+		bucket:      view.Bucket,
+		segments:    view.Disk,
+		keys:        keys,
+		windowSize:  window,
+		windowBytes: budget,
+		mts:         mts,
+		mtCount:     count,
 	}, nil
 }
 
@@ -398,21 +449,38 @@ func (r *RoaringSetBatchReader) fillWindow() error {
 	// Starting where the walk is, rather than on a grid: the caller reads
 	// forward, so the window it needs always begins at the key it is asking for.
 	r.winStart = r.pos
-	r.winEnd = min(r.winStart+r.windowSize, r.keys.Len())
-	width := r.winEnd - r.winStart
+	// The widest this window may be. Each memtable may narrow it, so winEnd is
+	// only settled once they have all read.
+	wide := min(r.winStart+r.windowSize, r.keys.Len())
+	width := wide - r.winStart
+	r.winEnd = wide
 
 	// This window's own copying, so the peak below is a window rather than the
 	// batch: the total across a batch measures the copying, not what was ever
 	// held at once.
 	bytes := 0
 
+	// Shared across the memtables rather than given to each in full — see
+	// memtableWindowBytes for why.
+	share := r.windowBytes / max(1, r.mtCount)
+
 	for mt := 0; mt < r.mtCount; mt++ {
-		if cap(r.layers[mt]) < width {
+		if r.layers[mt] == nil {
+			// One allocation serves the batch: widths only shrink, since pos moves
+			// forward, so the first window is the widest. Handing over the whole
+			// buffer rather than this window's part of it is what keeps a clone the
+			// fold never reached from outliving the window it was made for — the
+			// read clears everything it is given.
 			r.layers[mt] = make([]roaringset.BitmapLayer, width)
 		}
-		r.layers[mt] = r.layers[mt][:width]
 
-		cloned, err := r.mts[mt].roaringSetGetWindow(r.keys, r.winStart, r.winEnd, r.layers[mt])
+		// Bounded by where the window already ends rather than by its widest
+		// extent, which winEnd carries since it only shrinks: a memtable read after
+		// one whose budget stopped early does not clone rows the fold will never
+		// ask for. One read before the narrowing is not spared, and the next fill
+		// asks it for those keys again; the alternative is a window per memtable.
+		fill, err := r.mts[mt].roaringSetGetWindow(
+			r.keys, r.winStart, r.winEnd, r.layers[mt], share)
 		if err != nil {
 			// One memtable is loaded for this window and the other still holds the
 			// last one, at its width. Emptying the window puts pos past its end,
@@ -420,11 +488,21 @@ func (r *RoaringSetBatchReader) fillWindow() error {
 			r.winStart, r.winEnd = r.pos, r.pos
 			return err
 		}
-		bytes += cloned
+
+		// The narrowest memtable decides the window: past its To it has written
+		// nothing, and a zero layer there would read as a key it does not hold
+		// rather than one it was not asked about.
+		r.winEnd = min(r.winEnd, fill.To)
+		bytes += fill.Bytes
 	}
 	// Counted here rather than on entry, so Fills times Memtables is the
 	// acquisitions that happened rather than the ones that were attempted.
 	r.fills++
+	if r.winEnd < wide {
+		// Ended on its budget rather than on the keys it was allowed, which is what
+		// says the byte limit is the one worth raising.
+		r.narrowedFills++
+	}
 	r.bytesPeak = max(r.bytesPeak, bytes)
 	r.bytesCopied += bytes
 	return nil

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -14,11 +14,12 @@ package lsmkv
 import (
 	"context"
 	"errors"
-	"sync/atomic"
+	"fmt"
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
@@ -131,100 +132,300 @@ func (b *Bucket) RoaringSetGet(ctx context.Context, key []byte) (bm *sroar.Bitma
 	return b.roaringSetGetFromConsistentView(view, key, mergeConc)
 }
 
-// A nil view.Active is skipped, the same way a nil view.Flushing is: the caller
-// has established that the layer contributes nothing.
 func (b *Bucket) roaringSetGetFromConsistentView(
 	view BucketConsistentView, key []byte, mergeConc int,
-) (bm *sroar.Bitmap, release func(), err error) {
-	diskBM, diskRelease, err := b.disk.roaringSetGet(key, view.Disk, mergeConc)
-	if err != nil {
-		return nil, noopRelease, err
-	}
-	// diskRelease (not the named return, which error paths overwrite with
-	// noopRelease) is what the defer frees, so a failed flushing/active
-	// read can't leak the disk bitmap's pooled buffer.
-	defer func() {
+) (*sroar.Bitmap, func(), error) {
+	mts, count := viewMemtablesOldestFirst(view)
+
+	// Memtables first, so a failure there returns before the disk row is read
+	// and there is no pooled buffer to unwind.
+	var layers [2]roaringset.BitmapLayer
+	found := 0
+	for i := 0; i < count; i++ {
+		layer, err := mts[i].roaringSetGet(key)
 		if err != nil {
-			diskRelease()
-		}
-	}()
-
-	// Fold the disk, flushing and active layers one at a time, oldest first,
-	// without materializing a []BitmapLayer. diskBM is the pooled base (with
-	// headroom); on a disk miss it is nil and the merger adopts the first
-	// memtable layer's clone instead of copying it.
-	merger := roaringset.NewLayerMerger(diskBM, false, mergeConc)
-
-	// Oldest first: the merger replays each layer's deletions before its
-	// additions, so a doc deleted in flushing and re-added in active survives
-	// only in this order.
-	for _, mt := range [2]memtable{view.Flushing, view.Active} {
-		if mt == nil {
-			continue
-		}
-		layer, mtErr := mt.roaringSetGet(key)
-		if mtErr != nil {
-			if !errors.Is(mtErr, lsmkv.NotFound) {
-				err = mtErr
+			if !errors.Is(err, lsmkv.NotFound) {
 				return nil, noopRelease, err
 			}
 			continue
 		}
+		layers[found] = layer
+		found++
+	}
+	return b.roaringSetGetWithLayers(view.Disk, key, mergeConc, layers[:found])
+}
+
+// roaringSetGetWithLayers folds key's disk row together with the memtable layers
+// the caller has already read, and is the only place the fold order is decided.
+// It takes the segments rather than the view because the memtables are the
+// caller's to read.
+//
+// layers must be oldest first, flushing before active: the merger replays each
+// layer's deletions before its additions, so a document deleted while flushing
+// and re-added in the active memtable survives only in that order.
+func (b *Bucket) roaringSetGetWithLayers(
+	segments []Segment, key []byte, mergeConc int, layers []roaringset.BitmapLayer,
+) (*sroar.Bitmap, func(), error) {
+	diskBM, diskRelease, err := b.disk.roaringSetGet(key, segments, mergeConc)
+	if err != nil {
+		return nil, noopRelease, err
+	}
+	merger := roaringset.NewLayerMerger(diskBM, false, mergeConc)
+	for _, layer := range layers {
 		merger.Add(layer)
 	}
-
 	return merger.Result(), diskRelease, nil
 }
 
-// ErrReaderReleased signals a lifetime bug in the caller, never a storage
-// failure.
-var ErrReaderReleased = errors.New("roaring set batch reader: Get after Release")
-
-// RoaringSetBatchReader reads many roaringset rows under one view, held until
-// Release. It must not outlive the bucket; Get is safe to call concurrently.
+// RoaringSetBatchReader reads many roaringset rows under one view.
 //
-// An active memtable empty at view time is skipped for the whole batch, so a
-// write into it afterwards is invisible to all keys rather than to only the
-// tail. Callers needing per-read freshness must use RoaringSetGet.
+// The view belongs to whoever acquired it and must outlive the reader: nothing
+// here releases it, and reading through a reader whose view has been released
+// touches segments that may already be unmapped.
+//
+// A reader serves one goroutine and walks its batch once. Next caches a window
+// of memtable rows in the reader, so overlapping calls race on that cache and
+// can return another key's row or panic. Concurrent callers need a reader each.
+//
+// Segments are a snapshot; memtable windows are not. A window is read when the
+// fold reaches it, so one batch can return a key read before a write and a later
+// key read after it. A caller needing one instant must read per key with
+// RoaringSetGet.
+//
+// A window costs a clone of every row it matched, per memtable, held until the
+// window moves on. See memtableWindowKeys.
 type RoaringSetBatchReader struct {
-	view     BucketConsistentView
-	released atomic.Bool
+	// What the reader took from the view, resolved once. mts[:mtCount] are the ones
+	// that contribute — an empty active memtable is already dropped — so there
+	// is nothing to skip while reading.
+	bucket   *Bucket
+	segments []Segment
+	mts      [2]memtable
+	mtCount  int
+
+	// pos is the next key to serve, and the window is the range filled around
+	// it: [winStart, winEnd). A key is served once and never looked at again, so
+	// there is nothing to remember about the ones behind pos.
+	keys             inverted.SortedKeys
+	pos              int
+	winStart, winEnd int
+	// layers[mt] is mts[mt]'s window, so they fold in the same oldest-first order
+	// the merger needs. Each is the width of the window, so key i sits at
+	// i-winStart and there is nothing to search; the allocation is reused.
+	//
+	// A zero BitmapLayer means the memtable contributes nothing for that key:
+	// both a key it does not hold and a row holding nothing, which the fold
+	// cannot tell apart. TestNilAndEmptyBitmapsMergeAlike pins it.
+	layers [2][]roaringset.BitmapLayer
+	// windowSize is how many keys one acquisition covers. See
+	// memtableWindowKeys for what it trades against.
+	windowSize int
+
+	// What the reader did, for the slow-query annotation. See Stats.
+	fills       int
+	bytesPeak   int
+	bytesCopied int
 }
 
-// NewRoaringSetBatchReader opens a reader on b. See RoaringSetBatchReader for
-// the lifetime and visibility contract.
-func (b *Bucket) NewRoaringSetBatchReader() (*RoaringSetBatchReader, error) {
-	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
+// RoaringSetBatchReaderStats is what one reader spent, for a caller annotating a
+// slow query: what the batching cost, and how far the fold got for it.
+type RoaringSetBatchReaderStats struct {
+	// Fills times Memtables is the acquisitions the windowing exists to reduce.
+	Fills int
+	// How far the fold got. Fills cannot say: a fold stopping after eight keys and
+	// one reading thousands both enter one window if the window is wide enough.
+	KeysRead int
+	// The most one window held, which is the memory to size against.
+	BytesPeak int
+	// Every byte copied under the memtable locks, which is the work rather than
+	// the footprint; a batch spanning many windows copies that many times its peak.
+	BytesCopied int
+	// One, or two while a flush is in flight — which is why the same filter can
+	// report twice the acquisitions on consecutive runs.
+	Memtables int
+}
+
+// Stats reports what this reader did. Safe to call after the fold; it reads
+// counters rather than the windows, which the fold has already emptied.
+func (r *RoaringSetBatchReader) Stats() RoaringSetBatchReaderStats {
+	return RoaringSetBatchReaderStats{
+		Fills:       r.fills,
+		KeysRead:    r.pos,
+		BytesPeak:   r.bytesPeak,
+		BytesCopied: r.bytesCopied,
+		Memtables:   r.mtCount,
+	}
+}
+
+// memtableWindowKeys is how many keys one lock acquisition covers.
+//
+// Speed does not settle it, and the two sides of the trade disagree: a bigger
+// window raises writer throughput, since readers take the lock less often, but
+// writer p99 rises with it once readers reach the core count. Memory settles it —
+// a window holds a clone of every row it matched, and nothing here bounds how big
+// a row is.
+//
+// Tune against [BenchmarkRoaringSetWindowRead] and
+// [BenchmarkRoaringSetWindowUnderWrite], reading clone-B rather than allocs/op,
+// which counts events and is flat here. Neither builds a second memtable.
+const memtableWindowKeys = 1024
+
+// NewRoaringSetBatchReader opens a reader on this view for one sorted batch,
+// which it serves in order through Next. The view stays the caller's to
+// release, and must outlive the reader — see RoaringSetBatchReader.
+//
+// keys must be sorted, which is what lets each memtable be read once per window
+// rather than once per key — an acquisition costs the same whether or not the
+// key is there, and costs more the more cores are taking it.
+//
+// The bucket comes from the view rather than a receiver, so the strategy checked,
+// the segment group the rows fold through and the segments themselves are one
+// bucket's by construction rather than by agreement.
+func NewRoaringSetBatchReader(
+	view BucketConsistentView, keys inverted.SortedKeys,
+) (*RoaringSetBatchReader, error) {
+	if err := CheckStrategyRoaringSet(view.Bucket.strategy); err != nil {
 		return nil, err
 	}
-	view := b.GetConsistentView()
-	if view.Active != nil && view.Active.Size() == 0 {
-		// Read outside flushLock, which is safe only because a memtable's size
-		// never decreases: a racing write leaves it stale-low, never stale-high,
-		// so the skip can miss that write but never drops a committed one.
-		view.Active = nil
-	}
-	return &RoaringSetBatchReader{view: view}, nil
+	return newRoaringSetBatchReader(view, keys, memtableWindowKeys)
 }
 
-// Get reads key's row under the held view. mergeConc reaches sroar unclamped —
-// pass what concurrency.BudgetFromCtxCapped returned, since SROAR_MERGE itself
-// bypasses the query's budget and a non-positive value means unbounded.
-// Returns ErrReaderReleased after Release: those segments may be unmapped.
-func (r *RoaringSetBatchReader) Get(key []byte, mergeConc int) (*sroar.Bitmap, func(), error) {
-	if r.released.Load() {
-		return nil, noopRelease, ErrReaderReleased
+// newRoaringSetBatchReader builds a reader with an explicit window size, which is
+// how a test reaches a boundary the production constant would take thousands of
+// keys to cross.
+func newRoaringSetBatchReader(
+	view BucketConsistentView, keys inverted.SortedKeys, window int,
+) (*RoaringSetBatchReader, error) {
+	if window <= 0 {
+		return nil, fmt.Errorf("roaring set batch reader: window size must be positive, got %d", window)
 	}
-	return r.view.Bucket.roaringSetGetFromConsistentView(r.view, key, mergeConc)
+	mts, count := viewMemtablesOldestFirst(view)
+
+	// Skipping the active memtable, which is last after the reversal. Its size is
+	// read outside flushLock, but a size never decreases, so a racing write leaves
+	// it low and the skip misses that write rather than dropping a committed one.
+	// A size of zero means no write changed a document, not that the tree is bare
+	// — an empty write still builds a node — but such rows add and delete nothing
+	// and fold as if absent. Only the active one qualifies: a flushing memtable
+	// grew before it was switched out and takes no writes after.
+	//
+	// No nil check: a bucket has an active memtable from the moment it opens, and a
+	// switch installs the replacement before publishing the outgoing one as
+	// flushing, so no view carries a flushing memtable and no active one.
+	if mts[count-1].Size() == 0 {
+		count--
+		mts[count] = nil
+	}
+
+	return &RoaringSetBatchReader{
+		bucket:     view.Bucket,
+		segments:   view.Disk,
+		keys:       keys,
+		windowSize: window,
+		mts:        mts,
+		mtCount:    count,
+	}, nil
 }
 
-// Release releases the held view. Later calls are no-ops: a second decRef could
-// take a concurrent reader's count to zero, and compaction then unmaps and
-// deletes a segment that reader is using. The guard detects misuse; it does not
-// synchronize a Release racing an in-flight Get.
-func (r *RoaringSetBatchReader) Release() {
-	if r.released.Swap(true) {
-		return
+// Len is how many keys the batch holds.
+func (r *RoaringSetBatchReader) Len() int { return r.keys.Len() }
+
+// Next reads the batch's next row under the held view. It returns either a row
+// and the release for it, or an error and neither, so there is nothing to release
+// on the error path and nothing to check on the other. The row is the caller's to
+// mutate, as RoaringSetGet's is.
+//
+// The batch is walked once, in order, which is the order the window makes cheap.
+// Len is how many times it can be called; calling it more is a caller error and
+// returns one rather than a row from nowhere.
+//
+// A call that fills a window is uninterruptible, so a cancelled fold stops at the
+// next Next rather than partway through one — a window's worth of work, which is
+// milliseconds at worst.
+//
+// mergeConc reaches sroar unclamped: pass what concurrency.BudgetFromCtxCapped
+// returned, since SROAR_MERGE bypasses the query's budget and a non-positive
+// value means unbounded.
+func (r *RoaringSetBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), error) {
+	if r.pos >= r.keys.Len() {
+		return nil, nil, fmt.Errorf("roaring set batch reader: batch of %d keys is exhausted",
+			r.keys.Len())
 	}
-	r.view.ReleaseView()
+	if r.pos >= r.winEnd {
+		if err := r.fillWindow(); err != nil {
+			return nil, nil, err
+		}
+	}
+	at := r.pos - r.winStart
+	var layers [2]roaringset.BitmapLayer
+	found := 0
+	for mt := 0; mt < r.mtCount; mt++ {
+		if layer := r.layers[mt][at]; layer.Additions != nil || layer.Deletions != nil {
+			layers[found] = layer
+			found++
+		}
+		// Handed over, so the window stops holding it — otherwise every row it
+		// matched stays live until the next fill, which a single-window batch
+		// never reaches.
+		r.layers[mt][at] = roaringset.BitmapLayer{}
+	}
+	// The fold below hands back a callable release even when it fails, which the
+	// per-key path's callers rely on. Next returns no release on error, so the
+	// error is passed on alone; nothing is dropped, since a failed disk read
+	// unwinds its own pooled buffer.
+	bm, release, err := r.bucket.roaringSetGetWithLayers(
+		r.segments, r.keys.At(r.pos), mergeConc, layers[:found])
+	if err != nil {
+		// This key's slots were emptied above, so leaving the window intact would
+		// let a retry read them as absence and fold the disk row alone — a wrong
+		// row, with no error to say so. Collapsing the window puts pos at its end
+		// and forces the refill, as fillWindow does for its own failures.
+		r.winStart, r.winEnd = r.pos, r.pos
+		return nil, nil, err
+	}
+	r.pos++
+	return bm, release, nil
+}
+
+// fillWindow has every memtable write the window containing r.pos into that
+// memtable's slice, so serving a key afterwards is an index rather than a
+// lookup.
+//
+// Windows are filled as the fold reaches them, so a fold that stops early pays
+// for the windows it entered — not for the keys it read. A batch inside one
+// window therefore saves nothing.
+func (r *RoaringSetBatchReader) fillWindow() error {
+	// Starting where the walk is, rather than on a grid: the caller reads
+	// forward, so the window it needs always begins at the key it is asking for.
+	r.winStart = r.pos
+	r.winEnd = min(r.winStart+r.windowSize, r.keys.Len())
+	width := r.winEnd - r.winStart
+
+	// This window's own copying, so the peak below is a window rather than the
+	// batch: the total across a batch measures the copying, not what was ever
+	// held at once.
+	bytes := 0
+
+	for mt := 0; mt < r.mtCount; mt++ {
+		if cap(r.layers[mt]) < width {
+			r.layers[mt] = make([]roaringset.BitmapLayer, width)
+		}
+		r.layers[mt] = r.layers[mt][:width]
+
+		cloned, err := r.mts[mt].roaringSetGetWindow(r.keys, r.winStart, r.winEnd, r.layers[mt])
+		if err != nil {
+			// One memtable is loaded for this window and the other still holds the
+			// last one, at its width. Emptying the window puts pos past its end,
+			// so a retry refills rather than serving that mixture.
+			r.winStart, r.winEnd = r.pos, r.pos
+			return err
+		}
+		bytes += cloned
+	}
+	// Counted here rather than on entry, so Fills times Memtables is the
+	// acquisitions that happened rather than the ones that were attempted.
+	r.fills++
+	r.bytesPeak = max(r.bytesPeak, bytes)
+	r.bytesCopied += bytes
+	return nil
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -71,9 +71,8 @@ type RoaringSetBatchEntry struct {
 	Values []uint64
 }
 
-// RoaringSetAddBatch writes multiple key-values pairs to the bucket under
-// a single flushLock acquisition and a single memtable lock acquisition,
-// reducing lock overhead compared to calling RoaringSetAddList in a loop.
+// RoaringSetAddBatch writes entries under a single memtable lock acquisition,
+// cheaper than calling RoaringSetAddList in a loop.
 func (b *Bucket) RoaringSetAddBatch(entries []RoaringSetBatchEntry) error {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err
@@ -88,9 +87,8 @@ func (b *Bucket) RoaringSetAddBatch(entries []RoaringSetBatchEntry) error {
 	return active.roaringSetAddBatch(entries)
 }
 
-// RoaringSetRemoveBatch removes multiple key-values pairs from the bucket under
-// a single flushLock acquisition and a single memtable lock acquisition,
-// reducing lock overhead compared to calling RoaringSetRemoveOne in a loop.
+// RoaringSetRemoveBatch removes entries under a single memtable lock acquisition,
+// cheaper than calling RoaringSetRemoveOne in a loop.
 func (b *Bucket) RoaringSetRemoveBatch(entries []RoaringSetBatchEntry) error {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err
@@ -155,10 +153,8 @@ func (b *Bucket) roaringSetGetFromConsistentView(
 	return b.roaringSetGetWithLayers(view.Disk, key, mergeConc, layers[:found])
 }
 
-// roaringSetGetWithLayers folds key's disk row together with the memtable layers
-// the caller has already read, and is the only place the fold order is decided.
-// It takes the segments rather than the view because the memtables are the
-// caller's to read.
+// roaringSetGetWithLayers folds key's disk row with the memtable layers the
+// caller already read.
 //
 // layers must be oldest first, flushing before active: the merger replays each
 // layer's deletions before its additions, so a document deleted while flushing
@@ -177,222 +173,248 @@ func (b *Bucket) roaringSetGetWithLayers(
 	return merger.Result(), diskRelease, nil
 }
 
+// memtableWindow is one memtable and the window read from it. The three parts
+// only mean anything together, so they travel as one value: a slot cannot end
+// up describing one memtable in its rows and another in the index that bounds
+// them.
+type memtableWindow struct {
+	mt memtable
+	// layer is this memtable's window, laid out as prefix [0, winEnd-winStart)
+	// so key i sits at i-winStart; one allocation is reused across fills.
+	//
+	// A zero BitmapLayer means the memtable contributes nothing for that key —
+	// both "key absent" and "row holds nothing" look the same to the fold.
+	// TestNilAndEmptyBitmapsMergeAlike pins this.
+	layer []roaringset.BitmapLayer
+	// filled is the key index layer holds rows up to, which runs past winEnd
+	// when a later memtable narrowed the window under one that had already
+	// read. Those rows are kept rather than dropped: they are already copied,
+	// so re-reading them would spend the budget and the lock again.
+	filled int
+	// carried is what those kept rows hold, charged against the next fill's
+	// share so what a window holds is still bounded by windowBytes.
+	carried int
+}
+
+// rebase lays the rows this slot kept out against a new window start, and
+// reports what they hold. Call it before the read that follows, which is what
+// moves filled and makes carried stale.
+//
+// Every slot from filled on is zero when this returns, so an unwritten slot
+// still means "this memtable holds nothing for that key".
+func (w *memtableWindow) rebase(winStart, prevStart, width int) (carriedIn int) {
+	switch {
+	case w.layer == nil:
+		// Widths only shrink (pos moves forward), so the first window is the
+		// widest and this one allocation serves the whole batch.
+		w.layer = make([]roaringset.BitmapLayer, width)
+		w.filled = winStart
+	case w.filled > winStart:
+		// Kept rows were laid out against the last window's start; move them to
+		// this one's, and clear the vacated tail or the same rows stay reachable
+		// twice.
+		copy(w.layer, w.layer[winStart-prevStart:w.filled-prevStart])
+		clear(w.layer[w.filled-winStart:])
+	default:
+		w.filled = winStart
+	}
+	return w.carried
+}
+
+// recountCarried charges this slot for the rows it holds past the window's end.
+// The next fill's share must cover them first, which is what bounds a window to
+// windowBytes across fills rather than only within one.
+func (w *memtableWindow) recountCarried(winStart, winEnd int) {
+	w.carried = 0
+	for i := winEnd; i < w.filled; i++ {
+		w.carried += w.layer[i-winStart].LenInBytes()
+	}
+}
+
 // RoaringSetBatchReader reads many roaringset rows under one view.
 //
 // The view belongs to whoever acquired it and must outlive the reader: nothing
-// here releases it, and reading through a reader whose view has been released
-// touches segments that may already be unmapped.
+// here releases it, and nothing here detects a reader outliving one: the
+// caller's defer is the whole protection, and Next on a released view reads
+// segments that may already be unmapped. A reader serves one goroutine; Next
+// caches a window of memtable rows internally, so concurrent Next calls race
+// on that cache.
 //
-// A reader serves one goroutine and walks its batch once. Next caches a window
-// of memtable rows in the reader, so overlapping calls race on that cache and
-// can return another key's row or panic. Concurrent callers need a reader each.
-//
-// Segments are a snapshot; memtable windows are not. A window is read when the
-// fold reaches it, so one batch can return a key read before a write and a later
-// key read after it. A caller needing one instant must read per key with
-// RoaringSetGet.
-//
-// A window costs a clone of every row it matched, per memtable, held until the
-// window moves on. See memtableWindowKeys.
+// Segments are a snapshot but memtable windows are not: a window is read when
+// Next reaches it, so one batch can read a key before a concurrent write
+// and a later key after it. One key is not a single instant either — a row
+// narrowed past a window's end is kept, so its flushing layer can predate its
+// active one by a window. RoaringSetGet is not an escape from that: it takes
+// each memtable's read lock separately too, so a write landing between the two
+// is in one layer and not the other. What differs is how wide the gap can be.
 type RoaringSetBatchReader struct {
-	// What the reader took from the view, resolved once. mts[:mtCount] are the ones
-	// that contribute — an empty active memtable is already dropped — so there
-	// is nothing to skip while reading.
 	bucket   *Bucket
 	segments []Segment
-	mts      [2]memtable
-	mtCount  int
+	// windows[:mtCount] are the memtables that contribute; an empty active
+	// memtable is already dropped here, so there is nothing to skip while
+	// reading.
+	windows [2]memtableWindow
+	mtCount int
 
-	// pos is the next key to serve, and the window is the range filled around
-	// it: [winStart, winEnd). A key is served once and never looked at again, so
-	// there is nothing to remember about the ones behind pos.
+	// [winStart, winEnd) is the filled window around pos, the next key to serve.
 	keys             inverted.SortedKeys
 	pos              int
 	winStart, winEnd int
-	// layers[mt] is mts[mt]'s window, so they fold in the same oldest-first order
-	// the merger needs. Each is as wide as the widest window the batch can need,
-	// and the window in it is the prefix [0, winEnd-winStart), so key i sits at
-	// i-winStart and there is nothing to search; one allocation serves them all.
-	//
-	// A zero BitmapLayer means the memtable contributes nothing for that key:
-	// both a key it does not hold and a row holding nothing, which the fold
-	// cannot tell apart. TestNilAndEmptyBitmapsMergeAlike pins it.
-	layers [2][]roaringset.BitmapLayer
-	// windowSize is how many keys one acquisition covers and windowBytes what
-	// they may cost; a window ends at whichever comes first. See
-	// memtableWindowKeys and memtableWindowBytes for what they trade against.
+	// windowSize/windowBytes bound one window; see memtableWindowKeys and
+	// readerWindowBytes.
 	windowSize  int
 	windowBytes int
 
 	// What the reader did, for the slow-query annotation. See Stats.
 	fills         int
 	narrowedFills int
+	memtableReads int
 	bytesPeak     int
 	bytesCopied   int
 }
 
-// RoaringSetBatchReaderStats is what one reader spent, for a caller annotating a
-// slow query: what the batching cost, and which of the two window limits to
-// change.
+// RoaringSetBatchReaderStats is what one reader spent, for a caller annotating
+// a slow query.
 type RoaringSetBatchReaderStats struct {
-	// Fills times Memtables is the acquisitions the windowing exists to reduce.
+	// Fills is the windows read, a fill that failed part way included, and
+	// MemtableReads the lock acquisitions they cost — at most one per memtable
+	// per fill. That is far fewer than one per key wherever a window's keys fit
+	// the byte budget, and one per key per memtable where every row exceeds a
+	// memtable's share, since such a window ends after the key it always takes.
+	// A window over no memtable is advanced but not counted.
 	Fills int
-	// Windows the allowance ended rather than the key count, which names the limit
-	// worth raising. Keys read against fills already shows that windows were cut;
-	// this says which bound did it.
+	// MemtableReads is short of Fills times Memtables whenever a fill skipped a
+	// memtable, which happens once one has read to the end of the batch or spent
+	// its share on the rows it carried.
+	MemtableReads int
+	// NarrowedFills is windows that ended on the byte budget rather than the key
+	// count. A fill that failed part way ended on neither, so it is not one.
+	// Both limits are compile-time constants, so this says which one is binding
+	// rather than what to change.
 	NarrowedFills int
-	// How far the fold got. Fills cannot say: a fold stopping after eight keys and
-	// one reading thousands both enter one window if the window is wide enough.
-	KeysRead int
-	// The most one window held, which is the memory to size against.
+	// KeysServed is how many rows Next returned, which a caller that stops
+	// before the end of the batch leaves short of what the windows read.
+	KeysServed int
+	// BytesPeak is the most one window held at once.
 	BytesPeak int
-	// Every byte copied under the memtable locks, summed over the windows, which
-	// is the work rather than the footprint. Against KeysRead it is what a row
-	// costs on this property.
+	// BytesCopied is every byte copied under the memtable locks, summed over
+	// all windows.
 	BytesCopied int
-	// One, or two while a flush is in flight — which is why the same filter can
-	// report twice the acquisitions on consecutive runs.
+	// Memtables is how many contributed, counted after an empty active memtable
+	// is dropped: 2, or 1, or 0 when the active one is empty with no flush
+	// behind it. It does not say whether a flush was in flight — a flush whose
+	// new active memtable has taken no write yet also reports 1.
 	Memtables int
 }
 
-// Stats reports what this reader did. Safe to call after the fold; it reads
-// counters rather than the windows, which the fold has already emptied.
+// Stats reports what this reader did. Safe to call once the caller has stopped
+// calling Next.
 func (r *RoaringSetBatchReader) Stats() RoaringSetBatchReaderStats {
 	return RoaringSetBatchReaderStats{
 		Fills:         r.fills,
+		MemtableReads: r.memtableReads,
 		NarrowedFills: r.narrowedFills,
-		KeysRead:      r.pos,
+		KeysServed:    r.pos,
 		BytesPeak:     r.bytesPeak,
 		BytesCopied:   r.bytesCopied,
 		Memtables:     r.mtCount,
 	}
 }
 
-// memtableWindowKeys is how many keys one lock acquisition covers, and
-// memtableWindowBytes what those keys may cost to copy. A window ends at
-// whichever it reaches first.
+// memtableWindowKeys caps how many keys one lock acquisition reads ahead;
+// readerWindowBytes caps what those keys may cost to copy, whichever is hit
+// first. Bigger windows lock less often but raise writer p99 once readers reach
+// the core count.
 //
-// Speed does not settle the key count, and the two sides of the trade disagree:
-// a bigger window raises writer throughput, since readers take the lock less
-// often, but writer p99 rises with it once readers reach the core count. Memory
-// settles it, and only jointly with the budget — raising this past what the
-// budget allows buys a window the budget cuts back.
-//
-// Tune against [BenchmarkRoaringSetWindowRead] and
-// [BenchmarkRoaringSetWindowUnderWrite], reading clone-B rather than allocs/op,
-// which counts events and is flat here. clone-B is measured unbudgeted, so it is
-// what a window of this size costs, not what production holds; neither benchmark
-// builds a second memtable.
+// [BenchmarkRoaringSetWindowRead] sweeps this against three row shapes, and
+// [BenchmarkRoaringSetWindowUnderWrite] the same under contention.
 const memtableWindowKeys = 1024
 
-// What makes a row expensive is how many containers its documents touch rather than
-// how many it holds, since a clone copies whole containers. A container spans 65,536
-// ids, so the stride between one value's documents decides the cost, and the two ends
-// are orders of magnitude apart: a thousand documents sharing one container clone to a
-// couple of kilobytes, the same thousand one per container to well over a hundred.
-// Where within a container a run starts matters too — a run that straddles a boundary
-// pays for both.
+// readerWindowBytes is the reader's whole allowance, not each memtable's, so a
+// flush in flight halves each share rather than doubling what the query holds.
+// It is not a ceiling: a window's first key is taken whatever it costs.
 //
-// It is a reader's whole allowance rather than each memtable's, despite the name. A
-// fill divides it between the memtables it reads, so a flush in flight halves each
-// share rather than doubling what the query holds, and the peak is this many bytes
-// per query — or one row, where a row alone exceeds a share, since a window always
-// takes its first key.
+// Sized against a row of a thousand documents clustered in one 65,536-id
+// container — one property ingested grouped by value. That clones to ~2KiB, so
+// a full window costs ~2MiB and two memtables still fit this where they would
+// not fit 4MiB. A row saturating that container costs ~4x more and is split.
 //
-// The value trades peak against acquisitions. Halving it would leave rows that share
-// a container almost untouched and roughly halve every window that any wider row
-// produces; doubling it would widen those windows and double the peak, through a
-// fan-out nothing bounds — filter children, shards and concurrent requests all fan
-// out uncapped, and turning the feature off is the only lever over the product. This
-// sits where clustered rows are not cut at all, flush or no flush, which is the
-// property worth keeping.
-//
-// [BenchmarkRoaringSetWindowRead] sweeps both spreads; read clone-B there rather than
-// allocs/op, which counts events and is flat.
-const memtableWindowBytes = 8 << 20
+// Nothing bounds the fan-out this multiplies across (filter children, shards,
+// concurrent requests).
+const readerWindowBytes = 8 << 20
 
 // NewRoaringSetBatchReader opens a reader on this view for one sorted batch,
-// which it serves in order through Next. The view stays the caller's to
-// release, and must outlive the reader — see RoaringSetBatchReader.
+// served in order through Next. The view stays the caller's to release and
+// must outlive the reader — see RoaringSetBatchReader.
 //
-// keys must be sorted, which is what lets each memtable be read once per window
-// rather than once per key — an acquisition costs the same whether or not the
-// key is there, and costs more the more cores are taking it.
+// keys must come from [inverted.SortedKeys], whose builder guarantees the order
+// and the dedup that let each memtable be read once per window. The walk skips
+// a repeat, leaving its slot unwritten, and an unwritten slot reads as "this
+// memtable holds nothing": the disk row is then served with that memtable's
+// deletions unapplied, and a ContainsAny returns a deleted document.
 //
-// The bucket comes from the view rather than a receiver, so the strategy checked,
-// the segment group the rows fold through and the segments themselves are one
-// bucket's by construction rather than by agreement.
+// view.Active must be set, and this panics rather than erroring if it is not.
+// No producer builds one that way, and the sibling read paths on this bucket
+// already dereference it unchecked.
 func NewRoaringSetBatchReader(
 	view BucketConsistentView, keys inverted.SortedKeys,
 ) (*RoaringSetBatchReader, error) {
 	if err := CheckStrategyRoaringSet(view.Bucket.strategy); err != nil {
 		return nil, err
 	}
-	return newRoaringSetBatchReader(view, keys, memtableWindowKeys, memtableWindowBytes)
+	return newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, readerWindowBytes)
 }
 
-// newRoaringSetBatchReader builds a reader with an explicit window size and byte
-// budget, both of which bound a window and only one of which a test can reach
-// cheaply: rows fat enough to spend the production budget take millions of
-// documents to build.
-func newRoaringSetBatchReader(
+// newRoaringSetBatchReaderWithBounds builds a reader with an explicit window
+// size and byte budget, so a test can exercise the window-size limit without
+// building rows fat enough to spend the production byte budget.
+//
+// It checks those bounds and not the strategy, which is the one check
+// [NewRoaringSetBatchReader] adds on top of it.
+func newRoaringSetBatchReaderWithBounds(
 	view BucketConsistentView, keys inverted.SortedKeys, window, budget int,
 ) (*RoaringSetBatchReader, error) {
 	if window <= 0 {
 		return nil, fmt.Errorf("roaring set batch reader: window size must be positive, got %d", window)
 	}
-	// Refused rather than tolerated, because tolerating it reads as working: a
-	// budget of nothing ends every window after its always-taken first key, so a
-	// batch pays a fill per key — the per-key read the windowing replaces, with
-	// the windowing still keeping its books. The window read itself takes any
-	// budget; this is where a caller's arithmetic is checked.
 	if budget <= 0 {
+		// The share below clamps to one byte, so a window ends after its
+		// always-taken first key: correct, but a fill per key and no windowing.
 		return nil, fmt.Errorf("roaring set batch reader: byte budget must be positive, got %d", budget)
 	}
 	mts, count := viewMemtablesOldestFirst(view)
 
-	// Skipping the active memtable, which is last after the reversal. Its size is
-	// read outside flushLock, but a size never decreases, so a racing write leaves
-	// it low and the skip misses that write rather than dropping a committed one.
-	// A size of zero means no write changed a document, not that the tree is bare
-	// — an empty write still builds a node — but such rows add and delete nothing
-	// and fold as if absent. Only the active one qualifies: a flushing memtable
-	// grew before it was switched out and takes no writes after.
-	//
-	// No nil check: a bucket has an active memtable from the moment it opens, and a
-	// switch installs the replacement before publishing the outgoing one as
-	// flushing, so no view carries a flushing memtable and no active one.
+	// Drop the active memtable if empty (size never decreases, so a racing write
+	// only makes this stale-low, never stale-high). Only the active one can be
+	// empty like this: the switch refuses to run on an empty memtable, so a
+	// flushing one always held something. No nil check: a bucket always has an
+	// active memtable.
 	if mts[count-1].Size() == 0 {
 		count--
-		mts[count] = nil
 	}
 
-	return &RoaringSetBatchReader{
+	r := &RoaringSetBatchReader{
 		bucket:      view.Bucket,
 		segments:    view.Disk,
 		keys:        keys,
 		windowSize:  window,
 		windowBytes: budget,
-		mts:         mts,
 		mtCount:     count,
-	}, nil
+	}
+	for mt := 0; mt < count; mt++ {
+		r.windows[mt].mt = mts[mt]
+	}
+	return r, nil
 }
 
-// Len is how many keys the batch holds.
 func (r *RoaringSetBatchReader) Len() int { return r.keys.Len() }
 
-// Next reads the batch's next row under the held view. It returns either a row
-// and the release for it, or an error and neither, so there is nothing to release
-// on the error path and nothing to check on the other. The row is the caller's to
-// mutate, as RoaringSetGet's is.
+// Next reads the batch's next row under the held view. On error it returns no
+// release; the row it does return is the caller's to mutate, as RoaringSetGet's
+// is. Calling it more than Len times is a caller error.
 //
-// The batch is walked once, in order, which is the order the window makes cheap.
-// Len is how many times it can be called; calling it more is a caller error and
-// returns one rather than a row from nowhere.
-//
-// A call that fills a window is uninterruptible, so a cancelled fold stops at the
-// next Next rather than partway through one — a window's worth of work, which is
-// milliseconds at worst.
+// A call that fills a window is uninterruptible, so a cancelled caller stops
+// at the next Next rather than mid-window.
 //
 // mergeConc reaches sroar unclamped: pass what concurrency.BudgetFromCtxCapped
 // returned, since SROAR_MERGE bypasses the query's budget and a non-positive
@@ -411,27 +433,21 @@ func (r *RoaringSetBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), erro
 	var layers [2]roaringset.BitmapLayer
 	found := 0
 	for mt := 0; mt < r.mtCount; mt++ {
-		if layer := r.layers[mt][at]; layer.Additions != nil || layer.Deletions != nil {
+		w := &r.windows[mt]
+		if layer := w.layer[at]; layer.Additions != nil || layer.Deletions != nil {
 			layers[found] = layer
 			found++
 		}
-		// Handed over, so the window stops holding it — otherwise every row it
-		// matched stays live until the next fill, which a single-window batch
-		// never reaches.
-		r.layers[mt][at] = roaringset.BitmapLayer{}
+		// Cleared so the window stops holding it; otherwise every matched row
+		// stays live until the next fill.
+		w.layer[at] = roaringset.BitmapLayer{}
 	}
-	// The fold below hands back a callable release even when it fails, which the
-	// per-key path's callers rely on. Next returns no release on error, so the
-	// error is passed on alone; nothing is dropped, since a failed disk read
-	// unwinds its own pooled buffer.
 	bm, release, err := r.bucket.roaringSetGetWithLayers(
 		r.segments, r.keys.At(r.pos), mergeConc, layers[:found])
 	if err != nil {
-		// This key's slots were emptied above, so leaving the window intact would
-		// let a retry read them as absence and fold the disk row alone — a wrong
-		// row, with no error to say so. Collapsing the window puts pos at its end
-		// and forces the refill, as fillWindow does for its own failures.
-		r.winStart, r.winEnd = r.pos, r.pos
+		// This key's slots were already emptied above; collapsing the window
+		// forces a refill on retry instead of folding the disk row alone.
+		r.dropWindow()
 		return nil, nil, err
 	}
 	r.pos++
@@ -440,70 +456,119 @@ func (r *RoaringSetBatchReader) Next(mergeConc int) (*sroar.Bitmap, func(), erro
 
 // fillWindow has every memtable write the window containing r.pos into that
 // memtable's slice, so serving a key afterwards is an index rather than a
-// lookup.
+// lookup. A batch that never leaves one window pays for it once.
 //
-// Windows are filled as the fold reaches them, so a fold that stops early pays
-// for the windows it entered — not for the keys it read. A batch inside one
-// window therefore saves nothing.
+// Two properties have to hold when it returns without an error, and both are
+// what keep an unwritten slot meaning "this memtable holds nothing for that
+// key" rather than "nobody asked for it" — the difference between a right
+// answer and a silently wrong one.
+//
+// The window is never zero-width. A memtable narrows it only to what that
+// memtable filled, and a read always takes the key it starts at whatever the
+// row costs, so a memtable that read leaves filled above winStart. One that was
+// skipped for want of budget carried something, and a memtable carrying nothing
+// is never skipped. Were one zero-width, Next would serve every key it covers
+// from the disk row alone, with that memtable's deletions unapplied, and
+// advance past it.
+//
+// Every slot from a memtable's filled index to the end of its slice is zero.
+// rebase allocates or clears the tail it vacates, a read clears the range it is
+// given, dropWindow clears what a failed read left behind, and Next clears each
+// slot as it serves it.
 func (r *RoaringSetBatchReader) fillWindow() error {
-	// Starting where the walk is, rather than on a grid: the caller reads
-	// forward, so the window it needs always begins at the key it is asking for.
+	prevStart := r.winStart
 	r.winStart = r.pos
-	// The widest this window may be. Each memtable may narrow it, so winEnd is
-	// only settled once they have all read.
-	wide := min(r.winStart+r.windowSize, r.keys.Len())
-	width := wide - r.winStart
-	r.winEnd = wide
+	// Opened at its widest; each memtable may narrow it below, so winEnd is only
+	// settled once they have all read.
+	r.winEnd = min(r.winStart+r.windowSize, r.keys.Len())
+	width := r.winEnd - r.winStart
 
-	// This window's own copying, so the peak below is a window rather than the
-	// batch: the total across a batch measures the copying, not what was ever
-	// held at once.
-	bytes := 0
+	if r.mtCount == 0 {
+		// The window exists to amortize a memtable's read lock, and there is no
+		// memtable to lock. It still has to advance, but counting a fill here
+		// would report work that never happened.
+		return nil
+	}
 
 	// Shared across the memtables rather than given to each in full — see
-	// memtableWindowBytes for why.
-	share := r.windowBytes / max(1, r.mtCount)
+	// readerWindowBytes. Never zero: a share of nothing reads nothing, and a
+	// window no memtable read answers every key it holds as absent.
+	share := max(1, r.windowBytes/r.mtCount)
+	// What this window holds is carriedIn plus copied: rows kept from an earlier
+	// fill, and rows read now. The two are disjoint, since a memtable only reads
+	// past what it already holds.
+	copied, carriedIn := 0, 0
 
 	for mt := 0; mt < r.mtCount; mt++ {
-		if r.layers[mt] == nil {
-			// One allocation serves the batch: widths only shrink, since pos moves
-			// forward, so the first window is the widest. Handing over the whole
-			// buffer rather than this window's part of it is what keeps a clone the
-			// fold never reached from outliving the window it was made for — the
-			// read clears everything it is given.
-			r.layers[mt] = make([]roaringset.BitmapLayer, width)
+		w := &r.windows[mt]
+		carriedIn += w.rebase(r.winStart, prevStart, width)
+
+		// Only what is not already held, and only what this memtable's share has
+		// left after the rows it carried in. Starting below filled would drop the
+		// kept rows and clone them again.
+		from := max(r.winStart, w.filled)
+		if avail := share - w.carried; from < r.winEnd && avail > 0 {
+			// Bounded by winEnd as already narrowed, not by the width this window
+			// opened at: a memtable read after one whose budget stopped early does
+			// not clone rows the fold will never ask for.
+			r.memtableReads++
+			fill, err := w.mt.roaringSetGetWindow(
+				r.keys, from, r.winEnd, w.layer[from-r.winStart:r.winEnd-r.winStart], avail)
+			// Counted before the error is checked: a read that failed part way
+			// still copied what it reports under the lock, as did every memtable
+			// ahead of it in this fill.
+			copied += fill.Bytes
+			if err != nil {
+				// One memtable loaded for this window, the other still at the last
+				// one's width; collapsing forces a clean refill on retry.
+				r.recordFill(false, carriedIn, copied)
+				r.dropWindow()
+				return err
+			}
+			w.filled = fill.To
 		}
 
-		// Bounded by where the window already ends rather than by its widest
-		// extent, which winEnd carries since it only shrinks: a memtable read after
-		// one whose budget stopped early does not clone rows the fold will never
-		// ask for. One read before the narrowing is not spared, and the next fill
-		// asks it for those keys again; the alternative is a window per memtable.
-		fill, err := r.mts[mt].roaringSetGetWindow(
-			r.keys, r.winStart, r.winEnd, r.layers[mt], share)
-		if err != nil {
-			// One memtable is loaded for this window and the other still holds the
-			// last one, at its width. Emptying the window puts pos past its end,
-			// so a retry refills rather than serving that mixture.
-			r.winStart, r.winEnd = r.pos, r.pos
-			return err
+		// The narrowest memtable decides the window: past what it holds a zero
+		// layer would read as absence rather than "not asked".
+		if w.filled < r.winEnd {
+			r.winEnd = w.filled
 		}
-
-		// The narrowest memtable decides the window: past its To it has written
-		// nothing, and a zero layer there would read as a key it does not hold
-		// rather than one it was not asked about.
-		r.winEnd = min(r.winEnd, fill.To)
-		bytes += fill.Bytes
 	}
-	// Counted here rather than on entry, so Fills times Memtables is the
-	// acquisitions that happened rather than the ones that were attempted.
+
+	for mt := 0; mt < r.mtCount; mt++ {
+		r.windows[mt].recountCarried(r.winStart, r.winEnd)
+	}
+
+	r.recordFill(r.winEnd-r.winStart < width, carriedIn, copied)
+	return nil
+}
+
+// recordFill adds what one fill did to the counters Stats reports. narrowed is
+// the caller's to decide: winEnd is still being narrowed while the memtables
+// read, so reading it here would answer differently depending on how far the
+// fill got.
+//
+// A fill that failed part way is still counted, or MemtableReads could exceed
+// Fills times Memtables. It is not narrowed, though: it ended on the failure
+// rather than on either limit.
+func (r *RoaringSetBatchReader) recordFill(narrowed bool, carriedIn, copied int) {
 	r.fills++
-	if r.winEnd < wide {
-		// Ended on its budget rather than on the keys it was allowed, which is what
-		// says the byte limit is the one worth raising.
+	if narrowed {
 		r.narrowedFills++
 	}
-	r.bytesPeak = max(r.bytesPeak, bytes)
-	r.bytesCopied += bytes
-	return nil
+	r.bytesPeak = max(r.bytesPeak, carriedIn+copied)
+	r.bytesCopied += copied
+}
+
+// dropWindow makes the next Next refill from scratch. Kept rows go with it:
+// a failed read can leave a hole in them, which would otherwise be served as
+// absence rather than re-read.
+func (r *RoaringSetBatchReader) dropWindow() {
+	r.winStart, r.winEnd = r.pos, r.pos
+	for mt := 0; mt < r.mtCount; mt++ {
+		w := &r.windows[mt]
+		clear(w.layer)
+		w.filled = r.pos
+		w.carried = 0
+	}
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_bench_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_bench_test.go
@@ -1,0 +1,378 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"slices"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/inverted"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// What memtableWindowKeys trades, measured on a bucket rather than on stand-ins.
+//
+// The window bounds how long the memtable's read lock is held, so it is a
+// reader/writer trade and neither side alone settles it. Three things decide
+// whether the numbers mean anything, and getting any of them wrong quietly
+// answers a different question:
+//
+//   - The fixture is built inside each sub-benchmark. Shared across a sweep, a
+//     writer grows the memtable as it runs and how much depends on the window
+//     under test, so the variable would be driving the conditions.
+//   - The writer only touches keys the memtable already holds, so it adds bytes
+//     and never nodes: the tree the readers walk stays the size it started.
+//   - The disk is populated. Against an empty one every row is a miss and
+//     cloning memtable rows becomes the reader's entire cost, which is not the
+//     shape a flushed bucket has. The disk hit rate is swept because it decides
+//     whether a row has a disk half to fold into at all.
+//
+// TestBenchWindowFixtureIsStable checks the first two before any number here is
+// worth reading.
+//
+// Reader cost is timed in the reader rather than taken from ns/op, which with
+// several readers sharing b.N is a fold divided by the reader count. Writer
+// throughput is per second, not a raw count over a wall time that varies from
+// one sub-benchmark to the next. Writer latencies are bimodal and the tail
+// needs a long run to settle, so the sample count is reported alongside it.
+//
+//	go test -run '^$' -bench BenchmarkRoaringSetWindow -benchtime 300x -count 5 \
+//	    ./adapters/repos/db/lsmkv/
+const (
+	benchWindowBatch = 20_000
+	// how many of the batch's keys the memtable holds; a memtable is a delta,
+	// so a filter asks it about far more keys than it has
+	benchWindowMemPct = 10
+)
+
+var benchWindows = []int{64, 128, 256, 512, 1024, 4096}
+
+// writeLatCap bounds the writer's latency samples. Appending without a bound
+// reallocates on the writer goroutine, inside the loop being timed, so the tail
+// this benchmark exists to report would carry the cost of recording it. The ring
+// is allocated once and never grows: the documented run fits entirely, and only a
+// sustained one wraps, keeping the most recent writes rather than the warm-up.
+const writeLatCap = 1 << 20
+
+// benchWindowReaderCounts straddles the core count, since that is what the
+// contention conclusions are stated against. Hardcoding readers instead ties
+// them to whichever machine picked the numbers: the same pair sits either side
+// of the threshold on one host and wholly below it on a bigger one, and the
+// sweep then reports a different shape without saying anything changed.
+func benchWindowReaderCounts() []int {
+	procs := runtime.GOMAXPROCS(0)
+	// Deduped: on a small host procs/2 and procs collide, and two sub-benchmarks
+	// under one name are not a sweep.
+	counts := []int{max(2, procs/2), procs, 2 * procs}
+	slices.Sort(counts)
+	return slices.Compact(counts)
+}
+
+func benchWindowKey(i int) string { return fmt.Sprintf("key_%08d", i) }
+
+// benchWindowDocs spreads a row's documents stride apart, which is what decides
+// what cloning the row costs: a clone copies whole containers, so a row's cost
+// follows how many of them its documents touch rather than how many documents it
+// holds.
+//
+// Both ends of that range are ordinary, and they are far apart. A property with N
+// values ingested in document order gives one value's documents a stride of N, so
+// at benchWindowBatch a thousand documents touch about 305 of the 65,536-id
+// containers and cost about 47KB. The same thousand ingested grouped by value sit
+// adjacent, share one container, and cost about 2KB. Twenty-two times apart for the
+// same count, which is why the spread is a dimension here and not a constant: a
+// figure from one end says nothing about the other. Neither end is the worst case —
+// a stride of a full container gives one container per document, about 141KB.
+func benchWindowDocs(key, docsPerRow, stride int) []uint64 {
+	docs := make([]uint64, docsPerRow)
+	for j := range docs {
+		docs[j] = uint64(key + j*stride)
+	}
+	return docs
+}
+
+// benchWindowFixture builds a bucket holding diskHitPct of the batch on disk
+// and benchWindowMemPct of it in the active memtable, and returns the batch
+// along with the memtable's own keys, which is all the writer may touch.
+//
+// docsPerRow and docsStride are together the dimension the window's memory cost
+// scales with, and the one a filter has no say over: a low-cardinality property
+// carries thousands of documents per value, and how those documents are spread
+// decides what each one adds. Both are separate from the key count because they
+// move independently — the batch decides how many rows are cloned, these decide
+// what each clone costs. See benchWindowDocs for how far apart the ends are.
+func benchWindowFixture(tb testing.TB, diskHitPct, docsPerRow, docsStride int) (*Bucket, inverted.SortedKeys, []string) {
+	tb.Helper()
+	ctx := context.Background()
+
+	// The pooled buffers the server wires in, so the disk read costs what it
+	// costs in production rather than allocating per row.
+	pool, closePool := roaringset.NewBitmapBufPoolDefault(nullLogger(), nil,
+		config.DefaultQueryBitmapBufsMaxBufSize, config.DefaultQueryBitmapBufsMaxMemory)
+	tb.Cleanup(closePool)
+
+	b, err := NewBucketCreator().NewBucket(ctx, tb.TempDir(), "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet), WithBitmapBufPool(pool))
+	require.NoError(tb, err)
+	tb.Cleanup(func() { require.NoError(tb, b.Shutdown(context.Background())) })
+	b.SetMemtableThreshold(1e9) // no auto-flush; the split is the fixture
+
+	names := make([]string, benchWindowBatch)
+	for i := range names {
+		names[i] = benchWindowKey(i)
+	}
+	for i, name := range names {
+		if i%100 < diskHitPct {
+			require.NoError(tb, b.RoaringSetAddList([]byte(name), benchWindowDocs(i, docsPerRow, docsStride)))
+		}
+	}
+	require.NoError(tb, b.FlushAndSwitch())
+
+	var memKeys []string
+	for i, name := range names {
+		if i%100 < benchWindowMemPct {
+			require.NoError(tb, b.RoaringSetAddList([]byte(name), benchWindowDocs(i+benchWindowBatch, docsPerRow, docsStride)))
+			memKeys = append(memKeys, name)
+		}
+	}
+	return b, sortedKeysOf(tb, names), memKeys
+}
+
+// benchWindowFold reads the whole batch through one reader the way the contains
+// fold does: in order, once each, releasing as it goes.
+func benchWindowFold(tb testing.TB, b *Bucket, keys inverted.SortedKeys, window int) {
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+
+	r, err := newRoaringSetBatchReader(view, keys, window)
+	if err != nil {
+		tb.Error(err)
+		return
+	}
+	for i := 0; i < keys.Len(); i++ {
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		if err != nil {
+			tb.Error(err)
+			return
+		}
+		release()
+	}
+}
+
+// benchWindowCloneBytes is what one filled window holds at once: the cost the
+// window size actually bounds, and the one allocs/op cannot report, since it
+// counts allocation events and this is live bytes. It fills through the reader
+// rather than serving through it, because a served slot releases its clone.
+func benchWindowCloneBytes(tb testing.TB, b *Bucket, keys inverted.SortedKeys, window int) int {
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+
+	r, err := newRoaringSetBatchReader(view, keys, window)
+	require.NoError(tb, err)
+	require.NoError(tb, r.fillWindow())
+
+	total := 0
+	for mt := 0; mt < r.mtCount; mt++ {
+		for _, layer := range r.layers[mt] {
+			if layer.Additions != nil {
+				total += len(layer.Additions.ToBuffer())
+			}
+			if layer.Deletions != nil {
+				total += len(layer.Deletions.ToBuffer())
+			}
+		}
+	}
+	return total
+}
+
+// TestBenchWindowFixtureIsStable is the harness checking itself, and the reason
+// the sweep can be read as a comparison: a fixture comes out the same every time
+// it is built, in nodes and in the bytes they hold, and running the writer
+// leaves the node count where it found it. A sweep sharing one fixture, or a
+// writer that grows the tree, measures the window against a moving target.
+func TestBenchWindowFixtureIsStable(t *testing.T) {
+	// Nodes and the bytes they hold, since the two move for different reasons.
+	// The node count is what a shared fixture or a tree-growing writer would
+	// disturb; the bytes are what a row costs to clone, which is what clone-B
+	// reports and what every memory conclusion drawn from these benchmarks
+	// rests on.
+	shape := func(b *Bucket) (nodes, bytes int) {
+		c := b.active.newRoaringSetCursor()
+		for k, layer, err := c.First(); k != nil && err == nil; k, layer, err = c.Next() {
+			nodes++
+			bytes += len(layer.Additions.ToBuffer()) + len(layer.Deletions.ToBuffer())
+		}
+		return nodes, bytes
+	}
+
+	first, _, memKeys := benchWindowFixture(t, 50, 1, benchWindowBatch)
+	second, _, _ := benchWindowFixture(t, 50, 1, benchWindowBatch)
+	firstNodes, firstBytes := shape(first)
+	secondNodes, secondBytes := shape(second)
+	require.NotZero(t, firstNodes)
+	require.Equal(t, firstNodes, secondNodes, "two builds of one fixture must match")
+	require.Equal(t, firstBytes, secondBytes,
+		"two builds must cost the same to clone, or clone-B is not a comparison")
+
+	for n := 0; n < 5*len(memKeys); n++ {
+		require.NoError(t, first.RoaringSetAddList([]byte(memKeys[n%len(memKeys)]), []uint64{uint64(n)}))
+	}
+	afterNodes, afterBytes := shape(first)
+	require.Equal(t, firstNodes, afterNodes, "the writer must add bytes, never nodes")
+	// Not that the encoding grows: at this write count sroar's containers absorb
+	// the new documents without growing, and the sweep's own writer runs long
+	// enough that they do. What is asserted is the bound — a fixture change that
+	// made a row cost several times more to clone fails here rather than
+	// silently moving every clone-B number.
+	require.LessOrEqual(t, afterBytes, 4*firstBytes,
+		"a row grew far more than this writer explains; clone-B moved with it")
+}
+
+// BenchmarkRoaringSetWindowRead is the reader side alone, with nothing writing:
+// what the window is worth before any contention.
+//
+// clone-B is reported beside the timings because the two answer different
+// questions and only one of them scales with the window: allocs/op is flat
+// across every size here, while clone-B — the live bytes one filled window
+// holds — is what a bigger window actually spends. Read the timings for what
+// the window is worth and clone-B for what it costs.
+func BenchmarkRoaringSetWindowRead(b *testing.B) {
+	// One row per document leaves nothing for a stride to spread, so the spread is
+	// swept only where it changes anything.
+	rows := []struct {
+		label      string
+		docsPerRow int
+		docsStride int
+	}{
+		{"docs=1", 1, benchWindowBatch},
+		{"docs=1000/spread=clustered", 1000, 1},
+		{"docs=1000/spread=strided", 1000, benchWindowBatch},
+	}
+	for _, row := range rows {
+		for _, diskHitPct := range []int{0, 90} {
+			for _, window := range benchWindows {
+				name := fmt.Sprintf("%s/disk=%d%%/window=%d", row.label, diskHitPct, window)
+				b.Run(name, func(b *testing.B) {
+					bucket, keys, _ := benchWindowFixture(b, diskHitPct, row.docsPerRow, row.docsStride)
+					cloneBytes := benchWindowCloneBytes(b, bucket, keys, window)
+					b.ResetTimer()
+					b.ReportAllocs()
+					for n := 0; n < b.N; n++ {
+						benchWindowFold(b, bucket, keys, window)
+					}
+					b.ReportMetric(float64(cloneBytes), "clone-B")
+				})
+			}
+		}
+	}
+}
+
+// BenchmarkRoaringSetWindowUnderWrite folds the batch from several readers with
+// one writer on the same memtable. b.N is the number of folds, shared out
+// across the readers; fold-ms is what one of them cost and the w- metrics are
+// what the writer paid for it.
+func BenchmarkRoaringSetWindowUnderWrite(b *testing.B) {
+	for _, readers := range benchWindowReaderCounts() {
+		for _, diskHitPct := range []int{0, 90} {
+			for _, window := range benchWindows {
+				name := fmt.Sprintf("readers=%d/disk=%d%%/window=%d", readers, diskHitPct, window)
+				b.Run(name, func(b *testing.B) {
+					bucket, keys, memKeys := benchWindowFixture(b, diskHitPct, 1, benchWindowBatch)
+
+					var remaining atomic.Int64
+					remaining.Store(int64(b.N))
+					var readersDone, writerDone sync.WaitGroup
+					var stopWriter atomic.Bool
+					var mu sync.Mutex
+					var foldLat, writeLat []time.Duration
+					var writeTotal int
+					var writeErr atomic.Pointer[error]
+
+					b.ResetTimer()
+					start := time.Now()
+
+					writerDone.Add(1)
+					go func() {
+						defer writerDone.Done()
+						local := make([]time.Duration, writeLatCap)
+						writes := 0
+						for ; !stopWriter.Load(); writes++ {
+							t0 := time.Now()
+							err := bucket.RoaringSetAddList([]byte(memKeys[writes%len(memKeys)]), []uint64{uint64(writes)})
+							if err != nil {
+								writeErr.Store(&err)
+								return
+							}
+							local[writes%writeLatCap] = time.Since(t0)
+						}
+						mu.Lock()
+						writeLat = local[:min(writes, writeLatCap)]
+						writeTotal = writes
+						mu.Unlock()
+					}()
+
+					for r := 0; r < readers; r++ {
+						readersDone.Add(1)
+						go func() {
+							defer readersDone.Done()
+							local := make([]time.Duration, 0, 64)
+							for remaining.Add(-1) >= 0 {
+								t0 := time.Now()
+								benchWindowFold(b, bucket, keys, window)
+								local = append(local, time.Since(t0))
+							}
+							mu.Lock()
+							foldLat = append(foldLat, local...)
+							mu.Unlock()
+						}()
+					}
+					readersDone.Wait()
+					stopWriter.Store(true)
+					writerDone.Wait()
+					elapsed := time.Since(start)
+					b.StopTimer()
+
+					if err := writeErr.Load(); err != nil {
+						b.Fatal(*err)
+					}
+					if len(foldLat) == 0 || len(writeLat) == 0 {
+						b.Fatal("nothing recorded")
+					}
+					pct := func(d []time.Duration, p int) float64 {
+						sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+						return float64(d[len(d)*p/100].Nanoseconds())
+					}
+					b.ReportMetric(pct(foldLat, 50)/1e6, "fold-ms")
+					b.ReportMetric(pct(writeLat, 50)/1e3, "w-p50-us")
+					b.ReportMetric(pct(writeLat, 99)/1e3, "w-p99-us")
+					// Throughput is every write; the percentiles above are the samples
+					// the ring retained, which w-samples reports so the two are not
+					// mistaken for each other.
+					b.ReportMetric(float64(writeTotal)/elapsed.Seconds(), "writes/s")
+					b.ReportMetric(float64(len(writeLat)), "w-samples")
+				})
+			}
+		}
+	}
+}

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_bench_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_bench_test.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"context"
 	"fmt"
+	"math"
 	"runtime"
 	"slices"
 	"sort"
@@ -161,11 +162,15 @@ func benchWindowFixture(tb testing.TB, diskHitPct, docsPerRow, docsStride int) (
 
 // benchWindowFold reads the whole batch through one reader the way the contains
 // fold does: in order, once each, releasing as it goes.
+//
+// At the production byte budget, so the timings carry whatever narrowing it
+// imposes. A window the budget cuts is a window entered more often, and that cost
+// belongs in the number rather than beside it.
 func benchWindowFold(tb testing.TB, b *Bucket, keys inverted.SortedKeys, window int) {
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	r, err := newRoaringSetBatchReader(view, keys, window)
+	r, err := newRoaringSetBatchReader(view, keys, window, memtableWindowBytes)
 	if err != nil {
 		tb.Error(err)
 		return
@@ -188,7 +193,11 @@ func benchWindowCloneBytes(tb testing.TB, b *Bucket, keys inverted.SortedKeys, w
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	r, err := newRoaringSetBatchReader(view, keys, window)
+	// Uncapped, which is the point: this measures what the window size costs, and
+	// memtableWindowBytes would clamp every size above it to the same figure and
+	// flatten the curve memtableWindowKeys is tuned against. What production
+	// actually holds is this or the budget, whichever is smaller.
+	r, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
 	require.NoError(tb, err)
 	require.NoError(tb, r.fillWindow())
 

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_bench_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_bench_test.go
@@ -31,31 +31,18 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-// What memtableWindowKeys trades, measured on a bucket rather than on stand-ins.
+// What memtableWindowKeys trades, measured on a bucket rather than on
+// stand-ins. Gotchas: the fixture is built inside each sub-benchmark, not
+// shared across a sweep, so a writer growing it doesn't drive the conditions;
+// the writer only touches keys already present, so it adds bytes but never
+// nodes; and the disk is populated, since an empty one makes cloning the
+// reader's whole cost, unlike a flushed bucket. TestBenchWindowFixtureIsStable
+// checks the first two.
 //
-// The window bounds how long the memtable's read lock is held, so it is a
-// reader/writer trade and neither side alone settles it. Three things decide
-// whether the numbers mean anything, and getting any of them wrong quietly
-// answers a different question:
-//
-//   - The fixture is built inside each sub-benchmark. Shared across a sweep, a
-//     writer grows the memtable as it runs and how much depends on the window
-//     under test, so the variable would be driving the conditions.
-//   - The writer only touches keys the memtable already holds, so it adds bytes
-//     and never nodes: the tree the readers walk stays the size it started.
-//   - The disk is populated. Against an empty one every row is a miss and
-//     cloning memtable rows becomes the reader's entire cost, which is not the
-//     shape a flushed bucket has. The disk hit rate is swept because it decides
-//     whether a row has a disk half to fold into at all.
-//
-// TestBenchWindowFixtureIsStable checks the first two before any number here is
-// worth reading.
-//
-// Reader cost is timed in the reader rather than taken from ns/op, which with
-// several readers sharing b.N is a fold divided by the reader count. Writer
-// throughput is per second, not a raw count over a wall time that varies from
-// one sub-benchmark to the next. Writer latencies are bimodal and the tail
-// needs a long run to settle, so the sample count is reported alongside it.
+// Reader cost is timed in the reader rather than read off ns/op, which with
+// several readers sharing b.N divides by the reader count. Writer throughput
+// is writes/s rather than a raw count over varying wall time; writer latency
+// is bimodal, so the sample count is reported alongside the percentiles.
 //
 //	go test -run '^$' -bench BenchmarkRoaringSetWindow -benchtime 300x -count 5 \
 //	    ./adapters/repos/db/lsmkv/
@@ -68,22 +55,17 @@ const (
 
 var benchWindows = []int{64, 128, 256, 512, 1024, 4096}
 
-// writeLatCap bounds the writer's latency samples. Appending without a bound
-// reallocates on the writer goroutine, inside the loop being timed, so the tail
-// this benchmark exists to report would carry the cost of recording it. The ring
-// is allocated once and never grows: the documented run fits entirely, and only a
-// sustained one wraps, keeping the most recent writes rather than the warm-up.
+// writeLatCap bounds the writer's latency samples so appending them doesn't
+// reallocate inside the timed loop. The ring is sized to fit the documented
+// run; a longer one wraps and keeps the most recent writes over the warm-up.
 const writeLatCap = 1 << 20
 
-// benchWindowReaderCounts straddles the core count, since that is what the
-// contention conclusions are stated against. Hardcoding readers instead ties
-// them to whichever machine picked the numbers: the same pair sits either side
-// of the threshold on one host and wholly below it on a bigger one, and the
-// sweep then reports a different shape without saying anything changed.
+// benchWindowReaderCounts straddles GOMAXPROCS rather than hardcoding reader
+// counts, so the contention conclusions hold across machines with different
+// core counts.
 func benchWindowReaderCounts() []int {
 	procs := runtime.GOMAXPROCS(0)
-	// Deduped: on a small host procs/2 and procs collide, and two sub-benchmarks
-	// under one name are not a sweep.
+	// Deduped: a small host's procs/2 and procs can collide.
 	counts := []int{max(2, procs/2), procs, 2 * procs}
 	slices.Sort(counts)
 	return slices.Compact(counts)
@@ -91,19 +73,13 @@ func benchWindowReaderCounts() []int {
 
 func benchWindowKey(i int) string { return fmt.Sprintf("key_%08d", i) }
 
-// benchWindowDocs spreads a row's documents stride apart, which is what decides
-// what cloning the row costs: a clone copies whole containers, so a row's cost
-// follows how many of them its documents touch rather than how many documents it
-// holds.
-//
-// Both ends of that range are ordinary, and they are far apart. A property with N
-// values ingested in document order gives one value's documents a stride of N, so
-// at benchWindowBatch a thousand documents touch about 305 of the 65,536-id
-// containers and cost about 47KB. The same thousand ingested grouped by value sit
-// adjacent, share one container, and cost about 2KB. Twenty-two times apart for the
-// same count, which is why the spread is a dimension here and not a constant: a
-// figure from one end says nothing about the other. Neither end is the worst case —
-// a stride of a full container gives one container per document, about 141KB.
+// benchWindowDocs spreads a row's documents stride apart. A clone copies
+// whole containers, so cost follows how many containers the documents touch,
+// not how many documents there are: at benchWindowBatch, a thousand documents
+// ingested in document order (stride N) touch ~305 of the 65,536-id
+// containers and cost ~47KB; the same thousand grouped by value (stride 1)
+// share one container and cost ~2KB. Neither is worst case — one container
+// per document (a full-container stride) costs ~141KB.
 func benchWindowDocs(key, docsPerRow, stride int) []uint64 {
 	docs := make([]uint64, docsPerRow)
 	for j := range docs {
@@ -116,12 +92,9 @@ func benchWindowDocs(key, docsPerRow, stride int) []uint64 {
 // and benchWindowMemPct of it in the active memtable, and returns the batch
 // along with the memtable's own keys, which is all the writer may touch.
 //
-// docsPerRow and docsStride are together the dimension the window's memory cost
-// scales with, and the one a filter has no say over: a low-cardinality property
-// carries thousands of documents per value, and how those documents are spread
-// decides what each one adds. Both are separate from the key count because they
-// move independently — the batch decides how many rows are cloned, these decide
-// what each clone costs. See benchWindowDocs for how far apart the ends are.
+// docsPerRow and docsStride are kept separate from the key count because they
+// move independently: the batch decides how many rows are cloned, these
+// decide what each clone costs (see benchWindowDocs).
 func benchWindowFixture(tb testing.TB, diskHitPct, docsPerRow, docsStride int) (*Bucket, inverted.SortedKeys, []string) {
 	tb.Helper()
 	ctx := context.Background()
@@ -160,17 +133,45 @@ func benchWindowFixture(tb testing.TB, diskHitPct, docsPerRow, docsStride int) (
 	return b, sortedKeysOf(tb, names), memKeys
 }
 
-// benchWindowFold reads the whole batch through one reader the way the contains
-// fold does: in order, once each, releasing as it goes.
-//
-// At the production byte budget, so the timings carry whatever narrowing it
-// imposes. A window the budget cuts is a window entered more often, and that cost
-// belongs in the number rather than beside it.
+// benchWindowSplitAcrossMemtables leaves the fixture with a flush in flight, so
+// a fold reads two memtables and splits each fill's budget between them. Every
+// other fixture here switches its memtable away before writing.
+func benchWindowSplitAcrossMemtables(tb testing.TB, b *Bucket, memKeys []string,
+	docsPerRow, docsStride int,
+) {
+	tb.Helper()
+
+	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	require.NoError(tb, err)
+	require.True(tb, switched, "the fixture wrote nothing, so there is nothing to flush")
+
+	// Nothing here will ever flush it: these fixtures run a noop cycle manager,
+	// and Shutdown polls for a nil flushing memtable on a context that never
+	// expires. Registered after the fixture's own Shutdown cleanup so it runs
+	// before it.
+	tb.Cleanup(func() {
+		b.flushLock.Lock()
+		defer b.flushLock.Unlock()
+		b.flushing = nil
+	})
+
+	// The new active memtable has to hold rows of its own: a reader drops an
+	// empty active one, which would put the fold back on a single memtable.
+	// Seeded past the flushing memtable's documents so the two do not coincide.
+	for i, name := range memKeys {
+		docs := benchWindowDocs(i+2*benchWindowBatch, docsPerRow, docsStride)
+		require.NoError(tb, b.RoaringSetAddList([]byte(name), docs))
+	}
+}
+
+// benchWindowFold reads the whole batch through one reader the way the
+// contains fold does: in order, once each, releasing as it goes. Runs at the
+// production byte budget, so the timings carry whatever narrowing it imposes.
 func benchWindowFold(tb testing.TB, b *Bucket, keys inverted.SortedKeys, window int) {
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	r, err := newRoaringSetBatchReader(view, keys, window, memtableWindowBytes)
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, window, readerWindowBytes)
 	if err != nil {
 		tb.Error(err)
 		return
@@ -185,25 +186,24 @@ func benchWindowFold(tb testing.TB, b *Bucket, keys inverted.SortedKeys, window 
 	}
 }
 
-// benchWindowCloneBytes is what one filled window holds at once: the cost the
-// window size actually bounds, and the one allocs/op cannot report, since it
-// counts allocation events and this is live bytes. It fills through the reader
-// rather than serving through it, because a served slot releases its clone.
+// benchWindowCloneBytes is what one filled window holds at once — live bytes,
+// which allocs/op cannot report since it counts allocation events. It fills
+// through the reader rather than serving through it, since a served slot
+// releases its clone.
 func benchWindowCloneBytes(tb testing.TB, b *Bucket, keys inverted.SortedKeys, window int) int {
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
 
-	// Uncapped, which is the point: this measures what the window size costs, and
-	// memtableWindowBytes would clamp every size above it to the same figure and
-	// flatten the curve memtableWindowKeys is tuned against. What production
-	// actually holds is this or the budget, whichever is smaller.
-	r, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
+	// Uncapped: a real budget would clamp every window size above it to the
+	// same figure, flattening the curve this measures. Production holds this
+	// or the budget, whichever is smaller.
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, window, math.MaxInt)
 	require.NoError(tb, err)
 	require.NoError(tb, r.fillWindow())
 
 	total := 0
 	for mt := 0; mt < r.mtCount; mt++ {
-		for _, layer := range r.layers[mt] {
+		for _, layer := range r.windows[mt].layer {
 			if layer.Additions != nil {
 				total += len(layer.Additions.ToBuffer())
 			}
@@ -215,17 +215,13 @@ func benchWindowCloneBytes(tb testing.TB, b *Bucket, keys inverted.SortedKeys, w
 	return total
 }
 
-// TestBenchWindowFixtureIsStable is the harness checking itself, and the reason
-// the sweep can be read as a comparison: a fixture comes out the same every time
-// it is built, in nodes and in the bytes they hold, and running the writer
-// leaves the node count where it found it. A sweep sharing one fixture, or a
-// writer that grows the tree, measures the window against a moving target.
+// TestBenchWindowFixtureIsStable is the harness checking itself: a fixture
+// must come out the same every time it's built (in nodes and in clone bytes),
+// and running the writer must leave the node count where it found it —
+// otherwise the sweep measures the window against a moving target.
 func TestBenchWindowFixtureIsStable(t *testing.T) {
-	// Nodes and the bytes they hold, since the two move for different reasons.
-	// The node count is what a shared fixture or a tree-growing writer would
-	// disturb; the bytes are what a row costs to clone, which is what clone-B
-	// reports and what every memory conclusion drawn from these benchmarks
-	// rests on.
+	// Nodes and clone bytes move for different reasons: nodes are what a
+	// tree-growing writer would disturb, bytes are what clone-B reports.
 	shape := func(b *Bucket) (nodes, bytes int) {
 		c := b.active.newRoaringSetCursor()
 		for k, layer, err := c.First(); k != nil && err == nil; k, layer, err = c.Next() {
@@ -249,41 +245,65 @@ func TestBenchWindowFixtureIsStable(t *testing.T) {
 	}
 	afterNodes, afterBytes := shape(first)
 	require.Equal(t, firstNodes, afterNodes, "the writer must add bytes, never nodes")
-	// Not that the encoding grows: at this write count sroar's containers absorb
-	// the new documents without growing, and the sweep's own writer runs long
-	// enough that they do. What is asserted is the bound — a fixture change that
-	// made a row cost several times more to clone fails here rather than
-	// silently moving every clone-B number.
+	// A loose bound, not a claim the encoding never grows: catches a fixture
+	// change that made a row several times costlier to clone.
 	require.LessOrEqual(t, afterBytes, 4*firstBytes,
 		"a row grew far more than this writer explains; clone-B moved with it")
 }
 
-// BenchmarkRoaringSetWindowRead is the reader side alone, with nothing writing:
-// what the window is worth before any contention.
-//
-// clone-B is reported beside the timings because the two answer different
-// questions and only one of them scales with the window: allocs/op is flat
-// across every size here, while clone-B — the live bytes one filled window
-// holds — is what a bigger window actually spends. Read the timings for what
-// the window is worth and clone-B for what it costs.
+// TestBenchWindowSplitLeavesTwoMemtables is the harness checking itself again.
+// A switch leaving the new active memtable empty would have the reader drop it,
+// and the flushing row of [BenchmarkRoaringSetWindowRead] would quietly re-time
+// the single-memtable case beside it under a different name.
+func TestBenchWindowSplitLeavesTwoMemtables(t *testing.T) {
+	bucket, keys, memKeys := benchWindowFixture(t, 50, 1, benchWindowBatch)
+
+	view := bucket.GetConsistentView()
+	defer view.ReleaseView()
+	before, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, readerWindowBytes)
+	require.NoError(t, err)
+	require.Equal(t, 1, before.Stats().Memtables,
+		"the fixture must start on one memtable, or the split below proves nothing")
+
+	benchWindowSplitAcrossMemtables(t, bucket, memKeys, 1, benchWindowBatch)
+
+	split := bucket.GetConsistentView()
+	defer split.ReleaseView()
+	after, err := newRoaringSetBatchReaderWithBounds(split, keys, memtableWindowKeys, readerWindowBytes)
+	require.NoError(t, err)
+	require.Equal(t, 2, after.Stats().Memtables,
+		"the split must leave a flushing memtable and a live one the reader keeps")
+}
+
+// BenchmarkRoaringSetWindowRead is the reader side alone, with nothing
+// writing: what the window is worth before any contention. clone-B is
+// reported beside the timings since allocs/op is flat across every size here;
+// read the timings for what the window is worth, clone-B for what it costs.
 func BenchmarkRoaringSetWindowRead(b *testing.B) {
-	// One row per document leaves nothing for a stride to spread, so the spread is
-	// swept only where it changes anything.
+	// One row per document leaves nothing for a stride to spread. The flushing
+	// row is the clustered one with a flush left in flight, so the pair prices
+	// a second memtable: two reads per fill against one, and half the budget
+	// each. These rows stay well inside that half, so nothing narrows here.
 	rows := []struct {
 		label      string
 		docsPerRow int
 		docsStride int
+		flushing   bool
 	}{
-		{"docs=1", 1, benchWindowBatch},
-		{"docs=1000/spread=clustered", 1000, 1},
-		{"docs=1000/spread=strided", 1000, benchWindowBatch},
+		{"docs=1", 1, benchWindowBatch, false},
+		{"docs=1000/spread=clustered", 1000, 1, false},
+		{"docs=1000/spread=clustered/flushing", 1000, 1, true},
+		{"docs=1000/spread=strided", 1000, benchWindowBatch, false},
 	}
 	for _, row := range rows {
 		for _, diskHitPct := range []int{0, 90} {
 			for _, window := range benchWindows {
 				name := fmt.Sprintf("%s/disk=%d%%/window=%d", row.label, diskHitPct, window)
 				b.Run(name, func(b *testing.B) {
-					bucket, keys, _ := benchWindowFixture(b, diskHitPct, row.docsPerRow, row.docsStride)
+					bucket, keys, memKeys := benchWindowFixture(b, diskHitPct, row.docsPerRow, row.docsStride)
+					if row.flushing {
+						benchWindowSplitAcrossMemtables(b, bucket, memKeys, row.docsPerRow, row.docsStride)
+					}
 					cloneBytes := benchWindowCloneBytes(b, bucket, keys, window)
 					b.ResetTimer()
 					b.ReportAllocs()
@@ -297,10 +317,9 @@ func BenchmarkRoaringSetWindowRead(b *testing.B) {
 	}
 }
 
-// BenchmarkRoaringSetWindowUnderWrite folds the batch from several readers with
-// one writer on the same memtable. b.N is the number of folds, shared out
-// across the readers; fold-ms is what one of them cost and the w- metrics are
-// what the writer paid for it.
+// BenchmarkRoaringSetWindowUnderWrite folds the batch from several readers
+// with one writer on the same memtable. b.N is the number of folds shared
+// across the readers; fold-ms is one fold's cost, w- metrics are the writer's.
 func BenchmarkRoaringSetWindowUnderWrite(b *testing.B) {
 	for _, readers := range benchWindowReaderCounts() {
 		for _, diskHitPct := range []int{0, 90} {
@@ -375,9 +394,8 @@ func BenchmarkRoaringSetWindowUnderWrite(b *testing.B) {
 					b.ReportMetric(pct(foldLat, 50)/1e6, "fold-ms")
 					b.ReportMetric(pct(writeLat, 50)/1e3, "w-p50-us")
 					b.ReportMetric(pct(writeLat, 99)/1e3, "w-p99-us")
-					// Throughput is every write; the percentiles above are the samples
-					// the ring retained, which w-samples reports so the two are not
-					// mistaken for each other.
+					// writes/s counts every write; the percentiles above only cover the
+					// samples the ring retained, which w-samples reports.
 					b.ReportMetric(float64(writeTotal)/elapsed.Seconds(), "writes/s")
 					b.ReportMetric(float64(len(writeLat)), "w-samples")
 				})

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_test.go
@@ -20,6 +20,7 @@ package lsmkv
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"slices"
 	"sort"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/inverted"
 )
@@ -93,6 +95,44 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 		}),
 	}
 
+	// Rows wide enough that a budget of one of them ends a window, so the memtable
+	// read first is the one that settles where it ends. Four thousand documents
+	// sixty-four apart stay within a handful of containers, so it is the count
+	// rather than the spread that makes these rows expensive.
+	fatRow := func(seed uint64) []uint64 {
+		docs := make([]uint64, 4096)
+		for i := range docs {
+			docs[i] = seed*1_000_000 + uint64(i)*64
+		}
+		return docs
+	}
+	narrowingFlushing := newTestMemtableRoaringSet(map[string][]uint64{
+		"aaa": fatRow(1), "bbb": fatRow(2), "ccc": fatRow(3), "ddd": fatRow(4),
+	})
+	// Holds keys past where the flushing memtable's budget stops it, which is what
+	// a window left wider than that turns into a wrong answer: those keys would be
+	// answered out of slots the flushing memtable never wrote.
+	narrowingActive := newTestMemtableRoaringSet(map[string][]uint64{
+		"bbb": {91}, "ddd": {92}, "eee": {93},
+	})
+	// Its own segment rather than a shared one: the fake counts the reads it is
+	// asked for without a lock, and the cases below run in parallel.
+	narrowingDisk := []Segment{
+		newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"aaa": bitmapFromSlice([]uint64{1, 2, 3}),
+			"ccc": bitmapFromSlice([]uint64{4}),
+			"eee": bitmapFromSlice([]uint64{5, 6}),
+		}),
+	}
+	oneFatRow := func() int {
+		single := sortedKeysOf(t, []string{"aaa"})
+		dst := make([]roaringset.BitmapLayer, 1)
+		fill, err := narrowingFlushing.roaringSetGetWindow(single, 0, 1, dst, math.MaxInt)
+		require.NoError(t, err)
+		require.Positive(t, fill.Bytes)
+		return fill.Bytes
+	}()
+
 	tests := []struct {
 		name     string
 		segments []Segment
@@ -100,6 +140,9 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 		active   *testMemtable
 		batch    []string
 		windows  []int
+		// Zero for no budget, so only a case about narrowing has to think about
+		// one.
+		budget int
 		// Written down rather than derived, where the fold's outcome is worth
 		// pinning against something other than the path under test. Optional:
 		// the differential above runs either way.
@@ -148,6 +191,22 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 				"ggg": nil,
 			},
 		},
+		{
+			// The narrowing memtable is read first, so what the second is asked for
+			// rests on the bound already settled. Asked for the window's full width
+			// instead, it would fill slots past that bound, and the keys beyond it
+			// would be answered from a flushing memtable that never wrote them.
+			//
+			// No want: the rows here are thousands of documents wide, and the
+			// differential against the per-key path is what this case is for.
+			name:     "a narrowing memtable read before one holding keys past it",
+			segments: narrowingDisk,
+			flushing: narrowingFlushing,
+			active:   narrowingActive,
+			batch:    []string{"aaa", "bbb", "ccc", "ddd", "eee"},
+			windows:  []int{5, memtableWindowKeys},
+			budget:   oneFatRow + 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -166,7 +225,11 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 			for _, window := range tt.windows {
 				t.Run(fmt.Sprintf("window %d", window), func(t *testing.T) {
 					keys := sortedKeysOf(t, tt.batch)
-					r, err := newRoaringSetBatchReader(view, keys, window)
+					budget := tt.budget
+					if budget == 0 {
+						budget = math.MaxInt
+					}
+					r, err := newRoaringSetBatchReader(view, keys, window, budget)
 					require.NoError(t, err)
 
 					requireMatchesPerKey(t, b, view, r, keys, "")
@@ -174,7 +237,7 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 						return
 					}
 					// A second reader: one walks its batch once.
-					r2, err := newRoaringSetBatchReader(view, keys, window)
+					r2, err := newRoaringSetBatchReader(view, keys, window, budget)
 					require.NoError(t, err)
 					requireRowsAre(t, r2, keys, tt.want)
 				})
@@ -248,7 +311,7 @@ func TestBatchReaderMatchesPerKeyReadsRandomized(t *testing.T) {
 		keys := sortedKeysOf(t, batch)
 		window := 1 + rnd.Intn(5)
 
-		r, err := newRoaringSetBatchReader(view, keys, window)
+		r, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
 		require.NoError(t, err)
 		requireMatchesPerKey(t, b, view, r, keys, fmt.Sprintf("round %d", round))
 
@@ -259,7 +322,7 @@ func TestBatchReaderMatchesPerKeyReadsRandomized(t *testing.T) {
 		}
 		// A second reader, since the first has served every key and would spend
 		// the pass refilling.
-		abs, err := newRoaringSetBatchReader(view, keys, window)
+		abs, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
 		require.NoError(t, err)
 		requireRowsAre(t, abs, keys, want)
 	}
@@ -351,7 +414,7 @@ func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 				mts = append(mts, active)
 
 				keys := sortedKeysOf(t, []string{"aaa", "bbb", "ccc"})
-				r, err := newRoaringSetBatchReader(view, keys, w.size)
+				r, err := newRoaringSetBatchReader(view, keys, w.size, math.MaxInt)
 				require.NoError(t, err)
 
 				for i := 0; i < keys.Len(); i++ {
@@ -436,7 +499,7 @@ func TestBatchReaderFillWindowError(t *testing.T) {
 					batch[i] = fmt.Sprintf("k%02d", i)
 				}
 				keys := sortedKeysOf(t, batch)
-				r, err := newRoaringSetBatchReader(view, keys, 4)
+				r, err := newRoaringSetBatchReader(view, keys, 4, math.MaxInt)
 				require.NoError(t, err)
 
 				for i := 0; i < tc.readBefore; i++ {
@@ -506,7 +569,7 @@ func TestBatchReaderDiskErrorLeavesNothingToRetryWrong(t *testing.T) {
 	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 
 	keys := sortedKeysOf(t, []string{"k0", "k1"})
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 
 	_, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -591,7 +654,7 @@ func TestBatchReaderReadsWhileMemtableIsWritten(t *testing.T) {
 	seenBefore, seenAfter := 0, 0
 	for pass := 0; ; pass++ {
 		done := written.Load()
-		r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+		r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
 		require.NoError(t, err)
 		for i := 0; i < keys.Len(); i++ {
 			got, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -620,7 +683,7 @@ func TestBatchReaderReadsWhileMemtableIsWritten(t *testing.T) {
 	require.Positive(t, seenAfter, "no row was read after the writer reached it; the two never overlapped")
 
 	// and once the writer has finished, every key must show the write
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 	for i := 0; i < keys.Len(); i++ {
 		got, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -672,7 +735,7 @@ func TestBatchReaderFillsWindowsLazily(t *testing.T) {
 			view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
 
 			keys := sortedKeysOf(t, batch)
-			r, err := newRoaringSetBatchReader(view, keys, 4)
+			r, err := newRoaringSetBatchReader(view, keys, 4, math.MaxInt)
 			require.NoError(t, err)
 			for i := 0; i < tc.readThrough; i++ {
 				_, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -764,7 +827,7 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 			view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 
 			keys := sortedKeysOf(t, batch)
-			r, err := newRoaringSetBatchReader(view, keys, 4)
+			r, err := newRoaringSetBatchReader(view, keys, 4, math.MaxInt)
 			require.NoError(t, err)
 			for i := 0; i < tc.reads; i++ {
 				_, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -777,6 +840,8 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 			require.Equal(t, tc.wantMemtables, got.Memtables)
 			require.Equal(t, tc.reads, got.KeysRead,
 				"how far the fold got, which the fill count cannot say")
+			require.Zero(t, got.NarrowedFills,
+				"no budget here, so every window ended on its key count")
 			if tc.wantCloned {
 				require.Positive(t, got.BytesPeak, "rows the memtable holds must be counted")
 				require.Positive(t, got.BytesCopied, "and counted again in the total")
@@ -822,20 +887,76 @@ func TestBatchReaderSkipsAnEmptyActiveMemtable(t *testing.T) {
 	view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
 
 	keys := sortedKeysOf(t, batch)
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 	require.Equal(t, 1, r.mtCount, "the empty active memtable must be dropped from the view")
 
 	requireMatchesPerKey(t, b, view, r, keys, "empty active memtable")
 	require.Zero(t, active.roaringSetGetWindowCalls, "a dropped memtable must not be read")
 
-	abs, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	abs, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 	requireRowsAre(t, abs, keys, map[string][]uint64{
 		"aaa": {1, 2},
 		"bbb": {9},
 		"ccc": {3},
 	})
+}
+
+// TestBatchReaderNarrowsTheWindowToTheBudget pins one thing, which is the reader's
+// half of the memory bound: that a fill adopts where the walk stopped. The walk
+// reporting the right stop is no use if the fill keeps the width it asked for, and
+// that failure is invisible to every other test here — the rows still read
+// correctly, they just cost a window's memory each time.
+//
+// Deliberately nothing else. The always-taken first key is pinned on the walk,
+// which is where a budget under one row can be handed in cheaply. Which slots the
+// walk wrote cannot be pinned from here: a lone memtable stops itself at its own
+// budget, so the slots past winEnd are untouched whatever bound the fill passed.
+// And that rows read correctly through a narrowed window belongs to
+// TestBatchReaderMatchesPerKeyReads' budgeted case, over the two memtables where
+// the bound is what decides it.
+func TestBatchReaderNarrowsTheWindowToTheBudget(t *testing.T) {
+	t.Parallel()
+
+	// Rows spread across containers, so each costs real bytes.
+	const rows, docsPerRow = 12, 4096
+	batch := make([]string, rows)
+	held := map[string][]uint64{}
+	for i := range batch {
+		batch[i] = fmt.Sprintf("k%02d", i)
+		docs := make([]uint64, docsPerRow)
+		for j := range docs {
+			docs[j] = uint64(i + j*rows*8)
+		}
+		held[batch[i]] = docs
+	}
+
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	active := newTestMemtableRoaringSet(held)
+	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+
+	keys := sortedKeysOf(t, batch)
+	// A window wide enough for the whole batch, so only the budget can narrow it.
+	// One row's worth of budget, so the window ends on cost rather than on the
+	// key count — the shape a low-cardinality property produces in production,
+	// where rows are fat enough to reach the real constant.
+	one := make([]roaringset.BitmapLayer, 1)
+	first, err := active.roaringSetGetWindow(keys, 0, 1, one, math.MaxInt)
+	require.NoError(t, err)
+	require.Positive(t, first.Bytes)
+	budget := 3 * first.Bytes
+
+	r, err := newRoaringSetBatchReader(view, keys, rows, budget)
+	require.NoError(t, err)
+	require.NoError(t, r.fillWindow())
+	require.Less(t, r.winEnd-r.winStart, rows,
+		"the budget must have ended the window before the key count did")
 }
 
 // TestBatchReaderReleasesWhatItHasServed pins that a served key's clone leaves
@@ -869,7 +990,7 @@ func TestBatchReaderReleasesWhatItHasServed(t *testing.T) {
 	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 
 	keys := sortedKeysOf(t, batch)
-	r, err := newRoaringSetBatchReader(view, keys, len(batch))
+	r, err := newRoaringSetBatchReader(view, keys, len(batch), math.MaxInt)
 	require.NoError(t, err)
 
 	const served = 3
@@ -949,19 +1070,29 @@ func TestBatchReaderAtProductionWindow(t *testing.T) {
 	require.Equal(t, windows, active.roaringSetGetWindowCalls, "one read per window")
 }
 
-// TestBatchReaderRejectsWindowSize covers the one argument the constructor can be
-// given wrong, and it does not fail gracefully further down: a window of zero
-// gives every fill an empty range, so the first read indexes a buffer with no
-// slots, and a negative one asks for a buffer of negative length. Both panic,
-// which is why they are refused where they are passed.
-func TestBatchReaderRejectsWindowSize(t *testing.T) {
+// TestBatchReaderRejectsItsBounds covers the two constructor arguments that fail
+// differently when wrong: a non-positive window panics deep in the first fill,
+// while a non-positive budget degrades silently to a fill per key — see the guards
+// in newRoaringSetBatchReader. Both are refused there instead.
+//
+// The window read itself takes any budget, and is tested at zero and one for the
+// first-key floor. This is the caller's arithmetic, not the walk's.
+func TestBatchReaderRejectsItsBounds(t *testing.T) {
 	t.Parallel()
 	keys := sortedKeysOf(t, []string{"a", "b"})
 	view := BucketConsistentView{Active: newTestMemtableRoaringSet(nil)}
+
 	for _, window := range []int{0, -1, -256} {
-		_, err := newRoaringSetBatchReader(view, keys, window)
+		_, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
 		require.Errorf(t, err, "window %d must be rejected", window)
 	}
+	for _, budget := range []int{0, -1, -256} {
+		_, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, budget)
+		require.Errorf(t, err, "budget %d must be rejected", budget)
+	}
+	// Both good, so the cases above fail on the bound named and not on the view.
+	_, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, memtableWindowBytes)
+	require.NoError(t, err)
 }
 
 // TestBatchReaderReadsPastTheBatch pins the one way left to ask for a row that
@@ -985,7 +1116,7 @@ func TestBatchReaderReadsPastTheBatch(t *testing.T) {
 		Active: newTestMemtableRoaringSet(map[string][]uint64{"b": {2}}),
 		Disk:   []Segment{diskSeg}, Bucket: b,
 	}
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 
 	for i := 0; i < keys.Len(); i++ {
@@ -1033,4 +1164,229 @@ func requireMatchesPerKey(t *testing.T, b *Bucket, view BucketConsistentView,
 		wr()
 		gr()
 	}
+}
+
+// TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked pins that a reader holding
+// two memtables ends a batch with none of their rows still copied into it.
+//
+// A slot is emptied when the fold takes the row, so the ones at risk are those
+// the fold never reaches: a memtable read before the one whose budget settles
+// the window fills past that settlement, and those slots are never served. Since
+// window widths only shrink, the batch's last windows are narrower than the
+// buffer, so a fill that cleared only its own width would leave them behind for
+// as long as the reader lives.
+func TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked(t *testing.T) {
+	const (
+		nKeys  = 10
+		window = 8
+	)
+
+	names := make([]string, nKeys)
+	for i := range names {
+		names[i] = fmt.Sprintf("k%03d", i)
+	}
+	keys := sortedKeysOf(t, names)
+
+	// Read first, and holds a row for every key, so it fills whatever width it
+	// is asked for.
+	flushing := newTestMemtableRoaringSet(nil)
+	for i, n := range names {
+		require.NoError(t, flushing.roaringSetAddList([]byte(n), []uint64{uint64(i)}))
+	}
+
+	// Read second, and its rows are wide enough that the budget below stops it
+	// after one — so it, not the width, decides where each window ends.
+	active := newTestMemtableRoaringSet(nil)
+	wide := make([]uint64, 4096)
+	for i := range wide {
+		wide[i] = uint64(i)
+	}
+	for _, n := range names {
+		require.NoError(t, active.roaringSetAddList([]byte(n), wide))
+	}
+
+	oneRow := make([]roaringset.BitmapLayer, 1)
+	first, err := active.roaringSetGetWindow(keys, 0, 1, oneRow, math.MaxInt)
+	require.NoError(t, err)
+
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	view := BucketConsistentView{Active: active, Flushing: flushing, Bucket: b}
+
+	r, err := newRoaringSetBatchReader(view, keys, window, first.Bytes+1)
+	require.NoError(t, err)
+
+	for i := range nKeys {
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		// After a row is served, not before: windows fill lazily, so both ends
+		// are zero until the first Next and any width would pass.
+		require.Lessf(t, r.winEnd-r.winStart, window,
+			"key %d: the budget must narrow the window, or nothing is left unserved", i)
+		release()
+	}
+
+	for mt := range r.mtCount {
+		buf := r.layers[mt][:cap(r.layers[mt])]
+		for at, layer := range buf {
+			require.Nil(t, layer.Additions,
+				"memtable %d still holds additions cloned into slot %d", mt, at)
+			require.Nil(t, layer.Deletions,
+				"memtable %d still holds deletions cloned into slot %d", mt, at)
+		}
+	}
+
+	// And the rows are right, which is the direction the batched parity table does
+	// not reach: there the memtable read first is the one whose budget settles the
+	// window, and here it is the one read second. What each is asked for depends on
+	// the other, so both orders have to answer as the per-key path does.
+	fresh, err := newRoaringSetBatchReader(view, keys, window, first.Bytes+1)
+	require.NoError(t, err)
+	requireMatchesPerKey(t, b, view, fresh, keys, "the second memtable narrowing")
+}
+
+// TestBatchReaderEndsWindowsOnEitherLimit covers a batch whose windows do not all
+// end the same way. A window ends at the key count or at the byte budget,
+// whichever it reaches first, and which one that is follows the rows: thin ones
+// run to the count, fat ones spend the budget first. Every other budget case here
+// meets one limit throughout, so a reader that had quietly stopped honouring the
+// other would still pass them.
+func TestBatchReaderEndsWindowsOnEitherLimit(t *testing.T) {
+	t.Parallel()
+
+	const window, thinKeys, fatKeys = 4, 6, 6
+
+	batch := make([]string, 0, thinKeys+fatKeys)
+	held := map[string][]uint64{}
+	for i := range thinKeys + fatKeys {
+		k := fmt.Sprintf("k%02d", i)
+		batch = append(batch, k)
+		if i < thinKeys {
+			held[k] = []uint64{uint64(i)}
+			continue
+		}
+		docs := make([]uint64, 4096)
+		for j := range docs {
+			docs[j] = uint64(i)*1_000_000 + uint64(j)*64
+		}
+		held[k] = docs
+	}
+
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	active := newTestMemtableRoaringSet(held)
+	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+	keys := sortedKeysOf(t, batch)
+
+	// Room for two of the fat rows, so a window of four keys reaches the count
+	// among the thin ones and the budget among the fat ones.
+	oneFat := func() int {
+		single := sortedKeysOf(t, []string{fmt.Sprintf("k%02d", thinKeys)})
+		dst := make([]roaringset.BitmapLayer, 1)
+		fill, err := active.roaringSetGetWindow(single, 0, 1, dst, math.MaxInt)
+		require.NoError(t, err)
+		require.Positive(t, fill.Bytes)
+		return fill.Bytes
+	}()
+
+	r, err := newRoaringSetBatchReader(view, keys, window, 2*oneFat+1)
+	require.NoError(t, err)
+
+	widths := map[int]bool{}
+	for range keys.Len() {
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		release()
+		widths[r.winEnd-r.winStart] = true
+	}
+
+	require.True(t, widths[window],
+		"the thin rows must let a window run to the key count, got widths %v", widths)
+	var narrowed bool
+	for w := range widths {
+		if w < window {
+			narrowed = true
+		}
+	}
+	require.True(t, narrowed,
+		"the fat rows must end a window before the key count, got widths %v", widths)
+
+	// And the stats say which limit did it, which is the whole reason an operator
+	// can tell "this batch was large" from "raise the byte budget".
+	st := r.Stats()
+	require.Positive(t, st.NarrowedFills, "the budget ended some windows")
+	require.Less(t, st.NarrowedFills, st.Fills, "and the key count ended others")
+	require.Equal(t, keys.Len(), st.KeysRead)
+	// The peak is one window; the total is every window. Fat rows read across
+	// several windows separate the two, which a running total alone would hide.
+	require.Positive(t, st.BytesPeak)
+	require.Greater(t, st.BytesCopied, st.BytesPeak,
+		"a batch spanning several windows must copy more than the widest of them held")
+
+	// And the rows are right either way, which is the point of ending early.
+	r2, err := newRoaringSetBatchReader(view, keys, window, 2*oneFat+1)
+	require.NoError(t, err)
+	requireMatchesPerKey(t, b, view, r2, keys, "")
+}
+
+// TestBatchReaderHoldsOneBudgetAcrossMemtables pins that the byte budget bounds
+// what a reader holds rather than what each of its memtables holds. Handing both
+// the whole budget would double the peak whenever a flush is in flight — a
+// condition the caller neither chooses nor observes — and nothing else here would
+// notice, since every other budget case builds a single-memtable view.
+func TestBatchReaderHoldsOneBudgetAcrossMemtables(t *testing.T) {
+	t.Parallel()
+
+	const nKeys = 200
+
+	names := make([]string, nKeys)
+	for i := range names {
+		names[i] = fmt.Sprintf("k%05d", i)
+	}
+	keys := sortedKeysOf(t, names)
+
+	// One document per container, which is the shape the budget exists for: the
+	// rows are wide enough that a window of them reaches the budget well before it
+	// reaches the key count.
+	spread := func(seed uint64) []uint64 {
+		docs := make([]uint64, 200)
+		for i := range docs {
+			docs[i] = seed*1_000_000_000 + uint64(i)*65536
+		}
+		return docs
+	}
+	build := func(seed uint64) *testMemtable {
+		m := newTestMemtableRoaringSet(nil)
+		for i, n := range names {
+			require.NoError(t, m.roaringSetAddList([]byte(n), spread(seed+uint64(i))))
+		}
+		return m
+	}
+
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	const budget = 4 << 20
+
+	peakOf := func(t *testing.T, view BucketConsistentView) RoaringSetBatchReaderStats {
+		r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, budget)
+		require.NoError(t, err)
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		release()
+		return r.Stats()
+	}
+
+	one := peakOf(t, BucketConsistentView{Active: build(1), Bucket: b})
+	two := peakOf(t, BucketConsistentView{Active: build(1), Flushing: build(500), Bucket: b})
+
+	require.Equal(t, 1, one.Memtables)
+	require.Equal(t, 2, two.Memtables)
+	require.Positive(t, one.BytesPeak, "the fixture must reach the budget, or this proves nothing")
+
+	require.LessOrEqual(t, two.BytesPeak, budget+one.BytesPeak/one.KeysRead,
+		"two memtables must hold one budget between them, not one each")
+	require.LessOrEqual(t, two.BytesPeak, one.BytesPeak*3/2,
+		"a flush in flight must not roughly double what a window holds")
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_test.go
@@ -1,0 +1,1036 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+// The batch reader against synthetic layers: window boundaries, fill counts,
+// error paths and the stats it reports, on fake segments and hand-built
+// memtables so a case costs nothing to add. What the reader does to a real
+// bucket — matching the per-key path, surviving a flush, folding tombstones —
+// is in bucket_roaring_set_test.go, where a case costs a temp dir and a flush.
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"slices"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/inverted"
+)
+
+// TestBatchReaderMatchesPerKeyReads is the differential the prefetch has to
+// survive: reading a batch by index, with each memtable consulted once per
+// window, must return exactly what reading each key on its own returns.
+//
+// The memtables here hold data. Against empty ones any prefetch agrees, since
+// there is nothing to find. The shapes that matter are a key held by both
+// memtables, a key held by a memtable and not by disk, and a document deleted
+// in flushing and re-added in active, which only survives if the layers fold
+// oldest first.
+//
+// The disk is varied because it changes how the fold begins. With one segment
+// the first one found becomes the base and nothing is merged onto it; with
+// several, each later one replays its deletions and additions in turn.
+func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
+	t.Parallel()
+
+	oneSegment := []Segment{
+		newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"aaa": bitmapFromSlice([]uint64{1, 2, 3}),
+			"ccc": bitmapFromSlice([]uint64{4}),
+			"eee": bitmapFromSlice([]uint64{5, 6}),
+			"ggg": bitmapFromSlice([]uint64{7}),
+		}),
+	}
+
+	oneSegmentFlushing := newTestMemtableRoaringSet(map[string][]uint64{
+		"bbb": {10, 11},
+		"ccc": {12},
+		"fff": {13},
+	})
+	// Written through the write path so the memtable's size agrees with its
+	// tree, as it would in a bucket. "aaa" is deleted while flushing and re-added
+	// in active, which is order-sensitive; "eee" is deleted and stays deleted, so
+	// the deletion has to survive the read on its own rather than being undone by
+	// a later layer.
+	require.NoError(t, oneSegmentFlushing.roaringSetRemoveList([]byte("aaa"), []uint64{2}))
+	require.NoError(t, oneSegmentFlushing.roaringSetRemoveList([]byte("eee"), []uint64{5}))
+	// A write carrying no values, which an empty Positions produces upstream. It
+	// builds a row with both bitmaps allocated and empty, so the two read paths
+	// describe it differently — the per-key one as a row, the window as absence
+	// — and must still answer the same.
+	require.NoError(t, oneSegmentFlushing.roaringSetAddList([]byte("ddd"), []uint64{}))
+
+	// oldest first: bbb is added by one segment and deleted by a later one,
+	// ccc is added by two, ddd only by the newest.
+	manySegments := []Segment{
+		newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"aaa": bitmapFromSlice([]uint64{1, 2}),
+			"bbb": bitmapFromSlice([]uint64{3}),
+			"ccc": bitmapFromSlice([]uint64{4}),
+		}),
+		newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"ccc": bitmapFromSlice([]uint64{5}),
+			"ddd": bitmapFromSlice([]uint64{6}),
+		}),
+		newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+			"aaa": bitmapFromSlice([]uint64{7}),
+		}),
+	}
+
+	tests := []struct {
+		name     string
+		segments []Segment
+		flushing *testMemtable
+		active   *testMemtable
+		batch    []string
+		windows  []int
+		// Written down rather than derived, where the fold's outcome is worth
+		// pinning against something other than the path under test. Optional:
+		// the differential above runs either way.
+		want map[string][]uint64
+	}{
+		{
+			name:     "one disk segment",
+			segments: oneSegment,
+			flushing: oneSegmentFlushing,
+			active: newTestMemtableRoaringSet(map[string][]uint64{
+				"aaa": {2},
+				"ccc": {14},
+				"hhh": {15},
+			}),
+			batch:   []string{"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii"},
+			windows: []int{1, 2, 3, 4096},
+			// "aaa" is disk {1,2,3} minus the flushing deletion of 2 plus the
+			// active re-add, which survives only folding oldest first; "eee" is
+			// disk {5,6} minus a deletion nothing re-adds.
+			want: map[string][]uint64{
+				"aaa": {1, 2, 3},
+				"bbb": {10, 11},
+				"ccc": {4, 12, 14},
+				"ddd": nil,
+				"eee": {6},
+				"fff": {13},
+				"ggg": {7},
+				"hhh": {15},
+				"iii": nil,
+			},
+		},
+		{
+			name:     "several disk segments",
+			segments: manySegments,
+			flushing: newTestMemtableRoaringSet(map[string][]uint64{"bbb": {30}, "eee": {31}}),
+			active:   newTestMemtableRoaringSet(map[string][]uint64{"ccc": {40}, "fff": {41}}),
+			batch:    []string{"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg"},
+			windows:  []int{1, 3, memtableWindowKeys},
+			want: map[string][]uint64{
+				"aaa": {1, 2, 7},
+				"bbb": {3, 30},
+				"ccc": {4, 5, 40},
+				"ddd": {6},
+				"eee": {31},
+				"fff": {41},
+				"ggg": nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := &Bucket{
+				strategy: StrategyRoaringSet,
+				disk:     &SegmentGroup{segments: tt.segments},
+				logger:   nullLogger(),
+			}
+			view := BucketConsistentView{
+				Active: tt.active, Flushing: tt.flushing, Disk: tt.segments, Bucket: b,
+			}
+
+			for _, window := range tt.windows {
+				t.Run(fmt.Sprintf("window %d", window), func(t *testing.T) {
+					keys := sortedKeysOf(t, tt.batch)
+					r, err := newRoaringSetBatchReader(view, keys, window)
+					require.NoError(t, err)
+
+					requireMatchesPerKey(t, b, view, r, keys, "")
+					if tt.want == nil {
+						return
+					}
+					// A second reader: one walks its batch once.
+					r2, err := newRoaringSetBatchReader(view, keys, window)
+					require.NoError(t, err)
+					requireRowsAre(t, r2, keys, tt.want)
+				})
+			}
+		})
+	}
+}
+
+// TestBatchReaderMatchesPerKeyReadsRandomized runs the same differential over random layer
+// contents, which is where an off-by-one in the per-layer cursor shows: it
+// would drop a match, or carry one key's layer onto its neighbour.
+//
+// The differential alone cannot see everything it looks like it can: both paths
+// end in roaringSetGetWithLayers, so a bug in that tail agrees with itself on
+// both sides. Every layer here only adds, which makes a row's contents the union
+// of what the three hold for its key — an expectation that comes from the
+// fixture rather than from either path, so the rounds also pin something no
+// symmetry can satisfy.
+func TestBatchReaderMatchesPerKeyReadsRandomized(t *testing.T) {
+	t.Parallel()
+	rnd := rand.New(rand.NewSource(3))
+
+	unionOf := func(docs ...[]uint64) []uint64 {
+		seen := map[uint64]struct{}{}
+		for _, d := range docs {
+			for _, v := range d {
+				seen[v] = struct{}{}
+			}
+		}
+		if len(seen) == 0 {
+			return nil
+		}
+		out := make([]uint64, 0, len(seen))
+		for v := range seen {
+			out = append(out, v)
+		}
+		slices.Sort(out)
+		return out
+	}
+
+	for round := 0; round < 60; round++ {
+		universe := 25
+		pick := func(n int) map[string][]uint64 {
+			out := map[string][]uint64{}
+			for _, k := range sampleDistinct(rnd, universe, n) {
+				out[k] = []uint64{uint64(rnd.Intn(50))}
+			}
+			return out
+		}
+		diskDocs := pick(rnd.Intn(universe))
+		flushingDocs := pick(rnd.Intn(universe))
+		activeDocs := pick(rnd.Intn(universe))
+
+		diskKeys := map[string]*sroar.Bitmap{}
+		for k, v := range diskDocs {
+			diskKeys[k] = bitmapFromSlice(v)
+		}
+		diskSeg := newFakeRoaringSetSegment(diskKeys)
+		flushing := newTestMemtableRoaringSet(flushingDocs)
+		active := newTestMemtableRoaringSet(activeDocs)
+
+		b := &Bucket{
+			strategy: StrategyRoaringSet,
+			disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+			logger:   nullLogger(),
+		}
+		view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
+
+		batch := sampleDistinct(rnd, universe, rnd.Intn(universe)+1)
+		sort.Strings(batch)
+		keys := sortedKeysOf(t, batch)
+		window := 1 + rnd.Intn(5)
+
+		r, err := newRoaringSetBatchReader(view, keys, window)
+		require.NoError(t, err)
+		requireMatchesPerKey(t, b, view, r, keys, fmt.Sprintf("round %d", round))
+
+		want := map[string][]uint64{}
+		for i := 0; i < keys.Len(); i++ {
+			k := string(keys.At(i))
+			want[k] = unionOf(diskDocs[k], flushingDocs[k], activeDocs[k])
+		}
+		// A second reader, since the first has served every key and would spend
+		// the pass refilling.
+		abs, err := newRoaringSetBatchReader(view, keys, window)
+		require.NoError(t, err)
+		requireRowsAre(t, abs, keys, want)
+	}
+}
+
+// TestBatchReaderSurvivesTheFoldMutatingItsRows covers what the fold does to
+// every row it is handed: it adopts the first as its accumulator and merges the
+// rest into it in place. A window clones once for all the keys it covers, so a
+// row the caller mutates must not be one the reader still needs — and the fills
+// must stay one per window while that happens.
+//
+// A key with a disk row is the boundary: there the merger folds onto the disk
+// base and never hands the window's clone out. The last case gives every key
+// one, deliberately — a single key the disk missed would hand the clone out
+// again and the case would stop being a control.
+func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		disk          map[string]*sroar.Bitmap
+		flushing      map[string][]uint64
+		active        map[string][]uint64
+		activeDeletes map[string][]uint64
+	}{
+		{
+			name:   "active alone",
+			disk:   map[string]*sroar.Bitmap{},
+			active: map[string][]uint64{"aaa": {1}, "bbb": {2}, "ccc": {3}},
+		},
+		{
+			name:     "flushing under active",
+			disk:     map[string]*sroar.Bitmap{},
+			flushing: map[string][]uint64{"aaa": {7}, "ccc": {8}},
+			active:   map[string][]uint64{"aaa": {1}, "bbb": {2}, "ccc": {3}},
+		},
+		{
+			name:          "active deletions replayed over flushing",
+			disk:          map[string]*sroar.Bitmap{},
+			flushing:      map[string][]uint64{"aaa": {7, 8}, "ccc": {9}},
+			active:        map[string][]uint64{"aaa": {1}, "bbb": {2}, "ccc": {3}},
+			activeDeletes: map[string][]uint64{"aaa": {8}},
+		},
+		{
+			name: "every key has a disk row",
+			disk: map[string]*sroar.Bitmap{
+				"aaa": bitmapFromSlice([]uint64{5}),
+				"bbb": bitmapFromSlice([]uint64{6}),
+				"ccc": bitmapFromSlice([]uint64{4}),
+			},
+			flushing: map[string][]uint64{"aaa": {7}},
+			active:   map[string][]uint64{"aaa": {1}, "bbb": {2}, "ccc": {3}},
+		},
+	}
+
+	windows := []struct {
+		size int
+		// wantFills is what the three keys cost: one window at the production
+		// size, two when the size splits them.
+		wantFills int
+	}{
+		{memtableWindowKeys, 1},
+		{2, 2},
+	}
+
+	for _, tc := range tests {
+		for _, w := range windows {
+			t.Run(fmt.Sprintf("%s/window=%d", tc.name, w.size), func(t *testing.T) {
+				t.Parallel()
+
+				diskSeg := newFakeRoaringSetSegment(tc.disk)
+				b := &Bucket{
+					strategy: StrategyRoaringSet,
+					disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+					logger:   nullLogger(),
+				}
+				view := BucketConsistentView{Disk: []Segment{diskSeg}, Bucket: b}
+				mts := []*testMemtable{}
+				if tc.flushing != nil {
+					flushing := newTestMemtableRoaringSet(tc.flushing)
+					view.Flushing = flushing
+					mts = append(mts, flushing)
+				}
+				active := newTestMemtableRoaringSet(tc.active)
+				for k, v := range tc.activeDeletes {
+					require.NoError(t, active.roaringSetRemoveList([]byte(k), v))
+				}
+				view.Active = active
+				mts = append(mts, active)
+
+				keys := sortedKeysOf(t, []string{"aaa", "bbb", "ccc"})
+				r, err := newRoaringSetBatchReader(view, keys, w.size)
+				require.NoError(t, err)
+
+				for i := 0; i < keys.Len(); i++ {
+					want, wr, err := b.roaringSetGetFromConsistentView(view, keys.At(i), concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					got, gr, err := r.Next(concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					require.Equalf(t, docsOrNil(want), docsOrNil(got), "key %d", i)
+					// What the fold does to every row it reads.
+					got.Set(9999)
+					wr()
+					gr()
+				}
+
+				for _, mt := range mts {
+					require.Equal(t, w.wantFills, mt.roaringSetGetWindowCalls,
+						"the walk must fill once per window, whatever the fold did to the rows")
+				}
+			})
+		}
+	}
+}
+
+// TestBatchReaderFillWindowError covers a memtable read that fails partway
+// through a window. The window is filled one memtable at a time, so the failure
+// leaves one loaded for the new window and the other still holding the last one
+// at its width — a mixture that must not be served. Depending on what the
+// previous window was, serving it drops a memtable's rows, returns another key's
+// row, or indexes past the end.
+func TestBatchReaderFillWindowError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("memtable read failed")
+
+	tests := []struct {
+		name string
+		// how far the walk gets before the read that fails; with a window of 4
+		// over 10 keys, 0 fails the first fill and 4 fails a later one, after a
+		// window has already been served.
+		readBefore int
+	}{
+		{name: "first window, nothing loaded yet", readBefore: 0},
+		{name: "a later window, one already served", readBefore: 4},
+		{name: "mid-window, no fill due", readBefore: 5},
+	}
+
+	// Which memtable fails decides how far the fill got. Flushing is index 0, so
+	// failing it aborts before the active one is read at all; failing active
+	// instead leaves flushing loaded for the new window and active holding the
+	// last one — the half-loaded state the invalidation exists for, which
+	// failing the first memtable never produces.
+	for _, tc := range tests {
+		for _, failFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/failFirst=%t", tc.name, failFirst), func(t *testing.T) {
+				t.Parallel()
+
+				diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+					"k05": bitmapFromSlice([]uint64{55}),
+				})
+				b := &Bucket{
+					strategy: StrategyRoaringSet,
+					disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+					logger:   nullLogger(),
+				}
+				// k05 puts a row inside the second window. Without it that window
+				// holds nothing, a stale all-zero window is accidentally the right
+				// answer, and the invalidation below cannot be caught failing.
+				active := newTestMemtableRoaringSet(map[string][]uint64{
+					"k00": {1}, "k01": {2}, "k03": {4}, "k05": {5}, "k08": {8}, "k09": {9},
+				})
+				view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+
+				flushing := newTestMemtableRoaringSet(map[string][]uint64{"k00": {100}, "k08": {108}})
+				view.Flushing = flushing
+				failing := active
+				if failFirst {
+					failing = flushing
+				}
+
+				batch := make([]string, 10)
+				for i := range batch {
+					batch[i] = fmt.Sprintf("k%02d", i)
+				}
+				keys := sortedKeysOf(t, batch)
+				r, err := newRoaringSetBatchReader(view, keys, 4)
+				require.NoError(t, err)
+
+				for i := 0; i < tc.readBefore; i++ {
+					_, release, err := r.Next(concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					release()
+				}
+
+				// Fails only if this read is due a fill; mid-window it is served
+				// from what is already loaded, which is equally worth pinning.
+				failing.roaringSetGetWindowErr = readErr
+				at := tc.readBefore
+				bm, release, err := r.Next(concurrency.SROAR_MERGE)
+				if err != nil {
+					require.ErrorIs(t, err, readErr)
+					require.Nil(t, bm, "a failed read returns no row")
+					require.Nil(t, release, "a failed read returns nothing to release")
+				} else {
+					// served from the loaded window, so the walk moved on
+					require.NotNil(t, release)
+					release()
+					at++
+				}
+				failing.roaringSetGetWindowErr = nil
+
+				// The walk resumes where it stopped. A failed fill left one
+				// memtable loaded for the new window and the other holding the
+				// last one, so serving from that mixture would answer with a
+				// memtable's rows for the wrong keys.
+				for i := at; i < keys.Len(); i++ {
+					want, wr, err := b.roaringSetGetFromConsistentView(view, keys.At(i), concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					got, gr, err := r.Next(concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					require.Equalf(t, docsOrNil(want), docsOrNil(got), "index %d after the failed fill", i)
+					wr()
+					gr()
+				}
+			})
+		}
+	}
+}
+
+// TestBatchReaderDiskErrorLeavesNothingToRetryWrong pins the other half of the
+// error contract. A failed disk read happens after the key's slots have been
+// emptied, so leaving the window intact would let a retry read them as absence
+// and fold the disk row alone — a wrong row, with no error to say so. The retry
+// must refill instead, and answer as the per-key path does.
+func TestBatchReaderDiskErrorLeavesNothingToRetryWrong(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("injected disk failure")
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+		"k0": bitmapFromSlice([]uint64{1}),
+		"k1": bitmapFromSlice([]uint64{2}),
+	})
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	// The memtable deletes what disk holds, so a row folded without it differs
+	// from the right answer — which is what makes the retry observable at all.
+	active := newTestMemtableRoaringSet(nil)
+	require.NoError(t, active.roaringSetRemoveList([]byte("k1"), []uint64{2}))
+	require.NoError(t, active.roaringSetAddList([]byte("k1"), []uint64{9}))
+	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+
+	keys := sortedKeysOf(t, []string{"k0", "k1"})
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	require.NoError(t, err)
+
+	_, release, err := r.Next(concurrency.SROAR_MERGE)
+	require.NoError(t, err)
+	release()
+
+	diskSeg.roaringSetGetErr = readErr
+	bm, release, err := r.Next(concurrency.SROAR_MERGE)
+	require.ErrorIs(t, err, readErr)
+	require.Nil(t, bm, "a failed read returns no row")
+	require.Nil(t, release, "a failed read returns nothing to release")
+	diskSeg.roaringSetGetErr = nil
+
+	want, wr, err := b.roaringSetGetFromConsistentView(view, keys.At(1), concurrency.SROAR_MERGE)
+	require.NoError(t, err)
+	defer wr()
+
+	got, gr, err := r.Next(concurrency.SROAR_MERGE)
+	require.NoError(t, err, "the retry must succeed")
+	defer gr()
+	require.Equal(t, docsOrNil(want), docsOrNil(got),
+		"the retry must refill: reading the emptied slots as absence would drop the memtable's row")
+}
+
+// TestBatchReaderReadsWhileMemtableIsWritten covers a window read running
+// against a live memtable: it holds the read lock while it walks the tree and
+// copies what it finds, and the memtable goes on taking writes throughout.
+//
+// A write landing mid-batch may or may not be visible — the windows are filled
+// as the fold reaches them, so which keys see it depends on timing, and the
+// reader's contract says as much. What may never happen is a row that is
+// neither the value before the write nor the value after: a torn read, or a
+// neighbour's row, or a bitmap caught half-copied.
+func TestBatchReaderReadsWhileMemtableIsWritten(t *testing.T) {
+	const (
+		n      = memtableWindowKeys*2 + 3
+		marker = uint64(999_999)
+	)
+
+	rows := map[string][]uint64{}
+	batch := make([]string, n)
+	for i := 0; i < n; i++ {
+		batch[i] = fmt.Sprintf("k%06d", i)
+		rows[batch[i]] = []uint64{uint64(i)}
+	}
+
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+	active := newTestMemtableRoaringSet(rows)
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+	keys := sortedKeysOf(t, batch)
+
+	var written atomic.Bool
+	var writeErr error
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Even on the way out, so a failed write ends the reader's loop below
+		// rather than leaving it spinning for a writer that has given up.
+		defer written.Store(true)
+		<-start
+		for _, k := range batch {
+			if err := active.roaringSetAddOne([]byte(k), marker); err != nil {
+				writeErr = err
+				return
+			}
+		}
+	}()
+
+	// Fold the batch repeatedly until the writer is done, so reads and writes
+	// overlap rather than merely interleaving once. Both states have to be
+	// observed: a run in which every row already carried the marker would
+	// satisfy the assertion below without ever having raced anything.
+	// Neither is left to the scheduler: the writer is held until one whole pass
+	// has been read, and the pass that ends the loop runs after it finished.
+	seenBefore, seenAfter := 0, 0
+	for pass := 0; ; pass++ {
+		done := written.Load()
+		r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+		require.NoError(t, err)
+		for i := 0; i < keys.Len(); i++ {
+			got, release, err := r.Next(concurrency.SROAR_MERGE)
+			require.NoError(t, err)
+			if len(docsOrNil(got)) == 1 {
+				seenBefore++
+			} else {
+				seenAfter++
+			}
+			require.Containsf(t, [][]uint64{{uint64(i)}, {uint64(i), marker}}, docsOrNil(got),
+				"pass %d index %d: row is neither the value before the write nor after it", pass, i)
+			release()
+		}
+		if pass == 0 {
+			// Only now, so every row above was read at its pre-write value. done
+			// cannot be true yet, so this always runs and the writer never hangs.
+			close(start)
+		}
+		if done {
+			break
+		}
+	}
+	wg.Wait()
+	require.NoError(t, writeErr)
+	require.Positive(t, seenBefore, "no row was read before the writer reached it; the two never overlapped")
+	require.Positive(t, seenAfter, "no row was read after the writer reached it; the two never overlapped")
+
+	// and once the writer has finished, every key must show the write
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	require.NoError(t, err)
+	for i := 0; i < keys.Len(); i++ {
+		got, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		require.Equal(t, []uint64{uint64(i), marker}, docsOrNil(got), "index %d after the writer finished", i)
+		release()
+	}
+}
+
+// TestBatchReaderFillsWindowsLazily pins the other half of the same contract.
+// ContainsAll abandons its fold as soon as the intersection empties, often after
+// a handful of keys, so a reader that filled the whole batch up front would read
+// windows whose keys nobody goes on to ask about — and on a large batch that is
+// most of them.
+func TestBatchReaderFillsWindowsLazily(t *testing.T) {
+	t.Parallel()
+
+	batch := make([]string, 20)
+	for i := range batch {
+		batch[i] = fmt.Sprintf("k%02d", i)
+	}
+
+	tests := []struct {
+		name        string
+		readThrough int // how many keys the fold reaches before giving up
+		wantFills   int
+	}{
+		{name: "abandoned inside the first window", readThrough: 1, wantFills: 1},
+		{name: "abandoned on a window boundary", readThrough: 4, wantFills: 1},
+		{name: "abandoned one key into the second", readThrough: 5, wantFills: 2},
+		// Reading everything is the other half of the same contract: one
+		// acquisition per window rather than one per key, which is the whole
+		// point of the window and which no differential would notice losing.
+		{name: "read to the end", readThrough: 20, wantFills: 5},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+			flushing := newTestMemtableRoaringSet(map[string][]uint64{"k03": {1}})
+			active := newTestMemtableRoaringSet(map[string][]uint64{"k00": {1}, "k07": {2}})
+			b := &Bucket{
+				strategy: StrategyRoaringSet,
+				disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+				logger:   nullLogger(),
+			}
+			view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
+
+			keys := sortedKeysOf(t, batch)
+			r, err := newRoaringSetBatchReader(view, keys, 4)
+			require.NoError(t, err)
+			for i := 0; i < tc.readThrough; i++ {
+				_, release, err := r.Next(concurrency.SROAR_MERGE)
+				require.NoError(t, err)
+				release()
+			}
+
+			for _, mt := range []*testMemtable{flushing, active} {
+				require.Equal(t, tc.wantFills, mt.roaringSetGetWindowCalls,
+					"a window may not be read before a key inside it is asked for")
+				require.Zero(t, mt.roaringSetGetCalls, "the per-key path must not be used")
+			}
+		})
+	}
+}
+
+// TestBatchReaderStatsReportTheWork pins what the slow-query annotation reads.
+// A batched filter that has gone slow is otherwise indistinguishable from one
+// that merely ran during a slow query: fills times memtables is the acquisitions
+// the batching paid for, and a fill count approaching the key count says the
+// windows were narrow rather than that the batch was large.
+func TestBatchReaderStatsReportTheWork(t *testing.T) {
+	t.Parallel()
+
+	batch := make([]string, 10)
+	for i := range batch {
+		batch[i] = fmt.Sprintf("k%02d", i)
+	}
+
+	tests := []struct {
+		name          string
+		held          map[string][]uint64
+		reads         int
+		wantFills     int
+		wantMemtables int
+		wantCloned    bool
+	}{
+		{
+			// 10 keys in windows of 4 is 3 windows, which is what a whole fold
+			// pays. Fills against Len is what says the batching, rather than the
+			// rows, is where a slow filter went.
+			name:          "the whole batch fills once per window",
+			held:          map[string][]uint64{"k00": {1}, "k05": {2}},
+			reads:         10,
+			wantFills:     3,
+			wantMemtables: 1,
+			wantCloned:    true,
+		},
+		{
+			// That the annotation reads the reader after the fold rather than
+			// before: a fold stopping inside the second window has to report the
+			// two windows it entered, not the three the batch spans. Lazy filling
+			// itself is TestBatchReaderFillsWindowsLazily's.
+			name:          "a fold that stops early pays for fewer windows",
+			held:          map[string][]uint64{"k00": {1}, "k05": {2}},
+			reads:         5,
+			wantFills:     2,
+			wantMemtables: 1,
+			wantCloned:    true,
+		},
+		{
+			// Nothing held, so the window costs acquisitions and no memory. This
+			// is the case the window cannot be blamed for.
+			name:          "a memtable holding nothing clones nothing",
+			held:          map[string][]uint64{},
+			reads:         10,
+			wantFills:     3,
+			wantMemtables: 1,
+			wantCloned:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+			active := newTestMemtableRoaringSet(tc.held)
+			// A memtable holding nothing is skipped by the constructor, so give it
+			// a write the skip does not remove.
+			if len(tc.held) == 0 {
+				require.NoError(t, active.roaringSetAddList([]byte("zzz"), []uint64{1}))
+			}
+			b := &Bucket{
+				strategy: StrategyRoaringSet,
+				disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+				logger:   nullLogger(),
+			}
+			view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+
+			keys := sortedKeysOf(t, batch)
+			r, err := newRoaringSetBatchReader(view, keys, 4)
+			require.NoError(t, err)
+			for i := 0; i < tc.reads; i++ {
+				_, release, err := r.Next(concurrency.SROAR_MERGE)
+				require.NoError(t, err)
+				release()
+			}
+
+			got := r.Stats()
+			require.Equal(t, tc.wantFills, got.Fills)
+			require.Equal(t, tc.wantMemtables, got.Memtables)
+			require.Equal(t, tc.reads, got.KeysRead,
+				"how far the fold got, which the fill count cannot say")
+			if tc.wantCloned {
+				require.Positive(t, got.BytesPeak, "rows the memtable holds must be counted")
+				require.Positive(t, got.BytesCopied, "and counted again in the total")
+			} else {
+				require.Zero(t, got.BytesPeak, "a window matching nothing must hold nothing")
+				require.Zero(t, got.BytesCopied, "and must copy nothing")
+			}
+		})
+	}
+}
+
+// TestBatchReaderSkipsAnEmptyActiveMemtable pins the skip the reader's
+// constructor argues for: an active memtable whose size is zero is dropped from
+// the view, and the rows it holds are ones that add and delete nothing, so the
+// answer is the same as the per-key path gives — and that path does not skip it.
+//
+// Size counts entries added or removed, so a write carrying no values builds a
+// node and leaves the size at zero. Replaying a commit log record with both
+// slices empty does the same. The argument is that such rows fold as if absent;
+// this runs the differential the argument implies.
+func TestBatchReaderSkipsAnEmptyActiveMemtable(t *testing.T) {
+	t.Parallel()
+
+	batch := []string{"aaa", "bbb", "ccc"}
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+		"aaa": bitmapFromSlice([]uint64{1, 2}),
+		"ccc": bitmapFromSlice([]uint64{3}),
+	})
+	flushing := newTestMemtableRoaringSet(map[string][]uint64{"bbb": {9}})
+
+	// Written through the write path, so size and tree disagree exactly as they
+	// would in a bucket: nodes for two keys, and a size still at zero.
+	active := newTestMemtableRoaringSet(map[string][]uint64{})
+	require.NoError(t, active.roaringSetAddList([]byte("aaa"), []uint64{}))
+	require.NoError(t, active.roaringSetAddList([]byte("ccc"), []uint64{}))
+	require.Zero(t, active.Size(), "the fixture must reach the state the skip is about")
+
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
+
+	keys := sortedKeysOf(t, batch)
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	require.NoError(t, err)
+	require.Equal(t, 1, r.mtCount, "the empty active memtable must be dropped from the view")
+
+	requireMatchesPerKey(t, b, view, r, keys, "empty active memtable")
+	require.Zero(t, active.roaringSetGetWindowCalls, "a dropped memtable must not be read")
+
+	abs, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	require.NoError(t, err)
+	requireRowsAre(t, abs, keys, map[string][]uint64{
+		"aaa": {1, 2},
+		"bbb": {9},
+		"ccc": {3},
+	})
+}
+
+// TestBatchReaderReleasesWhatItHasServed pins that a served key's clone leaves
+// the window. Only a fill drops clones, and a batch inside one window never
+// reaches a second fill, so without this every row the window matched would
+// stay live for as long as the fold runs — the whole window at once rather than
+// the part of it still to be read.
+//
+// It reads the front of the window and asserts on the back, so the assertion
+// cannot pass by the window having been refilled underneath it.
+func TestBatchReaderReleasesWhatItHasServed(t *testing.T) {
+	t.Parallel()
+
+	batch := make([]string, 8)
+	for i := range batch {
+		batch[i] = fmt.Sprintf("k%02d", i)
+	}
+
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+	// Every key held, so a slot left behind is a slot holding a clone.
+	held := map[string][]uint64{}
+	for i, k := range batch {
+		held[k] = []uint64{uint64(i)}
+	}
+	active := newTestMemtableRoaringSet(held)
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+
+	keys := sortedKeysOf(t, batch)
+	r, err := newRoaringSetBatchReader(view, keys, len(batch))
+	require.NoError(t, err)
+
+	const served = 3
+	for i := 0; i < served; i++ {
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		release()
+	}
+	require.Equal(t, 1, active.roaringSetGetWindowCalls, "the window must not have refilled")
+
+	for mt := 0; mt < r.mtCount; mt++ {
+		for i := 0; i < served; i++ {
+			require.Nilf(t, r.layers[mt][i].Additions, "layer %d slot %d still holds a served clone", mt, i)
+			require.Nilf(t, r.layers[mt][i].Deletions, "layer %d slot %d still holds a served clone", mt, i)
+		}
+		for i := served; i < len(batch); i++ {
+			require.NotNilf(t, r.layers[mt][i].Additions, "layer %d slot %d lost a row it has not served", mt, i)
+		}
+	}
+}
+
+// TestBatchReaderAtProductionWindow runs the differential over a batch several
+// times the real window, which no other test here does: they either set a tiny
+// window to reach the boundaries or carry too few keys for memtableWindowKeys to have a
+// second window at all. A window boundary that only appears at the real size
+// would have nothing else to fail.
+func TestBatchReaderAtProductionWindow(t *testing.T) {
+	t.Parallel()
+
+	const n = memtableWindowKeys*3 + 7
+
+	diskRows := map[string]*sroar.Bitmap{}
+	flushingRows := map[string][]uint64{}
+	activeRows := map[string][]uint64{}
+	batch := make([]string, n)
+	for i := 0; i < n; i++ {
+		batch[i] = fmt.Sprintf("k%06d", i)
+		switch {
+		case i%7 == 0:
+			diskRows[batch[i]] = bitmapFromSlice([]uint64{uint64(i)})
+		case i%11 == 0:
+			flushingRows[batch[i]] = []uint64{uint64(i)}
+		case i%13 == 0:
+			activeRows[batch[i]] = []uint64{uint64(i)}
+		}
+	}
+	// the boundaries themselves, held by every layer at once
+	for _, i := range []int{memtableWindowKeys - 1, memtableWindowKeys, memtableWindowKeys*2 - 1, memtableWindowKeys * 2, n - 1} {
+		diskRows[batch[i]] = bitmapFromSlice([]uint64{uint64(i)})
+		flushingRows[batch[i]] = []uint64{uint64(i) + 1}
+		activeRows[batch[i]] = []uint64{uint64(i) + 2}
+	}
+
+	diskSeg := newFakeRoaringSetSegment(diskRows)
+	flushing := newTestMemtableRoaringSet(flushingRows)
+	active := newTestMemtableRoaringSet(activeRows)
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+		active:   active,
+		flushing: flushing,
+	}
+	view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
+
+	// Through the constructor, at the real window: every other test here builds
+	// the reader by hand with a small one, so nothing else covers the size the
+	// constructor actually picks.
+	keys := sortedKeysOf(t, batch)
+	reader, err := NewRoaringSetBatchReader(view, keys)
+	require.NoError(t, err)
+
+	requireMatchesPerKey(t, b, view, reader, keys, "")
+
+	windows := (n + memtableWindowKeys - 1) / memtableWindowKeys
+	require.Equal(t, windows, flushing.roaringSetGetWindowCalls, "one read per window")
+	require.Equal(t, windows, active.roaringSetGetWindowCalls, "one read per window")
+}
+
+// TestBatchReaderRejectsWindowSize covers the one argument the constructor can be
+// given wrong, and it does not fail gracefully further down: a window of zero
+// gives every fill an empty range, so the first read indexes a buffer with no
+// slots, and a negative one asks for a buffer of negative length. Both panic,
+// which is why they are refused where they are passed.
+func TestBatchReaderRejectsWindowSize(t *testing.T) {
+	t.Parallel()
+	keys := sortedKeysOf(t, []string{"a", "b"})
+	view := BucketConsistentView{Active: newTestMemtableRoaringSet(nil)}
+	for _, window := range []int{0, -1, -256} {
+		_, err := newRoaringSetBatchReader(view, keys, window)
+		require.Errorf(t, err, "window %d must be rejected", window)
+	}
+}
+
+// TestBatchReaderReadsPastTheBatch pins the one way left to ask for a row that
+// is not there, and the shape of the failure: an error and neither a row nor a
+// release. A release handed back beside an error is one nobody calls, since the
+// folds drop it. Len is how many times Next answers, so asking again is the
+// caller's error rather than a row it could have found.
+func TestBatchReaderReadsPastTheBatch(t *testing.T) {
+	t.Parallel()
+
+	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+		"a": bitmapFromSlice([]uint64{1}),
+	})
+	b := &Bucket{
+		strategy: StrategyRoaringSet,
+		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+		logger:   nullLogger(),
+	}
+	keys := sortedKeysOf(t, []string{"a", "b"})
+	view := BucketConsistentView{
+		Active: newTestMemtableRoaringSet(map[string][]uint64{"b": {2}}),
+		Disk:   []Segment{diskSeg}, Bucket: b,
+	}
+	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys)
+	require.NoError(t, err)
+
+	for i := 0; i < keys.Len(); i++ {
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoErrorf(t, err, "read %d of %d", i, keys.Len())
+		release()
+	}
+	// Twice: a reader that has refused once must not then answer.
+	for i := 0; i < 2; i++ {
+		bm, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.Errorf(t, err, "read %d past the batch", i)
+		require.Nil(t, bm, "a failed read returns no row")
+		require.Nil(t, release, "a failed read returns nothing to release")
+	}
+}
+
+// requireRowsAre checks the reader against written-down rows rather than
+// against the per-key path. Both sides of the differential now fold through
+// roaringSetGetWithLayers, so a bug there — the layer order, say — agrees with
+// itself and passes every comparison. This is the only assertion that does not.
+func requireRowsAre(t *testing.T, r *RoaringSetBatchReader, keys inverted.SortedKeys, want map[string][]uint64) {
+	t.Helper()
+	for i := 0; i < keys.Len(); i++ {
+		got, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoErrorf(t, err, "read %d", i)
+		require.Equalf(t, want[string(keys.At(i))], docsOrNil(got), "key %q", keys.At(i))
+		release()
+	}
+}
+
+// requireMatchesPerKey is the differential: whatever the window did, each key
+// must read the same as it would on its own. The tests that vary how the window
+// falls use it; those asserting a specific row, a fill count or a rejected
+// argument assert that directly.
+func requireMatchesPerKey(t *testing.T, b *Bucket, view BucketConsistentView,
+	r *RoaringSetBatchReader, keys inverted.SortedKeys, msg string,
+) {
+	t.Helper()
+	for i := 0; i < keys.Len(); i++ {
+		want, wr, err := b.roaringSetGetFromConsistentView(view, keys.At(i), concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		got, gr, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoErrorf(t, err, "read %d", i)
+		require.Equalf(t, docsOrNil(want), docsOrNil(got), "%s: key %q (index %d)", msg, keys.At(i), i)
+		wr()
+		gr()
+	}
+}

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_prefetch_test.go
@@ -11,11 +11,9 @@
 
 package lsmkv
 
-// The batch reader against synthetic layers: window boundaries, fill counts,
-// error paths and the stats it reports, on fake segments and hand-built
-// memtables so a case costs nothing to add. What the reader does to a real
-// bucket — matching the per-key path, surviving a flush, folding tombstones —
-// is in bucket_roaring_set_test.go, where a case costs a temp dir and a flush.
+// The batch reader against synthetic layers and fake segments, so a case
+// costs nothing to add. Coverage against a real bucket (per-key path
+// parity, flushes, tombstones) is in bucket_roaring_set_test.go.
 
 import (
 	"errors"
@@ -36,18 +34,11 @@ import (
 )
 
 // TestBatchReaderMatchesPerKeyReads is the differential the prefetch has to
-// survive: reading a batch by index, with each memtable consulted once per
-// window, must return exactly what reading each key on its own returns.
-//
-// The memtables here hold data. Against empty ones any prefetch agrees, since
-// there is nothing to find. The shapes that matter are a key held by both
-// memtables, a key held by a memtable and not by disk, and a document deleted
-// in flushing and re-added in active, which only survives if the layers fold
-// oldest first.
-//
-// The disk is varied because it changes how the fold begins. With one segment
-// the first one found becomes the base and nothing is merged onto it; with
-// several, each later one replays its deletions and additions in turn.
+// survive: a batch read, with each memtable consulted once per window, must
+// return exactly what reading each key on its own returns. The fixtures cover
+// a key held by both memtables, a key held by a memtable and not disk, and a
+// document deleted while flushing and re-added in active (survives only if
+// layers fold oldest first).
 func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 	t.Parallel()
 
@@ -65,17 +56,12 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 		"ccc": {12},
 		"fff": {13},
 	})
-	// Written through the write path so the memtable's size agrees with its
-	// tree, as it would in a bucket. "aaa" is deleted while flushing and re-added
-	// in active, which is order-sensitive; "eee" is deleted and stays deleted, so
-	// the deletion has to survive the read on its own rather than being undone by
-	// a later layer.
+	// "aaa" is deleted while flushing and re-added in active (order-sensitive);
+	// "eee" is deleted and stays deleted.
 	require.NoError(t, oneSegmentFlushing.roaringSetRemoveList([]byte("aaa"), []uint64{2}))
 	require.NoError(t, oneSegmentFlushing.roaringSetRemoveList([]byte("eee"), []uint64{5}))
-	// A write carrying no values, which an empty Positions produces upstream. It
-	// builds a row with both bitmaps allocated and empty, so the two read paths
-	// describe it differently — the per-key one as a row, the window as absence
-	// — and must still answer the same.
+	// A write carrying no values (an empty Positions produces this upstream):
+	// the per-key path sees a row, the window sees absence, and both must agree.
 	require.NoError(t, oneSegmentFlushing.roaringSetAddList([]byte("ddd"), []uint64{}))
 
 	// oldest first: bbb is added by one segment and deleted by a later one,
@@ -95,10 +81,8 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 		}),
 	}
 
-	// Rows wide enough that a budget of one of them ends a window, so the memtable
-	// read first is the one that settles where it ends. Four thousand documents
-	// sixty-four apart stay within a handful of containers, so it is the count
-	// rather than the spread that makes these rows expensive.
+	// Rows wide enough that a one-row budget ends a window, so whichever
+	// memtable is read first settles where it ends.
 	fatRow := func(seed uint64) []uint64 {
 		docs := make([]uint64, 4096)
 		for i := range docs {
@@ -109,14 +93,13 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 	narrowingFlushing := newTestMemtableRoaringSet(map[string][]uint64{
 		"aaa": fatRow(1), "bbb": fatRow(2), "ccc": fatRow(3), "ddd": fatRow(4),
 	})
-	// Holds keys past where the flushing memtable's budget stops it, which is what
-	// a window left wider than that turns into a wrong answer: those keys would be
-	// answered out of slots the flushing memtable never wrote.
+	// Holds keys past where flushing's budget stops it: a window left too wide
+	// would answer them from slots flushing never wrote.
 	narrowingActive := newTestMemtableRoaringSet(map[string][]uint64{
 		"bbb": {91}, "ddd": {92}, "eee": {93},
 	})
-	// Its own segment rather than a shared one: the fake counts the reads it is
-	// asked for without a lock, and the cases below run in parallel.
+	// Its own segment, since the fake counts reads without a lock and the
+	// cases below run in parallel.
 	narrowingDisk := []Segment{
 		newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
 			"aaa": bitmapFromSlice([]uint64{1, 2, 3}),
@@ -140,13 +123,8 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 		active   *testMemtable
 		batch    []string
 		windows  []int
-		// Zero for no budget, so only a case about narrowing has to think about
-		// one.
-		budget int
-		// Written down rather than derived, where the fold's outcome is worth
-		// pinning against something other than the path under test. Optional:
-		// the differential above runs either way.
-		want map[string][]uint64
+		budget   int // zero for no budget
+		want     map[string][]uint64
 	}{
 		{
 			name:     "one disk segment",
@@ -160,8 +138,7 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 			batch:   []string{"aaa", "bbb", "ccc", "ddd", "eee", "fff", "ggg", "hhh", "iii"},
 			windows: []int{1, 2, 3, 4096},
 			// "aaa" is disk {1,2,3} minus the flushing deletion of 2 plus the
-			// active re-add, which survives only folding oldest first; "eee" is
-			// disk {5,6} minus a deletion nothing re-adds.
+			// active re-add, which survives only folding oldest first.
 			want: map[string][]uint64{
 				"aaa": {1, 2, 3},
 				"bbb": {10, 11},
@@ -192,13 +169,10 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 			},
 		},
 		{
-			// The narrowing memtable is read first, so what the second is asked for
-			// rests on the bound already settled. Asked for the window's full width
-			// instead, it would fill slots past that bound, and the keys beyond it
-			// would be answered from a flushing memtable that never wrote them.
-			//
-			// No want: the rows here are thousands of documents wide, and the
-			// differential against the per-key path is what this case is for.
+			// The narrowing memtable is read first, so what the second is asked
+			// for rests on the bound it already settled. No want: the rows here
+			// are thousands of documents wide; the per-key differential is what
+			// this case is for.
 			name:     "a narrowing memtable read before one holding keys past it",
 			segments: narrowingDisk,
 			flushing: narrowingFlushing,
@@ -229,7 +203,7 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 					if budget == 0 {
 						budget = math.MaxInt
 					}
-					r, err := newRoaringSetBatchReader(view, keys, window, budget)
+					r, err := newRoaringSetBatchReaderWithBounds(view, keys, window, budget)
 					require.NoError(t, err)
 
 					requireMatchesPerKey(t, b, view, r, keys, "")
@@ -237,7 +211,7 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 						return
 					}
 					// A second reader: one walks its batch once.
-					r2, err := newRoaringSetBatchReader(view, keys, window, budget)
+					r2, err := newRoaringSetBatchReaderWithBounds(view, keys, window, budget)
 					require.NoError(t, err)
 					requireRowsAre(t, r2, keys, tt.want)
 				})
@@ -246,16 +220,11 @@ func TestBatchReaderMatchesPerKeyReads(t *testing.T) {
 	}
 }
 
-// TestBatchReaderMatchesPerKeyReadsRandomized runs the same differential over random layer
-// contents, which is where an off-by-one in the per-layer cursor shows: it
-// would drop a match, or carry one key's layer onto its neighbour.
-//
-// The differential alone cannot see everything it looks like it can: both paths
-// end in roaringSetGetWithLayers, so a bug in that tail agrees with itself on
-// both sides. Every layer here only adds, which makes a row's contents the union
-// of what the three hold for its key — an expectation that comes from the
-// fixture rather than from either path, so the rounds also pin something no
-// symmetry can satisfy.
+// TestBatchReaderMatchesPerKeyReadsRandomized runs the same differential over
+// random layer contents, where an off-by-one in the per-layer cursor would
+// drop a match or carry one key's layer onto its neighbour. Every layer only
+// adds, so each row's contents are the union of what the three hold for its
+// key — an expectation independent of either read path.
 func TestBatchReaderMatchesPerKeyReadsRandomized(t *testing.T) {
 	t.Parallel()
 	rnd := rand.New(rand.NewSource(3))
@@ -311,7 +280,7 @@ func TestBatchReaderMatchesPerKeyReadsRandomized(t *testing.T) {
 		keys := sortedKeysOf(t, batch)
 		window := 1 + rnd.Intn(5)
 
-		r, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
+		r, err := newRoaringSetBatchReaderWithBounds(view, keys, window, math.MaxInt)
 		require.NoError(t, err)
 		requireMatchesPerKey(t, b, view, r, keys, fmt.Sprintf("round %d", round))
 
@@ -320,24 +289,17 @@ func TestBatchReaderMatchesPerKeyReadsRandomized(t *testing.T) {
 			k := string(keys.At(i))
 			want[k] = unionOf(diskDocs[k], flushingDocs[k], activeDocs[k])
 		}
-		// A second reader, since the first has served every key and would spend
-		// the pass refilling.
-		abs, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
+		// A second reader: the first has served every key already.
+		abs, err := newRoaringSetBatchReaderWithBounds(view, keys, window, math.MaxInt)
 		require.NoError(t, err)
 		requireRowsAre(t, abs, keys, want)
 	}
 }
 
 // TestBatchReaderSurvivesTheFoldMutatingItsRows covers what the fold does to
-// every row it is handed: it adopts the first as its accumulator and merges the
-// rest into it in place. A window clones once for all the keys it covers, so a
-// row the caller mutates must not be one the reader still needs — and the fills
-// must stay one per window while that happens.
-//
-// A key with a disk row is the boundary: there the merger folds onto the disk
-// base and never hands the window's clone out. The last case gives every key
-// one, deliberately — a single key the disk missed would hand the clone out
-// again and the case would stop being a control.
+// every row: adopts the first as its accumulator and merges the rest into it
+// in place. A window clones once for all the keys it covers, so a row the
+// caller mutates must not be one the reader still needs.
 func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 	t.Parallel()
 
@@ -367,6 +329,8 @@ func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 			activeDeletes: map[string][]uint64{"aaa": {8}},
 		},
 		{
+			// Every key has a disk row, deliberately: there the merger folds
+			// onto the disk base and never hands the window's clone out.
 			name: "every key has a disk row",
 			disk: map[string]*sroar.Bitmap{
 				"aaa": bitmapFromSlice([]uint64{5}),
@@ -379,10 +343,8 @@ func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 	}
 
 	windows := []struct {
-		size int
-		// wantFills is what the three keys cost: one window at the production
-		// size, two when the size splits them.
-		wantFills int
+		size      int
+		wantFills int // one window at the production size, two when it splits them
 	}{
 		{memtableWindowKeys, 1},
 		{2, 2},
@@ -414,7 +376,7 @@ func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 				mts = append(mts, active)
 
 				keys := sortedKeysOf(t, []string{"aaa", "bbb", "ccc"})
-				r, err := newRoaringSetBatchReader(view, keys, w.size, math.MaxInt)
+				r, err := newRoaringSetBatchReaderWithBounds(view, keys, w.size, math.MaxInt)
 				require.NoError(t, err)
 
 				for i := 0; i < keys.Len(); i++ {
@@ -423,8 +385,7 @@ func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 					got, gr, err := r.Next(concurrency.SROAR_MERGE)
 					require.NoError(t, err)
 					require.Equalf(t, docsOrNil(want), docsOrNil(got), "key %d", i)
-					// What the fold does to every row it reads.
-					got.Set(9999)
+					got.Set(9999) // what the fold does to every row it reads
 					wr()
 					gr()
 				}
@@ -439,11 +400,9 @@ func TestBatchReaderSurvivesTheFoldMutatingItsRows(t *testing.T) {
 }
 
 // TestBatchReaderFillWindowError covers a memtable read that fails partway
-// through a window. The window is filled one memtable at a time, so the failure
-// leaves one loaded for the new window and the other still holding the last one
-// at its width — a mixture that must not be served. Depending on what the
-// previous window was, serving it drops a memtable's rows, returns another key's
-// row, or indexes past the end.
+// through a window. The window is filled one memtable at a time, so the
+// failure leaves one loaded for the new window and the other still holding
+// the last one — a mixture that must not be served.
 func TestBatchReaderFillWindowError(t *testing.T) {
 	t.Parallel()
 
@@ -451,9 +410,8 @@ func TestBatchReaderFillWindowError(t *testing.T) {
 
 	tests := []struct {
 		name string
-		// how far the walk gets before the read that fails; with a window of 4
-		// over 10 keys, 0 fails the first fill and 4 fails a later one, after a
-		// window has already been served.
+		// how far the walk gets before the failing read; window is 4 over 10
+		// keys, so 0 fails the first fill and 4 fails a later one.
 		readBefore int
 	}{
 		{name: "first window, nothing loaded yet", readBefore: 0},
@@ -461,11 +419,9 @@ func TestBatchReaderFillWindowError(t *testing.T) {
 		{name: "mid-window, no fill due", readBefore: 5},
 	}
 
-	// Which memtable fails decides how far the fill got. Flushing is index 0, so
-	// failing it aborts before the active one is read at all; failing active
-	// instead leaves flushing loaded for the new window and active holding the
-	// last one — the half-loaded state the invalidation exists for, which
-	// failing the first memtable never produces.
+	// Failing flushing (index 0) aborts before active is read at all; failing
+	// active instead leaves flushing loaded for the new window and active
+	// holding the last one — the half-loaded state the invalidation exists for.
 	for _, tc := range tests {
 		for _, failFirst := range []bool{false, true} {
 			t.Run(fmt.Sprintf("%s/failFirst=%t", tc.name, failFirst), func(t *testing.T) {
@@ -479,9 +435,8 @@ func TestBatchReaderFillWindowError(t *testing.T) {
 					disk:     &SegmentGroup{segments: []Segment{diskSeg}},
 					logger:   nullLogger(),
 				}
-				// k05 puts a row inside the second window. Without it that window
-				// holds nothing, a stale all-zero window is accidentally the right
-				// answer, and the invalidation below cannot be caught failing.
+				// k05 puts a row inside the second window, so a stale all-zero
+				// window can't accidentally be the right answer.
 				active := newTestMemtableRoaringSet(map[string][]uint64{
 					"k00": {1}, "k01": {2}, "k03": {4}, "k05": {5}, "k08": {8}, "k09": {9},
 				})
@@ -499,7 +454,7 @@ func TestBatchReaderFillWindowError(t *testing.T) {
 					batch[i] = fmt.Sprintf("k%02d", i)
 				}
 				keys := sortedKeysOf(t, batch)
-				r, err := newRoaringSetBatchReader(view, keys, 4, math.MaxInt)
+				r, err := newRoaringSetBatchReaderWithBounds(view, keys, 4, math.MaxInt)
 				require.NoError(t, err)
 
 				for i := 0; i < tc.readBefore; i++ {
@@ -511,43 +466,184 @@ func TestBatchReaderFillWindowError(t *testing.T) {
 				// Fails only if this read is due a fill; mid-window it is served
 				// from what is already loaded, which is equally worth pinning.
 				failing.roaringSetGetWindowErr = readErr
-				at := tc.readBefore
 				bm, release, err := r.Next(concurrency.SROAR_MERGE)
 				if err != nil {
 					require.ErrorIs(t, err, readErr)
 					require.Nil(t, bm, "a failed read returns no row")
 					require.Nil(t, release, "a failed read returns nothing to release")
 				} else {
-					// served from the loaded window, so the walk moved on
-					require.NotNil(t, release)
+					require.NotNil(t, release) // served from the loaded window
 					release()
-					at++
 				}
 				failing.roaringSetGetWindowErr = nil
 
-				// The walk resumes where it stopped. A failed fill left one
-				// memtable loaded for the new window and the other holding the
-				// last one, so serving from that mixture would answer with a
-				// memtable's rows for the wrong keys.
-				for i := at; i < keys.Len(); i++ {
-					want, wr, err := b.roaringSetGetFromConsistentView(view, keys.At(i), concurrency.SROAR_MERGE)
-					require.NoError(t, err)
-					got, gr, err := r.Next(concurrency.SROAR_MERGE)
-					require.NoError(t, err)
-					require.Equalf(t, docsOrNil(want), docsOrNil(got), "index %d after the failed fill", i)
-					wr()
-					gr()
-				}
+				// The walk resumes where it stopped; serving from the half-loaded
+				// mixture would answer with a memtable's rows for the wrong keys.
+				requireMatchesPerKey(t, b, view, r, keys, "after the failed fill")
 			})
 		}
 	}
 }
 
+// TestBatchReaderFailedFillDropsCarriedRowsAndCountsItsWork covers the
+// interleaving the other error tests cannot reach. They run an unlimited
+// budget, so no window is ever narrowed and nothing is ever carried when the
+// error arrives. Here the fat memtable fails while the thin one's rows from an
+// earlier fill are still held, which is the only shape where dropping the
+// window has anything to drop.
+//
+// The two rows differ in which memtable fails. Failing the fat one, read
+// second, leaves the thin one's copy under its own lock inside the same fill,
+// which that fill must still report; failing the thin one, read first, makes
+// the bytes it reports the whole of what the fill copied.
+func TestBatchReaderFailedFillDropsCarriedRowsAndCountsItsWork(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nKeys       = 24
+		readBefore  = 3
+		windowWidth = 8
+	)
+	// What the failing read reports having copied before it gave up.
+	const partialCopy = 4096
+	readErr := errors.New("injected memtable failure")
+
+	tests := []struct {
+		name string
+		// failFirst picks the thin memtable, which the fold reads first, so no
+		// other memtable copies anything in the failed fill and the bytes it
+		// reports are the whole of what that fill copied.
+		failFirst bool
+	}{
+		{name: "the memtable read first fails", failFirst: true},
+		{name: "the memtable read second fails", failFirst: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			view, keys, budget, b := narrowingFixture(t, nKeys)
+			failing := view.Active.(*testMemtable)
+			if tc.failFirst {
+				failing = view.Flushing.(*testMemtable)
+			}
+
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, windowWidth, budget)
+			require.NoError(t, err)
+
+			for i := 0; i < readBefore; i++ {
+				_, release, err := r.Next(concurrency.SROAR_MERGE)
+				require.NoError(t, err)
+				release()
+			}
+			require.Positive(t, r.windows[0].carried+r.windows[1].carried,
+				"the fixture must be carrying rows when the read fails, or this covers nothing")
+			require.Equal(t, r.winEnd, r.pos, "the next read must be due a fill, or the error never fires")
+
+			before := r.Stats()
+			failing.roaringSetGetWindowErr = readErr
+			failing.roaringSetGetWindowErrBytes = partialCopy
+			bm, release, err := r.Next(concurrency.SROAR_MERGE)
+			require.ErrorIs(t, err, readErr)
+			require.Nil(t, bm, "a failed read returns no row")
+			require.Nil(t, release, "a failed read returns nothing to release")
+			failing.roaringSetGetWindowErr = nil
+			after := r.Stats()
+
+			requireNoClonesHeld(t, r)
+			require.Zero(t, r.windows[0].carried+r.windows[1].carried,
+				"rows dropped with the window must stop being charged against the next fill's share")
+
+			require.Equal(t, before.Fills+1, after.Fills,
+				"a fill that failed part way still acquired the locks it counted")
+			require.LessOrEqual(t, after.MemtableReads, after.Fills*after.Memtables,
+				"MemtableReads runs short of Fills times Memtables, never past it")
+
+			copied := after.BytesCopied - before.BytesCopied
+			if tc.failFirst {
+				require.Equal(t, partialCopy, copied,
+					"the rows copied before the read gave up are the whole of what this fill copied")
+			} else {
+				require.Greater(t, copied, partialCopy,
+					"the memtable read before the failure copied under its lock too, and that is work the fill did")
+			}
+
+			// The walk resumes where it stopped; a kept row would answer a later
+			// key with the row an abandoned window had loaded for it.
+			requireMatchesPerKey(t, b, view, r, keys, "after the failed fill")
+		})
+	}
+}
+
+// TestBatchReaderFailedFillIsNotNarrowed pins that a fill which failed counts
+// as no kind of ending.
+//
+// It needs a memtable that narrows the window and then a later one that fails:
+// that is the only order in which reading the narrowed end and asking the
+// caller give different answers.
+func TestBatchReaderFailedFillIsNotNarrowed(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nKeys       = 8
+		windowWidth = 8
+		narrowsAt   = 4
+	)
+	readErr := errors.New("injected memtable failure")
+
+	names := make([]string, nKeys)
+	for i := range names {
+		names[i] = fmt.Sprintf("k%02d", i)
+	}
+	keys := sortedKeysOf(t, names)
+
+	// Read first, and given a share that covers exactly narrowsAt of its rows,
+	// so it settles the window short of the width the fill opened at.
+	narrowing := newTestMemtableRoaringSet(nil)
+	for i, n := range names {
+		require.NoError(t, narrowing.roaringSetAddList([]byte(n), []uint64{uint64(100 + i)}))
+	}
+	// Read second, and made to fail, so the window is already narrowed when the
+	// fill gives up.
+	failing := newTestMemtableRoaringSet(nil)
+	for i, n := range names {
+		require.NoError(t, failing.roaringSetAddList([]byte(n), []uint64{uint64(200 + i)}))
+	}
+
+	oneRow := make([]roaringset.BitmapLayer, 1)
+	priced, err := narrowing.roaringSetGetWindow(keys, 0, 1, oneRow, math.MaxInt)
+	require.NoError(t, err)
+	narrowing.ranges = nil
+	// Two memtables split the budget, so this leaves each a share of exactly
+	// narrowsAt rows.
+	budget := 2 * narrowsAt * priced.Bytes
+
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	view := BucketConsistentView{Active: failing, Flushing: narrowing, Bucket: b}
+
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, windowWidth, budget)
+	require.NoError(t, err)
+	failing.roaringSetGetWindowErr = readErr
+
+	_, _, err = r.Next(concurrency.SROAR_MERGE)
+	require.ErrorIs(t, err, readErr)
+
+	st := r.Stats()
+	require.Equal(t, 1, st.Fills, "the failed fill is still a fill")
+	// Read off the memtable rather than the reader: the failed fill dropped its
+	// window, so what it settled at survives only in the range the memtable
+	// recorded, which is [from, fill.To).
+	require.Equal(t, [][2]int{{0, narrowsAt}}, narrowing.ranges,
+		"the first memtable must have narrowed the window, or the two answers cannot differ")
+	require.Zero(t, st.NarrowedFills,
+		"a fill that failed ended on the failure, not on the byte budget")
+}
+
 // TestBatchReaderDiskErrorLeavesNothingToRetryWrong pins the other half of the
 // error contract. A failed disk read happens after the key's slots have been
-// emptied, so leaving the window intact would let a retry read them as absence
-// and fold the disk row alone — a wrong row, with no error to say so. The retry
-// must refill instead, and answer as the per-key path does.
+// emptied, so leaving the window intact would let a retry fold the disk row
+// alone — a wrong row, with no error to say so. The retry must refill instead.
 func TestBatchReaderDiskErrorLeavesNothingToRetryWrong(t *testing.T) {
 	t.Parallel()
 
@@ -561,15 +657,15 @@ func TestBatchReaderDiskErrorLeavesNothingToRetryWrong(t *testing.T) {
 		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
 		logger:   nullLogger(),
 	}
-	// The memtable deletes what disk holds, so a row folded without it differs
-	// from the right answer — which is what makes the retry observable at all.
+	// The memtable deletes what disk holds, so folding without it differs from
+	// the right answer, making the retry observable.
 	active := newTestMemtableRoaringSet(nil)
 	require.NoError(t, active.roaringSetRemoveList([]byte("k1"), []uint64{2}))
 	require.NoError(t, active.roaringSetAddList([]byte("k1"), []uint64{9}))
 	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 
 	keys := sortedKeysOf(t, []string{"k0", "k1"})
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 
 	_, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -594,110 +690,157 @@ func TestBatchReaderDiskErrorLeavesNothingToRetryWrong(t *testing.T) {
 		"the retry must refill: reading the emptied slots as absence would drop the memtable's row")
 }
 
-// TestBatchReaderReadsWhileMemtableIsWritten covers a window read running
-// against a live memtable: it holds the read lock while it walks the tree and
-// copies what it finds, and the memtable goes on taking writes throughout.
+// TestBatchReaderReadsWhileMemtableIsWritten covers a window read racing a
+// live memtable: it holds the read lock while it walks and copies, and the
+// memtable keeps taking writes throughout. A write landing mid-batch may or
+// may not be visible depending on timing, but a row must never be torn, a
+// neighbour's, or half-copied.
 //
-// A write landing mid-batch may or may not be visible — the windows are filled
-// as the fold reaches them, so which keys see it depends on timing, and the
-// reader's contract says as much. What may never happen is a row that is
-// neither the value before the write nor the value after: a torn read, or a
-// neighbour's row, or a bitmap caught half-copied.
+// The flush-in-flight row adds what the first cannot reach: two memtables, a
+// budget split between them, and windows narrowed by that split. Both rows are
+// read while the active memtable takes writes.
 func TestBatchReaderReadsWhileMemtableIsWritten(t *testing.T) {
 	const (
 		n      = memtableWindowKeys*2 + 3
 		marker = uint64(999_999)
+		// The document the flushing memtable holds for key i, apart enough from
+		// the active one's that a swapped row is not a near miss.
+		flushedBase = uint64(500_000)
 	)
 
-	rows := map[string][]uint64{}
-	batch := make([]string, n)
-	for i := 0; i < n; i++ {
-		batch[i] = fmt.Sprintf("k%06d", i)
-		rows[batch[i]] = []uint64{uint64(i)}
+	tests := []struct {
+		name string
+		// flushed adds a second memtable the writer never touches.
+		flushed bool
+		// budget is the reader's byte allowance; the small one is what narrows
+		// a window.
+		budget int
+	}{
+		{name: "one memtable", budget: math.MaxInt},
+		{name: "a flush in flight", flushed: true, budget: 8 << 10},
 	}
 
-	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
-	active := newTestMemtableRoaringSet(rows)
-	b := &Bucket{
-		strategy: StrategyRoaringSet,
-		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
-		logger:   nullLogger(),
-	}
-	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
-	keys := sortedKeysOf(t, batch)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rows := map[string][]uint64{}
+			flushedRows := map[string][]uint64{}
+			batch := make([]string, n)
+			for i := 0; i < n; i++ {
+				batch[i] = fmt.Sprintf("k%06d", i)
+				rows[batch[i]] = []uint64{uint64(i)}
+				flushedRows[batch[i]] = []uint64{flushedBase + uint64(i)}
+			}
 
-	var written atomic.Bool
-	var writeErr error
-	var wg sync.WaitGroup
-	start := make(chan struct{})
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// Even on the way out, so a failed write ends the reader's loop below
-		// rather than leaving it spinning for a writer that has given up.
-		defer written.Store(true)
-		<-start
-		for _, k := range batch {
-			if err := active.roaringSetAddOne([]byte(k), marker); err != nil {
-				writeErr = err
+			// The two values a key may read as, in the sorted order ToArray
+			// returns: marker is above every other document here, and the
+			// flushed one above every active one.
+			rowBefore := func(i int) []uint64 {
+				if tc.flushed {
+					return []uint64{uint64(i), flushedBase + uint64(i)}
+				}
+				return []uint64{uint64(i)}
+			}
+			rowAfter := func(i int) []uint64 {
+				return append(rowBefore(i), marker)
+			}
+
+			diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
+			active := newTestMemtableRoaringSet(rows)
+			b := &Bucket{
+				strategy: StrategyRoaringSet,
+				disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+				logger:   nullLogger(),
+			}
+			view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+			if tc.flushed {
+				view.Flushing = newTestMemtableRoaringSet(flushedRows)
+			}
+			keys := sortedKeysOf(t, batch)
+
+			var written atomic.Bool
+			var writeErr error
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer written.Store(true) // even on error, so the reader loop below can't spin forever
+				<-start
+				for _, k := range batch {
+					if err := active.roaringSetAddOne([]byte(k), marker); err != nil {
+						writeErr = err
+						return
+					}
+				}
+			}()
+
+			// Fold repeatedly until the writer is done, so both pre- and post-write
+			// states are actually observed rather than left to the scheduler. The
+			// writer is held until one whole pass has been read.
+			seenBefore, seenAfter := 0, 0
+			for pass := 0; ; pass++ {
+				done := written.Load()
+				r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, tc.budget)
+				require.NoError(t, err)
+				for i := 0; i < keys.Len(); i++ {
+					got, release, err := r.Next(concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					switch {
+					case slices.Equal(docsOrNil(got), rowBefore(i)):
+						seenBefore++
+					case slices.Equal(docsOrNil(got), rowAfter(i)):
+						seenAfter++
+					}
+					require.Containsf(t, [][]uint64{rowBefore(i), rowAfter(i)}, docsOrNil(got),
+						"pass %d index %d: row is neither the value before the write nor after it", pass, i)
+					release()
+				}
+				if pass == 0 {
+					close(start) // only now, so the pass above always ran at the pre-write value
+				}
+				if done {
+					break
+				}
+			}
+			wg.Wait()
+			require.NoError(t, writeErr)
+			require.Positive(t, seenBefore, "no row was read before the writer reached it; the two never overlapped")
+			require.Positive(t, seenAfter, "no row was read after the writer reached it; the two never overlapped")
+
+			// and once the writer has finished, every key must show the write.
+			// The recorded reads are cleared first so what the stats below are
+			// compared against is this reader's alone, not every pass above it.
+			active.ranges = nil
+			if tc.flushed {
+				view.Flushing.(*testMemtable).ranges = nil
+			}
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, tc.budget)
+			require.NoError(t, err)
+			for i := 0; i < keys.Len(); i++ {
+				got, release, err := r.Next(concurrency.SROAR_MERGE)
+				require.NoError(t, err)
+				require.Equal(t, rowAfter(i), docsOrNil(got), "index %d after the writer finished", i)
+				release()
+			}
+
+			st := r.Stats()
+			if !tc.flushed {
+				require.Equal(t, 1, st.Memtables)
 				return
 			}
-		}
-	}()
-
-	// Fold the batch repeatedly until the writer is done, so reads and writes
-	// overlap rather than merely interleaving once. Both states have to be
-	// observed: a run in which every row already carried the marker would
-	// satisfy the assertion below without ever having raced anything.
-	// Neither is left to the scheduler: the writer is held until one whole pass
-	// has been read, and the pass that ends the loop runs after it finished.
-	seenBefore, seenAfter := 0, 0
-	for pass := 0; ; pass++ {
-		done := written.Load()
-		r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
-		require.NoError(t, err)
-		for i := 0; i < keys.Len(); i++ {
-			got, release, err := r.Next(concurrency.SROAR_MERGE)
-			require.NoError(t, err)
-			if len(docsOrNil(got)) == 1 {
-				seenBefore++
-			} else {
-				seenAfter++
-			}
-			require.Containsf(t, [][]uint64{{uint64(i)}, {uint64(i), marker}}, docsOrNil(got),
-				"pass %d index %d: row is neither the value before the write nor after it", pass, i)
-			release()
-		}
-		if pass == 0 {
-			// Only now, so every row above was read at its pre-write value. done
-			// cannot be true yet, so this always runs and the writer never hangs.
-			close(start)
-		}
-		if done {
-			break
-		}
-	}
-	wg.Wait()
-	require.NoError(t, writeErr)
-	require.Positive(t, seenBefore, "no row was read before the writer reached it; the two never overlapped")
-	require.Positive(t, seenAfter, "no row was read after the writer reached it; the two never overlapped")
-
-	// and once the writer has finished, every key must show the write
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
-	require.NoError(t, err)
-	for i := 0; i < keys.Len(); i++ {
-		got, release, err := r.Next(concurrency.SROAR_MERGE)
-		require.NoError(t, err)
-		require.Equal(t, []uint64{uint64(i), marker}, docsOrNil(got), "index %d after the writer finished", i)
-		release()
+			// Without these the row runs the first row's code path and proves
+			// nothing extra.
+			require.Equal(t, 2, st.Memtables, "the flushing memtable must be read too")
+			require.Positive(t, st.NarrowedFills, "the budget must be cutting windows short")
+			require.Equal(t, len(view.Flushing.(*testMemtable).ranges)+len(active.ranges), st.MemtableReads,
+				"every read a memtable served must be one the reader counted")
+		})
 	}
 }
 
-// TestBatchReaderFillsWindowsLazily pins the other half of the same contract.
-// ContainsAll abandons its fold as soon as the intersection empties, often after
-// a handful of keys, so a reader that filled the whole batch up front would read
-// windows whose keys nobody goes on to ask about — and on a large batch that is
-// most of them.
+// TestBatchReaderFillsWindowsLazily covers ContainsAll abandoning its fold
+// early: a reader that filled the whole batch up front would read windows
+// nobody goes on to ask about.
 func TestBatchReaderFillsWindowsLazily(t *testing.T) {
 	t.Parallel()
 
@@ -714,9 +857,6 @@ func TestBatchReaderFillsWindowsLazily(t *testing.T) {
 		{name: "abandoned inside the first window", readThrough: 1, wantFills: 1},
 		{name: "abandoned on a window boundary", readThrough: 4, wantFills: 1},
 		{name: "abandoned one key into the second", readThrough: 5, wantFills: 2},
-		// Reading everything is the other half of the same contract: one
-		// acquisition per window rather than one per key, which is the whole
-		// point of the window and which no differential would notice losing.
 		{name: "read to the end", readThrough: 20, wantFills: 5},
 	}
 
@@ -735,7 +875,7 @@ func TestBatchReaderFillsWindowsLazily(t *testing.T) {
 			view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
 
 			keys := sortedKeysOf(t, batch)
-			r, err := newRoaringSetBatchReader(view, keys, 4, math.MaxInt)
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, 4, math.MaxInt)
 			require.NoError(t, err)
 			for i := 0; i < tc.readThrough; i++ {
 				_, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -752,11 +892,10 @@ func TestBatchReaderFillsWindowsLazily(t *testing.T) {
 	}
 }
 
-// TestBatchReaderStatsReportTheWork pins what the slow-query annotation reads.
-// A batched filter that has gone slow is otherwise indistinguishable from one
-// that merely ran during a slow query: fills times memtables is the acquisitions
-// the batching paid for, and a fill count approaching the key count says the
-// windows were narrow rather than that the batch was large.
+// TestBatchReaderStatsReportTheWork pins what the slow-query annotation reads:
+// fills times memtables bounds the acquisitions batching paid for, and a fill
+// count near the key count says the windows were narrow, not that the batch
+// was large.
 func TestBatchReaderStatsReportTheWork(t *testing.T) {
 	t.Parallel()
 
@@ -774,9 +913,7 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 		wantCloned    bool
 	}{
 		{
-			// 10 keys in windows of 4 is 3 windows, which is what a whole fold
-			// pays. Fills against Len is what says the batching, rather than the
-			// rows, is where a slow filter went.
+			// 10 keys in windows of 4 is 3 windows, which is what a whole fold pays.
 			name:          "the whole batch fills once per window",
 			held:          map[string][]uint64{"k00": {1}, "k05": {2}},
 			reads:         10,
@@ -785,10 +922,8 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 			wantCloned:    true,
 		},
 		{
-			// That the annotation reads the reader after the fold rather than
-			// before: a fold stopping inside the second window has to report the
-			// two windows it entered, not the three the batch spans. Lazy filling
-			// itself is TestBatchReaderFillsWindowsLazily's.
+			// The annotation reads the reader after the fold: stopping inside the
+			// second window reports the two windows entered, not the three spanned.
 			name:          "a fold that stops early pays for fewer windows",
 			held:          map[string][]uint64{"k00": {1}, "k05": {2}},
 			reads:         5,
@@ -797,8 +932,6 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 			wantCloned:    true,
 		},
 		{
-			// Nothing held, so the window costs acquisitions and no memory. This
-			// is the case the window cannot be blamed for.
 			name:          "a memtable holding nothing clones nothing",
 			held:          map[string][]uint64{},
 			reads:         10,
@@ -814,8 +947,8 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 
 			diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
 			active := newTestMemtableRoaringSet(tc.held)
-			// A memtable holding nothing is skipped by the constructor, so give it
-			// a write the skip does not remove.
+			// An empty memtable is skipped by the constructor; give it a write
+			// the skip does not remove.
 			if len(tc.held) == 0 {
 				require.NoError(t, active.roaringSetAddList([]byte("zzz"), []uint64{1}))
 			}
@@ -827,7 +960,7 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 			view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 
 			keys := sortedKeysOf(t, batch)
-			r, err := newRoaringSetBatchReader(view, keys, 4, math.MaxInt)
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, 4, math.MaxInt)
 			require.NoError(t, err)
 			for i := 0; i < tc.reads; i++ {
 				_, release, err := r.Next(concurrency.SROAR_MERGE)
@@ -838,7 +971,7 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 			got := r.Stats()
 			require.Equal(t, tc.wantFills, got.Fills)
 			require.Equal(t, tc.wantMemtables, got.Memtables)
-			require.Equal(t, tc.reads, got.KeysRead,
+			require.Equal(t, tc.reads, got.KeysServed,
 				"how far the fold got, which the fill count cannot say")
 			require.Zero(t, got.NarrowedFills,
 				"no budget here, so every window ended on its key count")
@@ -853,120 +986,90 @@ func TestBatchReaderStatsReportTheWork(t *testing.T) {
 	}
 }
 
-// TestBatchReaderSkipsAnEmptyActiveMemtable pins the skip the reader's
-// constructor argues for: an active memtable whose size is zero is dropped from
-// the view, and the rows it holds are ones that add and delete nothing, so the
-// answer is the same as the per-key path gives — and that path does not skip it.
-//
-// Size counts entries added or removed, so a write carrying no values builds a
-// node and leaves the size at zero. Replaying a commit log record with both
-// slices empty does the same. The argument is that such rows fold as if absent;
-// this runs the differential the argument implies.
+// TestBatchReaderSkipsAnEmptyActiveMemtable pins the constructor's skip of an
+// active memtable whose size is zero: such rows add and delete nothing, so
+// the answer must match the per-key path, which does not skip it. A write
+// carrying no values (or a commit-log replay with both slices empty) builds a
+// node but leaves size at zero.
 func TestBatchReaderSkipsAnEmptyActiveMemtable(t *testing.T) {
 	t.Parallel()
 
 	batch := []string{"aaa", "bbb", "ccc"}
-	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
-		"aaa": bitmapFromSlice([]uint64{1, 2}),
-		"ccc": bitmapFromSlice([]uint64{3}),
-	})
-	flushing := newTestMemtableRoaringSet(map[string][]uint64{"bbb": {9}})
 
-	// Written through the write path, so size and tree disagree exactly as they
-	// would in a bucket: nodes for two keys, and a size still at zero.
-	active := newTestMemtableRoaringSet(map[string][]uint64{})
-	require.NoError(t, active.roaringSetAddList([]byte("aaa"), []uint64{}))
-	require.NoError(t, active.roaringSetAddList([]byte("ccc"), []uint64{}))
-	require.Zero(t, active.Size(), "the fixture must reach the state the skip is about")
-
-	b := &Bucket{
-		strategy: StrategyRoaringSet,
-		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
-		logger:   nullLogger(),
-	}
-	view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
-
-	keys := sortedKeysOf(t, batch)
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
-	require.NoError(t, err)
-	require.Equal(t, 1, r.mtCount, "the empty active memtable must be dropped from the view")
-
-	requireMatchesPerKey(t, b, view, r, keys, "empty active memtable")
-	require.Zero(t, active.roaringSetGetWindowCalls, "a dropped memtable must not be read")
-
-	abs, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
-	require.NoError(t, err)
-	requireRowsAre(t, abs, keys, map[string][]uint64{
-		"aaa": {1, 2},
-		"bbb": {9},
-		"ccc": {3},
-	})
-}
-
-// TestBatchReaderNarrowsTheWindowToTheBudget pins one thing, which is the reader's
-// half of the memory bound: that a fill adopts where the walk stopped. The walk
-// reporting the right stop is no use if the fill keeps the width it asked for, and
-// that failure is invisible to every other test here — the rows still read
-// correctly, they just cost a window's memory each time.
-//
-// Deliberately nothing else. The always-taken first key is pinned on the walk,
-// which is where a budget under one row can be handed in cheaply. Which slots the
-// walk wrote cannot be pinned from here: a lone memtable stops itself at its own
-// budget, so the slots past winEnd are untouched whatever bound the fill passed.
-// And that rows read correctly through a narrowed window belongs to
-// TestBatchReaderMatchesPerKeyReads' budgeted case, over the two memtables where
-// the bound is what decides it.
-func TestBatchReaderNarrowsTheWindowToTheBudget(t *testing.T) {
-	t.Parallel()
-
-	// Rows spread across containers, so each costs real bytes.
-	const rows, docsPerRow = 12, 4096
-	batch := make([]string, rows)
-	held := map[string][]uint64{}
-	for i := range batch {
-		batch[i] = fmt.Sprintf("k%02d", i)
-		docs := make([]uint64, docsPerRow)
-		for j := range docs {
-			docs[j] = uint64(i + j*rows*8)
-		}
-		held[batch[i]] = docs
+	tests := []struct {
+		name string
+		// A flush in flight leaves one memtable to read; without one an empty
+		// active leaves none, which is the shape a freshly flushed bucket serves
+		// every query from.
+		flushing  map[string][]uint64
+		wantMts   int
+		wantFills int
+		want      map[string][]uint64
+	}{
+		{
+			name:      "a flush in flight leaves one memtable",
+			flushing:  map[string][]uint64{"bbb": {9}},
+			wantMts:   1,
+			wantFills: 1,
+			want:      map[string][]uint64{"aaa": {1, 2}, "bbb": {9}, "ccc": {3}},
+		},
+		{
+			name:      "nothing flushing leaves none",
+			flushing:  nil,
+			wantMts:   0,
+			wantFills: 0,
+			want:      map[string][]uint64{"aaa": {1, 2}, "bbb": nil, "ccc": {3}},
+		},
 	}
 
-	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
-	b := &Bucket{
-		strategy: StrategyRoaringSet,
-		disk:     &SegmentGroup{segments: []Segment{diskSeg}},
-		logger:   nullLogger(),
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Per case: the fake segment counts the reads it is asked for without
+			// a lock, and the active memtable counts window calls.
+			diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{
+				"aaa": bitmapFromSlice([]uint64{1, 2}),
+				"ccc": bitmapFromSlice([]uint64{3}),
+			})
+
+			// Written through the write path, so size and tree disagree exactly as
+			// they would in a bucket: nodes for two keys, size still at zero.
+			active := newTestMemtableRoaringSet(map[string][]uint64{})
+			require.NoError(t, active.roaringSetAddList([]byte("aaa"), []uint64{}))
+			require.NoError(t, active.roaringSetAddList([]byte("ccc"), []uint64{}))
+			require.Zero(t, active.Size(), "the fixture must reach the state the skip is about")
+
+			b := &Bucket{
+				strategy: StrategyRoaringSet,
+				disk:     &SegmentGroup{segments: []Segment{diskSeg}},
+				logger:   nullLogger(),
+			}
+			view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
+			if tc.flushing != nil {
+				view.Flushing = newTestMemtableRoaringSet(tc.flushing)
+			}
+
+			keys := sortedKeysOf(t, batch)
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, math.MaxInt)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMts, r.mtCount, "the empty active memtable must be dropped from the view")
+			require.Equal(t, tc.wantMts, r.Stats().Memtables,
+				"Memtables reports what contributed, so it must drop the empty one too")
+
+			requireMatchesPerKey(t, b, view, r, keys, tc.name)
+			require.Zero(t, active.roaringSetGetWindowCalls, "a dropped memtable must not be read")
+			require.Equal(t, tc.wantFills, r.Stats().Fills,
+				"with nothing to read from there is no fill to count")
+
+			abs, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, math.MaxInt)
+			require.NoError(t, err)
+			requireRowsAre(t, abs, keys, tc.want)
+		})
 	}
-	active := newTestMemtableRoaringSet(held)
-	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
-
-	keys := sortedKeysOf(t, batch)
-	// A window wide enough for the whole batch, so only the budget can narrow it.
-	// One row's worth of budget, so the window ends on cost rather than on the
-	// key count — the shape a low-cardinality property produces in production,
-	// where rows are fat enough to reach the real constant.
-	one := make([]roaringset.BitmapLayer, 1)
-	first, err := active.roaringSetGetWindow(keys, 0, 1, one, math.MaxInt)
-	require.NoError(t, err)
-	require.Positive(t, first.Bytes)
-	budget := 3 * first.Bytes
-
-	r, err := newRoaringSetBatchReader(view, keys, rows, budget)
-	require.NoError(t, err)
-	require.NoError(t, r.fillWindow())
-	require.Less(t, r.winEnd-r.winStart, rows,
-		"the budget must have ended the window before the key count did")
 }
 
 // TestBatchReaderReleasesWhatItHasServed pins that a served key's clone leaves
-// the window. Only a fill drops clones, and a batch inside one window never
-// reaches a second fill, so without this every row the window matched would
-// stay live for as long as the fold runs — the whole window at once rather than
-// the part of it still to be read.
-//
-// It reads the front of the window and asserts on the back, so the assertion
-// cannot pass by the window having been refilled underneath it.
+// the window immediately (only a fill drops clones otherwise, and a batch
+// inside one window never reaches a second fill).
 func TestBatchReaderReleasesWhatItHasServed(t *testing.T) {
 	t.Parallel()
 
@@ -976,8 +1079,7 @@ func TestBatchReaderReleasesWhatItHasServed(t *testing.T) {
 	}
 
 	diskSeg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{})
-	// Every key held, so a slot left behind is a slot holding a clone.
-	held := map[string][]uint64{}
+	held := map[string][]uint64{} // every key held, so a leftover slot means a leftover clone
 	for i, k := range batch {
 		held[k] = []uint64{uint64(i)}
 	}
@@ -990,7 +1092,7 @@ func TestBatchReaderReleasesWhatItHasServed(t *testing.T) {
 	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 
 	keys := sortedKeysOf(t, batch)
-	r, err := newRoaringSetBatchReader(view, keys, len(batch), math.MaxInt)
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, len(batch), math.MaxInt)
 	require.NoError(t, err)
 
 	const served = 3
@@ -1003,20 +1105,18 @@ func TestBatchReaderReleasesWhatItHasServed(t *testing.T) {
 
 	for mt := 0; mt < r.mtCount; mt++ {
 		for i := 0; i < served; i++ {
-			require.Nilf(t, r.layers[mt][i].Additions, "layer %d slot %d still holds a served clone", mt, i)
-			require.Nilf(t, r.layers[mt][i].Deletions, "layer %d slot %d still holds a served clone", mt, i)
+			require.Nilf(t, r.windows[mt].layer[i].Additions, "layer %d slot %d still holds a served clone", mt, i)
+			require.Nilf(t, r.windows[mt].layer[i].Deletions, "layer %d slot %d still holds a served clone", mt, i)
 		}
 		for i := served; i < len(batch); i++ {
-			require.NotNilf(t, r.layers[mt][i].Additions, "layer %d slot %d lost a row it has not served", mt, i)
+			require.NotNilf(t, r.windows[mt].layer[i].Additions, "layer %d slot %d lost a row it has not served", mt, i)
 		}
 	}
 }
 
-// TestBatchReaderAtProductionWindow runs the differential over a batch several
-// times the real window, which no other test here does: they either set a tiny
-// window to reach the boundaries or carry too few keys for memtableWindowKeys to have a
-// second window at all. A window boundary that only appears at the real size
-// would have nothing else to fail.
+// TestBatchReaderAtProductionWindow runs the differential over a batch
+// several times the real window size, unlike every other test here which uses
+// a tiny window to reach the boundaries cheaply.
 func TestBatchReaderAtProductionWindow(t *testing.T) {
 	t.Parallel()
 
@@ -1056,9 +1156,7 @@ func TestBatchReaderAtProductionWindow(t *testing.T) {
 	}
 	view := BucketConsistentView{Active: active, Flushing: flushing, Disk: []Segment{diskSeg}, Bucket: b}
 
-	// Through the constructor, at the real window: every other test here builds
-	// the reader by hand with a small one, so nothing else covers the size the
-	// constructor actually picks.
+	// Through the constructor, at the real key limit.
 	keys := sortedKeysOf(t, batch)
 	reader, err := NewRoaringSetBatchReader(view, keys)
 	require.NoError(t, err)
@@ -1070,36 +1168,34 @@ func TestBatchReaderAtProductionWindow(t *testing.T) {
 	require.Equal(t, windows, active.roaringSetGetWindowCalls, "one read per window")
 }
 
-// TestBatchReaderRejectsItsBounds covers the two constructor arguments that fail
-// differently when wrong: a non-positive window panics deep in the first fill,
-// while a non-positive budget degrades silently to a fill per key — see the guards
-// in newRoaringSetBatchReader. Both are refused there instead.
-//
-// The window read itself takes any budget, and is tested at zero and one for the
-// first-key floor. This is the caller's arithmetic, not the walk's.
+// TestBatchReaderRejectsItsBounds covers the two constructor arguments that
+// fail differently when wrong: a non-positive window panics deep in the first
+// fill, while a non-positive budget silently degrades to a fill per key. Both
+// are refused up front instead.
 func TestBatchReaderRejectsItsBounds(t *testing.T) {
 	t.Parallel()
 	keys := sortedKeysOf(t, []string{"a", "b"})
-	view := BucketConsistentView{Active: newTestMemtableRoaringSet(nil)}
+	// A whole view, so the reader the last case builds is one Next could serve;
+	// without the bucket it would be accepted and then nil-dereference.
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	view := BucketConsistentView{Active: newTestMemtableRoaringSet(nil), Bucket: b}
 
 	for _, window := range []int{0, -1, -256} {
-		_, err := newRoaringSetBatchReader(view, keys, window, math.MaxInt)
+		_, err := newRoaringSetBatchReaderWithBounds(view, keys, window, math.MaxInt)
 		require.Errorf(t, err, "window %d must be rejected", window)
 	}
 	for _, budget := range []int{0, -1, -256} {
-		_, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, budget)
+		_, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, budget)
 		require.Errorf(t, err, "budget %d must be rejected", budget)
 	}
 	// Both good, so the cases above fail on the bound named and not on the view.
-	_, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, memtableWindowBytes)
+	_, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, readerWindowBytes)
 	require.NoError(t, err)
 }
 
-// TestBatchReaderReadsPastTheBatch pins the one way left to ask for a row that
-// is not there, and the shape of the failure: an error and neither a row nor a
-// release. A release handed back beside an error is one nobody calls, since the
-// folds drop it. Len is how many times Next answers, so asking again is the
-// caller's error rather than a row it could have found.
+// TestBatchReaderReadsPastTheBatch pins the shape of asking for a row past
+// Len: an error and neither a row nor a release (a release beside an error
+// would go uncalled, since folds drop it).
 func TestBatchReaderReadsPastTheBatch(t *testing.T) {
 	t.Parallel()
 
@@ -1116,7 +1212,7 @@ func TestBatchReaderReadsPastTheBatch(t *testing.T) {
 		Active: newTestMemtableRoaringSet(map[string][]uint64{"b": {2}}),
 		Disk:   []Segment{diskSeg}, Bucket: b,
 	}
-	r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, math.MaxInt)
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, math.MaxInt)
 	require.NoError(t, err)
 
 	for i := 0; i < keys.Len(); i++ {
@@ -1133,10 +1229,9 @@ func TestBatchReaderReadsPastTheBatch(t *testing.T) {
 	}
 }
 
-// requireRowsAre checks the reader against written-down rows rather than
-// against the per-key path. Both sides of the differential now fold through
-// roaringSetGetWithLayers, so a bug there — the layer order, say — agrees with
-// itself and passes every comparison. This is the only assertion that does not.
+// requireRowsAre checks the reader against written-down rows rather than the
+// per-key path — both sides of the differential fold through
+// roaringSetGetWithLayers, so a bug there would agree with itself.
 func requireRowsAre(t *testing.T, r *RoaringSetBatchReader, keys inverted.SortedKeys, want map[string][]uint64) {
 	t.Helper()
 	for i := 0; i < keys.Len(); i++ {
@@ -1148,14 +1243,16 @@ func requireRowsAre(t *testing.T, r *RoaringSetBatchReader, keys inverted.Sorted
 }
 
 // requireMatchesPerKey is the differential: whatever the window did, each key
-// must read the same as it would on its own. The tests that vary how the window
-// falls use it; those asserting a specific row, a fill count or a rejected
-// argument assert that directly.
+// must read the same as it would on its own.
+//
+// Starts wherever the reader has reached, so a walk resumed after a failed read
+// is the same assertion as a walk from the start; a reader fresh from the
+// constructor is at zero.
 func requireMatchesPerKey(t *testing.T, b *Bucket, view BucketConsistentView,
 	r *RoaringSetBatchReader, keys inverted.SortedKeys, msg string,
 ) {
 	t.Helper()
-	for i := 0; i < keys.Len(); i++ {
+	for i := r.pos; i < keys.Len(); i++ {
 		want, wr, err := b.roaringSetGetFromConsistentView(view, keys.At(i), concurrency.SROAR_MERGE)
 		require.NoError(t, err)
 		got, gr, err := r.Next(concurrency.SROAR_MERGE)
@@ -1166,20 +1263,13 @@ func requireMatchesPerKey(t *testing.T, b *Bucket, view BucketConsistentView,
 	}
 }
 
-// TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked pins that a reader holding
-// two memtables ends a batch with none of their rows still copied into it.
-//
-// A slot is emptied when the fold takes the row, so the ones at risk are those
-// the fold never reaches: a memtable read before the one whose budget settles
-// the window fills past that settlement, and those slots are never served. Since
-// window widths only shrink, the batch's last windows are narrower than the
-// buffer, so a fill that cleared only its own width would leave them behind for
-// as long as the reader lives.
-func TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked(t *testing.T) {
-	const (
-		nKeys  = 10
-		window = 8
-	)
+// narrowingFixture builds the shape the carry tests need: a thin memtable read
+// first, which fills whatever width it is asked for, and a fat one read second
+// whose share stops it after the always-taken first key, so it is what narrows
+// every window under the one already read. Key i of the thin memtable holds
+// document 100+i. The budget returned is one byte past a single fat row.
+func narrowingFixture(t *testing.T, nKeys int) (BucketConsistentView, inverted.SortedKeys, int, *Bucket) {
+	t.Helper()
 
 	names := make([]string, nKeys)
 	for i := range names {
@@ -1187,19 +1277,16 @@ func TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked(t *testing.T) {
 	}
 	keys := sortedKeysOf(t, names)
 
-	// Read first, and holds a row for every key, so it fills whatever width it
-	// is asked for.
 	flushing := newTestMemtableRoaringSet(nil)
 	for i, n := range names {
-		require.NoError(t, flushing.roaringSetAddList([]byte(n), []uint64{uint64(i)}))
+		require.NoError(t, flushing.roaringSetAddList([]byte(n), []uint64{uint64(100 + i)}))
 	}
 
-	// Read second, and its rows are wide enough that the budget below stops it
-	// after one — so it, not the width, decides where each window ends.
+	// One document per container, so a row is expensive next to the thin ones.
 	active := newTestMemtableRoaringSet(nil)
 	wide := make([]uint64, 4096)
 	for i := range wide {
-		wide[i] = uint64(i)
+		wide[i] = uint64(i) * 65536
 	}
 	for _, n := range names {
 		require.NoError(t, active.roaringSetAddList([]byte(n), wide))
@@ -1208,11 +1295,78 @@ func TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked(t *testing.T) {
 	oneRow := make([]roaringset.BitmapLayer, 1)
 	first, err := active.roaringSetGetWindow(keys, 0, 1, oneRow, math.MaxInt)
 	require.NoError(t, err)
+	// The pricing read above went through the same recorder a reader's reads do,
+	// so a test walking ranges would find it before the reader's first one.
+	active.ranges = nil
 
 	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
-	view := BucketConsistentView{Active: active, Flushing: flushing, Bucket: b}
+	return BucketConsistentView{Active: active, Flushing: flushing, Bucket: b}, keys, first.Bytes + 1, b
+}
 
-	r, err := newRoaringSetBatchReader(view, keys, window, first.Bytes+1)
+// requireWindowInvariants asserts that a slot's rows and the indices
+// describing them still agree. Holding them in one struct makes a slot one
+// value; it does not make the three fields consistent, and fillWindow settles
+// filled in one pass and recomputes carried in a second, so nothing but this
+// says they ended up in step.
+func requireWindowInvariants(t *testing.T, r *RoaringSetBatchReader) {
+	t.Helper()
+	for mt := 0; mt < r.mtCount; mt++ {
+		w := r.windows[mt]
+		require.GreaterOrEqualf(t, w.filled, r.winStart,
+			"memtable %d holds rows from before the window they are laid out against", mt)
+		require.GreaterOrEqualf(t, len(w.layer), r.winEnd-r.winStart,
+			"memtable %d has no slot for every key of the window", mt)
+
+		carried := 0
+		for i := r.winEnd; i < w.filled; i++ {
+			carried += w.layer[i-r.winStart].LenInBytes()
+		}
+		require.Equalf(t, carried, w.carried,
+			"memtable %d is charged for something other than the rows it kept past the window", mt)
+
+		for at := w.filled - r.winStart; at < len(w.layer); at++ {
+			require.Nilf(t, w.layer[at].Additions,
+				"memtable %d holds additions in slot %d, past what it filled", mt, at)
+			require.Nilf(t, w.layer[at].Deletions,
+				"memtable %d holds deletions in slot %d, past what it filled", mt, at)
+		}
+	}
+}
+
+// requireNoClonesHeld asserts the reader holds no bitmap anywhere in its
+// buffers, over the whole capacity rather than the current window: a row left
+// past winEnd is what a missed clear looks like.
+func requireNoClonesHeld(t *testing.T, r *RoaringSetBatchReader) {
+	t.Helper()
+	for mt := range r.mtCount {
+		for at, layer := range r.windows[mt].layer[:cap(r.windows[mt].layer)] {
+			require.Nilf(t, layer.Additions, "memtable %d still holds additions in slot %d", mt, at)
+			require.Nilf(t, layer.Deletions, "memtable %d still holds deletions in slot %d", mt, at)
+		}
+	}
+}
+
+// TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked pins that a reader with two
+// memtables ends a batch holding none of their rows. The fat memtable's share
+// stops it after the key it always takes, so every window here is one key wide
+// while the buffer stays at the width the first one opened at; a fill that
+// cleared only the window's own width would leave that tail behind for the
+// reader's whole lifetime.
+//
+// Only the thin memtable can hold such a tail: the fat one is what narrows the
+// window, so its filled index never runs past winEnd. The check's other half
+// therefore passes by construction on this fixture.
+func TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked(t *testing.T) {
+	t.Parallel()
+
+	const (
+		nKeys  = 10
+		window = 8
+	)
+
+	view, keys, budget, b := narrowingFixture(t, nKeys)
+
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, window, budget)
 	require.NoError(t, err)
 
 	for i := range nKeys {
@@ -1225,31 +1379,22 @@ func TestBatchReaderKeepsNoClonesOnceTheBatchIsWalked(t *testing.T) {
 		release()
 	}
 
-	for mt := range r.mtCount {
-		buf := r.layers[mt][:cap(r.layers[mt])]
-		for at, layer := range buf {
-			require.Nil(t, layer.Additions,
-				"memtable %d still holds additions cloned into slot %d", mt, at)
-			require.Nil(t, layer.Deletions,
-				"memtable %d still holds deletions cloned into slot %d", mt, at)
-		}
-	}
+	requireNoClonesHeld(t, r)
 
-	// And the rows are right, which is the direction the batched parity table does
-	// not reach: there the memtable read first is the one whose budget settles the
-	// window, and here it is the one read second. What each is asked for depends on
-	// the other, so both orders have to answer as the per-key path does.
-	fresh, err := newRoaringSetBatchReader(view, keys, window, first.Bytes+1)
+	// And the rows are right, which is the direction the batched parity table
+	// does not reach: there the memtable read first is the one whose budget
+	// settles the window, and here it is the one read second. What each is asked
+	// for depends on the other, so both orders have to answer as the per-key
+	// path does.
+	fresh, err := newRoaringSetBatchReaderWithBounds(view, keys, window, budget)
 	require.NoError(t, err)
 	requireMatchesPerKey(t, b, view, fresh, keys, "the second memtable narrowing")
 }
 
-// TestBatchReaderEndsWindowsOnEitherLimit covers a batch whose windows do not all
-// end the same way. A window ends at the key count or at the byte budget,
-// whichever it reaches first, and which one that is follows the rows: thin ones
-// run to the count, fat ones spend the budget first. Every other budget case here
-// meets one limit throughout, so a reader that had quietly stopped honouring the
-// other would still pass them.
+// TestBatchReaderEndsWindowsOnEitherLimit covers a batch whose windows don't
+// all end the same way: thin rows run to the key count, fat rows spend the
+// byte budget first. Every other budget case here meets one limit throughout,
+// so a reader that quietly stopped honouring the other would still pass them.
 func TestBatchReaderEndsWindowsOnEitherLimit(t *testing.T) {
 	t.Parallel()
 
@@ -1281,8 +1426,8 @@ func TestBatchReaderEndsWindowsOnEitherLimit(t *testing.T) {
 	view := BucketConsistentView{Active: active, Disk: []Segment{diskSeg}, Bucket: b}
 	keys := sortedKeysOf(t, batch)
 
-	// Room for two of the fat rows, so a window of four keys reaches the count
-	// among the thin ones and the budget among the fat ones.
+	// Room for two fat rows, so a window of four reaches the count among the
+	// thin ones and the budget among the fat ones.
 	oneFat := func() int {
 		single := sortedKeysOf(t, []string{fmt.Sprintf("k%02d", thinKeys)})
 		dst := make([]roaringset.BitmapLayer, 1)
@@ -1292,7 +1437,7 @@ func TestBatchReaderEndsWindowsOnEitherLimit(t *testing.T) {
 		return fill.Bytes
 	}()
 
-	r, err := newRoaringSetBatchReader(view, keys, window, 2*oneFat+1)
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, window, 2*oneFat+1)
 	require.NoError(t, err)
 
 	widths := map[int]bool{}
@@ -1314,29 +1459,26 @@ func TestBatchReaderEndsWindowsOnEitherLimit(t *testing.T) {
 	require.True(t, narrowed,
 		"the fat rows must end a window before the key count, got widths %v", widths)
 
-	// And the stats say which limit did it, which is the whole reason an operator
-	// can tell "this batch was large" from "raise the byte budget".
+	// The stats must say which limit did it, so an operator can tell "this
+	// batch was large" from "raise the byte budget".
 	st := r.Stats()
 	require.Positive(t, st.NarrowedFills, "the budget ended some windows")
 	require.Less(t, st.NarrowedFills, st.Fills, "and the key count ended others")
-	require.Equal(t, keys.Len(), st.KeysRead)
-	// The peak is one window; the total is every window. Fat rows read across
-	// several windows separate the two, which a running total alone would hide.
+	require.Equal(t, keys.Len(), st.KeysServed)
+	// Peak is one window; total is every window — a batch spanning several
+	// windows must separate the two.
 	require.Positive(t, st.BytesPeak)
 	require.Greater(t, st.BytesCopied, st.BytesPeak,
 		"a batch spanning several windows must copy more than the widest of them held")
 
-	// And the rows are right either way, which is the point of ending early.
-	r2, err := newRoaringSetBatchReader(view, keys, window, 2*oneFat+1)
+	r2, err := newRoaringSetBatchReaderWithBounds(view, keys, window, 2*oneFat+1)
 	require.NoError(t, err)
 	requireMatchesPerKey(t, b, view, r2, keys, "")
 }
 
-// TestBatchReaderHoldsOneBudgetAcrossMemtables pins that the byte budget bounds
-// what a reader holds rather than what each of its memtables holds. Handing both
-// the whole budget would double the peak whenever a flush is in flight — a
-// condition the caller neither chooses nor observes — and nothing else here would
-// notice, since every other budget case builds a single-memtable view.
+// TestBatchReaderHoldsOneBudgetAcrossMemtables pins that the byte budget
+// bounds what a reader holds, not what each of its memtables holds — handing
+// each the whole budget would double the peak whenever a flush is in flight.
 func TestBatchReaderHoldsOneBudgetAcrossMemtables(t *testing.T) {
 	t.Parallel()
 
@@ -1348,9 +1490,8 @@ func TestBatchReaderHoldsOneBudgetAcrossMemtables(t *testing.T) {
 	}
 	keys := sortedKeysOf(t, names)
 
-	// One document per container, which is the shape the budget exists for: the
-	// rows are wide enough that a window of them reaches the budget well before it
-	// reaches the key count.
+	// One document per container, so a window reaches the budget well before
+	// it reaches the key count.
 	spread := func(seed uint64) []uint64 {
 		docs := make([]uint64, 200)
 		for i := range docs {
@@ -1370,7 +1511,7 @@ func TestBatchReaderHoldsOneBudgetAcrossMemtables(t *testing.T) {
 	const budget = 4 << 20
 
 	peakOf := func(t *testing.T, view BucketConsistentView) RoaringSetBatchReaderStats {
-		r, err := newRoaringSetBatchReader(view, keys, memtableWindowKeys, budget)
+		r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, budget)
 		require.NoError(t, err)
 		_, release, err := r.Next(concurrency.SROAR_MERGE)
 		require.NoError(t, err)
@@ -1378,15 +1519,389 @@ func TestBatchReaderHoldsOneBudgetAcrossMemtables(t *testing.T) {
 		return r.Stats()
 	}
 
+	twoActive, twoFlushing := build(1), build(500)
 	one := peakOf(t, BucketConsistentView{Active: build(1), Bucket: b})
-	two := peakOf(t, BucketConsistentView{Active: build(1), Flushing: build(500), Bucket: b})
+	two := peakOf(t, BucketConsistentView{Active: twoActive, Flushing: twoFlushing, Bucket: b})
 
 	require.Equal(t, 1, one.Memtables)
 	require.Equal(t, 2, two.Memtables)
 	require.Positive(t, one.BytesPeak, "the fixture must reach the budget, or this proves nothing")
 
-	require.LessOrEqual(t, two.BytesPeak, budget+one.BytesPeak/one.KeysRead,
+	// A window's first key is taken whatever it costs, so the budget may be
+	// exceeded by the widest row each memtable holds — an average row would be
+	// a tighter bound than the reader promises.
+	widestRow := func(m *testMemtable) int {
+		widest := 0
+		dst := make([]roaringset.BitmapLayer, 1)
+		for i := 0; i < keys.Len(); i++ {
+			fill, err := m.roaringSetGetWindow(keys, i, i+1, dst, math.MaxInt)
+			require.NoError(t, err)
+			widest = max(widest, fill.Bytes)
+		}
+		return widest
+	}
+	require.LessOrEqual(t, two.BytesPeak, budget+widestRow(twoActive)+widestRow(twoFlushing),
 		"two memtables must hold one budget between them, not one each")
 	require.LessOrEqual(t, two.BytesPeak, one.BytesPeak*3/2,
 		"a flush in flight must not roughly double what a window holds")
+}
+
+// TestBatchReaderKeepsRowsNarrowedPast covers a memtable read before the one
+// that narrows the window: it read to the wide end, and what it holds past the
+// narrowed end is kept rather than dropped, so the next fill asks it only for
+// what it does not already have.
+//
+// Both halves are asserted. The ranges pin that no key is read twice, which is
+// the whole point — without it the reader is correct but re-clones the tail
+// every fill. The values pin that a kept row is served at the key it belongs
+// to: the buffer is re-based on each fill, and an offset slip there would serve
+// a neighbour's row with nothing else noticing.
+func TestBatchReaderKeepsRowsNarrowedPast(t *testing.T) {
+	t.Parallel()
+
+	const nKeys = 12
+
+	view, keys, budget, _ := narrowingFixture(t, nKeys)
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, 8, budget)
+	require.NoError(t, err)
+
+	// The thin memtable, which the fold reads first and so is the one that reads
+	// past a window a later memtable narrows.
+	counted := view.Flushing.(*testMemtable)
+
+	for i := 0; i < nKeys; i++ {
+		bm, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		require.Truef(t, bm.Contains(uint64(100+i)),
+			"key %d must be served the row the kept buffer holds for it", i)
+		release()
+	}
+
+	require.Greater(t, len(counted.ranges), 1, "the batch must span windows, or this proves nothing")
+	at := 0
+	for _, rng := range counted.ranges {
+		require.Equalf(t, at, rng[0], "read %v starts before the last one ended: a kept row was re-read", rng)
+		at = rng[1]
+	}
+	require.Equal(t, nKeys, at, "every key must be read exactly once")
+}
+
+// TestBatchReaderBytesPeakTracksWhatAWindowHolds walks a batch fill by fill and
+// compares BytesPeak against the peak the walk computes itself. A bound checked
+// only at the end is satisfied by a peak that is too small, which is what makes
+// the per-fill comparison the assertion that matters.
+//
+// The two fixtures answer different questions and neither answers both. With
+// rows of one size a memtable that carried n bytes copies n fewer, so every
+// fill holds the same amount and the peak has to stay inside the budget — but
+// the first fill carries nothing and already copied that whole amount, so
+// dropping the carry term reports the same number and nothing can tell. Rows
+// growing along the batch make a later window hold more than any single fill
+// copied, which is what exposes the term.
+func TestBatchReaderBytesPeakTracksWhatAWindowHolds(t *testing.T) {
+	t.Parallel()
+
+	const nKeys = 24
+
+	tests := []struct {
+		name string
+		// activeDocs is the active memtable's row width at key i. The flushing
+		// memtable is thin and uniform either way, so it fills whatever width it
+		// is asked for and carries what the active one narrows away.
+		activeDocs   func(i int) int
+		flushingDocs int
+		// budgetRows is the byte budget in whole first-active-rows. Several fit,
+		// so the "first key is taken whatever it costs" allowance is not in play
+		// and no row is ever oversized.
+		budgetRows int
+		check      func(t *testing.T, st RoaringSetBatchReaderStats, wantPeak, widestCopy, budget int)
+	}{
+		{
+			// Fat enough that a whole window of them costs more than one share,
+			// so the share rather than the key count is what stops a read. With
+			// the width binding instead, a read would be capped before the budget
+			// was consulted and this would pin nothing.
+			name:         "rows of one size hold the budget and no more",
+			activeDocs:   func(int) int { return 1024 },
+			flushingDocs: 614,
+			budgetRows:   5,
+			check: func(t *testing.T, st RoaringSetBatchReaderStats, wantPeak, widestCopy, budget int) {
+				require.Greater(t, st.Fills, 1, "the batch must span windows, or nothing is ever carried")
+				require.LessOrEqual(t, st.BytesPeak, budget,
+					"a window that carried rows in must hold the budget, not the budget plus what it carried")
+			},
+		},
+		{
+			name:         "rows growing along the batch expose the carry term",
+			activeDocs:   func(i int) int { return 64 + i*64 },
+			flushingDocs: 16,
+			budgetRows:   6,
+			check: func(t *testing.T, st RoaringSetBatchReaderStats, wantPeak, widestCopy, budget int) {
+				require.Greater(t, wantPeak, widestCopy,
+					"the fixture must hold more in some window than any one fill copied, or dropping the carry term reports the same peak")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			names := make([]string, nKeys)
+			for i := range names {
+				names[i] = fmt.Sprintf("k%03d", i)
+			}
+			keys := sortedKeysOf(t, names)
+
+			// One document per container, so a row costs roughly its count.
+			docs := func(n int) []uint64 {
+				out := make([]uint64, n)
+				for i := range out {
+					out[i] = uint64(i) * 65536
+				}
+				return out
+			}
+
+			flushing := newTestMemtableRoaringSet(nil)
+			for _, n := range names {
+				require.NoError(t, flushing.roaringSetAddList([]byte(n), docs(tc.flushingDocs)))
+			}
+			active := newTestMemtableRoaringSet(nil)
+			for i, n := range names {
+				require.NoError(t, active.roaringSetAddList([]byte(n), docs(tc.activeDocs(i))))
+			}
+
+			oneRow := make([]roaringset.BitmapLayer, 1)
+			first, err := active.roaringSetGetWindow(keys, 0, 1, oneRow, math.MaxInt)
+			require.NoError(t, err)
+
+			b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+			view := BucketConsistentView{Active: active, Flushing: flushing, Bucket: b}
+
+			budget := tc.budgetRows * first.Bytes
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, 8, budget)
+			require.NoError(t, err)
+
+			wantPeak, widestCopy, carryingFills := 0, 0, 0
+			for i := 0; i < nKeys; i++ {
+				carriedIn := r.windows[0].carried + r.windows[1].carried
+				copiedBefore, fillsBefore := r.bytesCopied, r.fills
+
+				_, release, err := r.Next(concurrency.SROAR_MERGE)
+				require.NoError(t, err)
+				release()
+
+				if r.fills == fillsBefore {
+					continue
+				}
+				copied := r.bytesCopied - copiedBefore
+				if carriedIn > 0 {
+					carryingFills++
+				}
+				widestCopy = max(widestCopy, copied)
+				wantPeak = max(wantPeak, carriedIn+copied)
+				require.Equal(t, wantPeak, r.bytesPeak, "peak after the fill that served key %d", i)
+				requireWindowInvariants(t, r)
+			}
+
+			require.Positive(t, carryingFills,
+				"the fixture must carry rows into a fill, or nothing here tracks the peak across one")
+			require.Equal(t, wantPeak, r.Stats().BytesPeak)
+			tc.check(t, r.Stats(), wantPeak, widestCopy, budget)
+		})
+	}
+}
+
+// TestBatchReaderNarrowsAtTheProductionByteBudget runs the exported
+// constructor, so the window is bounded by memtableWindowKeys and
+// readerWindowBytes rather than by numbers a test picked. Every other budget
+// assertion passes a hand-computed budget small enough to reason about, so
+// nothing asserted what the shipped one does.
+//
+// The two bounds are absolute on purpose. A budget derived from the constant
+// would move with it and pass whatever it was set to; these fail if it is
+// scaled far enough in either direction — too large and no window is ever cut
+// short, too small and a window cannot hold what it is asserted to hold.
+func TestBatchReaderNarrowsAtTheProductionByteBudget(t *testing.T) {
+	t.Parallel()
+
+	// One document per container, so a row costs roughly its container count
+	// and a window's worth of them runs past the shipped budget.
+	const (
+		nKeys       = 80
+		docsPerRow  = 1024
+		peakAtLeast = 4 << 20
+		minFills    = 2 // the fixture must take more than one window
+	)
+
+	names := make([]string, nKeys)
+	for i := range names {
+		names[i] = fmt.Sprintf("k%03d", i)
+	}
+	keys := sortedKeysOf(t, names)
+
+	wide := make([]uint64, docsPerRow)
+	for i := range wide {
+		wide[i] = uint64(i) * 65536
+	}
+	active := newTestMemtableRoaringSet(nil)
+	for _, n := range names {
+		require.NoError(t, active.roaringSetAddList([]byte(n), wide))
+	}
+
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	view := BucketConsistentView{Active: active, Bucket: b}
+
+	r, err := NewRoaringSetBatchReader(view, keys)
+	require.NoError(t, err)
+	require.Less(t, nKeys, memtableWindowKeys,
+		"the key count must not be what ends a window, or the byte budget is never consulted")
+
+	for range names {
+		_, release, err := r.Next(concurrency.SROAR_MERGE)
+		require.NoError(t, err)
+		release()
+	}
+
+	st := r.Stats()
+	require.GreaterOrEqual(t, st.Fills, minFills,
+		"the shipped byte budget must cut a window short of memtableWindowKeys")
+	require.Equal(t, st.Fills-1, st.NarrowedFills,
+		"every window but the last ends on the budget; the last ends because the batch does")
+	require.Greater(t, st.BytesPeak, peakAtLeast,
+		"a window at the shipped budget holds megabytes; a budget scaled down by orders of magnitude could not")
+}
+
+// TestBatchReaderSkipsAMemtableItHasReadToTheEnd pins that a fill does not
+// always read every memtable, which is why MemtableReads is counted rather
+// than derived from Fills times Memtables.
+//
+// This covers one of the two ways a fill skips a memtable: a window can never
+// be wider than the batch, so one that already reached the last key has nothing
+// left to be asked for. The other is
+// [TestBatchReaderSkipsAMemtableHoldingMoreThanItsShare].
+func TestBatchReaderSkipsAMemtableItHasReadToTheEnd(t *testing.T) {
+	t.Parallel()
+
+	const nKeys = 5
+	names := make([]string, nKeys)
+	for i := range names {
+		names[i] = fmt.Sprintf("k%02d", i)
+	}
+	keys := sortedKeysOf(t, names)
+
+	// Cheap rows, so one read covers the whole batch within its share.
+	thin := map[string][]uint64{}
+	// Fat enough that its share stops it after the always-taken first key.
+	fatRow := make([]uint64, 4096)
+	for i := range fatRow {
+		fatRow[i] = uint64(i) * 64
+	}
+	fat := map[string][]uint64{}
+	for i, n := range names {
+		thin[n] = []uint64{uint64(i)}
+		fat[n] = fatRow
+	}
+	flushing, active := newTestMemtableRoaringSet(thin), newTestMemtableRoaringSet(fat)
+
+	priceOne := func(mt *testMemtable) int {
+		dst := make([]roaringset.BitmapLayer, 1)
+		fill, err := mt.roaringSetGetWindow(keys, 0, 1, dst, math.MaxInt)
+		require.NoError(t, err)
+		return fill.Bytes
+	}
+	share := priceOne(active) - 1
+	require.Greater(t, share, nKeys*priceOne(flushing),
+		"the thin memtable must fit the whole batch in one share, or it never reaches the end")
+
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	view := BucketConsistentView{Active: active, Flushing: flushing, Bucket: b}
+
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, nKeys+3, 2*share)
+	require.NoError(t, err)
+	requireMatchesPerKey(t, b, view, r, keys, "a memtable read to the end of the batch")
+
+	st := r.Stats()
+	require.Less(t, st.MemtableReads, st.Fills*st.Memtables,
+		"a memtable already at the last key is skipped, so the product overcounts")
+	require.Positive(t, st.MemtableReads)
+}
+
+// TestBatchReaderSkipsAMemtableHoldingMoreThanItsShare covers the second way a
+// fill skips a memtable: what it kept from an earlier window already costs more
+// than its whole share.
+//
+// The read schedule is asserted whole rather than counted — the gap where no
+// read starts is the skip itself.
+func TestBatchReaderSkipsAMemtableHoldingMoreThanItsShare(t *testing.T) {
+	t.Parallel()
+
+	const nKeys = 8
+	names := make([]string, nKeys)
+	for i := range names {
+		names[i] = fmt.Sprintf("k%02d", i)
+	}
+	keys := sortedKeysOf(t, names)
+
+	// One document per container, so a row costs orders of magnitude more.
+	wide := make([]uint64, 4096)
+	for i := range wide {
+		wide[i] = uint64(i) * 65536
+	}
+
+	// Read first, so it fills a whole window and then has it narrowed under
+	// itself. Its wide row is what it ends up carrying.
+	const wideAt = 2
+	thin := newTestMemtableRoaringSet(nil)
+	for i, n := range names {
+		row := []uint64{uint64(100 + i)}
+		if i == wideAt {
+			row = wide
+		}
+		require.NoError(t, thin.roaringSetAddList([]byte(n), row))
+	}
+
+	// Read second, and every row too wide for its share, so it narrows every
+	// window to the one key it always takes.
+	fat := newTestMemtableRoaringSet(nil)
+	for _, n := range names {
+		require.NoError(t, fat.roaringSetAddList([]byte(n), wide))
+	}
+
+	priceOne := func(m *testMemtable, at int) int {
+		dst := make([]roaringset.BitmapLayer, 1)
+		fill, err := m.roaringSetGetWindow(keys, at, at+1, dst, math.MaxInt)
+		require.NoError(t, err)
+		return fill.Bytes
+	}
+	thinRow, wideRow := priceOne(thin, 0), priceOne(thin, wideAt)
+	// The pricing reads went through the same recorder the reader's do.
+	thin.ranges, fat.ranges = nil, nil
+
+	// Four thin rows per memtable, so the thin one fills several keys per read
+	// and the wide row is far outside what any share can hold.
+	budget := 8 * thinRow
+	share := budget / 2
+	require.Greater(t, wideRow, share,
+		"the carried row must cost more than a whole share, or no fill ever skips for want of budget")
+
+	b := &Bucket{strategy: StrategyRoaringSet, disk: &SegmentGroup{}, logger: nullLogger()}
+	view := BucketConsistentView{Active: fat, Flushing: thin, Bucket: b}
+
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, nKeys, budget)
+	require.NoError(t, err)
+	requireMatchesPerKey(t, b, view, r, keys, "a memtable holding more than its share")
+
+	// No read starts at key 3: the fill before it took the wide row at key 2,
+	// the window narrowed to key 2 alone, and the thin memtable entered the
+	// next fill carrying the whole row. Without the guard it reads [3,4) there.
+	require.Equal(t, [][2]int{{0, 2}, {2, 3}, {3, 7}, {7, 8}}, thin.ranges,
+		"no read may start at key 3 while the thin memtable is over its share")
+
+	st := r.Stats()
+	require.Equal(t, nKeys, st.Fills, "the fat memtable narrows every window to one key")
+	require.Equal(t, len(thin.ranges)+len(fat.ranges), st.MemtableReads,
+		"every read a memtable served must be one the reader counted")
+	require.Less(t, st.MemtableReads, st.Fills*st.Memtables,
+		"a skipped memtable is what makes the product an overcount")
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -77,8 +77,13 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())
 }
 
-// TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins a
-// disk-buffer leak on flushing/active read errors after acquisition.
+// TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins that
+// a failing memtable read cannot leak the disk row's pooled buffer.
+//
+// The memtables are read first, so a failure there returns before the buffer is
+// acquired at all. The assertions are therefore that the disk row was never
+// read, which is stronger than that it was read and released, and does not
+// depend on every error path remembering a defer.
 func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *testing.T) {
 	t.Parallel()
 
@@ -90,7 +95,7 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		})
 	}
 
-	t.Run("active read error frees disk layer via defer, returns caller-safe noop", func(t *testing.T) {
+	t.Run("active read error leaves the disk row unread, returns caller-safe noop", func(t *testing.T) {
 		diskSeg := newDiskSeg()
 		active := newTestMemtableRoaringSet(nil)
 		active.roaringSetGetErr = readErr
@@ -107,15 +112,17 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		require.Nil(t, bm)
 		require.NotNil(t, release)
 
-		require.Equal(t, 1, diskSeg.roaringSetReleases,
-			"disk layer's release must fire when the active read errors")
+		require.Equal(t, 0, diskSeg.getCounter,
+			"the disk row must not be read once the active read has failed")
+		require.Equal(t, 0, diskSeg.roaringSetReleases,
+			"nothing was acquired, so nothing needs releasing")
 
 		release()
-		require.Equal(t, 1, diskSeg.roaringSetReleases,
-			"returned release must be a noop; buffer already freed by defer")
+		require.Equal(t, 0, diskSeg.roaringSetReleases,
+			"returned release must be a noop")
 	})
 
-	t.Run("flushing read error frees disk layer via defer", func(t *testing.T) {
+	t.Run("flushing read error leaves the disk row unread", func(t *testing.T) {
 		diskSeg := newDiskSeg()
 		flushing := newTestMemtableRoaringSet(nil)
 		flushing.roaringSetGetErr = readErr
@@ -131,11 +138,13 @@ func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *test
 		bm, release, err := b.roaringSetGetFromConsistentView(view, []byte("key1"), concurrency.SROAR_MERGE)
 		require.ErrorIs(t, err, readErr)
 		require.Nil(t, bm)
-		require.Equal(t, 1, diskSeg.roaringSetReleases,
-			"disk layer's release must fire when the flushing read errors")
+		require.Equal(t, 0, diskSeg.getCounter,
+			"the disk row must not be read once the flushing read has failed")
+		require.Equal(t, 0, diskSeg.roaringSetReleases,
+			"nothing was acquired, so nothing needs releasing")
 
 		release()
-		require.Equal(t, 1, diskSeg.roaringSetReleases)
+		require.Equal(t, 0, diskSeg.roaringSetReleases)
 	})
 
 	t.Run("success path defers nothing, caller owns the release", func(t *testing.T) {
@@ -246,13 +255,13 @@ func TestBucket_RoaringSetGet_RespectsConcurrencyBudget(t *testing.T) {
 	})
 }
 
-// TestBucket_RoaringSetBatchReader_MatchesRoaringSetGet proves the batched-read
+// TestBatchReaderMatchesRoaringSetGet proves the batched-read
 // primitive returns byte-identical results to the per-key RoaringSetGet entry
 // point, whether the key is present across several on-disk segments plus the
 // active memtable, or absent entirely, and that one reader serves every read.
 // The active memtable holds unflushed data when the reader is built, so the
 // batch reads it too and parity is exact.
-func TestBucket_RoaringSetBatchReader_MatchesRoaringSetGet(t *testing.T) {
+func TestBatchReaderMatchesRoaringSetGet(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 	tmpDir := t.TempDir()
@@ -299,39 +308,32 @@ func TestBucket_RoaringSetBatchReader_MatchesRoaringSetGet(t *testing.T) {
 	require.Empty(t, arrWantMissing, "absent key must resolve to an empty, non-nil bitmap")
 
 	// one reader serves all three reads below
-	reader, err := b.NewRoaringSetBatchReader()
+	// one reader serves the whole batch, in the order it sorts into
+	keys := sortedKeysOf(t, []string{string(keyA), string(keyB), string(keyMissing)})
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+	reader, err := NewRoaringSetBatchReader(view, keys)
 	require.NoError(t, err)
-	defer reader.Release()
 
-	gotA, releaseA, err := reader.Get(keyA, concurrency.SROAR_MERGE)
-	require.NoError(t, err)
-	require.Equal(t, arrWantA, gotA.ToArray())
-	releaseA()
-
-	gotB, releaseB, err := reader.Get(keyB, concurrency.SROAR_MERGE)
-	require.NoError(t, err)
-	require.Equal(t, arrWantB, gotB.ToArray())
-	releaseB()
-
-	gotMissing, releaseMissing, err := reader.Get(keyMissing, concurrency.SROAR_MERGE)
-	require.NoError(t, err)
-	require.NotNil(t, gotMissing)
-	require.Empty(t, gotMissing.ToArray())
-	releaseMissing()
+	requireRowsAre(t, reader, keys, map[string][]uint64{
+		string(keyA):       arrWantA,
+		string(keyB):       arrWantB,
+		string(keyMissing): nil,
+	})
 }
 
-// TestBucket_RoaringSetBatchReader_SurvivesFlushAndSwitch pins the view
-// stability that justifies holding one view for a whole batch: reads through a
-// reader built before a FlushAndSwitch must keep resolving without error (the
-// flushed-away memtable stays readable through the held reference) and keep
-// returning the pre-switch state — writes landing in the new active memtable
-// must stay invisible. A fresh RoaringSetGet sees the post-switch write,
-// proving the view pinned state rather than the two paths coincidentally
+// TestBatchReaderSurvivesFlushAndSwitch pins the view
+// stability that justifies holding one view for a whole batch: a flush landing
+// mid-fold must not disturb the keys still to be read. The second key's window
+// is filled after the switch, through a memtable the bucket has already moved
+// past, and must still answer as it did before — writes landing in the new
+// active memtable stay invisible. A fresh RoaringSetGet sees the post-switch
+// write, proving the view pinned state rather than the two paths coincidentally
 // agreeing.
 // (A view is not a write snapshot: writes before the switch go to the old
 // active memtable the view references, so only post-switch invisibility is
 // asserted.)
-func TestBucket_RoaringSetBatchReader_SurvivesFlushAndSwitch(t *testing.T) {
+func TestBatchReaderSurvivesFlushAndSwitch(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
 
@@ -344,19 +346,28 @@ func TestBucket_RoaringSetBatchReader_SurvivesFlushAndSwitch(t *testing.T) {
 
 	b.SetMemtableThreshold(1e9) // flush only via the explicit switch below
 
-	key := []byte("key")
+	first, second := []byte("key1"), []byte("key2")
 
 	// one disk segment plus unflushed state in the active memtable, so the
 	// view references both layer kinds when taken
-	require.NoError(t, b.RoaringSetAddList(key, []uint64{1, 2, 3}))
+	for _, k := range [][]byte{first, second} {
+		require.NoError(t, b.RoaringSetAddList(k, []uint64{1, 2, 3}))
+	}
 	require.NoError(t, b.FlushAndSwitch())
-	require.NoError(t, b.RoaringSetAddList(key, []uint64{4}))
+	for _, k := range [][]byte{first, second} {
+		require.NoError(t, b.RoaringSetAddList(k, []uint64{4}))
+	}
 
-	reader, err := b.NewRoaringSetBatchReader()
+	keys := sortedKeysOf(t, []string{string(first), string(second)})
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+	// One key per window, so the second key's window is filled after the switch
+	// below rather than before it — which is the ordering a long fold meets and
+	// the only one that reads a memtable the bucket has already moved past.
+	reader, err := newRoaringSetBatchReader(view, keys, 1)
 	require.NoError(t, err)
-	defer reader.Release()
 
-	before, releaseBefore, err := reader.Get(key, concurrency.SROAR_MERGE)
+	before, releaseBefore, err := reader.Next(concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	arrBefore := append([]uint64(nil), before.ToArray()...)
 	releaseBefore()
@@ -364,15 +375,15 @@ func TestBucket_RoaringSetBatchReader_SurvivesFlushAndSwitch(t *testing.T) {
 
 	// flush the memtable the view references, then write past the view
 	require.NoError(t, b.FlushAndSwitch())
-	require.NoError(t, b.RoaringSetAddList(key, []uint64{5}))
+	require.NoError(t, b.RoaringSetAddList(second, []uint64{5}))
 
-	after, releaseAfter, err := reader.Get(key, concurrency.SROAR_MERGE)
+	after, releaseAfter, err := reader.Next(concurrency.SROAR_MERGE)
 	require.NoError(t, err)
 	require.Equal(t, arrBefore, after.ToArray(),
-		"view read must keep returning the pre-switch state")
+		"a window filled after the switch must still read the pre-switch state")
 	releaseAfter()
 
-	fresh, releaseFresh, err := b.RoaringSetGet(ctx, key)
+	fresh, releaseFresh, err := b.RoaringSetGet(ctx, second)
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1, 2, 3, 4, 5}, fresh.ToArray(),
 		"a fresh read must see the post-switch write the view cannot")
@@ -570,41 +581,25 @@ func requireRoaringSetElements(t *testing.T, ctx context.Context, b *Bucket, key
 	require.ElementsMatch(t, want, bm.ToArray())
 }
 
-// TestRoaringSetBatchReader pins the batch reader's contract: it validates the
+// TestBatchReaderValidatesAndFoldsLikeThePerKeyPath pins the batch reader's contract: it validates the
 // strategy once, and it folds exactly the layers a per-key read would — except
 // that an active memtable empty at view time is skipped for the whole batch,
 // the behavior the reader exists for.
-func TestRoaringSetBatchReader(t *testing.T) {
+func TestBatchReaderValidatesAndFoldsLikeThePerKeyPath(t *testing.T) {
 	t.Parallel()
 
-	t.Run("wrong strategy errors before taking a view", func(t *testing.T) {
-		b := Bucket{strategy: StrategyReplace, logger: nullLogger()}
-		reader, err := b.NewRoaringSetBatchReader()
+	t.Run("wrong strategy is refused", func(t *testing.T) {
+		b := Bucket{
+			strategy: StrategyReplace,
+			disk:     &SegmentGroup{},
+			logger:   nullLogger(),
+		}
+		view := b.GetConsistentView()
+		defer view.ReleaseView()
+
+		reader, err := NewRoaringSetBatchReader(view, sortedKeysOf(t, []string{"k"}))
 		require.Error(t, err)
 		require.Nil(t, reader)
-	})
-
-	// A bucket with no active memtable at all is distinct from one whose active
-	// memtable is empty, and the read path accepts it — so the constructor must
-	// too. It takes the view before inspecting the memtable, and no caller holds
-	// the reader yet, so a panic there leaves the segment refs held for good and
-	// Shutdown waits on them forever.
-	t.Run("no active memtable reads disk only", func(t *testing.T) {
-		b := Bucket{
-			strategy: StrategyRoaringSet,
-			disk: &SegmentGroup{segments: []Segment{newFakeRoaringSetSegment(
-				map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})}},
-			logger: nullLogger(),
-		}
-
-		reader, err := b.NewRoaringSetBatchReader()
-		require.NoError(t, err)
-		defer reader.Release()
-
-		bm, release, err := reader.Get([]byte("k"), 1)
-		require.NoError(t, err)
-		defer release()
-		require.Equal(t, []uint64{1, 2}, bm.ToArray())
 	})
 
 	// The eight presence combinations of the three layers — a new case belongs
@@ -678,16 +673,22 @@ func TestRoaringSetBatchReader(t *testing.T) {
 				b.flushing = newTestMemtableRoaringSet(map[string][]uint64{"k": tc.flushing})
 			}
 			if tc.flushingDeletes != nil {
+				// Written through roaringSetRemoveList rather than straight into
+				// the tree, so the memtable's size reflects what it holds. The
+				// reader skips a memtable reporting size 0, and inserting behind
+				// its accounting builds a memtable that holds a row and reports
+				// none — a state no write path produces.
 				mt := newTestMemtableRoaringSet(nil)
-				mt.roaringSet.Insert([]byte("k"), roaringset.Insert{Deletions: tc.flushingDeletes})
+				require.NoError(t, mt.roaringSetRemoveList([]byte("k"), tc.flushingDeletes))
 				b.flushing = mt
 			}
 
-			reader, err := b.NewRoaringSetBatchReader()
+			view := b.GetConsistentView()
+			defer view.ReleaseView()
+			reader, err := NewRoaringSetBatchReader(view, sortedKeysOf(t, []string{"k"}))
 			require.NoError(t, err)
-			defer reader.Release()
 
-			bm, release, err := reader.Get([]byte("k"), concurrency.SROAR_MERGE)
+			bm, release, err := reader.Next(concurrency.SROAR_MERGE)
 			require.NoError(t, err)
 			defer release()
 			require.Equal(t, tc.want, bm.ToArray())
@@ -703,16 +704,17 @@ func TestRoaringSetBatchReader(t *testing.T) {
 			logger: nullLogger(),
 		}
 
-		reader, err := b.NewRoaringSetBatchReader()
+		view := b.GetConsistentView()
+		defer view.ReleaseView()
+		reader, err := NewRoaringSetBatchReader(view, sortedKeysOf(t, []string{"k"}))
 		require.NoError(t, err)
-		defer reader.Release()
 
 		// a racing write into the active memtable the reader snapshotted as
 		// empty, through the same path a real writer takes so the size
 		// accounting is exercised too
 		require.NoError(t, b.RoaringSetAddList([]byte("k"), []uint64{99}))
 
-		bm, release, err := reader.Get([]byte("k"), 1)
+		bm, release, err := reader.Next(1)
 		require.NoError(t, err)
 		defer release()
 		require.Equal(t, []uint64{1, 2}, bm.ToArray(),
@@ -729,13 +731,13 @@ func rowOrNil(docIDs []uint64) map[string][]uint64 {
 	return map[string][]uint64{"k": docIDs}
 }
 
-// TestRoaringSetBatchReader_ActiveTombstones pins the invariant the
+// TestBatchReaderFoldsActiveTombstones pins the invariant the
 // empty-active-memtable skip rests on: a delete makes the active memtable
 // non-empty, so the batch still reads it. If deletions ever stopped counting
 // towards Memtable.Size(), the skip would silently resurrect every deleted doc
 // — a wrong-results bug with no error anywhere, and the read-path tests that
 // use RoaringSetGet would not catch it.
-func TestRoaringSetBatchReader_ActiveTombstones(t *testing.T) {
+func TestBatchReaderFoldsActiveTombstones(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -757,76 +759,14 @@ func TestRoaringSetBatchReader_ActiveTombstones(t *testing.T) {
 	// the tombstone stays in the otherwise-empty active memtable
 	require.NoError(t, b.RoaringSetRemoveOne(key, 2))
 
-	reader, err := b.NewRoaringSetBatchReader()
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+	reader, err := NewRoaringSetBatchReader(view, sortedKeysOf(t, []string{string(key)}))
 	require.NoError(t, err)
-	defer reader.Release()
 
-	bm, release, err := reader.Get(key, 1)
+	bm, release, err := reader.Next(1)
 	require.NoError(t, err)
 	defer release()
 	require.Equal(t, []uint64{1, 3}, bm.ToArray(),
 		"a tombstone-only active memtable must not be treated as empty")
-}
-
-// TestRoaringSetBatchReader_ReleaseGuard pins the reader's lifetime guard. The
-// case that matters is the one that never panics: with a second reader holding
-// the same segments, an unguarded double release drops the refcount to zero
-// while that reader is live, and the compaction cycle then unmaps and deletes
-// the segment out from under it. Asserting refcounts rather than
-// absence-of-panic is therefore the point.
-func TestRoaringSetBatchReader_ReleaseGuard(t *testing.T) {
-	t.Parallel()
-
-	newBucket := func(seg *fakeSegment) Bucket {
-		return Bucket{
-			strategy: StrategyRoaringSet,
-			disk:     &SegmentGroup{segments: []Segment{seg}},
-			active:   newTestMemtableRoaringSet(nil),
-			logger:   nullLogger(),
-		}
-	}
-
-	t.Run("double release keeps a concurrent reader's segment refs", func(t *testing.T) {
-		seg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})
-		b := newBucket(seg)
-
-		reader, err := b.NewRoaringSetBatchReader()
-		require.NoError(t, err)
-		other, err := b.NewRoaringSetBatchReader()
-		require.NoError(t, err)
-		defer other.Release()
-		require.Equal(t, 2, seg.getRefs(), "both readers pin the segment")
-
-		reader.Release()
-		reader.Release()
-		require.Equal(t, 1, seg.getRefs(),
-			"the surviving reader's ref must outlive the other's double release")
-
-		// the surviving reader still reads its pinned segment
-		bm, release, err := other.Get([]byte("k"), 1)
-		require.NoError(t, err)
-		defer release()
-		require.Equal(t, []uint64{1, 2}, bm.ToArray())
-	})
-
-	t.Run("get after release errors instead of reading a freed view", func(t *testing.T) {
-		seg := newFakeRoaringSetSegment(map[string]*sroar.Bitmap{"k": bitmapFromSlice([]uint64{1, 2})})
-		b := newBucket(seg)
-
-		reader, err := b.NewRoaringSetBatchReader()
-		require.NoError(t, err)
-
-		bm, release, err := reader.Get([]byte("k"), 1)
-		require.NoError(t, err)
-		require.Equal(t, []uint64{1, 2}, bm.ToArray(), "reads before Release still work")
-		release()
-
-		reader.Release()
-
-		bm, release, err = reader.Get([]byte("k"), 1)
-		require.ErrorIs(t, err, ErrReaderReleased)
-		require.Nil(t, bm)
-		require.NotNil(t, release, "the returned release must stay safe to call")
-		release()
-	})
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"testing"
 	"time"
@@ -364,7 +365,7 @@ func TestBatchReaderSurvivesFlushAndSwitch(t *testing.T) {
 	// One key per window, so the second key's window is filled after the switch
 	// below rather than before it — which is the ordering a long fold meets and
 	// the only one that reads a memtable the bucket has already moved past.
-	reader, err := newRoaringSetBatchReader(view, keys, 1)
+	reader, err := newRoaringSetBatchReader(view, keys, 1, math.MaxInt)
 	require.NoError(t, err)
 
 	before, releaseBefore, err := reader.Next(concurrency.SROAR_MERGE)

--- a/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set_test.go
@@ -78,14 +78,10 @@ func TestRoaringSetWritePathRefCount(t *testing.T) {
 	require.Equal(t, []uint64{1, 3, 4, 5, 6, 7}, v.ToArray())
 }
 
-// TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError pins that
-// a failing memtable read cannot leak the disk row's pooled buffer.
-//
-// The memtables are read first, so a failure there returns before the buffer is
-// acquired at all. The assertions are therefore that the disk row was never
-// read, which is stronger than that it was read and released, and does not
-// depend on every error path remembering a defer.
-func TestBucket_RoaringSetGetFromConsistentView_ReleasesDiskLayerOnError(t *testing.T) {
+// TestBucket_RoaringSetGetFromConsistentView_MemtableErrorLeavesTheDiskRowUnread
+// pins that a failing memtable read cannot leak the disk row's pooled buffer:
+// memtables are read first, so the buffer is never acquired at all.
+func TestBucket_RoaringSetGetFromConsistentView_MemtableErrorLeavesTheDiskRowUnread(t *testing.T) {
 	t.Parallel()
 
 	readErr := errors.New("simulated memtable read error")
@@ -323,17 +319,13 @@ func TestBatchReaderMatchesRoaringSetGet(t *testing.T) {
 	})
 }
 
-// TestBatchReaderSurvivesFlushAndSwitch pins the view
-// stability that justifies holding one view for a whole batch: a flush landing
-// mid-fold must not disturb the keys still to be read. The second key's window
-// is filled after the switch, through a memtable the bucket has already moved
-// past, and must still answer as it did before — writes landing in the new
-// active memtable stay invisible. A fresh RoaringSetGet sees the post-switch
-// write, proving the view pinned state rather than the two paths coincidentally
-// agreeing.
-// (A view is not a write snapshot: writes before the switch go to the old
-// active memtable the view references, so only post-switch invisibility is
-// asserted.)
+// TestBatchReaderSurvivesFlushAndSwitch pins the view stability a whole-batch
+// reader relies on: a flush landing mid-fold must not disturb keys still to be
+// read. The second key's window fills after the switch, through a memtable the
+// bucket has already moved past, and must still answer the pre-switch state —
+// a fresh RoaringSetGet, by contrast, sees the post-switch write. (Writes
+// before the switch still land in the old active memtable the view
+// references, so only post-switch invisibility is asserted.)
 func TestBatchReaderSurvivesFlushAndSwitch(t *testing.T) {
 	ctx := context.Background()
 	logger, _ := test.NewNullLogger()
@@ -362,10 +354,9 @@ func TestBatchReaderSurvivesFlushAndSwitch(t *testing.T) {
 	keys := sortedKeysOf(t, []string{string(first), string(second)})
 	view := b.GetConsistentView()
 	defer view.ReleaseView()
-	// One key per window, so the second key's window is filled after the switch
-	// below rather than before it — which is the ordering a long fold meets and
-	// the only one that reads a memtable the bucket has already moved past.
-	reader, err := newRoaringSetBatchReader(view, keys, 1, math.MaxInt)
+	// One key per window, so the second key's window fills after the switch
+	// below, reading a memtable the bucket has already moved past.
+	reader, err := newRoaringSetBatchReaderWithBounds(view, keys, 1, math.MaxInt)
 	require.NoError(t, err)
 
 	before, releaseBefore, err := reader.Next(concurrency.SROAR_MERGE)
@@ -674,11 +665,8 @@ func TestBatchReaderValidatesAndFoldsLikeThePerKeyPath(t *testing.T) {
 				b.flushing = newTestMemtableRoaringSet(map[string][]uint64{"k": tc.flushing})
 			}
 			if tc.flushingDeletes != nil {
-				// Written through roaringSetRemoveList rather than straight into
-				// the tree, so the memtable's size reflects what it holds. The
-				// reader skips a memtable reporting size 0, and inserting behind
-				// its accounting builds a memtable that holds a row and reports
-				// none — a state no write path produces.
+				// Through roaringSetRemoveList, not straight into the tree, so size
+				// tracks what it holds — the reader skips a memtable reporting 0.
 				mt := newTestMemtableRoaringSet(nil)
 				require.NoError(t, mt.roaringSetRemoveList([]byte("k"), tc.flushingDeletes))
 				b.flushing = mt
@@ -770,4 +758,163 @@ func TestBatchReaderFoldsActiveTombstones(t *testing.T) {
 	defer release()
 	require.Equal(t, []uint64{1, 3}, bm.ToArray(),
 		"a tombstone-only active memtable must not be treated as empty")
+}
+
+// completeParkedFlush finishes the flush b.flushing holds, so Bucket.Shutdown
+// can return. The slot is cleared whatever happens, because Shutdown waits on
+// it with no bound when its context is context.Background().
+func completeParkedFlush(t *testing.T, b *Bucket) {
+	t.Helper()
+	if b.flushing == nil {
+		return
+	}
+	defer func() { b.flushing = nil }()
+	b.waitForZeroWriters(b.flushing)
+	segmentPath, err := b.flushing.flush()
+	require.NoError(t, err)
+	segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
+	require.NoError(t, err)
+	require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(segment))
+	require.Nil(t, b.flushing, "the segment add must clear the flushing slot")
+}
+
+// TestBatchReaderFoldsARealSwitchOldestFirst pins the layer order against a
+// bucket that performed the switch itself. Every other two-memtable test puts a
+// memtable in b.flushing and another in b.active by hand — some of them behind
+// a real GetConsistentView — so the test is what decides which one is older.
+// Here the switch decides, which is what viewMemtablesOldestFirst assumes: that
+// b.flushing predates b.active.
+//
+// The fixture is a document deleted in the switched-out memtable and re-added
+// in the new active one. Folded oldest first it survives; reversed, the
+// deletion lands last and it disappears. An additions-only fixture answers the
+// same either way, which is why one is not enough here.
+func TestBatchReaderFoldsARealSwitchOldestFirst(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyRoaringSet),
+		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+	b.SetMemtableThreshold(1e9) // switch only where this test says so
+
+	// Registered after the Shutdown cleanup so it runs before it, and above
+	// b.FlushAndSwitch so a failure there is covered too. The Shutdown cleanup
+	// passes context.Background(), so Shutdown's wait on b.flushing never ends.
+	t.Cleanup(func() { completeParkedFlush(t, b) })
+
+	key := []byte("k")
+	require.NoError(t, b.RoaringSetAddList(key, []uint64{7}))
+	require.NoError(t, b.FlushAndSwitch()) // 7 is now on disk
+
+	require.NoError(t, b.RoaringSetRemoveOne(key, 7))
+	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	require.NoError(t, err)
+	require.True(t, switched, "the delete must land in a memtable the switch moves")
+
+	require.NoError(t, b.RoaringSetAddList(key, []uint64{7}))
+
+	view := b.GetConsistentView()
+	defer view.ReleaseView()
+	require.NotNil(t, view.Flushing, "without a flushing memtable there are no two orders to tell apart")
+
+	keys := sortedKeysOf(t, []string{string(key)})
+	r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, readerWindowBytes)
+	require.NoError(t, err)
+	got, release, err := r.Next(concurrency.SROAR_MERGE)
+	require.NoError(t, err)
+	defer release()
+	require.Equal(t, []uint64{7}, docsOrNil(got),
+		"the re-add in active must outlive the delete in flushing")
+}
+
+// TestBatchReaderLeavesNoSegmentRefBehind pins the reader's half of the
+// ownership split: it borrows the view's segments and releases nothing, so the
+// single GetConsistentView/ReleaseView pair around a fold is what has to
+// balance. Nothing inside the reader guards against a view already released,
+// which is why the balance is asserted from outside it.
+func TestBatchReaderLeavesNoSegmentRefBehind(t *testing.T) {
+	readErr := errors.New("injected memtable failure")
+
+	tests := []struct {
+		name string
+		// failing swaps in an active memtable that errors, so the fold stops on
+		// an error rather than reaching the end of the batch. The balance has to
+		// hold either way, and only the drained half was covered.
+		failing bool
+	}{
+		{name: "the batch is drained"},
+		{name: "a read fails part way", failing: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			logger, _ := test.NewNullLogger()
+
+			b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithStrategy(StrategyRoaringSet),
+				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, b.Shutdown(context.Background())) })
+			// Registered after the Shutdown cleanup so it runs before it, and above
+			// b.FlushAndSwitch so a failure there is covered too. The Shutdown cleanup
+			// passes context.Background(), so Shutdown's wait on b.flushing never ends.
+			t.Cleanup(func() { completeParkedFlush(t, b) })
+
+			names := []string{"aaa", "bbb", "ccc"}
+			for i, n := range names {
+				require.NoError(t, b.RoaringSetAddList([]byte(n), []uint64{uint64(i)}))
+			}
+			require.NoError(t, b.FlushAndSwitch())
+			require.Equal(t, 1, b.disk.Len(), "the fold must have a real segment to hold a ref on")
+
+			seg := b.disk.segments[0]
+			// Registered after the Shutdown cleanup so it runs before it, and above the
+			// assertions below: any failure among them can leave a ref outstanding, and
+			// SegmentGroup.waitForReferenceCountToReachZero waits on it with no context.
+			t.Cleanup(func() {
+				for n := seg.getRefs(); n > 0; n-- {
+					seg.decRef()
+				}
+			})
+			require.Zero(t, seg.getRefs(), "precondition: no view held yet")
+
+			view := b.GetConsistentView()
+			require.Positive(t, seg.getRefs(), "the view must hold the segment while the fold runs")
+
+			if tc.failing {
+				// The flush left the real active memtable empty, and the reader
+				// drops an empty one, so a memtable that can fail has to be put
+				// back before there is a read to fail.
+				active := newTestMemtableRoaringSet(map[string][]uint64{"aaa": {0}})
+				active.roaringSetGetWindowErr = readErr
+				view.Active = active
+			}
+
+			keys := sortedKeysOf(t, names)
+			r, err := newRoaringSetBatchReaderWithBounds(view, keys, memtableWindowKeys, readerWindowBytes)
+			require.NoError(t, err)
+
+			if tc.failing {
+				_, release, err := r.Next(concurrency.SROAR_MERGE)
+				require.ErrorIs(t, err, readErr)
+				require.Nil(t, release, "a failed read returns nothing to release")
+			} else {
+				for range names {
+					_, release, err := r.Next(concurrency.SROAR_MERGE)
+					require.NoError(t, err)
+					release()
+				}
+			}
+			require.Positive(t, seg.getRefs(), "the reader must not release what it borrowed")
+
+			view.ReleaseView()
+			require.Zero(t, seg.getRefs(), "one view, one release: the fold must leave the segment as it found it")
+		})
+	}
 }

--- a/adapters/repos/db/lsmkv/bucket_targeted_scan_test.go
+++ b/adapters/repos/db/lsmkv/bucket_targeted_scan_test.go
@@ -228,6 +228,9 @@ func TestScanTargetedReplaceFlushingMemtable(t *testing.T) {
 	ctx := context.Background()
 	b := newReusableTestBucket(t, ctx)
 	defer b.Shutdown(ctx)
+	// A defer rather than a cleanup, so it runs before the Shutdown above it:
+	// Shutdown waits on b.flushing with no bound, and cleanups run after defers.
+	defer completeParkedFlush(t, b)
 
 	put := func(id uint64, fillerLen int) { targetedPut(t, b, id, fillerLen) }
 	putEmpty := func(id uint64) { targetedPutEmpty(t, b, id) }
@@ -262,14 +265,6 @@ func TestScanTargetedReplaceFlushingMemtable(t *testing.T) {
 	}
 
 	require.Equal(t, collectMergedCursor(t, b), scanCollect(t, b, 16, 4))
-
-	// finish the parked flush the same way FlushAndSwitch would, so Shutdown
-	// sees a normal bucket
-	segPath, err := b.flushing.flush()
-	require.NoError(t, err)
-	seg, err := b.disk.initAndPrecomputeNewSegment(segPath)
-	require.NoError(t, err)
-	require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(seg))
 }
 
 // TestScanTargetedReplaceLazySegments reopens a populated bucket with lazy

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -2248,6 +2249,15 @@ type testMemtable struct {
 	// roaringSetGetErr, when set, makes roaringSetGet fail, simulating a
 	// memtable read error mid-way through a consistent-view lookup.
 	roaringSetGetErr error
+	// roaringSetGetWindowErr is the same for the windowed read, which fails a
+	// whole window rather than one key.
+	roaringSetGetWindowErr error
+	// Call counts for the two ways a memtable is read. Each is one acquisition
+	// of its read lock, which is the cost the batch path exists to reduce, so
+	// counting them is how a test states that reduction rather than inferring
+	// it from a timing.
+	roaringSetGetCalls       int
+	roaringSetGetWindowCalls int
 }
 
 func (t *testMemtable) incWriterCount() {
@@ -2255,7 +2265,16 @@ func (t *testMemtable) incWriterCount() {
 	t.Memtable.incWriterCount()
 }
 
+func (t *testMemtable) roaringSetGetWindow(keys inverted.SortedKeys, from, to int, into []roaringset.BitmapLayer) (int, error) {
+	t.roaringSetGetWindowCalls++
+	if t.roaringSetGetWindowErr != nil {
+		return 0, t.roaringSetGetWindowErr
+	}
+	return t.Memtable.roaringSetGetWindow(keys, from, to, into)
+}
+
 func (t *testMemtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
+	t.roaringSetGetCalls++
 	if t.roaringSetGetErr != nil {
 		return roaringset.BitmapLayer{}, t.roaringSetGetErr
 	}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2309,6 +2309,19 @@ func newTestMemtableRoaringSet(initialData map[string][]uint64) *testMemtable {
 	return &testMemtable{Memtable: m}
 }
 
+// docsOrNil is ToArray with one difference that matters to a differential test:
+// a bitmap holding nothing reads as nil whether it is nil or merely empty.
+// ToArray keeps those apart, as an empty slice and a nil one, and require.Equal
+// calls them unequal — so a path returning one and a path returning the other
+// would fail over a representation rather than over a document.
+func docsOrNil(bm *sroar.Bitmap) []uint64 {
+	out := bm.ToArray()
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func newTestMemtableRoaringSetRange(initialData map[uint64][]uint64) *testMemtable {
 	logger, _ := test.NewNullLogger()
 	metrics, err := newMemtableMetrics(nil, "", "")

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sync"
 	"testing"
 	"time"
 
@@ -798,6 +797,9 @@ func TestCountApproximate(t *testing.T) {
 		switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
 		require.NoError(t, err)
 		require.True(t, switched)
+		// Registered above the assertions so a failure among them still lands the
+		// flush: Shutdown waits on b.flushing with no bound.
+		t.Cleanup(func() { completeParkedFlush(t, b) })
 
 		require.NoError(t, b.Put([]byte("key-new"), []byte("value")))
 		require.NoError(t, b.Put([]byte("key-new-2"), []byte("value")))
@@ -805,13 +807,7 @@ func TestCountApproximate(t *testing.T) {
 		requireApprox(t, b, 6)
 		requireExact(t, b, 6)
 
-		// complete the flush the way FlushAndSwitch does
-		b.waitForZeroWriters(b.flushing)
-		segmentPath, err := b.flushing.flush()
-		require.NoError(t, err)
-		segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
-		require.NoError(t, err)
-		require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(segment))
+		completeParkedFlush(t, b)
 		requireApprox(t, b, 6)
 	})
 
@@ -2250,14 +2246,24 @@ type testMemtable struct {
 	// memtable read error mid-way through a consistent-view lookup.
 	roaringSetGetErr error
 	// roaringSetGetWindowErr is the same for the windowed read, which fails a
-	// whole window rather than one key.
-	roaringSetGetWindowErr error
+	// whole window rather than one key. No Memtable produces either error today:
+	// its two argument guards are ones fillWindow satisfies by construction, and
+	// the walk itself only errors from a cursor that returns none.
+	// roaringSetGetWindowErrBytes is what a failing read reports having copied
+	// already, which is what fillWindow's counting arm exists for.
+	roaringSetGetWindowErr      error
+	roaringSetGetWindowErrBytes int
 	// Call counts for the two ways a memtable is read. Each is one acquisition
 	// of its read lock, which is the cost the batch path exists to reduce, so
 	// counting them is how a test states that reduction rather than inferring
 	// it from a timing.
 	roaringSetGetCalls       int
 	roaringSetGetWindowCalls int
+	// ranges is [from, To) per windowed read, for a test stating that no key is
+	// read twice across a batch. Every read of this double lands here, a
+	// fixture's own pricing probe included, and a read that failed records the
+	// range it was asked for rather than what it filled.
+	ranges [][2]int
 }
 
 func (t *testMemtable) incWriterCount() {
@@ -2269,14 +2275,22 @@ func (t *testMemtable) roaringSetGetWindow(
 	keys inverted.SortedKeys, from, to int, into []roaringset.BitmapLayer, budget int,
 ) (windowFill, error) {
 	t.roaringSetGetWindowCalls++
-	if t.roaringSetGetWindowErr != nil {
-		// To as the real walk reports it when a read fails part way: the range it
-		// was asked for, since it cannot say how far it got. The caller discards
-		// the fill on an error, so this only keeps the double from being the looser
-		// of the two.
-		return windowFill{To: to}, t.roaringSetGetWindowErr
+
+	// To as the real walk reports it when a read fails part way: the range it
+	// was asked for, since it cannot say how far it got. The caller drops To on
+	// an error but does count Bytes, so the rows copied before the failure are
+	// what a test sets roaringSetGetWindowErrBytes to describe.
+	fill, err := windowFill{To: to, Bytes: t.roaringSetGetWindowErrBytes}, t.roaringSetGetWindowErr
+	if err == nil {
+		fill, err = t.Memtable.roaringSetGetWindow(keys, from, to, into, budget)
+	} else {
+		// The real walk clears dst before it reads anything, so an injected
+		// failure has to leave the same zeroed slots behind it.
+		clear(into)
 	}
-	return t.Memtable.roaringSetGetWindow(keys, from, to, into, budget)
+
+	t.ranges = append(t.ranges, [2]int{from, fill.To})
+	return fill, err
 }
 
 func (t *testMemtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {
@@ -3170,15 +3184,9 @@ func TestApplyToObjectDigestsWithFlushingMemtable(t *testing.T) {
 	require.True(t, switched)
 	require.NotNil(t, b.flushing, "the scan must run against a live flushing memtable")
 
-	// Shutdown blocks until b.flushing clears, so land it even if an assertion below fails.
-	landFlushing := sync.OnceFunc(func() {
-		segmentPath, err := b.flushing.flush()
-		require.NoError(t, err)
-		segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
-		require.NoError(t, err)
-		require.NoError(t, b.atomicallyAddDiskSegmentAndRemoveFlushing(segment))
-	})
-	t.Cleanup(landFlushing)
+	// Registered above the assertions so a failure among them still lands the
+	// flush: Shutdown waits on b.flushing with no bound.
+	t.Cleanup(func() { completeParkedFlush(t, b) })
 
 	require.NoError(t, b.Delete(keyB))
 	require.NoError(t, b.Put(keyD, objValue(t, keyD, 5, updateTime)))
@@ -3190,7 +3198,7 @@ func TestApplyToObjectDigestsWithFlushingMemtable(t *testing.T) {
 	}
 	require.Equal(t, want, scan(t, b))
 
-	landFlushing()
+	completeParkedFlush(t, b)
 
 	require.Equal(t, want, scan(t, b), "root must not depend on whether the flushing memtable had landed")
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2265,12 +2265,18 @@ func (t *testMemtable) incWriterCount() {
 	t.Memtable.incWriterCount()
 }
 
-func (t *testMemtable) roaringSetGetWindow(keys inverted.SortedKeys, from, to int, into []roaringset.BitmapLayer) (int, error) {
+func (t *testMemtable) roaringSetGetWindow(
+	keys inverted.SortedKeys, from, to int, into []roaringset.BitmapLayer, budget int,
+) (windowFill, error) {
 	t.roaringSetGetWindowCalls++
 	if t.roaringSetGetWindowErr != nil {
-		return 0, t.roaringSetGetWindowErr
+		// To as the real walk reports it when a read fails part way: the range it
+		// was asked for, since it cannot say how far it got. The caller discards
+		// the fill on an error, so this only keeps the double from being the looser
+		// of the two.
+		return windowFill{To: to}, t.roaringSetGetWindowErr
 	}
-	return t.Memtable.roaringSetGetWindow(keys, from, to, into)
+	return t.Memtable.roaringSetGetWindow(keys, from, to, into, budget)
 }
 
 func (t *testMemtable) roaringSetGet(key []byte) (roaringset.BitmapLayer, error) {

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
 	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -76,6 +77,11 @@ type memtable interface {
 	newCursorWithSecondaryIndex(pos int) innerCursorReplace
 	newCollectionCursor() innerCursorCollection
 	newRoaringSetCursor() roaringset.InnerCursor
+	// roaringSetGetWindow reads a window of a sorted batch in one pass and
+	// reports the bytes it copied. Absence is the zero layer rather than
+	// lsmkv.NotFound, and on error no slot is meaningful. See
+	// (*Memtable).roaringSetGetWindow for the contract.
+	roaringSetGetWindow(keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) (int, error)
 	newRoaringSetRangeReader() roaringsetrange.InnerReader
 	newMapCursor() innerCursorMap
 

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -77,11 +77,12 @@ type memtable interface {
 	newCursorWithSecondaryIndex(pos int) innerCursorReplace
 	newCollectionCursor() innerCursorCollection
 	newRoaringSetCursor() roaringset.InnerCursor
-	// roaringSetGetWindow reads a window of a sorted batch in one pass and
-	// reports the bytes it copied. Absence is the zero layer rather than
-	// lsmkv.NotFound, and on error no slot is meaningful. See
-	// (*Memtable).roaringSetGetWindow for the contract.
-	roaringSetGetWindow(keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) (int, error)
+	// roaringSetGetWindow reads a window of a sorted batch in one pass, stopping
+	// once it has copied budget bytes and reporting where it stopped and what it
+	// spent. Absence is the zero layer rather than lsmkv.NotFound, and on error
+	// no slot is meaningful. See (*Memtable).roaringSetGetWindow for the
+	// contract.
+	roaringSetGetWindow(keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer, budget int) (windowFill, error)
 	newRoaringSetRangeReader() roaringsetrange.InnerReader
 	newMapCursor() innerCursorMap
 

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_window.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_window.go
@@ -1,0 +1,110 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/inverted"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+// roaringSetGetWindow reads the keys of keys[from:to] that this memtable holds
+// under one read lock, rather than taking it once per key. A memtable is a
+// delta, so a large filter asks it about far more keys than it has, and most of
+// those acquisitions find nothing.
+//
+// keys must be sorted and hold no duplicates, both of which SortedKeys
+// guarantees. The walk advances the batch and the tree past a key it has
+// matched, so a repeat of that key would be jumped over and read back as a row
+// the memtable does not hold.
+//
+// Neither side is stepped through: whichever is behind jumps to where the other
+// already is, so the pass costs what the sparser side holds and there is no
+// ratio for the caller to pick.
+//
+// It reports the bytes it copied into dst, which is free to count here because the
+// rows are in hand.
+//
+// dst is the caller's, one slot per key of the range, so the key at position i
+// lands in dst[i-from]. Slots of keys this memtable does not hold are left as
+// the zero layer, which is how the caller reads absence; a row holding neither
+// additions nor deletions is absence too, and writing it changes nothing. The
+// bitmaps are copied, as roaringSetGet's are, so they outlive the lock.
+func (m *Memtable) roaringSetGetWindow(keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) (int, error) {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
+		return 0, err
+	}
+	// keys is indexed by the range and dst by the offset within it, so a slice
+	// wider than the range would write each row at the offset of a key the
+	// window does not cover — answering those keys with another's row, and the
+	// covered ones with none. An inverted range fails the same test, and an
+	// empty one is legal and takes no slots.
+	if from < 0 || to > keys.Len() || len(dst) != to-from {
+		return 0, fmt.Errorf("roaring set window read: range [%d,%d) of %d keys into %d slots",
+			from, to, keys.Len(), len(dst))
+	}
+	if from == to {
+		return 0, nil
+	}
+	// Absence is the zero layer, so the slots have to start that way. Clearing
+	// them here rather than asking the caller to keeps a reused buffer from
+	// answering this window's keys with the last one's rows.
+	clear(dst)
+
+	m.RLock()
+	defer m.RUnlock()
+
+	// The no-copy cursor is safe only under the read lock held above. It starts
+	// at the window rather than at the tree's first key, so a late window pays
+	// one descent instead of walking everything before it.
+	cursor := roaringset.NewBinarySearchTreeCursorNoCopy(m.roaringSet)
+	key, layer, err := cursor.Seek(keys.At(from))
+
+	// Counted where the copy is made rather than by rescanning dst afterwards,
+	// so the accounting costs what the window matched rather than how wide it is.
+	cloned := 0
+
+	// Both seeks below report NotFound once the tree is past its last key, which
+	// is exhaustion rather than failure, so the one check covers both.
+	for keyIdx := from; ; {
+		if err != nil {
+			if errors.Is(err, entlsmkv.NotFound) {
+				return cloned, nil
+			}
+			return cloned, err
+		}
+		if key == nil || keyIdx >= to {
+			return cloned, nil
+		}
+		switch cmp := bytes.Compare(key, keys.At(keyIdx)); {
+		case cmp == 0:
+			row := layer.CloneDroppingEmpty()
+			cloned += len(row.Additions.ToBuffer()) + len(row.Deletions.ToBuffer())
+			dst[keyIdx-from] = row
+			keyIdx++
+			key, layer, err = cursor.Next()
+		case cmp < 0:
+			// The memtable is behind. Seek lands on the first key at or past the
+			// one wanted, which is strictly past where the cursor sits, so this
+			// always advances.
+			key, layer, err = cursor.Seek(keys.At(keyIdx))
+		default:
+			// The batch is behind, and its first key at or past the memtable's
+			// is strictly past keyIdx for the same reason.
+			keyIdx = keys.FirstAtOrAfter(keyIdx, to, key)
+		}
+	}
+}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_window.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_window.go
@@ -21,48 +21,57 @@ import (
 	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 )
 
+// windowFill is what one window read produced: To is one past the last key it
+// filled, which is `to` unless the budget stopped it short, and Bytes is what
+// the rows it copied cost.
+type windowFill struct {
+	To    int
+	Bytes int
+}
+
 // roaringSetGetWindow reads the keys of keys[from:to] that this memtable holds
-// under one read lock, rather than taking it once per key. A memtable is a
-// delta, so a large filter asks it about far more keys than it has, and most of
-// those acquisitions find nothing.
+// under one read lock, rather than taking it once per key. A memtable is a delta,
+// so a large filter asks it about far more keys than it has and most of those
+// acquisitions find nothing.
 //
-// keys must be sorted and hold no duplicates, both of which SortedKeys
-// guarantees. The walk advances the batch and the tree past a key it has
-// matched, so a repeat of that key would be jumped over and read back as a row
-// the memtable does not hold.
+// keys must be sorted and free of duplicates, which SortedKeys guarantees: the
+// walk advances past a key it has matched, so a repeat would be jumped over and
+// read back as absent. Neither side is stepped through — whichever is behind
+// jumps to where the other is — so the pass costs what the sparser side holds.
 //
-// Neither side is stepped through: whichever is behind jumps to where the other
-// already is, so the pass costs what the sparser side holds and there is no
-// ratio for the caller to pick.
+// budget caps the bytes copied and the window ends before the row that would
+// cross it, so what it holds is the budget, or one row where a row alone is
+// bigger, since the key at from is taken whatever it costs. Where it ended is
+// reported.
 //
-// It reports the bytes it copied into dst, which is free to count here because the
-// rows are in hand.
-//
-// dst is the caller's, one slot per key of the range, so the key at position i
-// lands in dst[i-from]. Slots of keys this memtable does not hold are left as
-// the zero layer, which is how the caller reads absence; a row holding neither
-// additions nor deletions is absence too, and writing it changes nothing. The
-// bitmaps are copied, as roaringSetGet's are, so they outlive the lock.
-func (m *Memtable) roaringSetGetWindow(keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) (int, error) {
+// dst takes at least one slot per key of the range, the key at i landing in
+// dst[i-from], and all of it is cleared first — so a slot with no row reads as
+// absence, and a buffer wider than the range answers nothing from an earlier one.
+// The bitmaps are copied, as roaringSetGet's are, so they outlive the lock.
+func (m *Memtable) roaringSetGetWindow(
+	keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer, budget int,
+) (windowFill, error) {
 	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
-		return 0, err
+		return windowFill{}, err
 	}
-	// keys is indexed by the range and dst by the offset within it, so a slice
-	// wider than the range would write each row at the offset of a key the
-	// window does not cover — answering those keys with another's row, and the
-	// covered ones with none. An inverted range fails the same test, and an
-	// empty one is legal and takes no slots.
-	if from < 0 || to > keys.Len() || len(dst) != to-from {
-		return 0, fmt.Errorf("roaring set window read: range [%d,%d) of %d keys into %d slots",
+	// dst is indexed by the offset within the range, so too few slots would put
+	// a row past its end. More is legal, and is how a caller holding one buffer
+	// at the widest a window gets asks for a narrower range without reslicing
+	// it. An inverted range is rejected on its own, since a negative width is
+	// under every slice count; an empty one is legal and takes no slots.
+	if from < 0 || to < from || to > keys.Len() || len(dst) < to-from {
+		return windowFill{}, fmt.Errorf("roaring set window read: range [%d,%d) of %d keys into %d slots",
 			from, to, keys.Len(), len(dst))
-	}
-	if from == to {
-		return 0, nil
 	}
 	// Absence is the zero layer, so the slots have to start that way. Clearing
 	// them here rather than asking the caller to keeps a reused buffer from
-	// answering this window's keys with the last one's rows.
+	// answering this window's keys with the last one's rows, and covers the
+	// slots past the range for a caller that passed more than it asked for.
 	clear(dst)
+
+	if from == to {
+		return windowFill{To: to}, nil
+	}
 
 	m.RLock()
 	defer m.RUnlock()
@@ -75,25 +84,36 @@ func (m *Memtable) roaringSetGetWindow(keys inverted.SortedKeys, from, to int, d
 
 	// Counted where the copy is made rather than by rescanning dst afterwards,
 	// so the accounting costs what the window matched rather than how wide it is.
-	cloned := 0
+	// It is also what the budget is spent against.
+	fill := windowFill{To: to}
 
 	// Both seeks below report NotFound once the tree is past its last key, which
 	// is exhaustion rather than failure, so the one check covers both.
 	for keyIdx := from; ; {
 		if err != nil {
 			if errors.Is(err, entlsmkv.NotFound) {
-				return cloned, nil
+				return fill, nil
 			}
-			return cloned, err
+			return fill, err
 		}
 		if key == nil || keyIdx >= to {
-			return cloned, nil
+			return fill, nil
 		}
 		switch cmp := bytes.Compare(key, keys.At(keyIdx)); {
 		case cmp == 0:
-			row := layer.CloneDroppingEmpty()
-			cloned += len(row.Additions.ToBuffer()) + len(row.Deletions.ToBuffer())
-			dst[keyIdx-from] = row
+			// Priced before copying, which is free — ToBuffer hands back the
+			// bitmap's own bytes, and a clone copies exactly that many. Pricing it
+			// afterwards would bound the row after the one that broke the budget.
+			// The first key is taken whatever it costs: refusing it would leave the
+			// slot unwritten, read as a key this memtable does not hold rather than
+			// a row too big to fit.
+			cost := len(layer.Additions.ToBuffer()) + len(layer.Deletions.ToBuffer())
+			if fill.Bytes+cost > budget && keyIdx > from {
+				fill.To = keyIdx
+				return fill, nil
+			}
+			dst[keyIdx-from] = layer.CloneDroppingEmpty()
+			fill.Bytes += cost
 			keyIdx++
 			key, layer, err = cursor.Next()
 		case cmp < 0:

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_window.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_window.go
@@ -15,58 +15,46 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/inverted"
 	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 )
 
-// windowFill is what one window read produced: To is one past the last key it
-// filled, which is `to` unless the budget stopped it short, and Bytes is what
-// the rows it copied cost.
+// windowFill is what one window read produced: To is one past the last key
+// filled (== to unless budget cut it short), Bytes is the copy cost.
 type windowFill struct {
 	To    int
 	Bytes int
 }
 
-// roaringSetGetWindow reads the keys of keys[from:to] that this memtable holds
-// under one read lock, rather than taking it once per key. A memtable is a delta,
-// so a large filter asks it about far more keys than it has and most of those
-// acquisitions find nothing.
+// roaringSetGetWindow reads keys[from:to] from this memtable under a single
+// read lock instead of one acquisition per key. keys must be sorted and
+// deduplicated (SortedKeys guarantees this).
 //
-// keys must be sorted and free of duplicates, which SortedKeys guarantees: the
-// walk advances past a key it has matched, so a repeat would be jumped over and
-// read back as absent. Neither side is stepped through — whichever is behind
-// jumps to where the other is — so the pass costs what the sparser side holds.
+// budget caps the bytes copied: the window ends before the row that would
+// cross it, except the key at from is always taken regardless of cost. Where
+// it actually ended is reported in the result, which is meaningful only when
+// the error is nil.
 //
-// budget caps the bytes copied and the window ends before the row that would
-// cross it, so what it holds is the budget, or one row where a row alone is
-// bigger, since the key at from is taken whatever it costs. Where it ended is
-// reported.
-//
-// dst takes at least one slot per key of the range, the key at i landing in
-// dst[i-from], and all of it is cleared first — so a slot with no row reads as
-// absence, and a buffer wider than the range answers nothing from an earlier one.
-// The bitmaps are copied, as roaringSetGet's are, so they outlive the lock.
+// dst must have exactly one slot per key of the range, key i landing in
+// dst[i-from]; it is cleared in full first, so a reused buffer can't answer
+// with a stale window's rows. Bitmaps are copied, as roaringSetGet's are, so
+// they outlive the lock.
 func (m *Memtable) roaringSetGetWindow(
 	keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer, budget int,
 ) (windowFill, error) {
 	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return windowFill{}, err
 	}
-	// dst is indexed by the offset within the range, so too few slots would put
-	// a row past its end. More is legal, and is how a caller holding one buffer
-	// at the widest a window gets asks for a narrower range without reslicing
-	// it. An inverted range is rejected on its own, since a negative width is
-	// under every slice count; an empty one is legal and takes no slots.
-	if from < 0 || to < from || to > keys.Len() || len(dst) < to-from {
+	// dst is exactly the range: clear wipes all of it, so only an exact length
+	// makes what this read erases the same slots as the range it was asked for.
+	// A caller handing over a wider slice has computed its window wrong.
+	if from < 0 || to < from || to > keys.Len() || len(dst) != to-from {
 		return windowFill{}, fmt.Errorf("roaring set window read: range [%d,%d) of %d keys into %d slots",
 			from, to, keys.Len(), len(dst))
 	}
-	// Absence is the zero layer, so the slots have to start that way. Clearing
-	// them here rather than asking the caller to keeps a reused buffer from
-	// answering this window's keys with the last one's rows, and covers the
-	// slots past the range for a caller that passed more than it asked for.
 	clear(dst)
 
 	if from == to {
@@ -76,21 +64,14 @@ func (m *Memtable) roaringSetGetWindow(
 	m.RLock()
 	defer m.RUnlock()
 
-	// The no-copy cursor is safe only under the read lock held above. It starts
-	// at the window rather than at the tree's first key, so a late window pays
-	// one descent instead of walking everything before it.
+	// Seeking straight to from avoids walking every earlier key for a late window.
 	cursor := roaringset.NewBinarySearchTreeCursorNoCopy(m.roaringSet)
 	key, layer, err := cursor.Seek(keys.At(from))
-
-	// Counted where the copy is made rather than by rescanning dst afterwards,
-	// so the accounting costs what the window matched rather than how wide it is.
-	// It is also what the budget is spent against.
 	fill := windowFill{To: to}
 
-	// Both seeks below report NotFound once the tree is past its last key, which
-	// is exhaustion rather than failure, so the one check covers both.
 	for keyIdx := from; ; {
 		if err != nil {
+			// NotFound means the tree is exhausted, not that something failed.
 			if errors.Is(err, entlsmkv.NotFound) {
 				return fill, nil
 			}
@@ -101,29 +82,27 @@ func (m *Memtable) roaringSetGetWindow(
 		}
 		switch cmp := bytes.Compare(key, keys.At(keyIdx)); {
 		case cmp == 0:
-			// Priced before copying, which is free — ToBuffer hands back the
-			// bitmap's own bytes, and a clone copies exactly that many. Pricing it
-			// afterwards would bound the row after the one that broke the budget.
-			// The first key is taken whatever it costs: refusing it would leave the
-			// slot unwritten, read as a key this memtable does not hold rather than
-			// a row too big to fit.
-			cost := len(layer.Additions.ToBuffer()) + len(layer.Deletions.ToBuffer())
-			if fill.Bytes+cost > budget && keyIdx > from {
+			// The row that breaks the budget is priced but never copied. The
+			// first key is taken whatever it costs, so an unwritten slot always
+			// means "not held", never "refused".
+			avail := budget - fill.Bytes
+			if keyIdx == from {
+				avail = math.MaxInt
+			}
+			row, cost, ok := layer.CloneIfWithin(avail)
+			if !ok {
 				fill.To = keyIdx
 				return fill, nil
 			}
-			dst[keyIdx-from] = layer.CloneDroppingEmpty()
+			dst[keyIdx-from] = row
 			fill.Bytes += cost
 			keyIdx++
 			key, layer, err = cursor.Next()
 		case cmp < 0:
-			// The memtable is behind. Seek lands on the first key at or past the
-			// one wanted, which is strictly past where the cursor sits, so this
-			// always advances.
+			// Memtable is behind the batch: jump the cursor forward.
 			key, layer, err = cursor.Seek(keys.At(keyIdx))
 		default:
-			// The batch is behind, and its first key at or past the memtable's
-			// is strictly past keyIdx for the same reason.
+			// Batch is behind the memtable: jump keyIdx forward instead.
 			keyIdx = keys.FirstAtOrAfter(keyIdx, to, key)
 		}
 	}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_window_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_window_test.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"errors"
 	"fmt"
+	"math"
 	"math/rand"
 	"path"
 	"slices"
@@ -114,11 +115,12 @@ func TestRoaringSetGetWindowRandomized(t *testing.T) {
 // TestRoaringSetGetWindowMatchesWholeBatch pins that reading a batch in windows answers
 // exactly what reading it whole does.
 //
-// Windowing a large batch is what holds the lock briefly and keeps one window's
-// bitmaps in hand at a time, and it only works if the boundaries are invisible:
-// every window starts with its own descent rather than where the last one stopped,
-// so a key sitting on a boundary is the one a mistake drops or double-counts.
-// Window size 1 is the degenerate end of that — every key is its own boundary.
+// The caller windows a large batch so the lock is held briefly and only one
+// window's bitmaps are held at a time, which only works if the boundaries are
+// invisible: every window starts with its own descent rather than where the
+// last one stopped, so a key sitting on a boundary is the one a mistake drops
+// or double-counts. Window size 1 is the degenerate end of that — every key is
+// its own boundary.
 func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
 	t.Parallel()
 
@@ -135,10 +137,9 @@ func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
 		fillWindowOK(t, m, keys, 0, keys.Len(), whole)
 
 		for _, w := range []int{1, 2, 3, 7, 1000} {
-			// One slot per key, handed over a window at a time, which is how a
-			// caller reading a batch this way has to do it. Writing outside its
-			// window would index past the subslice rather than land in a
-			// neighbour's slot.
+			// One slot per key, handed over a window at a time, exactly as the
+			// batch reader does it. Writing outside its window would index past
+			// the subslice rather than land in a neighbour's slot.
 			got := make([]roaringset.BitmapLayer, keys.Len())
 			for from := 0; from < keys.Len(); from += w {
 				to := min(from+w, keys.Len())
@@ -150,15 +151,18 @@ func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowRangeGuards separates an empty window from a range or
-// a slice the caller got wrong. Only the empty one can be answered by reading
-// nothing; the rest cannot be answered with "this memtable holds none of those
-// keys", because nobody asked about those keys.
+// TestRoaringSetGetWindowRangeGuards separates the ranges that can be answered
+// by reading nothing from the ones nobody asked for. A range outside the batch
+// cannot be answered with "this memtable holds none of those keys", and a slice
+// too short for its range has nowhere to put the last rows.
 //
-// A caller that derives the range from its own batch and sizes the slice to it
-// reaches none of the erroring shapes. They are the arithmetic to get wrong by
-// hand — most of all the too-long slice, where the rows would land at the offsets
-// of keys outside the window.
+// A slice longer than the range is legal, and pinned here as such: fillWindow
+// holds one buffer at the widest a window gets and asks for the narrower range
+// its budget settled on.
+//
+// None of the erroring shapes is reachable from fillWindow, which always
+// produces a range inside the batch and a slice at least its width. They are the
+// arithmetic a second caller would get wrong.
 func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 	t.Parallel()
 
@@ -174,15 +178,14 @@ func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 		{name: "empty at the start", from: 0, to: 0, slots: 0},
 		{name: "empty at the end", from: 3, to: 3, slots: 0},
 		{name: "empty in the middle", from: 1, to: 1, slots: 0},
-		// caught by the width check: to-from is negative and no slice matches it
+		{name: "slice longer than the window", from: 0, to: 2, slots: 3},
+		{name: "whole batch passed for a late window", from: 1, to: 3, slots: 3},
+		{name: "slots for an empty window", from: 1, to: 1, slots: 3},
 		{name: "inverted", from: 2, to: 1, slots: 0, wantErr: true},
 		{name: "before the first key", from: -1, to: 2, slots: 3, wantErr: true},
 		{name: "one past the last", from: 0, to: 4, slots: 4, wantErr: true},
 		{name: "far past the last", from: 1, to: 99, slots: 99, wantErr: true},
 		{name: "slice shorter than the window", from: 0, to: 3, slots: 2, wantErr: true},
-		{name: "slice longer than the window", from: 0, to: 2, slots: 3, wantErr: true},
-		{name: "whole batch passed for a late window", from: 1, to: 3, slots: 3, wantErr: true},
-		{name: "slots for an empty window", from: 1, to: 1, slots: 3, wantErr: true},
 	}
 
 	for _, tc := range tests {
@@ -190,7 +193,7 @@ func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 			t.Parallel()
 
 			into := make([]roaringset.BitmapLayer, tc.slots)
-			_, err := m.roaringSetGetWindow(keys, tc.from, tc.to, into)
+			_, err := m.roaringSetGetWindow(keys, tc.from, tc.to, into, math.MaxInt)
 			if tc.wantErr {
 				require.Error(t, err)
 				return
@@ -203,7 +206,7 @@ func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 // TestRoaringSetGetWindowDropsEmptySides pins which clone the read uses. A row
 // written to but never deleted from still has both bitmaps allocated in the
 // tree, and the window must hand back a nil deletion side rather than an empty
-// one, since a caller distinguishes "no row here" by that nil. Plain Clone would
+// one — that nil is what the reader's presence test reads. Plain Clone would
 // return an allocated empty bitmap and go unnoticed everywhere else.
 func TestRoaringSetGetWindowDropsEmptySides(t *testing.T) {
 	t.Parallel()
@@ -305,7 +308,7 @@ func TestRoaringSetGetWindowRejectsOtherStrategies(t *testing.T) {
 	m := newTestMemtableReplace(map[string][]byte{"a": []byte("x")})
 	keys := sortedKeysOf(t, []string{"a"})
 	into := make([]roaringset.BitmapLayer, 1)
-	_, err := m.roaringSetGetWindow(keys, 0, 1, into)
+	_, err := m.roaringSetGetWindow(keys, 0, 1, into, math.MaxInt)
 	require.Error(t, err)
 }
 
@@ -440,11 +443,156 @@ func TestMemtableLayersAreNeverBothNil(t *testing.T) {
 	}
 }
 
-// fillWindowOK reads a window and fails the test if it errors, so the callers that
-// only care about what landed in dst stay one line. What it reports is discarded:
-// no caller here reads it.
+// TestRoaringSetGetWindowStopsAtTheBudget pins what bounds a window's memory.
+// The key count caps how many rows a fill clones and nothing caps how big a row
+// is, so without this a property with few values and many documents each turns
+// one window into a multiple of what the constant suggests.
+func TestRoaringSetGetWindowStopsAtTheBudget(t *testing.T) {
+	t.Parallel()
+
+	// Rows wide enough that a couple of them exhaust any budget worth setting.
+	// Documents are spread so each lands in its own container, which is what
+	// makes a row cost bytes rather than compress to nothing.
+	const rows, docsPerRow = 8, 4096
+	batch := make([]string, rows)
+	for i := range batch {
+		batch[i] = fmt.Sprintf("k%02d", i)
+	}
+	m := memtableWith(t, nil)
+	for i, k := range batch {
+		docs := make([]uint64, docsPerRow)
+		for j := range docs {
+			docs[j] = uint64(i + j*rows*8)
+		}
+		require.NoError(t, m.roaringSetAddList([]byte(k), docs))
+	}
+	keys := sortedKeysOf(t, batch)
+
+	// what one row costs, so the budget can be expressed in rows
+	one := make([]roaringset.BitmapLayer, 1)
+	first, err := m.roaringSetGetWindow(keys, 0, 1, one, math.MaxInt)
+	require.NoError(t, err)
+	require.Positive(t, first.Bytes)
+
+	tests := []struct {
+		name   string
+		budget int
+		wantTo int
+	}{
+		{name: "unbudgeted reads the whole range", budget: math.MaxInt, wantTo: rows},
+		{name: "stops before the row that would cross the budget", budget: 3 * first.Bytes, wantTo: 3},
+		{name: "a budget under one row still takes one", budget: 1, wantTo: 1},
+		{name: "a zero budget still takes one", budget: 0, wantTo: 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dst := make([]roaringset.BitmapLayer, keys.Len())
+			fill, err := m.roaringSetGetWindow(keys, 0, keys.Len(), dst, tc.budget)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantTo, fill.To)
+			require.LessOrEqual(t, fill.Bytes, max(tc.budget, first.Bytes),
+				"only the always-taken first key may exceed the budget")
+
+			// Past To the walk wrote nothing, and the caller must not read those
+			// slots as absence — which is why fillWindow narrows winEnd to To.
+			for i := fill.To; i < keys.Len(); i++ {
+				require.Nilf(t, dst[i].Additions, "slot %d past To must be untouched", i)
+			}
+			for i := 0; i < fill.To; i++ {
+				require.NotNilf(t, dst[i].Additions, "slot %d inside To must hold its row", i)
+			}
+		})
+	}
+}
+
+// fillWindowOK reads a window and fails the test if it errors, so the callers
+// that only care about what landed in dst stay one line. The bytes it reports
+// are asserted where that is the subject.
 func fillWindowOK(t *testing.T, m memtable, keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) {
 	t.Helper()
-	_, err := m.roaringSetGetWindow(keys, from, to, dst)
+	// A budget nothing here can reach, so these callers read the whole range
+	// they asked for. The budget's own behaviour is covered separately.
+	fill, err := m.roaringSetGetWindow(keys, from, to, dst, math.MaxInt)
 	require.NoError(t, err)
+	require.Equal(t, to, fill.To, "an unbudgeted read must fill the whole range")
+}
+
+// TestRoaringSetGetWindowHoldsAtMostTheBudget pins the ceiling the budget
+// enforces, which a fixture of equally sized rows cannot reach: spending there
+// lands on the budget and never past it, so the same numbers come out whether a
+// row is priced before it is copied or after. One fat row among thin ones is what
+// tells the two apart, and it is the shape the budget exists for — a property
+// whose values carry wildly different document counts.
+func TestRoaringSetGetWindowHoldsAtMostTheBudget(t *testing.T) {
+	t.Parallel()
+
+	const keyCount, thinDocs, fatDocs = 8, 8, 4096
+
+	// Sixty-four apart, and each key's documents are its own, so no two rows share a
+	// container. What costs bytes here is the document count: the fat row's four
+	// thousand fill a handful of containers densely, where the thin rows' eight share
+	// one.
+	docsFor := func(key, n int) []uint64 {
+		docs := make([]uint64, n)
+		for j := range docs {
+			docs[j] = uint64(key*1_000_000 + j*64)
+		}
+		return docs
+	}
+
+	build := func(t *testing.T, fatAt int) (*Memtable, inverted.SortedKeys) {
+		batch := make([]string, keyCount)
+		for i := range batch {
+			batch[i] = fmt.Sprintf("k%02d", i)
+		}
+		m := memtableWith(t, nil)
+		for i, k := range batch {
+			n := thinDocs
+			if i == fatAt {
+				n = fatDocs
+			}
+			require.NoError(t, m.roaringSetAddList([]byte(k), docsFor(i, n)))
+		}
+		return m, sortedKeysOf(t, batch)
+	}
+
+	costOf := func(t *testing.T, m *Memtable, keys inverted.SortedKeys, from, to int) int {
+		dst := make([]roaringset.BitmapLayer, to-from)
+		fill, err := m.roaringSetGetWindow(keys, from, to, dst, math.MaxInt)
+		require.NoError(t, err)
+		return fill.Bytes
+	}
+
+	t.Run("a fat row past the first ends the window before it", func(t *testing.T) {
+		m, keys := build(t, keyCount-1)
+
+		// Just past what the thin rows cost, so they all fit and the fat one cannot.
+		// Not exactly their total: a budget landing on it stops a walk that prices
+		// rows after copying them too, since its running total reaches the budget at
+		// the same boundary, and the case would pass either way.
+		thin := costOf(t, m, keys, 0, keyCount-1)
+		budget := thin + 1
+		require.Less(t, budget, thin+costOf(t, m, keys, keyCount-1, keyCount),
+			"the fat row must not fit in a budget the thin ones leave room under")
+
+		dst := make([]roaringset.BitmapLayer, keys.Len())
+		fill, err := m.roaringSetGetWindow(keys, 0, keys.Len(), dst, budget)
+		require.NoError(t, err)
+
+		require.Equal(t, keyCount-1, fill.To, "the window must end before the fat row")
+		require.LessOrEqual(t, fill.Bytes, budget, "a window must not hold more than the budget")
+		require.Nil(t, dst[keyCount-1].Additions, "the fat row must not have been copied")
+	})
+
+	t.Run("a fat row at the first is taken whatever it costs", func(t *testing.T) {
+		m, keys := build(t, 0)
+
+		dst := make([]roaringset.BitmapLayer, keys.Len())
+		fill, err := m.roaringSetGetWindow(keys, 0, keys.Len(), dst, 1)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, fill.To, "the window holds only the row that overran it")
+		require.Greater(t, fill.Bytes, 1, "the first row is taken past the budget")
+		require.NotNil(t, dst[0].Additions, "the first row must be readable at any size")
+	})
 }

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_window_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_window_test.go
@@ -1,0 +1,450 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"path"
+	"slices"
+	"sort"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/inverted"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+// TestRoaringSetGetWindowMatchesPerKey is the differential the batch read has to
+// survive: for any memtable and any batch, reading the batch in one pass must
+// answer exactly what reading each key on its own does. The two walk the tree
+// completely differently — one descends per key, the other advances two cursors
+// past each other — so agreement is the property worth pinning, and the shapes
+// below are the ones where a cursor can overshoot: batches far sparser than the
+// memtable, far denser, disjoint from it, and sharing only their ends.
+func TestRoaringSetGetWindowMatchesPerKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		memtableKeys []string
+		batchKeys    []string
+	}{
+		{"empty batch", []string{"b", "d"}, nil},
+		{"empty memtable", nil, []string{"a", "b"}},
+		{"single key, hit", []string{"b"}, []string{"b"}},
+		{"single key, missed", []string{"b"}, []string{"a", "c"}},
+		{"batch entirely before the memtable", []string{"y", "z"}, []string{"a", "b", "c"}},
+		{"batch entirely after the memtable", []string{"a", "b"}, []string{"y", "z"}},
+		{"disjoint, interleaved", []string{"b", "d", "f"}, []string{"a", "c", "e", "g"}},
+		{"identical", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"memtable much sparser", []string{"m"}, singleLetterKeys()},
+		{"batch much sparser", singleLetterKeys(), []string{"m"}},
+		{"only the ends shared", []string{"a", "m", "z"}, []string{"a", "z"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := memtableWith(t, tt.memtableKeys)
+			keys := sortedKeysOf(t, tt.batchKeys)
+
+			got := make([]roaringset.BitmapLayer, keys.Len())
+			fillWindowOK(t, m, keys, 0, keys.Len(), got)
+
+			// what reading one key at a time says, in the same form
+			want := make([]roaringset.BitmapLayer, keys.Len())
+			for i := 0; i < keys.Len(); i++ {
+				layer, err := m.roaringSetGet(keys.At(i))
+				if errors.Is(err, entlsmkv.NotFound) {
+					continue
+				}
+				require.NoError(t, err)
+				want[i] = layer
+			}
+
+			assert.Equal(t, layerDocsOf(want), layerDocsOf(got))
+		})
+	}
+}
+
+// TestRoaringSetGetWindowRandomized runs the same differential over random
+// shapes, which is where an off-by-one in either cursor's jump shows up: it
+// would drop or duplicate a key that no hand-written case happens to place.
+func TestRoaringSetGetWindowRandomized(t *testing.T) {
+	t.Parallel()
+
+	rnd := rand.New(rand.NewSource(7))
+	for round := 0; round < 200; round++ {
+		universe := 40
+		mem := sampleDistinct(rnd, universe, rnd.Intn(universe+1))
+		batch := sampleDistinct(rnd, universe, rnd.Intn(universe+1))
+
+		m := memtableWith(t, mem)
+		keys := sortedKeysOf(t, batch)
+
+		got := make([]roaringset.BitmapLayer, keys.Len())
+		fillWindowOK(t, m, keys, 0, keys.Len(), got)
+
+		want := make([]roaringset.BitmapLayer, keys.Len())
+		for i := 0; i < keys.Len(); i++ {
+			if layer, err := m.roaringSetGet(keys.At(i)); err == nil {
+				want[i] = layer
+			}
+		}
+		require.Equalf(t, layerDocsOf(want), layerDocsOf(got),
+			"round %d: memtable %v batch %v", round, mem, batch)
+	}
+}
+
+// TestRoaringSetGetWindowMatchesWholeBatch pins that reading a batch in windows answers
+// exactly what reading it whole does.
+//
+// Windowing a large batch is what holds the lock briefly and keeps one window's
+// bitmaps in hand at a time, and it only works if the boundaries are invisible:
+// every window starts with its own descent rather than where the last one stopped,
+// so a key sitting on a boundary is the one a mistake drops or double-counts.
+// Window size 1 is the degenerate end of that — every key is its own boundary.
+func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
+	t.Parallel()
+
+	rnd := rand.New(rand.NewSource(11))
+	for round := 0; round < 100; round++ {
+		universe := 30
+		mem := sampleDistinct(rnd, universe, rnd.Intn(universe+1))
+		batch := sampleDistinct(rnd, universe, rnd.Intn(universe+1))
+
+		m := memtableWith(t, mem)
+		keys := sortedKeysOf(t, batch)
+
+		whole := make([]roaringset.BitmapLayer, keys.Len())
+		fillWindowOK(t, m, keys, 0, keys.Len(), whole)
+
+		for _, w := range []int{1, 2, 3, 7, 1000} {
+			// One slot per key, handed over a window at a time, which is how a
+			// caller reading a batch this way has to do it. Writing outside its
+			// window would index past the subslice rather than land in a
+			// neighbour's slot.
+			got := make([]roaringset.BitmapLayer, keys.Len())
+			for from := 0; from < keys.Len(); from += w {
+				to := min(from+w, keys.Len())
+				fillWindowOK(t, m, keys, from, to, got[from:to])
+			}
+			require.Equalf(t, layerDocsOf(whole), layerDocsOf(got),
+				"round %d window %d: memtable %v batch %v", round, w, mem, batch)
+		}
+	}
+}
+
+// TestRoaringSetGetWindowRangeGuards separates an empty window from a range or
+// a slice the caller got wrong. Only the empty one can be answered by reading
+// nothing; the rest cannot be answered with "this memtable holds none of those
+// keys", because nobody asked about those keys.
+//
+// A caller that derives the range from its own batch and sizes the slice to it
+// reaches none of the erroring shapes. They are the arithmetic to get wrong by
+// hand — most of all the too-long slice, where the rows would land at the offsets
+// of keys outside the window.
+func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
+	t.Parallel()
+
+	m := memtableWith(t, []string{"a", "b", "c"})
+	keys := sortedKeysOf(t, []string{"a", "b", "c"})
+
+	tests := []struct {
+		name     string
+		from, to int
+		slots    int
+		wantErr  bool
+	}{
+		{name: "empty at the start", from: 0, to: 0, slots: 0},
+		{name: "empty at the end", from: 3, to: 3, slots: 0},
+		{name: "empty in the middle", from: 1, to: 1, slots: 0},
+		// caught by the width check: to-from is negative and no slice matches it
+		{name: "inverted", from: 2, to: 1, slots: 0, wantErr: true},
+		{name: "before the first key", from: -1, to: 2, slots: 3, wantErr: true},
+		{name: "one past the last", from: 0, to: 4, slots: 4, wantErr: true},
+		{name: "far past the last", from: 1, to: 99, slots: 99, wantErr: true},
+		{name: "slice shorter than the window", from: 0, to: 3, slots: 2, wantErr: true},
+		{name: "slice longer than the window", from: 0, to: 2, slots: 3, wantErr: true},
+		{name: "whole batch passed for a late window", from: 1, to: 3, slots: 3, wantErr: true},
+		{name: "slots for an empty window", from: 1, to: 1, slots: 3, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			into := make([]roaringset.BitmapLayer, tc.slots)
+			_, err := m.roaringSetGetWindow(keys, tc.from, tc.to, into)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestRoaringSetGetWindowDropsEmptySides pins which clone the read uses. A row
+// written to but never deleted from still has both bitmaps allocated in the
+// tree, and the window must hand back a nil deletion side rather than an empty
+// one, since a caller distinguishes "no row here" by that nil. Plain Clone would
+// return an allocated empty bitmap and go unnoticed everywhere else.
+func TestRoaringSetGetWindowDropsEmptySides(t *testing.T) {
+	t.Parallel()
+
+	m := memtableWith(t, []string{"a", "b", "c"})
+	require.NoError(t, m.roaringSetAddOne([]byte("adds-only"), 1))
+	require.NoError(t, m.roaringSetRemoveOne([]byte("dels-only"), 2))
+
+	keys := sortedKeysOf(t, []string{"adds-only", "dels-only"})
+	into := make([]roaringset.BitmapLayer, keys.Len())
+	fillWindowOK(t, m, keys, 0, keys.Len(), into)
+
+	for i := 0; i < keys.Len(); i++ {
+		switch string(keys.At(i)) {
+		case "adds-only":
+			require.NotNil(t, into[i].Additions)
+			require.Nil(t, into[i].Deletions, "a row never deleted from must carry no deletion side")
+		case "dels-only":
+			require.Nil(t, into[i].Additions, "a row never added to must carry no addition side")
+			require.NotNil(t, into[i].Deletions)
+		}
+	}
+}
+
+// TestRoaringSetGetWindowClearsWhatItIsGiven pins that absence is answered as
+// absence even when the caller hands over a buffer it has used before. The read
+// only writes the slots whose keys it holds, so anything left in the others
+// would be read as a row this memtable has for that key.
+func TestRoaringSetGetWindowClearsWhatItIsGiven(t *testing.T) {
+	t.Parallel()
+
+	m := memtableWith(t, []string{"a", "b", "c"})
+
+	tests := []struct {
+		name  string
+		batch []string
+	}{
+		{name: "memtable holds none of them", batch: []string{"x", "y", "z"}},
+		{name: "memtable holds some of them", batch: []string{"a", "y", "c"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			keys := sortedKeysOf(t, tc.batch)
+
+			dirty := make([]roaringset.BitmapLayer, keys.Len())
+			for i := range dirty {
+				dirty[i] = roaringset.BitmapLayer{Additions: bitmapFromSlice([]uint64{uint64(900 + i)})}
+			}
+			fillWindowOK(t, m, keys, 0, keys.Len(), dirty)
+
+			fresh := make([]roaringset.BitmapLayer, keys.Len())
+			fillWindowOK(t, m, keys, 0, keys.Len(), fresh)
+
+			require.Equal(t, layerDocsOf(fresh), layerDocsOf(dirty),
+				"a reused buffer must answer exactly what a clean one does")
+		})
+	}
+}
+
+// TestRoaringSetGetWindowCopiesWhatItYields pins that the rows leave the read
+// owning nothing of the memtable. The walk hands out the tree's own nodes, so
+// only the copy keeps a caller from editing the memtable through the row it was
+// given. The race detector catches the concurrent half of that; this catches the
+// half that is wrong even single-threaded.
+func TestRoaringSetGetWindowCopiesWhatItYields(t *testing.T) {
+	t.Parallel()
+
+	m := memtableWith(t, []string{"a", "b", "c"})
+	keys := sortedKeysOf(t, []string{"a", "b", "c"})
+
+	got := make([]roaringset.BitmapLayer, keys.Len())
+	fillWindowOK(t, m, keys, 0, keys.Len(), got)
+	before := layerDocsOf(got)
+
+	for _, l := range got {
+		if l.Additions != nil {
+			l.Additions.Set(777)
+		}
+		if l.Deletions != nil {
+			l.Deletions.Set(778)
+		}
+	}
+
+	again := make([]roaringset.BitmapLayer, keys.Len())
+	fillWindowOK(t, m, keys, 0, keys.Len(), again)
+	require.Equal(t, before, layerDocsOf(again),
+		"editing a row the read handed out must not reach the memtable")
+}
+
+// TestRoaringSetGetWindowRejectsOtherStrategies covers the guard that keeps the
+// roaringset walk off a memtable holding something else, whose tree it would
+// read as one.
+func TestRoaringSetGetWindowRejectsOtherStrategies(t *testing.T) {
+	t.Parallel()
+
+	m := newTestMemtableReplace(map[string][]byte{"a": []byte("x")})
+	keys := sortedKeysOf(t, []string{"a"})
+	into := make([]roaringset.BitmapLayer, 1)
+	_, err := m.roaringSetGetWindow(keys, 0, 1, into)
+	require.Error(t, err)
+}
+
+func memtableWith(t *testing.T, keys []string) *Memtable {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	dir := path.Join(t.TempDir(), "fake")
+
+	cl, err := newCommitLogger(dir, StrategyRoaringSet, 0)
+	require.NoError(t, err)
+	m, err := newMemtable(cl, nil, logger, nil, memtableConfig{
+		path:     dir,
+		strategy: StrategyRoaringSet,
+	})
+	require.NoError(t, err)
+
+	// Every third key also carries a deletion, and every fifth carries only
+	// one. Additions alone would make the deletion half of every comparison
+	// vacuous, and a deletion-only row is the shape whose layer has a nil
+	// Additions — the one a fold that assumes otherwise drops.
+	for i, k := range keys {
+		if i%5 != 0 {
+			require.NoError(t, m.roaringSetAddOne([]byte(k), uint64(i)))
+		}
+		if i%3 == 0 || i%5 == 0 {
+			require.NoError(t, m.roaringSetRemoveOne([]byte(k), uint64(1000+i)))
+		}
+	}
+	return m
+}
+
+// layerDocsOf renders layers as their doc IDs, which is the only way to compare
+// two reads of the same rows: each read clones, so the bitmaps are never the
+// same objects.
+func layerDocsOf(layers []roaringset.BitmapLayer) []layerDocs {
+	out := make([]layerDocs, len(layers))
+	for i, l := range layers {
+		out[i] = layerDocs{additions: docsOrNil(l.Additions), deletions: docsOrNil(l.Deletions)}
+	}
+	return out
+}
+
+type layerDocs struct{ additions, deletions []uint64 }
+
+func sortedKeysOf(tb testing.TB, keys []string) inverted.SortedKeys {
+	tb.Helper()
+	sorted := slices.Clone(keys)
+	slices.Sort(sorted)
+	total := 0
+	for _, k := range sorted {
+		total += len(k)
+	}
+	b := inverted.NewVarKeyBuilder(len(sorted), total)
+	for _, k := range sorted {
+		b.AppendString(k)
+	}
+	built, err := b.Build()
+	require.NoError(tb, err)
+	return built
+}
+
+func sampleDistinct(rnd *rand.Rand, universe, n int) []string {
+	perm := rnd.Perm(universe)[:n]
+	out := make([]string, 0, n)
+	for _, v := range perm {
+		out = append(out, fmt.Sprintf("key_%03d", v))
+	}
+	slices.Sort(out)
+	return out
+}
+
+func singleLetterKeys() []string {
+	out := make([]string, 0, 26)
+	for c := byte('a'); c <= 'z'; c++ {
+		out = append(out, string([]byte{c}))
+	}
+	return out
+}
+
+// TestMemtableLayersAreNeverBothNil pins what makes a window slot readable at
+// all. The slot is a plain BitmapLayer whose zero value says "no row for this
+// key", which only tells absent from present because every node a memtable
+// builds allocates both of its bitmaps. That invariant belongs to roaringset, not
+// to whatever reads a window, so it is checked rather than assumed: a
+// node-creation path leaving both nil would make keys the memtable holds read as
+// absent.
+func TestMemtableLayersAreNeverBothNil(t *testing.T) {
+	t.Parallel()
+	rnd := rand.New(rand.NewSource(5))
+
+	for round := 0; round < 30; round++ {
+		universe := 20
+		contents := map[string][]uint64{}
+		for _, k := range sampleDistinct(rnd, universe, rnd.Intn(universe)+1) {
+			contents[k] = []uint64{uint64(rnd.Intn(20))}
+		}
+		m := newTestMemtableRoaringSet(contents)
+
+		// deletions too: a key whose row is only a delete still has to come back
+		// as present, not as a zero layer
+		for _, k := range sampleDistinct(rnd, universe, 3) {
+			require.NoError(t, m.roaringSetRemoveOne([]byte(k), uint64(rnd.Intn(20))))
+			contents[k] = nil
+		}
+		held := make([]string, 0, len(contents))
+		for k := range contents {
+			held = append(held, k)
+		}
+		sort.Strings(held)
+
+		batch := sampleDistinct(rnd, universe, universe)
+		sort.Strings(batch)
+		keys := sortedKeysOf(t, batch)
+
+		into := make([]roaringset.BitmapLayer, keys.Len())
+		fillWindowOK(t, m, keys, 0, keys.Len(), into)
+
+		// A node with both bitmaps nil leaves its slot untouched, which is what
+		// absence looks like, so it goes missing from this list rather than
+		// arriving as a zero layer. Comparing against what the memtable was
+		// given is what catches it.
+		reported := make([]string, 0, len(into))
+		for i, layer := range into {
+			if layer.Additions != nil || layer.Deletions != nil {
+				reported = append(reported, string(keys.At(i)))
+			}
+		}
+		require.NotEmpty(t, reported, "round %d matched nothing, so it pins nothing", round)
+		require.Equalf(t, held, reported,
+			"round %d: the memtable holds keys it did not report, so the dense "+
+				"window reads them as absent", round)
+	}
+}
+
+// fillWindowOK reads a window and fails the test if it errors, so the callers that
+// only care about what landed in dst stay one line. What it reports is discarded:
+// no caller here reads it.
+func fillWindowOK(t *testing.T, m memtable, keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) {
+	t.Helper()
+	_, err := m.roaringSetGetWindow(keys, from, to, dst)
+	require.NoError(t, err)
+}

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_window_test.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_window_test.go
@@ -29,13 +29,12 @@ import (
 	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 )
 
-// TestRoaringSetGetWindowMatchesPerKey is the differential the batch read has to
-// survive: for any memtable and any batch, reading the batch in one pass must
-// answer exactly what reading each key on its own does. The two walk the tree
-// completely differently — one descends per key, the other advances two cursors
-// past each other — so agreement is the property worth pinning, and the shapes
-// below are the ones where a cursor can overshoot: batches far sparser than the
-// memtable, far denser, disjoint from it, and sharing only their ends.
+// TestRoaringSetGetWindowMatchesPerKey is the differential the batch read has
+// to survive: reading a batch in one pass must answer exactly what reading
+// each key on its own does. The two walk the tree completely differently —
+// one descends per key, the other advances two cursors past each other — so
+// the shapes below target where a cursor can overshoot: batches far sparser
+// or denser than the memtable, disjoint from it, or sharing only their ends.
 func TestRoaringSetGetWindowMatchesPerKey(t *testing.T) {
 	t.Parallel()
 
@@ -112,15 +111,11 @@ func TestRoaringSetGetWindowRandomized(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowMatchesWholeBatch pins that reading a batch in windows answers
-// exactly what reading it whole does.
-//
-// The caller windows a large batch so the lock is held briefly and only one
-// window's bitmaps are held at a time, which only works if the boundaries are
-// invisible: every window starts with its own descent rather than where the
-// last one stopped, so a key sitting on a boundary is the one a mistake drops
-// or double-counts. Window size 1 is the degenerate end of that — every key is
-// its own boundary.
+// TestRoaringSetGetWindowMatchesWholeBatch pins that reading a batch in
+// windows answers exactly what reading it whole does. Each window starts with
+// its own descent rather than where the last one stopped, so a key on a
+// window boundary is the one a mistake would drop or double-count; window
+// size 1 is the degenerate case where every key is a boundary.
 func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
 	t.Parallel()
 
@@ -137,9 +132,8 @@ func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
 		fillWindowOK(t, m, keys, 0, keys.Len(), whole)
 
 		for _, w := range []int{1, 2, 3, 7, 1000} {
-			// One slot per key, handed over a window at a time, exactly as the
-			// batch reader does it. Writing outside its window would index past
-			// the subslice rather than land in a neighbour's slot.
+			// One slot per key, handed over a window at a time, as the batch
+			// reader does it.
 			got := make([]roaringset.BitmapLayer, keys.Len())
 			for from := 0; from < keys.Len(); from += w {
 				to := min(from+w, keys.Len())
@@ -151,18 +145,13 @@ func TestRoaringSetGetWindowMatchesWholeBatch(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowRangeGuards separates the ranges that can be answered
-// by reading nothing from the ones nobody asked for. A range outside the batch
-// cannot be answered with "this memtable holds none of those keys", and a slice
-// too short for its range has nowhere to put the last rows.
-//
-// A slice longer than the range is legal, and pinned here as such: fillWindow
-// holds one buffer at the widest a window gets and asks for the narrower range
-// its budget settled on.
-//
-// None of the erroring shapes is reachable from fillWindow, which always
-// produces a range inside the batch and a slice at least its width. They are the
-// arithmetic a second caller would get wrong.
+// TestRoaringSetGetWindowRangeGuards covers the rejected shapes: a range
+// outside the batch, and a slice that is not exactly as wide as its range. A
+// longer slice is rejected rather than tolerated, because the read clears
+// everything it is given, so only an exact length makes what it erases the
+// slots it was asked for. None of the erroring shapes is reachable from
+// fillWindow, which slices exactly the range it asks for — they are the
+// arithmetic a second caller could get wrong.
 func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 	t.Parallel()
 
@@ -178,9 +167,9 @@ func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 		{name: "empty at the start", from: 0, to: 0, slots: 0},
 		{name: "empty at the end", from: 3, to: 3, slots: 0},
 		{name: "empty in the middle", from: 1, to: 1, slots: 0},
-		{name: "slice longer than the window", from: 0, to: 2, slots: 3},
-		{name: "whole batch passed for a late window", from: 1, to: 3, slots: 3},
-		{name: "slots for an empty window", from: 1, to: 1, slots: 3},
+		{name: "slice longer than the window", from: 0, to: 2, slots: 3, wantErr: true},
+		{name: "whole batch passed for a late window", from: 1, to: 3, slots: 3, wantErr: true},
+		{name: "slots for an empty window", from: 1, to: 1, slots: 3, wantErr: true},
 		{name: "inverted", from: 2, to: 1, slots: 0, wantErr: true},
 		{name: "before the first key", from: -1, to: 2, slots: 3, wantErr: true},
 		{name: "one past the last", from: 0, to: 4, slots: 4, wantErr: true},
@@ -203,11 +192,9 @@ func TestRoaringSetGetWindowRangeGuards(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowDropsEmptySides pins which clone the read uses. A row
-// written to but never deleted from still has both bitmaps allocated in the
-// tree, and the window must hand back a nil deletion side rather than an empty
-// one — that nil is what the reader's presence test reads. Plain Clone would
-// return an allocated empty bitmap and go unnoticed everywhere else.
+// TestRoaringSetGetWindowDropsEmptySides pins that a row's unused side comes
+// back nil, not an allocated-but-empty bitmap: that nil is what the reader's
+// presence test relies on, even though the tree itself allocates both sides.
 func TestRoaringSetGetWindowDropsEmptySides(t *testing.T) {
 	t.Parallel()
 
@@ -231,10 +218,9 @@ func TestRoaringSetGetWindowDropsEmptySides(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowClearsWhatItIsGiven pins that absence is answered as
-// absence even when the caller hands over a buffer it has used before. The read
-// only writes the slots whose keys it holds, so anything left in the others
-// would be read as a row this memtable has for that key.
+// TestRoaringSetGetWindowClearsWhatItIsGiven pins that a reused, dirty buffer
+// answers the same as a fresh one: the read only writes slots for keys it
+// holds, so a stale slot would otherwise read as a row present.
 func TestRoaringSetGetWindowClearsWhatItIsGiven(t *testing.T) {
 	t.Parallel()
 
@@ -269,11 +255,10 @@ func TestRoaringSetGetWindowClearsWhatItIsGiven(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowCopiesWhatItYields pins that the rows leave the read
-// owning nothing of the memtable. The walk hands out the tree's own nodes, so
-// only the copy keeps a caller from editing the memtable through the row it was
-// given. The race detector catches the concurrent half of that; this catches the
-// half that is wrong even single-threaded.
+// TestRoaringSetGetWindowCopiesWhatItYields pins that mutating a returned row
+// never reaches the memtable — the walk hands out the tree's own nodes, so
+// only the copy protects it. This is the single-threaded half of that
+// contract; the race detector covers the concurrent half.
 func TestRoaringSetGetWindowCopiesWhatItYields(t *testing.T) {
 	t.Parallel()
 
@@ -325,10 +310,8 @@ func memtableWith(t *testing.T, keys []string) *Memtable {
 	})
 	require.NoError(t, err)
 
-	// Every third key also carries a deletion, and every fifth carries only
-	// one. Additions alone would make the deletion half of every comparison
-	// vacuous, and a deletion-only row is the shape whose layer has a nil
-	// Additions — the one a fold that assumes otherwise drops.
+	// Every third key also carries a deletion, every fifth carries only a
+	// deletion (a layer with a nil Additions, which a careless fold drops).
 	for i, k := range keys {
 		if i%5 != 0 {
 			require.NoError(t, m.roaringSetAddOne([]byte(k), uint64(i)))
@@ -340,9 +323,8 @@ func memtableWith(t *testing.T, keys []string) *Memtable {
 	return m
 }
 
-// layerDocsOf renders layers as their doc IDs, which is the only way to compare
-// two reads of the same rows: each read clones, so the bitmaps are never the
-// same objects.
+// layerDocsOf renders layers as their doc IDs, since each read clones and the
+// bitmaps are never the same objects to compare directly.
 func layerDocsOf(layers []roaringset.BitmapLayer) []layerDocs {
 	out := make([]layerDocs, len(layers))
 	for i, l := range layers {
@@ -388,13 +370,10 @@ func singleLetterKeys() []string {
 	return out
 }
 
-// TestMemtableLayersAreNeverBothNil pins what makes a window slot readable at
-// all. The slot is a plain BitmapLayer whose zero value says "no row for this
-// key", which only tells absent from present because every node a memtable
-// builds allocates both of its bitmaps. That invariant belongs to roaringset, not
-// to whatever reads a window, so it is checked rather than assumed: a
-// node-creation path leaving both nil would make keys the memtable holds read as
-// absent.
+// TestMemtableLayersAreNeverBothNil pins the invariant a window slot's zero
+// value relies on to mean "absent": every node a memtable builds must
+// allocate at least one of its two bitmaps. A node-creation path that left
+// both nil would make a held key read as absent.
 func TestMemtableLayersAreNeverBothNil(t *testing.T) {
 	t.Parallel()
 	rnd := rand.New(rand.NewSource(5))
@@ -426,10 +405,8 @@ func TestMemtableLayersAreNeverBothNil(t *testing.T) {
 		into := make([]roaringset.BitmapLayer, keys.Len())
 		fillWindowOK(t, m, keys, 0, keys.Len(), into)
 
-		// A node with both bitmaps nil leaves its slot untouched, which is what
-		// absence looks like, so it goes missing from this list rather than
-		// arriving as a zero layer. Comparing against what the memtable was
-		// given is what catches it.
+		// A node with both bitmaps nil would leave its slot untouched — missing
+		// from this list rather than arriving as a zero layer.
 		reported := make([]string, 0, len(into))
 		for i, layer := range into {
 			if layer.Additions != nil || layer.Deletions != nil {
@@ -443,16 +420,13 @@ func TestMemtableLayersAreNeverBothNil(t *testing.T) {
 	}
 }
 
-// TestRoaringSetGetWindowStopsAtTheBudget pins what bounds a window's memory.
-// The key count caps how many rows a fill clones and nothing caps how big a row
-// is, so without this a property with few values and many documents each turns
-// one window into a multiple of what the constant suggests.
+// TestRoaringSetGetWindowStopsAtTheBudget pins the byte budget as a second
+// bound on window memory alongside the key count: nothing else caps how big a
+// single row is.
 func TestRoaringSetGetWindowStopsAtTheBudget(t *testing.T) {
 	t.Parallel()
 
-	// Rows wide enough that a couple of them exhaust any budget worth setting.
-	// Documents are spread so each lands in its own container, which is what
-	// makes a row cost bytes rather than compress to nothing.
+	// Documents spread one per container, so a row costs real bytes.
 	const rows, docsPerRow = 8, 4096
 	batch := make([]string, rows)
 	for i := range batch {
@@ -505,33 +479,27 @@ func TestRoaringSetGetWindowStopsAtTheBudget(t *testing.T) {
 	}
 }
 
-// fillWindowOK reads a window and fails the test if it errors, so the callers
-// that only care about what landed in dst stay one line. The bytes it reports
-// are asserted where that is the subject.
+// fillWindowOK reads a window and fails the test if it errors, so callers that
+// only care about what landed in dst stay one line.
 func fillWindowOK(t *testing.T, m memtable, keys inverted.SortedKeys, from, to int, dst []roaringset.BitmapLayer) {
 	t.Helper()
-	// A budget nothing here can reach, so these callers read the whole range
-	// they asked for. The budget's own behaviour is covered separately.
+	// Unbudgeted, so these callers always get the whole range they asked for.
 	fill, err := m.roaringSetGetWindow(keys, from, to, dst, math.MaxInt)
 	require.NoError(t, err)
 	require.Equal(t, to, fill.To, "an unbudgeted read must fill the whole range")
 }
 
-// TestRoaringSetGetWindowHoldsAtMostTheBudget pins the ceiling the budget
-// enforces, which a fixture of equally sized rows cannot reach: spending there
-// lands on the budget and never past it, so the same numbers come out whether a
-// row is priced before it is copied or after. One fat row among thin ones is what
-// tells the two apart, and it is the shape the budget exists for — a property
-// whose values carry wildly different document counts.
+// TestRoaringSetGetWindowHoldsAtMostTheBudget pins that pricing a row before
+// copying it (not after) matters: only a fat row among thin ones can tell the
+// two apart, since equally sized rows always land on the budget the same way
+// either way.
 func TestRoaringSetGetWindowHoldsAtMostTheBudget(t *testing.T) {
 	t.Parallel()
 
 	const keyCount, thinDocs, fatDocs = 8, 8, 4096
 
-	// Sixty-four apart, and each key's documents are its own, so no two rows share a
-	// container. What costs bytes here is the document count: the fat row's four
-	// thousand fill a handful of containers densely, where the thin rows' eight share
-	// one.
+	// Each key's documents are 64 apart and its own, so no two rows share a
+	// container.
 	docsFor := func(key, n int) []uint64 {
 		docs := make([]uint64, n)
 		for j := range docs {
@@ -566,10 +534,8 @@ func TestRoaringSetGetWindowHoldsAtMostTheBudget(t *testing.T) {
 	t.Run("a fat row past the first ends the window before it", func(t *testing.T) {
 		m, keys := build(t, keyCount-1)
 
-		// Just past what the thin rows cost, so they all fit and the fat one cannot.
-		// Not exactly their total: a budget landing on it stops a walk that prices
-		// rows after copying them too, since its running total reaches the budget at
-		// the same boundary, and the case would pass either way.
+		// One byte past the thin rows' total: exactly their total would also
+		// pass under price-after-copy pricing, so it wouldn't distinguish the two.
 		thin := costOf(t, m, keys, 0, keyCount-1)
 		budget := thin + 1
 		require.Less(t, budget, thin+costOf(t, m, keys, keyCount-1, keyCount),

--- a/adapters/repos/db/lsmkv/segment_fakes_test.go
+++ b/adapters/repos/db/lsmkv/segment_fakes_test.go
@@ -106,6 +106,9 @@ type fakeSegment struct {
 	// roaringSetGet was actually invoked, so tests can pin buffer-release
 	// behavior without a production seam.
 	roaringSetReleases int
+	// roaringSetGetErr, when set, fails the disk half of a row read — the half a
+	// memtable-read failure cannot reach.
+	roaringSetGetErr error
 	// roaringSetMergeErr, when set, makes roaringSetMergeWith fail, simulating a
 	// mid-merge disk read error.
 	roaringSetMergeErr error
@@ -352,6 +355,9 @@ func (f *fakeSegment) roaringSetGet(key []byte, bitmapBufPool roaringset.BitmapB
 	f.getCounter++
 	if f.strategy != segmentindex.StrategyRoaringSet {
 		return nil, nil, fmt.Errorf("not a roaring set segment")
+	}
+	if f.roaringSetGetErr != nil {
+		return nil, nil, f.roaringSetGetErr
 	}
 
 	if val, ok := f.roaringStore[string(key)]; ok {

--- a/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy.go
@@ -1,0 +1,115 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringset
+
+import (
+	"bytes"
+
+	"github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+// BinarySearchTreeCursorNoCopy is an [InnerCursor] that walks the tree's own
+// nodes, handing out their keys and bitmaps rather than copies.
+//
+// It locks nothing, so the caller carries what the copy would otherwise carry:
+// hold the tree's read lock for the cursor's whole lifetime, or use it only
+// where no writer can reach the tree at all. What it yields belongs to the
+// tree — mutating a bitmap corrupts it, and anything kept past the lock must be
+// copied first.
+//
+// Skipping the copy is what makes it worth having: [NewBinarySearchTreeCursor]
+// condenses and allocates every node's bitmaps before the first read, and this one
+// allocates only itself.
+type BinarySearchTreeCursorNoCopy struct {
+	root *BinarySearchNode
+	node *BinarySearchNode
+	// started distinguishes "before the first node" from "past the last", which
+	// a nil node alone cannot.
+	started bool
+}
+
+var _ InnerCursor = (*BinarySearchTreeCursorNoCopy)(nil)
+
+// NewBinarySearchTreeCursorNoCopy walks bst without copying it. See the type's
+// documentation for what the caller must guarantee.
+func NewBinarySearchTreeCursorNoCopy(bst *BinarySearchTree) *BinarySearchTreeCursorNoCopy {
+	return &BinarySearchTreeCursorNoCopy{root: bst.root}
+}
+
+func (c *BinarySearchTreeCursorNoCopy) First() ([]byte, BitmapLayer, error) {
+	c.started = true
+	c.node = leftmost(c.root)
+	return c.current()
+}
+
+func (c *BinarySearchTreeCursorNoCopy) Next() ([]byte, BitmapLayer, error) {
+	if !c.started {
+		return c.First()
+	}
+	if c.node == nil {
+		return nil, BitmapLayer{}, nil
+	}
+	c.node = successor(c.node)
+	return c.current()
+}
+
+// Seek moves to the first node whose key is greater than or equal to key,
+// descending the tree rather than scanning, and reports NotFound past the end.
+// A Seek that finds nothing leaves the position alone, so whatever Next would
+// have returned before it, Next still returns after.
+func (c *BinarySearchTreeCursorNoCopy) Seek(key []byte) ([]byte, BitmapLayer, error) {
+	var found *BinarySearchNode
+	for node := c.root; node != nil; {
+		if bytes.Compare(node.Key, key) < 0 {
+			node = node.right
+			continue
+		}
+		// a candidate, but an earlier one may sit to its left
+		found = node
+		node = node.left
+	}
+
+	if found == nil {
+		return nil, BitmapLayer{}, lsmkv.NotFound
+	}
+	c.started = true
+	c.node = found
+	return c.current()
+}
+
+func (c *BinarySearchTreeCursorNoCopy) current() ([]byte, BitmapLayer, error) {
+	if c.node == nil {
+		return nil, BitmapLayer{}, nil
+	}
+	return c.node.Key, c.node.Value, nil
+}
+
+func leftmost(node *BinarySearchNode) *BinarySearchNode {
+	if node == nil {
+		return nil
+	}
+	for node.left != nil {
+		node = node.left
+	}
+	return node
+}
+
+// successor is the next node in key order, walking the tree's parent pointers.
+func successor(node *BinarySearchNode) *BinarySearchNode {
+	if node.right != nil {
+		return leftmost(node.right)
+	}
+	for node.parent != nil && node.parent.right == node {
+		node = node.parent
+	}
+	return node.parent
+}

--- a/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy.go
@@ -18,17 +18,12 @@ import (
 )
 
 // BinarySearchTreeCursorNoCopy is an [InnerCursor] that walks the tree's own
-// nodes, handing out their keys and bitmaps rather than copies.
+// nodes, handing out their keys and bitmaps rather than copies. Unlike
+// [NewBinarySearchTreeCursor], it allocates nothing but itself.
 //
-// It locks nothing, so the caller carries what the copy would otherwise carry:
-// hold the tree's read lock for the cursor's whole lifetime, or use it only
-// where no writer can reach the tree at all. What it yields belongs to the
-// tree — mutating a bitmap corrupts it, and anything kept past the lock must be
-// copied first.
-//
-// Skipping the copy is what makes it worth having: [NewBinarySearchTreeCursor]
-// condenses and allocates every node's bitmaps before the first read, and this one
-// allocates only itself.
+// It locks nothing. The caller must hold the tree's read lock for the cursor's
+// whole lifetime, or otherwise keep writers away. What it yields belongs to the
+// tree, so anything kept past that lock must be copied.
 type BinarySearchTreeCursorNoCopy struct {
 	root *BinarySearchNode
 	node *BinarySearchNode
@@ -62,10 +57,9 @@ func (c *BinarySearchTreeCursorNoCopy) Next() ([]byte, BitmapLayer, error) {
 	return c.current()
 }
 
-// Seek moves to the first node whose key is greater than or equal to key,
-// descending the tree rather than scanning, and reports NotFound past the end.
-// A Seek that finds nothing leaves the position alone, so whatever Next would
-// have returned before it, Next still returns after.
+// Seek moves to the first node with key >= key by descending the tree, and
+// reports NotFound past the end. On NotFound the position is left unchanged,
+// so Next behaves as if Seek were never called.
 func (c *BinarySearchTreeCursorNoCopy) Seek(key []byte) ([]byte, BitmapLayer, error) {
 	var found *BinarySearchNode
 	for node := c.root; node != nil; {

--- a/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy_test.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy_test.go
@@ -1,0 +1,225 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package roaringset
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+type cursorEntry struct {
+	key  string
+	adds []uint64
+	dels []uint64
+}
+
+// drain walks a cursor to exhaustion, recording what it yields.
+func drain(c InnerCursor) []cursorEntry {
+	var out []cursorEntry
+	for k, layer, err := c.First(); k != nil && err == nil; k, layer, err = c.Next() {
+		e := cursorEntry{key: string(k)}
+		if layer.Additions != nil {
+			e.adds = layer.Additions.ToArray()
+		}
+		if layer.Deletions != nil {
+			e.dels = layer.Deletions.ToArray()
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func treeWith(t *testing.T, keys []string) *BinarySearchTree {
+	t.Helper()
+	bst := &BinarySearchTree{}
+	for i, k := range keys {
+		bst.Insert([]byte(k), Insert{Additions: []uint64{uint64(i)}})
+		if i%3 == 0 { // some keys carry deletions too
+			bst.Insert([]byte(k), Insert{Deletions: []uint64{uint64(1000 + i)}})
+		}
+	}
+	return bst
+}
+
+// TestCursorNoCopyMatchesCopyingCursor pins the fast cursor against the copying
+// one it shortcuts: walked from the start, the two yield the same keys and the
+// same bitmaps, which is what makes the fast one usable in place of it.
+//
+// What each yields is only half of that; where each is left afterwards is the
+// other half, and TestFailedSeekLeavesThePosition covers the state the two once
+// disagreed on.
+func TestCursorNoCopyMatchesCopyingCursor(t *testing.T) {
+	t.Parallel()
+
+	sizes := []int{0, 1, 2, 3, 7, 8, 100, 1000}
+
+	for _, n := range sizes {
+		t.Run(fmt.Sprintf("keys=%d", n), func(t *testing.T) {
+			t.Parallel()
+
+			keys := make([]string, n)
+			for i := range keys {
+				keys[i] = fmt.Sprintf("key_%05d", i)
+			}
+			// insert out of order so the tree actually has to rebalance
+			rnd := rand.New(rand.NewSource(int64(n)))
+			rnd.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+			bst := treeWith(t, keys)
+
+			want := drain(NewBinarySearchTreeCursor(bst))
+			got := drain(NewBinarySearchTreeCursorNoCopy(bst))
+			require.Equal(t, want, got, "the no-copy cursor must yield exactly what the copying one does")
+			require.Len(t, got, n)
+		})
+	}
+}
+
+// TestFailedSeekLeavesThePosition pins that a Seek finding nothing changes
+// nothing: whatever Next would have returned before it, Next returns after. It
+// runs both cursors from every state one can be in. The two reach that
+// guarantee differently: the copying one leaves its index alone, the no-copy one
+// assigns its node only once the descent has found something.
+//
+// The windowed memtable read returns as soon as a Seek reports NotFound and so
+// never asks. This is for the next caller, who may.
+func TestFailedSeekLeavesThePosition(t *testing.T) {
+	t.Parallel()
+
+	cursors := []struct {
+		name string
+		open func(*BinarySearchTree) InnerCursor
+	}{
+		{"copying", func(bst *BinarySearchTree) InnerCursor { return NewBinarySearchTreeCursor(bst) }},
+		{"no-copy", func(bst *BinarySearchTree) InnerCursor { return NewBinarySearchTreeCursorNoCopy(bst) }},
+	}
+
+	tests := []struct {
+		name string
+		// where the cursor is put before the failed seek
+		position func(t *testing.T, c InnerCursor)
+		wantNext string // "" for a cursor with nothing left
+	}{
+		{
+			name:     "never read from",
+			position: func(t *testing.T, c InnerCursor) {},
+			wantNext: "b",
+		},
+		{
+			name: "part way through",
+			position: func(t *testing.T, c InnerCursor) {
+				k, _, err := c.First()
+				require.NoError(t, err)
+				require.Equal(t, "b", string(k))
+			},
+			wantNext: "d",
+		},
+		{
+			name: "seeked to a key it holds",
+			position: func(t *testing.T, c InnerCursor) {
+				k, _, err := c.Seek([]byte("e"))
+				require.NoError(t, err)
+				require.Equal(t, "f", string(k))
+			},
+			wantNext: "h",
+		},
+		{
+			name: "already exhausted",
+			position: func(t *testing.T, c InnerCursor) {
+				require.Len(t, drain(c), 4)
+			},
+		},
+	}
+
+	for _, cursor := range cursors {
+		t.Run(cursor.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					t.Parallel()
+
+					c := cursor.open(treeWith(t, []string{"b", "d", "f", "h"}))
+					tt.position(t, c)
+
+					_, _, err := c.Seek([]byte("z"))
+					require.ErrorIs(t, err, lsmkv.NotFound)
+
+					k, _, err := c.Next()
+					require.NoError(t, err)
+					require.Equal(t, tt.wantNext, string(k))
+				})
+			}
+		})
+	}
+}
+
+// TestCursorNoCopySeek covers seeking, which descends the tree rather than
+// scanning a flattened slice.
+func TestCursorNoCopySeek(t *testing.T) {
+	t.Parallel()
+
+	bst := treeWith(t, []string{"b", "d", "f", "h"})
+
+	tests := []struct {
+		name     string
+		seek     string
+		wantKey  string
+		wantErr  error
+		thenNext string
+	}{
+		{name: "exact match", seek: "d", wantKey: "d", thenNext: "f"},
+		{name: "between keys", seek: "c", wantKey: "d", thenNext: "f"},
+		{name: "before the first", seek: "a", wantKey: "b", thenNext: "d"},
+		{name: "the last key", seek: "h", wantKey: "h"},
+		{name: "past the end", seek: "z", wantErr: lsmkv.NotFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := NewBinarySearchTreeCursorNoCopy(bst)
+			k, _, err := c.Seek([]byte(tt.seek))
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantKey, string(k))
+
+			if tt.thenNext != "" {
+				next, _, err := c.Next()
+				require.NoError(t, err)
+				require.Equal(t, tt.thenNext, string(next), "Next must continue from the seek")
+			}
+		})
+	}
+}
+
+// TestCursorNoCopyExhaustionIsStable pins that reading past the end keeps
+// reporting nothing rather than restarting or panicking.
+func TestCursorNoCopyExhaustionIsStable(t *testing.T) {
+	t.Parallel()
+
+	c := NewBinarySearchTreeCursorNoCopy(treeWith(t, []string{"a", "b"}))
+	require.Len(t, drain(c), 2)
+
+	for i := 0; i < 3; i++ {
+		k, _, err := c.Next()
+		require.NoError(t, err)
+		require.Nil(t, k)
+	}
+}

--- a/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy_test.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_cursor_nocopy_test.go
@@ -54,13 +54,10 @@ func treeWith(t *testing.T, keys []string) *BinarySearchTree {
 	return bst
 }
 
-// TestCursorNoCopyMatchesCopyingCursor pins the fast cursor against the copying
-// one it shortcuts: walked from the start, the two yield the same keys and the
-// same bitmaps, which is what makes the fast one usable in place of it.
-//
-// What each yields is only half of that; where each is left afterwards is the
-// other half, and TestFailedSeekLeavesThePosition covers the state the two once
-// disagreed on.
+// TestCursorNoCopyMatchesCopyingCursor pins the no-copy cursor against the
+// copying one it shortcuts: walked from the start, both must yield the same
+// keys and bitmaps. TestFailedSeekLeavesThePosition covers where each cursor
+// is left afterwards, which this does not.
 func TestCursorNoCopyMatchesCopyingCursor(t *testing.T) {
 	t.Parallel()
 
@@ -88,13 +85,10 @@ func TestCursorNoCopyMatchesCopyingCursor(t *testing.T) {
 }
 
 // TestFailedSeekLeavesThePosition pins that a Seek finding nothing changes
-// nothing: whatever Next would have returned before it, Next returns after. It
-// runs both cursors from every state one can be in. The two reach that
-// guarantee differently: the copying one leaves its index alone, the no-copy one
-// assigns its node only once the descent has found something.
-//
-// The windowed memtable read returns as soon as a Seek reports NotFound and so
-// never asks. This is for the next caller, who may.
+// nothing: whatever Next would have returned before it, Next returns after
+// too. Runs both cursors, which reach that guarantee differently — the
+// copying one leaves its index alone, the no-copy one assigns its node only
+// once the descent finds something.
 func TestFailedSeekLeavesThePosition(t *testing.T) {
 	t.Parallel()
 
@@ -174,7 +168,10 @@ func TestCursorNoCopySeek(t *testing.T) {
 	bst := treeWith(t, []string{"b", "d", "f", "h"})
 
 	tests := []struct {
-		name     string
+		name string
+		// keys, when set, replaces the shared tree; the empty case needs a tree
+		// with no root, which is a different tree rather than a different seek.
+		keys     []string
 		seek     string
 		wantKey  string
 		wantErr  error
@@ -185,13 +182,20 @@ func TestCursorNoCopySeek(t *testing.T) {
 		{name: "before the first", seek: "a", wantKey: "b", thenNext: "d"},
 		{name: "the last key", seek: "h", wantKey: "h"},
 		{name: "past the end", seek: "z", wantErr: lsmkv.NotFound},
+		// Reaches the same arm as "past the end" by never entering the descent
+		// rather than by falling off it.
+		{name: "empty tree", keys: []string{}, seek: "a", wantErr: lsmkv.NotFound},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			c := NewBinarySearchTreeCursorNoCopy(bst)
+			tree := bst
+			if tt.keys != nil {
+				tree = treeWith(t, tt.keys)
+			}
+			c := NewBinarySearchTreeCursorNoCopy(tree)
 			k, _, err := c.Seek([]byte(tt.seek))
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
@@ -221,5 +225,72 @@ func TestCursorNoCopyExhaustionIsStable(t *testing.T) {
 		k, _, err := c.Next()
 		require.NoError(t, err)
 		require.Nil(t, k)
+	}
+}
+
+// TestCursorNoCopyWalksARebalancedTree covers the tree this cursor is the first
+// to depend on the shape of. It descends by following each node's parent
+// pointer, where the copying cursor flattens the tree first and never reads
+// them; a rotation that failed to re-point a parent would show up here as a
+// skipped or repeated key and nowhere else.
+//
+// The other cursor tests use a handful of keys, which is too few to rotate.
+func TestCursorNoCopyWalksARebalancedTree(t *testing.T) {
+	t.Parallel()
+
+	const nKeys = 500
+
+	// Bounded, because a rotation that left a parent dangling makes successor()
+	// cycle: an unbounded walk would hang instead of failing.
+	collect := func(t *testing.T, c *BinarySearchTreeCursorNoCopy,
+		start func() ([]byte, BitmapLayer, error),
+	) []string {
+		t.Helper()
+		out := make([]string, 0, nKeys)
+		for k, _, err := start(); k != nil && err == nil; k, _, err = c.Next() {
+			out = append(out, string(k))
+			require.LessOrEqualf(t, len(out), nKeys,
+				"walked past %d keys without ending: a parent pointer cycles", nKeys)
+		}
+		return out
+	}
+
+	// Rotations depend on insertion order, and ascending is what a sorted bulk
+	// load produces.
+	orders := map[string]func(i int) int{
+		"ascending":  func(i int) int { return i },
+		"descending": func(i int) int { return nKeys - 1 - i },
+		"shuffled":   func(i int) int { return (i*137 + 41) % nKeys },
+	}
+
+	for name, order := range orders {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			keys := make([]string, nKeys)
+			for i := range keys {
+				keys[i] = fmt.Sprintf("k%04d", order(i))
+			}
+			bst := treeWith(t, keys)
+
+			want := make([]string, nKeys)
+			for i := range want {
+				want[i] = fmt.Sprintf("k%04d", i)
+			}
+
+			c := NewBinarySearchTreeCursorNoCopy(bst)
+			require.Equal(t, want, collect(t, c, c.First),
+				"the walk must yield every key once, in order")
+
+			// And from any starting point the rest of the walk is the tail from
+			// there, which is what the parent pointers decide after a descent.
+			for _, at := range []int{0, 1, nKeys / 3, nKeys / 2, nKeys - 2, nKeys - 1} {
+				c := NewBinarySearchTreeCursorNoCopy(bst)
+				rest := collect(t, c, func() ([]byte, BitmapLayer, error) {
+					return c.Seek([]byte(want[at]))
+				})
+				require.Equalf(t, want[at:], rest, "the walk from %q must be the tail from there", want[at])
+			}
+		})
 	}
 }

--- a/adapters/repos/db/roaringset/binary_search_tree_cursor_test.go
+++ b/adapters/repos/db/roaringset/binary_search_tree_cursor_test.go
@@ -111,22 +111,6 @@ func TestBSTCursor(t *testing.T) {
 		assert.ErrorIs(t, err, lsmkv.NotFound)
 	})
 
-	t.Run("next after seek missing element does not change cursor's position", func(t *testing.T) {
-		cursor := NewBinarySearchTreeCursor(bst)
-
-		key1, _, err1 := cursor.First()
-
-		missing := []byte("eee")
-		cursor.Seek(missing)
-
-		key2, _, err2 := cursor.Next()
-
-		assert.Equal(t, []byte("aaa"), key1)
-		assert.Nil(t, err1)
-		assert.Equal(t, []byte("bbb"), key2)
-		assert.Nil(t, err2)
-	})
-
 	t.Run("next after last is nil/empty", func(t *testing.T) {
 		cursor := NewBinarySearchTreeCursor(bst)
 

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -53,6 +53,28 @@ func (l *BitmapLayer) Clone() BitmapLayer {
 	return clone
 }
 
+// CloneDroppingEmpty copies the layer as [BitmapLayer.Clone] does, but leaves a
+// side that holds nothing nil rather than cloning it. A memtable node always
+// allocates both bitmaps, so a key only ever written to would otherwise pay a
+// clone to carry an empty deletion set.
+//
+// nil and empty are interchangeable to [LayerMerger]: its AndNot and Or take
+// either, and the branch that adopts a layer's additions outright is reached
+// only when no older layer contributed, which is when that layer's own
+// deletions have nothing to delete from. Pinned by
+// TestNilAndEmptyBitmapsMergeAlike.
+func (l *BitmapLayer) CloneDroppingEmpty() BitmapLayer {
+	clone := BitmapLayer{}
+	// IsEmpty is nil-safe, so a nil bitmap takes the same path as an empty one.
+	if !l.Additions.IsEmpty() {
+		clone.Additions = l.Additions.Clone()
+	}
+	if !l.Deletions.IsEmpty() {
+		clone.Deletions = l.Deletions.Clone()
+	}
+	return clone
+}
+
 // BitmapLayers are a helper type to perform operations on multiple layers,
 // such as [BitmapLayers.Flatten] or [BitmapLayers.Merge].
 type BitmapLayers []BitmapLayer
@@ -91,9 +113,16 @@ func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 		return sroar.NewBitmap()
 	}
 
+	// A first layer that only deletes has nothing to fold into, and every later
+	// layer's deletions would then be applied to a nil receiver. Cloning a nil
+	// bitmap yields an empty one, so a caller that clones never reaches this;
+	// one that does not would panic in sroar's OrConc without it.
 	merged := bml[0].Additions
-	if clone {
+	switch {
+	case clone:
 		merged = merged.Clone()
+	case merged == nil:
+		merged = sroar.NewBitmap()
 	}
 
 	for i := 1; i < len(bml); i++ {
@@ -118,8 +147,9 @@ type LayerMerger struct {
 
 // NewLayerMerger starts a fold from base, which becomes the accumulator and
 // is mutated in place by Add; pass clone=true when base must not be mutated.
-// A nil base means no layer yet: the first Add'd layer's additions are
-// adopted as the accumulator without a copy, as in Flatten.
+// A nil base means no layer yet: the first Add'd layer with non-nil additions
+// has them adopted as the accumulator without a copy, as in Flatten. One
+// holding only deletions is not that layer and leaves the fold unseeded.
 func NewLayerMerger(base *sroar.Bitmap, clone bool, maxConc int) LayerMerger {
 	if clone && base != nil {
 		base = base.Clone()

--- a/adapters/repos/db/roaringset/layers.go
+++ b/adapters/repos/db/roaringset/layers.go
@@ -42,6 +42,8 @@ type BitmapLayer struct {
 	Deletions *sroar.Bitmap
 }
 
+// Clone copies both sides, keeping an allocated-but-empty one allocated. Where
+// that distinction matters, see [BitmapLayer.CloneIfWithin].
 func (l *BitmapLayer) Clone() BitmapLayer {
 	clone := BitmapLayer{}
 	if l.Additions != nil {
@@ -53,26 +55,39 @@ func (l *BitmapLayer) Clone() BitmapLayer {
 	return clone
 }
 
-// CloneDroppingEmpty copies the layer as [BitmapLayer.Clone] does, but leaves a
-// side that holds nothing nil rather than cloning it. A memtable node always
-// allocates both bitmaps, so a key only ever written to would otherwise pay a
-// clone to carry an empty deletion set.
+// LenInBytes is what copying this layer allocates. An allocated-but-empty side
+// costs nothing here, where [sroar.Bitmap.LenInBytes] counts the buffer it
+// allocated; the two agree only once a bitmap holds something.
+func (l *BitmapLayer) LenInBytes() int {
+	// ToBuffer is nil-safe, and nil exactly when the bitmap is empty.
+	return len(l.Additions.ToBuffer()) + len(l.Deletions.ToBuffer())
+}
+
+// CloneIfWithin clones the layer if it fits the budget, leaving an empty side
+// nil — [LayerMerger] treats nil and empty alike. The cost comes back either
+// way, and only ok separates a refusal from a layer holding nothing, since both
+// clone to a zero value.
 //
-// nil and empty are interchangeable to [LayerMerger]: its AndNot and Or take
-// either, and the branch that adopts a layer's additions outright is reached
-// only when no older layer contributed, which is when that layer's own
-// deletions have nothing to delete from. Pinned by
-// TestNilAndEmptyBitmapsMergeAlike.
-func (l *BitmapLayer) CloneDroppingEmpty() BitmapLayer {
+// It repeats [BitmapLayer.Clone]'s body rather than calling it because of that
+// nil: Clone returns an allocated-but-empty side as non-nil, and a caller
+// testing a slot with Additions != nil || Deletions != nil would read a layer
+// holding nothing for the key as one holding something.
+//
+// A budget below zero refuses everything, an empty layer included: fitting is
+// cost against budget, not a question of whether there is anything to copy.
+func (l *BitmapLayer) CloneIfWithin(budget int) (BitmapLayer, int, bool) {
+	cost := l.LenInBytes()
+	if cost > budget {
+		return BitmapLayer{}, cost, false
+	}
 	clone := BitmapLayer{}
-	// IsEmpty is nil-safe, so a nil bitmap takes the same path as an empty one.
-	if !l.Additions.IsEmpty() {
-		clone.Additions = l.Additions.Clone()
+	if adds := l.Additions.ToBuffer(); len(adds) > 0 {
+		clone.Additions = sroar.FromBufferWithCopy(adds)
 	}
-	if !l.Deletions.IsEmpty() {
-		clone.Deletions = l.Deletions.Clone()
+	if dels := l.Deletions.ToBuffer(); len(dels) > 0 {
+		clone.Deletions = sroar.FromBufferWithCopy(dels)
 	}
-	return clone
+	return clone, cost, true
 }
 
 // BitmapLayers are a helper type to perform operations on multiple layers,
@@ -113,10 +128,8 @@ func (bml BitmapLayers) Flatten(clone bool, maxConc int) *sroar.Bitmap {
 		return sroar.NewBitmap()
 	}
 
-	// A first layer that only deletes has nothing to fold into, and every later
-	// layer's deletions would then be applied to a nil receiver. Cloning a nil
-	// bitmap yields an empty one, so a caller that clones never reaches this;
-	// one that does not would panic in sroar's OrConc without it.
+	// A first layer that only deletes has nothing to fold into, and sroar's
+	// OrConc panics on a nil receiver. Clone answers with a bitmap either way.
 	merged := bml[0].Additions
 	switch {
 	case clone:

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -384,6 +384,91 @@ func Test_BitmapLayers_Merge(t *testing.T) {
 	}
 }
 
+// Test_BitmapLayers_FlattenFirstLayerWithoutAdditions covers a first layer that
+// only deletes, which every later layer's deletions would otherwise be applied
+// to as a nil receiver. A delete-only row is ordinary — a memtable that has
+// only ever removed a document produces one — but Flatten reaches the case only
+// when the caller does not clone, and every production caller does; cloning a
+// nil bitmap yields an empty one, so no production caller reaches it.
+func Test_BitmapLayers_FlattenFirstLayerWithoutAdditions(t *testing.T) {
+	tests := []struct {
+		name  string
+		first BitmapLayer
+		want  []uint64
+	}{
+		{name: "nil additions", first: BitmapLayer{Deletions: NewBitmap(9)}, want: []uint64{1, 2}},
+		{name: "nil additions, deletes a later addition", first: BitmapLayer{Deletions: NewBitmap(1)}, want: []uint64{1, 2}},
+		{name: "empty additions", first: BitmapLayer{Additions: NewBitmap(), Deletions: NewBitmap(9)}, want: []uint64{1, 2}},
+		{name: "both sides nil", first: BitmapLayer{}, want: []uint64{1, 2}},
+		{name: "populated additions", first: BitmapLayer{Additions: NewBitmap(7)}, want: []uint64{1, 2, 7}},
+	}
+
+	for _, tc := range tests {
+		for _, clone := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/clone=%t", tc.name, clone), func(t *testing.T) {
+				layers := BitmapLayers{tc.first, {Additions: NewBitmap(1, 2)}}
+				got := layers.Flatten(clone, 1)
+				require.NotNil(t, got)
+				assert.Equal(t, tc.want, got.ToArray())
+			})
+		}
+	}
+}
+
+// Test_BitmapLayer_CloneDroppingEmpty pins what the variant does differently
+// from [BitmapLayer.Clone]: a side holding nothing comes back nil rather than
+// as an allocated empty bitmap. Nothing else asserts it, so swapping the one
+// call site used Clone, no other test would fail.
+//
+// Dropping a side is what puts nil layers in front of [LayerMerger], which has
+// to fold them as it would empty ones — TestNilAndEmptyBitmapsMergeAlike is
+// where that equivalence is pinned.
+func Test_BitmapLayer_CloneDroppingEmpty(t *testing.T) {
+	populated := func(v uint64) *sroar.Bitmap {
+		bm := NewBitmap()
+		bm.Set(v)
+		return bm
+	}
+
+	tests := []struct {
+		name          string
+		layer         BitmapLayer
+		wantAdditions []uint64 // nil means the side must come back nil
+		wantDeletions []uint64
+	}{
+		{name: "both sides populated", layer: BitmapLayer{populated(1), populated(2)}, wantAdditions: []uint64{1}, wantDeletions: []uint64{2}},
+		{name: "additions only", layer: BitmapLayer{Additions: populated(1)}, wantAdditions: []uint64{1}},
+		{name: "deletions only", layer: BitmapLayer{Deletions: populated(2)}, wantDeletions: []uint64{2}},
+		{name: "allocated but empty", layer: BitmapLayer{NewBitmap(), NewBitmap()}},
+		{name: "both nil", layer: BitmapLayer{}},
+		{name: "one side allocated and empty", layer: BitmapLayer{populated(1), NewBitmap()}, wantAdditions: []uint64{1}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.layer.CloneDroppingEmpty()
+
+			for _, side := range []struct {
+				name string
+				want []uint64
+				got  *sroar.Bitmap
+				src  *sroar.Bitmap
+			}{
+				{"additions", tc.wantAdditions, got.Additions, tc.layer.Additions},
+				{"deletions", tc.wantDeletions, got.Deletions, tc.layer.Deletions},
+			} {
+				if side.want == nil {
+					assert.Nilf(t, side.got, "%s holding nothing must come back nil", side.name)
+					continue
+				}
+				require.NotNilf(t, side.got, "%s", side.name)
+				assert.Equalf(t, side.want, side.got.ToArray(), "%s", side.name)
+				assert.NotSamef(t, side.src, side.got, "%s must be a copy, not the original", side.name)
+			}
+		})
+	}
+}
+
 func Test_BitmapLayer_Clone(t *testing.T) {
 	t.Run("cloning empty BitmapLayer", func(t *testing.T) {
 		layerEmpty := BitmapLayer{}
@@ -451,4 +536,119 @@ func Test_BitmapLayers_Merge_PanicSliceBoundOutOfRange(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.ElementsMatch(t, genSlice(289_800, 290_000), failingDeletionsLayer.Deletions.ToArray())
+}
+
+// TestNilAndEmptyBitmapsMergeAlike pins that a nil bitmap and an empty one are
+// interchangeable to the merger, which is what lets a reader leave an empty one
+// nil rather than pay to clone it.
+//
+// The case worth the test is not AndNot or Or but Add's first branch: with
+// nothing merged yet it adopts the layer's additions and returns, so a nil
+// there leaves nothing merged and that layer's deletions are never applied.
+// Sound, because a deletion only has to apply to layers older than itself and
+// nothing merged means no older layer contributed — but sound by argument
+// rather than by construction, so it is checked.
+func TestNilAndEmptyBitmapsMergeAlike(t *testing.T) {
+	nilIfEmpty := func(b *sroar.Bitmap) *sroar.Bitmap {
+		if b != nil && b.IsEmpty() {
+			return nil
+		}
+		return b
+	}
+
+	type layer struct{ add, del []uint64 }
+	for _, tt := range []struct {
+		name     string
+		disk     []uint64
+		diskMiss bool
+		layers   []layer
+	}{
+		{"disk hit, write-only layer", []uint64{1, 2}, false, []layer{{add: []uint64{3}}}},
+		{"disk hit, delete-only layer", []uint64{1, 2}, false, []layer{{del: []uint64{2}}}},
+		{"disk hit, delete then re-add", []uint64{1}, false, []layer{{del: []uint64{1}}, {add: []uint64{1}}}},
+		{"disk miss, delete-only then add", nil, true, []layer{{del: []uint64{5}}, {add: []uint64{5}}}},
+		{"disk miss, delete-only then unrelated add", nil, true, []layer{{del: []uint64{5}}, {add: []uint64{9}}}},
+		{"disk miss, delete-only alone", nil, true, []layer{{del: []uint64{5}}}},
+		{"disk miss, two delete-only", nil, true, []layer{{del: []uint64{5}}, {del: []uint64{6}}}},
+		{"disk miss, add then delete", nil, true, []layer{{add: []uint64{7}}, {del: []uint64{7}}}},
+		{"disk hit, layer holding nothing", []uint64{1, 2}, false, []layer{{}}},
+		{"disk miss, layer holding nothing", nil, true, []layer{{}}},
+		{"disk hit, layer holding nothing between two that do", []uint64{1}, false, []layer{{add: []uint64{2}}, {}, {del: []uint64{1}}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			run := func(nilEmpty bool) []uint64 {
+				var base *sroar.Bitmap
+				if !tt.diskMiss {
+					base = NewBitmap(tt.disk...)
+				}
+				m := NewLayerMerger(base, false, 1)
+				for _, l := range tt.layers {
+					lay := BitmapLayer{Additions: NewBitmap(l.add...), Deletions: NewBitmap(l.del...)}
+					if nilEmpty {
+						lay.Additions = nilIfEmpty(lay.Additions)
+						lay.Deletions = nilIfEmpty(lay.Deletions)
+					}
+					m.Add(lay)
+				}
+				return m.Result().ToArray()
+			}
+			require.Equal(t, run(false), run(true),
+				"nilling an empty bitmap must not change the merged result")
+		})
+	}
+}
+
+// TestLayerHoldingNothingMergesAsIfAbsent pins what the windowed reader encodes
+// absence with. It drops a layer whose sides are both empty, so a key the
+// memtable holds an empty row for is folded as if the memtable did not hold it
+// — the same shape an empty write produces, which reaches the tree through an
+// ordinary AddList with no values.
+//
+// The two are indistinguishable to the fold and to nothing else: an empty layer
+// deletes nothing and adds nothing. A consumer reading layers rather than
+// folding them would see a difference, and none does.
+func TestLayerHoldingNothingMergesAsIfAbsent(t *testing.T) {
+	empty := func() BitmapLayer { return BitmapLayer{Additions: sroar.NewBitmap(), Deletions: sroar.NewBitmap()} }
+
+	for _, tt := range []struct {
+		name     string
+		disk     []uint64
+		diskMiss bool
+		before   []BitmapLayer // layers folded before the empty one
+		after    []BitmapLayer // and after it
+	}{
+		{name: "alone, over a disk row", disk: []uint64{1, 2}},
+		{name: "alone, no disk row", diskMiss: true},
+		{
+			name: "between two that contribute", disk: []uint64{1},
+			before: []BitmapLayer{{Additions: NewBitmap(2)}},
+			after:  []BitmapLayer{{Deletions: NewBitmap(1)}},
+		},
+		{
+			name: "first, ahead of a delete-only layer", diskMiss: true,
+			after: []BitmapLayer{{Deletions: NewBitmap(5)}, {Additions: NewBitmap(5)}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fold := func(withEmpty bool) []uint64 {
+				var base *sroar.Bitmap
+				if !tt.diskMiss {
+					base = NewBitmap(tt.disk...)
+				}
+				m := NewLayerMerger(base, false, 1)
+				for _, l := range tt.before {
+					m.Add(l)
+				}
+				if withEmpty {
+					m.Add(empty())
+				}
+				for _, l := range tt.after {
+					m.Add(l)
+				}
+				return m.Result().ToArray()
+			}
+			require.Equal(t, fold(false), fold(true),
+				"a layer holding nothing must fold as if it were not there")
+		})
+	}
 }

--- a/adapters/repos/db/roaringset/layers_test.go
+++ b/adapters/repos/db/roaringset/layers_test.go
@@ -13,6 +13,7 @@ package roaringset
 
 import (
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -384,12 +385,10 @@ func Test_BitmapLayers_Merge(t *testing.T) {
 	}
 }
 
-// Test_BitmapLayers_FlattenFirstLayerWithoutAdditions covers a first layer that
-// only deletes, which every later layer's deletions would otherwise be applied
-// to as a nil receiver. A delete-only row is ordinary — a memtable that has
-// only ever removed a document produces one — but Flatten reaches the case only
-// when the caller does not clone, and every production caller does; cloning a
-// nil bitmap yields an empty one, so no production caller reaches it.
+// Test_BitmapLayers_FlattenFirstLayerWithoutAdditions covers a first layer
+// with a nil Additions, which every later layer's deletions would otherwise
+// apply to as a nil receiver. Only reachable when the caller does not clone;
+// every production caller does, so this is defensive.
 func Test_BitmapLayers_FlattenFirstLayerWithoutAdditions(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -415,15 +414,42 @@ func Test_BitmapLayers_FlattenFirstLayerWithoutAdditions(t *testing.T) {
 	}
 }
 
-// Test_BitmapLayer_CloneDroppingEmpty pins what the variant does differently
-// from [BitmapLayer.Clone]: a side holding nothing comes back nil rather than
-// as an allocated empty bitmap. Nothing else asserts it, so swapping the one
-// call site used Clone, no other test would fail.
-//
-// Dropping a side is what puts nil layers in front of [LayerMerger], which has
-// to fold them as it would empty ones — TestNilAndEmptyBitmapsMergeAlike is
-// where that equivalence is pinned.
-func Test_BitmapLayer_CloneDroppingEmpty(t *testing.T) {
+// Test_BitmapLayer_LenInBytes pins the price against a count taken from the
+// bitmaps themselves. Every other byte assertion in the tree is relative —
+// derived from a first row's price, or from what CloneIfWithin reported — so a
+// term missing here is invisible everywhere downstream.
+func Test_BitmapLayer_LenInBytes(t *testing.T) {
+	additions, deletions := NewBitmap(), NewBitmap()
+	additions.Set(1)
+	deletions.Set(2)
+	additionsLen, deletionsLen := len(additions.ToBuffer()), len(deletions.ToBuffer())
+	require.Positive(t, additionsLen, "the fixture must cost something, or this proves nothing")
+	require.Positive(t, deletionsLen, "the fixture must cost something, or this proves nothing")
+
+	tests := []struct {
+		name  string
+		layer BitmapLayer
+		want  int
+	}{
+		{name: "both nil", layer: BitmapLayer{}, want: 0},
+		{name: "allocated but empty", layer: BitmapLayer{NewBitmap(), NewBitmap()}, want: 0},
+		{name: "additions only", layer: BitmapLayer{Additions: additions}, want: additionsLen},
+		{name: "deletions only", layer: BitmapLayer{Deletions: deletions}, want: deletionsLen},
+		{name: "both sides populated", layer: BitmapLayer{additions, deletions}, want: additionsLen + deletionsLen},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.layer.LenInBytes())
+		})
+	}
+}
+
+// Test_BitmapLayer_CloneIfWithin pins what it does differently from
+// [BitmapLayer.Clone]: a side holding nothing comes back nil rather than an
+// allocated empty bitmap. That's what puts nil layers in front of
+// [LayerMerger] — see TestNilAndEmptyBitmapsMergeAlike for the fold side.
+func Test_BitmapLayer_CloneIfWithin(t *testing.T) {
 	populated := func(v uint64) *sroar.Bitmap {
 		bm := NewBitmap()
 		bm.Set(v)
@@ -446,7 +472,10 @@ func Test_BitmapLayer_CloneDroppingEmpty(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.layer.CloneDroppingEmpty()
+			got, cost, ok := tc.layer.CloneIfWithin(math.MaxInt)
+			require.True(t, ok, "nothing is refused at an unlimited budget")
+			require.Equal(t, tc.layer.LenInBytes(), cost,
+				"the clone reports the layer's own price rather than one of its own; what that price is, Test_BitmapLayer_LenInBytes pins")
 
 			for _, side := range []struct {
 				name string
@@ -465,6 +494,69 @@ func Test_BitmapLayer_CloneDroppingEmpty(t *testing.T) {
 				assert.Equalf(t, side.want, side.got.ToArray(), "%s", side.name)
 				assert.NotSamef(t, side.src, side.got, "%s must be a copy, not the original", side.name)
 			}
+		})
+	}
+}
+
+// Test_BitmapLayer_CloneIfWithin_Budget pins the pricing half: a row
+// that does not fit is priced but not copied, so a caller can decide against it
+// without paying. The cost is the same either way, or the caller could not use
+// it to decide.
+func Test_BitmapLayer_CloneIfWithin_Budget(t *testing.T) {
+	bm := NewBitmap()
+	bm.Set(1)
+	populated := BitmapLayer{Additions: bm}
+
+	_, full, ok := populated.CloneIfWithin(math.MaxInt)
+	require.True(t, ok)
+	require.Positive(t, full, "the fixture must cost something, or this proves nothing")
+
+	tests := []struct {
+		name     string
+		layer    BitmapLayer
+		budget   int
+		wantOK   bool
+		wantCost int
+		wantDocs []uint64
+	}{
+		{
+			name: "a row over budget is refused", layer: populated,
+			budget: full - 1, wantOK: false, wantCost: full,
+		},
+		{
+			name: "a row that exactly fits is taken", layer: populated,
+			budget: full, wantOK: true, wantCost: full,
+			wantDocs: []uint64{1},
+		},
+		{
+			// An empty layer costs nothing, so even a zero budget takes it, and
+			// only ok separates it from a refusal.
+			name: "a layer holding nothing is not a refusal", layer: BitmapLayer{},
+			budget: 0, wantOK: true, wantCost: 0,
+		},
+		{
+			// The caller subtracted what it had already spent, and a window
+			// whose always-taken first row overshot hands the next key a
+			// negative budget.
+			name: "nothing fits a budget below zero", layer: BitmapLayer{},
+			budget: -1, wantOK: false, wantCost: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, cost, ok := tc.layer.CloneIfWithin(tc.budget)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.wantCost, cost, "the cost is reported either way")
+
+			if tc.wantDocs == nil {
+				assert.Nil(t, got.Additions)
+				assert.Nil(t, got.Deletions)
+				return
+			}
+			require.NotNil(t, got.Additions, "a row that was taken must be copied")
+			assert.Equal(t, tc.wantDocs, got.Additions.ToArray())
+			assert.Nil(t, got.Deletions)
 		})
 	}
 }
@@ -539,15 +631,11 @@ func Test_BitmapLayers_Merge_PanicSliceBoundOutOfRange(t *testing.T) {
 }
 
 // TestNilAndEmptyBitmapsMergeAlike pins that a nil bitmap and an empty one are
-// interchangeable to the merger, which is what lets a reader leave an empty one
-// nil rather than pay to clone it.
-//
-// The case worth the test is not AndNot or Or but Add's first branch: with
-// nothing merged yet it adopts the layer's additions and returns, so a nil
-// there leaves nothing merged and that layer's deletions are never applied.
-// Sound, because a deletion only has to apply to layers older than itself and
-// nothing merged means no older layer contributed — but sound by argument
-// rather than by construction, so it is checked.
+// interchangeable to the merger, letting a reader leave an empty side nil
+// rather than pay to clone it. The case that matters is Add's first branch:
+// with nothing merged yet, it adopts the layer's additions and returns, so a
+// nil there means that layer's deletions are never applied — sound only
+// because no older layer could have contributed anything to delete yet.
 func TestNilAndEmptyBitmapsMergeAlike(t *testing.T) {
 	nilIfEmpty := func(b *sroar.Bitmap) *sroar.Bitmap {
 		if b != nil && b.IsEmpty() {
@@ -598,15 +686,9 @@ func TestNilAndEmptyBitmapsMergeAlike(t *testing.T) {
 	}
 }
 
-// TestLayerHoldingNothingMergesAsIfAbsent pins what the windowed reader encodes
-// absence with. It drops a layer whose sides are both empty, so a key the
-// memtable holds an empty row for is folded as if the memtable did not hold it
-// — the same shape an empty write produces, which reaches the tree through an
-// ordinary AddList with no values.
-//
-// The two are indistinguishable to the fold and to nothing else: an empty layer
-// deletes nothing and adds nothing. A consumer reading layers rather than
-// folding them would see a difference, and none does.
+// TestLayerHoldingNothingMergesAsIfAbsent pins that a layer with both sides
+// empty (the shape an AddList with no values produces) folds exactly as if
+// the memtable did not hold that key at all.
 func TestLayerHoldingNothingMergesAsIfAbsent(t *testing.T) {
 	empty := func() BitmapLayer { return BitmapLayer{Additions: sroar.NewBitmap(), Deletions: sroar.NewBitmap()} }
 

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -116,6 +116,41 @@ func (k SortedKeys) All() iter.Seq2[int, []byte] {
 	}
 }
 
+// FirstAtOrAfter returns the first position in [from, to) whose key is at or
+// past target, or to if there is none. It is a lower bound over a window of the
+// list rather than the whole of it, which is what a caller walking two sorted
+// runs past each other needs: to is where its window ends, and a search running
+// past that would answer with a key the caller is not reading.
+//
+// from is a hint, not a bound the answer has to clear — a target already at or
+// before keys[from] answers from. The cost is one comparison for a caller that
+// knows it is behind, and the alternative is a precondition that answers wrongly
+// and silently when it is broken.
+//
+// to is required, not a hint: 0 <= from <= to <= Len(), unchecked. Trimming a
+// range the caller got wrong would answer as if they had got it right.
+func (k SortedKeys) FirstAtOrAfter(from, to int, target []byte) int {
+	lo, hi := from, from
+	for step := 1; hi < to && bytes.Compare(k.At(hi), target) < 0; step *= 2 {
+		lo = hi + 1
+		hi = lo + step
+	}
+	if hi > to {
+		hi = to
+	}
+	// Everything before lo is before target, and hi is either past the window or
+	// at or past target, so the answer is in [lo, hi].
+	for lo < hi {
+		mid := int(uint(lo+hi) >> 1)
+		if bytes.Compare(k.At(mid), target) < 0 {
+			lo = mid + 1
+		} else {
+			hi = mid
+		}
+	}
+	return lo
+}
+
 // isAscending reports whether the keys are ordered. Off the query path — it
 // exists so tests can pin the invariant each producer promises.
 func (k SortedKeys) isAscending() bool {

--- a/entities/inverted/keys.go
+++ b/entities/inverted/keys.go
@@ -117,15 +117,12 @@ func (k SortedKeys) All() iter.Seq2[int, []byte] {
 }
 
 // FirstAtOrAfter returns the first position in [from, to) whose key is at or
-// past target, or to if there is none. It is a lower bound over a window of the
-// list rather than the whole of it, which is what a caller walking two sorted
-// runs past each other needs: to is where its window ends, and a search running
-// past that would answer with a key the caller is not reading.
+// past target, or to if there is none. It searches a sub-range rather than the
+// whole list, which is what a caller walking two sorted runs past each other
+// needs.
 //
-// from is a hint, not a bound the answer has to clear — a target already at or
-// before keys[from] answers from. The cost is one comparison for a caller that
-// knows it is behind, and the alternative is a precondition that answers wrongly
-// and silently when it is broken.
+// from is a hint, not a bound the answer has to clear: a target already at or
+// before keys[from] answers from.
 //
 // to is required, not a hint: 0 <= from <= to <= Len(), unchecked. Trimming a
 // range the caller got wrong would answer as if they had got it right.

--- a/entities/inverted/keys_test.go
+++ b/entities/inverted/keys_test.go
@@ -429,13 +429,10 @@ func TestBuildDropsDuplicatesAcrossShapes(t *testing.T) {
 }
 
 // TestFirstAtOrAfter pins the gallop against a linear scan, over every
-// (from, to, target) the list admits and both layouts, since the two index the
-// slab differently and the search reaches keys by index.
-//
-// to is swept as well as from: it is the caller's window rather than the list's
-// end, and a stride running past it would answer with a key outside the window.
-// So are targets at or before keys[from], which the answer is from — the case a
-// precondition would have made undefined.
+// (from, to, target) the list admits and both layouts, since the two index
+// the slab differently. to is swept along with from since it is the caller's
+// window, not the list's end, and a stride running past it must not answer
+// with a key outside that window.
 func TestFirstAtOrAfter(t *testing.T) {
 	t.Parallel()
 
@@ -445,15 +442,12 @@ func TestFirstAtOrAfter(t *testing.T) {
 	}{
 		{name: "variable width", build: buildVariable},
 		{name: "fixed width", build: fixedBuilder(1)},
-		// Wider than the keys, so the slab is strided rather than packed and an
-		// index the search reaches has to be scaled by the width to find its key.
-		// The builder zero-pads, and the scan below compares the padded keys the
-		// same way the search does.
+		// Wider than the keys and zero-padded, so the slab is strided rather
+		// than packed.
 		{name: "fixed width, padded", build: fixedBuilder(8)},
 	}
-	// Every other printable byte: gaps between the keys, so a target can fall on
-	// one or between two, and enough of them that the gallop's stride doubles
-	// several times instead of finding its answer inside the first step.
+	// Every other printable byte, so a target can fall on a key or in the gap
+	// between two, with enough gaps that the gallop's stride doubles a few times.
 	var letters []string
 	for c := byte('!'); c <= '~'; c += 2 {
 		letters = append(letters, string(c))
@@ -466,8 +460,7 @@ func TestFirstAtOrAfter(t *testing.T) {
 			keys := layout.build(t, letters)
 			n := keys.Len()
 
-			// On the first key, in the gap after it, and the same at the middle and
-			// the end, plus a target before every key and one past all of them.
+			// First key, its gap, middle, end, and one before/after all of them.
 			last := len(letters) - 1
 			targets := []string{
 				"", letters[0], next(letters[0]),
@@ -493,10 +486,9 @@ func TestFirstAtOrAfter(t *testing.T) {
 	}
 }
 
-// TestFirstAtOrAfterOutsideItsRange pins what the godoc says the caller must not
-// do, so the documented behaviour is the tested one rather than whatever the
-// arithmetic happens to produce. Both are caller errors that nothing checks: the
-// alternative is trimming them to fit, which answers as if the caller were right.
+// TestFirstAtOrAfterOutsideItsRange pins the two caller errors the godoc
+// warns about but nothing checks, so the documented behaviour is the tested
+// one rather than whatever the arithmetic happens to produce.
 func TestFirstAtOrAfterOutsideItsRange(t *testing.T) {
 	t.Parallel()
 
@@ -506,8 +498,6 @@ func TestFirstAtOrAfterOutsideItsRange(t *testing.T) {
 		t.Parallel()
 
 		keys := buildVariable(t, letters)
-		// Every target, since the answer comes from the range and not from the
-		// search: with from past to there is nothing to search.
 		for _, target := range []string{"", "a", "e", "z"} {
 			assert.Equalf(t, 4, keys.FirstAtOrAfter(4, 2, []byte(target)),
 				"target %q", target)
@@ -518,8 +508,6 @@ func TestFirstAtOrAfterOutsideItsRange(t *testing.T) {
 		t.Parallel()
 
 		keys := buildVariable(t, letters)
-		// A target past every key makes the gallop walk to to, which the caller
-		// has put beyond what the list holds.
 		require.Panics(t, func() {
 			keys.FirstAtOrAfter(0, keys.Len()+8, []byte("z"))
 		})

--- a/entities/inverted/keys_test.go
+++ b/entities/inverted/keys_test.go
@@ -428,6 +428,104 @@ func TestBuildDropsDuplicatesAcrossShapes(t *testing.T) {
 	}
 }
 
+// TestFirstAtOrAfter pins the gallop against a linear scan, over every
+// (from, to, target) the list admits and both layouts, since the two index the
+// slab differently and the search reaches keys by index.
+//
+// to is swept as well as from: it is the caller's window rather than the list's
+// end, and a stride running past it would answer with a key outside the window.
+// So are targets at or before keys[from], which the answer is from — the case a
+// precondition would have made undefined.
+func TestFirstAtOrAfter(t *testing.T) {
+	t.Parallel()
+
+	layouts := []struct {
+		name  string
+		build func(tb testing.TB, keys []string) SortedKeys
+	}{
+		{name: "variable width", build: buildVariable},
+		{name: "fixed width", build: fixedBuilder(1)},
+		// Wider than the keys, so the slab is strided rather than packed and an
+		// index the search reaches has to be scaled by the width to find its key.
+		// The builder zero-pads, and the scan below compares the padded keys the
+		// same way the search does.
+		{name: "fixed width, padded", build: fixedBuilder(8)},
+	}
+	// Every other printable byte: gaps between the keys, so a target can fall on
+	// one or between two, and enough of them that the gallop's stride doubles
+	// several times instead of finding its answer inside the first step.
+	var letters []string
+	for c := byte('!'); c <= '~'; c += 2 {
+		letters = append(letters, string(c))
+	}
+
+	for _, layout := range layouts {
+		t.Run(layout.name, func(t *testing.T) {
+			t.Parallel()
+
+			keys := layout.build(t, letters)
+			n := keys.Len()
+
+			// On the first key, in the gap after it, and the same at the middle and
+			// the end, plus a target before every key and one past all of them.
+			last := len(letters) - 1
+			targets := []string{
+				"", letters[0], next(letters[0]),
+				letters[last/2], next(letters[last/2]),
+				letters[last], next(letters[last]),
+			}
+			for _, target := range targets {
+				for from := 0; from <= n; from++ {
+					for _, to := range []int{from, (from + n) / 2, n} {
+						want := to
+						for i := from; i < to; i++ {
+							if string(keys.At(i)) >= target {
+								want = i
+								break
+							}
+						}
+						assert.Equalf(t, want, keys.FirstAtOrAfter(from, to, []byte(target)),
+							"FirstAtOrAfter(from=%d, to=%d, target=%q)", from, to, target)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestFirstAtOrAfterOutsideItsRange pins what the godoc says the caller must not
+// do, so the documented behaviour is the tested one rather than whatever the
+// arithmetic happens to produce. Both are caller errors that nothing checks: the
+// alternative is trimming them to fit, which answers as if the caller were right.
+func TestFirstAtOrAfterOutsideItsRange(t *testing.T) {
+	t.Parallel()
+
+	letters := []string{"a", "c", "e", "g", "i"}
+
+	t.Run("an inverted range answers from, which is past to", func(t *testing.T) {
+		t.Parallel()
+
+		keys := buildVariable(t, letters)
+		// Every target, since the answer comes from the range and not from the
+		// search: with from past to there is nothing to search.
+		for _, target := range []string{"", "a", "e", "z"} {
+			assert.Equalf(t, 4, keys.FirstAtOrAfter(4, 2, []byte(target)),
+				"target %q", target)
+		}
+	})
+
+	t.Run("a range past the end reads past the keys", func(t *testing.T) {
+		t.Parallel()
+
+		keys := buildVariable(t, letters)
+		// A target past every key makes the gallop walk to to, which the caller
+		// has put beyond what the list holds.
+		require.Panics(t, func() {
+			keys.FirstAtOrAfter(0, keys.Len()+8, []byte("z"))
+		})
+	})
+}
+
 // fixedBuilder adapts buildFixed to the table's build signature, which takes the
 // TB so a builder error fails the case rather than being dropped.
 func fixedBuilder(width int) func(tb testing.TB, keys []string) SortedKeys {
@@ -604,3 +702,7 @@ func TestShrinkKeysReleasesTheDedupedTail(t *testing.T) {
 		})
 	})
 }
+
+// next is the single-byte key after k, which for a list of every other byte is a
+// target sitting in the gap that follows it.
+func next(k string) string { return string(k[0] + 1) }


### PR DESCRIPTION
## Motivation

Part 10 of the stacked series toward batched `ContainsAny`/`ContainsAll` (#12242), and the part PR 9's own description asked for. PR 9 measured its win against a bucket whose active memtable happened to be empty, and said so. Force the memtable to be read and PR 9 loses three quarters of its throughput, floored by **100,000 lock acquisitions per query** — one per key. A memtable is a delta, so most of those find nothing, and each costs the same either way, and more the more cores are taking it.

## Approach

- **`roaringSetGetWindow` reads a range of the sorted batch under one acquisition.** Neither side is stepped through: whichever of the batch and the tree is behind jumps to where the other already is, so the pass costs what the sparser side holds. `SortedKeys.FirstAtOrAfter` is the batch's half of that jump.
- **A no-copy cursor** yields the tree's own nodes, valid only under the read lock the walk holds. The existing cursor allocates every node's bitmaps up front, so a window would pay for the whole memtable.
- **`RoaringSetBatchReader`** caches one window and serves the batch from it. A row is handed over and its slot emptied in the same step, so the window holds only what the fold has yet to reach. Windows fill lazily, because `ContainsAll` abandons its fold as soon as the intersection empties.
- **Layers fold oldest first**, flushing before active: the merger replays each layer's deletions before its additions, so a document deleted while flushing and re-added in active survives only in that order.
- **A window ends on bytes as well as on keys.** Cost follows containers touched, not documents held — a thousand documents clustered in one container cost ~2KiB, one per container ~141KiB. `BenchmarkRoaringSetWindowRead` sweeps both shapes (`spread=clustered` and `spread=strided`). The allowance is `readerWindowBytes`, a reader's rather than each memtable's, split between the memtables a fill reads, so a flush in flight halves each share rather than doubling what the query holds.

## Behaviour change

- **The per-key read path is rewritten and is not behind the flag.** Both paths now fold through one shared `roaringSetGetWithLayers`, which is where layer order is decided. Same rows, same errors, same ordering — but live either way. It is reached by every `Equal`, `NotEqual` and `IsNull` filter on a stock server, not only by the batched path.
- **Seven new slow-query fields**: `window_fills`, `window_narrowed_fills`, `batch_keys_served`, `window_bytes_peak`, `window_bytes_copied`, `memtable_reads`, `memtables`. Without the narrowed count, a large batch and one whose every window was cut log the same thing; without `memtables` the read count cannot be normalised, since reads per fill run from one to one per memtable.
- **The batched fold's read error now names the position in the batch** — `read row 3 of 100000` — because neither loop binds a key and a six-figure batch gives an operator nothing else to go on.
- **`NewRoaringSetBatchReader` requires `view.Active` and panics if it is unset**, rather than rejecting it. No producer builds such a view, and the sibling read paths on this bucket already dereferenced it unchecked.
- `QUERY_BATCHED_CONTAINS_ENABLED` still defaults off and is set nowhere, so the batched path reaches no production query yet. It is a runtime-override key as well as an environment variable.

## Risks and testing

- **A wrong window is silent.** A zero layer means "no row for that key", so a window left too wide answers held keys as **absent** — no error, a smaller result. Guarded by a differential against the per-key path over both narrowing directions, a table over widths 1/2/3/5/1024/4096, and a randomised sweep.
- **The no-copy cursor is unsafe without the lock**, is built at one site inside it, and never escapes. It satisfies `InnerCursor`, which does not mention the requirement.
- **Review rounds found no wrong-row bug, no leak, no race, and no unsound locking.** Three passes independently tried to produce the silent wrong answer above and could not. What they did find: a memory bound applied per memtable instead of per reader; errors in the prose describing the cost model; a share guard and a lock-acquisition count that no assertion covered; a narrowed-fill count that depended on which memtable failed; and an empty-tree `Seek` with no case. All but the first are addressed here.
- `go test -race` on `lsmkv`, `roaringset`, `inverted`, `entities/inverted`; each commit passes those four standalone; the `integrationTest` tag passes on the same trees; linters clean. No on-disk or API change.

## Known, and not addressed here

- **The window allowance is per reader, and nothing bounds the number of readers.** `readerWindowBytes` is 8 MiB for one reader; an `AND` of many `ContainsAny` leaves across many shards opens one reader each, and the two errgroup limits that bound the fan-out do not divide this allowance. Worth settling before the flag is flipped — either by carrying the allowance on the context the way the merge budget already is, or by charging each fill against `Bucket.allocChecker`.
- **Two defects graded confirmed and reachable are pinned by red tests on `parked/pr10-known-defects-red-tests`**, not on this branch: an unbounded wait on segment references during shutdown, and a BM25 recover into unnamed returns. Neither is introduced here.
- **No server-level acceptance test reaches the batched path**, because nothing sets the flag. Twelve integration-test sites do drive it against real LSM buckets under the `integrationTest` tag. The acceptance gate belongs to whichever PR in this stack flips the flag.

## Numbers

MacBook Pro M4 Pro (14 cores), 300K-object corpus, `contains_any` over 100K distinct ids, pre-serialising client, **mean of 3 rounds**, round-robin over targets. `mt` = the empty-active-memtable skip deleted, so every key pays the memtable's read lock — what a collection taking writes gets. All six binaries answered a 12-query correctness corpus byte-exactly as PR 9 before anything was timed; every run self-checked with 0 errors.

Acquisitions per query go from **one per key to one per window** — 100,000 to 98 at the production window of 1024.

**Concurrent throughput (requests/sec):**

| workers | pr9 | pr9mt | pr10 | pr10mt | memtable costs pr9 | costs pr10 |
|---|---:|---:|---:|---:|---:|---:|
| 16 | 297.4 | 76.0 | 300.1 | **300.6** | **−74%** | +0.2% |
| 32 | 301.2 | 76.4 | 306.2 | **304.0** | **−75%** | −0.7% |
| 64 | 301.7 | 76.9 | 307.7 | **307.1** | **−75%** | −0.2% |
| 100 | 302.0 | 77.8 | 307.9 | **305.9** | **−74%** | −0.7% |

**Concurrent latency, p50 / p99:**

| workers | pr9 | pr9mt | pr10 | pr10mt |
|---|---|---|---|---|
| 16 | 53ms / 82ms | 209ms / 269ms | 53ms / 81ms | **53ms / 81ms** |
| 32 | 101ms / 223ms | 413ms / 685ms | 99ms / 220ms | **100ms / 216ms** |
| 64 | 196ms / 529ms | 819ms / 1.60s | 194ms / 510ms | **186ms / 466ms** |
| 100 | 318ms / 843ms | 1.17s / 2.58s | 313ms / 818ms | **308ms / 790ms** |

**Sequential latency (1 worker), p50 / p99:**

| N | pr9 | pr9mt | pr10 | pr10mt |
|---|---|---|---|---|
| 100 | 0.34 / 0.47ms | 0.34 / 0.47ms | 0.34 / 0.46ms | 0.34 / 0.47ms |
| 1,000 | 1.06 / 1.34ms | 1.08 / 1.36ms | 1.05 / 1.33ms | 1.06 / 1.33ms |
| 10,000 | 6.33 / 7.40ms | 6.53 / 7.62ms | 6.30 / 7.37ms | 6.27 / 7.30ms |
| 100,000 | 32 / 35ms | 33 / 37ms | 31 / 35ms | 32 / 35ms |

**Allocations per query** — `BenchmarkDocIDs_ContainsAny`, median of 6, real `BitmapBufPool`:

| N | pr9 | pr10 |
|---|---|---|
| 100 | 103 allocs, 11.7KB, 0.04ms | 103 allocs, 11.8KB, 0.04ms |
| 1,000 | 40 allocs, 96.5KB, 0.26ms | 40 allocs, 96.6KB, 0.25ms |
| 10,000 | 42 allocs, 587.6KB, 2.53ms | 42 allocs, 586.9KB, 2.42ms |
| 100,000 | 47 allocs, 5.30MB, 21ms | 47 allocs, 5.30MB, 20ms |

Identical to the object: PR 10 changes *when* the memtable is read, not what the fold allocates. (N=100 exceeds N=1,000 because it falls below `containsAnyAccumulatorMinKeys = 256` and takes the incremental fold — lowering the gate puts it at 39 allocs. Unrelated to this PR.)

