### PR TITLE
fix(async-repl): repair rejoined replicas whose tenant shards were never written

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -684,11 +684,20 @@ func (s *Shard) filePutter(ctx context.Context,
 func (idx *Index) OverwriteObjects(ctx context.Context,
 	shard string, updates []*objects.VObject,
 ) ([]types.RepairResponse, error) {
-	// Never load from a repair write: a cold replica is activated by real
-	// traffic, not by async replication or read repair.
+	// A repair write never loads a cold replica that holds data: real traffic
+	// activates it, not async replication or read repair. A hosted shard that has
+	// never held an object is loaded here, as a user write would load it: the
+	// repair objects are the tenant's first data on this node.
 	s, release, err := idx.getLoadedShard(shard)
 	if err != nil {
 		return nil, fmt.Errorf("shard %q: %w", shard, err)
+	}
+	if s == nil && idx.hostsUnloadedEmptyShard(shard) {
+		release()
+		s, release, err = idx.GetShard(ctx, shard)
+		if err != nil {
+			return nil, fmt.Errorf("shard %q: %w", shard, err)
+		}
 	}
 
 	defer release()
@@ -1050,13 +1059,17 @@ func (i *Index) IncomingDigestObjects(ctx context.Context,
 func (i *Index) DigestObjectsInRange(ctx context.Context,
 	shardName string, initialUUID, finalUUID strfmt.UUID, limit int,
 ) (result []types.RepairResponse, err error) {
-	// Never load from async replication; empty success for unloaded would invite full propagation.
+	// Never load from async replication; empty success for an unloaded shard with
+	// data would invite full propagation. For a never-written shard it is the truth.
 	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w: shard %q", err, shardName)
 	}
 	defer release()
 	if shard == nil {
+		if i.hostsUnloadedEmptyShard(shardName) {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("%w: shard %q not loaded on this node", errAsyncReplicationNotActive, shardName)
 	}
 
@@ -1072,13 +1085,17 @@ func (i *Index) IncomingDigestObjectsInRange(ctx context.Context,
 func (i *Index) CompareDigests(ctx context.Context,
 	shardName string, sourceDigests []types.RepairResponse,
 ) ([]types.RepairResponse, error) {
-	// Never load from async replication's propagation pre-check.
+	// Never load from async replication's propagation pre-check; a never-written
+	// shard is missing every source object.
 	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w: shard %q", err, shardName)
 	}
 	defer release()
 	if shard == nil {
+		if i.hostsUnloadedEmptyShard(shardName) {
+			return allMissingDigests(sourceDigests), nil
+		}
 		return nil, fmt.Errorf("%w: shard %q not loaded on this node", errAsyncReplicationNotActive, shardName)
 	}
 
@@ -1088,13 +1105,21 @@ func (i *Index) CompareDigests(ctx context.Context,
 func (i *Index) HashTreeLevel(ctx context.Context,
 	shardName string, level int, discriminant *hashtree.Bitset,
 ) (digests []hashtree.Digest, err error) {
-	// Never load a shard from async replication.
+	// Never load a shard from async replication; a never-written shard is served
+	// from the empty tree.
 	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w: shard %q", err, shardName)
 	}
 	defer release()
 	if shard == nil {
+		if i.hostsUnloadedEmptyShard(shardName) {
+			ht, err := i.unloadedEmptyShardHashTree(shardName)
+			if err != nil {
+				return nil, err
+			}
+			return hashTreeLevel(ht, shardName, level, discriminant)
+		}
 		return nil, fmt.Errorf("%w: shard %q not loaded on this node", errAsyncReplicationNotActive, shardName)
 	}
 
@@ -1107,7 +1132,8 @@ func (i *Index) IncomingHashTreeLevel(ctx context.Context,
 	return i.HashTreeLevel(ctx, shardName, level, discriminant)
 }
 
-// CompareHashTreeRoots: differing, not-ready, or erroring shards diverge (source descends); unloaded ones are omitted without loading.
+// CompareHashTreeRoots: differing, not-ready, or erroring shards diverge (source descends); unloaded ones
+// are omitted without loading, except a never-written shard, which is compared as an empty tree.
 func (i *Index) CompareHashTreeRoots(ctx context.Context,
 	roots map[string]hashtree.Digest,
 ) ([]string, error) {
@@ -1123,7 +1149,11 @@ func (i *Index) CompareHashTreeRoots(ctx context.Context,
 				return true // teardown/closing: descend, never read as converged
 			}
 			if shard == nil {
-				return false // not loaded here: omit without loading
+				if !i.hostsUnloadedEmptyShard(shardName) {
+					return false // not loaded here: omit without loading
+				}
+				ht, err := i.unloadedEmptyShardHashTree(shardName)
+				return err != nil || ht.Root() != sourceRoot
 			}
 			root, ok := shard.HashTreeRoot()
 			return !ok || root != sourceRoot

--- a/adapters/repos/db/replication_empty_shard.go
+++ b/adapters/repos/db/replication_empty_shard.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+// Async replication never loads a shard that holds data (#12195). A hosted shard
+// that is unloaded because it has never held an object is the one exception a
+// replica needs to be repairable at all: a node that was down for a tenant's
+// first writes rejoins with an empty, unloaded shard and would otherwise answer
+// not-ready forever (#12526). Such a shard is answered as an empty shard —
+// empty hashtree, no digests — without loading it. Only a repair write loads it,
+// the same way a user write to the tenant would.
+
+// hostsUnloadedEmptyShard reports whether shardName is held here as an unloaded
+// shard that has never held an object. Only HOT local shards are in the map, so
+// COLD, offloaded, and dropped shards never qualify.
+func (i *Index) hostsUnloadedEmptyShard(shardName string) bool {
+	lazy, ok := i.shards.Load(shardName).(*LazyLoadShard)
+	return ok && !lazy.isLoaded() && lazy.neverWritten()
+}
+
+// unloadedEmptyShardHashTree returns the hashtree an unloaded never-written shard
+// would hold once loaded: the effective height, no leaves. Async replication off
+// for the shard answers errAsyncReplicationNotActive, as a loaded shard without a
+// hashtree does.
+func (i *Index) unloadedEmptyShardHashTree(shardName string) (hashtree.AggregatedHashTree, error) {
+	enabled, config := i.asyncReplicationStateForShard(shardName)
+	if !enabled {
+		return nil, fmt.Errorf("%w: async replication disabled for unloaded shard %q", errAsyncReplicationNotActive, shardName)
+	}
+	if i.globalreplicationConfig != nil {
+		config = config.Effective(*i.globalreplicationConfig)
+	}
+	return emptyHashTree(config.hashtreeHeight)
+}
+
+// emptyHashTrees caches one tree per height that nothing aggregates into; Root and
+// Level sync its inner nodes under the tree's own mutex, so sharing it across
+// requests is safe.
+var emptyHashTrees sync.Map // height (int) -> *hashtree.HashTree
+
+func emptyHashTree(height int) (*hashtree.HashTree, error) {
+	if ht, ok := emptyHashTrees.Load(height); ok {
+		return ht.(*hashtree.HashTree), nil
+	}
+	ht, err := hashtree.NewHashTree(height)
+	if err != nil {
+		return nil, err
+	}
+	actual, _ := emptyHashTrees.LoadOrStore(height, ht)
+	return actual.(*hashtree.HashTree), nil
+}
+
+// allMissingDigests is CompareDigests' answer for a shard with no objects: every
+// source object is absent here.
+func allMissingDigests(sourceDigests []types.RepairResponse) []types.RepairResponse {
+	result := make([]types.RepairResponse, len(sourceDigests))
+	for i, d := range sourceDigests {
+		result[i] = types.RepairResponse{ID: d.ID}
+	}
+	return result
+}

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1578,6 +1578,21 @@ func (s *Shard) removePartialHashTreeTmp(tmpFilename string) {
 // hashtree, filtered by discriminant (Size() == hashtree.LeavesCount(level)).
 // Returns an error if the hashtree is not yet fully initialised.
 func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
+	s.asyncReplicationRWMux.RLock()
+	defer s.asyncReplicationRWMux.RUnlock()
+
+	if s.hashtree == nil || !s.hashtreeFullyInitialized {
+		return nil, fmt.Errorf("%w: hashtree not initialized on shard %q", errAsyncReplicationNotActive, s.ID())
+	}
+
+	return hashTreeLevel(s.hashtree, s.ID(), level, discriminant)
+}
+
+// hashTreeLevel serves one level of ht for the async-replication descent, with
+// the request validation both callers need. Shared by loaded shards and by the
+// empty tree that stands in for a never-written unloaded shard, so both answer
+// identically.
+func hashTreeLevel(ht hashtree.AggregatedHashTree, shardID string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
 	if level < 0 {
 		return nil, fmt.Errorf("hashtree level must be non-negative: %d", level)
 	}
@@ -1589,17 +1604,10 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 		return nil, fmt.Errorf("hashtree level %d: nil discriminant", level)
 	}
 
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
-
-	if s.hashtree == nil || !s.hashtreeFullyInitialized {
-		return nil, fmt.Errorf("%w: hashtree not initialized on shard %q", errAsyncReplicationNotActive, s.ID())
-	}
-
 	// Transient during a rolling height change — retry-later, not an error.
-	if height := s.hashtree.Height(); level > height {
+	if height := ht.Height(); level > height {
 		return nil, fmt.Errorf("%w: hashtree level %d exceeds height %d on shard %q",
-			errAsyncReplicationNotActive, level, height, s.ID())
+			errAsyncReplicationNotActive, level, height, shardID)
 	}
 
 	expected := hashtree.LeavesCount(level)
@@ -1608,9 +1616,9 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 			level, discriminant.Size(), expected)
 	}
 
-	digests = make([]hashtree.Digest, discriminant.SetCount())
+	digests := make([]hashtree.Digest, discriminant.SetCount())
 
-	n, err := s.hashtree.Level(level, discriminant, digests)
+	n, err := ht.Level(level, discriminant, digests)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -17,6 +17,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -47,6 +48,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
@@ -859,40 +861,323 @@ func TestReconcileDoesNotForceLoadUnloadedShard(t *testing.T) {
 	require.False(t, lazy.isLoaded(), "reconcile must not force-load an unloaded shard")
 }
 
-// TestRepairEndpointsDoNotForceLoadUnloadedShard: the async-replication data
-// endpoints must return the typed not-ready error for a cold shard, never load it.
-func TestRepairEndpointsDoNotForceLoadUnloadedShard(t *testing.T) {
-	ctx := context.Background()
-	const class = "RepairEndpointsNoForceLoad"
-
-	_, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
-	setShardReplicas(t, idx, "node1", "node2")
-
-	const lazyName = "lazy-cold-shard-repair"
-	sl, err := idx.initShard(ctx, lazyName, &models.Class{Class: class}, nil, false, false)
+// unloadedLazyShard registers an unloaded lazy shard on idx. objectCount > 0
+// persists an index counter first, so the shard reads as holding data (the
+// counter is what unloadedShardIsEmpty consults); 0 leaves it never written.
+func unloadedLazyShard(t *testing.T, ctx context.Context, idx *Index, class, name string, objectCount uint64) *LazyLoadShard {
+	t.Helper()
+	if objectCount > 0 {
+		dir := shardPath(idx.path(), name)
+		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+		var buf [8]byte
+		binary.LittleEndian.PutUint64(buf[:], objectCount)
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), buf[:], 0o644))
+	}
+	sl, err := idx.initShard(ctx, name, &models.Class{Class: class}, nil, false, false)
 	require.NoError(t, err)
 	lazy, ok := sl.(*LazyLoadShard)
 	require.True(t, ok, "expected a *LazyLoadShard")
 	require.False(t, lazy.isLoaded(), "precondition: shard must start unloaded")
-	idx.shards.Store(lazyName, sl)
+	idx.shards.Store(name, sl)
+	return lazy
+}
 
-	t.Run("OverwriteObjects", func(t *testing.T) {
-		_, err := idx.OverwriteObjects(ctx, lazyName, []*objects.VObject{{}})
-		require.ErrorIs(t, err, errAsyncReplicationNotActive)
-		require.False(t, lazy.isLoaded(), "OverwriteObjects must not force-load an unloaded shard")
+// TestHostsUnloadedEmptyShard pins which shards are answered as never written:
+// only an unloaded lazy entry whose persisted counter reads 0. Anything not in
+// the map, loaded, holding data, or with an unreadable counter is not.
+func TestHostsUnloadedEmptyShard(t *testing.T) {
+	ctx := context.Background()
+	const class = "HostsUnloadedEmptyShard"
+
+	loadedSL, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx))
+	setShardReplicas(t, idx, "node1", "node2")
+
+	writeCounter := func(t *testing.T, name string, b []byte) {
+		t.Helper()
+		dir := shardPath(idx.path(), name)
+		require.NoError(t, os.MkdirAll(dir, os.ModePerm))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "indexcount"), b, 0o644))
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T) string
+		want  bool
+	}{
+		{"absent from the map", func(t *testing.T) string { return "not-hosted" }, false},
+		{"loaded eager shard", func(t *testing.T) string { return loadedSL.Name() }, false},
+		{"unloaded lazy, never written", func(t *testing.T) string {
+			unloadedLazyShard(t, ctx, idx, class, "never-written", 0)
+			return "never-written"
+		}, true},
+		{"unloaded lazy, holds data", func(t *testing.T) string {
+			unloadedLazyShard(t, ctx, idx, class, "holds-data", 10)
+			return "holds-data"
+		}, false},
+		{"unloaded lazy, unreadable counter", func(t *testing.T) string {
+			writeCounter(t, "corrupt-counter", []byte{1, 2, 3})
+			unloadedLazyShard(t, ctx, idx, class, "corrupt-counter", 0)
+			return "corrupt-counter"
+		}, false},
+		{"loaded lazy", func(t *testing.T) string {
+			lazy := unloadedLazyShard(t, ctx, idx, class, "loaded-lazy", 0)
+			require.NoError(t, lazy.Load(ctx))
+			return "loaded-lazy"
+		}, false},
+		{"lazy shut down after writing is judged from disk again", func(t *testing.T) string {
+			lazy := unloadedLazyShard(t, ctx, idx, class, "written-then-shutdown", 0)
+			require.True(t, idx.hostsUnloadedEmptyShard("written-then-shutdown"), "memoized as never written")
+			require.NoError(t, lazy.Load(ctx))
+			require.NoError(t, lazy.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+			require.NoError(t, lazy.Shutdown(ctx))
+			require.False(t, lazy.isLoaded())
+			return "written-then-shutdown"
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name := tt.setup(t)
+			require.Equal(t, tt.want, idx.hostsUnloadedEmptyShard(name))
+		})
+	}
+}
+
+// TestRepairEndpointsDoNotForceLoadColdShardWithData: for a cold shard that
+// holds data, every async-replication endpoint answers not-ready (or omits it
+// from the root compare) and never loads it.
+func TestRepairEndpointsDoNotForceLoadColdShardWithData(t *testing.T) {
+	ctx := context.Background()
+	const class = "RepairEndpointsNoForceLoad"
+
+	_, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx),
+		func(i *Index) { i.Config.AsyncReplicationConfig = minAsyncReplicationConfig() })
+	setShardReplicas(t, idx, "node1", "node2")
+
+	const name = "lazy-cold-shard-with-data"
+	lazy := unloadedLazyShard(t, ctx, idx, class, name, 10)
+
+	level0 := hashtree.NewBitset(1).SetAll()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"OverwriteObjects", func() error {
+			_, err := idx.OverwriteObjects(ctx, name, []*objects.VObject{{}})
+			return err
+		}},
+		{"CompareDigests", func() error {
+			_, err := idx.CompareDigests(ctx, name, []routerTypes.RepairResponse{{ID: string(uuidLow)}})
+			return err
+		}},
+		{"DigestObjectsInRange", func() error {
+			_, err := idx.DigestObjectsInRange(ctx, name, uuidLow, uuidHigh, 10)
+			return err
+		}},
+		{"HashTreeLevel", func() error {
+			_, err := idx.HashTreeLevel(ctx, name, 0, level0)
+			return err
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.ErrorIs(t, tt.call(), errAsyncReplicationNotActive)
+			require.False(t, lazy.isLoaded(), "%s must not force-load a cold shard with data", tt.name)
+		})
+	}
+
+	t.Run("CompareHashTreeRoots omits it", func(t *testing.T) {
+		diverging, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{name: {1, 2}})
+		require.NoError(t, err)
+		require.Empty(t, diverging)
+		require.False(t, lazy.isLoaded(), "CompareHashTreeRoots must not force-load a cold shard with data")
+	})
+}
+
+// TestRepairEndpointsAnswerNeverWrittenShardAsEmpty: a hosted shard that is
+// unloaded and has never held an object is answered as an empty shard without
+// loading it — a rejoined replica that missed a tenant's first writes must not
+// hide behind not-ready forever. Only a repair write loads it, as a user write
+// would (issue #12526).
+func TestRepairEndpointsAnswerNeverWrittenShardAsEmpty(t *testing.T) {
+	ctx := context.Background()
+	const class = "RepairEndpointsNeverWritten"
+
+	cfg := minAsyncReplicationConfig()
+	_, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx),
+		func(i *Index) { i.Config.AsyncReplicationConfig = cfg })
+	setShardReplicas(t, idx, "node1", "node2")
+
+	const name = "lazy-never-written-shard"
+	lazy := unloadedLazyShard(t, ctx, idx, class, name, 0)
+
+	emptyTree, err := hashtree.NewHashTree(cfg.hashtreeHeight)
+	require.NoError(t, err)
+	emptyRoot := emptyTree.Root()
+	otherRoot := hashtree.Digest{emptyRoot[0] + 1, emptyRoot[1]}
+
+	t.Run("HashTreeLevel serves the empty tree", func(t *testing.T) {
+		digests, err := idx.HashTreeLevel(ctx, name, 0, hashtree.NewBitset(1).SetAll())
+		require.NoError(t, err)
+		require.Equal(t, []hashtree.Digest{emptyRoot}, digests)
+
+		leaves, err := idx.HashTreeLevel(ctx, name, cfg.hashtreeHeight, hashtree.NewBitset(hashtree.LeavesCount(cfg.hashtreeHeight)).SetAll())
+		require.NoError(t, err)
+		require.Len(t, leaves, hashtree.LeavesCount(cfg.hashtreeHeight))
+		for _, d := range leaves {
+			require.Equal(t, hashtree.Digest{}, d, "an empty tree has zero leaves")
+		}
+
+		_, err = idx.HashTreeLevel(ctx, name, cfg.hashtreeHeight+1, hashtree.NewBitset(hashtree.LeavesCount(cfg.hashtreeHeight+1)).SetAll())
+		require.ErrorIs(t, err, errAsyncReplicationNotActive, "a level above the height is retry-later, as on a loaded shard")
+
+		_, err = idx.HashTreeLevel(ctx, name, -1, hashtree.NewBitset(1).SetAll())
+		require.Error(t, err, "a negative level is rejected, as on a loaded shard")
+
+		require.False(t, lazy.isLoaded(), "HashTreeLevel must not load a never-written shard")
 	})
 
-	t.Run("CompareDigests", func(t *testing.T) {
-		_, err := idx.CompareDigests(ctx, lazyName, []routerTypes.RepairResponse{{ID: string(uuidLow)}})
-		require.ErrorIs(t, err, errAsyncReplicationNotActive)
-		require.False(t, lazy.isLoaded(), "CompareDigests must not force-load an unloaded shard")
+	t.Run("CompareHashTreeRoots compares against the empty root", func(t *testing.T) {
+		diverging, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{name: emptyRoot})
+		require.NoError(t, err)
+		require.Empty(t, diverging, "an empty source matches an empty target")
+
+		diverging, err = idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{name: otherRoot})
+		require.NoError(t, err)
+		require.Equal(t, []string{name}, diverging, "a source with data diverges from an empty target")
+
+		require.False(t, lazy.isLoaded(), "CompareHashTreeRoots must not load a never-written shard")
 	})
 
-	t.Run("DigestObjectsInRange", func(t *testing.T) {
-		_, err := idx.DigestObjectsInRange(ctx, lazyName, uuidLow, uuidHigh, 10)
-		require.ErrorIs(t, err, errAsyncReplicationNotActive)
-		require.False(t, lazy.isLoaded(), "DigestObjectsInRange must not force-load an unloaded shard")
+	t.Run("CompareDigests reports every source object as missing", func(t *testing.T) {
+		source := []routerTypes.RepairResponse{{ID: string(uuidLow), UpdateTime: 5}, {ID: string(uuidHigh), UpdateTime: 7}}
+		got, err := idx.CompareDigests(ctx, name, source)
+		require.NoError(t, err)
+		require.Equal(t, []routerTypes.RepairResponse{{ID: string(uuidLow)}, {ID: string(uuidHigh)}}, got)
+		require.False(t, lazy.isLoaded(), "CompareDigests must not load a never-written shard")
 	})
+
+	t.Run("DigestObjectsInRange is empty", func(t *testing.T) {
+		got, err := idx.DigestObjectsInRange(ctx, name, uuidLow, uuidHigh, 10)
+		require.NoError(t, err)
+		require.Empty(t, got)
+		require.False(t, lazy.isLoaded(), "DigestObjectsInRange must not load a never-written shard")
+	})
+
+	// Last on purpose: it loads the shard the read subtests rely on being unloaded.
+	t.Run("OverwriteObjects loads the shard and writes", func(t *testing.T) {
+		obj := &models.Object{ID: uuidMid, Class: class, LastUpdateTimeUnix: 42}
+		res, err := idx.OverwriteObjects(ctx, name, []*objects.VObject{{LatestObject: obj, LastUpdateTimeUnixMilli: 42}})
+		require.NoError(t, err)
+		require.Empty(t, res, "no conflicts on a first write")
+		require.True(t, lazy.isLoaded(), "the first repair write must load a never-written shard")
+
+		exists, err := lazy.Exists(ctx, uuidMid)
+		require.NoError(t, err)
+		require.True(t, exists)
+
+		// Loaded now: the live shard answers with a root that holds the object.
+		awaitHashtreeInitialized(t, lazy.shard)
+		root, ok := lazy.shard.HashTreeRoot()
+		require.True(t, ok)
+		require.NotEqual(t, emptyRoot, root)
+		diverging, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{name: emptyRoot})
+		require.NoError(t, err)
+		require.Equal(t, []string{name}, diverging)
+	})
+}
+
+// TestRepairEndpointsNeverWrittenShardAsyncDisabled: with async replication off
+// for the shard, a never-written shard answers like a loaded shard with no
+// hashtree — not-ready on HashTreeLevel and diverging on the root compare — and
+// still is not loaded.
+func TestRepairEndpointsNeverWrittenShardAsyncDisabled(t *testing.T) {
+	ctx := context.Background()
+	const class = "RepairEndpointsNeverWrittenDisabled"
+
+	_, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx),
+		func(i *Index) { i.Config.AsyncReplicationConfig = minAsyncReplicationConfig() })
+	setShardReplicas(t, idx, "node1")
+
+	const name = "lazy-never-written-disabled"
+	lazy := unloadedLazyShard(t, ctx, idx, class, name, 0)
+
+	_, err := idx.HashTreeLevel(ctx, name, 0, hashtree.NewBitset(1).SetAll())
+	require.ErrorIs(t, err, errAsyncReplicationNotActive)
+
+	diverging, err := idx.CompareHashTreeRoots(ctx, map[string]hashtree.Digest{name: {1, 2}})
+	require.NoError(t, err)
+	require.Equal(t, []string{name}, diverging)
+
+	require.False(t, lazy.isLoaded())
+}
+
+// indexBackedClient forwards the RPCs a source shard issues during a hashbeat to
+// the handlers of a target index, under the target's shard name, so a cycle runs
+// end to end in-process. Everything else is FakeReplicationClient's no-op.
+type indexBackedClient struct {
+	FakeReplicationClient
+	target *Index
+	shard  string
+}
+
+func (c *indexBackedClient) HashTreeLevel(ctx context.Context, _, _, _ string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
+	return c.target.HashTreeLevel(ctx, c.shard, level, discriminant)
+}
+
+func (c *indexBackedClient) CompareDigests(ctx context.Context, _, _, _ string, digests []routerTypes.RepairResponse) ([]routerTypes.RepairResponse, error) {
+	return c.target.CompareDigests(ctx, c.shard, digests)
+}
+
+func (c *indexBackedClient) DigestObjectsInRange(ctx context.Context, _, _, _ string, initialUUID, finalUUID strfmt.UUID, limit int) ([]routerTypes.RepairResponse, error) {
+	return c.target.DigestObjectsInRange(ctx, c.shard, initialUUID, finalUUID, limit)
+}
+
+func (c *indexBackedClient) OverwriteObjects(ctx context.Context, _, _, _ string, objs []*objects.VObject) ([]routerTypes.RepairResponse, error) {
+	return c.target.OverwriteObjects(ctx, c.shard, objs)
+}
+
+// TestHashbeatRepairsNeverWrittenTargetShard: a source with objects hashbeats a
+// target whose shard is unloaded and has never held an object — the rejoined
+// replica of #12526. One cycle must push every object, loading the target shard
+// through the repair write; the next cycle finds no diff.
+func TestHashbeatRepairsNeverWrittenTargetShard(t *testing.T) {
+	ctx := context.Background()
+	const class = "HashbeatNeverWrittenTarget"
+	cfg := minAsyncReplicationConfig()
+	withCfg := func(i *Index) { i.Config.AsyncReplicationConfig = cfg }
+
+	_, targetIdx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx), withCfg)
+	setShardReplicas(t, targetIdx, "node1", "node2")
+	const targetShard = "never-written-target"
+	targetLazy := unloadedLazyShard(t, ctx, targetIdx, class, targetShard, 0)
+
+	client := &indexBackedClient{target: targetIdx, shard: targetShard}
+	sl, idx := testShard(t, ctx, class, asyncSchedulerOption(t, ctx), withRemoteReplicaClient(t, client), withCfg)
+	s := concreteShard(t, sl)
+	idx.SetReplicationFSMReader(nil)
+	setShardReplicas(t, idx, "node1", "node2")
+
+	ids := []strfmt.UUID{uuidLow, uuidMid, uuidHigh}
+	for _, id := range ids {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+	enableAndAwaitAsync(t, ctx, s)
+
+	propagated, err := s.runHashbeatCycle(ctx, cfg)
+	require.NoError(t, err)
+	require.True(t, propagated, "the source must push its objects to the never-written replica")
+	require.True(t, targetLazy.isLoaded(), "the repair write must have loaded the target shard")
+	for _, id := range ids {
+		exists, err := targetLazy.Exists(ctx, id)
+		require.NoError(t, err)
+		require.True(t, exists, "object %s must have been repaired onto the target", id)
+	}
+
+	awaitHashtreeInitialized(t, targetLazy.shard)
+	propagated, err = s.runHashbeatCycle(ctx, cfg)
+	require.ErrorIs(t, err, replicaerrors.ErrNoDiffFound, "the replicas must be converged after one repair cycle")
+	require.False(t, propagated)
 }
 
 // TestDBReconcileAsyncReplicationWalksEveryIndex verifies that

--- a/adapters/repos/db/shard_async_replication_unit_test.go
+++ b/adapters/repos/db/shard_async_replication_unit_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -295,4 +296,79 @@ func TestNoteHashbeatSkipEscalatesAfterConsecutiveRuns(t *testing.T) {
 	s.asyncRepConsecutiveSkips.Store(0)
 	s.noteHashbeatSkip(skipErr, time.Hour)
 	require.Equal(t, 1, warns())
+}
+
+// TestEmptyHashTree: the tree that stands in for a never-written unloaded shard
+// is one shared instance per height whose root equals a fresh empty tree's, and
+// hashTreeLevel on it validates like a loaded shard.
+func TestEmptyHashTree(t *testing.T) {
+	tests := []struct {
+		name   string
+		height int
+	}{
+		{"height 1", 1},
+		{"multi-tenant default", defaultHashtreeHeightMultiTenant},
+		{"single-tenant default", defaultHashtreeHeightSingleTenant},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ht, err := emptyHashTree(tt.height)
+			require.NoError(t, err)
+			again, err := emptyHashTree(tt.height)
+			require.NoError(t, err)
+			require.Same(t, ht, again, "one shared tree per height")
+
+			fresh, err := hashtree.NewHashTree(tt.height)
+			require.NoError(t, err)
+			require.Equal(t, fresh.Root(), ht.Root())
+
+			digests, err := hashTreeLevel(ht, "shard", 0, hashtree.NewBitset(1).SetAll())
+			require.NoError(t, err)
+			require.Equal(t, []hashtree.Digest{fresh.Root()}, digests)
+
+			_, err = hashTreeLevel(ht, "shard", tt.height+1, hashtree.NewBitset(hashtree.LeavesCount(tt.height+1)).SetAll())
+			require.ErrorIs(t, err, errAsyncReplicationNotActive, "a level above the height is retry-later")
+
+			_, err = hashTreeLevel(ht, "shard", 0, hashtree.NewBitset(2).SetAll())
+			require.Error(t, err, "a discriminant of the wrong size is rejected")
+
+			_, err = hashTreeLevel(ht, "shard", -1, hashtree.NewBitset(1).SetAll())
+			require.Error(t, err, "a negative level is rejected, not shifted")
+
+			_, err = hashTreeLevel(ht, "shard", maxHashtreeHeight+1, hashtree.NewBitset(1).SetAll())
+			require.Error(t, err, "a level above the maximum height is rejected")
+
+			_, err = hashTreeLevel(ht, "shard", 0, nil)
+			require.Error(t, err, "a nil discriminant is rejected")
+		})
+	}
+
+	t.Run("concurrent readers share one tree", func(t *testing.T) {
+		ht, err := emptyHashTree(4)
+		require.NoError(t, err)
+		want := ht.Root()
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range 50 {
+					digests, err := hashTreeLevel(ht, "shard", 4, hashtree.NewBitset(hashtree.LeavesCount(4)).SetAll())
+					assert.NoError(t, err)
+					assert.Len(t, digests, hashtree.LeavesCount(4))
+					assert.Equal(t, want, ht.Root())
+				}
+			}()
+		}
+		wg.Wait()
+	})
+
+	_, err := emptyHashTree(hashtree.MaxHeight + 1)
+	require.Error(t, err)
+
+	t.Run("allMissingDigests", func(t *testing.T) {
+		got := allMissingDigests([]routertypes.RepairResponse{{ID: "a", UpdateTime: 3}, {ID: "b", UpdateTime: 4}})
+		require.Equal(t, []routertypes.RepairResponse{{ID: "a"}, {ID: "b"}}, got)
+		require.Empty(t, allMissingDigests(nil))
+	})
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/loadlimiter"
@@ -64,7 +65,16 @@ type LazyLoadShard struct {
 	memMonitor       memwatch.AllocChecker
 	shardLoadLimiter *loadlimiter.LoadLimiter
 	lazyLoadSegments bool
+
+	// neverWrittenState memoizes neverWritten() while unloaded; see there.
+	neverWrittenState atomic.Int32
 }
+
+const (
+	neverWrittenUnknown int32 = iota
+	neverWrittenYes
+	neverWrittenNo
+)
 
 func NewLazyLoadShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	shardName string, index *Index, class *models.Class, jobQueueCh chan job,
@@ -797,7 +807,28 @@ func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 
 	// Mark as unloaded so drop() knows the correct state
 	l.loaded = false
+	l.neverWrittenState.Store(neverWrittenUnknown)
 	return nil
+}
+
+// neverWritten reports whether this unloaded shard has never held an object,
+// read from the persisted index counter. The counter only moves through a
+// loaded shard, so the answer is memoized: it holds until the shard loads, and
+// Shutdown clears it so a later unloaded state is judged from disk again.
+func (l *LazyLoadShard) neverWritten() bool {
+	switch l.neverWrittenState.Load() {
+	case neverWrittenYes:
+		return true
+	case neverWrittenNo:
+		return false
+	}
+	empty := l.shardOpts.index.unloadedShardIsEmpty(l.shardOpts.name)
+	if empty {
+		l.neverWrittenState.Store(neverWrittenYes)
+	} else {
+		l.neverWrittenState.Store(neverWrittenNo)
+	}
+	return empty
 }
 
 func (l *LazyLoadShard) preventShutdown() (release func(), err error) {

--- a/test/acceptance/replication/async_replication/async_repair_rejoined_empty_tenant_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_rejoined_empty_tenant_test.go
@@ -1,0 +1,151 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+// TestAsyncRepairRejoinedNodeEmptyTenantReplica: a node is down for a tenant's
+// first writes and rejoins with empty, unloaded tenant shards. Async replication
+// must repair them without anything touching the tenants on that node (#12526);
+// the /nodes probe used here reports unloaded shards without loading them.
+func (suite *AsyncReplicationTestSuite) TestAsyncRepairRejoinedNodeEmptyTenantReplica() {
+	t := suite.T()
+	mainCtx := context.Background()
+
+	var (
+		clusterSize      = 3
+		tenantCount      = 3
+		objectsPerTenant = 20
+		node             = 2
+		nodeName         = docker.Weaviate1
+	)
+
+	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
+	defer cancel()
+
+	compose := suite.compose
+
+	paragraphClass := articles.ParagraphsClass()
+
+	tenantNames := make([]string, tenantCount)
+	for i := range tenantNames {
+		tenantNames[i] = fmt.Sprintf("tenant-%d", i)
+	}
+
+	t.Run("create multi-tenant schema replicated on every node", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
+			Factor: int64(clusterSize),
+		}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
+			Enabled: true,
+		}
+
+		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("create hot tenants while every node is up", func(t *testing.T) {
+		tenants := make([]*models.Tenant, tenantCount)
+		for i, name := range tenantNames {
+			tenants[i] = &models.Tenant{Name: name, ActivityStatus: models.TenantActivityStatusHOT}
+		}
+		helper.CreateTenants(t, paragraphClass.Class, tenants)
+	})
+
+	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, node)
+	})
+
+	t.Run("insert the tenants' first objects on the surviving nodes", func(t *testing.T) {
+		for _, tenant := range tenantNames {
+			batch := make([]*models.Object, objectsPerTenant)
+			for i := range batch {
+				batch[i] = articles.NewParagraph().
+					WithContents(fmt.Sprintf("%s#%d", tenant, i)).
+					WithTenant(tenant).
+					Object()
+			}
+			common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
+		}
+	})
+
+	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, node)
+	})
+
+	t.Run("all nodes healthy", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, clusterSize)
+			for _, n := range body.Payload.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("every tenant is repaired on the restarted node without being touched there", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+
+			counts := map[string]int64{}
+			for _, n := range body.Payload.Nodes {
+				if n.Name != nodeName {
+					continue
+				}
+				for _, shard := range n.Shards {
+					if shard.Class == paragraphClass.Class {
+						counts[shard.Name] = shard.ObjectCount
+					}
+				}
+			}
+			for _, tenant := range tenantNames {
+				require.EqualValues(ct, objectsPerTenant, counts[tenant],
+					"tenant %s on %s not repaired: %v", tenant, nodeName, counts)
+			}
+		}, 240*time.Second, 5*time.Second, "the restarted node did not converge")
+	})
+
+	t.Run("the repaired tenants are readable on the restarted node", func(t *testing.T) {
+		for _, tenant := range tenantNames {
+			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(node).URI(),
+				paragraphClass.Class, types.ConsistencyLevelOne, tenant)
+			require.Len(t, resp, objectsPerTenant, "tenant %s", tenant)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #12526.

## Problem

A node that is down while a multi-tenant tenant receives its first writes rejoins with tenant shards whose index counter is 0. Startup keeps such shards unloaded to save memory (#12061). Since #12195, every async-replication handler resolves shards with `getLoadedShard`, so the rejoined node answers "not loaded" (412) to `HashTreeLevel` / `CompareDigests` / `OverwriteObjects` and omits the shard from `CompareHashTreeRoots`. Peers classify that as retry-later forever. The tenant stays at 0 objects on that node until a user request happens to touch it there.

Nightly evidence: `test_async_replication_correctness[multi_tenant-*]` fails deterministically on every build carrying #12195 (3- and 7-node clusters), see the issue comment.

Loading empty tenants when RF > 1 (issue option 2) was already proposed in #12232 and closed: it defeats the memory saving for the common RF=3 case.

## Fix

Local-empty is not cluster-empty. A hosted, HOT, unloaded shard that has **never held an object** (persisted `indexcount` == 0 or missing) is now answered as an empty shard **without loading it**:

| handler | before | after |
|---|---|---|
| `CompareHashTreeRoots` | omitted (reads as in sync) | compared against the empty tree root of the effective height |
| `HashTreeLevel` | 412 | served from a shared empty tree (same validation as a loaded shard) |
| `CompareDigests` | 412 | every source object reported missing |
| `DigestObjectsInRange` | 412 | empty |
| `OverwriteObjects` | 412 | loads the shard and writes — the repair objects are the tenant's first data on this node, exactly what a user write would do |

Unloaded shards that hold data keep the #12195 behaviour: never loaded, retry-later. Nothing on the source side or on the wire changes, so rolling upgrades are safe in both directions.

The "never written" verdict is the same `unloadedShardIsEmpty` probe startup uses (one 8-byte file read). The persisted counter only moves through a loaded shard, so the verdict is memoized on the `LazyLoadShard` while it stays unloaded (`Shutdown` clears it) — no per-hashbeat file I/O for classes with many empty tenants. Reads racing a concurrent load are harmless: at worst the source pushes objects the target already has and `OverwriteObjects` resolves by update time.

`Shard.HashTreeLevel`'s request validation and level serving moved into `hashTreeLevel`, shared with the empty-tree path, so both answer identically (including rejecting a negative level or nil discriminant).

## Tests

- `TestRepairEndpointsDoNotForceLoadColdShardWithData` keeps the #12195 pin (cold shard with data: every endpoint not-ready / omitted, never loaded). It replaces `TestRepairEndpointsDoNotForceLoadUnloadedShard`, whose fixture was a *fresh* lazy shard — i.e. a never-written one, the case whose behaviour changes here — and adds `HashTreeLevel` and `CompareHashTreeRoots` cases.
- `TestRepairEndpointsAnswerNeverWrittenShardAsEmpty`, `TestRepairEndpointsNeverWrittenShardAsyncDisabled`: the new answers, and that reads never load.
- `TestHashbeatRepairsNeverWrittenTargetShard`: a source shard runs a real hashbeat cycle against a target index whose shard is unloaded and never written; one cycle pushes everything and loads the target, the next finds no diff.
- `TestHostsUnloadedEmptyShard`: which shards qualify (absent / loaded / holds data / unreadable counter / loaded lazy / shut down after writing).
- `TestEmptyHashTree`: shared tree per height, root equals a fresh empty tree, level validation (negative level, nil discriminant, wrong discriminant size), concurrent readers under `-race`.
- Acceptance `TestAsyncRepairRejoinedNodeEmptyTenantReplica` (`test/acceptance/replication/async_replication`): 3 nodes, MT RF=3, stop a node, write, restart, and wait for `/nodes` verbose counts on the restarted node **without touching the tenants there** (that probe does not load shards). Existing MT tests pass because their convergence probe is a CL=ONE read on the restarted node, which loads the shard and hides the gap.

## Review notes

- Branch base is `stable/v1.38` (first affected release); branch-sync carries it forward.
- Reporting unloaded shards over the wire (issue option 1) is observability only and not needed for the fix; left out.
