### PR TITLE
Make the resource scanner's shard status check-and-set atomic

### DIFF
--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -3766,6 +3766,54 @@ func (_c *MockShardLike_UpdateStatus_Call) RunAndReturn(run func(string, string)
 	return _c
 }
 
+// UpdateStatusIf provides a mock function with given fields: cond, status, reason
+func (_m *MockShardLike) UpdateStatusIf(cond func(ShardStatus) bool, status string, reason string) error {
+	ret := _m.Called(cond, status, reason)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateStatusIf")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(func(ShardStatus) bool, string, string) error); ok {
+		r0 = rf(cond, status, reason)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockShardLike_UpdateStatusIf_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateStatusIf'
+type MockShardLike_UpdateStatusIf_Call struct {
+	*mock.Call
+}
+
+// UpdateStatusIf is a helper method to define mock.On call
+//   - cond func(ShardStatus) bool
+//   - status string
+//   - reason string
+func (_e *MockShardLike_Expecter) UpdateStatusIf(cond interface{}, status interface{}, reason interface{}) *MockShardLike_UpdateStatusIf_Call {
+	return &MockShardLike_UpdateStatusIf_Call{Call: _e.mock.On("UpdateStatusIf", cond, status, reason)}
+}
+
+func (_c *MockShardLike_UpdateStatusIf_Call) Run(run func(cond func(ShardStatus) bool, status string, reason string)) *MockShardLike_UpdateStatusIf_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(func(ShardStatus) bool), args[1].(string), args[2].(string))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_UpdateStatusIf_Call) Return(_a0 error) *MockShardLike_UpdateStatusIf_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardLike_UpdateStatusIf_Call) RunAndReturn(run func(func(ShardStatus) bool, string, string) error) *MockShardLike_UpdateStatusIf_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateVectorIndexConfig provides a mock function with given fields: ctx, updated
 func (_m *MockShardLike) UpdateVectorIndexConfig(ctx context.Context, updated config.VectorIndexConfig) error {
 	ret := _m.Called(ctx, updated)

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -258,12 +258,13 @@ func (db *DB) forEachIndexOutsideIndexLock(f func(index *Index)) {
 // non-resource reason (e.g. a vector-index config update), and relabeling it
 // would let the recovery pass flip it back to READY mid-operation.
 func (db *DB) markShardReadOnly(name string, shard ShardLike) {
-	if shard.GetStatus() == storagestate.StatusReadOnly {
-		return
+	notReadOnly := func(current ShardStatus) bool {
+		return current.Status != storagestate.StatusReadOnly
 	}
 	// A shard whose store closed concurrently (tenant deletion, deactivation,
 	// shutdown) is going away and takes no more writes.
-	err := shard.SetStatusReadonly(statusReasonResourcePressure)
+	err := shard.UpdateStatusIf(notReadOnly,
+		storagestate.StatusReadOnly.String(), statusReasonResourcePressure)
 	if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
 		db.logger.WithField("action", "set_shard_read_only").
 			WithField("path", db.config.RootPath).
@@ -275,14 +276,15 @@ func (db *DB) markShardReadOnly(name string, shard ShardLike) {
 // shard held read-only for any other reason alone. Reports whether the release
 // succeeded.
 func (db *DB) markShardReady(name string, shard ShardLike) bool {
-	if shard.GetStatus() != storagestate.StatusReadOnly ||
-		shard.GetStatusReason() != statusReasonResourcePressure {
-		return true
+	heldByResourcePressure := func(current ShardStatus) bool {
+		return current.Status == storagestate.StatusReadOnly &&
+			current.Reason == statusReasonResourcePressure
 	}
 	// A shard whose store closed concurrently (tenant deletion, deactivation,
 	// shutdown) takes no writes either way, and comes back READY if it is ever
 	// loaded again.
-	err := shard.UpdateStatus(storagestate.StatusReady.String(), statusReasonResourceRecovery)
+	err := shard.UpdateStatusIf(heldByResourcePressure,
+		storagestate.StatusReady.String(), statusReasonResourceRecovery)
 	if err != nil && !errors.Is(err, lsmkv.ErrAlreadyClosed) {
 		db.logger.WithField("action", "set_shard_ready").
 			WithField("path", db.config.RootPath).

--- a/adapters/repos/db/resource_use_shard_init_test.go
+++ b/adapters/repos/db/resource_use_shard_init_test.go
@@ -14,7 +14,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -285,15 +284,12 @@ func TestPublishShard_ReconcilesAgainstPressureTransition(t *testing.T) {
 			if tt.noOwningDB {
 				index.db = nil
 			}
-			shard, status, mu := newStatefulShardMock(t, tt.statusAtBuild)
+			shard := newStatusShard(t, tt.statusAtBuild)
 
 			index.publishShard("shard1", shard)
 
 			require.NotNil(t, index.shards.Load("shard1"), "the shard must be published")
-			mu.Lock()
-			defer mu.Unlock()
-			assert.Equal(t, tt.wantStatus, status.Status)
-			assert.Equal(t, tt.wantReason, status.Reason)
+			assert.Equal(t, ShardStatus{Status: tt.wantStatus, Reason: tt.wantReason}, shard.get())
 		})
 	}
 }
@@ -324,9 +320,8 @@ func TestPublishShard_ReconcileFailure(t *testing.T) {
 			db, index := testResourcePressureIndex(t, true)
 			hook := test.NewLocal(db.logger.(*logrus.Logger))
 
-			shard := NewMockShardLike(t)
-			shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-			shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(tt.shardErr)
+			shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+			shard.updateErr = tt.shardErr
 
 			assert.NotPanics(t, func() { index.publishShard("shard1", shard) })
 
@@ -371,25 +366,23 @@ func TestReconcileIndexResourcePressure_ShardCounts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			db, index := testResourcePressureIndex(t, true)
 
-			statuses := make([]*ShardStatus, 0, tt.loadedCount)
-			locks := make([]*sync.Mutex, 0, tt.loadedCount)
+			shards := make([]*statusShard, 0, tt.loadedCount)
 			for n := range tt.loadedCount {
-				shard, status, mu := newStatefulShardMock(t,
+				shard := newStatusShard(t,
 					ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady})
 				index.shards.Store(fmt.Sprintf("loaded_shard_%d", n), shard)
-				statuses = append(statuses, status)
-				locks = append(locks, mu)
+				shards = append(shards, shard)
 			}
 			cold := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
 			index.shards.Store("cold_shard", cold)
 
 			db.reconcileIndexResourcePressure(index)
 
-			for n, status := range statuses {
-				locks[n].Lock()
-				assert.Equal(t, storagestate.StatusReadOnly, status.Status)
-				assert.Equal(t, statusReasonResourcePressure, status.Reason)
-				locks[n].Unlock()
+			for _, shard := range shards {
+				assert.Equal(t, ShardStatus{
+					Status: storagestate.StatusReadOnly,
+					Reason: statusReasonResourcePressure,
+				}, shard.get())
 			}
 			assert.False(t, cold.isLoaded(), "a cold shard must not be loaded when its index is published")
 		})
@@ -406,14 +399,12 @@ func TestReconcileShardResourcePressure_HoldsOffFlagFlip(t *testing.T) {
 	release := make(chan struct{})
 	var flagDuringSettle atomic.Bool
 
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).RunAndReturn(func(string) error {
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+	shard.onUpdate = func() {
 		close(settling)
 		<-release
 		flagDuringSettle.Store(db.resourceScanState.isReadOnly.Load())
-		return nil
-	})
+	}
 
 	published := make(chan struct{})
 	enterrors.GoWrapper(func() {

--- a/adapters/repos/db/resource_use_test.go
+++ b/adapters/repos/db/resource_use_test.go
@@ -42,20 +42,9 @@ func newTestMemMonitor(usedMemory, limit int64) *memwatch.Monitor {
 	)
 }
 
-// testResourceDB creates a minimal DB with one index containing the given mock shards.
+// testResourceDB creates a minimal DB with one index containing the given shards.
 // The DB is configured with the given disk and memory readonly thresholds.
-func testResourceDB(t *testing.T, diskROPercent, memROPercent uint64, shards map[string]*MockShardLike) *DB {
-	t.Helper()
-	asShardLike := make(map[string]ShardLike, len(shards))
-	for name, shard := range shards {
-		asShardLike[name] = shard
-	}
-	return testResourceDBWithShards(t, diskROPercent, memROPercent, asShardLike)
-}
-
-// testResourceDBWithShards is testResourceDB for shards that are not mocks, e.g.
-// a LazyLoadShard.
-func testResourceDBWithShards(t *testing.T, diskROPercent, memROPercent uint64, shards map[string]ShardLike) *DB {
+func testResourceDB(t *testing.T, diskROPercent, memROPercent uint64, shards map[string]ShardLike) *DB {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 
@@ -87,115 +76,132 @@ func testResourceDBWithShards(t *testing.T, diskROPercent, memROPercent uint64, 
 	}
 }
 
-// newStatefulShardMock returns a MockShardLike whose GetStatus/GetStatusReason
-// reflect the mutations made by SetStatusReadonly/UpdateStatus. The mutex guards
-// reads from the test goroutine.
-func newStatefulShardMock(t *testing.T, initial ShardStatus) (*MockShardLike, *ShardStatus, *sync.Mutex) {
+// statusShard is a MockShardLike backed by an in-memory ShardStatus, so tests
+// assert the status the scanner leaves behind instead of the calls it made.
+type statusShard struct {
+	*MockShardLike
+
+	mu     sync.Mutex
+	status ShardStatus
+
+	// racingWrite stands in for a producer that changes the status inside the
+	// scanner's decision window. It is applied once, right before the scanner's
+	// own write would land.
+	racingWrite *ShardStatus
+
+	// updateErr is returned instead of writing the status, standing in for a
+	// shard whose store rejects the change.
+	updateErr error
+
+	// onUpdate runs at the start of every status update, before the shard's own
+	// lock is taken, so a probe can observe what the sweep holds around it.
+	onUpdate func()
+}
+
+func newStatusShard(t *testing.T, initial ShardStatus) *statusShard {
 	t.Helper()
-	mu := &sync.Mutex{}
-	status := &initial
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().RunAndReturn(func() storagestate.Status {
-		mu.Lock()
-		defer mu.Unlock()
-		return status.Status
-	}).Maybe()
-	shard.EXPECT().GetStatusReason().RunAndReturn(func() string {
-		mu.Lock()
-		defer mu.Unlock()
-		return status.Reason
-	}).Maybe()
-	shard.EXPECT().SetStatusReadonly(mock.AnythingOfType("string")).RunAndReturn(func(reason string) error {
-		mu.Lock()
-		defer mu.Unlock()
-		status.Status = storagestate.StatusReadOnly
-		status.Reason = reason
-		return nil
-	}).Maybe()
-	shard.EXPECT().UpdateStatus(mock.AnythingOfType("string"), mock.AnythingOfType("string")).RunAndReturn(func(in, reason string) error {
-		mu.Lock()
-		defer mu.Unlock()
-		st, err := storagestate.ValidateStatus(strings.ToUpper(in))
-		if err != nil {
-			return err
-		}
-		status.Status = st
-		status.Reason = reason
-		return nil
-	}).Maybe()
-	return shard, status, mu
+	s := &statusShard{MockShardLike: NewMockShardLike(t), status: initial}
+
+	s.EXPECT().UpdateStatusIf(mock.Anything, mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+		RunAndReturn(func(cond func(ShardStatus) bool, in, reason string) error {
+			if s.onUpdate != nil {
+				s.onUpdate()
+			}
+
+			s.mu.Lock()
+			defer s.mu.Unlock()
+
+			if s.racingWrite != nil {
+				s.status = *s.racingWrite
+				s.racingWrite = nil
+			}
+			if !cond(s.status) {
+				return nil
+			}
+			if s.updateErr != nil {
+				return s.updateErr
+			}
+
+			status, err := storagestate.ValidateStatus(strings.ToUpper(in))
+			if err != nil {
+				return err
+			}
+			s.status = ShardStatus{Status: status, Reason: reason}
+			return nil
+		}).Maybe()
+
+	return s
+}
+
+func (s *statusShard) get() ShardStatus {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.status
 }
 
 func TestDiskUseReadonly_OverThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
 
-	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 0, map[string]ShardLike{"shard1": shard})
 
 	// 95% disk usage, threshold is 90%
 	du := diskUse{total: 100, free: 5, avail: 5}
 	db.diskUseReadonly(du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be true after exceeding disk threshold")
-	shard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure}, shard.get())
 }
 
 func TestMemUseReadonly_OverThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
 
-	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 0, 90, map[string]ShardLike{"shard1": shard})
 
 	// 95% memory usage, threshold is 90%
 	mon := newTestMemMonitor(95, 100)
 	db.memUseReadonly(mon)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be true after exceeding memory threshold")
-	shard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure}, shard.get())
 }
 
 func TestResourceUseReadonly_BothOverThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	// May be called twice (once for disk, once for memory). The second call is
-	// technically redundant since isReadOnly is already true, but setShardsReadOnly
-	// is called for both.
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
+	// setShardsReadOnly runs for both disk and memory. The second pass finds the
+	// shard already read-only and leaves it alone.
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 
 	du := diskUse{total: 100, free: 5, avail: 5}
 	mon := newTestMemMonitor(95, 100)
 	db.resourceUseReadonly(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load())
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure}, shard.get())
 }
 
 func TestDiskUseReadonly_UnderThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	// SetStatusReadonly should NOT be called
-	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+	db := testResourceDB(t, 90, 0, map[string]ShardLike{"shard1": shard})
 
 	// 85% disk usage, threshold is 90%
 	du := diskUse{total: 100, free: 15, avail: 15}
 	db.diskUseReadonly(du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain false when under threshold")
-	shard.AssertNotCalled(t, "SetStatusReadonly", mock.Anything)
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 }
 
 func TestDiskUseReadonly_ThresholdDisabled(t *testing.T) {
-	shard := NewMockShardLike(t)
-	db := testResourceDB(t, 0, 0, map[string]*MockShardLike{"shard1": shard})
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+	db := testResourceDB(t, 0, 0, map[string]ShardLike{"shard1": shard})
 
 	// 95% disk usage, but threshold is 0 (disabled)
 	du := diskUse{total: 100, free: 5, avail: 5}
 	db.diskUseReadonly(du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain false when threshold is disabled")
-	shard.AssertNotCalled(t, "SetStatusReadonly", mock.Anything)
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 }
 
 // A shard that fails to go READONLY must not take the process down, and must not
@@ -219,15 +225,12 @@ func TestSetShardsReadOnly_ShardError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			failingShard := NewMockShardLike(t)
-			failingShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-			failingShard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(tt.shardErr)
+			failingShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+			failingShard.updateErr = tt.shardErr
 
-			healthyShard := NewMockShardLike(t)
-			healthyShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-			healthyShard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
+			healthyShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
 
-			db := testResourceDB(t, 90, 0, map[string]*MockShardLike{
+			db := testResourceDB(t, 90, 0, map[string]ShardLike{
 				"failing_shard": failingShard,
 				"healthy_shard": healthyShard,
 			})
@@ -240,7 +243,7 @@ func TestSetShardsReadOnly_ShardError(t *testing.T) {
 			db.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
 
 			assert.False(t, exited, "a failed shard status update must not exit the process")
-			healthyShard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
+			assert.Equal(t, storagestate.StatusReadOnly, healthyShard.get().Status)
 			assert.True(t, db.resourceScanState.isReadOnly.Load())
 
 			errLine := firstErrorEntry(hook)
@@ -261,38 +264,19 @@ func TestSetShardsReadOnly_ShardError(t *testing.T) {
 // read side, so holding it across a load would stall the whole node.
 func TestResourceSweep_DoesNotHoldIndexLock(t *testing.T) {
 	tests := []struct {
-		name  string
-		shard func(t *testing.T, probe func()) *MockShardLike
-		sweep func(db *DB)
+		name    string
+		initial ShardStatus
+		sweep   func(db *DB)
 	}{
 		{
-			name: "read-only sweep",
-			shard: func(t *testing.T, probe func()) *MockShardLike {
-				shard := NewMockShardLike(t)
-				shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-				shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).
-					RunAndReturn(func(string) error {
-						probe()
-						return nil
-					})
-				return shard
-			},
-			sweep: func(db *DB) { db.setShardsReadOnly(statusReasonResourcePressure) },
+			name:    "read-only sweep",
+			initial: ShardStatus{Status: storagestate.StatusReady},
+			sweep:   func(db *DB) { db.setShardsReadOnly(statusReasonResourcePressure) },
 		},
 		{
-			name: "recovery sweep",
-			shard: func(t *testing.T, probe func()) *MockShardLike {
-				shard := NewMockShardLike(t)
-				shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-				shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-				shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).
-					RunAndReturn(func(status, reason string) error {
-						probe()
-						return nil
-					})
-				return shard
-			},
-			sweep: func(db *DB) { db.setShardsReady() },
+			name:    "recovery sweep",
+			initial: ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure},
+			sweep:   func(db *DB) { db.setShardsReady() },
 		},
 	}
 
@@ -301,7 +285,8 @@ func TestResourceSweep_DoesNotHoldIndexLock(t *testing.T) {
 			var db *DB
 			var heldDuringSweep atomic.Bool
 
-			shard := tt.shard(t, func() {
+			shard := newStatusShard(t, tt.initial)
+			shard.onUpdate = func() {
 				// TryRLock fails while any goroutine holds the write side, and a
 				// RWMutex is not reentrant, so this reports the lock either way.
 				if db.indexLock.TryRLock() {
@@ -309,9 +294,9 @@ func TestResourceSweep_DoesNotHoldIndexLock(t *testing.T) {
 					return
 				}
 				heldDuringSweep.Store(true)
-			})
+			}
 
-			db = testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+			db = testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 			db.resourceScanState.isReadOnly.Store(true)
 
 			tt.sweep(db)
@@ -326,12 +311,10 @@ func TestResourceSweep_DoesNotHoldIndexLock(t *testing.T) {
 // a GoWrapper goroutine that recovers and exits, so a held lock would block
 // every later index operation for the life of the process.
 func TestSetShardsReadOnly_PanicReleasesIndexLock(t *testing.T) {
-	panickingShard := NewMockShardLike(t)
-	panickingShard.EXPECT().GetStatus().RunAndReturn(func() storagestate.Status {
-		panic("shard status read blew up")
-	})
+	panickingShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+	panickingShard.onUpdate = func() { panic("shard status write blew up") }
 
-	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"panicking_shard": panickingShard})
+	db := testResourceDB(t, 90, 0, map[string]ShardLike{"panicking_shard": panickingShard})
 
 	assert.Panics(t, func() {
 		db.setShardsReadOnly(statusReasonResourcePressure)
@@ -346,12 +329,9 @@ func TestSetShardsReadOnly_PanicReleasesIndexLock(t *testing.T) {
 // goroutine, leaving the node without resource protection.
 func TestSetShardsReadOnly_SkipsUnloadedShard(t *testing.T) {
 	coldShard := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
+	loadedShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
 
-	loadedShard := NewMockShardLike(t)
-	loadedShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	loadedShard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).Return(nil)
-
-	db := testResourceDBWithShards(t, 90, 0, map[string]ShardLike{
+	db := testResourceDB(t, 90, 0, map[string]ShardLike{
 		"cold_shard":   coldShard,
 		"loaded_shard": loadedShard,
 	})
@@ -362,7 +342,7 @@ func TestSetShardsReadOnly_SkipsUnloadedShard(t *testing.T) {
 	})
 
 	assert.False(t, coldShard.isLoaded(), "a cold shard must not be loaded by the resource scan")
-	loadedShard.AssertCalled(t, "SetStatusReadonly", statusReasonResourcePressure)
+	assert.Equal(t, storagestate.StatusReadOnly, loadedShard.get().Status)
 	assert.True(t, db.resourceScanState.isReadOnly.Load())
 }
 
@@ -374,14 +354,10 @@ func TestSetShardsReadOnly_FlagRaisedBeforeSweep(t *testing.T) {
 	var db *DB
 	var flagDuringSweep atomic.Bool
 
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	shard.EXPECT().SetStatusReadonly(statusReasonResourcePressure).RunAndReturn(func(string) error {
-		flagDuringSweep.Store(db.resourceScanState.isReadOnly.Load())
-		return nil
-	})
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
+	shard.onUpdate = func() { flagDuringSweep.Store(db.resourceScanState.isReadOnly.Load()) }
 
-	db = testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
+	db = testResourceDB(t, 90, 0, map[string]ShardLike{"shard1": shard})
 
 	// 95% disk usage, threshold is 90%
 	db.diskUseReadonly(diskUse{total: 100, free: 5, avail: 5})
@@ -391,12 +367,9 @@ func TestSetShardsReadOnly_FlagRaisedBeforeSweep(t *testing.T) {
 }
 
 func TestResourceUseRecovery_BothBelowThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	// 50% disk and 50% memory, both below 90% threshold
@@ -406,14 +379,13 @@ func TestResourceUseRecovery_BothBelowThreshold(t *testing.T) {
 	db.resourceUseRecovery(mon, du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be false after recovery")
-	shard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 }
 
 func TestResourceUseRecovery_DiskRecoveredMemoryStillOver(t *testing.T) {
-	shard := NewMockShardLike(t)
-	// No status changes expected since memory is still above threshold
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	// 50% disk (below 90%), 95% memory (above 90%)
@@ -423,14 +395,13 @@ func TestResourceUseRecovery_DiskRecoveredMemoryStillOver(t *testing.T) {
 	db.resourceUseRecovery(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when memory is still over threshold")
-	shard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
+	assert.Equal(t, storagestate.StatusReadOnly, shard.get().Status)
 }
 
 func TestResourceUseRecovery_MemoryRecoveredDiskStillOver(t *testing.T) {
-	shard := NewMockShardLike(t)
-	// No status changes expected since disk is still above threshold
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	// 95% disk (above 90%), 50% memory (below 90%)
@@ -440,13 +411,13 @@ func TestResourceUseRecovery_MemoryRecoveredDiskStillOver(t *testing.T) {
 	db.resourceUseRecovery(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when disk is still over threshold")
-	shard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
+	assert.Equal(t, storagestate.StatusReadOnly, shard.get().Status)
 }
 
 func TestResourceUseRecovery_BothStillOverThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	// 95% disk and 95% memory, both above 90% threshold
@@ -456,17 +427,14 @@ func TestResourceUseRecovery_BothStillOverThreshold(t *testing.T) {
 	db.resourceUseRecovery(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when both are over threshold")
-	shard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
+	assert.Equal(t, storagestate.StatusReadOnly, shard.get().Status)
 }
 
 func TestResourceUseRecovery_ThresholdsDisabled(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
 	// Both thresholds disabled (0), but isReadOnly was set somehow
-	db := testResourceDB(t, 0, 0, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 0, 0, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	du := diskUse{total: 100, free: 5, avail: 5}
@@ -475,16 +443,14 @@ func TestResourceUseRecovery_ThresholdsDisabled(t *testing.T) {
 	db.resourceUseRecovery(mon, du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should be false when thresholds are disabled")
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 }
 
 func TestResourceUseRecovery_OnlyDiskThresholdEnabled_BelowThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
 	// Only disk threshold enabled, memory disabled
-	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 0, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	// 50% disk (below threshold), memory high but threshold disabled
@@ -494,16 +460,14 @@ func TestResourceUseRecovery_OnlyDiskThresholdEnabled_BelowThreshold(t *testing.
 	db.resourceUseRecovery(mon, du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "should recover when only enabled threshold is below limit")
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 }
 
 func TestResourceUseRecovery_OnlyMemThresholdEnabled_BelowThreshold(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
 	// Only memory threshold enabled, disk disabled
-	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 0, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	// Disk high but threshold disabled, 50% memory (below threshold)
@@ -513,19 +477,14 @@ func TestResourceUseRecovery_OnlyMemThresholdEnabled_BelowThreshold(t *testing.T
 	db.resourceUseRecovery(mon, du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "should recover when only enabled threshold is below limit")
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 }
 
 func TestSetShardsReady_OnlyRecoverReadOnlyShards(t *testing.T) {
-	readonlyShard := NewMockShardLike(t)
-	readonlyShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	readonlyShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	readonlyShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	readonlyShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
+	readyShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady})
 
-	readyShard := NewMockShardLike(t)
-	readyShard.EXPECT().GetStatus().Return(storagestate.StatusReady)
-	// UpdateStatus should NOT be called on a shard that is already READY
-
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{
 		"readonly_shard": readonlyShard,
 		"ready_shard":    readyShard,
 	})
@@ -534,8 +493,9 @@ func TestSetShardsReady_OnlyRecoverReadOnlyShards(t *testing.T) {
 	db.setShardsReady()
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load())
-	readonlyShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
-	readyShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
+	assert.Equal(t, storagestate.StatusReady, readonlyShard.get().Status)
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady}, readyShard.get(),
+		"an already-READY shard must not be relabelled by the recovery sweep")
 }
 
 // The flag must be dropped before the sweep: a shard loading concurrently
@@ -546,16 +506,10 @@ func TestSetShardsReady_FlagDroppedBeforeSweep(t *testing.T) {
 	var db *DB
 	var flagDuringSweep atomic.Bool
 
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).
-		RunAndReturn(func(status, reason string) error {
-			flagDuringSweep.Store(db.resourceScanState.isReadOnly.Load())
-			return nil
-		})
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
+	shard.onUpdate = func() { flagDuringSweep.Store(db.resourceScanState.isReadOnly.Load()) }
 
-	db = testResourceDB(t, 90, 90, map[string]*MockShardLike{"shard1": shard})
+	db = testResourceDB(t, 90, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
@@ -568,13 +522,10 @@ func TestSetShardsReady_FlagDroppedBeforeSweep(t *testing.T) {
 // shutdown) must not hold the whole DB in read-only mode: it takes no writes
 // either way, and comes back READY the next time it is loaded.
 func TestSetShardsReady_ClosedStoreDoesNotBlockRecovery(t *testing.T) {
-	closingShard := NewMockShardLike(t)
-	closingShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	closingShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	closingShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).
-		Return(fmt.Errorf("%w: updating buckets state in store %q", lsmkv.ErrAlreadyClosed, "/data/shard"))
+	closingShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
+	closingShard.updateErr = fmt.Errorf("%w: updating buckets state in store %q", lsmkv.ErrAlreadyClosed, "/data/shard")
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"closing_shard": closingShard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"closing_shard": closingShard})
 	db.resourceScanState.isReadOnly.Store(true)
 	hook := test.NewLocal(db.logger.(*logrus.Logger))
 
@@ -592,13 +543,9 @@ func TestSetShardsReady_ClosedStoreDoesNotBlockRecovery(t *testing.T) {
 // into read-only.
 func TestSetShardsReady_SkipsUnloadedShard(t *testing.T) {
 	coldShard := &LazyLoadShard{shardOpts: &deferredShardOpts{name: "cold_shard"}}
+	loadedShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	loadedShard := NewMockShardLike(t)
-	loadedShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	loadedShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	loadedShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
-
-	db := testResourceDBWithShards(t, 90, 90, map[string]ShardLike{
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{
 		"cold_shard":   coldShard,
 		"loaded_shard": loadedShard,
 	})
@@ -607,7 +554,7 @@ func TestSetShardsReady_SkipsUnloadedShard(t *testing.T) {
 	assert.NotPanics(t, func() { db.setShardsReady() })
 
 	assert.False(t, coldShard.isLoaded(), "a cold shard must not be loaded by the recovery sweep")
-	loadedShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.Equal(t, storagestate.StatusReady, loadedShard.get().Status)
 	assert.False(t, db.resourceScanState.isReadOnly.Load(),
 		"a skipped cold shard must not count as a failed transition")
 }
@@ -617,12 +564,9 @@ func TestReadonlyRecoveryCycle(t *testing.T) {
 	// 1. Usage goes over threshold → shards become READONLY
 	// 2. Usage drops below threshold → shards recover to READY
 	// 3. Usage goes over threshold again → shards become READONLY again
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReady})
 
-	// Stateful mock so GetStatus reflects the actual transitions across the
-	// cycle (setShardsReadOnly now skips shards that are already read-only).
-	shard, status, mu := newStatefulShardMock(t, ShardStatus{Status: storagestate.StatusReady})
-
-	db := testResourceDB(t, 90, 0, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 90, 0, map[string]ShardLike{"shard1": shard})
 
 	// Step 1: Disk usage exceeds threshold → READONLY (resource pressure)
 	du := diskUse{total: 100, free: 5, avail: 5}
@@ -630,42 +574,28 @@ func TestReadonlyRecoveryCycle(t *testing.T) {
 	db.resourceUseReadonly(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "should be readonly after exceeding threshold")
-	mu.Lock()
-	assert.Equal(t, storagestate.StatusReadOnly, status.Status)
-	assert.Equal(t, statusReasonResourcePressure, status.Reason)
-	mu.Unlock()
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure}, shard.get())
 
 	// Step 2: Disk usage drops below threshold → recovery to READY
 	du = diskUse{total: 100, free: 50, avail: 50}
 	db.resourceUseRecovery(mon, du)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "should recover after usage drops below threshold")
-	mu.Lock()
-	assert.Equal(t, storagestate.StatusReady, status.Status)
-	mu.Unlock()
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
 
 	// Step 3: Disk usage exceeds threshold again → READONLY again
 	du = diskUse{total: 100, free: 5, avail: 5}
 	db.resourceUseReadonly(mon, du)
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "should be readonly again after re-exceeding threshold")
-	mu.Lock()
-	assert.Equal(t, storagestate.StatusReadOnly, status.Status)
-	mu.Unlock()
+	assert.Equal(t, storagestate.StatusReadOnly, shard.get().Status)
 }
 
 func TestSetShardsReady_MultipleIndices(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
-	shard1 := NewMockShardLike(t)
-	shard1.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard1.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard1.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
-
-	shard2 := NewMockShardLike(t)
-	shard2.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard2.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard2.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	shard1 := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
+	shard2 := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
 	idx1 := &Index{
 		closingCtx: context.Background(),
@@ -700,25 +630,18 @@ func TestSetShardsReady_MultipleIndices(t *testing.T) {
 	db.setShardsReady()
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load())
-	shard1.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
-	shard2.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.Equal(t, storagestate.StatusReady, shard1.get().Status)
+	assert.Equal(t, storagestate.StatusReady, shard2.get().Status)
 }
 
 func TestSetShardsReady_SkipsNonResourcePressureReadonly(t *testing.T) {
 	// A shard that is READONLY due to a vector index config update should NOT
 	// be recovered by the resource scanner. Only shards set READONLY due to
 	// resource pressure should be transitioned back to READY.
-	configUpdateShard := NewMockShardLike(t)
-	configUpdateShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	configUpdateShard.EXPECT().GetStatusReason().Return(statusReasonVectorIndexUpdate)
-	// UpdateStatus should NOT be called
+	configUpdateShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate})
+	resourcePressureShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	resourcePressureShard := NewMockShardLike(t)
-	resourcePressureShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	resourcePressureShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	resourcePressureShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
-
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{
 		"config_update_shard":     configUpdateShard,
 		"resource_pressure_shard": resourcePressureShard,
 	})
@@ -727,8 +650,8 @@ func TestSetShardsReady_SkipsNonResourcePressureReadonly(t *testing.T) {
 	db.setShardsReady()
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load())
-	configUpdateShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
-	resourcePressureShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate}, configUpdateShard.get())
+	assert.Equal(t, storagestate.StatusReady, resourcePressureShard.get().Status)
 }
 
 // A shard that is READONLY for a vector-index config update must stay READONLY
@@ -736,10 +659,9 @@ func TestSetShardsReady_SkipsNonResourcePressureReadonly(t *testing.T) {
 // relabel it as resource-pressure and then recover it mid-update.
 func TestResourceCycle_DoesNotRecoverConfigUpdateShard(t *testing.T) {
 	// Simulate UpdateVectorIndexConfig having marked the shard READONLY.
-	shard, status, mu := newStatefulShardMock(t,
-		ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate})
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"config_update_shard": shard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"config_update_shard": shard})
 
 	// Resource pressure trips while the config update is in flight.
 	mon := newTestMemMonitor(0, 100)
@@ -748,41 +670,31 @@ func TestResourceCycle_DoesNotRecoverConfigUpdateShard(t *testing.T) {
 	// Resource pressure clears → recovery pass runs.
 	db.resourceUseRecovery(mon, diskUse{total: 100, free: 50, avail: 50})
 
-	mu.Lock()
-	defer mu.Unlock()
-	assert.Equal(t, storagestate.StatusReadOnly, status.Status,
+	assert.Equal(t, storagestate.StatusReadOnly, shard.get().Status,
 		"config-update shard must stay READONLY across a resource readonly→recovery cycle; "+
 			"resource recovery must not re-admit writes while the vector-index config update is still in flight")
 }
 
 func TestSetShardsReady_SkipsUserInitiatedReadonly(t *testing.T) {
 	// A shard manually set to READONLY by a user should not be auto-recovered.
-	userShard := NewMockShardLike(t)
-	userShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	userShard.EXPECT().GetStatusReason().Return("manually set by user")
-	// UpdateStatus should NOT be called
+	userShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonManualUpdate})
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{"user_shard": userShard})
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{"user_shard": userShard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	db.setShardsReady()
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load())
-	userShard.AssertNotCalled(t, "UpdateStatus", mock.Anything, mock.Anything)
+	assert.Equal(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonManualUpdate}, userShard.get())
 }
 
 func TestSetShardsReady_PartialFailure(t *testing.T) {
-	successShard := NewMockShardLike(t)
-	successShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	successShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	successShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	successShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
-	failingShard := NewMockShardLike(t)
-	failingShard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	failingShard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	failingShard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(fmt.Errorf("disk I/O error"))
+	failingShard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
+	failingShard.updateErr = fmt.Errorf("disk I/O error")
 
-	db := testResourceDB(t, 90, 90, map[string]*MockShardLike{
+	db := testResourceDB(t, 90, 90, map[string]ShardLike{
 		"success_shard": successShard,
 		"failing_shard": failingShard,
 	})
@@ -791,28 +703,81 @@ func TestSetShardsReady_PartialFailure(t *testing.T) {
 	db.setShardsReady()
 
 	assert.True(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should remain true when some shards fail to transition")
-	successShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
-	failingShard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.Equal(t, storagestate.StatusReady, successShard.get().Status)
+	assert.Equal(t, storagestate.StatusReadOnly, failingShard.get().Status)
 }
 
 // Shards held read-only by memory pressure must go ready again once memory
 // drops — the scan pass is the only thing refreshing the monitor.
 func TestScanResourceUsageOnce_SeesMemoryDropWhileReadOnly(t *testing.T) {
-	shard := NewMockShardLike(t)
-	shard.EXPECT().GetStatus().Return(storagestate.StatusReadOnly)
-	shard.EXPECT().GetStatusReason().Return(statusReasonResourcePressure)
-	shard.EXPECT().UpdateStatus(storagestate.StatusReady.String(), mock.AnythingOfType("string")).Return(nil)
+	shard := newStatusShard(t, ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure})
 
 	var used atomic.Int64
 	used.Store(95)
 	mon := memwatch.NewMonitor(used.Load, func(int64) int64 { return 100 }, 1.0)
 
-	db := testResourceDB(t, 0, 90, map[string]*MockShardLike{"shard1": shard})
+	db := testResourceDB(t, 0, 90, map[string]ShardLike{"shard1": shard})
 	db.resourceScanState.isReadOnly.Store(true)
 
 	used.Store(10)
 	db.scanResourceUsageOnce(mon, diskUse{total: 100, free: 100, avail: 100}, false)
 
 	assert.False(t, db.resourceScanState.isReadOnly.Load(), "isReadOnly should lift once memory drops")
-	shard.AssertCalled(t, "UpdateStatus", storagestate.StatusReady.String(), mock.AnythingOfType("string"))
+	assert.Equal(t, storagestate.StatusReady, shard.get().Status)
+}
+
+// Both sweeps decide and write in one shard call, so a status set between the
+// two never gets overwritten. Reading the status first and writing it after
+// leaves a window in which a freeze another writer just set is relabelled as
+// resource pressure — and then lifted by the recovery sweep.
+func TestResourceScanner_StatusChangedInsideDecisionWindow(t *testing.T) {
+	tests := []struct {
+		name        string
+		initial     ShardStatus
+		racingWrite ShardStatus
+		recovery    bool
+	}{
+		{
+			name:        "readonly sweep, manual freeze lands first",
+			initial:     ShardStatus{Status: storagestate.StatusReady},
+			racingWrite: ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonManualUpdate},
+		},
+		{
+			name:        "readonly sweep, vector-index freeze lands first",
+			initial:     ShardStatus{Status: storagestate.StatusReady},
+			racingWrite: ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate},
+		},
+		{
+			name:        "recovery sweep, manual freeze lands first",
+			initial:     ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure},
+			racingWrite: ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonManualUpdate},
+			recovery:    true,
+		},
+		{
+			name:        "recovery sweep, vector-index freeze lands first",
+			initial:     ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonResourcePressure},
+			racingWrite: ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonVectorIndexUpdate},
+			recovery:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			shard := newStatusShard(t, tc.initial)
+			shard.racingWrite = &tc.racingWrite
+
+			db := testResourceDB(t, 90, 0, map[string]ShardLike{"shard1": shard})
+			mon := newTestMemMonitor(0, 100)
+
+			if tc.recovery {
+				db.resourceScanState.isReadOnly.Store(true)
+				db.resourceUseRecovery(mon, diskUse{total: 100, free: 50, avail: 50})
+			} else {
+				db.resourceUseReadonly(mon, diskUse{total: 100, free: 5, avail: 5})
+			}
+
+			require.Equal(t, tc.racingWrite, shard.get(),
+				"the scanner must not overwrite a status set inside its decision window")
+		})
+	}
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -76,6 +76,7 @@ type ShardLike interface {
 	GetStatus() storagestate.Status                                                                // Return the shard status
 	GetStatusReason() string                                                                       // Return the reason for the current status
 	UpdateStatus(status, reason string) error                                                      // Set shard status
+	UpdateStatusIf(cond func(ShardStatus) bool, status, reason string) error                       // Set shard status if cond holds, without loading an unloaded shard
 	SetStatusReadonly(reason string) error                                                         // Set shard status to readonly with reason
 	FindUUIDs(ctx context.Context, filters *filters.LocalFilter, limit int) ([]strfmt.UUID, error) // Search and return document ids
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -213,6 +213,19 @@ func (l *LazyLoadShard) UpdateStatus(status, reason string) error {
 	return l.shard.UpdateStatus(status, reason)
 }
 
+// UpdateStatusIf leaves an unloaded shard alone instead of loading it: the
+// status lives in the loaded shard, and loading one to record a status would
+// resurrect a shard that was deliberately unloaded.
+func (l *LazyLoadShard) UpdateStatusIf(cond func(ShardStatus) bool, status, reason string) error {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if !l.loaded {
+		return nil
+	}
+	return l.shard.UpdateStatusIf(cond, status, reason)
+}
+
 func (l *LazyLoadShard) SetStatusReadonly(reason string) error {
 	l.mustLoad()
 	return l.shard.SetStatusReadonly(reason)

--- a/adapters/repos/db/shard_status.go
+++ b/adapters/repos/db/shard_status.go
@@ -41,6 +41,10 @@ func (s *Shard) GetStatus() storagestate.Status {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
+	return s.getStatusUnlocked()
+}
+
+func (s *Shard) getStatusUnlocked() storagestate.Status {
 	if s.status.Status != storagestate.StatusReady && s.status.Status != storagestate.StatusIndexing {
 		return s.status.Status
 	}
@@ -91,6 +95,21 @@ func (s *Shard) UpdateStatus(in, reason string) error {
 	s.statusLock.Lock()
 	defer s.statusLock.Unlock()
 
+	return s.updateStatusUnlocked(in, reason)
+}
+
+// UpdateStatusIf writes the new status only if cond holds for the current one,
+// evaluating cond and writing under a single statusLock acquisition so a status
+// another writer sets in between cannot be overwritten. cond runs with the lock
+// held and must not call back into the shard.
+func (s *Shard) UpdateStatusIf(cond func(ShardStatus) bool, in, reason string) error {
+	s.statusLock.Lock()
+	defer s.statusLock.Unlock()
+
+	current := ShardStatus{Status: s.getStatusUnlocked(), Reason: s.status.Reason}
+	if !cond(current) {
+		return nil
+	}
 	return s.updateStatusUnlocked(in, reason)
 }
 

--- a/adapters/repos/db/shard_status_test.go
+++ b/adapters/repos/db/shard_status_test.go
@@ -1,0 +1,167 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/storagestate"
+)
+
+func TestShardUpdateStatusIf(t *testing.T) {
+	tests := []struct {
+		name       string
+		initial    ShardStatus
+		cond       func(ShardStatus) bool
+		wantStatus storagestate.Status
+		wantReason string
+	}{
+		{
+			name:       "condition holds",
+			initial:    ShardStatus{Status: storagestate.StatusReady, Reason: statusReasonNotifyReady},
+			cond:       func(ShardStatus) bool { return true },
+			wantStatus: storagestate.StatusReadOnly,
+			wantReason: statusReasonResourcePressure,
+		},
+		{
+			name:       "condition does not hold",
+			initial:    ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonManualUpdate},
+			cond:       func(ShardStatus) bool { return false },
+			wantStatus: storagestate.StatusReadOnly,
+			wantReason: statusReasonManualUpdate,
+		},
+		{
+			name:    "condition reads the current status and reason",
+			initial: ShardStatus{Status: storagestate.StatusReadOnly, Reason: statusReasonManualUpdate},
+			cond: func(current ShardStatus) bool {
+				return current.Status == storagestate.StatusReadOnly &&
+					current.Reason == statusReasonManualUpdate
+			},
+			wantStatus: storagestate.StatusReadOnly,
+			wantReason: statusReasonResourcePressure,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			shard, _ := testShard(t, t.Context(), "UpdateStatusIfCondition")
+			s := underlyingShard(t, shard)
+			require.NoError(t, s.UpdateStatus(tc.initial.Status.String(), tc.initial.Reason))
+
+			require.NoError(t, s.UpdateStatusIf(tc.cond,
+				storagestate.StatusReadOnly.String(), statusReasonResourcePressure))
+
+			require.Equal(t, tc.wantStatus, s.GetStatus())
+			require.Equal(t, tc.wantReason, s.GetStatusReason())
+		})
+	}
+}
+
+// The condition and the write share one statusLock acquisition, so whichever of
+// the two calls runs second sees what the first left behind. Reading the status
+// and writing it in separate acquisitions lets the resource scanner miss a
+// freeze that lands in between and relabel it as resource pressure — after
+// which the recovery sweep lifts a freeze it never set.
+func TestShardUpdateStatusIf_ConcurrentFreezeKeepsItsReason(t *testing.T) {
+	shard, _ := testShard(t, t.Context(), "UpdateStatusIfConcurrent")
+	s := underlyingShard(t, shard)
+
+	// The sleep holds the decision open long enough for the other writer to
+	// land in it. An implementation that reads the status, drops the lock and
+	// writes afterwards overwrites that write; one that holds the lock across
+	// both makes the other writer queue up, and either order it ends up in
+	// leaves the manual reason in place.
+	notReadOnly := func(current ShardStatus) bool {
+		time.Sleep(50 * time.Microsecond)
+		return current.Status != storagestate.StatusReadOnly
+	}
+
+	for i := 0; i < 1000; i++ {
+		require.NoError(t, s.UpdateStatus(storagestate.StatusReady.String(), statusReasonNotifyReady))
+
+		var wg sync.WaitGroup
+		// Both writers park on start so they are released together. Spawning
+		// them one after the other lets the first finish before the second is
+		// scheduled, which leaves iterations that never overlap at all.
+		start := make(chan struct{})
+		errs := make([]error, 2)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[0] = s.UpdateStatus(storagestate.StatusReadOnly.String(), statusReasonManualUpdate)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			errs[1] = s.UpdateStatusIf(notReadOnly,
+				storagestate.StatusReadOnly.String(), statusReasonResourcePressure)
+		}()
+		close(start)
+		wg.Wait()
+
+		require.NoError(t, errs[0])
+		require.NoError(t, errs[1])
+		require.Equal(t, statusReasonManualUpdate, s.GetStatusReason(),
+			"a manual freeze must survive a concurrent resource-pressure sweep")
+	}
+}
+
+// An unloaded shard holds no status to change, and loading one to record a
+// status resurrects a shard that was deliberately unloaded — under the very
+// memory pressure that makes the resource scanner sweep in the first place.
+func TestLazyLoadShardUpdateStatusIf(t *testing.T) {
+	shard, idx := testShard(t, t.Context(), "LazyUpdateStatusIf")
+	loaded := underlyingShard(t, shard)
+
+	tests := []struct {
+		name  string
+		shard *LazyLoadShard
+		// loaded is both the shard's state going in and what the call must
+		// leave behind: an unloaded shard is never loaded to serve the update.
+		loaded bool
+	}{
+		{
+			name:  "unloaded shard is left untouched",
+			shard: newColdShard(idx, "cold_tenant"),
+		},
+		{
+			name:   "loaded shard is updated",
+			shard:  &LazyLoadShard{loaded: true, shard: loaded},
+			loaded: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			condRun := false
+			cond := func(ShardStatus) bool {
+				condRun = true
+				return true
+			}
+
+			require.NoError(t, tc.shard.UpdateStatusIf(cond,
+				storagestate.StatusReadOnly.String(), statusReasonResourcePressure))
+
+			require.Equal(t, tc.loaded, condRun, "the condition must only run against a loaded shard")
+			require.Equal(t, tc.loaded, tc.shard.isLoaded())
+			if tc.loaded {
+				require.Equal(t, storagestate.StatusReadOnly, tc.shard.GetStatus())
+				require.Equal(t, statusReasonResourcePressure, tc.shard.GetStatusReason())
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Closes DKF-73 / weaviate/dirk-claude-issues#155.**

Both resource-scanner sweeps took `statusLock` twice, once to read the shard's status and once to write it, with nothing held in between. If a vector-index config update or an operator set that shard READONLY in the gap, the sweep overwrote the reason with `"resource pressure"`. The next recovery sweep read that reason and set the shard back to READY. The shard then accepted writes while the config update was still running. The same gap let the sweep call `mustLoad()` on a shard a tenant deactivation had just unloaded, rebuilding it outside the shard map.

`Shard.UpdateStatusIf(cond, status, reason)` (`shard_status.go:105`) runs `cond` and writes under one `statusLock`. Both sweeps now hand it their skip rule as `cond` instead of reading the status first (`resource_use.go:261`, `:279`). `LazyLoadShard.UpdateStatusIf` returns `nil` for an unloaded shard, so writing a status never loads one. `cond` runs while `statusLock` is held, so it must not call back into the shard.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

