### PR TITLE
chore(reindex): remove unreachable reindex and shard symbols

### DIFF
--- a/adapters/repos/db/inverted_reindex_sidecar_props_writers_test.go
+++ b/adapters/repos/db/inverted_reindex_sidecar_props_writers_test.go
@@ -117,7 +117,7 @@ func TestEveryPerPropertyStrategyWritesASidecarThatRebuildsItsDirName(t *testing
 			}
 			t.Run(s.name+"/"+pl.name, func(t *testing.T) {
 				task := s.newTask(logger, pl.props, 1)
-				dirName := task.MigrationDirName()
+				dirName := task.strategy.MigrationDirName()
 
 				require.Equal(t, migrationDirWithProps(s.prefix, pl.props),
 					migrationDirBase(dirName),
@@ -251,7 +251,7 @@ func TestPersistRecoveryRecordWritesThePropsSidecar(t *testing.T) {
 			want := slices.Clone(tc.props)
 			sort.Strings(want)
 			for _, task := range tasks {
-				migDir := filepath.Join(lsm, ".migrations", task.MigrationDirName())
+				migDir := task.migrationPath(lsm)
 				got, err := readMigrationProps(migDir)
 				require.NoErrorf(t, err, "task %q wrote no properties.mig", task.Name())
 				require.Equal(t, want, got)
@@ -318,7 +318,7 @@ func TestSaveSelectedPropsWritesNoSidecarWithoutASelectedList(t *testing.T) {
 			defer shard.Shutdown(ctx)
 
 			task := tc.newTask(className, shard.Name())
-			migDir := filepath.Join(shard.pathLSM(), ".migrations", task.MigrationDirName())
+			migDir := task.migrationPath(shard.pathLSM())
 			require.NoError(t, os.MkdirAll(migDir, 0o777))
 
 			require.NoError(t, task.SaveSelectedProps(shard))
@@ -377,7 +377,7 @@ func TestAZeroBytePropsSidecarIsRebuiltNotObeyed(t *testing.T) {
 			defer shard.Shutdown(ctx)
 
 			task := tc.newTask(className)
-			rt := NewFileReindexTracker(shard.pathLSM(), task.MigrationDirName(), &UuidKeyParser{})
+			rt := NewFileReindexTracker(shard.pathLSM(), task.strategy.MigrationDirName(), &UuidKeyParser{})
 			require.NoError(t, rt.init())
 			migDir := rt.config.migrationPath
 			require.NoError(t, os.WriteFile(filepath.Join(migDir, "properties.mig"), nil, 0o644))
@@ -418,7 +418,7 @@ func TestAPropsSidecarNamingNoPropertyIsAnError(t *testing.T) {
 	defer shard.Shutdown(ctx)
 
 	task := newTestTask(logger, &MapToBlockmaxStrategy{generation: 1})
-	rt := NewFileReindexTracker(shard.pathLSM(), task.MigrationDirName(), &UuidKeyParser{})
+	rt := NewFileReindexTracker(shard.pathLSM(), task.strategy.MigrationDirName(), &UuidKeyParser{})
 	require.NoError(t, rt.init())
 	// Non-empty, so the file reads as a recorded list, yet it names nothing.
 	require.NoError(t, os.WriteFile(

--- a/adapters/repos/db/inverted_reindex_strategy.go
+++ b/adapters/repos/db/inverted_reindex_strategy.go
@@ -77,10 +77,6 @@ type MigrationStrategy interface {
 	WriteToReindexBucket(shard ShardLike, bucket *lsmkv.Bucket, docID uint64,
 		prop inverted.Property) error
 
-	// ShouldProcessProperty returns true if this property should be handled
-	// by the double-write callbacks.
-	ShouldProcessProperty(property *inverted.Property) bool
-
 	// MakeAddCallback creates a double-write callback for property additions.
 	// forTargetStrategy=true during ingest phase, false during backup phase.
 	MakeAddCallback(bucketNamer func(string) string, propsByName map[string]struct{},

--- a/adapters/repos/db/inverted_reindex_strategy_blockmax.go
+++ b/adapters/repos/db/inverted_reindex_strategy_blockmax.go
@@ -78,10 +78,6 @@ func (s *MapToBlockmaxStrategy) WriteToReindexBucket(shard ShardLike, bucket *ls
 	return nil
 }
 
-func (s *MapToBlockmaxStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return property.HasSearchableIndex
-}
-
 func (s *MapToBlockmaxStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_filterable.go
@@ -82,14 +82,6 @@ func (s *EnableFilterableStrategy) WriteToReindexBucket(shard ShardLike, bucket 
 	return nil
 }
 
-// ShouldProcessProperty always returns true. Scope is driven by the
-// reindexTaskConfig.selectedPropsByCollection set in the task constructor,
-// not by the schema flag — during this migration IndexFilterable is still
-// false on every targeted property.
-func (s *EnableFilterableStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return true
-}
-
 func (s *EnableFilterableStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_strategy_enable_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_searchable.go
@@ -75,14 +75,6 @@ func (s *EnableSearchableStrategy) WriteToReindexBucket(shard ShardLike, bucket 
 	return writeBlockmaxSearchablePostings(shard, bucket, docID, prop)
 }
 
-// ShouldProcessProperty always returns true — scope is driven by
-// selectedPropsByCollection (see NewRuntimeEnableSearchableTask). The
-// HasSearchableIndex schema flag is still false on targeted properties
-// until OnMigrationComplete flips it.
-func (s *EnableSearchableStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return true
-}
-
 func (s *EnableSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_filterable_retokenize.go
@@ -86,10 +86,6 @@ func (s *FilterableRetokenizeStrategy) WriteToReindexBucket(_ ShardLike, bucket 
 	return nil
 }
 
-func (s *FilterableRetokenizeStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return property.HasFilterableIndex && property.Name == s.propName
-}
-
 // MakeAddCallback returns a callback for adding documents to the filterable (RoaringSet) index.
 // forTargetStrategy controls which tokenization is used: true uses the new target
 // tokenization (for the reindex bucket), false uses the existing tokenization

--- a/adapters/repos/db/inverted_reindex_strategy_rangeable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rangeable.go
@@ -103,16 +103,6 @@ func (s *FilterableToRangeableStrategy) WriteToReindexBucket(shard ShardLike, bu
 	return nil
 }
 
-// ShouldProcessProperty always returns true. Scope is driven by the
-// reindexTaskConfig.selectedPropsByCollection set in the task constructor,
-// not by the live schema flag — during this migration IndexRangeFilters
-// is still false on every targeted property, and IndexFilterable may also
-// be false (the data is rebuilt from the objects bucket, not from
-// filterable).
-func (s *FilterableToRangeableStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return true
-}
-
 func (s *FilterableToRangeableStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
@@ -62,10 +62,6 @@ func (s *RebuildSearchableStrategy) WriteToReindexBucket(shard ShardLike, bucket
 	return writeBlockmaxSearchablePostings(shard, bucket, docID, prop)
 }
 
-// ShouldProcessProperty is true for every targeted property — selection is
-// driven by selectedPropsByCollection in the task config.
-func (s *RebuildSearchableStrategy) ShouldProcessProperty(_ *inverted.Property) bool { return true }
-
 func (s *RebuildSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_strategy_retokenize.go
+++ b/adapters/repos/db/inverted_reindex_strategy_retokenize.go
@@ -93,10 +93,6 @@ func (s *SearchableRetokenizeStrategy) WriteToReindexBucket(shard ShardLike, buc
 	return nil
 }
 
-func (s *SearchableRetokenizeStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return property.HasSearchableIndex && property.Name == s.propName
-}
-
 // MakeAddCallback returns a callback for adding documents to the searchable index.
 // forTargetStrategy controls which tokenization is used: true uses the new target
 // tokenization (for the reindex bucket), false uses the existing tokenization

--- a/adapters/repos/db/inverted_reindex_strategy_roaringset.go
+++ b/adapters/repos/db/inverted_reindex_strategy_roaringset.go
@@ -76,10 +76,6 @@ func (s *RoaringSetRefreshStrategy) WriteToReindexBucket(shard ShardLike, bucket
 	return nil
 }
 
-func (s *RoaringSetRefreshStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return property.HasFilterableIndex
-}
-
 func (s *RoaringSetRefreshStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -321,14 +321,6 @@ func (t *ShardReindexTaskGeneric) SetProgressCallback(fn func(float32)) {
 	t.progressCallback = fn
 }
 
-// MigrationDirName returns the strategy-specific sub-directory under each
-// shard's <lsm>/.migrations/ that this task owns. Exposed so callers can
-// drop or read recovery sentinels (e.g. payload.mig) without depending on
-// the unexported reindexTracker.
-func (t *ShardReindexTaskGeneric) MigrationDirName() string {
-	return t.strategy.MigrationDirName()
-}
-
 // migrationPath returns the absolute path to the migration directory for
 // this task on the given shard LSM path.
 func (t *ShardReindexTaskGeneric) migrationPath(lsmPath string) string {

--- a/adapters/repos/db/inverted_reindex_task_generic_test.go
+++ b/adapters/repos/db/inverted_reindex_task_generic_test.go
@@ -62,13 +62,6 @@ func (r *testShardReindexer) RunAfterLsmInit(ctx context.Context, shard *Shard) 
 	return r.task.OnAfterLsmInit(ctx, shard)
 }
 
-func (r *testShardReindexer) RunAfterLsmInitAsync(ctx context.Context, shard *Shard) error {
-	_, _, err := r.task.OnAfterLsmInitAsync(ctx, shard)
-	return err
-}
-
-func (r *testShardReindexer) Stop(_ *Shard, _ error) {}
-
 func createTestObjectWithText(className, text string) *storobj.Object {
 	return &storobj.Object{
 		MarshallerVersion: 1,

--- a/adapters/repos/db/inverted_reindexer_v3.go
+++ b/adapters/repos/db/inverted_reindexer_v3.go
@@ -18,8 +18,6 @@ import (
 type ShardReindexerV3 interface {
 	RunBeforeLsmInit(ctx context.Context, shard *Shard) error
 	RunAfterLsmInit(ctx context.Context, shard *Shard) error
-	RunAfterLsmInitAsync(ctx context.Context, shard *Shard) error
-	Stop(shard *Shard, cause error)
 }
 
 // -----------------------------------------------------------------------------
@@ -37,9 +35,3 @@ func (r *shardReindexerV3Noop) RunBeforeLsmInit(ctx context.Context, shard *Shar
 func (r *shardReindexerV3Noop) RunAfterLsmInit(ctx context.Context, shard *Shard) error {
 	return nil
 }
-
-func (r *shardReindexerV3Noop) RunAfterLsmInitAsync(ctx context.Context, shard *Shard) error {
-	return nil
-}
-
-func (r *shardReindexerV3Noop) Stop(shard *Shard, cause error) {}

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -4209,54 +4209,6 @@ func (_c *MockShardLike_addToPropertyMapBucket_Call) RunAndReturn(run func(*lsmk
 	return _c
 }
 
-// addToPropertyRangeBucket provides a mock function with given fields: bucket, docID, key
-func (_m *MockShardLike) addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	ret := _m.Called(bucket, docID, key)
-
-	if len(ret) == 0 {
-		panic("no return value specified for addToPropertyRangeBucket")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*lsmkv.Bucket, uint64, []byte) error); ok {
-		r0 = rf(bucket, docID, key)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockShardLike_addToPropertyRangeBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'addToPropertyRangeBucket'
-type MockShardLike_addToPropertyRangeBucket_Call struct {
-	*mock.Call
-}
-
-// addToPropertyRangeBucket is a helper method to define mock.On call
-//   - bucket *lsmkv.Bucket
-//   - docID uint64
-//   - key []byte
-func (_e *MockShardLike_Expecter) addToPropertyRangeBucket(bucket interface{}, docID interface{}, key interface{}) *MockShardLike_addToPropertyRangeBucket_Call {
-	return &MockShardLike_addToPropertyRangeBucket_Call{Call: _e.mock.On("addToPropertyRangeBucket", bucket, docID, key)}
-}
-
-func (_c *MockShardLike_addToPropertyRangeBucket_Call) Run(run func(bucket *lsmkv.Bucket, docID uint64, key []byte)) *MockShardLike_addToPropertyRangeBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*lsmkv.Bucket), args[1].(uint64), args[2].([]byte))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_addToPropertyRangeBucket_Call) Return(_a0 error) *MockShardLike_addToPropertyRangeBucket_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockShardLike_addToPropertyRangeBucket_Call) RunAndReturn(run func(*lsmkv.Bucket, uint64, []byte) error) *MockShardLike_addToPropertyRangeBucket_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // addToPropertySetBucket provides a mock function with given fields: bucket, docID, key
 func (_m *MockShardLike) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
 	ret := _m.Called(bucket, docID, key)
@@ -4353,53 +4305,6 @@ func (_c *MockShardLike_batchDeleteObject_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
-// batchExtendInvertedIndexItemsLSMNoFrequency provides a mock function with given fields: b, item
-func (_m *MockShardLike) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error {
-	ret := _m.Called(b, item)
-
-	if len(ret) == 0 {
-		panic("no return value specified for batchExtendInvertedIndexItemsLSMNoFrequency")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*lsmkv.Bucket, inverted.MergeItem) error); ok {
-		r0 = rf(b, item)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'batchExtendInvertedIndexItemsLSMNoFrequency'
-type MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call struct {
-	*mock.Call
-}
-
-// batchExtendInvertedIndexItemsLSMNoFrequency is a helper method to define mock.On call
-//   - b *lsmkv.Bucket
-//   - item inverted.MergeItem
-func (_e *MockShardLike_Expecter) batchExtendInvertedIndexItemsLSMNoFrequency(b interface{}, item interface{}) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
-	return &MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call{Call: _e.mock.On("batchExtendInvertedIndexItemsLSMNoFrequency", b, item)}
-}
-
-func (_c *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call) Run(run func(b *lsmkv.Bucket, item inverted.MergeItem)) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*lsmkv.Bucket), args[1].(inverted.MergeItem))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call) Return(_a0 error) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call) RunAndReturn(run func(*lsmkv.Bucket, inverted.MergeItem) error) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // commitReplication provides a mock function with given fields: _a0, _a1
 func (_m *MockShardLike) commitReplication(_a0 context.Context, _a1 string) interface{} {
 	ret := _m.Called(_a0, _a1)
@@ -4445,102 +4350,6 @@ func (_c *MockShardLike_commitReplication_Call) Return(_a0 interface{}) *MockSha
 }
 
 func (_c *MockShardLike_commitReplication_Call) RunAndReturn(run func(context.Context, string) interface{}) *MockShardLike_commitReplication_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// deleteFromPropertyRangeBucket provides a mock function with given fields: bucket, docID, key
-func (_m *MockShardLike) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	ret := _m.Called(bucket, docID, key)
-
-	if len(ret) == 0 {
-		panic("no return value specified for deleteFromPropertyRangeBucket")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*lsmkv.Bucket, uint64, []byte) error); ok {
-		r0 = rf(bucket, docID, key)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockShardLike_deleteFromPropertyRangeBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deleteFromPropertyRangeBucket'
-type MockShardLike_deleteFromPropertyRangeBucket_Call struct {
-	*mock.Call
-}
-
-// deleteFromPropertyRangeBucket is a helper method to define mock.On call
-//   - bucket *lsmkv.Bucket
-//   - docID uint64
-//   - key []byte
-func (_e *MockShardLike_Expecter) deleteFromPropertyRangeBucket(bucket interface{}, docID interface{}, key interface{}) *MockShardLike_deleteFromPropertyRangeBucket_Call {
-	return &MockShardLike_deleteFromPropertyRangeBucket_Call{Call: _e.mock.On("deleteFromPropertyRangeBucket", bucket, docID, key)}
-}
-
-func (_c *MockShardLike_deleteFromPropertyRangeBucket_Call) Run(run func(bucket *lsmkv.Bucket, docID uint64, key []byte)) *MockShardLike_deleteFromPropertyRangeBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*lsmkv.Bucket), args[1].(uint64), args[2].([]byte))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_deleteFromPropertyRangeBucket_Call) Return(_a0 error) *MockShardLike_deleteFromPropertyRangeBucket_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockShardLike_deleteFromPropertyRangeBucket_Call) RunAndReturn(run func(*lsmkv.Bucket, uint64, []byte) error) *MockShardLike_deleteFromPropertyRangeBucket_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// deleteFromPropertySetBucket provides a mock function with given fields: bucket, docID, key
-func (_m *MockShardLike) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	ret := _m.Called(bucket, docID, key)
-
-	if len(ret) == 0 {
-		panic("no return value specified for deleteFromPropertySetBucket")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*lsmkv.Bucket, uint64, []byte) error); ok {
-		r0 = rf(bucket, docID, key)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockShardLike_deleteFromPropertySetBucket_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'deleteFromPropertySetBucket'
-type MockShardLike_deleteFromPropertySetBucket_Call struct {
-	*mock.Call
-}
-
-// deleteFromPropertySetBucket is a helper method to define mock.On call
-//   - bucket *lsmkv.Bucket
-//   - docID uint64
-//   - key []byte
-func (_e *MockShardLike_Expecter) deleteFromPropertySetBucket(bucket interface{}, docID interface{}, key interface{}) *MockShardLike_deleteFromPropertySetBucket_Call {
-	return &MockShardLike_deleteFromPropertySetBucket_Call{Call: _e.mock.On("deleteFromPropertySetBucket", bucket, docID, key)}
-}
-
-func (_c *MockShardLike_deleteFromPropertySetBucket_Call) Run(run func(bucket *lsmkv.Bucket, docID uint64, key []byte)) *MockShardLike_deleteFromPropertySetBucket_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*lsmkv.Bucket), args[1].(uint64), args[2].([]byte))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_deleteFromPropertySetBucket_Call) Return(_a0 error) *MockShardLike_deleteFromPropertySetBucket_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockShardLike_deleteFromPropertySetBucket_Call) RunAndReturn(run func(*lsmkv.Bucket, uint64, []byte) error) *MockShardLike_deleteFromPropertySetBucket_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4928,54 +4737,6 @@ func (_c *MockShardLike_isReadOnly_Call) Return(_a0 error) *MockShardLike_isRead
 }
 
 func (_c *MockShardLike_isReadOnly_Call) RunAndReturn(run func() error) *MockShardLike_isReadOnly_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// mayUpsertObjectHashTree provides a mock function with given fields: object, idBytes, status
-func (_m *MockShardLike) mayUpsertObjectHashTree(object *storobj.Object, idBytes []byte, status objectInsertStatus) error {
-	ret := _m.Called(object, idBytes, status)
-
-	if len(ret) == 0 {
-		panic("no return value specified for mayUpsertObjectHashTree")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*storobj.Object, []byte, objectInsertStatus) error); ok {
-		r0 = rf(object, idBytes, status)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockShardLike_mayUpsertObjectHashTree_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'mayUpsertObjectHashTree'
-type MockShardLike_mayUpsertObjectHashTree_Call struct {
-	*mock.Call
-}
-
-// mayUpsertObjectHashTree is a helper method to define mock.On call
-//   - object *storobj.Object
-//   - idBytes []byte
-//   - status objectInsertStatus
-func (_e *MockShardLike_Expecter) mayUpsertObjectHashTree(object interface{}, idBytes interface{}, status interface{}) *MockShardLike_mayUpsertObjectHashTree_Call {
-	return &MockShardLike_mayUpsertObjectHashTree_Call{Call: _e.mock.On("mayUpsertObjectHashTree", object, idBytes, status)}
-}
-
-func (_c *MockShardLike_mayUpsertObjectHashTree_Call) Run(run func(object *storobj.Object, idBytes []byte, status objectInsertStatus)) *MockShardLike_mayUpsertObjectHashTree_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*storobj.Object), args[1].([]byte), args[2].(objectInsertStatus))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_mayUpsertObjectHashTree_Call) Return(_a0 error) *MockShardLike_mayUpsertObjectHashTree_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockShardLike_mayUpsertObjectHashTree_Call) RunAndReturn(run func(*storobj.Object, []byte, objectInsertStatus) error) *MockShardLike_mayUpsertObjectHashTree_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5979,62 +5740,6 @@ func (_c *MockShardLike_updateVectorIndexesIgnoreDelete_Call) Return(_a0 error) 
 }
 
 func (_c *MockShardLike_updateVectorIndexesIgnoreDelete_Call) RunAndReturn(run func(context.Context, map[string][]float32, objectInsertStatus) error) *MockShardLike_updateVectorIndexesIgnoreDelete_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// uuidFromDocID provides a mock function with given fields: docID
-func (_m *MockShardLike) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
-	ret := _m.Called(docID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for uuidFromDocID")
-	}
-
-	var r0 strfmt.UUID
-	var r1 error
-	if rf, ok := ret.Get(0).(func(uint64) (strfmt.UUID, error)); ok {
-		return rf(docID)
-	}
-	if rf, ok := ret.Get(0).(func(uint64) strfmt.UUID); ok {
-		r0 = rf(docID)
-	} else {
-		r0 = ret.Get(0).(strfmt.UUID)
-	}
-
-	if rf, ok := ret.Get(1).(func(uint64) error); ok {
-		r1 = rf(docID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockShardLike_uuidFromDocID_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'uuidFromDocID'
-type MockShardLike_uuidFromDocID_Call struct {
-	*mock.Call
-}
-
-// uuidFromDocID is a helper method to define mock.On call
-//   - docID uint64
-func (_e *MockShardLike_Expecter) uuidFromDocID(docID interface{}) *MockShardLike_uuidFromDocID_Call {
-	return &MockShardLike_uuidFromDocID_Call{Call: _e.mock.On("uuidFromDocID", docID)}
-}
-
-func (_c *MockShardLike_uuidFromDocID_Call) Run(run func(docID uint64)) *MockShardLike_uuidFromDocID_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(uint64))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_uuidFromDocID_Call) Return(_a0 strfmt.UUID, _a1 error) *MockShardLike_uuidFromDocID_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockShardLike_uuidFromDocID_Call) RunAndReturn(run func(uint64) (strfmt.UUID, error)) *MockShardLike_uuidFromDocID_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/repos/db/reindex_provider_barrier_integration_test.go
+++ b/adapters/repos/db/reindex_provider_barrier_integration_test.go
@@ -285,7 +285,7 @@ func TestReindexProviderBarrierIntegration_CrashAfterPersistRecoveryRecord(t *te
 		shard, []*ShardReindexTaskGeneric{task}, &selectedPropsFailures{}))
 
 	// Sanity: payload.mig is on disk in the migration dir.
-	migDir := filepath.Join(shard.pathLSM(), ".migrations", task.MigrationDirName())
+	migDir := task.migrationPath(shard.pathLSM())
 	payloadPath := filepath.Join(migDir, reindexRecoveryPayloadFile)
 	rawPayload, err := os.ReadFile(payloadPath)
 	require.NoError(t, err, "payload.mig must exist after persistRecoveryRecord")

--- a/adapters/repos/db/reindex_provider_payload.go
+++ b/adapters/repos/db/reindex_provider_payload.go
@@ -17,11 +17,9 @@ import "encoding/json"
 const ReindexNamespace = "reindex"
 
 // ExtractReindexTaskCollection decodes the class name a reindex task is
-// bound to. Registered on startup through the cluster config's
-// DistributedTaskCollectionExtractors map (see configure_api.go) so that
-// DELETE_CLASS cascades into reindex task GC
-// (weaviate/0-weaviate-issues#231). Lives next to [ReindexTaskPayload] so
-// the payload format and its scoping-decoder evolve together.
+// bound to. Wired into DistributedTaskCollectionExtractors (see
+// configure_api.go) so DELETE_CLASS cascades into reindex task GC
+// (weaviate/0-weaviate-issues#231).
 func ExtractReindexTaskCollection(payload []byte) (string, bool) {
 	var p ReindexTaskPayload
 	if err := json.Unmarshal(payload, &p); err != nil {

--- a/adapters/repos/db/reindex_provider_payload.go
+++ b/adapters/repos/db/reindex_provider_payload.go
@@ -17,11 +17,11 @@ import "encoding/json"
 const ReindexNamespace = "reindex"
 
 // ExtractReindexTaskCollection decodes the class name a reindex task is
-// bound to. Registered on startup via
-// [Raft.RegisterDistributedTaskCollectionExtractor] so that DELETE_CLASS
-// cascades into reindex task GC (weaviate/0-weaviate-issues#231). Lives
-// next to [ReindexTaskPayload] so the payload format and its
-// scoping-decoder evolve together.
+// bound to. Registered on startup through the cluster config's
+// DistributedTaskCollectionExtractors map (see configure_api.go) so that
+// DELETE_CLASS cascades into reindex task GC
+// (weaviate/0-weaviate-issues#231). Lives next to [ReindexTaskPayload] so
+// the payload format and its scoping-decoder evolve together.
 func ExtractReindexTaskCollection(payload []byte) (string, bool) {
 	var p ReindexTaskPayload
 	if err := json.Unmarshal(payload, &p); err != nil {

--- a/adapters/repos/db/reindex_provider_payload_test.go
+++ b/adapters/repos/db/reindex_provider_payload_test.go
@@ -18,10 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Pins the extractor wired into the cluster config's
-// DistributedTaskCollectionExtractors map (see configure_api.go) for the
-// reindex namespace (weaviate/0-weaviate-issues#231). A regression here
-// would silently disable the DELETE_CLASS cascade for reindex tasks.
+// Pins the DELETE_CLASS cascade extractor for the reindex namespace
+// (weaviate/0-weaviate-issues#231).
 func TestExtractReindexTaskCollection(t *testing.T) {
 	t.Run("well-formed payload returns class name", func(t *testing.T) {
 		payload, err := json.Marshal(ReindexTaskPayload{

--- a/adapters/repos/db/reindex_provider_payload_test.go
+++ b/adapters/repos/db/reindex_provider_payload_test.go
@@ -18,9 +18,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Pins the extractor wired into [Raft.RegisterDistributedTaskCollectionExtractor]
-// for the reindex namespace (weaviate/0-weaviate-issues#231). A regression
-// here would silently disable the DELETE_CLASS cascade for reindex tasks.
+// Pins the extractor wired into the cluster config's
+// DistributedTaskCollectionExtractors map (see configure_api.go) for the
+// reindex namespace (weaviate/0-weaviate-issues#231). A regression here
+// would silently disable the DELETE_CLASS cascade for reindex tasks.
 func TestExtractReindexTaskCollection(t *testing.T) {
 	t.Run("well-formed payload returns class name", func(t *testing.T) {
 		payload, err := json.Marshal(ReindexTaskPayload{

--- a/adapters/repos/db/reindex_provider_selected_props_log_volume_test.go
+++ b/adapters/repos/db/reindex_provider_selected_props_log_volume_test.go
@@ -64,7 +64,7 @@ func TestPersistRecoveryRecordDoesNotWarnPerUnit(t *testing.T) {
 	// write: the recovery payload, already on disk with identical content,
 	// still writes fine.
 	for _, task := range tasks {
-		migDir := filepath.Join(lsm, ".migrations", task.MigrationDirName())
+		migDir := task.migrationPath(lsm)
 		require.FileExists(t, filepath.Join(migDir, "properties.mig"),
 			"first call must write the sidecar, or the arm below proves nothing")
 		require.NoError(t, os.Remove(filepath.Join(migDir, "properties.mig")))

--- a/adapters/repos/db/reindex_recovery.go
+++ b/adapters/repos/db/reindex_recovery.go
@@ -408,12 +408,3 @@ func (r *shardReindexerV3RecoveryOnly) RunAfterLsmInit(ctx context.Context, shar
 	}
 	return nil
 }
-
-func (r *shardReindexerV3RecoveryOnly) RunAfterLsmInitAsync(_ context.Context, _ *Shard) error {
-	// Intentionally a no-op. See type doc.
-	return nil
-}
-
-func (r *shardReindexerV3RecoveryOnly) Stop(_ *Shard, _ error) {
-	// Nothing to stop — we don't run any background loops.
-}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -167,20 +167,14 @@ type ShardLike interface {
 	resetDimensionsLSM(ctx context.Context) error
 
 	addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
-	deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error
-	addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
-	deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error
 	pairPropertyWithFrequency(docID uint64, freq, propLen float32) lsmkv.MapPair
 
 	setFallbackToSearchable(fallback bool)
 	addJobToQueue(job job)
-	uuidFromDocID(docID uint64) (strfmt.UUID, error)
 	batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error
 	putObjectLSM(ctx context.Context, object *storobj.Object, idBytes []byte) (objectInsertStatus, error)
-	mayUpsertObjectHashTree(object *storobj.Object, idBytes []byte, status objectInsertStatus) error
 	mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error)
-	batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error
 	updatePropertySpecificIndices(ctx context.Context, object *storobj.Object, status objectInsertStatus) error
 	updateVectorIndexIgnoreDelete(ctx context.Context, vector []float32, status objectInsertStatus) error
 	updateVectorIndexesIgnoreDelete(ctx context.Context, vectors map[string][]float32, status objectInsertStatus) error

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -35,7 +35,6 @@ import (
 // to complete before the files are deleted.
 func (s *Shard) drop(keepFiles bool) (err error) {
 	s.shutCtxCancel(fmt.Errorf("drop %q", s.ID()))
-	s.reindexer.Stop(s, fmt.Errorf("shard drop"))
 
 	s.metrics.DeleteShardLabels(s.index.Config.ClassName.String(), s.name)
 	s.replicationMap.clear()

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -202,7 +202,6 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	}
 
 	_ = s.reindexer.RunAfterLsmInit(ctx, s)
-	_ = s.reindexer.RunAfterLsmInitAsync(ctx, s)
 	return s, nil
 }
 

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -940,11 +940,6 @@ func (l *LazyLoadShard) addToPropertySetBucket(bucket *lsmkv.Bucket, docID uint6
 	return l.shard.addToPropertySetBucket(bucket, docID, key)
 }
 
-func (l *LazyLoadShard) addToPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	l.mustLoad()
-	return l.shard.addToPropertyRangeBucket(bucket, docID, key)
-}
-
 func (l *LazyLoadShard) addToPropertyMapBucket(bucket *lsmkv.Bucket, pair lsmkv.MapPair, key []byte) error {
 	l.mustLoad()
 	return l.shard.addToPropertyMapBucket(bucket, pair, key)
@@ -965,11 +960,6 @@ func (l *LazyLoadShard) addJobToQueue(job job) {
 	l.shard.addJobToQueue(job)
 }
 
-func (l *LazyLoadShard) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
-	l.mustLoad()
-	return l.shard.uuidFromDocID(docID)
-}
-
 func (l *LazyLoadShard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
 	if err := l.Load(ctx); err != nil {
 		return err
@@ -982,29 +972,9 @@ func (l *LazyLoadShard) putObjectLSM(ctx context.Context, object *storobj.Object
 	return l.shard.putObjectLSM(ctx, object, idBytes)
 }
 
-func (l *LazyLoadShard) mayUpsertObjectHashTree(object *storobj.Object, idBytes []byte, status objectInsertStatus) error {
-	l.mustLoad()
-	return l.shard.mayUpsertObjectHashTree(object, idBytes, status)
-}
-
 func (l *LazyLoadShard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error) {
 	l.mustLoad()
 	return l.shard.mutableMergeObjectLSM(ctx, merge, idBytes)
-}
-
-func (l *LazyLoadShard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	l.mustLoad()
-	return l.shard.deleteFromPropertySetBucket(bucket, docID, key)
-}
-
-func (l *LazyLoadShard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {
-	l.mustLoad()
-	return l.shard.deleteFromPropertyRangeBucket(bucket, docID, key)
-}
-
-func (l *LazyLoadShard) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error {
-	l.mustLoad()
-	return l.shard.batchExtendInvertedIndexItemsLSMNoFrequency(b, item)
 }
 
 func (l *LazyLoadShard) updatePropertySpecificIndices(ctx context.Context, object *storobj.Object, status objectInsertStatus) error {

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -254,8 +254,6 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 		s.index.metrics.ObserveUpdateShardStatus(storagestate.StatusShutdown.String(), time.Since(start))
 	}()
 
-	s.reindexer.Stop(s, fmt.Errorf("shard shutdown"))
-
 	s.haltForTransferMux.Lock()
 	// also drops an already-fired monitor waiting on the mux, so it can't resume mid-teardown.
 	s.mayStopInactivityMonitoring()

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -1239,7 +1239,6 @@ func TestManager_RecordPostCompletionAck_Success(t *testing.T) {
 		require.False(t, ack.AckedAt.IsZero(), "AckedAt must be set on apply")
 	}
 	require.Empty(t, task.MissingPostCompletionAckNodes())
-	require.False(t, task.AnyPostCompletionAckFailed())
 }
 
 // TestManager_RecordPostCompletionAck_FailureTransitionsToFailed
@@ -1295,7 +1294,7 @@ func TestManager_RecordPostCompletionAck_FailureTransitionsToFailed(t *testing.T
 		"any failure ack must transition the task to FAILED")
 	require.Contains(t, task.Error, "post-completion swap failed on node node-2")
 	require.Contains(t, task.Error, "synthetic swap failure")
-	require.True(t, task.AnyPostCompletionAckFailed())
+	require.False(t, task.PostCompletionAcks["node-2"].Success)
 }
 
 // TestManager_RecordPostCompletionAck_Idempotent pins the duplicate-ack

--- a/cluster/distributedtask/scheduler.go
+++ b/cluster/distributedtask/scheduler.go
@@ -1394,17 +1394,6 @@ func (s *Scheduler) setCompletionRecorders(recorder TaskCompletionRecorder) {
 	}
 }
 
-func (s *Scheduler) totalRunningTaskCount() int {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	count := 0
-	for _, tasks := range s.runningTasks {
-		count += len(tasks)
-	}
-	return count
-}
-
 func (s *Scheduler) loggerWithTask(namespace string, taskDesc TaskDescriptor) *logrus.Entry {
 	return s.logger.WithFields(logrus.Fields{
 		"namespace":   namespace,

--- a/cluster/distributedtask/scheduler_test.go
+++ b/cluster/distributedtask/scheduler_test.go
@@ -70,7 +70,6 @@ func TestHappyPathTaskLifecycleWithSingleNode(t *testing.T) {
 	require.Equal(t, taskID, recvWithTimeout(t, h.provider.completedCh).ID)
 
 	h.advanceClock(h.schedulerTickInterval)
-	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
 	// advance the clock just before expected clean up time to check whether it respects it
 	h.advanceClock(h.completedTaskTTL - h.clockAdvancedSoFar - time.Minute)
@@ -121,7 +120,6 @@ func TestHappyPathTaskLifecycleWithMultipleNode(t *testing.T) {
 
 	// local task completed
 	h.advanceClock(h.schedulerTickInterval)
-	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
 	// however, task is not finished in the cluster yet
 	tasks := h.listManagerTasks(t)[h.tasksNamespace]
@@ -219,7 +217,6 @@ func TestTaskFailureInAnotherNode(t *testing.T) {
 	// locally running task should be cancelled
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, taskID, recvWithTimeout(t, h.provider.cancelledCh).ID)
-	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
 	tasks := h.listManagerTasks(t)[h.tasksNamespace]
 	require.Len(t, tasks, 1)
@@ -264,7 +261,6 @@ func TestTaskFailureInLocalNode(t *testing.T) {
 	recvWithTimeout(t, h.provider.failedCh)
 
 	h.advanceClock(h.schedulerTickInterval)
-	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
 	tasks := h.listManagerTasks(t)[h.tasksNamespace]
 	require.Len(t, tasks, 1)
@@ -461,7 +457,6 @@ func TestMultiNamespaceMultiTasks(t *testing.T) {
 	require.NoError(t, err)
 
 	h.advanceClock(h.schedulerTickInterval)
-	require.Equal(t, 3, h.scheduler.totalRunningTaskCount())
 
 	startedTasks := map[string]*testTask{}
 	for range 2 {
@@ -489,10 +484,6 @@ func TestMultiNamespaceMultiTasks(t *testing.T) {
 		CancelledAtUnixMillis: h.clock.Now().UnixMilli(),
 	}))
 	require.NoError(t, err)
-
-	h.advanceClock(h.schedulerTickInterval)
-
-	require.Zero(t, h.scheduler.totalRunningTaskCount())
 }
 
 func TestOverrideExistingFinishedTask(t *testing.T) {
@@ -521,8 +512,6 @@ func TestOverrideExistingFinishedTask(t *testing.T) {
 	recvWithTimeout(t, h.provider.completedCh)
 
 	h.advanceClock(h.schedulerTickInterval)
-
-	require.Zero(t, h.scheduler.totalRunningTaskCount())
 
 	err = h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
 		Namespace:             h.tasksNamespace,
@@ -1007,49 +996,6 @@ func TestReactiveFiring_NilNotifierIsSafe(t *testing.T) {
 	// No notifier → scheduler is idle. Advance past one tick to fire it.
 	h.advanceClock(h.schedulerTickInterval)
 	require.Equal(t, "1234", recvWithTimeout(t, h.provider.startedCh).ID)
-}
-
-// TestReactiveFiring_PeriodicTickFallback verifies that the periodic
-// tick still fires even when reactive firing is wired — this catches
-// any regression where the new select arm accidentally starves the tick
-// path, or where the scheduler's loop only progresses on wake-ups.
-func TestReactiveFiring_PeriodicTickFallback(t *testing.T) {
-	defer leaktest.Check(t)()
-
-	h := newTestHarness(t).init(t)
-	h.manager.SetSchedulerNotifier(h.scheduler)
-
-	h.startScheduler(t)
-	defer h.Close()
-
-	// AddTask wakes the scheduler reactively; consume the started signal.
-	require.NoError(t, h.manager.AddTask(toCmd(t, &cmd.AddDistributedTaskRequest{
-		Namespace:             h.tasksNamespace,
-		Id:                    "1234",
-		Payload:               []byte("payload"),
-		SubmittedAtUnixMillis: h.clock.Now().UnixMilli(),
-		UnitIds:               []string{"su-1"},
-	}), 10))
-	startedTask := recvWithTimeout(t, h.provider.startedCh)
-
-	// Complete the unit; the scheduler should clean up on the NEXT tick.
-	// We deliberately complete via the manager FIRST then advance the
-	// clock, to confirm that the periodic tick still drives the cleanup
-	// path. In a reactive-firing-only design, this would also fire via
-	// Wake; the fallback assertion here ensures the timer arm of the
-	// loop's select is still active.
-	startedTask.Complete()
-	completeUnit(t, h, h.tasksNamespace, "1234", 10, h.localNodeID, "su-1")
-	recvWithTimeout(t, h.provider.completedCh)
-
-	// Now advance the clock and confirm the periodic tick clears the
-	// running task entry. (totalRunningTaskCount is zero only after a
-	// tick observes the task is no longer in startedTasks.)
-	h.advanceClock(h.schedulerTickInterval)
-	require.Eventually(t, func() bool {
-		return h.scheduler.totalRunningTaskCount() == 0
-	}, 2*time.Second, 50*time.Millisecond,
-		"periodic tick should clear completed task even with reactive firing wired")
 }
 
 // flappyTasksLister proxies to inner for succeedsLeft calls, then fails

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -487,23 +487,6 @@ func (t TaskStatus) IsCompleted() bool {
 	return t == TaskStatusSwapping || t == TaskStatusFinished
 }
 
-// IsCoordinationPhase is true for the post-units, pre-terminal phases
-// (PREPARING, SWAPPING) — the scheduler-driven callback states.
-//
-// A status this build does not recognize answers false here and true from
-// [TaskStatus.IsActive]: this asks which phase a task is in, IsActive
-// whether to assume it is still running.
-func (t TaskStatus) IsCoordinationPhase() bool {
-	switch t {
-	case TaskStatusPreparing, TaskStatusSwapping:
-		return true
-	case TaskStatusStarted, TaskStatusFinished, TaskStatusFailed, TaskStatusCancelled:
-		return false
-	}
-	// A status this build never declared cannot be placed in a phase.
-	return false
-}
-
 // IsRecognized is false for a status this build never declared — what a
 // node sees when a newer release introduces one mid rolling-upgrade.
 func (t TaskStatus) IsRecognized() bool {
@@ -663,17 +646,6 @@ func (t *Task) AnyUnitFailed() bool {
 	return false
 }
 
-// LocalUnitIDs returns the IDs of units assigned to the given node.
-func (t *Task) LocalUnitIDs(nodeID string) []string {
-	var ids []string
-	for id, u := range t.Units {
-		if u.NodeID == nodeID {
-			ids = append(ids, id)
-		}
-	}
-	return ids
-}
-
 // Groups returns the distinct GroupIDs across all units (includes "" for ungrouped).
 func (t *Task) Groups() []string {
 	seen := map[string]bool{}
@@ -768,20 +740,6 @@ func (t *Task) MissingPostCompletionAckNodes() []string {
 		}
 	}
 	return missing
-}
-
-// AnyPostCompletionAckFailed returns true iff any node has recorded a
-// post-completion ack with [PostCompletionAck.Success]==false. The
-// FSM uses this on the apply path to flip the task to FAILED — once
-// any node reports failure, the schema flip must be skipped and the
-// task must not progress to FINISHED.
-func (t *Task) AnyPostCompletionAckFailed() bool {
-	for _, ack := range t.PostCompletionAcks {
-		if !ack.Success {
-			return true
-		}
-	}
-	return false
 }
 
 type ListDistributedTasksResponse struct {

--- a/cluster/distributedtask/types_predicates_test.go
+++ b/cluster/distributedtask/types_predicates_test.go
@@ -32,7 +32,7 @@ var unknownFutureStatus = TaskStatus("UNKNOWN_FUTURE_STATE")
 // fixtureTask builds a Task with a controlled unit assignment for the
 // table tests below. Two groups (g1, g2), three nodes (n-1, n-2, n-3),
 // one unit on n-3 that is "unassigned" (empty NodeID) to exercise the
-// edge in NodesWithLocalUnits / LocalUnitIDs.
+// edge in NodesWithLocalUnits / LocalGroupUnitIDs.
 func fixtureTask() *Task {
 	return &Task{
 		Status: TaskStatusStarted,
@@ -132,65 +132,6 @@ func TestTaskStatus_IsRecognized(t *testing.T) {
 	}
 }
 
-// TestTaskStatus_IsCoordinationPhase pins the PREPARING/SWAPPING
-// classification — the phase question the docs' predicate table
-// answers. The method's switch has no default arm, so a newly declared
-// status fails the build until someone places it; this table pins where
-// each one landed.
-func TestTaskStatus_IsCoordinationPhase(t *testing.T) {
-	cases := []struct {
-		status       TaskStatus
-		coordination bool
-	}{
-		{TaskStatusStarted, false},
-		{TaskStatusPreparing, true},
-		{TaskStatusSwapping, true},
-		{TaskStatusFinished, false},
-		{TaskStatusFailed, false},
-		{TaskStatusCancelled, false},
-		{unknownFutureStatus, false},
-		{TaskStatus(""), false},
-	}
-	for _, tc := range cases {
-		t.Run(string(tc.status), func(t *testing.T) {
-			assert.Equal(t, tc.coordination, tc.status.IsCoordinationPhase(),
-				"%q.IsCoordinationPhase() should be %v", tc.status, tc.coordination)
-		})
-	}
-}
-
-// TestTask_LocalUnitIDs pins per-node ownership. Production callers that
-// rely on the empty-NodeID skip include `NodesWithLocalUnits` (and
-// therefore `MissingPostCompletionAckNodes`). A regression that started
-// returning unassigned units under any specific node would corrupt the
-// ack-barrier predicate.
-func TestTask_LocalUnitIDs(t *testing.T) {
-	task := fixtureTask()
-	cases := []struct {
-		node string
-		want []string // sorted
-	}{
-		{"n-1", []string{"u-1-g1-n1-done", "u-3-g2-n1-pending"}},
-		{"n-2", []string{"u-2-g1-n2-failed", "u-4-g2-n2-prog"}},
-		{"n-3", []string{"u-5-noGroup-n3"}},
-		{"n-doesnotexist", nil},
-		// Empty NodeID literally matches units with empty NodeID — the
-		// load-bearing difference from NodesWithLocalUnits (which skips
-		// the unassigned unit, since it can't have a node-side ack).
-		// Production callers of LocalUnitIDs always pass a real node ID,
-		// but the literal-equality semantics are pinned here so a future
-		// "skip empty" refactor doesn't silently change the contract.
-		{"", []string{"u-6-g1-unassigned"}},
-	}
-	for _, tc := range cases {
-		t.Run("node="+tc.node, func(t *testing.T) {
-			got := task.LocalUnitIDs(tc.node)
-			sort.Strings(got)
-			assert.Equal(t, tc.want, got)
-		})
-	}
-}
-
 // TestTask_LocalGroupUnitIDs pins per-(group,node) ownership — the
 // predicate used by [ReindexProvider.OnGroupCompleted] to pick which
 // shards' swap to fire on a given node. Empty-NodeID skip matters here
@@ -208,7 +149,7 @@ func TestTask_LocalGroupUnitIDs(t *testing.T) {
 		{"g2", "n-2", []string{"u-4-g2-n2-prog"}},
 		{"", "n-3", []string{"u-5-noGroup-n3"}}, // ungrouped on n-3
 		// Empty NodeID matches the unassigned unit when the group also
-		// matches — literal-equality semantics, same as LocalUnitIDs.
+		// matches — literal-equality semantics.
 		{"g1", "", []string{"u-6-g1-unassigned"}},
 		{"unknownGroup", "n-1", nil},
 	}
@@ -283,24 +224,6 @@ func TestTask_MissingPostCompletionAckNodes(t *testing.T) {
 	sort.Strings(got)
 	assert.Equal(t, []string{"n-1", "n-3"}, got,
 		"extraneous acks (from nodes not in NodesWithLocalUnits) must be ignored")
-}
-
-// TestTask_AnyPostCompletionAckFailed pins the failure-detector: once
-// ANY node records Success=false, the FSM must transition to FAILED.
-func TestTask_AnyPostCompletionAckFailed(t *testing.T) {
-	task := &Task{
-		PostCompletionAcks: map[string]PostCompletionAck{
-			"n-1": {Success: true},
-			"n-2": {Success: true},
-		},
-	}
-	assert.False(t, task.AnyPostCompletionAckFailed())
-
-	task.PostCompletionAcks["n-3"] = PostCompletionAck{Success: false, Error: "swap failed"}
-	assert.True(t, task.AnyPostCompletionAckFailed())
-
-	// Edge: nil map.
-	assert.False(t, (&Task{}).AnyPostCompletionAckFailed())
 }
 
 // TestTask_AllUnitsTerminal and TestTask_AnyUnitFailed pin the two

--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -103,13 +103,6 @@ func (s *Raft) LocalUnrecognizedDistributedTasks() map[string][]*distributedtask
 	return s.store.LocalUnrecognizedDistributedTasks()
 }
 
-// RegisterDistributedTaskCollectionExtractor opts a task namespace into
-// the DELETE_CLASS cascade. See [distributedtask.CollectionExtractor]
-// and weaviate/0-weaviate-issues#231.
-func (s *Raft) RegisterDistributedTaskCollectionExtractor(namespace string, extractor distributedtask.CollectionExtractor) {
-	s.store.RegisterDistributedTaskCollectionExtractor(namespace, extractor)
-}
-
 func (s *Raft) Ready() bool {
 	return s.store.Ready()
 }

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -450,13 +450,6 @@ func (st *Store) LocalUnrecognizedDistributedTasks() map[string][]*distributedta
 	return st.distributedTasksManager.LocalUnrecognizedDistributedTasks()
 }
 
-// RegisterDistributedTaskCollectionExtractor opts a task namespace into
-// [SchemaManager.DeleteClass]'s cascade-delete of task records.
-// weaviate/0-weaviate-issues#231.
-func (st *Store) RegisterDistributedTaskCollectionExtractor(namespace string, extractor distributedtask.CollectionExtractor) {
-	st.distributedTasksManager.RegisterCollectionExtractor(namespace, extractor)
-}
-
 // lastIndex returns the last index in stable storage,
 // either from the last log or from the last snapshot.
 // this method work as a protection from applying anything was applied to the db

--- a/docs/runtime-reindex.md
+++ b/docs/runtime-reindex.md
@@ -625,7 +625,7 @@ Key types & contracts:
 |---|---|
 | `IsTerminal()` | `FINISHED`, `FAILED`, `CANCELLED` |
 | `IsActive()` | everything else (defined as the exact negation of `IsTerminal()`) |
-| `IsCoordinationPhase()` | `PREPARING`, `SWAPPING` |
+| `IsCompleted()` | `SWAPPING`, `FINISHED` — every unit succeeded |
 | `IsRecognized()` | any status this build declares |
 | `IsCancellable()` | `STARTED`, and nothing else |
 
@@ -1576,7 +1576,7 @@ already GC'd) resolves as WAND on the older binary until a re-migration.
 **DTM**
 
 - [`cluster/distributedtask/doc.go`](../cluster/distributedtask/doc.go) — package-level architecture + the four "journey" shapes.
-- [`cluster/distributedtask/types.go`](../cluster/distributedtask/types.go) — `Task`, `Unit`, `UnitSpec`, `TaskStatusPreparing`, `TaskStatusSwapping`, `NeedsPreparationBarrier`, the `TaskStatus.IsTerminal()` / `IsActive()` / `IsCoordinationPhase()` / `IsRecognized()` classification helpers, and `IsCancellable()` (§4.2).
+- [`cluster/distributedtask/types.go`](../cluster/distributedtask/types.go) — `Task`, `Unit`, `UnitSpec`, `TaskStatusPreparing`, `TaskStatusSwapping`, `NeedsPreparationBarrier`, the `TaskStatus.IsTerminal()` / `IsActive()` / `IsCompleted()` / `IsRecognized()` classification helpers, and `IsCancellable()` (§4.2).
 - [`cluster/distributedtask/manager.go`](../cluster/distributedtask/manager.go) — FSM. `RecordPostCompletionAck`, `MarkTaskFinalized` godocs are essential reading.
 - [`cluster/distributedtask/scheduler.go`](../cluster/distributedtask/scheduler.go) — per-node loop, callback dispatch.
 - [`cluster/distributedtask/errors.go`](../cluster/distributedtask/errors.go) — permanent-rejection sentinels + gRPC wire encoding.

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -207,9 +207,6 @@ type Config struct {
 	HaltForTransferTimeout              time.Duration                  `json:"halt_for_transfer_timeout" yaml:"halt_for_transfer_timeout"`
 	RecountPropertiesAtStartup          bool                           `json:"recount_properties_at_startup" yaml:"recount_properties_at_startup"`
 	ReindexSetToRoaringsetAtStartup     bool                           `json:"reindex_set_to_roaringset_at_startup" yaml:"reindex_set_to_roaringset_at_startup"`
-	ReindexerGoroutinesFactor           float64                        `json:"reindexer_goroutines_factor" yaml:"reindexer_goroutines_factor"`
-	ReindexMapToBlockmaxAtStartup       bool                           `json:"reindex_map_to_blockmax_at_startup" yaml:"reindex_map_to_blockmax_at_startup"`
-	ReindexMapToBlockmaxConfig          MapToBlockamaxConfig           `json:"reindex_map_to_blockmax_config" yaml:"reindex_map_to_blockmax_config"`
 	IndexMissingTextFilterableAtStartup bool                           `json:"index_missing_text_filterable_at_startup" yaml:"index_missing_text_filterable_at_startup"`
 	DisableGraphQL                      *runtime.DynamicValue[bool]    `json:"disable_graphql" yaml:"disable_graphql"`
 	ExperimentalRESTSearchEnabled       *runtime.DynamicValue[bool]    `json:"rest_search_enabled" yaml:"rest_search_enabled"`
@@ -351,19 +348,6 @@ type Config struct {
 
 	// Disable vector dimension tracking that are used for billing. These metrics are being deprecated in favor of more accurate metrics
 	DisableDimensionMetrics *runtime.DynamicValue[bool] `json:"disable_dimension_metrics" yaml:"disable_dimension_metrics"`
-}
-
-type MapToBlockamaxConfig struct {
-	SwapBuckets                bool                     `json:"swap_buckets" yaml:"swap_buckets"`
-	UnswapBuckets              bool                     `json:"unswap_buckets" yaml:"unswap_buckets"`
-	TidyBuckets                bool                     `json:"tidy_buckets" yaml:"tidy_buckets"`
-	ReloadShards               bool                     `json:"reload_shards" yaml:"reload_shards"`
-	Rollback                   bool                     `json:"rollback" yaml:"rollback"`
-	ConditionalStart           bool                     `json:"conditional_start" yaml:"conditional_start"`
-	ProcessingDurationSeconds  int                      `json:"processing_duration_seconds" yaml:"processing_duration_seconds"`
-	PauseDurationSeconds       int                      `json:"pause_duration_seconds" yaml:"pause_duration_seconds"`
-	PerObjectDelayMilliseconds int                      `json:"per_object_delay_milliseconds" yaml:"per_object_delay_milliseconds"`
-	Selected                   []CollectionPropsTenants `json:"selected" yaml:"selected"`
 }
 
 type CollectionPropsTenants struct {
@@ -1028,10 +1012,6 @@ const DefaultPersistenceLSMSegmentsCleanupIntervalSeconds = 0
 const DefaultPersistenceLSMCycleManagerRoutinesFactor = 2
 
 const DefaultPersistenceHNSWMaxLogSize = 500 * 1024 * 1024 // 500MB for backward compatibility
-
-const (
-	DefaultReindexerGoroutinesFactor = 0.5
-)
 
 // MetadataServer is experimental.
 type MetadataServer struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -16,7 +16,6 @@ import (
 	"math"
 	"os"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -698,10 +697,6 @@ func FromEnv(config *Config) error {
 			config.Persistence.DataPath = DefaultPersistenceDataPath
 		}
 	}
-
-	parsePositiveFloat("REINDEXER_GOROUTINES_FACTOR",
-		func(val float64) { config.ReindexerGoroutinesFactor = val },
-		DefaultReindexerGoroutinesFactor)
 
 	if err := config.parseMemtableConfig(); err != nil {
 		return err
@@ -2116,16 +2111,6 @@ func parseClusterConfig() (cluster.Config, error) {
 	}
 
 	return cfg, nil
-}
-
-func enabledForHost(envName string, localHostname string) bool {
-	if v := os.Getenv(envName); v != "" {
-		if entcfg.Enabled(v) {
-			return true
-		}
-		return slices.Contains(strings.Split(v, ","), localHostname)
-	}
-	return false
 }
 
 /*

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -12,7 +12,6 @@
 package config
 
 import (
-	"fmt"
 	"math"
 	"os"
 	"testing"
@@ -1557,27 +1556,6 @@ func TestEnvironmentHNSWAcornFilterRatio(t *testing.T) {
 			} else {
 				require.Equal(t, tt.expected, conf.HNSWAcornFilterRatio)
 			}
-		})
-	}
-}
-
-func TestEnabledForHost(t *testing.T) {
-	localHostname := "weaviate-1"
-	envName := "HOSTBASED_SETTING"
-
-	enabledVals := []string{"enabled", "1", "true", "on", "weaviate-1", "weaviate-0,weaviate-1,weaviate-2"}
-	for _, val := range enabledVals {
-		t.Run(fmt.Sprintf("enabled %q", val), func(t *testing.T) {
-			t.Setenv(envName, val)
-			assert.True(t, enabledForHost(envName, localHostname))
-		})
-	}
-
-	disabledVals := []string{"disabled", "0", "false", "off", "weaviate-0", "weaviate-0,weaviate-2,weaviate-3", ""}
-	for _, val := range disabledVals {
-		t.Run(fmt.Sprintf("disabled %q", val), func(t *testing.T) {
-			t.Setenv(envName, val)
-			assert.False(t, enabledForHost(envName, localHostname))
 		})
 	}
 }


### PR DESCRIPTION
Deletes 24 symbols with no production caller: `MigrationStrategy.ShouldProcessProperty` (+ 8 impls), `ShardReindexerV3.RunAfterLsmInitAsync`/`Stop` (+ impls and 3 call sites), 6 `ShardLike` methods (+ 6 `LazyLoadShard` forwarders and the regenerated mock), `Raft`/`Store.RegisterDistributedTaskCollectionExtractor`, `Scheduler.totalRunningTaskCount`, `ShardReindexTaskGeneric.MigrationDirName`, `enabledForHost`, three test-only `distributedtask` predicates, and four config fields — `ReindexerGoroutinesFactor` (plus the `REINDEXER_GOROUTINES_FACTOR` parse), `ReindexMapToBlockmaxAtStartup`, `ReindexMapToBlockmaxConfig` and the `MapToBlockamaxConfig` type it names.

**-217 production lines, -295 generated mock lines, -160 test lines.** No behavior change: each symbol was either unreachable from production or a no-op at every production implementation.

**Evidence.** Three independent oracles, cross-checked: a type-checked def/use analyzer over `go/packages` (catches interface dispatch grep misses), `deadcode` RTA from `cmd/weaviate-server`, and the build. The whole set was deleted together in a scratch worktree and re-verified before this branch existed, so it is known to be internally consistent rather than 24 independent guesses. `golangci-lint run --enable unused` reports `0 issues.` on every touched package, and was demonstrated to fail when one deleted symbol was reintroduced.

**Tests follow the code, not the reverse.** Where a test only went red because the symbol under it was unreachable, the test went too — `TestReactiveFiring_PeriodicTickFallback` had no assertion left once `totalRunningTaskCount` was gone. Its last assertion read the scheduler's private `runningTasks` map; the neighbouring `perTaskState` map is the one never freed in production (weaviate/etienne-claude-issues#381), and no test covered that either. The other seven `totalRunningTaskCount` call sites were incidental — each already proved the same thing one line later through a provider channel or a manager status assertion.

**Kept deliberately:** `ShardReindexTaskGeneric.OnAfterLsmInitAsync` — the *task* method stays, live via `StartTask`; only the `ShardReindexerV3` wrapper around it is gone. And `Stop` was verified before removal, not merely built without: its callbacks live in a plain `*Shard` field, nothing registers them into a process-global, and `RunAfterLsmInit` starts no goroutine — so it is dead weight, not a missing teardown.

**Caveat.** `Raft.RegisterDistributedTaskCollectionExtractor` and its `Store` counterpart are exported with zero in-repo callers. I can only prove the in-repo half; an out-of-tree consumer is conceivable, though the live wiring has always been the `DistributedTaskCollectionExtractors` config map (two godocs that named the dead method now point there).

## On removing `reindexer.Stop`

It looks load-bearing in the diff — a `Stop` taking an error "cause", called from `drop` and `shutdown` — but it was inert in every configuration. Both production implementations are empty:

```go
func (r *shardReindexerV3Noop) Stop(shard *Shard, cause error) {}

func (r *shardReindexerV3RecoveryOnly) Stop(_ *Shard, _ error) {
	// Nothing to stop — we don't run any background loops.
}
```

`configureReindexer` returns exactly one of those two, so there was no third implementation and no call that did anything. The `fmt.Errorf("shard drop")` argument was built only to be discarded.

The actual cancellation on that path is `s.shutCtxCancel(...)`, one line above the removed call, and it stays.

Removed as a closure rather than a call site: the interface method, both implementations, the test double, and both callers.
