### PR TITLE
perf(async-repl): carry byte-ID digests end-to-end on the compare pipeline

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -223,17 +223,7 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords
 func (c *replicationClient) CompareDigests(ctx context.Context,
 	host, index, shard string, digests []types.RepairDigest,
 ) ([]types.RepairDigest, error) {
-	body := make([]byte, 0, len(digests)*replica.CompareDigestsRecordLength)
-	var buf [replica.CompareDigestsRecordLength]byte
-	for _, d := range digests {
-		copy(buf[:16], d.ID[:])
-		binary.BigEndian.PutUint64(buf[16:], uint64(d.UpdateTime))
-		buf[24] = 0
-		if d.Deleted {
-			buf[24] = replica.CompareDigestsFlagDeleted
-		}
-		body = append(body, buf[:]...)
-	}
+	body := replica.RepairDigestsToBinary(digests)
 
 	// No internal timeout: the async-replication scheduler manages the
 	// per-cycle deadline on the incoming context.

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -110,7 +110,7 @@ func (c *replicationClient) DigestObjects(ctx context.Context,
 
 func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 	host, index, shard string, initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	body, err := json.Marshal(replica.DigestObjectsInRangeReq{
 		InitialUUID: initialUUID,
 		FinalUUID:   finalUUID,
@@ -153,20 +153,34 @@ func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 		return readDigestsInRangeBinaryStream(res.Body, res.ContentLength, limit)
 	}
 
-	// Legacy JSON fallback for older nodes.
+	// Legacy JSON fallback for older nodes; string IDs are parsed at this edge only.
 	var resp replica.DigestObjectsInRangeResp
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
 		return nil, fmt.Errorf("decode response: %w", err)
 	}
-	return resp.Digests, nil
+	return repairResponsesToDigests(resp.Digests)
+}
+
+// repairResponsesToDigests converts the string-ID JSON wire form into the
+// internal byte-ID digests (legacy-peer fallback paths only).
+func repairResponsesToDigests(responses []types.RepairResponse) ([]types.RepairDigest, error) {
+	digests := make([]types.RepairDigest, len(responses))
+	for i, r := range responses {
+		id, err := uuid.Parse(r.ID)
+		if err != nil {
+			return nil, fmt.Errorf("parse digest uuid %q: %w", r.ID, err)
+		}
+		digests[i] = types.RepairDigest{ID: id, UpdateTime: r.UpdateTime, Deleted: r.Deleted}
+	}
+	return digests, nil
 }
 
 // readDigestsInRangeBinaryStream decodes a fixed-size binary stream produced
 // by writeDigestsInRangeResponse. Each record is
 // replica.DigestObjectsInRangeRecordLength bytes: 16-byte UUID (RFC-4122
 // binary form) + 8-byte UpdateTime (int64 big-endian).
-func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]types.RepairResponse, error) {
-	var results []types.RepairResponse
+func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]types.RepairDigest, error) {
+	var results []types.RepairDigest
 	if contentLength > 0 {
 		// Content-Length is peer-controlled; never pre-size beyond the request's own bound
 		recordCount := contentLength / int64(replica.DigestObjectsInRangeRecordLength)
@@ -177,7 +191,7 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords
 		if recordCount < 0 {
 			recordCount = 0
 		}
-		results = make([]types.RepairResponse, 0, int(recordCount))
+		results = make([]types.RepairDigest, 0, int(recordCount))
 	}
 	var buf [replica.DigestObjectsInRangeRecordLength]byte
 	for {
@@ -193,8 +207,8 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords
 			return nil, fmt.Errorf("parse uuid from binary record: %w", err)
 		}
 		updateTime := int64(binary.BigEndian.Uint64(buf[16:]))
-		results = append(results, types.RepairResponse{
-			ID:         id.String(),
+		results = append(results, types.RepairDigest{
+			ID:         id,
 			UpdateTime: updateTime,
 		})
 	}
@@ -207,16 +221,12 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64, maxRecords
 // Wire format: CompareDigestsRecordLength bytes per record —
 // 16-byte UUID (big-endian) + 8-byte UpdateTime (int64 big-endian) + 1-byte flags.
 func (c *replicationClient) CompareDigests(ctx context.Context,
-	host, index, shard string, digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	host, index, shard string, digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	body := make([]byte, 0, len(digests)*replica.CompareDigestsRecordLength)
 	var buf [replica.CompareDigestsRecordLength]byte
 	for _, d := range digests {
-		u, err := uuid.Parse(d.ID)
-		if err != nil {
-			return nil, fmt.Errorf("encode source digest uuid %q: %w", d.ID, err)
-		}
-		copy(buf[:16], u[:])
+		copy(buf[:16], d.ID[:])
 		binary.BigEndian.PutUint64(buf[16:], uint64(d.UpdateTime))
 		buf[24] = 0
 		if d.Deleted {
@@ -253,8 +263,8 @@ func (c *replicationClient) CompareDigests(ctx context.Context,
 
 // readCompareDigestsBinaryStream decodes a fixed-size binary stream produced
 // by postCompareDigests. Each record is replica.CompareDigestsRecordLength bytes.
-func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]types.RepairResponse, error) {
-	var results []types.RepairResponse
+func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords int) ([]types.RepairDigest, error) {
+	var results []types.RepairDigest
 	if contentLength > 0 {
 		recordCount := contentLength / int64(replica.CompareDigestsRecordLength)
 		if recordCount > int64(maxRecords) {
@@ -263,7 +273,7 @@ func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords
 		if recordCount < 0 {
 			recordCount = 0
 		}
-		results = make([]types.RepairResponse, 0, int(recordCount))
+		results = make([]types.RepairDigest, 0, int(recordCount))
 	}
 	var buf [replica.CompareDigestsRecordLength]byte
 	for {
@@ -280,8 +290,8 @@ func readCompareDigestsBinaryStream(r io.Reader, contentLength int64, maxRecords
 		}
 		updateTime := int64(binary.BigEndian.Uint64(buf[16:]))
 		deleted := buf[24]&replica.CompareDigestsFlagDeleted != 0
-		results = append(results, types.RepairResponse{
-			ID:         id.String(),
+		results = append(results, types.RepairDigest{
+			ID:         id,
 			UpdateTime: updateTime,
 			Deleted:    deleted,
 		})

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -362,7 +363,7 @@ func (c *grpcReplicationClient) DigestObjects(ctx context.Context, host, index, 
 
 func (c *grpcReplicationClient) DigestObjectsInRange(ctx context.Context, host, index, shard string,
 	initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	client, err := c.getClient(host)
 	if err != nil {
 		return nil, err
@@ -385,12 +386,12 @@ func (c *grpcReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 		return nil, fmt.Errorf("gRPC DigestObjectsInRange: %w", err)
 	}
 
-	return protoToRepairResponses(resp.GetDigests()), nil
+	return protoToRepairDigests(resp.GetDigests())
 }
 
 func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
-	digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	client, err := c.getClient(host)
 	if err != nil {
 		return nil, err
@@ -401,7 +402,7 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 	req := &protocol.CompareDigestsRequest{
 		Index:   index,
 		Shard:   shard,
-		Digests: repairResponsesToProto(digests),
+		Digests: repairDigestsToProto(digests),
 	}
 	resp, err := client.CompareDigests(ctx, req)
 	if err != nil {
@@ -410,7 +411,7 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 		}
 		return nil, fmt.Errorf("gRPC CompareDigests: %w", err)
 	}
-	return protoToRepairResponses(resp.GetDigests()), nil
+	return protoToRepairDigests(resp.GetDigests())
 }
 
 func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
@@ -731,14 +732,29 @@ func protoToRepairResponses(results []*protocol.RepairResponse) []types.RepairRe
 	return out
 }
 
-func repairResponsesToProto(digests []types.RepairResponse) []*protocol.RepairResponse {
+// String IDs exist only at the proto boundary; the digest pipeline is byte-ID.
+func protoToRepairDigests(results []*protocol.RepairResponse) ([]types.RepairDigest, error) {
+	out := make([]types.RepairDigest, len(results))
+	for i, r := range results {
+		id, err := uuid.Parse(r.GetId())
+		if err != nil {
+			return nil, fmt.Errorf("parse digest uuid %q: %w", r.GetId(), err)
+		}
+		out[i] = types.RepairDigest{
+			ID:         id,
+			UpdateTime: r.GetUpdateTime(),
+			Deleted:    r.GetDeleted(),
+		}
+	}
+	return out, nil
+}
+
+func repairDigestsToProto(digests []types.RepairDigest) []*protocol.RepairResponse {
 	out := make([]*protocol.RepairResponse, len(digests))
 	for i, d := range digests {
 		out[i] = &protocol.RepairResponse{
-			Id:         d.ID,
-			Version:    d.Version,
+			Id:         d.ID.String(),
 			UpdateTime: d.UpdateTime,
-			Err:        d.Err,
 			Deleted:    d.Deleted,
 		}
 	}

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -416,11 +416,7 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 		return nil, fmt.Errorf("gRPC CompareDigests: %w", err)
 	}
 
-	// A packed-aware server always echoes the packed encoding when asked, so a
-	// proto-encoded reply proves an older peer that ignored the packed field and
-	// compared an empty digest list. Its reply is meaningless — resend once in
-	// the proto dialect it understands so repair keeps working during rolling
-	// upgrades (mirrors the REST legacy JSON fallback).
+	// A proto reply means an old peer that ignored digests_packed and compared nothing — resend in the proto dialect it understands.
 	if resp.GetEncoding() == replica.RepairDigestsEncodingProto {
 		resp, err = client.CompareDigests(ctx, &protocol.CompareDigestsRequest{
 			Index:          index,

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -373,11 +373,12 @@ func (c *grpcReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 	defer cancel()
 
 	resp, err := client.DigestObjectsInRange(ctx, &protocol.DigestObjectsInRangeRequest{
-		Index:       index,
-		Shard:       shard,
-		InitialUuid: initialUUID.String(),
-		FinalUuid:   finalUUID.String(),
-		Limit:       int32(limit),
+		Index:          index,
+		Shard:          shard,
+		InitialUuid:    initialUUID.String(),
+		FinalUuid:      finalUUID.String(),
+		Limit:          int32(limit),
+		AcceptEncoding: replica.RepairDigestsEncodingPacked,
 	})
 	if err != nil {
 		if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
@@ -386,6 +387,11 @@ func (c *grpcReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 		return nil, fmt.Errorf("gRPC DigestObjectsInRange: %w", err)
 	}
 
+	if resp.GetEncoding() == replica.RepairDigestsEncodingPacked {
+		return decodePackedDigests(resp.GetDigestsPacked(), limit)
+	}
+
+	// Proto records: older servers ignore accept_encoding.
 	return protoToRepairDigests(resp.GetDigests())
 }
 
@@ -400,9 +406,11 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 	// No internal timeout: the async-replication scheduler manages the
 	// per-cycle deadline on the incoming context.
 	req := &protocol.CompareDigestsRequest{
-		Index:   index,
-		Shard:   shard,
-		Digests: repairDigestsToProto(digests),
+		Index:          index,
+		Shard:          shard,
+		DigestsPacked:  replica.RepairDigestsToBinary(digests),
+		Encoding:       replica.RepairDigestsEncodingPacked,
+		AcceptEncoding: replica.RepairDigestsEncodingPacked,
 	}
 	resp, err := client.CompareDigests(ctx, req)
 	if err != nil {
@@ -411,7 +419,25 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 		}
 		return nil, fmt.Errorf("gRPC CompareDigests: %w", err)
 	}
+
+	// The result is a subset of the sent digests, so their count bounds the decode.
+	if resp.GetEncoding() == replica.RepairDigestsEncodingPacked {
+		return decodePackedDigests(resp.GetDigestsPacked(), len(digests))
+	}
+
+	// Proto records: an older server ignored the packed request and compared an
+	// empty digest list — degraded to a no-op until the peer upgrades.
 	return protoToRepairDigests(resp.GetDigests())
+}
+
+// decodePackedDigests decodes a packed digests payload, rejecting payloads
+// larger than maxRecords records before allocating.
+func decodePackedDigests(payload []byte, maxRecords int) ([]types.RepairDigest, error) {
+	if maxLen := maxRecords * replica.CompareDigestsRecordLength; maxRecords > 0 && len(payload) > maxLen {
+		return nil, fmt.Errorf("packed digests payload of %d bytes exceeds the %d bytes for %d records",
+			len(payload), maxLen, maxRecords)
+	}
+	return replica.RepairDigestsFromBinary(payload)
 }
 
 func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
@@ -747,16 +773,4 @@ func protoToRepairDigests(results []*protocol.RepairResponse) ([]types.RepairDig
 		}
 	}
 	return out, nil
-}
-
-func repairDigestsToProto(digests []types.RepairDigest) []*protocol.RepairResponse {
-	out := make([]*protocol.RepairResponse, len(digests))
-	for i, d := range digests {
-		out[i] = &protocol.RepairResponse{
-			Id:         d.ID.String(),
-			UpdateTime: d.UpdateTime,
-			Deleted:    d.Deleted,
-		}
-	}
-	return out
 }

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -387,12 +387,8 @@ func (c *grpcReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 		return nil, fmt.Errorf("gRPC DigestObjectsInRange: %w", err)
 	}
 
-	if resp.GetEncoding() == replica.RepairDigestsEncodingPacked {
-		return decodePackedDigests(resp.GetDigestsPacked(), limit)
-	}
-
-	// Proto records: older servers ignore accept_encoding.
-	return protoToRepairDigests(resp.GetDigests())
+	// Proto-records replies come from older servers that ignore accept_encoding.
+	return decodeDigestsReply(resp, limit)
 }
 
 func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
@@ -420,14 +416,28 @@ func (c *grpcReplicationClient) CompareDigests(ctx context.Context, host, index,
 		return nil, fmt.Errorf("gRPC CompareDigests: %w", err)
 	}
 
-	// The result is a subset of the sent digests, so their count bounds the decode.
-	if resp.GetEncoding() == replica.RepairDigestsEncodingPacked {
-		return decodePackedDigests(resp.GetDigestsPacked(), len(digests))
+	// A packed-aware server always echoes the packed encoding when asked, so a
+	// proto-encoded reply proves an older peer that ignored the packed field and
+	// compared an empty digest list. Its reply is meaningless — resend once in
+	// the proto dialect it understands so repair keeps working during rolling
+	// upgrades (mirrors the REST legacy JSON fallback).
+	if resp.GetEncoding() == replica.RepairDigestsEncodingProto {
+		resp, err = client.CompareDigests(ctx, &protocol.CompareDigestsRequest{
+			Index:          index,
+			Shard:          shard,
+			Digests:        repairDigestsToProto(digests),
+			AcceptEncoding: replica.RepairDigestsEncodingPacked,
+		})
+		if err != nil {
+			if nrErr := asyncNotReadyGRPCError(err); nrErr != nil {
+				return nil, nrErr
+			}
+			return nil, fmt.Errorf("gRPC CompareDigests (proto dialect): %w", err)
+		}
 	}
 
-	// Proto records: an older server ignored the packed request and compared an
-	// empty digest list — degraded to a no-op until the peer upgrades.
-	return protoToRepairDigests(resp.GetDigests())
+	// The result is a subset of the sent digests, so their count bounds the decode.
+	return decodeDigestsReply(resp, len(digests))
 }
 
 // decodePackedDigests decodes a packed digests payload, rejecting payloads
@@ -438,6 +448,26 @@ func decodePackedDigests(payload []byte, maxRecords int) ([]types.RepairDigest, 
 			len(payload), maxLen, maxRecords)
 	}
 	return replica.RepairDigestsFromBinary(payload)
+}
+
+// digestsReply is the reply surface shared by the two digest RPCs.
+type digestsReply interface {
+	GetEncoding() uint32
+	GetDigestsPacked() []byte
+	GetDigests() []*protocol.RepairResponse
+}
+
+// decodeDigestsReply decodes a digest RPC reply by its declared encoding,
+// failing closed on encodings this client does not know.
+func decodeDigestsReply(resp digestsReply, maxRecords int) ([]types.RepairDigest, error) {
+	switch resp.GetEncoding() {
+	case replica.RepairDigestsEncodingPacked:
+		return decodePackedDigests(resp.GetDigestsPacked(), maxRecords)
+	case replica.RepairDigestsEncodingProto:
+		return protoToRepairDigests(resp.GetDigests())
+	default:
+		return nil, fmt.Errorf("unsupported digests encoding %d", resp.GetEncoding())
+	}
 }
 
 func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
@@ -753,6 +783,20 @@ func protoToRepairResponses(results []*protocol.RepairResponse) []types.RepairRe
 			UpdateTime: r.GetUpdateTime(),
 			Err:        r.GetErr(),
 			Deleted:    r.GetDeleted(),
+		}
+	}
+	return out
+}
+
+// repairDigestsToProto encodes digests in the proto-records dialect for peers
+// that predate the packed encoding.
+func repairDigestsToProto(digests []types.RepairDigest) []*protocol.RepairResponse {
+	out := make([]*protocol.RepairResponse, len(digests))
+	for i, d := range digests {
+		out[i] = &protocol.RepairResponse{
+			Id:         d.ID.String(),
+			UpdateTime: d.UpdateTime,
+			Deleted:    d.Deleted,
 		}
 	}
 	return out

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -961,7 +962,7 @@ func TestGRPCReplicationHashTreeLevelNotReady(t *testing.T) {
 		defer cleanup()
 
 		_, err := client.CompareDigests(ctx, "passthrough:bufnet", "C1", "S1",
-			[]types.RepairResponse{{ID: UUID1.String(), UpdateTime: 1}})
+			[]types.RepairDigest{{ID: uuid.MustParse(UUID1.String()), UpdateTime: 1}})
 		require.ErrorIs(t, err, replica.ErrAsyncReplicationNotActive)
 	})
 

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -76,6 +76,12 @@ type fakeGRPCReplicationServer struct {
 	// hashTreeLevelResp, when set, is returned verbatim; the last request is captured.
 	hashTreeLevelResp    *pb.HashTreeLevelResponse
 	lastHashTreeLevelReq atomic.Pointer[pb.HashTreeLevelRequest]
+
+	// Pre-configured digest responses, returned verbatim when set.
+	compareDigestsResp    *pb.CompareDigestsResponse
+	digestsInRangeResp    *pb.DigestObjectsInRangeResponse
+	lastCompareDigestsReq atomic.Pointer[pb.CompareDigestsRequest]
+	lastDigestsInRangeReq atomic.Pointer[pb.DigestObjectsInRangeRequest]
 }
 
 func newFakeGRPCReplicationServer(t *testing.T) *fakeGRPCReplicationServer {
@@ -123,11 +129,23 @@ func (f *fakeGRPCReplicationServer) HashTreeLevel(_ context.Context, req *pb.Has
 	return &pb.HashTreeLevelResponse{DigestsData: []byte("[]")}, nil
 }
 
-func (f *fakeGRPCReplicationServer) CompareDigests(_ context.Context, _ *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
+func (f *fakeGRPCReplicationServer) CompareDigests(_ context.Context, req *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
+	f.lastCompareDigestsReq.Store(req)
 	if f.compareDigestsErr != nil {
 		return nil, f.compareDigestsErr
 	}
+	if f.compareDigestsResp != nil {
+		return f.compareDigestsResp, nil
+	}
 	return &pb.CompareDigestsResponse{}, nil
+}
+
+func (f *fakeGRPCReplicationServer) DigestObjectsInRange(_ context.Context, req *pb.DigestObjectsInRangeRequest) (*pb.DigestObjectsInRangeResponse, error) {
+	f.lastDigestsInRangeReq.Store(req)
+	if f.digestsInRangeResp != nil {
+		return f.digestsInRangeResp, nil
+	}
+	return &pb.DigestObjectsInRangeResponse{}, nil
 }
 
 func (f *fakeGRPCReplicationServer) PutObject(_ context.Context, req *pb.PutObjectRequest) (*pb.PutObjectResponse, error) {
@@ -1155,4 +1173,133 @@ func TestAsyncNotReadyGRPCErrorMapping(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGRPCReplicationCompareDigestsEncoding(t *testing.T) {
+	source := []types.RepairDigest{
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), UpdateTime: 1},
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), UpdateTime: 2, Deleted: true},
+	}
+
+	t.Run("PackedRoundTrip", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsResp = &pb.CompareDigestsResponse{
+			DigestsPacked: replica.RepairDigestsToBinary(source[1:]),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		resp, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.NoError(t, err)
+		require.Equal(t, source[1:], resp)
+
+		req := fake.lastCompareDigestsReq.Load()
+		require.NotNil(t, req)
+		assert.Equal(t, replica.RepairDigestsToBinary(source), req.GetDigestsPacked())
+		assert.Equal(t, replica.RepairDigestsEncodingPacked, req.GetEncoding())
+		assert.Equal(t, replica.RepairDigestsEncodingPacked, req.GetAcceptEncoding())
+		assert.Empty(t, req.GetDigests())
+	})
+
+	t.Run("LegacyEmptyFromOldServer", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		resp, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.NoError(t, err)
+		assert.Empty(t, resp)
+	})
+
+	t.Run("LegacyDigestsDecoded", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsResp = &pb.CompareDigestsResponse{
+			Digests: []*pb.RepairResponse{{Id: source[0].ID.String(), UpdateTime: 1}},
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		resp, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.NoError(t, err)
+		require.Equal(t, source[:1], resp)
+	})
+
+	t.Run("OversizedPackedRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsResp = &pb.CompareDigestsResponse{
+			DigestsPacked: make([]byte, (len(source)+1)*replica.CompareDigestsRecordLength),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.ErrorContains(t, err, "exceeds")
+	})
+
+	t.Run("TruncatedPackedRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsResp = &pb.CompareDigestsResponse{
+			DigestsPacked: make([]byte, replica.CompareDigestsRecordLength-3),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.ErrorContains(t, err, "not a multiple")
+	})
+}
+
+func TestGRPCReplicationDigestObjectsInRangeEncoding(t *testing.T) {
+	initial := strfmt.UUID("00000000-0000-0000-0000-000000000001")
+	final := strfmt.UUID("00000000-0000-0000-0000-0000000000ff")
+	digests := []types.RepairDigest{
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000005"), UpdateTime: 5, Deleted: true},
+	}
+
+	t.Run("PackedRoundTrip", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.digestsInRangeResp = &pb.DigestObjectsInRangeResponse{
+			DigestsPacked: replica.RepairDigestsToBinary(digests),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		resp, err := client.DigestObjectsInRange(context.Background(), "passthrough:bufnet", "C1", "S1", initial, final, 10)
+		require.NoError(t, err)
+		require.Equal(t, digests, resp)
+
+		req := fake.lastDigestsInRangeReq.Load()
+		require.NotNil(t, req)
+		assert.Equal(t, replica.RepairDigestsEncodingPacked, req.GetAcceptEncoding())
+	})
+
+	t.Run("LegacyDigestsDecoded", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.digestsInRangeResp = &pb.DigestObjectsInRangeResponse{
+			Digests: []*pb.RepairResponse{{Id: digests[0].ID.String(), UpdateTime: 5, Deleted: true}},
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		resp, err := client.DigestObjectsInRange(context.Background(), "passthrough:bufnet", "C1", "S1", initial, final, 10)
+		require.NoError(t, err)
+		require.Equal(t, digests, resp)
+	})
+
+	t.Run("OversizedPackedRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.digestsInRangeResp = &pb.DigestObjectsInRangeResponse{
+			DigestsPacked: make([]byte, 2*replica.CompareDigestsRecordLength),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.DigestObjectsInRange(context.Background(), "passthrough:bufnet", "C1", "S1", initial, final, 1)
+		require.ErrorContains(t, err, "exceeds")
+	})
 }

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -77,8 +77,11 @@ type fakeGRPCReplicationServer struct {
 	hashTreeLevelResp    *pb.HashTreeLevelResponse
 	lastHashTreeLevelReq atomic.Pointer[pb.HashTreeLevelRequest]
 
-	// Pre-configured digest responses, returned verbatim when set.
+	// Pre-configured digest responses, returned verbatim when set; the handler,
+	// when set, takes precedence and computes the response per call.
 	compareDigestsResp    *pb.CompareDigestsResponse
+	compareDigestsHandler func(*pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error)
+	compareDigestsCalls   atomic.Int32
 	digestsInRangeResp    *pb.DigestObjectsInRangeResponse
 	lastCompareDigestsReq atomic.Pointer[pb.CompareDigestsRequest]
 	lastDigestsInRangeReq atomic.Pointer[pb.DigestObjectsInRangeRequest]
@@ -131,6 +134,10 @@ func (f *fakeGRPCReplicationServer) HashTreeLevel(_ context.Context, req *pb.Has
 
 func (f *fakeGRPCReplicationServer) CompareDigests(_ context.Context, req *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
 	f.lastCompareDigestsReq.Store(req)
+	f.compareDigestsCalls.Add(1)
+	if f.compareDigestsHandler != nil {
+		return f.compareDigestsHandler(req)
+	}
 	if f.compareDigestsErr != nil {
 		return nil, f.compareDigestsErr
 	}
@@ -1200,22 +1207,18 @@ func TestGRPCReplicationCompareDigestsEncoding(t *testing.T) {
 		assert.Equal(t, replica.RepairDigestsEncodingPacked, req.GetEncoding())
 		assert.Equal(t, replica.RepairDigestsEncodingPacked, req.GetAcceptEncoding())
 		assert.Empty(t, req.GetDigests())
+		assert.Equal(t, int32(1), fake.compareDigestsCalls.Load())
 	})
 
-	t.Run("LegacyEmptyFromOldServer", func(t *testing.T) {
+	t.Run("OldServerFallsBackToProtoDialect", func(t *testing.T) {
 		fake := newFakeGRPCReplicationServer(t)
-		client, cleanup := setupGRPCTestServer(t, fake)
-		defer cleanup()
-
-		resp, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
-		require.NoError(t, err)
-		assert.Empty(t, resp)
-	})
-
-	t.Run("LegacyDigestsDecoded", func(t *testing.T) {
-		fake := newFakeGRPCReplicationServer(t)
-		fake.compareDigestsResp = &pb.CompareDigestsResponse{
-			Digests: []*pb.RepairResponse{{Id: source[0].ID.String(), UpdateTime: 1}},
+		fake.compareDigestsHandler = func(req *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
+			if len(req.GetDigests()) == 0 {
+				return &pb.CompareDigestsResponse{}, nil
+			}
+			return &pb.CompareDigestsResponse{
+				Digests: []*pb.RepairResponse{{Id: req.GetDigests()[0].GetId(), UpdateTime: 1}},
+			}, nil
 		}
 		client, cleanup := setupGRPCTestServer(t, fake)
 		defer cleanup()
@@ -1223,6 +1226,51 @@ func TestGRPCReplicationCompareDigestsEncoding(t *testing.T) {
 		resp, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
 		require.NoError(t, err)
 		require.Equal(t, source[:1], resp)
+		assert.Equal(t, int32(2), fake.compareDigestsCalls.Load())
+
+		req := fake.lastCompareDigestsReq.Load()
+		require.NotNil(t, req)
+		require.Len(t, req.GetDigests(), len(source))
+		assert.Equal(t, source[0].ID.String(), req.GetDigests()[0].GetId())
+		assert.Equal(t, source[1].ID.String(), req.GetDigests()[1].GetId())
+		assert.True(t, req.GetDigests()[1].GetDeleted())
+		assert.Empty(t, req.GetDigestsPacked())
+		assert.Equal(t, replica.RepairDigestsEncodingProto, req.GetEncoding())
+		assert.Equal(t, replica.RepairDigestsEncodingPacked, req.GetAcceptEncoding())
+	})
+
+	t.Run("PeerUpgradedBetweenResends", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsHandler = func(req *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
+			if fake.compareDigestsCalls.Load() == 1 {
+				return &pb.CompareDigestsResponse{}, nil
+			}
+			return &pb.CompareDigestsResponse{
+				DigestsPacked: replica.RepairDigestsToBinary(source[1:]),
+				Encoding:      replica.RepairDigestsEncodingPacked,
+			}, nil
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		resp, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.NoError(t, err)
+		require.Equal(t, source[1:], resp)
+		assert.Equal(t, int32(2), fake.compareDigestsCalls.Load())
+	})
+
+	t.Run("UnknownEncodingRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.compareDigestsResp = &pb.CompareDigestsResponse{
+			DigestsPacked: replica.RepairDigestsToBinary(source[1:]),
+			Encoding:      replica.RepairDigestsEncodingPacked + 1,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.CompareDigests(context.Background(), "passthrough:bufnet", "C1", "S1", source)
+		require.ErrorContains(t, err, "unsupported digests encoding")
+		assert.Equal(t, int32(1), fake.compareDigestsCalls.Load())
 	})
 
 	t.Run("OversizedPackedRejected", func(t *testing.T) {
@@ -1301,5 +1349,18 @@ func TestGRPCReplicationDigestObjectsInRangeEncoding(t *testing.T) {
 
 		_, err := client.DigestObjectsInRange(context.Background(), "passthrough:bufnet", "C1", "S1", initial, final, 1)
 		require.ErrorContains(t, err, "exceeds")
+	})
+
+	t.Run("UnknownEncodingRejected", func(t *testing.T) {
+		fake := newFakeGRPCReplicationServer(t)
+		fake.digestsInRangeResp = &pb.DigestObjectsInRangeResponse{
+			DigestsPacked: replica.RepairDigestsToBinary(digests),
+			Encoding:      replica.RepairDigestsEncodingPacked + 1,
+		}
+		client, cleanup := setupGRPCTestServer(t, fake)
+		defer cleanup()
+
+		_, err := client.DigestObjectsInRange(context.Background(), "passthrough:bufnet", "C1", "S1", initial, final, 10)
+		require.ErrorContains(t, err, "unsupported digests encoding")
 	})
 }

--- a/adapters/clients/replication_mixed.go
+++ b/adapters/clients/replication_mixed.go
@@ -158,7 +158,7 @@ func (s *switchReplicationClient) DigestObjects(ctx context.Context, host, index
 
 func (s *switchReplicationClient) DigestObjectsInRange(ctx context.Context, host, index, shard string,
 	initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	if s.useGRPC() {
 		return s.grpcClient.DigestObjectsInRange(ctx, host, index, shard, initialUUID, finalUUID, limit)
 	}
@@ -193,8 +193,8 @@ func (s *switchReplicationClient) HashTreeLevel(ctx context.Context, host, index
 }
 
 func (s *switchReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
-	digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	if s.useGRPC() {
 		return s.grpcClient.CompareDigests(ctx, host, index, shard, digests)
 	}

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -764,9 +764,9 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
-		assert.Equal(t, expected[0].ID, got[0].ID)
+		assert.Equal(t, uuid.MustParse(expected[0].ID), got[0].ID)
 		assert.Equal(t, expected[0].UpdateTime, got[0].UpdateTime)
-		assert.Equal(t, expected[1].ID, got[1].ID)
+		assert.Equal(t, uuid.MustParse(expected[1].ID), got[1].ID)
 		assert.Equal(t, expected[1].UpdateTime, got[1].UpdateTime)
 	})
 
@@ -782,9 +782,9 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
-		assert.Equal(t, expected[0].ID, got[0].ID)
+		assert.Equal(t, uuid.MustParse(expected[0].ID), got[0].ID)
 		assert.Equal(t, expected[0].UpdateTime, got[0].UpdateTime)
-		assert.Equal(t, expected[1].ID, got[1].ID)
+		assert.Equal(t, uuid.MustParse(expected[1].ID), got[1].ID)
 		assert.Equal(t, expected[1].UpdateTime, got[1].UpdateTime)
 	})
 

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -102,8 +102,8 @@ func (f *fakeReplicator) DigestObjects(ctx context.Context, class, shardName str
 	return []types.RepairResponse{}, nil
 }
 
-func (f *fakeReplicator) DigestObjectsInRange(ctx context.Context, class, shardName string, initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairResponse, err error) {
-	return []types.RepairResponse{}, nil
+func (f *fakeReplicator) DigestObjectsInRange(ctx context.Context, class, shardName string, initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairDigest, err error) {
+	return []types.RepairDigest{}, nil
 }
 
 func (f *fakeReplicator) HashTreeLevel(ctx context.Context, index, shard string, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
@@ -114,7 +114,7 @@ func (f *fakeReplicator) CountObjects(ctx context.Context, index, shard string) 
 	return 0, nil
 }
 
-func (f *fakeReplicator) CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error) {
+func (f *fakeReplicator) CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairDigest) ([]types.RepairDigest, error) {
 	return nil, nil
 }
 

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
@@ -1477,14 +1477,15 @@ func (x *DigestObjectsResponse) GetDigests() []*RepairResponse {
 
 // DigestObjectsInRange fetches digests for objects in a UUID range.
 type DigestObjectsInRangeRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
-	Shard         string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
-	InitialUuid   string                 `protobuf:"bytes,3,opt,name=initial_uuid,json=initialUuid,proto3" json:"initial_uuid,omitempty"`
-	FinalUuid     string                 `protobuf:"bytes,4,opt,name=final_uuid,json=finalUuid,proto3" json:"final_uuid,omitempty"`
-	Limit         int32                  `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Index          string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	Shard          string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
+	InitialUuid    string                 `protobuf:"bytes,3,opt,name=initial_uuid,json=initialUuid,proto3" json:"initial_uuid,omitempty"`
+	FinalUuid      string                 `protobuf:"bytes,4,opt,name=final_uuid,json=finalUuid,proto3" json:"final_uuid,omitempty"`
+	Limit          int32                  `protobuf:"varint,5,opt,name=limit,proto3" json:"limit,omitempty"`
+	AcceptEncoding uint32                 `protobuf:"varint,6,opt,name=accept_encoding,json=acceptEncoding,proto3" json:"accept_encoding,omitempty"` // response encoding the sender accepts; servers only emit 1 when asked
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *DigestObjectsInRangeRequest) Reset() {
@@ -1552,9 +1553,18 @@ func (x *DigestObjectsInRangeRequest) GetLimit() int32 {
 	return 0
 }
 
+func (x *DigestObjectsInRangeRequest) GetAcceptEncoding() uint32 {
+	if x != nil {
+		return x.AcceptEncoding
+	}
+	return 0
+}
+
 type DigestObjectsInRangeResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Digests       []*RepairResponse      `protobuf:"bytes,1,rep,name=digests,proto3" json:"digests,omitempty"`
+	DigestsPacked []byte                 `protobuf:"bytes,2,opt,name=digests_packed,json=digestsPacked,proto3" json:"digests_packed,omitempty"` // replica.RepairDigestsToBinary output
+	Encoding      uint32                 `protobuf:"varint,3,opt,name=encoding,proto3" json:"encoding,omitempty"`                               // 0 (older responders) = digests; 1 = digests_packed
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1596,14 +1606,31 @@ func (x *DigestObjectsInRangeResponse) GetDigests() []*RepairResponse {
 	return nil
 }
 
+func (x *DigestObjectsInRangeResponse) GetDigestsPacked() []byte {
+	if x != nil {
+		return x.DigestsPacked
+	}
+	return nil
+}
+
+func (x *DigestObjectsInRangeResponse) GetEncoding() uint32 {
+	if x != nil {
+		return x.Encoding
+	}
+	return 0
+}
+
 // CompareDigests sends source digests to the target and returns those that need repair.
 type CompareDigestsRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Index         string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
-	Shard         string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
-	Digests       []*RepairResponse      `protobuf:"bytes,3,rep,name=digests,proto3" json:"digests,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Index          string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	Shard          string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
+	Digests        []*RepairResponse      `protobuf:"bytes,3,rep,name=digests,proto3" json:"digests,omitempty"`
+	DigestsPacked  []byte                 `protobuf:"bytes,4,opt,name=digests_packed,json=digestsPacked,proto3" json:"digests_packed,omitempty"`     // replica.RepairDigestsToBinary output
+	Encoding       uint32                 `protobuf:"varint,5,opt,name=encoding,proto3" json:"encoding,omitempty"`                                   // 0 (older senders) = digests; 1 = digests_packed
+	AcceptEncoding uint32                 `protobuf:"varint,6,opt,name=accept_encoding,json=acceptEncoding,proto3" json:"accept_encoding,omitempty"` // response encoding the sender accepts; servers only emit 1 when asked
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CompareDigestsRequest) Reset() {
@@ -1657,9 +1684,32 @@ func (x *CompareDigestsRequest) GetDigests() []*RepairResponse {
 	return nil
 }
 
+func (x *CompareDigestsRequest) GetDigestsPacked() []byte {
+	if x != nil {
+		return x.DigestsPacked
+	}
+	return nil
+}
+
+func (x *CompareDigestsRequest) GetEncoding() uint32 {
+	if x != nil {
+		return x.Encoding
+	}
+	return 0
+}
+
+func (x *CompareDigestsRequest) GetAcceptEncoding() uint32 {
+	if x != nil {
+		return x.AcceptEncoding
+	}
+	return 0
+}
+
 type CompareDigestsResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Digests       []*RepairResponse      `protobuf:"bytes,1,rep,name=digests,proto3" json:"digests,omitempty"`
+	DigestsPacked []byte                 `protobuf:"bytes,2,opt,name=digests_packed,json=digestsPacked,proto3" json:"digests_packed,omitempty"` // replica.RepairDigestsToBinary output
+	Encoding      uint32                 `protobuf:"varint,3,opt,name=encoding,proto3" json:"encoding,omitempty"`                               // 0 (older responders) = digests; 1 = digests_packed
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1699,6 +1749,20 @@ func (x *CompareDigestsResponse) GetDigests() []*RepairResponse {
 		return x.Digests
 	}
 	return nil
+}
+
+func (x *CompareDigestsResponse) GetDigestsPacked() []byte {
+	if x != nil {
+		return x.DigestsPacked
+	}
+	return nil
+}
+
+func (x *CompareDigestsResponse) GetEncoding() uint32 {
+	if x != nil {
+		return x.Encoding
+	}
+	return 0
 }
 
 // OverwriteObjects conditionally updates existing objects
@@ -2785,22 +2849,30 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x12\x10\n" +
 	"\x03ids\x18\x03 \x03(\tR\x03ids\"M\n" +
 	"\x15DigestObjectsResponse\x124\n" +
-	"\adigests\x18\x01 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\"\xa1\x01\n" +
+	"\adigests\x18\x01 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\"\xca\x01\n" +
 	"\x1bDigestObjectsInRangeRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x12!\n" +
 	"\finitial_uuid\x18\x03 \x01(\tR\vinitialUuid\x12\x1d\n" +
 	"\n" +
 	"final_uuid\x18\x04 \x01(\tR\tfinalUuid\x12\x14\n" +
-	"\x05limit\x18\x05 \x01(\x05R\x05limit\"T\n" +
+	"\x05limit\x18\x05 \x01(\x05R\x05limit\x12'\n" +
+	"\x0faccept_encoding\x18\x06 \x01(\rR\x0eacceptEncoding\"\x97\x01\n" +
 	"\x1cDigestObjectsInRangeResponse\x124\n" +
-	"\adigests\x18\x01 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\"y\n" +
+	"\adigests\x18\x01 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\x12%\n" +
+	"\x0edigests_packed\x18\x02 \x01(\fR\rdigestsPacked\x12\x1a\n" +
+	"\bencoding\x18\x03 \x01(\rR\bencoding\"\xe5\x01\n" +
 	"\x15CompareDigestsRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x124\n" +
-	"\adigests\x18\x03 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\"N\n" +
+	"\adigests\x18\x03 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\x12%\n" +
+	"\x0edigests_packed\x18\x04 \x01(\fR\rdigestsPacked\x12\x1a\n" +
+	"\bencoding\x18\x05 \x01(\rR\bencoding\x12'\n" +
+	"\x0faccept_encoding\x18\x06 \x01(\rR\x0eacceptEncoding\"\x91\x01\n" +
 	"\x16CompareDigestsResponse\x124\n" +
-	"\adigests\x18\x01 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\"\x86\x01\n" +
+	"\adigests\x18\x01 \x03(\v2\x1a.clusterapi.RepairResponseR\adigests\x12%\n" +
+	"\x0edigests_packed\x18\x02 \x01(\fR\rdigestsPacked\x12\x1a\n" +
+	"\bencoding\x18\x03 \x01(\rR\bencoding\"\x86\x01\n" +
 	"\x17OverwriteObjectsRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\x12#\n" +

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
@@ -206,10 +206,13 @@ message DigestObjectsInRangeRequest {
   string initial_uuid = 3;
   string final_uuid = 4;
   int32 limit = 5;
+  uint32 accept_encoding = 6; // response encoding the sender accepts; servers only emit 1 when asked
 }
 
 message DigestObjectsInRangeResponse {
   repeated RepairResponse digests = 1;
+  bytes digests_packed = 2; // replica.RepairDigestsToBinary output
+  uint32 encoding = 3; // 0 (older responders) = digests; 1 = digests_packed
 }
 
 // CompareDigests sends source digests to the target and returns those that need repair.
@@ -217,10 +220,15 @@ message CompareDigestsRequest {
   string index = 1;
   string shard = 2;
   repeated RepairResponse digests = 3;
+  bytes digests_packed = 4; // replica.RepairDigestsToBinary output
+  uint32 encoding = 5; // 0 (older senders) = digests; 1 = digests_packed
+  uint32 accept_encoding = 6; // response encoding the sender accepts; servers only emit 1 when asked
 }
 
 message CompareDigestsResponse {
   repeated RepairResponse digests = 1;
+  bytes digests_packed = 2; // replica.RepairDigestsToBinary output
+  uint32 encoding = 3; // 0 (older responders) = digests; 1 = digests_packed
 }
 
 // OverwriteObjects conditionally updates existing objects

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -200,11 +200,30 @@ func (s *ReplicationService) DigestObjectsInRange(ctx context.Context, req *pb.D
 		return nil, replicationErrorToGRPC(err)
 	}
 
+	if req.GetAcceptEncoding() == replica.RepairDigestsEncodingPacked {
+		return &pb.DigestObjectsInRangeResponse{
+			DigestsPacked: replica.RepairDigestsToBinary(results),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}, nil
+	}
+
+	// Proto records: older callers never set accept_encoding.
 	return &pb.DigestObjectsInRangeResponse{Digests: repairDigestsToProto(results)}, nil
 }
 
 func (s *ReplicationService) CompareDigests(ctx context.Context, req *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
-	digests, err := repairDigestsFromProto(req.GetDigests())
+	var digests []types.RepairDigest
+	var err error
+	switch req.GetEncoding() {
+	case replica.RepairDigestsEncodingPacked:
+		if len(req.GetDigestsPacked()) > replica.CompareDigestsMaxBodyBytes {
+			return nil, status.Errorf(codes.InvalidArgument, "packed digests payload of %d bytes exceeds %d",
+				len(req.GetDigestsPacked()), replica.CompareDigestsMaxBodyBytes)
+		}
+		digests, err = replica.RepairDigestsFromBinary(req.GetDigestsPacked())
+	default:
+		digests, err = repairDigestsFromProto(req.GetDigests())
+	}
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "decode digests: %v", err)
 	}
@@ -214,6 +233,14 @@ func (s *ReplicationService) CompareDigests(ctx context.Context, req *pb.Compare
 		return nil, replicationErrorToGRPC(err)
 	}
 
+	if req.GetAcceptEncoding() == replica.RepairDigestsEncodingPacked {
+		return &pb.CompareDigestsResponse{
+			DigestsPacked: replica.RepairDigestsToBinary(results),
+			Encoding:      replica.RepairDigestsEncodingPacked,
+		}, nil
+	}
+
+	// Proto records: older callers never set accept_encoding.
 	return &pb.CompareDigestsResponse{Digests: repairDigestsToProto(results)}, nil
 }
 

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -221,8 +221,12 @@ func (s *ReplicationService) CompareDigests(ctx context.Context, req *pb.Compare
 				len(req.GetDigestsPacked()), replica.CompareDigestsMaxBodyBytes)
 		}
 		digests, err = replica.RepairDigestsFromBinary(req.GetDigestsPacked())
-	default:
+	case replica.RepairDigestsEncodingProto:
 		digests, err = repairDigestsFromProto(req.GetDigests())
+	default:
+		// Fail closed: silently decoding an unknown dialect as proto records
+		// would compare an empty digest list and report a clean no-op.
+		return nil, status.Errorf(codes.InvalidArgument, "unsupported digests encoding %d", req.GetEncoding())
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "decode digests: %v", err)

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -15,9 +15,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -198,18 +200,21 @@ func (s *ReplicationService) DigestObjectsInRange(ctx context.Context, req *pb.D
 		return nil, replicationErrorToGRPC(err)
 	}
 
-	return &pb.DigestObjectsInRangeResponse{Digests: repairResponsesToProto(results)}, nil
+	return &pb.DigestObjectsInRangeResponse{Digests: repairDigestsToProto(results)}, nil
 }
 
 func (s *ReplicationService) CompareDigests(ctx context.Context, req *pb.CompareDigestsRequest) (*pb.CompareDigestsResponse, error) {
-	digests := repairResponsesFromProto(req.GetDigests())
+	digests, err := repairDigestsFromProto(req.GetDigests())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "decode digests: %v", err)
+	}
 
 	results, err := s.server.CompareDigests(ctx, req.GetIndex(), req.GetShard(), digests)
 	if err != nil {
 		return nil, replicationErrorToGRPC(err)
 	}
 
-	return &pb.CompareDigestsResponse{Digests: repairResponsesToProto(results)}, nil
+	return &pb.CompareDigestsResponse{Digests: repairDigestsToProto(results)}, nil
 }
 
 func (s *ReplicationService) OverwriteObjects(ctx context.Context, req *pb.OverwriteObjectsRequest) (*pb.OverwriteObjectsResponse, error) {
@@ -408,20 +413,6 @@ func simpleResponseToProto(r *replica.SimpleResponse) *pb.SimpleReplicaResponse 
 	return &pb.SimpleReplicaResponse{Errors: errs}
 }
 
-func repairResponsesFromProto(in []*pb.RepairResponse) []types.RepairResponse {
-	out := make([]types.RepairResponse, len(in))
-	for i, r := range in {
-		out[i] = types.RepairResponse{
-			ID:         r.GetId(),
-			Version:    r.GetVersion(),
-			UpdateTime: r.GetUpdateTime(),
-			Err:        r.GetErr(),
-			Deleted:    r.GetDeleted(),
-		}
-	}
-	return out
-}
-
 func repairResponsesToProto(results []types.RepairResponse) []*pb.RepairResponse {
 	out := make([]*pb.RepairResponse, len(results))
 	for i, r := range results {
@@ -430,6 +421,35 @@ func repairResponsesToProto(results []types.RepairResponse) []*pb.RepairResponse
 			Version:    r.Version,
 			UpdateTime: r.UpdateTime,
 			Err:        r.Err,
+			Deleted:    r.Deleted,
+		}
+	}
+	return out
+}
+
+// String IDs exist only at the proto boundary; the digest pipeline is byte-ID.
+func repairDigestsFromProto(in []*pb.RepairResponse) ([]types.RepairDigest, error) {
+	out := make([]types.RepairDigest, len(in))
+	for i, r := range in {
+		id, err := uuid.Parse(r.GetId())
+		if err != nil {
+			return nil, fmt.Errorf("parse digest uuid %q: %w", r.GetId(), err)
+		}
+		out[i] = types.RepairDigest{
+			ID:         id,
+			UpdateTime: r.GetUpdateTime(),
+			Deleted:    r.GetDeleted(),
+		}
+	}
+	return out, nil
+}
+
+func repairDigestsToProto(results []types.RepairDigest) []*pb.RepairResponse {
+	out := make([]*pb.RepairResponse, len(results))
+	for i, r := range results {
+		out[i] = &pb.RepairResponse{
+			Id:         r.ID.String(),
+			UpdateTime: r.UpdateTime,
 			Deleted:    r.Deleted,
 		}
 	}

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -224,8 +224,6 @@ func (s *ReplicationService) CompareDigests(ctx context.Context, req *pb.Compare
 	case replica.RepairDigestsEncodingProto:
 		digests, err = repairDigestsFromProto(req.GetDigests())
 	default:
-		// Fail closed: silently decoding an unknown dialect as proto records
-		// would compare an empty digest list and report a clean no-op.
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported digests encoding %d", req.GetEncoding())
 	}
 	if err != nil {

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -311,6 +311,16 @@ func TestCompareDigestsEncoding(t *testing.T) {
 			wantCode: codes.InvalidArgument,
 			wantMsg:  "exceeds",
 		},
+		{
+			name: "unknown encoding rejected",
+			req: &pb.CompareDigestsRequest{
+				Index: index, Shard: shard,
+				DigestsPacked: replica.RepairDigestsToBinary(source),
+				Encoding:      replica.RepairDigestsEncodingPacked + 1,
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "unsupported digests encoding",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -18,12 +18,15 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
+	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/replica"
 	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
@@ -229,4 +232,158 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, st.Code())
 	})
+}
+
+func TestCompareDigestsEncoding(t *testing.T) {
+	const index, shard = "MyClass", "myshard"
+	source := []routerTypes.RepairDigest{
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), UpdateTime: 1},
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), UpdateTime: 2, Deleted: true},
+	}
+	stale := source[:1]
+
+	tests := []struct {
+		name         string
+		req          *pb.CompareDigestsRequest
+		expectSource []routerTypes.RepairDigest
+		ret          []routerTypes.RepairDigest
+		wantCode     codes.Code
+		wantMsg      string
+		wantEncoding uint32
+		wantPacked   []byte
+		wantProtoIDs []string
+	}{
+		{
+			name: "packed request and packed reply when asked",
+			req: &pb.CompareDigestsRequest{
+				Index: index, Shard: shard,
+				DigestsPacked:  replica.RepairDigestsToBinary(source),
+				Encoding:       replica.RepairDigestsEncodingPacked,
+				AcceptEncoding: replica.RepairDigestsEncodingPacked,
+			},
+			expectSource: source,
+			ret:          stale,
+			wantEncoding: replica.RepairDigestsEncodingPacked,
+			wantPacked:   replica.RepairDigestsToBinary(stale),
+		},
+		{
+			name: "proto request gets proto reply",
+			req: &pb.CompareDigestsRequest{
+				Index: index, Shard: shard,
+				Digests: []*pb.RepairResponse{
+					{Id: source[0].ID.String(), UpdateTime: 1},
+					{Id: source[1].ID.String(), UpdateTime: 2, Deleted: true},
+				},
+			},
+			expectSource: source,
+			ret:          stale,
+			wantEncoding: replica.RepairDigestsEncodingProto,
+			wantProtoIDs: []string{source[0].ID.String()},
+		},
+		{
+			name: "empty packed request",
+			req: &pb.CompareDigestsRequest{
+				Index: index, Shard: shard,
+				Encoding:       replica.RepairDigestsEncodingPacked,
+				AcceptEncoding: replica.RepairDigestsEncodingPacked,
+			},
+			expectSource: []routerTypes.RepairDigest{},
+			wantEncoding: replica.RepairDigestsEncodingPacked,
+			wantPacked:   []byte{},
+		},
+		{
+			name: "truncated packed request rejected",
+			req: &pb.CompareDigestsRequest{
+				Index: index, Shard: shard,
+				DigestsPacked: make([]byte, replica.CompareDigestsRecordLength-1),
+				Encoding:      replica.RepairDigestsEncodingPacked,
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "not a multiple",
+		},
+		{
+			name: "oversized packed request rejected",
+			req: &pb.CompareDigestsRequest{
+				Index: index, Shard: shard,
+				DigestsPacked: make([]byte, replica.CompareDigestsMaxBodyBytes+replica.CompareDigestsRecordLength),
+				Encoding:      replica.RepairDigestsEncodingPacked,
+			},
+			wantCode: codes.InvalidArgument,
+			wantMsg:  "exceeds",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockReplicator := replicaTypes.NewMockReplicator(t)
+			svc := &ReplicationService{server: mockReplicator}
+			if tt.expectSource != nil {
+				mockReplicator.EXPECT().CompareDigests(mock.Anything, index, shard, tt.expectSource).Return(tt.ret, nil)
+			}
+			resp, err := svc.CompareDigests(context.Background(), tt.req)
+			if tt.wantCode != codes.OK {
+				st, ok := status.FromError(err)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantCode, st.Code())
+				assert.Contains(t, st.Message(), tt.wantMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEncoding, resp.GetEncoding())
+			assert.Equal(t, tt.wantPacked, resp.GetDigestsPacked())
+			var gotIDs []string
+			for _, d := range resp.GetDigests() {
+				gotIDs = append(gotIDs, d.GetId())
+			}
+			assert.Equal(t, tt.wantProtoIDs, gotIDs)
+		})
+	}
+}
+
+func TestDigestObjectsInRangeEncoding(t *testing.T) {
+	const index, shard = "MyClass", "myshard"
+	initial, final := strfmt.UUID("00000000-0000-0000-0000-000000000001"), strfmt.UUID("00000000-0000-0000-0000-0000000000ff")
+	results := []routerTypes.RepairDigest{
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000005"), UpdateTime: 5},
+	}
+
+	tests := []struct {
+		name           string
+		acceptEncoding uint32
+		wantEncoding   uint32
+		wantPacked     []byte
+		wantProtoIDs   []string
+	}{
+		{
+			name:           "packed reply when asked",
+			acceptEncoding: replica.RepairDigestsEncodingPacked,
+			wantEncoding:   replica.RepairDigestsEncodingPacked,
+			wantPacked:     replica.RepairDigestsToBinary(results),
+		},
+		{
+			name:         "proto reply when accept_encoding unset",
+			wantEncoding: replica.RepairDigestsEncodingProto,
+			wantProtoIDs: []string{results[0].ID.String()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockReplicator := replicaTypes.NewMockReplicator(t)
+			svc := &ReplicationService{server: mockReplicator}
+			mockReplicator.EXPECT().DigestObjectsInRange(mock.Anything, index, shard, initial, final, 10).
+				Return(results, nil)
+			resp, err := svc.DigestObjectsInRange(context.Background(), &pb.DigestObjectsInRangeRequest{
+				Index: index, Shard: shard,
+				InitialUuid: initial.String(), FinalUuid: final.String(), Limit: 10,
+				AcceptEncoding: tt.acceptEncoding,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantEncoding, resp.GetEncoding())
+			assert.Equal(t, tt.wantPacked, resp.GetDigestsPacked())
+			var gotIDs []string
+			for _, d := range resp.GetDigests() {
+				gotIDs = append(gotIDs, d.GetId())
+			}
+			assert.Equal(t, tt.wantProtoIDs, gotIDs)
+		})
+	}
 }

--- a/adapters/handlers/rest/clusterapi/grpc/server_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/server_test.go
@@ -143,6 +143,20 @@ func Test_ServerReplicationService(t *testing.T) {
 				require.Equal(t, int64(2), resp[1].UpdateTime)
 			})
 
+			t.Run("CompareDigests", func(t *testing.T) {
+				c := "C"
+				s := "S"
+				source := []routerTypes.RepairDigest{
+					{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), UpdateTime: 1},
+					{ID: uuid.MustParse("00000000-0000-0000-0000-000000000002"), UpdateTime: 2, Deleted: true},
+				}
+				mockReplicator.EXPECT().CompareDigests(mock.Anything, c, s, source).Return(source[1:], nil)
+				resp, err := client.CompareDigests(context.Background(), host, c, s, source)
+				require.NoError(t, err)
+				require.Len(t, resp, 1)
+				require.Equal(t, source[1], resp[0])
+			})
+
 			t.Run("FindUUIDs", func(t *testing.T) {
 				c := "C"
 				s := "S"

--- a/adapters/handlers/rest/clusterapi/grpc/server_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/server_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -124,20 +125,22 @@ func Test_ServerReplicationService(t *testing.T) {
 			t.Run("DigestObjectsInRange", func(t *testing.T) {
 				c := "C"
 				s := "S"
-				initialUUID := strfmt.UUID("id1")
-				finalUUID := strfmt.UUID("id2")
+				id1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+				id2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+				initialUUID := strfmt.UUID(id1.String())
+				finalUUID := strfmt.UUID(id2.String())
 				limit := 10
-				mockReplicator.EXPECT().DigestObjectsInRange(mock.Anything, c, s, initialUUID, finalUUID, limit).Return([]routerTypes.RepairResponse{
-					{ID: "id1", Version: 1},
-					{ID: "id2", Version: 2},
+				mockReplicator.EXPECT().DigestObjectsInRange(mock.Anything, c, s, initialUUID, finalUUID, limit).Return([]routerTypes.RepairDigest{
+					{ID: id1, UpdateTime: 1},
+					{ID: id2, UpdateTime: 2},
 				}, nil)
 				resp, err := client.DigestObjectsInRange(context.Background(), host, c, s, initialUUID, finalUUID, limit)
 				require.NoError(t, err)
 				require.Len(t, resp, 2)
-				require.Equal(t, "id1", resp[0].ID)
-				require.Equal(t, int64(1), resp[0].Version)
-				require.Equal(t, "id2", resp[1].ID)
-				require.Equal(t, int64(2), resp[1].Version)
+				require.Equal(t, id1, resp[0].ID)
+				require.Equal(t, int64(1), resp[0].UpdateTime)
+				require.Equal(t, id2, resp[1].ID)
+				require.Equal(t, int64(2), resp[1].UpdateTime)
 			})
 
 			t.Run("FindUUIDs", func(t *testing.T) {

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -174,7 +174,7 @@ type shards interface {
 	DigestObjects(ctx context.Context, indexName, shardName string,
 		ids []strfmt.UUID) (result []types.RepairResponse, err error)
 	DigestObjectsInRange(ctx context.Context, indexName, shardName string,
-		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairResponse, err error)
+		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairDigest, err error)
 	HashTreeLevel(ctx context.Context, indexName, shardName string,
 		level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 	"github.com/sirupsen/logrus"
 
@@ -764,28 +763,10 @@ func (i *replicatedIndices) postCompareDigests() http.Handler {
 			return
 		}
 
-		var sourceDigests []types.RepairDigest
-		if len(body) > 0 {
-			if len(body)%replica.CompareDigestsRecordLength != 0 {
-				http.Error(w, "invalid binary payload length", http.StatusBadRequest)
-				return
-			}
-			n := len(body) / replica.CompareDigestsRecordLength
-			sourceDigests = make([]types.RepairDigest, n)
-			for j := 0; j < n; j++ {
-				off := j * replica.CompareDigestsRecordLength
-				rec := body[off : off+replica.CompareDigestsRecordLength]
-				id, err := uuid.FromBytes(rec[:16])
-				if err != nil {
-					http.Error(w, "parse uuid from binary: "+err.Error(), http.StatusBadRequest)
-					return
-				}
-				sourceDigests[j] = types.RepairDigest{
-					ID:         id,
-					UpdateTime: int64(binary.BigEndian.Uint64(rec[16:24])),
-					Deleted:    rec[24]&replica.CompareDigestsFlagDeleted != 0,
-				}
-			}
+		sourceDigests, err := replica.RepairDigestsFromBinary(body)
+		if err != nil {
+			http.Error(w, "decode packed digests: "+err.Error(), http.StatusBadRequest)
+			return
 		}
 
 		stale, err := i.replicator.CompareDigests(r.Context(), index, shard, sourceDigests)
@@ -794,17 +775,7 @@ func (i *replicatedIndices) postCompareDigests() http.Handler {
 			return
 		}
 
-		out := make([]byte, 0, len(stale)*replica.CompareDigestsRecordLength)
-		var obuf [replica.CompareDigestsRecordLength]byte
-		for _, d := range stale {
-			copy(obuf[:16], d.ID[:])
-			binary.BigEndian.PutUint64(obuf[16:24], uint64(d.UpdateTime))
-			obuf[24] = 0
-			if d.Deleted {
-				obuf[24] = replica.CompareDigestsFlagDeleted
-			}
-			out = append(out, obuf[:]...)
-		}
+		out := replica.RepairDigestsToBinary(stale)
 
 		w.Header().Set("Content-Type", "application/octet-stream")
 		w.Header().Set("Content-Length", strconv.Itoa(len(out)))

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -578,9 +578,14 @@ func (i *replicatedIndices) postCompareHashTreeRoots() http.Handler {
 // binary form) followed by 8 bytes UpdateTime (int64 big-endian). The Err and
 // Deleted fields are intentionally omitted — ObjectDigestsInRange never
 // populates them.
-func writeDigestsInRangeResponse(w http.ResponseWriter, r *http.Request, results []types.RepairResponse) {
+func writeDigestsInRangeResponse(w http.ResponseWriter, r *http.Request, results []types.RepairDigest) {
 	if r.Header.Get("X-Accept-Response-Encoding") != "binary" {
-		resBytes, err := json.Marshal(replica.DigestObjectsInRangeResp{Digests: results})
+		// Legacy JSON shape keeps string IDs; conversion happens only on this fallback.
+		responses := make([]types.RepairResponse, len(results))
+		for i, d := range results {
+			responses[i] = types.RepairResponse{ID: d.ID.String(), UpdateTime: d.UpdateTime, Deleted: d.Deleted}
+		}
+		resBytes, err := json.Marshal(replica.DigestObjectsInRangeResp{Digests: responses})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -589,18 +594,10 @@ func writeDigestsInRangeResponse(w http.ResponseWriter, r *http.Request, results
 		return
 	}
 
-	// Encode all records before writing any headers so that errors don't
-	// produce an http.Error response with a stale Content-Length already set.
 	body := make([]byte, 0, len(results)*replica.DigestObjectsInRangeRecordLength)
 	var buf [replica.DigestObjectsInRangeRecordLength]byte
 	for _, d := range results {
-		uuidParsed, err := uuid.Parse(d.ID)
-		if err != nil {
-			// Should never happen — IDs come directly from the LSM store.
-			http.Error(w, "parse uuid: "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-		copy(buf[:16], uuidParsed[:])
+		copy(buf[:16], d.ID[:])
 		binary.BigEndian.PutUint64(buf[16:], uint64(d.UpdateTime))
 		body = append(body, buf[:]...)
 	}
@@ -767,14 +764,14 @@ func (i *replicatedIndices) postCompareDigests() http.Handler {
 			return
 		}
 
-		var sourceDigests []types.RepairResponse
+		var sourceDigests []types.RepairDigest
 		if len(body) > 0 {
 			if len(body)%replica.CompareDigestsRecordLength != 0 {
 				http.Error(w, "invalid binary payload length", http.StatusBadRequest)
 				return
 			}
 			n := len(body) / replica.CompareDigestsRecordLength
-			sourceDigests = make([]types.RepairResponse, n)
+			sourceDigests = make([]types.RepairDigest, n)
 			for j := 0; j < n; j++ {
 				off := j * replica.CompareDigestsRecordLength
 				rec := body[off : off+replica.CompareDigestsRecordLength]
@@ -783,8 +780,8 @@ func (i *replicatedIndices) postCompareDigests() http.Handler {
 					http.Error(w, "parse uuid from binary: "+err.Error(), http.StatusBadRequest)
 					return
 				}
-				sourceDigests[j] = types.RepairResponse{
-					ID:         id.String(),
+				sourceDigests[j] = types.RepairDigest{
+					ID:         id,
 					UpdateTime: int64(binary.BigEndian.Uint64(rec[16:24])),
 					Deleted:    rec[24]&replica.CompareDigestsFlagDeleted != 0,
 				}
@@ -797,17 +794,10 @@ func (i *replicatedIndices) postCompareDigests() http.Handler {
 			return
 		}
 
-		// Encode all records before writing headers so that a UUID parse error
-		// doesn't produce an http.Error after headers have been sent.
 		out := make([]byte, 0, len(stale)*replica.CompareDigestsRecordLength)
 		var obuf [replica.CompareDigestsRecordLength]byte
 		for _, d := range stale {
-			id, err := uuid.Parse(d.ID)
-			if err != nil {
-				http.Error(w, "parse uuid: "+err.Error(), http.StatusInternalServerError)
-				return
-			}
-			copy(obuf[:16], id[:])
+			copy(obuf[:16], d.ID[:])
 			binary.BigEndian.PutUint64(obuf[16:24], uint64(d.UpdateTime))
 			obuf[24] = 0
 			if d.Deleted {

--- a/adapters/repos/db/fakes_for_tests.go
+++ b/adapters/repos/db/fakes_for_tests.go
@@ -549,7 +549,7 @@ func (*FakeReplicationClient) FindUUIDs(ctx context.Context,
 
 func (c *FakeReplicationClient) DigestObjectsInRange(ctx context.Context, host, index, shard string,
 	initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	return nil, nil
 }
 
@@ -560,8 +560,8 @@ func (c *FakeReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 }
 
 func (c *FakeReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
-	digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	return nil, nil
 }
 

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -260,12 +260,12 @@ func stubDBWithNoLiveReindex() *DB {
 	return db
 }
 
-func testShard(t *testing.T, ctx context.Context, className string, indexOpts ...func(*Index)) (ShardLike, *Index) {
+func testShard(t testing.TB, ctx context.Context, className string, indexOpts ...func(*Index)) (ShardLike, *Index) {
 	return testShardWithSettings(t, ctx, &models.Class{Class: className}, enthnsw.UserConfig{Skip: true},
 		false, false, false, indexOpts...)
 }
 
-func testShardMultiTenant(t *testing.T, ctx context.Context, className string, indexOpts ...func(*Index)) (ShardLike, *Index) {
+func testShardMultiTenant(t testing.TB, ctx context.Context, className string, indexOpts ...func(*Index)) (ShardLike, *Index) {
 	return testShardWithMultiTenantSettings(t, ctx, &models.Class{Class: className}, enthnsw.UserConfig{Skip: true},
 		false, false, false, indexOpts...)
 }
@@ -353,7 +353,7 @@ func getSingleShardNameFromRepo(repo *DB, className string) string {
 	return shardName
 }
 
-func setupTestShardWithSettings(t *testing.T, ctx context.Context, class *models.Class,
+func setupTestShardWithSettings(t testing.TB, ctx context.Context, class *models.Class,
 	vic schemaConfig.VectorIndexConfig, withStopwords, withCheckpoints, multiTenant, withAsyncIndexingEnabled bool, indexOpts ...func(*Index),
 ) (ShardLike, *Index) {
 	// With async indexing on, NewShard reads the checkpoint store from a
@@ -547,13 +547,13 @@ func setupTestShardWithSettings(t *testing.T, ctx context.Context, class *models
 }
 
 // Simplified functions that delegate to the common helper
-func testShardWithMultiTenantSettings(t *testing.T, ctx context.Context, class *models.Class,
+func testShardWithMultiTenantSettings(t testing.TB, ctx context.Context, class *models.Class,
 	vic schemaConfig.VectorIndexConfig, withStopwords, withCheckpoints, withAsyncIndexingEnabled bool, indexOpts ...func(*Index),
 ) (ShardLike, *Index) {
 	return setupTestShardWithSettings(t, ctx, class, vic, withStopwords, withCheckpoints, true, withAsyncIndexingEnabled, indexOpts...)
 }
 
-func testShardWithSettings(t *testing.T, ctx context.Context, class *models.Class,
+func testShardWithSettings(t testing.TB, ctx context.Context, class *models.Class,
 	vic schemaConfig.VectorIndexConfig, withStopwords, withCheckpoints, withAsyncIndexingEnabled bool, indexOpts ...func(*Index),
 ) (ShardLike, *Index) {
 	return setupTestShardWithSettings(t, ctx, class, vic, withStopwords, withCheckpoints, false, withAsyncIndexingEnabled, indexOpts...)

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -525,27 +525,27 @@ func (_c *MockShardLike_AsyncCheckpointRoot_Call) RunAndReturn(run func(context.
 }
 
 // CompareDigests provides a mock function with given fields: ctx, sourceDigests
-func (_m *MockShardLike) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+func (_m *MockShardLike) CompareDigests(ctx context.Context, sourceDigests []types.RepairDigest) ([]types.RepairDigest, error) {
 	ret := _m.Called(ctx, sourceDigests)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CompareDigests")
 	}
 
-	var r0 []types.RepairResponse
+	var r0 []types.RepairDigest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []types.RepairResponse) ([]types.RepairResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []types.RepairDigest) ([]types.RepairDigest, error)); ok {
 		return rf(ctx, sourceDigests)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []types.RepairResponse) []types.RepairResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []types.RepairDigest) []types.RepairDigest); ok {
 		r0 = rf(ctx, sourceDigests)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.RepairResponse)
+			r0 = ret.Get(0).([]types.RepairDigest)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, []types.RepairResponse) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, []types.RepairDigest) error); ok {
 		r1 = rf(ctx, sourceDigests)
 	} else {
 		r1 = ret.Error(1)
@@ -561,24 +561,24 @@ type MockShardLike_CompareDigests_Call struct {
 
 // CompareDigests is a helper method to define mock.On call
 //   - ctx context.Context
-//   - sourceDigests []types.RepairResponse
+//   - sourceDigests []types.RepairDigest
 func (_e *MockShardLike_Expecter) CompareDigests(ctx interface{}, sourceDigests interface{}) *MockShardLike_CompareDigests_Call {
 	return &MockShardLike_CompareDigests_Call{Call: _e.mock.On("CompareDigests", ctx, sourceDigests)}
 }
 
-func (_c *MockShardLike_CompareDigests_Call) Run(run func(ctx context.Context, sourceDigests []types.RepairResponse)) *MockShardLike_CompareDigests_Call {
+func (_c *MockShardLike_CompareDigests_Call) Run(run func(ctx context.Context, sourceDigests []types.RepairDigest)) *MockShardLike_CompareDigests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]types.RepairResponse))
+		run(args[0].(context.Context), args[1].([]types.RepairDigest))
 	})
 	return _c
 }
 
-func (_c *MockShardLike_CompareDigests_Call) Return(_a0 []types.RepairResponse, _a1 error) *MockShardLike_CompareDigests_Call {
+func (_c *MockShardLike_CompareDigests_Call) Return(_a0 []types.RepairDigest, _a1 error) *MockShardLike_CompareDigests_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockShardLike_CompareDigests_Call) RunAndReturn(run func(context.Context, []types.RepairResponse) ([]types.RepairResponse, error)) *MockShardLike_CompareDigests_Call {
+func (_c *MockShardLike_CompareDigests_Call) RunAndReturn(run func(context.Context, []types.RepairDigest) ([]types.RepairDigest, error)) *MockShardLike_CompareDigests_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -2908,23 +2908,23 @@ func (_c *MockShardLike_ObjectDigests_Call) RunAndReturn(run func(context.Contex
 }
 
 // ObjectDigestsInRange provides a mock function with given fields: ctx, initialUUID, finalUUID, limit
-func (_m *MockShardLike) ObjectDigestsInRange(ctx context.Context, initialUUID strfmt.UUID, finalUUID strfmt.UUID, limit int) ([]types.RepairResponse, error) {
+func (_m *MockShardLike) ObjectDigestsInRange(ctx context.Context, initialUUID strfmt.UUID, finalUUID strfmt.UUID, limit int) ([]types.RepairDigest, error) {
 	ret := _m.Called(ctx, initialUUID, finalUUID, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ObjectDigestsInRange")
 	}
 
-	var r0 []types.RepairResponse
+	var r0 []types.RepairDigest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, strfmt.UUID, int) ([]types.RepairResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, strfmt.UUID, int) ([]types.RepairDigest, error)); ok {
 		return rf(ctx, initialUUID, finalUUID, limit)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, strfmt.UUID, int) []types.RepairResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, strfmt.UUID, int) []types.RepairDigest); ok {
 		r0 = rf(ctx, initialUUID, finalUUID, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.RepairResponse)
+			r0 = ret.Get(0).([]types.RepairDigest)
 		}
 	}
 
@@ -2958,12 +2958,12 @@ func (_c *MockShardLike_ObjectDigestsInRange_Call) Run(run func(ctx context.Cont
 	return _c
 }
 
-func (_c *MockShardLike_ObjectDigestsInRange_Call) Return(objs []types.RepairResponse, err error) *MockShardLike_ObjectDigestsInRange_Call {
+func (_c *MockShardLike_ObjectDigestsInRange_Call) Return(objs []types.RepairDigest, err error) *MockShardLike_ObjectDigestsInRange_Call {
 	_c.Call.Return(objs, err)
 	return _c
 }
 
-func (_c *MockShardLike_ObjectDigestsInRange_Call) RunAndReturn(run func(context.Context, strfmt.UUID, strfmt.UUID, int) ([]types.RepairResponse, error)) *MockShardLike_ObjectDigestsInRange_Call {
+func (_c *MockShardLike_ObjectDigestsInRange_Call) RunAndReturn(run func(context.Context, strfmt.UUID, strfmt.UUID, int) ([]types.RepairDigest, error)) *MockShardLike_ObjectDigestsInRange_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -6041,8 +6041,7 @@ func (_c *MockShardLike_uuidFromDocID_Call) RunAndReturn(run func(uint64) (strfm
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockShardLike {
+}) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -165,7 +165,7 @@ func (db *DB) DigestObjects(ctx context.Context, className, shardName string, id
 	return index.DigestObjects(ctx, shardName, ids)
 }
 
-func (db *DB) DigestObjectsInRange(ctx context.Context, className, shardName string, initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairResponse, err error) {
+func (db *DB) DigestObjectsInRange(ctx context.Context, className, shardName string, initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairDigest, err error) {
 	index, pr := db.replicatedIndex(className)
 	if pr != nil {
 		return nil, pr.FirstError()
@@ -173,7 +173,7 @@ func (db *DB) DigestObjectsInRange(ctx context.Context, className, shardName str
 	return index.DigestObjectsInRange(ctx, shardName, initialUUID, finalUUID, limit)
 }
 
-func (db *DB) CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error) {
+func (db *DB) CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairDigest) ([]types.RepairDigest, error) {
 	index, pr := db.replicatedIndex(className)
 	if pr != nil {
 		return nil, pr.FirstError()
@@ -1049,7 +1049,7 @@ func (i *Index) IncomingDigestObjects(ctx context.Context,
 
 func (i *Index) DigestObjectsInRange(ctx context.Context,
 	shardName string, initialUUID, finalUUID strfmt.UUID, limit int,
-) (result []types.RepairResponse, err error) {
+) (result []types.RepairDigest, err error) {
 	// Never load from async replication; empty success for unloaded would invite full propagation.
 	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {
@@ -1065,13 +1065,13 @@ func (i *Index) DigestObjectsInRange(ctx context.Context,
 
 func (i *Index) IncomingDigestObjectsInRange(ctx context.Context,
 	shardName string, initialUUID, finalUUID strfmt.UUID, limit int,
-) (result []types.RepairResponse, err error) {
+) (result []types.RepairDigest, err error) {
 	return i.DigestObjectsInRange(ctx, shardName, initialUUID, finalUUID, limit)
 }
 
 func (i *Index) CompareDigests(ctx context.Context,
-	shardName string, sourceDigests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	shardName string, sourceDigests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	// Never load from async replication's propagation pre-check.
 	shard, release, err := i.getLoadedShard(shardName)
 	if err != nil {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -99,8 +99,8 @@ type ShardLike interface {
 	DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error                                           // Delete object by id
 	MultiObjectByID(ctx context.Context, query []multi.Identifier) ([]*storobj.Object, error)
 	ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error)
-	ObjectDigestsInRange(ctx context.Context, initialUUID, finalUUID strfmt.UUID, limit int) (objs []types.RepairResponse, err error)
-	CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error)
+	ObjectDigestsInRange(ctx context.Context, initialUUID, finalUUID strfmt.UUID, limit int) (objs []types.RepairDigest, err error)
+	CompareDigests(ctx context.Context, sourceDigests []types.RepairDigest) ([]types.RepairDigest, error)
 	ID() string // Get the shard id
 	drop(keepFiles bool) error
 	HaltForTransfer(ctx context.Context, offloading bool, inactivityTimeout time.Duration) error

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -2142,14 +2142,14 @@ type objectToPropagate struct {
 
 // propagationScratch holds buffers reused across all diff ranges of a hashBeat, allocating them per-beat not per-range.
 type propagationScratch struct {
-	filteredDigests    []types.RepairResponse
+	filteredDigests    []types.RepairDigest
 	localDigestsByUUID map[uuid.UUID]int64
 	objectsToPropagate []objectToPropagate
 }
 
 func newPropagationScratch(diffBatchSize int) *propagationScratch {
 	return &propagationScratch{
-		filteredDigests:    make([]types.RepairResponse, 0, diffBatchSize),
+		filteredDigests:    make([]types.RepairDigest, 0, diffBatchSize),
 		localDigestsByUUID: make(map[uuid.UUID]int64, diffBatchSize),
 		objectsToPropagate: make([]objectToPropagate, 0, diffBatchSize),
 	}
@@ -2292,28 +2292,19 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 			break
 		}
 
-		lastLocalUUIDBytes, err := bytesFromUUID(strfmt.UUID(allLocalDigests[len(allLocalDigests)-1].ID))
-		if err != nil {
-			return localObjectsCount, objectsToPropagate, err
-		}
+		lastLocalUUID := allLocalDigests[len(allLocalDigests)-1].ID
+		lastLocalUUIDBytes := lastLocalUUID[:]
 
-		// Drop too-recent objects; index the rest by parsed UUID so the
-		// CompareDigests response can be matched back without re-parsing.
+		// Drop too-recent objects; index the rest by UUID so the CompareDigests
+		// response can be matched back directly.
 		filteredDigests = filteredDigests[:0]
 		clear(localDigestsByUUID)
 		for _, d := range allLocalDigests {
 			if d.UpdateTime > maxUpdateTime {
 				continue
 			}
-			parsed, err := uuid.Parse(d.ID)
-			if err != nil {
-				// Unparseable UUID => corrupt local data; log and skip.
-				s.index.logger.WithField("uuid", d.ID).
-					Error("async replication: skipping local digest with invalid UUID")
-				continue
-			}
 			filteredDigests = append(filteredDigests, d)
-			localDigestsByUUID[parsed] = d.UpdateTime
+			localDigestsByUUID[d.ID] = d.UpdateTime
 		}
 		localObjectsCount += len(filteredDigests)
 
@@ -2340,16 +2331,10 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 		}
 
 		for _, stale := range staleDigests {
-			key, err := uuid.Parse(stale.ID)
-			if err != nil {
-				s.index.logger.WithField("uuid", stale.ID).
-					Error("async replication: skipping stale digest with invalid UUID")
-				continue
-			}
-			localUT, ok := localDigestsByUUID[key]
+			localUT, ok := localDigestsByUUID[stale.ID]
 			if !ok {
 				// Target returned an ID we did not send — protocol/remote bug; skip.
-				s.index.logger.WithField("uuid", stale.ID).
+				s.index.logger.WithField("uuid", stale.ID.String()).
 					Error("async replication: target returned a digest not present in source batch")
 				continue
 			}
@@ -2357,7 +2342,7 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 			// Queue every returned digest (stale or missing/tombstoned); the
 			// target's Overwrite handler + resolveObjectConflict settle deletions.
 			objectsToPropagate = append(objectsToPropagate, objectToPropagate{
-				uuid:                  strfmt.UUID(stale.ID),
+				uuid:                  strfmt.UUID(stale.ID.String()),
 				lastUpdateTime:        localUT,
 				remoteStaleUpdateTime: stale.UpdateTime, // 0 when missing-or-tombstoned on target
 			})

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -86,37 +87,37 @@ func testObjWithTime(class string, id strfmt.UUID, updateTime int64) *storobj.Ob
 // CompareDigests protocol.
 type fixedDigestsClient struct {
 	FakeReplicationClient
-	digests          []routerTypes.RepairResponse
+	digests          []routerTypes.RepairDigest
 	compareDigestErr error // if non-nil, CompareDigests returns this error instead of comparing
 }
 
 func (c *fixedDigestsClient) DigestObjectsInRange(
 	_ context.Context, _, _, _ string, _, _ strfmt.UUID, _ int,
-) ([]routerTypes.RepairResponse, error) {
+) ([]routerTypes.RepairDigest, error) {
 	return c.digests, nil
 }
 
 func (c *fixedDigestsClient) CompareDigests(
-	_ context.Context, _, _, _ string, source []routerTypes.RepairResponse,
-) ([]routerTypes.RepairResponse, error) {
+	_ context.Context, _, _, _ string, source []routerTypes.RepairDigest,
+) ([]routerTypes.RepairDigest, error) {
 	if c.compareDigestErr != nil {
 		return nil, c.compareDigestErr
 	}
-	remote := make(map[string]int64, len(c.digests))
+	remote := make(map[uuid.UUID]int64, len(c.digests))
 	for _, d := range c.digests {
 		remote[d.ID] = d.UpdateTime
 	}
-	out := make([]routerTypes.RepairResponse, 0, len(source))
+	out := make([]routerTypes.RepairDigest, 0, len(source))
 	for _, s := range source {
 		rt, ok := remote[s.ID]
 		if !ok {
 			// Missing on remote.
-			out = append(out, routerTypes.RepairResponse{ID: s.ID, UpdateTime: 0})
+			out = append(out, routerTypes.RepairDigest{ID: s.ID, UpdateTime: 0})
 			continue
 		}
 		if s.UpdateTime > rt {
 			// Source is strictly newer than remote — stale on target.
-			out = append(out, routerTypes.RepairResponse{ID: s.ID, UpdateTime: rt})
+			out = append(out, routerTypes.RepairDigest{ID: s.ID, UpdateTime: rt})
 		}
 		// Equal or remote-newer → no action needed.
 	}
@@ -130,8 +131,8 @@ type countingDigestsClient struct {
 }
 
 func (c *countingDigestsClient) CompareDigests(
-	ctx context.Context, index, shard, host string, source []routerTypes.RepairResponse,
-) ([]routerTypes.RepairResponse, error) {
+	ctx context.Context, index, shard, host string, source []routerTypes.RepairDigest,
+) ([]routerTypes.RepairDigest, error) {
 	c.compareCalls.Add(1)
 	return c.fixedDigestsClient.CompareDigests(ctx, index, shard, host, source)
 }
@@ -247,7 +248,7 @@ func withAsyncScheduler(t *testing.T) func(*Index) {
 // concreteShard unwraps the *Shard from a ShardLike returned by testShard.
 // testShard passes EnableLazyLoadShards=true which causes initShard to create
 // a real *Shard directly (not a LazyLoadShard wrapper).
-func concreteShard(t *testing.T, sl ShardLike) *Shard {
+func concreteShard(t testing.TB, sl ShardLike) *Shard {
 	t.Helper()
 	s, ok := sl.(*Shard)
 	require.True(t, ok, "expected *Shard from testShard (EnableLazyLoadShards=true)")
@@ -322,9 +323,9 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 	// objects with equal or newer timestamps, so nothing should be propagated.
 	t.Run("SourceBehindRemote", func(t *testing.T) {
 		// Pre-configure the remote to return the same digests as local.
-		remoteDigests := []routerTypes.RepairResponse{
-			{ID: string(uuidLow), UpdateTime: tsFarPast},
-			{ID: string(uuidHigh), UpdateTime: tsFarPast},
+		remoteDigests := []routerTypes.RepairDigest{
+			{ID: uuid.MustParse(string(uuidLow)), UpdateTime: tsFarPast},
+			{ID: uuid.MustParse(string(uuidHigh)), UpdateTime: tsFarPast},
 		}
 		sl, idx := testShard(t, ctx, class, withReplicationClient(t, &fixedDigestsClient{digests: remoteDigests}))
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
@@ -374,10 +375,10 @@ func TestObjectsToPropagateWithinRange(t *testing.T) {
 	// and limit=1, the whole leaf must be scanned in a single CompareDigests RPC
 	// (diffBatchSize=100), not one round-trip per object.
 	t.Run("FetchBatchDecoupledFromBudget", func(t *testing.T) {
-		remoteDigests := []routerTypes.RepairResponse{
-			{ID: string(uuidLow), UpdateTime: tsFarPast},
-			{ID: string(uuidMid), UpdateTime: tsFarPast},
-			{ID: string(uuidHigh), UpdateTime: tsFarPast},
+		remoteDigests := []routerTypes.RepairDigest{
+			{ID: uuid.MustParse(string(uuidLow)), UpdateTime: tsFarPast},
+			{ID: uuid.MustParse(string(uuidMid)), UpdateTime: tsFarPast},
+			{ID: uuid.MustParse(string(uuidHigh)), UpdateTime: tsFarPast},
 		}
 		client := &countingDigestsClient{fixedDigestsClient: &fixedDigestsClient{digests: remoteDigests}}
 		sl, idx := testShard(t, ctx, class, withReplicationClient(t, client))
@@ -883,7 +884,7 @@ func TestRepairEndpointsDoNotForceLoadUnloadedShard(t *testing.T) {
 	})
 
 	t.Run("CompareDigests", func(t *testing.T) {
-		_, err := idx.CompareDigests(ctx, lazyName, []routerTypes.RepairResponse{{ID: string(uuidLow)}})
+		_, err := idx.CompareDigests(ctx, lazyName, []routerTypes.RepairDigest{{ID: uuid.MustParse(string(uuidLow))}})
 		require.ErrorIs(t, err, errAsyncReplicationNotActive)
 		require.False(t, lazy.isLoaded(), "CompareDigests must not force-load an unloaded shard")
 	})

--- a/adapters/repos/db/shard_compare_digests_test.go
+++ b/adapters/repos/db/shard_compare_digests_test.go
@@ -63,7 +63,7 @@ func TestShardCompareDigestsStrategies(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, out)
 
-		out, err = s.CompareDigests(ctx, []routerTypes.RepairResponse{})
+		out, err = s.CompareDigests(ctx, []routerTypes.RepairDigest{})
 		require.NoError(t, err)
 		assert.Empty(t, out)
 	})
@@ -73,8 +73,8 @@ func TestShardCompareDigestsStrategies(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsMiddle)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(uuidLow), UpdateTime: tsMiddle},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(uuidLow), UpdateTime: tsMiddle},
 		})
 		require.NoError(t, err)
 		assert.Empty(t, out, "equal-timestamp entries are intentionally not returned")
@@ -85,12 +85,12 @@ func TestShardCompareDigestsStrategies(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsOlder)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(uuidLow), UpdateTime: tsNewer},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(uuidLow), UpdateTime: tsNewer},
 		})
 		require.NoError(t, err)
 		require.Len(t, out, 1)
-		assert.Equal(t, string(uuidLow), out[0].ID)
+		assert.Equal(t, mustUUID(uuidLow), out[0].ID)
 		assert.Equal(t, tsOlder, out[0].UpdateTime, "must report local UpdateTime so caller treats source as stale-on-target")
 		assert.False(t, out[0].Deleted)
 	})
@@ -100,8 +100,8 @@ func TestShardCompareDigestsStrategies(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsNewer)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(uuidLow), UpdateTime: tsOlder},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(uuidLow), UpdateTime: tsOlder},
 		})
 		require.NoError(t, err)
 		assert.Empty(t, out, "local has the newer object — source must not propagate")
@@ -112,12 +112,12 @@ func TestShardCompareDigestsStrategies(t *testing.T) {
 		// no PutObject — uuidLow is missing
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(uuidLow), UpdateTime: tsMiddle},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(uuidLow), UpdateTime: tsMiddle},
 		})
 		require.NoError(t, err)
 		require.Len(t, out, 1)
-		assert.Equal(t, string(uuidLow), out[0].ID)
+		assert.Equal(t, mustUUID(uuidLow), out[0].ID)
 		assert.Equal(t, int64(0), out[0].UpdateTime, "missing entries are signalled with UpdateTime=0")
 		assert.False(t, out[0].Deleted)
 	})
@@ -141,12 +141,12 @@ func TestShardCompareDigestsStrategies(t *testing.T) {
 				require.NoError(t, sl.DeleteObject(ctx, uuidLow, time.UnixMilli(tsNewer)))
 
 				s := concreteShard(t, sl)
-				out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-					{ID: string(uuidLow), UpdateTime: tsOlder},
+				out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+					{ID: mustUUID(uuidLow), UpdateTime: tsOlder},
 				})
 				require.NoError(t, err)
 				require.Len(t, out, 1)
-				assert.Equal(t, string(uuidLow), out[0].ID)
+				assert.Equal(t, mustUUID(uuidLow), out[0].ID)
 				assert.False(t, out[0].Deleted,
 					"target must never set Deleted=true; tombstone resolution is the source's job")
 				assert.Equal(t, int64(0), out[0].UpdateTime,
@@ -179,13 +179,13 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, c, ts)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(b), UpdateTime: ts},     // exact match — must NOT be returned
-			{ID: string(d), UpdateTime: ts + 1}, // missing — must be returned with UpdateTime=0
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(b), UpdateTime: ts},     // exact match — must NOT be returned
+			{ID: mustUUID(d), UpdateTime: ts + 1}, // missing — must be returned with UpdateTime=0
 		})
 		require.NoError(t, err)
 		require.Len(t, out, 1)
-		assert.Equal(t, string(d), out[0].ID)
+		assert.Equal(t, mustUUID(d), out[0].ID)
 		assert.Equal(t, int64(0), out[0].UpdateTime)
 		assert.False(t, out[0].Deleted, "target must never set Deleted=true; tombstone resolution is the source's job")
 	})
@@ -201,21 +201,21 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, a, ts)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(a), UpdateTime: ts + 1},
-			{ID: string(b), UpdateTime: ts + 1},
-			{ID: string(c), UpdateTime: ts + 1},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(a), UpdateTime: ts + 1},
+			{ID: mustUUID(b), UpdateTime: ts + 1},
+			{ID: mustUUID(c), UpdateTime: ts + 1},
 		})
 		require.NoError(t, err)
 		require.Len(t, out, 3)
 		// Sort the output for stable assertions; CompareDigests preserves source order.
-		assert.Equal(t, string(a), out[0].ID)
+		assert.Equal(t, mustUUID(a), out[0].ID)
 		assert.Equal(t, ts, out[0].UpdateTime, "A is stale — must report local UpdateTime")
 		assert.False(t, out[0].Deleted)
-		assert.Equal(t, string(b), out[1].ID)
+		assert.Equal(t, mustUUID(b), out[1].ID)
 		assert.Equal(t, int64(0), out[1].UpdateTime, "B is missing")
 		assert.False(t, out[1].Deleted)
-		assert.Equal(t, string(c), out[2].ID)
+		assert.Equal(t, mustUUID(c), out[2].ID)
 		assert.Equal(t, int64(0), out[2].UpdateTime, "C is missing")
 		assert.False(t, out[2].Deleted)
 	})
@@ -225,16 +225,16 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 		sl, _ := testShard(t, ctx, class)
 		s := concreteShard(t, sl)
 
-		_, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(ids[1]), UpdateTime: ts},
-			{ID: string(ids[0]), UpdateTime: ts},
+		_, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(ids[1]), UpdateTime: ts},
+			{ID: mustUUID(ids[0]), UpdateTime: ts},
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not in strict lex order")
 
-		_, err = s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(ids[0]), UpdateTime: ts},
-			{ID: string(ids[0]), UpdateTime: ts},
+		_, err = s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(ids[0]), UpdateTime: ts},
+			{ID: mustUUID(ids[0]), UpdateTime: ts},
 		})
 		require.Error(t, err, "duplicates violate strict order and must also be rejected")
 	})
@@ -256,10 +256,10 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 		}
 
 		// Take every other UUID — exercises cursor advancement past unmatched keys.
-		probe := make([]routerTypes.RepairResponse, 0, n/2)
+		probe := make([]routerTypes.RepairDigest, 0, n/2)
 		for i := 0; i < n; i += 2 {
-			probe = append(probe, routerTypes.RepairResponse{
-				ID: string(ids[i]), UpdateTime: tsSource,
+			probe = append(probe, routerTypes.RepairDigest{
+				ID: mustUUID(ids[i]), UpdateTime: tsSource,
 			})
 		}
 
@@ -268,7 +268,7 @@ func TestShardCompareDigestsCursorMergeJoin(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, out, len(probe), "every probed UUID is stale — all must be returned")
 		for i, r := range out {
-			assert.Equal(t, string(ids[2*i]), r.ID, "result order must mirror source order")
+			assert.Equal(t, mustUUID(ids[2*i]), r.ID, "result order must mirror source order")
 			assert.Equal(t, tsLocal, r.UpdateTime)
 			assert.False(t, r.Deleted)
 		}
@@ -288,7 +288,11 @@ func orderedUUIDs(n int) []strfmt.UUID {
 	return out
 }
 
-// TestShardCompareDigestsMemtableBounds pins the bounded-memtable-snapshot behavior: unflushed keys outside the source span are invisible, keys inside are joined, and the added last-UUID parse rejects bad input.
+func mustUUID(id strfmt.UUID) uuid.UUID {
+	return uuid.MustParse(string(id))
+}
+
+// TestShardCompareDigestsMemtableBounds pins the bounded-memtable-snapshot behavior: unflushed keys outside the source span are invisible while keys inside are joined.
 func TestShardCompareDigestsMemtableBounds(t *testing.T) {
 	ctx := context.Background()
 	const class = "CompareDigestsMemtableBoundsTest"
@@ -305,18 +309,18 @@ func TestShardCompareDigestsMemtableBounds(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[4], tsLocal)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(ids[1]), UpdateTime: tsSource},
-			{ID: string(ids[2]), UpdateTime: tsSource},
-			{ID: string(ids[3]), UpdateTime: tsSource},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(ids[1]), UpdateTime: tsSource},
+			{ID: mustUUID(ids[2]), UpdateTime: tsSource},
+			{ID: mustUUID(ids[3]), UpdateTime: tsSource},
 		})
 		require.NoError(t, err)
 		require.Len(t, out, 3)
-		assert.Equal(t, string(ids[1]), out[0].ID)
+		assert.Equal(t, mustUUID(ids[1]), out[0].ID)
 		assert.Equal(t, int64(0), out[0].UpdateTime)
-		assert.Equal(t, string(ids[2]), out[1].ID)
+		assert.Equal(t, mustUUID(ids[2]), out[1].ID)
 		assert.Equal(t, tsLocal, out[1].UpdateTime)
-		assert.Equal(t, string(ids[3]), out[2].ID)
+		assert.Equal(t, mustUUID(ids[3]), out[2].ID)
 		assert.Equal(t, int64(0), out[2].UpdateTime)
 	})
 
@@ -328,34 +332,41 @@ func TestShardCompareDigestsMemtableBounds(t *testing.T) {
 		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, ids[2], tsLocal)))
 
 		s := concreteShard(t, sl)
-		out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(ids[0]), UpdateTime: tsLocal},
-			{ID: string(ids[2]), UpdateTime: tsSource},
+		out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+			{ID: mustUUID(ids[0]), UpdateTime: tsLocal},
+			{ID: mustUUID(ids[2]), UpdateTime: tsSource},
 		})
 		require.NoError(t, err)
 		require.Len(t, out, 1)
-		assert.Equal(t, string(ids[2]), out[0].ID)
+		assert.Equal(t, mustUUID(ids[2]), out[0].ID)
 		assert.Equal(t, tsLocal, out[0].UpdateTime)
 	})
+}
 
-	t.Run("InvalidLastUUID_Rejected", func(t *testing.T) {
-		ids := orderedUUIDs(1)
-		sl, _ := testShard(t, ctx, class)
-		s := concreteShard(t, sl)
+func BenchmarkShardCompareDigests(b *testing.B) {
+	ctx := context.Background()
+	const class = "CompareDigestsBench"
+	const n = 1000
 
-		_, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: string(ids[0]), UpdateTime: tsSource},
-			{ID: "not-a-uuid", UpdateTime: tsSource},
-		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "parse source uuid")
+	ids := orderedUUIDs(n)
+	sl, _ := testShard(b, ctx, class)
+	s := concreteShard(b, sl)
+	for i, id := range ids {
+		require.NoError(b, sl.PutObject(ctx, testObjWithTime(class, id, int64(100+i%2))))
+	}
 
-		_, err = s.CompareDigests(ctx, []routerTypes.RepairResponse{
-			{ID: "not-a-uuid", UpdateTime: tsSource},
-		})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "parse source uuid")
-	})
+	probe := make([]routerTypes.RepairDigest, n)
+	for i, id := range ids {
+		probe[i] = routerTypes.RepairDigest{ID: mustUUID(id), UpdateTime: 101}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := s.CompareDigests(ctx, probe); err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 // TestCompareDigestsBatchSizeFitsBodyCap guards that maxDiffBatchSize batches

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -463,7 +463,7 @@ func (l *LazyLoadShard) ObjectDigests(ctx context.Context, query []multi.Identif
 
 func (l *LazyLoadShard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int,
-) (objs []types.RepairResponse, err error) {
+) (objs []types.RepairDigest, err error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err
 	}
@@ -851,7 +851,7 @@ func (l *LazyLoadShard) HashTreeRoot() (root hashtree.Digest, ok bool) {
 	return l.shard.HashTreeRoot()
 }
 
-func (l *LazyLoadShard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+func (l *LazyLoadShard) CompareDigests(ctx context.Context, sourceDigests []types.RepairDigest) ([]types.RepairDigest, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -218,7 +218,7 @@ func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]
 
 func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int) (
-	objs []types.RepairResponse, err error,
+	objs []types.RepairDigest, err error,
 ) {
 	initialUUID16, err := uuid.Parse(initialUUID.String())
 	if err != nil {
@@ -241,7 +241,7 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 // digests with key <= finalKey. The cursor is reused across calls by the
 // async-replication scan, so it must not be opened/closed here.
 func collectObjectDigests(ctx context.Context, cursor *lsmkv.CursorReplace,
-	initialKey, finalKey []byte, limit int) (objs []types.RepairResponse, err error,
+	initialKey, finalKey []byte, limit int) (objs []types.RepairDigest, err error,
 ) {
 	n := 0
 
@@ -260,8 +260,8 @@ func collectObjectDigests(ctx context.Context, cursor *lsmkv.CursorReplace,
 			return objs, fmt.Errorf("cannot parse object uuid: %w", err)
 		}
 
-		objs = append(objs, types.RepairResponse{
-			ID:         uuidParsed.String(),
+		objs = append(objs, types.RepairDigest{
+			ID:         uuidParsed,
 			UpdateTime: updateTime,
 		})
 
@@ -279,22 +279,16 @@ func collectObjectDigests(ctx context.Context, cursor *lsmkv.CursorReplace,
 // post-Overwrite resolveObjectConflict path.
 //
 // sourceDigests must be in strict lex order of the parsed UUID bytes;
-// enforced mid-join, not up front.
-func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+// order is enforced mid-join: out-of-order input is rejected, not silently mis-joined.
+func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.RepairDigest) ([]types.RepairDigest, error) {
 	if len(sourceDigests) == 0 {
 		return nil, nil
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	firstUUID, err := uuid.Parse(sourceDigests[0].ID)
-	if err != nil {
-		return nil, fmt.Errorf("parse source uuid %q: %w", sourceDigests[0].ID, err)
-	}
-	lastUUID, err := uuid.Parse(sourceDigests[len(sourceDigests)-1].ID)
-	if err != nil {
-		return nil, fmt.Errorf("parse source uuid %q: %w", sourceDigests[len(sourceDigests)-1].ID, err)
-	}
+	firstUUID := sourceDigests[0].ID
+	lastUUID := sourceDigests[len(sourceDigests)-1].ID
 
 	// Digest mode: only the header is read below (localTime), skip the full
 	// value. The join only inspects keys within the source digest span, so the
@@ -304,19 +298,15 @@ func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.Repair
 
 	cursorKey, cursorVal := cursor.Seek(firstUUID[:])
 
-	result := make([]types.RepairResponse, 0, len(sourceDigests))
+	result := make([]types.RepairDigest, 0, len(sourceDigests))
 	var prevUUID uuid.UUID
-	var prevID string
 	for i, d := range sourceDigests {
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
-		srcUUID, err := uuid.Parse(d.ID)
-		if err != nil {
-			return nil, fmt.Errorf("parse source uuid %q: %w", d.ID, err)
-		}
+		srcUUID := d.ID
 		if i > 0 && bytes.Compare(srcUUID[:], prevUUID[:]) <= 0 {
-			return nil, fmt.Errorf("source digests not in strict lex order: %q after %q", d.ID, prevID)
+			return nil, fmt.Errorf("source digests not in strict lex order: %q after %q", srcUUID, prevUUID)
 		}
 
 		for cursorKey != nil && bytes.Compare(cursorKey, srcUUID[:]) < 0 {
@@ -326,18 +316,17 @@ func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.Repair
 		if cursorKey != nil && bytes.Equal(cursorKey, srcUUID[:]) {
 			_, localTime, err := storobj.DocIDAndTimeFromBinary(cursorVal)
 			if err != nil {
-				return nil, fmt.Errorf("extract update time for %q: %w", d.ID, err)
+				return nil, fmt.Errorf("extract update time for %q: %w", srcUUID, err)
 			}
 			if d.UpdateTime > localTime {
-				result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: localTime})
+				result = append(result, types.RepairDigest{ID: d.ID, UpdateTime: localTime})
 			}
 			cursorKey, cursorVal = cursor.Next()
 		} else {
-			result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: 0})
+			result = append(result, types.RepairDigest{ID: d.ID, UpdateTime: 0})
 		}
 
 		prevUUID = srcUUID
-		prevID = d.ID
 	}
 
 	return result, nil

--- a/adapters/repos/db/shard_skipupsert_timestamp_test.go
+++ b/adapters/repos/db/shard_skipupsert_timestamp_test.go
@@ -81,8 +81,8 @@ func TestPutIdenticalContentAdvancesUpdateTime(t *testing.T) {
 			require.NotNil(t, obj)
 			assert.Equal(t, tt.wantStoredTime, obj.LastUpdateTimeUnix())
 
-			out, err := s.CompareDigests(ctx, []routerTypes.RepairResponse{
-				{ID: string(uuidLow), UpdateTime: tt.wantStoredTime},
+			out, err := s.CompareDigests(ctx, []routerTypes.RepairDigest{
+				{ID: mustUUID(uuidLow), UpdateTime: tt.wantStoredTime},
 			})
 			require.NoError(t, err)
 			assert.Empty(t, out, "replicas converged; no further propagation expected")

--- a/cluster/router/types/repair_response.go
+++ b/cluster/router/types/repair_response.go
@@ -11,10 +11,21 @@
 
 package types
 
+import "github.com/google/uuid"
+
 type RepairResponse struct {
 	ID         string // object id
 	Version    int64  // sender's current version of the object
 	UpdateTime int64  // sender's current update time
 	Err        string
+	Deleted    bool
+}
+
+// RepairDigest is the byte-ID digest used end-to-end on the async-replication
+// compare/propagate pipeline; the string-ID RepairResponse survives only at
+// JSON and proto boundaries. Field set mirrors the binary wire records.
+type RepairDigest struct {
+	ID         uuid.UUID
+	UpdateTime int64
 	Deleted    bool
 }

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -638,7 +638,7 @@ func (c *fakeReplicationClient) FindUUIDs(ctx context.Context, host, index, shar
 
 func (c *fakeReplicationClient) DigestObjectsInRange(ctx context.Context, host, index, shard string,
 	initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	return nil, nil
 }
 
@@ -649,8 +649,8 @@ func (c *fakeReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 }
 
 func (c *fakeReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
-	digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	return nil, nil
 }
 

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -534,15 +534,15 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 
 func (f *Finder) DigestObjectsInRange(ctx context.Context,
 	shardName string, host string, initialUUID, finalUUID strfmt.UUID, limit int,
-) (ds []types.RepairResponse, err error) {
+) (ds []types.RepairDigest, err error) {
 	return f.client.DigestObjectsInRange(ctx, host, f.class, shardName, initialUUID, finalUUID, limit)
 }
 
 // CompareDigests is a thin transport wrapper around the remote shard's
 // comparator; see RClient.CompareDigests for the contract.
 func (f *Finder) CompareDigests(ctx context.Context,
-	shardName string, host string, digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	shardName string, host string, digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	return f.client.CompareDigests(ctx, host, f.class, shardName, digests)
 }
 

--- a/usecases/replica/mock_r_client.go
+++ b/usecases/replica/mock_r_client.go
@@ -49,27 +49,27 @@ func (_m *MockRClient) EXPECT() *MockRClient_Expecter {
 }
 
 // CompareDigests provides a mock function with given fields: ctx, host, index, shard, digests
-func (_m *MockRClient) CompareDigests(ctx context.Context, host string, index string, shard string, digests []types.RepairResponse) ([]types.RepairResponse, error) {
+func (_m *MockRClient) CompareDigests(ctx context.Context, host string, index string, shard string, digests []types.RepairDigest) ([]types.RepairDigest, error) {
 	ret := _m.Called(ctx, host, index, shard, digests)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CompareDigests")
 	}
 
-	var r0 []types.RepairResponse
+	var r0 []types.RepairDigest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []types.RepairResponse) ([]types.RepairResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []types.RepairDigest) ([]types.RepairDigest, error)); ok {
 		return rf(ctx, host, index, shard, digests)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []types.RepairResponse) []types.RepairResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []types.RepairDigest) []types.RepairDigest); ok {
 		r0 = rf(ctx, host, index, shard, digests)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.RepairResponse)
+			r0 = ret.Get(0).([]types.RepairDigest)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, []types.RepairResponse) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, []types.RepairDigest) error); ok {
 		r1 = rf(ctx, host, index, shard, digests)
 	} else {
 		r1 = ret.Error(1)
@@ -88,24 +88,24 @@ type MockRClient_CompareDigests_Call struct {
 //   - host string
 //   - index string
 //   - shard string
-//   - digests []types.RepairResponse
+//   - digests []types.RepairDigest
 func (_e *MockRClient_Expecter) CompareDigests(ctx interface{}, host interface{}, index interface{}, shard interface{}, digests interface{}) *MockRClient_CompareDigests_Call {
 	return &MockRClient_CompareDigests_Call{Call: _e.mock.On("CompareDigests", ctx, host, index, shard, digests)}
 }
 
-func (_c *MockRClient_CompareDigests_Call) Run(run func(ctx context.Context, host string, index string, shard string, digests []types.RepairResponse)) *MockRClient_CompareDigests_Call {
+func (_c *MockRClient_CompareDigests_Call) Run(run func(ctx context.Context, host string, index string, shard string, digests []types.RepairDigest)) *MockRClient_CompareDigests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].([]types.RepairResponse))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].([]types.RepairDigest))
 	})
 	return _c
 }
 
-func (_c *MockRClient_CompareDigests_Call) Return(_a0 []types.RepairResponse, _a1 error) *MockRClient_CompareDigests_Call {
+func (_c *MockRClient_CompareDigests_Call) Return(_a0 []types.RepairDigest, _a1 error) *MockRClient_CompareDigests_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockRClient_CompareDigests_Call) RunAndReturn(run func(context.Context, string, string, string, []types.RepairResponse) ([]types.RepairResponse, error)) *MockRClient_CompareDigests_Call {
+func (_c *MockRClient_CompareDigests_Call) RunAndReturn(run func(context.Context, string, string, string, []types.RepairDigest) ([]types.RepairDigest, error)) *MockRClient_CompareDigests_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -394,23 +394,23 @@ func (_c *MockRClient_DigestObjects_Call) RunAndReturn(run func(context.Context,
 }
 
 // DigestObjectsInRange provides a mock function with given fields: ctx, host, index, shard, initialUUID, finalUUID, limit
-func (_m *MockRClient) DigestObjectsInRange(ctx context.Context, host string, index string, shard string, initialUUID strfmt.UUID, finalUUID strfmt.UUID, limit int) ([]types.RepairResponse, error) {
+func (_m *MockRClient) DigestObjectsInRange(ctx context.Context, host string, index string, shard string, initialUUID strfmt.UUID, finalUUID strfmt.UUID, limit int) ([]types.RepairDigest, error) {
 	ret := _m.Called(ctx, host, index, shard, initialUUID, finalUUID, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DigestObjectsInRange")
 	}
 
-	var r0 []types.RepairResponse
+	var r0 []types.RepairDigest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, strfmt.UUID, strfmt.UUID, int) ([]types.RepairResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, strfmt.UUID, strfmt.UUID, int) ([]types.RepairDigest, error)); ok {
 		return rf(ctx, host, index, shard, initialUUID, finalUUID, limit)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, strfmt.UUID, strfmt.UUID, int) []types.RepairResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, strfmt.UUID, strfmt.UUID, int) []types.RepairDigest); ok {
 		r0 = rf(ctx, host, index, shard, initialUUID, finalUUID, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.RepairResponse)
+			r0 = ret.Get(0).([]types.RepairDigest)
 		}
 	}
 
@@ -447,12 +447,12 @@ func (_c *MockRClient_DigestObjectsInRange_Call) Run(run func(ctx context.Contex
 	return _c
 }
 
-func (_c *MockRClient_DigestObjectsInRange_Call) Return(_a0 []types.RepairResponse, _a1 error) *MockRClient_DigestObjectsInRange_Call {
+func (_c *MockRClient_DigestObjectsInRange_Call) Return(_a0 []types.RepairDigest, _a1 error) *MockRClient_DigestObjectsInRange_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockRClient_DigestObjectsInRange_Call) RunAndReturn(run func(context.Context, string, string, string, strfmt.UUID, strfmt.UUID, int) ([]types.RepairResponse, error)) *MockRClient_DigestObjectsInRange_Call {
+func (_c *MockRClient_DigestObjectsInRange_Call) RunAndReturn(run func(context.Context, string, string, string, strfmt.UUID, strfmt.UUID, int) ([]types.RepairDigest, error)) *MockRClient_DigestObjectsInRange_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/replica/repair_digests_codec.go
+++ b/usecases/replica/repair_digests_codec.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+)
+
+// Digest payload encodings declared on the gRPC digest RPCs; zero keeps older
+// peers on the repeated-proto path.
+const (
+	RepairDigestsEncodingProto  uint32 = 0
+	RepairDigestsEncodingPacked uint32 = 1
+)
+
+// RepairDigestsToBinary encodes digests as fixed CompareDigestsRecordLength
+// records — the shared wire format of the REST compareDigests endpoint and the
+// gRPC packed encoding.
+func RepairDigestsToBinary(digests []types.RepairDigest) []byte {
+	out := make([]byte, 0, len(digests)*CompareDigestsRecordLength)
+	var buf [CompareDigestsRecordLength]byte
+	for _, d := range digests {
+		copy(buf[:16], d.ID[:])
+		binary.BigEndian.PutUint64(buf[16:24], uint64(d.UpdateTime))
+		buf[24] = 0
+		if d.Deleted {
+			buf[24] = CompareDigestsFlagDeleted
+		}
+		out = append(out, buf[:]...)
+	}
+	return out
+}
+
+// RepairDigestsFromBinary decodes a RepairDigestsToBinary payload, rejecting
+// any length that is not a whole number of records.
+func RepairDigestsFromBinary(data []byte) ([]types.RepairDigest, error) {
+	if len(data)%CompareDigestsRecordLength != 0 {
+		return nil, fmt.Errorf("invalid packed digests length %d: not a multiple of %d",
+			len(data), CompareDigestsRecordLength)
+	}
+	digests := make([]types.RepairDigest, len(data)/CompareDigestsRecordLength)
+	for i := range digests {
+		rec := data[i*CompareDigestsRecordLength : (i+1)*CompareDigestsRecordLength]
+		id, err := uuid.FromBytes(rec[:16])
+		if err != nil {
+			return nil, fmt.Errorf("parse uuid from binary record: %w", err)
+		}
+		digests[i] = types.RepairDigest{
+			ID:         id,
+			UpdateTime: int64(binary.BigEndian.Uint64(rec[16:24])),
+			Deleted:    rec[24]&CompareDigestsFlagDeleted != 0,
+		}
+	}
+	return digests, nil
+}

--- a/usecases/replica/repair_digests_codec_test.go
+++ b/usecases/replica/repair_digests_codec_test.go
@@ -1,0 +1,62 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+)
+
+func TestRepairDigestsBinaryCodec(t *testing.T) {
+	digests := []types.RepairDigest{
+		{ID: uuid.MustParse("00000000-0000-0000-0000-000000000001"), UpdateTime: 1},
+		{ID: uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff"), UpdateTime: math.MaxInt64, Deleted: true},
+		{ID: uuid.New(), UpdateTime: -42},
+		{ID: uuid.UUID{}, UpdateTime: 0},
+	}
+
+	t.Run("round trip", func(t *testing.T) {
+		decoded, err := RepairDigestsFromBinary(RepairDigestsToBinary(digests))
+		require.NoError(t, err)
+		assert.Equal(t, digests, decoded)
+	})
+
+	t.Run("record layout", func(t *testing.T) {
+		out := RepairDigestsToBinary(digests[:2])
+		require.Len(t, out, 2*CompareDigestsRecordLength)
+		assert.Equal(t, digests[0].ID[:], out[:16])
+		assert.Equal(t, uint64(1), binary.BigEndian.Uint64(out[16:24]))
+		assert.Equal(t, byte(0), out[24])
+		assert.Equal(t, CompareDigestsFlagDeleted, out[2*CompareDigestsRecordLength-1])
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		assert.Empty(t, RepairDigestsToBinary(nil))
+		decoded, err := RepairDigestsFromBinary(nil)
+		require.NoError(t, err)
+		assert.Empty(t, decoded)
+	})
+
+	t.Run("invalid lengths", func(t *testing.T) {
+		for _, n := range []int{1, 24, 26, 49, 51} {
+			_, err := RepairDigestsFromBinary(make([]byte, n))
+			assert.ErrorContains(t, err, "not a multiple", "length %d", n)
+		}
+	})
+}

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -138,7 +138,7 @@ type RClient interface {
 		filters *filters.LocalFilter, limit int) ([]strfmt.UUID, error)
 
 	DigestObjectsInRange(ctx context.Context, host, index, shard string,
-		initialUUID, finalUUID strfmt.UUID, limit int) ([]types.RepairResponse, error)
+		initialUUID, finalUUID strfmt.UUID, limit int) ([]types.RepairDigest, error)
 
 	// CompareDigests sends the source's local digests to the target and returns
 	// only the subset needing source-side action: objects missing on the target
@@ -148,7 +148,7 @@ type RClient interface {
 	// objects are never returned (identical hashtree digests, hence already
 	// invisible to the hashtree diff that drives this call).
 	CompareDigests(ctx context.Context, host, index, shard string,
-		digests []types.RepairResponse) ([]types.RepairResponse, error)
+		digests []types.RepairDigest) ([]types.RepairDigest, error)
 
 	HashTreeLevel(ctx context.Context, host, index, shard string, level int,
 		discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
@@ -209,14 +209,14 @@ func (fc FinderClient) DigestReads(ctx context.Context,
 func (fc FinderClient) DigestObjectsInRange(ctx context.Context,
 	host, index, shard string,
 	initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	return fc.cl.DigestObjectsInRange(ctx, host, index, shard, initialUUID, finalUUID, limit)
 }
 
 func (fc FinderClient) CompareDigests(ctx context.Context,
 	host, index, shard string,
-	digests []types.RepairResponse,
-) ([]types.RepairResponse, error) {
+	digests []types.RepairDigest,
+) ([]types.RepairDigest, error) {
 	return fc.cl.CompareDigests(ctx, host, index, shard, digests)
 }
 

--- a/usecases/replica/types/mock_replicator.go
+++ b/usecases/replica/types/mock_replicator.go
@@ -150,27 +150,27 @@ func (_c *MockReplicator_CommitReplication_Call) RunAndReturn(run func(context.C
 }
 
 // CompareDigests provides a mock function with given fields: ctx, className, shardName, digests
-func (_m *MockReplicator) CompareDigests(ctx context.Context, className string, shardName string, digests []routertypes.RepairResponse) ([]routertypes.RepairResponse, error) {
+func (_m *MockReplicator) CompareDigests(ctx context.Context, className string, shardName string, digests []routertypes.RepairDigest) ([]routertypes.RepairDigest, error) {
 	ret := _m.Called(ctx, className, shardName, digests)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CompareDigests")
 	}
 
-	var r0 []routertypes.RepairResponse
+	var r0 []routertypes.RepairDigest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, []routertypes.RepairResponse) ([]routertypes.RepairResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []routertypes.RepairDigest) ([]routertypes.RepairDigest, error)); ok {
 		return rf(ctx, className, shardName, digests)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, []routertypes.RepairResponse) []routertypes.RepairResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []routertypes.RepairDigest) []routertypes.RepairDigest); ok {
 		r0 = rf(ctx, className, shardName, digests)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]routertypes.RepairResponse)
+			r0 = ret.Get(0).([]routertypes.RepairDigest)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, []routertypes.RepairResponse) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, []routertypes.RepairDigest) error); ok {
 		r1 = rf(ctx, className, shardName, digests)
 	} else {
 		r1 = ret.Error(1)
@@ -188,24 +188,24 @@ type MockReplicator_CompareDigests_Call struct {
 //   - ctx context.Context
 //   - className string
 //   - shardName string
-//   - digests []routertypes.RepairResponse
+//   - digests []routertypes.RepairDigest
 func (_e *MockReplicator_Expecter) CompareDigests(ctx interface{}, className interface{}, shardName interface{}, digests interface{}) *MockReplicator_CompareDigests_Call {
 	return &MockReplicator_CompareDigests_Call{Call: _e.mock.On("CompareDigests", ctx, className, shardName, digests)}
 }
 
-func (_c *MockReplicator_CompareDigests_Call) Run(run func(ctx context.Context, className string, shardName string, digests []routertypes.RepairResponse)) *MockReplicator_CompareDigests_Call {
+func (_c *MockReplicator_CompareDigests_Call) Run(run func(ctx context.Context, className string, shardName string, digests []routertypes.RepairDigest)) *MockReplicator_CompareDigests_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].([]routertypes.RepairResponse))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].([]routertypes.RepairDigest))
 	})
 	return _c
 }
 
-func (_c *MockReplicator_CompareDigests_Call) Return(_a0 []routertypes.RepairResponse, _a1 error) *MockReplicator_CompareDigests_Call {
+func (_c *MockReplicator_CompareDigests_Call) Return(_a0 []routertypes.RepairDigest, _a1 error) *MockReplicator_CompareDigests_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockReplicator_CompareDigests_Call) RunAndReturn(run func(context.Context, string, string, []routertypes.RepairResponse) ([]routertypes.RepairResponse, error)) *MockReplicator_CompareDigests_Call {
+func (_c *MockReplicator_CompareDigests_Call) RunAndReturn(run func(context.Context, string, string, []routertypes.RepairDigest) ([]routertypes.RepairDigest, error)) *MockReplicator_CompareDigests_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -488,23 +488,23 @@ func (_c *MockReplicator_DigestObjects_Call) RunAndReturn(run func(context.Conte
 }
 
 // DigestObjectsInRange provides a mock function with given fields: ctx, className, shardName, initialUUID, finalUUID, limit
-func (_m *MockReplicator) DigestObjectsInRange(ctx context.Context, className string, shardName string, initialUUID strfmt.UUID, finalUUID strfmt.UUID, limit int) ([]routertypes.RepairResponse, error) {
+func (_m *MockReplicator) DigestObjectsInRange(ctx context.Context, className string, shardName string, initialUUID strfmt.UUID, finalUUID strfmt.UUID, limit int) ([]routertypes.RepairDigest, error) {
 	ret := _m.Called(ctx, className, shardName, initialUUID, finalUUID, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DigestObjectsInRange")
 	}
 
-	var r0 []routertypes.RepairResponse
+	var r0 []routertypes.RepairDigest
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, strfmt.UUID, strfmt.UUID, int) ([]routertypes.RepairResponse, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, strfmt.UUID, strfmt.UUID, int) ([]routertypes.RepairDigest, error)); ok {
 		return rf(ctx, className, shardName, initialUUID, finalUUID, limit)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, strfmt.UUID, strfmt.UUID, int) []routertypes.RepairResponse); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, strfmt.UUID, strfmt.UUID, int) []routertypes.RepairDigest); ok {
 		r0 = rf(ctx, className, shardName, initialUUID, finalUUID, limit)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]routertypes.RepairResponse)
+			r0 = ret.Get(0).([]routertypes.RepairDigest)
 		}
 	}
 
@@ -540,12 +540,12 @@ func (_c *MockReplicator_DigestObjectsInRange_Call) Run(run func(ctx context.Con
 	return _c
 }
 
-func (_c *MockReplicator_DigestObjectsInRange_Call) Return(result []routertypes.RepairResponse, err error) *MockReplicator_DigestObjectsInRange_Call {
+func (_c *MockReplicator_DigestObjectsInRange_Call) Return(result []routertypes.RepairDigest, err error) *MockReplicator_DigestObjectsInRange_Call {
 	_c.Call.Return(result, err)
 	return _c
 }
 
-func (_c *MockReplicator_DigestObjectsInRange_Call) RunAndReturn(run func(context.Context, string, string, strfmt.UUID, strfmt.UUID, int) ([]routertypes.RepairResponse, error)) *MockReplicator_DigestObjectsInRange_Call {
+func (_c *MockReplicator_DigestObjectsInRange_Call) RunAndReturn(run func(context.Context, string, string, strfmt.UUID, strfmt.UUID, int) ([]routertypes.RepairDigest, error)) *MockReplicator_DigestObjectsInRange_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/replica/types/replicator.go
+++ b/usecases/replica/types/replicator.go
@@ -41,10 +41,10 @@ type Replicator interface {
 	FetchObjects(ctx context.Context, className, shardName string, ids []strfmt.UUID) ([]replica.Replica, error)
 	DigestObjects(ctx context.Context, className, shardName string, ids []strfmt.UUID) (result []types.RepairResponse, err error)
 	DigestObjectsInRange(ctx context.Context, className, shardName string,
-		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairResponse, err error)
+		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairDigest, err error)
 	// CompareDigests accepts a batch of source digests and returns only those that require repair
 	// (missing, stale, or tombstoned on this node). Eliminates the two-round-trip pattern.
-	CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error)
+	CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairDigest) ([]types.RepairDigest, error)
 	HashTreeLevel(ctx context.Context, className, shardName string,
 		level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 	// CompareHashTreeRoots returns shards whose local root was read and differs;

--- a/usecases/sharding/remote_index_incoming.go
+++ b/usecases/sharding/remote_index_incoming.go
@@ -88,7 +88,7 @@ type RemoteIndexIncomingRepo interface {
 	IncomingDigestObjects(ctx context.Context, shardName string,
 		ids []strfmt.UUID) (result []types.RepairResponse, err error)
 	IncomingDigestObjectsInRange(ctx context.Context, shardName string,
-		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairResponse, err error)
+		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairDigest, err error)
 	IncomingHashTreeLevel(ctx context.Context, shardName string,
 		level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 	IncomingCountObjects(ctx context.Context, shardName string) (int, error)
@@ -378,7 +378,7 @@ func (rii *RemoteIndexIncoming) IndexForIncomingWrite(ctx context.Context, index
 
 func (rii *RemoteIndexIncoming) DigestObjectsInRange(ctx context.Context,
 	indexName, shardName string, initialUUID, finalUUID strfmt.UUID, limit int,
-) ([]types.RepairResponse, error) {
+) ([]types.RepairDigest, error) {
 	index := rii.repo.GetIndexForIncomingSharding(schema.ClassName(indexName))
 	if index == nil {
 		return nil, fmt.Errorf("local index %q not found", indexName)


### PR DESCRIPTION
## Motivation

Async replication's compare/propagate pipeline (`ObjectDigestsInRange` → `CompareDigests` → source-side filter) carried object IDs as strings in `types.RepairResponse` while every binary wire hop was already byte-based. Each 1000-digest `CompareDigests` round trip paid ≥4000 UUID text conversions and ~2000 string allocations: IDs were stringified per scanned key at the LSM cursor, re-parsed for the merge join, re-materialized and re-parsed in the REST handler and client, and parsed once more in the source-side filter. Hashbeat digest traffic runs continuously on every replicated shard, so this was a steady background tax on top of the wins from #12665.

## Approach

The pipeline now uses [`types.RepairDigest{ID uuid.UUID; UpdateTime; Deleted}`](https://github.com/weaviate/weaviate/blob/59d9bab5c4/cluster/router/types/repair_response.go#L27) end-to-end. String IDs survive only at two edges, converted exactly once each:

- the legacy REST JSON fallback (peers predating the binary encoding), and
- the legacy gRPC proto-records dialect (`pb.RepairResponse` with string `id`), kept only for traffic with older peers — see the gRPC section below.

Wire formats are bit-for-bit unchanged on all three encodings (binary REST records, legacy JSON, proto). `RepairDigest` drops the `Version`/`Err` fields, but no digest producer ever populated them, and proto3 omits zero scalars — so the proto bytes are identical too. The read-repair `DigestObjects` path, which does use those fields, keeps `RepairResponse` untouched.

A semantic tightening falls out of the design: an unparseable ID can now only appear at a boundary, where it fails the RPC loudly (client-side parse error; server-side `InvalidArgument`) instead of being logged-and-skipped deep inside the propagation filter. Interior digests are valid by construction, so the two log-and-skip paths in `objectsToPropagateWithinRange` are gone.

## gRPC packed digests (second commit)

The gRPC digest RPCs (`CompareDigests`, `DigestObjectsInRange`) now carry digests as **packed 25-byte records** — the exact REST compareDigests wire format (16B UUID + 8B BE UpdateTime + 1B flags), extracted into a shared codec (`replica.RepairDigestsToBinary/FromBinary`) that the REST writer/reader and both gRPC ends reuse. This removes the per-digest `pb.RepairResponse` allocation and the uuid format/parse per record on both peers.

Encoding declaration follows the `OverwriteObjectsRequest.encoding` precedent (sender declares in-message); packed **replies** are additionally gated on a `accept_encoding` request field (the #12666 pattern), so servers only emit packed when asked. New proto fields (additions only; freeze: `CompareDigestsRequest` 4–6, `CompareDigestsResponse` 2–3, `DigestObjectsInRangeRequest` 6, `DigestObjectsInRangeResponse` 2–3 — no overlap with #12666's HashTreeLevel fields).

Mixed-version behavior — fully functional in every direction, no repair pause:

| Direction | Behavior during mixed window |
|---|---|
| new client → old server, `CompareDigests` | fully functional: a packed-aware server always echoes the packed encoding when asked, so a proto-encoded reply deterministically identifies a legacy peer that compared an empty list — the client resends that batch once in the proto dialect (one extra RPC per batch, legacy peers only) |
| old client → new server (both RPCs) | fully functional (server decodes both dialects, replies proto records) |
| new client → old server, `DigestObjectsInRange` | fully functional (client decodes the proto-records reply) |
| new ↔ new | packed both ways, zero string conversions, no resends |

All packed decodes are hardened: length-multiple-of-record checks, `CompareDigestsMaxBodyBytes` cap server-side, and response-size bounds client-side (sent-digest count × record for `CompareDigests`, `limit` × record for `DigestObjectsInRange`) — malformed payloads fail with `InvalidArgument`/wrapped errors, never a slice panic. Unknown `encoding` values fail closed on both ends (`InvalidArgument` server-side, wrapped error client-side) instead of being misread as the proto dialect and compared as an empty list.

## Measured

New `BenchmarkShardCompareDigests` (1000-digest merge join against a real shard — the server-side hop only; medians of 5×300 iterations):

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before (string IDs) | 112,756 | 202,128 | 2,015 |
| after (byte IDs) | 82,166 | 177,552 | 2,015 |

−27% time and −12% bytes on the join alone (smaller result records; no per-record parse). The per-record string allocations eliminated by this PR live in the hops the benchmark doesn't cover — cursor-side `String()` per scanned key, and the REST/gRPC client decode paths — roughly 2 conversions and 1 allocation per digest on top of the join-side win.

## Key areas for review

- [`shard_read.go:283`](https://github.com/weaviate/weaviate/blob/59d9bab5c4/adapters/repos/db/shard_read.go#L283) — `Shard.CompareDigests` merge join now compares raw 16-byte keys; verify the strict-order rejection survives intact (`bytes.Compare` on ID bytes, still enforced mid-join)
- [`shard_async_replication.go:2247`](https://github.com/weaviate/weaviate/blob/59d9bab5c4/adapters/repos/db/shard_async_replication.go#L2247) — `objectsToPropagateWithinRange` deletes the two invalid-UUID log-and-skip paths; confirm you agree they're unreachable now that IDs enter the pipeline only via boundary parses
- [`indices_replicas.go:581`](https://github.com/weaviate/weaviate/blob/59d9bab5c4/adapters/handlers/rest/clusterapi/indices_replicas.go#L581) — binary writers copy `d.ID[:]` directly; the "encode before headers" defensive comments went away because encoding can no longer fail mid-stream (the body is still fully built before any write)
- `adapters/clients/replication.go`, `replication_grpc.go`, `clusterapi/grpc/replication_service.go` — the four edge conversions; each rejects malformed IDs with an error rather than propagating garbage

## Risks and mitigations

- **Mixed-version clusters**: no wire change on any encoding. The legacy JSON fallback keeps the exact `RepairResponse` shape via an edge conversion, and the binary framing hardening (strict record-length validation, peer-controlled Content-Length capping from #12564) is untouched.
- **Stricter malformed-ID handling**: a peer sending an unparseable UUID now fails the RPC instead of having the record silently dropped. A healthy peer cannot do this — IDs originate from UUIDs parsed off LSM keys — so the only affected sender is a corrupt or buggy one, and failing loudly beats silently under-repairing.
- **Field narrowing**: `Version`/`Err` disappear from the digest path only; verified against the parent commit that no digest producer ever set them.

## Testing

- `shard_compare_digests_test.go` (integrationTest, `-race`): full join matrix on the new type — empty input, newer/older/equal timestamps, missing keys, tombstone flags, out-of-order and duplicate source rejection, result-order-mirrors-source, and the bounded-memtable-span pin from #12665 — plus the new benchmark
- gRPC `server_test.go` round-trips `DigestObjectsInRange`/`CompareDigests` through a real client/server pair; REST client tests cover both the binary stream decode and the legacy JSON fallback conversion
- Unit suites for `adapters/clients`, `clusterapi` (+`/grpc`), `usecases/replica`, `cluster/router` pass; `golangci-lint` clean on all touched packages
- gRPC packed encoding: shared-codec round-trip/malformed-input tests; service-level dialect tests (packed/proto requests, accept-gated replies, `InvalidArgument` on garbage and on unknown encodings); real client/server-pair round-trips for both RPCs; bufconn client tests incl. old-server simulations pinning the proto-dialect fallback resend (plus the peer-upgraded-between-resends race and the no-spurious-resend path), unknown-encoding rejection on both reply decodes, and oversized/truncated payload rejection
- Live 3-node chaos check on a `-race` build with `REPLICATION_GRPC_ENABLED=true`: divergent CL=ONE writes under node stop and SIGKILL healed via the packed gRPC digest path (21 shards digest-identical in ≤6 s), zero panics/races in logs; the `async-replication-grpc` CI matrix job covers the acceptance suite on this transport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

