### PR TITLE
RAFT: Wait for a new leader to catch up before it validates schema writes

### DIFF
--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -313,6 +313,17 @@ func (s *Raft) UpdateTenantsProcess(ctx context.Context, class string, req *cmd.
 	return s.Execute(ctx, command)
 }
 
+// classifyLeaderErr marks err for the retry loop in [Raft.Execute]. Only
+// raft.ErrNotLeader and raft.ErrLeadershipLost clear by trying again; every other
+// error fails the caller rather than repeating a wait that has already timed out.
+// Nil stays nil.
+func classifyLeaderErr(err error) error {
+	if errors.Is(err, raft.ErrNotLeader) || errors.Is(err, raft.ErrLeadershipLost) {
+		return err
+	}
+	return backoff.Permanent(err)
+}
+
 func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, error) {
 	t := prometheus.NewTimer(
 		monitoring.GetMetrics().SchemaWrites.WithLabelValues(
@@ -334,11 +345,7 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 		// We are the leader, let's apply
 		if s.store.IsLeader() {
 			schemaVersion, err = s.store.Execute(req)
-			// We might fail due to leader not found as we are losing or transferring leadership, retry
-			if errors.Is(err, raft.ErrNotLeader) || errors.Is(err, raft.ErrLeadershipLost) {
-				return err
-			}
-			return backoff.Permanent(err)
+			return classifyLeaderErr(err)
 		}
 
 		leader := s.store.Leader()

--- a/cluster/raft_namespace_endpoints_test.go
+++ b/cluster/raft_namespace_endpoints_test.go
@@ -13,9 +13,7 @@ package cluster
 
 import (
 	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,7 +32,6 @@ func setupRaftForNamespaceTests(t *testing.T) (*Raft, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
 	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
-	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
 
 	m.indexer.On("Open", Anything).Return(nil)
 	m.indexer.On("Close", Anything).Return(nil)
@@ -42,10 +39,7 @@ func setupRaftForNamespaceTests(t *testing.T) (*Raft, context.Context, func()) {
 
 	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	require.NoError(t, srv.Open(ctx, m.indexer))
-	require.NoError(t, srv.store.Notify(m.cfg.NodeID, addr))
-	require.NoError(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	require.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
-	require.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
+	electRaftLeader(t, srv, &m)
 
 	cleanup := func() {
 		_ = srv.Close(ctx)

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -37,7 +37,6 @@ import (
 func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	ctx := context.Background()
 	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
-	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
 	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 
 	// Open
@@ -45,10 +44,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 
 	// Ensure Raft starts and a leader is elected
-	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
-	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
+	electRaftLeader(t, srv, &m)
 
 	// DeleteClass
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
@@ -108,10 +104,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	// shall be called because of restoring from snapshot
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return().Once()
 	assert.Nil(t, srv.Open(ctx, m.indexer))
-	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
-	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
+	electRaftLeader(t, srv, &m)
 
 	// Ensure that the class has been restored and that the tenant is present with the right state
 	schemaReader = srv.SchemaReader()
@@ -131,16 +124,13 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 func TestSnapshotRestoreReloadsDBBeforeWaitToRestoreDB(t *testing.T) {
 	ctx := context.Background()
 	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
-	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
 	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 
 	// Seed a node: one class, then snapshot as the last raft entry so the
 	// reopen restores through the snapshot path.
 	m.indexer.On("Open", Anything).Return(nil)
 	require.NoError(t, srv.Open(ctx, m.indexer))
-	require.NoError(t, srv.store.Notify(m.cfg.NodeID, addr))
-	require.NoError(t, srv.WaitUntilDBRestored(ctx, time.Second, make(chan struct{})))
-	require.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
+	electRaftLeader(t, srv, &m)
 
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 	m.indexer.On("AddClass", Anything).Return(nil)

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -238,6 +238,11 @@ type Store struct {
 	// applyTimeout timeout limit the amount of time raft waits for a command to be applied
 	applyTimeout time.Duration
 
+	// fsmCaughtUpTerm is the leader term whose FSM catch-up a barrier has already
+	// confirmed; see [Store.waitLeaderFSMCaughtUp]. Zero until the first barrier
+	// succeeds.
+	fsmCaughtUpTerm atomic.Uint64
+
 	// raft snapshot store
 	snapshotStore *raft.FileSnapshotStore
 
@@ -813,6 +818,37 @@ func (st *Store) IsLeader() bool {
 	return st.raft != nil && st.raft.State() == raft.Leader
 }
 
+// waitLeaderFSMCaughtUp returns once this leader's FSM has applied everything
+// committed before it took office. Callers must already be leader.
+//
+// raft reports leadership as soon as the election is won, so without this
+// PreApplyFilter in [Store.Execute] would judge a propose against a schema map
+// that is behind the log this node is already leading. A barrier entry applies
+// after everything ahead of it, which is where the map is trustworthy again.
+//
+// One barrier per term covers the lag a leader inherits at election, not the
+// order of two proposes within a term, and concurrent first proposes each append
+// their own. The wait is unbounded if the FSM stops draining, as the raft.Apply
+// in [Store.Execute] already is.
+func (st *Store) waitLeaderFSMCaughtUp() error {
+	term := st.raft.CurrentTerm()
+	// fsmCaughtUpTerm's zero value means no term has been confirmed, and raft reports
+	// term 0 until the first election, so that pair must not read as a match. No
+	// leader is ever in that state, but a non-leader caller is, which is what the
+	// failure test exercises.
+	if term != 0 && st.fsmCaughtUpTerm.Load() == term {
+		return nil
+	}
+	if err := st.raft.Barrier(st.applyTimeout).Error(); err != nil {
+		st.log.Warnf("leader FSM catch-up barrier failed on term %d: %v", term, err)
+		return fmt.Errorf("waiting for leader FSM to catch up: %w", err)
+	}
+	// Stamping the term read above is safe even if a later term has since begun:
+	// terms only climb, so a stale stamp never matches and only costs a barrier.
+	st.fsmCaughtUpTerm.Store(term)
+	return nil
+}
+
 // SchemaReader returns a SchemaReader from the underlying schema manager using a wait function that will make it wait
 // for a raft log entry to be applied in the FSM Store before authorizing the read to continue.
 func (st *Store) SchemaReader() schema.SchemaReader {
@@ -1186,8 +1222,9 @@ func (st *Store) maybeCommitClusterID() {
 		Type:       api.ApplyRequest_TYPE_CLUSTER_ID_SET,
 		SubCommand: subCmd,
 	}
-	// A new leader may commit a duplicate before replaying the existing entry;
-	// harmless, since applyClusterIDSet is set-once.
+	// Execute drains this leader's FSM first, so the ClusterID check above has
+	// normally settled the question by now; a duplicate that still slips through
+	// is harmless, since applyClusterIDSet is set-once.
 	if _, err := st.Execute(applyReq); err != nil {
 		st.log.WithFields(logrus.Fields{"cluster_id": id}).Warnf("commit cluster-id set command: %v", err)
 	}

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -27,11 +27,21 @@ import (
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
+// Execute proposes req to raft, first rejecting it outright if PreApplyFilter
+// finds it invalid, so an invalid command never reaches the log. The caller must
+// already be leader.
 func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 	st.log.WithFields(logrus.Fields{
 		"type":  api.ApplyRequest_Type_name[int32(req.Type)],
 		"class": req.Class,
 	}).Debug("server.execute")
+
+	// PreApplyFilter below judges this propose against in-memory FSM state, so a
+	// leader that has not drained what it inherited must not judge yet. Ahead of
+	// the tenant lock, which is not worth holding across a barrier round-trip.
+	if err := st.waitLeaderFSMCaughtUp(); err != nil {
+		return 0, err
+	}
 
 	// Serialize AddTenants per class so the pre-commit cap check can't race the
 	// apply that increments the count (Execute blocks until apply). Skipped when

--- a/cluster/store_propose_barrier_test.go
+++ b/cluster/store_propose_barrier_test.go
@@ -1,0 +1,226 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/raft"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/utils"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/cluster/mocks"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// singleShardState is the minimum AddClass accepts.
+func singleShardState(shard string) *sharding.State {
+	return &sharding.State{Physical: map[string]sharding.Physical{
+		shard: {Name: shard, BelongsToNodes: []string{"Node-1"}},
+	}}
+}
+
+// setupSingleNodeRaft brings up a single-node service on real raft. notify
+// triggers the bootstrap that elects it; without it the node stays a follower. A
+// non-empty blockClass holds the FSM inside that class's apply until the returned
+// release runs, which is how an entry is left committed but unapplied.
+func setupSingleNodeRaft(t *testing.T, notify bool, blockClass string) (*Raft, func()) {
+	t.Helper()
+
+	blocked := make(chan struct{})
+	var once sync.Once
+	release := func() { once.Do(func() { close(blocked) }) }
+
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	// Nothing else may propose inside the window these tests measure log-index
+	// deltas over. onLeaderFound's 1s ticker would otherwise commit a cluster-id
+	// entry mid-test, and — since Store.Execute drains first — a barrier with it,
+	// stamping fsmCaughtUpTerm before the first AddClass is measured. The ticker
+	// normally fires after the measurement, so leaving telemetry on is a rare
+	// flake rather than a hard failure; off removes the race entirely.
+	m.store.cfg.TelemetryEnabled = false
+	m.indexer.On("Open", mock.Anything).Return(nil)
+	m.indexer.On("Close", mock.Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+	m.indexer.On("AddClass", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		if blockClass == "" {
+			return
+		}
+		req, ok := args.Get(0).(command.AddClassRequest)
+		if ok && req.Class != nil && req.Class.Class == blockClass {
+			<-blocked
+		}
+	})
+	m.parser.On("ParseClass", mock.Anything).Return(nil)
+
+	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
+	ctx := context.Background()
+	require.NoError(t, srv.Open(ctx, m.indexer))
+	t.Cleanup(func() {
+		release()
+		srv.Close(ctx)
+	})
+
+	if notify {
+		electRaftLeader(t, srv, &m)
+	}
+
+	return srv, release
+}
+
+// settledLastIndex waits out the configuration entry and the leader no-op that
+// raft appends on its own at election, so a delta measured after it belongs to
+// the propose under test.
+func settledLastIndex(t *testing.T, srv *Raft) uint64 {
+	t.Helper()
+
+	var last uint64
+	require.True(t, tryNTimesWithWait(50, 100*time.Millisecond, func() bool {
+		idx := srv.store.raft.LastIndex()
+		settled := idx != 0 && idx == last
+		last = idx
+		return settled
+	}), "raft log did not settle after the election")
+	return last
+}
+
+// waitForIndexPast blocks until raft has appended past want.
+func waitForIndexPast(t *testing.T, srv *Raft, want uint64, msg string) {
+	t.Helper()
+
+	require.True(t, tryNTimesWithWait(50, 100*time.Millisecond, func() bool {
+		return srv.store.raft.LastIndex() > want
+	}), msg)
+}
+
+// TestProposeBarrier_OnePerLeaderTerm pins that the first propose of a term
+// appends a barrier entry of its own and a later one does not. The delta is what
+// makes this a drain: a leadership check would satisfy every other assertion here
+// while appending nothing and confirming nothing about the FSM.
+func TestProposeBarrier_OnePerLeaderTerm(t *testing.T) {
+	srv, _ := setupSingleNodeRaft(t, true, "")
+	ctx := context.Background()
+
+	require.Zero(t, srv.store.fsmCaughtUpTerm.Load(), "no propose has been admitted yet")
+	before := settledLastIndex(t, srv)
+
+	_, err := srv.AddClass(ctx, &models.Class{Class: "First"}, singleShardState("S1"))
+	require.NoError(t, err)
+
+	term := srv.store.raft.CurrentTerm()
+	assert.Equal(t, before+2, srv.store.raft.LastIndex(),
+		"the first propose appends a barrier and then its own command")
+	assert.Equal(t, term, srv.store.fsmCaughtUpTerm.Load(),
+		"a confirmed drain is recorded against the term it was confirmed in")
+
+	before = srv.store.raft.LastIndex()
+	_, err = srv.AddClass(ctx, &models.Class{Class: "Second"}, singleShardState("S1"))
+	require.NoError(t, err)
+
+	assert.Equal(t, before+1, srv.store.raft.LastIndex(),
+		"a later propose in the same term reuses the barrier")
+	assert.Equal(t, term, srv.store.fsmCaughtUpTerm.Load())
+}
+
+// TestProposeBarrier_RefusesADuplicateTheFSMHasNotApplied pins the bug the barrier
+// exists for. A leader holding committed entries it has not applied must refuse a
+// class the log already contains, rather than admitting a second copy of it.
+func TestProposeBarrier_RefusesADuplicateTheFSMHasNotApplied(t *testing.T) {
+	srv, release := setupSingleNodeRaft(t, true, "Blocker")
+	ctx := context.Background()
+	staged := settledLastIndex(t, srv)
+
+	// Blocker stops the FSM. Target then commits behind it, so the committed log
+	// holds a class the schema map does not.
+	go srv.AddClass(ctx, &models.Class{Class: "Blocker"}, singleShardState("S1"))
+	waitForIndexPast(t, srv, staged+1, "Blocker's barrier and command were not appended")
+
+	staged = srv.store.raft.LastIndex()
+	go srv.AddClass(ctx, &models.Class{Class: "Target"}, singleShardState("S1"))
+	waitForIndexPast(t, srv, staged, "Target was not appended")
+
+	require.False(t, srv.store.SchemaReader().ClassInfo("Target").Exists,
+		"Target must be committed but not yet applied")
+
+	// The state a leader is in right after an election: entries inherited, no
+	// drain confirmed for the term.
+	srv.store.fsmCaughtUpTerm.Store(0)
+	go func() {
+		time.Sleep(time.Second)
+		release()
+	}()
+
+	_, err := srv.AddClass(ctx, &models.Class{Class: "Target"}, singleShardState("S1"))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "class name Target already exists",
+		"PreApplyFilter must refuse the duplicate, rather than the apply rejecting it later")
+}
+
+// TestProposeBarrier_FailureIsRetryableAndNotRecorded covers the arm a leader
+// losing its election lands on. Raft.Execute classifies by the sentinel, so it has
+// to survive wrapping, and a failed barrier must record no drain.
+func TestProposeBarrier_FailureIsRetryableAndNotRecorded(t *testing.T) {
+	srv, _ := setupSingleNodeRaft(t, false, "")
+	require.False(t, srv.store.IsLeader(), "an un-notified node must not be leader")
+
+	err := srv.store.waitLeaderFSMCaughtUp()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, raft.ErrNotLeader)
+	assert.Zero(t, srv.store.fsmCaughtUpTerm.Load(), "a failed barrier confirms no term")
+
+	var permanent *backoff.PermanentError
+	assert.False(t, errors.As(classifyLeaderErr(err), &permanent),
+		"losing the election is worth retrying")
+}
+
+// TestClassifyLeaderErr pins which failures Raft.Execute retries against a leader.
+// Retrying anything else repeats a wait that has already timed out.
+func TestClassifyLeaderErr(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{name: "nil stays nil", err: nil},
+		{name: "not leader", err: raft.ErrNotLeader, retryable: true},
+		{name: "leadership lost", err: raft.ErrLeadershipLost, retryable: true},
+		{name: "wrapped not leader", err: fmt.Errorf("barrier: %w", raft.ErrNotLeader), retryable: true},
+		{name: "enqueue timeout", err: fmt.Errorf("barrier: %w", raft.ErrEnqueueTimeout)},
+		{name: "raft shutdown", err: fmt.Errorf("barrier: %w", raft.ErrRaftShutdown)},
+		{name: "aborted by restore", err: fmt.Errorf("barrier: %w", raft.ErrAbortedByRestore)},
+		{name: "leadership transfer in progress", err: raft.ErrLeadershipTransferInProgress},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyLeaderErr(tt.err)
+			if tt.err == nil {
+				require.NoError(t, got)
+				return
+			}
+
+			var permanent *backoff.PermanentError
+			assert.Equal(t, !tt.retryable, errors.As(got, &permanent))
+			assert.ErrorIs(t, got, tt.err, "the sentinel must survive classification")
+		})
+	}
+}

--- a/cluster/store_test.go
+++ b/cluster/store_test.go
@@ -1598,6 +1598,21 @@ func (m *MockStore) Store(doBefore func(*MockStore)) *Store {
 	return m.store
 }
 
+// electRaftLeader bootstraps srv as the only voter in its cluster and blocks
+// until it has won the election and is ready to serve. srv must already be open,
+// and whatever mocks the test needs must already be set on m.
+func electRaftLeader(t *testing.T, srv *Raft, m *MockStore) {
+	t.Helper()
+
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
+	require.NoError(t, srv.store.Notify(m.cfg.NodeID, addr))
+	require.NoError(t, srv.WaitUntilDBRestored(context.Background(), time.Second, make(chan struct{})))
+	require.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader),
+		"node did not become raft leader")
+	require.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready),
+		"raft did not become ready to serve")
+}
+
 // Runs the provided function `predicate` up to `n` times, sleeping `sleepDuration` between each
 // function call until `f` returns true or returns false if all `n` calls return false.
 // Useful in tests which require an unknown but bounded delay where the component under test has

--- a/test/acceptance/multi_node/leader_failover_schema_test.go
+++ b/test/acceptance/multi_node/leader_failover_schema_test.go
@@ -1,0 +1,240 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package multi_node
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	httptransport "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	apiclient "github.com/weaviate/weaviate/client"
+	clcluster "github.com/weaviate/weaviate/client/cluster"
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+// TestSchemaWritesAfterLeaderFailover pins that a node which has just won an
+// election adjudicates schema writes against what the cluster has committed,
+// not against whatever its own FSM happened to hold at the moment it took
+// office. Raft reports leadership as soon as the election is won, so a leader
+// can be serving while still replaying entries it inherited; PreApplyFilter
+// reads the in-memory schema map, and Store.Execute drains the FSM before it
+// judges. A duplicate admitted here means that drain is gone.
+//
+// This is a contract test, not a deterministic reproduction: the drain window
+// is milliseconds wide and nothing exposed to an out-of-process test can widen
+// it, so this passes with the drain removed more often than not. The mechanism
+// itself is pinned deterministically by
+// TestProposeBarrier_RefusesADuplicateTheFSMHasNotApplied in package cluster,
+// which blocks the FSM through the indexer mock. What this adds is the real
+// election, real replication and real request timing that a unit test cannot.
+func TestSchemaWritesAfterLeaderFailover(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		With3NodeCluster().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		// The cluster may be mid-election; docker stop is forceful either way.
+		_ = compose.Terminate(context.Background())
+	}()
+
+	// Keyed by raft node id, which is CLUSTER_HOSTNAME ("weaviate-N") and is
+	// what /v1/cluster/statistics reports as Statistics.Name.
+	clients := make(map[string]*apiclient.Weaviate, 3)
+	for i := 1; i <= 3; i++ {
+		clients[fmt.Sprintf("weaviate-%d", i-1)] = raftNodeClient(compose.GetWeaviateNode(i).URI())
+	}
+	firstNode := clients["weaviate-0"]
+
+	const (
+		seeded = "FailoverSeeded"
+		fresh  = "FailoverFresh"
+	)
+
+	t.Run("seed a class every node has committed", func(t *testing.T) {
+		require.NoError(t, createClassOn(ctx, firstNode, seeded))
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for name, c := range clients {
+				assert.NoError(ct, getClassOn(ctx, c, seeded),
+					"node %s has not applied %s yet", name, seeded)
+			}
+		}, 60*time.Second, time.Second)
+	})
+
+	var oldLeader string
+	t.Run("identify the leader", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			name, err := raftLeaderName(ctx, firstNode)
+			if !assert.NoError(ct, err) {
+				return
+			}
+			assert.NotEmpty(ct, name)
+			oldLeader = name
+		}, 60*time.Second, time.Second)
+		require.Contains(t, clients, oldLeader, "leader is not one of the three nodes")
+	})
+
+	// A failure above leaves oldLeader empty, and every step below is about that
+	// node; stop here rather than cascading into misleading failures.
+	require.NotEmpty(t, oldLeader, "no leader identified")
+
+	// A node that stays up, so leadership can still be read after the stop.
+	var survivor *apiclient.Weaviate
+	for name, c := range clients {
+		if name != oldLeader {
+			survivor = c
+			break
+		}
+	}
+	require.NotNil(t, survivor)
+
+	t.Run("stop the leader", func(t *testing.T) {
+		require.NoError(t, compose.StopNode(ctx, raftNodeSuffix(t, oldLeader), nil))
+	})
+
+	var newLeader *apiclient.Weaviate
+	t.Run("a survivor takes over", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			name, err := raftLeaderName(ctx, survivor)
+			if !assert.NoError(ct, err) {
+				return
+			}
+			if !assert.NotEmpty(ct, name) {
+				return
+			}
+			assert.NotEqual(ct, oldLeader, name, "the stopped node is still reported as leader")
+			newLeader = clients[name]
+		}, 90*time.Second, time.Second)
+		require.NotNil(t, newLeader)
+	})
+
+	t.Run("the new leader refuses a class the cluster already has", func(t *testing.T) {
+		// Not EventuallyWithT: a success is the bug, so it has to fail the test
+		// outright rather than be retried away. Only errors that mean "not
+		// serving yet" are worth another attempt.
+		want := fmt.Sprintf("class name %s already exists", seeded)
+		deadline := time.Now().Add(90 * time.Second)
+		for {
+			err := createClassOn(ctx, newLeader, seeded)
+			if err == nil {
+				t.Fatalf("the new leader admitted a duplicate of %q: it judged the propose "+
+					"against an FSM it had not drained", seeded)
+			}
+			if strings.Contains(swaggerErrText(err), want) {
+				return
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("the new leader never refused the duplicate; last response: %s",
+					swaggerErrText(err))
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+	})
+
+	t.Run("the new leader still admits a class the cluster does not have", func(t *testing.T) {
+		// The refusal above is only meaningful if the leader is not simply
+		// rejecting everything it is handed.
+		require.NoError(t, createClassOn(ctx, newLeader, fresh))
+	})
+
+	t.Run("the restarted node converges on both classes", func(t *testing.T) {
+		suffix := raftNodeSuffix(t, oldLeader)
+		require.NoError(t, compose.StartNode(ctx, suffix))
+
+		// StartNode re-maps the container's published port, so the client built
+		// before the stop points at an address that is no longer served.
+		restarted := raftNodeClient(compose.GetWeaviateNode(suffix + 1).URI())
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, class := range []string{seeded, fresh} {
+				assert.NoError(ct, getClassOn(ctx, restarted, class),
+					"restarted node %s is missing %s", oldLeader, class)
+			}
+		}, 120*time.Second, 2*time.Second)
+	})
+}
+
+func raftNodeClient(hostPort string) *apiclient.Weaviate {
+	transport := httptransport.New(hostPort, "/v1", []string{"http"})
+	return apiclient.New(transport, strfmt.Default)
+}
+
+// raftNodeSuffix turns a raft node id ("weaviate-1") into the container suffix
+// StopNode and StartNode take.
+func raftNodeSuffix(t *testing.T, nodeID string) int {
+	t.Helper()
+
+	var n int
+	_, err := fmt.Sscanf(nodeID, "weaviate-%d", &n)
+	require.NoError(t, err, "unexpected raft node id %q", nodeID)
+	return n
+}
+
+// raftLeaderName reports which node c believes is the raft leader. A node that
+// is down reports no raft block at all, so it cannot be named here.
+func raftLeaderName(ctx context.Context, c *apiclient.Weaviate) (string, error) {
+	params := clcluster.NewClusterGetStatisticsParams().WithContext(ctx)
+	resp, err := c.Cluster.ClusterGetStatistics(params, nil)
+	if err != nil {
+		return "", err
+	}
+	if resp.Payload == nil {
+		return "", fmt.Errorf("empty statistics payload")
+	}
+	for _, s := range resp.Payload.Statistics {
+		if s != nil && s.Raft != nil && s.Raft.State == "Leader" {
+			return s.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no node reports raft state Leader")
+}
+
+func createClassOn(ctx context.Context, c *apiclient.Weaviate, class string) error {
+	params := clschema.NewSchemaObjectsCreateParams().
+		WithContext(ctx).
+		WithObjectClass(&models.Class{
+			Class:             class,
+			Vectorizer:        "none",
+			ReplicationConfig: &models.ReplicationConfig{Factor: 3},
+		})
+	_, err := c.Schema.SchemaObjectsCreate(params, nil)
+	return err
+}
+
+func getClassOn(ctx context.Context, c *apiclient.Weaviate, class string) error {
+	params := clschema.NewSchemaObjectsGetParams().WithContext(ctx).WithClassName(class)
+	_, err := c.Schema.SchemaObjectsGet(params, nil)
+	return err
+}
+
+// swaggerErrText renders a generated-client error so the API's message can be
+// matched. The typed errors carry the payload only in their Payload field, and
+// Error() prints the status code alone.
+func swaggerErrText(err error) string {
+	b, marshalErr := json.MarshalIndent(err, "", " ")
+	if marshalErr != nil {
+		return err.Error()
+	}
+	return fmt.Sprintf("%s %s", err.Error(), b)
+}

--- a/test/acceptance/schema/update_shard_status_cold_tenant_test.go
+++ b/test/acceptance/schema/update_shard_status_cold_tenant_test.go
@@ -114,14 +114,17 @@ func TestUpdateShardStatusViaFollowerWhileTenantCold(t *testing.T) {
 		}
 		require.NotEmpty(t, leaderName, "no leader in cluster/statistics; got: %+v", stats.Statistics)
 
-		// docker/compose.go sets CLUSTER_HOSTNAME=nodeN.
+		// docker/compose.go sets CLUSTER_HOSTNAME=weaviate-<n>, and
+		// /v1/cluster/statistics reports that as Statistics.Name. GetWeaviateNode
+		// counts from 1, so its node i is container weaviate-<i-1>.
 		for i := 1; i <= 3; i++ {
-			if fmt.Sprintf("node%d", i) != leaderName {
+			if fmt.Sprintf("weaviate-%d", i-1) != leaderName {
 				followerClient = newNodeClient(compose.GetWeaviateNode(i).URI())
 				break
 			}
 		}
 		require.NotNil(t, followerClient, "could not identify a follower")
+		t.Logf("leader is %s; issuing the update via a different node", leaderName)
 	})
 
 	t.Run("update shard status via follower returns without error", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

A node becomes raft leader the moment it wins the election, but it applies log entries in the background. So a new leader can start serving requests while it is still working through entries it inherited. Its in-memory schema map is behind its own log during that window.

PreApplyFilter checks new schema commands against that map. If the map is behind, the check passes on a class the log already contains, and the leader accepts a duplicate.

Fix: before the first schema write of each leader term, wait on a raft.Barrier. A barrier entry is applied after everything queued ahead of it, so once it completes the map is up to date. Store.fsmCaughtUpTerm remembers which term was already confirmed, so later writes in the same term skip the wait. That costs one extra log entry per leadership change, not per write.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
