### PR TITLE
Align returns for HOT and COLD tenants from usage module

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -99,6 +99,11 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 		}
 		activeVectorConfigs[targetVector] = cfg
 	}
+	// computed once per collection: every shard's saved usage is checked against it
+	vectorConfigsFingerprint, err := shardusage.VectorConfigsFingerprint(activeVectorConfigs)
+	if err != nil {
+		return nil, fmt.Errorf("fingerprint vector configs: %w", err)
+	}
 
 	localShards := map[string]struct{}{}
 
@@ -106,7 +111,7 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 	// the entire state for the duration of the potentially long-running usage calculation. Therefore, we do this in steps:
 	// 1) lock sharding state using schemaReader.Read while we collect all local shards and their status
 	// 2) calculate usage depending on shard state below where only the given shard is locked (below)
-	err := i.schemaReader.Read(i.Config.ClassName.String(), false, func(_ *models.Class, ss *sharding.State) error {
+	err = i.schemaReader.Read(i.Config.ClassName.String(), false, func(_ *models.Class, ss *sharding.State) error {
 		for shardName := range ss.Physical {
 			isLocal := ss.IsLocalShard(shardName)
 			if !isLocal {
@@ -145,7 +150,7 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 		eg.Go(func() error {
 			defer shardReadSem.Release(1)
 
-			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, activeVectorConfigs)
+			shardUsage, err := i.usageForShard(egCtx, shardName, exactObjectCount, activeVectorConfigs, vectorConfigsFingerprint)
 			if err != nil {
 				return err
 			}
@@ -197,7 +202,7 @@ func (i *Index) usageForCollection(ctx context.Context, shardReadSem *semaphore.
 // in the _local_ state (i.e. loading/unloading) for the duration of the calculation. A nil
 // *ShardUsage with a nil error means the shard should be skipped (transitional states like
 // FREEZING/OFFLOADING). Safe to call concurrently for distinct shards.
-func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, activeVectorConfigs map[string]models.VectorConfig) (*types.ShardUsage, error) {
+func (i *Index) usageForShard(ctx context.Context, shardName string, exactObjectCount bool, activeVectorConfigs map[string]models.VectorConfig, vectorConfigsFingerprint string) (*types.ShardUsage, error) {
 	i.shardCreateLocks.RLock(shardName)
 	defer i.shardCreateLocks.RUnlock(shardName)
 
@@ -244,7 +249,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 						err2 = fmt.Errorf("loaded lazy shard %s: %w", shardName, err2)
 					}
 				} else {
-					shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, activeVectorConfigs)
+					shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, activeVectorConfigs, vectorConfigsFingerprint)
 					if err2 != nil {
 						err2 = fmt.Errorf("unloaded lazy shard %s: %w", shardName, err2)
 					}
@@ -261,7 +266,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 			}
 		}
 	case models.TenantActivityStatusINACTIVE, models.TenantActivityStatusCOLD:
-		shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, activeVectorConfigs)
+		shardUsage, err2 = i.calculateUnloadedShardUsage(ctx, shardName, activeVectorConfigs, vectorConfigsFingerprint)
 		if err2 != nil {
 			err2 = fmt.Errorf("inactive shard %s: %w", shardName, err2)
 		}
@@ -483,21 +488,23 @@ func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
 }
 
 // calculateUnloadedShardUsage computes usage for a cold shard from disk. vectorConfigs must
-// contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig.
-func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig) (*types.ShardUsage, error) {
+// contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig —
+// and vectorConfigsFingerprint must be their [shardusage.VectorConfigsFingerprint].
+func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig, vectorConfigsFingerprint string) (*types.ShardUsage, error) {
 	if shardusage.ComputedUsageDataExists(i.path(), shardName) {
 		// usage has been pre-calculated and can be read from disk
-		shardUsage, err := shardusage.LoadComputedUsageData(i.path(), shardName)
-		if err != nil {
-			// the computation below overwrites the unusable file, so a stale
-			// version is routine; anything else is worth an operator's attention
-			if errors.Is(err, shardusage.ErrUsageVersionMismatch) {
-				i.logger.Debugf("recomputing usage data for shard %s: %v", shardName, err)
-			} else {
-				i.logger.Warnf("failed to load pre-calculated usage data for shard %s: %v", shardName, err)
-			}
-		} else {
-			return shardUsage, nil
+		saved, err := shardusage.LoadComputedUsageData(i.path(), shardName)
+		// the computation below overwrites whatever cannot be served. A stale version
+		// is routine. An unreadable file is worth an operator's attention.
+		switch {
+		case errors.Is(err, shardusage.ErrUsageVersionMismatch):
+			i.logger.Debugf("recomputing usage data for shard %s: %v", shardName, err)
+		case err != nil:
+			i.logger.Warnf("failed to load pre-calculated usage data for shard %s: %v", shardName, err)
+		case saved.VectorConfigsFingerprint != vectorConfigsFingerprint:
+			i.logger.Debugf("recomputing usage data for shard %s: vector configs changed since it was saved", shardName)
+		default:
+			return saved.ShardUsage, nil
 		}
 	}
 	lsmPath := shardPathLSM(i.path(), shardName)
@@ -575,7 +582,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 		FullShardStorageBytes: vectorCommitLogsStorageSize + otherNonLSMFoldersStorageSize + indexUsage + uint64(objectUsage.StorageBytes) + uint64(vectorMetrics.StorageBytes),
 		NamedVectors:          namedVectors,
 	}
-	if err := shardusage.SaveComputedUsageData(i.path(), shardName, shardUsage); err != nil {
+	if err := shardusage.SaveComputedUsageData(i.path(), shardName, shardUsage, vectorConfigsFingerprint); err != nil {
 		return nil, fmt.Errorf("save usage to disk: %w", err)
 	}
 	return shardUsage, err

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -594,10 +594,13 @@ func (i *Index) splitObjectsBucketSize(shardName string, objectsBucketSize, unco
 	return objectsBucketSize - uncompressedVectorSize, uncompressedVectorSize
 }
 
+// emptyShardUsageWithNameAndActivity reports zero usage for a shard with no data on disk. Callers
+// pass the schema's upper-case activity constants, while the report spells the status in lower case
+// like the computed paths do.
 func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.ShardUsage {
 	return &types.ShardUsage{
 		Name:                shardName,
-		Status:              activity,
+		Status:              strings.ToLower(activity),
 		ObjectsCount:        0,
 		ObjectsStorageBytes: 0,
 		VectorStorageBytes:  0,

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -354,13 +354,17 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 	vectorConfigs := i.GetVectorIndexConfigs()
 	var usages types.VectorsUsage
 	if err := shard.ForEachVectorIndex(func(targetVector string, vectorIndex VectorIndex) error {
-		var vectorIndexConfig schemaConfig.VectorIndexConfig
-		if vecCfg, exists := vectorConfigs[targetVector]; exists {
-			vectorIndexConfig = vecCfg
-		} else if vecCfg, exists := vectorConfigs[""]; exists {
-			vectorIndexConfig = vecCfg
-		} else {
-			return fmt.Errorf("vector index %s not found in config", targetVector)
+		vectorIndexConfig, exists := vectorConfigs[targetVector]
+		if !exists {
+			// dropVectorIndex deletes the config before it drops the index from every
+			// shard, so a report that runs in between finds an index it cannot
+			// describe. Routine enough for Debug: the next shard init drops the index.
+			i.logger.WithFields(logrus.Fields{
+				"class":         i.Config.ClassName.String(),
+				"shard":         shard.Name(),
+				"target_vector": targetVector,
+			}).Debug("leaving vector index without a config out of the usage report")
+			return nil
 		}
 		indexType := vectorIndexConfig.IndexType()
 
@@ -386,33 +390,32 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 			dimensionality = scan.Reported
 		}
 
-		compressionRatio := vectorIndex.CompressionStats().CompressionRatio(dimensionality.Dimensions)
-
-		vectorUsage := &types.VectorUsage{
+		usages = append(usages, &types.VectorUsage{
 			Name:                   targetVector,
 			Compression:            dimInfo.category.String(),
 			VectorIndexType:        indexType,
 			IsDynamic:              isDynamic,
-			VectorCompressionRatio: compressionRatio,
+			VectorCompressionRatio: vectorCompressionRatio(vectorIndex.CompressionStats(), dimensionality.Dimensions),
 			Bits:                   dimInfo.bits,
 			MultiVectorConfig:      multiVectorConfigFromConfig(vectorIndexConfig),
-		}
-
-		// Only add dimensionalities if there's valid data
-		if dimensionality.Count > 0 || dimensionality.Dimensions > 0 {
-			vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &types.Dimensionality{
-				Dimensions: dimensionality.Dimensions,
-				Count:      dimensionality.Count,
-			})
-		}
-
-		usages = append(usages, vectorUsage)
+			Dimensionalities:       trackedDimensionalities(dimensionality),
+		})
 		return nil
 	}); err != nil {
 		return nil, err
 	}
 	sort.Sort(usages)
 	return usages, nil
+}
+
+// trackedDimensionalities wraps one target vector's dimensionality for the report,
+// and returns nothing when nothing was tracked. A configured vector holding no data
+// has no dimensionality to bill, rather than one of zero.
+func trackedDimensionalities(dimensionality types.Dimensionality) []*types.Dimensionality {
+	if dimensionality.Count <= 0 && dimensionality.Dimensions <= 0 {
+		return nil
+	}
+	return []*types.Dimensionality{&dimensionality}
 }
 
 // unloadedVectorState is what a shard's files say about one target vector that
@@ -466,7 +469,7 @@ func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
 		VectorCompressionRatio: dimInfo.compressionRatio(dimensionality.Dimensions, state.quantizedVectorsExist),
 		VectorIndexType:        vectorIndexConfig.IndexType(),
 		IsDynamic:              vectorConfig.VectorIndexType == common.IndexTypeDynamic,
-		Dimensionalities:       []*types.Dimensionality{&dimensionality},
+		Dimensionalities:       trackedDimensionalities(dimensionality),
 		MultiVectorConfig:      multiVectorConfigFromConfig(vectorIndexConfig),
 	}
 	if vectorUsage.IsDynamic {

--- a/adapters/repos/db/index_usage_cache_test.go
+++ b/adapters/repos/db/index_usage_cache_test.go
@@ -59,7 +59,7 @@ func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
 			ctx := context.Background()
 			tenantName := "test-tenant"
 
-			index := setupPopulatedLazyIndex(ctx, t)
+			index, _ := setupPopulatedLazyIndex(ctx, t, usageIndexParams{})
 			t.Cleanup(func() { _ = index.Shutdown(ctx) })
 
 			writeSavedShardUsage(t, index.path(), tenantName, tt.savedVersion,

--- a/adapters/repos/db/index_usage_cache_test.go
+++ b/adapters/repos/db/index_usage_cache_test.go
@@ -22,35 +22,57 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 
+	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/modelsext"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
+
+// populatedObjectsCount is how many objects setupPopulatedLazyIndex writes.
+const populatedObjectsCount = int64(20)
+
+// savedObjectsCount marks a shard usage as coming from the saved file: a report
+// serving it read the file instead of the shard.
+const savedObjectsCount = int64(7)
 
 // TestUnloadedShardUsageSavedToDisk pins which saved usage a cold shard serves.
 // Nothing deletes the file of a shard that stays cold, so a UsageDiskVersion bump
-// only reaches those shards if a version it does not know makes them recompute.
+// or a new field only reaches those shards if what they hold makes them recompute.
 func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
-	// distinguishable from the 20 objects the shard actually holds
-	const savedObjectsCount = int64(7)
+	currentFingerprint, err := shardusage.VectorConfigsFingerprint(nil)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name             string
 		savedVersion     int
+		savedFingerprint string
 		wantObjectsCount int64
 	}{
 		{
 			name:             "usage of the current version is served",
 			savedVersion:     types.UsageDiskVersion,
+			savedFingerprint: currentFingerprint,
 			wantObjectsCount: savedObjectsCount,
 		},
 		{
 			name:             "usage of an older version is recomputed",
 			savedVersion:     types.UsageDiskVersion - 1,
-			wantObjectsCount: 20,
+			savedFingerprint: currentFingerprint,
+			wantObjectsCount: populatedObjectsCount,
 		},
 		{
 			name:             "usage of a newer version is recomputed",
 			savedVersion:     types.UsageDiskVersion + 1,
-			wantObjectsCount: 20,
+			savedFingerprint: currentFingerprint,
+			wantObjectsCount: populatedObjectsCount,
+		},
+		{
+			// what a build that saved no fingerprint left behind
+			name:             "usage without a fingerprint is recomputed",
+			savedVersion:     types.UsageDiskVersion,
+			savedFingerprint: "",
+			wantObjectsCount: populatedObjectsCount,
 		},
 	}
 
@@ -62,8 +84,11 @@ func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
 			index, _ := setupPopulatedLazyIndex(ctx, t, usageIndexParams{})
 			t.Cleanup(func() { _ = index.Shutdown(ctx) })
 
-			writeSavedShardUsage(t, index.path(), tenantName, tt.savedVersion,
-				&types.ShardUsage{Name: tenantName, ObjectsCount: savedObjectsCount})
+			writeSavedShardUsage(t, index.path(), tenantName, &types.UsageDisk{
+				Version:                  tt.savedVersion,
+				VectorConfigsFingerprint: tt.savedFingerprint,
+				ShardUsage:               &types.ShardUsage{Name: tenantName, ObjectsCount: savedObjectsCount},
+			})
 
 			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(1), true, nil)
 			require.NoError(t, err)
@@ -73,13 +98,145 @@ func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
 	}
 }
 
-// writeSavedShardUsage writes the file [shardusage.SaveComputedUsageData] writes,
-// at an arbitrary version. It repeats that file's name because the package keeps
-// it private and stamps the current version on everything it saves.
-func writeSavedShardUsage(t *testing.T, indexPath, shardName string, version int, usage *types.ShardUsage) {
+// TestUnloadedShardUsageAfterVectorConfigChange pins that a cold shard stops
+// serving usage computed from vector configs the collection no longer has. Only
+// loading the shard deletes the saved file, so a tenant left cold would otherwise
+// keep reporting a dropped vector index — and the object/vector byte split that
+// went with it — for good. [TestUnloadedShardUsageSavedToDisk] covers what the
+// saved record itself has to hold to be served.
+func TestUnloadedShardUsageAfterVectorConfigChange(t *testing.T) {
+	hnswConfig := func(mutate func(*enthnsw.UserConfig)) models.VectorConfig {
+		cfg := enthnsw.NewDefaultUserConfig()
+		mutate(&cfg)
+		return models.VectorConfig{VectorIndexType: cfg.IndexType(), VectorIndexConfig: cfg}
+	}
+	live := hnswConfig(func(*enthnsw.UserConfig) {})
+	dropped := models.VectorConfig{VectorIndexType: modelsext.VectorIndexTypeNone}
+
+	tests := []struct {
+		name string
+		// change is applied to the configs the second report runs with. The first
+		// report always runs with the legacy vector plus "first" and "second".
+		change func(map[string]models.VectorConfig)
+		// servedFromFile says whether the second report may still answer from the
+		// file the first one saved.
+		servedFromFile bool
+		// wantCompressions maps every reported vector name to its compression.
+		wantCompressions map[string]string
+	}{
+		{
+			name:             "configs unchanged, saved usage is served",
+			change:           func(map[string]models.VectorConfig) {},
+			servedFromFile:   true,
+			wantCompressions: map[string]string{"": "standard", "first": "standard", "second": "standard"},
+		},
+		{
+			name:             "one vector dropped",
+			change:           func(c map[string]models.VectorConfig) { c["second"] = dropped },
+			wantCompressions: map[string]string{"": "standard", "first": "standard"},
+		},
+		{
+			name: "every vector dropped",
+			change: func(c map[string]models.VectorConfig) {
+				for targetVector := range c {
+					c[targetVector] = dropped
+				}
+			},
+			wantCompressions: map[string]string{},
+		},
+		{
+			name:             "a vector added",
+			change:           func(c map[string]models.VectorConfig) { c["third"] = live },
+			wantCompressions: map[string]string{"": "standard", "first": "standard", "second": "standard", "third": "standard"},
+		},
+		{
+			name: "a vector reconfigured",
+			change: func(c map[string]models.VectorConfig) {
+				c["second"] = hnswConfig(func(cfg *enthnsw.UserConfig) { cfg.BQ.Enabled = true })
+			},
+			wantCompressions: map[string]string{"": "standard", "first": "standard", "second": "bq"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tenantName := "test-tenant"
+
+			index, vectorConfigs := setupPopulatedLazyIndex(ctx, t, usageIndexParams{
+				namedVectors:     map[string]models.VectorConfig{"first": live, "second": live},
+				vectorDimensions: 32,
+			})
+			t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+			// the first report is what saves the file the second one may serve
+			_, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err)
+			markSavedShardUsage(t, index.path(), tenantName)
+
+			tt.change(vectorConfigs)
+			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, usage.Shards, 1)
+
+			wantObjectsCount := populatedObjectsCount
+			if tt.servedFromFile {
+				wantObjectsCount = savedObjectsCount
+			}
+			assert.Equal(t, wantObjectsCount, usage.Shards[0].ObjectsCount)
+			gotCompressions := map[string]string{}
+			for _, namedVector := range usage.Shards[0].NamedVectors {
+				gotCompressions[namedVector.Name] = namedVector.Compression
+			}
+			assert.Equal(t, tt.wantCompressions, gotCompressions)
+
+			// the recompute must have saved usage the changed configs can serve again,
+			// or every later report pays for the shard anew
+			markSavedShardUsage(t, index.path(), tenantName)
+			again, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, again.Shards, 1)
+			assert.Equal(t, savedObjectsCount, again.Shards[0].ObjectsCount)
+
+			if tt.servedFromFile {
+				return
+			}
+			// a recompute must land on what a shard with no saved file reports
+			require.NoError(t, os.Remove(savedShardUsagePath(index.path(), tenantName)))
+			fresh, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, fresh.Shards, 1)
+			assert.Equal(t, fresh.Shards[0], usage.Shards[0])
+		})
+	}
+}
+
+// savedShardUsagePath repeats the name of the file [shardusage.SaveComputedUsageData]
+// writes, because the package keeps it private.
+func savedShardUsagePath(indexPath, shardName string) string {
+	return filepath.Join(indexPath, shardName, "usage.json.tmp")
+}
+
+// writeSavedShardUsage writes the file a cold shard's usage is served from,
+// at an arbitrary version and fingerprint.
+func writeSavedShardUsage(t *testing.T, indexPath, shardName string, saved *types.UsageDisk) {
 	t.Helper()
 
-	data, err := json.Marshal(&types.UsageDisk{Version: version, ShardUsage: usage})
+	data, err := json.Marshal(saved)
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(indexPath, shardName, "usage.json.tmp"), data, 0o600))
+	require.NoError(t, os.WriteFile(savedShardUsagePath(indexPath, shardName), data, 0o600))
+}
+
+// markSavedShardUsage stamps savedObjectsCount on the usage a report saved, leaving
+// everything the cache validates untouched.
+func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
+	t.Helper()
+
+	data, err := os.ReadFile(savedShardUsagePath(indexPath, shardName))
+	require.NoError(t, err)
+	saved := &types.UsageDisk{}
+	require.NoError(t, json.Unmarshal(data, saved))
+	require.NotNil(t, saved.ShardUsage, "the first report must have saved usage")
+	saved.ShardUsage.ObjectsCount = savedObjectsCount
+	writeSavedShardUsage(t, indexPath, shardName, saved)
 }

--- a/adapters/repos/db/index_usage_dropped_vector_test.go
+++ b/adapters/repos/db/index_usage_dropped_vector_test.go
@@ -90,7 +90,7 @@ func TestIndex_UsageForCollection_DroppedNamedVector(t *testing.T) {
 				ctx := context.Background()
 				tenantName := "test-tenant"
 
-				index := setupPopulatedLazyIndex(ctx, t)
+				index, _ := setupPopulatedLazyIndex(ctx, t, usageIndexParams{namedVectors: tt.vectorConfig})
 				t.Cleanup(func() { _ = index.Shutdown(ctx) })
 
 				if state.loadAndDelete {
@@ -109,5 +109,61 @@ func TestIndex_UsageForCollection_DroppedNamedVector(t *testing.T) {
 				assert.Equal(t, tt.wantVectors, gotVectors)
 			})
 		}
+	}
+}
+
+// TestIndex_UsageForCollection_VectorIndexWithoutConfig is the loaded-shard half:
+// an index the schema no longer configures is left out of the report instead of
+// failing it. A drop that failed halfway leaves this shape behind for good.
+func TestIndex_UsageForCollection_VectorIndexWithoutConfig(t *testing.T) {
+	liveConfig := models.VectorConfig{
+		VectorIndexType:   "hnsw",
+		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+	}
+
+	tests := []struct {
+		name string
+		// dropped is the named vector whose config is removed while the shard keeps
+		// its index.
+		dropped     string
+		wantVectors []string
+	}{
+		{name: "one of two vectors dropped", dropped: "two", wantVectors: []string{"", "one"}},
+		{name: "the legacy vector dropped", dropped: "", wantVectors: []string{"one", "two"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tenantName := "test-tenant"
+
+			index, vectorConfigs := setupPopulatedLazyIndex(ctx, t, usageIndexParams{
+				namedVectors: map[string]models.VectorConfig{"one": liveConfig, "two": liveConfig},
+			})
+			t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+			_, release, err := index.GetShard(ctx, tenantName)
+			require.NoError(t, err)
+			defer release()
+
+			index.vectorIndexUserConfigLock.Lock()
+			if tt.dropped == "" {
+				index.vectorIndexUserConfig = nil
+			} else {
+				delete(index.vectorIndexUserConfigs, tt.dropped)
+			}
+			index.vectorIndexUserConfigLock.Unlock()
+			delete(vectorConfigs, tt.dropped)
+
+			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err, "an index without a config must not fail the report")
+			require.Len(t, usage.Shards, 1)
+
+			var gotVectors []string
+			for _, namedVector := range usage.Shards[0].NamedVectors {
+				gotVectors = append(gotVectors, namedVector.Name)
+			}
+			assert.Equal(t, tt.wantVectors, gotVectors)
+		})
 	}
 }

--- a/adapters/repos/db/index_usage_hot_cold_test.go
+++ b/adapters/repos/db/index_usage_hot_cold_test.go
@@ -20,15 +20,17 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/semaphore"
 
+	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/models"
 	entflat "github.com/weaviate/weaviate/entities/vectorindex/flat"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 // TestIndex_UsageForCollection_LoadedAndUnloadedAgree pins that one shard reports
-// the same named vectors whether it is loaded or not. The loaded path asks the
-// shard's index, the unloaded path reads the shard's files. A bill must not change
-// because a tenant happened to be active when the report ran.
+// the same named vectors and the same full storage size whether it is loaded or
+// not. The loaded path asks the shard's index, the unloaded path reads the shard's
+// files. A bill must not change because a tenant happened to be active when the
+// report ran.
 func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
 	hnswConfig := func(mutate func(*enthnsw.UserConfig)) models.VectorConfig {
 		cfg := enthnsw.NewDefaultUserConfig()
@@ -119,6 +121,18 @@ func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
 
 			require.Len(t, loaded.Shards[0].NamedVectors, len(vectorConfigs))
 			assert.Equal(t, loaded.Shards[0].NamedVectors, unloaded.Shards[0].NamedVectors)
+			assert.Equal(t, loaded.Shards[0].FullShardStorageBytes, unloaded.Shards[0].FullShardStorageBytes)
+
+			// the first cold report leaves its saved usage in the shard directory, so
+			// a second one walks a directory the loaded shard never has
+			writeSavedShardUsage(t, index.path(), tenantName, &types.UsageDisk{
+				Version:    types.UsageDiskVersion,
+				ShardUsage: unloaded.Shards[0],
+			})
+			recomputed, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, recomputed.Shards, 1)
+			assert.Equal(t, loaded.Shards[0].FullShardStorageBytes, recomputed.Shards[0].FullShardStorageBytes)
 		})
 	}
 }

--- a/adapters/repos/db/index_usage_hot_cold_test.go
+++ b/adapters/repos/db/index_usage_hot_cold_test.go
@@ -1,0 +1,124 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+
+	"github.com/weaviate/weaviate/entities/models"
+	entflat "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// TestIndex_UsageForCollection_LoadedAndUnloadedAgree pins that one shard reports
+// the same named vectors whether it is loaded or not. The loaded path asks the
+// shard's index, the unloaded path reads the shard's files. A bill must not change
+// because a tenant happened to be active when the report ran.
+func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
+	hnswConfig := func(mutate func(*enthnsw.UserConfig)) models.VectorConfig {
+		cfg := enthnsw.NewDefaultUserConfig()
+		mutate(&cfg)
+		return models.VectorConfig{VectorIndexType: cfg.IndexType(), VectorIndexConfig: cfg}
+	}
+	flatConfig := func(mutate func(*entflat.UserConfig)) models.VectorConfig {
+		cfg := entflat.NewDefaultUserConfig()
+		mutate(&cfg)
+		return models.VectorConfig{VectorIndexType: cfg.IndexType(), VectorIndexConfig: cfg}
+	}
+
+	namedVectors := map[string]models.VectorConfig{
+		"hnsw-standard": hnswConfig(func(cfg *enthnsw.UserConfig) {}),
+		"hnsw-bq":       hnswConfig(func(cfg *enthnsw.UserConfig) { cfg.BQ.Enabled = true }),
+		"hnsw-sq":       hnswConfig(func(cfg *enthnsw.UserConfig) { cfg.SQ.Enabled = true }),
+		"hnsw-pq": hnswConfig(func(cfg *enthnsw.UserConfig) {
+			cfg.PQ.Enabled = true
+			cfg.PQ.Segments = 4
+		}),
+		"hnsw-rq": hnswConfig(func(cfg *enthnsw.UserConfig) { cfg.RQ.Enabled = true }),
+		"flat-bq": flatConfig(func(cfg *entflat.UserConfig) { cfg.BQ.Enabled = true }),
+		"flat-rq": flatConfig(func(cfg *entflat.UserConfig) { cfg.RQ.Enabled = true }),
+	}
+	// a multivector index rejects the single vectors this test writes, so it only
+	// takes part in the case that writes none
+	withMultiVector := maps.Clone(namedVectors)
+	withMultiVector["hnsw-multivector"] = hnswConfig(func(cfg *enthnsw.UserConfig) {
+		cfg.Multivector.Enabled = true
+	})
+
+	tests := []struct {
+		name         string
+		namedVectors map[string]models.VectorConfig
+		// vectorDimensions is the size of the vector stored for every object under
+		// every named vector. 0 leaves every configured vector without data.
+		vectorDimensions  int
+		dimensionTracking dimensionTracking
+	}{
+		{name: "configured vectors without data", namedVectors: withMultiVector},
+		{name: "configured vectors with data", namedVectors: namedVectors, vectorDimensions: 32},
+		{
+			// a node reporting usage without TRACK_VECTOR_DIMENSIONS has no dimensions
+			// bucket for the loaded path to read, and the report must survive that
+			name:              "vectors whose dimensions were never tracked",
+			namedVectors:      namedVectors,
+			vectorDimensions:  32,
+			dimensionTracking: trackingOff,
+		},
+		{
+			// dimensions tracked earlier stay on disk, where the unloaded path reads
+			// them; the loaded path holds no bucket covering them
+			name:              "dimensions tracked before tracking was turned off",
+			namedVectors:      namedVectors,
+			vectorDimensions:  32,
+			dimensionTracking: trackingStoppedAfterImport,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tenantName := "test-tenant"
+
+			index, vectorConfigs := setupPopulatedLazyIndex(ctx, t, usageIndexParams{
+				namedVectors:      tt.namedVectors,
+				vectorDimensions:  tt.vectorDimensions,
+				dimensionTracking: tt.dimensionTracking,
+			})
+			t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+			_, release, err := index.GetShard(ctx, tenantName)
+			require.NoError(t, err)
+			loaded, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			release()
+			require.NoError(t, err)
+			require.Len(t, loaded.Shards, 1)
+
+			// the unloaded path opens the same buckets, so the loaded shard has to
+			// let go of them first
+			loadedShard, ok := index.shards.LoadAndDelete(tenantName)
+			require.True(t, ok)
+			require.NoError(t, loadedShard.Shutdown(ctx))
+
+			unloaded, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, unloaded.Shards, 1)
+
+			require.Len(t, loaded.Shards[0].NamedVectors, len(vectorConfigs))
+			assert.Equal(t, loaded.Shards[0].NamedVectors, unloaded.Shards[0].NamedVectors)
+		})
+	}
+}

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -177,7 +177,7 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T, params usageInde
 
 	className := "TestUsageClass"
 	tenantName := "test-tenant"
-	objectCount := 20
+	objectCount := int(populatedObjectsCount)
 
 	shardState := &sharding.State{
 		Physical: map[string]sharding.Physical{

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -39,6 +39,7 @@ import (
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storobj"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
@@ -105,7 +106,7 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			ctx := context.Background()
 			tenantName := "test-tenant"
 
-			index := setupPopulatedLazyIndex(ctx, t)
+			index, _ := setupPopulatedLazyIndex(ctx, t, usageIndexParams{})
 			t.Cleanup(func() { _ = index.Shutdown(ctx) })
 
 			if tt.loadAndDelete {
@@ -138,11 +139,37 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 	}
 }
 
+// dimensionTracking says which phases of setupPopulatedLazyIndex run with
+// TRACK_VECTOR_DIMENSIONS on.
+type dimensionTracking int
+
+const (
+	trackingOn dimensionTracking = iota
+	trackingOff
+	// trackingStoppedAfterImport tracks the imported objects and then returns an
+	// index that no longer tracks, leaving dimensions on disk that no bucket in
+	// memory covers.
+	trackingStoppedAfterImport
+)
+
+// usageIndexParams parametrizes setupPopulatedLazyIndex.
+type usageIndexParams struct {
+	// namedVectors go on the class alongside the legacy vector. An entry with a nil
+	// VectorIndexConfig is left out of the index's parsed configs, matching a
+	// dropped vector, whose config the schema parser leaves nil.
+	namedVectors map[string]models.VectorConfig
+	// vectorDimensions, when positive, stores a vector of that many dimensions
+	// for every object under every configured named vector.
+	vectorDimensions  int
+	dimensionTracking dimensionTracking
+}
+
 // setupPopulatedLazyIndex creates an index for a multi-tenant class, populates
 // one tenant with objects, flushes it to disk, then returns a fresh index with
 // lazy loading enabled so the populated tenant is a registered-but-unloaded
-// lazy shard reading from disk.
-func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
+// lazy shard reading from disk. The returned map is what the schema would hand
+// to the usage report for this index, legacy vector included.
+func setupPopulatedLazyIndex(ctx context.Context, t *testing.T, params usageIndexParams) (*Index, map[string]models.VectorConfig) {
 	t.Helper()
 
 	dirName := t.TempDir()
@@ -177,6 +204,22 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled: shardState.PartitioningEnabled,
 		},
+		VectorConfig: params.namedVectors,
+	}
+
+	legacyVectorConfig := enthnsw.UserConfig{VectorCacheMaxObjects: 1000}
+	namedVectorConfigs := make(map[string]schemaConfig.VectorIndexConfig, len(params.namedVectors))
+	reportedVectorConfigs := map[string]models.VectorConfig{
+		"": {VectorIndexType: legacyVectorConfig.IndexType(), VectorIndexConfig: legacyVectorConfig},
+	}
+	for targetVector, vectorConfig := range params.namedVectors {
+		reportedVectorConfigs[targetVector] = vectorConfig
+		if vectorConfig.VectorIndexConfig == nil {
+			continue
+		}
+		parsed, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
+		require.True(t, ok, "named vector %q needs a parsed config", targetVector)
+		namedVectorConfigs[targetVector] = parsed
 	}
 
 	fakeSchema := schema.Schema{
@@ -214,17 +257,17 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 		}, nil).Maybe()
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
 
-	newIndexFn := func(lazy bool, vectorConfigs map[string]schemaConfig.VectorIndexConfig) *Index {
+	newIndexFn := func(lazy, trackDimensions bool) *Index {
 		idx, err := NewIndex(ctx, IndexConfig{
 			RootPath:              dirName,
 			ClassName:             schema.ClassName(className),
 			ReplicationFactor:     1,
 			ShardLoadLimiter:      loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
-			TrackVectorDimensions: true,
+			TrackVectorDimensions: trackDimensions,
 			EnableLazyLoadShards:  lazy,
 		}, inverted.ConfigFromModel(class.InvertedIndexConfig),
-			enthnsw.UserConfig{VectorCacheMaxObjects: 1000},
-			vectorConfigs,
+			legacyVectorConfig,
+			namedVectorConfigs,
 			mockRouter,
 			shardResolver,
 			mockSchema,
@@ -240,7 +283,7 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 			nil,
 			scheduler,
 			nil,
-			nil,
+			memwatch.NewDummyMonitor(),
 			NewShardReindexerV3Noop(),
 			roaringset.NewBitmapBufPoolNoop(),
 			false,
@@ -251,7 +294,7 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 	}
 
 	// Phase 1: eagerly-loaded index, populate and flush to disk.
-	index := newIndexFn(false, nil)
+	index := newIndexFn(false, params.dimensionTracking != trackingOff)
 	for _, prop := range class.Properties {
 		require.NoError(t, index.addProperty(ctx, prop))
 	}
@@ -264,7 +307,18 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 				"name": fmt.Sprintf("test-object-%d", i),
 			},
 		}
-		require.NoError(t, index.putObject(ctx, storobj.FromObject(obj, nil, nil, nil), nil, tenantName, 0))
+		var vectors map[string][]float32
+		if params.vectorDimensions > 0 {
+			vector := make([]float32, params.vectorDimensions)
+			for dim := range vector {
+				vector[dim] = float32(i*params.vectorDimensions + dim)
+			}
+			vectors = make(map[string][]float32, len(namedVectorConfigs))
+			for targetVector := range namedVectorConfigs {
+				vectors[targetVector] = vector
+			}
+		}
+		require.NoError(t, index.putObject(ctx, storobj.FromObject(obj, nil, vectors, nil), nil, tenantName, 0))
 	}
 
 	shard, release, err := index.GetShard(ctx, tenantName)
@@ -277,9 +331,8 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T) *Index {
 	require.NoError(t, shard.Store().FlushMemtables(ctx))
 	release()
 
-	vectorConfigs := index.GetVectorIndexConfigs()
 	require.NoError(t, index.Shutdown(ctx))
 
 	// Phase 2: fresh lazy index reading the populated tenant from disk.
-	return newIndexFn(true, vectorConfigs)
+	return newIndexFn(true, params.dimensionTracking == trackingOn), reportedVectorConfigs
 }

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -63,9 +64,20 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 		// registered-but-unloaded lazy shard (the exact reported journey).
 		loadAndDelete bool
 		// removeRelPath, relative to the shard directory, is deleted to simulate
-		// the half-deleted on-disk state.
+		// the half-deleted on-disk state. "." removes the shard directory itself,
+		// which is also the shape of a tenant that was never written to.
 		removeRelPath string
 	}{
+		{
+			name:          "unloaded lazy shard, whole shard dir gone",
+			loadAndDelete: false,
+			removeRelPath: ".",
+		},
+		{
+			name:          "inactive shard, whole shard dir gone",
+			loadAndDelete: true,
+			removeRelPath: ".",
+		},
 		{
 			name:          "unloaded lazy shard, missing lsm/objects",
 			loadAndDelete: false,
@@ -115,6 +127,13 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			assert.Equal(t, tenantName, shardUsage.Name)
 			assert.Equal(t, int64(0), shardUsage.ObjectsCount, "missing shard must be recorded as empty")
 			assert.Equal(t, uint64(0), shardUsage.ObjectsStorageBytes)
+
+			// an empty shard must spell its status the same way a computed one does
+			wantStatus := strings.ToLower(models.TenantActivityStatusACTIVE)
+			if tt.loadAndDelete {
+				wantStatus = strings.ToLower(models.TenantActivityStatusINACTIVE)
+			}
+			assert.Equal(t, wantStatus, shardUsage.Status)
 		})
 	}
 }

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -301,7 +301,9 @@ func (db *DB) totalShardSizeBytes(className schema.ClassName, shardNames []strin
 		// Prefer precomputed usage data if available; it is cheap to read
 		// and already contains the full shard storage size.
 		if shardusage.ComputedUsageDataExists(indexPath, shardName) {
-			shardUsage, err := shardusage.LoadComputedUsageData(indexPath, shardName)
+			// the fingerprint of the vector configs is not compared here. The full
+			// shard size on disk does not depend on them.
+			saved, err := shardusage.LoadComputedUsageData(indexPath, shardName)
 			if errors.Is(err, shardusage.ErrUsageVersionMismatch) {
 				// a version bump leaves this behind on every shard that stayed
 				// cold across it; the on-disk size below is exact anyway
@@ -314,8 +316,8 @@ func (db *DB) totalShardSizeBytes(className schema.ClassName, shardNames []strin
 					WithField("class", className).
 					WithField("shard", shardName).
 					Warnf("failed to load pre-calculated shard usage; falling back to on-disk size: %v", err)
-			} else if shardUsage != nil {
-				total += shardUsage.FullShardStorageBytes
+			} else {
+				total += saved.ShardUsage.FullShardStorageBytes
 				if sizeThresholdBytes > 0 && total > sizeThresholdBytes {
 					return total
 				}

--- a/adapters/repos/db/init_test.go
+++ b/adapters/repos/db/init_test.go
@@ -110,7 +110,7 @@ func TestNewShard_AbortsWhenUsageFileRemovalFails(t *testing.T) {
 	// non-empty directory and drop write permission on it, so os.RemoveAll fails
 	// on its child while the (writable) shard dir leaves the rest of NewShard
 	// unaffected.
-	usageTmp := path.Join(index.path(), shardName, "usage.json.tmp")
+	usageTmp := savedShardUsagePath(index.path(), shardName)
 	require.NoError(t, os.MkdirAll(usageTmp, 0o700))
 	require.NoError(t, os.WriteFile(path.Join(usageTmp, "child"), []byte("x"), 0o600))
 	require.NoError(t, os.Chmod(usageTmp, 0o500))
@@ -148,34 +148,58 @@ func TestTotalShardSizeBytes_FallsBackToDirSizeWhenNoMeta(t *testing.T) {
 }
 
 func TestTotalShardSizeBytes_PrefersMetaFileWhenPresent(t *testing.T) {
-	tmpDir := t.TempDir()
+	const fullShardBytes = uint64(1234)
+	// on-disk data, so a fallback to the directory size is distinguishable
+	onDisk := []byte("0123456789")
 
-	db := &DB{
-		logger: logrus.New(),
-		config: Config{
-			RootPath: tmpDir,
+	tests := []struct {
+		name  string
+		usage *types.ShardUsage
+		// wantFromDir expects the shard's files to be summed instead of the saved
+		// FullShardStorageBytes.
+		wantFromDir bool
+	}{
+		{
+			name: "saved usage is preferred",
+			usage: &types.ShardUsage{
+				Name:                  "shard1",
+				FullShardStorageBytes: fullShardBytes,
+			},
+		},
+		{
+			// nothing to prefer, so the shard is sized from disk like an unsaved one
+			name:        "a saved record holding no usage falls back to the directory size",
+			wantFromDir: true,
 		},
 	}
 
-	className := schema.ClassName("MyClass")
-	indexPath := path.Join(tmpDir, indexID(className))
-	shardName := "shard1"
-	shardPath := path.Join(indexPath, shardName)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
 
-	require.NoError(t, os.MkdirAll(shardPath, 0o777))
+			db := &DB{
+				logger: logrus.New(),
+				config: Config{
+					RootPath: tmpDir,
+				},
+			}
 
-	// Write a meta file with a known size
-	const fullShardBytes = uint64(1234)
-	err := shardusage.SaveComputedUsageData(indexPath, shardName, &types.ShardUsage{
-		Name:                  shardName,
-		FullShardStorageBytes: fullShardBytes,
-	})
-	require.NoError(t, err)
+			className := schema.ClassName("MyClass")
+			indexPath := path.Join(tmpDir, indexID(className))
+			shardName := "shard1"
+			shardPath := path.Join(indexPath, shardName)
 
-	// Also create some on-disk data to ensure we really prefer the meta value
-	data := []byte("0123456789") // 10 bytes
-	require.NoError(t, os.WriteFile(path.Join(shardPath, "data.bin"), data, 0o644))
+			require.NoError(t, os.MkdirAll(shardPath, 0o777))
+			require.NoError(t, shardusage.SaveComputedUsageData(indexPath, shardName, tt.usage, ""))
+			require.NoError(t, os.WriteFile(path.Join(shardPath, "data.bin"), onDisk, 0o644))
 
-	got := db.totalShardSizeBytes(className, []string{shardName}, 0)
-	require.Equal(t, fullShardBytes, got)
+			want := fullShardBytes
+			if tt.wantFromDir {
+				saved, err := os.Stat(savedShardUsagePath(indexPath, shardName))
+				require.NoError(t, err)
+				want = uint64(len(onDisk)) + uint64(saved.Size())
+			}
+			require.Equal(t, want, db.totalShardSizeBytes(className, []string{shardName}, 0))
+		})
+	}
 }

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -93,11 +93,20 @@ func (s *Shard) QuantizedDimensions(ctx context.Context, targetVector string, se
 
 func (s *Shard) calcTargetVectorDimensions(ctx context.Context, targetVector string,
 ) (types.Dimensionality, error) {
-	scan, err := s.DimensionsUsage(ctx, targetVector, 0)
-	if err != nil {
-		return types.Dimensionality{}, err
+	if b := s.store.Bucket(helpers.DimensionsBucketLSM); b != nil {
+		scan, err := shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, 0)
+		if err != nil {
+			return types.Dimensionality{}, err
+		}
+		return scan.Raw, nil
 	}
-	return scan.Raw, nil
+	if s.index.Config.TrackVectorDimensions {
+		return types.Dimensionality{}, errors.Errorf("calcTargetVectorDimensions: no bucket dimensions")
+	}
+	// A shard that does not track dimensions never opened the bucket, so read what
+	// an earlier tracking run left on disk — the same source an unloaded shard
+	// reads, so one shard reports the same either way.
+	return shardusage.CalculateUnloadedDimensionsUsage(ctx, s.index.logger, s.index.path(), s.name, targetVector)
 }
 
 // DimensionMetrics represents the dimension tracking metrics for a vector.
@@ -242,35 +251,44 @@ func getDynamicCompression(config dynamicent.UserConfig, dynamicUpgraded bool) D
 // training limit before compressing anything, and until then the vectors on disk
 // are float32. hfresh is exempt — it keeps its codes in its own postings.
 func (di DimensionInfo) compressionRatio(dimensions int, quantizedVectorsExist bool) float64 {
+	if !quantizedVectorsExist && di.category != DimensionCategoryAuto {
+		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
+	}
+
+	var stats compressionhelpers.CompressionStats
+	switch di.category {
+	case DimensionCategoryPQ:
+		stats = compressionhelpers.PQStats{M: correctEmptySegments(di.segments, dimensions)}
+	case DimensionCategoryBQ:
+		stats = compressionhelpers.BQStats{}
+	case DimensionCategorySQ:
+		stats = compressionhelpers.SQStats{}
+	case DimensionCategoryRQ:
+		if di.bits == 1 {
+			stats = compressionhelpers.BinaryRQStats{}
+		} else {
+			stats = compressionhelpers.RQStats{Bits: uint32(di.bits)}
+		}
+	case DimensionCategoryAuto:
+		// hfresh quantizes with RQ on 1 bit; its config validation rejects
+		// disabling it or asking for another bit count
+		stats = compressionhelpers.BinaryRQStats{}
+	default:
+		stats = compressionhelpers.UncompressedStats{}
+	}
+	return vectorCompressionRatio(stats, dimensions)
+}
+
+// vectorCompressionRatio turns a quantizer's stats into the ratio the usage
+// report carries, for a loaded shard's index and an unloaded shard's
+// configuration alike.
+func vectorCompressionRatio(stats compressionhelpers.CompressionStats, dimensions int) float64 {
 	// with nothing tracked there is nothing to compress, and PQ's optimal
 	// segment count would collapse to zero and divide by it
 	if dimensions <= 0 {
 		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
 	}
-
-	if !quantizedVectorsExist && di.category != DimensionCategoryAuto {
-		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
-	}
-
-	switch di.category {
-	case DimensionCategoryPQ:
-		return compressionhelpers.PQStats{M: correctEmptySegments(di.segments, dimensions)}.CompressionRatio(dimensions)
-	case DimensionCategoryBQ:
-		return compressionhelpers.BQStats{}.CompressionRatio(dimensions)
-	case DimensionCategorySQ:
-		return compressionhelpers.SQStats{}.CompressionRatio(dimensions)
-	case DimensionCategoryRQ:
-		if di.bits == 1 {
-			return compressionhelpers.BinaryRQStats{}.CompressionRatio(dimensions)
-		}
-		return compressionhelpers.RQStats{Bits: uint32(di.bits)}.CompressionRatio(dimensions)
-	case DimensionCategoryAuto:
-		// hfresh quantizes with RQ on 1 bit; its config validation rejects
-		// disabling it or asking for another bit count
-		return compressionhelpers.BinaryRQStats{}.CompressionRatio(dimensions)
-	default:
-		return compressionhelpers.UncompressedStats{}.CompressionRatio(dimensions)
-	}
+	return stats.CompressionRatio(dimensions)
 }
 
 func correctEmptySegments(segments int, dimensions int) int {

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -14,7 +14,9 @@ package shardusage
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/entities/models"
 	entsync "github.com/weaviate/weaviate/entities/sync"
 )
 
@@ -47,8 +50,11 @@ func shardPathDimensionsLSM(indexPath, shardName string) string {
 	return path.Join(shardPathLSM(indexPath, shardName), helpers.DimensionsBucketLSM)
 }
 
+// usageTmpFileName names the file holding a shard's saved usage, in the shard's own directory.
+const usageTmpFileName = "usage.json.tmp"
+
 func usageTmpFilePath(indexPath, shardName string) string {
-	return path.Join(indexPath, shardName, "usage.json.tmp")
+	return path.Join(indexPath, shardName, usageTmpFileName)
 }
 
 // ComputedUsageDataExists checks if pre-calculated shard usage data file exists
@@ -68,9 +74,14 @@ func RemoveComputedUsageDataForUnloadedShard(indexPath, shardName string) error 
 	return nil
 }
 
-// SaveComputedUsageData saves pre-calculated shard usage data to disk
-func SaveComputedUsageData(indexPath, shardName string, shardUsage *types.ShardUsage) error {
-	data, err := json.Marshal(usageDisk(shardUsage))
+// SaveComputedUsageData saves pre-calculated shard usage data to disk, stamped with
+// the fingerprint of the vector configs it was computed from.
+func SaveComputedUsageData(indexPath, shardName string, shardUsage *types.ShardUsage, vectorConfigsFingerprint string) error {
+	data, err := json.Marshal(&types.UsageDisk{
+		Version:                  types.UsageDiskVersion,
+		ShardUsage:               shardUsage,
+		VectorConfigsFingerprint: vectorConfigsFingerprint,
+	})
 	if err != nil {
 		return fmt.Errorf("marshal pre-calculated usage for disk: %w", err)
 	}
@@ -80,13 +91,32 @@ func SaveComputedUsageData(indexPath, shardName string, shardUsage *types.ShardU
 	return nil
 }
 
+// VectorConfigsFingerprint identifies a collection's vector configs, so that a shard
+// staying cold across a vector index being added, dropped, or reconfigured recomputes
+// its usage instead of serving what the previous configs produced.
+func VectorConfigsFingerprint(vectorConfigs map[string]models.VectorConfig) (string, error) {
+	if vectorConfigs == nil {
+		// an absent and an empty map describe the same collection
+		vectorConfigs = map[string]models.VectorConfig{}
+	}
+	// json.Marshal sorts map keys, so the same configs always hash the same
+	data, err := json.Marshal(vectorConfigs)
+	if err != nil {
+		return "", fmt.Errorf("marshal vector configs: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
 // ErrUsageVersionMismatch reports usage written by another version of the format.
 // Every caller recomputes, so it is the expected outcome of a version bump for
 // each shard that stayed cold across it — routine, unlike an unreadable file.
 var ErrUsageVersionMismatch = errors.New("usage data saved to disk version mismatch")
 
-// LoadComputedUsageData loads pre-calculated shard usage data, checks version of saved data before returning
-func LoadComputedUsageData(indexPath, shardName string) (*types.ShardUsage, error) {
+// LoadComputedUsageData loads the pre-calculated usage record of a shard, rejecting a
+// version this build does not know. Callers that depend on the vector configs must also
+// compare its fingerprint against [VectorConfigsFingerprint] of their current ones.
+func LoadComputedUsageData(indexPath, shardName string) (*types.UsageDisk, error) {
 	// usage has been pre-calculated and can be read from disk
 	usage, err := os.ReadFile(usageTmpFilePath(indexPath, shardName))
 	if err != nil {
@@ -100,11 +130,10 @@ func LoadComputedUsageData(indexPath, shardName string) (*types.ShardUsage, erro
 		return nil, fmt.Errorf("%w, currently supported version is %d but got %d",
 			ErrUsageVersionMismatch, types.UsageDiskVersion, usageDisk.Version)
 	}
-	return usageDisk.ShardUsage, nil
-}
-
-func usageDisk(shardUsage *types.ShardUsage) *types.UsageDisk {
-	return &types.UsageDisk{Version: types.UsageDiskVersion, ShardUsage: shardUsage}
+	if usageDisk.ShardUsage == nil {
+		return nil, errors.New("pre-calculated usage from disk holds no shard usage")
+	}
+	return usageDisk, nil
 }
 
 // unloadedDimensionsBucketLocks serializes access to the same unloaded dimensions bucket.
@@ -346,7 +375,13 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 	}
 
 	// Add sizes of all files in the shard root directory
-	for _, size := range files {
+	for file, size := range files {
+		if file == usageTmpFileName {
+			// a shard must not grow by the size of its own saved usage: the file only
+			// exists while the shard is cold, so counting it would also make a cold
+			// shard report more than the same shard loaded
+			continue
+		}
 		otherNonLSMFoldersStorageSize += uint64(size)
 	}
 	for _, dir := range dirs {

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -216,44 +216,6 @@ func getFileTypeCount(t *testing.T, path string) map[string]int {
 	return fileTypes
 }
 
-// Nothing deletes the pre-calculated usage of a shard that stays cold, so the
-// version check is the only guard against serving outdated sizes.
-func TestLoadComputedUsageDataVersion(t *testing.T) {
-	tests := []struct {
-		name      string
-		version   int
-		wantError bool
-	}{
-		{name: "current version is served", version: types.UsageDiskVersion},
-		{name: "older version is rejected", version: types.UsageDiskVersion - 1, wantError: true},
-		{name: "newer version is rejected", version: types.UsageDiskVersion + 1, wantError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dirName := t.TempDir()
-			require.NoError(t, os.MkdirAll(filepath.Join(dirName, "shard1"), 0o777))
-
-			stored := &types.UsageDisk{
-				Version:    tt.version,
-				ShardUsage: &types.ShardUsage{Name: "shard1", IndexStorageBytes: 42},
-			}
-			data, err := json.Marshal(stored)
-			require.NoError(t, err)
-			require.NoError(t, os.WriteFile(usageTmpFilePath(dirName, "shard1"), data, 0o600))
-
-			usage, err := LoadComputedUsageData(dirName, "shard1")
-			if tt.wantError {
-				require.ErrorIs(t, err, ErrUsageVersionMismatch,
-					"callers tell a stale version from an unreadable file by this error")
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, uint64(42), usage.IndexStorageBytes)
-		})
-	}
-}
-
 func TestStorageCalculation(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
@@ -502,6 +464,12 @@ func TestCalculateNonLSMStorage_NestedHFreshDirectories(t *testing.T) {
 	otherTopLevelFile := filepath.Join(otherTopLevel, "file8")
 	require.NoError(t, os.WriteFile(otherTopLevelFile, make([]byte, 8000), 0o644))
 
+	topLevelFile := filepath.Join(shardPath, "file9")
+	require.NoError(t, os.WriteFile(topLevelFile, make([]byte, 9000), 0o644))
+
+	// the shard's own saved usage sits next to it and must not be billed as shard data
+	require.NoError(t, os.WriteFile(usageTmpFilePath(dirName, "shard1"), make([]byte, 500), 0o644))
+
 	vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, err := CalculateNonLSMStorage(dirName, "shard1")
 	require.NoError(t, err)
 
@@ -517,7 +485,8 @@ func TestCalculateNonLSMStorage_NestedHFreshDirectories(t *testing.T) {
 	// - otherDir: 6000
 	// - hfreshFile: 7000
 	// - otherTopLevel: 8000
-	expectedOtherSize := uint64(6000 + 7000 + 8000)
+	// - topLevelFile: 9000
+	expectedOtherSize := uint64(6000 + 7000 + 8000 + 9000)
 
 	assert.Equal(t, expectedCommitLogSize, vectorCommitLogsStorageSize, "commitlog/snapshot/queue storage should match")
 	assert.Equal(t, expectedOtherSize, otherNonLSMFoldersStorageSize, "other storage should match")
@@ -828,20 +797,43 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 	})
 }
 
-// Only the current format version is served; any other is rejected so the caller recomputes.
+// Only a record of the current format version that holds usage is served; anything
+// else is rejected so the caller recomputes. Nothing deletes the record of a shard
+// that stays cold, so this and the fingerprint the caller compares are the only
+// guards against serving outdated sizes.
 func TestLoadComputedUsageData(t *testing.T) {
+	stored := &types.ShardUsage{Name: "shard", ObjectsCount: 7, ObjectsStorageBytes: 1234}
+
 	tests := []struct {
-		name    string
-		version int
-		wantErr bool
+		name      string
+		version   int
+		usage     *types.ShardUsage
+		wantErr   bool
+		wantErrIs error
 	}{
 		{
 			name:    "current version",
 			version: types.UsageDiskVersion,
+			usage:   stored,
 		},
 		{
-			name:    "version from a newer release",
-			version: types.UsageDiskVersion + 1,
+			name:      "version from an older release",
+			version:   types.UsageDiskVersion - 1,
+			usage:     stored,
+			wantErr:   true,
+			wantErrIs: ErrUsageVersionMismatch,
+		},
+		{
+			name:      "version from a newer release",
+			version:   types.UsageDiskVersion + 1,
+			usage:     stored,
+			wantErr:   true,
+			wantErrIs: ErrUsageVersionMismatch,
+		},
+		{
+			// serving this would drop the shard from the report instead of billing it
+			name:    "no usage in the record",
+			version: types.UsageDiskVersion,
 			wantErr: true,
 		},
 	}
@@ -852,18 +844,26 @@ func TestLoadComputedUsageData(t *testing.T) {
 			shardName := "shard"
 			require.NoError(t, os.MkdirAll(filepath.Join(indexPath, shardName), 0o755))
 
-			stored := &types.ShardUsage{Name: shardName, ObjectsCount: 7, ObjectsStorageBytes: 1234}
-			data, err := json.Marshal(&types.UsageDisk{Version: tt.version, ShardUsage: stored})
+			data, err := json.Marshal(&types.UsageDisk{
+				Version:                  tt.version,
+				ShardUsage:               tt.usage,
+				VectorConfigsFingerprint: "fingerprint",
+			})
 			require.NoError(t, err)
 			require.NoError(t, os.WriteFile(usageTmpFilePath(indexPath, shardName), data, 0o600))
 
 			loaded, err := LoadComputedUsageData(indexPath, shardName)
 			if tt.wantErr {
 				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					require.ErrorIs(t, err, tt.wantErrIs,
+						"callers tell a stale version from an unreadable file by this error")
+				}
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, stored, loaded)
+			assert.Equal(t, tt.usage, loaded.ShardUsage)
+			assert.Equal(t, "fingerprint", loaded.VectorConfigsFingerprint)
 		})
 	}
 }

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -13,6 +13,8 @@ package types
 
 // UsageDiskVersion invalidates usage already stored on disk. Bump it when reported
 // sizes change meaning, or shards that stay cold keep serving the old numbers.
+// VectorConfigsFingerprint invalidates the same file on its own, for the numbers
+// that depend on the collection's vector configs rather than on this format.
 const UsageDiskVersion int = 2
 
 // UsageDisk defines format of saved pre-computed shard usage data
@@ -21,6 +23,10 @@ type UsageDisk struct {
 	Version int `json:"version"`
 	// ShardUsage
 	ShardUsage *ShardUsage `json:"shardUsage"`
+	// VectorConfigsFingerprint identifies the vector configs the usage was computed
+	// from. Serving it under different ones would bill a vector index that has since
+	// been dropped, or leave out one that was added, until the shard is loaded again.
+	VectorConfigsFingerprint string `json:"vectorConfigsFingerprint,omitempty"`
 }
 
 // Report represents the usage metrics report from the metrics endpoint

--- a/test/acceptance_with_go_client/usage/empty_vector_test.go
+++ b/test/acceptance_with_go_client/usage/empty_vector_test.go
@@ -1,0 +1,106 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package usage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+
+	"acceptance_tests_with_client/internal/wvhost"
+)
+
+// TestUsageOfConfiguredVectorWithoutData pins that a configured, never-written
+// named vector reports the same ratio and dimensionality whether its tenant is
+// loaded or cold. A quantizer is on from the moment its index exists, while the
+// quantized vectors a cold shard looks for only appear once something is written,
+// so the two paths have to agree on a vector that holds nothing.
+func TestUsageOfConfiguredVectorWithoutData(t *testing.T) {
+	ctx := context.Background()
+
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
+	require.NoError(t, err)
+
+	const (
+		populatedVector = "populated"
+		emptyHNSWBQ     = "emptyHnswBq"
+		emptyFlatBQ     = "emptyFlatBq"
+		emptyPlain      = "emptyPlain"
+		dimensions      = 8
+		objectCount     = 5
+	)
+	className := t.Name() + "Class"
+	tenantName := "tenant0"
+
+	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+	defer c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+	noVectorizer := map[string]any{"none": map[string]any{}}
+	quantized := map[string]any{"bq": map[string]any{"enabled": true}}
+	require.NoError(t, c.Schema().ClassCreator().WithClass(&models.Class{
+		Class:              className,
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		Properties: []*models.Property{
+			{Name: "name", DataType: []string{string(schema.DataTypeText)}},
+			{Name: "description", DataType: []string{string(schema.DataTypeText)}},
+		},
+		VectorConfig: map[string]models.VectorConfig{
+			populatedVector: {Vectorizer: noVectorizer, VectorIndexType: "hnsw"},
+			emptyHNSWBQ:     {Vectorizer: noVectorizer, VectorIndexType: "hnsw", VectorIndexConfig: quantized},
+			emptyFlatBQ:     {Vectorizer: noVectorizer, VectorIndexType: "flat", VectorIndexConfig: quantized},
+			emptyPlain:      {Vectorizer: noVectorizer, VectorIndexType: "hnsw"},
+		},
+	}).Do(ctx))
+
+	require.NoError(t, c.Schema().TenantsCreator().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName}).Do(ctx))
+
+	insertObjects(t, objectCount, c, className, tenantName,
+		models.Vectors{populatedVector: generateRandomVector(dimensions)}, nil)
+
+	onlyShardUsage := func(t require.TestingT) *usagetypes.ShardUsage {
+		colUsage, err := GetDebugUsageForCollection(className)
+		require.NoError(t, err)
+		require.Len(t, colUsage.Shards, 1)
+		return colUsage.Shards[0]
+	}
+
+	loadedShard := onlyShardUsage(t)
+	require.Equal(t, []string{emptyFlatBQ, emptyHNSWBQ, emptyPlain, populatedVector},
+		namedVectorNames(loadedShard))
+	for _, vectorUsage := range loadedShard.NamedVectors {
+		if vectorUsage.Name == populatedVector {
+			continue
+		}
+		assert.Empty(t, vectorUsage.Dimensionalities,
+			"vector %q holds nothing and has no dimensionality to bill", vectorUsage.Name)
+		assert.Equal(t, float64(1), vectorUsage.VectorCompressionRatio,
+			"vector %q holds nothing to compress", vectorUsage.Name)
+	}
+
+	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
+		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusCOLD}).Do(ctx))
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		unloadedShard := onlyShardUsage(ct)
+		require.Equal(ct, "inactive", unloadedShard.Status)
+		require.NoError(ct, vectorsDifference(loadedShard.NamedVectors, unloadedShard.NamedVectors))
+	}, 60*time.Second, 500*time.Millisecond)
+}

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -478,6 +478,19 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	require.Len(t, colUsageCold.Shards, 1)
 	require.Equal(t, expected, namedVectorDimensionalities(t, colUsageCold.Shards[0]))
 
+	// Drop vector2's index while the tenant stays cold. The report above saved its
+	// numbers to the shard directory and only loading the shard deletes that file,
+	// so the next report has to notice the schema changed under it.
+	require.NoError(t, c.Schema().VectorIndexDeleter().
+		WithClassName(className).WithVectorIndexName(vector2).Do(ctx))
+	delete(expected, vector2)
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		colUsageColdAfterDrop, err := GetDebugUsageForCollection(className)
+		require.NoError(ct, err)
+		require.Len(ct, colUsageColdAfterDrop.Shards, 1)
+		require.Equal(ct, expected, namedVectorDimensionalities(ct, colUsageColdAfterDrop.Shards[0]))
+	}, 30*time.Second, 500*time.Millisecond)
+
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
 		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx))
 


### PR DESCRIPTION
### What's being changed:

Couple more alignments between HOT and COLD shards return from the usage module:
1. Empty shards reported an upper-case status
2. Loaded and cold shards disagreed on vectors and on size
3. Cold shards served usage computed from vector configs the collection no longer has

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
