### PR TITLE
fix(drop-vector-index): remove hfresh directory and buckets when the index is dropped

### DIFF
--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -55,6 +55,27 @@ func GetMuveraBucketName(targetVector string) string {
 	return "main_muvera_vectors"
 }
 
+// HFresh keeps more on-disk state than the other index types: a directory of
+// its own under the shard, plus two dedicated LSM buckets. All three are keyed
+// on the index ID (vectorIndexID, i.e. "vectors_<target>" for a named vector),
+// and they live here so the index that creates them and the drop that removes
+// them cannot drift apart.
+
+// HFreshDirName is the hfresh index's own directory under the shard.
+func HFreshDirName(indexID string) string {
+	return fmt.Sprintf("%s.hfresh.d", indexID)
+}
+
+// HFreshPostingsBucketName is the LSM bucket holding hfresh's posting lists.
+func HFreshPostingsBucketName(indexID string) string {
+	return fmt.Sprintf("hfresh_postings_%s", indexID)
+}
+
+// HFreshSharedBucketName is the LSM bucket holding hfresh's shared metadata.
+func HFreshSharedBucketName(indexID string) string {
+	return fmt.Sprintf("hfresh_shared_%s", indexID)
+}
+
 func GetHNSWCommitLogDirName(targetVector string) string {
 	if targetVector != "" {
 		return fmt.Sprintf("%s.hnsw.commitlog.d", GetVectorsBucketName(targetVector))

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -53,6 +53,8 @@ func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
 // - LSM muvera bucket: vectors_{name}_muvera_vectors (multi-vector + muvera only)
 // - HNSW commit log directory: vectors_{name}.hnsw.commitlog.d
 // - HNSW snapshot directory: vectors_{name}.hnsw.snapshot.d
+// - HFresh directory: vectors_{name}.hfresh.d (hfresh only)
+// - HFresh LSM buckets: hfresh_postings_vectors_{name}, hfresh_shared_vectors_{name}
 func (h *vectorDropIndexHelper) removeVectorIndexFiles(indexPath, shardName, targetVector string) error {
 	lsmDir := filepath.Join(indexPath, shardName, "lsm")
 	shardDir := filepath.Join(indexPath, shardName)
@@ -60,6 +62,10 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(indexPath, shardName, tar
 	vectorsBucket := helpers.GetVectorsBucketName(targetVector)
 	compressedBucket := helpers.GetCompressedBucketName(targetVector)
 	muveraBucket := helpers.GetMuveraBucketName(targetVector)
+	indexID := helpers.GetVectorsBucketName(targetVector)
+	hfreshDir := helpers.HFreshDirName(indexID)
+	hfreshPostings := helpers.HFreshPostingsBucketName(indexID)
+	hfreshShared := helpers.HFreshSharedBucketName(indexID)
 	hnswCommitLogDir := helpers.GetHNSWCommitLogDirName(targetVector)
 	hnswSnapshotDir := helpers.GetHNSWSnapshotDirName(targetVector)
 
@@ -67,6 +73,9 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(indexPath, shardName, tar
 		filepath.Join(lsmDir, vectorsBucket),
 		filepath.Join(lsmDir, compressedBucket),
 		filepath.Join(lsmDir, muveraBucket),
+		filepath.Join(lsmDir, hfreshPostings),
+		filepath.Join(lsmDir, hfreshShared),
+		filepath.Join(shardDir, hfreshDir),
 		filepath.Join(shardDir, hnswCommitLogDir),
 		filepath.Join(shardDir, hnswSnapshotDir),
 	}

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -105,6 +105,57 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		assert.True(t, pathExists(sibling), "another vector's muvera bucket must survive")
 	})
 
+	t.Run("removes the directory and buckets of an hfresh index", func(t *testing.T) {
+		// hfresh keeps its state outside the vectors/compressed pair that every
+		// index has, and its own Drop() removes none of it — so a per-vector
+		// drop used to leave all of it behind. Nothing collects it afterwards:
+		// once the drop completes the vector's schema entry is gone, so
+		// ensureFilesAreRemovedForDroppedVectorIndexes never iterates over it.
+		indexPath, shardName := setup(t)
+
+		const target = "hfresh_vec"
+		indexID := helpers.GetVectorsBucketName(target)
+		lsm := filepath.Join(indexPath, shardName, "lsm")
+		postings := filepath.Join(lsm, helpers.HFreshPostingsBucketName(indexID))
+		shared := filepath.Join(lsm, helpers.HFreshSharedBucketName(indexID))
+		hfreshDir := filepath.Join(indexPath, shardName, helpers.HFreshDirName(indexID))
+
+		for _, dir := range []string{postings, shared, hfreshDir} {
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "segment.db"), []byte("data"), 0o644))
+		}
+		// Pinned literally: these are the names the running index creates, and
+		// a rename on either side has to fail here rather than silently leave
+		// the sweep looking for something that no longer exists.
+		require.Equal(t, filepath.Join(lsm, "hfresh_postings_vectors_hfresh_vec"), postings)
+		require.Equal(t, filepath.Join(lsm, "hfresh_shared_vectors_hfresh_vec"), shared)
+		require.Equal(t, filepath.Join(indexPath, shardName, "vectors_hfresh_vec.hfresh.d"), hfreshDir)
+
+		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, target))
+
+		assert.False(t, pathExists(postings), "the hfresh postings bucket must not survive the drop")
+		assert.False(t, pathExists(shared), "the hfresh shared bucket must not survive the drop")
+		assert.False(t, pathExists(hfreshDir), "the hfresh directory must not survive the drop")
+	})
+
+	t.Run("a sibling vector's hfresh state is untouched", func(t *testing.T) {
+		// The names share a prefix, so a sweep matching loosely would take a
+		// live index's postings with it.
+		indexPath, shardName := setup(t)
+
+		lsm := filepath.Join(indexPath, shardName, "lsm")
+		dropped := filepath.Join(lsm, helpers.HFreshPostingsBucketName(helpers.GetVectorsBucketName("hf")))
+		sibling := filepath.Join(lsm, helpers.HFreshPostingsBucketName(helpers.GetVectorsBucketName("hf_other")))
+		for _, dir := range []string{dropped, sibling} {
+			require.NoError(t, os.MkdirAll(dir, 0o755))
+		}
+
+		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, "hf"))
+
+		assert.False(t, pathExists(dropped))
+		assert.True(t, pathExists(sibling), "another vector's hfresh postings must survive")
+	})
+
 	t.Run("removes all hnsw vector artifacts", func(t *testing.T) {
 		indexPath, shardName := setup(t)
 

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -238,7 +238,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
 		hfreshConfigID := s.vectorIndexID(targetVector)
-		rootPath := filepath.Join(s.path(), fmt.Sprintf("%s.hfresh.d", hfreshConfigID))
+		rootPath := filepath.Join(s.path(), helpers.HFreshDirName(hfreshConfigID))
 
 		hfreshConfig := &hfresh.Config{
 			Logger:            s.index.logger,
@@ -447,6 +447,24 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 	muveraBucket := helpers.GetMuveraBucketName(targetVector)
 	if err := s.removeBucket(ctx, muveraBucket); err != nil {
 		return fmt.Errorf("drop muvera vectors bucket for %q: %w", targetVector, err)
+	}
+
+	// An hfresh index keeps its state outside the two buckets above: a
+	// directory of its own under the shard, plus two dedicated LSM buckets. Its
+	// own Drop() removes none of them ("Shard::drop will take care of handling
+	// store buckets" holds when the whole shard goes, not when one named vector
+	// is dropped out from under a shard that stays), so they are named here.
+	// Unconditional: reading the type back to decide would miss an index that
+	// failed to load, and both removals are no-ops when the target is absent.
+	indexID := s.vectorIndexID(targetVector)
+	if err := s.removeBucket(ctx, helpers.HFreshPostingsBucketName(indexID)); err != nil {
+		return fmt.Errorf("drop hfresh postings bucket for %q: %w", targetVector, err)
+	}
+	if err := s.removeBucket(ctx, helpers.HFreshSharedBucketName(indexID)); err != nil {
+		return fmt.Errorf("drop hfresh shared bucket for %q: %w", targetVector, err)
+	}
+	if err := s.removeDirIfExists(s.path(), helpers.HFreshDirName(indexID)); err != nil {
+		return fmt.Errorf("drop hfresh directory for %q: %w", targetVector, err)
 	}
 
 	// Remove the index checkpoint entry for this vector.

--- a/adapters/repos/db/vector/hfresh/index_metadata.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+
 	"github.com/pkg/errors"
 	"github.com/vmihailenco/msgpack/v5"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -78,7 +80,7 @@ func NewSharedBucket(store *lsmkv.Store, indexID string, cfg StoreConfig) (*lsmk
 }
 
 func sharedBucketName(id string) string {
-	return fmt.Sprintf("hfresh_shared_%s", id)
+	return helpers.HFreshSharedBucketName(id)
 }
 
 func cleanupLegacyReassignBucket(bucket *lsmkv.Bucket) error {

--- a/adapters/repos/db/vector/hfresh/store.go
+++ b/adapters/repos/db/vector/hfresh/store.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+
 	"github.com/maypok86/otter/v2"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -186,7 +188,7 @@ func (p *PostingStore) Append(ctx context.Context, postingID uint64, vector Vect
 }
 
 func postingsBucketName(id string) string {
-	return fmt.Sprintf("hfresh_postings_%s", id)
+	return helpers.HFreshPostingsBucketName(id)
 }
 
 // PostingVersions keeps track of the version of the posting list.

--- a/test/acceptance/drop_vector_index/hfresh_test.go
+++ b/test/acceptance/drop_vector_index/hfresh_test.go
@@ -1,0 +1,220 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package drop_vector_index
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcexec "github.com/testcontainers/testcontainers-go/exec"
+
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// testHFreshLeavesNoFilesOnDisk pins the on-disk cleanup of a dropped hfresh
+// index.
+//
+// Shard.DropVectorIndex removes the vectors and compressed buckets by name, and
+// HFresh.Drop itself removes nothing — its comment says "Shard::drop will take
+// care of handling store buckets", which is true when the whole SHARD is
+// dropped and its directory goes wholesale, but not when a single named vector
+// is dropped out from under a shard that stays. hfresh does not even use those
+// two buckets, so ALL of its on-disk state used to survive: a directory of its
+// own under the shard plus two dedicated LSM buckets, unreachable and
+// uncollectable, because once the drop completes the vector's schema entry is
+// gone and the startup sweep never looks at it again.
+func testHFreshLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		const (
+			className = "DropVectorIndexHFreshDisk"
+			dropped   = "hfresh_vec"
+			sibling   = "sibling"
+			dim       = 32
+			count     = 200
+		)
+
+		deleteParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+		defer helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+
+		t.Run("create an hfresh vector and fill it", func(t *testing.T) {
+			cls := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{Name: "name", DataType: []string{schema.DataTypeText.String()}},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					dropped: {
+						Vectorizer:      map[string]any{"none": map[string]any{}},
+						VectorIndexType: "hfresh",
+					},
+					// Keeps the collection from going vectorless after the drop,
+					// which is its own path.
+					sibling: noneVectorConfig(),
+				},
+			}
+			_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+				clschema.NewSchemaObjectsCreateParams().WithObjectClass(cls), nil)
+			require.NoError(t, err)
+
+			// A type that silently fell back to hnsw would create none of the
+			// hfresh state this test is about.
+			got := helper.GetClass(t, className)
+			require.Equal(t, "hfresh", got.VectorConfig[dropped].VectorIndexType,
+				"the vector must actually be an hfresh index")
+
+			batch := make([]*models.Object, count)
+			for i := range count {
+				batch[i] = &models.Object{
+					ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-00000000%04d", i)),
+					Class:      className,
+					Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
+					Vectors: models.Vectors{
+						dropped: randVec(dim, float32(i)),
+						sibling: randVec(dim, float32(i+1000)),
+					},
+				}
+			}
+			helper.CreateObjectsBatch(t, batch)
+			time.Sleep(5 * time.Second) // past the 1s dirty-flush, so segments land on disk
+		})
+
+		var owned []string
+		t.Run("the hfresh index owns directories on disk", func(t *testing.T) {
+			owned = hfreshDirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
+			require.NotEmpty(t, owned,
+				"precondition: the index must have on-disk state, or dropping it proves nothing")
+			t.Logf("%s owns:\n  %s", dropped, strings.Join(owned, "\n  "))
+
+			// The three hfresh-specific artifacts, named explicitly: if a
+			// refactor renames one, this fails here rather than passing later
+			// because the sweep had nothing left to find.
+			for _, want := range hfreshArtifactNames(dropped) {
+				require.True(t, hasBase(owned, want),
+					"precondition: %s must exist before the drop, got %v", want, owned)
+			}
+		})
+
+		t.Run("drop the hfresh index and wait for completion", func(t *testing.T) {
+			dropTargetVector(t, className, dropped)
+			eventuallyTargetVectorRemoved(t, className, dropped)
+			waitForNoActiveDropTask(t)
+		})
+
+		t.Run("no directory of the dropped index survives", func(t *testing.T) {
+			left := hfreshDirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
+			for _, dir := range left {
+				t.Logf("SURVIVED: %s", dir)
+			}
+			require.Empty(t, left,
+				"a completed drop must leave no on-disk state for %q, but these survived:\n  %s",
+				dropped, strings.Join(left, "\n  "))
+		})
+	}
+}
+
+// hfreshArtifactNames lists the directory basenames an hfresh index owns beyond
+// the vectors/compressed buckets every index has: its own directory under the
+// shard, and the two LSM buckets it keeps its postings and shared state in
+// (see hfresh.postingsBucketName / sharedBucketName, both keyed on the index
+// ID, which is "vectors_<target>").
+func hfreshArtifactNames(targetVector string) []string {
+	indexID := "vectors_" + targetVector
+	return []string{
+		indexID + ".hfresh.d",
+		"hfresh_postings_" + indexID,
+		"hfresh_shared_" + indexID,
+	}
+}
+
+// hfreshDirsOwnedBy returns the directories belonging to targetVector, matched
+// on EXACT names. Substring matching would be wrong: another vector's name may
+// contain this one as a prefix, and claiming its directories would report a
+// leak that is not there.
+func hfreshDirsOwnedBy(allDirs []string, targetVector string) []string {
+	indexID := "vectors_" + targetVector
+	names := map[string]struct{}{
+		indexID:                              {}, // vectors bucket
+		"vectors_compressed_" + targetVector: {}, // compressed bucket
+	}
+	for _, n := range hfreshArtifactNames(targetVector) {
+		names[n] = struct{}{}
+	}
+	var out []string
+	for _, dir := range allDirs {
+		if _, ok := names[path.Base(dir)]; ok {
+			out = append(out, dir)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// hfreshDirsOnEveryNode collects candidate directories from EVERY node. The
+// class's shard lives on whichever node the hash lands it on, so checking only
+// the node the client happens to talk to would pass on the other two by
+// looking in the wrong place.
+func hfreshDirsOnEveryNode(ctx context.Context, t *testing.T, compose *docker.DockerCompose) []string {
+	t.Helper()
+	var dirs []string
+	for n := 1; n <= 3; n++ {
+		node := compose.GetWeaviateNode(n)
+		if node == nil {
+			continue
+		}
+		out := hfreshExec(ctx, t, node.Container(), []string{
+			"find", "/", "-xdev", "-type", "d",
+			"(", "-name", "vectors_*", "-o", "-name", "hfresh_*", ")",
+		})
+		for _, line := range strings.Split(out, "\n") {
+			if line = strings.TrimSpace(line); line != "" {
+				dirs = append(dirs, node.Name()+":"+line)
+			}
+		}
+	}
+	return dirs
+}
+
+func hasBase(paths []string, base string) bool {
+	for _, p := range paths {
+		if path.Base(p) == base {
+			return true
+		}
+	}
+	return false
+}
+
+func hfreshExec(ctx context.Context, t *testing.T, c testcontainers.Container, cmd []string) string {
+	t.Helper()
+	code, reader, err := c.Exec(ctx, cmd, tcexec.Multiplexed())
+	require.NoError(t, err, "exec %v", cmd)
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, reader)
+	require.NoError(t, err)
+	// find exits non-zero only on a real error; "no matches" is exit 0 + empty.
+	require.Zero(t, code, "exec %v failed: %s", cmd, buf.String())
+	return buf.String()
+}

--- a/test/acceptance/drop_vector_index/setup_test.go
+++ b/test/acceptance/drop_vector_index/setup_test.go
@@ -106,4 +106,5 @@ func runSuite(t *testing.T, compose *docker.DockerCompose) {
 	t.Run("re-drop after re-create", testRedropAfterRecreate())
 	t.Run("multi vector", testMultiVector())
 	t.Run("multi vector drop leaves no files on disk", testMultiVectorLeavesNoFilesOnDisk(compose))
+	t.Run("hfresh drop leaves no files on disk", testHFreshLeavesNoFilesOnDisk(compose))
 }


### PR DESCRIPTION
### What's being changed:

This PR fixes HFresh vector index removal.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
