### PR TITLE
test(usage): settle the reactivated shard before taking the drop-vector baseline

### DIFF
--- a/test/acceptance_with_go_client/internal/wvhost/wvhost.go
+++ b/test/acceptance_with_go_client/internal/wvhost/wvhost.go
@@ -10,8 +10,9 @@
 //
 
 // Package wvhost resolves the Weaviate REST and gRPC endpoints for acceptance
-// tests. Defaults are localhost:8080 / localhost:50051; WV_TEST_HOST,
-// WV_TEST_REST_PORT, and WV_TEST_GRPC_PORT override host and port independently.
+// tests. Defaults are localhost:8080 / localhost:50051 / localhost:6060;
+// WV_TEST_HOST, WV_TEST_REST_PORT, WV_TEST_GRPC_PORT and WV_TEST_DEBUG_PORT
+// override host and port independently.
 package wvhost
 
 import "os"
@@ -22,6 +23,10 @@ func REST() string {
 
 func GRPC() string {
 	return host() + ":" + port("WV_TEST_GRPC_PORT", "50051")
+}
+
+func Debug() string {
+	return host() + ":" + port("WV_TEST_DEBUG_PORT", "6060")
 }
 
 func host() string {

--- a/test/acceptance_with_go_client/usage/get_debug_usage.go
+++ b/test/acceptance_with_go_client/usage/get_debug_usage.go
@@ -12,6 +12,7 @@
 package usage
 
 import (
+	"acceptance_tests_with_client/internal/wvhost"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,7 +26,7 @@ import (
 type CollectionUsage = usagetypes.CollectionUsage
 
 func getDebugUsage() (*usagetypes.Report, error) {
-	return getDebugUsageWithPort("localhost:6060")
+	return getDebugUsageWithPort(wvhost.Debug())
 }
 
 // Get the debug usage report from the endpoint

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -376,7 +376,7 @@ func TestAlterSchemaDropPropertyIndex(t *testing.T) {
 
 func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	ctx := context.Background()
-	c, err := client.NewClient(client.Config{Scheme: "http", Host: "localhost:8080"})
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: wvhost.REST()})
 	require.NoError(t, err)
 
 	className := t.Name() + "Class"
@@ -481,11 +481,12 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).
 		WithTenants(models.Tenant{Name: tenantName, ActivityStatus: models.TenantActivityStatusHOT}).Do(ctx))
 
-	// Verify all named vectors appear in usage
-	colUsageBefore, err := GetDebugUsageForCollection(className)
-	require.NoError(t, err)
-	require.Len(t, colUsageBefore.Shards, 1)
-	shard := colUsageBefore.Shards[0]
+	// Verify all named vectors appear in usage. The baseline waits for the
+	// reactivated shard to stop growing: reloading it makes every HNSW index
+	// snapshot its commit log, and one snapshot is a whole 4 MiB block whatever it
+	// holds. Sampling before those land measures a shard that is still only on
+	// disk against one that has reloaded, and the drop below then reads as growth.
+	shard := settledShardUsage(t, c, className, tenantName)
 	require.Equal(t, int64(numObjects), shard.ObjectsCount)
 	require.Equal(t, expected, namedVectorDimensionalities(t, shard))
 
@@ -732,6 +733,42 @@ func namedVectors(t require.TestingT, shard *usagetypes.ShardUsage, want ...stri
 		require.Contains(t, vectors, name)
 	}
 	return vectors
+}
+
+// settledShardUsage loads a tenant's shard and reports its usage once the shard has
+// stopped growing, so a caller's baseline is measured in the state the reports it is
+// compared against are measured in. A reload lets the HNSW commit-log maintenance
+// cycle run, which writes files a shard sitting on disk does not have; the cycle
+// backs off to 10s between runs, so the shard has to hold still for longer than that
+// before it counts as settled.
+func settledShardUsage(t *testing.T, c *client.Client, className, tenantName string) *usagetypes.ShardUsage {
+	t.Helper()
+
+	// reading the tenant materializes its lazily loaded shard before the wait starts
+	_, err := c.Data().ObjectsGetter().WithClassName(className).
+		WithTenant(tenantName).WithLimit(1).Do(context.Background())
+	require.NoError(t, err)
+
+	const settleFor = 15 * time.Second
+	var settled *usagetypes.ShardUsage
+	var unchangedSince time.Time
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		colUsage, err := GetDebugUsageForCollection(className)
+		require.NoError(ct, err)
+		require.Len(ct, colUsage.Shards, 1)
+		current := colUsage.Shards[0]
+
+		if settled == nil || current.FullShardStorageBytes != settled.FullShardStorageBytes ||
+			current.VectorStorageBytes != settled.VectorStorageBytes {
+			settled, unchangedSince = current, time.Now()
+		}
+		if held := time.Since(unchangedSince); held < settleFor {
+			ct.Errorf("shard %q still growing: %d full / %d vector bytes, unchanged for %s",
+				current.Name, current.FullShardStorageBytes, current.VectorStorageBytes, held)
+		}
+	}, 90*time.Second, 500*time.Millisecond)
+
+	return settled
 }
 
 // namedVectorDimensionalities maps every named vector of a shard usage report to the


### PR DESCRIPTION
### What's being changed:

Fixes flaky test:

```
--- FAIL: TestAlterSchemaDropVectorIndex (31.19s)
    usage_test.go:504:
        	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:511
        	            				/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771
        	Error:      	"4621016" is not less than "439492"
    usage_test.go:504:
        	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:512
        	            				/opt/hostedtoolcache/go/1.26.5/x64/src/runtime/asm_amd64.s:1771
        	Error:      	"4411347" is not less than "294459"
    usage_test.go:504:
        	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance_with_go_client/usage/usage_test.go:504
        	Error:      	Condition never satisfied
        	Test:       	TestAlterSchemaDropVectorIndex
FAIL
FAIL	acceptance_tests_with_client/usage	496.447s
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
