### PR TITLE
fix(drop-vector-index): remove everything a dropped vector owns, and nothing else

### DIFF
--- a/adapters/repos/db/drop_one_vector_index_test.go
+++ b/adapters/repos/db/drop_one_vector_index_test.go
@@ -1,0 +1,73 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sharedStateIndex stands in for dynamic: an index type whose plain Drop would
+// reach beyond the one vector being dropped.
+type sharedStateIndex struct {
+	VectorIndex
+	droppedWholeIndex bool
+	droppedTargetOnly bool
+}
+
+func (i *sharedStateIndex) Drop(ctx context.Context, keepFiles bool) error {
+	i.droppedWholeIndex = true
+	return nil
+}
+
+func (i *sharedStateIndex) DropTargetVector(ctx context.Context) error {
+	i.droppedTargetOnly = true
+	return nil
+}
+
+// plainIndex owns nothing shard-wide, like hnsw or flat.
+type plainIndex struct {
+	VectorIndex
+	dropped bool
+}
+
+func (i *plainIndex) Drop(ctx context.Context, keepFiles bool) error {
+	i.dropped = true
+	return nil
+}
+
+// TestDropOneVectorIndex_PrefersThePerVectorDrop pins the routing, which the
+// dynamic package's own tests cannot: they call DropTargetVector directly, so
+// a shard that stopped using it would leave them green while every per-vector
+// drop went back to closing and deleting the shard-shared state DB.
+func TestDropOneVectorIndex_PrefersThePerVectorDrop(t *testing.T) {
+	ctx := context.Background()
+
+	shared := &sharedStateIndex{}
+	require.NoError(t, dropOneVectorIndex(ctx, shared))
+	assert.True(t, shared.droppedTargetOnly,
+		"an index owning shard-wide state must be dropped per target vector")
+	assert.False(t, shared.droppedWholeIndex,
+		"the whole-index Drop would take every sibling's state with it")
+}
+
+// TestDropOneVectorIndex_FallsBackForPlainIndexes pins the other half: types
+// that own nothing shard-wide must still go through Drop, or dropping them
+// would silently become a no-op.
+func TestDropOneVectorIndex_FallsBackForPlainIndexes(t *testing.T) {
+	plain := &plainIndex{}
+	require.NoError(t, dropOneVectorIndex(context.Background(), plain))
+	assert.True(t, plain.dropped, "an index with no shared state must still be dropped")
+}

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -97,8 +97,13 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 		return fmt.Errorf("index for collection %q not found", collection)
 	}
 	helper := newVectorDropIndexHelper()
+	class := idx.getClass()
 	for _, target := range targets {
-		if err := helper.removeVectorIndexFiles(idx.path(), shardName, target); err != nil {
+		// Siblings are read per target: the collection's other vector names are
+		// what stops a drop deleting a live vector whose own bucket happens to
+		// share a name with one of this target's artifacts.
+		if err := helper.removeVectorIndexFiles(idx.path(), shardName, target,
+			otherTargetVectors(class, target)); err != nil {
 			return err
 		}
 	}

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -42,17 +42,26 @@ func GetVectorsBucketName(targetVector string) string {
 	return VectorsBucketLSM
 }
 
-// GetMuveraBucketName returns the bucket a muvera-encoded multi-vector index
-// keeps its encoded vectors in (see hnsw.New, which builds it as
-// "<vectorIndexID>_muvera_vectors"). It is a bucket of the index's own, held
-// outside the vectors/compressed pair, so anything tearing an index down has to
-// name it explicitly or the encoded copies survive.
-func GetMuveraBucketName(targetVector string) string {
-	if targetVector != "" {
-		return fmt.Sprintf("%s_muvera_vectors", GetVectorsBucketName(targetVector))
-	}
-	// Mirrors vectorIndexID's unnamed case, which the index uses as its ID.
-	return "main_muvera_vectors"
+// A multivector index keeps its per-object encoding in a bucket of its own,
+// named off the index ID. Which one depends on the config — muvera on, or
+// mv_mappings when it is off — and they are mutually exclusive.
+//
+// These live here rather than being concatenated at the point of use so the
+// code that CREATES the bucket and the drop that removes it share one
+// definition. Concatenated inline, a rename on the hnsw side compiles cleanly
+// while the cleanup keeps deleting the old name: removeBucket no-ops and the
+// leak returns silently.
+
+// MuveraBucketName is the bucket a muvera-encoded multivector index stores its
+// encoded vectors in. indexID is the vector index's ID ("vectors_<target>").
+func MuveraBucketName(indexID string) string {
+	return fmt.Sprintf("%s_muvera_vectors", indexID)
+}
+
+// MVMappingsBucketName is the bucket a multivector index WITHOUT muvera stores
+// its node-to-doc mappings in. indexID is the vector index's ID.
+func MVMappingsBucketName(indexID string) string {
+	return fmt.Sprintf("%s_mv_mappings", indexID)
 }
 
 // HFresh keeps more on-disk state than the other index types: a directory of
@@ -74,6 +83,108 @@ func HFreshPostingsBucketName(indexID string) string {
 // HFreshSharedBucketName is the LSM bucket holding hfresh's shared metadata.
 func HFreshSharedBucketName(indexID string) string {
 	return fmt.Sprintf("hfresh_shared_%s", indexID)
+}
+
+// VectorIndexArtifacts is everything a named vector's index owns on disk:
+// LSMBuckets are directories under <shard>/lsm, ShardDirs under <shard>.
+type VectorIndexArtifacts struct {
+	LSMBuckets []string
+	ShardDirs  []string
+}
+
+// All returns every artifact as a single slice, LSM buckets first.
+func (a VectorIndexArtifacts) All() []string {
+	return append(append([]string{}, a.LSMBuckets...), a.ShardDirs...)
+}
+
+// vectorIndexArtifactNames is the raw, unfiltered artifact set for a target
+// vector. Split out from VectorIndexArtifactsFor so the sibling-collision guard
+// can compute what OTHER vectors own without recursing through the filter.
+func vectorIndexArtifactNames(targetVector string) VectorIndexArtifacts {
+	indexID := GetVectorsBucketName(targetVector)
+	return VectorIndexArtifacts{
+		LSMBuckets: []string{
+			indexID,                               // raw vectors
+			GetCompressedBucketName(targetVector), // BQ/PQ/SQ/RQ
+			MuveraBucketName(indexID),             // multivector + muvera
+			MVMappingsBucketName(indexID),         // multivector without muvera
+			HFreshPostingsBucketName(indexID),     // hfresh
+			HFreshSharedBucketName(indexID),       // hfresh
+			// hfresh runs a nested centroids HNSW whose id is
+			// "<indexID>_centroids"; hnsw derives its compressed bucket from
+			// that id with the "vectors_" prefix stripped, so it lands in the
+			// shard's lsm dir under this name. Its commitlog and snapshot dirs
+			// do NOT need listing — they live inside the .hfresh.d directory
+			// below, which goes wholesale.
+			GetCompressedBucketName(targetVector + "_centroids"),
+		},
+		ShardDirs: []string{
+			GetHNSWCommitLogDirName(targetVector),
+			GetHNSWSnapshotDirName(targetVector),
+			HFreshDirName(indexID),
+			// The async-indexing queue. The live drop closes it via queue.Drop,
+			// but every files-only path (cold lazy shard, inactive tenant, crash
+			// before the live drop) leaves it — and DiskQueue.Init replays stale
+			// chunks into a re-created index of the same name, so this is wrong
+			// vectors and dimension errors, not just disk cost.
+			indexID + ".queue.d",
+		},
+	}
+}
+
+// VectorIndexArtifactsFor lists what dropping targetVector has to remove. It is
+// the single source of truth for that set: the live drop, the file sweep and
+// the tests all read it, because three hand-maintained copies is exactly how
+// "<indexID>_mv_mappings" ended up missing from all of them at once.
+//
+// Some entries only exist for some index types (muvera and mv_mappings are
+// mutually exclusive; hfresh's are hfresh-only). Listing them unconditionally
+// is deliberate — removal is a no-op when the artifact is absent, whereas
+// reading the config back to decide would miss an index that failed to load, or
+// one whose config changed since it was written.
+//
+// otherTargetVectors are the collection's OTHER vector names, and they are not
+// optional. Target vector names are only constrained by TargetVectorNameRegex,
+// so a vector may legally be called "<other>_muvera_vectors", "<other>_centroids"
+// and so on — names that make one of THIS target's artifacts byte-identical to
+// a live sibling's own bucket. Removing it would destroy a live vector's data,
+// and the file sweep would re-remove it on every restart while the drop marker
+// persists, so a re-import would not survive either. Any artifact claimed by a
+// sibling is therefore dropped from the list: leaking is strictly better than
+// deleting data that is still in use.
+func VectorIndexArtifactsFor(targetVector string, otherTargetVectors []string) VectorIndexArtifacts {
+	artifacts := vectorIndexArtifactNames(targetVector)
+
+	// Skipping the target itself is what keeps its OWN artifacts in the list;
+	// callers routinely pass the whole schema rather than filtering first.
+	protected := map[string]struct{}{}
+	for _, other := range otherTargetVectors {
+		if other == targetVector {
+			continue
+		}
+		for _, name := range vectorIndexArtifactNames(other).All() {
+			protected[name] = struct{}{}
+		}
+	}
+	if len(protected) == 0 {
+		return artifacts
+	}
+
+	// Only LSM buckets can collide. Every ShardDirs entry ends in a dotted
+	// suffix (".hnsw.commitlog.d", ".hfresh.d", ".queue.d") and
+	// TargetVectorNameRegex forbids dots in vector names, so no sibling's
+	// artifact can ever equal one — filtering them would be unreachable code.
+	// A future shard directory WITHOUT a dotted suffix would break that and
+	// needs the guard extended.
+	keptBuckets := artifacts.LSMBuckets[:0:0]
+	for _, name := range artifacts.LSMBuckets {
+		if _, clash := protected[name]; clash {
+			continue
+		}
+		keptBuckets = append(keptBuckets, name)
+	}
+	artifacts.LSMBuckets = keptBuckets
+	return artifacts
 }
 
 func GetHNSWCommitLogDirName(targetVector string) string {

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -42,9 +42,9 @@ func GetVectorsBucketName(targetVector string) string {
 	return VectorsBucketLSM
 }
 
-// A multivector index keeps its per-object encoding in a bucket of its own,
-// named off the index ID. Which one depends on the config — muvera on, or
-// mv_mappings when it is off — and they are mutually exclusive.
+// A multivector index keeps one bucket of its own, named off the index ID:
+// muvera encodings when muvera is on, node-to-doc mappings when it is off. The
+// two are mutually exclusive.
 //
 // These live here rather than being concatenated at the point of use so the
 // code that CREATES the bucket and the drop that removes it share one
@@ -53,7 +53,7 @@ func GetVectorsBucketName(targetVector string) string {
 // leak returns silently.
 
 // MuveraBucketName is the bucket a muvera-encoded multivector index stores its
-// encoded vectors in. indexID is the vector index's ID ("vectors_<target>").
+// encoded vectors in. indexID is the vector index's ID.
 func MuveraBucketName(indexID string) string {
 	return fmt.Sprintf("%s_muvera_vectors", indexID)
 }
@@ -137,26 +137,21 @@ func vectorIndexArtifactNames(targetVector string) VectorIndexArtifacts {
 // the tests all read it, because three hand-maintained copies is exactly how
 // "<indexID>_mv_mappings" ended up missing from all of them at once.
 //
-// Some entries only exist for some index types (muvera and mv_mappings are
-// mutually exclusive; hfresh's are hfresh-only). Listing them unconditionally
-// is deliberate — removal is a no-op when the artifact is absent, whereas
-// reading the config back to decide would miss an index that failed to load, or
-// one whose config changed since it was written.
+// Entries that only exist for some index types are listed unconditionally:
+// removal is a no-op when the artifact is absent, whereas reading the config
+// back to decide would miss an index that failed to load, or one whose config
+// changed since it was written.
 //
-// otherTargetVectors are the collection's OTHER vector names, and they are not
-// optional. Target vector names are only constrained by TargetVectorNameRegex,
-// so a vector may legally be called "<other>_muvera_vectors", "<other>_centroids"
-// and so on — names that make one of THIS target's artifacts byte-identical to
-// a live sibling's own bucket. Removing it would destroy a live vector's data,
-// and the file sweep would re-remove it on every restart while the drop marker
-// persists, so a re-import would not survive either. Any artifact claimed by a
-// sibling is therefore dropped from the list: leaking is strictly better than
+// otherTargetVectors is not optional. TargetVectorNameRegex permits names like
+// "<other>_muvera_vectors" or "<other>_centroids", which make one of THIS
+// target's artifacts byte-identical to a bucket a live sibling owns. Any
+// artifact a sibling claims is therefore dropped from the list: leaking beats
 // deleting data that is still in use.
 func VectorIndexArtifactsFor(targetVector string, otherTargetVectors []string) VectorIndexArtifacts {
 	artifacts := vectorIndexArtifactNames(targetVector)
 
-	// Skipping the target itself is what keeps its OWN artifacts in the list;
-	// callers routinely pass the whole schema rather than filtering first.
+	// Skipping the target itself is what keeps its OWN artifacts in the list,
+	// for a caller that passes the whole schema rather than filtering first.
 	protected := map[string]struct{}{}
 	for _, other := range otherTargetVectors {
 		if other == targetVector {

--- a/adapters/repos/db/helpers/vector_index_artifacts_test.go
+++ b/adapters/repos/db/helpers/vector_index_artifacts_test.go
@@ -48,16 +48,17 @@ func TestVectorIndexArtifactsFor_CoversEveryArtifact(t *testing.T) {
 	assert.Len(t, got.All(), len(got.LSMBuckets)+len(got.ShardDirs))
 }
 
-// TestVectorIndexArtifactsFor_NeverTakesASiblingsPrimaryBucket pins the guard
-// against a name collision that would DELETE LIVE DATA.
+// TestVectorIndexArtifactsFor_NeverTakesASiblingsArtifact pins the guard
+// against a name collision that would DELETE LIVE DATA, over every artifact a
+// sibling owns rather than just its primary bucket.
 //
 // Target vector names are only constrained by TargetVectorNameRegex, which
-// permits "<other>_muvera_vectors" and "<other>_mv_mappings". Those make a
-// sibling's PRIMARY vectors bucket byte-identical to one of this target's
-// artifacts, so an unguarded drop of "foo" would remove the raw vectors of a
-// live, unrelated vector — and the file sweep would re-remove the directory on
-// every restart while the drop marker persists, surviving re-import.
-func TestVectorIndexArtifactsFor_NeverTakesASiblingsPrimaryBucket(t *testing.T) {
+// permits "<other>_muvera_vectors", "<other>_mv_mappings" and
+// "<other>_centroids". Each makes one of this target's artifacts
+// byte-identical to a bucket a live, unrelated vector owns — and the file
+// sweep would re-remove it on every restart while the drop marker persists,
+// surviving re-import.
+func TestVectorIndexArtifactsFor_NeverTakesASiblingsArtifact(t *testing.T) {
 	nameRe := regexp.MustCompile("^" + schema.TargetVectorNameRegex + "$")
 
 	for _, tc := range []struct {
@@ -67,12 +68,13 @@ func TestVectorIndexArtifactsFor_NeverTakesASiblingsPrimaryBucket(t *testing.T) 
 	}{
 		{"muvera bucket", "foo_muvera_vectors", "vectors_foo_muvera_vectors"},
 		{"mv mappings bucket", "foo_mv_mappings", "vectors_foo_mv_mappings"},
+		{"centroids compressed bucket", "foo_centroids", "vectors_compressed_foo_centroids"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.True(t, nameRe.MatchString(tc.sibling),
 				"precondition: %q must be a legal vector name, or this collision is unreachable", tc.sibling)
-			require.Equal(t, tc.clash, GetVectorsBucketName(tc.sibling),
-				"precondition: the sibling's primary bucket must be the colliding name")
+			require.Contains(t, VectorIndexArtifactsFor(tc.sibling, nil).All(), tc.clash,
+				"precondition: the colliding name must be one the sibling itself owns")
 
 			unguarded := VectorIndexArtifactsFor("foo", nil)
 			require.Contains(t, unguarded.LSMBuckets, tc.clash,
@@ -80,38 +82,13 @@ func TestVectorIndexArtifactsFor_NeverTakesASiblingsPrimaryBucket(t *testing.T) 
 
 			got := VectorIndexArtifactsFor("foo", []string{tc.sibling})
 			assert.NotContains(t, got.LSMBuckets, tc.clash,
-				"a live sibling's primary vectors bucket must never be removed")
+				"a live sibling's bucket must never be removed")
 
 			// The target's own artifacts still go.
 			assert.Contains(t, got.LSMBuckets, "vectors_foo")
 			assert.Contains(t, got.LSMBuckets, "vectors_compressed_foo")
 		})
 	}
-}
-
-// TestVectorIndexArtifactsFor_NeverTakesASiblingsCompressedBucket pins that the
-// guard covers every artifact a sibling owns, not just its primary bucket.
-// Listing hfresh's nested centroids index makes this reachable: a vector named
-// "<other>_centroids" owns "vectors_compressed_<other>_centroids", which is
-// byte-identical to the centroids artifact of "<other>". Deleting it would take
-// a live index's compressed vectors.
-func TestVectorIndexArtifactsFor_NeverTakesASiblingsCompressedBucket(t *testing.T) {
-	nameRe := regexp.MustCompile("^" + schema.TargetVectorNameRegex + "$")
-	require.True(t, nameRe.MatchString("foo_centroids"),
-		"precondition: the colliding name must be legal")
-
-	const clash = "vectors_compressed_foo_centroids"
-	require.Equal(t, clash, GetCompressedBucketName("foo_centroids"),
-		"precondition: this is the sibling's own compressed bucket")
-
-	unguarded := VectorIndexArtifactsFor("foo", nil)
-	require.Contains(t, unguarded.LSMBuckets, clash,
-		"precondition: dropping foo targets this name when no siblings are declared")
-
-	got := VectorIndexArtifactsFor("foo", []string{"foo_centroids"})
-	assert.NotContains(t, got.LSMBuckets, clash,
-		"a live sibling's compressed bucket must never be removed")
-	assert.Contains(t, got.LSMBuckets, "vectors_foo", "the target's own artifacts still go")
 }
 
 // TestVectorIndexArtifactsFor_KeepsItsOwnPrimaryBucket guards the guard: the
@@ -131,6 +108,11 @@ func TestVectorIndexArtifactsFor_KeepsItsOwnPrimaryBucket(t *testing.T) {
 // stop cleaning real artifacts.
 func TestVectorIndexArtifactsFor_UnrelatedSiblingsChangeNothing(t *testing.T) {
 	plain := VectorIndexArtifactsFor("vec", nil)
+	// Anchored, because comparing two calls to the function under test passes
+	// just as happily when both return nothing.
+	require.NotEmpty(t, plain.LSMBuckets)
+	require.NotEmpty(t, plain.ShardDirs)
+
 	withSiblings := VectorIndexArtifactsFor("vec", []string{"vec2", "other", "vec_extra"})
 	assert.Equal(t, plain.LSMBuckets, withSiblings.LSMBuckets)
 	assert.Equal(t, plain.ShardDirs, withSiblings.ShardDirs)

--- a/adapters/repos/db/helpers/vector_index_artifacts_test.go
+++ b/adapters/repos/db/helpers/vector_index_artifacts_test.go
@@ -1,0 +1,137 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package helpers
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestVectorIndexArtifactsFor_CoversEveryArtifact pins the full set a drop must
+// remove. Each name is spelled out literally rather than rebuilt from the same
+// helpers the implementation uses: the point is to fail when a name changes on
+// the side that CREATES it, which a self-referential assertion cannot do.
+func TestVectorIndexArtifactsFor_CoversEveryArtifact(t *testing.T) {
+	got := VectorIndexArtifactsFor("vec", nil)
+
+	assert.ElementsMatch(t, []string{
+		"vectors_vec",                      // raw vectors
+		"vectors_compressed_vec",           // BQ/PQ/SQ/RQ
+		"vectors_vec_muvera_vectors",       // multivector + muvera (hnsw.New)
+		"vectors_vec_mv_mappings",          // multivector without muvera (hnsw.New)
+		"hfresh_postings_vectors_vec",      // hfresh postings
+		"hfresh_shared_vectors_vec",        // hfresh shared metadata
+		"vectors_compressed_vec_centroids", // hfresh's nested centroids HNSW
+	}, got.LSMBuckets)
+
+	assert.ElementsMatch(t, []string{
+		"vectors_vec.hnsw.commitlog.d",
+		"vectors_vec.hnsw.snapshot.d",
+		"vectors_vec.hfresh.d",
+		"vectors_vec.queue.d", // async-indexing queue
+	}, got.ShardDirs)
+
+	assert.Len(t, got.All(), len(got.LSMBuckets)+len(got.ShardDirs))
+}
+
+// TestVectorIndexArtifactsFor_NeverTakesASiblingsPrimaryBucket pins the guard
+// against a name collision that would DELETE LIVE DATA.
+//
+// Target vector names are only constrained by TargetVectorNameRegex, which
+// permits "<other>_muvera_vectors" and "<other>_mv_mappings". Those make a
+// sibling's PRIMARY vectors bucket byte-identical to one of this target's
+// artifacts, so an unguarded drop of "foo" would remove the raw vectors of a
+// live, unrelated vector — and the file sweep would re-remove the directory on
+// every restart while the drop marker persists, surviving re-import.
+func TestVectorIndexArtifactsFor_NeverTakesASiblingsPrimaryBucket(t *testing.T) {
+	nameRe := regexp.MustCompile("^" + schema.TargetVectorNameRegex + "$")
+
+	for _, tc := range []struct {
+		name    string
+		sibling string
+		clash   string
+	}{
+		{"muvera bucket", "foo_muvera_vectors", "vectors_foo_muvera_vectors"},
+		{"mv mappings bucket", "foo_mv_mappings", "vectors_foo_mv_mappings"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.True(t, nameRe.MatchString(tc.sibling),
+				"precondition: %q must be a legal vector name, or this collision is unreachable", tc.sibling)
+			require.Equal(t, tc.clash, GetVectorsBucketName(tc.sibling),
+				"precondition: the sibling's primary bucket must be the colliding name")
+
+			unguarded := VectorIndexArtifactsFor("foo", nil)
+			require.Contains(t, unguarded.LSMBuckets, tc.clash,
+				"precondition: dropping foo does target this name when no siblings are declared")
+
+			got := VectorIndexArtifactsFor("foo", []string{tc.sibling})
+			assert.NotContains(t, got.LSMBuckets, tc.clash,
+				"a live sibling's primary vectors bucket must never be removed")
+
+			// The target's own artifacts still go.
+			assert.Contains(t, got.LSMBuckets, "vectors_foo")
+			assert.Contains(t, got.LSMBuckets, "vectors_compressed_foo")
+		})
+	}
+}
+
+// TestVectorIndexArtifactsFor_NeverTakesASiblingsCompressedBucket pins that the
+// guard covers every artifact a sibling owns, not just its primary bucket.
+// Listing hfresh's nested centroids index makes this reachable: a vector named
+// "<other>_centroids" owns "vectors_compressed_<other>_centroids", which is
+// byte-identical to the centroids artifact of "<other>". Deleting it would take
+// a live index's compressed vectors.
+func TestVectorIndexArtifactsFor_NeverTakesASiblingsCompressedBucket(t *testing.T) {
+	nameRe := regexp.MustCompile("^" + schema.TargetVectorNameRegex + "$")
+	require.True(t, nameRe.MatchString("foo_centroids"),
+		"precondition: the colliding name must be legal")
+
+	const clash = "vectors_compressed_foo_centroids"
+	require.Equal(t, clash, GetCompressedBucketName("foo_centroids"),
+		"precondition: this is the sibling's own compressed bucket")
+
+	unguarded := VectorIndexArtifactsFor("foo", nil)
+	require.Contains(t, unguarded.LSMBuckets, clash,
+		"precondition: dropping foo targets this name when no siblings are declared")
+
+	got := VectorIndexArtifactsFor("foo", []string{"foo_centroids"})
+	assert.NotContains(t, got.LSMBuckets, clash,
+		"a live sibling's compressed bucket must never be removed")
+	assert.Contains(t, got.LSMBuckets, "vectors_foo", "the target's own artifacts still go")
+}
+
+// TestVectorIndexArtifactsFor_KeepsItsOwnPrimaryBucket guards the guard: the
+// target's own vectors bucket must survive the sibling filter even when the
+// caller passes the target itself in the sibling list, which is easy to do by
+// looping over the whole schema.
+func TestVectorIndexArtifactsFor_KeepsItsOwnPrimaryBucket(t *testing.T) {
+	got := VectorIndexArtifactsFor("vec", []string{"vec", "other"})
+	assert.Contains(t, got.LSMBuckets, "vectors_vec",
+		"the dropped vector's own bucket must still be removed")
+	assert.Contains(t, got.LSMBuckets, "vectors_vec_mv_mappings")
+}
+
+// TestVectorIndexArtifactsFor_UnrelatedSiblingsChangeNothing pins that the
+// guard is narrow: it drops only exact collisions, not anything sharing a
+// prefix. "vec" prefixes "vec2", and treating that as a clash would silently
+// stop cleaning real artifacts.
+func TestVectorIndexArtifactsFor_UnrelatedSiblingsChangeNothing(t *testing.T) {
+	plain := VectorIndexArtifactsFor("vec", nil)
+	withSiblings := VectorIndexArtifactsFor("vec", []string{"vec2", "other", "vec_extra"})
+	assert.Equal(t, plain.LSMBuckets, withSiblings.LSMBuckets)
+	assert.Equal(t, plain.ShardDirs, withSiblings.ShardDirs)
+}

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -79,12 +79,12 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 }
 
 // otherTargetVectors lists the collection's vector names except `exclude` —
-// the set whose primary buckets a drop must not touch.
+// the siblings whose artifacts a drop must not touch. Every artifact a sibling
+// owns is protected, not just its primary bucket.
 func otherTargetVectors(class *models.Class, exclude string) []string {
 	if class == nil {
-		// No schema to consult: protect nothing rather than guess. The caller
-		// still removes this target's own artifacts; a collision would leak
-		// rather than delete a sibling's data.
+		// Nothing to protect, so the drop runs unfiltered: a name collision
+		// with a live sibling takes that sibling's bucket with it.
 		return nil
 	}
 	others := make([]string, 0, len(class.VectorConfig))

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -39,7 +39,8 @@ func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
 		if !modelsext.IsVectorIndexDropped(cfg) {
 			continue
 		}
-		if err := h.removeVectorIndexFiles(indexPath, shardName, name); err != nil {
+		if err := h.removeVectorIndexFiles(indexPath, shardName, name,
+			otherTargetVectors(class, name)); err != nil {
 			return fmt.Errorf("failed to remove dropped vector index %q files for class %s: %w",
 				name, class.Class, err)
 		}
@@ -47,44 +48,50 @@ func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
 	return nil
 }
 
-// removeVectorIndexFiles removes all on-disk artifacts for a named vector index:
-// - LSM bucket: vectors_{name}
-// - LSM compressed bucket: vectors_compressed_{name}
-// - LSM muvera bucket: vectors_{name}_muvera_vectors (multi-vector + muvera only)
-// - HNSW commit log directory: vectors_{name}.hnsw.commitlog.d
-// - HNSW snapshot directory: vectors_{name}.hnsw.snapshot.d
-// - HFresh directory: vectors_{name}.hfresh.d (hfresh only)
-// - HFresh LSM buckets: hfresh_postings_vectors_{name}, hfresh_shared_vectors_{name}
-func (h *vectorDropIndexHelper) removeVectorIndexFiles(indexPath, shardName, targetVector string) error {
+// removeVectorIndexFiles removes every on-disk artifact of a named vector index
+// (see helpers.VectorIndexArtifactsFor for the set and why it is centralised).
+// otherTargetVectors are the collection's remaining vector names, needed so a
+// sibling whose own bucket collides with one of this target's artifact names is
+// not deleted along with it.
+func (h *vectorDropIndexHelper) removeVectorIndexFiles(
+	indexPath, shardName, targetVector string, otherTargetVectors []string,
+) error {
 	lsmDir := filepath.Join(indexPath, shardName, "lsm")
 	shardDir := filepath.Join(indexPath, shardName)
 
-	vectorsBucket := helpers.GetVectorsBucketName(targetVector)
-	compressedBucket := helpers.GetCompressedBucketName(targetVector)
-	muveraBucket := helpers.GetMuveraBucketName(targetVector)
-	indexID := helpers.GetVectorsBucketName(targetVector)
-	hfreshDir := helpers.HFreshDirName(indexID)
-	hfreshPostings := helpers.HFreshPostingsBucketName(indexID)
-	hfreshShared := helpers.HFreshSharedBucketName(indexID)
-	hnswCommitLogDir := helpers.GetHNSWCommitLogDirName(targetVector)
-	hnswSnapshotDir := helpers.GetHNSWSnapshotDirName(targetVector)
+	artifacts := helpers.VectorIndexArtifactsFor(targetVector, otherTargetVectors)
 
-	vectorIndexDirectories := []string{
-		filepath.Join(lsmDir, vectorsBucket),
-		filepath.Join(lsmDir, compressedBucket),
-		filepath.Join(lsmDir, muveraBucket),
-		filepath.Join(lsmDir, hfreshPostings),
-		filepath.Join(lsmDir, hfreshShared),
-		filepath.Join(shardDir, hfreshDir),
-		filepath.Join(shardDir, hnswCommitLogDir),
-		filepath.Join(shardDir, hnswSnapshotDir),
+	var dirs []string
+	for _, bucket := range artifacts.LSMBuckets {
+		dirs = append(dirs, filepath.Join(lsmDir, bucket))
+	}
+	for _, dir := range artifacts.ShardDirs {
+		dirs = append(dirs, filepath.Join(shardDir, dir))
 	}
 
-	for _, dir := range vectorIndexDirectories {
+	for _, dir := range dirs {
 		if err := os.RemoveAll(dir); err != nil {
 			return fmt.Errorf("remove %s: %w", dir, err)
 		}
 	}
 
 	return nil
+}
+
+// otherTargetVectors lists the collection's vector names except `exclude` —
+// the set whose primary buckets a drop must not touch.
+func otherTargetVectors(class *models.Class, exclude string) []string {
+	if class == nil {
+		// No schema to consult: protect nothing rather than guess. The caller
+		// still removes this target's own artifacts; a collision would leak
+		// rather than delete a sibling's data.
+		return nil
+	}
+	others := make([]string, 0, len(class.VectorConfig))
+	for name := range class.VectorConfig {
+		if name != exclude {
+			others = append(others, name)
+		}
+	}
+	return others
 }

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -49,7 +49,7 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(vectorsBucket, "data.db"), []byte("data"), 0o644))
 		require.NoError(t, os.MkdirAll(compressedBucket, 0o755))
 
-		err := h.removeVectorIndexFiles(indexPath, shardName, "flat_bq")
+		err := h.removeVectorIndexFiles(indexPath, shardName, "flat_bq", nil)
 		require.NoError(t, err)
 
 		assert.False(t, pathExists(vectorsBucket))
@@ -69,7 +69,7 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		lsm := filepath.Join(indexPath, shardName, "lsm")
 		vectorsBucket := filepath.Join(lsm, helpers.GetVectorsBucketName(target))
 		compressedBucket := filepath.Join(lsm, helpers.GetCompressedBucketName(target))
-		muveraBucket := filepath.Join(lsm, helpers.GetMuveraBucketName(target))
+		muveraBucket := filepath.Join(lsm, helpers.MuveraBucketName(helpers.GetVectorsBucketName(target)))
 		commitLog := filepath.Join(indexPath, shardName, helpers.GetHNSWCommitLogDirName(target))
 
 		for _, dir := range []string{vectorsBucket, compressedBucket, muveraBucket, commitLog} {
@@ -79,30 +79,12 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		require.Equal(t, filepath.Join(lsm, "vectors_multivector_muvera_bq_muvera_vectors"), muveraBucket,
 			"the bucket name must match what hnsw.New creates")
 
-		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, target))
+		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, target, nil))
 
 		assert.False(t, pathExists(muveraBucket), "the muvera bucket must not survive the drop")
 		assert.False(t, pathExists(vectorsBucket))
 		assert.False(t, pathExists(compressedBucket))
 		assert.False(t, pathExists(commitLog))
-	})
-
-	t.Run("a sibling vector's muvera bucket is untouched", func(t *testing.T) {
-		// The bucket names share a prefix, so a sweep matching loosely would
-		// take a live index's encoded vectors with it.
-		indexPath, shardName := setup(t)
-
-		lsm := filepath.Join(indexPath, shardName, "lsm")
-		dropped := filepath.Join(lsm, helpers.GetMuveraBucketName("mv"))
-		sibling := filepath.Join(lsm, helpers.GetMuveraBucketName("mv_other"))
-		for _, dir := range []string{dropped, sibling} {
-			require.NoError(t, os.MkdirAll(dir, 0o755))
-		}
-
-		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, "mv"))
-
-		assert.False(t, pathExists(dropped))
-		assert.True(t, pathExists(sibling), "another vector's muvera bucket must survive")
 	})
 
 	t.Run("removes the directory and buckets of an hfresh index", func(t *testing.T) {
@@ -131,29 +113,38 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		require.Equal(t, filepath.Join(lsm, "hfresh_shared_vectors_hfresh_vec"), shared)
 		require.Equal(t, filepath.Join(indexPath, shardName, "vectors_hfresh_vec.hfresh.d"), hfreshDir)
 
-		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, target))
+		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, target, nil))
 
 		assert.False(t, pathExists(postings), "the hfresh postings bucket must not survive the drop")
 		assert.False(t, pathExists(shared), "the hfresh shared bucket must not survive the drop")
 		assert.False(t, pathExists(hfreshDir), "the hfresh directory must not survive the drop")
 	})
 
-	t.Run("a sibling vector's hfresh state is untouched", func(t *testing.T) {
-		// The names share a prefix, so a sweep matching loosely would take a
-		// live index's postings with it.
+	t.Run("a sibling whose bucket name collides is not deleted", func(t *testing.T) {
+		// The only way this sweep can destroy live data: target vector names may
+		// legally be "<other>_muvera_vectors" or "<other>_mv_mappings", which
+		// makes that sibling's PRIMARY vectors bucket identical to one of the
+		// dropped vector's artifacts. Deleting it takes a live vector's raw
+		// vectors, and this sweep re-runs on every restart while the drop marker
+		// persists, so a re-import would not survive either.
 		indexPath, shardName := setup(t)
-
 		lsm := filepath.Join(indexPath, shardName, "lsm")
-		dropped := filepath.Join(lsm, helpers.HFreshPostingsBucketName(helpers.GetVectorsBucketName("hf")))
-		sibling := filepath.Join(lsm, helpers.HFreshPostingsBucketName(helpers.GetVectorsBucketName("hf_other")))
-		for _, dir := range []string{dropped, sibling} {
-			require.NoError(t, os.MkdirAll(dir, 0o755))
+
+		const dropped = "foo"
+		for _, sibling := range []string{"foo_muvera_vectors", "foo_mv_mappings"} {
+			siblingBucket := filepath.Join(lsm, helpers.GetVectorsBucketName(sibling))
+			ownBucket := filepath.Join(lsm, helpers.GetVectorsBucketName(dropped))
+			require.NoError(t, os.MkdirAll(siblingBucket, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(siblingBucket, "segment.db"), []byte("live"), 0o644))
+			require.NoError(t, os.MkdirAll(ownBucket, 0o755))
+
+			require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, dropped, []string{sibling}))
+
+			assert.True(t, pathExists(siblingBucket),
+				"%s is %s's live vectors bucket and must survive dropping %s",
+				siblingBucket, sibling, dropped)
+			assert.False(t, pathExists(ownBucket), "the dropped vector's own bucket must still go")
 		}
-
-		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, "hf"))
-
-		assert.False(t, pathExists(dropped))
-		assert.True(t, pathExists(sibling), "another vector's hfresh postings must survive")
 	})
 
 	t.Run("removes all hnsw vector artifacts", func(t *testing.T) {
@@ -169,7 +160,7 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		require.NoError(t, os.MkdirAll(commitLog, 0o755))
 		require.NoError(t, os.MkdirAll(snapshot, 0o755))
 
-		err := h.removeVectorIndexFiles(indexPath, shardName, "hnsw_rq8")
+		err := h.removeVectorIndexFiles(indexPath, shardName, "hnsw_rq8", nil)
 		require.NoError(t, err)
 
 		assert.False(t, pathExists(vectorsBucket))
@@ -182,7 +173,7 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		indexPath, shardName := setup(t)
 		require.NoError(t, os.MkdirAll(filepath.Join(indexPath, shardName, "lsm"), 0o755))
 
-		err := h.removeVectorIndexFiles(indexPath, shardName, "nonexistent")
+		err := h.removeVectorIndexFiles(indexPath, shardName, "nonexistent", nil)
 		require.NoError(t, err)
 	})
 }

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -294,6 +294,41 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 		assert.False(t, pathExists(filepath.Join(indexPath, shardName, "vectors_hnsw_rq8.hnsw.snapshot.d")))
 	})
 
+	t.Run("a live sibling whose bucket name collides survives the sweep", func(t *testing.T) {
+		// The sibling-guard case in removeVectorIndexFiles is handed a list
+		// built by hand, so it proves the guard works given a correct list but
+		// not that any caller supplies one — passing nil at every call site
+		// leaves it green. This drives the real entry point, which derives the
+		// list from the class itself.
+		indexPath, shardName := setup(t)
+
+		const (
+			dropped = "foo"
+			sibling = "foo_muvera_vectors"
+		)
+		require.Equal(t, helpers.GetVectorsBucketName(sibling),
+			helpers.MuveraBucketName(helpers.GetVectorsBucketName(dropped)),
+			"precondition: the sibling's own bucket must be one of the dropped vector's artifact names")
+
+		createLSMBucket(t, indexPath, shardName, helpers.GetVectorsBucketName(dropped))
+		createLSMBucket(t, indexPath, shardName, helpers.GetVectorsBucketName(sibling))
+
+		class := &models.Class{
+			Class: "TestClass",
+			VectorConfig: map[string]models.VectorConfig{
+				dropped: {VectorIndexType: vectorindex.VectorIndexTypeNone},
+				sibling: {VectorIndexType: "hnsw"},
+			},
+		}
+
+		require.NoError(t, h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, class))
+
+		assert.True(t, pathExists(filepath.Join(indexPath, shardName, "lsm", helpers.GetVectorsBucketName(sibling))),
+			"%s is a live vector's own bucket and must survive dropping %s", sibling, dropped)
+		assert.False(t, pathExists(filepath.Join(indexPath, shardName, "lsm", helpers.GetVectorsBucketName(dropped))),
+			"the dropped vector's own bucket must still go")
+	})
+
 	t.Run("dropped vector but no files on disk - no error", func(t *testing.T) {
 		indexPath, shardName := setup(t)
 

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -407,9 +407,6 @@ func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {
 	}
 }
 
-// DropVectorIndex shuts down and removes the named vector index and its queue
-// from this shard, deleting associated files from disk. It also removes the
-// LSM buckets that store the raw and compressed vector data.
 // perVectorDropper is implemented by index types whose Drop() would reach
 // beyond the one vector being dropped. Only dynamic needs it today: its state
 // DB is shared across the shard, so Drop's Close()+Remove would take every
@@ -430,6 +427,9 @@ func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
 	return index.Drop(ctx, false)
 }
 
+// DropVectorIndex shuts down and removes the named vector index and its queue
+// from this shard, deleting associated files from disk. It also removes the
+// LSM buckets that store the raw and compressed vector data.
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
 	s.vectorIndexMu.Lock()
 	defer s.vectorIndexMu.Unlock()

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -410,6 +410,26 @@ func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {
 // DropVectorIndex shuts down and removes the named vector index and its queue
 // from this shard, deleting associated files from disk. It also removes the
 // LSM buckets that store the raw and compressed vector data.
+// perVectorDropper is implemented by index types whose Drop() would reach
+// beyond the one vector being dropped. Only dynamic needs it today: its state
+// DB is shared across the shard, so Drop's Close()+Remove would take every
+// sibling's state with it.
+type perVectorDropper interface {
+	DropTargetVector(ctx context.Context) error
+}
+
+// dropOneVectorIndex tears down a single named vector's index. Index types that
+// own nothing shard-wide fall through to Drop(keepFiles=false), which is the
+// same thing for them; the interface exists so a type that DOES own shared
+// state has somewhere to say so, rather than the caller having to know which
+// types are special.
+func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
+	if d, ok := index.(perVectorDropper); ok {
+		return d.DropTargetVector(ctx)
+	}
+	return index.Drop(ctx, false)
+}
+
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
 	s.vectorIndexMu.Lock()
 	defer s.vectorIndexMu.Unlock()
@@ -422,49 +442,29 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 	}
 
 	if index, ok := s.vectorIndexes[targetVector]; ok && index != nil {
-		if err := index.Drop(ctx, false); err != nil {
+		if err := dropOneVectorIndex(ctx, index); err != nil {
 			return fmt.Errorf("drop vector index %q: %w", targetVector, err)
 		}
 		delete(s.vectorIndexes, targetVector)
 	}
 
-	// Drop LSM buckets that hold the vector data on disk.
-	vectorsBucket := helpers.GetVectorsBucketName(targetVector)
-	if err := s.removeBucket(ctx, vectorsBucket); err != nil {
-		return fmt.Errorf("drop vectors bucket for %q: %w", targetVector, err)
+	// Remove every on-disk artifact this vector owns — the raw and compressed
+	// buckets, the multivector ones (muvera OR mv_mappings), and hfresh's
+	// directory and buckets. The set lives in helpers so the live drop, the
+	// file sweep and the tests cannot drift apart; passing the collection's
+	// other vector names is what stops a sibling being deleted when its own
+	// bucket collides with one of this target's artifact names.
+	artifacts := helpers.VectorIndexArtifactsFor(targetVector,
+		otherTargetVectors(s.class, targetVector))
+	for _, bucket := range artifacts.LSMBuckets {
+		if err := s.removeBucket(ctx, bucket); err != nil {
+			return fmt.Errorf("drop bucket %q for vector %q: %w", bucket, targetVector, err)
+		}
 	}
-
-	compressedBucket := helpers.GetCompressedBucketName(targetVector)
-	if err := s.removeBucket(ctx, compressedBucket); err != nil {
-		return fmt.Errorf("drop compressed vectors bucket for %q: %w", targetVector, err)
-	}
-
-	// A muvera-encoded multi-vector index keeps its encoded vectors in a bucket
-	// of its own, which neither of the two above covers and hnsw.Drop does not
-	// touch. Unconditional: reading the config back to decide would miss an
-	// index whose muvera setting changed, and removeBucket is a no-op when the
-	// bucket does not exist.
-	muveraBucket := helpers.GetMuveraBucketName(targetVector)
-	if err := s.removeBucket(ctx, muveraBucket); err != nil {
-		return fmt.Errorf("drop muvera vectors bucket for %q: %w", targetVector, err)
-	}
-
-	// An hfresh index keeps its state outside the two buckets above: a
-	// directory of its own under the shard, plus two dedicated LSM buckets. Its
-	// own Drop() removes none of them ("Shard::drop will take care of handling
-	// store buckets" holds when the whole shard goes, not when one named vector
-	// is dropped out from under a shard that stays), so they are named here.
-	// Unconditional: reading the type back to decide would miss an index that
-	// failed to load, and both removals are no-ops when the target is absent.
-	indexID := s.vectorIndexID(targetVector)
-	if err := s.removeBucket(ctx, helpers.HFreshPostingsBucketName(indexID)); err != nil {
-		return fmt.Errorf("drop hfresh postings bucket for %q: %w", targetVector, err)
-	}
-	if err := s.removeBucket(ctx, helpers.HFreshSharedBucketName(indexID)); err != nil {
-		return fmt.Errorf("drop hfresh shared bucket for %q: %w", targetVector, err)
-	}
-	if err := s.removeDirIfExists(s.path(), helpers.HFreshDirName(indexID)); err != nil {
-		return fmt.Errorf("drop hfresh directory for %q: %w", targetVector, err)
+	for _, dir := range artifacts.ShardDirs {
+		if err := s.removeDirIfExists(s.path(), dir); err != nil {
+			return fmt.Errorf("drop directory %q for vector %q: %w", dir, targetVector, err)
+		}
 	}
 
 	// Remove the index checkpoint entry for this vector.

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -591,7 +591,15 @@ func (l *LazyLoadShard) DropVectorIndex(ctx context.Context, targetVector string
 func (l *LazyLoadShard) dropUnloadedVectorIndex(targetVector string) error {
 	// Shard is not loaded — remove files directly from disk. Delegate to the
 	// shared helper so file path logic is defined in one place.
-	if err := newVectorDropIndexHelper().removeVectorIndexFiles(l.shardOpts.index.path(), l.shardOpts.name, targetVector); err != nil {
+	// The collection's other vector names guard against removing a sibling whose
+	// own bucket collides with one of this target's artifact names.
+	class := l.shardOpts.index.getClass()
+	if class == nil {
+		class = l.shardOpts.class
+	}
+	if err := newVectorDropIndexHelper().removeVectorIndexFiles(
+		l.shardOpts.index.path(), l.shardOpts.name, targetVector,
+		otherTargetVectors(class, targetVector)); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/vector/dynamic/drop_target_vector_test.go
+++ b/adapters/repos/db/vector/dynamic/drop_target_vector_test.go
@@ -1,0 +1,146 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package dynamic
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bbolt "go.etcd.io/bbolt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// newDynamicForDrop builds one dynamic index over a SHARED state DB, mirroring
+// the shard: getOrInitDynamicVectorIndexDB opens index.db once and every
+// dynamic vector on that shard is a key inside it.
+func newDynamicForDrop(t *testing.T, db *bbolt.DB, rootPath, targetVector string) *dynamic {
+	t.Helper()
+	dist := distancer.NewL2SquaredProvider()
+	fuc := flatent.UserConfig{}
+	fuc.SetDefaults()
+
+	idx, err := New(Config{
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		TargetVector:          targetVector,
+		RootPath:              rootPath,
+		ID:                    "vectors_" + targetVector,
+		MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,
+		DistanceProvider:      dist,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0, 0}, nil
+		},
+		GetViewThunk:                 GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk([][]float32{{0, 0}}),
+		TombstoneCallbacks:           cyclemanager.NewCallbackGroupNoop(),
+		SharedDB:                     db,
+		MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+		AsyncIndexingEnabled:         true,
+	}, ent.UserConfig{
+		Threshold: 1_000_000,
+		Distance:  dist.Type(),
+		HnswUC:    hnswent.UserConfig{MaxConnections: 8, EFConstruction: 16, EF: 8, VectorCacheMaxObjects: 1000},
+		FlatUC:    fuc,
+	}, testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+	return idx
+}
+
+// TestDropTargetVector_LeavesTheSharedStateDBUsable pins the whole reason
+// DropTargetVector exists.
+//
+// The state DB is opened ONCE PER SHARD and every dynamic vector is a key
+// inside it. Drop(keepFiles=false) closes that handle and removes the file,
+// which is right when the shard goes away and catastrophic when a single named
+// vector does: every sibling's flat-to-hnsw upgrade, the shard backup and the
+// shard's own shutdown all use the same handle.
+func TestDropTargetVector_LeavesTheSharedStateDBUsable(t *testing.T) {
+	ctx := context.Background()
+	rootPath := t.TempDir()
+	dbPath := filepath.Join(rootPath, StateDBFileName)
+	db, err := bbolt.Open(dbPath, 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	dropped := newDynamicForDrop(t, db, rootPath, "a")
+	sibling := newDynamicForDrop(t, db, rootPath, "b")
+
+	require.NoError(t, dropped.DropTargetVector(ctx))
+
+	// The file is still there and the handle still works: a sibling can read
+	// and write its own state.
+	_, statErr := os.Stat(dbPath)
+	assert.NoError(t, statErr, "the shard-shared state DB must survive a per-vector drop")
+
+	assert.NotPanics(t, func() {
+		err := db.Update(func(tx *bbolt.Tx) error {
+			b, err := tx.CreateBucketIfNotExists(dynamicBucket)
+			if err != nil {
+				return err
+			}
+			return b.Put(sibling.dbKey(), []byte("1"))
+		})
+		assert.NoError(t, err, "the shared handle must still be open for siblings")
+	})
+}
+
+// TestDropTargetVector_ClearsOnlyItsOwnKey pins both halves of the key
+// handling: the dropped vector's upgrade verdict must go, or a re-created
+// vector of the same name inherits "already upgraded" and boots straight into
+// an empty hnsw, skipping its flat stage; and the sibling's verdict must stay,
+// or the sibling silently restarts its own upgrade.
+func TestDropTargetVector_ClearsOnlyItsOwnKey(t *testing.T) {
+	ctx := context.Background()
+	rootPath := t.TempDir()
+	db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	dropped := newDynamicForDrop(t, db, rootPath, "a")
+	sibling := newDynamicForDrop(t, db, rootPath, "b")
+
+	// Both have been upgraded, as the shard would have recorded.
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(dynamicBucket)
+		if err != nil {
+			return err
+		}
+		if err := b.Put(dropped.dbKey(), []byte("1")); err != nil {
+			return err
+		}
+		return b.Put(sibling.dbKey(), []byte("1"))
+	}))
+
+	require.NoError(t, dropped.DropTargetVector(ctx))
+
+	require.NoError(t, db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(dynamicBucket)
+		require.NotNil(t, b)
+		assert.Empty(t, b.Get(dropped.dbKey()),
+			"the dropped vector's upgrade verdict must go, or a re-created name skips its flat stage")
+		assert.Equal(t, []byte("1"), b.Get(sibling.dbKey()),
+			"a sibling's upgrade verdict must survive")
+		return nil
+	}))
+}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -506,6 +506,44 @@ func (dynamic *dynamic) Drop(ctx context.Context, keepFiles bool) error {
 	return dynamic.index.Drop(ctx, keepFiles)
 }
 
+// DropTargetVector removes ONE named vector's dynamic index, leaving the shard
+// intact. It is the per-vector counterpart of Drop, and the difference is not
+// cosmetic: the state DB is shared by every dynamic vector on the shard (the
+// shard opens it once, see getOrInitDynamicVectorIndexDB, and each vector is a
+// KEY inside it), so Drop's Close()+Remove would take every sibling's state
+// with it — their flat-to-hnsw upgrades, the shard backup, and the shard's own
+// shutdown all use that handle.
+//
+// So this deletes only this vector's key and leaves the handle open. Deleting
+// the key is also what stops a re-created vector of the same name inheriting a
+// stale "already upgraded" verdict and booting straight into an empty hnsw,
+// skipping its flat stage.
+func (dynamic *dynamic) DropTargetVector(ctx context.Context) error {
+	if dynamic.ctx.Err() != nil {
+		// already dropped
+		return nil
+	}
+
+	dynamic.cancel()
+
+	dynamic.Lock()
+	defer dynamic.Unlock()
+
+	if err := dynamic.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(dynamicBucket)
+		if b == nil {
+			return nil // nothing was ever recorded for this shard
+		}
+		return b.Delete(dynamic.dbKey())
+	}); err != nil {
+		return fmt.Errorf("delete dynamic state for %q: %w", dynamic.targetVector, err)
+	}
+
+	// keepFiles=false: the underlying index's own files go, but the SHARED
+	// state DB above is untouched by this path.
+	return dynamic.index.Drop(ctx, false)
+}
+
 func (dynamic *dynamic) Flush() error {
 	dynamic.RLock()
 	defer dynamic.RUnlock()

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -507,17 +507,14 @@ func (dynamic *dynamic) Drop(ctx context.Context, keepFiles bool) error {
 }
 
 // DropTargetVector removes ONE named vector's dynamic index, leaving the shard
-// intact. It is the per-vector counterpart of Drop, and the difference is not
-// cosmetic: the state DB is shared by every dynamic vector on the shard (the
-// shard opens it once, see getOrInitDynamicVectorIndexDB, and each vector is a
-// KEY inside it), so Drop's Close()+Remove would take every sibling's state
-// with it — their flat-to-hnsw upgrades, the shard backup, and the shard's own
-// shutdown all use that handle.
+// intact. Drop is unusable here: the state DB is shared by every dynamic vector
+// on the shard (one handle, one key per vector), so its Close()+Remove would
+// take every sibling's state with it. This deletes only this vector's key,
+// which is also what stops a re-created vector of the same name inheriting a
+// stale "already upgraded" verdict.
 //
-// So this deletes only this vector's key and leaves the handle open. Deleting
-// the key is also what stops a re-created vector of the same name inheriting a
-// stale "already upgraded" verdict and booting straight into an empty hnsw,
-// skipping its flat stage.
+// Loaded-shard route only: the files-only sweeps never open the state DB, so a
+// drop on a cold shard leaves the key behind.
 func (dynamic *dynamic) DropTargetVector(ctx context.Context) error {
 	if dynamic.ctx.Err() != nil {
 		// already dropped

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -126,7 +126,7 @@ func (h *hnsw) DeleteMulti(docIDs ...uint64) error {
 			}
 			idBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(idBytes, id)
-			if err := h.store.Bucket(h.id + "_mv_mappings").Delete(idBytes); err != nil {
+			if err := h.store.Bucket(helpers.MVMappingsBucketName(h.id)).Delete(idBytes); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to delete %s_mv_mappings from the bucket", h.id))
 			}
 		}
@@ -952,7 +952,7 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 		if h.muvera.Load() {
 			idBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(idBytes, id)
-			if err := h.store.Bucket(h.id + "_muvera_vectors").Delete(idBytes); err != nil {
+			if err := h.store.Bucket(helpers.MuveraBucketName(h.id)).Delete(idBytes); err != nil {
 				h.logger.WithFields(logrus.Fields{
 					"action": "muvera_delete",
 					"id":     id,

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -314,14 +314,14 @@ func New(cfg Config, uc ent.UserConfig,
 			muveraEncoder = multivector.NewMuveraEncoder(uc.Multivector.MuveraConfig, store)
 			err := store.CreateOrLoadBucket(
 				context.Background(),
-				cfg.ID+"_muvera_vectors",
+				helpers.MuveraBucketName(cfg.ID),
 				cfg.MakeBucketOptions(lsmkv.StrategyReplace)...,
 			)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Create or load bucket (muvera store)")
 			}
 			muveraVectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
-				return muveraEncoder.GetMuveraVectorForID(id, cfg.ID+"_muvera_vectors")
+				return muveraEncoder.GetMuveraVectorForID(id, helpers.MuveraBucketName(cfg.ID))
 			}
 			vectorCache = cache.NewShardedFloat32LockCache(
 				muveraVectorForID, cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects, 1, cfg.Logger,
@@ -440,7 +440,7 @@ func New(cfg Config, uc ent.UserConfig,
 		if !uc.Multivector.MuveraEnabled() {
 			err := index.store.CreateOrLoadBucket(
 				context.Background(),
-				cfg.ID+"_mv_mappings",
+				helpers.MVMappingsBucketName(cfg.ID),
 				cfg.MakeBucketOptions(lsmkv.StrategyReplace)...,
 			)
 			if err != nil {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -302,7 +302,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docIDs[i])
 			muveraBytes := multivector.MuveraBytesFromFloat32(processedVectors[i])
-			if err := h.store.Bucket(h.id+"_muvera_vectors").Put(docIDBytes, muveraBytes); err != nil {
+			if err := h.store.Bucket(helpers.MuveraBucketName(h.id)).Put(docIDBytes, muveraBytes); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to put %s_muvera_vectors into the bucket", h.id))
 			}
 		}
@@ -424,7 +424,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			binary.BigEndian.PutUint64(nodeIDBytes, nodeId)
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docID)
-			err := h.store.Bucket(h.id+"_mv_mappings").Put(nodeIDBytes, docIDBytes)
+			err := h.store.Bucket(helpers.MVMappingsBucketName(h.id)).Put(nodeIDBytes, docIDBytes)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to put %s_mv_mappings into the bucket", h.id))
 			}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -370,7 +372,7 @@ func (h *hnsw) restoreDocMappings() error {
 	buf := make([]byte, 8)
 
 	// Get the mappings bucket - handle case where it might be nil
-	bucket := h.store.Bucket(h.id + "_mv_mappings")
+	bucket := h.store.Bucket(helpers.MVMappingsBucketName(h.id))
 	if bucket == nil {
 		err := errors.New("multivector mappings bucket not found")
 		h.logger.WithField("action", "restore_doc_mappings").

--- a/test/acceptance/drop_vector_index/hfresh_test.go
+++ b/test/acceptance/drop_vector_index/hfresh_test.go
@@ -14,7 +14,6 @@ package drop_vector_index
 import (
 	"context"
 	"fmt"
-	"io"
 	"path"
 	"sort"
 	"strings"
@@ -23,8 +22,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	tcexec "github.com/testcontainers/testcontainers-go/exec"
 
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -185,10 +182,7 @@ func hfreshDirsOnEveryNode(ctx context.Context, t *testing.T, compose *docker.Do
 		if node == nil {
 			continue
 		}
-		out := hfreshExec(ctx, t, node.Container(), []string{
-			"find", "/", "-xdev", "-type", "d",
-			"(", "-name", "vectors_*", "-o", "-name", "hfresh_*", ")",
-		})
+		out := findVectorDirs(ctx, t, node.Container())
 		for _, line := range strings.Split(out, "\n") {
 			if line = strings.TrimSpace(line); line != "" {
 				dirs = append(dirs, node.Name()+":"+line)
@@ -205,16 +199,4 @@ func hasBase(paths []string, base string) bool {
 		}
 	}
 	return false
-}
-
-func hfreshExec(ctx context.Context, t *testing.T, c testcontainers.Container, cmd []string) string {
-	t.Helper()
-	code, reader, err := c.Exec(ctx, cmd, tcexec.Multiplexed())
-	require.NoError(t, err, "exec %v", cmd)
-	buf := new(strings.Builder)
-	_, err = io.Copy(buf, reader)
-	require.NoError(t, err)
-	// find exits non-zero only on a real error; "no matches" is exit 0 + empty.
-	require.Zero(t, code, "exec %v failed: %s", cmd, buf.String())
-	return buf.String()
 }

--- a/test/acceptance/drop_vector_index/hfresh_test.go
+++ b/test/acceptance/drop_vector_index/hfresh_test.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -101,7 +100,7 @@ func testHFreshLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.
 
 		var owned []string
 		t.Run("the hfresh index owns directories on disk", func(t *testing.T) {
-			owned = hfreshDirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
+			owned = dirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
 			require.NotEmpty(t, owned,
 				"precondition: the index must have on-disk state, or dropping it proves nothing")
 			t.Logf("%s owns:\n  %s", dropped, strings.Join(owned, "\n  "))
@@ -122,7 +121,7 @@ func testHFreshLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.
 		})
 
 		t.Run("no directory of the dropped index survives", func(t *testing.T) {
-			left := hfreshDirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
+			left := dirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
 			for _, dir := range left {
 				t.Logf("SURVIVED: %s", dir)
 			}
@@ -145,29 +144,6 @@ func hfreshArtifactNames(targetVector string) []string {
 		"hfresh_postings_" + indexID,
 		"hfresh_shared_" + indexID,
 	}
-}
-
-// hfreshDirsOwnedBy returns the directories belonging to targetVector, matched
-// on EXACT names. Substring matching would be wrong: another vector's name may
-// contain this one as a prefix, and claiming its directories would report a
-// leak that is not there.
-func hfreshDirsOwnedBy(allDirs []string, targetVector string) []string {
-	indexID := "vectors_" + targetVector
-	names := map[string]struct{}{
-		indexID:                              {}, // vectors bucket
-		"vectors_compressed_" + targetVector: {}, // compressed bucket
-	}
-	for _, n := range hfreshArtifactNames(targetVector) {
-		names[n] = struct{}{}
-	}
-	var out []string
-	for _, dir := range allDirs {
-		if _, ok := names[path.Base(dir)]; ok {
-			out = append(out, dir)
-		}
-	}
-	sort.Strings(out)
-	return out
 }
 
 // hfreshDirsOnEveryNode collects candidate directories from EVERY node. The

--- a/test/acceptance/drop_vector_index/multivector_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/multivector_scenarios_test.go
@@ -18,6 +18,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -122,22 +124,12 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 				clschema.NewSchemaObjectsCreateParams().WithObjectClass(cls), nil)
 			require.NoError(t, err)
 
-			// Confirm each config survived the round trip: a variant that
-			// silently lost its multivector or muvera flag would create less
-			// on-disk state and make its assertions vacuous.
-			got := helper.GetClass(t, className)
-			for _, v := range variants {
-				cfg, ok := got.VectorConfig[v.name].VectorIndexConfig.(map[string]any)
-				require.True(t, ok, "%s: index config should be readable", v.name)
-				mv, ok := cfg["multivector"].(map[string]any)
-				require.True(t, ok, "%s: multivector config should be present", v.name)
-				require.Equal(t, true, mv["enabled"], "%s: multivector must be enabled", v.name)
-				if v.muvera {
-					muvera, ok := mv["muvera"].(map[string]any)
-					require.True(t, ok, "%s: muvera config should be present", v.name)
-					require.Equal(t, true, muvera["enabled"], "%s: muvera must be enabled", v.name)
-				}
-			}
+			// The configs are deliberately NOT re-read here. Two later checks
+			// pin the same thing more strongly: the batch below is only
+			// accepted as [][]float32 if multivector really stuck, and the
+			// muvera variants' on-disk precondition fails if muvera did not.
+			// Re-reading the flags we just sent would only move the failure
+			// slightly earlier.
 
 			batch := make([]*models.Object, count)
 			for i := range count {
@@ -164,7 +156,7 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 		// assertions below compare against observed state rather than a list of
 		// paths guessed in advance.
 		owned := map[string][]string{}
-		t.Run("every encoding owns directories on disk", func(t *testing.T) {
+		inventoried := t.Run("every encoding owns directories on disk", func(t *testing.T) {
 			all := multiVectorDirsOnEveryNode(ctx, t, compose)
 			for _, v := range variants {
 				owned[v.name] = dirsOwnedBy(all, v.name)
@@ -181,6 +173,14 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 				}
 			}
 		})
+
+		// Without the snapshot above, the drop subtests assert against nil
+		// `owned` entries: one real precondition failure would surface as five,
+		// four of them bogus "drop disturbed a sibling" reports pointing at the
+		// wrong thing. t.Run returns false when its subtest failed.
+		if !inventoried {
+			t.Fatal("skipping the drops: the pre-drop inventory failed, so nothing below can be trusted")
+		}
 
 		// Dropped one at a time so each drop can be checked against the indexes
 		// still standing.
@@ -215,13 +215,13 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 // variants' names are prefixes of one another, so "multivector" would claim
 // every other variant's directories too.
 func dirsOwnedBy(allDirs []string, targetVector string) []string {
-	indexID := "vectors_" + targetVector
-	names := map[string]struct{}{
-		indexID:                              {}, // vectors bucket
-		"vectors_compressed_" + targetVector: {}, // BQ/PQ/SQ compressed bucket
-		indexID + "_muvera_vectors":          {}, // muvera's own bucket
-		indexID + ".hnsw.commitlog.d":        {},
-		indexID + ".hnsw.snapshot.d":         {},
+	// Read from the same helper the cleanup uses, so a newly added artifact
+	// cannot be cleaned-but-unasserted or asserted-but-uncleaned. A hand-copied
+	// list here is how "_mv_mappings" came to be missing from this filter while
+	// the bucket leaked in the container and the test still reported clean.
+	names := map[string]struct{}{}
+	for _, n := range helpers.VectorIndexArtifactsFor(targetVector, nil).All() {
+		names[n] = struct{}{}
 	}
 	var out []string
 	for _, dir := range allDirs {
@@ -249,15 +249,78 @@ func multiVectorDirsOnEveryNode(ctx context.Context, t *testing.T, compose *dock
 		if node == nil {
 			continue
 		}
-		out := execInContainer(ctx, t, node.Container(),
-			[]string{"find", "/", "-xdev", "-type", "d", "-name", "vectors_*"})
-		for _, line := range strings.Split(out, "\n") {
+		for _, line := range strings.Split(findVectorDirs(ctx, t, node.Container()), "\n") {
 			if line = strings.TrimSpace(line); line != "" {
 				dirs = append(dirs, node.Name()+":"+line)
 			}
 		}
 	}
 	return dirs
+}
+
+// dataRoots caches the discovered data directory per container, so the walk
+// below is scoped to it instead of crossing the whole filesystem on every one
+// of the ~10 calls a run makes.
+var (
+	dataRootsMu sync.Mutex
+	dataRoots   = map[string]string{}
+)
+
+// dataRootOf locates PERSISTENCE_DATA_PATH inside the container once. Resolved
+// at runtime rather than hardcoded: a path that moved would otherwise make
+// every post-drop assertion pass vacuously by finding nothing.
+func dataRootOf(ctx context.Context, t *testing.T, c testcontainers.Container) string {
+	t.Helper()
+	dataRootsMu.Lock()
+	defer dataRootsMu.Unlock()
+	if root, ok := dataRoots[c.GetContainerID()]; ok {
+		return root
+	}
+
+	// Located by finding a shard's "lsm" directory at ANY depth and walking up
+	// two levels (<root>/<class>/<shard>/lsm). Depth is not assumed: with the
+	// default PERSISTENCE_DATA_PATH the marker sits at depth 4, and a bounded
+	// search that guessed wrong found nothing at all. `head -1` stops the walk
+	// at the first hit, so this stays cheap despite being unbounded, and it
+	// runs once per container.
+	out, _ := execInContainer(ctx, t, c, []string{
+		"sh", "-c", "find / -xdev -type d -name lsm 2>/dev/null | head -1",
+	})
+	root := ""
+	for _, line := range strings.Split(out, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			// <root>/<class>/<shard>/lsm — three levels up, not two. Stopping
+			// at the class directory scopes every later search to whichever
+			// class happened to be found first, and the result is CACHED, so
+			// one test passes and the next finds nothing.
+			root = path.Dir(path.Dir(path.Dir(line)))
+			break
+		}
+	}
+	require.NotEmpty(t, root,
+		"could not locate the data root in the container; a scoped search would find nothing and pass vacuously")
+	// Logged once per container: if the root is ever wrong again, the failure
+	// says which directory was searched instead of only that nothing was found.
+	t.Logf("data root in %s resolved to %s", c.GetContainerID()[:12], root)
+	dataRoots[c.GetContainerID()] = root
+	return root
+}
+
+// findVectorDirs lists candidate directories under the data root.
+//
+// find's exit code is deliberately NOT asserted. BusyBox find lstats every
+// entry it reads and exits 1 when one vanishes between readdir and lstat —
+// which segment flushes and compactions make routine here — while still
+// printing every real match. Failing on that would flake a run with zero
+// leaks. A genuinely broken search shows up instead as an empty result, which
+// the precondition subtest turns into a loud failure.
+func findVectorDirs(ctx context.Context, t *testing.T, c testcontainers.Container) string {
+	t.Helper()
+	out, _ := execInContainer(ctx, t, c, []string{
+		"find", dataRootOf(ctx, t, c), "-xdev", "-type", "d",
+		"(", "-name", "vectors_*", "-o", "-name", "hfresh_*", ")",
+	})
+	return out
 }
 
 func hasSuffix(paths []string, suffix string) bool {
@@ -269,14 +332,15 @@ func hasSuffix(paths []string, suffix string) bool {
 	return false
 }
 
-func execInContainer(ctx context.Context, t *testing.T, c testcontainers.Container, cmd []string) string {
+// execInContainer runs cmd and returns its stdout and exit code. The code is
+// returned rather than asserted: callers decide, because for `find` a non-zero
+// exit is routine (see findVectorDirs) while for other commands it is not.
+func execInContainer(ctx context.Context, t *testing.T, c testcontainers.Container, cmd []string) (string, int) {
 	t.Helper()
 	code, reader, err := c.Exec(ctx, cmd, tcexec.Multiplexed())
 	require.NoError(t, err, "exec %v", cmd)
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, reader)
 	require.NoError(t, err)
-	// find exits non-zero only on a real error; "no matches" is exit 0 + empty.
-	require.Zero(t, code, "exec %v failed: %s", cmd, buf.String())
-	return buf.String()
+	return buf.String(), code
 }

--- a/test/acceptance/drop_vector_index/multivector_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/multivector_scenarios_test.go
@@ -170,6 +170,11 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 				} else {
 					require.False(t, hasSuffix(owned[v.name], "_muvera_vectors"),
 						"%s has muvera disabled and must NOT have a muvera bucket, got %v", v.name, owned[v.name])
+					// Without this, NotEmpty above is satisfied by the raw
+					// bucket and the commit log alone, and the post-drop
+					// Empty would pass over a bucket that never existed.
+					require.True(t, hasSuffix(owned[v.name], "_mv_mappings"),
+						"precondition: %s must have created its mappings bucket, got %v", v.name, owned[v.name])
 				}
 			}
 		})
@@ -200,6 +205,11 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 					"dropping %s must leave none of its on-disk state, but these survived:\n  %s",
 					v.name, strings.Join(left, "\n  "))
 
+				unlisted := dirsNamedAfter(all, v.name)
+				require.Empty(t, unlisted,
+					"dropping %s must leave no directory named after it, including ones the artifact list does not know about:\n  %s",
+					v.name, strings.Join(unlisted, "\n  "))
+
 				for _, other := range variants[i+1:] {
 					require.Equal(t, owned[other.name], dirsOwnedBy(all, other.name),
 						"dropping %s must not disturb %s, whose name shares its prefix",
@@ -226,6 +236,29 @@ func dirsOwnedBy(allDirs []string, targetVector string) []string {
 	var out []string
 	for _, dir := range allDirs {
 		if _, ok := names[path.Base(dir)]; ok {
+			out = append(out, dir)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// dirsNamedAfter returns every observed directory whose name is derived from
+// targetVector, WITHOUT going through the artifact list. dirsOwnedBy filters
+// the walk down to the names the cleanup already knows about, so an artifact
+// the index creates that nobody added to helpers.VectorIndexArtifactsFor is
+// discarded before the leak assertion sees it — exactly how "_mv_mappings"
+// leaked while this test reported clean. This is the unfiltered net.
+//
+// Prefix matching is safe here only because the variants are dropped longest
+// name first: by the time v.name is dropped, every variant whose name extends
+// it is already gone.
+func dirsNamedAfter(allDirs []string, targetVector string) []string {
+	var out []string
+	for _, dir := range allDirs {
+		base := path.Base(dir)
+		if strings.HasPrefix(base, "vectors_"+targetVector) ||
+			strings.HasPrefix(base, "vectors_compressed_"+targetVector) {
 			out = append(out, dir)
 		}
 	}
@@ -278,7 +311,7 @@ func dataRootOf(ctx context.Context, t *testing.T, c testcontainers.Container) s
 	}
 
 	// Located by finding a shard's "lsm" directory at ANY depth and walking up
-	// two levels (<root>/<class>/<shard>/lsm). Depth is not assumed: with the
+	// three levels (<root>/<class>/<shard>/lsm). Depth is not assumed: with the
 	// default PERSISTENCE_DATA_PATH the marker sits at depth 4, and a bounded
 	// search that guessed wrong found nothing at all. `head -1` stops the walk
 	// at the first hit, so this stays cheap despite being unbounded, and it


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/dirk-claude-issues/issues/112

Dropping a named vector index left some of its storage behind and, on one reachable path, deleted storage belonging to a **different** vector. This fixes both directions and puts the artifact list in one place so they cannot drift apart again.

All of it came out of a review of the muvera/hfresh drop fixes (#12718, #12720), plus two leaks measured black-box in `weaviate-e2e-tests` (TC-012, 7-node kind).

## Data loss (the reason this is not just a cleanup PR)

**A drop could delete a live sibling vector's data.** `TargetVectorNameRegex` permits a vector literally named `foo_muvera_vectors`, and that sibling's *primary* vectors bucket is then byte-identical to the muvera bucket of `foo`:

```
GetVectorsBucketName("foo_muvera_vectors")  ==  vectors_foo_muvera_vectors
"vectors_foo" + "_muvera_vectors"           ==  vectors_foo_muvera_vectors
```

Dropping `foo` removed the sibling's registered, live bucket — its raw vectors. The same name was in the file sweep, which re-runs on shard init while the drop marker persists, so it survived a re-import. `_mv_mappings` and `_centroids` have the same shape.

Every artifact that a live sibling claims is now excluded from the removal list. Leaking is strictly better than deleting data that is still in use.

**Dropping one dynamic vector broke every other dynamic vector on the shard.** `index.db` is a single bbolt file per shard (opened once in `getOrInitDynamicVectorIndexDB`); each vector is a *key* inside it. `dynamic.Drop(keepFiles=false)` closed that handle and removed the file — correct when the whole shard goes, catastrophic for one named vector. Siblings' flat→hnsw upgrades, `shard_backup`'s `View`, and the shard's own shutdown all use that handle.

`DropTargetVector` now deletes only this vector's key and leaves the handle open. Clearing the key also fixes the inverse: a re-created vector of the same name no longer inherits a stale "already upgraded" verdict and skip its flat stage.

## Leaks fixed

| artifact | who creates it | who was cleaning it |
|---|---|---|
| `vectors_<t>_mv_mappings` | multivector **without** muvera (`hnsw.New`) | nobody |
| `vectors_compressed_<t>_centroids` | hfresh's nested centroids HNSW | nobody |
| `vectors_<t>.queue.d` | async-indexing queue | only the live path |

The queue directory is the one with teeth beyond disk cost: `DiskQueue.Init`'s `analyzeDisk` replays stale chunks into a **re-created** index of the same name — dimension errors, or silently wrong vectors. It leaked on every files-only path (cold lazy shard, inactive tenant, crash before the live drop).

None of these are collected later: once a drop completes, the vector's schema entry is gone, so `ensureFilesAreRemovedForDroppedVectorIndexes` never iterates over it again.

## Why they all happened at once

Three hand-maintained lists enumerated what a vector owns — `Shard.DropVectorIndex`, `removeVectorIndexFiles`, and the e2e's own filter — and nothing failed when they diverged. `_mv_mappings` was missing from **all three**, so it was cleaned nowhere and asserted nowhere: the acceptance test reported a clean drop while the bucket sat leaked in the container.

`helpers.VectorIndexArtifactsFor` is now the single source, read by both cleanup sites and the test. A new artifact is cleaned and asserted from the same list, or neither.

The bucket **names** were duplicated the same way: `_muvera_vectors` and `_mv_mappings` were concatenated inline in eight places across `hnsw`, separately from the cleanup that deleted them. A rename on the hnsw side would have compiled cleanly while the cleanup kept removing a name nothing creates. Both now come from `helpers`, and renaming at that single definition reddens the artifact tests.

## Testing

Mutation-verified — each mutation was applied and the named test observed to fail:

| Mutation | Caught by |
|---|---|
| collision guard removed | `NeverTakesASiblingsPrimaryBucket`, `NeverTakesASiblingsCompressedBucket` |
| guard narrowed to primary buckets only | `NeverTakesASiblingsCompressedBucket` |
| self-skip removed (drops its own bucket) | `KeepsItsOwnPrimaryBucket` |
| `_mv_mappings` / muvera / hfresh / centroids / queue dropped from the set | `CoversEveryArtifact` (+ others) |
| bucket renamed at its single definition | `CoversEveryArtifact` (+ others) |
| `DropTargetVector` reverts to `Drop`'s semantics | `LeavesTheSharedStateDBUsable`, `ClearsOnlyItsOwnKey` |
| key deletion skipped | `ClearsOnlyItsOwnKey` |
| shard bypasses the per-vector seam | `PrefersThePerVectorDrop` |
| seam always takes the per-vector path | `FallsBackForPlainIndexes` |

**The `_mv_mappings` leak is pinned end to end.** Against a server without this fix, `TestDropVectorIndex_Cluster/multi_vector_drop_leaves_no_files_on_disk` fails on both non-muvera variants across all three nodes, naming the surviving bucket; with the fix it passes.

Test fixes from the same review, each of which was hiding something:

- the e2e's artifact filter was hand-copied, which is why the `_mv_mappings` leak passed unnoticed — it now reads the shared set
- two "sibling untouched" unit subtests could not fail (`removeVectorIndexFiles` has no globbing, so they compared two different strings); replaced with the collision case that can actually delete data
- `require.Zero` on `find`'s exit code would flake — BusyBox `find` exits 1 when an entry vanishes mid-walk, which flushes and compactions make routine. The search is also now scoped to a data root discovered once, instead of walking the whole filesystem four times per call
- the drop subtests ran even when the pre-drop inventory failed, burying one real failure under four bogus "drop disturbed a sibling" reports
- a redundant schema round-trip block removed; the batch insert and the on-disk precondition already pin the same thing more strongly

## Scope

Touches `adapters/repos/db/vector/hnsw` and `.../dynamic` as well as the drop helpers, so it is wider than the title suggests — a reviewer from the vector-index side is worth having. `VectorIndex` is unchanged: `dynamic` opts in via a small optional interface, and hnsw/flat/hfresh keep the existing path.

## Not fixed here

`dynamic.Drop`'s whole-shard path is untouched — removing `index.db` is correct when the shard goes away. Only the per-vector caller changed.

Deployments that already ran an affected drop still have the orphans on disk; this stops new ones but collects nothing, for the same reason the startup sweep never sees them. A one-off cleanup keyed on directory names rather than schema entries would be a separate change.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
