### PR TITLE
fix(schema): read sharding state under the class lock in CopyShardingState

### DIFF
--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -320,9 +320,18 @@ func (s *schema) CopyShardingState(class string) (*sharding.State, uint64) {
 	if meta == nil {
 		return nil, 0
 	}
-	shardingState := meta.Sharding.DeepCopy()
 
-	return &shardingState, meta.version()
+	var (
+		shardingState sharding.State
+		version       uint64
+	)
+	_ = meta.RLockGuard(func(_ *models.Class, state *sharding.State) error {
+		shardingState = state.DeepCopy()
+		version = meta.version()
+		return nil
+	})
+
+	return &shardingState, version
 }
 
 func (s *schema) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -82,6 +82,10 @@ func TestConcurrentSchemaAccess(t *testing.T) {
 			name: "concurrent alias snapshot and alias writes",
 			test: testConcurrentAliasSnapshot,
 		},
+		{
+			name: "concurrent sharding state copy and class update",
+			test: testConcurrentCopyShardingStateAndUpdate,
+		},
 	}
 
 	for _, tt := range tests {
@@ -821,4 +825,80 @@ func (m *mockShardReader) GetShardsStatus(class, tenant string) (models.ShardSta
 	return models.ShardStatusList{
 		{Status: "HOT", Name: "shard1"},
 	}, nil
+}
+
+// testConcurrentCopyShardingStateAndUpdate reproduces the production pair that
+// raced: the RAFT FSM applying an UpdateClass while a gRPC QueryShardingState
+// copies the same class.
+//
+// CopyShardingState resolves the metaClass through metaClass(), which releases
+// the schema-map lock before returning the pointer — so reading Sharding and
+// ClassVersion afterwards is unsynchronised, while updateClass mutates exactly
+// those fields under the class lock. The sibling test above only drives
+// GetShardsStatus, which goes through a different reader, so it never covered
+// this path.
+//
+// Only meaningful under -race: without the class lock the detector reports the
+// write/read pair; the assertions alone would usually pass.
+func testConcurrentCopyShardingStateAndUpdate(t *testing.T, s *schema) {
+	class := &models.Class{
+		Class:      "TestClass",
+		Properties: []*models.Property{{Name: "prop1", DataType: []string{"string"}}},
+	}
+	shardState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"shard1": {Name: "shard1", Status: "HOT"},
+		},
+	}
+	require.NoError(t, s.addClass(class, shardState, 1))
+
+	const numGoroutines = 8
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines * 2)
+
+	// Readers: what QueryShardingState does.
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				state, version := s.CopyShardingState("TestClass")
+				if state != nil {
+					// Touch the copy: a state handed out under no lock would be
+					// mutated underneath this read.
+					_ = len(state.Physical)
+					_ = version
+				}
+			}
+		}()
+	}
+
+	// Writers: what the FSM's UpdateClass does — replace the sharding state and
+	// bump the version, both under the class lock.
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = s.updateClass("TestClass", func(mc *metaClass) error {
+					mc.Sharding = sharding.State{
+						Physical: map[string]sharding.Physical{
+							fmt.Sprintf("shard%d_%d", id, j): {
+								Name:   fmt.Sprintf("shard%d_%d", id, j),
+								Status: "HOT",
+							},
+						},
+					}
+					mc.ClassVersion = uint64(j) + 2
+					return nil
+				})
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	state, version := s.CopyShardingState("TestClass")
+	require.NotNil(t, state, "the class must still be readable after the churn")
+	assert.NotZero(t, version)
 }


### PR DESCRIPTION
### What's being changed:

Fixes data race:
```
==================
  WARNING: DATA RACE
  Write at 0x00c0030315e8 by goroutine 4716:
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).UpdateClass.func1()
        github.com/weaviate/weaviate/cluster/schema/manager.go:564 +0x1b25
    github.com/weaviate/weaviate/cluster/schema.(*metaClass).LockGuard()
        github.com/weaviate/weaviate/cluster/schema/meta_class.go:586 +0x96
    github.com/weaviate/weaviate/cluster/schema.(*schema).updateClass()
        github.com/weaviate/weaviate/cluster/schema/schema.go:389 +0x118
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).UpdateClass.func2()
        github.com/weaviate/weaviate/cluster/schema/manager.go:581 +0x8a
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).apply()
        github.com/weaviate/weaviate/cluster/schema/manager.go:1038 +0x3a9
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).UpdateClass()
        github.com/weaviate/weaviate/cluster/schema/manager.go:578 +0x667
    github.com/weaviate/weaviate/cluster.(*Store).Apply.func6()
        github.com/weaviate/weaviate/cluster/store_apply.go:353 +0xa4
    github.com/weaviate/weaviate/cluster.(*Store).Apply.func64()
        github.com/weaviate/weaviate/cluster/store_apply.go:633 +0x7b
    github.com/weaviate/weaviate/entities/errors.GoWrapper.func1()
        github.com/weaviate/weaviate/entities/errors/go_wrapper.go:35 +0x97
  
  Previous read at 0x00c0030315e8 by goroutine 4715:
    github.com/weaviate/weaviate/cluster/schema.(*metaClass).version()
        github.com/weaviate/weaviate/cluster/schema/meta_class.go:72 +0x33d
    github.com/weaviate/weaviate/cluster/schema.(*schema).CopyShardingState()
        github.com/weaviate/weaviate/cluster/schema/schema.go:325 +0x380
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).QueryShardingState()
        github.com/weaviate/weaviate/cluster/schema/manager_query.go:143 +0x2a4
    github.com/weaviate/weaviate/cluster.(*Store).Query()
        github.com/weaviate/weaviate/cluster/store_query.go:70 +0xb97
    github.com/weaviate/weaviate/cluster.(*Raft).Query()
        github.com/weaviate/weaviate/cluster/raft_query_endpoints.go:382 +0x38d
    github.com/weaviate/weaviate/cluster/rpc.(*Server).Query()
        github.com/weaviate/weaviate/cluster/rpc/server.go:138 +0x69
    github.com/weaviate/weaviate/cluster/proto/api._ClusterService_Query_Handler()
        github.com/weaviate/weaviate/cluster/proto/api/message_grpc.pb.go:231 +0x294
    google.golang.org/grpc.(*Server).processUnaryRPC()
        google.golang.org/grpc@v1.82.1/server.go:1443 +0x1a49
    google.golang.org/grpc.(*Server).handleStream()
        google.golang.org/grpc@v1.82.1/server.go:1858 +0x11c4
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.82.1/server.go:1078 +0x149
  
  Goroutine 4716 (running) created at:
    github.com/weaviate/weaviate/entities/errors.GoWrapper()
        github.com/weaviate/weaviate/entities/errors/go_wrapper.go:25 +0xd9
    github.com/weaviate/weaviate/cluster.(*Store).Apply()
        github.com/weaviate/weaviate/cluster/store_apply.go:635 +0x5847
    github.com/hashicorp/raft.(*Raft).runFSM.func1()
        github.com/hashicorp/raft@v1.7.2/fsm.go:107 +0x38e
    github.com/hashicorp/raft.(*Raft).runFSM.func2()
        github.com/hashicorp/raft@v1.7.2/fsm.go:130 +0x12b4
    github.com/hashicorp/raft.(*Raft).runFSM()
        github.com/hashicorp/raft@v1.7.2/fsm.go:246 +0x983
    github.com/hashicorp/raft.(*Raft).runFSM-fm()
        <autogenerated>:1 +0x2e
    github.com/hashicorp/raft.(*raftState).goFunc.func1()
        github.com/hashicorp/raft@v1.7.2/state.go:149 +0x86
  
  Goroutine 4715 (finished) created at:
    google.golang.org/grpc.(*Server).serveStreams.func2()
        google.golang.org/grpc@v1.82.1/server.go:1089 +0x212
    google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
        google.golang.org/grpc@v1.82.1/internal/transport/http2_server.go:632 +0x3182
    google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
        google.golang.org/grpc@v1.82.1/internal/transport/http2_server.go:673 +0x3b7
    google.golang.org/grpc.(*Server).serveStreams()
        google.golang.org/grpc@v1.82.1/server.go:1072 +0x63a
    google.golang.org/grpc.(*Server).handleRawConn.func1()
        google.golang.org/grpc@v1.82.1/server.go:1006 +0x86
  ==================
  ==================
  WARNING: DATA RACE
  Write at 0x00c003031680 by goroutine 4716:
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).UpdateClass.func1()
        github.com/weaviate/weaviate/cluster/schema/manager.go:572 +0x1ca6
    github.com/weaviate/weaviate/cluster/schema.(*metaClass).LockGuard()
        github.com/weaviate/weaviate/cluster/schema/meta_class.go:586 +0x96
    github.com/weaviate/weaviate/cluster/schema.(*schema).updateClass()
        github.com/weaviate/weaviate/cluster/schema/schema.go:389 +0x118
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).UpdateClass.func2()
        github.com/weaviate/weaviate/cluster/schema/manager.go:581 +0x8a
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).apply()
        github.com/weaviate/weaviate/cluster/schema/manager.go:1038 +0x3a9
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).UpdateClass()
        github.com/weaviate/weaviate/cluster/schema/manager.go:578 +0x667
    github.com/weaviate/weaviate/cluster.(*Store).Apply.func6()
        github.com/weaviate/weaviate/cluster/store_apply.go:353 +0xa4
    github.com/weaviate/weaviate/cluster.(*Store).Apply.func64()
        github.com/weaviate/weaviate/cluster/store_apply.go:633 +0x7b
    github.com/weaviate/weaviate/entities/errors.GoWrapper.func1()
        github.com/weaviate/weaviate/entities/errors/go_wrapper.go:35 +0x97
  
  Previous read at 0x00c003031680 by goroutine 4715:
    github.com/weaviate/weaviate/cluster/schema.(*schema).CopyShardingState()
        github.com/weaviate/weaviate/cluster/schema/schema.go:323 +0xac
    github.com/weaviate/weaviate/cluster/schema.(*SchemaManager).QueryShardingState()
        github.com/weaviate/weaviate/cluster/schema/manager_query.go:143 +0x2a4
    github.com/weaviate/weaviate/cluster.(*Store).Query()
        github.com/weaviate/weaviate/cluster/store_query.go:70 +0xb97
    github.com/weaviate/weaviate/cluster.(*Raft).Query()
        github.com/weaviate/weaviate/cluster/raft_query_endpoints.go:382 +0x38d
    github.com/weaviate/weaviate/cluster/rpc.(*Server).Query()
        github.com/weaviate/weaviate/cluster/rpc/server.go:138 +0x69
    github.com/weaviate/weaviate/cluster/proto/api._ClusterService_Query_Handler()
        github.com/weaviate/weaviate/cluster/proto/api/message_grpc.pb.go:231 +0x294
    google.golang.org/grpc.(*Server).processUnaryRPC()
        google.golang.org/grpc@v1.82.1/server.go:1443 +0x1a49
    google.golang.org/grpc.(*Server).handleStream()
        google.golang.org/grpc@v1.82.1/server.go:1858 +0x11c4
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
        google.golang.org/grpc@v1.82.1/server.go:1078 +0x149
  
  Goroutine 4716 (running) created at:
    github.com/weaviate/weaviate/entities/errors.GoWrapper()
        github.com/weaviate/weaviate/entities/errors/go_wrapper.go:25 +0xd9
    github.com/weaviate/weaviate/cluster.(*Store).Apply()
        github.com/weaviate/weaviate/cluster/store_apply.go:635 +0x5847
    github.com/hashicorp/raft.(*Raft).runFSM.func1()
        github.com/hashicorp/raft@v1.7.2/fsm.go:107 +0x38e
    github.com/hashicorp/raft.(*Raft).runFSM.func2()
        github.com/hashicorp/raft@v1.7.2/fsm.go:130 +0x12b4
    github.com/hashicorp/raft.(*Raft).runFSM()
        github.com/hashicorp/raft@v1.7.2/fsm.go:246 +0x983
    github.com/hashicorp/raft.(*Raft).runFSM-fm()
        <autogenerated>:1 +0x2e
    github.com/hashicorp/raft.(*raftState).goFunc.func1()
        github.com/hashicorp/raft@v1.7.2/state.go:149 +0x86
  
  Goroutine 4715 (finished) created at:
    google.golang.org/grpc.(*Server).serveStreams.func2()
        google.golang.org/grpc@v1.82.1/server.go:1089 +0x212
    google.golang.org/grpc/internal/transport.(*http2Server).operateHeaders()
        google.golang.org/grpc@v1.82.1/internal/transport/http2_server.go:632 +0x3182
    google.golang.org/grpc/internal/transport.(*http2Server).HandleStreams()
        google.golang.org/grpc@v1.82.1/internal/transport/http2_server.go:673 +0x3b7
    google.golang.org/grpc.(*Server).serveStreams()
        google.golang.org/grpc@v1.82.1/server.go:1072 +0x63a
    google.golang.org/grpc.(*Server).handleRawConn.func1()
        google.golang.org/grpc@v1.82.1/server.go:1006 +0x86
  ==================
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
