### PR TITLE
fix(drop-vector-index): remove the flat metadata file on the files-only path, add an async-indexing CI run

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -853,6 +853,8 @@ jobs:
             test: "--acceptance-drop-vector-index-restart-cluster"
           - name: "rolling-restart"
             test: "--acceptance-drop-vector-index-rolling-restart"
+          - name: "async-indexing"
+            test: "--acceptance-drop-vector-index-async-indexing"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -85,8 +85,18 @@ func HFreshSharedBucketName(indexID string) string {
 	return fmt.Sprintf("hfresh_shared_%s", indexID)
 }
 
+// FlatMetadataFileName is the flat index's quantisation metadata, under the
+// shard directory (see flat.getMetadataFile).
+func FlatMetadataFileName(targetVector string) string {
+	if targetVector != "" {
+		return fmt.Sprintf("meta_%s.db", targetVector)
+	}
+	return "meta.db"
+}
+
 // VectorIndexArtifacts is everything a named vector's index owns on disk:
-// LSMBuckets are directories under <shard>/lsm, ShardDirs under <shard>.
+// LSMBuckets are directories under <shard>/lsm; ShardDirs are entries under
+// <shard> — directories, plus the flat metadata file. Both go via os.RemoveAll.
 type VectorIndexArtifacts struct {
 	LSMBuckets []string
 	ShardDirs  []string
@@ -128,6 +138,9 @@ func vectorIndexArtifactNames(targetVector string) VectorIndexArtifacts {
 			// chunks into a re-created index of the same name, so this is wrong
 			// vectors and dimension errors, not just disk cost.
 			indexID + ".queue.d",
+			// flat.Drop removes this on the live path only; the files-only
+			// paths leave it, same gap as the queue directory above.
+			FlatMetadataFileName(targetVector),
 		},
 	}
 }

--- a/adapters/repos/db/helpers/vector_index_artifacts_test.go
+++ b/adapters/repos/db/helpers/vector_index_artifacts_test.go
@@ -43,6 +43,7 @@ func TestVectorIndexArtifactsFor_CoversEveryArtifact(t *testing.T) {
 		"vectors_vec.hnsw.snapshot.d",
 		"vectors_vec.hfresh.d",
 		"vectors_vec.queue.d", // async-indexing queue
+		"meta_vec.db",         // flat quantisation metadata (a FILE)
 	}, got.ShardDirs)
 
 	assert.Len(t, got.All(), len(got.LSMBuckets)+len(got.ShardDirs))

--- a/test/acceptance/drop_vector_index/flat_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/flat_scenarios_test.go
@@ -1,0 +1,134 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package drop_vector_index
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/require"
+
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// testFlatLeavesNoFilesOnDisk pins cleanup of a dropped flat index, whose
+// meta_<target>.db is removed by flat.Drop on the live path only — the
+// files-only sweep never named it. The other disk scenarios use hnsw and
+// hfresh, so none of them creates this file.
+func testFlatLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		const (
+			className  = "DropVectorIndexFlatDisk"
+			dropped    = "flat_bq"
+			sibling    = "sibling"
+			coldTenant = "tenant-cold"
+			dim        = 32
+			count      = 100
+		)
+
+		deleteParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+		defer helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+
+		t.Run("create a flat vector and fill it", func(t *testing.T) {
+			cls := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{Name: "name", DataType: []string{schema.DataTypeText.String()}},
+				},
+				MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+				VectorConfig: map[string]models.VectorConfig{
+					dropped: {
+						Vectorizer:      map[string]any{"none": map[string]any{}},
+						VectorIndexType: "flat",
+						// BQ is what makes the metadata file exist.
+						VectorIndexConfig: map[string]any{
+							"bq": map[string]any{"enabled": true},
+						},
+					},
+					// Keeps the collection from going vectorless after the drop.
+					sibling: noneVectorConfig(),
+				},
+			}
+			_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+				clschema.NewSchemaObjectsCreateParams().WithObjectClass(cls), nil)
+			require.NoError(t, err)
+			helper.CreateTenants(t, className, []*models.Tenant{{Name: coldTenant}})
+
+			got := helper.GetClass(t, className)
+			require.Equal(t, "flat", got.VectorConfig[dropped].VectorIndexType,
+				"the vector must actually be a flat index, or its metadata file never exists")
+
+			batch := make([]*models.Object, count)
+			for i := range count {
+				batch[i] = &models.Object{
+					ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-00000000%04d", i)),
+					Class:      className,
+					Tenant:     coldTenant,
+					Properties: map[string]any{"name": fmt.Sprintf("object-%d", i)},
+					Vectors: models.Vectors{
+						dropped: randVec(dim, float32(i)),
+						sibling: randVec(dim, float32(i+1000)),
+					},
+				}
+			}
+			helper.CreateObjectsBatch(t, batch)
+			time.Sleep(5 * time.Second) // past the 1s dirty-flush
+		})
+
+		var owned []string
+		t.Run("the flat index owns state on disk", func(t *testing.T) {
+			owned = dirsOwnedBy(multiVectorDirsOnEveryNode(ctx, t, compose), dropped)
+			require.NotEmpty(t, owned,
+				"precondition: the index must have on-disk state, or dropping it proves nothing")
+			t.Logf("%s owns:\n  %s", dropped, strings.Join(owned, "\n  "))
+
+			require.True(t, hasBase(owned, "meta_"+dropped+".db"),
+				"precondition: a flat index must have written its metadata file, got %v", owned)
+		})
+
+		t.Run("drop the flat index and wait for completion", func(t *testing.T) {
+			// Deactivate first: with the shard unloaded the live path never
+			// runs and cleanup falls to removeVectorIndexFiles, which is where
+			// the bug is. Dropping a hot tenant passes either way.
+			setTenantStatusEventually(t, className, coldTenant, models.TenantActivityStatusCOLD)
+
+			dropTargetVector(t, className, dropped)
+
+			// A cold tenant defers the drop; reactivating lets reconciliation
+			// re-enqueue the cleanup that must remove the file.
+			setTenantStatusEventually(t, className, coldTenant, models.TenantActivityStatusHOT)
+
+			eventuallyTargetVectorRemoved(t, className, dropped)
+			waitForNoActiveDropTask(t)
+		})
+
+		t.Run("no state of the dropped index survives", func(t *testing.T) {
+			left := dirsOwnedBy(multiVectorDirsOnEveryNode(ctx, t, compose), dropped)
+			for _, entry := range left {
+				t.Logf("SURVIVED: %s", entry)
+			}
+			require.Empty(t, left,
+				"a completed drop must leave no on-disk state for %q, but these survived:\n  %s",
+				dropped, strings.Join(left, "\n  "))
+		})
+	}
+}

--- a/test/acceptance/drop_vector_index/helpers_test.go
+++ b/test/acceptance/drop_vector_index/helpers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/distributed_tasks"
+	"github.com/weaviate/weaviate/client/nodes"
 	clobjects "github.com/weaviate/weaviate/client/objects"
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
@@ -63,6 +64,10 @@ func vecDim(t *testing.T, v models.Vector) int {
 
 func dropTargetVector(t *testing.T, className, targetVector string) {
 	t.Helper()
+	// With ASYNC_INDEXING a drop issued straight after a batch races the
+	// indexing still creating the artifacts it must remove. Here rather than at
+	// the insert sites, so every drop is covered.
+	waitForVectorIndexing(t, className)
 	_, err := helper.Client(t).Schema.SchemaObjectsVectorsDelete(
 		clschema.NewSchemaObjectsVectorsDeleteParams().
 			WithClassName(className).WithVectorIndexName(targetVector), nil)
@@ -121,6 +126,10 @@ func nearVectorResults(t *testing.T, className, targetVector string, vector []fl
 
 func nearVectorTenantResults(t *testing.T, className, tenant, targetVector string, vector []float32, limit int) int {
 	t.Helper()
+	// A vector search only finds what the index already holds. With
+	// ASYNC_INDEXING the batch returns before that is true, so every count
+	// asserted here would otherwise read 0. Same reason as in dropTargetVector.
+	waitForVectorIndexing(t, className)
 	resp := graphqlhelper.QueryGraphQLOrFatal(t, nil, "", nearVectorQuery(className, tenant, targetVector, vector, limit), nil)
 	require.Empty(t, resp.Errors)
 	get := resp.Data["Get"].(map[string]interface{})
@@ -300,4 +309,34 @@ func createMTDropClass(t *testing.T, className, dropped, sibling string, tenantN
 		tenants[i] = &models.Tenant{Name: name}
 	}
 	helper.CreateTenants(t, className, tenants)
+}
+
+// asyncIndexingTimeout bounds the wait for the vector-index queues to drain.
+const asyncIndexingTimeout = 2 * time.Minute
+
+// waitForVectorIndexing blocks until every shard of className reports an empty
+// vector queue and a READY index. Both are needed: the length reads zero before
+// the first batch is enqueued as well as after the last one is written.
+// Without ASYNC_INDEXING it returns on the first poll.
+func waitForVectorIndexing(t *testing.T, className string) {
+	t.Helper()
+	verbose := "verbose"
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		params := nodes.NewNodesGetClassParams().WithClassName(className).WithOutput(&verbose)
+		resp, err := helper.Client(t).Nodes.NodesGetClass(params, nil)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		if !assert.NotEmpty(collect, resp.Payload.Nodes, "no nodes reported") {
+			return
+		}
+		for _, node := range resp.Payload.Nodes {
+			for _, shard := range node.Shards {
+				assert.Zero(collect, shard.VectorQueueLength,
+					"shard %s/%s still has %d queued vectors", node.Name, shard.Name, shard.VectorQueueLength)
+				assert.Equal(collect, "READY", shard.VectorIndexingStatus,
+					"shard %s/%s is %s", node.Name, shard.Name, shard.VectorIndexingStatus)
+			}
+		}
+	}, asyncIndexingTimeout, time.Second, "vector indexing did not settle for %s", className)
 }

--- a/test/acceptance/drop_vector_index/multivector_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/multivector_scenarios_test.go
@@ -282,6 +282,9 @@ func multiVectorDirsOnEveryNode(ctx context.Context, t *testing.T, compose *dock
 		if node == nil {
 			continue
 		}
+		if dataRootOf(ctx, t, node.Container()) == "" {
+			continue // this node holds no shard data yet
+		}
 		for _, line := range strings.Split(findVectorDirs(ctx, t, node.Container()), "\n") {
 			if line = strings.TrimSpace(line); line != "" {
 				dirs = append(dirs, node.Name()+":"+line)
@@ -330,8 +333,12 @@ func dataRootOf(ctx context.Context, t *testing.T, c testcontainers.Container) s
 			break
 		}
 	}
-	require.NotEmpty(t, root,
-		"could not locate the data root in the container; a scoped search would find nothing and pass vacuously")
+	// Empty is legitimate: an MT tenant's shard lives on one node, so others
+	// hold nothing. Each scenario's precondition still requires a non-empty
+	// inventory cluster-wide, so a wrong root cannot pass unnoticed.
+	if root == "" {
+		return ""
+	}
 	// Logged once per container: if the root is ever wrong again, the failure
 	// says which directory was searched instead of only that nothing was found.
 	t.Logf("data root in %s resolved to %s", c.GetContainerID()[:12], root)
@@ -349,9 +356,10 @@ func dataRootOf(ctx context.Context, t *testing.T, c testcontainers.Container) s
 // the precondition subtest turns into a loud failure.
 func findVectorDirs(ctx context.Context, t *testing.T, c testcontainers.Container) string {
 	t.Helper()
+	// Not -type d: the flat metadata (meta_<target>.db) is a file.
 	out, _ := execInContainer(ctx, t, c, []string{
-		"find", dataRootOf(ctx, t, c), "-xdev", "-type", "d",
-		"(", "-name", "vectors_*", "-o", "-name", "hfresh_*", ")",
+		"find", dataRootOf(ctx, t, c), "-xdev",
+		"(", "-name", "vectors_*", "-o", "-name", "hfresh_*", "-o", "-name", "meta_*", ")",
 	})
 	return out
 }

--- a/test/acceptance/drop_vector_index/setup_test.go
+++ b/test/acceptance/drop_vector_index/setup_test.go
@@ -41,6 +41,32 @@ func TestDropVectorIndex_Cluster(t *testing.T) {
 	t.Run("replicated cold tenant", testReplicatedColdTenant(compose))
 }
 
+// TestDropVectorIndex_AsyncIndexing runs the cluster journeys with
+// ASYNC_INDEXING on. That gives every index a vectors_<name>.queue.d the
+// synchronous path never creates, so the disk assertions — unchanged, they read
+// helpers.VectorIndexArtifactsFor — cover an artifact the cluster job cannot.
+func TestDropVectorIndex_AsyncIndexing(t *testing.T) {
+	ctx := context.Background()
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "1").
+		WithWeaviateEnv("ASYNC_INDEXING", "true").
+		// Flush partial queue chunks promptly, or the drain sits idle.
+		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "500ms").
+		WithWeaviateEnv("DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS", "5").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		dumpLogsOnFailure(ctx, t, compose)
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	runSuite(t, compose)
+	t.Run("replicated drop", testReplicatedDrop(compose))
+	t.Run("replicated cold tenant", testReplicatedColdTenant(compose))
+}
+
 func TestDropVectorIndex_Restart_Cluster(t *testing.T) {
 	ctx := context.Background()
 	compose, err := docker.New().
@@ -107,4 +133,5 @@ func runSuite(t *testing.T, compose *docker.DockerCompose) {
 	t.Run("multi vector", testMultiVector())
 	t.Run("multi vector drop leaves no files on disk", testMultiVectorLeavesNoFilesOnDisk(compose))
 	t.Run("hfresh drop leaves no files on disk", testHFreshLeavesNoFilesOnDisk(compose))
+	t.Run("flat drop leaves no files on disk", testFlatLeavesNoFilesOnDisk(compose))
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -63,6 +63,7 @@ function main() {
   run_acceptance_drop_vector_index_cluster=false
   run_acceptance_drop_vector_index_restart_cluster=false
   run_acceptance_drop_vector_index_rolling_restart=false
+  run_acceptance_drop_vector_index_async_indexing=false
   run_acceptance_backups=false
 
   while [[ "$#" -gt 0 ]]; do
@@ -126,6 +127,7 @@ function main() {
           --acceptance-drop-vector-index-cluster|-advic) run_all_tests=false; run_acceptance_drop_vector_index_cluster=true;;
           --acceptance-drop-vector-index-restart-cluster|-advirc) run_all_tests=false; run_acceptance_drop_vector_index_restart_cluster=true;;
           --acceptance-drop-vector-index-rolling-restart|-advirr) run_all_tests=false; run_acceptance_drop_vector_index_rolling_restart=true;;
+          --acceptance-drop-vector-index-async-indexing|-advia) run_all_tests=false; run_acceptance_drop_vector_index_async_indexing=true;;
           --acceptance-backups|-ab) run_all_tests=false; run_acceptance_backups=true;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
           --cleanup) run_all_tests=false; run_cleanup=true;;
@@ -441,6 +443,11 @@ function main() {
   if $run_acceptance_drop_vector_index_rolling_restart; then
     echo "running drop-vector-index rolling-restart acceptance tests"
     run_acceptance_drop_vector_index_rolling_restart
+  fi
+
+  if $run_acceptance_drop_vector_index_async_indexing; then
+    echo "running drop-vector-index async-indexing acceptance tests"
+    run_acceptance_drop_vector_index_async_indexing
   fi
 
   if $run_acceptance_backups; then
@@ -1082,6 +1089,13 @@ function run_acceptance_drop_vector_index_restart_cluster() {
   echo_green "acceptance — drop-vector-index-restart-cluster"
   AOF_GROUP_RUN='^TestDropVectorIndex_Restart_Cluster$' \
     run_aof_group "drop-vector-index-restart-cluster" test/acceptance/drop_vector_index
+}
+
+function run_acceptance_drop_vector_index_async_indexing() {
+  build_weaviate_test_image
+  echo_green "acceptance — drop-vector-index-async-indexing"
+  AOF_GROUP_RUN='^TestDropVectorIndex_AsyncIndexing$' \
+    run_aof_group "drop-vector-index-async-indexing" test/acceptance/drop_vector_index
 }
 
 function run_acceptance_drop_vector_index_rolling_restart() {


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/dirk-claude-issues/issues/163

Two related things: a leak on the drop path, and the CI coverage that exposes it.

**Fix — the flat index's metadata file is left behind.** `meta_<target>.db` (flat/BQ quantisation metadata, under the shard directory) was never in the artifact set a dropped vector owns. `flat.Drop` removes it on the *live* path, so a hot shard was clean and the gap was invisible; the files-only sweep — a cold tenant, or shard init reconciling a drop that happened while the tenant was inactive — left the file on disk. Re-creating a vector under the same name then reads stale quantisation state. One entry in `helpers.vectorIndexArtifactNames`, so both drop paths pick it up from the single source of truth.

**New CI job — "async-indexing".** The same suite as Cluster, with `ASYNC_INDEXING=true`. This is not redundant: `vectors_<t>.queue.d` only exists when async indexing is on, so the Cluster job has been asserting its removal vacuously. Verified by mutation — with queue removal disabled server-side, the suite goes red on exactly `tenant-cold/vectors_flat_bq.queue.d` and nothing else. Worth noting the queue entry is inert on the hot-shard path (hnsw's own `Drop` handles it there); it only earns its keep on the files-only sweep, which is why the cold-tenant flat scenario is the one that catches it.

**Async waits in the shared helpers.** A batch returns before the index is built, so counts read 0 and drops race artifact creation. `waitForVectorIndexing` (nodes API: `VectorQueueLength == 0` and `VectorIndexingStatus == READY`) now sits in `dropTargetVector` and `nearVectorTenantResults`, covering every call site through two edits rather than sprinkling waits at ~20 sites.

New `flat_scenarios_test.go` covers the leak end to end: MT class, tenant cold at drop time, reactivated so reconciliation runs, then asserts nothing the vector owned survives on any node.

### Verification

- `meta_<t>.db`: red on a pre-fix server (survived at `tenant-cold/meta_flat_bq.db`), green on the fixed one
- `.queue.d`: red under server-side mutation, green unmutated
- Full async suite 22/22 green; Cluster suite green (1092s), so the shared-helper waits don't disturb the non-async job

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
