### PR TITLE
fix(test): give node readiness 120s instead of the 60s testcontainers default

### DIFF
--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -27,6 +27,10 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+// nodeReadinessTimeout replaces the testcontainers default of 60s, which a node
+// replaying a large commit log routinely exceeds.
+const nodeReadinessTimeout = 120 * time.Second
+
 type DockerCompose struct {
 	network    *testcontainers.DockerNetwork
 	netOctet   int // second octet of this cluster's subnet (10.<netOctet>.0.0/16)
@@ -241,7 +245,8 @@ func (d *DockerCompose) StartAt(ctx context.Context, nodeIndex int) error {
 	c.endpoints = endPoints
 
 	if e, ok := endPoints[HTTP]; ok {
-		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port))
+		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port)).
+			WithStartupTimeout(nodeReadinessTimeout)
 		if err := waitStrategy.WaitUntilReady(ctx, c.container); err != nil {
 			return fmt.Errorf("StartAt[%s]: readiness check /v1/.well-known/ready failed: %w",
 				c.name, err)
@@ -295,7 +300,8 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 	c.endpoints = endPoints
 
 	if e, ok := endPoints[HTTP]; ok {
-		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port))
+		waitStrategy := wait.ForHTTP("/v1/.well-known/ready").WithPort(nat.Port(e.port)).
+			WithStartupTimeout(nodeReadinessTimeout)
 		if err := waitStrategy.WaitUntilReady(ctx, c.container); err != nil {
 			return fmt.Errorf("RestartAt[%s]: readiness check /v1/.well-known/ready failed: %w",
 				c.name, err)


### PR DESCRIPTION
### What's being changed:

Prolong testcontainers node readiness check 120s instead of default 60s

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
