### PR TITLE
feat(repl): fix concurrent map write race in replicated writes

### DIFF
--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	middleware "github.com/go-openapi/runtime/middleware"
@@ -828,34 +829,41 @@ func (h *objectHandlers) deleteObjectReferenceDeprecated(params objects.ObjectsR
 	return h.deleteObjectReference(req, principal)
 }
 
+// extendPropertiesWithAPILinks returns schema with Href set on every
+// SingleRef. The input map and its ref values are never written.
 func (h *objectHandlers) extendPropertiesWithAPILinks(schema map[string]interface{}) map[string]interface{} {
 	if schema == nil {
 		return schema
 	}
 
+	var out map[string]interface{}
 	for key, value := range schema {
 		asMultiRef, ok := value.(models.MultipleRef)
 		if !ok {
 			continue
 		}
-
-		schema[key] = h.extendReferencesWithAPILinks(asMultiRef)
+		if out == nil {
+			out = maps.Clone(schema)
+		}
+		out[key] = h.extendReferencesWithAPILinks(asMultiRef)
 	}
-	return schema
+	if out == nil {
+		return schema
+	}
+	return out
 }
 
 func (h *objectHandlers) extendReferencesWithAPILinks(refs models.MultipleRef) models.MultipleRef {
+	out := make(models.MultipleRef, len(refs))
 	for i, ref := range refs {
-		refs[i] = h.extendReferenceWithAPILink(ref)
+		out[i] = h.extendReferenceWithAPILink(ref)
 	}
-
-	return refs
+	return out
 }
 
 func (h *objectHandlers) extendReferenceWithAPILink(ref *models.SingleRef) *models.SingleRef {
 	parsed, err := crossref.Parse(ref.Beacon.String())
 	if err != nil {
-		// ignore return unchanged
 		return ref
 	}
 	// Defensive: beacons are written short, but strip here so a stray qualified
@@ -865,8 +873,9 @@ func (h *objectHandlers) extendReferenceWithAPILink(ref *models.SingleRef) *mode
 	if parsed.Class == "" {
 		href = fmt.Sprintf("%s/v1/objects/%s", h.config.Origin, parsed.TargetID)
 	}
-	ref.Href = strfmt.URI(href)
-	return ref
+	cp := *ref
+	cp.Href = strfmt.URI(href)
+	return &cp
 }
 
 func (h *objectHandlers) shouldIncludeGetObjectsModuleParams() bool {

--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -1099,6 +1099,37 @@ func TestParseIncludeParam_VectorIncludesTargetVectors(t *testing.T) {
 	require.False(t, out.IncludeAllTargetVectors)
 }
 
+func TestExtendProperties(t *testing.T) {
+	t.Run("API links don't mutate input", func(t *testing.T) {
+		h := &objectHandlers{config: config.Config{Origin: "http://host"}}
+
+		origRef := &models.SingleRef{
+			Beacon: strfmt.URI("weaviate://localhost/SomeClass/85f78e29-5937-4390-a121-5379f262b4e5"),
+		}
+		origRefs := models.MultipleRef{origRef}
+
+		input := map[string]interface{}{
+			"ref":  origRefs,
+			"name": "x",
+		}
+
+		out := h.extendPropertiesWithAPILinks(input)
+
+		assert.Empty(t, origRef.Href, "input SingleRef.Href must not be mutated")
+
+		inputRefs, ok := input["ref"].(models.MultipleRef)
+		require.True(t, ok)
+		assert.Len(t, inputRefs, 1)
+		assert.Same(t, origRef, inputRefs[0], "input slice element must point to original SingleRef")
+
+		outRefs, ok := out["ref"].(models.MultipleRef)
+		require.True(t, ok)
+		require.Len(t, outRefs, 1)
+		assert.NotEmpty(t, outRefs[0].Href, "output SingleRef.Href must be set")
+		assert.Contains(t, string(outRefs[0].Href), "85f78e29-5937-4390-a121-5379f262b4e5")
+	})
+}
+
 type fakeManager struct {
 	getObjectReturn *models.Object
 	getObjectErr    error

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path"
 	"path/filepath"
@@ -831,7 +832,12 @@ func (idx *Index) OverwriteObjects(ctx context.Context,
 		if rawObj != nil {
 			updateBatch = append(updateBatch, rawObj)
 		} else {
-			updateBatch = append(updateBatch, storobj.FromObject(incomingObj, u.Vector, u.Vectors, u.MultiVectors))
+			cp := *incomingObj
+			// The object is shared with goroutines that read it concurrently; give FromObject a private copy to write on.
+			if props, ok := cp.Properties.(map[string]interface{}); ok {
+				cp.Properties = maps.Clone(props)
+			}
+			updateBatch = append(updateBatch, storobj.FromObject(&cp, u.Vector, u.Vectors, u.MultiVectors))
 		}
 	}
 

--- a/adapters/repos/db/replication_overwrite_objects_test.go
+++ b/adapters/repos/db/replication_overwrite_objects_test.go
@@ -1,0 +1,79 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+func TestIndexOverwriteObjects(t *testing.T) {
+	t.Run("repair write doesn't mutate the caller's object", func(t *testing.T) {
+		ctx := testCtx()
+		className := "OverwriteMut_" + uuid.NewString()[:8]
+
+		class := &models.Class{
+			Class:             className,
+			VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+			InvertedIndexConfig: &models.InvertedIndexConfig{
+				CleanupIntervalSeconds: 60,
+			},
+			Properties: []*models.Property{
+				{
+					Name:         "name",
+					DataType:     []string{"text"},
+					Tokenization: models.PropertyTokenizationWord,
+				},
+			},
+		}
+
+		shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+			false, false, false)
+		shard := shd.(*Shard)
+		defer shard.Shutdown(ctx)
+
+		obj := &models.Object{
+			ID:                 strfmt.UUID(uuid.NewString()),
+			Class:              className,
+			CreationTimeUnix:   1,
+			LastUpdateTimeUnix: 1,
+			Properties: map[string]interface{}{
+				"name":  "x",
+				"other": nil,
+			},
+		}
+
+		results, err := idx.OverwriteObjects(ctx, shard.Name(), []*objects.VObject{{
+			LatestObject:            obj,
+			StaleUpdateTime:         0,
+			LastUpdateTimeUnixMilli: 1,
+		}})
+		require.NoError(t, err)
+
+		for _, r := range results {
+			assert.Empty(t, r.Err, "repair write must succeed, got error: %s", r.Err)
+		}
+
+		props, ok := obj.Properties.(map[string]interface{})
+		require.True(t, ok)
+		_, hasOther := props["other"]
+		assert.True(t, hasOther, "nil-valued key 'other' must survive in the caller's object")
+	})
+}

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -79,6 +80,8 @@ func (s *Shard) analyzeObjectCommon(object *storobj.Object, c *models.Class) (ma
 		if schemaMap == nil {
 			schemaMap = make(map[string]interface{})
 		}
+		// The map is shared with goroutines that read it concurrently; write only a private clone.
+		schemaMap = maps.Clone(schemaMap)
 		schemaMap[filters.InternalPropCreationTimeUnix] = object.Object.CreationTimeUnix
 		schemaMap[filters.InternalPropLastUpdateTimeUnix] = object.Object.LastUpdateTimeUnix
 	}

--- a/adapters/repos/db/shard_write_inverted_test.go
+++ b/adapters/repos/db/shard_write_inverted_test.go
@@ -1,0 +1,130 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+func TestAnalyzeObject(t *testing.T) {
+	ctx := testCtx()
+	className := "AnalyzeTS_" + uuid.NewString()[:8]
+
+	class := &models.Class{
+		Class:             className,
+		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: &models.InvertedIndexConfig{
+			CleanupIntervalSeconds: 60,
+			IndexTimestamps:        true,
+		},
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     []string{"text"},
+				Tokenization: models.PropertyTokenizationWord,
+			},
+		},
+	}
+
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(ctx)
+
+	makeObj := func() *storobj.Object {
+		return &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:                 strfmt.UUID(uuid.NewString()),
+				Class:              className,
+				CreationTimeUnix:   1000,
+				LastUpdateTimeUnix: 2000,
+				Properties: map[string]interface{}{
+					"name": "hello",
+				},
+			},
+		}
+	}
+
+	t.Run("timestamp props don't leak into object properties", func(t *testing.T) {
+		obj := makeObj()
+		props, _, _, err := shard.AnalyzeObject(obj)
+		require.NoError(t, err)
+
+		var hasCreation, hasUpdate bool
+		for _, p := range props {
+			switch p.Name {
+			case filters.InternalPropCreationTimeUnix:
+				hasCreation = true
+			case filters.InternalPropLastUpdateTimeUnix:
+				hasUpdate = true
+			}
+		}
+		assert.True(t, hasCreation, "analyzer must emit _creationTimeUnix property")
+		assert.True(t, hasUpdate, "analyzer must emit _lastUpdateTimeUnix property")
+
+		m, ok := obj.Properties().(map[string]interface{})
+		require.True(t, ok)
+		_, leaked1 := m[filters.InternalPropCreationTimeUnix]
+		_, leaked2 := m[filters.InternalPropLastUpdateTimeUnix]
+		assert.False(t, leaked1, "_creationTimeUnix must not leak into object properties")
+		assert.False(t, leaked2, "_lastUpdateTimeUnix must not leak into object properties")
+	})
+
+	t.Run("no map write racing a concurrent marshal", func(t *testing.T) {
+		const n = 100
+		objs := make([]*storobj.Object, n)
+		for i := range objs {
+			objs[i] = makeObj()
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		// Goroutine A: marshals the object (reads Properties).
+		go func() {
+			defer wg.Done()
+			for _, o := range objs {
+				_, _ = o.PrepareMarshalOptional(additional.Properties{Vector: true})
+			}
+		}()
+
+		// Goroutine B: analyzes the object (touches the Properties map).
+		go func() {
+			defer wg.Done()
+			for _, o := range objs {
+				_, _, _, _ = shard.AnalyzeObject(o)
+			}
+		}()
+
+		wg.Wait()
+
+		for i, o := range objs {
+			m, ok := o.Properties().(map[string]interface{})
+			require.True(t, ok)
+			_, leaked := m[filters.InternalPropCreationTimeUnix]
+			assert.False(t, leaked, "object %d: _creationTimeUnix leaked", i)
+		}
+	})
+}


### PR DESCRIPTION
Since v1.39.0 the local copy of a replicated write runs in-process (#11596), so the local commit path shares the very same objects that background goroutines are still serializing for the other replicas. When the commit path writes an object's properties map while a slower replica's goroutine is reading it, Go kills the node with a fatal concurrent map error. When the runtime surfaces the collision as a recoverable panic instead, the request succeeds but that replica silently never receives the write. QA hit three node crashes in one batch re-ingestion run on a five node cluster.

This PR makes every writer of a shared properties map work on a private copy instead. No locks, no ordering changes, no wire or disk format changes, and the inverted index output is byte-identical.

## What's being changed

- The commit path's analyzer step clones the properties map before inserting the two internal timestamp keys (`analyzeObjectCommon`). This fixes the crash and also stops those keys leaking into user-visible properties, which previously caused replicas to persist different property sets.
- The REST add/update response decoration (`extendPropertiesWithAPILinks` and helpers) now returns copies instead of setting `Href` in place on state a lagging replica broadcast may still be marshalling.
- Read repair (`Index.OverwriteObjects`) hands the write path a private copy of the object, so sibling per-replica goroutines never see it mutated.
- Three regression tests, all red on the base commit and green with the fix: `TestAnalyzeObject` (a deterministic key-leak subtest and a race-detector subtest reproducing the QA stack), `TestExtendProperties`, `TestIndexOverwriteObjects`.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
