### PR TITLE
fix(hnsw): restore cache reads for uncompressed non-MUVERA late-interaction rescore

### DIFF
--- a/adapters/repos/db/vector/hnsw/multivector_hnsw_test.go
+++ b/adapters/repos/db/vector/hnsw/multivector_hnsw_test.go
@@ -446,8 +446,6 @@ func TestMultivectorPersistence(t *testing.T) {
 
 // The uncompressed non-MUVERA rescore must read token vectors from the
 // in-memory vector cache, never through the per-candidate LSM view thunk
-// (the thunk costs an object-store read plus deserialization per candidate —
-// a ~40% QPS regression on plain multivector search).
 func TestMultiVectorRescoreUsesCacheNotViewThunk(t *testing.T) {
 	ctx := context.Background()
 	index, err := New(Config{

--- a/adapters/repos/db/vector/hnsw/multivector_hnsw_test.go
+++ b/adapters/repos/db/vector/hnsw/multivector_hnsw_test.go
@@ -444,6 +444,49 @@ func TestMultivectorPersistence(t *testing.T) {
 	}
 }
 
+// The uncompressed non-MUVERA rescore must read token vectors from the
+// in-memory vector cache, never through the per-candidate LSM view thunk
+// (the thunk costs an object-store read plus deserialization per candidate —
+// a ~40% QPS regression on plain multivector search).
+func TestMultiVectorRescoreUsesCacheNotViewThunk(t *testing.T) {
+	ctx := context.Background()
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "rescore-data-source",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewDotProductProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{0}, errors.New("can not use VectorForIDThunk with multivector")
+		},
+		MultiVectorForIDThunk: func(ctx context.Context, id uint64) ([][]float32, error) {
+			return multiVectors[id], nil
+		},
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+		AllocChecker:      memwatch.NewDummyMonitor(),
+		GetViewThunk:      func() common.BucketView { return &multivectorNoopBucketView{} },
+		TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+			return nil, errors.New("uncompressed non-muvera rescore must not read through the view thunk")
+		},
+	}, ent.UserConfig{
+		VectorCacheMaxObjects: 1e12,
+		MaxConnections:        8,
+		EFConstruction:        64,
+		EF:                    64,
+		Multivector:           ent.MultivectorConfig{Enabled: true},
+	}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+
+	for i, vec := range multiVectors {
+		require.Nil(t, index.AddMulti(ctx, uint64(i), vec))
+	}
+
+	for i, query := range multiQueries {
+		ids, _, err := index.SearchByMultiVector(ctx, query, 10, nil)
+		require.Nil(t, err)
+		require.Equal(t, expectedResults[i], ids)
+	}
+}
+
 func TestMuveraHnsw(t *testing.T) {
 	var vectorIndex *hnsw
 	ctx := context.Background()

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -1021,10 +1021,6 @@ func (h *hnsw) computeLateInteraction(ctx context.Context, queryVectors [][]floa
 		ids = append(ids, docID)
 	}
 
-	// The uncompressed non-MUVERA rescore must read token vectors from the
-	// in-memory vector cache: fetching them through the LSM view thunk costs
-	// an object-store read plus a full multi-vector deserialization per
-	// candidate, which regressed plain multivector QPS by ~40% at low ef.
 	useCache := !h.compressed.Load() && !h.muvera.Load()
 
 	// Acquire a single consistent view for all disk reads to avoid per-candidate flushLock acquisitions.

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -1021,9 +1021,18 @@ func (h *hnsw) computeLateInteraction(ctx context.Context, queryVectors [][]floa
 		ids = append(ids, docID)
 	}
 
+	// The uncompressed non-MUVERA rescore must read token vectors from the
+	// in-memory vector cache: fetching them through the LSM view thunk costs
+	// an object-store read plus a full multi-vector deserialization per
+	// candidate, which regressed plain multivector QPS by ~40% at low ef.
+	useCache := !h.compressed.Load() && !h.muvera.Load()
+
 	// Acquire a single consistent view for all disk reads to avoid per-candidate flushLock acquisitions.
-	view := h.GetViewThunk()
-	defer view.ReleaseView()
+	var view common.BucketView
+	if !useCache {
+		view = h.GetViewThunk()
+		defer view.ReleaseView()
+	}
 
 	resultsQueue := priorityqueue.NewMax[any](k)
 	mu := sync.Mutex{}
@@ -1046,15 +1055,24 @@ func (h *hnsw) computeLateInteraction(ctx context.Context, queryVectors [][]floa
 	for workerID := 0; workerID < workers; workerID++ {
 		workerID := workerID
 		eg.Go(func() error {
-			slice := h.pools.tempVectors.Get(int(h.dims.Load()))
-			defer h.pools.tempVectors.Put(slice)
+			var slice *common.VectorSlice
+			if !useCache {
+				slice = h.pools.tempVectors.Get(int(h.dims.Load()))
+				defer h.pools.tempVectors.Put(slice)
+			}
 
 			for idPos := workerID; idPos < len(ids); idPos += workers {
 				if err := ctx.Err(); err != nil {
 					return fmt.Errorf("computeLateInteraction: %w", err)
 				}
 				docID := ids[idPos]
-				sim, err := h.computeScoreWithView(ctx, queryVectors, docID, slice, view)
+				var sim float32
+				var err error
+				if useCache {
+					sim, err = h.computeScore(queryVectors, docID)
+				} else {
+					sim, err = h.computeScoreWithView(ctx, queryVectors, docID, slice, view)
+				}
 				if err != nil {
 					h.logger.
 						WithField("action", "computeLateInteraction").


### PR DESCRIPTION
## Motivation

-  https://github.com/weaviate/weaviate/pull/11838 introduced a regression to non-MUVERA multivector search while improving the MUVERA path.
- The change was a genuine win for MUVERA - one shared LSM view instead of a per-candidate flushLock acquisition, parallel workers — but it also switched the *plain multivector* rescore's data source: candidates that were previously read from the in-memory vector cache (`multiVectorForID`) are now fetched through `TempMultiVectorForIDWithViewThunk`, i.e. an object-store read plus a full `MultiVectorFromBinary` deserialization per rescored candidate, on every query. Recall is unchanged; it is pure per-query overhead, worst at low ef where fixed costs dominate.

## Approach

Keep the parallel worker pool and the shared-view structure, restore only the data source split that the pre-parallelization `computeScore` already had:

- `useCache := !h.compressed.Load() && !h.muvera.Load()` — when set, workers score via the existing `computeScore`, which reads token vectors from the in-memory cache.
- The LSM view and the pooled temp slices are now only acquired for the compressed/MUVERA branches, which keep the view-thunk path (the cache does not hold their original token vectors).

A revert was considered and rejected: it would reintroduce the single-threaded, flushLock-per-candidate MUVERA rescore, and no longer reverts cleanly past `d97a7cdd03` and `e63a6ca709`.

## Forward-merge note

When this merges up through stable/v1.38 into main, it will conflict in `computeLateInteraction` with PR #12443, which moves that function into `late_interaction.go`. **Resolve by taking main's side** — #12443 already contains this same fix in the moved file.

## Testing

`TestMultiVectorRescoreUsesCacheNotViewThunk` builds a plain multivector index whose view thunk errors if ever called and asserts search still returns the exact expected results — red without the fix (rescore skips every candidate and returns empty results), green with it. Full hnsw unit suite and all multivector/MUVERA integration tests pass.