### PR TITLE
fix(runtime-config): register disable_dimension_metrics as a runtime override

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2269,6 +2269,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.RaftDrainSleep = appState.ServerConfig.Config.Raft.DrainSleep
 		registered.RaftTimoutsMultiplier = appState.ServerConfig.Config.Raft.TimeoutsMultiplier
 		registered.OperationalMode = appState.ServerConfig.Config.OperationalMode
+		registered.DisableDimensionMetrics = appState.ServerConfig.Config.DisableDimensionMetrics
 		registered.ObjectsTTLDeleteSchedule = appState.ServerConfig.Config.ObjectsTTLDeleteSchedule
 		registered.ObjectsTTLBatchSize = appState.ServerConfig.Config.ObjectsTTLBatchSize
 		registered.ObjectsTTLPauseEveryNoBatches = appState.ServerConfig.Config.ObjectsTTLPauseEveryNoBatches

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1243,7 +1243,7 @@ func startupRoutine(ctx, serverShutdownCtx context.Context, options *swag.Comman
 		logger.Exit(1)
 	}
 	// Initialize runtime config and load overridden config
-	runtimeConfigManager := initRuntimeOverrides(appState)
+	runtimeConfigManager := initRuntimeOverrides(appState, prometheus.DefaultRegisterer)
 	dataPath := serverConfig.Config.Persistence.DataPath
 	if err := os.MkdirAll(dataPath, 0o777); err != nil {
 		logger.WithField("action", "startup").
@@ -2223,7 +2223,7 @@ func (m membership) LeaderID() string {
 
 // initRuntimeOverrides assumes, Configs from envs are loaded before
 // initializing runtime overrides.
-func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[config.WeaviateRuntimeConfig] {
+func initRuntimeOverrides(appState *state.State, registerer prometheus.Registerer) *configRuntime.ConfigManager[config.WeaviateRuntimeConfig] {
 	// Enable runtime config manager
 	if appState.ServerConfig.Config.RuntimeOverrides.Enabled {
 		// Runtimeconfig manager takes of keeping the `registered` config values upto date
@@ -2301,7 +2301,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 			registered,
 			appState.ServerConfig.Config.RuntimeOverrides.LoadInterval,
 			appState.Logger,
-			prometheus.DefaultRegisterer)
+			registerer)
 		if err != nil {
 			appState.Logger.WithField("action", "runtime_overrides_parse").Errorf("could not create runtime config manager: %v", err)
 		}

--- a/adapters/handlers/rest/configure_api_runtime_overrides_test.go
+++ b/adapters/handlers/rest/configure_api_runtime_overrides_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +48,7 @@ func TestInitRuntimeOverrides_DisableDimensionMetrics(t *testing.T) {
 	appState.ServerConfig.Config.RuntimeOverrides.Path = overrides
 	appState.ServerConfig.Config.RuntimeOverrides.LoadInterval = time.Hour
 
-	cm := initRuntimeOverrides(appState)
+	cm := initRuntimeOverrides(appState, prometheus.NewRegistry())
 	require.NotNil(t, cm)
 
 	assert.True(t, appState.ServerConfig.Config.DisableDimensionMetrics.Get())

--- a/adapters/handlers/rest/configure_api_runtime_overrides_test.go
+++ b/adapters/handlers/rest/configure_api_runtime_overrides_test.go
@@ -1,0 +1,54 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+// A DynamicValue that is declared in WeaviateRuntimeConfig but never assigned in
+// initRuntimeOverrides is a typed nil: the overrides file key parses, SetValue is
+// a no-op on the nil receiver, and the override silently does nothing. This test
+// pins the wiring for disable_dimension_metrics end to end.
+func TestInitRuntimeOverrides_DisableDimensionMetrics(t *testing.T) {
+	overrides := filepath.Join(t.TempDir(), "overrides.yaml")
+	require.NoError(t, os.WriteFile(overrides, []byte("disable_dimension_metrics: true\n"), 0o644))
+
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+
+	appState := &state.State{
+		Logger:       logger,
+		ServerConfig: &config.WeaviateConfig{},
+	}
+	appState.ServerConfig.Config.DisableDimensionMetrics = runtime.NewDynamicValue(false)
+	appState.ServerConfig.Config.RuntimeOverrides.Enabled = true
+	appState.ServerConfig.Config.RuntimeOverrides.Path = overrides
+	appState.ServerConfig.Config.RuntimeOverrides.LoadInterval = time.Hour
+
+	cm := initRuntimeOverrides(appState)
+	require.NotNil(t, cm)
+
+	assert.True(t, appState.ServerConfig.Config.DisableDimensionMetrics.Get())
+}

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -70,6 +70,7 @@ type WeaviateRuntimeConfig struct {
 	UsageVerifyPermissions                    *runtime.DynamicValue[bool]          `json:"usage_verify_permissions" yaml:"usage_verify_permissions"`
 	ReplicationGRPCEnabled                    *runtime.DynamicValue[bool]          `json:"replication_grpc_enabled" yaml:"replication_grpc_enabled"`
 	OperationalMode                           *runtime.DynamicValue[string]        `json:"operational_mode" yaml:"operational_mode"`
+	DisableDimensionMetrics                   *runtime.DynamicValue[bool]          `json:"disable_dimension_metrics" yaml:"disable_dimension_metrics"`
 	DefaultQuantization                       *runtime.DynamicValue[string]        `yaml:"default_quantization" json:"default_quantization"`
 	DefaultVectorIndexType                    *runtime.DynamicValue[string]        `yaml:"default_vector_index" json:"default_vector_index"`
 	DefaultShardingCount                      *runtime.DynamicValue[int]           `yaml:"default_sharding_count" json:"default_sharding_count"`

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -175,6 +175,39 @@ func TestBackupMaxIndividualFilesRuntimeOverride(t *testing.T) {
 	})
 }
 
+func TestDisableDimensionMetricsRuntimeOverride(t *testing.T) {
+	// ParseRuntimeConfig ignores unknown keys, so only an explicit assertion catches a
+	// renamed or misspelled yaml tag.
+	t.Run("yaml key is parsed", func(t *testing.T) {
+		cfg, err := ParseRuntimeConfig([]byte(`disable_dimension_metrics: true`))
+		require.NoError(t, err)
+		assert.Equal(t, true, cfg.DisableDimensionMetrics.Get())
+	})
+
+	t.Run("override applies to the env-registered value and removal restores it", func(t *testing.T) {
+		log := logrus.New()
+		log.SetOutput(io.Discard)
+
+		t.Setenv("DIMENSION_METRICS_DISABLED", "true")
+		conf := Config{}
+		require.NoError(t, FromEnv(&conf))
+		require.Equal(t, true, conf.DisableDimensionMetrics.Get())
+
+		reg := &WeaviateRuntimeConfig{DisableDimensionMetrics: conf.DisableDimensionMetrics}
+
+		parsed, err := ParseRuntimeConfig([]byte(`disable_dimension_metrics: false`))
+		require.NoError(t, err)
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
+		assert.Equal(t, false, conf.DisableDimensionMetrics.Get())
+
+		// Removing the key from the overrides file restores the env-supplied value.
+		parsed, err = ParseRuntimeConfig(nil)
+		require.NoError(t, err)
+		require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
+		assert.Equal(t, true, conf.DisableDimensionMetrics.Get())
+	})
+}
+
 func TestUpdateRuntimeConfig(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(io.Discard)


### PR DESCRIPTION
## What

`disable_dimension_metrics` in the runtime overrides file was silently ignored: the field was declared only on the env-backed `Config` struct, never on `WeaviateRuntimeConfig`, and never assigned in `initRuntimeOverrides`. The overrides parser drops unknown keys without logging, so setting the key parsed fine and did nothing — `DIMENSION_METRICS_DISABLED` plus a rolling restart was the only way to change the flag.

## Fix

- Declare `DisableDimensionMetrics` on `WeaviateRuntimeConfig` (`disable_dimension_metrics`).
- Register the env-backed `DynamicValue` in `initRuntimeOverrides`, next to its neighbour `OperationalMode`. The DB config shares the same pointer (`configure_api.go`), and the dimension-metrics publisher reads it via `Get()` on every cycle, so the override takes effect on the next overrides reload without a restart.

## Tests

- `TestInitRuntimeOverrides_DisableDimensionMetrics` (rest package) pins the wiring end to end: overrides file → config manager → the shared `DynamicValue` flips. Fails without the fix (the unregistered field is a typed-nil `DynamicValue`; `SetValue` is a no-op on a nil receiver).
- `TestDisableDimensionMetricsRuntimeOverride` (usecases/config) pins the yaml tag and the apply/reset round-trip against the env-supplied default.

Same gap exists on stable/v1.38 and main; this PR targets the oldest affected stable branch and should be forward-ported.