### PR TITLE
perf(lsmkv): cache sorted map-row postings in memtable

### DIFF
--- a/adapters/repos/db/lsmkv/binary_search_tree_map.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map.go
@@ -14,6 +14,7 @@ package lsmkv
 import (
 	"bytes"
 	"sort"
+	"sync/atomic"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/rbtree"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -55,6 +56,15 @@ func (t *binarySearchTreeMap) flattenInOrder() []*binarySearchNodeMap {
 	return t.root.flattenInOrder()
 }
 
+// mapRowSorted is an immutable snapshot of a row's postings sorted by Key and
+// deduped (last insert wins), covering the first upTo entries of the node's
+// append-only values slice. Never mutated after publish, so concurrent
+// readers share it without copying.
+type mapRowSorted struct {
+	upTo   int
+	sorted []MapPair
+}
+
 type binarySearchNodeMap struct {
 	key         []byte
 	values      []MapPair
@@ -62,6 +72,7 @@ type binarySearchNodeMap struct {
 	right       *binarySearchNodeMap
 	parent      *binarySearchNodeMap
 	colourIsRed bool
+	sortedCache atomic.Pointer[mapRowSorted]
 }
 
 func (n *binarySearchNodeMap) Parent() rbtree.Node {
@@ -178,7 +189,7 @@ func (n *binarySearchNodeMap) insert(key []byte, pair MapPair) *binarySearchNode
 
 func (n *binarySearchNodeMap) get(key []byte) ([]MapPair, error) {
 	if bytes.Equal(n.key, key) {
-		return sortAndDedupValues(n.values), nil
+		return n.sortedValues(), nil
 	}
 
 	if bytes.Compare(key, n.key) < 0 {
@@ -262,6 +273,53 @@ func sortAndDedupValues(in []MapPair) []MapPair {
 	return out[:outIndex]
 }
 
+// sortedValues returns the row's postings sorted by Key, deduped (last insert
+// wins). The result is a shared immutable snapshot — callers must not modify
+// it. values is append-only, so a stale snapshot is still a valid sorted
+// prefix: only entries appended since it was taken are sorted and merged in.
+// Callers hold at least the memtable read lock; concurrent readers may race
+// to publish equivalent snapshots, which is benign.
+func (n *binarySearchNodeMap) sortedValues() []MapPair {
+	total := len(n.values)
+	c := n.sortedCache.Load()
+	if c != nil && c.upTo == total {
+		return c.sorted
+	}
+	var sorted []MapPair
+	if c == nil || c.upTo == 0 {
+		sorted = sortAndDedupValues(n.values[:total])
+	} else {
+		fresh := sortAndDedupValues(n.values[c.upTo:total])
+		sorted = mergeSortedPairs(c.sorted, fresh)
+	}
+	n.sortedCache.Store(&mapRowSorted{upTo: total, sorted: sorted})
+	return sorted
+}
+
+// mergeSortedPairs merges two sorted, deduped slices into a new slice. On
+// equal keys the pair from fresh wins (it was inserted later).
+func mergeSortedPairs(old, fresh []MapPair) []MapPair {
+	out := make([]MapPair, 0, len(old)+len(fresh))
+	i, j := 0, 0
+	for i < len(old) && j < len(fresh) {
+		cmp := bytes.Compare(old[i].Key, fresh[j].Key)
+		switch {
+		case cmp < 0:
+			out = append(out, old[i])
+			i++
+		case cmp > 0:
+			out = append(out, fresh[j])
+			j++
+		default:
+			out = append(out, fresh[j])
+			i++
+			j++
+		}
+	}
+	out = append(out, old[i:]...)
+	return append(out, fresh[j:]...)
+}
+
 func binarySearchNodeMapFromRB(rbNode rbtree.Node) (bsNode *binarySearchNodeMap) {
 	if rbNode == nil {
 		bsNode = nil
@@ -272,9 +330,14 @@ func binarySearchNodeMapFromRB(rbNode rbtree.Node) (bsNode *binarySearchNodeMap)
 }
 
 func (n *binarySearchNodeMap) shallowCopy() *binarySearchNodeMap {
+	// private copy: flatten consumers (cursors) may sort values in place,
+	// and the cache snapshot is shared with concurrent get callers
+	sorted := n.sortedValues()
+	values := make([]MapPair, len(sorted))
+	copy(values, sorted)
 	return &binarySearchNodeMap{
 		key:         n.key,
-		values:      sortAndDedupValues(n.values),
+		values:      values,
 		colourIsRed: n.colourIsRed,
 	}
 }

--- a/adapters/repos/db/lsmkv/binary_search_tree_map.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map.go
@@ -15,6 +15,7 @@ import (
 	"bytes"
 	"sort"
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/rbtree"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -22,6 +23,11 @@ import (
 
 type binarySearchTreeMap struct {
 	root *binarySearchNodeMap
+	// cacheSize tracks bytes retained by all rows' sortedCache MapPair arrays
+	// (Key/Value payloads are already charged to Memtable.size at append
+	// time). Included in Memtable.Size() so cache growth counts toward the
+	// flush threshold.
+	cacheSize atomic.Int64
 }
 
 func (t *binarySearchTreeMap) insert(key []byte, pair MapPair) {
@@ -45,7 +51,13 @@ func (t *binarySearchTreeMap) get(key []byte) ([]MapPair, error) {
 		return nil, lsmkv.NotFound
 	}
 
-	return t.root.get(key)
+	return t.root.get(key, &t.cacheSize)
+}
+
+// cacheSizeBytes returns the bytes currently retained by all rows' sortedCache
+// MapPair arrays.
+func (t *binarySearchTreeMap) cacheSizeBytes() int64 {
+	return t.cacheSize.Load()
 }
 
 func (t *binarySearchTreeMap) flattenInOrder() []*binarySearchNodeMap {
@@ -56,13 +68,13 @@ func (t *binarySearchTreeMap) flattenInOrder() []*binarySearchNodeMap {
 	return t.root.flattenInOrder()
 }
 
-// mapRowSorted is an immutable snapshot of a row's postings sorted by Key and
-// deduped (last insert wins), covering the first upTo entries of the node's
-// append-only values slice. Never mutated after publish, so concurrent
-// readers share it without copying.
-type mapRowSorted struct {
-	upTo   int
-	sorted []MapPair
+// mapRowSnapshot is an immutable snapshot of a row's postings sorted by Key
+// and deduped (last insert wins), covering the first valueCount entries of
+// the node's append-only values slice. Never mutated after publish, so
+// concurrent readers share it without copying.
+type mapRowSnapshot struct {
+	valueCount int
+	sorted     []MapPair
 }
 
 type binarySearchNodeMap struct {
@@ -72,7 +84,7 @@ type binarySearchNodeMap struct {
 	right       *binarySearchNodeMap
 	parent      *binarySearchNodeMap
 	colourIsRed bool
-	sortedCache atomic.Pointer[mapRowSorted]
+	sortedCache atomic.Pointer[mapRowSnapshot]
 }
 
 func (n *binarySearchNodeMap) Parent() rbtree.Node {
@@ -187,9 +199,9 @@ func (n *binarySearchNodeMap) insert(key []byte, pair MapPair) *binarySearchNode
 	}
 }
 
-func (n *binarySearchNodeMap) get(key []byte) ([]MapPair, error) {
+func (n *binarySearchNodeMap) get(key []byte, cacheSize *atomic.Int64) ([]MapPair, error) {
 	if bytes.Equal(n.key, key) {
-		return n.sortedValues(), nil
+		return n.sortedValues(cacheSize), nil
 	}
 
 	if bytes.Compare(key, n.key) < 0 {
@@ -197,13 +209,13 @@ func (n *binarySearchNodeMap) get(key []byte) ([]MapPair, error) {
 			return nil, lsmkv.NotFound
 		}
 
-		return n.left.get(key)
+		return n.left.get(key, cacheSize)
 	} else {
 		if n.right == nil {
 			return nil, lsmkv.NotFound
 		}
 
-		return n.right.get(key)
+		return n.right.get(key, cacheSize)
 	}
 }
 
@@ -273,26 +285,39 @@ func sortAndDedupValues(in []MapPair) []MapPair {
 	return out[:outIndex]
 }
 
-// sortedValues returns the row's postings sorted by Key, deduped (last insert
-// wins). The result is a shared immutable snapshot — callers must not modify
-// it. values is append-only, so a stale snapshot is still a valid sorted
-// prefix: only entries appended since it was taken are sorted and merged in.
-// Callers hold at least the memtable read lock; concurrent readers may race
-// to publish equivalent snapshots, which is benign.
-func (n *binarySearchNodeMap) sortedValues() []MapPair {
+// computeSorted returns the row's postings sorted by Key, deduped (last
+// insert wins), reusing snapshot c as a sorted prefix when it covers part of
+// values. The result is freshly allocated and private to the caller.
+func (n *binarySearchNodeMap) computeSorted(c *mapRowSnapshot, total int) []MapPair {
+	if c == nil || c.valueCount == 0 {
+		return sortAndDedupValues(n.values[:total])
+	}
+	fresh := sortAndDedupValues(n.values[c.valueCount:total])
+	return mergeSortedPairs(c.sorted, fresh)
+}
+
+// sortedValues returns the row's postings sorted by Key, deduped (last
+// insert wins) — a shared immutable snapshot, callers must not modify it.
+// values is append-only, so a stale snapshot is a valid sorted prefix and
+// only the appended tail needs sorting and merging in. Callers hold at least
+// the memtable read lock; concurrent readers may race to publish equivalent
+// snapshots, which is benign — only the CAS winner accounts the bytes.
+func (n *binarySearchNodeMap) sortedValues(cacheSize *atomic.Int64) []MapPair {
 	total := len(n.values)
 	c := n.sortedCache.Load()
-	if c != nil && c.upTo == total {
+	if c != nil && c.valueCount == total {
 		return c.sorted
 	}
-	var sorted []MapPair
-	if c == nil || c.upTo == 0 {
-		sorted = sortAndDedupValues(n.values[:total])
-	} else {
-		fresh := sortAndDedupValues(n.values[c.upTo:total])
-		sorted = mergeSortedPairs(c.sorted, fresh)
+	sorted := n.computeSorted(c, total)
+	if n.sortedCache.CompareAndSwap(c, &mapRowSnapshot{valueCount: total, sorted: sorted}) && cacheSize != nil {
+		// merged output is always a superset of the old snapshot's keys, so
+		// delta never goes negative
+		delta := int64(len(sorted))
+		if c != nil {
+			delta -= int64(len(c.sorted))
+		}
+		cacheSize.Add(delta * int64(unsafe.Sizeof(MapPair{})))
 	}
-	n.sortedCache.Store(&mapRowSorted{upTo: total, sorted: sorted})
 	return sorted
 }
 
@@ -330,11 +355,17 @@ func binarySearchNodeMapFromRB(rbNode rbtree.Node) (bsNode *binarySearchNodeMap)
 }
 
 func (n *binarySearchNodeMap) shallowCopy() *binarySearchNodeMap {
-	// private copy: flatten consumers (cursors) may sort values in place,
-	// and the cache snapshot is shared with concurrent get callers
-	sorted := n.sortedValues()
-	values := make([]MapPair, len(sorted))
-	copy(values, sorted)
+	// private slice: flatten consumers (cursors) may sort values in place.
+	// A cold row computes without publishing, so flushing an unread
+	// memtable retains no cache.
+	c := n.sortedCache.Load()
+	var values []MapPair
+	if c != nil && c.valueCount == len(n.values) {
+		values = make([]MapPair, len(c.sorted))
+		copy(values, c.sorted)
+	} else {
+		values = n.computeSorted(c, len(n.values))
+	}
 	return &binarySearchNodeMap{
 		key:         n.key,
 		values:      values,

--- a/adapters/repos/db/lsmkv/binary_search_tree_map_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map_test.go
@@ -12,13 +12,16 @@
 package lsmkv
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	mathrand "math/rand"
 	"path"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -325,11 +328,8 @@ func TestBSTMap_Flatten(t *testing.T) {
 	})
 }
 
-// TestBSTMap_SortedValuesIncremental drives one row (or two, for the
-// cross-row case) through interleaved insert/get sequences and checks every
-// get against an independently computed reference: sortAndDedupValues over
-// the raw pairs inserted so far. This exercises the sortedValues() cold-cache,
-// incremental-merge, and dedup-across-the-merge-boundary paths.
+// TestBSTMap_SortedValuesIncremental drives interleaved insert/get sequences
+// and checks every get against sortAndDedupValues over the raw pairs inserted so far.
 func TestBSTMap_SortedValuesIncremental(t *testing.T) {
 	type opKind int
 	const (
@@ -537,11 +537,132 @@ func TestBSTMap_FlattenGivesPrivateCopies(t *testing.T) {
 	}, flat2[1].values)
 }
 
-// TestBSTMap_RandomizedAgainstReference throws a large, fixed-seed sequence
-// of inserts and gets, across a handful of rows and a small map-key space
-// (forcing heavy duplication/dedup), at the tree and checks every get
-// against sortAndDedupValues over the raw insert history. It also captures
-// snapshots periodically and re-checks them at the end for in-place mutation.
+// TestBSTMap_CacheContract pins the cache contract: repeated reads share one
+// immutable snapshot (same backing array, zero allocations); an append publishes a replacement, leaving prior snapshots untouched.
+func TestBSTMap_CacheContract(t *testing.T) {
+	tree := &binarySearchTreeMap{}
+	row := []byte("row")
+
+	tree.insert(row, MapPair{Key: []byte("k1"), Value: []byte("v1")})
+	tree.insert(row, MapPair{Key: []byte("k2"), Value: []byte("v2")})
+	tree.insert(row, MapPair{Key: []byte("k3"), Value: []byte("v3")})
+
+	got1, err := tree.get(row)
+	require.NoError(t, err)
+	got2, err := tree.get(row)
+	require.NoError(t, err)
+	require.NotEmpty(t, got1)
+	require.Same(t, &got1[0], &got2[0], "two consecutive reads must share the same backing array")
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if _, err := tree.get(row); err != nil {
+			t.Fatal(err)
+		}
+	})
+	require.Equal(t, float64(0), allocs, "a warm read must not allocate")
+
+	preInsertSnapshot := got2
+	preInsertCopy := make([]MapPair, len(preInsertSnapshot))
+	copy(preInsertCopy, preInsertSnapshot)
+
+	tree.insert(row, MapPair{Key: []byte("k4"), Value: []byte("v4")})
+	_, err = tree.get(row)
+	require.NoError(t, err)
+
+	require.Equal(t, len(tree.root.values), tree.root.sortedCache.Load().valueCount)
+	require.Equal(t, preInsertCopy, preInsertSnapshot, "a snapshot returned before an insert must not change after it")
+}
+
+// TestBSTMap_CacheAccounting pins cacheSizeBytes(): it charges exactly the
+// deduped MapPair count on a get, adjusts on structural changes, and is
+// never touched by flattenInOrder's private, publish-free reads.
+func TestBSTMap_CacheAccounting(t *testing.T) {
+	pairSize := int64(unsafe.Sizeof(MapPair{}))
+
+	tree := &binarySearchTreeMap{}
+	require.Zero(t, tree.cacheSizeBytes())
+
+	row := []byte("row")
+	tree.insert(row, MapPair{Key: []byte("k1"), Value: []byte("v1")})
+	tree.insert(row, MapPair{Key: []byte("k3"), Value: []byte("v3")})
+	tree.insert(row, MapPair{Key: []byte("k2"), Value: []byte("v2")})
+
+	t.Run("charges the deduped count on first get", func(t *testing.T) {
+		_, err := tree.get(row)
+		require.NoError(t, err)
+		require.Equal(t, 3*pairSize, tree.cacheSizeBytes())
+	})
+
+	t.Run("adjusts after appending a new key", func(t *testing.T) {
+		tree.insert(row, MapPair{Key: []byte("k4"), Value: []byte("v4")})
+		_, err := tree.get(row)
+		require.NoError(t, err)
+		require.Equal(t, 4*pairSize, tree.cacheSizeBytes())
+	})
+
+	t.Run("unchanged after an update to an existing key", func(t *testing.T) {
+		tree.insert(row, MapPair{Key: []byte("k2"), Value: []byte("v2-updated")})
+		_, err := tree.get(row)
+		require.NoError(t, err)
+		require.Equal(t, 4*pairSize, tree.cacheSizeBytes())
+	})
+
+	t.Run("flattenInOrder on a cold row does not publish a cache", func(t *testing.T) {
+		coldTree := &binarySearchTreeMap{}
+		coldRow := []byte("cold-row")
+		coldTree.insert(coldRow, MapPair{Key: []byte("a"), Value: []byte("1")})
+		coldTree.insert(coldRow, MapPair{Key: []byte("b"), Value: []byte("2")})
+
+		flat := coldTree.flattenInOrder()
+		require.Len(t, flat, 1)
+		require.Zero(t, coldTree.cacheSizeBytes())
+	})
+
+	t.Run("flattenInOrder on a warm row does not double-charge", func(t *testing.T) {
+		before := tree.cacheSizeBytes()
+		flat := tree.flattenInOrder()
+		require.Len(t, flat, 1)
+		require.Equal(t, before, tree.cacheSizeBytes())
+	})
+
+	t.Run("Memtable.Size() grows by the cache bytes after the first getMap", func(t *testing.T) {
+		dir := t.TempDir()
+		logger, _ := test.NewNullLogger()
+		cl, err := newCommitLogger(dir, StrategyMapCollection, 0)
+		require.NoError(t, err)
+
+		m, err := newMemtable(cl, nil, logger, nil, memtableConfig{
+			path:     path.Join(dir, "cache-accounting"),
+			strategy: StrategyMapCollection,
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, m.commitlog.close())
+		})
+
+		mRow := []byte("m-row")
+		const k = 5
+		for i := 0; i < k; i++ {
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, uint64(i))
+			require.NoError(t, m.appendMapSorted(mRow, MapPair{Key: key, Value: []byte("v")}))
+		}
+
+		sizeBefore := m.Size()
+
+		_, err = m.getMap(mRow)
+		require.NoError(t, err)
+		sizeAfterFirst := m.Size()
+		require.Equal(t, sizeBefore+uint64(k*pairSize), sizeAfterFirst)
+
+		_, err = m.getMap(mRow)
+		require.NoError(t, err)
+		require.Equal(t, sizeAfterFirst, m.Size())
+	})
+}
+
+// TestBSTMap_RandomizedAgainstReference runs a large fixed-seed sequence of
+// inserts/gets against sortAndDedupValues, and re-checks captured snapshots at the end for in-place mutation.
 func TestBSTMap_RandomizedAgainstReference(t *testing.T) {
 	rng := mathrand.New(mathrand.NewSource(42))
 	tree := &binarySearchTreeMap{}
@@ -608,12 +729,8 @@ func TestBSTMap_RandomizedAgainstReference(t *testing.T) {
 	}
 }
 
-// TestMemtable_MapConcurrentReadWrite exercises the memtable-level
-// concurrency contract: writers hold the exclusive lock (appendMapSorted),
-// readers hold at least the read lock (getMap, newMapCursor). Multiple
-// concurrent readers may race to publish equivalent sortedValues() caches;
-// this must be benign and produce correct reads throughout, and be race-free
-// under -race.
+// TestMemtable_MapConcurrentReadWrite: one writer per row appends a
+// deterministic key sequence while readers validate every read is a sorted, contiguous prefix of it.
 func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
 	dir := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -630,36 +747,69 @@ func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
 	})
 
 	rowKeys := [][]byte{[]byte("row-0"), []byte("row-1"), []byte("row-2")}
-	const numWriters = 4
-	const opsPerWriter = 500
+	const opsPerWriter = 2000
 	const numReaders = 4
 
-	var refMu sync.Mutex
-	reference := map[string][]MapPair{}
+	seqKey := func(seq uint64) []byte {
+		k := make([]byte, 8)
+		binary.BigEndian.PutUint64(k, seq)
+		return k
+	}
+	seqValue := func(seq uint64) []byte {
+		return []byte(fmt.Sprintf("v%08d", seq))
+	}
+	rowIndex := func(key []byte) int {
+		for i, row := range rowKeys {
+			if bytes.Equal(key, row) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	// committed[i] counts appendMapSorted calls that have returned for
+	// rowKeys[i]; a single writer per row makes it a sound lower bound on
+	// what a concurrent read must observe.
+	committed := make([]atomic.Int64, len(rowKeys))
+
+	// validateRead pins the single-writer-per-row invariant: a read is
+	// always the sorted, unique, contiguous prefix [0, len) of that row's
+	// key sequence, at least as long as what was committed before the read.
+	validateRead := func(rowIdx int, got []MapPair, committedBefore int64) {
+		for i, p := range got {
+			if !bytes.Equal(p.Key, seqKey(uint64(i))) {
+				t.Errorf("row %d: pair %d has key %x, want seq key %d", rowIdx, i, p.Key, i)
+				return
+			}
+			if !bytes.Equal(p.Value, seqValue(uint64(i))) {
+				t.Errorf("row %d: pair %d has value %q, want %q", rowIdx, i, p.Value, seqValue(uint64(i)))
+				return
+			}
+		}
+		if int64(len(got)) < committedBefore {
+			t.Errorf("row %d: read returned %d pairs, fewer than %d committed before the read", rowIdx, len(got), committedBefore)
+		}
+	}
 
 	var writersWG sync.WaitGroup
 	var allWG sync.WaitGroup
 	done := make(chan struct{})
 
-	writersWG.Add(numWriters)
-	allWG.Add(numWriters)
-	for w := 0; w < numWriters; w++ {
-		go func(writerID int) {
+	writersWG.Add(len(rowKeys))
+	allWG.Add(len(rowKeys))
+	for rowIdx, row := range rowKeys {
+		go func(rowIdx int, row []byte) {
 			defer writersWG.Done()
 			defer allWG.Done()
-			for i := 0; i < opsPerWriter; i++ {
-				row := rowKeys[(writerID+i)%len(rowKeys)]
-				mapKey := make([]byte, 8)
-				binary.BigEndian.PutUint64(mapKey, uint64(writerID)<<32|uint64(i))
-				pair := MapPair{Key: mapKey, Value: []byte("v")}
-
-				require.NoError(t, m.appendMapSorted(row, pair))
-
-				refMu.Lock()
-				reference[string(row)] = append(reference[string(row)], pair)
-				refMu.Unlock()
+			for seq := 0; seq < opsPerWriter; seq++ {
+				pair := MapPair{Key: seqKey(uint64(seq)), Value: seqValue(uint64(seq))}
+				if err := m.appendMapSorted(row, pair); err != nil {
+					t.Errorf("appendMapSorted: %v", err)
+					return
+				}
+				committed[rowIdx].Add(1)
 			}
-		}(w)
+		}(rowIdx, row)
 	}
 
 	allWG.Add(numReaders)
@@ -671,10 +821,14 @@ func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
 				case <-done:
 					return
 				default:
-					for _, row := range rowKeys {
-						if _, err := m.getMap(row); err != nil && !errors.Is(err, lsmkv.NotFound) {
+					for rowIdx, row := range rowKeys {
+						before := committed[rowIdx].Load()
+						got, err := m.getMap(row)
+						if err != nil && !errors.Is(err, lsmkv.NotFound) {
 							t.Errorf("getMap: %v", err)
+							continue
 						}
+						validateRead(rowIdx, got, before)
 					}
 				}
 			}
@@ -690,10 +844,19 @@ func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
 				return
 			default:
 			}
+
+			before := make([]int64, len(rowKeys))
+			for i := range rowKeys {
+				before[i] = committed[i].Load()
+			}
+
 			cursor := m.newMapCursor()
-			_, _, err := cursor.first()
+			key, got, err := cursor.first()
 			for err == nil {
-				_, _, err = cursor.next()
+				if rowIdx := rowIndex(key); rowIdx >= 0 {
+					validateRead(rowIdx, got, before[rowIdx])
+				}
+				key, got, err = cursor.next()
 			}
 		}
 	}()
@@ -702,8 +865,12 @@ func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
 	close(done)
 	allWG.Wait()
 
-	for _, row := range rowKeys {
-		want := sortAndDedupValues(reference[string(row)])
+	for rowIdx, row := range rowKeys {
+		n := committed[rowIdx].Load()
+		want := make([]MapPair, n)
+		for seq := int64(0); seq < n; seq++ {
+			want[seq] = MapPair{Key: seqKey(uint64(seq)), Value: seqValue(uint64(seq))}
+		}
 		got, err := m.getMap(row)
 		require.NoError(t, err)
 		require.Equal(t, want, got)
@@ -731,6 +898,9 @@ func BenchmarkBSTMapGet(b *testing.B) {
 			for i := 0; i < n; i++ {
 				tree.insert(row, MapPair{Key: makeKey(i), Value: []byte("v")})
 			}
+			if _, err := tree.get(row); err != nil { // warm the cache
+				b.Fatal(err)
+			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -740,16 +910,21 @@ func BenchmarkBSTMapGet(b *testing.B) {
 			}
 		})
 
-		b.Run(fmt.Sprintf("read-after-append/n=%d", n), func(b *testing.B) {
+		b.Run(fmt.Sprintf("read-after-update/n=%d", n), func(b *testing.B) {
 			tree := &binarySearchTreeMap{}
 			row := []byte("row")
 			for i := 0; i < n; i++ {
 				tree.insert(row, MapPair{Key: makeKey(i), Value: []byte("v")})
 			}
+			if _, err := tree.get(row); err != nil { // warm the cache
+				b.Fatal(err)
+			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				tree.insert(row, MapPair{Key: makeKey(n + i), Value: []byte("v")})
+				// updates an existing key, so the deduped row stays at size n
+				// and per-op cost doesn't drift across the run
+				tree.insert(row, MapPair{Key: makeKey(i % n), Value: []byte("v-updated")})
 				if _, err := tree.get(row); err != nil {
 					b.Fatal(err)
 				}

--- a/adapters/repos/db/lsmkv/binary_search_tree_map_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map_test.go
@@ -12,10 +12,18 @@
 package lsmkv
 
 import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	mathrand "math/rand"
+	"path"
+	"sync"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/lsmkv"
 )
 
 func Test_BinarySearchTreeMap(t *testing.T) {
@@ -315,4 +323,437 @@ func TestBSTMap_Flatten(t *testing.T) {
 			assertFlattenedMatches(t, flatAfterUpdate, expectedAfterUpdate)
 		})
 	})
+}
+
+// TestBSTMap_SortedValuesIncremental drives one row (or two, for the
+// cross-row case) through interleaved insert/get sequences and checks every
+// get against an independently computed reference: sortAndDedupValues over
+// the raw pairs inserted so far. This exercises the sortedValues() cold-cache,
+// incremental-merge, and dedup-across-the-merge-boundary paths.
+func TestBSTMap_SortedValuesIncremental(t *testing.T) {
+	type opKind int
+	const (
+		opInsert opKind = iota
+		opGet
+	)
+
+	type step struct {
+		op   opKind
+		row  string
+		pair MapPair
+	}
+
+	insert := func(row string, key, value string) step {
+		return step{op: opInsert, row: row, pair: MapPair{Key: []byte(key), Value: []byte(value)}}
+	}
+	tombstone := func(row string, key string) step {
+		return step{op: opInsert, row: row, pair: MapPair{Key: []byte(key), Tombstone: true}}
+	}
+	get := func(row string) step {
+		return step{op: opGet, row: row}
+	}
+
+	cases := []struct {
+		name  string
+		steps []step
+	}{
+		{
+			name:  "get on cold row",
+			steps: []step{insert("r1", "k1", "v1"), get("r1")},
+		},
+		{
+			name: "get-insert-get with a new map key",
+			steps: []step{
+				insert("r1", "k1", "v1"), get("r1"),
+				insert("r1", "k2", "v2"), get("r1"),
+			},
+		},
+		{
+			name: "get-insert-get updating an existing key",
+			steps: []step{
+				insert("r1", "k1", "v1"), get("r1"),
+				insert("r1", "k1", "v1-updated"), get("r1"),
+			},
+		},
+		{
+			name: "get-tombstone-get",
+			steps: []step{
+				insert("r1", "k1", "v1"), get("r1"),
+				tombstone("r1", "k1"), get("r1"),
+			},
+		},
+		{
+			name: "several rounds of interleaved get/insert",
+			steps: []step{
+				insert("r1", "k3", "v3"), get("r1"),
+				insert("r1", "k1", "v1"), get("r1"),
+				insert("r1", "k2", "v2"), get("r1"),
+				insert("r1", "k1", "v1-b"), get("r1"),
+				insert("r1", "k4", "v4"), get("r1"),
+			},
+		},
+		{
+			name: "updates arriving in non-sorted key order",
+			steps: []step{
+				insert("r1", "k5", "v5"),
+				insert("r1", "k1", "v1"),
+				insert("r1", "k3", "v3"),
+				get("r1"),
+				insert("r1", "k2", "v2"),
+				insert("r1", "k4", "v4"),
+				get("r1"),
+			},
+		},
+		{
+			name: "two rows interleaved, writes to one must not disturb the other's cache",
+			steps: []step{
+				insert("r1", "k1", "v1"), insert("r2", "z1", "y1"),
+				get("r1"), get("r2"),
+				insert("r2", "z2", "y2"),
+				get("r1"), get("r2"),
+				insert("r1", "k2", "v2"),
+				get("r1"), get("r2"),
+			},
+		},
+		{
+			name: "multiple updates to the same key between two gets",
+			steps: []step{
+				insert("r1", "k1", "v1"), get("r1"),
+				insert("r1", "k1", "v1-a"),
+				insert("r1", "k1", "v1-b"),
+				insert("r1", "k1", "v1-c"),
+				get("r1"),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &binarySearchTreeMap{}
+			raw := map[string][]MapPair{}
+
+			for i, s := range tc.steps {
+				switch s.op {
+				case opInsert:
+					tree.insert([]byte(s.row), s.pair)
+					raw[s.row] = append(raw[s.row], s.pair)
+				case opGet:
+					want := sortAndDedupValues(raw[s.row])
+					got, err := tree.get([]byte(s.row))
+					require.NoError(t, err, "step %d", i)
+					require.Equal(t, want, got, "step %d", i)
+				}
+			}
+		})
+	}
+}
+
+// TestBSTMap_SnapshotImmutability verifies that a slice returned by get() is
+// never mutated by later inserts, including inserts that update a key
+// present in the already-returned snapshot.
+func TestBSTMap_SnapshotImmutability(t *testing.T) {
+	tree := &binarySearchTreeMap{}
+	row := []byte("row")
+
+	tree.insert(row, MapPair{Key: []byte("k1"), Value: []byte("v1")})
+	tree.insert(row, MapPair{Key: []byte("k2"), Value: []byte("v2")})
+	tree.insert(row, MapPair{Key: []byte("k3"), Value: []byte("v3")})
+
+	snap, err := tree.get(row)
+	require.NoError(t, err)
+
+	snapCopy := make([]MapPair, len(snap))
+	for i, p := range snap {
+		snapCopy[i] = MapPair{
+			Key:       append([]byte(nil), p.Key...),
+			Value:     append([]byte(nil), p.Value...),
+			Tombstone: p.Tombstone,
+		}
+	}
+
+	// a brand new key, plus an update to a key already present in snap
+	tree.insert(row, MapPair{Key: []byte("k4"), Value: []byte("v4")})
+	tree.insert(row, MapPair{Key: []byte("k2"), Value: []byte("v2-updated")})
+
+	assert.Equal(t, snapCopy, snap, "previously returned snapshot must not change after later inserts")
+
+	fresh, err := tree.get(row)
+	require.NoError(t, err)
+	assert.Equal(t, []MapPair{
+		{Key: []byte("k1"), Value: []byte("v1")},
+		{Key: []byte("k2"), Value: []byte("v2-updated")},
+		{Key: []byte("k3"), Value: []byte("v3")},
+		{Key: []byte("k4"), Value: []byte("v4")},
+	}, fresh)
+}
+
+// TestBSTMap_FlattenGivesPrivateCopies verifies that flattenInOrder's
+// per-node values slices belong to the caller: mutating them in place (as
+// cursor consumers do, see legacyRequireManualSorting) must not corrupt the
+// tree's own cached snapshot or a later flatten.
+func TestBSTMap_FlattenGivesPrivateCopies(t *testing.T) {
+	tree := &binarySearchTreeMap{}
+	rowA := []byte("rowA")
+	rowB := []byte("rowB")
+
+	tree.insert(rowA, MapPair{Key: []byte("a1"), Value: []byte("va1")})
+	tree.insert(rowA, MapPair{Key: []byte("a2"), Value: []byte("va2")})
+	tree.insert(rowB, MapPair{Key: []byte("b1"), Value: []byte("vb1")})
+
+	flat := tree.flattenInOrder()
+	require.Len(t, flat, 2)
+
+	for _, node := range flat {
+		vals := node.values
+		for i, j := 0, len(vals)-1; i < j; i, j = i+1, j-1 {
+			vals[i], vals[j] = vals[j], vals[i]
+		}
+		if len(vals) > 0 {
+			vals[0].Value = []byte("mutated")
+		}
+	}
+
+	gotA, err := tree.get(rowA)
+	require.NoError(t, err)
+	assert.Equal(t, []MapPair{
+		{Key: []byte("a1"), Value: []byte("va1")},
+		{Key: []byte("a2"), Value: []byte("va2")},
+	}, gotA)
+
+	gotB, err := tree.get(rowB)
+	require.NoError(t, err)
+	assert.Equal(t, []MapPair{
+		{Key: []byte("b1"), Value: []byte("vb1")},
+	}, gotB)
+
+	flat2 := tree.flattenInOrder()
+	require.Len(t, flat2, 2)
+	assert.Equal(t, []MapPair{
+		{Key: []byte("a1"), Value: []byte("va1")},
+		{Key: []byte("a2"), Value: []byte("va2")},
+	}, flat2[0].values)
+	assert.Equal(t, []MapPair{
+		{Key: []byte("b1"), Value: []byte("vb1")},
+	}, flat2[1].values)
+}
+
+// TestBSTMap_RandomizedAgainstReference throws a large, fixed-seed sequence
+// of inserts and gets, across a handful of rows and a small map-key space
+// (forcing heavy duplication/dedup), at the tree and checks every get
+// against sortAndDedupValues over the raw insert history. It also captures
+// snapshots periodically and re-checks them at the end for in-place mutation.
+func TestBSTMap_RandomizedAgainstReference(t *testing.T) {
+	rng := mathrand.New(mathrand.NewSource(42))
+	tree := &binarySearchTreeMap{}
+
+	rowKeys := []string{"row-0", "row-1", "row-2", "row-3"}
+	const numMapKeys = 16
+	mapKeys := make([][]byte, numMapKeys)
+	for i := range mapKeys {
+		mapKeys[i] = []byte(fmt.Sprintf("mk-%02d", i))
+	}
+
+	raw := map[string][]MapPair{}
+
+	type snapshot struct {
+		row  string
+		vals []MapPair
+		copy []MapPair
+	}
+	var snapshots []snapshot
+
+	const numOps = 5000
+	for op := 0; op < numOps; op++ {
+		row := rowKeys[rng.Intn(len(rowKeys))]
+
+		if rng.Intn(2) == 0 {
+			pair := MapPair{Key: append([]byte(nil), mapKeys[rng.Intn(numMapKeys)]...)}
+			if rng.Intn(10) == 0 {
+				pair.Tombstone = true
+			} else {
+				val := make([]byte, 4)
+				rng.Read(val)
+				pair.Value = val
+			}
+			tree.insert([]byte(row), pair)
+			raw[row] = append(raw[row], pair)
+		} else {
+			want := sortAndDedupValues(raw[row])
+			got, err := tree.get([]byte(row))
+			if len(raw[row]) == 0 {
+				require.ErrorIs(t, err, lsmkv.NotFound)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, want, got)
+			}
+		}
+
+		if op%500 == 0 && len(raw[row]) > 0 {
+			vals, err := tree.get([]byte(row))
+			require.NoError(t, err)
+			cp := make([]MapPair, len(vals))
+			for i, p := range vals {
+				cp[i] = MapPair{
+					Key:       append([]byte(nil), p.Key...),
+					Value:     append([]byte(nil), p.Value...),
+					Tombstone: p.Tombstone,
+				}
+			}
+			snapshots = append(snapshots, snapshot{row: row, vals: vals, copy: cp})
+		}
+	}
+
+	for _, s := range snapshots {
+		assert.Equal(t, s.copy, s.vals, "captured snapshot for row %q mutated after later inserts", s.row)
+	}
+}
+
+// TestMemtable_MapConcurrentReadWrite exercises the memtable-level
+// concurrency contract: writers hold the exclusive lock (appendMapSorted),
+// readers hold at least the read lock (getMap, newMapCursor). Multiple
+// concurrent readers may race to publish equivalent sortedValues() caches;
+// this must be benign and produce correct reads throughout, and be race-free
+// under -race.
+func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
+	dir := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	cl, err := newCommitLogger(dir, StrategyMapCollection, 0)
+	require.NoError(t, err)
+
+	m, err := newMemtable(cl, nil, logger, nil, memtableConfig{
+		path:     path.Join(dir, "concurrent-map"),
+		strategy: StrategyMapCollection,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, m.commitlog.close())
+	})
+
+	rowKeys := [][]byte{[]byte("row-0"), []byte("row-1"), []byte("row-2")}
+	const numWriters = 4
+	const opsPerWriter = 500
+	const numReaders = 4
+
+	var refMu sync.Mutex
+	reference := map[string][]MapPair{}
+
+	var writersWG sync.WaitGroup
+	var allWG sync.WaitGroup
+	done := make(chan struct{})
+
+	writersWG.Add(numWriters)
+	allWG.Add(numWriters)
+	for w := 0; w < numWriters; w++ {
+		go func(writerID int) {
+			defer writersWG.Done()
+			defer allWG.Done()
+			for i := 0; i < opsPerWriter; i++ {
+				row := rowKeys[(writerID+i)%len(rowKeys)]
+				mapKey := make([]byte, 8)
+				binary.BigEndian.PutUint64(mapKey, uint64(writerID)<<32|uint64(i))
+				pair := MapPair{Key: mapKey, Value: []byte("v")}
+
+				require.NoError(t, m.appendMapSorted(row, pair))
+
+				refMu.Lock()
+				reference[string(row)] = append(reference[string(row)], pair)
+				refMu.Unlock()
+			}
+		}(w)
+	}
+
+	allWG.Add(numReaders)
+	for r := 0; r < numReaders; r++ {
+		go func() {
+			defer allWG.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					for _, row := range rowKeys {
+						if _, err := m.getMap(row); err != nil && !errors.Is(err, lsmkv.NotFound) {
+							t.Errorf("getMap: %v", err)
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	allWG.Add(1)
+	go func() {
+		defer allWG.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			cursor := m.newMapCursor()
+			_, _, err := cursor.first()
+			for err == nil {
+				_, _, err = cursor.next()
+			}
+		}
+	}()
+
+	writersWG.Wait()
+	close(done)
+	allWG.Wait()
+
+	for _, row := range rowKeys {
+		want := sortAndDedupValues(reference[string(row)])
+		got, err := m.getMap(row)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	}
+}
+
+// BenchmarkBSTMapGet covers the two access patterns sortedValues() is meant
+// to speed up: repeated reads with no new writes (cache hit, no sort at all)
+// and a read immediately after a single new append (incremental merge of
+// just the appended tail against the cached sorted snapshot).
+func BenchmarkBSTMapGet(b *testing.B) {
+	sizes := []int{1_000, 10_000, 100_000}
+
+	makeKey := func(i int) []byte {
+		k := make([]byte, 8)
+		binary.BigEndian.PutUint64(k, uint64(i))
+		return k
+	}
+
+	for _, n := range sizes {
+		n := n
+		b.Run(fmt.Sprintf("repeat-read/n=%d", n), func(b *testing.B) {
+			tree := &binarySearchTreeMap{}
+			row := []byte("row")
+			for i := 0; i < n; i++ {
+				tree.insert(row, MapPair{Key: makeKey(i), Value: []byte("v")})
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := tree.get(row); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("read-after-append/n=%d", n), func(b *testing.B) {
+			tree := &binarySearchTreeMap{}
+			row := []byte("row")
+			for i := 0; i < n; i++ {
+				tree.insert(row, MapPair{Key: makeKey(i), Value: []byte("v")})
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				tree.insert(row, MapPair{Key: makeKey(n + i), Value: []byte("v")})
+				if _, err := tree.get(row); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/adapters/repos/db/lsmkv/binary_search_tree_map_test.go
+++ b/adapters/repos/db/lsmkv/binary_search_tree_map_test.go
@@ -17,13 +17,11 @@ import (
 	"errors"
 	"fmt"
 	mathrand "math/rand"
-	"path"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"unsafe"
 
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -626,19 +624,7 @@ func TestBSTMap_CacheAccounting(t *testing.T) {
 	})
 
 	t.Run("Memtable.Size() grows by the cache bytes after the first getMap", func(t *testing.T) {
-		dir := t.TempDir()
-		logger, _ := test.NewNullLogger()
-		cl, err := newCommitLogger(dir, StrategyMapCollection, 0)
-		require.NoError(t, err)
-
-		m, err := newMemtable(cl, nil, logger, nil, memtableConfig{
-			path:     path.Join(dir, "cache-accounting"),
-			strategy: StrategyMapCollection,
-		})
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, m.commitlog.close())
-		})
+		m := newTestMemtableMap(nil)
 
 		mRow := []byte("m-row")
 		const k = 5
@@ -650,7 +636,7 @@ func TestBSTMap_CacheAccounting(t *testing.T) {
 
 		sizeBefore := m.Size()
 
-		_, err = m.getMap(mRow)
+		_, err := m.getMap(mRow)
 		require.NoError(t, err)
 		sizeAfterFirst := m.Size()
 		require.Equal(t, sizeBefore+uint64(k*pairSize), sizeAfterFirst)
@@ -732,19 +718,7 @@ func TestBSTMap_RandomizedAgainstReference(t *testing.T) {
 // TestMemtable_MapConcurrentReadWrite: one writer per row appends a
 // deterministic key sequence while readers validate every read is a sorted, contiguous prefix of it.
 func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
-	dir := t.TempDir()
-	logger, _ := test.NewNullLogger()
-	cl, err := newCommitLogger(dir, StrategyMapCollection, 0)
-	require.NoError(t, err)
-
-	m, err := newMemtable(cl, nil, logger, nil, memtableConfig{
-		path:     path.Join(dir, "concurrent-map"),
-		strategy: StrategyMapCollection,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		require.NoError(t, m.commitlog.close())
-	})
+	m := newTestMemtableMap(nil)
 
 	rowKeys := [][]byte{[]byte("row-0"), []byte("row-1"), []byte("row-2")}
 	const opsPerWriter = 2000
@@ -884,23 +858,10 @@ func TestMemtable_MapConcurrentReadWrite(t *testing.T) {
 func BenchmarkBSTMapGet(b *testing.B) {
 	sizes := []int{1_000, 10_000, 100_000}
 
-	makeKey := func(i int) []byte {
-		k := make([]byte, 8)
-		binary.BigEndian.PutUint64(k, uint64(i))
-		return k
-	}
-
 	for _, n := range sizes {
 		n := n
 		b.Run(fmt.Sprintf("repeat-read/n=%d", n), func(b *testing.B) {
-			tree := &binarySearchTreeMap{}
-			row := []byte("row")
-			for i := 0; i < n; i++ {
-				tree.insert(row, MapPair{Key: makeKey(i), Value: []byte("v")})
-			}
-			if _, err := tree.get(row); err != nil { // warm the cache
-				b.Fatal(err)
-			}
+			tree, row := buildWarmRow(b, n)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
@@ -911,24 +872,38 @@ func BenchmarkBSTMapGet(b *testing.B) {
 		})
 
 		b.Run(fmt.Sprintf("read-after-update/n=%d", n), func(b *testing.B) {
-			tree := &binarySearchTreeMap{}
-			row := []byte("row")
-			for i := 0; i < n; i++ {
-				tree.insert(row, MapPair{Key: makeKey(i), Value: []byte("v")})
-			}
-			if _, err := tree.get(row); err != nil { // warm the cache
-				b.Fatal(err)
-			}
+			tree, row := buildWarmRow(b, n)
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				// updates an existing key, so the deduped row stays at size n
 				// and per-op cost doesn't drift across the run
-				tree.insert(row, MapPair{Key: makeKey(i % n), Value: []byte("v-updated")})
+				tree.insert(row, MapPair{Key: bstMapBenchKey(i % n), Value: []byte("v-updated")})
 				if _, err := tree.get(row); err != nil {
 					b.Fatal(err)
 				}
 			}
 		})
 	}
+}
+
+func bstMapBenchKey(i int) []byte {
+	k := make([]byte, 8)
+	binary.BigEndian.PutUint64(k, uint64(i))
+	return k
+}
+
+// buildWarmRow inserts n distinct pairs into a fresh row and performs one
+// get to warm sortedValues()'s cache before the benchmark timer starts.
+func buildWarmRow(b *testing.B, n int) (*binarySearchTreeMap, []byte) {
+	b.Helper()
+	tree := &binarySearchTreeMap{}
+	row := []byte("row")
+	for i := 0; i < n; i++ {
+		tree.insert(row, MapPair{Key: bstMapBenchKey(i), Value: []byte("v")})
+	}
+	if _, err := tree.get(row); err != nil {
+		b.Fatal(err)
+	}
+	return tree, row
 }

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1238,6 +1238,17 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 
 	// fmt.Printf("--map-list: get all disk segments took %s\n", time.Since(before))
 
+	if c.legacyRequireManualSorting {
+		// Sort to support segments which were stored in an unsorted fashion. Only
+		// disk entries need this: memtable postings are already sorted, and their
+		// slices are shared cache snapshots that must not be sorted in place.
+		for i := range entriesPerSegment {
+			sort.Slice(entriesPerSegment[i], func(a, b int) bool {
+				return bytes.Compare(entriesPerSegment[i][a].Key, entriesPerSegment[i][b].Key) == -1
+			})
+		}
+	}
+
 	// before = time.Now()
 	// fmt.Printf("--map-list: append all disk segments took %s\n", time.Since(before))
 
@@ -1265,15 +1276,6 @@ func (b *Bucket) mapListFromConsistentView(ctx context.Context, view BucketConsi
 	// defer func() {
 	// 	fmt.Printf("--map-list: run decoder took %s\n", time.Since(before))
 	// }()
-
-	if c.legacyRequireManualSorting {
-		// Sort to support segments which were stored in an unsorted fashion
-		for i := range entriesPerSegment {
-			sort.Slice(entriesPerSegment[i], func(a, b int) bool {
-				return bytes.Compare(entriesPerSegment[i][a].Key, entriesPerSegment[i][b].Key) == -1
-			})
-		}
-	}
 
 	return newSortedMapMerger().do(ctx, entriesPerSegment)
 }

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -1865,15 +1865,8 @@ func TestBucketMapStrategyConsistentView(t *testing.T) {
 	}, v)
 }
 
-// TestBucketMapListLegacyManualSorting covers the legacyRequireManualSorting
-// path in mapListFromConsistentView, which had no dedicated coverage: the
-// sort-unsorted-disk-segments block was moved (see bucket.go) to run right
-// after the disk-segment loop, before memtable results are appended to
-// entriesPerSegment, specifically so it never sorts a memtable's returned
-// slice in place. That slice is a shared, immutable cache snapshot
-// (binarySearchNodeMap.sortedCache) that concurrent readers hold pointers
-// into; sorting it in place would both corrupt the cache and race with other
-// readers/the incremental-merge writer.
+// TestBucketMapListLegacyManualSorting covers reads with
+// MapListLegacySortingRequired(), which must never sort a memtable's shared cache snapshot in place.
 func TestBucketMapListLegacyManualSorting(t *testing.T) {
 	t.Run("sorts unsorted disk segments", func(t *testing.T) {
 		t.Parallel()
@@ -1938,11 +1931,10 @@ func TestBucketMapListLegacyManualSorting(t *testing.T) {
 		row := []byte("row")
 
 		// A regressed in-place sort of the shared snapshot is not directly
-		// visible to -race: sort.Slice performs zero writes on already-sorted
-		// input (pdqsort bails on sorted runs), and memtable snapshots are
-		// always sorted. This subtest instead pins correctness while
-		// legacy-sorting reads race with appends that incrementally re-merge
-		// the shared cache snapshot.
+		// visible to -race here: sort.Slice performs zero writes on
+		// already-sorted input, and memtable snapshots are always sorted.
+		// This subtest instead pins correctness while reads with
+		// MapListLegacySortingRequired() race with appends.
 		const numInitial = 60
 		initial := make([]MapPair, numInitial)
 		for i := range initial {

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -1862,6 +1863,157 @@ func TestBucketMapStrategyConsistentView(t *testing.T) {
 	require.ElementsMatch(t, []MapPair{
 		{Key: []byte("ak1"), Value: []byte("av1")},
 	}, v)
+}
+
+// TestBucketMapListLegacyManualSorting covers the legacyRequireManualSorting
+// path in mapListFromConsistentView, which had no dedicated coverage: the
+// sort-unsorted-disk-segments block was moved (see bucket.go) to run right
+// after the disk-segment loop, before memtable results are appended to
+// entriesPerSegment, specifically so it never sorts a memtable's returned
+// slice in place. That slice is a shared, immutable cache snapshot
+// (binarySearchNodeMap.sortedCache) that concurrent readers hold pointers
+// into; sorting it in place would both corrupt the cache and race with other
+// readers/the incremental-merge writer.
+func TestBucketMapListLegacyManualSorting(t *testing.T) {
+	t.Run("sorts unsorted disk segments", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+
+		diskSegments := &SegmentGroup{
+			segments: []Segment{
+				newFakeMapSegment(map[string][]MapPair{
+					// deliberately unsorted, >=3 keys, one ("k3") overlaps
+					// with the active memtable and must lose to it
+					"row": {
+						{Key: []byte("k5"), Value: []byte("dv5")},
+						{Key: []byte("k1"), Value: []byte("dv1")},
+						{Key: []byte("k3"), Value: []byte("dv3-old")},
+					},
+					// disk-only row, also unsorted, pins the plain
+					// disk-only case
+					"diskonly": {
+						{Key: []byte("d3"), Value: []byte("v3")},
+						{Key: []byte("d1"), Value: []byte("v1")},
+						{Key: []byte("d2"), Value: []byte("v2")},
+					},
+				}),
+			},
+		}
+
+		active := newTestMemtableMap(map[string][]MapPair{
+			"row": {
+				{Key: []byte("k3"), Value: []byte("dv3-new")},
+				{Key: []byte("k2"), Value: []byte("mv2")},
+			},
+		})
+
+		b := Bucket{
+			active:   active,
+			disk:     diskSegments,
+			strategy: StrategyMapCollection,
+			logger:   nullLogger(),
+		}
+
+		got, err := b.MapList(ctx, []byte("row"), MapListLegacySortingRequired())
+		require.NoError(t, err)
+		require.Equal(t, []MapPair{
+			{Key: []byte("k1"), Value: []byte("dv1")},
+			{Key: []byte("k2"), Value: []byte("mv2")},
+			{Key: []byte("k3"), Value: []byte("dv3-new")}, // active wins over disk
+			{Key: []byte("k5"), Value: []byte("dv5")},
+		}, got)
+
+		got, err = b.MapList(ctx, []byte("diskonly"), MapListLegacySortingRequired())
+		require.NoError(t, err)
+		require.Equal(t, []MapPair{
+			{Key: []byte("d1"), Value: []byte("v1")},
+			{Key: []byte("d2"), Value: []byte("v2")},
+			{Key: []byte("d3"), Value: []byte("v3")},
+		}, got)
+	})
+
+	t.Run("does not touch memtable snapshots under concurrency", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		row := []byte("row")
+
+		// A regressed in-place sort of the shared snapshot is not directly
+		// visible to -race: sort.Slice performs zero writes on already-sorted
+		// input (pdqsort bails on sorted runs), and memtable snapshots are
+		// always sorted. This subtest instead pins correctness while
+		// legacy-sorting reads race with appends that incrementally re-merge
+		// the shared cache snapshot.
+		const numInitial = 60
+		initial := make([]MapPair, numInitial)
+		for i := range initial {
+			key := make([]byte, 8)
+			binary.BigEndian.PutUint64(key, uint64(i))
+			initial[i] = MapPair{Key: key, Value: []byte(fmt.Sprintf("v%03d", i))}
+		}
+
+		active := newTestMemtableMap(map[string][]MapPair{"row": initial})
+
+		b := Bucket{
+			active:   active,
+			disk:     &SegmentGroup{},
+			strategy: StrategyMapCollection,
+			logger:   nullLogger(),
+		}
+
+		// warm the sortedValues() cache before the concurrent phase
+		_, err := b.MapList(ctx, row, MapListLegacySortingRequired())
+		require.NoError(t, err)
+
+		var refMu sync.Mutex
+		allRaw := append([]MapPair(nil), initial...)
+
+		var wg sync.WaitGroup
+
+		const numReaders = 2
+		const readerIters = 50
+		wg.Add(numReaders)
+		for r := 0; r < numReaders; r++ {
+			go func() {
+				defer wg.Done()
+				for i := 0; i < readerIters; i++ {
+					got, err := b.MapList(ctx, row, MapListLegacySortingRequired())
+					require.NoError(t, err)
+					for _, p := range got {
+						_ = p.Key[0]
+						if len(p.Value) > 0 {
+							_ = p.Value[0]
+						}
+					}
+				}
+			}()
+		}
+
+		const writerIters = 50
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writerIters; i++ {
+				// unique keys beyond the initial range, so every write is a
+				// genuinely new map key forcing an incremental cache merge
+				key := make([]byte, 8)
+				binary.BigEndian.PutUint64(key, uint64(numInitial+1000+i))
+				pair := MapPair{Key: key, Value: []byte(fmt.Sprintf("new%03d", i))}
+
+				require.NoError(t, b.active.appendMapSorted(row, pair))
+
+				refMu.Lock()
+				allRaw = append(allRaw, pair)
+				refMu.Unlock()
+			}
+		}()
+
+		wg.Wait()
+
+		want := sortAndDedupValues(allRaw)
+		got, err := b.MapList(ctx, row)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
 }
 
 func TestBucketMapStrategyDocPointersConsistentView(t *testing.T) {

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -45,6 +45,7 @@ type memtable interface {
 
 	getCollection(key []byte) ([]value, error)
 	getCollectionBytes(key []byte) ([][]byte, error)
+	// getMap's result may alias shared immutable cache state; callers must not modify it.
 	getMap(key []byte) ([]MapPair, error)
 	append(key []byte, values []value) error
 	appendMapSorted(key []byte, pair MapPair) error
@@ -614,7 +615,13 @@ func (m *Memtable) Size() uint64 {
 	m.RLock()
 	defer m.RUnlock()
 
-	return m.size
+	size := m.size
+	if m.keyMap != nil {
+		// cache bytes count toward the flush threshold like any other
+		// retained memory, even though they're not tallied at append time
+		size += uint64(m.keyMap.cacheSizeBytes())
+	}
+	return size
 }
 
 func (m *Memtable) Path() string {

--- a/adapters/repos/db/lsmkv/strategies_map_sorted_merger.go
+++ b/adapters/repos/db/lsmkv/strategies_map_sorted_merger.go
@@ -59,6 +59,13 @@ func (s *sortedMapMerger) do(ctx context.Context, segments [][]MapPair) ([]MapPa
 // same as .do() but does not remove the tombstone if the most latest version
 // of a key is a tombstone. It can thus also be used in compactions
 func (s *sortedMapMerger) doKeepTombstones(segments [][]MapPair) ([]MapPair, error) {
+	if len(segments) == 2 {
+		// same contract as the K-way loop below: rightmost wins on equal
+		// keys, tombstones preserved; each segment must already be sorted
+		// by Key and deduped
+		return mergeSortedPairs(segments[0], segments[1]), nil
+	}
+
 	if err := s.init(segments); err != nil {
 		return nil, errors.Wrap(err, "init sorted map decoder")
 	}

--- a/adapters/repos/db/lsmkv/strategies_map_sorted_merger_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_sorted_merger_test.go
@@ -370,3 +370,114 @@ func Test_SortedMapMerger_KeepTombstones(t *testing.T) {
 		})
 	})
 }
+
+// Test_SortedMapMerger_TwoInputFastPath pins doKeepTombstones's len==2 fast
+// path (mergeSortedPairs) against an independently computed expected result
+// and against doKeepTombstonesReusable on the same two segments.
+func Test_SortedMapMerger_TwoInputFastPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		left     []MapPair
+		right    []MapPair
+		expected []MapPair
+	}{
+		{
+			name: "disjoint keys",
+			left: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+				{Key: []byte("c"), Value: []byte("c1")},
+			},
+			right: []MapPair{
+				{Key: []byte("b"), Value: []byte("b1")},
+				{Key: []byte("d"), Value: []byte("d1")},
+			},
+			expected: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+				{Key: []byte("b"), Value: []byte("b1")},
+				{Key: []byte("c"), Value: []byte("c1")},
+				{Key: []byte("d"), Value: []byte("d1")},
+			},
+		},
+		{
+			name: "overlapping keys, right-hand precedence",
+			left: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+				{Key: []byte("b"), Value: []byte("b1")},
+				{Key: []byte("c"), Value: []byte("c1")},
+			},
+			right: []MapPair{
+				{Key: []byte("b"), Value: []byte("b2")},
+				{Key: []byte("c"), Value: []byte("c2")},
+			},
+			expected: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+				{Key: []byte("b"), Value: []byte("b2")},
+				{Key: []byte("c"), Value: []byte("c2")},
+			},
+		},
+		{
+			name: "tombstone on the left, overwritten on the right",
+			left: []MapPair{
+				{Key: []byte("a"), Tombstone: true},
+				{Key: []byte("b"), Value: []byte("b1")},
+			},
+			right: []MapPair{
+				{Key: []byte("a"), Value: []byte("a2")},
+			},
+			expected: []MapPair{
+				{Key: []byte("a"), Value: []byte("a2")},
+				{Key: []byte("b"), Value: []byte("b1")},
+			},
+		},
+		{
+			name: "tombstone on the right, shadows the left",
+			left: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+			},
+			right: []MapPair{
+				{Key: []byte("a"), Tombstone: true},
+				{Key: []byte("b"), Value: []byte("b2")},
+			},
+			expected: []MapPair{
+				{Key: []byte("a"), Tombstone: true},
+				{Key: []byte("b"), Value: []byte("b2")},
+			},
+		},
+		{
+			name: "empty left side",
+			left: nil,
+			right: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+			},
+			expected: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+			},
+		},
+		{
+			name: "empty right side",
+			left: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+			},
+			right: nil,
+			expected: []MapPair{
+				{Key: []byte("a"), Value: []byte("a1")},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			segments := [][]MapPair{tc.left, tc.right}
+
+			actual, err := newSortedMapMerger().doKeepTombstones(segments)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+
+			reusable := newSortedMapMerger()
+			require.NoError(t, reusable.reset(segments))
+			viaReusable, err := reusable.doKeepTombstonesReusable()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, viaReusable)
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/strategies_map_sorted_merger_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_sorted_merger_test.go
@@ -371,6 +371,12 @@ func Test_SortedMapMerger_KeepTombstones(t *testing.T) {
 	})
 }
 
+// mpKV and mpTomb build one-line MapPair table entries for
+// Test_SortedMapMerger_TwoInputFastPath below (prefixed to avoid colliding
+// with the existing `kv` struct used by other tests in this package).
+func mpKV(k, v string) MapPair { return MapPair{Key: []byte(k), Value: []byte(v)} }
+func mpTomb(k string) MapPair  { return MapPair{Key: []byte(k), Tombstone: true} }
+
 // Test_SortedMapMerger_TwoInputFastPath pins doKeepTombstones's len==2 fast
 // path (mergeSortedPairs) against an independently computed expected result
 // and against doKeepTombstonesReusable on the same two segments.
@@ -382,86 +388,40 @@ func Test_SortedMapMerger_TwoInputFastPath(t *testing.T) {
 		expected []MapPair
 	}{
 		{
-			name: "disjoint keys",
-			left: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-				{Key: []byte("c"), Value: []byte("c1")},
-			},
-			right: []MapPair{
-				{Key: []byte("b"), Value: []byte("b1")},
-				{Key: []byte("d"), Value: []byte("d1")},
-			},
-			expected: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-				{Key: []byte("b"), Value: []byte("b1")},
-				{Key: []byte("c"), Value: []byte("c1")},
-				{Key: []byte("d"), Value: []byte("d1")},
-			},
+			name:     "disjoint keys",
+			left:     []MapPair{mpKV("a", "a1"), mpKV("c", "c1")},
+			right:    []MapPair{mpKV("b", "b1"), mpKV("d", "d1")},
+			expected: []MapPair{mpKV("a", "a1"), mpKV("b", "b1"), mpKV("c", "c1"), mpKV("d", "d1")},
 		},
 		{
-			name: "overlapping keys, right-hand precedence",
-			left: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-				{Key: []byte("b"), Value: []byte("b1")},
-				{Key: []byte("c"), Value: []byte("c1")},
-			},
-			right: []MapPair{
-				{Key: []byte("b"), Value: []byte("b2")},
-				{Key: []byte("c"), Value: []byte("c2")},
-			},
-			expected: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-				{Key: []byte("b"), Value: []byte("b2")},
-				{Key: []byte("c"), Value: []byte("c2")},
-			},
+			name:     "overlapping keys, right-hand precedence",
+			left:     []MapPair{mpKV("a", "a1"), mpKV("b", "b1"), mpKV("c", "c1")},
+			right:    []MapPair{mpKV("b", "b2"), mpKV("c", "c2")},
+			expected: []MapPair{mpKV("a", "a1"), mpKV("b", "b2"), mpKV("c", "c2")},
 		},
 		{
-			name: "tombstone on the left, overwritten on the right",
-			left: []MapPair{
-				{Key: []byte("a"), Tombstone: true},
-				{Key: []byte("b"), Value: []byte("b1")},
-			},
-			right: []MapPair{
-				{Key: []byte("a"), Value: []byte("a2")},
-			},
-			expected: []MapPair{
-				{Key: []byte("a"), Value: []byte("a2")},
-				{Key: []byte("b"), Value: []byte("b1")},
-			},
+			name:     "tombstone on the left, overwritten on the right",
+			left:     []MapPair{mpTomb("a"), mpKV("b", "b1")},
+			right:    []MapPair{mpKV("a", "a2")},
+			expected: []MapPair{mpKV("a", "a2"), mpKV("b", "b1")},
 		},
 		{
-			name: "tombstone on the right, shadows the left",
-			left: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-			},
-			right: []MapPair{
-				{Key: []byte("a"), Tombstone: true},
-				{Key: []byte("b"), Value: []byte("b2")},
-			},
-			expected: []MapPair{
-				{Key: []byte("a"), Tombstone: true},
-				{Key: []byte("b"), Value: []byte("b2")},
-			},
+			name:     "tombstone on the right, shadows the left",
+			left:     []MapPair{mpKV("a", "a1")},
+			right:    []MapPair{mpTomb("a"), mpKV("b", "b2")},
+			expected: []MapPair{mpTomb("a"), mpKV("b", "b2")},
 		},
 		{
-			name: "empty left side",
-			left: nil,
-			right: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-			},
-			expected: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-			},
+			name:     "empty left side",
+			left:     nil,
+			right:    []MapPair{mpKV("a", "a1")},
+			expected: []MapPair{mpKV("a", "a1")},
 		},
 		{
-			name: "empty right side",
-			left: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-			},
-			right: nil,
-			expected: []MapPair{
-				{Key: []byte("a"), Value: []byte("a1")},
-			},
+			name:     "empty right side",
+			left:     []MapPair{mpKV("a", "a1")},
+			right:    nil,
+			expected: []MapPair{mpKV("a", "a1")},
 		},
 	}
 


### PR DESCRIPTION
## What's being changed

`binarySearchNodeMap.get` re-sorted and copied a row's entire pending posting list on every read: each memtable BM25 term lookup paid a full `sortAndDedupValues` — O(n log n) stable sort plus a full-row allocation (measured ~9ms and 28MB per read for a 500k-entry hot row). Under combined ingest+query load this turns hot term rows into a lock-contention feedback loop: queries hold the memtable `RLock` longer → writers queue on the exclusive lock → flush waits in `waitForZeroWriters` behind tens of thousands of parked writers → the row grows further and reads get even slower. The flushing memtable is the worst case: frozen at maximum row size, it paid the full sort on every query for the entire drain.

This PR caches an immutable sorted+deduped snapshot per row behind an `atomic.Pointer`:

- `values` is append-only, so a stale snapshot remains a valid sorted prefix. A read after k appends sorts only the appended tail and merges it with the snapshot — O(n + k log k) instead of O(n log n).
- Repeated reads of an unchanged row return the shared snapshot with no work (~3ns flat in benchmarks, independent of row size). The flushing memtable pays the sort exactly once.
- Appends stay O(1): staleness is detected by comparing the snapshot's covered length against `len(values)`, so the write path never touches the cache.
- Writers hold the memtable's exclusive lock and readers hold `RLock`, so `values` is stable during a read; concurrent readers may race to publish equivalent snapshots for the same length, which is benign (atomic pointer, last store wins).

Consumer audit for the shared (must-not-mutate) snapshot returned by `get`/`getMap`: `sortedMapMerger`, `addDataToTerm`/BlockMax term construction, `fillTerm`, and `flushDataInverted` are all read-only. Two sites required care:

- `mapListFromConsistentView`'s `legacyRequireManualSorting` block sorted the memtable-returned slices in place. It now runs before memtable results are appended, so it only sorts disk-decoded entries — memtable postings are sorted by construction, so this was dead work even before.
- `flattenInOrder`/`shallowCopy` (cursor and flush paths) keeps handing out private copies, because `CursorMap`'s legacy path sorts those slices in place. It now copies from the cached snapshot instead of re-sorting, so it's still cheaper than before.

## Testing

- Table-driven unit tests for the incremental-merge paths: cold row, merge of new keys, dedup across the merge boundary (later write wins), tombstones, multi-round read/write interleavings, out-of-order keys, cross-row cache isolation.
- Snapshot immutability: slices returned by `get` are never mutated by later inserts; flatten output is private and mutable by consumers without corrupting the tree.
- 5000-op fixed-seed randomized test verifying every read against an independent `sortAndDedupValues` reference, with periodic snapshot captures re-checked at the end.
- Memtable-level concurrency test (4 writers × `appendMapSorted`, 4 readers × `getMap`, plus a cursor) — race-clean.
- `TestBucketMapListLegacyManualSorting` pins the previously-uncovered `MapListLegacySortingRequired` path: unsorted disk segments still get sorted, memtable wins overlapping keys, and legacy-sorting reads racing with concurrent appends stay correct under `-race`.
- Full `adapters/repos/db/lsmkv` suite passes with `-race`; `golangci-lint`, `go vet`, gofumpt, and the goroutine linter are clean.
