### PR TITLE
fix(lsmkv): write WAL tombstone pair before publishing inverted doc tombstone

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1374,6 +1374,13 @@ func (b *Bucket) MapDeleteKey(rowKey, mapKey []byte) error {
 		Tombstone: true,
 	}
 
+	// The doc-tombstone bitmap must never lead the WAL: replay reconstructs it
+	// from the persisted pair (commitlogger_parser_collection.go), so a failed
+	// append must leave no bitmap change.
+	if err := active.appendMapSorted(rowKey, pair); err != nil {
+		return err
+	}
+
 	if active.getStrategy() == StrategyInverted {
 		docID := binary.BigEndian.Uint64(mapKey)
 		if err := active.SetTombstone(docID); err != nil {
@@ -1381,7 +1388,7 @@ func (b *Bucket) MapDeleteKey(rowKey, mapKey []byte) error {
 		}
 	}
 
-	return active.appendMapSorted(rowKey, pair)
+	return nil
 }
 
 // Delete removes the given row. Note that LSM stores are append only, thus

--- a/adapters/repos/db/lsmkv/bucket_map_delete_test.go
+++ b/adapters/repos/db/lsmkv/bucket_map_delete_test.go
@@ -1,0 +1,147 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// errInjectingMemtable wraps a real memtable and lets a test force
+// appendMapSorted to fail on demand, while every other call (including
+// SetTombstone, ReadOnlyTombstones, getMap, GetPropLengths) passes straight
+// through to the wrapped memtable via interface embedding.
+type errInjectingMemtable struct {
+	memtable
+	appendMapSortedErr error
+}
+
+func (e *errInjectingMemtable) appendMapSorted(key []byte, pair MapPair) error {
+	if e.appendMapSortedErr != nil {
+		return e.appendMapSortedErr
+	}
+	return e.memtable.appendMapSorted(key, pair)
+}
+
+// TestBucketMapDeleteKey_InvertedWALOrder pins MapDeleteKey's ordering for
+// StrategyInverted: the WAL append (appendMapSorted) must happen before the
+// doc-tombstone bitmap is published (SetTombstone). If appendMapSorted fails,
+// the bitmap must be left untouched -- otherwise a restart (which replays the
+// WAL and derives the bitmap from persisted pairs) would silently resurrect a
+// document that reads currently suppress.
+func TestBucketMapDeleteKey_InvertedWALOrder(t *testing.T) {
+	rowKey := []byte("row1")
+	docID := uint64(42)
+	mapKey := NewMapPairFromDocIdAndTf(docID, 1, 5, false).Key
+	boom := errors.New("boom: simulated WAL append failure")
+
+	tests := []struct {
+		name           string
+		appendErr      error
+		wantTombstoned bool
+	}{
+		{
+			name:           "failed append leaves no doc tombstone",
+			appendErr:      boom,
+			wantTombstoned: false,
+		},
+		{
+			name:           "successful append publishes doc tombstone",
+			appendErr:      nil,
+			wantTombstoned: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			real := newTestMemtableInverted(map[string][]MapPair{
+				string(rowKey): {NewMapPairFromDocIdAndTf(docID, 1, 5, false)},
+			})
+			sumBefore, countBefore := real.GetPropLengths()
+
+			wrapped := &errInjectingMemtable{memtable: real, appendMapSortedErr: tt.appendErr}
+			b := Bucket{
+				active:   wrapped,
+				disk:     &SegmentGroup{},
+				strategy: StrategyInverted,
+				logger:   nullLogger(),
+			}
+
+			err := b.MapDeleteKey(rowKey, mapKey)
+			if tt.appendErr != nil {
+				require.ErrorIs(t, err, tt.appendErr)
+			} else {
+				require.NoError(t, err)
+			}
+
+			tomb, tErr := real.ReadOnlyTombstones()
+			require.NoError(t, tErr)
+			require.Equal(t, tt.wantTombstoned, tomb.Contains(docID))
+
+			if tt.appendErr != nil {
+				// A failed append must be a complete no-op on prop-length tracking too.
+				sumAfter, countAfter := real.GetPropLengths()
+				require.Equal(t, sumBefore, sumAfter)
+				require.Equal(t, countBefore, countAfter)
+			} else {
+				pairs, gErr := real.getMap(rowKey)
+				require.NoError(t, gErr)
+				found := false
+				for _, p := range pairs {
+					if string(p.Key) == string(mapKey) && p.Tombstone {
+						found = true
+					}
+				}
+				require.True(t, found, "expected a tombstone MapPair for the docID in the row")
+			}
+		})
+	}
+}
+
+// TestBucketMapDeleteKey_InvertedWALOrder_PartialFailure pins the multi-doc
+// case: a failed delete for one docID must not affect an unrelated,
+// successful delete for another docID in the same row.
+func TestBucketMapDeleteKey_InvertedWALOrder_PartialFailure(t *testing.T) {
+	rowKey := []byte("row1")
+	docID1, docID2 := uint64(1), uint64(2)
+	mapKey1 := NewMapPairFromDocIdAndTf(docID1, 1, 5, false).Key
+	mapKey2 := NewMapPairFromDocIdAndTf(docID2, 1, 5, false).Key
+	boom := errors.New("boom: simulated WAL append failure")
+
+	real := newTestMemtableInverted(map[string][]MapPair{
+		string(rowKey): {
+			NewMapPairFromDocIdAndTf(docID1, 1, 5, false),
+			NewMapPairFromDocIdAndTf(docID2, 1, 5, false),
+		},
+	})
+	wrapped := &errInjectingMemtable{memtable: real, appendMapSortedErr: boom}
+	b := Bucket{
+		active:   wrapped,
+		disk:     &SegmentGroup{},
+		strategy: StrategyInverted,
+		logger:   nullLogger(),
+	}
+
+	err := b.MapDeleteKey(rowKey, mapKey1)
+	require.ErrorIs(t, err, boom)
+
+	wrapped.appendMapSortedErr = nil
+	err = b.MapDeleteKey(rowKey, mapKey2)
+	require.NoError(t, err)
+
+	tomb, tErr := real.ReadOnlyTombstones()
+	require.NoError(t, tErr)
+	require.False(t, tomb.Contains(docID1), "doc1's failed delete must not be tombstoned")
+	require.True(t, tomb.Contains(docID2), "doc2's successful delete must be tombstoned")
+}

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -595,7 +595,13 @@ func (m *Memtable) appendMapSorted(key []byte, pair MapPair) error {
 	m.updateDirtyAt()
 
 	if m.strategy == StrategyInverted && !pair.Tombstone {
-		docID := binary.LittleEndian.Uint64(pair.Key)
+		// Must match SetTombstone's decode (BigEndian): StrategyInverted keys are
+		// always BigEndian, required for byte-wise sortability. A mismatch here
+		// makes propLengthExists.Set/Remove address different bitmap positions for
+		// the same doc, so SetTombstone can't re-arm the dedup gate below — a doc
+		// re-added after being tombstoned in the same memtable (e.g. an update)
+		// has its new prop length silently dropped instead of recounted.
+		docID := binary.BigEndian.Uint64(pair.Key)
 		fieldLength := math.Float32frombits(binary.LittleEndian.Uint32(pair.Value[4:]))
 		// propLengthExists + currPropLength* are shared with SetTombstone, which no
 		// longer holds the tree lock; guard them with invMu (nested inside m.Lock).

--- a/adapters/repos/db/lsmkv/memtable_prop_length_docid_test.go
+++ b/adapters/repos/db/lsmkv/memtable_prop_length_docid_test.go
@@ -1,0 +1,56 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAppendMapSortedPropLengthDocIDMatchesSetTombstone pins that
+// appendMapSorted and SetTombstone agree on how a MapPair.Key encodes a
+// docID for StrategyInverted. Every other docID key in the package (bucket.go
+// MapDeleteKey, commitlogger_parser_collection.go WAL replay,
+// segment_serialization_inverted.go on-disk encoding) uses BigEndian, since
+// StrategyInverted requires byte-wise-sortable keys.
+//
+// SetTombstone's propLengthExists.Remove(docId) exists to re-arm the
+// propLengthExists.Set(docId) dedup gate in appendMapSorted, so that a doc
+// re-indexed after being tombstoned within the same still-active memtable
+// (delete immediately followed by re-add, e.g. an object update) has its new
+// prop length counted again rather than silently dropped as a "duplicate."
+// If appendMapSorted decodes the docID with a different endianness than
+// SetTombstone, Remove operates on a different bitmap position than the one
+// Set used, so the re-arm never happens: the update's new prop length is
+// dropped from GetPropLengths' running sum/count instead of replacing the
+// stale one.
+func TestAppendMapSortedPropLengthDocIDMatchesSetTombstone(t *testing.T) {
+	m := newTestMemtableInverted(nil)
+	rowKey := []byte("key1")
+	docID := uint64(42)
+
+	require.NoError(t, m.appendMapSorted(rowKey, NewMapPairFromDocIdAndTf(docID, 3, 7, false)))
+	sum, count := m.GetPropLengths()
+	require.Equal(t, uint64(7), sum)
+	require.Equal(t, uint64(1), count)
+
+	require.NoError(t, m.SetTombstone(docID))
+
+	// Re-add the same docID with a different prop length, simulating an
+	// update applied within the same live memtable.
+	require.NoError(t, m.appendMapSorted(rowKey, NewMapPairFromDocIdAndTf(docID, 3, 20, false)))
+
+	sum, count = m.GetPropLengths()
+	require.Equal(t, uint64(27), sum, "the re-add after tombstone must be counted, not silently dropped")
+	require.Equal(t, uint64(2), count, "the re-add after tombstone must be counted, not silently dropped")
+}


### PR DESCRIPTION
## What's being changed

Two related fixes to the inverted-strategy delete path in `lsmkv`, both pinned with tests that fail on the unfixed code.

### 1. `MapDeleteKey` published the doc tombstone before the WAL append could fail

For `StrategyInverted`, `MapDeleteKey` called `SetTombstone(docID)` — publishing the doc-level tombstone bitmap and removing the doc from `propLengthExists` — *before* `appendMapSorted`, which is what writes the tombstone pair to the WAL. If the WAL append failed, the bitmap mutation stood with no durable record: reads suppressed the document, but a restart replayed the WAL, reconstructed the bitmap from persisted pairs, and silently resurrected it.

WAL replay (`commitlogger_parser_collection.go`) derives the bitmap *from* the persisted pair, so recovery order is append → tombstone. Runtime now matches: the pair is appended first, and the bitmap is only published once the append succeeds. A failed delete leaves no state change at all.

A grep audit confirmed these are the only two mutators of the doc-tombstone state: `MapDeleteKey` (fixed here) and the WAL replay parser (derives from already-durable data, no equivalent hazard).

### 2. Endianness regression in `appendMapSorted`'s prop-length tracking

`appendMapSorted` decoded the inverted docID with `binary.LittleEndian.Uint64(pair.Key)`, while every other reader of the same key — `SetTombstone` via `MapDeleteKey`, WAL replay, the on-disk decode path — uses `BigEndian` (inverted keys are BigEndian for byte-wise sortability). Git history shows the original code used BigEndian; #10596 reintroduced the block with LittleEndian by mistake.

The mismatch means `propLengthExists.Set` (append) and `.Remove` (tombstone) address different bitmap positions for the same doc, so tombstoning never re-arms the dedup gate: a document re-added after being deleted within the same active memtable (i.e. an object update) has its new property length silently dropped from the running `GetPropLengths` sum/count, skewing the live memtable's contribution to BM25's average property length until flush. The red test showed sum=7/count=1 where sum=27/count=2 was expected.

This regression also exists on `stable/v1.38` and `main` and needs front-porting.

## Testing

- `TestBucketMapDeleteKey_InvertedWALOrder`: failed append leaves the tombstone bitmap and prop-length counters untouched (red on unfixed code); successful delete sets the bitmap and the row shows the tombstone pair; a two-doc partial-failure case tombstones only the doc whose append succeeded.
- `TestAppendMapSortedPropLengthDocIDMatchesSetTombstone`: tombstone-then-readd recounts the new prop length (red on unfixed code).
- Full `adapters/repos/db/lsmkv` suite with `-race`, `go vet`, `golangci-lint`, gofumpt, goroutine linter: clean.
