### PR TITLE
fix(lsmkv): retain and retry failed flushing memtable instead of overwriting it

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1617,6 +1617,26 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.metrics.ObserveBucketShutdownDurationByStrategy(b.strategy, time.Since(start))
 	}()
 
+	// A retained flushing memtable from a failed flush has no worker left
+	// once the flush cycle is unregistered below: nothing will ever turn
+	// b.flushing back to nil on its own, so the wait loop further down would
+	// just run out the clock on ctx. Drain it now, while disk is still live
+	// (addInitializedSegment below needs it) — deliberately bypassing the
+	// shard-readonly gate that flushRetainedOnly enforces for new switches,
+	// because shutdown must still persist writes the caller already got an
+	// ack for, readonly or not.
+	if b.hasPendingFlush() {
+		b.flushAndSwitchMu.Lock()
+		var drainErr error
+		if b.hasPendingFlush() {
+			drainErr = b.flushRetained()
+		}
+		b.flushAndSwitchMu.Unlock()
+		if drainErr != nil {
+			return drainErr
+		}
+	}
+
 	if err := b.disk.shutdown(ctx); err != nil {
 		return err
 	}
@@ -1693,8 +1713,8 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 	walTooLarge := uint64(commitLogSize) >= b.walThreshold
 	dirtyTooLong := b.active.DirtyDuration() >= b.flushDirtyAfter
 	shouldSwitch := memtableTooLarge || walTooLarge || dirtyTooLong
-	// A retained b.flushing from a previously failed flush must be retried
-	// even if the current active memtable is otherwise quiet, or it would
+	// A retained b.flushing from a failed flush must be retried even if the
+	// current active memtable is otherwise quiet, or it would
 	// never get another chance: its own thresholds no longer drive anything
 	// once it's off the active path.
 	needsRetry := b.flushing != nil
@@ -1702,8 +1722,10 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 	// If true, the parent shard has indicated that it has
 	// entered an immutable state. During this time, the
 	// bucket should refrain from flushing until its shard
-	// indicates otherwise
-	if shouldSwitch && b.isReadOnly() {
+	// indicates otherwise. A retained flush counts too: if the shard is
+	// READONLY, do not retry it here — that would error-log on every
+	// callback invocation instead of backing off with haltedFlushTimer.
+	if (shouldSwitch || needsRetry) && b.isReadOnly() {
 		if b.haltedFlushTimer.IntervalElapsed() {
 			b.logger.WithField("action", "lsm_memtable_flush").
 				WithField("path", b.dir).
@@ -1721,17 +1743,33 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 	}
 
 	b.flushLock.RUnlock()
-	if shouldSwitch || needsRetry {
+
+	// A retained flush with an otherwise-quiet active memtable is drained on
+	// its own, without switching or resizing based on the quiet memtable's
+	// (irrelevant) cycle length.
+	if needsRetry && !shouldSwitch {
+		b.haltedFlushTimer.Reset()
+		if err := b.flushRetainedOnly(); err != nil {
+			b.logger.WithField("action", "lsm_memtable_flush").
+				WithField("path", b.GetDir()).
+				Errorf("flush and switch failed: %v", err)
+			return false
+		}
+		return true
+	}
+
+	if shouldSwitch {
 		b.haltedFlushTimer.Reset()
 		cycleLength := b.active.ActiveDuration()
-		if err := b.FlushAndSwitch(); err != nil {
+		switched, err := b.flushAndSwitch()
+		if err != nil {
 			b.logger.WithField("action", "lsm_memtable_flush").
 				WithField("path", b.GetDir()).
 				Errorf("flush and switch failed: %v", err)
 			return false
 		}
 
-		if b.memtableResizer != nil {
+		if switched && b.memtableResizer != nil {
 			next, ok := b.memtableResizer.NextTarget(int(b.memtableThreshold), cycleLength)
 			if ok {
 				b.memtableThreshold = uint64(next)
@@ -1790,10 +1828,6 @@ func (b *Bucket) readOnlyErr() error {
 // Flushing and adding a segment can take considerable time, which is why the
 // whole process is designed to be non-blocking.
 //
-// If steps 2-4 below fail, the memtable stays in b.flushing rather than
-// being discarded, and the next FlushAndSwitch call retries it (via
-// flushRetained) before switching a new memtable in.
-//
 // To achieve a non-blocking flush, the process is split into four parts:
 //
 //  1. atomicallySwitchMemtable: A new memtable is created, the previous
@@ -1836,12 +1870,24 @@ func (b *Bucket) readOnlyErr() error {
 // calling, but there are some situations where this might be intended, such as
 // in test scenarios or when a force flush is desired.
 func (b *Bucket) FlushAndSwitch() error {
-	if err := b.readOnlyErr(); err != nil {
-		return err
-	}
+	_, err := b.flushAndSwitch()
+	return err
+}
 
+// flushAndSwitch is FlushAndSwitch's implementation. switched reports
+// whether the active memtable itself was switched and flushed — false when
+// there was nothing to switch, or when only a retained flush was drained.
+func (b *Bucket) flushAndSwitch() (switched bool, err error) {
 	b.flushAndSwitchMu.Lock()
 	defer b.flushAndSwitchMu.Unlock()
+
+	// The authoritative read-only check: it must happen after acquiring
+	// flushAndSwitchMu, not before, or a caller that passes the check while
+	// queued behind another FlushAndSwitch could still flush once the
+	// bucket has since gone READONLY.
+	if err := b.readOnlyErr(); err != nil {
+		return false, err
+	}
 
 	before := time.Now()
 	bucketPath := b.GetDir()
@@ -1850,33 +1896,28 @@ func (b *Bucket) FlushAndSwitch() error {
 		WithField("path", bucketPath).
 		Trace("start flush and switch")
 
-	// A previous FlushAndSwitch call may have switched the active memtable
-	// into b.flushing and then failed before the flush reached disk.
-	// Switching again here would overwrite b.flushing and permanently hide
-	// its acknowledged writes from every reader until the WAL is replayed
-	// on restart, so drain it before considering a new switch.
 	if b.hasPendingFlush() {
 		if err := b.flushRetained(); err != nil {
-			return err
+			return false, err
 		}
 	}
 
-	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	didSwitch, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
 	if err != nil {
 		b.logger.WithField("action", "lsm_memtable_flush_start").
 			WithField("path", bucketPath).
 			Errorf("switch memtable: %v", err)
-		return fmt.Errorf("flush and switch: %w", err)
+		return false, fmt.Errorf("flush and switch: %w", err)
 	}
-	if !switched {
+	if !didSwitch {
 		b.logger.WithField("action", "lsm_memtable_flush_start").
 			WithField("path", bucketPath).
 			Trace("flush and switch not needed")
-		return nil
+		return false, nil
 	}
 
 	if err := b.flushRetained(); err != nil {
-		return err
+		return false, err
 	}
 
 	took := time.Since(before)
@@ -1889,7 +1930,24 @@ func (b *Bucket) FlushAndSwitch() error {
 		WithField("took", took).
 		Debugf("flush and switch took %s\n", took)
 
-	return nil
+	return true, nil
+}
+
+// flushRetainedOnly drains a retained flush left by a failed FlushAndSwitch,
+// without switching or resizing the active memtable. It is a no-op if
+// nothing is retained.
+func (b *Bucket) flushRetainedOnly() error {
+	b.flushAndSwitchMu.Lock()
+	defer b.flushAndSwitchMu.Unlock()
+
+	if err := b.readOnlyErr(); err != nil {
+		return err
+	}
+
+	if !b.hasPendingFlush() {
+		return nil
+	}
+	return b.flushRetained()
 }
 
 // hasPendingFlush reports whether b.flushing is populated, i.e. a previous

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -91,7 +91,17 @@ type Bucket struct {
 
 	// Lock() means a move from active to flushing is happening, RLock() is
 	// normal operation
-	flushLock        sync.RWMutex
+	flushLock sync.RWMutex
+
+	// flushAndSwitchMu serializes FlushAndSwitch calls, and with them the
+	// retry drain that flushRetained performs against b.flushing. Without
+	// it, two overlapping callers (the flush cycle callback and a
+	// control-plane caller such as FlushMemtable) could both observe a
+	// retained b.flushing and race to clear it, or one could switch the
+	// active memtable out from under the other's retry.
+	//
+	// Lock ordering: flushAndSwitchMu MUST be acquired BEFORE flushLock.
+	flushAndSwitchMu sync.Mutex
 	haltedFlushTimer *interval.BackoffTimer
 
 	minWalThreshold   uint64
@@ -1683,6 +1693,11 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 	walTooLarge := uint64(commitLogSize) >= b.walThreshold
 	dirtyTooLong := b.active.DirtyDuration() >= b.flushDirtyAfter
 	shouldSwitch := memtableTooLarge || walTooLarge || dirtyTooLong
+	// A retained b.flushing from a previously failed flush must be retried
+	// even if the current active memtable is otherwise quiet, or it would
+	// never get another chance: its own thresholds no longer drive anything
+	// once it's off the active path.
+	needsRetry := b.flushing != nil
 
 	// If true, the parent shard has indicated that it has
 	// entered an immutable state. During this time, the
@@ -1700,20 +1715,19 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 		return false
 	}
 
-	if b.shouldReuseWAL() {
+	if !needsRetry && b.shouldReuseWAL() {
 		defer b.flushLock.RUnlock()
 		return b.getAndUpdateWritesSinceLastSync()
 	}
 
 	b.flushLock.RUnlock()
-	if shouldSwitch {
+	if shouldSwitch || needsRetry {
 		b.haltedFlushTimer.Reset()
 		cycleLength := b.active.ActiveDuration()
 		if err := b.FlushAndSwitch(); err != nil {
 			b.logger.WithField("action", "lsm_memtable_flush").
 				WithField("path", b.GetDir()).
-				WithError(err).
-				Errorf("flush and switch failed")
+				Errorf("flush and switch failed: %v", err)
 			return false
 		}
 
@@ -1776,6 +1790,10 @@ func (b *Bucket) readOnlyErr() error {
 // Flushing and adding a segment can take considerable time, which is why the
 // whole process is designed to be non-blocking.
 //
+// If steps 2-4 below fail, the memtable stays in b.flushing rather than
+// being discarded, and the next FlushAndSwitch call retries it (via
+// flushRetained) before switching a new memtable in.
+//
 // To achieve a non-blocking flush, the process is split into four parts:
 //
 //  1. atomicallySwitchMemtable: A new memtable is created, the previous
@@ -1822,20 +1840,32 @@ func (b *Bucket) FlushAndSwitch() error {
 		return err
 	}
 
-	before := time.Now()
-	var err error
+	b.flushAndSwitchMu.Lock()
+	defer b.flushAndSwitchMu.Unlock()
 
+	before := time.Now()
 	bucketPath := b.GetDir()
 
 	b.logger.WithField("action", "lsm_memtable_flush_start").
 		WithField("path", bucketPath).
 		Trace("start flush and switch")
 
+	// A previous FlushAndSwitch call may have switched the active memtable
+	// into b.flushing and then failed before the flush reached disk.
+	// Switching again here would overwrite b.flushing and permanently hide
+	// its acknowledged writes from every reader until the WAL is replayed
+	// on restart, so drain it before considering a new switch.
+	if b.hasPendingFlush() {
+		if err := b.flushRetained(); err != nil {
+			return err
+		}
+	}
+
 	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
 	if err != nil {
 		b.logger.WithField("action", "lsm_memtable_flush_start").
 			WithField("path", bucketPath).
-			Error(err)
+			Errorf("switch memtable: %v", err)
 		return fmt.Errorf("flush and switch: %w", err)
 	}
 	if !switched {
@@ -1845,6 +1875,36 @@ func (b *Bucket) FlushAndSwitch() error {
 		return nil
 	}
 
+	if err := b.flushRetained(); err != nil {
+		return err
+	}
+
+	took := time.Since(before)
+	b.logger.WithField("action", "lsm_memtable_flush_complete").
+		WithField("path", bucketPath).
+		Trace("finish flush and switch")
+
+	b.logger.WithField("action", "lsm_memtable_flush_complete").
+		WithField("path", bucketPath).
+		WithField("took", took).
+		Debugf("flush and switch took %s\n", took)
+
+	return nil
+}
+
+// hasPendingFlush reports whether b.flushing is populated, i.e. a previous
+// FlushAndSwitch switched a memtable out of active but did not finish
+// flushing it to disk.
+func (b *Bucket) hasPendingFlush() bool {
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+	return b.flushing != nil
+}
+
+// flushRetained flushes the current b.flushing memtable to disk and adds
+// the resulting segment to the segment group. Callers must hold
+// flushAndSwitchMu and must only call this when b.flushing is non-nil.
+func (b *Bucket) flushRetained() error {
 	// Before we can start the actual flush, we need to make sure that all
 	// ongoing writers have finished their write, otherwise we could lose the
 	// write.
@@ -1925,16 +1985,6 @@ func (b *Bucket) FlushAndSwitch() error {
 		}
 	}
 
-	took := time.Since(before)
-	b.logger.WithField("action", "lsm_memtable_flush_complete").
-		WithField("path", bucketPath).
-		Trace("finish flush and switch")
-
-	b.logger.WithField("action", "lsm_memtable_flush_complete").
-		WithField("path", bucketPath).
-		WithField("took", took).
-		Debugf("flush and switch took %s\n", took)
-
 	return nil
 }
 
@@ -1945,6 +1995,15 @@ func (b *Bucket) FlushAndSwitch() error {
 func (b *Bucket) atomicallySwitchMemtable(createNewActiveMemtable func() (memtable, error)) (bool, error) {
 	b.flushLock.Lock()
 	defer b.flushLock.Unlock()
+
+	// A non-nil b.flushing still holds acknowledged, unflushed writes.
+	// Overwriting it here would drop that memtable from the read path
+	// entirely until the WAL is replayed on restart. FlushAndSwitch always
+	// drains a pending flush before switching again; reaching this with
+	// b.flushing set means a caller bypassed that drain.
+	if b.flushing != nil {
+		return false, fmt.Errorf("switch active memtable: previous flushing memtable not yet cleared")
+	}
 
 	if b.active.Size() == 0 {
 		return false, nil

--- a/adapters/repos/db/lsmkv/bucket_backup.go
+++ b/adapters/repos/db/lsmkv/bucket_backup.go
@@ -28,8 +28,12 @@ import (
 //
 // This is a preparatory stage for creating backups.
 //
-// Method should be run only if flushCycle is not running
-// (was not started, is stopped, or noop impl is provided)
+// FlushMemtable is serialized with the periodic flush cycle through
+// flushAndSwitchMu, so it is safe to call while the cycle is running.
+// Callers that need the on-disk file set to stay stable afterward (e.g.
+// while copying segment files for a backup) must still deactivate the
+// flush cycle themselves — serialization only prevents concurrent flushes,
+// it does not stop a later one from adding a new segment.
 func (b *Bucket) FlushMemtable() error {
 	if err := b.readOnlyErr(); err != nil {
 		return fmt.Errorf("flush memtable: %w", err)

--- a/adapters/repos/db/lsmkv/bucket_flush_retry_crash_sim_integration_test.go
+++ b/adapters/repos/db/lsmkv/bucket_flush_retry_crash_sim_integration_test.go
@@ -1,0 +1,152 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// TestFlushAfterCommitLogCloseFailureSurvivesReopen crash-sims a flush that
+// completed despite a commit-log close failure: the segment landed and the
+// WAL was deleted as part of that same successful flush, so a copy of the
+// directory taken afterward must reopen and read the row straight from the
+// segment.
+func TestFlushAfterCommitLogCloseFailureSurvivesReopen(t *testing.T) {
+	ctx := testCtx()
+	dir := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1e9)
+
+	realCL, err := newCommitLogger(filepath.Join(b.GetDir(), "segment-custom"), StrategyReplace, 0)
+	require.NoError(t, err)
+	m := newRealMemtableWithCommitLogger(t, filepath.Join(b.GetDir(), "segment-custom"), StrategyReplace,
+		&failNCloseCommitLogger{memtableCommitLogger: realCL, failN: 1})
+	b.active = m
+
+	require.NoError(t, b.Put([]byte("key"), []byte("value")))
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.Shutdown(ctx))
+
+	recoveryDir := t.TempDir()
+	copyDir(t, dir, recoveryDir)
+
+	reopened, err := NewBucketCreator().NewBucket(ctx, recoveryDir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	defer reopened.Shutdown(ctx)
+
+	v, err := reopened.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), v)
+}
+
+// TestFlushAndSwitchRetainedFlushSurvivesReopen crash-sims a retained flush
+// that never got a chance to retry: the injected failure returns before
+// Memtable.flush() ever runs, so the WAL is untouched. A copy of the
+// directory taken right after the failed FlushAndSwitch call must recover
+// the retained row through ordinary WAL replay on open.
+func TestFlushAndSwitchRetainedFlushSurvivesReopen(t *testing.T) {
+	ctx := testCtx()
+	dir := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1e9)
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	// WriteWAL is what callers actually rely on for durability (Bucket.Put
+	// alone only buffers); force it here so the crash-sim below reflects a
+	// genuinely acknowledged write, not an artifact of the test never
+	// syncing the WAL.
+	require.NoError(t, b.WriteWAL())
+
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+	require.NoError(t, b.WriteWAL())
+
+	recoveryDir := t.TempDir()
+	copyDir(t, dir, recoveryDir)
+	require.NoError(t, b.Shutdown(ctx))
+
+	reopened, err := NewBucketCreator().NewBucket(ctx, recoveryDir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	defer reopened.Shutdown(ctx)
+
+	vA, err := reopened.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+
+	vB, err := reopened.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+}
+
+// TestFlushRetryPostDurableFailureCrashWindow documents a real gap rather
+// than pinning a guarantee: if the segment file becomes unreadable strictly
+// after Memtable.flush() already succeeded (WAL closed AND deleted, as the
+// last step of that same successful call) and the process is replaced
+// before the in-process retry gets to run, there is nothing left to recover
+// from — the WAL is gone and the only on-disk copy is corrupt. This test
+// pins the actual observed behavior of opening a bucket in that state, so a
+// silent behavior change here is caught; it is not a claim that the data is
+// recoverable.
+func TestFlushRetryPostDurableFailureCrashWindow(t *testing.T) {
+	ctx := testCtx()
+	dir := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1e9)
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &corruptSegmentOnceMemtable{memtable: b.active}
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	recoveryDir := t.TempDir()
+	copyDir(t, dir, recoveryDir)
+	require.NoError(t, b.Shutdown(ctx))
+
+	// No .wal file survives this state: flush() already deleted it as the
+	// last step of its otherwise-successful run, before the corruption was
+	// injected on the return path.
+	entries, err := os.ReadDir(recoveryDir)
+	require.NoError(t, err)
+	sawWAL := false
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".wal" {
+			sawWAL = true
+		}
+	}
+	require.False(t, sawWAL, "no WAL should survive: flush() deletes it as its last successful step")
+
+	_, err = NewBucketCreator().NewBucket(ctx, recoveryDir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.Error(t, err, "opening a bucket on a corrupt, unrecoverable segment is expected to fail loudly rather than silently drop the row")
+}

--- a/adapters/repos/db/lsmkv/bucket_flush_retry_hardening_test.go
+++ b/adapters/repos/db/lsmkv/bucket_flush_retry_hardening_test.go
@@ -1,0 +1,503 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storagestate"
+)
+
+var errInjectedCloseFailure = errors.New("injected commit log close failure")
+
+// failNCloseCommitLogger wraps a real memtableCommitLogger and makes its
+// next N close() calls fail without touching the underlying logger, so a
+// test can simulate a WAL close failure independently of the flush that
+// follows it.
+type failNCloseCommitLogger struct {
+	memtableCommitLogger
+	failN int
+}
+
+func (cl *failNCloseCommitLogger) close() error {
+	if cl.failN > 0 {
+		cl.failN--
+		return errInjectedCloseFailure
+	}
+	return cl.memtableCommitLogger.close()
+}
+
+// newRealMemtableWithCommitLogger builds a real *Memtable backed by cl, for
+// tests that need to control commit-log behavior independently of
+// Memtable.flush() itself.
+func newRealMemtableWithCommitLogger(t *testing.T, path, strategy string, cl memtableCommitLogger) *Memtable {
+	t.Helper()
+	m, err := newMemtable(cl, nil, nullLogger(), nil, memtableConfig{
+		path:     path,
+		strategy: strategy,
+	})
+	require.NoError(t, err)
+	return m
+}
+
+// TestCommitLoggerCloseTerminalOnError pins that a close() failure still
+// leaves the logger in its terminal closed state: the underlying fd is
+// unusable either way (bufio.Writer errors are sticky, and a failed
+// os.File.Close still consumes the fd), so a second close() must not
+// attempt the sequence again.
+func TestCommitLoggerCloseTerminalOnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "segment")
+	cl, err := newCommitLogger(path, StrategyReplace, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, cl.put(segmentReplaceNode{primaryKey: []byte("k"), value: []byte("v")}))
+
+	// Close the fd out from under the logger: writer.Flush's pending bytes
+	// now have nowhere to go.
+	require.NoError(t, cl.file.Close())
+
+	require.Error(t, cl.close())
+	require.NoError(t, cl.close())
+}
+
+// TestFlushProceedsAfterCommitLogCloseFailure pins that Memtable.flush()
+// treats a commit-log close failure as non-fatal: the memtable is the
+// source of truth for the segment written right after, so the flush must
+// still land the row on disk instead of aborting.
+func TestFlushProceedsAfterCommitLogCloseFailure(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	realCL, err := newCommitLogger(filepath.Join(b.GetDir(), "segment-custom"), StrategyReplace, 0)
+	require.NoError(t, err)
+	m := newRealMemtableWithCommitLogger(t, filepath.Join(b.GetDir(), "segment-custom"), StrategyReplace,
+		&failNCloseCommitLogger{memtableCommitLogger: realCL, failN: 1})
+	b.active = m
+
+	require.NoError(t, b.Put([]byte("key"), []byte("value")))
+
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.Nil(t, b.flushing)
+	require.Zero(t, b.active.Size())
+
+	v, err := b.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), v)
+}
+
+// TestFlushAndSwitchReadOnlyCheckInsideMutex pins that the shard-readonly
+// check happens after flushAndSwitchMu is acquired, not before: a caller
+// queued behind an in-flight FlushAndSwitch must see the bucket's current
+// status, not a stale snapshot taken before it was queued.
+func TestFlushAndSwitchReadOnlyCheckInsideMutex(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+
+	blocker := &blockingFlushMemtable{
+		memtable: b.active,
+		started:  make(chan struct{}),
+		proceed:  make(chan struct{}),
+	}
+	b.active = blocker
+
+	firstDone := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		firstDone <- b.FlushAndSwitch()
+	}, nullLogger())
+
+	<-blocker.started
+
+	type result struct {
+		switched bool
+		err      error
+	}
+	secondDone := make(chan result, 1)
+	enterrors.GoWrapper(func() {
+		switched, err := b.flushAndSwitch()
+		secondDone <- result{switched, err}
+	}, nullLogger())
+
+	// Give the second caller a chance to actually reach flushAndSwitchMu.Lock
+	// before flipping the status: this is what makes the assertion below
+	// exercise the "queued, then bucket goes READONLY" ordering rather than
+	// racing it. On the fix this ordering doesn't matter — the second
+	// caller always re-reads status after acquiring the mutex — but without
+	// it a still-buggy check-before-lock could win the race often enough to
+	// pass by luck.
+	time.Sleep(50 * time.Millisecond)
+
+	b.UpdateStatus(storagestate.StatusReadOnly)
+	close(blocker.proceed)
+
+	require.NoError(t, <-firstDone)
+
+	res := <-secondDone
+	require.False(t, res.switched)
+	require.ErrorIs(t, res.err, storagestate.ErrStatusReadOnly)
+
+	b.UpdateStatus(storagestate.StatusReady)
+}
+
+// blockingFlushMemtable wraps a real memtable and blocks inside flush()
+// until released, signaling started once it has entered the call. Used to
+// deterministically queue a second FlushAndSwitch caller behind the first.
+type blockingFlushMemtable struct {
+	memtable
+	started chan struct{}
+	proceed chan struct{}
+	once    sync.Once
+}
+
+func (m *blockingFlushMemtable) flush() (string, error) {
+	m.once.Do(func() { close(m.started) })
+	<-m.proceed
+	return m.memtable.flush()
+}
+
+// TestFlushAndSwitchIfThresholdsMetDoesNotForceFlushQuietActive pins that a
+// retained flush is drained on its own: it must not force-flush an
+// otherwise-quiet active memtable just because it happened to be there,
+// discarding the active memtable's in-progress dirty state along with it.
+func TestFlushAndSwitchIfThresholdsMetDoesNotForceFlushQuietActive(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+	activeBefore := b.active
+
+	noAbort := func() bool { return false }
+	require.True(t, b.flushAndSwitchIfThresholdsMet(noAbort))
+
+	require.Nil(t, b.flushing)
+
+	// The active memtable is the same instance from before the callback,
+	// still holding row B unflushed in memory: only the retained flush (row
+	// A) was drained.
+	require.Same(t, activeBefore, b.active)
+	require.NotZero(t, b.active.Size())
+
+	vA, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+
+	vB, err := b.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+}
+
+// TestFlushAndSwitchIfThresholdsMetRetryDoesNotResize pins that draining a
+// retained flush alone never feeds the memtable size advisor: the quiet
+// active memtable's (near-zero) cycle length is not a meaningful signal for
+// resizing, and must not be treated as one.
+func TestFlushAndSwitchIfThresholdsMetRetryDoesNotResize(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	logger := nullLogger()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+	b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil, noopCB, noopCB,
+		WithStrategy(StrategyReplace),
+		WithDynamicMemtableSizing(1, 2, 60, 120),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	thresholdBefore := b.memtableThreshold
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	noAbort := func() bool { return false }
+	require.True(t, b.flushAndSwitchIfThresholdsMet(noAbort))
+
+	require.Nil(t, b.flushing)
+	require.Equal(t, thresholdBefore, b.memtableThreshold)
+}
+
+// TestFlushAndSwitchIfThresholdsMetReadonlyThenReady pins the READONLY
+// backoff path for a retained flush: while the shard is READONLY, the
+// retry must not run — and must hit the existing halted-flush backoff
+// warning instead of error-logging on every callback tick — and once the
+// shard returns to READY the retained flush completes.
+func TestFlushAndSwitchIfThresholdsMetReadonlyThenReady(t *testing.T) {
+	ctx := context.Background()
+	logger, hook := logrustest.NewNullLogger()
+	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	b.SetMemtableThreshold(1e9)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	b.UpdateStatus(storagestate.StatusReadOnly)
+	hook.Reset()
+
+	noAbort := func() bool { return false }
+	for i := 0; i < 3; i++ {
+		require.False(t, b.flushAndSwitchIfThresholdsMet(noAbort))
+		require.NotNil(t, b.flushing, "retained flush must not be dropped while READONLY")
+	}
+
+	for _, entry := range hook.AllEntries() {
+		// logrus severity is inverted (ErrorLevel=2 < WarnLevel=3): this
+		// rejects Error/Fatal/Panic while allowing the expected Warn.
+		require.Greaterf(t, entry.Level, logrus.ErrorLevel, "unexpected error-level log while READONLY: %s", entry.Message)
+	}
+
+	b.UpdateStatus(storagestate.StatusReady)
+
+	require.True(t, b.flushAndSwitchIfThresholdsMet(noAbort))
+	require.Nil(t, b.flushing)
+
+	v, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), v)
+}
+
+// TestShutdownDrainsRetainedFlush pins that Shutdown does not strand a
+// retained flush: with no flush-cycle worker left to retry it, the wait
+// loop further down would otherwise just run out the clock on ctx.
+func TestShutdownDrainsRetainedFlush(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := createTestBucket(t, ctx, dir, StrategyReplace)
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+
+	shutdownCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	require.NoError(t, b.Shutdown(shutdownCtx))
+
+	reopened, err := NewBucketCreator().NewBucket(ctx, dir, "", nullLogger(), nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Shutdown(ctx)) })
+
+	vA, err := reopened.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+
+	vB, err := reopened.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+}
+
+// TestFlushAndSwitchRecoversFromTwoConsecutiveFailures pins that the retry
+// is not a one-shot: a memtable can be retried across more than one failed
+// attempt without losing data.
+func TestFlushAndSwitchRecoversFromTwoConsecutiveFailures(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 2}
+
+	require.Error(t, b.FlushAndSwitch())
+	vA, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+	require.Error(t, b.FlushAndSwitch())
+
+	vA, err = b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+	vB, err := b.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+
+	require.NoError(t, b.Put([]byte("C"), []byte("vC")))
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.Nil(t, b.flushing)
+	for k, v := range map[string]string{"A": "vA", "B": "vB", "C": "vC"} {
+		got, err := b.Get([]byte(k))
+		require.NoError(t, err)
+		require.Equal(t, []byte(v), got)
+	}
+}
+
+// TestConcurrentFlushAndSwitchWithRetainedState drives two overlapping
+// FlushAndSwitch callers against a bucket that already has a retained
+// flush: flushAndSwitchMu must serialize them so neither loses data nor
+// overwrites the other's retained memtable. Run with -race.
+func TestConcurrentFlushAndSwitchWithRetainedState(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+
+	blocker := &blockingFlushMemtable{
+		memtable: b.active,
+		started:  make(chan struct{}),
+		proceed:  make(chan struct{}),
+	}
+	b.active = blocker
+
+	firstDone := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		firstDone <- b.FlushAndSwitch()
+	}, nullLogger())
+
+	<-blocker.started
+
+	secondDone := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		secondDone <- b.FlushAndSwitch()
+	}, nullLogger())
+
+	close(blocker.proceed)
+
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+
+	require.Nil(t, b.flushing)
+	vA, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+	vB, err := b.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+}
+
+// corruptSegmentOnceMemtable lets flush() succeed for real (so the commit
+// log is genuinely closed and the WAL genuinely deleted, exactly as a
+// successful flush would), then truncates the segment file it just wrote,
+// once. This simulates the segment becoming unreadable strictly after a
+// successful flush() call — e.g. out-of-band corruption — so the failure
+// surfaces one step later, in initAndPrecomputeNewSegment.
+type corruptSegmentOnceMemtable struct {
+	memtable
+	corrupted bool
+}
+
+func (m *corruptSegmentOnceMemtable) flush() (string, error) {
+	segmentPath, err := m.memtable.flush()
+	if err != nil || m.corrupted {
+		return segmentPath, err
+	}
+	m.corrupted = true
+	if err := os.Truncate(segmentPath, 4); err != nil {
+		return segmentPath, err
+	}
+	return segmentPath, nil
+}
+
+// TestFlushRetryRewritesSegmentAfterPostDurableFailure pins that a retry
+// recovers even when the failure happens after flush() itself already
+// succeeded (WAL closed and deleted, segment written and renamed): the
+// retry re-runs flush() from the memtable's in-memory state regardless,
+// which overwrites whatever partial/corrupt file is sitting at the target
+// path with a fresh, complete one.
+func TestFlushRetryRewritesSegmentAfterPostDurableFailure(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+	b.active = &corruptSegmentOnceMemtable{memtable: b.active}
+
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.Nil(t, b.flushing)
+	vA, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+	vB, err := b.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+}
+
+// TestFlushAndSwitchInvertedRetry pins the inverted-strategy-specific steps
+// on the retry path: setAveragePropertyLength must be recomputed from disk
+// truth (not compounded) on a retried flush, and a tombstone recorded in a
+// retained memtable must still reach existing segments once the retry
+// succeeds.
+func TestFlushAndSwitchInvertedRetry(t *testing.T) {
+	ctx := context.Background()
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyInverted)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.MapSet([]byte("term"), NewMapPairFromDocIdAndTf(1, 3, 5, false)))
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.NoError(t, b.MapSet([]byte("term"), NewMapPairFromDocIdAndTf(2, 1, 7, false)))
+	require.NoError(t, b.active.SetTombstone(1))
+
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	require.NoError(t, b.FlushAndSwitch())
+	require.Nil(t, b.flushing)
+
+	avg, count := b.GetAveragePropertyLength()
+	require.EqualValues(t, 2, count)
+	require.InDelta(t, 6.0, avg, 0.0001)
+
+	// Segment #1 (the one written before the failure, holding doc 1) must
+	// have picked up the tombstone recorded in the retried memtable.
+	require.Len(t, b.disk.segments, 2)
+	tombstones, err := b.disk.segments[0].ReadOnlyTombstones()
+	require.NoError(t, err)
+	require.True(t, tombstones.Contains(1))
+}

--- a/adapters/repos/db/lsmkv/bucket_flush_retry_test.go
+++ b/adapters/repos/db/lsmkv/bucket_flush_retry_test.go
@@ -18,10 +18,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
-
-	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
 var errInjectedFlushFailure = errors.New("injected flush failure")
@@ -42,26 +39,16 @@ func (m *failNFlushesMemtable) flush() (string, error) {
 	return m.memtable.flush()
 }
 
-func newFlushRetryTestBucket(t *testing.T, dir string) *Bucket {
-	t.Helper()
-	noopCB := cyclemanager.NewCallbackGroupNoop()
-	logger, _ := test.NewNullLogger()
-	b, err := NewBucketCreator().NewBucket(context.Background(), dir, "", logger, nil,
-		noopCB, noopCB, WithStrategy(StrategyReplace))
-	require.NoError(t, err)
-	return b
-}
-
 // TestFlushAndSwitchRetainsFailedFlush pins the core bug: a memtable that
 // failed to flush must be retried by the next FlushAndSwitch call, not
-// discarded by it. Before the fix, atomicallySwitchMemtable overwrites
-// b.flushing unconditionally, so the second FlushAndSwitch call below drops
-// row A's memtable on the floor: it was never added to a disk segment, and
-// it's no longer reachable from b.active or b.flushing, so every reader
-// stops seeing it until the WAL is replayed on restart.
+// discarded by it. atomicallySwitchMemtable must never overwrite a non-nil
+// b.flushing, or the second FlushAndSwitch call below drops row A's
+// memtable on the floor: it was never added to a disk segment, and it's no
+// longer reachable from b.active or b.flushing, so every reader stops
+// seeing it until the WAL is replayed on restart.
 func TestFlushAndSwitchRetainsFailedFlush(t *testing.T) {
 	ctx := context.Background()
-	b := newFlushRetryTestBucket(t, t.TempDir())
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
 	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
 
 	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
@@ -106,7 +93,7 @@ func TestFlushAndSwitchRetryAfterPermissionFailure(t *testing.T) {
 
 	ctx := context.Background()
 	dir := t.TempDir()
-	b := newFlushRetryTestBucket(t, dir)
+	b := createTestBucket(t, ctx, dir, StrategyReplace)
 	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
 
 	require.NoError(t, b.Put([]byte("key"), []byte("value")))
@@ -182,7 +169,7 @@ func TestCommitLoggerCloseDeleteIdempotent(t *testing.T) {
 // memtable is quiet and would otherwise never cross a threshold.
 func TestFlushAndSwitchIfThresholdsMetRetriesPendingFlush(t *testing.T) {
 	ctx := context.Background()
-	b := newFlushRetryTestBucket(t, t.TempDir())
+	b := createTestBucket(t, ctx, t.TempDir(), StrategyReplace)
 	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
 
 	require.NoError(t, b.Put([]byte("A"), []byte("vA")))

--- a/adapters/repos/db/lsmkv/bucket_flush_retry_test.go
+++ b/adapters/repos/db/lsmkv/bucket_flush_retry_test.go
@@ -1,0 +1,205 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+var errInjectedFlushFailure = errors.New("injected flush failure")
+
+// failNFlushesMemtable wraps a real memtable and makes its next N flush()
+// calls fail, so tests can drive a real Bucket through a genuine failed
+// flush without faking the whole memtable.
+type failNFlushesMemtable struct {
+	memtable
+	failN int
+}
+
+func (m *failNFlushesMemtable) flush() (string, error) {
+	if m.failN > 0 {
+		m.failN--
+		return "", errInjectedFlushFailure
+	}
+	return m.memtable.flush()
+}
+
+func newFlushRetryTestBucket(t *testing.T, dir string) *Bucket {
+	t.Helper()
+	noopCB := cyclemanager.NewCallbackGroupNoop()
+	logger, _ := test.NewNullLogger()
+	b, err := NewBucketCreator().NewBucket(context.Background(), dir, "", logger, nil,
+		noopCB, noopCB, WithStrategy(StrategyReplace))
+	require.NoError(t, err)
+	return b
+}
+
+// TestFlushAndSwitchRetainsFailedFlush pins the core bug: a memtable that
+// failed to flush must be retried by the next FlushAndSwitch call, not
+// discarded by it. Before the fix, atomicallySwitchMemtable overwrites
+// b.flushing unconditionally, so the second FlushAndSwitch call below drops
+// row A's memtable on the floor: it was never added to a disk segment, and
+// it's no longer reachable from b.active or b.flushing, so every reader
+// stops seeing it until the WAL is replayed on restart.
+func TestFlushAndSwitchRetainsFailedFlush(t *testing.T) {
+	ctx := context.Background()
+	b := newFlushRetryTestBucket(t, t.TempDir())
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+
+	// Wrap the memtable that already holds row A so its flush fails once.
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+
+	err := b.FlushAndSwitch()
+	require.Error(t, err)
+
+	vA, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+
+	// Goes to the real active memtable created by the failed attempt's
+	// switch; only the first memtable was wrapped.
+	require.NoError(t, b.Put([]byte("B"), []byte("vB")))
+
+	require.NoError(t, b.FlushAndSwitch())
+
+	vA, err = b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), vA)
+
+	vB, err := b.Get([]byte("B"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vB"), vB)
+
+	require.Nil(t, b.flushing)
+}
+
+// TestFlushAndSwitchRetryAfterPermissionFailure drives a real memtable
+// through a flush failure that happens after its commit log has already
+// been closed (the tmp-segment OpenFile call, once the bucket directory is
+// unwritable). The retry re-enters Memtable.flush() on the same memtable,
+// which re-closes the already-closed commit log; without idempotent close()
+// that second close fails on the closed file descriptor.
+func TestFlushAndSwitchRetryAfterPermissionFailure(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permission checks")
+	}
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	b := newFlushRetryTestBucket(t, dir)
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("key"), []byte("value")))
+
+	require.NoError(t, os.Chmod(dir, 0o500))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(dir, 0o700)) })
+
+	require.Error(t, b.FlushAndSwitch())
+
+	require.NoError(t, os.Chmod(dir, 0o700))
+
+	require.NoError(t, b.FlushAndSwitch())
+
+	require.Nil(t, b.flushing)
+	require.Zero(t, b.active.Size())
+
+	v, err := b.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), v)
+}
+
+// TestCommitLoggerCloseDeleteIdempotent covers the idempotency that a
+// retried Memtable.flush() relies on directly: a second close() or delete()
+// call, on a commit log the first flush attempt already closed/deleted,
+// must be a no-op rather than an error.
+func TestCommitLoggerCloseDeleteIdempotent(t *testing.T) {
+	newLogger := func(t *testing.T) *commitLogger {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "segment")
+		cl, err := newCommitLogger(path, StrategyReplace, 0)
+		require.NoError(t, err)
+		return cl
+	}
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, cl *commitLogger)
+	}{
+		{
+			name: "close twice",
+			run: func(t *testing.T, cl *commitLogger) {
+				require.NoError(t, cl.close())
+				require.NoError(t, cl.close())
+			},
+		},
+		{
+			name: "delete twice",
+			run: func(t *testing.T, cl *commitLogger) {
+				require.NoError(t, cl.delete())
+				require.NoError(t, cl.delete())
+			},
+		},
+		{
+			name: "close then delete",
+			run: func(t *testing.T, cl *commitLogger) {
+				require.NoError(t, cl.close())
+				require.NoError(t, cl.delete())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := newLogger(t)
+			tt.run(t, cl)
+		})
+	}
+}
+
+// TestFlushAndSwitchIfThresholdsMetRetriesPendingFlush covers the trigger
+// gap: once a flush fails and leaves b.flushing retained, the periodic
+// flush-cycle callback must keep retrying it even while the new active
+// memtable is quiet and would otherwise never cross a threshold.
+func TestFlushAndSwitchIfThresholdsMetRetriesPendingFlush(t *testing.T) {
+	ctx := context.Background()
+	b := newFlushRetryTestBucket(t, t.TempDir())
+	t.Cleanup(func() { require.NoError(t, b.Shutdown(ctx)) })
+
+	require.NoError(t, b.Put([]byte("A"), []byte("vA")))
+
+	b.active = &failNFlushesMemtable{memtable: b.active, failN: 1}
+
+	require.Error(t, b.FlushAndSwitch())
+	require.NotNil(t, b.flushing)
+
+	// The new active memtable is fresh and empty: every threshold is false,
+	// so only the retained-flush check can drive a retry here.
+	noAbort := func() bool { return false }
+	require.True(t, b.flushAndSwitchIfThresholdsMet(noAbort))
+
+	require.Nil(t, b.flushing)
+
+	v, err := b.Get([]byte("A"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("vA"), v)
+}

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -2270,6 +2270,7 @@ func newTestMemtableReplace(initialData map[string][]byte) *testMemtable {
 		key:       &binarySearchTree{},
 		commitlog: newDummyCommitLogger(),
 		metrics:   metrics,
+		logger:    nullLogger(),
 	}
 
 	for k, v := range initialData {
@@ -2291,6 +2292,7 @@ func newTestMemtableRoaringSet(initialData map[string][]uint64) *testMemtable {
 		roaringSet: &roaringset.BinarySearchTree{},
 		commitlog:  newDummyCommitLogger(),
 		metrics:    metrics,
+		logger:     nullLogger(),
 	}
 
 	for k, v := range initialData {
@@ -2313,6 +2315,7 @@ func newTestMemtableRoaringSetRange(initialData map[uint64][]uint64) *testMemtab
 		roaringSetRange: roaringsetrange.NewMemtable(logger),
 		commitlog:       newDummyCommitLogger(),
 		metrics:         metrics,
+		logger:          logger,
 	}
 
 	for k, v := range initialData {
@@ -2334,6 +2337,7 @@ func newTestMemtableSet(initialData map[string][][]byte) *testMemtable {
 		keyMulti:  &binarySearchTreeMulti{},
 		commitlog: newDummyCommitLogger(),
 		metrics:   metrics,
+		logger:    nullLogger(),
 	}
 
 	for k, v := range initialData {
@@ -2354,6 +2358,7 @@ func newTestMemtableMap(initialData map[string][]MapPair) *testMemtable {
 		keyMap:    &binarySearchTreeMap{},
 		commitlog: newDummyCommitLogger(),
 		metrics:   metrics,
+		logger:    nullLogger(),
 	}
 
 	for k, v := range initialData {
@@ -2378,6 +2383,7 @@ func newTestMemtableInverted(initialData map[string][]MapPair) *testMemtable {
 		metrics:          metrics,
 		tombstones:       sroar.NewBitmap(),
 		propLengthExists: sroar.NewBitmap(),
+		logger:           nullLogger(),
 	}
 
 	for k, v := range initialData {

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -187,6 +187,12 @@ type commitLogger struct {
 	// e.g. when recovering from an existing log, we do not want to write into a
 	// new log again
 	paused bool
+
+	// closed makes close() idempotent: a retried Memtable.flush() (after an
+	// earlier attempt failed downstream of a successful close) must be able
+	// to call close() again without re-flushing/re-syncing an already-closed
+	// file.
+	closed bool
 }
 
 // commit log entry data format
@@ -392,6 +398,10 @@ func (cl *commitLogger) sync() error {
 }
 
 func (cl *commitLogger) close() error {
+	if cl.closed {
+		return nil
+	}
+
 	if !cl.paused {
 		if err := cl.writer.Flush(); err != nil {
 			return err
@@ -402,7 +412,12 @@ func (cl *commitLogger) close() error {
 		}
 	}
 
-	return cl.file.Close()
+	if err := cl.file.Close(); err != nil {
+		return err
+	}
+	cl.closed = true
+
+	return nil
 }
 
 func (cl *commitLogger) pause() {
@@ -414,7 +429,10 @@ func (cl *commitLogger) unpause() {
 }
 
 func (cl *commitLogger) delete() error {
-	return os.Remove(cl.path)
+	if err := os.Remove(cl.path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 func (cl *commitLogger) flushBuffers() error {

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -188,10 +188,7 @@ type commitLogger struct {
 	// new log again
 	paused bool
 
-	// closed makes close() idempotent: a retried Memtable.flush() (after an
-	// earlier attempt failed downstream of a successful close) must be able
-	// to call close() again without re-flushing/re-syncing an already-closed
-	// file.
+	// closed makes close() idempotent and terminal; see close()'s doc.
 	closed bool
 }
 
@@ -397,27 +394,35 @@ func (cl *commitLogger) sync() error {
 	return cl.file.Sync()
 }
 
+// close is terminal: once called, this logger stays "closed" even if the
+// flush/sync/close sequence below errors out. bufio.Writer errors are
+// sticky (every later Flush call on the same writer keeps failing) and a
+// failed os.File.Close still leaves the fd unusable, so a retry can never
+// make this file descriptor usable again — every step below runs
+// best-effort instead of stopping at the first error, since a later step
+// (e.g. Sync) can still make already-written bytes durable even after an
+// earlier one failed.
 func (cl *commitLogger) close() error {
 	if cl.closed {
 		return nil
 	}
-
-	if !cl.paused {
-		if err := cl.writer.Flush(); err != nil {
-			return err
-		}
-
-		if err := cl.file.Sync(); err != nil {
-			return err
-		}
-	}
-
-	if err := cl.file.Close(); err != nil {
-		return err
-	}
 	cl.closed = true
 
-	return nil
+	var firstErr error
+	if !cl.paused {
+		if err := cl.writer.Flush(); err != nil {
+			firstErr = err
+		}
+		if err := cl.file.Sync(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	if err := cl.file.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+
+	return firstErr
 }
 
 func (cl *commitLogger) pause() {

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -119,6 +119,7 @@ type Memtable struct {
 	roaringSetRange *roaringsetrange.Memtable
 	commitlog       memtableCommitLogger
 	allocChecker    memwatch.AllocChecker
+	logger          logrus.FieldLogger
 	size            uint64
 	// netCountAdditions approximates the net live keys this memtable adds on
 	// top of the rest of the LSM tree. Whether a key already exists further
@@ -202,6 +203,7 @@ func newMemtable(cl memtableCommitLogger, metrics *Metrics, logger logrus.FieldL
 		roaringSet:                   &roaringset.BinarySearchTree{},
 		roaringSetRange:              roaringsetrange.NewMemtable(logger),
 		commitlog:                    cl,
+		logger:                       logger,
 		path:                         config.path,
 		strategy:                     config.strategy,
 		secondaryIndices:             config.secondaryIndices,

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -66,14 +66,18 @@ func (m *Memtable) flush() (segmentPath string, rerr error) {
 		m.metrics.observeFlushingDuration(m.strategy, time.Since(start))
 	}()
 
-	// close the commit log first, this also forces it to be fsynced. If
-	// something fails there, don't proceed with flushing. The commit log will
-	// only be deleted at the very end, if the flush was successful
-	// (indicated by a successful close of the flush file - which indicates a
-	// successful fsync)
-
+	// Close the commit log first, this also forces it to be fsynced. A close
+	// failure does not abort the flush: the memtable itself is the source of
+	// truth here, and the fsynced segment written below is what makes this
+	// data durable. bufio.Writer errors are sticky (every later Flush call
+	// on the same writer keeps failing), and a failed file.Close still
+	// leaves the fd unusable, so there is no way to recover the WAL's
+	// unwritten tail after this point in-process either way. Aborting would
+	// only leave the data memory-only indefinitely across retries.
 	if err := m.commitlog.close(); err != nil {
-		return "", errors.Wrap(err, "close commit log file")
+		m.logger.WithField("action", "lsm_memtable_flush").
+			WithField("path", m.path).
+			Warnf("close commit log file: %v", err)
 	}
 
 	if m.Size() == 0 {

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -241,11 +241,30 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		_ = fadviseSequential(file)
 	}
 
+	// mmap has some overhead, we can read small files directly to memory.
+	// Declared here (ahead of use) so the defer below can unmap on any
+	// constructor error from this point on, however contents ends up set.
+	var contents []byte
+	var unMapContents bool
+
 	// The lifetime of the `file` exceeds this constructor as we store the open file for later use in `contentFile`.
 	// invariant: We close **only** if any error happened after successfully opening the file. To avoid leaking open file descriptor.
 	// NOTE: This `defer` works even with `err` being shadowed in the whole function because defer checks for named `rerr` return value.
+	//
+	// A constructor error after mmap.MapRegion succeeds (unMapContents set)
+	// must also unmap contents, or every failed load/retry leaks one
+	// mapping — this defer runs after both variables are assigned, so it
+	// always sees their final values.
 	defer func() {
 		if rerr != nil {
+			if unMapContents {
+				m := mmap.MMap(contents)
+				if err := m.Unmap(); err != nil {
+					logger.WithField("action", "lsm_segment_init").
+						WithField("path", path).
+						Warnf("unmap segment file after init error: %v", err)
+				}
+			}
 			file.Close()
 		}
 	}()
@@ -266,9 +285,6 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		size = fileInfo.Size()
 	}
 
-	// mmap has some overhead, we can read small files directly to memory
-	var contents []byte
-	var unMapContents bool
 	var allocCheckerErr error
 
 	if size <= cfg.MinMMapSize { // check if it is a candidate for full reading


### PR DESCRIPTION
## What's being changed

`atomicallySwitchMemtable` set `b.flushing` unconditionally. When a flush failed *after* the active→flushing switch (any error in `Memtable.flush()`, `initAndPrecomputeNewSegment`, or `atomicallyAddDiskSegmentAndRemoveFlushing`), `FlushAndSwitch` returned with `b.flushing` still holding acknowledged, unflushed writes — reads still saw them through the consistent view, and the WAL survived on disk. But the next `FlushAndSwitch` switched again and overwrote `b.flushing`, dropping that memtable from the read path entirely: its acknowledged rows became invisible to every reader until a restart replayed the WAL.

The fix makes a failed flush retryable instead of discardable:

- **`FlushAndSwitch` drains before switching**: a retained `b.flushing` from a previous failure is flushed to completion (extracted `flushRetained()`) before a new switch is considered. `atomicallySwitchMemtable` now refuses to overwrite a non-nil `b.flushing` (invariant guard; unreachable from production once the drain runs first).
- **`flushAndSwitchMu`** serializes `FlushAndSwitch` callers (the flush cycle callback and control-plane callers like `FlushMemtable` can overlap). `stable/v1.38` already has this mutex under the same name for a related race; the retry drain needs it, so this carries it to 1.37 with matching naming to keep future merges clean.
- **`commitLogger.close()` and `delete()` are idempotent**: a retried `Memtable.flush()` re-closes a commit log the failed attempt already closed, and a retry after a post-`flush()` failure re-deletes an already-deleted WAL file. Without these the retry could never succeed.
- **Retry trigger**: `flushAndSwitchIfThresholdsMet` computes its thresholds from the *new* active memtable, which can stay small and idle forever — so a retained flushing memtable would never be retried. It now enters `FlushAndSwitch` whenever a retained flush is pending, regardless of active-memtable thresholds.

`Memtable.flush()` was audited step-by-step for re-entrancy: the tmp-file write/rename path repeats safely (`O_TRUNC` + rename overwrite), and the inverted average-property-length update is re-seeded from disk truth by the caller before every attempt, so a retry recomputes rather than compounds it.

## Testing

- `TestFlushAndSwitchRetainsFailedFlush` — the core red test: on unfixed code, a row written before a failed flush provably vanishes after the next `FlushAndSwitch`; with the fix both the retained and the new memtable's rows survive and `b.flushing` is cleared.
- `TestFlushAndSwitchRetryAfterPermissionFailure` — real `Memtable.flush()` failure via a read-only bucket directory; the retry after restoring permissions succeeds and the data reaches disk (exercises the idempotent `close()` for real).
- `TestCommitLoggerCloseDeleteIdempotent` — close/close, delete/delete, close-then-delete.
- `TestFlushAndSwitchIfThresholdsMetRetriesPendingFlush` — a quiet active memtable no longer strands a retained flush.
- Full `adapters/repos/db/lsmkv` suite with `-race` (unit and `integrationTest` tags), `go vet`, `golangci-lint`, gofumpt, goroutine linter: clean; no existing test needed adaptation for the new invariant guard.
