### PR TITLE
feat(backups): cleanup no longer cancels shard pauses it does not own

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -485,7 +485,7 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 
 	shards := map[string]*backup.ShardDescriptor{}
 	for _, name := range shardNames {
-		sd, err := i.backupShardWithoutHardlinks(ctx, name, classBaseDescrs)
+		sd, err := i.backupShardWithoutHardlinks(ctx, name, classBaseDescrs, backupID)
 		if err != nil {
 			if errors.Is(err, errShardNoLocalData) {
 				i.logger.WithField("shard", name).Debug("skipping shard with no local data")
@@ -515,7 +515,7 @@ func (i *Index) descriptorWithoutHardlinks(ctx context.Context, backupID string,
 // until ReleaseBackup to block both activation and FREEZE/FROZEN file operations.
 //
 // Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
-func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, classBaseDescrs []*backup.ClassDescriptor) (*backup.ShardDescriptor, error) {
+func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, classBaseDescrs []*backup.ClassDescriptor, backupID string) (*backup.ShardDescriptor, error) {
 	shardBaseDescr := i.collectShardBaseDescrs(name, classBaseDescrs)
 
 	i.backupLock.Lock(name)
@@ -539,7 +539,9 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 		if shard == nil {
 			// Not in shardMap => back up from disk if directory exists.
 			// Mark as protected and keep backupLock.Lock held until ReleaseBackup.
-			i.backupProtectedShards.Store(name, struct{}{})
+			if err := i.recordBackupShardState(backupID, name, &i.backupProtectedShards); err != nil {
+				return err
+			}
 			unlockOnReturn = false
 			return i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
 		}
@@ -551,7 +553,9 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 			defer releaseBlock()
 			if !lazyShard.loaded {
 				// Shard is in the map but not loaded; protect and keep lock held.
-				i.backupProtectedShards.Store(name, struct{}{})
+				if err := i.recordBackupShardState(backupID, name, &i.backupProtectedShards); err != nil {
+					return err
+				}
 				unlockOnReturn = false
 				return i.backupInactiveShardWithoutHardlinks(name, &sd, shardBaseDescr)
 			}
@@ -566,6 +570,13 @@ func (i *Index) backupShardWithoutHardlinks(ctx context.Context, name string, cl
 	// backupLock.Lock is released on return (unlockOnReturn=true).
 	if err := shard.HaltForTransfer(ctx, false, 0); err != nil {
 		return nil, fmt.Errorf("halt shard %v for backup: %w", name, err)
+	}
+
+	// Record the halt under the backup owner. If recording fails because the
+	// backup was already released, resume the halt just taken and return the error.
+	if err := i.recordBackupShardState(backupID, name, &i.backupHaltedShards); err != nil {
+		_ = shard.resumeMaintenanceCycles(ctx)
+		return nil, err
 	}
 
 	files, err := shard.ListBackupFiles(ctx, &sd)
@@ -650,48 +661,97 @@ func backupStagingDir(rootPath, backupID string, className schema.ClassName) str
 	return filepath.Join(rootPath, name)
 }
 
-// ReleaseBackup marks the specified backup as inactive and restarts all
-// async background and maintenance processes. It errors if the backup does not exist
-// or is already inactive.
+// ReleaseBackup marks the specified backup as inactive and resumes maintenance
+// for any shards it halted. It releases only the holds this backup acquired;
+// holds from other callers survive.
 func (i *Index) ReleaseBackup(ctx context.Context, id string) error {
 	i.logger.WithField("backup_id", id).WithField("class", i.Config.ClassName).Info("release backup")
 
-	// Clean up staging directory (idempotent — RemoveAll on non-existent dir is no-op)
+	// Clean up staging directory (idempotent — RemoveAll on non-existent dir is no-op).
 	stagingDir := backupStagingDir(i.Config.RootPath, id, i.Config.ClassName)
 	if err := os.RemoveAll(stagingDir); err != nil {
-		i.logger.WithField("staging_dir", stagingDir).WithError(err).Warn("failed to remove backup staging dir")
+		i.logger.WithField("staging_dir", stagingDir).Warnf("failed to remove backup staging dir: %v", err)
 	}
 
-	// Release non-hardlink backup protections: clear the protection flag and
-	// release the held backupLock.Lock for each protected shard.
-	//
-	// NO-HARDLINK-BACKUP: removed in v1.40; bugs here are not fixed.
-	i.backupProtectedShards.Range(func(key, _ any) bool {
-		name := key.(string)
-		i.backupLock.Unlock(name)
-		i.backupProtectedShards.Delete(key)
-		return true
-	})
+	// Release backup state under backupStateMu: only the owner of this backup
+	// id may touch it.
+	var haltedNames []string
+	i.backupStateMu.Lock()
+	cur := i.lastBackup.Load()
+	if cur == nil || cur.BackupID != id {
+		// This caller does not own any backup state; skip.
+		i.backupStateMu.Unlock()
+	} else {
+		// Release the protections held for the no-hardlink path's inactive
+		// shards: unlock and remove each entry.
+		i.backupProtectedShards.Range(func(key, _ any) bool {
+			name := key.(string)
+			i.backupLock.Unlock(name)
+			i.backupProtectedShards.Delete(key)
+			return true
+		})
 
-	i.resetBackupState()
+		// Collect and clear the shard names the no-hardlink path halted; their
+		// resumes run below, after the mutex is released.
+		i.backupHaltedShards.Range(func(key, _ any) bool {
+			haltedNames = append(haltedNames, key.(string))
+			i.backupHaltedShards.Delete(key)
+			return true
+		})
 
-	// Releasing backupLock above unblocks a waiting index.drop(), which shuts the
-	// shard stores down. Resuming their cycles now would be a use-after-drop.
-	if err := i.enterRead(); err != nil {
-		return nil
+		i.lastBackup.Store(nil)
+		i.backupStateMu.Unlock()
+
+		// Releasing backupLock above unblocks a waiting index.drop(), which
+		// shuts the shard stores down. Resuming their cycles now would be a
+		// use-after-drop.
+		if err := i.enterRead(); err != nil {
+			return nil
+		}
+		defer i.exitRead()
+
+		// Resume only the shards this backup halted (no-hardlink path only).
+		// On the production hardlink path both maps are empty and this loop
+		// does nothing: CreateBackupSnapshot releases its own owned hold.
+		var lastErr error
+		for _, name := range haltedNames {
+			if shard := i.shards.Loaded(name); shard != nil {
+				if err := shard.resumeMaintenanceCycles(ctx); err != nil {
+					lastErr = err
+					i.logger.WithField("shard", name).WithField("op", "resume_maintenance").
+						Errorf("resuming halted shard: %v", err)
+				}
+			}
+		}
+		if lastErr != nil {
+			return lastErr
+		}
 	}
-	defer i.exitRead()
 
-	// resumeMaintenanceCycles is still called for safety, but is a no-op since
-	// CreateBackupSnapshot already resumed compaction. Handles edge cases where
-	// a snapshot creation failed mid-way.
-	if err := i.resumeMaintenanceCycles(ctx); err != nil {
-		return err
-	}
 	return nil
 }
 
+// resumeMaintenanceCycles resumes maintenance on every loaded shard.
+// No production caller uses this; retained for
+// shard_lazyloader_coldshard_test.go:TestResumeMaintenanceCycles_DoesNotForceLoadColdShards.
+func (i *Index) resumeMaintenanceCycles(ctx context.Context) (lastErr error) {
+	// Only loaded shards have maintenance cycles to resume; a cold shard has
+	// none, so skip it rather than force-load every shard after a backup.
+	i.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		if err := shard.resumeMaintenanceCycles(ctx); err != nil {
+			lastErr = err
+			i.logger.WithField("shard", name).WithField("op", "resume_maintenance").Errorf("resuming shard: %v", err)
+		}
+		time.Sleep(time.Millisecond * 10)
+		return nil
+	})
+	return lastErr
+}
+
 func (i *Index) initBackup(id string) error {
+	i.backupStateMu.Lock()
+	defer i.backupStateMu.Unlock()
+
 	new := &BackupState{
 		BackupID:   id,
 		InProgress: true,
@@ -710,22 +770,23 @@ func (i *Index) initBackup(id string) error {
 	return nil
 }
 
-func (i *Index) resetBackupState() {
-	i.lastBackup.Store(nil)
-}
+// recordBackupShardState records that shard `name` has been halted or protected
+// by the backup identified by `backupID`. Under backupStateMu, it verifies that
+// lastBackup is set and carries the same backupID; otherwise (the backup was
+// already released, for example after a cancellation) it returns an error so
+// the caller can undo its own side effect.
+//
+// Deprecated: NO-HARDLINK-BACKUP. Only the no-hardlink path calls this.
+func (i *Index) recordBackupShardState(backupID, name string, m *sync.Map) error {
+	i.backupStateMu.Lock()
+	defer i.backupStateMu.Unlock()
 
-func (i *Index) resumeMaintenanceCycles(ctx context.Context) (lastErr error) {
-	// Only loaded shards have maintenance cycles to resume; a cold shard has
-	// none, so skip it rather than force-load every shard after a backup.
-	i.ForEachLoadedShard(func(name string, shard ShardLike) error {
-		if err := shard.resumeMaintenanceCycles(ctx); err != nil {
-			lastErr = err
-			i.logger.WithField("shard", name).WithField("op", "resume_maintenance").Error(err)
-		}
-		time.Sleep(time.Millisecond * 10)
-		return nil
-	})
-	return lastErr
+	cur := i.lastBackup.Load()
+	if cur == nil || cur.BackupID != backupID {
+		return fmt.Errorf("backup %q is no longer the active backup; shard %q state not recorded", backupID, name)
+	}
+	m.Store(name, struct{}{})
+	return nil
 }
 
 func (i *Index) marshalSchema() ([]byte, error) {

--- a/adapters/repos/db/backup_halt_ownership_test.go
+++ b/adapters/repos/db/backup_halt_ownership_test.go
@@ -1,0 +1,448 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/backup"
+)
+
+func TestIndexReleaseBackupOwnership(t *testing.T) {
+	t.Run("release does not resume a halt it did not acquire", func(t *testing.T) {
+		index, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		// Another operation's hold (replica transfer, second backup, or offload).
+		require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+
+		// Backup A never halts the shard: on the production hardlink path,
+		// CreateBackupSnapshot releases its own halt.
+		require.NoError(t, index.initBackup("bak-a"))
+		require.NoError(t, index.ReleaseBackup(ctx, "bak-a"))
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+
+		require.EqualValues(t, 1, count,
+			"ReleaseBackup must not decrement a hold it did not acquire")
+
+		_, err := shard.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+		require.NoError(t, err, "shard must still be paused for transfer")
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+	})
+
+	t.Run("straggler release cannot touch a successor backup's state", func(t *testing.T) {
+		index, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		require.NoError(t, index.initBackup("a"))
+		require.NoError(t, index.ReleaseBackup(ctx, "a"))
+
+		require.NoError(t, index.initBackup("b"))
+		require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+
+		// A late duplicate release: backup A was already released above.
+		require.NoError(t, index.ReleaseBackup(ctx, "a"))
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+
+		require.EqualValues(t, 1, count,
+			"straggler release must not consume the successor backup's hold")
+
+		cur := index.lastBackup.Load()
+		require.NotNil(t, cur)
+		require.Equal(t, "b", cur.BackupID)
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+		require.NoError(t, index.ReleaseBackup(ctx, "b"))
+	})
+
+	t.Run("concurrent stale releases never consume a successor's holds", func(t *testing.T) {
+		for iteration := range 50 {
+			func() {
+				index, shard := newSharedHaltTestShard(t)
+				ctx := context.Background()
+
+				require.NoError(t, index.initBackup("a"),
+					"iteration %d: initBackup(a)", iteration)
+
+				var wg sync.WaitGroup
+				for range 3 {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						_ = index.ReleaseBackup(ctx, "a")
+					}()
+				}
+
+				// Retry until one of the racing releases clears A's slot.
+				for {
+					if err := index.initBackup("b"); err == nil {
+						break
+					}
+				}
+
+				// Record one halt under B via the no-hardlink path.
+				sd, err := index.backupShardWithoutHardlinks(ctx, "shard1", nil, "b")
+				require.NoError(t, err, "iteration %d: backupShardWithoutHardlinks", iteration)
+				require.NotNil(t, sd)
+
+				wg.Wait()
+
+				shard.haltForTransferMux.Lock()
+				count := shard.haltForTransferCount.Load()
+				shard.haltForTransferMux.Unlock()
+
+				require.EqualValues(t, 1, count,
+					"iteration %d: stale goroutines must not consume B's hold", iteration)
+
+				cur := index.lastBackup.Load()
+				require.NotNil(t, cur, "iteration %d: lastBackup must still be B", iteration)
+				require.Equal(t, "b", cur.BackupID)
+
+				require.NoError(t, index.ReleaseBackup(ctx, "b"))
+
+				shard.haltForTransferMux.Lock()
+				finalCount := shard.haltForTransferCount.Load()
+				shard.haltForTransferMux.Unlock()
+				require.Zero(t, finalCount, "iteration %d: final count must be 0", iteration)
+			}()
+		}
+	})
+
+	t.Run("release still resumes the no-hardlink halts it recorded", func(t *testing.T) {
+		index, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		require.NoError(t, index.initBackup("test-id"))
+
+		sd, err := index.backupShardWithoutHardlinks(ctx, "shard1", nil, "test-id")
+		require.NoError(t, err)
+		require.NotNil(t, sd)
+
+		shard.haltForTransferMux.Lock()
+		countBefore := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+		require.EqualValues(t, 1, countBefore)
+
+		require.NoError(t, index.ReleaseBackup(ctx, "test-id"))
+
+		shard.haltForTransferMux.Lock()
+		countAfter := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+		require.Zero(t, countAfter, "ReleaseBackup must resume halts it recorded")
+	})
+
+	t.Run("record after release fails and self-resumes", func(t *testing.T) {
+		index, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		require.NoError(t, index.initBackup("test-id"))
+		require.NoError(t, index.ReleaseBackup(ctx, "test-id"))
+
+		// The halt inside backupShardWithoutHardlinks succeeds, but the
+		// ownership record fails because the backup is gone; the halt is rolled back.
+		sd, err := index.backupShardWithoutHardlinks(ctx, "shard1", nil, "test-id")
+		require.Error(t, err, "record must fail when backup is no longer active")
+		require.Nil(t, sd)
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+		require.Zero(t, count, "failed record must self-resume the halt")
+	})
+}
+
+func TestShardHaltForTransferForcedResume(t *testing.T) {
+	t.Run("watchdog fire clears only timeout-armed holds", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		// A hold with no inactivity timeout, as backups take.
+		require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+		// A hold with an inactivity timeout, as replica transfers take; it arms the watchdog.
+		require.NoError(t, shard.HaltForTransfer(ctx, false, time.Hour))
+
+		timer := time.NewTimer(time.Hour)
+		defer timer.Stop()
+
+		shard.haltForTransferMux.Lock()
+		shard.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+		shard.haltForTransferMux.Unlock()
+
+		keepWatching := shard.handleInactivityFire(context.Background(), timer)
+
+		shard.haltForTransferMux.Lock()
+		countAfterFire := shard.haltForTransferCount.Load()
+		cancelAfterFire := shard.haltForTransferCtxCancel
+		shard.haltForTransferMux.Unlock()
+
+		require.False(t, keepWatching)
+		require.EqualValues(t, 1, countAfterFire,
+			"fire must clear only the armed hold, leaving the unarmed hold intact")
+		require.Nil(t, cancelAfterFire,
+			"monitor sentinel must be cleared after fire")
+
+		_, err := shard.ListBackupFiles(ctx, &backup.ShardDescriptor{})
+		require.NoError(t, err, "shard must still be paused for transfer")
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+	})
+
+	t.Run("solo armed hold fully resumes on fire", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		require.NoError(t, shard.HaltForTransfer(ctx, false, time.Hour))
+
+		timer := time.NewTimer(time.Hour)
+		defer timer.Stop()
+
+		shard.haltForTransferMux.Lock()
+		shard.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+		shard.haltForTransferMux.Unlock()
+
+		keepWatching := shard.handleInactivityFire(context.Background(), timer)
+
+		shard.haltForTransferMux.Lock()
+		countAfterFire := shard.haltForTransferCount.Load()
+		cancelAfterFire := shard.haltForTransferCtxCancel
+		shard.haltForTransferMux.Unlock()
+
+		require.False(t, keepWatching)
+		require.Zero(t, countAfterFire, "solo armed hold must be fully resumed")
+		require.Nil(t, cancelAfterFire, "monitor sentinel must be cleared")
+	})
+
+	t.Run("fire with clamped-zero armed count still clears monitor", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		release, err := shard.haltForTransferOwned(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, shard.HaltForTransfer(ctx, false, time.Hour))
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+
+		shard.haltForTransferMux.Lock()
+		require.EqualValues(t, 1, shard.haltForTransferCount.Load(), "owned hold keeps count at 1")
+		require.Equal(t, 0, shard.haltForTransferArmedCount, "anonymous release clamped armed to 0")
+		shard.haltForTransferMux.Unlock()
+
+		timer := time.NewTimer(time.Hour)
+		defer timer.Stop()
+
+		shard.haltForTransferMux.Lock()
+		shard.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+		shard.haltForTransferMux.Unlock()
+
+		keepWatching := shard.handleInactivityFire(context.Background(), timer)
+
+		shard.haltForTransferMux.Lock()
+		countAfterFire := shard.haltForTransferCount.Load()
+		cancelAfterFire := shard.haltForTransferCtxCancel
+		timeoutAfterFire := shard.haltForTransferInactivityTimeout
+		deadlineAfterFire := shard.haltForTransferInactivityDeadline
+		shard.haltForTransferMux.Unlock()
+
+		require.False(t, keepWatching)
+		require.EqualValues(t, 1, countAfterFire,
+			"owned hold survives: count must stay 1")
+		require.Nil(t, cancelAfterFire,
+			"monitor sentinel must be nil after fire even with zero armed holds")
+		require.Zero(t, timeoutAfterFire, "timeout must be reset")
+		require.True(t, deadlineAfterFire.IsZero(), "deadline must be reset")
+
+		require.NoError(t, shard.HaltForTransfer(ctx, false, time.Hour))
+
+		shard.haltForTransferMux.Lock()
+		freshCancel := shard.haltForTransferCtxCancel
+		shard.haltForTransferMux.Unlock()
+
+		require.NotNil(t, freshCancel,
+			"new armed halt must start a fresh monitor (sentinel non-nil)")
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+		require.NoError(t, release(ctx))
+	})
+
+	t.Run("forced call on an idle shard is a no-op", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+
+		shard.haltForTransferMux.Lock()
+		err := shard.mayForceResumeMaintenanceCycles(context.Background(), true)
+		count := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+
+		require.NoError(t, err)
+		require.Zero(t, count)
+	})
+}
+
+func TestShardHaltForTransferOwned(t *testing.T) {
+	t.Run("anonymous resume cannot consume an owned hold", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		release, err := shard.haltForTransferOwned(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		owned := shard.haltForTransferOwnedCount
+		shard.haltForTransferMux.Unlock()
+
+		require.EqualValues(t, 1, count, "owned hold must survive anonymous resume")
+		require.Equal(t, 1, owned)
+
+		require.NoError(t, release(ctx))
+
+		shard.haltForTransferMux.Lock()
+		count = shard.haltForTransferCount.Load()
+		owned = shard.haltForTransferOwnedCount
+		shard.haltForTransferMux.Unlock()
+
+		require.Zero(t, count)
+		require.Zero(t, owned)
+	})
+
+	t.Run("watchdog fire cannot consume an owned hold", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		release, err := shard.haltForTransferOwned(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, shard.HaltForTransfer(ctx, false, time.Hour))
+
+		timer := time.NewTimer(time.Hour)
+		defer timer.Stop()
+
+		shard.haltForTransferMux.Lock()
+		shard.haltForTransferInactivityDeadline = time.Now().Add(-time.Hour)
+		shard.haltForTransferMux.Unlock()
+
+		keepWatching := shard.handleInactivityFire(context.Background(), timer)
+		require.False(t, keepWatching)
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+
+		require.EqualValues(t, 1, count, "owned hold must survive watchdog fire")
+
+		require.NoError(t, release(ctx))
+
+		shard.haltForTransferMux.Lock()
+		count = shard.haltForTransferCount.Load()
+		shard.haltForTransferMux.Unlock()
+		require.Zero(t, count)
+	})
+
+	t.Run("release is idempotent", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		release, err := shard.haltForTransferOwned(ctx)
+		require.NoError(t, err)
+
+		require.NoError(t, release(ctx))
+		require.NoError(t, release(ctx)) // second call is a no-op
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		owned := shard.haltForTransferOwnedCount
+		shard.haltForTransferMux.Unlock()
+
+		require.Zero(t, count)
+		require.Zero(t, owned)
+	})
+
+	t.Run("failed owned acquire rolls back both counts", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		// First take an anonymous hold so the count is above 1; the pause
+		// steps run only for the first hold.
+		require.NoError(t, shard.HaltForTransfer(ctx, false, 0))
+
+		// Acquire an owned hold with a cancelled context: at count above 1 the
+		// pause steps are skipped, and the seal steps (FlushMemtables) fail
+		// deterministically.
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		_, err := shard.haltForTransferOwned(cancelledCtx)
+		require.Error(t, err)
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		owned := shard.haltForTransferOwnedCount
+		shard.haltForTransferMux.Unlock()
+
+		require.EqualValues(t, 1, count, "failed owned acquire must roll back count")
+		require.Zero(t, owned, "failed owned acquire must roll back owned count")
+
+		require.NoError(t, shard.resumeMaintenanceCycles(ctx))
+	})
+
+	t.Run("CreateBackupSnapshot self-releases on success", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+		ctx := context.Background()
+
+		sd := &backup.ShardDescriptor{}
+		stagingRoot := t.TempDir()
+
+		_, err := shard.CreateBackupSnapshot(ctx, sd, stagingRoot)
+		require.NoError(t, err)
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		owned := shard.haltForTransferOwnedCount
+		shard.haltForTransferMux.Unlock()
+
+		require.Zero(t, count, "owned hold must be released after successful snapshot")
+		require.Zero(t, owned, "owned count must be zero after successful snapshot")
+	})
+
+	t.Run("CreateBackupSnapshot self-releases on error", func(t *testing.T) {
+		_, shard := newSharedHaltTestShard(t)
+
+		cancelledCtx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		sd := &backup.ShardDescriptor{}
+		stagingRoot := t.TempDir()
+
+		_, err := shard.CreateBackupSnapshot(cancelledCtx, sd, stagingRoot)
+		require.Error(t, err)
+
+		shard.haltForTransferMux.Lock()
+		count := shard.haltForTransferCount.Load()
+		owned := shard.haltForTransferOwnedCount
+		shard.haltForTransferMux.Unlock()
+
+		require.Zero(t, count, "owned hold must be released after failed snapshot")
+		require.Zero(t, owned, "owned count must be zero after failed snapshot")
+	})
+}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -312,6 +312,21 @@ type Index struct {
 	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
 	backupProtectedShards sync.Map
 
+	// backupStateMu serializes every write to lastBackup and every mutation of
+	// backupProtectedShards and backupHaltedShards. Reading lastBackup without
+	// this lock is valid (e.g. Index.drop does).
+	// Lock ordering: acquire backupLock or shardCreateLocks before backupStateMu.
+	// backupStateMu is otherwise a leaf lock; the only lock operation made while
+	// holding it is the non-blocking backupLock.Unlock.
+	backupStateMu sync.Mutex
+
+	// backupHaltedShards records shard names halted by the in-progress
+	// no-hardlink backup. ReleaseBackup for the owning backup id removes and
+	// resumes each entry exactly once.
+	//
+	// Deprecated: NO-HARDLINK-BACKUP. Removed in v1.40; bugs here are not fixed.
+	backupHaltedShards sync.Map
+
 	// Release uses this to decide whether to resume the shard (halt-for-duration
 	// fallback) or skip resume (snapshot already resumed at create time).
 	replicaSnapshotsMu sync.Mutex

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -357,6 +357,14 @@ type Shard struct {
 	// Mutations under haltForTransferMux; atomic so halt probes read lock-free.
 	haltForTransferCount     atomic.Int64
 	haltForTransferCtxCancel context.CancelFunc
+	// haltForTransferOwnedCount tracks holds acquired via haltForTransferOwned.
+	// Owned holds are immune to anonymous resumes and watchdog force-resumes.
+	// Mutated under haltForTransferMux; invariant: 0 <= owned <= count.
+	haltForTransferOwnedCount int
+	// haltForTransferArmedCount tracks holds acquired with inactivityTimeout > 0.
+	// A watchdog fire clears exactly these holds and no others.
+	// Mutated under haltForTransferMux; invariant: 0 <= armed <= count - owned.
+	haltForTransferArmedCount int
 
 	status              ShardStatus
 	statusLock          sync.RWMutex

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -35,11 +35,17 @@ func (s *Shard) haltedForTransfer() bool {
 // HaltForTransfer stops compaction, and flushing memtable and commit log to begin with backup or cloud offload.
 // This method could be called multiple times with different inactivity timeouts,
 // a zeroed `inactivityTimeout` implies no timeout.
-// If inactivity timeout is reached it will resume maintenance cycle independently on how many halt request has been made.
+// When the inactivity timeout expires, the watchdog clears only the holds that
+// asked for a timeout; owned holds and holds without a timeout survive and
+// keep the shard paused.
 // The preparation work (pausing compaction, flushing memtables, readying vector indexes and queues)
 // is additionally bounded by `HaltForTransferTimeout`, independent of `inactivityTimeout`;
 // a zeroed `HaltForTransferTimeout` implies no bound.
 func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivityTimeout time.Duration) (err error) {
+	return s.haltForTransfer(ctx, offloading, inactivityTimeout, false)
+}
+
+func (s *Shard) haltForTransfer(ctx context.Context, offloading bool, inactivityTimeout time.Duration, owned bool) (err error) {
 	innerCtx := ctx
 	if timeout := s.index.Config.HaltForTransferTimeout; timeout > 0 {
 		var cancel context.CancelFunc
@@ -64,12 +70,16 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 	}
 
 	s.haltForTransferCount.Add(1)
+	if owned {
+		s.haltForTransferOwnedCount++
+	}
 
 	defer func() {
 		if err != nil {
 			return
 		}
 		if inactivityTimeout > 0 {
+			s.haltForTransferArmedCount++
 			s.mayUpdateInactivityTimeout(inactivityTimeout)
 			s.mayInitInactivityMonitoring()
 		}
@@ -84,13 +94,14 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 	}
 
 	// Placed before the pause branch so it also covers count>1 callers: on error
-	// mayForceResumeMaintenanceCycles(ctx, false) decrements our own increment and
-	// only truly resumes at count==0, so a failed count>1 caller rolls back 2→1
+	// the rollback decrements our own increment (and, for an owned hold, the owned count) and
+	// only truly resumes at count==0, so a failed count>1 caller rolls back 2->1
 	// without unhalting the shard the first op still holds.
 	defer func() {
 		if err != nil {
-			// each preparation step below wraps its own error; only append
-			// the outcome of the cleanup attempt here
+			if owned {
+				s.haltForTransferOwnedCount--
+			}
 			if err2 := s.mayForceResumeMaintenanceCycles(ctx, false); err2 != nil {
 				err = fmt.Errorf("%w: resume maintenance: %w", err, err2)
 			}
@@ -173,6 +184,45 @@ func (s *Shard) HaltForTransfer(ctx context.Context, offloading bool, inactivity
 	}
 
 	return nil
+}
+
+// haltForTransferOwned acquires an owned halt-for-transfer hold. An owned hold
+// can only be released by the returned closure; anonymous resumes
+// (resumeMaintenanceCycles) and watchdog force-resumes cannot consume it.
+// The release closure is idempotent.
+func (s *Shard) haltForTransferOwned(ctx context.Context) (release func(context.Context) error, err error) {
+	if err := s.haltForTransfer(ctx, false, 0, true); err != nil {
+		return nil, err
+	}
+
+	var released bool
+	return func(ctx context.Context) error {
+		s.haltForTransferMux.Lock()
+
+		if released {
+			s.haltForTransferMux.Unlock()
+			return nil
+		}
+		released = true
+		s.haltForTransferOwnedCount--
+		s.haltForTransferCount.Add(-1)
+
+		fullyResumed := s.haltForTransferCount.Load() == 0
+		if !fullyResumed {
+			s.haltForTransferMux.Unlock()
+			return nil
+		}
+
+		// doPhysicalResume requires the mux to be held.
+		s.mayStopInactivityMonitoring()
+		s.haltForTransferInactivityTimeout = 0
+		s.haltForTransferInactivityDeadline = time.Time{}
+		resumeErr := s.doPhysicalResume(ctx)
+		s.haltForTransferMux.Unlock()
+
+		s.reapplyAsyncReplicationAfterResume(ctx)
+		return resumeErr
+	}, nil
 }
 
 // MayResetTransferInactivityTimer counts an in-flight transfer RPC as
@@ -282,7 +332,8 @@ func (s *Shard) handleInactivityFire(ctx context.Context, timer *time.Timer) (ke
 	if err := s.mayForceResumeMaintenanceCycles(context.Background(), true); err != nil {
 		s.index.logger.Error(err)
 	}
-	forceResumed = true
+	// Reapply async replication only when the fire fully resumed the shard.
+	forceResumed = s.haltForTransferCount.Load() == 0
 	return false
 }
 
@@ -290,11 +341,20 @@ func (s *Shard) handleInactivityFire(ctx context.Context, timer *time.Timer) (ke
 // a staging directory, then immediately resumes compaction. This minimizes the
 // compaction pause to just the time needed for enumeration and hardlink creation
 // (typically 2-5s), rather than blocking for the entire upload duration.
+//
+// The halt is acquired as an owned hold so that anonymous resumes and watchdog
+// fires from other callers cannot consume it.
 func (s *Shard) CreateBackupSnapshot(ctx context.Context, sd *backup.ShardDescriptor, stagingRoot string) ([]string, error) {
-	if err := s.HaltForTransfer(ctx, false, 0); err != nil {
+	release, err := s.haltForTransferOwned(ctx)
+	if err != nil {
 		return nil, fmt.Errorf("halt for snapshot: %w", err)
 	}
-	defer s.resumeMaintenanceCycles(ctx)
+	defer func() {
+		if err := release(ctx); err != nil {
+			s.index.logger.WithField("shard", s.name).
+				Warnf("releasing owned halt after snapshot: %v", err)
+		}
+	}()
 
 	files, err := s.ListBackupFiles(ctx, sd)
 	if err != nil {
@@ -461,6 +521,16 @@ func (s *Shard) reapplyAsyncReplicationAfterResume(ctx context.Context) {
 	}
 }
 
+// mayForceResumeMaintenanceCycles decrements or clears halt holds and runs the
+// physical resume steps when the count reaches zero. Caller must hold haltForTransferMux.
+//
+// forced=false (anonymous release): decrements one non-owned hold; does
+// nothing when only owned holds remain (count - owned == 0). Lowers armed if
+// it now exceeds the non-owned count.
+//
+// forced=true (watchdog fire): clears exactly the armed holds (those acquired
+// with inactivityTimeout > 0); the metric increments only when armed > 0.
+// Owned holds and holds without a timeout survive.
 func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool) error {
 	if s.haltForTransferCount.Load() == 0 {
 		// noop, maintenance cycles not halted
@@ -468,31 +538,63 @@ func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool
 	}
 
 	if forced {
-		s.haltForTransferCount.Store(0)
-		// Non-zero in steady state means a transfer was force-resumed
-		// mid-stream — i.e. the read-path timer reset isn't reaching us.
-		if s.promMetrics != nil && s.promMetrics.ShardHaltForTransferForceResume != nil {
+		n := s.haltForTransferArmedCount
+		s.haltForTransferCount.Add(int64(-n))
+		s.haltForTransferArmedCount = 0
+
+		if n > 0 && s.promMetrics != nil && s.promMetrics.ShardHaltForTransferForceResume != nil {
 			s.promMetrics.ShardHaltForTransferForceResume.
 				WithLabelValues().
 				Inc()
 		}
+
+		// Runs even when n == 0: an anonymous release may have already
+		// zeroed the armed count while the monitor goroutine is exiting.
+		// haltForTransferCtxCancel must end up nil, or a future armed halt
+		// cannot start a new monitor.
+		s.mayStopInactivityMonitoring()
+		s.haltForTransferInactivityTimeout = 0
+		s.haltForTransferInactivityDeadline = time.Time{}
+
+		if s.haltForTransferCount.Load() > 0 {
+			// Remaining holds (owned, or anonymous without a timeout) keep the pause.
+			return nil
+		}
 	} else {
+		nonOwned := s.haltForTransferCount.Load() - int64(s.haltForTransferOwnedCount)
+		if nonOwned <= 0 {
+			// Only owned holds remain; an anonymous release cannot consume them.
+			return nil
+		}
 		s.haltForTransferCount.Add(-1)
+
+		// An anonymous release cannot tell which hold it consumed, so lower
+		// armed if it now exceeds the non-owned count.
+		newNonOwned := s.haltForTransferCount.Load() - int64(s.haltForTransferOwnedCount)
+		if int64(s.haltForTransferArmedCount) > newNonOwned {
+			s.haltForTransferArmedCount = int(newNonOwned)
+		}
 
 		if s.haltForTransferCount.Load() > 0 {
 			// maintenance cycles are not resumed as there is at least one active halt request
 			return nil
 		}
+
+		// terminate the inactivity monitor synchronously under the mux, so a subsequent
+		// HaltForTransfer reliably starts a new monitor.
+		s.mayStopInactivityMonitoring()
+
+		// fully resumed: reset so the next halt cycle uses its own timeout, not the shortest ever seen.
+		s.haltForTransferInactivityTimeout = 0
+		s.haltForTransferInactivityDeadline = time.Time{}
 	}
 
-	// terminate the inactivity monitor synchronously under the mux, so a subsequent
-	// HaltForTransfer reliably starts a new monitor.
-	s.mayStopInactivityMonitoring()
+	return s.doPhysicalResume(ctx)
+}
 
-	// fully resumed: reset so the next halt cycle uses its own timeout, not the shortest ever seen.
-	s.haltForTransferInactivityTimeout = 0
-	s.haltForTransferInactivityDeadline = time.Time{}
-
+// doPhysicalResume runs the errgroup that re-enables compaction, cycle callbacks,
+// maintenance modes, and vector/geo indexes. Caller must hold haltForTransferMux.
+func (s *Shard) doPhysicalResume(ctx context.Context) error {
 	g := enterrors.NewErrorGroupWrapper(s.index.logger)
 
 	g.Go(func() error {


### PR DESCRIPTION
Backups pause shard maintenance (compaction, memtable flushing) while they copy files. That pause is a shared counter with no owner, so any release consumes any hold. A backup's cleanup runs in background goroutines that can outlive it, and those goroutines could cancel a pause that a later backup or another operation still needed. The visible failure is a backup failing with "shard is not paused for transfer". The silent failure is compaction restarting underneath a live snapshot. This change makes backup releases consume only the holds the same backup acquired.

### What's being changed

- Snapshot creation now takes an owned hold on the shard pause. Only its own release can free it. Other callers' cleanup and the inactivity watchdog cannot.
- Releasing a backup now resumes only the shards that backup halted. A late or duplicate release from an earlier backup does nothing.
- All changes to an index's backup ownership state are serialized under one mutex. This closes the race between a new backup starting and an old one's cleanup.
- The inactivity watchdog now clears only holds that asked for a timeout. Holds without a timeout keep the shard paused.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
