### PR TITLE
fix(aggregator): merge remote shard aggregations after JSON round trip (mean/median/mode panic on multi-node)

### DIFF
--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -116,9 +116,7 @@ type datePairJSON struct {
 	Count uint64 `json:"count"`
 }
 
-// MarshalJSON ships the raw timestamp counts across the cluster-internal REST
-// API so the coordinating node can merge mode/median. Without it the
-// unexported fields would serialize as {} and the shard's data would be lost.
+// MarshalJSON is the cluster-internal wire form of the merge state.
 func (a *dateAggregator) MarshalJSON() ([]byte, error) {
 	a.Lock()
 	defer a.Unlock()
@@ -135,28 +133,34 @@ func (a *dateAggregator) MarshalJSON() ([]byte, error) {
 	}{Pairs: pairs})
 }
 
-// dateAggregatorFromJSON rebuilds an aggregator from the generic map that
-// unmarshalling a remote shard result produces (DateAggregations is a
-// map[string]interface{}, so the concrete type is not recoverable by
-// json.Unmarshal itself).
-func dateAggregatorFromJSON(raw map[string]interface{}) *dateAggregator {
+// dateAggregatorFromJSON rebuilds the wire form from the generic map
+// json.Unmarshal produces for an interface{} target.
+func dateAggregatorFromJSON(raw map[string]interface{}) (*dateAggregator, error) {
+	pairs, ok := raw["pairs"].([]interface{})
+	if !ok {
+		return nil, errors.New("date aggregator state missing from remote shard result, " +
+			"the remote node likely runs an older version")
+	}
+
 	agg := newDateAggregator()
-	pairs, _ := raw["pairs"].([]interface{})
 	for _, pair := range pairs {
 		pairMap, ok := pair.(map[string]interface{})
 		if !ok {
-			continue
+			return nil, errors.New("malformed date aggregator pair in remote shard result")
 		}
-		value, _ := pairMap["value"].(string)
-		count, _ := pairMap["count"].(float64)
+		value, okValue := pairMap["value"].(string)
+		count, okCount := pairMap["count"].(float64)
+		if !okValue || !okCount {
+			return nil, errors.New("malformed date aggregator pair in remote shard result")
+		}
 		t, err := time.Parse(time.RFC3339Nano, value)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("malformed date aggregator pair in remote shard result: %w", err)
 		}
 		agg.addRow(timestamp{epochNano: t.UnixNano(), rfc3339: value}, uint64(count))
 	}
 	agg.buildPairsFromCounts()
-	return agg
+	return agg, nil
 }
 
 func (a *dateAggregator) AddTimestamp(rfc3339 string) error {

--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -12,6 +12,7 @@
 package aggregator
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -108,6 +109,54 @@ func newTimestamp(epochNano int64) timestamp {
 type timestampCountPair struct {
 	value timestamp
 	count uint64
+}
+
+type datePairJSON struct {
+	Value string `json:"value"`
+	Count uint64 `json:"count"`
+}
+
+// MarshalJSON ships the raw timestamp counts across the cluster-internal REST
+// API so the coordinating node can merge mode/median. Without it the
+// unexported fields would serialize as {} and the shard's data would be lost.
+func (a *dateAggregator) MarshalJSON() ([]byte, error) {
+	a.Lock()
+	defer a.Unlock()
+
+	pairs := make([]datePairJSON, 0, len(a.valueCounter))
+	for ts, count := range a.valueCounter {
+		pairs = append(pairs, datePairJSON{Value: ts.rfc3339, Count: count})
+	}
+	sort.Slice(pairs, func(x, y int) bool {
+		return pairs[x].Value < pairs[y].Value
+	})
+	return json.Marshal(struct {
+		Pairs []datePairJSON `json:"pairs"`
+	}{Pairs: pairs})
+}
+
+// dateAggregatorFromJSON rebuilds an aggregator from the generic map that
+// unmarshalling a remote shard result produces (DateAggregations is a
+// map[string]interface{}, so the concrete type is not recoverable by
+// json.Unmarshal itself).
+func dateAggregatorFromJSON(raw map[string]interface{}) *dateAggregator {
+	agg := newDateAggregator()
+	pairs, _ := raw["pairs"].([]interface{})
+	for _, pair := range pairs {
+		pairMap, ok := pair.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		value, _ := pairMap["value"].(string)
+		count, _ := pairMap["count"].(float64)
+		t, err := time.Parse(time.RFC3339Nano, value)
+		if err != nil {
+			continue
+		}
+		agg.addRow(timestamp{epochNano: t.UnixNano(), rfc3339: value}, uint64(count))
+	}
+	agg.buildPairsFromCounts()
+	return agg
 }
 
 func (a *dateAggregator) AddTimestamp(rfc3339 string) error {

--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -116,18 +116,14 @@ type datePairJSON struct {
 	Count uint64 `json:"count"`
 }
 
-// MarshalJSON is the cluster-internal wire form of the merge state.
+// MarshalJSON is the cluster-internal wire form of the merge state. It runs on
+// the request-scoped aggregator after aggregation finished, so no locking; pair
+// order on the wire is irrelevant, the decoder rebuilds and re-sorts.
 func (a *dateAggregator) MarshalJSON() ([]byte, error) {
-	a.Lock()
-	defer a.Unlock()
-
 	pairs := make([]datePairJSON, 0, len(a.valueCounter))
 	for ts, count := range a.valueCounter {
 		pairs = append(pairs, datePairJSON{Value: ts.rfc3339, Count: count})
 	}
-	sort.Slice(pairs, func(x, y int) bool {
-		return pairs[x].Value < pairs[y].Value
-	})
 	return json.Marshal(struct {
 		Pairs []datePairJSON `json:"pairs"`
 	}{Pairs: pairs})
@@ -136,10 +132,14 @@ func (a *dateAggregator) MarshalJSON() ([]byte, error) {
 // dateAggregatorFromJSON rebuilds the wire form from the generic map
 // json.Unmarshal produces for an interface{} target.
 func dateAggregatorFromJSON(raw map[string]interface{}) (*dateAggregator, error) {
-	pairs, ok := raw["pairs"].([]interface{})
-	if !ok {
+	rawPairs, hasPairs := raw["pairs"]
+	if !hasPairs || rawPairs == nil {
 		return nil, errors.New("date aggregator state missing from remote shard result, " +
 			"the remote node likely runs an older version")
+	}
+	pairs, ok := rawPairs.([]interface{})
+	if !ok {
+		return nil, errors.New("malformed date aggregator pairs in remote shard result")
 	}
 
 	agg := newDateAggregator()
@@ -157,10 +157,27 @@ func dateAggregatorFromJSON(raw map[string]interface{}) (*dateAggregator, error)
 		if err != nil {
 			return nil, fmt.Errorf("malformed date aggregator pair in remote shard result: %w", err)
 		}
-		agg.addRow(timestamp{epochNano: t.UnixNano(), rfc3339: value}, uint64(count))
+		restored, err := wireCount(count)
+		if err != nil {
+			return nil, err
+		}
+		agg.addRow(timestamp{epochNano: t.UnixNano(), rfc3339: value}, restored)
 	}
 	agg.buildPairsFromCounts()
 	return agg, nil
+}
+
+// hasCompleteDistribution reports whether the value pairs account for every
+// counted element; mode/median recomputation relies on that.
+func (a *dateAggregator) hasCompleteDistribution() bool {
+	if a.count == 0 {
+		return false
+	}
+	var total uint64
+	for _, pair := range a.pairs {
+		total += pair.count
+	}
+	return total == a.count
 }
 
 func (a *dateAggregator) AddTimestamp(rfc3339 string) error {

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -116,22 +116,29 @@ type numericalAggregatorJSON struct {
 	Pairs []numericalPairJSON `json:"pairs,omitempty"`
 }
 
-// MarshalJSON is the cluster-internal wire form of the merge state.
+// MarshalJSON is the cluster-internal wire form of the merge state. It runs on
+// the request-scoped aggregator after aggregation finished, so no locking; pair
+// order on the wire is irrelevant, the decoder rebuilds and re-sorts.
 func (a *numericalAggregator) MarshalJSON() ([]byte, error) {
-	a.Lock()
-	defer a.Unlock()
-
 	out := numericalAggregatorJSON{Count: a.count, Sum: a.sum}
 	if a.serializePairs {
 		out.Pairs = make([]numericalPairJSON, 0, len(a.valueCounter))
 		for value, count := range a.valueCounter {
 			out.Pairs = append(out.Pairs, numericalPairJSON{Value: value, Count: count})
 		}
-		sort.Slice(out.Pairs, func(x, y int) bool {
-			return out.Pairs[x].Value < out.Pairs[y].Value
-		})
 	}
 	return json.Marshal(out)
+}
+
+// wireCount validates a count decoded from a cluster-internal JSON payload.
+// JSON numbers decode as float64, so a count >= 2^53 may already differ from
+// what the remote node sent; reject it alongside negative and non-integral
+// counts instead of silently truncating.
+func wireCount(f float64) (uint64, error) {
+	if f < 0 || f != math.Trunc(f) || f >= 1<<53 {
+		return 0, errors.Errorf("invalid count %v in remote shard result", f)
+	}
+	return uint64(f), nil
 }
 
 // numericalAggregatorFromJSON rebuilds the wire form from the generic map
@@ -145,13 +152,22 @@ func numericalAggregatorFromJSON(raw map[string]interface{}) (*numericalAggregat
 	}
 
 	agg := newNumericalAggregator()
-	pairs, hasPairs := raw["pairs"].([]interface{})
-	if !hasPairs {
-		agg.count = uint64(count)
+	rawPairs, hasPairs := raw["pairs"]
+	if !hasPairs || rawPairs == nil {
+		// mean-only wire form
+		restored, err := wireCount(count)
+		if err != nil {
+			return nil, err
+		}
+		agg.count = restored
 		agg.sum = sum
 		return agg, nil
 	}
 
+	pairs, ok := rawPairs.([]interface{})
+	if !ok {
+		return nil, errors.New("malformed numerical aggregator pairs in remote shard result")
+	}
 	agg.serializePairs = true
 	for _, pair := range pairs {
 		pairMap, ok := pair.(map[string]interface{})
@@ -163,10 +179,27 @@ func numericalAggregatorFromJSON(raw map[string]interface{}) (*numericalAggregat
 		if !okValue || !okPairCount {
 			return nil, errors.New("malformed numerical aggregator pair in remote shard result")
 		}
-		agg.AddNumberRow(value, uint64(pairCount))
+		restored, err := wireCount(pairCount)
+		if err != nil {
+			return nil, err
+		}
+		agg.AddNumberRow(value, restored)
 	}
 	agg.buildPairsFromCounts()
 	return agg, nil
+}
+
+// hasCompleteDistribution reports whether the value pairs account for every
+// counted element; mode/median recomputation relies on that.
+func (a *numericalAggregator) hasCompleteDistribution() bool {
+	if a.count == 0 {
+		return false
+	}
+	var total uint64
+	for _, pair := range a.pairs {
+		total += pair.count
+	}
+	return total == a.count
 }
 
 // absorb adds other's distribution; an aggregator restored from a mean-only

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -130,10 +130,9 @@ func (a *numericalAggregator) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// wireCount validates a count decoded from a cluster-internal JSON payload.
-// JSON numbers decode as float64, so a count >= 2^53 may already differ from
-// what the remote node sent; reject it alongside negative and non-integral
-// counts instead of silently truncating.
+// wireCount validates a count decoded from a cluster-internal JSON payload:
+// negative or non-integral counts are malformed, and a count >= 2^53 may
+// already differ from what the remote node sent (float64 decoding).
 func wireCount(f float64) (uint64, error) {
 	if f < 0 || f != math.Trunc(f) || f >= 1<<53 {
 		return 0, errors.Errorf("invalid count %v in remote shard result", f)

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -12,6 +12,7 @@
 package aggregator
 
 import (
+	"encoding/json"
 	"math"
 	"sort"
 	"sync"
@@ -98,6 +99,50 @@ type numericalAggregator struct {
 type floatCountPair struct {
 	value float64
 	count uint64
+}
+
+type numericalPairJSON struct {
+	Value float64 `json:"value"`
+	Count uint64  `json:"count"`
+}
+
+// MarshalJSON ships the raw value counts across the cluster-internal REST API
+// so the coordinating node can merge mean/median/mode. Without it the
+// unexported fields would serialize as {} and the shard's data would be lost.
+func (a *numericalAggregator) MarshalJSON() ([]byte, error) {
+	a.Lock()
+	defer a.Unlock()
+
+	pairs := make([]numericalPairJSON, 0, len(a.valueCounter))
+	for value, count := range a.valueCounter {
+		pairs = append(pairs, numericalPairJSON{Value: value, Count: count})
+	}
+	sort.Slice(pairs, func(x, y int) bool {
+		return pairs[x].Value < pairs[y].Value
+	})
+	return json.Marshal(struct {
+		Pairs []numericalPairJSON `json:"pairs"`
+	}{Pairs: pairs})
+}
+
+// numericalAggregatorFromJSON rebuilds an aggregator from the generic map that
+// unmarshalling a remote shard result produces (NumericalAggregations is a
+// map[string]interface{}, so the concrete type is not recoverable by
+// json.Unmarshal itself).
+func numericalAggregatorFromJSON(raw map[string]interface{}) *numericalAggregator {
+	agg := newNumericalAggregator()
+	pairs, _ := raw["pairs"].([]interface{})
+	for _, pair := range pairs {
+		pairMap, ok := pair.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		value, _ := pairMap["value"].(float64)
+		count, _ := pairMap["count"].(float64)
+		agg.AddNumberRow(value, uint64(count))
+	}
+	agg.buildPairsFromCounts()
+	return agg
 }
 
 func (a *numericalAggregator) AddFloat64(value float64) error {

--- a/adapters/repos/db/aggregator/numerical.go
+++ b/adapters/repos/db/aggregator/numerical.go
@@ -44,12 +44,13 @@ func addNumericalAggregations(prop *aggregation.Property,
 
 	// when combining the results from different shards, we need the raw numbers to recompute the mode, mean and median.
 	// Therefore we add a reference later which needs to be cleared out before returning the results to a user
-loop:
 	for _, aProp := range aggs {
 		switch aProp {
-		case aggregation.ModeAggregator, aggregation.MedianAggregator, aggregation.MeanAggregator:
+		case aggregation.ModeAggregator, aggregation.MedianAggregator:
+			agg.serializePairs = true
 			prop.NumericalAggregations["_numericalAggregator"] = agg
-			break loop
+		case aggregation.MeanAggregator:
+			prop.NumericalAggregations["_numericalAggregator"] = agg
 		}
 	}
 
@@ -94,6 +95,9 @@ type numericalAggregator struct {
 	mode         float64
 	pairs        []floatCountPair   // for row-based median calculation
 	valueCounter map[float64]uint64 // for individual median calculation
+
+	// mode/median need the full distribution on the wire; mean only count and sum
+	serializePairs bool
 }
 
 type floatCountPair struct {
@@ -106,43 +110,77 @@ type numericalPairJSON struct {
 	Count uint64  `json:"count"`
 }
 
-// MarshalJSON ships the raw value counts across the cluster-internal REST API
-// so the coordinating node can merge mean/median/mode. Without it the
-// unexported fields would serialize as {} and the shard's data would be lost.
+type numericalAggregatorJSON struct {
+	Count uint64              `json:"count"`
+	Sum   float64             `json:"sum"`
+	Pairs []numericalPairJSON `json:"pairs,omitempty"`
+}
+
+// MarshalJSON is the cluster-internal wire form of the merge state.
 func (a *numericalAggregator) MarshalJSON() ([]byte, error) {
 	a.Lock()
 	defer a.Unlock()
 
-	pairs := make([]numericalPairJSON, 0, len(a.valueCounter))
-	for value, count := range a.valueCounter {
-		pairs = append(pairs, numericalPairJSON{Value: value, Count: count})
+	out := numericalAggregatorJSON{Count: a.count, Sum: a.sum}
+	if a.serializePairs {
+		out.Pairs = make([]numericalPairJSON, 0, len(a.valueCounter))
+		for value, count := range a.valueCounter {
+			out.Pairs = append(out.Pairs, numericalPairJSON{Value: value, Count: count})
+		}
+		sort.Slice(out.Pairs, func(x, y int) bool {
+			return out.Pairs[x].Value < out.Pairs[y].Value
+		})
 	}
-	sort.Slice(pairs, func(x, y int) bool {
-		return pairs[x].Value < pairs[y].Value
-	})
-	return json.Marshal(struct {
-		Pairs []numericalPairJSON `json:"pairs"`
-	}{Pairs: pairs})
+	return json.Marshal(out)
 }
 
-// numericalAggregatorFromJSON rebuilds an aggregator from the generic map that
-// unmarshalling a remote shard result produces (NumericalAggregations is a
-// map[string]interface{}, so the concrete type is not recoverable by
-// json.Unmarshal itself).
-func numericalAggregatorFromJSON(raw map[string]interface{}) *numericalAggregator {
+// numericalAggregatorFromJSON rebuilds the wire form from the generic map
+// json.Unmarshal produces for an interface{} target.
+func numericalAggregatorFromJSON(raw map[string]interface{}) (*numericalAggregator, error) {
+	count, okCount := raw["count"].(float64)
+	sum, okSum := raw["sum"].(float64)
+	if !okCount || !okSum {
+		return nil, errors.New("numerical aggregator state missing from remote shard result, " +
+			"the remote node likely runs an older version")
+	}
+
 	agg := newNumericalAggregator()
-	pairs, _ := raw["pairs"].([]interface{})
+	pairs, hasPairs := raw["pairs"].([]interface{})
+	if !hasPairs {
+		agg.count = uint64(count)
+		agg.sum = sum
+		return agg, nil
+	}
+
+	agg.serializePairs = true
 	for _, pair := range pairs {
 		pairMap, ok := pair.(map[string]interface{})
 		if !ok {
-			continue
+			return nil, errors.New("malformed numerical aggregator pair in remote shard result")
 		}
-		value, _ := pairMap["value"].(float64)
-		count, _ := pairMap["count"].(float64)
-		agg.AddNumberRow(value, uint64(count))
+		value, okValue := pairMap["value"].(float64)
+		pairCount, okPairCount := pairMap["count"].(float64)
+		if !okValue || !okPairCount {
+			return nil, errors.New("malformed numerical aggregator pair in remote shard result")
+		}
+		agg.AddNumberRow(value, uint64(pairCount))
 	}
 	agg.buildPairsFromCounts()
-	return agg
+	return agg, nil
+}
+
+// absorb adds other's distribution; an aggregator restored from a mean-only
+// wire payload carries just count and sum.
+func (a *numericalAggregator) absorb(other *numericalAggregator) {
+	if len(other.valueCounter) == 0 && len(other.pairs) == 0 {
+		a.count += other.count
+		a.sum += other.sum
+		return
+	}
+	for _, pair := range other.pairs {
+		a.AddNumberRow(pair.value, pair.count)
+	}
+	a.buildPairsFromCounts()
 }
 
 func (a *numericalAggregator) AddFloat64(value float64) error {

--- a/adapters/repos/db/aggregator/shard_combiner.go
+++ b/adapters/repos/db/aggregator/shard_combiner.go
@@ -429,10 +429,8 @@ func (sc *ShardCombiner) mergeNumericalProp(first, second map[string]interface{}
 	return nil
 }
 
-// finalizeDateProp and finalizeNumerical re-check distribution completeness on
-// the fully combined state: the per-merge checks only run for shards that carry
-// the mode/median key, so a trailing shard can still leave the combined
-// distribution incomplete.
+// The per-merge completeness checks only run for shards that carry the
+// mode/median key, so the fully combined state is re-checked at finalize.
 func (sc *ShardCombiner) finalizeDateProp(combined map[string]interface{}) error {
 	if agg, ok := combined["_dateAggregator"].(*dateAggregator); ok {
 		if err := requireCompleteForModeMedian(combined, agg.hasCompleteDistribution()); err != nil {

--- a/adapters/repos/db/aggregator/shard_combiner.go
+++ b/adapters/repos/db/aggregator/shard_combiner.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/aggregation"
 )
 
@@ -32,11 +33,13 @@ func (sc *ShardCombiner) Do(results []*aggregation.Result) (*aggregation.Result,
 		if res == nil || len(res.Groups) < 1 {
 			continue
 		}
-		if err := sc.restoreSerializedAggregators(res); err != nil {
+		if err := sc.RestoreSerializedAggregators(res); err != nil {
 			return nil, err
 		}
+		if allResultsAreNil {
+			firstNonNilRes = i
+		}
 		allResultsAreNil = false
-		firstNonNilRes = i
 	}
 
 	if allResultsAreNil {
@@ -44,89 +47,167 @@ func (sc *ShardCombiner) Do(results []*aggregation.Result) (*aggregation.Result,
 	}
 
 	if results[firstNonNilRes].Groups[0].GroupedBy == nil {
-		return sc.combineUngrouped(results), nil
+		return sc.combineUngrouped(results)
 	}
 
-	return sc.combineGrouped(results), nil
+	return sc.combineGrouped(results)
 }
 
-func (sc *ShardCombiner) combineUngrouped(results []*aggregation.Result) *aggregation.Result {
+func (sc *ShardCombiner) combineUngrouped(results []*aggregation.Result) (*aggregation.Result, error) {
 	combined := aggregation.Result{
 		Groups: make([]aggregation.Group, 1),
 	}
 
 	for _, shard := range results {
-		if len(shard.Groups) == 0 { // not every shard has results
+		if shard == nil || len(shard.Groups) == 0 { // not every shard has results
 			continue
 		}
-		sc.mergeIntoCombinedGroupAtPos(combined.Groups, 0, shard.Groups[0])
+		if shard.Groups[0].GroupedBy != nil {
+			return nil, errors.New("mixed grouped and ungrouped shard results")
+		}
+		if err := sc.mergeIntoCombinedGroupAtPos(combined.Groups, 0, shard.Groups[0]); err != nil {
+			return nil, err
+		}
 	}
 
-	sc.finalizeGroup(&combined.Groups[0])
-	return &combined
+	if err := sc.finalizeGroup(&combined.Groups[0]); err != nil {
+		return nil, err
+	}
+	return &combined, nil
 }
 
-func (sc *ShardCombiner) combineGrouped(results []*aggregation.Result) *aggregation.Result {
+func (sc *ShardCombiner) combineGrouped(results []*aggregation.Result) (*aggregation.Result, error) {
 	combined := aggregation.Result{}
 
 	for _, shard := range results {
+		if shard == nil {
+			continue
+		}
 		for _, shardGroup := range shard.Groups {
+			if shardGroup.GroupedBy == nil {
+				return nil, errors.New("mixed grouped and ungrouped shard results")
+			}
 			pos := getPosOfGroup(combined.Groups, shardGroup.GroupedBy.Value)
 			if pos < 0 {
 				combined.Groups = append(combined.Groups, shardGroup)
-			} else {
-				sc.mergeIntoCombinedGroupAtPos(combined.Groups, pos, shardGroup)
+			} else if err := sc.mergeIntoCombinedGroupAtPos(combined.Groups, pos, shardGroup); err != nil {
+				return nil, err
 			}
 		}
 	}
 
 	for i := range combined.Groups {
-		sc.finalizeGroup(&combined.Groups[i])
+		if err := sc.finalizeGroup(&combined.Groups[i]); err != nil {
+			return nil, err
+		}
 	}
 
 	sort.Slice(combined.Groups, func(a, b int) bool {
 		return combined.Groups[a].Count > combined.Groups[b].Count
 	})
-	return &combined
+	return &combined, nil
 }
 
-// restoreSerializedAggregators converts aggregator merge state that crossed
+// RestoreSerializedAggregators converts aggregator merge state that crossed
 // the cluster-internal JSON boundary back into its concrete in-memory types.
-func (sc *ShardCombiner) restoreSerializedAggregators(res *aggregation.Result) error {
+// It is idempotent: already-typed local state is left untouched.
+func (sc *ShardCombiner) RestoreSerializedAggregators(res *aggregation.Result) error {
 	for gi := range res.Groups {
 		for name, prop := range res.Groups[gi].Properties {
 			switch prop.Type {
 			case aggregation.PropertyTypeNumerical:
-				if raw, ok := prop.NumericalAggregations["_numericalAggregator"].(map[string]interface{}); ok {
-					agg, err := numericalAggregatorFromJSON(raw)
-					if err != nil {
-						return fmt.Errorf("prop %q: %w", name, err)
-					}
-					prop.NumericalAggregations["_numericalAggregator"] = agg
+				if err := restoreNumericalAggregations(name, prop.NumericalAggregations); err != nil {
+					return err
 				}
 			case aggregation.PropertyTypeDate:
-				if raw, ok := prop.DateAggregations["_dateAggregator"].(map[string]interface{}); ok {
-					agg, err := dateAggregatorFromJSON(raw)
-					if err != nil {
-						return fmt.Errorf("prop %q: %w", name, err)
-					}
-					prop.DateAggregations["_dateAggregator"] = agg
-				}
-				if count, ok := prop.DateAggregations["count"].(float64); ok {
-					prop.DateAggregations["count"] = int64(count)
+				if err := restoreDateAggregations(name, prop.DateAggregations); err != nil {
+					return err
 				}
 			default:
-				continue
+				// only numerical and date merge state crosses the wire untyped
 			}
-			res.Groups[gi].Properties[name] = prop
 		}
+	}
+	return nil
+}
+
+func restoreNumericalAggregations(name string, aggs map[string]interface{}) error {
+	state, ok := aggs["_numericalAggregator"]
+	if !ok {
+		return requirePairsForModeMedian(name, aggs, 0)
+	}
+	if _, typed := state.(*numericalAggregator); typed {
+		return nil
+	}
+	raw, ok := state.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("prop %q: malformed numerical aggregator state in remote shard result", name)
+	}
+	agg, err := numericalAggregatorFromJSON(raw)
+	if err != nil {
+		return fmt.Errorf("prop %q: %w", name, err)
+	}
+	if err := requirePairsForModeMedian(name, aggs, len(agg.pairs)); err != nil {
+		return err
+	}
+	aggs["_numericalAggregator"] = agg
+	return nil
+}
+
+func restoreDateAggregations(name string, aggs map[string]interface{}) error {
+	if state, ok := aggs["_dateAggregator"]; !ok {
+		if err := requirePairsForModeMedian(name, aggs, 0); err != nil {
+			return err
+		}
+	} else {
+		if _, typed := state.(*dateAggregator); !typed {
+			raw, ok := state.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("prop %q: malformed date aggregator state in remote shard result", name)
+			}
+			agg, err := dateAggregatorFromJSON(raw)
+			if err != nil {
+				return fmt.Errorf("prop %q: %w", name, err)
+			}
+			if err := requirePairsForModeMedian(name, aggs, len(agg.pairs)); err != nil {
+				return err
+			}
+			aggs["_dateAggregator"] = agg
+		}
+	}
+
+	switch count := aggs["count"].(type) {
+	case nil, int64:
+		// absent, or a local shard result: nothing to restore
+	case float64:
+		restored, err := wireCount(count)
+		if err != nil {
+			return fmt.Errorf("prop %q: %w", name, err)
+		}
+		aggs["count"] = int64(restored)
+	default:
+		return fmt.Errorf("prop %q: malformed count in remote shard result", name)
+	}
+	return nil
+}
+
+// requirePairsForModeMedian rejects wire state that carries a mode or median
+// result but no distribution to recompute it from during the merge.
+func requirePairsForModeMedian(name string, aggs map[string]interface{}, numPairs int) error {
+	if numPairs > 0 {
+		return nil
+	}
+	_, hasMode := aggs["mode"]
+	_, hasMedian := aggs["median"]
+	if hasMode || hasMedian {
+		return fmt.Errorf("prop %q: mode/median aggregation without value pairs in remote shard result", name)
 	}
 	return nil
 }
 
 func (sc *ShardCombiner) mergeIntoCombinedGroupAtPos(combinedGroups []aggregation.Group,
 	pos int, shardGroup aggregation.Group,
-) {
+) error {
 	combinedGroups[pos].Count += shardGroup.Count
 
 	for propName, prop := range shardGroup.Properties {
@@ -143,14 +224,18 @@ func (sc *ShardCombiner) mergeIntoCombinedGroupAtPos(combinedGroups []aggregatio
 			if combinedProp.NumericalAggregations == nil {
 				combinedProp.NumericalAggregations = map[string]interface{}{}
 			}
-			sc.mergeNumericalProp(
-				combinedProp.NumericalAggregations, prop.NumericalAggregations)
+			if err := sc.mergeNumericalProp(
+				combinedProp.NumericalAggregations, prop.NumericalAggregations); err != nil {
+				return fmt.Errorf("prop %q: %w", propName, err)
+			}
 		case aggregation.PropertyTypeDate:
 			if combinedProp.DateAggregations == nil {
 				combinedProp.DateAggregations = map[string]interface{}{}
 			}
-			sc.mergeDateProp(
-				combinedProp.DateAggregations, prop.DateAggregations)
+			if err := sc.mergeDateProp(
+				combinedProp.DateAggregations, prop.DateAggregations); err != nil {
+				return fmt.Errorf("prop %q: %w", propName, err)
+			}
 		case aggregation.PropertyTypeBoolean:
 			sc.mergeBooleanProp(
 				&combinedProp.BooleanAggregation, &prop.BooleanAggregation)
@@ -161,138 +246,223 @@ func (sc *ShardCombiner) mergeIntoCombinedGroupAtPos(combinedGroups []aggregatio
 			sc.mergeRefProp(
 				&combinedProp.ReferenceAggregation, &prop.ReferenceAggregation)
 		default:
-			panic("unknown prop type: " + prop.Type)
+			return fmt.Errorf("unknown property type %q in shard result", prop.Type)
 		}
 		combinedGroups[pos].Properties[propName] = combinedProp
-
 	}
+	return nil
 }
 
-func (sc *ShardCombiner) mergeDateProp(first, second map[string]interface{}) {
+func (sc *ShardCombiner) mergeDateProp(first, second map[string]interface{}) error {
 	if len(second) == 0 {
-		return
+		return nil
 	}
 
-	// add all values from the second map to the first one. This is needed to compute median and mode correctly
-	for propType := range second {
-		switch propType {
-		case "_dateAggregator":
-			dateAggSource := second[propType].(*dateAggregator)
-			if dateAggCombined, ok := first[propType]; ok {
-				dateAggCombinedTyped := dateAggCombined.(*dateAggregator)
-				for _, pair := range dateAggSource.pairs {
-					dateAggCombinedTyped.addRow(pair.value, pair.count)
-				}
-				dateAggCombinedTyped.buildPairsFromCounts()
-				first[propType] = dateAggCombinedTyped
-
-			} else {
-				first[propType] = second[propType]
+	// merge the raw distributions first, so that mode/median recompute over both shards
+	if source, ok := second["_dateAggregator"]; ok {
+		sourceTyped, ok := source.(*dateAggregator)
+		if !ok {
+			return errors.New("malformed date aggregator state in shard result")
+		}
+		if combined, ok := first["_dateAggregator"]; ok {
+			combinedTyped, ok := combined.(*dateAggregator)
+			if !ok {
+				return errors.New("malformed date aggregator state in shard result")
 			}
+			for _, pair := range sourceTyped.pairs {
+				combinedTyped.addRow(pair.value, pair.count)
+			}
+			combinedTyped.buildPairsFromCounts()
+		} else {
+			first["_dateAggregator"] = source
 		}
 	}
 
 	for propType, value := range second {
 		switch propType {
 		case "count":
+			sourceCount, ok := value.(int64)
+			if !ok {
+				return fmt.Errorf("malformed %q entry in shard result", propType)
+			}
 			if val, ok := first[propType]; ok {
-				first[propType] = val.(int64) + value.(int64)
+				combinedCount, ok := val.(int64)
+				if !ok {
+					return fmt.Errorf("malformed %q entry in shard result", propType)
+				}
+				first[propType] = combinedCount + sourceCount
 			} else {
 				first[propType] = value
 			}
-		case "mode":
-			dateAggCombined := first["_dateAggregator"].(*dateAggregator)
-			first[propType] = dateAggCombined.Mode()
-		case "median":
-			dateAggCombined := first["_dateAggregator"].(*dateAggregator)
-			first[propType] = dateAggCombined.Median()
-		case "minimum":
-			val, ok := first["minimum"]
-			if !ok {
-				first["minimum"] = value
-			} else {
-				source1Time, _ := time.Parse(time.RFC3339, val.(string))
-				source2Time, _ := time.Parse(time.RFC3339, value.(string))
-				if source2Time.Before(source1Time) {
-					first["minimum"] = value
-				}
+		case "mode", "median":
+			if _, ok := second["_dateAggregator"]; !ok {
+				return fmt.Errorf("%s aggregation without distribution state in shard result", propType)
 			}
-		case "maximum":
-			val, ok := first["maximum"]
+			agg, ok := first["_dateAggregator"].(*dateAggregator)
 			if !ok {
-				first["maximum"] = value
+				return fmt.Errorf("%s aggregation without distribution state in shard result", propType)
+			}
+			if !agg.hasCompleteDistribution() {
+				return fmt.Errorf("%s aggregation with incomplete distribution state in shard result", propType)
+			}
+			if propType == "mode" {
+				first[propType] = agg.Mode()
 			} else {
-				source1Time, _ := time.Parse(time.RFC3339, val.(string))
-				source2Time, _ := time.Parse(time.RFC3339, value.(string))
-				if source2Time.After(source1Time) {
-					first["maximum"] = value
-				}
+				first[propType] = agg.Median()
+			}
+		case "minimum", "maximum":
+			sourceStr, ok := value.(string)
+			if !ok {
+				return fmt.Errorf("malformed %q entry in shard result", propType)
+			}
+			val, ok := first[propType]
+			if !ok {
+				first[propType] = value
+				continue
+			}
+			combinedStr, ok := val.(string)
+			if !ok {
+				return fmt.Errorf("malformed %q entry in shard result", propType)
+			}
+			combinedTime, err := time.Parse(time.RFC3339, combinedStr)
+			if err != nil {
+				return fmt.Errorf("malformed %q entry in shard result: %w", propType, err)
+			}
+			sourceTime, err := time.Parse(time.RFC3339, sourceStr)
+			if err != nil {
+				return fmt.Errorf("malformed %q entry in shard result: %w", propType, err)
+			}
+			if (propType == "minimum" && sourceTime.Before(combinedTime)) ||
+				(propType == "maximum" && sourceTime.After(combinedTime)) {
+				first[propType] = value
 			}
 		case "_dateAggregator":
 			continue
 		default:
-			panic("unknown map entry: " + propType)
+			return fmt.Errorf("unknown aggregation %q in shard result", propType)
 		}
 	}
+	return nil
 }
 
-func (sc *ShardCombiner) mergeNumericalProp(first, second map[string]interface{}) {
+func (sc *ShardCombiner) mergeNumericalProp(first, second map[string]interface{}) error {
 	if len(second) == 0 {
-		return
+		return nil
 	}
 
-	// add all values from the second map to the first one. This is needed to compute median, mean and mode correctly
-	for propType := range second {
-		switch propType {
-		case "_numericalAggregator":
-			numAggSecondTyped := second[propType].(*numericalAggregator)
-			if numAggFirst, ok := first[propType]; ok {
-				numAggFirst.(*numericalAggregator).absorb(numAggSecondTyped)
-			} else {
-				first[propType] = numAggSecondTyped
+	// merge the raw distributions first, so that mode/mean/median recompute over both shards
+	if source, ok := second["_numericalAggregator"]; ok {
+		sourceTyped, ok := source.(*numericalAggregator)
+		if !ok {
+			return errors.New("malformed numerical aggregator state in shard result")
+		}
+		if combined, ok := first["_numericalAggregator"]; ok {
+			combinedTyped, ok := combined.(*numericalAggregator)
+			if !ok {
+				return errors.New("malformed numerical aggregator state in shard result")
 			}
+			combinedTyped.absorb(sourceTyped)
+		} else {
+			first["_numericalAggregator"] = source
 		}
 	}
 
 	for propType, value := range second {
 		switch propType {
 		case "count", "sum":
+			sourceVal, ok := value.(float64)
+			if !ok {
+				return fmt.Errorf("malformed %q entry in shard result", propType)
+			}
 			if val, ok := first[propType]; ok {
-				first[propType] = val.(float64) + value.(float64)
+				combinedVal, ok := val.(float64)
+				if !ok {
+					return fmt.Errorf("malformed %q entry in shard result", propType)
+				}
+				first[propType] = combinedVal + sourceVal
 			} else {
 				first[propType] = value
 			}
-		case "mode":
-			numAggFirst := first["_numericalAggregator"].(*numericalAggregator)
-			first[propType] = numAggFirst.Mode()
-		case "mean":
-			numAggFirst := first["_numericalAggregator"].(*numericalAggregator)
-			first[propType] = numAggFirst.Mean()
-		case "median":
-			numAggFirst := first["_numericalAggregator"].(*numericalAggregator)
-			first[propType] = numAggFirst.Median()
-		case "minimum":
-			if _, ok := first["minimum"]; !ok || value.(float64) < first["minimum"].(float64) {
-				first["minimum"] = value
+		case "mode", "mean", "median":
+			if _, ok := second["_numericalAggregator"]; !ok {
+				return fmt.Errorf("%s aggregation without distribution state in shard result", propType)
 			}
-		case "maximum":
-			if _, ok := first["maximum"]; !ok || value.(float64) > first["maximum"].(float64) {
-				first["maximum"] = value
+			agg, ok := first["_numericalAggregator"].(*numericalAggregator)
+			if !ok {
+				return fmt.Errorf("%s aggregation without distribution state in shard result", propType)
+			}
+			if propType != "mean" && !agg.hasCompleteDistribution() {
+				return fmt.Errorf("%s aggregation with incomplete distribution state in shard result", propType)
+			}
+			switch propType {
+			case "mode":
+				first[propType] = agg.Mode()
+			case "mean":
+				first[propType] = agg.Mean()
+			case "median":
+				first[propType] = agg.Median()
+			}
+		case "minimum", "maximum":
+			sourceVal, ok := value.(float64)
+			if !ok {
+				return fmt.Errorf("malformed %q entry in shard result", propType)
+			}
+			val, ok := first[propType]
+			if !ok {
+				first[propType] = value
+				continue
+			}
+			combinedVal, ok := val.(float64)
+			if !ok {
+				return fmt.Errorf("malformed %q entry in shard result", propType)
+			}
+			if (propType == "minimum" && sourceVal < combinedVal) ||
+				(propType == "maximum" && sourceVal > combinedVal) {
+				first[propType] = value
 			}
 		case "_numericalAggregator":
 			continue
 		default:
-			panic("unknown map entry: " + propType)
+			return fmt.Errorf("unknown aggregation %q in shard result", propType)
 		}
 	}
+	return nil
 }
 
-func (sc *ShardCombiner) finalizeDateProp(combined map[string]interface{}) {
+// finalizeDateProp and finalizeNumerical re-check distribution completeness on
+// the fully combined state: the per-merge checks only run for shards that carry
+// the mode/median key, so a trailing shard can still leave the combined
+// distribution incomplete.
+func (sc *ShardCombiner) finalizeDateProp(combined map[string]interface{}) error {
+	if agg, ok := combined["_dateAggregator"].(*dateAggregator); ok {
+		if err := requireCompleteForModeMedian(combined, agg.hasCompleteDistribution()); err != nil {
+			return err
+		}
+	}
 	delete(combined, "_dateAggregator")
+	return nil
 }
 
-func (sc *ShardCombiner) finalizeNumerical(combined map[string]interface{}) {
+func (sc *ShardCombiner) finalizeNumerical(combined map[string]interface{}) error {
+	if agg, ok := combined["_numericalAggregator"].(*numericalAggregator); ok {
+		if err := requireCompleteForModeMedian(combined, agg.hasCompleteDistribution()); err != nil {
+			return err
+		}
+	}
 	delete(combined, "_numericalAggregator")
+	return nil
+}
+
+func requireCompleteForModeMedian(combined map[string]interface{}, complete bool) error {
+	if complete {
+		return nil
+	}
+	_, hasMode := combined["mode"]
+	_, hasMedian := combined["median"]
+	if hasMode || hasMedian {
+		return errors.New("incomplete distribution state for a mode/median aggregation in shard result")
+	}
+	return nil
 }
 
 func (sc *ShardCombiner) mergeBooleanProp(combined, source *aggregation.Boolean) {
@@ -339,24 +509,29 @@ func getPosOfTextOcc(haystack []aggregation.TextOccurrence, needle string) int {
 	return -1
 }
 
-func (sc *ShardCombiner) finalizeGroup(group *aggregation.Group) {
+func (sc *ShardCombiner) finalizeGroup(group *aggregation.Group) error {
 	for propName, prop := range group.Properties {
 		switch prop.Type {
 		case aggregation.PropertyTypeNumerical:
-			sc.finalizeNumerical(prop.NumericalAggregations)
+			if err := sc.finalizeNumerical(prop.NumericalAggregations); err != nil {
+				return fmt.Errorf("prop %q: %w", propName, err)
+			}
 		case aggregation.PropertyTypeBoolean:
 			sc.finalizeBoolean(&prop.BooleanAggregation)
 		case aggregation.PropertyTypeText:
 			sc.finalizeText(&prop.TextAggregation)
 		case aggregation.PropertyTypeDate:
-			sc.finalizeDateProp(prop.DateAggregations)
+			if err := sc.finalizeDateProp(prop.DateAggregations); err != nil {
+				return fmt.Errorf("prop %q: %w", propName, err)
+			}
 		case aggregation.PropertyTypeReference:
 			continue
 		default:
-			panic("Unknown prop type: " + prop.Type)
+			return fmt.Errorf("unknown property type %q in shard result", prop.Type)
 		}
 		group.Properties[propName] = prop
 	}
+	return nil
 }
 
 func getPosOfGroup(haystack []aggregation.Group, needle interface{}) int {

--- a/adapters/repos/db/aggregator/shard_combiner.go
+++ b/adapters/repos/db/aggregator/shard_combiner.go
@@ -12,6 +12,7 @@
 package aggregator
 
 import (
+	"fmt"
 	"sort"
 	"time"
 
@@ -24,27 +25,29 @@ func NewShardCombiner() *ShardCombiner {
 	return &ShardCombiner{}
 }
 
-func (sc *ShardCombiner) Do(results []*aggregation.Result) *aggregation.Result {
+func (sc *ShardCombiner) Do(results []*aggregation.Result) (*aggregation.Result, error) {
 	allResultsAreNil := true
 	firstNonNilRes := 0
 	for i, res := range results {
 		if res == nil || len(res.Groups) < 1 {
 			continue
 		}
-		sc.restoreSerializedAggregators(res)
+		if err := sc.restoreSerializedAggregators(res); err != nil {
+			return nil, err
+		}
 		allResultsAreNil = false
 		firstNonNilRes = i
 	}
 
 	if allResultsAreNil {
-		return &aggregation.Result{}
+		return &aggregation.Result{}, nil
 	}
 
 	if results[firstNonNilRes].Groups[0].GroupedBy == nil {
-		return sc.combineUngrouped(results)
+		return sc.combineUngrouped(results), nil
 	}
 
-	return sc.combineGrouped(results)
+	return sc.combineGrouped(results), nil
 }
 
 func (sc *ShardCombiner) combineUngrouped(results []*aggregation.Result) *aggregation.Result {
@@ -87,21 +90,27 @@ func (sc *ShardCombiner) combineGrouped(results []*aggregation.Result) *aggregat
 	return &combined
 }
 
-// restoreSerializedAggregators converts shard results that were fetched from
-// another node back into their in-memory form: the JSON round trip over the
-// cluster-internal REST API turns the raw aggregators (needed to merge
-// mean/median/mode) into generic maps and date counts into float64.
-func (sc *ShardCombiner) restoreSerializedAggregators(res *aggregation.Result) {
+// restoreSerializedAggregators converts aggregator merge state that crossed
+// the cluster-internal JSON boundary back into its concrete in-memory types.
+func (sc *ShardCombiner) restoreSerializedAggregators(res *aggregation.Result) error {
 	for gi := range res.Groups {
 		for name, prop := range res.Groups[gi].Properties {
 			switch prop.Type {
 			case aggregation.PropertyTypeNumerical:
 				if raw, ok := prop.NumericalAggregations["_numericalAggregator"].(map[string]interface{}); ok {
-					prop.NumericalAggregations["_numericalAggregator"] = numericalAggregatorFromJSON(raw)
+					agg, err := numericalAggregatorFromJSON(raw)
+					if err != nil {
+						return fmt.Errorf("prop %q: %w", name, err)
+					}
+					prop.NumericalAggregations["_numericalAggregator"] = agg
 				}
 			case aggregation.PropertyTypeDate:
 				if raw, ok := prop.DateAggregations["_dateAggregator"].(map[string]interface{}); ok {
-					prop.DateAggregations["_dateAggregator"] = dateAggregatorFromJSON(raw)
+					agg, err := dateAggregatorFromJSON(raw)
+					if err != nil {
+						return fmt.Errorf("prop %q: %w", name, err)
+					}
+					prop.DateAggregations["_dateAggregator"] = agg
 				}
 				if count, ok := prop.DateAggregations["count"].(float64); ok {
 					prop.DateAggregations["count"] = int64(count)
@@ -112,6 +121,7 @@ func (sc *ShardCombiner) restoreSerializedAggregators(res *aggregation.Result) {
 			res.Groups[gi].Properties[name] = prop
 		}
 	}
+	return nil
 }
 
 func (sc *ShardCombiner) mergeIntoCombinedGroupAtPos(combinedGroups []aggregation.Group,
@@ -237,14 +247,9 @@ func (sc *ShardCombiner) mergeNumericalProp(first, second map[string]interface{}
 		case "_numericalAggregator":
 			numAggSecondTyped := second[propType].(*numericalAggregator)
 			if numAggFirst, ok := first[propType]; ok {
-				numAggFirstTyped := numAggFirst.(*numericalAggregator)
-				for _, pair := range numAggSecondTyped.pairs {
-					numAggFirstTyped.AddNumberRow(pair.value, pair.count)
-				}
-				numAggFirstTyped.buildPairsFromCounts()
-				first[propType] = numAggFirstTyped
+				numAggFirst.(*numericalAggregator).absorb(numAggSecondTyped)
 			} else {
-				first[propType] = second[propType]
+				first[propType] = numAggSecondTyped
 			}
 		}
 	}

--- a/adapters/repos/db/aggregator/shard_combiner.go
+++ b/adapters/repos/db/aggregator/shard_combiner.go
@@ -31,6 +31,7 @@ func (sc *ShardCombiner) Do(results []*aggregation.Result) *aggregation.Result {
 		if res == nil || len(res.Groups) < 1 {
 			continue
 		}
+		sc.restoreSerializedAggregators(res)
 		allResultsAreNil = false
 		firstNonNilRes = i
 	}
@@ -84,6 +85,33 @@ func (sc *ShardCombiner) combineGrouped(results []*aggregation.Result) *aggregat
 		return combined.Groups[a].Count > combined.Groups[b].Count
 	})
 	return &combined
+}
+
+// restoreSerializedAggregators converts shard results that were fetched from
+// another node back into their in-memory form: the JSON round trip over the
+// cluster-internal REST API turns the raw aggregators (needed to merge
+// mean/median/mode) into generic maps and date counts into float64.
+func (sc *ShardCombiner) restoreSerializedAggregators(res *aggregation.Result) {
+	for gi := range res.Groups {
+		for name, prop := range res.Groups[gi].Properties {
+			switch prop.Type {
+			case aggregation.PropertyTypeNumerical:
+				if raw, ok := prop.NumericalAggregations["_numericalAggregator"].(map[string]interface{}); ok {
+					prop.NumericalAggregations["_numericalAggregator"] = numericalAggregatorFromJSON(raw)
+				}
+			case aggregation.PropertyTypeDate:
+				if raw, ok := prop.DateAggregations["_dateAggregator"].(map[string]interface{}); ok {
+					prop.DateAggregations["_dateAggregator"] = dateAggregatorFromJSON(raw)
+				}
+				if count, ok := prop.DateAggregations["count"].(float64); ok {
+					prop.DateAggregations["count"] = int64(count)
+				}
+			default:
+				continue
+			}
+			res.Groups[gi].Properties[name] = prop
+		}
+	}
 }
 
 func (sc *ShardCombiner) mergeIntoCombinedGroupAtPos(combinedGroups []aggregation.Group,
@@ -143,9 +171,7 @@ func (sc *ShardCombiner) mergeDateProp(first, second map[string]interface{}) {
 			if dateAggCombined, ok := first[propType]; ok {
 				dateAggCombinedTyped := dateAggCombined.(*dateAggregator)
 				for _, pair := range dateAggSource.pairs {
-					for i := uint64(0); i < pair.count; i++ {
-						dateAggCombinedTyped.AddTimestamp(pair.value.rfc3339)
-					}
+					dateAggCombinedTyped.addRow(pair.value, pair.count)
 				}
 				dateAggCombinedTyped.buildPairsFromCounts()
 				first[propType] = dateAggCombinedTyped
@@ -213,9 +239,7 @@ func (sc *ShardCombiner) mergeNumericalProp(first, second map[string]interface{}
 			if numAggFirst, ok := first[propType]; ok {
 				numAggFirstTyped := numAggFirst.(*numericalAggregator)
 				for _, pair := range numAggSecondTyped.pairs {
-					for i := uint64(0); i < pair.count; i++ {
-						numAggFirstTyped.AddFloat64(pair.value)
-					}
+					numAggFirstTyped.AddNumberRow(pair.value, pair.count)
 				}
 				numAggFirstTyped.buildPairsFromCounts()
 				first[propType] = numAggFirstTyped

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -13,7 +13,6 @@ package aggregator
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"testing"
 
@@ -205,6 +204,26 @@ func TestShardCombinerMergeNil(t *testing.T) {
 			},
 			totalResults: 1,
 		},
+		{
+			name: "Literal nil first",
+			results: []*aggregation.Result{
+				nil,
+				{
+					Groups: []aggregation.Group{{Count: 1}},
+				},
+			},
+			totalResults: 1,
+		},
+		{
+			name: "Literal nil last, grouped",
+			results: []*aggregation.Result{
+				{
+					Groups: []aggregation.Group{{GroupedBy: &aggregation.GroupedBy{Value: 10, Path: []string{"something"}}}},
+				},
+				nil,
+			},
+			totalResults: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -314,38 +333,17 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 	numbers2 := []float64{15, 15, 2.5}
 	dates1 := []string{"55", "26", "10"}
 	dates2 := []string{"15", "26", "45", "26"}
+	unionNumbers := append(append([]float64{}, numbers1...), numbers2...)
+	unionDates := append(append([]string{}, dates1...), dates2...)
 
-	assertCombined := func(t *testing.T, combined *aggregation.Result) {
-		require.Len(t, combined.Groups, 1)
-
-		expectedNum := createNumericalAgg(append(append([]float64{}, numbers1...), numbers2...))
-		num := combined.Groups[0].Properties["number"].NumericalAggregations
-		assert.Equal(t, float64(len(numbers1)+len(numbers2)), num["count"])
-		assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
-		assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
-		assert.Equal(t, expectedNum["mode"], num["mode"])
-		assert.NotContains(t, num, "_numericalAggregator")
-
-		expectedDate := createDateAgg(append(append([]string{}, dates1...), dates2...))
-		date := combined.Groups[0].Properties["date"].DateAggregations
-		assert.Equal(t, int64(len(dates1)+len(dates2)), date["count"])
-		for _, key := range []string{"minimum", "maximum", "median", "mode"} {
-			assert.Equal(t, expectedDate[key], date[key], key)
-		}
-		assert.NotContains(t, date, "_dateAggregator")
-	}
-
-	tests := []struct {
+	for _, tt := range []struct {
 		name    string
 		remote1 bool
 		remote2 bool
 	}{
 		{name: "first shard remote", remote1: true},
 		{name: "second shard remote", remote2: true},
-		{name: "both shards remote", remote1: true, remote2: true},
-	}
-
-	for _, tt := range tests {
+	} {
 		t.Run("ungrouped, "+tt.name, func(t *testing.T) {
 			res1 := makeResult(numbers1, dates1, nil)
 			res2 := makeResult(numbers2, dates2, nil)
@@ -357,20 +355,9 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 			}
 			combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
 			require.NoError(t, err)
-			assertCombined(t, combined)
+			assertCombinedResult(t, combined, unionNumbers, unionDates)
 		})
 	}
-
-	t.Run("grouped, remote group appended before merge", func(t *testing.T) {
-		groupedBy := func() *aggregation.GroupedBy {
-			return &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
-		}
-		res1 := roundTrip(t, makeResult(numbers1, dates1, groupedBy()))
-		res2 := makeResult(numbers2, dates2, groupedBy())
-		combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
-		require.NoError(t, err)
-		assertCombined(t, combined)
-	})
 
 	t.Run("mean-only query ships count and sum instead of pairs", func(t *testing.T) {
 		meanOnly := func(numbers []float64) *aggregation.Result {
@@ -396,126 +383,30 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 		assert.Equal(t, float64(len(all)), num["count"])
 	})
 
-	t.Run("payload from an older node is rejected, not merged wrong", func(t *testing.T) {
-		for _, propName := range []string{"number", "date"} {
-			res1 := makeResult(numbers1, dates1, nil)
-			res2 := roundTrip(t, makeResult(numbers2, dates2, nil))
-			// an older node serializes the aggregator's unexported fields as {}
-			props := res2.Groups[0].Properties[propName]
-			switch propName {
-			case "number":
-				props.NumericalAggregations["_numericalAggregator"] = map[string]interface{}{}
-			case "date":
-				props.DateAggregations["_dateAggregator"] = map[string]interface{}{}
-			}
-			_, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
-			require.ErrorContains(t, err, "older version")
-		}
-	})
+	t.Run("date count-only query has no merge state", func(t *testing.T) {
+		res1 := makeDateResult(dates1, aggregation.CountAggregator)
+		res2 := roundTrip(t, makeDateResult(dates2, aggregation.CountAggregator))
 
-	t.Run("malformed pairs are rejected", func(t *testing.T) {
-		res2 := roundTrip(t, makeResult(numbers2, dates2, nil))
-		res2.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
-			"count": float64(1), "sum": float64(1), "pairs": []interface{}{"garbage"},
-		}
-		_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers1, dates1, nil), res2})
-		require.ErrorContains(t, err, "malformed")
-	})
-
-	t.Run("selector-specific wire round trips", func(t *testing.T) {
-		unionNumbers := append(append([]float64{}, numbers1...), numbers2...)
-		unionDates := append(append([]string{}, dates1...), dates2...)
-
-		tests := []struct {
-			name   string
-			isDate bool
-			aggs   []aggregation.Aggregator
-			keys   []string
-		}{
-			{
-				name: "numerical median-only",
-				aggs: []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.CountAggregator},
-				keys: []string{"median", "count"},
-			},
-			{
-				name: "numerical mode-only",
-				aggs: []aggregation.Aggregator{aggregation.ModeAggregator, aggregation.CountAggregator},
-				keys: []string{"mode", "count"},
-			},
-			{
-				name:   "date median-only",
-				isDate: true,
-				aggs:   []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.CountAggregator},
-				keys:   []string{"median", "count"},
-			},
-			{
-				name:   "date mode-only",
-				isDate: true,
-				aggs:   []aggregation.Aggregator{aggregation.ModeAggregator, aggregation.CountAggregator},
-				keys:   []string{"mode", "count"},
-			},
-			{
-				name:   "date count-only",
-				isDate: true,
-				aggs:   []aggregation.Aggregator{aggregation.CountAggregator},
-				keys:   []string{"count"},
-			},
-		}
-
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				var res1, res2 *aggregation.Result
-				var expected map[string]interface{}
-				if tt.isDate {
-					res1 = makeDateResult(dates1, tt.aggs...)
-					res2 = roundTrip(t, makeDateResult(dates2, tt.aggs...))
-					expected = createDateAggWith(unionDates, tt.aggs)
-				} else {
-					res1 = makeNumberResult(numbers1, tt.aggs...)
-					res2 = roundTrip(t, makeNumberResult(numbers2, tt.aggs...))
-					expected = createNumericalAggWith(unionNumbers, tt.aggs)
-				}
-
-				combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
-				require.NoError(t, err)
-				require.Len(t, combined.Groups, 1)
-
-				var got map[string]interface{}
-				if tt.isDate {
-					got = combined.Groups[0].Properties["date"].DateAggregations
-					assert.NotContains(t, got, "_dateAggregator")
-					assert.IsType(t, int64(0), got["count"])
-				} else {
-					got = combined.Groups[0].Properties["number"].NumericalAggregations
-					assert.NotContains(t, got, "_numericalAggregator")
-				}
-				for _, key := range tt.keys {
-					assert.Equal(t, expected[key], got[key], key)
-				}
-			})
-		}
-	})
-
-	t.Run("single remote result is restored and finalized", func(t *testing.T) {
-		combined, err := NewShardCombiner().Do([]*aggregation.Result{roundTrip(t, makeResult(numbers2, dates2, nil))})
+		combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
 		require.NoError(t, err)
 		require.Len(t, combined.Groups, 1)
-
-		expectedNum := createNumericalAgg(numbers2)
-		num := combined.Groups[0].Properties["number"].NumericalAggregations
-		assert.Equal(t, float64(len(numbers2)), num["count"])
-		assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
-		assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
-		assert.Equal(t, expectedNum["mode"], num["mode"])
-		assert.NotContains(t, num, "_numericalAggregator")
-
-		expectedDate := createDateAgg(dates2)
 		date := combined.Groups[0].Properties["date"].DateAggregations
-		assert.Equal(t, int64(len(dates2)), date["count"])
-		for _, key := range []string{"minimum", "maximum", "median", "mode"} {
-			assert.Equal(t, expectedDate[key], date[key], key)
-		}
+		assert.Equal(t, int64(len(dates1)+len(dates2)), date["count"])
 		assert.NotContains(t, date, "_dateAggregator")
+	})
+
+	t.Run("zero-row shard merges cleanly", func(t *testing.T) {
+		for _, emptyFirst := range []bool{false, true} {
+			data := roundTrip(t, makeResult(numbers2, dates2, nil))
+			empty := roundTrip(t, makeResult([]float64{}, []string{}, nil))
+			results := []*aggregation.Result{data, empty}
+			if emptyFirst {
+				results = []*aggregation.Result{empty, data}
+			}
+			combined, err := NewShardCombiner().Do(results)
+			require.NoError(t, err)
+			assertCombinedResult(t, combined, numbers2, dates2)
+		}
 	})
 
 	t.Run("grouped, remote-only group is restored", func(t *testing.T) {
@@ -558,432 +449,301 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 		assert.Equal(t, int64(len(datesB)), dateB["count"])
 		assert.NotContains(t, dateB, "_dateAggregator")
 	})
-
-	t.Run("later group failure surfaces after earlier group merged", func(t *testing.T) {
-		groupA := &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
-		groupB := &aggregation.GroupedBy{Value: "b", Path: []string{"prop"}}
-		twoGroups := func() *aggregation.Result {
-			return &aggregation.Result{Groups: []aggregation.Group{
-				makeResult(numbers1, dates1, groupA).Groups[0],
-				makeResult(numbers2, dates2, groupB).Groups[0],
-			}}
-		}
-
-		res2 := roundTrip(t, twoGroups())
-		res2.Groups[1].Properties["number"].NumericalAggregations["percentile"] = float64(5)
-
-		_, err := NewShardCombiner().Do([]*aggregation.Result{twoGroups(), res2})
-		require.ErrorContains(t, err, `unknown aggregation "percentile"`)
-	})
 }
 
-func TestShardCombinerRejectsInvalidWireCounts(t *testing.T) {
+func assertCombinedResult(t *testing.T, combined *aggregation.Result, numbers []float64, dates []string) {
+	t.Helper()
+	require.Len(t, combined.Groups, 1)
+	assert.Equal(t, len(numbers), combined.Groups[0].Count)
+
+	expectedNum := createNumericalAgg(numbers)
+	num := combined.Groups[0].Properties["number"].NumericalAggregations
+	assert.Equal(t, float64(len(numbers)), num["count"])
+	assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
+	assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
+	assert.Equal(t, expectedNum["mode"], num["mode"])
+	assert.NotContains(t, num, "_numericalAggregator")
+
+	expectedDate := createDateAgg(dates)
+	date := combined.Groups[0].Properties["date"].DateAggregations
+	assert.Equal(t, int64(len(dates)), date["count"])
+	for _, key := range []string{"minimum", "maximum", "median", "mode"} {
+		assert.Equal(t, expectedDate[key], date[key], key)
+	}
+	assert.NotContains(t, date, "_dateAggregator")
+}
+
+// TestShardCombinerRejectsMalformedPayloads pins every payload-rejection
+// branch: one row per branch, each expecting an error instead of the panic or
+// silent mis-merge the branch replaces.
+func TestShardCombinerRejectsMalformedPayloads(t *testing.T) {
 	numbers := []float64{0, 5, 10, 15}
 	dates := []string{"55", "26", "10"}
+	groupedBy := &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
+	ts26 := YearMonthDayHourMinute + "26" + NanoSecondsTimeZone
 
-	targets := []struct {
-		name    string
-		results func(t *testing.T, bad float64) []*aggregation.Result
-	}{
-		{
-			name: "numerical mean-only top-level count",
-			results: func(t *testing.T, bad float64) []*aggregation.Result {
-				meanOnly := func() *aggregation.Result {
-					return makeNumberResult(numbers, aggregation.MeanAggregator, aggregation.CountAggregator)
-				}
-				remote := roundTrip(t, meanOnly())
-				remote.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
-					"count": bad, "sum": float64(1),
-				}
-				return []*aggregation.Result{meanOnly(), remote}
-			},
-		},
-		{
-			name: "numerical pair count",
-			results: func(t *testing.T, bad float64) []*aggregation.Result {
-				remote := roundTrip(t, makeResult(numbers, dates, nil))
-				remote.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
-					"count": float64(1), "sum": float64(1),
-					"pairs": []interface{}{map[string]interface{}{"value": float64(1), "count": bad}},
-				}
-				return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
-			},
-		},
-		{
-			name: "date pair count",
-			results: func(t *testing.T, bad float64) []*aggregation.Result {
-				remote := roundTrip(t, makeResult(numbers, dates, nil))
-				remote.Groups[0].Properties["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
-					"pairs": []interface{}{map[string]interface{}{
-						"value": YearMonthDayHourMinute + "26" + NanoSecondsTimeZone, "count": bad,
-					}},
-				}
-				return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
-			},
-		},
-		{
-			name: "date count scalar",
-			results: func(t *testing.T, bad float64) []*aggregation.Result {
-				remote := roundTrip(t, makeResult(numbers, dates, nil))
-				remote.Groups[0].Properties["date"].DateAggregations["count"] = bad
-				return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
-			},
-		},
-	}
-
-	badCounts := []float64{-1, 1.5, 1 << 53, 1e19}
-	for _, target := range targets {
-		for _, bad := range badCounts {
-			t.Run(fmt.Sprintf("%s with %v", target.name, bad), func(t *testing.T) {
-				_, err := NewShardCombiner().Do(target.results(t, bad))
-				require.ErrorContains(t, err, "invalid count")
-			})
-		}
-	}
-}
-
-func TestShardCombinerRejectsMalformedAggregatorState(t *testing.T) {
-	numbers := []float64{0, 5, 10, 15}
-	dates := []string{"55", "26", "10"}
-	badStates := []interface{}{nil, "garbage", float64(42), []interface{}{}}
-
-	for _, marker := range []string{"_numericalAggregator", "_dateAggregator"} {
-		for _, state := range badStates {
-			t.Run(fmt.Sprintf("%s set to %v", marker, state), func(t *testing.T) {
-				remote := roundTrip(t, makeResult(numbers, dates, nil))
-				props := remote.Groups[0].Properties
-				switch marker {
-				case "_numericalAggregator":
-					props["number"].NumericalAggregations[marker] = state
-				case "_dateAggregator":
-					props["date"].DateAggregations[marker] = state
-				}
-				_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
-				require.ErrorContains(t, err, "malformed")
-				require.ErrorContains(t, err, "aggregator state")
-			})
-		}
-	}
-}
-
-func TestShardCombinerRejectsPairlessModeMedian(t *testing.T) {
-	numbers := []float64{0, 5, 10, 15}
-	dates := []string{"55", "26", "10"}
-
-	tests := []struct {
-		name   string
-		mutate func(props map[string]aggregation.Property)
-	}{
-		{
-			name: "numerical state without pairs",
-			mutate: func(props map[string]aggregation.Property) {
-				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
-					"count": float64(3), "sum": float64(6),
-				}
-			},
-		},
-		{
-			name: "date state with empty pairs",
-			mutate: func(props map[string]aggregation.Property) {
-				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
-					"pairs": []interface{}{},
-				}
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			remote := roundTrip(t, makeResult(numbers, dates, nil))
-			tt.mutate(remote.Groups[0].Properties)
-			_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
-			require.ErrorContains(t, err, "without value pairs")
-		})
-	}
-}
-
-func TestShardCombinerRejectsUnknownAggregationKey(t *testing.T) {
-	numbers := []float64{0, 5, 10, 15}
-	dates := []string{"55", "26", "10"}
-
-	remote := roundTrip(t, makeResult(numbers, dates, nil))
-	remote.Groups[0].Properties["number"].NumericalAggregations["percentile"] = float64(5)
-
-	_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
-	require.ErrorContains(t, err, `unknown aggregation "percentile"`)
-}
-
-func TestShardCombinerRejectsMissingDistributionState(t *testing.T) {
-	t.Run("mode/median without marker is rejected at restore", func(t *testing.T) {
-		remote := roundTrip(t, makeResult([]float64{0, 5, 10, 15}, []string{"55", "26", "10"}, nil))
-		delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
-
-		_, err := NewShardCombiner().Do([]*aggregation.Result{remote})
-		require.ErrorContains(t, err, "without value pairs")
-	})
-
-	t.Run("mean without marker is rejected at merge", func(t *testing.T) {
-		remote := roundTrip(t, makeNumberResult([]float64{0, 5},
-			aggregation.MeanAggregator, aggregation.CountAggregator))
-		delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
-
-		_, err := NewShardCombiner().Do([]*aggregation.Result{remote})
-		require.ErrorContains(t, err, "without distribution state")
-	})
-}
-
-func TestShardCombinerRejectsMeanOnlyModeMedianMixture(t *testing.T) {
 	meanOnly := func() *aggregation.Result {
-		return makeNumberResult([]float64{0, 5}, aggregation.MeanAggregator, aggregation.CountAggregator)
+		return makeNumberResult(numbers, aggregation.MeanAggregator, aggregation.CountAggregator)
 	}
 	full := func() *aggregation.Result {
-		return makeNumberResult([]float64{10, 15, 15},
+		return makeNumberResult(numbers,
 			aggregation.MedianAggregator, aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.CountAggregator)
+	}
+	mutated := func(mutate func(props map[string]aggregation.Property)) func(t *testing.T) []*aggregation.Result {
+		return func(t *testing.T) []*aggregation.Result {
+			remote := roundTrip(t, makeResult(numbers, dates, nil))
+			mutate(remote.Groups[0].Properties)
+			return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
+		}
 	}
 
 	tests := []struct {
 		name    string
 		results func(t *testing.T) []*aggregation.Result
+		errText string
 	}{
 		{
-			name: "mean-only shard first",
+			name: "old-node numerical payload",
+			results: func(t *testing.T) []*aggregation.Result {
+				var remote aggregation.Result
+				require.NoError(t, json.Unmarshal([]byte(oldNodeNumericalWireJSON), &remote))
+				return []*aggregation.Result{full(), &remote}
+			},
+			errText: "older version",
+		},
+		{
+			name: "old-node date marker",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{}
+			}),
+			errText: "older version",
+		},
+		{
+			name: "numerical marker as null",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = nil
+			}),
+			errText: "malformed numerical aggregator state",
+		},
+		{
+			name: "date marker as string",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = "garbage"
+			}),
+			errText: "malformed date aggregator state",
+		},
+		{
+			name: "garbage numerical pair element",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(1), "sum": float64(1), "pairs": []interface{}{"garbage"},
+				}
+			}),
+			errText: "malformed numerical aggregator pair",
+		},
+		{
+			name: "numerical pairs as string",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(2), "sum": float64(3), "pairs": "garbage",
+				}
+			}),
+			errText: "malformed numerical aggregator pairs",
+		},
+		{
+			name: "date pairs as string",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{"pairs": "garbage"}
+			}),
+			errText: "malformed date aggregator pairs",
+		},
+		{
+			name: "negative numerical pair count",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(1), "sum": float64(1),
+					"pairs": []interface{}{map[string]interface{}{"value": float64(1), "count": float64(-1)}},
+				}
+			}),
+			errText: "invalid count",
+		},
+		{
+			name: "fractional mean-only count",
+			results: func(t *testing.T) []*aggregation.Result {
+				remote := roundTrip(t, meanOnly())
+				remote.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": 1.5, "sum": float64(3),
+				}
+				return []*aggregation.Result{meanOnly(), remote}
+			},
+			errText: "invalid count",
+		},
+		{
+			name: "float64-inexact date pair count",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
+					"pairs": []interface{}{map[string]interface{}{"value": ts26, "count": float64(1 << 53)}},
+				}
+			}),
+			errText: "invalid count",
+		},
+		{
+			name: "out-of-range date count scalar",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["count"] = 1e19
+			}),
+			errText: "invalid count",
+		},
+		{
+			name: "numerical mode/median state without pairs",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(3), "sum": float64(6),
+				}
+			}),
+			errText: "without value pairs",
+		},
+		{
+			name: "date state with empty pairs",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{"pairs": []interface{}{}}
+			}),
+			errText: "without value pairs",
+		},
+		{
+			name: "mode/median without marker",
+			results: mutated(func(props map[string]aggregation.Property) {
+				delete(props["number"].NumericalAggregations, "_numericalAggregator")
+			}),
+			errText: "without value pairs",
+		},
+		{
+			name: "mean scalar without marker",
+			results: func(t *testing.T) []*aggregation.Result {
+				remote := roundTrip(t, meanOnly())
+				delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
+				return []*aggregation.Result{roundTrip(t, meanOnly()), remote}
+			},
+			errText: "without distribution state",
+		},
+		{
+			name: "mean-only shard mixed with mode/median shard",
 			results: func(t *testing.T) []*aggregation.Result {
 				return []*aggregation.Result{roundTrip(t, meanOnly()), roundTrip(t, full())}
 			},
+			errText: "incomplete distribution state",
 		},
 		{
-			name: "mode/median shard first",
+			name: "mode/median shard mixed with mean-only shard",
 			results: func(t *testing.T) []*aggregation.Result {
 				return []*aggregation.Result{roundTrip(t, full()), roundTrip(t, meanOnly())}
 			},
+			errText: "incomplete distribution state",
+		},
+		{
+			name: "unknown aggregation key",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["percentile"] = float64(5)
+			}),
+			errText: `unknown aggregation "percentile"`,
+		},
+		{
+			name: "unknown aggregation key in a later group",
+			results: func(t *testing.T) []*aggregation.Result {
+				groupB := &aggregation.GroupedBy{Value: "b", Path: []string{"prop"}}
+				twoGroups := func() *aggregation.Result {
+					return &aggregation.Result{Groups: []aggregation.Group{
+						makeResult(numbers, dates, groupedBy).Groups[0],
+						makeResult(numbers, dates, groupB).Groups[0],
+					}}
+				}
+				remote := roundTrip(t, twoGroups())
+				remote.Groups[1].Properties["number"].NumericalAggregations["percentile"] = float64(5)
+				return []*aggregation.Result{twoGroups(), remote}
+			},
+			errText: `unknown aggregation "percentile"`,
+		},
+		{
+			name: "mixed groupedness, ungrouped first",
+			results: func(t *testing.T) []*aggregation.Result {
+				return []*aggregation.Result{
+					roundTrip(t, makeResult(numbers, dates, nil)),
+					roundTrip(t, makeResult(numbers, dates, groupedBy)),
+				}
+			},
+			errText: "mixed grouped and ungrouped",
+		},
+		{
+			name: "mixed groupedness, grouped first",
+			results: func(t *testing.T) []*aggregation.Result {
+				return []*aggregation.Result{
+					roundTrip(t, makeResult(numbers, dates, groupedBy)),
+					roundTrip(t, makeResult(numbers, dates, nil)),
+				}
+			},
+			errText: "mixed grouped and ungrouped",
+		},
+		{
+			name: "date count as string",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["count"] = "garbage"
+			}),
+			errText: "malformed count",
+		},
+		{
+			name: "date minimum as number",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["minimum"] = float64(5)
+			}),
+			errText: `malformed "minimum" entry`,
+		},
+		{
+			name: "date minimum as unparseable string",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["minimum"] = "not-a-date"
+			}),
+			errText: `malformed "minimum" entry`,
+		},
+		{
+			name: "numerical sum as string",
+			results: mutated(func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["sum"] = "garbage"
+			}),
+			errText: `malformed "sum" entry`,
+		},
+		{
+			name: "unknown property type",
+			results: func(t *testing.T) []*aggregation.Result {
+				bogus := &aggregation.Result{Groups: []aggregation.Group{{Count: 1, Properties: map[string]aggregation.Property{
+					"weird": {Type: aggregation.PropertyType("bogus")},
+				}}}}
+				return []*aggregation.Result{makeResult(numbers, dates, nil), bogus}
+			},
+			errText: "unknown property type",
+		},
+		{
+			name: "unknown property type in appended group",
+			results: func(t *testing.T) []*aggregation.Result {
+				return []*aggregation.Result{{Groups: []aggregation.Group{{
+					GroupedBy:  groupedBy,
+					Count:      1,
+					Properties: map[string]aggregation.Property{"weird": {Type: aggregation.PropertyType("bogus")}},
+				}}}}
+			},
+			errText: "unknown property type",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := NewShardCombiner().Do(tt.results(t))
-			require.ErrorContains(t, err, "incomplete distribution state")
-		})
-	}
-}
-
-func TestShardCombinerRejectsBareScalarFromSecondShard(t *testing.T) {
-	meanOnly := func() *aggregation.Result {
-		return makeNumberResult([]float64{0, 5}, aggregation.MeanAggregator, aggregation.CountAggregator)
-	}
-
-	remote := roundTrip(t, meanOnly())
-	delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
-
-	_, err := NewShardCombiner().Do([]*aggregation.Result{roundTrip(t, meanOnly()), remote})
-	require.ErrorContains(t, err, "without distribution state")
-}
-
-func TestShardCombinerRejectsMixedGroupedness(t *testing.T) {
-	numbers := []float64{0, 5, 10, 15}
-	dates := []string{"55", "26", "10"}
-	groupedBy := &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
-
-	tests := []struct {
-		name         string
-		groupedFirst bool
-	}{
-		{name: "ungrouped first"},
-		{name: "grouped first", groupedFirst: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ungrouped := roundTrip(t, makeResult(numbers, dates, nil))
-			grouped := roundTrip(t, makeResult(numbers, dates, groupedBy))
-			results := []*aggregation.Result{ungrouped, grouped}
-			if tt.groupedFirst {
-				results = []*aggregation.Result{grouped, ungrouped}
-			}
-
-			_, err := NewShardCombiner().Do(results)
-			require.ErrorContains(t, err, "mixed grouped and ungrouped")
-		})
-	}
-}
-
-func TestShardCombinerRejectsMalformedWireEntries(t *testing.T) {
-	numbers := []float64{0, 5, 10, 15}
-	dates := []string{"55", "26", "10"}
-
-	tests := []struct {
-		name    string
-		mutate  func(props map[string]aggregation.Property)
-		errText string
-	}{
-		{
-			name: "date count as string",
-			mutate: func(props map[string]aggregation.Property) {
-				props["date"].DateAggregations["count"] = "garbage"
-			},
-			errText: "malformed count",
-		},
-		{
-			name: "numerical pairs as string",
-			mutate: func(props map[string]aggregation.Property) {
-				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
-					"count": float64(2), "sum": float64(3), "pairs": "garbage",
-				}
-			},
-			errText: "malformed numerical aggregator pairs",
-		},
-		{
-			name: "date pairs as string",
-			mutate: func(props map[string]aggregation.Property) {
-				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
-					"pairs": "garbage",
-				}
-			},
-			errText: "malformed date aggregator pairs",
-		},
-		{
-			name: "date minimum as number",
-			mutate: func(props map[string]aggregation.Property) {
-				props["date"].DateAggregations["minimum"] = float64(5)
-			},
-			errText: `malformed "minimum" entry`,
-		},
-		{
-			name: "numerical sum as string",
-			mutate: func(props map[string]aggregation.Property) {
-				props["number"].NumericalAggregations["sum"] = "garbage"
-			},
-			errText: `malformed "sum" entry`,
-		},
-		{
-			name: "date minimum as unparseable string",
-			mutate: func(props map[string]aggregation.Property) {
-				props["date"].DateAggregations["minimum"] = "not-a-date"
-			},
-			errText: `malformed "minimum" entry`,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			remote := roundTrip(t, makeResult(numbers, dates, nil))
-			tt.mutate(remote.Groups[0].Properties)
-			_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
 			require.ErrorContains(t, err, tt.errText)
 		})
 	}
 }
 
-func TestShardCombinerRejectsUnknownPropertyType(t *testing.T) {
-	bogusProps := func() map[string]aggregation.Property {
-		return map[string]aggregation.Property{
-			"weird": {Type: aggregation.PropertyType("bogus")},
-		}
-	}
-
-	t.Run("ungrouped merge path", func(t *testing.T) {
-		bogus := &aggregation.Result{Groups: []aggregation.Group{{Count: 1, Properties: bogusProps()}}}
-		_, err := NewShardCombiner().Do([]*aggregation.Result{
-			makeResult([]float64{0, 5}, []string{"26"}, nil), bogus,
-		})
-		require.ErrorContains(t, err, "unknown property type")
-	})
-
-	t.Run("grouped finalize path", func(t *testing.T) {
-		bogus := &aggregation.Result{Groups: []aggregation.Group{{
-			GroupedBy:  &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}},
-			Count:      1,
-			Properties: bogusProps(),
-		}}}
-		_, err := NewShardCombiner().Do([]*aggregation.Result{bogus})
-		require.ErrorContains(t, err, "unknown property type")
-	})
-}
-
-func TestShardCombinerMergesEmptyShardForModeMedian(t *testing.T) {
-	numbers := []float64{15, 15, 2.5}
-	dates := []string{"15", "26", "45", "26"}
-
-	tests := []struct {
-		name       string
-		emptyFirst bool
-	}{
-		{name: "empty shard last"},
-		{name: "empty shard first", emptyFirst: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			data := roundTrip(t, makeResult(numbers, dates, nil))
-			empty := roundTrip(t, makeResult([]float64{}, []string{}, nil))
-			results := []*aggregation.Result{data, empty}
-			if tt.emptyFirst {
-				results = []*aggregation.Result{empty, data}
-			}
-
-			combined, err := NewShardCombiner().Do(results)
-			require.NoError(t, err)
-			require.Len(t, combined.Groups, 1)
-			assert.Equal(t, len(numbers), combined.Groups[0].Count)
-
-			expectedNum := createNumericalAgg(numbers)
-			num := combined.Groups[0].Properties["number"].NumericalAggregations
-			assert.Equal(t, float64(len(numbers)), num["count"])
-			assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
-			assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
-			assert.Equal(t, expectedNum["mode"], num["mode"])
-			assert.NotContains(t, num, "_numericalAggregator")
-
-			expectedDate := createDateAgg(dates)
-			date := combined.Groups[0].Properties["date"].DateAggregations
-			assert.Equal(t, int64(len(dates)), date["count"])
-			for _, key := range []string{"minimum", "maximum", "median", "mode"} {
-				assert.Equal(t, expectedDate[key], date[key], key)
-			}
-			assert.NotContains(t, date, "_dateAggregator")
-		})
-	}
-}
-
-func TestShardCombinerMergeLiteralNil(t *testing.T) {
-	numbers := []float64{0, 5, 10, 15}
-	dates := []string{"55", "26", "10"}
-
-	tests := []struct {
-		name      string
-		groupedBy *aggregation.GroupedBy
-		nilFirst  bool
-	}{
-		{name: "ungrouped, nil first", nilFirst: true},
-		{name: "ungrouped, nil last"},
-		{name: "grouped, nil first", groupedBy: &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}, nilFirst: true},
-		{name: "grouped, nil last", groupedBy: &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			valid := makeResult(numbers, dates, tt.groupedBy)
-			results := []*aggregation.Result{valid, nil}
-			if tt.nilFirst {
-				results = []*aggregation.Result{nil, valid}
-			}
-
-			combined, err := NewShardCombiner().Do(results)
-			require.NoError(t, err)
-			require.Len(t, combined.Groups, 1)
-			assert.Equal(t, len(numbers), combined.Groups[0].Count)
-
-			expected := createNumericalAgg(numbers)
-			num := combined.Groups[0].Properties["number"].NumericalAggregations
-			assert.Equal(t, float64(len(numbers)), num["count"])
-			assert.Equal(t, expected["mode"], num["mode"])
-		})
-	}
-}
-
-// oldNodeNumericalWireJSON is the exact body a pre-fix node produces for an
-// ungrouped numerical mean/mode/median query: the aggregator's unexported
-// fields marshal as {}.
+// oldNodeNumericalWireJSON is the body a pre-fix node produces: the
+// aggregator's unexported fields marshal as {}.
 const oldNodeNumericalWireJSON = `{
 	"groups": [
 		{
@@ -1009,16 +769,6 @@ const oldNodeNumericalWireJSON = `{
 		}
 	]
 }`
-
-func TestShardCombinerRejectsOldNodeRawPayload(t *testing.T) {
-	var remote aggregation.Result
-	require.NoError(t, json.Unmarshal([]byte(oldNodeNumericalWireJSON), &remote))
-
-	local := makeNumberResult([]float64{0, 5, 10, 15},
-		aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.MedianAggregator, aggregation.CountAggregator)
-	_, err := NewShardCombiner().Do([]*aggregation.Result{local, &remote})
-	require.ErrorContains(t, err, "older version")
-}
 
 func createRandomSlice() []float64 {
 	size := rand.Intn(100) + 1 // at least one entry

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -204,7 +204,8 @@ func TestShardCombinerMergeNil(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			combinedResults := NewShardCombiner().Do(tt.results)
+			combinedResults, err := NewShardCombiner().Do(tt.results)
+			require.NoError(t, err)
 			assert.Equal(t, len(combinedResults.Groups), tt.totalResults)
 		})
 	}
@@ -229,6 +230,11 @@ func testNumbers(t *testing.T, numbers1, numbers2 []float64, testMode bool) {
 }
 
 func createNumericalAgg(numbers []float64) map[string]interface{} {
+	return createNumericalAggWith(numbers,
+		[]aggregation.Aggregator{aggregation.MedianAggregator, aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.CountAggregator})
+}
+
+func createNumericalAggWith(numbers []float64, aggs []aggregation.Aggregator) map[string]interface{} {
 	agg := newNumericalAggregator()
 	for _, num := range numbers {
 		agg.AddFloat64(num)
@@ -236,14 +242,11 @@ func createNumericalAgg(numbers []float64) map[string]interface{} {
 	agg.buildPairsFromCounts() // needed to populate all required info
 
 	prop := aggregation.Property{}
-	aggs := []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.CountAggregator}
 	addNumericalAggregations(&prop, aggs, agg)
 	return prop.NumericalAggregations
 }
 
-// TestShardCombinerRemoteShardResults covers shard results fetched from
-// another node: those cross the cluster-internal REST API as plain JSON, which
-// turns the raw aggregators into generic maps and date counts into float64
+// Remote shard results cross the cluster-internal REST API as plain JSON
 // (https://github.com/weaviate/weaviate/issues/11687).
 func TestShardCombinerRemoteShardResults(t *testing.T) {
 	roundTrip := func(t *testing.T, res *aggregation.Result) *aggregation.Result {
@@ -318,7 +321,9 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 			if tt.remote2 {
 				res2 = roundTrip(t, res2)
 			}
-			assertCombined(t, NewShardCombiner().Do([]*aggregation.Result{res1, res2}))
+			combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
+			require.NoError(t, err)
+			assertCombined(t, combined)
 		})
 	}
 
@@ -328,7 +333,70 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 		}
 		res1 := roundTrip(t, makeResult(numbers1, dates1, groupedBy()))
 		res2 := makeResult(numbers2, dates2, groupedBy())
-		assertCombined(t, NewShardCombiner().Do([]*aggregation.Result{res1, res2}))
+		combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
+		require.NoError(t, err)
+		assertCombined(t, combined)
+	})
+
+	t.Run("mean-only query ships count and sum instead of pairs", func(t *testing.T) {
+		meanOnly := func(numbers []float64) *aggregation.Result {
+			return &aggregation.Result{
+				Groups: []aggregation.Group{{
+					Count: len(numbers),
+					Properties: map[string]aggregation.Property{
+						"number": {
+							Type: aggregation.PropertyTypeNumerical,
+							NumericalAggregations: createNumericalAggWith(numbers,
+								[]aggregation.Aggregator{aggregation.MeanAggregator, aggregation.CountAggregator}),
+						},
+					},
+				}},
+			}
+		}
+
+		res2 := roundTrip(t, meanOnly(numbers2))
+		marker, ok := res2.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"].(map[string]interface{})
+		require.True(t, ok)
+		assert.NotContains(t, marker, "pairs")
+
+		combined, err := NewShardCombiner().Do([]*aggregation.Result{meanOnly(numbers1), res2})
+		require.NoError(t, err)
+		require.Len(t, combined.Groups, 1)
+
+		all := append(append([]float64{}, numbers1...), numbers2...)
+		var sum float64
+		for _, v := range all {
+			sum += v
+		}
+		num := combined.Groups[0].Properties["number"].NumericalAggregations
+		assert.InDelta(t, sum/float64(len(all)), num["mean"], 0.0001)
+		assert.Equal(t, float64(len(all)), num["count"])
+	})
+
+	t.Run("payload from an older node is rejected, not merged wrong", func(t *testing.T) {
+		for _, propName := range []string{"number", "date"} {
+			res1 := makeResult(numbers1, dates1, nil)
+			res2 := roundTrip(t, makeResult(numbers2, dates2, nil))
+			// an older node serializes the aggregator's unexported fields as {}
+			props := res2.Groups[0].Properties[propName]
+			switch propName {
+			case "number":
+				props.NumericalAggregations["_numericalAggregator"] = map[string]interface{}{}
+			case "date":
+				props.DateAggregations["_dateAggregator"] = map[string]interface{}{}
+			}
+			_, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
+			require.ErrorContains(t, err, "older version")
+		}
+	})
+
+	t.Run("malformed pairs are rejected", func(t *testing.T) {
+		res2 := roundTrip(t, makeResult(numbers2, dates2, nil))
+		res2.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+			"count": float64(1), "sum": float64(1), "pairs": []interface{}{"garbage"},
+		}
+		_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers1, dates1, nil), res2})
+		require.ErrorContains(t, err, "malformed")
 	})
 }
 

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -13,6 +13,7 @@ package aggregator
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -70,7 +71,7 @@ func testDates(t *testing.T, dates1, dates2 []string, tt TestStructDates) {
 	dateMap1 := createDateAgg(dates1)
 	dateMap2 := createDateAgg(dates2)
 
-	sc.mergeDateProp(dateMap1, dateMap2)
+	require.NoError(t, sc.mergeDateProp(dateMap1, dateMap2))
 	sc.finalizeDateProp(dateMap1)
 	assert.Equal(t, YearMonthDayHourMinute+tt.expectedMinimum+NanoSecondsTimeZone, dateMap1["minimum"])
 	assert.Equal(t, YearMonthDayHourMinute+tt.expectedMaximum+NanoSecondsTimeZone, dateMap1["maximum"])
@@ -80,6 +81,11 @@ func testDates(t *testing.T, dates1, dates2 []string, tt TestStructDates) {
 }
 
 func createDateAgg(dates []string) map[string]interface{} {
+	return createDateAggWith(dates,
+		[]aggregation.Aggregator{aggregation.MedianAggregator, aggregation.MinimumAggregator, aggregation.MaximumAggregator, aggregation.CountAggregator, aggregation.ModeAggregator})
+}
+
+func createDateAggWith(dates []string, aggs []aggregation.Aggregator) map[string]interface{} {
 	agg := newDateAggregator()
 	for _, date := range dates {
 		agg.AddTimestamp(YearMonthDayHourMinute + date + NanoSecondsTimeZone)
@@ -87,7 +93,6 @@ func createDateAgg(dates []string) map[string]interface{} {
 	agg.buildPairsFromCounts() // needed to populate all required info
 
 	prop := aggregation.Property{}
-	aggs := []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.MinimumAggregator, aggregation.MaximumAggregator, aggregation.CountAggregator, aggregation.ModeAggregator}
 	addDateAggregations(&prop, aggs, agg)
 	return prop.DateAggregations
 }
@@ -218,7 +223,7 @@ func testNumbers(t *testing.T, numbers1, numbers2 []float64, testMode bool) {
 
 	combinedMap := createNumericalAgg(append(numbers1, numbers2...))
 
-	sc.mergeNumericalProp(numberMap1, numberMap2)
+	require.NoError(t, sc.mergeNumericalProp(numberMap1, numberMap2))
 	sc.finalizeNumerical(numberMap1)
 
 	assert.Equal(t, len(numbers1)+len(numbers2), int(numberMap1["count"].(float64)))
@@ -246,36 +251,65 @@ func createNumericalAggWith(numbers []float64, aggs []aggregation.Aggregator) ma
 	return prop.NumericalAggregations
 }
 
+func roundTrip(t *testing.T, res *aggregation.Result) *aggregation.Result {
+	t.Helper()
+	b, err := json.Marshal(res)
+	require.NoError(t, err)
+	var out aggregation.Result
+	require.NoError(t, json.Unmarshal(b, &out))
+	return &out
+}
+
+func makeResult(numbers []float64, dates []string, groupedBy *aggregation.GroupedBy) *aggregation.Result {
+	return &aggregation.Result{
+		Groups: []aggregation.Group{{
+			GroupedBy: groupedBy,
+			Count:     len(numbers),
+			Properties: map[string]aggregation.Property{
+				"number": {
+					Type:                  aggregation.PropertyTypeNumerical,
+					NumericalAggregations: createNumericalAgg(numbers),
+				},
+				"date": {
+					Type:             aggregation.PropertyTypeDate,
+					DateAggregations: createDateAgg(dates),
+				},
+			},
+		}},
+	}
+}
+
+func makeNumberResult(numbers []float64, aggs ...aggregation.Aggregator) *aggregation.Result {
+	return &aggregation.Result{
+		Groups: []aggregation.Group{{
+			Count: len(numbers),
+			Properties: map[string]aggregation.Property{
+				"number": {
+					Type:                  aggregation.PropertyTypeNumerical,
+					NumericalAggregations: createNumericalAggWith(numbers, aggs),
+				},
+			},
+		}},
+	}
+}
+
+func makeDateResult(dates []string, aggs ...aggregation.Aggregator) *aggregation.Result {
+	return &aggregation.Result{
+		Groups: []aggregation.Group{{
+			Count: len(dates),
+			Properties: map[string]aggregation.Property{
+				"date": {
+					Type:             aggregation.PropertyTypeDate,
+					DateAggregations: createDateAggWith(dates, aggs),
+				},
+			},
+		}},
+	}
+}
+
 // Remote shard results cross the cluster-internal REST API as plain JSON
 // (https://github.com/weaviate/weaviate/issues/11687).
 func TestShardCombinerRemoteShardResults(t *testing.T) {
-	roundTrip := func(t *testing.T, res *aggregation.Result) *aggregation.Result {
-		b, err := json.Marshal(res)
-		require.NoError(t, err)
-		var out aggregation.Result
-		require.NoError(t, json.Unmarshal(b, &out))
-		return &out
-	}
-
-	makeResult := func(numbers []float64, dates []string, groupedBy *aggregation.GroupedBy) *aggregation.Result {
-		return &aggregation.Result{
-			Groups: []aggregation.Group{{
-				GroupedBy: groupedBy,
-				Count:     len(numbers),
-				Properties: map[string]aggregation.Property{
-					"number": {
-						Type:                  aggregation.PropertyTypeNumerical,
-						NumericalAggregations: createNumericalAgg(numbers),
-					},
-					"date": {
-						Type:             aggregation.PropertyTypeDate,
-						DateAggregations: createDateAgg(dates),
-					},
-				},
-			}},
-		}
-	}
-
 	numbers1 := []float64{0, 5, 10, 15}
 	numbers2 := []float64{15, 15, 2.5}
 	dates1 := []string{"55", "26", "10"}
@@ -340,18 +374,7 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 
 	t.Run("mean-only query ships count and sum instead of pairs", func(t *testing.T) {
 		meanOnly := func(numbers []float64) *aggregation.Result {
-			return &aggregation.Result{
-				Groups: []aggregation.Group{{
-					Count: len(numbers),
-					Properties: map[string]aggregation.Property{
-						"number": {
-							Type: aggregation.PropertyTypeNumerical,
-							NumericalAggregations: createNumericalAggWith(numbers,
-								[]aggregation.Aggregator{aggregation.MeanAggregator, aggregation.CountAggregator}),
-						},
-					},
-				}},
-			}
+			return makeNumberResult(numbers, aggregation.MeanAggregator, aggregation.CountAggregator)
 		}
 
 		res2 := roundTrip(t, meanOnly(numbers2))
@@ -398,6 +421,603 @@ func TestShardCombinerRemoteShardResults(t *testing.T) {
 		_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers1, dates1, nil), res2})
 		require.ErrorContains(t, err, "malformed")
 	})
+
+	t.Run("selector-specific wire round trips", func(t *testing.T) {
+		unionNumbers := append(append([]float64{}, numbers1...), numbers2...)
+		unionDates := append(append([]string{}, dates1...), dates2...)
+
+		tests := []struct {
+			name   string
+			isDate bool
+			aggs   []aggregation.Aggregator
+			keys   []string
+		}{
+			{
+				name: "numerical median-only",
+				aggs: []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.CountAggregator},
+				keys: []string{"median", "count"},
+			},
+			{
+				name: "numerical mode-only",
+				aggs: []aggregation.Aggregator{aggregation.ModeAggregator, aggregation.CountAggregator},
+				keys: []string{"mode", "count"},
+			},
+			{
+				name:   "date median-only",
+				isDate: true,
+				aggs:   []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.CountAggregator},
+				keys:   []string{"median", "count"},
+			},
+			{
+				name:   "date mode-only",
+				isDate: true,
+				aggs:   []aggregation.Aggregator{aggregation.ModeAggregator, aggregation.CountAggregator},
+				keys:   []string{"mode", "count"},
+			},
+			{
+				name:   "date count-only",
+				isDate: true,
+				aggs:   []aggregation.Aggregator{aggregation.CountAggregator},
+				keys:   []string{"count"},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var res1, res2 *aggregation.Result
+				var expected map[string]interface{}
+				if tt.isDate {
+					res1 = makeDateResult(dates1, tt.aggs...)
+					res2 = roundTrip(t, makeDateResult(dates2, tt.aggs...))
+					expected = createDateAggWith(unionDates, tt.aggs)
+				} else {
+					res1 = makeNumberResult(numbers1, tt.aggs...)
+					res2 = roundTrip(t, makeNumberResult(numbers2, tt.aggs...))
+					expected = createNumericalAggWith(unionNumbers, tt.aggs)
+				}
+
+				combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
+				require.NoError(t, err)
+				require.Len(t, combined.Groups, 1)
+
+				var got map[string]interface{}
+				if tt.isDate {
+					got = combined.Groups[0].Properties["date"].DateAggregations
+					assert.NotContains(t, got, "_dateAggregator")
+					assert.IsType(t, int64(0), got["count"])
+				} else {
+					got = combined.Groups[0].Properties["number"].NumericalAggregations
+					assert.NotContains(t, got, "_numericalAggregator")
+				}
+				for _, key := range tt.keys {
+					assert.Equal(t, expected[key], got[key], key)
+				}
+			})
+		}
+	})
+
+	t.Run("single remote result is restored and finalized", func(t *testing.T) {
+		combined, err := NewShardCombiner().Do([]*aggregation.Result{roundTrip(t, makeResult(numbers2, dates2, nil))})
+		require.NoError(t, err)
+		require.Len(t, combined.Groups, 1)
+
+		expectedNum := createNumericalAgg(numbers2)
+		num := combined.Groups[0].Properties["number"].NumericalAggregations
+		assert.Equal(t, float64(len(numbers2)), num["count"])
+		assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
+		assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
+		assert.Equal(t, expectedNum["mode"], num["mode"])
+		assert.NotContains(t, num, "_numericalAggregator")
+
+		expectedDate := createDateAgg(dates2)
+		date := combined.Groups[0].Properties["date"].DateAggregations
+		assert.Equal(t, int64(len(dates2)), date["count"])
+		for _, key := range []string{"minimum", "maximum", "median", "mode"} {
+			assert.Equal(t, expectedDate[key], date[key], key)
+		}
+		assert.NotContains(t, date, "_dateAggregator")
+	})
+
+	t.Run("grouped, remote-only group is restored", func(t *testing.T) {
+		groupA := &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
+		groupB := &aggregation.GroupedBy{Value: "b", Path: []string{"prop"}}
+		numbersB := []float64{1, 2, 2}
+		datesB := []string{"15", "45"}
+
+		res1 := makeResult(numbers1, dates1, groupA)
+		res2 := roundTrip(t, &aggregation.Result{Groups: []aggregation.Group{
+			makeResult(numbers2, dates2, groupA).Groups[0],
+			makeResult(numbersB, datesB, groupB).Groups[0],
+		}})
+
+		combined, err := NewShardCombiner().Do([]*aggregation.Result{res1, res2})
+		require.NoError(t, err)
+		require.Len(t, combined.Groups, 2)
+
+		byValue := map[interface{}]aggregation.Group{}
+		for _, group := range combined.Groups {
+			byValue[group.GroupedBy.Value] = group
+		}
+
+		unionNum := createNumericalAgg(append(append([]float64{}, numbers1...), numbers2...))
+		numA := byValue["a"].Properties["number"].NumericalAggregations
+		assert.Equal(t, len(numbers1)+len(numbers2), byValue["a"].Count)
+		assert.Equal(t, float64(len(numbers1)+len(numbers2)), numA["count"])
+		assert.Equal(t, unionNum["mode"], numA["mode"])
+		assert.NotContains(t, numA, "_numericalAggregator")
+
+		expectedB := createNumericalAgg(numbersB)
+		numB := byValue["b"].Properties["number"].NumericalAggregations
+		assert.Equal(t, len(numbersB), byValue["b"].Count)
+		assert.Equal(t, float64(len(numbersB)), numB["count"])
+		assert.Equal(t, expectedB["mode"], numB["mode"])
+		assert.InDelta(t, expectedB["median"], numB["median"], 0.0001)
+		assert.NotContains(t, numB, "_numericalAggregator")
+
+		dateB := byValue["b"].Properties["date"].DateAggregations
+		assert.Equal(t, int64(len(datesB)), dateB["count"])
+		assert.NotContains(t, dateB, "_dateAggregator")
+	})
+
+	t.Run("later group failure surfaces after earlier group merged", func(t *testing.T) {
+		groupA := &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
+		groupB := &aggregation.GroupedBy{Value: "b", Path: []string{"prop"}}
+		twoGroups := func() *aggregation.Result {
+			return &aggregation.Result{Groups: []aggregation.Group{
+				makeResult(numbers1, dates1, groupA).Groups[0],
+				makeResult(numbers2, dates2, groupB).Groups[0],
+			}}
+		}
+
+		res2 := roundTrip(t, twoGroups())
+		res2.Groups[1].Properties["number"].NumericalAggregations["percentile"] = float64(5)
+
+		_, err := NewShardCombiner().Do([]*aggregation.Result{twoGroups(), res2})
+		require.ErrorContains(t, err, `unknown aggregation "percentile"`)
+	})
+}
+
+func TestShardCombinerRejectsInvalidWireCounts(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+
+	targets := []struct {
+		name    string
+		results func(t *testing.T, bad float64) []*aggregation.Result
+	}{
+		{
+			name: "numerical mean-only top-level count",
+			results: func(t *testing.T, bad float64) []*aggregation.Result {
+				meanOnly := func() *aggregation.Result {
+					return makeNumberResult(numbers, aggregation.MeanAggregator, aggregation.CountAggregator)
+				}
+				remote := roundTrip(t, meanOnly())
+				remote.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": bad, "sum": float64(1),
+				}
+				return []*aggregation.Result{meanOnly(), remote}
+			},
+		},
+		{
+			name: "numerical pair count",
+			results: func(t *testing.T, bad float64) []*aggregation.Result {
+				remote := roundTrip(t, makeResult(numbers, dates, nil))
+				remote.Groups[0].Properties["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(1), "sum": float64(1),
+					"pairs": []interface{}{map[string]interface{}{"value": float64(1), "count": bad}},
+				}
+				return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
+			},
+		},
+		{
+			name: "date pair count",
+			results: func(t *testing.T, bad float64) []*aggregation.Result {
+				remote := roundTrip(t, makeResult(numbers, dates, nil))
+				remote.Groups[0].Properties["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
+					"pairs": []interface{}{map[string]interface{}{
+						"value": YearMonthDayHourMinute + "26" + NanoSecondsTimeZone, "count": bad,
+					}},
+				}
+				return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
+			},
+		},
+		{
+			name: "date count scalar",
+			results: func(t *testing.T, bad float64) []*aggregation.Result {
+				remote := roundTrip(t, makeResult(numbers, dates, nil))
+				remote.Groups[0].Properties["date"].DateAggregations["count"] = bad
+				return []*aggregation.Result{makeResult(numbers, dates, nil), remote}
+			},
+		},
+	}
+
+	badCounts := []float64{-1, 1.5, 1 << 53, 1e19}
+	for _, target := range targets {
+		for _, bad := range badCounts {
+			t.Run(fmt.Sprintf("%s with %v", target.name, bad), func(t *testing.T) {
+				_, err := NewShardCombiner().Do(target.results(t, bad))
+				require.ErrorContains(t, err, "invalid count")
+			})
+		}
+	}
+}
+
+func TestShardCombinerRejectsMalformedAggregatorState(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+	badStates := []interface{}{nil, "garbage", float64(42), []interface{}{}}
+
+	for _, marker := range []string{"_numericalAggregator", "_dateAggregator"} {
+		for _, state := range badStates {
+			t.Run(fmt.Sprintf("%s set to %v", marker, state), func(t *testing.T) {
+				remote := roundTrip(t, makeResult(numbers, dates, nil))
+				props := remote.Groups[0].Properties
+				switch marker {
+				case "_numericalAggregator":
+					props["number"].NumericalAggregations[marker] = state
+				case "_dateAggregator":
+					props["date"].DateAggregations[marker] = state
+				}
+				_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
+				require.ErrorContains(t, err, "malformed")
+				require.ErrorContains(t, err, "aggregator state")
+			})
+		}
+	}
+}
+
+func TestShardCombinerRejectsPairlessModeMedian(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+
+	tests := []struct {
+		name   string
+		mutate func(props map[string]aggregation.Property)
+	}{
+		{
+			name: "numerical state without pairs",
+			mutate: func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(3), "sum": float64(6),
+				}
+			},
+		},
+		{
+			name: "date state with empty pairs",
+			mutate: func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
+					"pairs": []interface{}{},
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remote := roundTrip(t, makeResult(numbers, dates, nil))
+			tt.mutate(remote.Groups[0].Properties)
+			_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
+			require.ErrorContains(t, err, "without value pairs")
+		})
+	}
+}
+
+func TestShardCombinerRejectsUnknownAggregationKey(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+
+	remote := roundTrip(t, makeResult(numbers, dates, nil))
+	remote.Groups[0].Properties["number"].NumericalAggregations["percentile"] = float64(5)
+
+	_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
+	require.ErrorContains(t, err, `unknown aggregation "percentile"`)
+}
+
+func TestShardCombinerRejectsMissingDistributionState(t *testing.T) {
+	t.Run("mode/median without marker is rejected at restore", func(t *testing.T) {
+		remote := roundTrip(t, makeResult([]float64{0, 5, 10, 15}, []string{"55", "26", "10"}, nil))
+		delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
+
+		_, err := NewShardCombiner().Do([]*aggregation.Result{remote})
+		require.ErrorContains(t, err, "without value pairs")
+	})
+
+	t.Run("mean without marker is rejected at merge", func(t *testing.T) {
+		remote := roundTrip(t, makeNumberResult([]float64{0, 5},
+			aggregation.MeanAggregator, aggregation.CountAggregator))
+		delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
+
+		_, err := NewShardCombiner().Do([]*aggregation.Result{remote})
+		require.ErrorContains(t, err, "without distribution state")
+	})
+}
+
+func TestShardCombinerRejectsMeanOnlyModeMedianMixture(t *testing.T) {
+	meanOnly := func() *aggregation.Result {
+		return makeNumberResult([]float64{0, 5}, aggregation.MeanAggregator, aggregation.CountAggregator)
+	}
+	full := func() *aggregation.Result {
+		return makeNumberResult([]float64{10, 15, 15},
+			aggregation.MedianAggregator, aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.CountAggregator)
+	}
+
+	tests := []struct {
+		name    string
+		results func(t *testing.T) []*aggregation.Result
+	}{
+		{
+			name: "mean-only shard first",
+			results: func(t *testing.T) []*aggregation.Result {
+				return []*aggregation.Result{roundTrip(t, meanOnly()), roundTrip(t, full())}
+			},
+		},
+		{
+			name: "mode/median shard first",
+			results: func(t *testing.T) []*aggregation.Result {
+				return []*aggregation.Result{roundTrip(t, full()), roundTrip(t, meanOnly())}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewShardCombiner().Do(tt.results(t))
+			require.ErrorContains(t, err, "incomplete distribution state")
+		})
+	}
+}
+
+func TestShardCombinerRejectsBareScalarFromSecondShard(t *testing.T) {
+	meanOnly := func() *aggregation.Result {
+		return makeNumberResult([]float64{0, 5}, aggregation.MeanAggregator, aggregation.CountAggregator)
+	}
+
+	remote := roundTrip(t, meanOnly())
+	delete(remote.Groups[0].Properties["number"].NumericalAggregations, "_numericalAggregator")
+
+	_, err := NewShardCombiner().Do([]*aggregation.Result{roundTrip(t, meanOnly()), remote})
+	require.ErrorContains(t, err, "without distribution state")
+}
+
+func TestShardCombinerRejectsMixedGroupedness(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+	groupedBy := &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
+
+	tests := []struct {
+		name         string
+		groupedFirst bool
+	}{
+		{name: "ungrouped first"},
+		{name: "grouped first", groupedFirst: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ungrouped := roundTrip(t, makeResult(numbers, dates, nil))
+			grouped := roundTrip(t, makeResult(numbers, dates, groupedBy))
+			results := []*aggregation.Result{ungrouped, grouped}
+			if tt.groupedFirst {
+				results = []*aggregation.Result{grouped, ungrouped}
+			}
+
+			_, err := NewShardCombiner().Do(results)
+			require.ErrorContains(t, err, "mixed grouped and ungrouped")
+		})
+	}
+}
+
+func TestShardCombinerRejectsMalformedWireEntries(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+
+	tests := []struct {
+		name    string
+		mutate  func(props map[string]aggregation.Property)
+		errText string
+	}{
+		{
+			name: "date count as string",
+			mutate: func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["count"] = "garbage"
+			},
+			errText: "malformed count",
+		},
+		{
+			name: "numerical pairs as string",
+			mutate: func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["_numericalAggregator"] = map[string]interface{}{
+					"count": float64(2), "sum": float64(3), "pairs": "garbage",
+				}
+			},
+			errText: "malformed numerical aggregator pairs",
+		},
+		{
+			name: "date pairs as string",
+			mutate: func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["_dateAggregator"] = map[string]interface{}{
+					"pairs": "garbage",
+				}
+			},
+			errText: "malformed date aggregator pairs",
+		},
+		{
+			name: "date minimum as number",
+			mutate: func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["minimum"] = float64(5)
+			},
+			errText: `malformed "minimum" entry`,
+		},
+		{
+			name: "numerical sum as string",
+			mutate: func(props map[string]aggregation.Property) {
+				props["number"].NumericalAggregations["sum"] = "garbage"
+			},
+			errText: `malformed "sum" entry`,
+		},
+		{
+			name: "date minimum as unparseable string",
+			mutate: func(props map[string]aggregation.Property) {
+				props["date"].DateAggregations["minimum"] = "not-a-date"
+			},
+			errText: `malformed "minimum" entry`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			remote := roundTrip(t, makeResult(numbers, dates, nil))
+			tt.mutate(remote.Groups[0].Properties)
+			_, err := NewShardCombiner().Do([]*aggregation.Result{makeResult(numbers, dates, nil), remote})
+			require.ErrorContains(t, err, tt.errText)
+		})
+	}
+}
+
+func TestShardCombinerRejectsUnknownPropertyType(t *testing.T) {
+	bogusProps := func() map[string]aggregation.Property {
+		return map[string]aggregation.Property{
+			"weird": {Type: aggregation.PropertyType("bogus")},
+		}
+	}
+
+	t.Run("ungrouped merge path", func(t *testing.T) {
+		bogus := &aggregation.Result{Groups: []aggregation.Group{{Count: 1, Properties: bogusProps()}}}
+		_, err := NewShardCombiner().Do([]*aggregation.Result{
+			makeResult([]float64{0, 5}, []string{"26"}, nil), bogus,
+		})
+		require.ErrorContains(t, err, "unknown property type")
+	})
+
+	t.Run("grouped finalize path", func(t *testing.T) {
+		bogus := &aggregation.Result{Groups: []aggregation.Group{{
+			GroupedBy:  &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}},
+			Count:      1,
+			Properties: bogusProps(),
+		}}}
+		_, err := NewShardCombiner().Do([]*aggregation.Result{bogus})
+		require.ErrorContains(t, err, "unknown property type")
+	})
+}
+
+func TestShardCombinerMergesEmptyShardForModeMedian(t *testing.T) {
+	numbers := []float64{15, 15, 2.5}
+	dates := []string{"15", "26", "45", "26"}
+
+	tests := []struct {
+		name       string
+		emptyFirst bool
+	}{
+		{name: "empty shard last"},
+		{name: "empty shard first", emptyFirst: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := roundTrip(t, makeResult(numbers, dates, nil))
+			empty := roundTrip(t, makeResult([]float64{}, []string{}, nil))
+			results := []*aggregation.Result{data, empty}
+			if tt.emptyFirst {
+				results = []*aggregation.Result{empty, data}
+			}
+
+			combined, err := NewShardCombiner().Do(results)
+			require.NoError(t, err)
+			require.Len(t, combined.Groups, 1)
+			assert.Equal(t, len(numbers), combined.Groups[0].Count)
+
+			expectedNum := createNumericalAgg(numbers)
+			num := combined.Groups[0].Properties["number"].NumericalAggregations
+			assert.Equal(t, float64(len(numbers)), num["count"])
+			assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
+			assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
+			assert.Equal(t, expectedNum["mode"], num["mode"])
+			assert.NotContains(t, num, "_numericalAggregator")
+
+			expectedDate := createDateAgg(dates)
+			date := combined.Groups[0].Properties["date"].DateAggregations
+			assert.Equal(t, int64(len(dates)), date["count"])
+			for _, key := range []string{"minimum", "maximum", "median", "mode"} {
+				assert.Equal(t, expectedDate[key], date[key], key)
+			}
+			assert.NotContains(t, date, "_dateAggregator")
+		})
+	}
+}
+
+func TestShardCombinerMergeLiteralNil(t *testing.T) {
+	numbers := []float64{0, 5, 10, 15}
+	dates := []string{"55", "26", "10"}
+
+	tests := []struct {
+		name      string
+		groupedBy *aggregation.GroupedBy
+		nilFirst  bool
+	}{
+		{name: "ungrouped, nil first", nilFirst: true},
+		{name: "ungrouped, nil last"},
+		{name: "grouped, nil first", groupedBy: &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}, nilFirst: true},
+		{name: "grouped, nil last", groupedBy: &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := makeResult(numbers, dates, tt.groupedBy)
+			results := []*aggregation.Result{valid, nil}
+			if tt.nilFirst {
+				results = []*aggregation.Result{nil, valid}
+			}
+
+			combined, err := NewShardCombiner().Do(results)
+			require.NoError(t, err)
+			require.Len(t, combined.Groups, 1)
+			assert.Equal(t, len(numbers), combined.Groups[0].Count)
+
+			expected := createNumericalAgg(numbers)
+			num := combined.Groups[0].Properties["number"].NumericalAggregations
+			assert.Equal(t, float64(len(numbers)), num["count"])
+			assert.Equal(t, expected["mode"], num["mode"])
+		})
+	}
+}
+
+// oldNodeNumericalWireJSON is the exact body a pre-fix node produces for an
+// ungrouped numerical mean/mode/median query: the aggregator's unexported
+// fields marshal as {}.
+const oldNodeNumericalWireJSON = `{
+	"groups": [
+		{
+			"properties": {
+				"number": {
+					"type": "numerical",
+					"numericalAggregations": {
+						"_numericalAggregator": {},
+						"count": 4,
+						"mean": 7.5,
+						"median": 7.5,
+						"mode": 0
+					},
+					"textAggregation": {"items": null, "count": 0},
+					"booleanAggregation": {"count": 0, "totalTrue": 0, "totalFalse": 0, "percentageTrue": 0, "percentageFalse": 0},
+					"schemaType": "int",
+					"referenceAggregation": {"pointingTo": null},
+					"dateAggregation": null
+				}
+			},
+			"groupedBy": null,
+			"count": 4
+		}
+	]
+}`
+
+func TestShardCombinerRejectsOldNodeRawPayload(t *testing.T) {
+	var remote aggregation.Result
+	require.NoError(t, json.Unmarshal([]byte(oldNodeNumericalWireJSON), &remote))
+
+	local := makeNumberResult([]float64{0, 5, 10, 15},
+		aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.MedianAggregator, aggregation.CountAggregator)
+	_, err := NewShardCombiner().Do([]*aggregation.Result{local, &remote})
+	require.ErrorContains(t, err, "older version")
 }
 
 func createRandomSlice() []float64 {

--- a/adapters/repos/db/aggregator/shard_combiner_test.go
+++ b/adapters/repos/db/aggregator/shard_combiner_test.go
@@ -12,10 +12,12 @@
 package aggregator
 
 import (
+	"encoding/json"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/aggregation"
 )
 
@@ -237,6 +239,97 @@ func createNumericalAgg(numbers []float64) map[string]interface{} {
 	aggs := []aggregation.Aggregator{aggregation.MedianAggregator, aggregation.MeanAggregator, aggregation.ModeAggregator, aggregation.CountAggregator}
 	addNumericalAggregations(&prop, aggs, agg)
 	return prop.NumericalAggregations
+}
+
+// TestShardCombinerRemoteShardResults covers shard results fetched from
+// another node: those cross the cluster-internal REST API as plain JSON, which
+// turns the raw aggregators into generic maps and date counts into float64
+// (https://github.com/weaviate/weaviate/issues/11687).
+func TestShardCombinerRemoteShardResults(t *testing.T) {
+	roundTrip := func(t *testing.T, res *aggregation.Result) *aggregation.Result {
+		b, err := json.Marshal(res)
+		require.NoError(t, err)
+		var out aggregation.Result
+		require.NoError(t, json.Unmarshal(b, &out))
+		return &out
+	}
+
+	makeResult := func(numbers []float64, dates []string, groupedBy *aggregation.GroupedBy) *aggregation.Result {
+		return &aggregation.Result{
+			Groups: []aggregation.Group{{
+				GroupedBy: groupedBy,
+				Count:     len(numbers),
+				Properties: map[string]aggregation.Property{
+					"number": {
+						Type:                  aggregation.PropertyTypeNumerical,
+						NumericalAggregations: createNumericalAgg(numbers),
+					},
+					"date": {
+						Type:             aggregation.PropertyTypeDate,
+						DateAggregations: createDateAgg(dates),
+					},
+				},
+			}},
+		}
+	}
+
+	numbers1 := []float64{0, 5, 10, 15}
+	numbers2 := []float64{15, 15, 2.5}
+	dates1 := []string{"55", "26", "10"}
+	dates2 := []string{"15", "26", "45", "26"}
+
+	assertCombined := func(t *testing.T, combined *aggregation.Result) {
+		require.Len(t, combined.Groups, 1)
+
+		expectedNum := createNumericalAgg(append(append([]float64{}, numbers1...), numbers2...))
+		num := combined.Groups[0].Properties["number"].NumericalAggregations
+		assert.Equal(t, float64(len(numbers1)+len(numbers2)), num["count"])
+		assert.InDelta(t, expectedNum["mean"], num["mean"], 0.0001)
+		assert.InDelta(t, expectedNum["median"], num["median"], 0.0001)
+		assert.Equal(t, expectedNum["mode"], num["mode"])
+		assert.NotContains(t, num, "_numericalAggregator")
+
+		expectedDate := createDateAgg(append(append([]string{}, dates1...), dates2...))
+		date := combined.Groups[0].Properties["date"].DateAggregations
+		assert.Equal(t, int64(len(dates1)+len(dates2)), date["count"])
+		for _, key := range []string{"minimum", "maximum", "median", "mode"} {
+			assert.Equal(t, expectedDate[key], date[key], key)
+		}
+		assert.NotContains(t, date, "_dateAggregator")
+	}
+
+	tests := []struct {
+		name    string
+		remote1 bool
+		remote2 bool
+	}{
+		{name: "first shard remote", remote1: true},
+		{name: "second shard remote", remote2: true},
+		{name: "both shards remote", remote1: true, remote2: true},
+	}
+
+	for _, tt := range tests {
+		t.Run("ungrouped, "+tt.name, func(t *testing.T) {
+			res1 := makeResult(numbers1, dates1, nil)
+			res2 := makeResult(numbers2, dates2, nil)
+			if tt.remote1 {
+				res1 = roundTrip(t, res1)
+			}
+			if tt.remote2 {
+				res2 = roundTrip(t, res2)
+			}
+			assertCombined(t, NewShardCombiner().Do([]*aggregation.Result{res1, res2}))
+		})
+	}
+
+	t.Run("grouped, remote group appended before merge", func(t *testing.T) {
+		groupedBy := func() *aggregation.GroupedBy {
+			return &aggregation.GroupedBy{Value: "a", Path: []string{"prop"}}
+		}
+		res1 := roundTrip(t, makeResult(numbers1, dates1, groupedBy()))
+		res2 := makeResult(numbers2, dates2, groupedBy())
+		assertCombined(t, NewShardCombiner().Do([]*aggregation.Result{res1, res2}))
+	})
 }
 
 func createRandomSlice() []float64 {

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -433,7 +433,7 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 		logger, _ := test.NewNullLogger()
 		node := nodes[rnd.Intn(len(nodes))]
 		res, err := node.repo.Aggregate(context.Background(), params, modules.NewProvider(logger, config.Config{}))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Len(t, res.Groups, 1)
 
 		num := res.Groups[0].Properties["int_property"].NumericalAggregations
@@ -471,7 +471,7 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 		logger, _ := test.NewNullLogger()
 		node := nodes[rnd.Intn(len(nodes))]
 		res, err := node.repo.Aggregate(context.Background(), params, modules.NewProvider(logger, config.Config{}))
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Len(t, res.Groups, 1)
 		assert.InDelta(t, sum/float64(len(data)),
 			res.Groups[0].Properties["int_property"].NumericalAggregations["mean"], 0.0001)

--- a/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
+++ b/adapters/repos/db/clusterintegrationtest/cluster_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -382,6 +383,98 @@ func testDistributed(t *testing.T, dirName string, rnd *rand.Rand, batch bool) {
 		}
 
 		assert.Equal(t, expectedResult, res)
+	})
+
+	// regression test for https://github.com/weaviate/weaviate/issues/11687:
+	// mean/median/mode require merging raw aggregator state from remote shards
+	t.Run("aggregate numerical and date props across shards", func(t *testing.T) {
+		values := make([]float64, len(data))
+		for i, obj := range data {
+			values[i] = float64(obj.Properties.(map[string]interface{})["int_property"].(int))
+		}
+		var sum float64
+		counts := map[float64]int{}
+		for _, v := range values {
+			sum += v
+			counts[v]++
+		}
+		expectedMean := sum / float64(len(values))
+		var expectedMode float64
+		best := 0
+		for v, c := range counts {
+			if c > best || (c == best && v < expectedMode) {
+				best, expectedMode = c, v
+			}
+		}
+		sorted := append([]float64{}, values...)
+		sort.Float64s(sorted)
+		expectedMedian := (sorted[len(sorted)/2-1] + sorted[len(sorted)/2]) / 2
+
+		params := aggregation.Params{
+			ClassName: schema.ClassName(distributedClass),
+			Properties: []aggregation.ParamProperty{
+				{
+					Name: "int_property",
+					Aggregators: []aggregation.Aggregator{
+						aggregation.MeanAggregator, aggregation.MedianAggregator,
+						aggregation.ModeAggregator, aggregation.CountAggregator,
+					},
+				},
+				{
+					Name: "date_property",
+					Aggregators: []aggregation.Aggregator{
+						aggregation.MedianAggregator, aggregation.MinimumAggregator,
+						aggregation.MaximumAggregator, aggregation.CountAggregator,
+					},
+				},
+			},
+		}
+
+		logger, _ := test.NewNullLogger()
+		node := nodes[rnd.Intn(len(nodes))]
+		res, err := node.repo.Aggregate(context.Background(), params, modules.NewProvider(logger, config.Config{}))
+		require.Nil(t, err)
+		require.Len(t, res.Groups, 1)
+
+		num := res.Groups[0].Properties["int_property"].NumericalAggregations
+		assert.Equal(t, float64(len(data)), num["count"])
+		assert.InDelta(t, expectedMean, num["mean"], 0.0001)
+		assert.InDelta(t, expectedMedian, num["median"], 0.0001)
+		assert.Equal(t, expectedMode, num["mode"])
+
+		// date_property values are unique hourly timestamps starting at epoch
+		date := res.Groups[0].Properties["date_property"].DateAggregations
+		assert.Equal(t, int64(len(data)), date["count"])
+		assert.Equal(t, time.Unix(0, 0).UTC().Format(time.RFC3339Nano), date["minimum"])
+		assert.Equal(t, time.Unix(0, 0).Add(time.Duration(len(data)-1)*time.Hour).UTC().Format(time.RFC3339Nano),
+			date["maximum"])
+		assert.Equal(t, time.Unix(0, 0).Add(time.Duration(len(data)/2-1)*time.Hour+30*time.Minute).UTC().Format(time.RFC3339Nano),
+			date["median"])
+	})
+
+	t.Run("aggregate mean only across shards", func(t *testing.T) {
+		var sum float64
+		for _, obj := range data {
+			sum += float64(obj.Properties.(map[string]interface{})["int_property"].(int))
+		}
+
+		params := aggregation.Params{
+			ClassName: schema.ClassName(distributedClass),
+			Properties: []aggregation.ParamProperty{
+				{
+					Name:        "int_property",
+					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
+				},
+			},
+		}
+
+		logger, _ := test.NewNullLogger()
+		node := nodes[rnd.Intn(len(nodes))]
+		res, err := node.repo.Aggregate(context.Background(), params, modules.NewProvider(logger, config.Config{}))
+		require.Nil(t, err)
+		require.Len(t, res.Groups, 1)
+		assert.InDelta(t, sum/float64(len(data)),
+			res.Groups[0].Properties["int_property"].NumericalAggregations["mean"], 0.0001)
 	})
 
 	t.Run("modify an object using patch", func(t *testing.T) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3028,7 +3028,7 @@ func (i *Index) aggregate(ctx context.Context, replProps *additional.Replication
 		results[j] = res
 	}
 
-	return aggregator.NewShardCombiner().Do(results), nil
+	return aggregator.NewShardCombiner().Do(results)
 }
 
 func (i *Index) aggregateCount(ctx context.Context, shards []string) (*aggregation.Result, error) {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3019,7 +3019,11 @@ func (i *Index) aggregate(ctx context.Context, replProps *additional.Replication
 			func() error {
 				var err error
 				res, err = i.remote.Aggregate(ctx, shardName, params)
-				return err
+				if err != nil || res == nil {
+					return err
+				}
+				// restore wire state here so a malformed payload error still names the shard
+				return aggregator.NewShardCombiner().RestoreSerializedAggregators(res)
 			})
 		if err != nil {
 			return nil, errors.Wrapf(err, "shard %s", shardName)


### PR DESCRIPTION
## What

Fixes the panic `interface conversion: interface {} is map[string]interface {}, not *aggregator.numericalAggregator` when an aggregate query requesting **mean, median, or mode** runs on a multi-node cluster and the coordinating node has to fetch at least one shard result from another node.

Fixes weaviate/weaviate#11687. Present since v1.15.1 (commit 1786fa1387).

## Root cause

When mean/median/mode is requested, the shard stores its raw `*numericalAggregator` / `*dateAggregator` under `_numericalAggregator` / `_dateAggregator` in the result map so the coordinator can recompute those stats across shards. That state crosses the cluster-internal REST API as plain JSON — and since the aggregators have only unexported fields, they serialize as `{}` and come back as `map[string]interface{}`, failing the combiner's type assertions. Date `count` additionally comes back as `float64` instead of `int64`, so even a plain date count aggregation panics cross-node.

## Fix

- `MarshalJSON` on both aggregators defines a real wire form: `{count, sum, pairs?}` for numerical, `{pairs}` for date. `pairs` (the exact value/count distribution, required for exact mode/median) is only included when mode or median was requested — a mean-only query ships just count and sum.
- `ShardCombiner.Do` restores the concrete aggregator types (and date count `int64`) before merging, and now returns an error: payloads from nodes predating the wire format (`{}`) or malformed payloads are rejected with a clear error instead of a panic or a silently wrong result.
- Merge loops add each distinct value with its count in one call instead of re-inserting values one at a time (the date path also re-parsed the RFC3339 string per element).

## Mixed-version behavior during rolling upgrades

- new coordinator + old remote shard: clean error ("remote node likely runs an older version") instead of today's panic.
- old coordinator + new remote shard: fails as it does today (unfixable without protocol negotiation); resolves once the coordinator is upgraded.

## Testing

- `TestShardCombinerRemoteShardResults` (unit): JSON round trip for first/second/both shards, grouped and ungrouped, mean-only wire form, old-node and malformed payload rejection. Reproduces the exact production panic on the unfixed code.
- `TestDistributedSetup/aggregate numerical and date props across shards` (clusterintegrationtest): 10 in-process nodes over the real cluster REST API and payload codec; numerical mean/median/mode/count and date median/min/max/count across remote shards, plus a mean-only query. Fails with the production panic on the unfixed code, green with `-race` on this branch.

To be forward-ported to stable/v1.38, stable/v1.39, and main.
