### PR TITLE
fix: prevent goroutine leak in gRPC batch stream recv

### DIFF
--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -384,10 +384,17 @@ func (h *StreamHandler) recv(stream pb.Weaviate_BatchStreamServer) (chan *pb.Bat
 			// including server shutdowns
 			req, err := stream.Recv()
 			if err != nil {
-				errCh <- err
+				select {
+				case errCh <- err:
+				case <-stream.Context().Done():
+				}
 				return
 			}
-			reqCh <- req
+			select {
+			case reqCh <- req:
+			case <-stream.Context().Done():
+				return
+			}
 		}
 	}, h.logger)
 	return reqCh, errCh


### PR DESCRIPTION
Fixes #12749

## Root cause

The `recv()` helper spawns a goroutine that sends on unbuffered `errCh` and `reqCh` channels. When `receiver()` exits via `ctx.Done()` (e.g. client disconnect, server shutdown, grace period expiry), these channels have no reader, and the goroutine blocks forever.

## Fix

Wrap each channel send in a `select` that also listens on `stream.Context().Done()`:

```go
select {
case errCh <- err:
case <-stream.Context().Done():
}

// and similarly for reqCh
select {
case reqCh <- req:
case <-stream.Context().Done():
    return
}
```

## Verification

- The fix mirrors the exact pattern suggested in the issue.
- `recv`'s goroutine exits cleanly on either `stream.Recv()` returning an error OR the stream context being cancelled.
- No test added because the leak is timing-dependent (requires abnormal stream termination), but the change is a straightforward select-guard that cannot introduce new deadlocks — the `default` case is absent, so the select blocks on either branch, which is strictly safer than the current unbuffered send.

Signed-off-by: waterWang <waterwang@proton.me>