### PR TITLE
fix(grpc): prevent batch stream recv goroutine leak on abandoned channel sends

### DIFF
--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -435,6 +435,7 @@ func (h *StreamHandler) receiver(ctx context.Context, streamId string, consisten
 
 		var request *pb.BatchStreamRequest
 		var err error
+		var open bool
 		// non-blocking select to receive messages from the stream
 		// this allows us to detect hanging clients during server shutdown
 		// we either receive a request, an error, or a shutdown signal
@@ -443,8 +444,8 @@ func (h *StreamHandler) receiver(ctx context.Context, streamId string, consisten
 		// if we receive a request or an error, we process it as normal
 		// if the context is cancelled, we exit the loop
 		select {
-		case request = <-reqCh:
-		case err = <-errCh:
+		case request, open = <-reqCh:
+		case err, open = <-errCh:
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-shuttingDownDone:
@@ -460,6 +461,11 @@ func (h *StreamHandler) receiver(ctx context.Context, streamId string, consisten
 			log.Warn("grace period expired, closing recv stream")
 			cancel()
 			return fmt.Errorf("server is shutting down, recv stream closed after grace period: %w", ctx.Err())
+		}
+		if !open {
+			// both channels are closed: recv observed ctx.Done and exited without
+			// delivering anything, so the cancellation is the real reason
+			return ctx.Err()
 		}
 
 		if errors.Is(err, io.EOF) {

--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -363,7 +363,7 @@ func (h *StreamHandler) close(streamId string, wg *sync.WaitGroup) {
 	h.workerStatsPerStream.Delete(streamId)
 }
 
-func (h *StreamHandler) recv(stream pb.Weaviate_BatchStreamServer) (chan *pb.BatchStreamRequest, chan error) {
+func (h *StreamHandler) recv(ctx context.Context, stream pb.Weaviate_BatchStreamServer) (chan *pb.BatchStreamRequest, chan error) {
 	reqCh := make(chan *pb.BatchStreamRequest)
 	errCh := make(chan error)
 	enterrors.GoWrapper(func() {
@@ -372,16 +372,23 @@ func (h *StreamHandler) recv(stream pb.Weaviate_BatchStreamServer) (chan *pb.Bat
 			close(reqCh)
 		}()
 		for {
-			// stream context is cancelled once the send() method returns
-			// cleaning up this goroutine without needing any additional signalling
-			// i.e. when the stream is closed by the client or an error occurs
-			// including server shutdowns
+			// stream context cancellation unblocks stream.Recv, e.g. when the stream
+			// is closed by the client, an error occurs or the server shuts down
 			req, err := stream.Recv()
 			if err != nil {
-				errCh <- err
+				// the consumer (receiver) cancels ctx on every exit path; without the
+				// select a send after the consumer is gone blocks forever (issue #12749)
+				select {
+				case errCh <- err:
+				case <-ctx.Done():
+				}
 				return
 			}
-			reqCh <- req
+			select {
+			case reqCh <- req:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}, h.logger)
 	return reqCh, errCh
@@ -404,7 +411,7 @@ func (h *StreamHandler) receiver(ctx context.Context, streamId string, consisten
 	shuttingDownDone := h.shuttingDownCtx.Done()
 	var gracePeriod <-chan time.Time
 
-	reqCh, errCh := h.recv(stream)
+	reqCh, errCh := h.recv(ctx, stream)
 	for {
 		// we must check for shutting down before we start blocking on h.recv in the event
 		// that the client is misbehaving by sending more messages after the shutdown signal

--- a/adapters/handlers/grpc/v1/batch/stream_internal_test.go
+++ b/adapters/handlers/grpc/v1/batch/stream_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"io"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -65,7 +66,8 @@ func TestRecvGoroutineExitsWhenConsumerIsGone(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Zero(t, recvGoroutines(), "leftover recv goroutines from a previous test")
+			require.Eventually(t, func() bool { return recvGoroutines() == 0 }, 3*time.Second, 10*time.Millisecond,
+				"leftover recv goroutines from a previous test")
 			h := &StreamHandler{logger: logrus.New()}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -86,7 +88,8 @@ func TestRecvGoroutineExitsWhenConsumerIsGone(t *testing.T) {
 // TestRecvDeliversRequestsAndError verifies the normal path: requests then the
 // terminating error are delivered, and the goroutine exits closing both channels.
 func TestRecvDeliversRequestsAndError(t *testing.T) {
-	require.Zero(t, recvGoroutines(), "leftover recv goroutines from a previous test")
+	require.Eventually(t, func() bool { return recvGoroutines() == 0 }, 3*time.Second, 10*time.Millisecond,
+		"leftover recv goroutines from a previous test")
 	h := &StreamHandler{logger: logrus.New()}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -119,4 +122,55 @@ func TestRecvDeliversRequestsAndError(t *testing.T) {
 	_, open = <-errCh
 	require.False(t, open, "errCh should be closed after recv exits")
 	require.Eventually(t, func() bool { return recvGoroutines() == 0 }, 3*time.Second, 10*time.Millisecond)
+}
+
+// TestReceiverReportsCancellationNotClosedChannels covers the follow-up to issue
+// #12749: once recv exits through ctx.Done and closes its channels, receiver must
+// report the cancellation instead of misreading the closed channels as a nil
+// request ("invalid batch send request"). The hot request loop gives the race
+// window many chances; with the fix the misread is impossible, so the test passes
+// deterministically.
+func TestReceiverReportsCancellationNotClosedChannels(t *testing.T) {
+	emptyData := &pb.BatchStreamRequest{
+		Message: &pb.BatchStreamRequest_Data_{Data: &pb.BatchStreamRequest_Data{}},
+	}
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	for i := 0; i < 100; i++ {
+		h := &StreamHandler{
+			logger:               logger,
+			shuttingDownCtx:      context.Background(),
+			reportingQueues:      NewReportingQueues(),
+			workerStatsPerStream: &sync.Map{},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		recvErr := errors.New("stream aborted")
+		// a data message without values makes receiver log a warning and continue,
+		// so it cycles between its select and the processing code while requests
+		// keep arriving; the cancel below lands at an arbitrary point of that loop
+		stream := &fakeRecvStream{recvFn: func() (*pb.BatchStreamRequest, error) {
+			select {
+			case <-ctx.Done():
+				return nil, recvErr
+			default:
+				return emptyData, nil
+			}
+		}}
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- h.receiver(ctx, "test-stream", nil, stream)
+		}()
+		time.Sleep(time.Millisecond)
+		cancel()
+
+		select {
+		case err := <-errCh:
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "invalid batch send request",
+				"receiver misread closed recv channels as a nil request")
+		case <-time.After(3 * time.Second):
+			t.Fatal("receiver did not return after cancellation")
+		}
+	}
 }

--- a/adapters/handlers/grpc/v1/batch/stream_internal_test.go
+++ b/adapters/handlers/grpc/v1/batch/stream_internal_test.go
@@ -1,0 +1,122 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package batch
+
+import (
+	"context"
+	"errors"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+)
+
+// fakeRecvStream implements only the methods recv uses. The embedded interface
+// covers the rest; calling an unimplemented method panics.
+type fakeRecvStream struct {
+	pb.Weaviate_BatchStreamServer
+	recvFn func() (*pb.BatchStreamRequest, error)
+}
+
+func (f *fakeRecvStream) Recv() (*pb.BatchStreamRequest, error) {
+	return f.recvFn()
+}
+
+func recvGoroutines() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "(*StreamHandler).recv.func")
+}
+
+// TestRecvGoroutineExitsWhenConsumerIsGone pins the leak from
+// https://github.com/weaviate/weaviate/issues/12749: the goroutine spawned by recv
+// blocked forever on its unbuffered channel sends when the receiver loop returned
+// (for example via ctx.Done()) without draining them.
+func TestRecvGoroutineExitsWhenConsumerIsGone(t *testing.T) {
+	tests := []struct {
+		name   string
+		recvFn func() (*pb.BatchStreamRequest, error)
+	}{
+		{
+			// recv is blocked sending the Recv error into errCh
+			name:   "blocked on error send",
+			recvFn: func() (*pb.BatchStreamRequest, error) { return nil, errors.New("stream broken") },
+		},
+		{
+			// recv is blocked sending a request into reqCh
+			name:   "blocked on request send",
+			recvFn: func() (*pb.BatchStreamRequest, error) { return &pb.BatchStreamRequest{}, nil },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Zero(t, recvGoroutines(), "leftover recv goroutines from a previous test")
+			h := &StreamHandler{logger: logrus.New()}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			h.recv(ctx, &fakeRecvStream{recvFn: tt.recvFn})
+			require.Eventually(t, func() bool { return recvGoroutines() == 1 }, 3*time.Second, 10*time.Millisecond,
+				"recv goroutine did not start")
+
+			// The consumer never reads reqCh/errCh; cancelling ctx is how the receiver
+			// loop signals it is gone (it cancels its ctx on every exit path).
+			cancel()
+			require.Eventually(t, func() bool { return recvGoroutines() == 0 }, 3*time.Second, 10*time.Millisecond,
+				"recv goroutine leaked after the consumer went away")
+		})
+	}
+}
+
+// TestRecvDeliversRequestsAndError verifies the normal path: requests then the
+// terminating error are delivered, and the goroutine exits closing both channels.
+func TestRecvDeliversRequestsAndError(t *testing.T) {
+	require.Zero(t, recvGoroutines(), "leftover recv goroutines from a previous test")
+	h := &StreamHandler{logger: logrus.New()}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	calls := 0
+	stream := &fakeRecvStream{recvFn: func() (*pb.BatchStreamRequest, error) {
+		calls++
+		if calls == 1 {
+			return &pb.BatchStreamRequest{}, nil
+		}
+		return nil, io.EOF
+	}}
+
+	reqCh, errCh := h.recv(ctx, stream)
+	select {
+	case req := <-reqCh:
+		require.NotNil(t, req)
+	case <-time.After(3 * time.Second):
+		t.Fatal("request was not delivered")
+	}
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, io.EOF)
+	case <-time.After(3 * time.Second):
+		t.Fatal("error was not delivered")
+	}
+
+	_, open := <-reqCh
+	require.False(t, open, "reqCh should be closed after recv exits")
+	_, open = <-errCh
+	require.False(t, open, "errCh should be closed after recv exits")
+	require.Eventually(t, func() bool { return recvGoroutines() == 0 }, 3*time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## Motivation

Fixes #12749. Every batch stream that ends through context cancellation leaks one goroutine, permanently. On a v1.39.0 production cluster the three longest-running nodes had accumulated 16, 9, and 10 goroutines parked at the `errCh <- err` send in `StreamHandler.recv` — one per abnormally-ended stream. A client that aborts stream starts in a loop (weaviate/weaviate-python-client#2139) produces them continuously, so the growth is unbounded until restart.

## Root cause

`recv` spawns a goroutine that forwards `stream.Recv()` results over two unbuffered channels. Its comment assumed stream-context cancellation cleans the goroutine up, but cancellation only unblocks `stream.Recv()`, not the channel send after it. The consumer (`receiver`'s select loop) has exit paths that abandon those channels — `ctx.Done()` and the two grace-period `cancel()` returns — after which the send blocks forever. The `reqCh <- req` send between messages can leak the same way.

## Fix

`receiver` already cancels its child context on every exit path (`defer cancel()`), so that context is a reliable signal that the consumer is gone. `recv` now takes it and wraps both sends in a `select` against `ctx.Done()`. A buffered `errCh` (cap 1) would fix only the error send; the select covers both.

Second commit (review follow-up): the new exit path lets `recv` close its channels while `receiver` is still looping; `receiver`'s select could then read a closed channel instead of `ctx.Done()` (select picks randomly among ready cases) and return a bogus `invalid batch send request: data field is nil` on ordinary disconnects. `receiver` now checks the channels' open flag and returns `ctx.Err()` when they are closed.

## Key area for review

- `recv` in `stream.go` — the two selects. The invariant they rely on: `receiver` cancels `ctx` on every return path, which its `defer cancel()` guarantees.

## Risks

- A request or error in flight when ctx is cancelled is dropped. Correct by construction: ctx is only cancelled once `receiver` has returned, so nothing would ever read it. Same observable behavior as before, minus the leak.
- Normal delivery is unchanged: with a live consumer the send case proceeds exactly as the bare send did.

## Target branch

Based on `stable/v1.37`: the affected code is identical from stable/v1.37 through main (only line offsets differ), so the fix reaches the newer branches through the regular stable-into-next merges.

## Testing

`stream_internal_test.go` pins the leak by counting `recv` goroutine frames in a runtime stack dump:

- `TestRecvGoroutineExitsWhenConsumerIsGone` — table-driven over both leak sites (blocked on `errCh` send, blocked on `reqCh` send): cancel ctx with no reader, require the count to drop to zero. Both cases fail without the fix.
- `TestRecvDeliversRequestsAndError` — normal path: request then terminating error delivered, both channels close, goroutine exits.
- `TestReceiverReportsCancellationNotClosedChannels` — drives `receiver` with a hot request loop and cancels mid-processing; fails with the closed-channel misread before the second commit, passes deterministically after.

Full `./adapters/handlers/grpc/v1/batch` suite passes with `-race`; golangci-lint, gofumpt, and the goroutine linter report nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
