### PR TITLE
fix(drop-vector-index): clear the dynamic upgrade verdict on the cold-tenant path

### DIFF
--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
 )
@@ -73,6 +74,13 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 		if err := os.RemoveAll(dir); err != nil {
 			return fmt.Errorf("remove %s: %w", dir, err)
 		}
+	}
+
+	// A dynamic index records its flat-to-hnsw verdict in the shard-shared state
+	// DB, which no artifact above can reach: it is one file per shard, not per
+	// vector, so removing it would take every sibling's verdict too.
+	if err := dynamic.RemoveStateKey(shardDir, targetVector); err != nil {
+		return fmt.Errorf("remove dynamic state for %q: %w", targetVector, err)
 	}
 
 	return nil

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -76,9 +76,14 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 		}
 	}
 
-	// A dynamic index records its flat-to-hnsw verdict in the shard-shared state
-	// DB, which no artifact above can reach: it is one file per shard, not per
-	// vector, so removing it would take every sibling's verdict too.
+	// A dynamic index records its flat-to-hnsw upgrade as a key in the shard's
+	// index.db, which no artifact above can reach: that file is one per shard,
+	// not one per vector, so removing it would take every sibling's state too.
+	//
+	// Unconditional because nothing here can tell a dynamic vector from any
+	// other — the drop rewrote this entry's VectorIndexType to "none" and
+	// discarded the original type along with its config. A shard that never ran
+	// a dynamic index has no index.db, so this costs it one stat.
 	if err := dynamic.RemoveStateKey(shardDir, targetVector); err != nil {
 		return fmt.Errorf("remove dynamic state for %q: %w", targetVector, err)
 	}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -295,6 +295,51 @@ func dbKey(targetVector string) []byte {
 	return key
 }
 
+// RemoveStateKey deletes targetVector's flat-to-hnsw verdict from the shard's
+// state DB. It is the files-only counterpart of DropTargetVector: the sweeps
+// that never load a shard remove directories, and the state DB is not one of
+// them — it belongs to the shard, not to any one vector, so no artifact list
+// can carry it.
+//
+// A verdict left behind is inherited by the next vector created under the same
+// name: it boots straight into an empty hnsw and never serves its flat stage.
+//
+// A missing file is success — a shard that never ran a dynamic index has no
+// verdict to clear, and the file is deliberately not created here. So is a
+// locked one: the lock is held only by a loaded shard in this process, and
+// every route that loads a shard deletes the key through that handle.
+func RemoveStateKey(rootPath, targetVector string) error {
+	path := filepath.Join(rootPath, StateDBFileName)
+	// Statted rather than opened straight away: bbolt.Open CREATES the file, so
+	// a plain open would leave an empty state DB in every shard a drop touches.
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat dynamic state db: %w", err)
+	}
+
+	db, err := bbolt.Open(path, 0o600, &bbolt.Options{Timeout: stateDBOpenTimeout})
+	if err != nil {
+		if simpleErrors.Is(err, bbolt.ErrTimeout) {
+			return nil
+		}
+		return fmt.Errorf("open dynamic state db: %w", err)
+	}
+	defer db.Close()
+
+	if err := db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(dynamicBucket)
+		if b == nil {
+			return nil
+		}
+		return b.Delete(dbKey(targetVector))
+	}); err != nil {
+		return fmt.Errorf("delete dynamic state for %q: %w", targetVector, err)
+	}
+	return nil
+}
+
 // UpgradedOnDisk reports whether the dynamic index of an unloaded shard already
 // switched to hnsw, reading the same state the shard's own load reads: the
 // shared state DB, falling back for a named vector to the hnsw commit log

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -296,18 +297,13 @@ func dbKey(targetVector string) []byte {
 }
 
 // RemoveStateKey deletes targetVector's flat-to-hnsw verdict from the shard's
-// state DB. It is the files-only counterpart of DropTargetVector: the sweeps
-// that never load a shard remove directories, and the state DB is not one of
-// them — it belongs to the shard, not to any one vector, so no artifact list
-// can carry it.
+// state DB. No artifact list can carry it — index.db belongs to the shard, not
+// to any one vector — so the sweeps that never load a shard clear it here. A
+// verdict left behind is inherited by the next vector of the same name, which
+// boots straight into an empty hnsw and never serves its flat stage.
 //
-// A verdict left behind is inherited by the next vector created under the same
-// name: it boots straight into an empty hnsw and never serves its flat stage.
-//
-// A missing file is success — a shard that never ran a dynamic index has no
-// verdict to clear, and the file is deliberately not created here. So is a
-// locked one: the lock is held only by a loaded shard in this process, and
-// every route that loads a shard deletes the key through that handle.
+// A missing or locked state DB is success: nothing was upgraded, or a loaded
+// shard owns the key and deletes it through its own handle.
 func RemoveStateKey(rootPath, targetVector string) error {
 	path := filepath.Join(rootPath, StateDBFileName)
 	// Statted rather than opened straight away: bbolt.Open CREATES the file, so
@@ -321,7 +317,7 @@ func RemoveStateKey(rootPath, targetVector string) error {
 
 	db, err := bbolt.Open(path, 0o600, &bbolt.Options{Timeout: stateDBOpenTimeout})
 	if err != nil {
-		if simpleErrors.Is(err, bbolt.ErrTimeout) {
+		if simpleErrors.Is(err, bolterrors.ErrTimeout) {
 			return nil
 		}
 		return fmt.Errorf("open dynamic state db: %w", err)

--- a/adapters/repos/db/vector/dynamic/remove_state_key_test.go
+++ b/adapters/repos/db/vector/dynamic/remove_state_key_test.go
@@ -1,0 +1,136 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package dynamic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	bbolt "go.etcd.io/bbolt"
+)
+
+// writeVerdicts records an "upgraded" verdict for each target, as a shard that
+// crossed the threshold would have.
+func writeVerdicts(t *testing.T, rootPath string, targets ...string) {
+	t.Helper()
+	db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600, nil)
+	require.NoError(t, err)
+	defer db.Close()
+	require.NoError(t, db.Update(func(tx *bbolt.Tx) error {
+		b, err := tx.CreateBucketIfNotExists(dynamicBucket)
+		if err != nil {
+			return err
+		}
+		for _, target := range targets {
+			if err := b.Put(dbKey(target), []byte{1}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}))
+}
+
+func hasVerdict(t *testing.T, rootPath, target string) bool {
+	t.Helper()
+	upgraded, err := UpgradedOnDisk(rootPath, "vectors_"+target, target)
+	require.NoError(t, err)
+	return upgraded
+}
+
+// TestRemoveStateKey covers the routes that clean a dropped vector WITHOUT
+// loading the shard. They remove directories, and the state DB is not one: it
+// holds one key per vector in a file the whole shard shares, so a verdict left
+// behind is inherited by the next vector created under the same name.
+func TestRemoveStateKey(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// setup prepares rootPath and returns nothing; assertions follow.
+		setup  func(t *testing.T, rootPath string)
+		target string
+		assert func(t *testing.T, rootPath string)
+	}{
+		{
+			name:   "removes the target's verdict and leaves its siblings",
+			setup:  func(t *testing.T, rootPath string) { writeVerdicts(t, rootPath, "a", "b") },
+			target: "a",
+			assert: func(t *testing.T, rootPath string) {
+				assert.False(t, hasVerdict(t, rootPath, "a"), "the dropped vector's verdict must go")
+				assert.True(t, hasVerdict(t, rootPath, "b"), "a sibling's verdict must survive")
+			},
+		},
+		{
+			name:   "removes the unnamed vector's verdict",
+			setup:  func(t *testing.T, rootPath string) { writeVerdicts(t, rootPath, "", "b") },
+			target: "",
+			assert: func(t *testing.T, rootPath string) {
+				assert.False(t, hasVerdict(t, rootPath, ""))
+				assert.True(t, hasVerdict(t, rootPath, "b"))
+			},
+		},
+		{
+			name:   "no state db is not an error, and none is created",
+			setup:  func(t *testing.T, rootPath string) {},
+			target: "a",
+			assert: func(t *testing.T, rootPath string) {
+				// A shard that never ran a dynamic index must not gain an empty
+				// state DB from being swept: bbolt.Open creates what it opens.
+				_, err := os.Stat(filepath.Join(rootPath, StateDBFileName))
+				assert.True(t, os.IsNotExist(err), "the sweep must not create a state db")
+			},
+		},
+		{
+			name: "a state db without the bucket is not an error",
+			setup: func(t *testing.T, rootPath string) {
+				db, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600, nil)
+				require.NoError(t, err)
+				require.NoError(t, db.Close())
+			},
+			target: "a",
+			assert: func(t *testing.T, rootPath string) {},
+		},
+		{
+			name:   "a verdict that was never recorded is not an error",
+			setup:  func(t *testing.T, rootPath string) { writeVerdicts(t, rootPath, "b") },
+			target: "a",
+			assert: func(t *testing.T, rootPath string) {
+				assert.True(t, hasVerdict(t, rootPath, "b"))
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rootPath := t.TempDir()
+			tc.setup(t, rootPath)
+			require.NoError(t, RemoveStateKey(rootPath, tc.target))
+			tc.assert(t, rootPath)
+		})
+	}
+}
+
+// TestRemoveStateKey_LockedStateDBIsSkipped pins the tolerance the group-completion
+// sweep needs. That sweep re-runs over every local tenant including loaded ones,
+// which hold the state DB's flock through their own handle. Failing there would
+// fail the group's ack and replay the callback forever; the loaded routes delete
+// the key through that handle, so there is nothing left for this one to do.
+func TestRemoveStateKey_LockedStateDBIsSkipped(t *testing.T) {
+	rootPath := t.TempDir()
+	writeVerdicts(t, rootPath, "a")
+
+	held, err := bbolt.Open(filepath.Join(rootPath, StateDBFileName), 0o600, nil)
+	require.NoError(t, err)
+	defer held.Close()
+
+	require.NoError(t, RemoveStateKey(rootPath, "a"),
+		"a locked state db means a loaded shard owns the key, not an error to propagate")
+}

--- a/test/acceptance/drop_vector_index/dynamic_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/dynamic_scenarios_test.go
@@ -1,0 +1,262 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package drop_vector_index
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
+)
+
+// dynamicVectorConfig is a named vector on the dynamic index: it starts flat
+// and rebuilds itself as hnsw once it holds more than threshold vectors.
+func dynamicVectorConfig(threshold int) models.VectorConfig {
+	return models.VectorConfig{
+		Vectorizer:        map[string]any{"none": map[string]any{}},
+		VectorIndexType:   "dynamic",
+		VectorIndexConfig: map[string]any{"threshold": threshold},
+	}
+}
+
+// testDynamicUpgradeVerdictCleared pins what a drop has to remove beyond files
+// when the vector runs a dynamic index.
+//
+// A dynamic index records its flat-to-hnsw verdict as a KEY in index.db, the
+// state DB the shard opens once and every dynamic vector on it shares. No
+// artifact list can carry it — index.db is one file per shard, not per vector —
+// so the routes that never load a shard (the cold lazy shard, the
+// group-completion safety net, the shard-init sweep) reach the key through
+// dynamic.RemoveStateKey instead of by removing a directory.
+//
+// A verdict left behind is inherited by the next vector created under the same
+// name: it boots straight into an empty hnsw and never serves its flat stage,
+// paying hnsw's cost below the threshold that was configured to avoid it.
+//
+// Both shard states at drop time are run. Cold is the one the verdict used to
+// survive, since it is the only one no loaded route ever sees. Hot is the state
+// in which the shard holds index.db open, so a files-only route that insisted
+// on reaching the key through the file would wedge the drop of every live
+// tenant instead.
+//
+// The sibling dynamic vector is not decoration either: it is what keeps
+// index.db open, and its own verdict has to come through untouched.
+func testDynamicUpgradeVerdictCleared(compose *docker.DockerCompose) func(*testing.T) {
+	return func(t *testing.T) {
+		// Own client setup: this runs outside runSuite, whose deferred
+		// ResetClient has already pointed the helper back at the default
+		// localhost - which may be some unrelated local Weaviate.
+		helper.SetupClient(compose.GetWeaviate().URI())
+		defer helper.ResetClient()
+
+		for _, test := range []struct {
+			name      string
+			className string
+			// coldAtDrop deactivates the tenant for the drop and reactivates it
+			// afterwards, so the shard is unloaded while the drop is applied.
+			coldAtDrop bool
+		}{
+			{name: "shard cold at the drop", className: "DropVectorIndexDynamicCold", coldAtDrop: true},
+			{name: "shard loaded at the drop", className: "DropVectorIndexDynamicHot"},
+		} {
+			t.Run(test.name, testDynamicUpgradeVerdictClearedCase(compose, test.className, test.coldAtDrop))
+		}
+	}
+}
+
+func testDynamicUpgradeVerdictClearedCase(
+	compose *docker.DockerCompose, className string, coldAtDrop bool,
+) func(*testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		const (
+			dropped = "dyn"
+			sibling = "keep"
+			dim     = 32
+			tenant  = "tenant-1"
+
+			// Small enough that the import below crosses it, so both vectors
+			// reach hnsw and record an "upgraded" verdict.
+			upgradeThreshold = 20
+			upgradeCount     = 40
+
+			// Far above what the re-created vector receives: a fresh dynamic
+			// index at this threshold must still be flat, so the hnsw commit
+			// log directory appearing can only come from an inherited verdict.
+			freshThreshold = 100_000
+			freshCount     = 5
+		)
+
+		insert := func(t *testing.T, count, idBase int) {
+			t.Helper()
+			batch := make([]*models.Object, count)
+			for i := range count {
+				batch[i] = &models.Object{
+					ID:         strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-0000000027%02d", idBase+i)),
+					Class:      className,
+					Tenant:     tenant,
+					Properties: map[string]any{"name": fmt.Sprintf("object-%d", idBase+i)},
+					Vectors: models.Vectors{
+						dropped: randVec(dim, float32(idBase+i)),
+						sibling: randVec(dim, float32(idBase+i+100)),
+					},
+				}
+			}
+			helper.CreateObjectsBatch(t, batch)
+		}
+
+		deleteParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+		defer helper.Client(t).Schema.SchemaObjectsDelete(deleteParams, nil)
+
+		t.Run("both dynamic vectors upgrade to hnsw", func(t *testing.T) {
+			cls := &models.Class{
+				Class: className,
+				Properties: []*models.Property{
+					{Name: "name", DataType: []string{schema.DataTypeText.String()}},
+				},
+				MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+				VectorConfig: map[string]models.VectorConfig{
+					dropped: dynamicVectorConfig(upgradeThreshold),
+					sibling: dynamicVectorConfig(upgradeThreshold),
+				},
+			}
+			_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+				clschema.NewSchemaObjectsCreateParams().WithObjectClass(cls), nil)
+			require.NoError(t, err)
+			helper.CreateTenants(t, className, []*models.Tenant{{Name: tenant}})
+			insert(t, upgradeCount, 0)
+
+			// The precondition the whole test rests on: without a recorded
+			// "upgraded" verdict there is no stale verdict to inherit, and
+			// every assertion below would pass on an index that was never
+			// anything but flat.
+			for _, target := range []string{dropped, sibling} {
+				require.EventuallyWithT(t, func(collect *assert.CollectT) {
+					assert.NotEmpty(collect, hnswCommitLogDirs(vectorDirsOnEveryNode(ctx, t, compose), className, target),
+						"%s must reach hnsw before the drop", target)
+				}, 3*time.Minute, 2*time.Second)
+			}
+		})
+
+		t.Run("drop the vector", func(t *testing.T) {
+			if coldAtDrop {
+				setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusCOLD)
+			}
+			dropTargetVector(t, className, dropped)
+			if coldAtDrop {
+				setTenantStatusEventually(t, className, tenant, models.TenantActivityStatusHOT)
+			}
+
+			eventuallyTargetVectorRemoved(t, className, dropped)
+			waitForNoActiveDropTask(t)
+
+			all := vectorDirsOnEveryNode(ctx, t, compose)
+			require.Empty(t, hnswCommitLogDirs(all, className, dropped),
+				"the dropped vector's hnsw commit log must go with it")
+			require.NotEmpty(t, hnswCommitLogDirs(all, className, sibling),
+				"the sibling is still hnsw: a lost verdict would have booted it flat, "+
+					"which removes this directory")
+		})
+
+		t.Run("a vector re-created under the same name starts flat", func(t *testing.T) {
+			cls := helper.GetClass(t, className)
+			cls.VectorConfig[dropped] = dynamicVectorConfig(freshThreshold)
+			_, err := helper.Client(t).Schema.SchemaObjectsUpdate(
+				clschema.NewSchemaObjectsUpdateParams().WithClassName(className).WithObjectClass(cls), nil)
+			require.NoError(t, err)
+			insert(t, freshCount, 50)
+
+			// Serving its own writes is what says the re-created index is
+			// live, so the shape checked below is a shape it really booted
+			// into rather than one it has not reached yet.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				got, err := nearVectorTenantResultsErr(className, tenant, dropped, randVec(dim, 51), freshCount)
+				if !assert.NoError(collect, err) {
+					return
+				}
+				assert.Equal(collect, freshCount, got,
+					"the re-created vector must serve the objects written to it")
+			}, time.Minute, time.Second)
+
+			require.Never(t, func() bool {
+				return len(hnswCommitLogDirs(vectorDirsOnEveryNode(ctx, t, compose), className, dropped)) > 0
+			}, 15*time.Second, 3*time.Second,
+				"the re-created %q holds %d vectors against a threshold of %d, so it must still be flat; "+
+					"an hnsw commit log here means it inherited the dropped vector's upgrade verdict",
+				dropped, freshCount, freshThreshold)
+
+			require.NotEmpty(t, hnswCommitLogDirs(vectorDirsOnEveryNode(ctx, t, compose), className, sibling),
+				"the sibling's verdict must survive the re-create too")
+		})
+	}
+}
+
+// nearVectorTenantResultsErr is the outer-t-free variant of
+// nearVectorTenantResults, safe inside an EventuallyWithT condition (see
+// listObjectsWithVectorsErr for why one is needed).
+func nearVectorTenantResultsErr(className, tenant, targetVector string, vector []float32, limit int) (int, error) {
+	resp, err := graphqlhelper.QueryGraphQL(nil, nil, "",
+		nearVectorQuery(className, tenant, targetVector, vector, limit), nil)
+	if err != nil {
+		return 0, err
+	}
+	if len(resp.Errors) > 0 {
+		return 0, fmt.Errorf("graphql: %s", resp.Errors[0].Message)
+	}
+	get, ok := resp.Data["Get"].(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("unexpected Get payload %T", resp.Data["Get"])
+	}
+	results, ok := get[className].([]interface{})
+	if !ok {
+		return 0, fmt.Errorf("unexpected %s payload %T", className, get[className])
+	}
+	return len(results), nil
+}
+
+// hnswCommitLogDirs returns the hnsw commit log directories belonging to
+// className's targetVector. For a dynamic vector this directory is the on-disk
+// tell of which index it booted into: hnsw creates it eagerly on startup, and a
+// dynamic index that boots flat removes it.
+//
+// Scoped to the collection because the search that produced allDirs covers the
+// whole data root: two collections carrying a vector of the same name would
+// otherwise answer for each other.
+func hnswCommitLogDirs(allDirs []string, className, targetVector string) []string {
+	want := helpers.GetHNSWCommitLogDirName(targetVector)
+	// <root>/<lowercased class>/<shard>/<dir>
+	collection := "/" + strings.ToLower(className) + "/"
+	var out []string
+	for _, dir := range allDirs {
+		if path.Base(dir) == want && strings.Contains(dir, collection) {
+			out = append(out, dir)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/test/acceptance/drop_vector_index/dynamic_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/dynamic_scenarios_test.go
@@ -28,9 +28,10 @@ import (
 	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
-	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
+	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
 // dynamicVectorConfig is a named vector on the dynamic index: it starts flat
@@ -43,28 +44,15 @@ func dynamicVectorConfig(threshold int) models.VectorConfig {
 	}
 }
 
-// testDynamicUpgradeVerdictCleared pins what a drop has to remove beyond files
-// when the vector runs a dynamic index.
+// testDynamicUpgradeVerdictCleared covers what a drop has to remove beyond
+// files when the vector runs a dynamic index: the flat-to-hnsw upgrade, which
+// lives as a key in the shard's index.db and not in any directory. If it
+// survives the drop, the next vector created under the same name inherits it
+// and boots straight into hnsw, below the threshold it was configured with.
 //
-// A dynamic index records its flat-to-hnsw verdict as a KEY in index.db, the
-// state DB the shard opens once and every dynamic vector on it shares. No
-// artifact list can carry it — index.db is one file per shard, not per vector —
-// so the routes that never load a shard (the cold lazy shard, the
-// group-completion safety net, the shard-init sweep) reach the key through
-// dynamic.RemoveStateKey instead of by removing a directory.
-//
-// A verdict left behind is inherited by the next vector created under the same
-// name: it boots straight into an empty hnsw and never serves its flat stage,
-// paying hnsw's cost below the threshold that was configured to avoid it.
-//
-// Both shard states at drop time are run. Cold is the one the verdict used to
-// survive, since it is the only one no loaded route ever sees. Hot is the state
-// in which the shard holds index.db open, so a files-only route that insisted
-// on reaching the key through the file would wedge the drop of every live
-// tenant instead.
-//
-// The sibling dynamic vector is not decoration either: it is what keeps
-// index.db open, and its own verdict has to come through untouched.
+// Both shard states at drop time are covered. Cold is where the key used to
+// survive; hot is where the shard holds index.db open. The sibling dynamic
+// vector is what keeps that file open, and must come through with its own key.
 func testDynamicUpgradeVerdictCleared(compose *docker.DockerCompose) func(*testing.T) {
 	return func(t *testing.T) {
 		// Own client setup: this runs outside runSuite, whose deferred
@@ -72,6 +60,11 @@ func testDynamicUpgradeVerdictCleared(compose *docker.DockerCompose) func(*testi
 		// localhost - which may be some unrelated local Weaviate.
 		helper.SetupClient(compose.GetWeaviate().URI())
 		defer helper.ResetClient()
+
+		grpcConn, err := helper.CreateGrpcConnectionClient(compose.GetWeaviate().GrpcURI())
+		require.NoError(t, err)
+		defer grpcConn.Close()
+		grpcClient := helper.CreateGrpcWeaviateClient(grpcConn)
 
 		for _, test := range []struct {
 			name      string
@@ -83,13 +76,15 @@ func testDynamicUpgradeVerdictCleared(compose *docker.DockerCompose) func(*testi
 			{name: "shard cold at the drop", className: "DropVectorIndexDynamicCold", coldAtDrop: true},
 			{name: "shard loaded at the drop", className: "DropVectorIndexDynamicHot"},
 		} {
-			t.Run(test.name, testDynamicUpgradeVerdictClearedCase(compose, test.className, test.coldAtDrop))
+			t.Run(test.name, testDynamicUpgradeVerdictClearedCase(
+				compose, grpcClient, test.className, test.coldAtDrop))
 		}
 	}
 }
 
 func testDynamicUpgradeVerdictClearedCase(
-	compose *docker.DockerCompose, className string, coldAtDrop bool,
+	compose *docker.DockerCompose, grpcClient pb.WeaviateClient,
+	className string, coldAtDrop bool,
 ) func(*testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
@@ -195,7 +190,8 @@ func testDynamicUpgradeVerdictClearedCase(
 			// live, so the shape checked below is a shape it really booted
 			// into rather than one it has not reached yet.
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
-				got, err := nearVectorTenantResultsErr(className, tenant, dropped, randVec(dim, 51), freshCount)
+				got, err := nearVectorTenantHits(ctx, grpcClient,
+					className, tenant, dropped, randVec(dim, 51), freshCount)
 				if !assert.NoError(collect, err) {
 					return
 				}
@@ -216,27 +212,28 @@ func testDynamicUpgradeVerdictClearedCase(
 	}
 }
 
-// nearVectorTenantResultsErr is the outer-t-free variant of
-// nearVectorTenantResults, safe inside an EventuallyWithT condition (see
+// nearVectorTenantHits counts what a near-vector search over targetVector
+// returns. It takes the client and returns the error rather than taking a
+// *testing.T, so it is safe inside an EventuallyWithT condition (see
 // listObjectsWithVectorsErr for why one is needed).
-func nearVectorTenantResultsErr(className, tenant, targetVector string, vector []float32, limit int) (int, error) {
-	resp, err := graphqlhelper.QueryGraphQL(nil, nil, "",
-		nearVectorQuery(className, tenant, targetVector, vector, limit), nil)
+func nearVectorTenantHits(
+	ctx context.Context, grpcClient pb.WeaviateClient,
+	className, tenant, targetVector string, vector []float32, limit int,
+) (int, error) {
+	resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+		Collection: className,
+		Tenant:     tenant,
+		Limit:      uint32(limit),
+		NearVector: &pb.NearVector{
+			VectorBytes: byteops.Fp32SliceToBytes(vector),
+			Targets:     &pb.Targets{TargetVectors: []string{targetVector}},
+		},
+		Uses_127Api: true,
+	})
 	if err != nil {
 		return 0, err
 	}
-	if len(resp.Errors) > 0 {
-		return 0, fmt.Errorf("graphql: %s", resp.Errors[0].Message)
-	}
-	get, ok := resp.Data["Get"].(map[string]interface{})
-	if !ok {
-		return 0, fmt.Errorf("unexpected Get payload %T", resp.Data["Get"])
-	}
-	results, ok := get[className].([]interface{})
-	if !ok {
-		return 0, fmt.Errorf("unexpected %s payload %T", className, get[className])
-	}
-	return len(results), nil
+	return len(resp.Results), nil
 }
 
 // hnswCommitLogDirs returns the hnsw commit log directories belonging to

--- a/test/acceptance/drop_vector_index/flat_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/flat_scenarios_test.go
@@ -96,7 +96,7 @@ func testFlatLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.T)
 
 		var owned []string
 		t.Run("the flat index owns state on disk", func(t *testing.T) {
-			owned = dirsOwnedBy(multiVectorDirsOnEveryNode(ctx, t, compose), dropped)
+			owned = dirsOwnedBy(vectorDirsOnEveryNode(ctx, t, compose), dropped)
 			require.NotEmpty(t, owned,
 				"precondition: the index must have on-disk state, or dropping it proves nothing")
 			t.Logf("%s owns:\n  %s", dropped, strings.Join(owned, "\n  "))
@@ -122,7 +122,7 @@ func testFlatLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.T)
 		})
 
 		t.Run("no state of the dropped index survives", func(t *testing.T) {
-			left := dirsOwnedBy(multiVectorDirsOnEveryNode(ctx, t, compose), dropped)
+			left := dirsOwnedBy(vectorDirsOnEveryNode(ctx, t, compose), dropped)
 			for _, entry := range left {
 				t.Logf("SURVIVED: %s", entry)
 			}

--- a/test/acceptance/drop_vector_index/hfresh_test.go
+++ b/test/acceptance/drop_vector_index/hfresh_test.go
@@ -100,7 +100,7 @@ func testHFreshLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.
 
 		var owned []string
 		t.Run("the hfresh index owns directories on disk", func(t *testing.T) {
-			owned = dirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
+			owned = dirsOwnedBy(vectorDirsOnEveryNode(ctx, t, compose), dropped)
 			require.NotEmpty(t, owned,
 				"precondition: the index must have on-disk state, or dropping it proves nothing")
 			t.Logf("%s owns:\n  %s", dropped, strings.Join(owned, "\n  "))
@@ -121,7 +121,7 @@ func testHFreshLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*testing.
 		})
 
 		t.Run("no directory of the dropped index survives", func(t *testing.T) {
-			left := dirsOwnedBy(hfreshDirsOnEveryNode(ctx, t, compose), dropped)
+			left := dirsOwnedBy(vectorDirsOnEveryNode(ctx, t, compose), dropped)
 			for _, dir := range left {
 				t.Logf("SURVIVED: %s", dir)
 			}
@@ -144,28 +144,6 @@ func hfreshArtifactNames(targetVector string) []string {
 		"hfresh_postings_" + indexID,
 		"hfresh_shared_" + indexID,
 	}
-}
-
-// hfreshDirsOnEveryNode collects candidate directories from EVERY node. The
-// class's shard lives on whichever node the hash lands it on, so checking only
-// the node the client happens to talk to would pass on the other two by
-// looking in the wrong place.
-func hfreshDirsOnEveryNode(ctx context.Context, t *testing.T, compose *docker.DockerCompose) []string {
-	t.Helper()
-	var dirs []string
-	for n := 1; n <= 3; n++ {
-		node := compose.GetWeaviateNode(n)
-		if node == nil {
-			continue
-		}
-		out := findVectorDirs(ctx, t, node.Container())
-		for _, line := range strings.Split(out, "\n") {
-			if line = strings.TrimSpace(line); line != "" {
-				dirs = append(dirs, node.Name()+":"+line)
-			}
-		}
-	}
-	return dirs
 }
 
 func hasBase(paths []string, base string) bool {

--- a/test/acceptance/drop_vector_index/multivector_scenarios_test.go
+++ b/test/acceptance/drop_vector_index/multivector_scenarios_test.go
@@ -157,7 +157,7 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 		// paths guessed in advance.
 		owned := map[string][]string{}
 		inventoried := t.Run("every encoding owns directories on disk", func(t *testing.T) {
-			all := multiVectorDirsOnEveryNode(ctx, t, compose)
+			all := vectorDirsOnEveryNode(ctx, t, compose)
 			for _, v := range variants {
 				owned[v.name] = dirsOwnedBy(all, v.name)
 				require.NotEmpty(t, owned[v.name],
@@ -195,7 +195,7 @@ func testMultiVectorLeavesNoFilesOnDisk(compose *docker.DockerCompose) func(*tes
 				eventuallyTargetVectorRemoved(t, className, v.name)
 				waitForNoActiveDropTask(t)
 
-				all := multiVectorDirsOnEveryNode(ctx, t, compose)
+				all := vectorDirsOnEveryNode(ctx, t, compose)
 
 				left := dirsOwnedBy(all, v.name)
 				for _, dir := range left {
@@ -266,15 +266,16 @@ func dirsNamedAfter(allDirs []string, targetVector string) []string {
 	return out
 }
 
-// multiVectorDirsOnEveryNode collects candidate directories from EVERY node.
-// The class's shard lives on whichever node the hash lands it on, so checking
-// only the node the client happens to talk to would pass on the other two by
-// looking in the wrong place.
+// vectorDirsOnEveryNode collects candidate directories from EVERY node. The
+// class's shard lives on whichever node the hash lands it on, so checking only
+// the node the client happens to talk to would pass on the other two by
+// looking in the wrong place. Single-node composes fall out of the same loop:
+// GetWeaviateNode returns nil past the first.
 //
 // Searched from / with -xdev rather than a hardcoded PERSISTENCE_DATA_PATH (so
 // /proc and /sys are skipped): a path that moved would otherwise make the
 // post-drop assertions pass vacuously by finding nothing.
-func multiVectorDirsOnEveryNode(ctx context.Context, t *testing.T, compose *docker.DockerCompose) []string {
+func vectorDirsOnEveryNode(ctx context.Context, t *testing.T, compose *docker.DockerCompose) []string {
 	t.Helper()
 	var dirs []string
 	for n := 1; n <= 3; n++ {

--- a/test/acceptance/drop_vector_index/setup_test.go
+++ b/test/acceptance/drop_vector_index/setup_test.go
@@ -45,6 +45,8 @@ func TestDropVectorIndex_Cluster(t *testing.T) {
 // ASYNC_INDEXING on. That gives every index a vectors_<name>.queue.d the
 // synchronous path never creates, so the disk assertions — unchanged, they read
 // helpers.VectorIndexArtifactsFor — cover an artifact the cluster job cannot.
+// It also owns the dynamic-index journeys: a dynamic vector is refused at class
+// creation unless async indexing is on, so they cannot run in the suite above.
 func TestDropVectorIndex_AsyncIndexing(t *testing.T) {
 	ctx := context.Background()
 	compose, err := docker.New().
@@ -65,6 +67,7 @@ func TestDropVectorIndex_AsyncIndexing(t *testing.T) {
 	runSuite(t, compose)
 	t.Run("replicated drop", testReplicatedDrop(compose))
 	t.Run("replicated cold tenant", testReplicatedColdTenant(compose))
+	t.Run("dynamic upgrade verdict cleared", testDynamicUpgradeVerdictCleared(compose))
 }
 
 func TestDropVectorIndex_Restart_Cluster(t *testing.T) {

--- a/test/acceptance/drop_vector_index/setup_test.go
+++ b/test/acceptance/drop_vector_index/setup_test.go
@@ -54,6 +54,8 @@ func TestDropVectorIndex_AsyncIndexing(t *testing.T) {
 		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "1").
 		WithWeaviateEnv("ASYNC_INDEXING", "true").
+		// The dynamic journeys search over gRPC.
+		WithWeaviateExposeGRPCPort().
 		// Flush partial queue chunks promptly, or the drain sits idle.
 		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "500ms").
 		WithWeaviateEnv("DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS", "5").


### PR DESCRIPTION
Dropping a dynamic vector left its flat-to-hnsw verdict behind in `index.db` whenever the tenant was cold at drop time. The next vector created under the same name inherited it and booted straight into an empty hnsw, never serving its flat stage — paying hnsw's cost below the threshold that was configured to avoid it.

### Why it was missed

`index.db` is one file per **shard**, not per vector: one key per dynamic vector, opened once by the shard. So it cannot go in `helpers.VectorIndexArtifactsFor` — `os.RemoveAll` on it would take every sibling's verdict too. Only `dynamic.DropTargetVector` deleted the key, and that runs on the loaded-shard route alone. A tenant cold at the drop is cleaned by the files-only routes, which remove directories and never open the state DB.

### Fix

New `dynamic.RemoveStateKey(rootPath, targetVector)`, called once from `removeVectorIndexFiles` so all three files-only routes inherit it (cold lazy shard, shard-init sweep, group-completion net).

Two deliberate tolerances:

- **Missing file is success**, behind an `os.Stat`. `bbolt.Open` creates what it opens, so without the stat every drop would leave an empty `index.db` in shards that never ran a dynamic index.
- **Locked file is success.** The flock is only ever held by a loaded shard in this process, which deletes the key through its own handle. `OnGroupCompleted` re-runs over every local tenant including hot ones, so erroring there would fail the group ack and replay the callback forever.

### Tests

`TestDropVectorIndex_AsyncIndexing` gains a `dynamic upgrade verdict cleared` journey, cold and hot at drop time (thanks @dirkkul for the reproduction). It cannot live in `runSuite` — the synchronous cluster test shares that, and a dynamic vector is refused at class creation without async indexing.

Verified red then green: the cold case failed at 2.05s with an hnsw commit log on a 5-vector index against a threshold of 100 000, and passes the full 17s `require.Never` window with the fix. Hot passed throughout.

`TestRemoveStateKey` covers sibling isolation, the unnamed vector, no file, no bucket, absent key, and a locked DB. Stubbing the function to `return nil` reddens exactly the two deletion cases.

Full suites on the fix: `Cluster` 1056s and `AsyncIndexing` 1091s green, then the async suite again with the journey folded in — 1188s, 0 failures.

### Note

Stacked on #12726, but based on `stable/v1.39` here, so the diff currently shows the parent PRs' changes too.
