### PR TITLE
Put both cron jobs on one shared registration helper

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	goruntime "runtime"
 	"runtime/debug"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -2717,6 +2718,82 @@ func initRuntimeOverrides(appState *state.State, registerer prometheus.Registere
 	return nil
 }
 
+// mergeRuntimeHooks adds src into dst, refusing the whole merge on a key that
+// is empty, that dst already holds, or that prefixes no runtime config field.
+// Hooks fire by prefix-matching a changed field's Go name, so a key matching
+// nothing disables that knob's hot reload and a key already taken replaces a
+// live hook, both without an error anywhere.
+func mergeRuntimeHooks(dst, src map[string]func() error) error {
+	// Sorted so two bad keys always name the same one in the boot error.
+	for _, key := range slices.Sorted(maps.Keys(src)) {
+		if key == "" {
+			return fmt.Errorf("runtime config hook has an empty key, which prefixes every field")
+		}
+		if _, taken := dst[key]; taken {
+			return fmt.Errorf("runtime config hook %q is already registered", key)
+		}
+		if !config.HookKeyMatchesAnyField(key) {
+			return fmt.Errorf("runtime config hook %q prefixes no runtime config field", key)
+		}
+	}
+	maps.Copy(dst, src)
+
+	return nil
+}
+
+// runtimeConfigHooks builds every hook the runtime config manager fires. The
+// cron jobs' hooks merge in last, so the guard in mergeRuntimeHooks sees every
+// key registered by hand ahead of them.
+func runtimeConfigHooks(appState *state.State, serverShutdownCtx context.Context) (map[string]func() error, error) {
+	hooks := make(map[string]func() error)
+	if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
+		hooks["OIDC"] = appState.OIDC.Init
+	}
+	// Reconcile loaded shards when the async-replication kill-switch is
+	// toggled at runtime. Run in the background: ReconcileAsyncReplication
+	// does per-shard hashtree disk I/O, which must not block the runtime-
+	// config reload loop. serverShutdownCtx makes it cancellable on shutdown;
+	// errors are logged here and surfaced via the reconcileFailures metric.
+	hooks["AsyncReplicationDisabled"] = func() error {
+		restcompat.SetAsyncReplicationGloballyDisabled(appState.ServerConfig.Config.Replication.AsyncReplicationDisabled.Get())
+		enterrors.GoWrapper(func() {
+			if err := appState.DB.ReconcileAsyncReplication(serverShutdownCtx); err != nil {
+				appState.Logger.WithField("action", "reconcile_async_replication").Error(err)
+			}
+		}, appState.Logger)
+		return nil
+	}
+	// GraphQL is loaded lazily on toggle: makeUpdateSchemaCall skips the build
+	// while disabled, so on enable rebuild from the current schema, and on
+	// disable drop the graph (it's no longer served).
+	hooks["DisableGraphQL"] = func() error {
+		if appState.ServerConfig.Config.DisableGraphQL.Get() {
+			appState.SetGraphQL(nil)
+		} else {
+			rebuildGraphQLOnEnable(appState)
+		}
+		return nil
+	}
+
+	// Re-run cross-field restriction validation on runtime YAML pushes
+	// (per-value runs at SetValue time). Keys are exact struct-field
+	// names — matchUpdatedFields uses HasPrefix, so "Default" would
+	// also match DefaultShardingCount and friends.
+	restrictionHook := func() error {
+		return appState.ServerConfig.Config.ValidateRestrictionsRuntime(appState.Logger)
+	}
+	hooks["AllowedVectorIndexTypes"] = restrictionHook
+	hooks["AllowedCompressionTypes"] = restrictionHook
+	hooks["DefaultVectorIndexType"] = restrictionHook
+	hooks["DefaultQuantization"] = restrictionHook
+
+	if err := mergeRuntimeHooks(hooks, appState.Crons.RuntimeConfigHooks()); err != nil {
+		return nil, err
+	}
+
+	return hooks, nil
+}
+
 // postInitRuntimeOverrides registers hooks and starts runtime config background process
 func postInitRuntimeOverrides(appState *state.State, serverShutdownCtx context.Context, cm *configRuntime.ConfigManager[config.WeaviateRuntimeConfig]) {
 	if appState.ServerConfig.Config.RuntimeOverrides.Enabled && cm != nil {
@@ -2736,49 +2813,11 @@ func postInitRuntimeOverrides(appState *state.State, serverShutdownCtx context.C
 				registered.UsageVerifyPermissions = appState.ServerConfig.Config.Usage.VerifyPermissions
 			})
 		}
-		// register hooks
-		hooks := make(map[string]func() error)
-		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
-			hooks["OIDC"] = appState.OIDC.Init
+		hooks, err := runtimeConfigHooks(appState, serverShutdownCtx)
+		if err != nil {
+			appState.Logger.WithField("action", "startup").
+				Fatalf("cannot register cron runtime config hooks: %v", err)
 		}
-		// Reconcile loaded shards when the async-replication kill-switch is
-		// toggled at runtime. Run in the background: ReconcileAsyncReplication
-		// does per-shard hashtree disk I/O, which must not block the runtime-
-		// config reload loop. serverShutdownCtx makes it cancellable on shutdown;
-		// errors are logged here and surfaced via the reconcileFailures metric.
-		hooks["AsyncReplicationDisabled"] = func() error {
-			restcompat.SetAsyncReplicationGloballyDisabled(appState.ServerConfig.Config.Replication.AsyncReplicationDisabled.Get())
-			enterrors.GoWrapper(func() {
-				if err := appState.DB.ReconcileAsyncReplication(serverShutdownCtx); err != nil {
-					appState.Logger.WithField("action", "reconcile_async_replication").Error(err)
-				}
-			}, appState.Logger)
-			return nil
-		}
-		// GraphQL is loaded lazily on toggle: makeUpdateSchemaCall skips the build
-		// while disabled, so on enable rebuild from the current schema, and on
-		// disable drop the graph (it's no longer served).
-		hooks["DisableGraphQL"] = func() error {
-			if appState.ServerConfig.Config.DisableGraphQL.Get() {
-				appState.SetGraphQL(nil)
-			} else {
-				rebuildGraphQLOnEnable(appState)
-			}
-			return nil
-		}
-		maps.Copy(hooks, appState.Crons.RuntimeConfigHooks())
-
-		// Re-run cross-field restriction validation on runtime YAML pushes
-		// (per-value runs at SetValue time). Keys are exact struct-field
-		// names — matchUpdatedFields uses HasPrefix, so "Default" would
-		// also match DefaultShardingCount and friends.
-		restrictionHook := func() error {
-			return appState.ServerConfig.Config.ValidateRestrictionsRuntime(appState.Logger)
-		}
-		hooks["AllowedVectorIndexTypes"] = restrictionHook
-		hooks["AllowedCompressionTypes"] = restrictionHook
-		hooks["DefaultVectorIndexType"] = restrictionHook
-		hooks["DefaultQuantization"] = restrictionHook
 
 		appState.Logger.Log(logrus.InfoLevel, "registering runtime overrides hooks")
 		cm.RegisterHooks(hooks)

--- a/adapters/handlers/rest/configure_api_runtime_hooks_test.go
+++ b/adapters/handlers/rest/configure_api_runtime_hooks_test.go
@@ -1,0 +1,179 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/cron"
+)
+
+// appStateWithOIDC carries the fields runtimeConfigHooks reads while it builds
+// the map. The hooks it stores are closures nothing here calls, so the
+// collaborators they capture may stay nil.
+func appStateWithOIDC(logger *logrus.Logger, crons *cron.Crons, enabled bool) *state.State {
+	return &state.State{
+		Logger: logger,
+		Crons:  crons,
+		ServerConfig: &config.WeaviateConfig{Config: config.Config{
+			Authentication: config.Authentication{OIDC: config.OIDC{Enabled: enabled}},
+		}},
+	}
+}
+
+func TestRuntimeConfigHooks(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	crons, err := cron.NewCrons(t.Context(), logger, func() config.Config { return config.Config{} })
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		oidc     bool
+		wantKeys []string
+	}{
+		{
+			name: "the keys a deployment without OIDC registers",
+			wantKeys: []string{
+				"AllowedCompressionTypes", "AllowedVectorIndexTypes", "AsyncReplicationDisabled",
+				"DefaultQuantization", "DefaultVectorIndexType", "DisableGraphQL",
+				"NamespaceCleanup", "ObjectsTTL",
+			},
+		},
+		{
+			// OIDC is the one key configuration turns on, so a map asserted
+			// without this row would miss it going stale.
+			name: "OIDC joins the map once it is enabled",
+			oidc: true,
+			wantKeys: []string{
+				"AllowedCompressionTypes", "AllowedVectorIndexTypes", "AsyncReplicationDisabled",
+				"DefaultQuantization", "DefaultVectorIndexType", "DisableGraphQL",
+				"NamespaceCleanup", "OIDC", "ObjectsTTL",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks, err := runtimeConfigHooks(appStateWithOIDC(logger, crons, tt.oidc), t.Context())
+
+			require.NoError(t, err, "the map a real deployment registers must pass the merge guard")
+			assert.Equal(t, tt.wantKeys, slices.Sorted(maps.Keys(hooks)))
+		})
+	}
+}
+
+func TestMergeRuntimeHooks(t *testing.T) {
+	hook := func() error { return nil }
+	// The real cron keys, so the rows follow hookKey() rather than a literal
+	// that can go stale.
+	logger, _ := test.NewNullLogger()
+	crons, err := cron.NewCrons(t.Context(), logger, func() config.Config { return config.Config{} })
+	require.NoError(t, err)
+
+	// The keys postInitRuntimeOverrides registers ahead of the cron merge,
+	// taken from the builder itself and stripped of what the merge adds, so a
+	// key renamed there cannot leave this test asserting against a stale one.
+	registered := func() map[string]func() error {
+		hooks, err := runtimeConfigHooks(appStateWithOIDC(logger, crons, true), t.Context())
+		require.NoError(t, err)
+		for key := range crons.RuntimeConfigHooks() {
+			delete(hooks, key)
+		}
+		return hooks
+	}
+
+	tests := []struct {
+		name    string
+		dst     map[string]func() error
+		src     map[string]func() error
+		wantErr string
+	}{
+		{
+			name: "the cron keys against the keys registered ahead of them",
+			dst:  registered(),
+			src:  crons.RuntimeConfigHooks(),
+		},
+		{
+			// mergeRuntimeHooks walks src, so the keys written by hand only
+			// reach the guard from this side.
+			name: "the keys registered by hand ahead of the merge",
+			dst:  map[string]func() error{},
+			src:  registered(),
+		},
+		{
+			name:    "a cron key colliding with a key registered ahead of it",
+			dst:     registered(),
+			src:     map[string]func() error{"OIDC": hook},
+			wantErr: "already registered",
+		},
+		{
+			name:    "a key registered ahead of the merge colliding with a cron key",
+			dst:     map[string]func() error{"NamespaceCleanup": hook},
+			src:     map[string]func() error{"NamespaceCleanup": hook},
+			wantErr: "already registered",
+		},
+		{
+			name:    "a key matching no field at all",
+			dst:     registered(),
+			src:     map[string]func() error{"NoSuchKnob": hook},
+			wantErr: "prefixes no runtime config field",
+		},
+		{
+			// NamespaceCleanupInterval is the field; the match is by prefix,
+			// so naming its tail matches nothing.
+			name:    "a key contained in a field name but not prefixing it",
+			dst:     registered(),
+			src:     map[string]func() error{"CleanupInterval": hook},
+			wantErr: "prefixes no runtime config field",
+		},
+		{
+			// ObjectsTTLz prefixes no field and sorts after the good key, so
+			// a merge that wrote as it walked would leave the good one behind.
+			name:    "a good key merged alongside a typo'd one",
+			dst:     registered(),
+			src:     map[string]func() error{"NamespaceCleanup": hook, "ObjectsTTLz": hook},
+			wantErr: "prefixes no runtime config field",
+		},
+		{
+			name:    "an empty key",
+			dst:     registered(),
+			src:     map[string]func() error{"": hook},
+			wantErr: "prefixes every field",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := slices.Sorted(maps.Keys(tt.dst))
+
+			err := mergeRuntimeHooks(tt.dst, tt.src)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				assert.Equal(t, before, slices.Sorted(maps.Keys(tt.dst)),
+					"a refused merge must leave the hook map as it was")
+				return
+			}
+			require.NoError(t, err)
+			for key := range tt.src {
+				assert.Contains(t, tt.dst, key)
+			}
+		})
+	}
+}

--- a/adapters/handlers/rest/configure_server.go
+++ b/adapters/handlers/rest/configure_server.go
@@ -137,7 +137,12 @@ func configureOIDC(appState *state.State) *oidc.Client {
 }
 
 func configureCrons(appState *state.State, serverShutdownCtx context.Context) *cron.Crons {
-	return cron.NewCrons(serverShutdownCtx, appState.Logger, func() config.Config { return appState.ServerConfig.Config })
+	c, err := cron.NewCrons(serverShutdownCtx, appState.Logger, func() config.Config { return appState.ServerConfig.Config })
+	if err != nil {
+		appState.Logger.WithField("action", "crons_init").Fatalf("crons could not start up: %v", err)
+	}
+
+	return c
 }
 
 func configureAPIKey(appState *state.State) *apikey.ApiKey {

--- a/entities/cron/gocron.go
+++ b/entities/cron/gocron.go
@@ -17,6 +17,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// RunOnEveryNode is the tick gate for a cron job every node runs, rather than
+// only the leader.
+func RunOnEveryNode() bool { return true }
+
 func NewGoCronLogger(logger logrus.FieldLogger, infoLevel logrus.Level) *GoCronLogger {
 	return &GoCronLogger{logger: logger, infoLevel: infoLevel}
 }

--- a/entities/cron/gocron.go
+++ b/entities/cron/gocron.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"time"
 
+	gocron "github.com/netresearch/go-cron"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,6 +25,10 @@ func RunOnEveryNode() bool { return true }
 
 // EverySpec renders d as an `@every` cron descriptor.
 func EverySpec(d time.Duration) string { return fmt.Sprintf("@every %s", d) }
+
+// Parser is the schedule parser both the validator and the scheduler run, so a
+// spec one accepts is one the other can schedule.
+func Parser() gocron.Parser { return gocron.FullParser() }
 
 func NewGoCronLogger(logger logrus.FieldLogger, infoLevel logrus.Level) *GoCronLogger {
 	return &GoCronLogger{logger: logger, infoLevel: infoLevel}
@@ -40,9 +45,12 @@ func (l *GoCronLogger) Info(msg string, keysAndValues ...any) {
 }
 
 func (l *GoCronLogger) Error(err error, msg string, keysAndValues ...any) {
-	l.logger.WithFields(l.toFields(keysAndValues)).
-		WithError(err).
-		Error(msg)
+	logger := l.logger.WithFields(l.toFields(keysAndValues))
+	if err == nil {
+		logger.Error(msg)
+		return
+	}
+	logger.Errorf("%s: %v", msg, err)
 }
 
 func (l *GoCronLogger) toFields(keysAndValues []any) logrus.Fields {

--- a/entities/cron/gocron.go
+++ b/entities/cron/gocron.go
@@ -13,6 +13,7 @@ package cron
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -20,6 +21,9 @@ import (
 // RunOnEveryNode is the tick gate for a cron job every node runs, rather than
 // only the leader.
 func RunOnEveryNode() bool { return true }
+
+// EverySpec renders d as an `@every` cron descriptor.
+func EverySpec(d time.Duration) string { return fmt.Sprintf("@every %s", d) }
 
 func NewGoCronLogger(logger logrus.FieldLogger, infoLevel logrus.Level) *GoCronLogger {
 	return &GoCronLogger{logger: logger, infoLevel: infoLevel}

--- a/entities/cron/gocron_test.go
+++ b/entities/cron/gocron_test.go
@@ -12,10 +12,13 @@
 package cron
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,11 +38,39 @@ func TestEverySpec(t *testing.T) {
 			spec := EverySpec(tt.interval)
 
 			assert.Equal(t, tt.want, spec)
-			// Round-trip through the parser the scheduler runs: a spec that
-			// renders but will not parse is what one home for the prefix prevents.
-			schedule, err := gocron.FullParser().Parse(spec)
+			// Round-trip through Parser(), which the scheduler also runs: a spec
+			// that renders but will not parse is what a single shared parser prevents.
+			schedule, err := Parser().Parse(spec)
 			require.NoError(t, err)
 			assert.Equal(t, tt.interval, schedule.(gocron.ConstantDelaySchedule).Delay)
+		})
+	}
+}
+
+func TestGoCronLoggerError(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantMessage string
+	}{
+		{name: "the cause joins the message", err: errors.New("boom"), wantMessage: "panic: boom"},
+		{name: "no cause leaves the message alone", wantMessage: "panic"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+
+			NewGoCronLogger(logger, logrus.DebugLevel).
+				Error(tt.err, "panic", "panic_type", "runtime error", "stack", "goroutine 1")
+
+			entry := hook.LastEntry()
+			require.NotNil(t, entry)
+			assert.Equal(t, tt.wantMessage, entry.Message)
+			assert.Equal(t, "runtime error", entry.Data["c_panic_type"])
+			assert.Equal(t, "goroutine 1", entry.Data["c_stack"])
+			// An operator's log aggregator renders a sibling error field as its
+			// own column, so the cause has to be in the message.
+			assert.NotContains(t, entry.Data, logrus.ErrorKey)
 		})
 	}
 }

--- a/entities/cron/gocron_test.go
+++ b/entities/cron/gocron_test.go
@@ -1,0 +1,45 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cron
+
+import (
+	"testing"
+	"time"
+
+	gocron "github.com/netresearch/go-cron"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEverySpec(t *testing.T) {
+	tests := []struct {
+		interval time.Duration
+		want     string
+	}{
+		{interval: time.Second, want: "@every 1s"},
+		{interval: 30 * time.Second, want: "@every 30s"},
+		{interval: time.Minute + 30*time.Second, want: "@every 1m30s"},
+		{interval: time.Hour, want: "@every 1h0m0s"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			spec := EverySpec(tt.interval)
+
+			assert.Equal(t, tt.want, spec)
+			// Round-trip through the parser the scheduler runs: a spec that
+			// renders but will not parse is what one home for the prefix prevents.
+			schedule, err := gocron.FullParser().Parse(spec)
+			require.NoError(t, err)
+			assert.Equal(t, tt.interval, schedule.(gocron.ConstantDelaySchedule).Delay)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/mark3labs/mcp-go v0.37.1-0.20250812151906-9f16336f83e1
 	github.com/maypok86/otter/v2 v2.2.1
 	github.com/minio/minio-go/v7 v7.2.1
-	github.com/netresearch/go-cron v0.9.1
+	github.com/netresearch/go-cron v0.15.1
 	github.com/nyaruka/phonenumbers v1.2.2
 	github.com/parquet-go/parquet-go v0.29.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.sum
+++ b/go.sum
@@ -540,8 +540,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netresearch/go-cron v0.9.1 h1:lEjuHz4oJmbR622XTAHcHH0Ekec0tjwMLQyQWQm7UDQ=
-github.com/netresearch/go-cron v0.9.1/go.mod h1:oRPUA7fHC/ul86n+d3SdUD54cEuHIuCLiFJCua5a5/E=
+github.com/netresearch/go-cron v0.15.1 h1:bTqeJwHizd5fZWlU1CPtzrCILAkp6UL8KLW4IU7HRhk=
+github.com/netresearch/go-cron v0.15.1/go.mod h1:79iktHfV90py3jcaFUtWcGSKbZXRev+WwoLMyV5eMvo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nyaruka/phonenumbers v1.2.2 h1:OwVjf7Y4uHoK9VJUrA8ebR0ha2yc6sEYbfrwkq0asCY=

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -164,7 +164,7 @@ require (
 	github.com/moby/term v0.5.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/netresearch/go-cron v0.9.1 // indirect
+	github.com/netresearch/go-cron v0.15.1 // indirect
 	github.com/nyaruka/phonenumbers v1.2.2 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -431,8 +431,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netresearch/go-cron v0.9.1 h1:lEjuHz4oJmbR622XTAHcHH0Ekec0tjwMLQyQWQm7UDQ=
-github.com/netresearch/go-cron v0.9.1/go.mod h1:oRPUA7fHC/ul86n+d3SdUD54cEuHIuCLiFJCua5a5/E=
+github.com/netresearch/go-cron v0.15.1 h1:bTqeJwHizd5fZWlU1CPtzrCILAkp6UL8KLW4IU7HRhk=
+github.com/netresearch/go-cron v0.15.1/go.mod h1:79iktHfV90py3jcaFUtWcGSKbZXRev+WwoLMyV5eMvo=
 github.com/nyaruka/phonenumbers v1.2.2 h1:OwVjf7Y4uHoK9VJUrA8ebR0ha2yc6sEYbfrwkq0asCY=
 github.com/nyaruka/phonenumbers v1.2.2/go.mod h1:wzk2qq7qwsaBKrfbkWKdgHYOOH+QFTesSpIq53ELw8M=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=

--- a/test/benchmark_bm25/go.mod
+++ b/test/benchmark_bm25/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/miekg/dns v1.1.68 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/netresearch/go-cron v0.9.1 // indirect
+	github.com/netresearch/go-cron v0.15.1 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/test/benchmark_bm25/go.sum
+++ b/test/benchmark_bm25/go.sum
@@ -210,8 +210,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netresearch/go-cron v0.9.1 h1:lEjuHz4oJmbR622XTAHcHH0Ekec0tjwMLQyQWQm7UDQ=
-github.com/netresearch/go-cron v0.9.1/go.mod h1:oRPUA7fHC/ul86n+d3SdUD54cEuHIuCLiFJCua5a5/E=
+github.com/netresearch/go-cron v0.15.1 h1:bTqeJwHizd5fZWlU1CPtzrCILAkp6UL8KLW4IU7HRhk=
+github.com/netresearch/go-cron v0.15.1/go.mod h1:79iktHfV90py3jcaFUtWcGSKbZXRev+WwoLMyV5eMvo=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -1126,7 +1126,10 @@ type Namespaces struct {
 	Enabled bool `json:"enabled" yaml:"enabled"`
 
 	// CleanupInterval drives the deleting-namespace sweep on the leader.
-	// NAMESPACE_CLEANUP_INTERVAL; <= 0 disables.
+	// NAMESPACE_CLEANUP_INTERVAL. Get() reports the configured value, while
+	// newCronsNamespaceCleanup applies DefaultNamespaceCleanupInterval at or
+	// below zero. No value of this field stops the sweep — a very long
+	// interval parks it, and Enabled above turns it off.
 	CleanupInterval *runtime.DynamicValue[time.Duration] `json:"cleanup_interval" yaml:"cleanup_interval"`
 }
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1045,7 +1045,7 @@ func FromEnv(config *Config) error {
 
 	if err := parser.ParseDynamicDurationWithValidation("NAMESPACE_CLEANUP_INTERVAL",
 		DefaultNamespaceCleanupInterval,
-		parser.ValidateDurationGreaterThanEqual0,
+		parser.ValidateCronInterval,
 		func(val *configRuntime.DynamicValue[time.Duration]) { config.Namespaces.CleanupInterval = val }); err != nil {
 		return err
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -2350,3 +2350,45 @@ func TestEnvironmentAsyncReplicationGlobalSentinels(t *testing.T) {
 		})
 	}
 }
+
+func TestNamespaceCleanupIntervalValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		wantErr string
+		wantGet time.Duration
+	}{
+		{name: "a sub-second interval fails the boot", env: "500ms", wantErr: "NAMESPACE_CLEANUP_INTERVAL"},
+		{name: "unset yields the default", wantGet: DefaultNamespaceCleanupInterval},
+		// newCronsNamespaceCleanup substitutes the default; Get() keeps the 0 the
+		// operator wrote, and /debug/config omits a zero interval entirely.
+		{name: "a value at or below zero is kept as configured", env: "0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env != "" {
+				t.Setenv("NAMESPACE_CLEANUP_INTERVAL", tt.env)
+			}
+			var conf Config
+
+			err := FromEnv(&conf)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantGet, conf.Namespaces.CleanupInterval.Get())
+		})
+	}
+
+	t.Run("a sub-second runtime push is refused and the interval stands", func(t *testing.T) {
+		t.Setenv("NAMESPACE_CLEANUP_INTERVAL", "1m")
+		var conf Config
+		require.NoError(t, FromEnv(&conf))
+
+		require.Error(t, conf.Namespaces.CleanupInterval.SetValue(500*time.Millisecond))
+		assert.Equal(t, time.Minute, conf.Namespaces.CleanupInterval.Get(),
+			"a refused push must leave the previous interval in place")
+	})
+}

--- a/usecases/config/parser/validation.go
+++ b/usecases/config/parser/validation.go
@@ -15,7 +15,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/netresearch/go-cron"
+	gocron "github.com/netresearch/go-cron"
+
+	"github.com/weaviate/weaviate/entities/cron"
 )
 
 func ValidateFloatGreaterThan0(val float64) error {
@@ -71,9 +73,18 @@ func ValidateDurationZeroOrInRange(min, max time.Duration) func(time.Duration) e
 	}
 }
 
+// ValidateCronInterval passes a value at or below zero, which asks the caller to
+// apply its own default, and otherwise requires an interval the scheduler can run.
+func ValidateCronInterval(val time.Duration) error {
+	if val <= 0 {
+		return nil
+	}
+	return ValidateGocronSchedule(cron.EverySpec(val))
+}
+
 func ValidateGocronSchedule(val string) error {
 	if val != "" {
-		if _, err := cron.FullParser().Parse(val); err != nil {
+		if _, err := gocron.FullParser().Parse(val); err != nil {
 			return err
 		}
 	}

--- a/usecases/config/parser/validation.go
+++ b/usecases/config/parser/validation.go
@@ -15,8 +15,6 @@ import (
 	"fmt"
 	"time"
 
-	gocron "github.com/netresearch/go-cron"
-
 	"github.com/weaviate/weaviate/entities/cron"
 )
 
@@ -84,7 +82,7 @@ func ValidateCronInterval(val time.Duration) error {
 
 func ValidateGocronSchedule(val string) error {
 	if val != "" {
-		if _, err := gocron.FullParser().Parse(val); err != nil {
+		if _, err := cron.Parser().Parse(val); err != nil {
 			return err
 		}
 	}

--- a/usecases/config/parser/validation_test.go
+++ b/usecases/config/parser/validation_test.go
@@ -1,0 +1,52 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package parser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCronInterval(t *testing.T) {
+	tests := []struct {
+		interval time.Duration
+		wantErr  bool
+		// wantErrGreaterThanEqual0 is the other validator's verdict on the same
+		// interval, so the two rows where they disagree are visible here.
+		wantErrGreaterThanEqual0 bool
+	}{
+		{interval: -time.Second, wantErrGreaterThanEqual0: true},
+		{interval: 0},
+		{interval: 999 * time.Millisecond, wantErr: true},
+		{interval: time.Second},
+		{interval: 30 * time.Second},
+		{interval: time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.interval.String(), func(t *testing.T) {
+			err := ValidateCronInterval(tt.interval)
+
+			if tt.wantErr {
+				require.Error(t, err, "the cron parser cannot schedule this interval")
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantErrGreaterThanEqual0 {
+				require.Error(t, ValidateDurationGreaterThanEqual0(tt.interval))
+			} else {
+				require.NoError(t, ValidateDurationGreaterThanEqual0(tt.interval))
+			}
+		})
+	}
+}

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -369,7 +369,7 @@ func updateRuntimeConfig(log logrus.FieldLogger, source, parsed reflect.Value, s
 		})
 
 		if r.err != nil {
-			logger.WithError(r.err).Errorf("runtime overrides: config '%v' change failed", r.field)
+			logger.Errorf("runtime overrides: config '%v' change failed: %v", r.field, r.err)
 			continue
 		}
 		logger.WithField("new_value", r.newV).Infof("runtime overrides: config '%v' changed from '%v' to '%v'", r.field, r.oldV, r.newV)

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -402,7 +402,7 @@ type updateLogRecord struct {
 
 func matchUpdatedFields(match string, records []updateLogRecord) bool {
 	for _, v := range records {
-		if strings.HasPrefix(v.field, match) {
+		if hookKeyMatchesField(match, v.field) {
 			return true
 		}
 	}
@@ -494,4 +494,25 @@ func BuildRegisteredRuntimeConfig(cfg *Config) *WeaviateRuntimeConfig {
 	}
 
 	return registered
+}
+
+// hookKeyMatchesField is the one rule deciding whether a runtime config hook
+// key names a field: the key prefixes the field's Go name.
+func hookKeyMatchesField(hookKey, fieldName string) bool {
+	return strings.HasPrefix(fieldName, hookKey)
+}
+
+// HookKeyMatchesAnyField reports whether a hook key names any
+// WeaviateRuntimeConfig field. A key naming none never fires, so a caller
+// registering hooks can refuse it instead of leaving that knob's hot reload
+// quiet. An empty key names every field.
+func HookKeyMatchesAnyField(hookKey string) bool {
+	runtimeConfig := reflect.TypeFor[WeaviateRuntimeConfig]()
+	for i := range runtimeConfig.NumField() {
+		if hookKeyMatchesField(hookKey, runtimeConfig.Field(i).Name) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4/json"
 	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -849,6 +850,50 @@ maximum_allowed_collections_count: 13`)
 			require.NoError(t, UpdateRuntimeConfig(log, reg, parsed, nil, nil))
 			assert.Equal(t, float64(DefaultObjectsTTLConcurrencyFactor), concurrencyFactor.Get())
 		})
+	})
+
+	t.Run("a refused value logs why in the message an operator reads", func(t *testing.T) {
+		refusingLog, hook := test.NewNullLogger()
+		interval, err := runtime.NewDynamicValueWithValidation(time.Minute,
+			func(d time.Duration) error {
+				if d < time.Second {
+					return fmt.Errorf("interval %s is below the one second floor", d)
+				}
+				return nil
+			})
+		require.NoError(t, err)
+		// A second field the same push accepts, so the refusal is one record of
+		// two rather than the whole batch.
+		var autoSchema runtime.DynamicValue[bool]
+		reg := &WeaviateRuntimeConfig{
+			NamespaceCleanupInterval: interval,
+			AutoschemaEnabled:        &autoSchema,
+		}
+
+		parsed, err := ParseRuntimeConfig([]byte("namespace_cleanup_interval: 500ms\nautoschema_enabled: true"))
+		require.NoError(t, err)
+
+		require.NoError(t, UpdateRuntimeConfig(refusingLog, reg, parsed, nil, nil))
+
+		atLevel := func(level logrus.Level) []*logrus.Entry {
+			var got []*logrus.Entry
+			for _, entry := range hook.AllEntries() {
+				if entry.Level == level {
+					got = append(got, entry)
+				}
+			}
+			return got
+		}
+
+		refused := atLevel(logrus.ErrorLevel)
+		require.Len(t, refused, 1, "only the refused field logs an error")
+		assert.Contains(t, refused[0].Message, "interval 500ms is below the one second floor",
+			"the reason a push was refused belongs in the message, not beside it")
+		assert.NotContains(t, refused[0].Data, logrus.ErrorKey)
+		assert.Equal(t, time.Minute, interval.Get(), "a refused field keeps its previous value")
+		assert.Len(t, atLevel(logrus.InfoLevel), 1,
+			"the accepted field still reports its change")
+		assert.True(t, autoSchema.Get(), "one refused field must not hold back the rest of the push")
 	})
 }
 

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -276,6 +276,30 @@ func TestDisableDimensionMetricsRuntimeOverride(t *testing.T) {
 	})
 }
 
+func TestHookKeyMatchesAnyField(t *testing.T) {
+	tests := []struct {
+		name    string
+		hookKey string
+		want    bool
+	}{
+		{name: "a whole field name", hookKey: "DisableGraphQL", want: true},
+		{name: "a prefix of a field name", hookKey: "OIDC", want: true},
+		{
+			// NamespaceCleanupInterval is the field. The rule is a prefix
+			// match, so naming its tail names nothing.
+			name:    "a substring that is not a prefix",
+			hookKey: "CleanupInterval",
+		},
+		{name: "a name no field carries", hookKey: "NoSuchKnob"},
+		{name: "the empty key, which names every field", hookKey: "", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, HookKeyMatchesAnyField(tt.hookKey))
+		})
+	}
+}
+
 func TestUpdateRuntimeConfig(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(io.Discard)

--- a/usecases/cron/gocron.go
+++ b/usecases/cron/gocron.go
@@ -55,9 +55,14 @@ func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, conf
 	logger = logger.WithField("action", "cron")
 	gocronLogger := cron.NewGoCronLogger(logger, logrus.DebugLevel)
 
+	namespaceCleanup, err := newCronsNamespaceCleanup(serverShutdownCtx, logger, gocronLogger, configGetter)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &Crons{
 		objectsttl:        newCronsObjectsTTL(serverShutdownCtx, logger, gocronLogger, configGetter),
-		namespaceCleanup:  newCronsNamespaceCleanup(serverShutdownCtx, logger, gocronLogger, configGetter),
+		namespaceCleanup:  namespaceCleanup,
 		logger:            logger,
 		gocronLogger:      gocronLogger,
 		serverShutdownCtx: serverShutdownCtx,
@@ -75,9 +80,9 @@ func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, conf
 }
 
 // add appends a registrant, refusing a job name that is empty or already
-// taken. Each registration loop removes the entry by name before adding it,
-// so two registrants sharing a name would take over each other's entry on
-// every reload, each seeing a successful registration.
+// taken. Two registrants sharing a name would take over each other's entry on
+// every reload, each seeing a successful registration, because
+// DrainAndUpsertJob never reports a duplicate name.
 func (c *Crons) add(r registrant) error {
 	name := r.jobName()
 	if name == "" {
@@ -107,12 +112,8 @@ func (c *Crons) Init(clusterService *cluster.Service, ttlCoordinator *objectttl.
 ) error {
 	cr := initGoCron(c.serverShutdownCtx, c.gocronLogger)
 
-	if err := c.objectsttl.Init(cr, clusterService, ttlCoordinator); err != nil {
-		return fmt.Errorf("init objects ttl cron: %w", err)
-	}
-
-	if err := c.namespaceCleanup.Init(cr, clusterService, nsCleanupCoordinator); err != nil {
-		return fmt.Errorf("init namespace cleanup cron: %w", err)
+	if err := c.initJobs(cr, clusterService, ttlCoordinator, nsCleanupCoordinator); err != nil {
+		return err
 	}
 
 	cr.Start()
@@ -121,6 +122,23 @@ func (c *Crons) Init(clusterService *cluster.Service, ttlCoordinator *objectttl.
 	// Await the namespace-cleanup registration goroutine before returning.
 	c.namespaceCleanup.wait()
 
+	return nil
+}
+
+// initJobs starts each job's registration loop on cr, handing namespace
+// cleanup clusterService.IsLeader so only the leader ticks it. Each loop adds
+// its entry on its own goroutine, and a job its config disables adds none.
+// Init blocks on serverShutdownCtx straight after this call, so everything
+// Init does before cr.Start() goes here.
+func (c *Crons) initJobs(cr *gocron.Cron, clusterService *cluster.Service,
+	ttlCoordinator *objectttl.Coordinator, nsCleanupCoordinator *namespacecleanup.Coordinator,
+) error {
+	if err := c.objectsttl.Init(cr, clusterService, ttlCoordinator); err != nil {
+		return fmt.Errorf("init objects ttl cron: %w", err)
+	}
+	if err := c.namespaceCleanup.Init(cr, clusterService.IsLeader, nsCleanupCoordinator); err != nil {
+		return fmt.Errorf("init namespace cleanup cron: %w", err)
+	}
 	return nil
 }
 

--- a/usecases/cron/gocron.go
+++ b/usecases/cron/gocron.go
@@ -14,6 +14,7 @@ package cron
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -29,26 +30,75 @@ import (
 
 type configGetter func() config.Config
 
+// registrant is one cron job Crons owns.
+type registrant interface {
+	// jobName is the cron entry name, unique across registrants.
+	jobName() string
+	// hookKey prefix-matches runtime-config Go field names, so it must
+	// prefix the field whose changes RuntimeConfigHook reacts to.
+	hookKey() string
+	RuntimeConfigHook() error
+}
+
 type Crons struct {
 	objectsttl       *cronsObjectsTTL
 	namespaceCleanup *cronsNamespaceCleanup
+
+	registrations []registrant
 
 	logger            logrus.FieldLogger
 	gocronLogger      gocron.Logger
 	serverShutdownCtx context.Context
 }
 
-func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, configGetter configGetter) *Crons {
+func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, configGetter configGetter) (*Crons, error) {
 	logger = logger.WithField("action", "cron")
 	gocronLogger := cron.NewGoCronLogger(logger, logrus.DebugLevel)
 
-	return &Crons{
+	c := &Crons{
 		objectsttl:        newCronsObjectsTTL(serverShutdownCtx, logger, gocronLogger, configGetter),
 		namespaceCleanup:  newCronsNamespaceCleanup(serverShutdownCtx, logger, gocronLogger, configGetter),
 		logger:            logger,
 		gocronLogger:      gocronLogger,
 		serverShutdownCtx: serverShutdownCtx,
 	}
+
+	// Registering here rather than in Init is what makes RuntimeConfigHooks
+	// complete: startup collects the hook map before the goroutine running
+	// Init exists, so a slice filled in Init would hand it no keys at all.
+	for _, r := range []registrant{c.objectsttl, c.namespaceCleanup} {
+		if err := c.add(r); err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+// add appends a registrant, refusing a job name that is empty or already
+// taken. Each registration loop removes the entry by name before adding it,
+// so two registrants sharing a name would take over each other's entry on
+// every reload, each seeing a successful registration.
+func (c *Crons) add(r registrant) error {
+	name := r.jobName()
+	if name == "" {
+		return fmt.Errorf("cron registrant has an empty job name")
+	}
+	if slices.ContainsFunc(c.registrations, func(other registrant) bool {
+		return other.jobName() == name
+	}) {
+		return fmt.Errorf("cron job %q is already registered", name)
+	}
+	// RuntimeConfigHooks keeps one hook per key, so a second job holding a
+	// key would replace the first and leave it reading a value nobody pushes
+	// to it. Two jobs paced by one config field need that map to call every
+	// job holding the key; this guard goes when it does.
+	if key := r.hookKey(); slices.ContainsFunc(c.registrations, func(other registrant) bool {
+		return other.hookKey() == key
+	}) {
+		return fmt.Errorf("cron job %q shares runtime config hook key %q with another job", name, key)
+	}
+	c.registrations = append(c.registrations, r)
+	return nil
 }
 
 // blocking
@@ -75,13 +125,16 @@ func (c *Crons) Init(clusterService *cluster.Service, ttlCoordinator *objectttl.
 }
 
 func (c *Crons) RuntimeConfigHooks() map[string]func() error {
-	return map[string]func() error{
-		"ObjectsTTL":       c.objectsttl.RuntimeConfigHook,
-		"NamespaceCleanup": c.namespaceCleanup.RuntimeConfigHook,
+	hooks := make(map[string]func() error, len(c.registrations))
+	for _, r := range c.registrations {
+		hooks[r.hookKey()] = r.RuntimeConfigHook
 	}
+	return hooks
 }
 
 // ----------------------------------------------------------------------------
+
+const objectsTTLJobName = "trigger_objects_ttl_deletion"
 
 type cronsObjectsTTL struct {
 	lock            *sync.Mutex
@@ -120,8 +173,7 @@ func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
 		return fmt.Errorf("objects ttl coordinator is nil")
 	}
 	errors.GoWrapper(func() {
-		jobName := "trigger_objects_ttl_deletion"
-		jobLogger := c.logger.WithField("job", jobName)
+		jobLogger := c.logger.WithField("job", objectsTTLJobName)
 		var jobCtx context.Context
 		var cancel context.CancelFunc = func() {} // noop
 		wgRunning := new(sync.WaitGroup)
@@ -130,7 +182,7 @@ func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
 			select {
 			case schedule := <-c.scheduleCh:
 				cancel()
-				if cr.RemoveByName(jobName) {
+				if cr.RemoveByName(objectsTTLJobName) {
 					jobLogger.Info("cron job removed")
 				}
 
@@ -152,7 +204,7 @@ func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
 				jobCtx, cancel = context.WithCancel(c.serverShutdownCtx)
 				job := c.createJob(jobCtx, jobLogger, c.gocronLogger, clusterService, coordinator, wgRunning)
 
-				entryId, err := cr.AddJob(schedule, job, gocron.WithName(jobName))
+				entryId, err := cr.AddJob(schedule, job, gocron.WithName(objectsTTLJobName))
 				if err != nil {
 					jobLogger.WithError(err).Error("cron job not added")
 					continue
@@ -203,6 +255,10 @@ func (c *cronsObjectsTTL) createJob(ctx context.Context, jobLogger logrus.FieldL
 		err = coordinator.Start(ctx, false, started, started)
 	}))
 }
+
+func (c *cronsObjectsTTL) jobName() string { return objectsTTLJobName }
+
+func (c *cronsObjectsTTL) hookKey() string { return "ObjectsTTL" }
 
 func (c *cronsObjectsTTL) RuntimeConfigHook() error {
 	newSchedule := c.configGetter().ObjectsTTLDeleteSchedule.Get()

--- a/usecases/cron/gocron.go
+++ b/usecases/cron/gocron.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sync"
 	"time"
 
 	gocron "github.com/netresearch/go-cron"
@@ -28,6 +27,11 @@ import (
 	objectttl "github.com/weaviate/weaviate/usecases/object_ttl"
 )
 
+// cronStopTimeout bounds each of the two shutdown waits on its own: the tick
+// drain, and then the registration join. One wedged tick can spend both, so
+// the worst case is twice this. A var so a test can shorten it.
+var cronStopTimeout = 30 * time.Second
+
 type configGetter func() config.Config
 
 // registrant is one cron job Crons owns.
@@ -38,6 +42,8 @@ type registrant interface {
 	// prefix the field whose changes RuntimeConfigHook reacts to.
 	hookKey() string
 	RuntimeConfigHook() error
+	// wait blocks until this registrant's registration goroutine has exited.
+	wait()
 }
 
 type Crons struct {
@@ -55,13 +61,17 @@ func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, conf
 	logger = logger.WithField("action", "cron")
 	gocronLogger := cron.NewGoCronLogger(logger, logrus.DebugLevel)
 
+	objectsTTL, err := newCronsObjectsTTL(serverShutdownCtx, logger, gocronLogger, configGetter)
+	if err != nil {
+		return nil, err
+	}
 	namespaceCleanup, err := newCronsNamespaceCleanup(serverShutdownCtx, logger, gocronLogger, configGetter)
 	if err != nil {
 		return nil, err
 	}
 
 	c := &Crons{
-		objectsttl:        newCronsObjectsTTL(serverShutdownCtx, logger, gocronLogger, configGetter),
+		objectsttl:        objectsTTL,
 		namespaceCleanup:  namespaceCleanup,
 		logger:            logger,
 		gocronLogger:      gocronLogger,
@@ -112,31 +122,65 @@ func (c *Crons) Init(clusterService *cluster.Service, ttlCoordinator *objectttl.
 ) error {
 	cr := initGoCron(c.serverShutdownCtx, c.gocronLogger)
 
-	if err := c.initJobs(cr, clusterService, ttlCoordinator, nsCleanupCoordinator); err != nil {
+	if err := c.initJobs(cr, clusterService.IsLeader, ttlCoordinator, nsCleanupCoordinator); err != nil {
 		return err
 	}
 
 	cr.Start()
 	<-c.serverShutdownCtx.Done()
-	cr.Stop()
-	// Await the namespace-cleanup registration goroutine before returning.
-	c.namespaceCleanup.wait()
+	// StopWithTimeout halts future fires and drains the ticks already
+	// running. This and the join below are separately bounded, and the same
+	// wedged tick blocks each of them, so the two waits run back to back.
+	if !cr.StopWithTimeout(cronStopTimeout) {
+		c.logger.Warnf("cron ticks still running after %s, shutting down anyway", cronStopTimeout)
+	}
+	c.waitForRegistrations()
 
 	return nil
 }
 
-// initJobs starts each job's registration loop on cr, handing namespace
-// cleanup clusterService.IsLeader so only the leader ticks it. Each loop adds
-// its entry on its own goroutine, and a job its config disables adds none.
-// Init blocks on serverShutdownCtx straight after this call, so everything
-// Init does before cr.Start() goes here.
-func (c *Crons) initJobs(cr *gocron.Cron, clusterService *cluster.Service,
+// waitForRegistrations joins every registration goroutine under the same bound
+// as the drain, so a loop parked behind a tick that ignores its cancelled
+// context delays the exit rather than holding it for good.
+func (c *Crons) waitForRegistrations() {
+	joined := make(chan string, len(c.registrations))
+	for _, r := range c.registrations {
+		errors.GoWrapper(func() {
+			r.wait()
+			joined <- r.jobName()
+		}, c.logger)
+	}
+
+	stopped := map[string]bool{}
+	deadline := time.After(cronStopTimeout)
+	for range c.registrations {
+		select {
+		case name := <-joined:
+			stopped[name] = true
+		case <-deadline:
+			var running []string
+			for _, r := range c.registrations {
+				if !stopped[r.jobName()] {
+					running = append(running, r.jobName())
+				}
+			}
+			c.logger.Warnf("cron registration loops still running after %s, shutting down anyway: %v",
+				cronStopTimeout, running)
+			return
+		}
+	}
+}
+
+// initJobs starts each job's registration loop on cr, handing each job
+// isLeader as its tick gate. Init blocks on serverShutdownCtx straight after
+// this call, so anything Init must do before cr.Start() goes here.
+func (c *Crons) initJobs(cr *gocron.Cron, isLeader func() bool,
 	ttlCoordinator *objectttl.Coordinator, nsCleanupCoordinator *namespacecleanup.Coordinator,
 ) error {
-	if err := c.objectsttl.Init(cr, clusterService, ttlCoordinator); err != nil {
+	if err := c.objectsttl.Init(cr, isLeader, ttlCoordinator); err != nil {
 		return fmt.Errorf("init objects ttl cron: %w", err)
 	}
-	if err := c.namespaceCleanup.Init(cr, clusterService.IsLeader, nsCleanupCoordinator); err != nil {
+	if err := c.namespaceCleanup.Init(cr, isLeader, nsCleanupCoordinator); err != nil {
 		return fmt.Errorf("init namespace cleanup cron: %w", err)
 	}
 	return nil
@@ -154,154 +198,62 @@ func (c *Crons) RuntimeConfigHooks() map[string]func() error {
 
 const objectsTTLJobName = "trigger_objects_ttl_deletion"
 
+// cronsObjectsTTL runs Coordinator.Start on the leader, on the schedule
+// OBJECTS_TTL_DELETE_SCHEDULE configures. Start has no leadership check of its
+// own, so the tick gate is the only thing keeping every node off it.
 type cronsObjectsTTL struct {
-	lock            *sync.Mutex
-	currentSchedule string
-	scheduleCh      chan string
-
-	logger            logrus.FieldLogger
-	gocronLogger      gocron.Logger
-	configGetter      configGetter
-	serverShutdownCtx context.Context
+	*cronsRegistration[string]
 }
 
 func newCronsObjectsTTL(serverShutdownCtx context.Context,
 	logger logrus.FieldLogger, gocronLogger gocron.Logger, configGetter configGetter,
-) *cronsObjectsTTL {
-	currentSchedule := configGetter().ObjectsTTLDeleteSchedule.Get()
-	scheduleCh := make(chan string, 1)
-	scheduleCh <- currentSchedule
+) (*cronsObjectsTTL, error) {
+	registration, err := newCronsRegistration(cronsRegistrationConfig[string]{
+		name:           objectsTTLJobName,
+		runtimeHookKey: "ObjectsTTL",
 
-	return &cronsObjectsTTL{
-		lock:            new(sync.Mutex),
-		currentSchedule: currentSchedule,
-		scheduleCh:      scheduleCh,
+		configuredValue: func() string { return configGetter().ObjectsTTLDeleteSchedule.Get() },
+		// An empty schedule disables the job rather than falling back to a default.
+		resolve: func(schedule string) (string, bool) { return schedule, schedule != "" },
+		// A schedule change cancels the tick context. On the single-node path
+		// that only stops the next collection from starting, so the barrier can
+		// still wait out deletions already in flight.
+		cancelOnChange: true,
 
 		logger:            logger,
 		gocronLogger:      gocronLogger,
-		configGetter:      configGetter,
 		serverShutdownCtx: serverShutdownCtx,
+	})
+	if err != nil {
+		return nil, err
 	}
+
+	return &cronsObjectsTTL{cronsRegistration: registration}, nil
 }
 
-func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
+// Init registers the deletion job and keeps it in step with the configured
+// schedule. Rejects a nil coordinator.
+func (c *cronsObjectsTTL) Init(cr *gocron.Cron, tickGate func() bool,
 	coordinator *objectttl.Coordinator,
 ) error {
 	if coordinator == nil {
 		return fmt.Errorf("objects ttl coordinator is nil")
 	}
-	errors.GoWrapper(func() {
-		jobLogger := c.logger.WithField("job", objectsTTLJobName)
-		var jobCtx context.Context
-		var cancel context.CancelFunc = func() {} // noop
-		wgRunning := new(sync.WaitGroup)
 
-		for {
-			select {
-			case schedule := <-c.scheduleCh:
-				cancel()
-				if cr.RemoveByName(objectsTTLJobName) {
-					jobLogger.Info("cron job removed")
-				}
+	_, err := c.start(cr, tickGate, func(ctx context.Context) {
+		started := time.Now()
+		c.jobLogger.Debug("trigger ttl deletion started")
 
-				if schedule == "" {
-					jobLogger.Info("cron job skipped, no schedule")
-					continue
-				}
+		err := coordinator.Start(ctx, false, started, started)
 
-				// ensure removed job is no longer running before adding one with new schedule
-				wgRunning.Wait()
-				// ensure context still valid after waiting
-				select {
-				case <-c.serverShutdownCtx.Done():
-					jobLogger.Debug("server shutdown context cancelled")
-					return
-				default:
-				}
-
-				jobCtx, cancel = context.WithCancel(c.serverShutdownCtx)
-				job := c.createJob(jobCtx, jobLogger, c.gocronLogger, clusterService, coordinator, wgRunning)
-
-				entryId, err := cr.AddJob(schedule, job, gocron.WithName(objectsTTLJobName))
-				if err != nil {
-					jobLogger.WithError(err).Error("cron job not added")
-					continue
-				}
-				jobLogger.WithFields(logrus.Fields{
-					"entry_id": entryId,
-					"schedule": schedule,
-				}).Info("cron job added")
-
-			case <-c.serverShutdownCtx.Done():
-				cancel()
-				jobLogger.Debug("server shutdown context cancelled")
-				return
-			}
-		}
-	}, c.logger)
-
-	return nil
-}
-
-func (c *cronsObjectsTTL) createJob(ctx context.Context, jobLogger logrus.FieldLogger, gocronLogger gocron.Logger,
-	clusterService *cluster.Service, coordinator *objectttl.Coordinator, wgRunning *sync.WaitGroup,
-) gocron.Job {
-	return gocron.NewChain(
-		gocron.SkipIfStillRunning(gocronLogger),
-	).Then(gocron.FuncJob(func() {
-		wgRunning.Add(1)
-		defer wgRunning.Done()
-
-		if !clusterService.IsLeader() {
-			jobLogger.Debug("not a ttl scheduler - skipping")
+		jobLogger := c.jobLogger.WithField("took", time.Since(started))
+		if err != nil {
+			jobLogger.Errorf("trigger ttl deletion failed: %v", err)
 			return
 		}
-
-		var err error
-		started := time.Now()
-
-		jobLogger.Debug("trigger ttl deletion started")
-		defer func() {
-			jobLogger := jobLogger.WithField("took", time.Since(started))
-			if err != nil {
-				jobLogger.WithError(err).Error("trigger ttl deletion failed")
-				return
-			}
-			jobLogger.Debug("trigger ttl deletion finished")
-		}()
-
-		err = coordinator.Start(ctx, false, started, started)
-	}))
-}
-
-func (c *cronsObjectsTTL) jobName() string { return objectsTTLJobName }
-
-func (c *cronsObjectsTTL) hookKey() string { return "ObjectsTTL" }
-
-func (c *cronsObjectsTTL) RuntimeConfigHook() error {
-	newSchedule := c.configGetter().ObjectsTTLDeleteSchedule.Get()
-	c.lock.Lock()
-	if c.currentSchedule == newSchedule {
-		c.lock.Unlock()
-		// nothing to do, schedule have not changed
-		return nil
-	}
-	c.currentSchedule = newSchedule
-	c.lock.Unlock()
-
-	select {
-	case <-c.scheduleCh:
-		// read previous, not yet handled value. discard in favour of new one
-		//
-		// It could happen that schedule A was changed to B and then back to A.
-		// If B as not applied and read here, effectively it will be A changed to A
-		// which could be skipped. For now this unlikely case will be ignored.
-	default:
-		// nothing in the channel, safe to push new one
-	}
-
-	c.scheduleCh <- newSchedule
-	return nil
+		jobLogger.Debug("trigger ttl deletion finished")
+	})
+	return err
 }
 
 func initGoCron(ctx context.Context, logger gocron.Logger) *gocron.Cron {
@@ -309,6 +261,6 @@ func initGoCron(ctx context.Context, logger gocron.Logger) *gocron.Cron {
 		gocron.WithContext(ctx),
 		gocron.WithLogger(logger),
 		gocron.WithChain(gocron.Recover(logger)),
-		gocron.WithParser(gocron.FullParser()),
+		gocron.WithParser(cron.Parser()),
 	)
 }

--- a/usecases/cron/gocron_test.go
+++ b/usecases/cron/gocron_test.go
@@ -13,11 +13,115 @@ package cron
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster"
+	"github.com/weaviate/weaviate/entities/cron"
+	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
+	objectttl "github.com/weaviate/weaviate/usecases/object_ttl"
 )
+
+// followerService answers IsLeader false without panicking. Store.raft is nil
+// and unexported, so no fixture built here can answer true.
+func followerService() *cluster.Service {
+	return &cluster.Service{Raft: cluster.NewRaft(nil, &cluster.Store{}, nil)}
+}
+
+func newTestCrons(t *testing.T) (*Crons, *gocron.Cron, context.CancelFunc) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	ctx, cancel := context.WithCancel(context.Background())
+	crons, err := NewCrons(ctx, logger, intervalConfig(time.Minute))
+	require.NoError(t, err)
+	return crons, initGoCron(ctx, gocron.DiscardLogger), cancel
+}
+
+func TestCrons_InitJobs(t *testing.T) {
+	t.Run("a follower's tick never reaches the cleanup coordinator", func(t *testing.T) {
+		tests := []struct {
+			name string
+			wire func(*Crons, *gocron.Cron, *namespacecleanup.Coordinator) error
+			want int64
+		}{
+			{
+				name: "initJobs gates the cleanup job on leadership",
+				wire: func(crons *Crons, cr *gocron.Cron, co *namespacecleanup.Coordinator) error {
+					return crons.initJobs(cr, followerService(), &objectttl.Coordinator{}, co)
+				},
+				want: 0,
+			},
+			{
+				// The control: the same counter reads 1 once a gate lets the
+				// tick through, so a zero above means the gate denied it
+				// rather than that nothing ran.
+				name: "a job every node runs reaches the coordinator",
+				wire: func(crons *Crons, cr *gocron.Cron, co *namespacecleanup.Coordinator) error {
+					return crons.namespaceCleanup.Init(cr, cron.RunOnEveryNode, co)
+				},
+				want: 1,
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				crons, cr, cancel := newTestCrons(t)
+				defer cancel()
+
+				var listDeletingCalls atomic.Int64
+				require.NoError(t, tt.wire(crons, cr,
+					nonNilCoordinator(t, stubLister{listDeletingCalls: &listDeletingCalls})))
+				require.Eventually(t, func() bool {
+					return cr.EntryByName(namespaceCleanupJobName).Valid()
+				}, 2*time.Second, 10*time.Millisecond, "cleanup job should have been registered")
+
+				cr.EntryByName(namespaceCleanupJobName).Run()
+
+				assert.Equal(t, tt.want, listDeletingCalls.Load(),
+					"the tick must reach Coordinator.Tick only when its gate allows it")
+
+				cancel()
+				crons.namespaceCleanup.wait()
+			})
+		}
+	})
+
+	t.Run("a coordinator one arm refuses leaves cleanup unregistered", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			ttl     *objectttl.Coordinator
+			cleanup bool
+			wantErr string
+		}{
+			{name: "objects ttl", ttl: nil, cleanup: true, wantErr: "init objects ttl cron"},
+			{name: "namespace cleanup", ttl: &objectttl.Coordinator{}, wantErr: "init namespace cleanup cron"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				crons, cr, cancel := newTestCrons(t)
+				defer cancel()
+
+				var cleanup *namespacecleanup.Coordinator
+				if tt.cleanup {
+					cleanup = nonNilCoordinator(t, stubLister{})
+				}
+				require.ErrorContains(t,
+					crons.initJobs(cr, followerService(), tt.ttl, cleanup), tt.wantErr)
+
+				requireNoGoroutine(t, crons.namespaceCleanup.cronsRegistration)
+				assert.False(t, cr.EntryByName(namespaceCleanupJobName).Valid(),
+					"cleanup must not register once an earlier job failed")
+				assert.False(t, cr.EntryByName(objectsTTLJobName).Valid(),
+					"the ttl job must stay unregistered; the fixture coordinator carries no schedule")
+			})
+		}
+	})
+}
 
 func TestGoCronInit(t *testing.T) {
 	t.Run("cron accepts different schedule formats", func(t *testing.T) {

--- a/usecases/cron/gocron_test.go
+++ b/usecases/cron/gocron_test.go
@@ -13,17 +13,22 @@ package cron
 
 import (
 	"context"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster"
 	"github.com/weaviate/weaviate/entities/cron"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/parser"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
 	objectttl "github.com/weaviate/weaviate/usecases/object_ttl"
 )
@@ -34,13 +39,28 @@ func followerService() *cluster.Service {
 	return &cluster.Service{Raft: cluster.NewRaft(nil, &cluster.Store{}, nil)}
 }
 
-func newTestCrons(t *testing.T) (*Crons, *gocron.Cron, context.CancelFunc) {
+func newTestCrons(t *testing.T) (*Crons, *gocron.Cron, *test.Hook, context.CancelFunc) {
 	t.Helper()
-	logger, _ := test.NewNullLogger()
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
 	ctx, cancel := context.WithCancel(context.Background())
-	crons, err := NewCrons(ctx, logger, intervalConfig(time.Minute))
+	crons, err := NewCrons(ctx, logger, bothJobsConfig(time.Minute, "@every 1m"))
 	require.NoError(t, err)
-	return crons, initGoCron(ctx, gocron.DiscardLogger), cancel
+	return crons, initGoCron(ctx, gocron.DiscardLogger), hook, cancel
+}
+
+// bothJobsConfig turns on the namespace cleanup job at interval and the objects
+// ttl job at schedule, so a Crons built on it registers both.
+func bothJobsConfig(interval time.Duration, schedule string) configGetter {
+	return func() config.Config {
+		return config.Config{
+			ObjectsTTLDeleteSchedule: configRuntime.NewDynamicValue(schedule),
+			Namespaces: config.Namespaces{
+				Enabled:         true,
+				CleanupInterval: configRuntime.NewDynamicValue(interval),
+			},
+		}
+	}
 }
 
 func TestCrons_InitJobs(t *testing.T) {
@@ -53,7 +73,7 @@ func TestCrons_InitJobs(t *testing.T) {
 			{
 				name: "initJobs gates the cleanup job on leadership",
 				wire: func(crons *Crons, cr *gocron.Cron, co *namespacecleanup.Coordinator) error {
-					return crons.initJobs(cr, followerService(), &objectttl.Coordinator{}, co)
+					return crons.initJobs(cr, followerService().IsLeader, &objectttl.Coordinator{}, co)
 				},
 				want: 0,
 			},
@@ -70,7 +90,7 @@ func TestCrons_InitJobs(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				crons, cr, cancel := newTestCrons(t)
+				crons, cr, _, cancel := newTestCrons(t)
 				defer cancel()
 
 				var listDeletingCalls atomic.Int64
@@ -97,13 +117,19 @@ func TestCrons_InitJobs(t *testing.T) {
 			ttl     *objectttl.Coordinator
 			cleanup bool
 			wantErr string
+			// wantTTL is true where objects ttl was accepted, so its
+			// registration goroutine is live and adds the entry.
+			wantTTL bool
 		}{
 			{name: "objects ttl", ttl: nil, cleanup: true, wantErr: "init objects ttl cron"},
-			{name: "namespace cleanup", ttl: &objectttl.Coordinator{}, wantErr: "init namespace cleanup cron"},
+			{
+				name: "namespace cleanup", ttl: &objectttl.Coordinator{},
+				wantErr: "init namespace cleanup cron", wantTTL: true,
+			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				crons, cr, cancel := newTestCrons(t)
+				crons, cr, _, cancel := newTestCrons(t)
 				defer cancel()
 
 				var cleanup *namespacecleanup.Coordinator
@@ -111,13 +137,18 @@ func TestCrons_InitJobs(t *testing.T) {
 					cleanup = nonNilCoordinator(t, stubLister{})
 				}
 				require.ErrorContains(t,
-					crons.initJobs(cr, followerService(), tt.ttl, cleanup), tt.wantErr)
+					crons.initJobs(cr, followerService().IsLeader, tt.ttl, cleanup), tt.wantErr)
 
 				requireNoGoroutine(t, crons.namespaceCleanup.cronsRegistration)
 				assert.False(t, cr.EntryByName(namespaceCleanupJobName).Valid(),
 					"cleanup must not register once an earlier job failed")
+				if tt.wantTTL {
+					requireRegisteredAt(t, cr, objectsTTLJobName, time.Minute)
+					return
+				}
+				requireNoGoroutine(t, crons.objectsttl.cronsRegistration)
 				assert.False(t, cr.EntryByName(objectsTTLJobName).Valid(),
-					"the ttl job must stay unregistered; the fixture coordinator carries no schedule")
+					"a refused coordinator must leave the ttl job unregistered")
 			})
 		}
 	})
@@ -167,4 +198,398 @@ func TestGoCronInit(t *testing.T) {
 			}
 		})
 	})
+}
+
+// ttlConfig wires OBJECTS_TTL_DELETE_SCHEDULE to schedule and leaves namespaces
+// off, so a Crons built on it registers the ttl job alone.
+func ttlConfig(schedule string) configGetter {
+	return func() config.Config {
+		return config.Config{ObjectsTTLDeleteSchedule: configRuntime.NewDynamicValue(schedule)}
+	}
+}
+
+func newTestObjectsTTL(t *testing.T, schedule string) (
+	*cronsObjectsTTL, *gocron.Cron, *test.Hook, context.CancelFunc,
+) {
+	t.Helper()
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	ctx, cancel := context.WithCancel(context.Background())
+	c, err := newCronsObjectsTTL(ctx, logger, gocron.DiscardLogger, ttlConfig(schedule))
+	require.NoError(t, err)
+	return c, initGoCron(ctx, gocron.DiscardLogger), hook, cancel
+}
+
+func TestCronsObjectsTTL_Registration(t *testing.T) {
+	tests := []struct {
+		name           string
+		schedule       string
+		pushes         []string
+		wantRegistered bool
+		wantDelay      time.Duration // zero means don't assert the delay
+	}{
+		{name: "an empty schedule registers nothing", schedule: ""},
+		{
+			name: "an interval schedule registers", schedule: "@every 1m",
+			wantRegistered: true, wantDelay: time.Minute,
+		},
+		{name: "a cron expression registers", schedule: "0 16 * * *", wantRegistered: true},
+		{
+			// A first value that disables the job must leave the loop running,
+			// so a later push still registers.
+			name:     "a schedule pushed after an empty one registers",
+			schedule: "", pushes: []string{"@every 1m"},
+			wantRegistered: true, wantDelay: time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cr, _, cancel := newTestObjectsTTL(t, tt.schedule)
+			defer cancel()
+			require.NoError(t, c.Init(cr, cron.RunOnEveryNode, &objectttl.Coordinator{}))
+
+			for _, push := range tt.pushes {
+				c.valueCh <- push
+			}
+
+			if !tt.wantRegistered {
+				// Absence needs a settling window; the loop consumes its first
+				// value well inside it.
+				time.Sleep(50 * time.Millisecond)
+				assert.False(t, cr.EntryByName(objectsTTLJobName).Valid())
+				return
+			}
+			require.Eventually(t, func() bool {
+				return cr.EntryByName(objectsTTLJobName).Valid()
+			}, 2*time.Second, 10*time.Millisecond, "the ttl job should be registered")
+			if tt.wantDelay > 0 {
+				requireRegisteredAt(t, cr, objectsTTLJobName, tt.wantDelay)
+			}
+		})
+	}
+}
+
+func TestCronsObjectsTTL_RuntimeDisableRemovesTheJob(t *testing.T) {
+	c, cr, hook, cancel := newTestObjectsTTL(t, "@every 1m")
+	defer cancel()
+	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, &objectttl.Coordinator{}))
+	requireRegisteredAt(t, cr, objectsTTLJobName, time.Minute)
+
+	c.valueCh <- ""
+
+	// Poll the log, not the entry: the loop removes the entry and then logs.
+	require.Eventually(t, func() bool {
+		return slices.Contains(messages(hook), "cron job removed")
+	}, 2*time.Second, 10*time.Millisecond, "taking the job away must be reported")
+	assert.False(t, cr.EntryByName(objectsTTLJobName).Valid())
+}
+
+func TestCronsObjectsTTL_Init_NilCoordinator(t *testing.T) {
+	c, cr, _, cancel := newTestObjectsTTL(t, "@every 1m")
+	defer cancel()
+
+	require.ErrorContains(t, c.Init(cr, cron.RunOnEveryNode, nil), "objects ttl coordinator is nil")
+	requireNoGoroutine(t, c.cronsRegistration)
+}
+
+func TestCrons_InitJobs_ObjectsTTLIsGated(t *testing.T) {
+	tests := []struct {
+		name    string
+		wire    func(*Crons, *gocron.Cron) error
+		wantRun bool
+	}{
+		{
+			name: "initJobs gates the ttl job on leadership",
+			wire: func(crons *Crons, cr *gocron.Cron) error {
+				return crons.initJobs(cr, followerService().IsLeader, &objectttl.Coordinator{},
+					nonNilCoordinator(t, stubLister{}))
+			},
+		},
+		{
+			// The control row: with a gate that always allows, the same assertion
+			// reads true, so a false above means the gate denied rather than that
+			// nothing ran. It drives initJobs too, so the hand-off itself is
+			// pinned on both sides. The body then panics on the empty
+			// coordinator's nil schema reader, and initGoCron's Recover contains it.
+			name: "a job every node runs enters the tick body",
+			wire: func(crons *Crons, cr *gocron.Cron) error {
+				return crons.initJobs(cr, cron.RunOnEveryNode, &objectttl.Coordinator{},
+					nonNilCoordinator(t, stubLister{}))
+			},
+			wantRun: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			crons, cr, hook, cancel := newTestCrons(t)
+			defer cancel()
+			require.NoError(t, tt.wire(crons, cr))
+			requireRegisteredAt(t, cr, objectsTTLJobName, time.Minute)
+
+			cr.EntryByName(objectsTTLJobName).Run()
+
+			assert.Equal(t, tt.wantRun,
+				slices.Contains(messages(hook), "trigger ttl deletion started"),
+				"the tick body must run only when its gate allows it")
+		})
+	}
+}
+
+// TestCrons_InitGatesOnClusterLeadership pins where Init sources the gate it
+// hands both jobs: the tests above drive initJobs and pass one in, so only a
+// scheduler-driven tick covers the cluster service reaching it. No control row
+// pairs with it — cluster.Service answers IsLeader true only from a raft field
+// no fixture can set — so the skip line is what proves a tick reached the gate.
+func TestCrons_InitGatesOnClusterLeadership(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	ctx, cancel := context.WithCancel(context.Background())
+	// A second is the shortest interval the parser takes, so the scheduler
+	// dispatches a tick inside the test rather than an hour later.
+	crons, err := NewCrons(ctx, logger, bothJobsConfig(time.Minute, "@every 1s"))
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- crons.Init(followerService(), &objectttl.Coordinator{},
+			nonNilCoordinator(t, stubLister{}))
+	}()
+	require.Eventually(t, func() bool {
+		return countMessage(hook, "cron job added") == 2
+	}, 5*time.Second, 10*time.Millisecond, "both jobs should have registered")
+
+	require.Eventually(t, func() bool {
+		return slices.Contains(messages(hook), "cron tick skipped by its gate")
+	}, 5*time.Second, 10*time.Millisecond, "a dispatched tick should have reached the gate")
+	assert.NotContains(t, messages(hook), "trigger ttl deletion started",
+		"a follower must not enter the deletion body")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Init must return once the shutdown context is cancelled")
+	}
+}
+
+func TestCrons_InitJoinsEveryRegistration(t *testing.T) {
+	tests := []struct {
+		name string
+		// park holds one registrant's loop on its barrier and hands back the
+		// release, so the two loops stop at different moments.
+		park func(*Crons) func()
+	}{
+		{
+			name: "the ttl registration is joined",
+			park: func(crons *Crons) func() {
+				crons.objectsttl.runMu.Lock()
+				crons.objectsttl.valueCh <- "@every 2m"
+				return crons.objectsttl.runMu.Unlock
+			},
+		},
+		{
+			name: "the cleanup registration is joined",
+			park: func(crons *Crons) func() {
+				crons.namespaceCleanup.runMu.Lock()
+				crons.namespaceCleanup.valueCh <- 2 * time.Minute
+				return crons.namespaceCleanup.runMu.Unlock
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+			logger.SetLevel(logrus.DebugLevel)
+			ctx, cancel := context.WithCancel(context.Background())
+			crons, err := NewCrons(ctx, logger, bothJobsConfig(time.Minute, "@every 1m"))
+			require.NoError(t, err)
+			require.Len(t, crons.registrations, 2, "both registrants must be joined, not one")
+
+			done := make(chan error, 1)
+			go func() {
+				done <- crons.Init(followerService(), &objectttl.Coordinator{},
+					nonNilCoordinator(t, stubLister{}))
+			}()
+			// Init owns its cron, so wait on the two registration lines rather
+			// than on an entry: both loops must be running before the shutdown
+			// is meaningful.
+			require.Eventually(t, func() bool {
+				return countMessage(hook, "cron job added") == 2
+			}, 5*time.Second, 10*time.Millisecond, "both jobs should have registered")
+
+			release := tt.park(crons)
+			require.Eventually(t, func() bool {
+				return slices.Contains(messages(hook), "cron job waiting for the tick in flight")
+			}, 5*time.Second, 10*time.Millisecond, "the loop should be parked on the barrier")
+
+			cancel()
+
+			select {
+			case <-done:
+				t.Fatal("Init returned while a registration goroutine was still parked")
+			case <-time.After(300 * time.Millisecond):
+			}
+			release()
+
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(5 * time.Second):
+				t.Fatal("Init must return once every registration goroutine has exited")
+			}
+		})
+	}
+}
+
+// TestCrons_InitAwaitsTheTickInFlight pins the bounded drain: Init must not
+// return while the scheduler still has a tick running.
+func TestCrons_InitAwaitsTheTickInFlight(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	ctx, cancel := context.WithCancel(context.Background())
+	// A second is the shortest interval the parser takes, so the scheduler
+	// dispatches a tick inside the test rather than an hour later.
+	crons, err := NewCrons(ctx, logger, bothJobsConfig(time.Minute, "@every 1s"))
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- crons.Init(followerService(), &objectttl.Coordinator{},
+			nonNilCoordinator(t, stubLister{}))
+	}()
+	require.Eventually(t, func() bool {
+		return countMessage(hook, "cron job added") == 2
+	}, 5*time.Second, 10*time.Millisecond, "both jobs should have registered")
+
+	// Park every tick the scheduler dispatches. tickJob takes runMu before it
+	// consults the gate, so the job counts as in flight on a follower too.
+	crons.objectsttl.runMu.Lock()
+	// gocron writes "run" once it has counted the fire into the group the
+	// drain waits on, so this proves there is a tick to wait for rather than
+	// assuming one landed. Cleanup runs once a minute, so the fire is the
+	// ttl job's.
+	require.Eventually(t, func() bool {
+		return countMessage(hook, "run") > 0
+	}, 5*time.Second, 10*time.Millisecond, "the scheduler should have dispatched a tick")
+
+	cancel()
+
+	select {
+	case err := <-done:
+		t.Fatalf("Init returned while a tick was still in flight: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	crons.objectsttl.runMu.Unlock()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Init must return once the tick has drained")
+	}
+}
+
+func TestCronsObjectsTTL_RuntimeConfigHookKeyMatchesField(t *testing.T) {
+	tests := []struct {
+		name   string
+		pushed string
+		want   time.Duration // zero means the job must be gone
+	}{
+		{name: "an accepted push re-registers the job", pushed: `"@every 2m"`, want: 2 * time.Minute},
+		{name: "an empty schedule takes the job away", pushed: `""`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current, err := configRuntime.NewDynamicValueWithValidation(
+				"@every 1m", parser.ValidateGocronSchedule)
+			require.NoError(t, err)
+			getter := func() config.Config {
+				return config.Config{ObjectsTTLDeleteSchedule: current}
+			}
+			logger, _ := test.NewNullLogger()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			crons, err := NewCrons(ctx, logger, getter)
+			require.NoError(t, err)
+			cr := initGoCron(ctx, gocron.DiscardLogger)
+			require.NoError(t, crons.objectsttl.Init(cr, cron.RunOnEveryNode, &objectttl.Coordinator{}))
+			requireRegisteredAt(t, cr, objectsTTLJobName, time.Minute)
+
+			// Through the field-name match rather than the method: the hook key
+			// "ObjectsTTL" has to prefix ObjectsTTLDeleteSchedule.
+			source := &config.WeaviateRuntimeConfig{ObjectsTTLDeleteSchedule: current}
+			skipped := map[string]struct{}{}
+			parsed, err := config.NewRuntimeConfigParser(logger)(
+				[]byte("objects_ttl_delete_schedule: "+tt.pushed), skipped)
+			require.NoError(t, err)
+
+			require.NoError(t, config.UpdateRuntimeConfig(logger, source, parsed, skipped,
+				crons.RuntimeConfigHooks()))
+
+			if tt.want == 0 {
+				require.Eventually(t, func() bool {
+					return !cr.EntryByName(objectsTTLJobName).Valid()
+				}, 2*time.Second, 10*time.Millisecond, "the disabled job should be gone")
+				return
+			}
+			requireRegisteredAt(t, cr, objectsTTLJobName, tt.want)
+		})
+	}
+}
+
+// TestCrons_CancelOnChangePerRegistrant pins the one registration flag the two
+// registrants set differently. A schedule change must not wait out a full TTL
+// pass, and a cleanup interval change must not kill the sweep in flight.
+func TestCrons_CancelOnChangePerRegistrant(t *testing.T) {
+	tests := []struct {
+		name          string
+		wantCancelled bool
+	}{
+		{
+			name:          "a re-registered ttl job ends the tick it replaces",
+			wantCancelled: true,
+		},
+		{name: "a re-registered cleanup job leaves it running"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			logger, _ := test.NewNullLogger()
+			cr := initGoCron(ctx, gocron.DiscardLogger)
+			var tickCtx atomic.Pointer[context.Context]
+			capture := func(c context.Context) { tickCtx.Store(&c) }
+
+			var name string
+			var push func()
+			if tt.wantCancelled {
+				c, err := newCronsObjectsTTL(ctx, logger, gocron.DiscardLogger, ttlConfig("@every 1m"))
+				require.NoError(t, err)
+				_, err = c.start(cr, cron.RunOnEveryNode, capture)
+				require.NoError(t, err)
+				name, push = objectsTTLJobName, func() { c.valueCh <- "@every 2m" }
+			} else {
+				c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, intervalConfig(time.Minute))
+				require.NoError(t, err)
+				_, err = c.start(cr, cron.RunOnEveryNode, capture)
+				require.NoError(t, err)
+				name, push = namespaceCleanupJobName, func() { c.valueCh <- 2 * time.Minute }
+			}
+			requireRegisteredAt(t, cr, name, time.Minute)
+
+			cr.EntryByName(name).Run()
+			require.NotNil(t, tickCtx.Load())
+			replaced := *tickCtx.Load()
+			require.NoError(t, replaced.Err())
+
+			push()
+
+			// The cancel runs ahead of the upsert, so a visible replacement
+			// means it has already fired or never will.
+			requireRegisteredAt(t, cr, name, 2*time.Minute)
+			assert.Equal(t, tt.wantCancelled, replaced.Err() != nil)
+		})
+	}
 }

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -159,6 +159,10 @@ func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
 	}))
 }
 
+func (c *cronsNamespaceCleanup) jobName() string { return namespaceCleanupJobName }
+
+func (c *cronsNamespaceCleanup) hookKey() string { return "NamespaceCleanup" }
+
 // RuntimeConfigHook re-reads the interval from config and, on change,
 // pushes the new value to the registration loop. The whole read-compare-
 // store-and-push runs under mu so concurrent callers can't interleave and

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -14,175 +14,67 @@ package cron
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	gocron "github.com/netresearch/go-cron"
 	"github.com/sirupsen/logrus"
 
-	"github.com/weaviate/weaviate/cluster"
-	"github.com/weaviate/weaviate/entities/errors"
 	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
 )
 
 const namespaceCleanupJobName = "namespace_cleanup"
 
-// cronsNamespaceCleanup runs Coordinator.Tick on a configurable interval.
-// The interval is read from runtime config and hot-reloads via
-// RuntimeConfigHook.
+// cronsNamespaceCleanup runs Coordinator.Tick on the leader, on the interval
+// NAMESPACE_CLEANUP_INTERVAL configures. The tick gate only spares a follower
+// the call; Tick re-checks leadership itself.
 type cronsNamespaceCleanup struct {
-	// mu serialises RuntimeConfigHook so the read-compare-store and the
-	// channel drain+push run as one unit. Without it, concurrent callers
-	// can interleave and leave the channel holding a different interval
-	// than currentInterval.
-	mu              sync.Mutex
-	currentInterval time.Duration // guarded by mu
-	intervalCh      chan time.Duration
-
-	// registerWG lets shutdown await Init's registration goroutine instead
-	// of returning while it still runs.
-	registerWG sync.WaitGroup
-
-	logger            logrus.FieldLogger
-	gocronLogger      gocron.Logger
-	configGetter      configGetter
-	serverShutdownCtx context.Context
+	*cronsRegistration[time.Duration]
 }
 
 func newCronsNamespaceCleanup(serverShutdownCtx context.Context,
 	logger logrus.FieldLogger, gocronLogger gocron.Logger, configGetter configGetter,
-) *cronsNamespaceCleanup {
-	current := configGetter().Namespaces.CleanupInterval.Get()
-	intervalCh := make(chan time.Duration, 1)
-	intervalCh <- current
+) (*cronsNamespaceCleanup, error) {
+	registration, err := newCronsRegistration(cronsRegistrationConfig[time.Duration]{
+		name:           namespaceCleanupJobName,
+		runtimeHookKey: "NamespaceCleanup",
 
-	c := &cronsNamespaceCleanup{
-		currentInterval:   current,
-		intervalCh:        intervalCh,
+		shouldRegister:  func() bool { return configGetter().Namespaces.Enabled },
+		configuredValue: func() time.Duration { return configGetter().Namespaces.CleanupInterval.Get() },
+		resolve: func(interval time.Duration) (string, bool) {
+			return fmt.Sprintf("@every %s", interval), interval > 0
+		},
+
 		logger:            logger,
 		gocronLogger:      gocronLogger,
-		configGetter:      configGetter,
 		serverShutdownCtx: serverShutdownCtx,
+	})
+	if err != nil {
+		return nil, err
 	}
-	return c
+
+	return &cronsNamespaceCleanup{cronsRegistration: registration}, nil
 }
 
-// Init launches a goroutine that registers (and re-registers, on
-// interval changes) the cleanup job. Returns immediately when namespaces
-// are disabled. Rejects a nil coordinator.
-func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Service,
+// Init registers the cleanup job and keeps it in step with the configured
+// interval. Registers nothing when namespaces are disabled. Rejects a nil
+// coordinator.
+func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, tickGate func() bool,
 	coordinator *namespacecleanup.Coordinator,
 ) error {
-	if !c.configGetter().Namespaces.Enabled {
-		c.logger.WithField("job", namespaceCleanupJobName).Info("cron job skipped, namespaces disabled")
-		return nil
-	}
 	if coordinator == nil {
 		return fmt.Errorf("namespace cleanup coordinator is nil")
 	}
-	c.registerWG.Add(1)
-	errors.GoWrapper(func() {
-		defer c.registerWG.Done()
-		jobLogger := c.logger.WithField("job", namespaceCleanupJobName)
-		// runMu serialises the cron callback with the re-registration
-		// loop: the callback holds it for one tick, the loop Lock/Unlocks
-		// as a barrier before swapping the job.
-		runMu := new(sync.Mutex)
 
-		for {
-			select {
-			case interval := <-c.intervalCh:
-				if cr.RemoveByName(namespaceCleanupJobName) {
-					jobLogger.Info("cron job removed")
-				}
-				if interval <= 0 {
-					jobLogger.Info("cron job skipped, interval <= 0")
-					continue
-				}
-
-				runMu.Lock()
-				runMu.Unlock()
-				select {
-				case <-c.serverShutdownCtx.Done():
-					jobLogger.Debug("server shutdown context cancelled")
-					return
-				default:
-				}
-
-				schedule := fmt.Sprintf("@every %s", interval)
-				job := c.createJob(jobLogger, clusterService, coordinator, runMu)
-				entryId, err := cr.AddJob(schedule, job, gocron.WithName(namespaceCleanupJobName))
-				if err != nil {
-					jobLogger.Errorf("cron job not added: %v", err)
-					continue
-				}
-				jobLogger.WithFields(logrus.Fields{
-					"entry_id": entryId,
-					"schedule": schedule,
-				}).Info("cron job added")
-
-			case <-c.serverShutdownCtx.Done():
-				jobLogger.Debug("server shutdown context cancelled")
-				return
-			}
+	started, err := c.start(cr, tickGate, func(ctx context.Context) {
+		if err := coordinator.Tick(ctx); err != nil {
+			c.jobLogger.Errorf("namespace cleanup tick failed: %v", err)
 		}
-	}, c.logger)
-
-	return nil
-}
-
-// wait blocks until Init's registration goroutine has exited. Returns at
-// once when Init never launched one (namespaces disabled, nil coordinator).
-func (c *cronsNamespaceCleanup) wait() {
-	c.registerWG.Wait()
-}
-
-// createJob returns the per-tick callback. SkipIfStillRunning prevents
-// overlap at the cron layer; the coordinator additionally guards against
-// concurrent ticks.
-func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
-	clusterService *cluster.Service, coordinator *namespacecleanup.Coordinator,
-	runMu *sync.Mutex,
-) gocron.Job {
-	return gocron.NewChain(
-		gocron.SkipIfStillRunning(c.gocronLogger),
-	).Then(gocron.FuncJob(func() {
-		runMu.Lock()
-		defer runMu.Unlock()
-
-		if !clusterService.IsLeader() {
-			return
-		}
-		if err := coordinator.Tick(c.serverShutdownCtx); err != nil {
-			jobLogger.Errorf("namespace cleanup tick failed: %v", err)
-		}
-	}))
-}
-
-func (c *cronsNamespaceCleanup) jobName() string { return namespaceCleanupJobName }
-
-func (c *cronsNamespaceCleanup) hookKey() string { return "NamespaceCleanup" }
-
-// RuntimeConfigHook re-reads the interval from config and, on change,
-// pushes the new value to the registration loop. The whole read-compare-
-// store-and-push runs under mu so concurrent callers can't interleave and
-// leave the channel holding a different interval than currentInterval.
-func (c *cronsNamespaceCleanup) RuntimeConfigHook() error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	newInterval := c.configGetter().Namespaces.CleanupInterval.Get()
-	if newInterval == c.currentInterval {
-		return nil
+	})
+	if err != nil {
+		return err
 	}
-	c.currentInterval = newInterval
-
-	// Drain the stale value (if any) before pushing. The buffer is size 1,
-	// so the send stays non-blocking while we hold the lock.
-	select {
-	case <-c.intervalCh:
-	default:
+	if !started {
+		c.jobLogger.Info("cron job skipped, namespaces disabled")
 	}
-	c.intervalCh <- newInterval
 	return nil
 }

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -19,6 +19,8 @@ import (
 	gocron "github.com/netresearch/go-cron"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/entities/cron"
+	"github.com/weaviate/weaviate/usecases/config"
 	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
 )
 
@@ -34,14 +36,23 @@ type cronsNamespaceCleanup struct {
 func newCronsNamespaceCleanup(serverShutdownCtx context.Context,
 	logger logrus.FieldLogger, gocronLogger gocron.Logger, configGetter configGetter,
 ) (*cronsNamespaceCleanup, error) {
+	jobLogger := logger.WithField("job", namespaceCleanupJobName)
 	registration, err := newCronsRegistration(cronsRegistrationConfig[time.Duration]{
 		name:           namespaceCleanupJobName,
 		runtimeHookKey: "NamespaceCleanup",
 
-		shouldRegister:  func() bool { return configGetter().Namespaces.Enabled },
-		configuredValue: func() time.Duration { return configGetter().Namespaces.CleanupInterval.Get() },
+		shouldRegister: func() bool { return configGetter().Namespaces.Enabled },
+		configuredValue: func() time.Duration {
+			interval := configGetter().Namespaces.CleanupInterval.Get()
+			if interval > 0 {
+				return interval
+			}
+			jobLogger.Warnf("namespace cleanup interval %s is at or below zero, applying the default %s",
+				interval, config.DefaultNamespaceCleanupInterval)
+			return config.DefaultNamespaceCleanupInterval
+		},
 		resolve: func(interval time.Duration) (string, bool) {
-			return fmt.Sprintf("@every %s", interval), interval > 0
+			return cron.EverySpec(interval), true
 		},
 
 		logger:            logger,

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -13,7 +13,9 @@ package cron
 
 import (
 	"context"
+	"slices"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/entities/cron"
 	"github.com/weaviate/weaviate/usecases/config"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
@@ -45,18 +48,19 @@ func newTestNamespaceCleanup(t *testing.T, interval time.Duration) (*cronsNamesp
 	logger.SetLevel(logrus.DebugLevel)
 	ctx, cancel := context.WithCancel(context.Background())
 	cr := initGoCron(ctx, gocron.DiscardLogger)
-	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, intervalConfig(interval))
+	c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, intervalConfig(interval))
+	require.NoError(t, err)
 	return c, cr, cancel
 }
 
-func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
+func nonNilCoordinator(t *testing.T, lister stubLister) *namespacecleanup.Coordinator {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	return namespacecleanup.NewCoordinator(
-		stubLister{},
-		stubLister{},
-		stubLister{},
-		stubLister{},
+		lister,
+		lister,
+		lister,
+		lister,
 		nil,
 		func() bool { return true },
 		logger,
@@ -64,10 +68,17 @@ func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
 }
 
 // stubLister satisfies every coordinator dependency. Methods return zero
-// values; the cron-level tests don't invoke them.
-type stubLister struct{}
+// values. ListDeleting increments listDeletingCalls when it is non-nil, so a
+// test can tell whether a tick reached Coordinator.Tick.
+type stubLister struct{ listDeletingCalls *atomic.Int64 }
 
-func (stubLister) ListDeleting() []string                               { return nil }
+func (s stubLister) ListDeleting() []string {
+	if s.listDeletingCalls != nil {
+		s.listDeletingCalls.Add(1)
+	}
+	return nil
+}
+
 func (stubLister) ClassesInNamespace(string) ([]string, error)          { return nil, nil }
 func (stubLister) AliasesInNamespace(string) []string                   { return nil }
 func (stubLister) UsersInNamespace(string) []string                     { return nil }
@@ -89,7 +100,7 @@ func (stubLister) RevokeRolesForUser(string, ...string) error { return nil }
 func TestCronsNamespaceCleanup_Init_NilCoordinator(t *testing.T) {
 	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
 	defer cancel()
-	require.Error(t, c.Init(cr, nil, nil))
+	require.Error(t, c.Init(cr, cron.RunOnEveryNode, nil))
 }
 
 func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
@@ -102,10 +113,11 @@ func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	require.NoError(t, err)
 	cr := initGoCron(ctx, gocron.DiscardLogger)
 
-	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 	time.Sleep(50 * time.Millisecond)
 	assert.False(t, cr.RemoveByName(namespaceCleanupJobName),
 		"job must not be registered when namespaces are disabled")
@@ -114,7 +126,7 @@ func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
 func TestCronsNamespaceCleanup_Init_RegistersForPositiveInterval(t *testing.T) {
 	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
 	defer cancel()
-	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 	assert.Eventually(t, func() bool {
 		return cr.RemoveByName(namespaceCleanupJobName)
 	}, 2*time.Second, 10*time.Millisecond,
@@ -127,7 +139,7 @@ func TestCronsNamespaceCleanup_Init_SkipsForNonPositiveInterval(t *testing.T) {
 		t.Run(interval.String(), func(t *testing.T) {
 			c, cr, cancel := newTestNamespaceCleanup(t, interval)
 			defer cancel()
-			require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+			require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 			// Give the registration goroutine a moment; it must not register.
 			time.Sleep(50 * time.Millisecond)
 			assert.False(t, cr.RemoveByName(namespaceCleanupJobName),
@@ -138,7 +150,7 @@ func TestCronsNamespaceCleanup_Init_SkipsForNonPositiveInterval(t *testing.T) {
 
 func TestCronsNamespaceCleanup_Wait_AwaitsRegistrationGoroutine(t *testing.T) {
 	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
-	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 
 	// While the shutdown ctx is live the registration goroutine is parked in
 	// its select, so wait() must block.
@@ -174,26 +186,18 @@ func TestCronsNamespaceCleanup_Wait_ReturnsWhenNoGoroutineLaunched(t *testing.T)
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	require.NoError(t, err)
 	cr := initGoCron(ctx, gocron.DiscardLogger)
-	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 
-	done := make(chan struct{})
-	go func() {
-		c.wait()
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("wait() blocked even though no registration goroutine was launched")
-	}
+	requireNoGoroutine(t, c.cronsRegistration)
 }
 
 func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 	// Drive the hook directly: set up a configGetter whose returned value
 	// can change between Hook calls, and assert the new value reaches
-	// intervalCh.
+	// valueCh.
 	current := configRuntime.NewDynamicValue(time.Minute)
 	getter := func() config.Config {
 		return config.Config{Namespaces: config.Namespaces{Enabled: true, CleanupInterval: current}}
@@ -201,14 +205,15 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	require.NoError(t, err)
 	// Drain the initial value pushed by the constructor.
-	<-c.intervalCh
+	<-c.valueCh
 
 	require.NoError(t, current.SetValue(2*time.Minute))
 	require.NoError(t, c.RuntimeConfigHook())
 	select {
-	case got := <-c.intervalCh:
+	case got := <-c.valueCh:
 		assert.Equal(t, 2*time.Minute, got)
 	case <-time.After(time.Second):
 		t.Fatal("hook did not push the new interval")
@@ -217,7 +222,7 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 	// Same value again is a no-op (no push, channel stays empty).
 	require.NoError(t, c.RuntimeConfigHook())
 	select {
-	case got := <-c.intervalCh:
+	case got := <-c.valueCh:
 		t.Fatalf("hook pushed on unchanged value: %s", got)
 	case <-time.After(50 * time.Millisecond):
 	}
@@ -225,9 +230,9 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 
 // TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent is a
 // regression test for the read-compare-store-push race: concurrent hook
-// callers must not leave intervalCh holding a different interval than
-// currentInterval. Many goroutines flip the config and call the hook at
-// once; afterwards the buffered channel value must equal currentInterval.
+// callers must not leave valueCh holding a different interval than
+// currentValue. Many goroutines flip the config and call the hook at
+// once; afterwards the buffered channel value must equal currentValue.
 // Run with -race to also catch the underlying data race directly.
 func TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent(t *testing.T) {
 	dv := configRuntime.NewDynamicValue(time.Minute)
@@ -237,8 +242,9 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent(t *te
 	logger, _ := test.NewNullLogger()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
-	<-c.intervalCh // drain the constructor's initial value
+	c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	require.NoError(t, err)
+	<-c.valueCh // drain the constructor's initial value
 
 	const n = 64
 	var wg sync.WaitGroup
@@ -252,16 +258,57 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent(t *te
 	}
 	wg.Wait()
 
-	// Each change path stores currentInterval and pushes the same value under
+	// Each change path stores currentValue and pushes the same value under
 	// mu, so once the goroutines settle the channel must agree with
-	// currentInterval — the invariant the mutex restores.
+	// currentValue — the invariant the mutex restores.
 	c.mu.Lock()
-	current := c.currentInterval
+	current := c.currentValue
 	c.mu.Unlock()
 	select {
-	case got := <-c.intervalCh:
-		assert.Equal(t, current, got, "channel interval diverged from currentInterval")
+	case got := <-c.valueCh:
+		assert.Equal(t, current, got, "channel interval diverged from currentValue")
 	case <-time.After(time.Second):
 		t.Fatal("channel empty after concurrent hooks")
+	}
+}
+
+// TestCronsNamespaceCleanup_EveryLineNamesTheJob pins the one thing a second
+// jobLogger derivation could get wrong: the loop and the registrant naming the
+// same job two ways, which splits a job=<name> log filter down the middle.
+func TestCronsNamespaceCleanup_EveryLineNamesTheJob(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled bool
+		wantMsg string
+	}{
+		{name: "the loop's registration line", enabled: true, wantMsg: "cron job added"},
+		{name: "the registrant's own skip line", wantMsg: "cron job skipped, namespaces disabled"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, hook := test.NewNullLogger()
+			logger.SetLevel(logrus.DebugLevel)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			getter := func() config.Config {
+				return config.Config{Namespaces: config.Namespaces{
+					Enabled:         tt.enabled,
+					CleanupInterval: configRuntime.NewDynamicValue(time.Minute),
+				}}
+			}
+			c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+			require.NoError(t, err)
+
+			require.NoError(t, c.Init(initGoCron(ctx, gocron.DiscardLogger),
+				cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
+
+			require.Eventually(t, func() bool {
+				return slices.Contains(messages(hook), tt.wantMsg)
+			}, 2*time.Second, 10*time.Millisecond, "expected the %q line", tt.wantMsg)
+			for _, entry := range hook.AllEntries() {
+				assert.Equal(t, namespaceCleanupJobName, entry.Data["job"],
+					"every line carries the one job name, whichever side wrote it: %q", entry.Message)
+			}
+		})
 	}
 }

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -14,6 +14,7 @@ package cron
 import (
 	"context"
 	"slices"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/cron"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/parser"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
 )
@@ -42,15 +44,17 @@ func intervalConfig(d time.Duration) configGetter {
 	}
 }
 
-func newTestNamespaceCleanup(t *testing.T, interval time.Duration) (*cronsNamespaceCleanup, *gocron.Cron, context.CancelFunc) {
+func newTestNamespaceCleanup(t *testing.T, interval time.Duration) (
+	*cronsNamespaceCleanup, *gocron.Cron, *test.Hook, context.CancelFunc,
+) {
 	t.Helper()
-	logger, _ := test.NewNullLogger()
+	logger, hook := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
 	ctx, cancel := context.WithCancel(context.Background())
 	cr := initGoCron(ctx, gocron.DiscardLogger)
 	c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, intervalConfig(interval))
 	require.NoError(t, err)
-	return c, cr, cancel
+	return c, cr, hook, cancel
 }
 
 func nonNilCoordinator(t *testing.T, lister stubLister) *namespacecleanup.Coordinator {
@@ -98,7 +102,7 @@ func (stubLister) DeleteRoles(...string) error                { return nil }
 func (stubLister) RevokeRolesForUser(string, ...string) error { return nil }
 
 func TestCronsNamespaceCleanup_Init_NilCoordinator(t *testing.T) {
-	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
+	c, cr, _, cancel := newTestNamespaceCleanup(t, time.Minute)
 	defer cancel()
 	require.Error(t, c.Init(cr, cron.RunOnEveryNode, nil))
 }
@@ -124,7 +128,7 @@ func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
 }
 
 func TestCronsNamespaceCleanup_Init_RegistersForPositiveInterval(t *testing.T) {
-	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
+	c, cr, _, cancel := newTestNamespaceCleanup(t, time.Minute)
 	defer cancel()
 	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 	assert.Eventually(t, func() bool {
@@ -133,23 +137,60 @@ func TestCronsNamespaceCleanup_Init_RegistersForPositiveInterval(t *testing.T) {
 		"job should have been registered under the documented name")
 }
 
-func TestCronsNamespaceCleanup_Init_SkipsForNonPositiveInterval(t *testing.T) {
-	tests := []time.Duration{0, -time.Second}
-	for _, interval := range tests {
-		t.Run(interval.String(), func(t *testing.T) {
-			c, cr, cancel := newTestNamespaceCleanup(t, interval)
-			defer cancel()
-			require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
-			// Give the registration goroutine a moment; it must not register.
-			time.Sleep(50 * time.Millisecond)
-			assert.False(t, cr.RemoveByName(namespaceCleanupJobName),
-				"job must not be registered when interval <= 0")
-		})
-	}
+func TestCronsNamespaceCleanup_FallsBackToDefaultForNonPositiveInterval(t *testing.T) {
+	t.Run("at boot", func(t *testing.T) {
+		tests := []struct {
+			interval time.Duration
+			want     time.Duration
+			wantWarn bool
+		}{
+			{interval: 0, want: config.DefaultNamespaceCleanupInterval, wantWarn: true},
+			{interval: -time.Second, want: config.DefaultNamespaceCleanupInterval, wantWarn: true},
+			{interval: time.Minute, want: time.Minute},
+		}
+		for _, tt := range tests {
+			t.Run(tt.interval.String(), func(t *testing.T) {
+				c, cr, hook, cancel := newTestNamespaceCleanup(t, tt.interval)
+				defer cancel()
+
+				require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
+
+				requireRegisteredAt(t, cr, namespaceCleanupJobName, tt.want)
+				warns := messages(hook, logrus.WarnLevel)
+				if !tt.wantWarn {
+					assert.Empty(t, warns, "an interval the scheduler can run needs no warning")
+					return
+				}
+				require.Len(t, warns, 1)
+				assert.Contains(t, warns[0], "interval "+tt.interval.String(),
+					"the warning names the configured value")
+				assert.Contains(t, warns[0], config.DefaultNamespaceCleanupInterval.String(),
+					"the warning names the applied default")
+			})
+		}
+	})
+
+	t.Run("a namespaces-disabled cluster still warns", func(t *testing.T) {
+		// The substitution reads ahead of the enable gate, so an operator
+		// learns their 0 will become 30s before they turn namespaces on.
+		logger, hook := test.NewNullLogger()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		getter := func() config.Config {
+			return config.Config{Namespaces: config.Namespaces{
+				Enabled: false, CleanupInterval: configRuntime.NewDynamicValue(time.Duration(0)),
+			}}
+		}
+
+		_, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+
+		require.NoError(t, err)
+		assert.Len(t, messages(hook, logrus.WarnLevel), 1)
+	})
 }
 
 func TestCronsNamespaceCleanup_Wait_AwaitsRegistrationGoroutine(t *testing.T) {
-	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
+	c, cr, _, cancel := newTestNamespaceCleanup(t, time.Minute)
 	require.NoError(t, c.Init(cr, cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 
 	// While the shutdown ctx is live the registration goroutine is parked in
@@ -277,12 +318,14 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook_ConcurrentCallsConsistent(t *te
 // same job two ways, which splits a job=<name> log filter down the middle.
 func TestCronsNamespaceCleanup_EveryLineNamesTheJob(t *testing.T) {
 	tests := []struct {
-		name    string
-		enabled bool
-		wantMsg string
+		name     string
+		enabled  bool
+		interval time.Duration
+		wantMsg  string
 	}{
-		{name: "the loop's registration line", enabled: true, wantMsg: "cron job added"},
-		{name: "the registrant's own skip line", wantMsg: "cron job skipped, namespaces disabled"},
+		{name: "the loop's registration line", enabled: true, interval: time.Minute, wantMsg: "cron job added"},
+		{name: "the registrant's own skip line", interval: time.Minute, wantMsg: "cron job skipped, namespaces disabled"},
+		{name: "the default-substitution warning", enabled: true, interval: 0, wantMsg: "at or below zero"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -293,7 +336,7 @@ func TestCronsNamespaceCleanup_EveryLineNamesTheJob(t *testing.T) {
 			getter := func() config.Config {
 				return config.Config{Namespaces: config.Namespaces{
 					Enabled:         tt.enabled,
-					CleanupInterval: configRuntime.NewDynamicValue(time.Minute),
+					CleanupInterval: configRuntime.NewDynamicValue(tt.interval),
 				}}
 			}
 			c, err := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
@@ -303,12 +346,107 @@ func TestCronsNamespaceCleanup_EveryLineNamesTheJob(t *testing.T) {
 				cron.RunOnEveryNode, nonNilCoordinator(t, stubLister{})))
 
 			require.Eventually(t, func() bool {
-				return slices.Contains(messages(hook), tt.wantMsg)
+				return slices.ContainsFunc(messages(hook), func(msg string) bool {
+					return strings.Contains(msg, tt.wantMsg)
+				})
 			}, 2*time.Second, 10*time.Millisecond, "expected the %q line", tt.wantMsg)
 			for _, entry := range hook.AllEntries() {
 				assert.Equal(t, namespaceCleanupJobName, entry.Data["job"],
 					"every line carries the one job name, whichever side wrote it: %q", entry.Message)
 			}
+		})
+	}
+}
+
+func TestCronsNamespaceCleanup_EnvVarReachesSchedule(t *testing.T) {
+	// The hop neither half above covers: usecases/config stops at Get(), and
+	// the cron tests start from a stubbed getter.
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{
+			name: "a value at or below zero applies the default",
+			env:  "0", want: config.DefaultNamespaceCleanupInterval,
+		},
+		{
+			name: "a positive value reaches the schedule as configured",
+			env:  "45s", want: 45 * time.Second,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("NAMESPACE_CLEANUP_INTERVAL", tt.env)
+			var conf config.Config
+			require.NoError(t, config.FromEnv(&conf))
+			conf.Namespaces.Enabled = true
+
+			logger, _ := test.NewNullLogger()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			crons, err := NewCrons(ctx, logger, func() config.Config { return conf })
+			require.NoError(t, err)
+			cr := initGoCron(ctx, gocron.DiscardLogger)
+
+			require.NoError(t, crons.namespaceCleanup.Init(cr, cron.RunOnEveryNode,
+				nonNilCoordinator(t, stubLister{})))
+
+			requireRegisteredAt(t, cr, namespaceCleanupJobName, tt.want)
+		})
+	}
+}
+
+func TestCronsNamespaceCleanup_RuntimeConfigHookKeyMatchesField(t *testing.T) {
+	tests := []struct {
+		name   string
+		pushed string
+		// want is the schedule the job lands on; wantConfigured is what the knob
+		// holds. They differ where the cron layer substitutes its default.
+		want           time.Duration
+		wantConfigured time.Duration
+	}{
+		{name: "an accepted push re-registers the job", pushed: "2m", want: 2 * time.Minute, wantConfigured: 2 * time.Minute},
+		{name: "a refused push leaves the job as it was", pushed: "500ms", want: time.Minute, wantConfigured: time.Minute},
+		{name: "a zero push re-registers at the default", pushed: "0s", want: config.DefaultNamespaceCleanupInterval},
+		{name: "a negative push re-registers at the default", pushed: "-1s", want: config.DefaultNamespaceCleanupInterval, wantConfigured: -time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current, err := configRuntime.NewDynamicValueWithValidation(
+				time.Minute, parser.ValidateCronInterval)
+			require.NoError(t, err)
+			getter := func() config.Config {
+				return config.Config{Namespaces: config.Namespaces{
+					Enabled: true, CleanupInterval: current,
+				}}
+			}
+			logger, _ := test.NewNullLogger()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			crons, err := NewCrons(ctx, logger, getter)
+			require.NoError(t, err)
+			cr := initGoCron(ctx, gocron.DiscardLogger)
+			require.NoError(t, crons.namespaceCleanup.Init(cr, cron.RunOnEveryNode,
+				nonNilCoordinator(t, stubLister{})))
+			requireRegisteredAt(t, cr, namespaceCleanupJobName, time.Minute)
+
+			// Through the field-name match rather than the method: a hook
+			// keyed on the job name would never fire at all.
+			source := &config.WeaviateRuntimeConfig{NamespaceCleanupInterval: current}
+			skipped := map[string]struct{}{}
+			parsed, err := config.NewRuntimeConfigParser(logger)(
+				[]byte("namespace_cleanup_interval: "+tt.pushed), skipped)
+			require.NoError(t, err)
+
+			require.NoError(t, config.UpdateRuntimeConfig(logger, source, parsed, skipped,
+				crons.RuntimeConfigHooks()))
+
+			requireRegisteredAt(t, cr, namespaceCleanupJobName, tt.want)
+			// Without this the refused row cannot fail: the job stays at a minute
+			// whether the push was rejected or never validated at all.
+			assert.Equal(t, tt.wantConfigured, current.Get(),
+				"the knob must hold the value the push left it on")
 		})
 	}
 }

--- a/usecases/cron/registration.go
+++ b/usecases/cron/registration.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	gocron "github.com/netresearch/go-cron"
 	"github.com/sirupsen/logrus"
@@ -60,6 +61,12 @@ type cronsRegistration[T comparable] struct {
 	// registerWG lets shutdown await start's goroutine instead of returning
 	// while it still runs.
 	registerWG sync.WaitGroup
+
+	// stopped reports that the loop goroutine has exited. GoWrapper recovers a
+	// panic in it and returns normally, so without this RuntimeConfigHook would
+	// push a value no loop ever reads. A registrant whose enable gate declined
+	// never had a loop, and still reads as running.
+	stopped atomic.Bool
 
 	// runMu keeps the tick off the job that replaces it: the tick holds it
 	// for its whole body, and the loop Lock/Unlocks it as a barrier before
@@ -144,6 +151,7 @@ func (c *cronsRegistration[T]) start(cr *gocron.Cron, tickGate func() bool,
 	c.registerWG.Add(1)
 	errors.GoWrapper(func() {
 		defer c.registerWG.Done()
+		defer c.stopped.Store(true)
 		c.loop(cr, tickGate, tick)
 	}, c.jobLogger)
 
@@ -241,6 +249,12 @@ func (c *cronsRegistration[T]) tickJob(ctx context.Context, tickGate func() bool
 	return gocron.NewChain(
 		gocron.SkipIfStillRunning(c.gocronLogger),
 	).Then(gocron.FuncJob(func() {
+		// A fire dispatched between the cancel and the swap belongs to the
+		// generation being replaced, and its context is already dead.
+		if ctx.Err() != nil {
+			return
+		}
+
 		c.runMu.Lock()
 		defer c.runMu.Unlock()
 
@@ -268,6 +282,12 @@ func (c *cronsRegistration[T]) RuntimeConfigHook() error {
 	newValue := c.configuredValue()
 	if newValue == c.currentValue {
 		return nil
+	}
+	// Below the no-change return, so a sibling field's change does not report
+	// a failure this hook had nothing to apply. currentValue stays behind, so
+	// the next push of the same value still reports.
+	if c.stopped.Load() {
+		return fmt.Errorf("cron job %q has no registration loop running", c.name)
 	}
 	c.currentValue = newValue
 

--- a/usecases/cron/registration.go
+++ b/usecases/cron/registration.go
@@ -1,0 +1,282 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cron
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/entities/errors"
+)
+
+// cronsRegistrationConfig is everything a cron job supplies.
+// newCronsRegistration checks it and builds the registration around it, which
+// owns the channel, the locks and the value the loop last registered.
+type cronsRegistrationConfig[T comparable] struct {
+	name           string
+	runtimeHookKey string
+
+	// shouldRegister is read once, when start runs. nil means always.
+	shouldRegister  func() bool
+	configuredValue func() T
+	// resolve turns a configured value into a cron spec, and reports false
+	// for a value that means "do not run".
+	resolve func(T) (spec string, register bool)
+	// cancelOnChange cancels the tick in flight before the replacement, so
+	// the drain does not wait out a full run. false lets it finish.
+	cancelOnChange bool
+
+	logger            logrus.FieldLogger
+	gocronLogger      gocron.Logger
+	serverShutdownCtx context.Context
+}
+
+// cronsRegistration holds a cron job's enable gate, the buffered channel its
+// runtime-config hook pushes to, and the loop that registers the job and
+// re-registers it as values arrive.
+type cronsRegistration[T comparable] struct {
+	// mu guards currentValue and the valueCh drain+push.
+	mu           sync.Mutex
+	currentValue T // guarded by mu
+	valueCh      chan T
+
+	// jobLogger is logger with the job field set to name, so every line the
+	// loop and the tick write names the job the same way.
+	jobLogger logrus.FieldLogger
+
+	// registerWG lets shutdown await start's goroutine instead of returning
+	// while it still runs.
+	registerWG sync.WaitGroup
+
+	// runMu keeps the tick off the job that replaces it: the tick holds it
+	// for its whole body, and the loop Lock/Unlocks it as a barrier before
+	// swapping. DrainAndUpsertJob supplies that exclusion only while a named
+	// entry survives, and the disable path removes the entry.
+	runMu sync.Mutex
+
+	cronsRegistrationConfig[T]
+}
+
+func (c *cronsRegistration[T]) jobName() string { return c.name }
+
+func (c *cronsRegistration[T]) hookKey() string { return c.runtimeHookKey }
+
+// newCronsRegistration checks the fields a registration cannot work without
+// and opens the value channel, seeded with the current configured value. start
+// refuses a registration built any other way, because a nil channel parks its
+// loop silently.
+func newCronsRegistration[T comparable](cfg cronsRegistrationConfig[T]) (*cronsRegistration[T], error) {
+	if cfg.name == "" {
+		return nil, fmt.Errorf("cron job has no name")
+	}
+	// Only usecases/config interprets this key, where an empty one
+	// prefix-matches every runtime config field name.
+	if cfg.runtimeHookKey == "" {
+		return nil, fmt.Errorf("cron job %q has no runtime config hook key", cfg.name)
+	}
+	if cfg.configuredValue == nil {
+		return nil, fmt.Errorf("cron job %q reads no configured value", cfg.name)
+	}
+	if cfg.resolve == nil {
+		return nil, fmt.Errorf("cron job %q resolves no schedule", cfg.name)
+	}
+	if cfg.logger == nil {
+		return nil, fmt.Errorf("cron job %q has no logger", cfg.name)
+	}
+	if cfg.gocronLogger == nil {
+		return nil, fmt.Errorf("cron job %q has no cron logger", cfg.name)
+	}
+	if cfg.serverShutdownCtx == nil {
+		return nil, fmt.Errorf("cron job %q has no shutdown context", cfg.name)
+	}
+
+	c := &cronsRegistration[T]{
+		cronsRegistrationConfig: cfg,
+		valueCh:                 make(chan T, 1),
+	}
+	c.jobLogger = cfg.logger.WithField("job", cfg.name)
+	c.currentValue = c.configuredValue()
+	c.valueCh <- c.currentValue
+	return c, nil
+}
+
+// enabled reports whether this job registers. A nil shouldRegister means it
+// does.
+func (c *cronsRegistration[T]) enabled() bool {
+	return c.shouldRegister == nil || c.shouldRegister()
+}
+
+// start launches the registration loop and reports whether it did. A job
+// shouldRegister turns off gets no goroutine. tickGate is consulted once per
+// tick, before tick runs.
+func (c *cronsRegistration[T]) start(cr *gocron.Cron, tickGate func() bool,
+	tick func(context.Context),
+) (started bool, err error) {
+	// Caught at startup rather than at the first fire: a nil gate or tick
+	// panics into initGoCron's Recover chain on every tick, which logs a
+	// stack and keeps firing, and a nil channel parks the loop with no output.
+	if tickGate == nil {
+		return false, fmt.Errorf("cron job %q has no tick gate", c.name)
+	}
+	if tick == nil {
+		return false, fmt.Errorf("cron job %q has no tick", c.name)
+	}
+	if c.valueCh == nil {
+		return false, fmt.Errorf("cron job %q was not built by newCronsRegistration", c.name)
+	}
+	if !c.enabled() {
+		return false, nil
+	}
+
+	c.registerWG.Add(1)
+	errors.GoWrapper(func() {
+		defer c.registerWG.Done()
+		c.loop(cr, tickGate, tick)
+	}, c.jobLogger)
+
+	return true, nil
+}
+
+// loop registers the job for every value the channel carries, and returns once
+// the server shuts down.
+func (c *cronsRegistration[T]) loop(cr *gocron.Cron, tickGate func() bool,
+	tick func(context.Context),
+) {
+	cancel := func() {} // noop until a cancelOnChange job replaces it
+
+	for {
+		select {
+		case value := <-c.valueCh:
+			spec, register := c.resolve(value)
+			if !register {
+				cancel()
+				if cr.RemoveByName(c.name) {
+					c.jobLogger.Info("cron job removed")
+				}
+				c.jobLogger.WithField("value", value).
+					Info("cron job skipped, its configured value disables it")
+				continue
+			}
+
+			// Parse before touching the entry, so a spec the library
+			// refuses leaves the running job as it was, with its tick
+			// context uncancelled.
+			if err := cr.ValidateSpec(spec); err != nil {
+				outcome := "no job is registered"
+				if cr.EntryByName(c.name).Valid() {
+					outcome = "keeping the previous registration"
+				}
+				c.jobLogger.WithField("schedule", spec).
+					Errorf("cron job schedule refused, %s: %v", outcome, err)
+				continue
+			}
+			cancel()
+
+			// The barrier can wait out a whole tick body, so say so rather
+			// than going quiet for a full run. It is released before
+			// DrainAndUpsertJob below, which waits for the tick in flight,
+			// and that tick takes runMu first: holding runMu across the
+			// upsert deadlocks the two against each other.
+			if !c.runMu.TryLock() {
+				c.jobLogger.Debug("cron job waiting for the tick in flight")
+				c.runMu.Lock()
+			}
+			c.runMu.Unlock()
+			select {
+			case <-c.serverShutdownCtx.Done():
+				c.jobLogger.Debug("server shutdown context cancelled")
+				return
+			default:
+			}
+
+			tickCtx := c.serverShutdownCtx
+			if c.cancelOnChange {
+				tickCtx, cancel = context.WithCancel(c.serverShutdownCtx)
+			}
+			entryId, err := cr.DrainAndUpsertJob(spec, c.tickJob(tickCtx, tickGate, tick),
+				gocron.WithName(c.name))
+			if err != nil {
+				// The entry the upsert did not replace still holds the tick
+				// cancel() ended above, so leaving it registered keeps a job
+				// firing that can only skip itself.
+				outcome := "no job is registered"
+				if cr.RemoveByName(c.name) {
+					outcome = "the previous registration was removed"
+				}
+				c.jobLogger.WithField("schedule", spec).
+					Errorf("cron job not added, %s: %v", outcome, err)
+				continue
+			}
+			c.jobLogger.WithFields(logrus.Fields{
+				"entry_id": entryId,
+				"schedule": spec,
+			}).Info("cron job added")
+
+		case <-c.serverShutdownCtx.Done():
+			cancel()
+			c.jobLogger.Debug("server shutdown context cancelled")
+			return
+		}
+	}
+}
+
+// tickJob returns the per-tick callback. SkipIfStillRunning keeps a tick off
+// itself. runMu keeps it off the job that replaces it.
+func (c *cronsRegistration[T]) tickJob(ctx context.Context, tickGate func() bool,
+	tick func(context.Context),
+) gocron.Job {
+	return gocron.NewChain(
+		gocron.SkipIfStillRunning(c.gocronLogger),
+	).Then(gocron.FuncJob(func() {
+		c.runMu.Lock()
+		defer c.runMu.Unlock()
+
+		if !tickGate() {
+			return
+		}
+		tick(ctx)
+	}))
+}
+
+// wait blocks until start's goroutine has exited. Returns at once when start
+// never launched one.
+func (c *cronsRegistration[T]) wait() {
+	c.registerWG.Wait()
+}
+
+// RuntimeConfigHook re-reads the configured value and, on change, pushes it
+// to the registration loop. The whole read-compare-store-and-push runs under
+// mu so concurrent callers can't interleave and leave the channel holding a
+// different value than currentValue.
+func (c *cronsRegistration[T]) RuntimeConfigHook() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	newValue := c.configuredValue()
+	if newValue == c.currentValue {
+		return nil
+	}
+	c.currentValue = newValue
+
+	// Drain the stale value (if any) before pushing. The buffer is size 1,
+	// so the send stays non-blocking while we hold the lock.
+	select {
+	case <-c.valueCh:
+	default:
+	}
+	c.valueCh <- newValue
+	return nil
+}

--- a/usecases/cron/registration.go
+++ b/usecases/cron/registration.go
@@ -256,10 +256,12 @@ func (c *cronsRegistration[T]) tickJob(ctx context.Context, tickGate func() bool
 		// a fire from the replaced generation must not run. The read sits under
 		// runMu so a fire that waited for the lock still sees that cancel.
 		if ctx.Err() != nil {
+			c.jobLogger.Debug("cron tick skipped, its context has ended")
 			return
 		}
 
 		if !tickGate() {
+			c.jobLogger.Debug("cron tick skipped by its gate")
 			return
 		}
 		tick(ctx)

--- a/usecases/cron/registration.go
+++ b/usecases/cron/registration.go
@@ -203,11 +203,9 @@ func (c *cronsRegistration[T]) loop(cr *gocron.Cron, tickGate func() bool,
 				c.runMu.Lock()
 			}
 			c.runMu.Unlock()
-			select {
-			case <-c.serverShutdownCtx.Done():
+			if c.serverShutdownCtx.Err() != nil {
 				c.jobLogger.Debug("server shutdown context cancelled")
 				return
-			default:
 			}
 
 			tickCtx := c.serverShutdownCtx

--- a/usecases/cron/registration.go
+++ b/usecases/cron/registration.go
@@ -249,14 +249,15 @@ func (c *cronsRegistration[T]) tickJob(ctx context.Context, tickGate func() bool
 	return gocron.NewChain(
 		gocron.SkipIfStillRunning(c.gocronLogger),
 	).Then(gocron.FuncJob(func() {
-		// A fire dispatched between the cancel and the swap belongs to the
-		// generation being replaced, and its context is already dead.
+		c.runMu.Lock()
+		defer c.runMu.Unlock()
+
+		// A cancelOnChange job cancels its tick context before the barrier, so
+		// a fire from the replaced generation must not run. The read sits under
+		// runMu so a fire that waited for the lock still sees that cancel.
 		if ctx.Err() != nil {
 			return
 		}
-
-		c.runMu.Lock()
-		defer c.runMu.Unlock()
 
 		if !tickGate() {
 			return

--- a/usecases/cron/registration.go
+++ b/usecases/cron/registration.go
@@ -193,11 +193,12 @@ func (c *cronsRegistration[T]) loop(cr *gocron.Cron, tickGate func() bool,
 			}
 			cancel()
 
-			// The barrier can wait out a whole tick body, so say so rather
-			// than going quiet for a full run. It is released before
-			// DrainAndUpsertJob below, which waits for the tick in flight,
-			// and that tick takes runMu first: holding runMu across the
-			// upsert deadlocks the two against each other.
+			// Wait out the tick in flight before swapping the job, and say so:
+			// the wait can last a whole tick body. gocron drains for us only
+			// while the named entry survives, and a disable removed it, so on
+			// the re-enable DrainAndUpsertJob finds nothing to wait for.
+			// Released before that upsert, which waits for a tick that takes
+			// runMu first: holding runMu across the call deadlocks the two.
 			if !c.runMu.TryLock() {
 				c.jobLogger.Debug("cron job waiting for the tick in flight")
 				c.runMu.Lock()

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -13,15 +13,202 @@ package cron
 
 import (
 	"context"
+	"fmt"
 	"maps"
 	"slices"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/cron"
 )
+
+const testJobName = "test_job"
+
+// newTestRegistration builds a registration on a cron the caller owns, wired
+// to interval, and hands back the shutdown cancel. The loop goroutine reads
+// resolve, shouldRegister and cancelOnChange, so a test sets them before it
+// calls start, or right before the valueCh send that publishes the change.
+func newTestRegistration(t *testing.T, interval time.Duration) (
+	*cronsRegistration[time.Duration], *gocron.Cron, *test.Hook, context.CancelFunc,
+) {
+	t.Helper()
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	c, err := newCronsRegistration(cronsRegistrationConfig[time.Duration]{
+		name:            testJobName,
+		runtimeHookKey:  "TestJob",
+		configuredValue: func() time.Duration { return interval },
+		resolve: func(interval time.Duration) (string, bool) {
+			return fmt.Sprintf("@every %s", interval), interval > 0
+		},
+		logger:            logger,
+		gocronLogger:      gocron.DiscardLogger,
+		serverShutdownCtx: ctx,
+	})
+	require.NoError(t, err)
+	return c, initGoCron(ctx, gocron.DiscardLogger), hook, cancel
+}
+
+func scheduleDelay(cr *gocron.Cron, name string) (time.Duration, bool) {
+	entry := cr.EntryByName(name)
+	if !entry.Valid() {
+		return 0, false
+	}
+	schedule, ok := entry.Schedule.(gocron.ConstantDelaySchedule)
+	return schedule.Delay, ok
+}
+
+func requireRegisteredAt(t *testing.T, cr *gocron.Cron, delay time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		got, ok := scheduleDelay(cr, testJobName)
+		return ok && got == delay
+	}, 2*time.Second, 10*time.Millisecond, "job should be registered at %s", delay)
+}
+
+// requireNoGoroutine asserts start launched no registration goroutine. wait
+// blocks until one exits, and these tests never trigger the shutdown that
+// would end it, so the helper times out rather than hanging.
+func requireNoGoroutine(t *testing.T, c *cronsRegistration[time.Duration]) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		c.wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("start launched a registration goroutine it reported it had not")
+	}
+}
+
+// messages returns the logged messages, narrowed to levels when any are given.
+func messages(hook *test.Hook, levels ...logrus.Level) []string {
+	var msgs []string
+	for _, entry := range hook.AllEntries() {
+		if len(levels) > 0 && !slices.Contains(levels, entry.Level) {
+			continue
+		}
+		msgs = append(msgs, entry.Message)
+	}
+	return msgs
+}
+
+// blockingTick returns a tick that parks until release is closed, plus the
+// highest number of tick bodies that ever ran at once. inTick reports each
+// body's start without ever blocking the tick.
+func blockingTick(release <-chan struct{}) (
+	tick func(context.Context), inTick chan struct{}, peak *atomic.Int32,
+) {
+	inTick = make(chan struct{}, 1)
+	var running, highest atomic.Int32
+	peak = &highest
+	return func(context.Context) {
+		n := running.Add(1)
+		for {
+			was := highest.Load()
+			if n <= was || highest.CompareAndSwap(was, n) {
+				break
+			}
+		}
+		select {
+		case inTick <- struct{}{}:
+		default:
+		}
+		<-release
+		running.Add(-1)
+	}, inTick, peak
+}
+
+func TestNewCronsRegistration_Rejects(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	valid := func() cronsRegistrationConfig[time.Duration] {
+		return cronsRegistrationConfig[time.Duration]{
+			name:              testJobName,
+			runtimeHookKey:    "TestJob",
+			configuredValue:   testConfiguredValue,
+			resolve:           testResolve,
+			logger:            logger,
+			gocronLogger:      gocron.DiscardLogger,
+			serverShutdownCtx: context.Background(),
+		}
+	}
+
+	// The control: every row below strips one field from this, so a valid()
+	// the constructor already refuses would pass every row for the wrong
+	// reason.
+	accepted, err := newCronsRegistration(valid())
+	require.NoError(t, err)
+	require.NotNil(t, accepted.valueCh)
+
+	tests := []struct {
+		name    string
+		strip   func(*cronsRegistrationConfig[time.Duration])
+		wantErr string
+	}{
+		{
+			name:    "no job name",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.name = "" },
+			wantErr: "cron job has no name",
+		},
+		{
+			name:    "no runtime config hook key",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.runtimeHookKey = "" },
+			wantErr: "has no runtime config hook key",
+		},
+		{
+			name:    "no way to read the configured value",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.configuredValue = nil },
+			wantErr: "reads no configured value",
+		},
+		{
+			name:    "no way to resolve a schedule",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.resolve = nil },
+			wantErr: "resolves no schedule",
+		},
+		{
+			name:    "no logger",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.logger = nil },
+			wantErr: "has no logger",
+		},
+		{
+			name:    "no cron logger",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.gocronLogger = nil },
+			wantErr: "has no cron logger",
+		},
+		{
+			name:    "no shutdown context",
+			strip:   func(c *cronsRegistrationConfig[time.Duration]) { c.serverShutdownCtx = nil },
+			wantErr: "has no shutdown context",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := valid()
+			tt.strip(&cfg)
+
+			got, err := newCronsRegistration(cfg)
+
+			require.ErrorContains(t, err, tt.wantErr)
+			assert.Nil(t, got)
+		})
+	}
+}
+
+func testConfiguredValue() time.Duration { return time.Minute }
+
+func testResolve(time.Duration) (string, bool) { return "@every 1m", true }
 
 // stubRegistrant carries no cron job, so add can be driven on names the two
 // real registrants cannot produce.
@@ -77,12 +264,8 @@ func TestCrons_RuntimeConfigHooks(t *testing.T) {
 			// must already be there without one.
 			name: "both registrants, collected before Init",
 			crons: func(t *testing.T) *Crons {
-				logger, _ := test.NewNullLogger()
-				ctx, cancel := context.WithCancel(context.Background())
+				c, _, cancel := newTestCrons(t)
 				t.Cleanup(cancel)
-
-				c, err := NewCrons(ctx, logger, intervalConfig(time.Minute))
-				require.NoError(t, err)
 				return c
 			},
 			want: []string{"NamespaceCleanup", "ObjectsTTL"},
@@ -99,4 +282,493 @@ func TestCrons_RuntimeConfigHooks(t *testing.T) {
 			assert.ElementsMatch(t, tt.want, slices.Collect(maps.Keys(hooks)))
 		})
 	}
+}
+
+func TestCronsRegistration_StartRejects(t *testing.T) {
+	tick := func(context.Context) {}
+
+	tests := []struct {
+		name         string
+		tickGate     func() bool
+		tick         func(context.Context)
+		registration func(*testing.T) *cronsRegistration[time.Duration]
+		wantErr      string
+	}{
+		{name: "no tick gate", tick: tick, wantErr: "has no tick gate"},
+		{name: "no tick", tickGate: cron.RunOnEveryNode, wantErr: "has no tick"},
+		{
+			name: "built by struct literal", tickGate: cron.RunOnEveryNode, tick: tick,
+			registration: func(*testing.T) *cronsRegistration[time.Duration] {
+				return &cronsRegistration[time.Duration]{
+					cronsRegistrationConfig: cronsRegistrationConfig[time.Duration]{name: testJobName},
+				}
+			},
+			wantErr: "was not built by newCronsRegistration",
+		},
+		{
+			// The guards run ahead of the enable gate, so a disabled job
+			// reports its nil tick gate at boot rather than on the restart
+			// after someone enables it.
+			name: "disabled and missing its tick gate", tick: tick,
+			registration: func(t *testing.T) *cronsRegistration[time.Duration] {
+				c, _, _, _ := newTestRegistration(t, time.Minute)
+				c.shouldRegister = func() bool { return false }
+				return c
+			},
+			wantErr: "has no tick gate",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cr, _, _ := newTestRegistration(t, time.Minute)
+			if tt.registration != nil {
+				c = tt.registration(t)
+			}
+
+			started, err := c.start(cr, tt.tickGate, tt.tick)
+
+			require.ErrorContains(t, err, tt.wantErr)
+			assert.False(t, started)
+			requireNoGoroutine(t, c)
+		})
+	}
+}
+
+func TestCronsRegistration_Registration(t *testing.T) {
+	tests := []struct {
+		name           string
+		shouldRegister func() bool
+		resolve        func(time.Duration) (string, bool)
+		wantStarted    bool
+		wantRegistered bool
+	}{
+		{
+			name:           "a nil enable gate registers",
+			wantStarted:    true,
+			wantRegistered: true,
+		},
+		{
+			name:           "an enable gate that allows registers",
+			shouldRegister: func() bool { return true },
+			wantStarted:    true,
+			wantRegistered: true,
+		},
+		{
+			name:           "an enable gate that denies launches no goroutine",
+			shouldRegister: func() bool { return false },
+			wantStarted:    false,
+			wantRegistered: false,
+		},
+		{
+			name:           "a value resolving to no schedule registers nothing",
+			resolve:        func(time.Duration) (string, bool) { return "", false },
+			wantStarted:    true,
+			wantRegistered: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cr, _, _ := newTestRegistration(t, time.Minute)
+			c.shouldRegister = tt.shouldRegister
+			if tt.resolve != nil {
+				c.resolve = tt.resolve
+			}
+
+			started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStarted, started)
+			if tt.wantRegistered {
+				requireRegisteredAt(t, cr, time.Minute)
+				return
+			}
+			// Absence needs a settling window; the loop consumes its first
+			// value well inside it.
+			time.Sleep(50 * time.Millisecond)
+			assert.False(t, cr.EntryByName(testJobName).Valid())
+			if !tt.wantStarted {
+				requireNoGoroutine(t, c)
+			}
+		})
+	}
+}
+
+func TestCronsRegistration_ReRegistrationReplacesTheEntry(t *testing.T) {
+	c, cr, hook, _ := newTestRegistration(t, time.Minute)
+
+	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, time.Minute)
+
+	before := cr.EntryByName(testJobName).ID
+
+	c.valueCh <- 2 * time.Minute
+
+	requireRegisteredAt(t, cr, 2*time.Minute)
+	assert.Len(t, cr.Entries(), 1)
+	// The upsert reuses the entry; a remove-and-add would allocate a new id.
+	assert.Equal(t, before, cr.EntryByName(testJobName).ID)
+	assert.NotContains(t, messages(hook), "cron job removed",
+		"replacing a job must not report the removal only the disable path does")
+}
+
+func TestCronsRegistration_DisableRemovesRunningJob(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial time.Duration
+		pushes  []time.Duration
+		want    time.Duration // zero means the job must not be registered
+	}{
+		{
+			name:    "a disabling value takes the running job away",
+			initial: time.Minute,
+			pushes:  []time.Duration{0},
+		},
+		{
+			// The loop's cancel starts as a no-op, so a first-turn skip must
+			// leave the goroutine alive to handle the value after it.
+			name:    "a first-turn disabling value leaves the loop alive",
+			initial: 0,
+			pushes:  []time.Duration{time.Minute},
+			want:    time.Minute,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cr, hook, _ := newTestRegistration(t, tt.initial)
+
+			started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+			require.NoError(t, err)
+			require.True(t, started)
+			if tt.initial > 0 {
+				requireRegisteredAt(t, cr, tt.initial)
+			}
+
+			for _, push := range tt.pushes {
+				c.valueCh <- push
+			}
+
+			if tt.want > 0 {
+				requireRegisteredAt(t, cr, tt.want)
+				return
+			}
+			// Poll the log, not the entry: the loop deletes the entry and
+			// then logs, so an entry poll can return before the line lands.
+			require.Eventually(t, func() bool {
+				return slices.Contains(messages(hook), "cron job removed")
+			}, 2*time.Second, 10*time.Millisecond, "taking the job away must be reported")
+			assert.False(t, cr.EntryByName(testJobName).Valid(),
+				"the disabled job should be gone")
+		})
+	}
+}
+
+func TestCronsRegistration_BadScheduleKeepsRegistration(t *testing.T) {
+	c, cr, hook, _ := newTestRegistration(t, time.Minute)
+	// cancelOnChange is what makes the live-context assertion below able to
+	// fail: under false the tick context is serverShutdownCtx, which nothing
+	// in this test cancels.
+	c.cancelOnChange = true
+
+	var tickCtx atomic.Pointer[context.Context]
+	started, err := c.start(cr, cron.RunOnEveryNode, func(ctx context.Context) {
+		tickCtx.Store(&ctx)
+	})
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, time.Minute)
+
+	// No validator clears a sub-second @every, so the parser refuses it.
+	c.resolve = func(time.Duration) (string, bool) { return "@every 500ms", true }
+	c.valueCh <- time.Second
+
+	require.Eventually(t, func() bool {
+		return len(messages(hook, logrus.ErrorLevel)) == 1
+	}, 2*time.Second, 10*time.Millisecond, "the refused schedule should log one error")
+	assert.Contains(t, messages(hook, logrus.ErrorLevel)[0],
+		"cron job schedule refused, keeping the previous registration",
+		"a refused schedule must not report the same outcome as a failed replacement")
+	assert.Equal(t, "@every 500ms", hook.LastEntry().Data["schedule"],
+		"the refused spec must reach the log record")
+
+	delay, ok := scheduleDelay(cr, testJobName)
+	require.True(t, ok, "the previous registration must survive a refused schedule")
+	assert.Equal(t, time.Minute, delay)
+
+	// Run the survivor to read the context it was handed: a cancel that fired
+	// for the refused schedule would leave it dead.
+	cr.EntryByName(testJobName).Run()
+	require.NotNil(t, tickCtx.Load())
+	assert.NoError(t, (*tickCtx.Load()).Err())
+}
+
+func TestCronsRegistration_TickGate(t *testing.T) {
+	tests := []struct {
+		name     string
+		tickGate func() bool
+		wantTick bool
+	}{
+		{name: "a gate that denies never calls the tick", tickGate: func() bool { return false }},
+		{name: "a gate that allows calls the tick", tickGate: func() bool { return true }, wantTick: true},
+		{name: "RunOnEveryNode always calls the tick", tickGate: cron.RunOnEveryNode, wantTick: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _, _, _ := newTestRegistration(t, time.Minute)
+			var ticked bool
+
+			// Drive the job directly: initGoCron returns an unstarted cron and
+			// @every cannot go below a second, so a gate assertion made through
+			// the scheduler would hold whether the gate exists or not.
+			c.tickJob(context.Background(), tt.tickGate, func(context.Context) { ticked = true }).Run()
+
+			assert.Equal(t, tt.wantTick, ticked)
+		})
+	}
+}
+
+func TestCronsRegistration_SwapDrainsTickInFlight(t *testing.T) {
+	c, cr, _, _ := newTestRegistration(t, time.Second)
+	release := make(chan struct{})
+	tick, inTick, peak := blockingTick(release)
+
+	started, err := c.start(cr, cron.RunOnEveryNode, tick)
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, time.Second)
+	cr.Start()
+	t.Cleanup(func() { cr.Stop() })
+
+	<-inTick // a tick is in flight and holds runMu
+	before := cr.EntryByName(testJobName).ID
+	c.valueCh <- 2 * time.Second
+
+	// Long enough for the replacement's own first fire to land if the swap
+	// let it: the replacement is @every 2s.
+	time.Sleep(2500 * time.Millisecond)
+	delay, ok := scheduleDelay(cr, testJobName)
+	require.True(t, ok, "the job must stay registered while a tick runs")
+	assert.Equal(t, time.Second, delay, "the swap completed before the tick returned")
+
+	close(release)
+	requireRegisteredAt(t, cr, 2*time.Second)
+	// The barrier alone would also hold the assertion above, so pin the swap
+	// itself: the upsert keeps the entry id, a remove-and-add allocates one.
+	assert.Equal(t, before, cr.EntryByName(testJobName).ID)
+	assert.Equal(t, int32(1), peak.Load(), "a second tick body must not run alongside the first")
+}
+
+func TestCronsRegistration_ExcludesAcrossRemoveAndReAdd(t *testing.T) {
+	c, cr, _, _ := newTestRegistration(t, time.Second)
+	release := make(chan struct{})
+	tick, inTick, peak := blockingTick(release)
+
+	started, err := c.start(cr, cron.RunOnEveryNode, tick)
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, time.Second)
+	cr.Start()
+	t.Cleanup(func() { cr.Stop() })
+
+	<-inTick // a tick is in flight and holds runMu
+	// Disabling removes the entry, so the re-enable takes DrainAndUpsertJob's
+	// create branch and gets no exclusion from the library. runMu is what
+	// keeps the next generation off the tick still running.
+	c.valueCh <- 0
+	c.valueCh <- time.Second
+
+	// Longer than the @every floor, so a generation that registered early
+	// would have fired by now.
+	time.Sleep(1500 * time.Millisecond)
+	assert.Equal(t, int32(1), peak.Load(), "a second tick body must not run alongside the first")
+
+	close(release)
+	requireRegisteredAt(t, cr, time.Second)
+}
+
+func TestCronsRegistration_RefusedFirstScheduleRegistersNothing(t *testing.T) {
+	c, cr, hook, _ := newTestRegistration(t, time.Minute)
+	// No validator clears a sub-second @every, so the parser refuses it.
+	c.resolve = func(time.Duration) (string, bool) { return "@every 500ms", true }
+
+	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+	require.NoError(t, err)
+	require.True(t, started)
+
+	require.Eventually(t, func() bool {
+		return len(messages(hook, logrus.ErrorLevel)) == 1
+	}, 2*time.Second, 10*time.Millisecond, "the refused schedule should log one error")
+	assert.Contains(t, messages(hook, logrus.ErrorLevel)[0],
+		"cron job schedule refused, no job is registered",
+		"the first schedule is refused with no registration to keep")
+	assert.False(t, cr.EntryByName(testJobName).Valid())
+}
+
+func TestCronsRegistration_CancelOnChangeEndsTheReplacedTick(t *testing.T) {
+	tests := []struct {
+		name           string
+		cancelOnChange bool
+		wantCancelled  bool
+	}{
+		{
+			name:           "cancelOnChange ends the replaced tick's context",
+			cancelOnChange: true,
+			wantCancelled:  true,
+		},
+		{name: "without it the replaced tick's context stays live"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cr, _, _ := newTestRegistration(t, time.Minute)
+			c.cancelOnChange = tt.cancelOnChange
+
+			var tickCtx atomic.Pointer[context.Context]
+			started, err := c.start(cr, cron.RunOnEveryNode, func(ctx context.Context) {
+				tickCtx.Store(&ctx)
+			})
+			require.NoError(t, err)
+			require.True(t, started)
+			requireRegisteredAt(t, cr, time.Minute)
+
+			// Run the job to read the context it was handed, then replace it.
+			cr.EntryByName(testJobName).Run()
+			require.NotNil(t, tickCtx.Load())
+			replaced := *tickCtx.Load()
+			require.NoError(t, replaced.Err())
+
+			c.valueCh <- 2 * time.Minute
+
+			// The cancel runs ahead of the upsert, so a visible replacement
+			// means it has already fired or never will.
+			requireRegisteredAt(t, cr, 2*time.Minute)
+			assert.Equal(t, tt.wantCancelled, replaced.Err() != nil,
+				"only a cancelOnChange job ends the tick it replaces")
+		})
+	}
+}
+
+func TestCronsRegistration_ShutdownAfterTheBarrierRegistersNothing(t *testing.T) {
+	c, cr, hook, cancel := newTestRegistration(t, time.Minute)
+
+	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, time.Minute)
+
+	// Stand in for a tick in flight: the loop parks on the barrier, which is
+	// the window the shutdown re-check behind it covers.
+	c.runMu.Lock()
+	c.valueCh <- 2 * time.Minute
+	require.Eventually(t, func() bool {
+		return slices.Contains(messages(hook), "cron job waiting for the tick in flight")
+	}, 2*time.Second, 10*time.Millisecond, "the loop should report the wait it is parked on")
+
+	cancel()
+	c.runMu.Unlock()
+	c.wait()
+
+	delay, ok := scheduleDelay(cr, testJobName)
+	require.True(t, ok, "the previous registration must survive the shutdown")
+	assert.Equal(t, time.Minute, delay, "a shutdown the barrier waited through registers nothing")
+	assert.Equal(t, 1, countMessage(hook, "cron job added"),
+		"the value the barrier held back must not reach the cron")
+	assert.Empty(t, messages(hook, logrus.ErrorLevel))
+}
+
+func countMessage(hook *test.Hook, message string) int {
+	var n int
+	for _, msg := range messages(hook) {
+		if msg == message {
+			n++
+		}
+	}
+	return n
+}
+
+func TestCronsRegistration_TickSkipsAFireLandingOnARunningTick(t *testing.T) {
+	c, _, _, _ := newTestRegistration(t, time.Minute)
+	release := make(chan struct{})
+	body, inTick, _ := blockingTick(release)
+	var bodies atomic.Int32
+	job := c.tickJob(context.Background(), cron.RunOnEveryNode, func(ctx context.Context) {
+		bodies.Add(1)
+		body(ctx)
+	})
+
+	go job.Run()
+	<-inTick // the first body holds runMu
+
+	returned := make(chan struct{})
+	go func() {
+		defer close(returned)
+		job.Run()
+	}()
+	// SkipIfStillRunning drops the second fire and returns at once. runMu
+	// alone would park it here until the body above returns, which is a
+	// delayed run rather than a skipped one.
+	skipped := true
+	select {
+	case <-returned:
+	case <-time.After(2 * time.Second):
+		skipped = false
+	}
+
+	close(release)
+	<-returned
+	assert.True(t, skipped, "a fire landing on a running tick must be dropped, not queued")
+	assert.Equal(t, int32(1), bodies.Load(), "the dropped fire must not run a tick body")
+}
+
+// requireHookReturns calls the runtime config hook off the test goroutine, so a
+// hook that pushes onto a channel it did not drain fails rather than wedging.
+func requireHookReturns(t *testing.T, c *cronsRegistration[time.Duration]) {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- c.RuntimeConfigHook() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("the runtime config hook must drain the channel before it pushes")
+	}
+}
+
+func TestCronsRegistration_RuntimeConfigHookKeepsTheLatestValue(t *testing.T) {
+	c, _, _, _ := newTestRegistration(t, time.Minute)
+	var interval atomic.Int64
+	c.configuredValue = func() time.Duration { return time.Duration(interval.Load()) }
+
+	// Nothing consumes the channel here, so the seeded value is still in it
+	// and both pushes have to replace what they find.
+	interval.Store(int64(2 * time.Minute))
+	requireHookReturns(t, c)
+	interval.Store(int64(3 * time.Minute))
+	requireHookReturns(t, c)
+
+	require.Len(t, c.valueCh, 1, "the channel must hold one value, not a backlog")
+	assert.Equal(t, 3*time.Minute, <-c.valueCh, "the loop must read the latest value")
+}
+
+func TestCrons_RuntimeConfigHookReRegistersTheJob(t *testing.T) {
+	c, cr, _, _ := newTestRegistration(t, time.Minute)
+	var interval atomic.Int64
+	interval.Store(int64(time.Minute))
+	c.configuredValue = func() time.Duration { return time.Duration(interval.Load()) }
+	crons := &Crons{}
+	require.NoError(t, crons.add(c))
+
+	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, time.Minute)
+
+	// Through the map startup reads, not the method: that map is the only
+	// thing joining a runtime config change to the registration loop.
+	hook, ok := crons.RuntimeConfigHooks()["TestJob"]
+	require.True(t, ok, "the registrant's hook key must reach the map")
+	interval.Store(int64(2 * time.Minute))
+	require.NoError(t, hook())
+
+	requireRegisteredAt(t, cr, 2*time.Minute)
 }

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -68,12 +68,12 @@ func scheduleDelay(cr *gocron.Cron, name string) (time.Duration, bool) {
 	return schedule.Delay, ok
 }
 
-func requireRegisteredAt(t *testing.T, cr *gocron.Cron, delay time.Duration) {
+func requireRegisteredAt(t *testing.T, cr *gocron.Cron, name string, delay time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		got, ok := scheduleDelay(cr, testJobName)
+		got, ok := scheduleDelay(cr, name)
 		return ok && got == delay
-	}, 2*time.Second, 10*time.Millisecond, "job should be registered at %s", delay)
+	}, 2*time.Second, 10*time.Millisecond, "%s should be registered at %s", name, delay)
 }
 
 // requireNoGoroutine asserts start launched no registration goroutine. wait
@@ -379,7 +379,7 @@ func TestCronsRegistration_Registration(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, tt.wantStarted, started)
 			if tt.wantRegistered {
-				requireRegisteredAt(t, cr, time.Minute)
+				requireRegisteredAt(t, cr, testJobName, time.Minute)
 				return
 			}
 			// Absence needs a settling window; the loop consumes its first
@@ -399,13 +399,13 @@ func TestCronsRegistration_ReRegistrationReplacesTheEntry(t *testing.T) {
 	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
 	require.NoError(t, err)
 	require.True(t, started)
-	requireRegisteredAt(t, cr, time.Minute)
+	requireRegisteredAt(t, cr, testJobName, time.Minute)
 
 	before := cr.EntryByName(testJobName).ID
 
 	c.valueCh <- 2 * time.Minute
 
-	requireRegisteredAt(t, cr, 2*time.Minute)
+	requireRegisteredAt(t, cr, testJobName, 2*time.Minute)
 	assert.Len(t, cr.Entries(), 1)
 	// The upsert reuses the entry; a remove-and-add would allocate a new id.
 	assert.Equal(t, before, cr.EntryByName(testJobName).ID)
@@ -442,7 +442,7 @@ func TestCronsRegistration_DisableRemovesRunningJob(t *testing.T) {
 			require.NoError(t, err)
 			require.True(t, started)
 			if tt.initial > 0 {
-				requireRegisteredAt(t, cr, tt.initial)
+				requireRegisteredAt(t, cr, testJobName, tt.initial)
 			}
 
 			for _, push := range tt.pushes {
@@ -450,7 +450,7 @@ func TestCronsRegistration_DisableRemovesRunningJob(t *testing.T) {
 			}
 
 			if tt.want > 0 {
-				requireRegisteredAt(t, cr, tt.want)
+				requireRegisteredAt(t, cr, testJobName, tt.want)
 				return
 			}
 			// Poll the log, not the entry: the loop deletes the entry and
@@ -477,7 +477,7 @@ func TestCronsRegistration_BadScheduleKeepsRegistration(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.True(t, started)
-	requireRegisteredAt(t, cr, time.Minute)
+	requireRegisteredAt(t, cr, testJobName, time.Minute)
 
 	// No validator clears a sub-second @every, so the parser refuses it.
 	c.resolve = func(time.Duration) (string, bool) { return "@every 500ms", true }
@@ -536,7 +536,7 @@ func TestCronsRegistration_SwapDrainsTickInFlight(t *testing.T) {
 	started, err := c.start(cr, cron.RunOnEveryNode, tick)
 	require.NoError(t, err)
 	require.True(t, started)
-	requireRegisteredAt(t, cr, time.Second)
+	requireRegisteredAt(t, cr, testJobName, time.Second)
 	cr.Start()
 	t.Cleanup(func() { cr.Stop() })
 
@@ -552,7 +552,7 @@ func TestCronsRegistration_SwapDrainsTickInFlight(t *testing.T) {
 	assert.Equal(t, time.Second, delay, "the swap completed before the tick returned")
 
 	close(release)
-	requireRegisteredAt(t, cr, 2*time.Second)
+	requireRegisteredAt(t, cr, testJobName, 2*time.Second)
 	// The barrier alone would also hold the assertion above, so pin the swap
 	// itself: the upsert keeps the entry id, a remove-and-add allocates one.
 	assert.Equal(t, before, cr.EntryByName(testJobName).ID)
@@ -567,7 +567,7 @@ func TestCronsRegistration_ExcludesAcrossRemoveAndReAdd(t *testing.T) {
 	started, err := c.start(cr, cron.RunOnEveryNode, tick)
 	require.NoError(t, err)
 	require.True(t, started)
-	requireRegisteredAt(t, cr, time.Second)
+	requireRegisteredAt(t, cr, testJobName, time.Second)
 	cr.Start()
 	t.Cleanup(func() { cr.Stop() })
 
@@ -584,7 +584,7 @@ func TestCronsRegistration_ExcludesAcrossRemoveAndReAdd(t *testing.T) {
 	assert.Equal(t, int32(1), peak.Load(), "a second tick body must not run alongside the first")
 
 	close(release)
-	requireRegisteredAt(t, cr, time.Second)
+	requireRegisteredAt(t, cr, testJobName, time.Second)
 }
 
 func TestCronsRegistration_RefusedFirstScheduleRegistersNothing(t *testing.T) {
@@ -629,7 +629,7 @@ func TestCronsRegistration_CancelOnChangeEndsTheReplacedTick(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.True(t, started)
-			requireRegisteredAt(t, cr, time.Minute)
+			requireRegisteredAt(t, cr, testJobName, time.Minute)
 
 			// Run the job to read the context it was handed, then replace it.
 			cr.EntryByName(testJobName).Run()
@@ -641,7 +641,7 @@ func TestCronsRegistration_CancelOnChangeEndsTheReplacedTick(t *testing.T) {
 
 			// The cancel runs ahead of the upsert, so a visible replacement
 			// means it has already fired or never will.
-			requireRegisteredAt(t, cr, 2*time.Minute)
+			requireRegisteredAt(t, cr, testJobName, 2*time.Minute)
 			assert.Equal(t, tt.wantCancelled, replaced.Err() != nil,
 				"only a cancelOnChange job ends the tick it replaces")
 		})
@@ -654,7 +654,7 @@ func TestCronsRegistration_ShutdownAfterTheBarrierRegistersNothing(t *testing.T)
 	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
 	require.NoError(t, err)
 	require.True(t, started)
-	requireRegisteredAt(t, cr, time.Minute)
+	requireRegisteredAt(t, cr, testJobName, time.Minute)
 
 	// Stand in for a tick in flight: the loop parks on the barrier, which is
 	// the window the shutdown re-check behind it covers.
@@ -761,7 +761,7 @@ func TestCrons_RuntimeConfigHookReRegistersTheJob(t *testing.T) {
 	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
 	require.NoError(t, err)
 	require.True(t, started)
-	requireRegisteredAt(t, cr, time.Minute)
+	requireRegisteredAt(t, cr, testJobName, time.Minute)
 
 	// Through the map startup reads, not the method: that map is the only
 	// thing joining a runtime config change to the registration loop.
@@ -770,5 +770,5 @@ func TestCrons_RuntimeConfigHookReRegistersTheJob(t *testing.T) {
 	interval.Store(int64(2 * time.Minute))
 	require.NoError(t, hook())
 
-	requireRegisteredAt(t, cr, 2*time.Minute)
+	requireRegisteredAt(t, cr, testJobName, 2*time.Minute)
 }

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -506,7 +506,7 @@ func TestCronsRegistration_BadScheduleKeepsRegistration(t *testing.T) {
 }
 
 func TestCronsRegistration_TickSkipsADeadContext(t *testing.T) {
-	c, _, _, _ := newTestRegistration(t, time.Minute)
+	c, _, hook, _ := newTestRegistration(t, time.Minute)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	var ticked bool
@@ -516,6 +516,8 @@ func TestCronsRegistration_TickSkipsADeadContext(t *testing.T) {
 	c.tickJob(ctx, cron.RunOnEveryNode, func(context.Context) { ticked = true }).Run()
 
 	assert.False(t, ticked, "a fire from the generation being replaced must not run")
+	assert.Contains(t, messages(hook), "cron tick skipped, its context has ended",
+		"a skipped fire must say why, so a gap in the sweep log is explainable")
 	require.True(t, c.runMu.TryLock(), "the skipped fire must release runMu")
 	c.runMu.Unlock()
 }
@@ -558,17 +560,22 @@ func TestCronsRegistration_TickChecksItsContextUnderRunMu(t *testing.T) {
 
 func TestCronsRegistration_TickGate(t *testing.T) {
 	tests := []struct {
-		name     string
-		tickGate func() bool
-		wantTick bool
+		name        string
+		tickGate    func() bool
+		wantTick    bool
+		wantSkipLog bool
 	}{
-		{name: "a gate that denies never calls the tick", tickGate: func() bool { return false }},
+		{
+			name:        "a gate that denies never calls the tick",
+			tickGate:    func() bool { return false },
+			wantSkipLog: true,
+		},
 		{name: "a gate that allows calls the tick", tickGate: func() bool { return true }, wantTick: true},
 		{name: "RunOnEveryNode always calls the tick", tickGate: cron.RunOnEveryNode, wantTick: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, _, _, _ := newTestRegistration(t, time.Minute)
+			c, _, hook, _ := newTestRegistration(t, time.Minute)
 			var ticked bool
 
 			// Drive the job directly: initGoCron returns an unstarted cron and
@@ -577,6 +584,9 @@ func TestCronsRegistration_TickGate(t *testing.T) {
 			c.tickJob(context.Background(), tt.tickGate, func(context.Context) { ticked = true }).Run()
 
 			assert.Equal(t, tt.wantTick, ticked)
+			assert.Equal(t, tt.wantSkipLog,
+				slices.Contains(messages(hook), "cron tick skipped by its gate"),
+				"only a denied fire says the gate skipped it")
 		})
 	}
 }

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -505,6 +505,43 @@ func TestCronsRegistration_BadScheduleKeepsRegistration(t *testing.T) {
 	assert.NoError(t, (*tickCtx.Load()).Err())
 }
 
+// TestCronsRegistration_RefusedRegistrationLeavesNoEntry pins the branch a
+// failed replacement takes: it names the state it left and removes the stale
+// entry, so no job survives firing into a context the loop already cancelled.
+// Only the arm with nothing to remove is reachable — an entry already carrying
+// the job name sends DrainAndUpsertJob down a pause-and-swap path the library
+// gives no way to fail — so the other arm is an explicit gap.
+func TestCronsRegistration_RefusedRegistrationLeavesNoEntry(t *testing.T) {
+	c, _, hook, _ := newTestRegistration(t, time.Minute)
+	// One slot, already taken, is what makes the registration fail: initGoCron
+	// caps nothing, so the cron it builds accepts every job it is offered.
+	cr := gocron.New(gocron.WithParser(cron.Parser()),
+		gocron.WithLogger(gocron.DiscardLogger), gocron.WithMaxEntries(1))
+	_, err := cr.AddFunc("@every 1h", func() {}, gocron.WithName("occupied"))
+	require.NoError(t, err)
+
+	started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+	require.NoError(t, err)
+	require.True(t, started)
+
+	require.Eventually(t, func() bool {
+		return len(messages(hook, logrus.ErrorLevel)) == 1
+	}, 2*time.Second, 10*time.Millisecond, "the refused registration should log one error")
+	assert.Contains(t, messages(hook, logrus.ErrorLevel)[0],
+		"cron job not added, no job is registered",
+		"a failed registration must name the state it left the job in")
+	assert.Equal(t, "@every 1m0s", hook.LastEntry().Data["schedule"],
+		"the refused spec must reach the log record")
+	assert.False(t, cr.EntryByName(testJobName).Valid(),
+		"a failed registration must leave no entry under the job name")
+
+	// The loop survives the refusal rather than exiting on it: freeing the slot
+	// and pushing again registers the job.
+	require.True(t, cr.RemoveByName("occupied"))
+	c.valueCh <- 2 * time.Minute
+	requireRegisteredAt(t, cr, testJobName, 2*time.Minute)
+}
+
 func TestCronsRegistration_TickSkipsADeadContext(t *testing.T) {
 	c, _, hook, _ := newTestRegistration(t, time.Minute)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -79,7 +79,7 @@ func requireRegisteredAt(t *testing.T, cr *gocron.Cron, name string, delay time.
 // requireNoGoroutine asserts start launched no registration goroutine. wait
 // blocks until one exits, and these tests never trigger the shutdown that
 // would end it, so the helper times out rather than hanging.
-func requireNoGoroutine(t *testing.T, c *cronsRegistration[time.Duration]) {
+func requireNoGoroutine[T comparable](t *testing.T, c *cronsRegistration[T]) {
 	t.Helper()
 	done := make(chan struct{})
 	go func() {
@@ -220,6 +220,7 @@ type stubRegistrant struct {
 func (r stubRegistrant) jobName() string          { return r.name }
 func (r stubRegistrant) hookKey() string          { return r.key }
 func (r stubRegistrant) RuntimeConfigHook() error { return nil }
+func (r stubRegistrant) wait()                    {}
 
 func TestCrons_AddRejects(t *testing.T) {
 	tests := []struct {
@@ -264,7 +265,7 @@ func TestCrons_RuntimeConfigHooks(t *testing.T) {
 			// must already be there without one.
 			name: "both registrants, collected before Init",
 			crons: func(t *testing.T) *Crons {
-				c, _, cancel := newTestCrons(t)
+				c, _, _, cancel := newTestCrons(t)
 				t.Cleanup(cancel)
 				return c
 			},
@@ -501,6 +502,19 @@ func TestCronsRegistration_BadScheduleKeepsRegistration(t *testing.T) {
 	cr.EntryByName(testJobName).Run()
 	require.NotNil(t, tickCtx.Load())
 	assert.NoError(t, (*tickCtx.Load()).Err())
+}
+
+func TestCronsRegistration_TickSkipsADeadContext(t *testing.T) {
+	c, _, _, _ := newTestRegistration(t, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var ticked bool
+
+	// Drive the job directly: this is the fire the loop cannot prevent, the one
+	// dispatched between its cancel and its swap.
+	c.tickJob(ctx, cron.RunOnEveryNode, func(context.Context) { ticked = true }).Run()
+
+	assert.False(t, ticked, "a fire from the generation being replaced must not run")
 }
 
 func TestCronsRegistration_TickGate(t *testing.T) {
@@ -770,5 +784,83 @@ func TestCrons_RuntimeConfigHookReRegistersTheJob(t *testing.T) {
 	interval.Store(int64(2 * time.Minute))
 	require.NoError(t, hook())
 
+	requireRegisteredAt(t, cr, testJobName, 2*time.Minute)
+}
+
+func TestCronsRegistration_DeadLoopReportsAnError(t *testing.T) {
+	tests := []struct {
+		name    string
+		stopped bool
+		wantErr string
+	}{
+		{
+			name:    "a stopped loop refuses the value it cannot apply",
+			stopped: true,
+			wantErr: "has no registration loop running",
+		},
+		{name: "a live loop takes it"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, cr, _, cancel := newTestRegistration(t, time.Minute)
+			var interval atomic.Int64
+			interval.Store(int64(2 * time.Minute))
+			c.configuredValue = func() time.Duration { return time.Duration(interval.Load()) }
+			if tt.stopped {
+				started, err := c.start(cr, cron.RunOnEveryNode, func(context.Context) {})
+				require.NoError(t, err)
+				require.True(t, started)
+				requireRegisteredAt(t, cr, testJobName, time.Minute)
+				cancel()
+				c.wait()
+			}
+
+			err := c.RuntimeConfigHook()
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				// A refused hook queues nothing, so no value waits for a loop
+				// that will never read it.
+				assert.Empty(t, c.valueCh)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, 2*time.Minute, <-c.valueCh)
+		})
+	}
+}
+
+// TestCronsRegistration_CancelPrecedesTheSwap pins the ordering inside the
+// loop: a cancelOnChange job ends the tick in flight before it waits on the
+// barrier, so a re-registration never waits out a full run.
+func TestCronsRegistration_CancelPrecedesTheSwap(t *testing.T) {
+	c, cr, _, _ := newTestRegistration(t, time.Minute)
+	c.cancelOnChange = true
+	release := make(chan struct{})
+	defer close(release)
+	inTick := make(chan struct{}, 1)
+	// The tick returns on its own context as well as on release, so a cancel
+	// that fires ends it and one that does not leaves it parked.
+	started, err := c.start(cr, cron.RunOnEveryNode, func(ctx context.Context) {
+		select {
+		case inTick <- struct{}{}:
+		default:
+		}
+		select {
+		case <-ctx.Done():
+		case <-release:
+		}
+	})
+	require.NoError(t, err)
+	require.True(t, started)
+	requireRegisteredAt(t, cr, testJobName, time.Minute)
+
+	go cr.EntryByName(testJobName).Run()
+	<-inTick // a tick is in flight and holds runMu
+
+	c.valueCh <- 2 * time.Minute
+
+	// Nothing releases the tick, so the re-registration can only complete if
+	// the cancel ran ahead of the barrier.
 	requireRegisteredAt(t, cr, testJobName, 2*time.Minute)
 }

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -1,0 +1,102 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cron
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRegistrant carries no cron job, so add can be driven on names the two
+// real registrants cannot produce.
+type stubRegistrant struct {
+	name string
+	key  string
+}
+
+func (r stubRegistrant) jobName() string          { return r.name }
+func (r stubRegistrant) hookKey() string          { return r.key }
+func (r stubRegistrant) RuntimeConfigHook() error { return nil }
+
+func TestCrons_AddRejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing []registrant
+		add      registrant
+	}{
+		{
+			name: "an empty job name",
+			add:  stubRegistrant{name: "", key: "ObjectsTTL"},
+		},
+		{
+			name:     "a job name another registrant already holds",
+			existing: []registrant{stubRegistrant{name: namespaceCleanupJobName, key: "NamespaceCleanup"}},
+			add:      stubRegistrant{name: namespaceCleanupJobName, key: "ObjectsTTL"},
+		},
+		{
+			name:     "a runtime config hook key another registrant already holds",
+			existing: []registrant{stubRegistrant{name: namespaceCleanupJobName, key: "NamespaceCleanup"}},
+			add:      stubRegistrant{name: objectsTTLJobName, key: "NamespaceCleanup"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Crons{registrations: tt.existing}
+
+			require.Error(t, c.add(tt.add))
+			assert.Len(t, c.registrations, len(tt.existing),
+				"a rejected registrant must not join the slice")
+		})
+	}
+}
+
+func TestCrons_RuntimeConfigHooks(t *testing.T) {
+	tests := []struct {
+		name  string
+		crons func(t *testing.T) *Crons
+		want  []string
+	}{
+		{
+			// Startup reads the map before anything calls Init, so both keys
+			// must already be there without one.
+			name: "both registrants, collected before Init",
+			crons: func(t *testing.T) *Crons {
+				logger, _ := test.NewNullLogger()
+				ctx, cancel := context.WithCancel(context.Background())
+				t.Cleanup(cancel)
+
+				c, err := NewCrons(ctx, logger, intervalConfig(time.Minute))
+				require.NoError(t, err)
+				return c
+			},
+			want: []string{"NamespaceCleanup", "ObjectsTTL"},
+		},
+		{
+			name:  "no registrants",
+			crons: func(*testing.T) *Crons { return &Crons{} },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hooks := tt.crons(t).RuntimeConfigHooks()
+
+			assert.ElementsMatch(t, tt.want, slices.Collect(maps.Keys(hooks)))
+		})
+	}
+}

--- a/usecases/cron/registration_test.go
+++ b/usecases/cron/registration_test.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -515,6 +516,44 @@ func TestCronsRegistration_TickSkipsADeadContext(t *testing.T) {
 	c.tickJob(ctx, cron.RunOnEveryNode, func(context.Context) { ticked = true }).Run()
 
 	assert.False(t, ticked, "a fire from the generation being replaced must not run")
+	require.True(t, c.runMu.TryLock(), "the skipped fire must release runMu")
+	c.runMu.Unlock()
+}
+
+// lockProbeCtx cancels itself when a context check reads it while mu is held,
+// and reports the value that cancel leaves. A check made ahead of the lock
+// finds mu free and reads a live context.
+type lockProbeCtx struct {
+	context.Context
+	mu     *sync.Mutex
+	cancel context.CancelFunc
+}
+
+func (c *lockProbeCtx) Err() error {
+	if c.mu.TryLock() {
+		c.mu.Unlock()
+	} else {
+		c.cancel()
+	}
+	return c.Context.Err()
+}
+
+// TestCronsRegistration_TickChecksItsContextUnderRunMu pins where the check
+// sits. The loop cancels the tick context before its barrier, so a check made
+// ahead of runMu misses a cancel that lands while the fire waits for the lock.
+func TestCronsRegistration_TickChecksItsContextUnderRunMu(t *testing.T) {
+	c, _, _, _ := newTestRegistration(t, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var ticked bool
+
+	// The probe stands in for the loop's cancel, which only a check made under
+	// runMu can see: a fire waiting for the lock reaches its check behind it.
+	tickCtx := &lockProbeCtx{Context: ctx, mu: &c.runMu, cancel: cancel}
+	c.tickJob(tickCtx, cron.RunOnEveryNode, func(context.Context) { ticked = true }).Run()
+
+	assert.False(t, ticked,
+		"a fire whose context died while it waited for runMu must not run")
 }
 
 func TestCronsRegistration_TickGate(t *testing.T) {

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -85,9 +85,12 @@ type RBACLister interface {
 	GetRolesForUserOrGroup(user string, authMethod authentication.AuthType, isGroup bool) (map[string][]authorization.Policy, error)
 }
 
-// Coordinator runs one cleanup pass per Tick on the leader. isLeader is
-// re-checked before every RAFT write so the old leader stops issuing
-// writes once leadership moves.
+// Coordinator runs one cleanup pass per Tick on the leader. Tick re-checks
+// isLeader itself, so it holds under any caller, and re-checks it again before
+// every RAFT write, so a leader demoted mid-pass stops issuing them. A
+// partitioned leader still reads true; its writes fail to reach a quorum. A
+// cleanly demoted one has its write forwarded to the new leader and applied,
+// so those re-checks, not RAFT, bound a stale pass to one write.
 type Coordinator struct {
 	namespaces namespaceLister
 	schema     schemaLister

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -35,6 +35,17 @@ type stubNamespaces struct{ deleting []string }
 
 func (s stubNamespaces) ListDeleting() []string { return s.deleting }
 
+// countingNamespaces records how many times the deleting list was read.
+type countingNamespaces struct {
+	deleting []string
+	calls    *int
+}
+
+func (c countingNamespaces) ListDeleting() []string {
+	*c.calls++
+	return c.deleting
+}
+
 // stubSchema returns the configured per-namespace residuals.
 type stubSchema struct {
 	classes    map[string][]string
@@ -897,4 +908,33 @@ func opsOf(calls []recordedCall) []string {
 		out = append(out, c.op)
 	}
 	return out
+}
+
+// TestCoordinator_Tick_FollowerReadsNothing pins Tick's own leadership check.
+// The guards below it already keep raftExecutor untouched on a follower, so a
+// test asserting only on raft calls stays green with that check deleted. The
+// list read is the first thing the check actually prevents.
+func TestCoordinator_Tick_FollowerReadsNothing(t *testing.T) {
+	tests := []struct {
+		name      string
+		isLeader  func() bool
+		wantCalls int
+	}{
+		{name: "a follower never reads the deleting list", isLeader: func() bool { return false }},
+		{name: "a leader reads it once per tick", isLeader: alwaysLeader, wantCalls: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			ns := countingNamespaces{deleting: []string{"alpha"}, calls: &calls}
+			logger, _ := test.NewNullLogger()
+
+			c := NewCoordinator(ns, stubSchema{}, stubUsers{}, newStubRaft(), nil, tt.isLeader, logger)
+
+			require.NoError(t, c.Tick(context.Background()))
+
+			assert.Equal(t, tt.wantCalls, calls,
+				"Tick must not reach the deleting list unless this node leads")
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed

Closes: https://github.com/weaviate/weaviate/pull/10477 which also introduced the goCron update

Both cron jobs — objects-TTL deletion and namespace cleanup — carried their own copy of the same plumbing: read a config value, render a cron spec, register, re-register on a runtime-config push, gate the tick on leadership, join at
shutdown. 

This PR refactors it into one generic `cronsRegistration[T]` helper in `usecases/cron` and rebuilds both jobs on it. Two more cron jobs are planned and register on the same helper rather than becoming copies three and four.

**gocron v0.9.1 → v0.15.1** is required for `DrainAndUpsertJob`: it pauses an entry, waits out a tick in flight, swaps the schedule and job, and resumes. Remove-then-add left a window where the job was doubled or missing.

**Behaviour changes**

- `NAMESPACE_CLEANUP_INTERVAL` at or below zero schedules at the 30s default instead of disabling the sweep. Setting `0` no longer stops it.
- A positive interval under one second is refused at startup; a negative one is now accepted.
- Cron job names and runtime-config hook keys are validated at boot. A typo'd hook key used to silently disable that setting's hot reload.
- `OBJECTS_TTL_DELETE_SCHEDULE` accepts more schedule grammars with the new parser.
- A tick whose context ended while it waited for the lock skips instead of running, and says so in the log.
- `Crons.Init` drains running ticks and joins every registration goroutine under a 30s cap. Nothing at the shutdown site waits on that yet; it lands separately.
