### PR TITLE
perf(async-replication): size prefilter chunk map by input, release dispatch buckets every pass

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -574,7 +574,7 @@ type AsyncReplicationScheduler struct {
 
 	// batchPool recycles the []*asyncSchedulerEntry slices sent on workCh.
 	batchPool sync.Pool
-	// dispatchBuckets groups due entries by index during one dispatch pass; dispatcher-owned.
+	// dispatchBuckets groups due entries by index during one dispatch pass; dispatcher-owned, emptied at the end of every pass.
 	dispatchBuckets map[*Index][]*asyncSchedulerEntry
 
 	metrics asyncReplicationSchedulerMetrics
@@ -1114,18 +1114,18 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 	}
 
 	// Flush partial buckets: a bucket below the cap ships as a smaller batch, or
-	// rolls back on a full channel.
+	// rolls back on a full channel. Keys are deleted so a dropped index (and the
+	// stale entry pointers in its bucket's backing array) is never pinned.
 	for idx, entries := range sched.dispatchBuckets {
-		if len(entries) == 0 {
-			continue
-		}
-		if full || !sched.trySendBatchLocked(entries) {
-			for _, e := range entries {
-				sched.rollbackReservedLocked(e)
+		if len(entries) > 0 {
+			if full || !sched.trySendBatchLocked(entries) {
+				for _, e := range entries {
+					sched.rollbackReservedLocked(e)
+				}
+				full = true
 			}
-			full = true
 		}
-		sched.dispatchBuckets[idx] = entries[:0]
+		delete(sched.dispatchBuckets, idx)
 	}
 	sched.metrics.setQueueDepth(len(sched.h))
 }
@@ -1246,7 +1246,7 @@ func (sched *AsyncReplicationScheduler) settleDispatchBucketsOnExit() {
 			entry.inFlight = false
 			entry.settleDone()
 		}
-		sched.dispatchBuckets[idx] = entries[:0]
+		delete(sched.dispatchBuckets, idx)
 	}
 }
 

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -3047,7 +3047,53 @@ func TestSettleDispatchBucketsOnExit(t *testing.T) {
 
 	awaitAsyncRepWg(t, s, "stranded bucket reservation must settle")
 	assert.False(t, entry.inFlight)
-	assert.Empty(t, sched.dispatchBuckets[idx])
+	assert.Empty(t, sched.dispatchBuckets)
+}
+
+// TestDispatchBucketsEmptiedEveryPass: no *Index key may survive a dispatch pass, or dropped collections stay pinned forever.
+func TestDispatchBucketsEmptiedEveryPass(t *testing.T) {
+	t.Run("after coalesced dispatch", func(t *testing.T) {
+		sched := newBareScheduler(512, 16)
+		a := &Index{Config: IndexConfig{ClassName: "A"}}
+		b := &Index{Config: IndexConfig{ClassName: "B"}}
+		for range 3 {
+			sched.onAddLocked(&Shard{index: a, class: &models.Class{Class: "A"}})
+		}
+		for range 2 {
+			sched.onAddLocked(&Shard{index: b, class: &models.Class{Class: "B"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.ElementsMatch(t, []int{3, 2}, drainBatchSizes(sched.workCh))
+		assert.Empty(t, sched.dispatchBuckets)
+	})
+
+	t.Run("after mid-pass full batch", func(t *testing.T) {
+		sched := newBareScheduler(2, 16)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}}
+		for range 4 {
+			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.ElementsMatch(t, []int{2, 2}, drainBatchSizes(sched.workCh))
+		assert.Empty(t, sched.dispatchBuckets)
+	})
+
+	t.Run("after full-channel rollback", func(t *testing.T) {
+		sched := newBareScheduler(512, 0)
+		idx := &Index{Config: IndexConfig{ClassName: "C"}}
+		for range 3 {
+			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
+		}
+
+		sched.dispatchDueLocked()
+
+		assert.Len(t, sched.h, 3)
+		assert.Empty(t, sched.dispatchBuckets)
+	})
 }
 
 // TestDeregisterSettlesEntriesAwaitingPrefilter: entries parked behind the root pre-filter stay settleable, so teardown drains never wait out an RPC bound to sched.ctx.

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
+	entschema "github.com/weaviate/weaviate/entities/schema"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
@@ -3052,48 +3053,35 @@ func TestSettleDispatchBucketsOnExit(t *testing.T) {
 
 // TestDispatchBucketsEmptiedEveryPass: no *Index key may survive a dispatch pass, or dropped collections stay pinned forever.
 func TestDispatchBucketsEmptiedEveryPass(t *testing.T) {
-	t.Run("after coalesced dispatch", func(t *testing.T) {
-		sched := newBareScheduler(512, 16)
-		a := &Index{Config: IndexConfig{ClassName: "A"}}
-		b := &Index{Config: IndexConfig{ClassName: "B"}}
-		for range 3 {
-			sched.onAddLocked(&Shard{index: a, class: &models.Class{Class: "A"}})
-		}
-		for range 2 {
-			sched.onAddLocked(&Shard{index: b, class: &models.Class{Class: "B"}})
-		}
+	tests := []struct {
+		name           string
+		batchSize      int
+		workChCap      int
+		shardsByClass  map[string]int
+		wantBatchSizes []int
+		wantHeapLen    int
+	}{
+		{"after coalesced dispatch", 512, 16, map[string]int{"A": 3, "B": 2}, []int{3, 2}, 0},
+		{"after mid-pass full batch", 2, 16, map[string]int{"C": 4}, []int{2, 2}, 0},
+		{"after full-channel rollback", 512, 0, map[string]int{"C": 3}, nil, 3},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sched := newBareScheduler(tc.batchSize, tc.workChCap)
+			for class, n := range tc.shardsByClass {
+				idx := &Index{Config: IndexConfig{ClassName: entschema.ClassName(class)}}
+				for range n {
+					sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: class}})
+				}
+			}
 
-		sched.dispatchDueLocked()
+			sched.dispatchDueLocked()
 
-		assert.ElementsMatch(t, []int{3, 2}, drainBatchSizes(sched.workCh))
-		assert.Empty(t, sched.dispatchBuckets)
-	})
-
-	t.Run("after mid-pass full batch", func(t *testing.T) {
-		sched := newBareScheduler(2, 16)
-		idx := &Index{Config: IndexConfig{ClassName: "C"}}
-		for range 4 {
-			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
-		}
-
-		sched.dispatchDueLocked()
-
-		assert.ElementsMatch(t, []int{2, 2}, drainBatchSizes(sched.workCh))
-		assert.Empty(t, sched.dispatchBuckets)
-	})
-
-	t.Run("after full-channel rollback", func(t *testing.T) {
-		sched := newBareScheduler(512, 0)
-		idx := &Index{Config: IndexConfig{ClassName: "C"}}
-		for range 3 {
-			sched.onAddLocked(&Shard{index: idx, class: &models.Class{Class: "C"}})
-		}
-
-		sched.dispatchDueLocked()
-
-		assert.Len(t, sched.h, 3)
-		assert.Empty(t, sched.dispatchBuckets)
-	})
+			assert.ElementsMatch(t, tc.wantBatchSizes, drainBatchSizes(sched.workCh))
+			assert.Len(t, sched.h, tc.wantHeapLen)
+			assert.Empty(t, sched.dispatchBuckets)
+		})
+	}
 }
 
 // TestDeregisterSettlesEntriesAwaitingPrefilter: entries parked behind the root pre-filter stay settleable, so teardown drains never wait out an RPC bound to sched.ctx.

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -613,7 +613,7 @@ func (f *Finder) PrefilterShardRoots(ctx context.Context,
 	}
 
 	var stats PrefilterStats
-	chunk := make(map[string]hashtree.Digest, prefilterMaxShardsPerRPC)
+	chunk := make(map[string]hashtree.Digest, min(len(roots), prefilterMaxShardsPerRPC))
 	flush := func(host string) {
 		if len(chunk) == 0 {
 			return

--- a/usecases/replica/finder_prefilter_internal_test.go
+++ b/usecases/replica/finder_prefilter_internal_test.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPrefilterShardRootsAllocsScaleWithInput: per-call allocations must scale with len(roots), not prefilterMaxShardsPerRPC.
+func TestPrefilterShardRootsAllocsScaleWithInput(t *testing.T) {
+	f := &Finder{}
+	ctx := context.Background()
+	f.PrefilterShardRoots(ctx, nil)
+
+	const iters = 100
+	runtime.GC()
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	for range iters {
+		f.PrefilterShardRoots(ctx, nil)
+	}
+	runtime.ReadMemStats(&after)
+
+	perCall := (after.TotalAlloc - before.TotalAlloc) / iters
+	assert.Less(t, perCall, uint64(8*1024))
+}


### PR DESCRIPTION
## Motivation

Production alloc profiles on fleets with thousands of single-tenant collections show the async-replication root-prefilter path as the scheduler's dominant allocator (10GB-scale `alloc_space`): `PrefilterShardRoots` pre-sized its per-RPC chunk map for the worst case (`prefilterMaxShardsPerRPC` = 1000, ~82KB of map buckets) on every call, while per-index batches on such fleets carry only a few shards. Separately, the scheduler's `dispatchBuckets` map never released its keys: a dropped collection's `*Index` (and stale entry pointers in the bucket backing arrays) stayed pinned for the process lifetime, and every dispatch pass walked every bucket ever seen. Continues the async-replication allocation triage of #12481 and #12665.

## Approach

Two independent one-mechanism fixes, no pooling scheme:

- Size the chunk map by `min(len(roots), prefilterMaxShardsPerRPC)`. The hint stays exact in both regimes: per-host sub-maps are subsets of `roots`, and the existing flush threshold caps chunk occupancy at 1000 — small batches get small maps, large batches keep the old worst-case hint.
- Delete `dispatchBuckets` keys at the end of every dispatch pass (and in the panic-settlement path) instead of truncating to `[:0]`. The mid-pass cap-hit path still reuses the bucket within a pass; only cross-pass retention is dropped. The cost is one small slice allocation per active index per pass, traded against unbounded pinning of dropped indexes.

## Key areas for review

- [`finder.go#L616`](https://github.com/weaviate/weaviate/blob/b01348040fd58e4796a64033ab44f16fede23e6f/usecases/replica/finder.go#L616) — capacity hint only; flush threshold and chunk semantics untouched.
- [`async_replication_scheduler.go#L1119`](https://github.com/weaviate/weaviate/blob/b01348040fd58e4796a64033ab44f16fede23e6f/adapters/repos/db/async_replication_scheduler.go#L1119) — the flush loop now deletes keys during `range` (well-defined in Go). Verify entry ownership: rollback of reserved entries runs before the delete, and entries live in the heap and `entries` map — buckets are dispatcher-local scratch.
- Batches sent on `workCh` are copies made by `trySendBatchLocked` from `batchPool`, so releasing buckets cannot touch in-flight worker batches.

## Risks and mitigations

- **Losing entries on rollback or panic paths**: buckets never own entries — the heap and `entries` map do. Tests pin `dispatchBuckets` empty with the heap intact after a full-channel rollback, and after panic settlement.
- **Undersized map on large fleets**: `min` keeps the 1000 hint whenever `len(roots)` reaches the cap; chunk occupancy can never exceed either bound.

## Testing

- `TestPrefilterShardRootsAllocsScaleWithInput` pins per-call allocations under 8KB for a small input (~82KB before the fix).
- `TestDispatchBucketsEmptiedEveryPass` covers the three exits of a dispatch pass: coalesced multi-index dispatch, mid-pass full batch, and full-channel rollback.
- `TestSettleDispatchBucketsOnExit` tightened to assert the whole map is empty after panic settlement.
- Both packages pass with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
