### PR TITLE
perf(replication): cap zstd encoder concurrency and window in shared encoders

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"runtime"
 	"time"
 
 	"github.com/google/uuid"
@@ -56,14 +57,19 @@ const (
 
 type replicationClient struct {
 	retryClient
-	// Shared instance: EncodeAll is concurrency-safe and internally multiplexes GOMAXPROCS sub-encoders.
+	// Shared instance: EncodeAll is concurrency-safe and internally multiplexes a capped set of sub-encoders.
 	zstdEncoder *zstd.Encoder
 }
 
 var _ replica.Client = (*replicationClient)(nil)
 
 func NewReplicationClient(httpClient *http.Client) (*replicationClient, error) {
-	enc, err := zstd.NewWriter(nil)
+	// Sub-encoder state is retained for the process lifetime, so concurrency and
+	// window are capped: defaults hold GOMAXPROCS×~1.5MiB permanently and grow by
+	// 16MiB per sub-encoder on any payload over one block (128KiB).
+	enc, err := zstd.NewWriter(nil,
+		zstd.WithEncoderConcurrency(min(4, runtime.GOMAXPROCS(0))),
+		zstd.WithWindowSize(1<<20))
 	if err != nil {
 		return nil, fmt.Errorf("create zstd encoder: %w", err)
 	}

--- a/adapters/handlers/rest/clusterapi/shared/overwrite_compression.go
+++ b/adapters/handlers/rest/clusterapi/shared/overwrite_compression.go
@@ -13,6 +13,7 @@ package shared
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/klauspost/compress/zstd"
 )
@@ -30,7 +31,12 @@ const maxDecodedOverwriteRaw = 2 << 30 // 2 GiB
 
 func init() {
 	var err error
-	if overwriteRawZstdEncoder, err = zstd.NewWriter(nil); err != nil {
+	// Sub-encoder state is retained for the process lifetime, so concurrency and
+	// window are capped: defaults hold GOMAXPROCS×~1.5MiB permanently and grow by
+	// 16MiB per sub-encoder on any payload over one block (128KiB).
+	if overwriteRawZstdEncoder, err = zstd.NewWriter(nil,
+		zstd.WithEncoderConcurrency(min(4, runtime.GOMAXPROCS(0))),
+		zstd.WithWindowSize(1<<20)); err != nil {
 		panic(fmt.Sprintf("init overwrite raw zstd encoder: %v", err))
 	}
 	if overwriteRawZstdDecoder, err = zstd.NewReader(nil, zstd.WithDecoderMaxMemory(maxDecodedOverwriteRaw)); err != nil {

--- a/adapters/handlers/rest/clusterapi/shared/overwrite_compression_test.go
+++ b/adapters/handlers/rest/clusterapi/shared/overwrite_compression_test.go
@@ -69,3 +69,16 @@ func TestDecompressOverwriteRawRejectsGarbage(t *testing.T) {
 	_, err := DecompressOverwriteRaw([]byte("not zstd"))
 	require.Error(t, err)
 }
+
+// TestOverwriteRawCompressionRoundTripMultiBlock: payloads beyond the encoder window must survive the multi-block path.
+func TestOverwriteRawCompressionRoundTripMultiBlock(t *testing.T) {
+	payload := bytes.Repeat([]byte("weaviate-overwrite-raw-multi-block-payload-"), 100_000)
+	require.Greater(t, len(payload), 2<<20)
+
+	compressed := CompressOverwriteRaw(payload)
+	require.Less(t, len(compressed), len(payload))
+
+	restored, err := DecompressOverwriteRaw(compressed)
+	require.NoError(t, err)
+	assert.Equal(t, payload, restored)
+}


### PR DESCRIPTION
## Motivation

Inuse heap profiles attribute ~24.7MB (14% of inuse on the profiled node) to `zstd.(*Encoder).EncodeAll` under the replication REST client. This is not a leak: `zstd.NewWriter(nil)` with default options eagerly builds GOMAXPROCS sub-encoders of ~1.5MiB each (fast/double-fast tables plus block buffers) on first use, retained for the process lifetime. At 16 cores that is ~24.5MiB — matching the profile — and a second identical encoder exists on the gRPC overwrite path (`shared.CompressOverwriteRaw`), doubling the footprint when both transports are exercised.

There is also a latent cliff: with the default 8MiB window, any payload over one 128KiB block makes `ensureHist` permanently grow that sub-encoder by 16MiB (2× window). A height-20 hashtree level body is 131,080 bytes — 8 bytes over the block threshold — and large overwrite bodies cross it routinely; worst case is ~256MiB per encoder.

## Approach

Cap both shared encoders with `WithEncoderConcurrency(min(4, GOMAXPROCS))` and `WithWindowSize(1<<20)`:

- **Concurrency 4**: concurrent `EncodeAll` callers are the async-replication scheduler workers (default 1) plus read-repair overwrites; excess callers block briefly on the sub-encoder channel rather than erroring. Resident footprint drops from GOMAXPROCS×1.5MiB to ≤4×1.5MiB per encoder.
- **Window 1MiB**: no effect on hashtree-level bodies (≤128KiB); bounds worst-case history at 2MiB per sub-encoder (8MiB per encoder instead of 256MiB). Overwrite payloads larger than 1MiB lose some compression ratio on intra-cluster links — an acceptable trade for a hard memory bound.

Deliberately not `WithLowMem(true)`: lowMem trades resident bytes for per-call reallocation churn, the same churn that motivated replacing the old per-call `sync.Pool` encoders with these singletons.

Operational note: with `REPLICATION_GRPC_ENABLED=true` the hashtree-level path (#12666) skips zstd entirely and the REST client's encoder is never initialized (lazy `init.Do`).

## Key areas for review

- Encoder option parity between [`replication.go`](https://github.com/weaviate/weaviate/blob/4ffbe36b510cf34e8e746da5eb0d78872de52886/adapters/clients/replication.go#L65-L77) and [`overwrite_compression.go`](https://github.com/weaviate/weaviate/blob/4ffbe36b510cf34e8e746da5eb0d78872de52886/adapters/handlers/rest/clusterapi/shared/overwrite_compression.go#L31-L45); decoders are unchanged.
- Wire compatibility: window size is an encoder-side bound; frames remain standard zstd, so mixed-version peers decode them unchanged.

## Testing

- New `TestOverwriteRawCompressionRoundTripMultiBlock` round-trips a >2MiB payload through the capped encoder's multi-block path.
- Existing client tests already round-trip zstd request bodies through a fake server; all pass with `-race`, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
