### PR TITLE
perf(router): avoid full shard-list copy on single-shard routing plans

### DIFF
--- a/cluster/router/router.go
+++ b/cluster/router/router.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 // Builder provides a builder for creating router instances based on configuration.
@@ -277,20 +278,18 @@ func (r *singleTenantRouter) getWriteReplicasLocation(collection string, tenant 
 
 // targetShards returns either all shards or a single one, depending on the value of the shard parameter.
 func (r *singleTenantRouter) targetShards(collection, shardName string) ([]string, error) {
-	shards, err := r.schemaReader.Shards(collection)
-	if err != nil {
-		return nil, err
-	}
 	if shardName == "" {
-		return shards, nil
+		return r.schemaReader.Shards(collection)
 	}
 
+	// Membership check only — avoids Shards' sorted copy of the full shard list on every routing-plan build.
 	found := false
-	for _, shard := range shards {
-		if shard == shardName {
-			found = true
-			break
-		}
+	err := r.schemaReader.Read(collection, true, func(_ *models.Class, state *sharding.State) error {
+		_, found = state.Physical[shardName]
+		return nil
+	})
+	if err != nil {
+		return nil, err
 	}
 	if !found {
 		return nil, fmt.Errorf("error while trying to find shard: %s in collection: %s", shardName, collection)

--- a/cluster/router/router_test.go
+++ b/cluster/router/router_test.go
@@ -1031,13 +1031,10 @@ func TestSingleTenantRouter_GetReadWriteReplicasLocation_InvalidShard(t *testing
 	mockNodeSelector := mocks.NewMockNodeSelector("node1", "node2")
 
 	state := createShardingStateWithShards([]string{"shard1", "shard2"})
-	mockSchemaReader.EXPECT().Shards(mock.Anything).RunAndReturn(func(class string) ([]string, error) {
-		return []string{"foo", "bar"}, nil
-	})
 	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
 		class := &models.Class{Class: className}
 		return readFunc(class, state)
-	}).Maybe()
+	})
 
 	r := router.NewBuilder(
 		"TestClass",

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -457,7 +457,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	// If the caller provided a list of target node overrides, filter the replicas to only include
 	// the relevant overrides so that we only "push" updates to the specified nodes.
 	localNodeName := f.LocalNodeName()
-	targetNodesToUse := routingPlan.NodeNames()
+	var targetNodesToUse []string
 	if len(targetNodeOverrides) > 0 {
 		targetNodesToUse = make([]string, 0, len(targetNodeOverrides))
 		for _, override := range targetNodeOverrides {
@@ -465,10 +465,12 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 				targetNodesToUse = append(targetNodesToUse, override.TargetNode)
 			}
 		}
+	} else {
+		targetNodesToUse = routingPlan.NodeNames()
 	}
 
-	replicaNodeNames := make([]string, 0, len(routingPlan.Replicas()))
-	replicasHostAddrs := make([]string, 0, len(routingPlan.HostAddresses()))
+	replicaNodeNames := make([]string, 0, len(targetNodesToUse))
+	replicasHostAddrs := make([]string, 0, len(targetNodesToUse))
 	for _, replica := range targetNodesToUse {
 		replicaHostAddr, ok := f.nodeResolver.NodeHostname(replica)
 		if ok {
@@ -560,12 +562,13 @@ func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 		return nil, fmt.Errorf("could not resolve hostname for local node %q: class %q shard %q", localNodeName, f.class, shardName)
 	}
 
-	var hosts []string
-	for _, node := range routingPlan.NodeNames() {
-		if node == localNodeName {
+	replicas := routingPlan.Replicas()
+	hosts := make([]string, 0, len(replicas))
+	for _, replica := range replicas {
+		if replica.NodeName == localNodeName {
 			continue
 		}
-		addr, ok := f.nodeResolver.NodeHostname(node)
+		addr, ok := f.nodeResolver.NodeHostname(replica.NodeName)
 		if !ok || addr == localHostAddr {
 			continue
 		}


### PR DESCRIPTION
## Motivation

Alloc profiles from a cluster with 4000+ single-tenant collections show the routing-plan chain as a steady per-cycle allocator on the async-replication path (it feeds both `PrefilterShardRoots`' callee cost and part of `CollectShardDifferences`' 7.25GB cumulative). Two sources:

- `singleTenantRouter.targetShards` called `SchemaReader.Shards`, which copies **and sorts** the collection's entire physical shard list (`State.AllPhysicalShards`), only to check whether one named shard exists. This runs on every single-shard read routing plan — per shard per hashbeat cycle, and on foreground single-shard reads.
- The replica finder built throwaway slices just to read their length (`routingPlan.HostAddresses()`), built `NodeNames()` even when target-node overrides discard it, and built `NodeNames()` in `targetHostAddrsForShard` when iterating `Replicas()` directly suffices.

## Approach

- `targetShards` with a named shard now checks existence directly against the sharding state's `Physical` map through the **existing** `SchemaReader.Read` — same retry, sharding-state validation, and not-found error as before, no interface change (so no mock regeneration). The map key is the shard name (the same idiom `State` itself uses internally). The empty-shard broadcast path still returns `Shards(collection)` unchanged.
- Finder: size `replicaNodeNames`/`replicasHostAddrs` by `len(targetNodesToUse)` (the true append bound), move `NodeNames()` into the no-overrides branch, and iterate `Replicas()` in `targetHostAddrsForShard`.

Behavior is identical on all paths; only allocation shapes change. `cluster/router` serves foreground reads, so parity mattered: the not-found error string, retry semantics (`retryIfClassNotFound=true`), and the invalid-sharding-state backoff all flow through the same `Read` used before.

## Key areas for review

- [`router.go#L279`](https://github.com/weaviate/weaviate/blob/9902159c1e5920940efd06818e35673939623edb/cluster/router/router.go#L279) — the `Read` closure runs under the schema read lock; it only does a map lookup.
- [`finder.go#L459`](https://github.com/weaviate/weaviate/blob/9902159c1e5920940efd06818e35673939623edb/usecases/replica/finder.go#L459) — `targetNodesToUse` is never nil afterward: overrides branch allocates, else branch takes `NodeNames()`.
- `TestSingleTenantRouter_GetReadWriteReplicasLocation_InvalidShard` updated: the named-shard path no longer calls `Shards`, so the test now pins the `Read`-based membership check (the mock's `.Maybe()` dropped — the call is required).

## Testing

- Existing router suites cover broadcast, targeted-shard success, and invalid-shard error paths; all pass with `-race`.
- `go build ./...`, `go test -race ./cluster/router/... ./usecases/replica/`, `golangci-lint`, and the goroutine linter are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
