### PR TITLE
perf(async-replication): batch root pre-filter across classes per target node

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -368,14 +368,41 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	return result, err
 }
 
-func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
-	roots map[string]hashtree.Digest,
-) ([]string, error) {
+func wireDigests(roots map[string]hashtree.Digest) map[string][2]uint64 {
 	wireRoots := make(map[string][2]uint64, len(roots))
 	for shard, root := range roots {
 		wireRoots[shard] = [2]uint64(root)
 	}
-	body, err := json.Marshal(replica.CompareHashTreeRootsReq{Roots: wireRoots})
+	return wireRoots
+}
+
+// postCompareRoots posts a root-compare payload and decodes into out; 404 maps to
+// ErrCompareHashTreeRootsUnsupported so callers fall back to an older RPC shape.
+func (c *replicationClient) postCompareRoots(req *http.Request, out any) error {
+	res, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		return replica.ErrCompareHashTreeRootsUnsupported
+	}
+	if code := res.StatusCode; !successCode(code) {
+		errBody, _ := io.ReadAll(res.Body)
+		return fmt.Errorf("status code: %v, error: %s", code, errBody)
+	}
+
+	if err := json.NewDecoder(res.Body).Decode(out); err != nil {
+		return fmt.Errorf("decode compare hashtree roots response: %w", err)
+	}
+	return nil
+}
+
+func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, index string,
+	roots map[string]hashtree.Digest,
+) ([]string, error) {
+	body, err := json.Marshal(replica.CompareHashTreeRootsReq{Roots: wireDigests(roots)})
 	if err != nil {
 		return nil, fmt.Errorf("marshal compare hashtree roots request: %w", err)
 	}
@@ -389,24 +416,9 @@ func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, inde
 		return nil, fmt.Errorf("create http request: %w", err)
 	}
 
-	res, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("connect: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == http.StatusNotFound {
-		// Older peers don't expose this route; fall back to the per-shard path.
-		return nil, replica.ErrCompareHashTreeRootsUnsupported
-	}
-	if code := res.StatusCode; !successCode(code) {
-		errBody, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("status code: %v, error: %s", code, errBody)
-	}
-
 	var resp replica.CompareHashTreeRootsResp
-	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-		return nil, fmt.Errorf("decode compare hashtree roots response: %w", err)
+	if err := c.postCompareRoots(req, &resp); err != nil {
+		return nil, err
 	}
 	return resp.DivergingShards, nil
 }
@@ -416,11 +428,7 @@ func (c *replicationClient) CompareHashTreeRootsMulti(ctx context.Context, host 
 ) (*replica.CompareHashTreeRootsMultiResp, error) {
 	wire := make(map[string]map[string][2]uint64, len(classes))
 	for class, roots := range classes {
-		wireRoots := make(map[string][2]uint64, len(roots))
-		for shard, root := range roots {
-			wireRoots[shard] = [2]uint64(root)
-		}
-		wire[class] = wireRoots
+		wire[class] = wireDigests(roots)
 	}
 	body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: wire})
 	if err != nil {
@@ -436,24 +444,9 @@ func (c *replicationClient) CompareHashTreeRootsMulti(ctx context.Context, host 
 		return nil, fmt.Errorf("create http request: %w", err)
 	}
 
-	res, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("connect: %w", err)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == http.StatusNotFound {
-		// Older peers lack this route; callers fall back to the per-class RPC.
-		return nil, replica.ErrCompareHashTreeRootsUnsupported
-	}
-	if code := res.StatusCode; !successCode(code) {
-		errBody, _ := io.ReadAll(res.Body)
-		return nil, fmt.Errorf("status code: %v, error: %s", code, errBody)
-	}
-
 	var resp replica.CompareHashTreeRootsMultiResp
-	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-		return nil, fmt.Errorf("decode compare hashtree roots multi response: %w", err)
+	if err := c.postCompareRoots(req, &resp); err != nil {
+		return nil, err
 	}
 	return &resp, nil
 }

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -411,6 +411,53 @@ func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, inde
 	return resp.DivergingShards, nil
 }
 
+func (c *replicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	wire := make(map[string]map[string][2]uint64, len(classes))
+	for class, roots := range classes {
+		wireRoots := make(map[string][2]uint64, len(roots))
+		for shard, root := range roots {
+			wireRoots[shard] = [2]uint64(root)
+		}
+		wire[class] = wireRoots
+	}
+	body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: wire})
+	if err != nil {
+		return nil, fmt.Errorf("marshal compare hashtree roots multi request: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
+	defer cancel()
+
+	u := url.URL{Scheme: "http", Host: host, Path: clusterapi.CompareHashTreeRootsMultiPath}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create http request: %w", err)
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == http.StatusNotFound {
+		// Older peers lack this route; callers fall back to the per-class RPC.
+		return nil, replica.ErrCompareHashTreeRootsUnsupported
+	}
+	if code := res.StatusCode; !successCode(code) {
+		errBody, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("status code: %v, error: %s", code, errBody)
+	}
+
+	var resp replica.CompareHashTreeRootsMultiResp
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("decode compare hashtree roots multi response: %w", err)
+	}
+	return &resp, nil
+}
+
 func (c *replicationClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {
 	var resp int
 	req, err := newHttpReplicaRequest(

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -497,11 +497,48 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 	return resp.GetDivergingShards(), nil
 }
 
-// CompareHashTreeRootsMulti has no gRPC RPC yet; Unsupported routes callers to the per-class gRPC compare.
 func (c *grpcReplicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
 	classes map[string]map[string]hashtree.Digest,
 ) (*replica.CompareHashTreeRootsMultiResp, error) {
-	return nil, replica.ErrCompareHashTreeRootsUnsupported
+	client, err := c.getClient(host)
+	if err != nil {
+		return nil, err
+	}
+
+	req := &protocol.CompareHashTreeRootsMultiRequest{
+		Classes: make([]*protocol.ClassShardRootDigests, 0, len(classes)),
+	}
+	for class, roots := range classes {
+		shards := make([]*protocol.ShardRootDigest, 0, len(roots))
+		for shard, root := range roots {
+			shards = append(shards, &protocol.ShardRootDigest{
+				Shard:        shard,
+				RootHashHigh: root[0],
+				RootHashLow:  root[1],
+			})
+		}
+		req.Classes = append(req.Classes, &protocol.ClassShardRootDigests{Index: class, ShardRootDigests: shards})
+	}
+
+	grpcResp, err := client.CompareHashTreeRootsMulti(ctx, req)
+	if err != nil {
+		// Older peers don't serve this RPC; sentinel lets the caller fall back.
+		if status.Code(err) == codes.Unimplemented {
+			return nil, replica.ErrCompareHashTreeRootsUnsupported
+		}
+		return nil, fmt.Errorf("gRPC CompareHashTreeRootsMulti: %w", err)
+	}
+
+	resp := &replica.CompareHashTreeRootsMultiResp{
+		Classes: make(map[string]replica.CompareHashTreeRootsMultiClassResp, len(grpcResp.GetClasses())),
+	}
+	for _, cls := range grpcResp.GetClasses() {
+		resp.Classes[cls.GetIndex()] = replica.CompareHashTreeRootsMultiClassResp{
+			DivergingShards: cls.GetDivergingShards(),
+			Error:           cls.GetError(),
+		}
+	}
+	return resp, nil
 }
 
 func (c *grpcReplicationClient) OverwriteObjects(ctx context.Context, host, index, shard string,

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -497,6 +497,13 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 	return resp.GetDivergingShards(), nil
 }
 
+// CompareHashTreeRootsMulti has no gRPC RPC yet; Unsupported routes callers to the per-class gRPC compare.
+func (c *grpcReplicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	return nil, replica.ErrCompareHashTreeRootsUnsupported
+}
+
 func (c *grpcReplicationClient) OverwriteObjects(ctx context.Context, host, index, shard string,
 	vobjects []*objects.VObject,
 ) ([]types.RepairResponse, error) {

--- a/adapters/clients/replication_mixed.go
+++ b/adapters/clients/replication_mixed.go
@@ -210,6 +210,15 @@ func (s *switchReplicationClient) CompareHashTreeRoots(ctx context.Context, host
 	return s.restClient.CompareHashTreeRoots(ctx, host, index, roots)
 }
 
+func (s *switchReplicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	if s.useGRPC() {
+		return s.grpcClient.CompareHashTreeRootsMulti(ctx, host, classes)
+	}
+	return s.restClient.CompareHashTreeRootsMulti(ctx, host, classes)
+}
+
 func (s *switchReplicationClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {
 	if s.useGRPC() {
 		return s.grpcClient.CountObjects(ctx, host, index, shard)

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication.pb.go
@@ -2289,6 +2289,209 @@ func (x *CompareHashTreeRootsResponse) GetDivergingShards() []string {
 	return nil
 }
 
+// CompareHashTreeRootsMulti is the cross-class form of CompareHashTreeRoots: one
+// request carries every class's due shard roots for this target node.
+type ClassShardRootDigests struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Index            string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	ShardRootDigests []*ShardRootDigest     `protobuf:"bytes,2,rep,name=shard_root_digests,json=shardRootDigests,proto3" json:"shard_root_digests,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *ClassShardRootDigests) Reset() {
+	*x = ClassShardRootDigests{}
+	mi := &file_protocol_replication_proto_msgTypes[38]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClassShardRootDigests) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClassShardRootDigests) ProtoMessage() {}
+
+func (x *ClassShardRootDigests) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[38]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClassShardRootDigests.ProtoReflect.Descriptor instead.
+func (*ClassShardRootDigests) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{38}
+}
+
+func (x *ClassShardRootDigests) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *ClassShardRootDigests) GetShardRootDigests() []*ShardRootDigest {
+	if x != nil {
+		return x.ShardRootDigests
+	}
+	return nil
+}
+
+type CompareHashTreeRootsMultiRequest struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Classes       []*ClassShardRootDigests `protobuf:"bytes,1,rep,name=classes,proto3" json:"classes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CompareHashTreeRootsMultiRequest) Reset() {
+	*x = CompareHashTreeRootsMultiRequest{}
+	mi := &file_protocol_replication_proto_msgTypes[39]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompareHashTreeRootsMultiRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompareHashTreeRootsMultiRequest) ProtoMessage() {}
+
+func (x *CompareHashTreeRootsMultiRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[39]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompareHashTreeRootsMultiRequest.ProtoReflect.Descriptor instead.
+func (*CompareHashTreeRootsMultiRequest) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{39}
+}
+
+func (x *CompareHashTreeRootsMultiRequest) GetClasses() []*ClassShardRootDigests {
+	if x != nil {
+		return x.Classes
+	}
+	return nil
+}
+
+// error set means the class could not be compared; the sender descends its shards.
+type ClassDivergingShards struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Index           string                 `protobuf:"bytes,1,opt,name=index,proto3" json:"index,omitempty"`
+	DivergingShards []string               `protobuf:"bytes,2,rep,name=diverging_shards,json=divergingShards,proto3" json:"diverging_shards,omitempty"`
+	Error           string                 `protobuf:"bytes,3,opt,name=error,proto3" json:"error,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *ClassDivergingShards) Reset() {
+	*x = ClassDivergingShards{}
+	mi := &file_protocol_replication_proto_msgTypes[40]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ClassDivergingShards) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ClassDivergingShards) ProtoMessage() {}
+
+func (x *ClassDivergingShards) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[40]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ClassDivergingShards.ProtoReflect.Descriptor instead.
+func (*ClassDivergingShards) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{40}
+}
+
+func (x *ClassDivergingShards) GetIndex() string {
+	if x != nil {
+		return x.Index
+	}
+	return ""
+}
+
+func (x *ClassDivergingShards) GetDivergingShards() []string {
+	if x != nil {
+		return x.DivergingShards
+	}
+	return nil
+}
+
+func (x *ClassDivergingShards) GetError() string {
+	if x != nil {
+		return x.Error
+	}
+	return ""
+}
+
+type CompareHashTreeRootsMultiResponse struct {
+	state         protoimpl.MessageState  `protogen:"open.v1"`
+	Classes       []*ClassDivergingShards `protobuf:"bytes,1,rep,name=classes,proto3" json:"classes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CompareHashTreeRootsMultiResponse) Reset() {
+	*x = CompareHashTreeRootsMultiResponse{}
+	mi := &file_protocol_replication_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CompareHashTreeRootsMultiResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CompareHashTreeRootsMultiResponse) ProtoMessage() {}
+
+func (x *CompareHashTreeRootsMultiResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_protocol_replication_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CompareHashTreeRootsMultiResponse.ProtoReflect.Descriptor instead.
+func (*CompareHashTreeRootsMultiResponse) Descriptor() ([]byte, []int) {
+	return file_protocol_replication_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *CompareHashTreeRootsMultiResponse) GetClasses() []*ClassDivergingShards {
+	if x != nil {
+		return x.Classes
+	}
+	return nil
+}
+
 // CountObjects fetches hash tree level digests.
 type CountObjectsRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -2300,7 +2503,7 @@ type CountObjectsRequest struct {
 
 func (x *CountObjectsRequest) Reset() {
 	*x = CountObjectsRequest{}
-	mi := &file_protocol_replication_proto_msgTypes[38]
+	mi := &file_protocol_replication_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2312,7 +2515,7 @@ func (x *CountObjectsRequest) String() string {
 func (*CountObjectsRequest) ProtoMessage() {}
 
 func (x *CountObjectsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[38]
+	mi := &file_protocol_replication_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2325,7 +2528,7 @@ func (x *CountObjectsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountObjectsRequest.ProtoReflect.Descriptor instead.
 func (*CountObjectsRequest) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{38}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *CountObjectsRequest) GetIndex() string {
@@ -2352,7 +2555,7 @@ type CountObjectsResponse struct {
 
 func (x *CountObjectsResponse) Reset() {
 	*x = CountObjectsResponse{}
-	mi := &file_protocol_replication_proto_msgTypes[39]
+	mi := &file_protocol_replication_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2364,7 +2567,7 @@ func (x *CountObjectsResponse) String() string {
 func (*CountObjectsResponse) ProtoMessage() {}
 
 func (x *CountObjectsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[39]
+	mi := &file_protocol_replication_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2377,7 +2580,7 @@ func (x *CountObjectsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CountObjectsResponse.ProtoReflect.Descriptor instead.
 func (*CountObjectsResponse) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{39}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *CountObjectsResponse) GetCount() int32 {
@@ -2401,7 +2604,7 @@ type CreateAsyncCheckpointRequest struct {
 
 func (x *CreateAsyncCheckpointRequest) Reset() {
 	*x = CreateAsyncCheckpointRequest{}
-	mi := &file_protocol_replication_proto_msgTypes[40]
+	mi := &file_protocol_replication_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2413,7 +2616,7 @@ func (x *CreateAsyncCheckpointRequest) String() string {
 func (*CreateAsyncCheckpointRequest) ProtoMessage() {}
 
 func (x *CreateAsyncCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[40]
+	mi := &file_protocol_replication_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2426,7 +2629,7 @@ func (x *CreateAsyncCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAsyncCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*CreateAsyncCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{40}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *CreateAsyncCheckpointRequest) GetIndex() string {
@@ -2465,7 +2668,7 @@ type CreateAsyncCheckpointResponse struct {
 
 func (x *CreateAsyncCheckpointResponse) Reset() {
 	*x = CreateAsyncCheckpointResponse{}
-	mi := &file_protocol_replication_proto_msgTypes[41]
+	mi := &file_protocol_replication_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2477,7 +2680,7 @@ func (x *CreateAsyncCheckpointResponse) String() string {
 func (*CreateAsyncCheckpointResponse) ProtoMessage() {}
 
 func (x *CreateAsyncCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[41]
+	mi := &file_protocol_replication_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2490,7 +2693,7 @@ func (x *CreateAsyncCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateAsyncCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*CreateAsyncCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{41}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{45}
 }
 
 type DeleteAsyncCheckpointRequest struct {
@@ -2503,7 +2706,7 @@ type DeleteAsyncCheckpointRequest struct {
 
 func (x *DeleteAsyncCheckpointRequest) Reset() {
 	*x = DeleteAsyncCheckpointRequest{}
-	mi := &file_protocol_replication_proto_msgTypes[42]
+	mi := &file_protocol_replication_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2515,7 +2718,7 @@ func (x *DeleteAsyncCheckpointRequest) String() string {
 func (*DeleteAsyncCheckpointRequest) ProtoMessage() {}
 
 func (x *DeleteAsyncCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[42]
+	mi := &file_protocol_replication_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2528,7 +2731,7 @@ func (x *DeleteAsyncCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAsyncCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*DeleteAsyncCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{42}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *DeleteAsyncCheckpointRequest) GetIndex() string {
@@ -2553,7 +2756,7 @@ type DeleteAsyncCheckpointResponse struct {
 
 func (x *DeleteAsyncCheckpointResponse) Reset() {
 	*x = DeleteAsyncCheckpointResponse{}
-	mi := &file_protocol_replication_proto_msgTypes[43]
+	mi := &file_protocol_replication_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2565,7 +2768,7 @@ func (x *DeleteAsyncCheckpointResponse) String() string {
 func (*DeleteAsyncCheckpointResponse) ProtoMessage() {}
 
 func (x *DeleteAsyncCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[43]
+	mi := &file_protocol_replication_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2578,7 +2781,7 @@ func (x *DeleteAsyncCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteAsyncCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAsyncCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{43}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{47}
 }
 
 // GetAsyncCheckpointStatusResponse omits shards not loaded on this node, so
@@ -2593,7 +2796,7 @@ type GetAsyncCheckpointStatusRequest struct {
 
 func (x *GetAsyncCheckpointStatusRequest) Reset() {
 	*x = GetAsyncCheckpointStatusRequest{}
-	mi := &file_protocol_replication_proto_msgTypes[44]
+	mi := &file_protocol_replication_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2605,7 +2808,7 @@ func (x *GetAsyncCheckpointStatusRequest) String() string {
 func (*GetAsyncCheckpointStatusRequest) ProtoMessage() {}
 
 func (x *GetAsyncCheckpointStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[44]
+	mi := &file_protocol_replication_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2618,7 +2821,7 @@ func (x *GetAsyncCheckpointStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAsyncCheckpointStatusRequest.ProtoReflect.Descriptor instead.
 func (*GetAsyncCheckpointStatusRequest) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{44}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *GetAsyncCheckpointStatusRequest) GetIndex() string {
@@ -2647,7 +2850,7 @@ type AsyncCheckpointShardStatus struct {
 
 func (x *AsyncCheckpointShardStatus) Reset() {
 	*x = AsyncCheckpointShardStatus{}
-	mi := &file_protocol_replication_proto_msgTypes[45]
+	mi := &file_protocol_replication_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2862,7 @@ func (x *AsyncCheckpointShardStatus) String() string {
 func (*AsyncCheckpointShardStatus) ProtoMessage() {}
 
 func (x *AsyncCheckpointShardStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[45]
+	mi := &file_protocol_replication_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2875,7 @@ func (x *AsyncCheckpointShardStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AsyncCheckpointShardStatus.ProtoReflect.Descriptor instead.
 func (*AsyncCheckpointShardStatus) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{45}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *AsyncCheckpointShardStatus) GetRoot() []byte {
@@ -2705,7 +2908,7 @@ type GetAsyncCheckpointStatusResponse struct {
 
 func (x *GetAsyncCheckpointStatusResponse) Reset() {
 	*x = GetAsyncCheckpointStatusResponse{}
-	mi := &file_protocol_replication_proto_msgTypes[46]
+	mi := &file_protocol_replication_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2717,7 +2920,7 @@ func (x *GetAsyncCheckpointStatusResponse) String() string {
 func (*GetAsyncCheckpointStatusResponse) ProtoMessage() {}
 
 func (x *GetAsyncCheckpointStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_protocol_replication_proto_msgTypes[46]
+	mi := &file_protocol_replication_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2730,7 +2933,7 @@ func (x *GetAsyncCheckpointStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetAsyncCheckpointStatusResponse.ProtoReflect.Descriptor instead.
 func (*GetAsyncCheckpointStatusResponse) Descriptor() ([]byte, []int) {
-	return file_protocol_replication_proto_rawDescGZIP(), []int{46}
+	return file_protocol_replication_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *GetAsyncCheckpointStatusResponse) GetStatuses() map[string]*AsyncCheckpointShardStatus {
@@ -2905,7 +3108,18 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12I\n" +
 	"\x12shard_root_digests\x18\x02 \x03(\v2\x1b.clusterapi.ShardRootDigestR\x10shardRootDigests\"I\n" +
 	"\x1cCompareHashTreeRootsResponse\x12)\n" +
-	"\x10diverging_shards\x18\x01 \x03(\tR\x0fdivergingShards\"A\n" +
+	"\x10diverging_shards\x18\x01 \x03(\tR\x0fdivergingShards\"x\n" +
+	"\x15ClassShardRootDigests\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x12I\n" +
+	"\x12shard_root_digests\x18\x02 \x03(\v2\x1b.clusterapi.ShardRootDigestR\x10shardRootDigests\"_\n" +
+	" CompareHashTreeRootsMultiRequest\x12;\n" +
+	"\aclasses\x18\x01 \x03(\v2!.clusterapi.ClassShardRootDigestsR\aclasses\"m\n" +
+	"\x14ClassDivergingShards\x12\x14\n" +
+	"\x05index\x18\x01 \x01(\tR\x05index\x12)\n" +
+	"\x10diverging_shards\x18\x02 \x03(\tR\x0fdivergingShards\x12\x14\n" +
+	"\x05error\x18\x03 \x01(\tR\x05error\"_\n" +
+	"!CompareHashTreeRootsMultiResponse\x12:\n" +
+	"\aclasses\x18\x01 \x03(\v2 .clusterapi.ClassDivergingShardsR\aclasses\"A\n" +
 	"\x13CountObjectsRequest\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\tR\x05index\x12\x14\n" +
 	"\x05shard\x18\x02 \x01(\tR\x05shard\",\n" +
@@ -2932,7 +3146,7 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\bstatuses\x18\x01 \x03(\v2:.clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntryR\bstatuses\x1ac\n" +
 	"\rStatusesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12<\n" +
-	"\x05value\x18\x02 \x01(\v2&.clusterapi.AsyncCheckpointShardStatusR\x05value:\x028\x012\xc6\x0e\n" +
+	"\x05value\x18\x02 \x01(\v2&.clusterapi.AsyncCheckpointShardStatusR\x05value:\x028\x012\xc0\x0f\n" +
 	"\x12ReplicationService\x12H\n" +
 	"\tPutObject\x12\x1c.clusterapi.PutObjectRequest\x1a\x1d.clusterapi.PutObjectResponse\x12K\n" +
 	"\n" +
@@ -2951,7 +3165,8 @@ const file_protocol_replication_proto_rawDesc = "" +
 	"\x10OverwriteObjects\x12#.clusterapi.OverwriteObjectsRequest\x1a$.clusterapi.OverwriteObjectsResponse\x12H\n" +
 	"\tFindUUIDs\x12\x1c.clusterapi.FindUUIDsRequest\x1a\x1d.clusterapi.FindUUIDsResponse\x12T\n" +
 	"\rHashTreeLevel\x12 .clusterapi.HashTreeLevelRequest\x1a!.clusterapi.HashTreeLevelResponse\x12i\n" +
-	"\x14CompareHashTreeRoots\x12'.clusterapi.CompareHashTreeRootsRequest\x1a(.clusterapi.CompareHashTreeRootsResponse\x12Q\n" +
+	"\x14CompareHashTreeRoots\x12'.clusterapi.CompareHashTreeRootsRequest\x1a(.clusterapi.CompareHashTreeRootsResponse\x12x\n" +
+	"\x19CompareHashTreeRootsMulti\x12,.clusterapi.CompareHashTreeRootsMultiRequest\x1a-.clusterapi.CompareHashTreeRootsMultiResponse\x12Q\n" +
 	"\fCountObjects\x12\x1f.clusterapi.CountObjectsRequest\x1a .clusterapi.CountObjectsResponse\x12l\n" +
 	"\x15CreateAsyncCheckpoint\x12(.clusterapi.CreateAsyncCheckpointRequest\x1a).clusterapi.CreateAsyncCheckpointResponse\x12l\n" +
 	"\x15DeleteAsyncCheckpoint\x12(.clusterapi.DeleteAsyncCheckpointRequest\x1a).clusterapi.DeleteAsyncCheckpointResponse\x12u\n" +
@@ -2973,56 +3188,60 @@ func file_protocol_replication_proto_rawDescGZIP() []byte {
 	return file_protocol_replication_proto_rawDescData
 }
 
-var file_protocol_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 48)
+var file_protocol_replication_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
 var file_protocol_replication_proto_goTypes = []any{
-	(*ReplicaError)(nil),                     // 0: clusterapi.ReplicaError
-	(*SimpleReplicaResponse)(nil),            // 1: clusterapi.SimpleReplicaResponse
-	(*RepairResponse)(nil),                   // 2: clusterapi.RepairResponse
-	(*PutObjectRequest)(nil),                 // 3: clusterapi.PutObjectRequest
-	(*PutObjectResponse)(nil),                // 4: clusterapi.PutObjectResponse
-	(*PutObjectsRequest)(nil),                // 5: clusterapi.PutObjectsRequest
-	(*PutObjectsResponse)(nil),               // 6: clusterapi.PutObjectsResponse
-	(*MergeObjectRequest)(nil),               // 7: clusterapi.MergeObjectRequest
-	(*MergeObjectResponse)(nil),              // 8: clusterapi.MergeObjectResponse
-	(*DeleteObjectRequest)(nil),              // 9: clusterapi.DeleteObjectRequest
-	(*DeleteObjectResponse)(nil),             // 10: clusterapi.DeleteObjectResponse
-	(*DeleteObjectsRequest)(nil),             // 11: clusterapi.DeleteObjectsRequest
-	(*DeleteObjectsResponse)(nil),            // 12: clusterapi.DeleteObjectsResponse
-	(*AddReferencesRequest)(nil),             // 13: clusterapi.AddReferencesRequest
-	(*AddReferencesResponse)(nil),            // 14: clusterapi.AddReferencesResponse
-	(*CommitRequest)(nil),                    // 15: clusterapi.CommitRequest
-	(*CommitResponse)(nil),                   // 16: clusterapi.CommitResponse
-	(*AbortRequest)(nil),                     // 17: clusterapi.AbortRequest
-	(*AbortResponse)(nil),                    // 18: clusterapi.AbortResponse
-	(*FetchObjectRequest)(nil),               // 19: clusterapi.FetchObjectRequest
-	(*FetchObjectResponse)(nil),              // 20: clusterapi.FetchObjectResponse
-	(*FetchObjectsRequest)(nil),              // 21: clusterapi.FetchObjectsRequest
-	(*FetchObjectsResponse)(nil),             // 22: clusterapi.FetchObjectsResponse
-	(*DigestObjectsRequest)(nil),             // 23: clusterapi.DigestObjectsRequest
-	(*DigestObjectsResponse)(nil),            // 24: clusterapi.DigestObjectsResponse
-	(*DigestObjectsInRangeRequest)(nil),      // 25: clusterapi.DigestObjectsInRangeRequest
-	(*DigestObjectsInRangeResponse)(nil),     // 26: clusterapi.DigestObjectsInRangeResponse
-	(*CompareDigestsRequest)(nil),            // 27: clusterapi.CompareDigestsRequest
-	(*CompareDigestsResponse)(nil),           // 28: clusterapi.CompareDigestsResponse
-	(*OverwriteObjectsRequest)(nil),          // 29: clusterapi.OverwriteObjectsRequest
-	(*OverwriteObjectsResponse)(nil),         // 30: clusterapi.OverwriteObjectsResponse
-	(*FindUUIDsRequest)(nil),                 // 31: clusterapi.FindUUIDsRequest
-	(*FindUUIDsResponse)(nil),                // 32: clusterapi.FindUUIDsResponse
-	(*HashTreeLevelRequest)(nil),             // 33: clusterapi.HashTreeLevelRequest
-	(*HashTreeLevelResponse)(nil),            // 34: clusterapi.HashTreeLevelResponse
-	(*ShardRootDigest)(nil),                  // 35: clusterapi.ShardRootDigest
-	(*CompareHashTreeRootsRequest)(nil),      // 36: clusterapi.CompareHashTreeRootsRequest
-	(*CompareHashTreeRootsResponse)(nil),     // 37: clusterapi.CompareHashTreeRootsResponse
-	(*CountObjectsRequest)(nil),              // 38: clusterapi.CountObjectsRequest
-	(*CountObjectsResponse)(nil),             // 39: clusterapi.CountObjectsResponse
-	(*CreateAsyncCheckpointRequest)(nil),     // 40: clusterapi.CreateAsyncCheckpointRequest
-	(*CreateAsyncCheckpointResponse)(nil),    // 41: clusterapi.CreateAsyncCheckpointResponse
-	(*DeleteAsyncCheckpointRequest)(nil),     // 42: clusterapi.DeleteAsyncCheckpointRequest
-	(*DeleteAsyncCheckpointResponse)(nil),    // 43: clusterapi.DeleteAsyncCheckpointResponse
-	(*GetAsyncCheckpointStatusRequest)(nil),  // 44: clusterapi.GetAsyncCheckpointStatusRequest
-	(*AsyncCheckpointShardStatus)(nil),       // 45: clusterapi.AsyncCheckpointShardStatus
-	(*GetAsyncCheckpointStatusResponse)(nil), // 46: clusterapi.GetAsyncCheckpointStatusResponse
-	nil,                                      // 47: clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntry
+	(*ReplicaError)(nil),                      // 0: clusterapi.ReplicaError
+	(*SimpleReplicaResponse)(nil),             // 1: clusterapi.SimpleReplicaResponse
+	(*RepairResponse)(nil),                    // 2: clusterapi.RepairResponse
+	(*PutObjectRequest)(nil),                  // 3: clusterapi.PutObjectRequest
+	(*PutObjectResponse)(nil),                 // 4: clusterapi.PutObjectResponse
+	(*PutObjectsRequest)(nil),                 // 5: clusterapi.PutObjectsRequest
+	(*PutObjectsResponse)(nil),                // 6: clusterapi.PutObjectsResponse
+	(*MergeObjectRequest)(nil),                // 7: clusterapi.MergeObjectRequest
+	(*MergeObjectResponse)(nil),               // 8: clusterapi.MergeObjectResponse
+	(*DeleteObjectRequest)(nil),               // 9: clusterapi.DeleteObjectRequest
+	(*DeleteObjectResponse)(nil),              // 10: clusterapi.DeleteObjectResponse
+	(*DeleteObjectsRequest)(nil),              // 11: clusterapi.DeleteObjectsRequest
+	(*DeleteObjectsResponse)(nil),             // 12: clusterapi.DeleteObjectsResponse
+	(*AddReferencesRequest)(nil),              // 13: clusterapi.AddReferencesRequest
+	(*AddReferencesResponse)(nil),             // 14: clusterapi.AddReferencesResponse
+	(*CommitRequest)(nil),                     // 15: clusterapi.CommitRequest
+	(*CommitResponse)(nil),                    // 16: clusterapi.CommitResponse
+	(*AbortRequest)(nil),                      // 17: clusterapi.AbortRequest
+	(*AbortResponse)(nil),                     // 18: clusterapi.AbortResponse
+	(*FetchObjectRequest)(nil),                // 19: clusterapi.FetchObjectRequest
+	(*FetchObjectResponse)(nil),               // 20: clusterapi.FetchObjectResponse
+	(*FetchObjectsRequest)(nil),               // 21: clusterapi.FetchObjectsRequest
+	(*FetchObjectsResponse)(nil),              // 22: clusterapi.FetchObjectsResponse
+	(*DigestObjectsRequest)(nil),              // 23: clusterapi.DigestObjectsRequest
+	(*DigestObjectsResponse)(nil),             // 24: clusterapi.DigestObjectsResponse
+	(*DigestObjectsInRangeRequest)(nil),       // 25: clusterapi.DigestObjectsInRangeRequest
+	(*DigestObjectsInRangeResponse)(nil),      // 26: clusterapi.DigestObjectsInRangeResponse
+	(*CompareDigestsRequest)(nil),             // 27: clusterapi.CompareDigestsRequest
+	(*CompareDigestsResponse)(nil),            // 28: clusterapi.CompareDigestsResponse
+	(*OverwriteObjectsRequest)(nil),           // 29: clusterapi.OverwriteObjectsRequest
+	(*OverwriteObjectsResponse)(nil),          // 30: clusterapi.OverwriteObjectsResponse
+	(*FindUUIDsRequest)(nil),                  // 31: clusterapi.FindUUIDsRequest
+	(*FindUUIDsResponse)(nil),                 // 32: clusterapi.FindUUIDsResponse
+	(*HashTreeLevelRequest)(nil),              // 33: clusterapi.HashTreeLevelRequest
+	(*HashTreeLevelResponse)(nil),             // 34: clusterapi.HashTreeLevelResponse
+	(*ShardRootDigest)(nil),                   // 35: clusterapi.ShardRootDigest
+	(*CompareHashTreeRootsRequest)(nil),       // 36: clusterapi.CompareHashTreeRootsRequest
+	(*CompareHashTreeRootsResponse)(nil),      // 37: clusterapi.CompareHashTreeRootsResponse
+	(*ClassShardRootDigests)(nil),             // 38: clusterapi.ClassShardRootDigests
+	(*CompareHashTreeRootsMultiRequest)(nil),  // 39: clusterapi.CompareHashTreeRootsMultiRequest
+	(*ClassDivergingShards)(nil),              // 40: clusterapi.ClassDivergingShards
+	(*CompareHashTreeRootsMultiResponse)(nil), // 41: clusterapi.CompareHashTreeRootsMultiResponse
+	(*CountObjectsRequest)(nil),               // 42: clusterapi.CountObjectsRequest
+	(*CountObjectsResponse)(nil),              // 43: clusterapi.CountObjectsResponse
+	(*CreateAsyncCheckpointRequest)(nil),      // 44: clusterapi.CreateAsyncCheckpointRequest
+	(*CreateAsyncCheckpointResponse)(nil),     // 45: clusterapi.CreateAsyncCheckpointResponse
+	(*DeleteAsyncCheckpointRequest)(nil),      // 46: clusterapi.DeleteAsyncCheckpointRequest
+	(*DeleteAsyncCheckpointResponse)(nil),     // 47: clusterapi.DeleteAsyncCheckpointResponse
+	(*GetAsyncCheckpointStatusRequest)(nil),   // 48: clusterapi.GetAsyncCheckpointStatusRequest
+	(*AsyncCheckpointShardStatus)(nil),        // 49: clusterapi.AsyncCheckpointShardStatus
+	(*GetAsyncCheckpointStatusResponse)(nil),  // 50: clusterapi.GetAsyncCheckpointStatusResponse
+	nil,                                       // 51: clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntry
 }
 var file_protocol_replication_proto_depIdxs = []int32{
 	0,  // 0: clusterapi.SimpleReplicaResponse.errors:type_name -> clusterapi.ReplicaError
@@ -3039,55 +3258,60 @@ var file_protocol_replication_proto_depIdxs = []int32{
 	2,  // 11: clusterapi.CompareDigestsResponse.digests:type_name -> clusterapi.RepairResponse
 	2,  // 12: clusterapi.OverwriteObjectsResponse.results:type_name -> clusterapi.RepairResponse
 	35, // 13: clusterapi.CompareHashTreeRootsRequest.shard_root_digests:type_name -> clusterapi.ShardRootDigest
-	47, // 14: clusterapi.GetAsyncCheckpointStatusResponse.statuses:type_name -> clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntry
-	45, // 15: clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntry.value:type_name -> clusterapi.AsyncCheckpointShardStatus
-	3,  // 16: clusterapi.ReplicationService.PutObject:input_type -> clusterapi.PutObjectRequest
-	5,  // 17: clusterapi.ReplicationService.PutObjects:input_type -> clusterapi.PutObjectsRequest
-	7,  // 18: clusterapi.ReplicationService.MergeObject:input_type -> clusterapi.MergeObjectRequest
-	9,  // 19: clusterapi.ReplicationService.DeleteObject:input_type -> clusterapi.DeleteObjectRequest
-	11, // 20: clusterapi.ReplicationService.DeleteObjects:input_type -> clusterapi.DeleteObjectsRequest
-	13, // 21: clusterapi.ReplicationService.AddReferences:input_type -> clusterapi.AddReferencesRequest
-	15, // 22: clusterapi.ReplicationService.Commit:input_type -> clusterapi.CommitRequest
-	17, // 23: clusterapi.ReplicationService.Abort:input_type -> clusterapi.AbortRequest
-	19, // 24: clusterapi.ReplicationService.FetchObject:input_type -> clusterapi.FetchObjectRequest
-	21, // 25: clusterapi.ReplicationService.FetchObjects:input_type -> clusterapi.FetchObjectsRequest
-	23, // 26: clusterapi.ReplicationService.DigestObjects:input_type -> clusterapi.DigestObjectsRequest
-	25, // 27: clusterapi.ReplicationService.DigestObjectsInRange:input_type -> clusterapi.DigestObjectsInRangeRequest
-	27, // 28: clusterapi.ReplicationService.CompareDigests:input_type -> clusterapi.CompareDigestsRequest
-	29, // 29: clusterapi.ReplicationService.OverwriteObjects:input_type -> clusterapi.OverwriteObjectsRequest
-	31, // 30: clusterapi.ReplicationService.FindUUIDs:input_type -> clusterapi.FindUUIDsRequest
-	33, // 31: clusterapi.ReplicationService.HashTreeLevel:input_type -> clusterapi.HashTreeLevelRequest
-	36, // 32: clusterapi.ReplicationService.CompareHashTreeRoots:input_type -> clusterapi.CompareHashTreeRootsRequest
-	38, // 33: clusterapi.ReplicationService.CountObjects:input_type -> clusterapi.CountObjectsRequest
-	40, // 34: clusterapi.ReplicationService.CreateAsyncCheckpoint:input_type -> clusterapi.CreateAsyncCheckpointRequest
-	42, // 35: clusterapi.ReplicationService.DeleteAsyncCheckpoint:input_type -> clusterapi.DeleteAsyncCheckpointRequest
-	44, // 36: clusterapi.ReplicationService.GetAsyncCheckpointStatus:input_type -> clusterapi.GetAsyncCheckpointStatusRequest
-	4,  // 37: clusterapi.ReplicationService.PutObject:output_type -> clusterapi.PutObjectResponse
-	6,  // 38: clusterapi.ReplicationService.PutObjects:output_type -> clusterapi.PutObjectsResponse
-	8,  // 39: clusterapi.ReplicationService.MergeObject:output_type -> clusterapi.MergeObjectResponse
-	10, // 40: clusterapi.ReplicationService.DeleteObject:output_type -> clusterapi.DeleteObjectResponse
-	12, // 41: clusterapi.ReplicationService.DeleteObjects:output_type -> clusterapi.DeleteObjectsResponse
-	14, // 42: clusterapi.ReplicationService.AddReferences:output_type -> clusterapi.AddReferencesResponse
-	16, // 43: clusterapi.ReplicationService.Commit:output_type -> clusterapi.CommitResponse
-	18, // 44: clusterapi.ReplicationService.Abort:output_type -> clusterapi.AbortResponse
-	20, // 45: clusterapi.ReplicationService.FetchObject:output_type -> clusterapi.FetchObjectResponse
-	22, // 46: clusterapi.ReplicationService.FetchObjects:output_type -> clusterapi.FetchObjectsResponse
-	24, // 47: clusterapi.ReplicationService.DigestObjects:output_type -> clusterapi.DigestObjectsResponse
-	26, // 48: clusterapi.ReplicationService.DigestObjectsInRange:output_type -> clusterapi.DigestObjectsInRangeResponse
-	28, // 49: clusterapi.ReplicationService.CompareDigests:output_type -> clusterapi.CompareDigestsResponse
-	30, // 50: clusterapi.ReplicationService.OverwriteObjects:output_type -> clusterapi.OverwriteObjectsResponse
-	32, // 51: clusterapi.ReplicationService.FindUUIDs:output_type -> clusterapi.FindUUIDsResponse
-	34, // 52: clusterapi.ReplicationService.HashTreeLevel:output_type -> clusterapi.HashTreeLevelResponse
-	37, // 53: clusterapi.ReplicationService.CompareHashTreeRoots:output_type -> clusterapi.CompareHashTreeRootsResponse
-	39, // 54: clusterapi.ReplicationService.CountObjects:output_type -> clusterapi.CountObjectsResponse
-	41, // 55: clusterapi.ReplicationService.CreateAsyncCheckpoint:output_type -> clusterapi.CreateAsyncCheckpointResponse
-	43, // 56: clusterapi.ReplicationService.DeleteAsyncCheckpoint:output_type -> clusterapi.DeleteAsyncCheckpointResponse
-	46, // 57: clusterapi.ReplicationService.GetAsyncCheckpointStatus:output_type -> clusterapi.GetAsyncCheckpointStatusResponse
-	37, // [37:58] is the sub-list for method output_type
-	16, // [16:37] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	35, // 14: clusterapi.ClassShardRootDigests.shard_root_digests:type_name -> clusterapi.ShardRootDigest
+	38, // 15: clusterapi.CompareHashTreeRootsMultiRequest.classes:type_name -> clusterapi.ClassShardRootDigests
+	40, // 16: clusterapi.CompareHashTreeRootsMultiResponse.classes:type_name -> clusterapi.ClassDivergingShards
+	51, // 17: clusterapi.GetAsyncCheckpointStatusResponse.statuses:type_name -> clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntry
+	49, // 18: clusterapi.GetAsyncCheckpointStatusResponse.StatusesEntry.value:type_name -> clusterapi.AsyncCheckpointShardStatus
+	3,  // 19: clusterapi.ReplicationService.PutObject:input_type -> clusterapi.PutObjectRequest
+	5,  // 20: clusterapi.ReplicationService.PutObjects:input_type -> clusterapi.PutObjectsRequest
+	7,  // 21: clusterapi.ReplicationService.MergeObject:input_type -> clusterapi.MergeObjectRequest
+	9,  // 22: clusterapi.ReplicationService.DeleteObject:input_type -> clusterapi.DeleteObjectRequest
+	11, // 23: clusterapi.ReplicationService.DeleteObjects:input_type -> clusterapi.DeleteObjectsRequest
+	13, // 24: clusterapi.ReplicationService.AddReferences:input_type -> clusterapi.AddReferencesRequest
+	15, // 25: clusterapi.ReplicationService.Commit:input_type -> clusterapi.CommitRequest
+	17, // 26: clusterapi.ReplicationService.Abort:input_type -> clusterapi.AbortRequest
+	19, // 27: clusterapi.ReplicationService.FetchObject:input_type -> clusterapi.FetchObjectRequest
+	21, // 28: clusterapi.ReplicationService.FetchObjects:input_type -> clusterapi.FetchObjectsRequest
+	23, // 29: clusterapi.ReplicationService.DigestObjects:input_type -> clusterapi.DigestObjectsRequest
+	25, // 30: clusterapi.ReplicationService.DigestObjectsInRange:input_type -> clusterapi.DigestObjectsInRangeRequest
+	27, // 31: clusterapi.ReplicationService.CompareDigests:input_type -> clusterapi.CompareDigestsRequest
+	29, // 32: clusterapi.ReplicationService.OverwriteObjects:input_type -> clusterapi.OverwriteObjectsRequest
+	31, // 33: clusterapi.ReplicationService.FindUUIDs:input_type -> clusterapi.FindUUIDsRequest
+	33, // 34: clusterapi.ReplicationService.HashTreeLevel:input_type -> clusterapi.HashTreeLevelRequest
+	36, // 35: clusterapi.ReplicationService.CompareHashTreeRoots:input_type -> clusterapi.CompareHashTreeRootsRequest
+	39, // 36: clusterapi.ReplicationService.CompareHashTreeRootsMulti:input_type -> clusterapi.CompareHashTreeRootsMultiRequest
+	42, // 37: clusterapi.ReplicationService.CountObjects:input_type -> clusterapi.CountObjectsRequest
+	44, // 38: clusterapi.ReplicationService.CreateAsyncCheckpoint:input_type -> clusterapi.CreateAsyncCheckpointRequest
+	46, // 39: clusterapi.ReplicationService.DeleteAsyncCheckpoint:input_type -> clusterapi.DeleteAsyncCheckpointRequest
+	48, // 40: clusterapi.ReplicationService.GetAsyncCheckpointStatus:input_type -> clusterapi.GetAsyncCheckpointStatusRequest
+	4,  // 41: clusterapi.ReplicationService.PutObject:output_type -> clusterapi.PutObjectResponse
+	6,  // 42: clusterapi.ReplicationService.PutObjects:output_type -> clusterapi.PutObjectsResponse
+	8,  // 43: clusterapi.ReplicationService.MergeObject:output_type -> clusterapi.MergeObjectResponse
+	10, // 44: clusterapi.ReplicationService.DeleteObject:output_type -> clusterapi.DeleteObjectResponse
+	12, // 45: clusterapi.ReplicationService.DeleteObjects:output_type -> clusterapi.DeleteObjectsResponse
+	14, // 46: clusterapi.ReplicationService.AddReferences:output_type -> clusterapi.AddReferencesResponse
+	16, // 47: clusterapi.ReplicationService.Commit:output_type -> clusterapi.CommitResponse
+	18, // 48: clusterapi.ReplicationService.Abort:output_type -> clusterapi.AbortResponse
+	20, // 49: clusterapi.ReplicationService.FetchObject:output_type -> clusterapi.FetchObjectResponse
+	22, // 50: clusterapi.ReplicationService.FetchObjects:output_type -> clusterapi.FetchObjectsResponse
+	24, // 51: clusterapi.ReplicationService.DigestObjects:output_type -> clusterapi.DigestObjectsResponse
+	26, // 52: clusterapi.ReplicationService.DigestObjectsInRange:output_type -> clusterapi.DigestObjectsInRangeResponse
+	28, // 53: clusterapi.ReplicationService.CompareDigests:output_type -> clusterapi.CompareDigestsResponse
+	30, // 54: clusterapi.ReplicationService.OverwriteObjects:output_type -> clusterapi.OverwriteObjectsResponse
+	32, // 55: clusterapi.ReplicationService.FindUUIDs:output_type -> clusterapi.FindUUIDsResponse
+	34, // 56: clusterapi.ReplicationService.HashTreeLevel:output_type -> clusterapi.HashTreeLevelResponse
+	37, // 57: clusterapi.ReplicationService.CompareHashTreeRoots:output_type -> clusterapi.CompareHashTreeRootsResponse
+	41, // 58: clusterapi.ReplicationService.CompareHashTreeRootsMulti:output_type -> clusterapi.CompareHashTreeRootsMultiResponse
+	43, // 59: clusterapi.ReplicationService.CountObjects:output_type -> clusterapi.CountObjectsResponse
+	45, // 60: clusterapi.ReplicationService.CreateAsyncCheckpoint:output_type -> clusterapi.CreateAsyncCheckpointResponse
+	47, // 61: clusterapi.ReplicationService.DeleteAsyncCheckpoint:output_type -> clusterapi.DeleteAsyncCheckpointResponse
+	50, // 62: clusterapi.ReplicationService.GetAsyncCheckpointStatus:output_type -> clusterapi.GetAsyncCheckpointStatusResponse
+	41, // [41:63] is the sub-list for method output_type
+	19, // [19:41] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_protocol_replication_proto_init() }
@@ -3101,7 +3325,7 @@ func file_protocol_replication_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protocol_replication_proto_rawDesc), len(file_protocol_replication_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   48,
+			NumMessages:   52,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication_grpc.pb.go
+++ b/adapters/handlers/rest/clusterapi/grpc/generated/protocol/replication_grpc.pb.go
@@ -19,27 +19,28 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	ReplicationService_PutObject_FullMethodName                = "/clusterapi.ReplicationService/PutObject"
-	ReplicationService_PutObjects_FullMethodName               = "/clusterapi.ReplicationService/PutObjects"
-	ReplicationService_MergeObject_FullMethodName              = "/clusterapi.ReplicationService/MergeObject"
-	ReplicationService_DeleteObject_FullMethodName             = "/clusterapi.ReplicationService/DeleteObject"
-	ReplicationService_DeleteObjects_FullMethodName            = "/clusterapi.ReplicationService/DeleteObjects"
-	ReplicationService_AddReferences_FullMethodName            = "/clusterapi.ReplicationService/AddReferences"
-	ReplicationService_Commit_FullMethodName                   = "/clusterapi.ReplicationService/Commit"
-	ReplicationService_Abort_FullMethodName                    = "/clusterapi.ReplicationService/Abort"
-	ReplicationService_FetchObject_FullMethodName              = "/clusterapi.ReplicationService/FetchObject"
-	ReplicationService_FetchObjects_FullMethodName             = "/clusterapi.ReplicationService/FetchObjects"
-	ReplicationService_DigestObjects_FullMethodName            = "/clusterapi.ReplicationService/DigestObjects"
-	ReplicationService_DigestObjectsInRange_FullMethodName     = "/clusterapi.ReplicationService/DigestObjectsInRange"
-	ReplicationService_CompareDigests_FullMethodName           = "/clusterapi.ReplicationService/CompareDigests"
-	ReplicationService_OverwriteObjects_FullMethodName         = "/clusterapi.ReplicationService/OverwriteObjects"
-	ReplicationService_FindUUIDs_FullMethodName                = "/clusterapi.ReplicationService/FindUUIDs"
-	ReplicationService_HashTreeLevel_FullMethodName            = "/clusterapi.ReplicationService/HashTreeLevel"
-	ReplicationService_CompareHashTreeRoots_FullMethodName     = "/clusterapi.ReplicationService/CompareHashTreeRoots"
-	ReplicationService_CountObjects_FullMethodName             = "/clusterapi.ReplicationService/CountObjects"
-	ReplicationService_CreateAsyncCheckpoint_FullMethodName    = "/clusterapi.ReplicationService/CreateAsyncCheckpoint"
-	ReplicationService_DeleteAsyncCheckpoint_FullMethodName    = "/clusterapi.ReplicationService/DeleteAsyncCheckpoint"
-	ReplicationService_GetAsyncCheckpointStatus_FullMethodName = "/clusterapi.ReplicationService/GetAsyncCheckpointStatus"
+	ReplicationService_PutObject_FullMethodName                 = "/clusterapi.ReplicationService/PutObject"
+	ReplicationService_PutObjects_FullMethodName                = "/clusterapi.ReplicationService/PutObjects"
+	ReplicationService_MergeObject_FullMethodName               = "/clusterapi.ReplicationService/MergeObject"
+	ReplicationService_DeleteObject_FullMethodName              = "/clusterapi.ReplicationService/DeleteObject"
+	ReplicationService_DeleteObjects_FullMethodName             = "/clusterapi.ReplicationService/DeleteObjects"
+	ReplicationService_AddReferences_FullMethodName             = "/clusterapi.ReplicationService/AddReferences"
+	ReplicationService_Commit_FullMethodName                    = "/clusterapi.ReplicationService/Commit"
+	ReplicationService_Abort_FullMethodName                     = "/clusterapi.ReplicationService/Abort"
+	ReplicationService_FetchObject_FullMethodName               = "/clusterapi.ReplicationService/FetchObject"
+	ReplicationService_FetchObjects_FullMethodName              = "/clusterapi.ReplicationService/FetchObjects"
+	ReplicationService_DigestObjects_FullMethodName             = "/clusterapi.ReplicationService/DigestObjects"
+	ReplicationService_DigestObjectsInRange_FullMethodName      = "/clusterapi.ReplicationService/DigestObjectsInRange"
+	ReplicationService_CompareDigests_FullMethodName            = "/clusterapi.ReplicationService/CompareDigests"
+	ReplicationService_OverwriteObjects_FullMethodName          = "/clusterapi.ReplicationService/OverwriteObjects"
+	ReplicationService_FindUUIDs_FullMethodName                 = "/clusterapi.ReplicationService/FindUUIDs"
+	ReplicationService_HashTreeLevel_FullMethodName             = "/clusterapi.ReplicationService/HashTreeLevel"
+	ReplicationService_CompareHashTreeRoots_FullMethodName      = "/clusterapi.ReplicationService/CompareHashTreeRoots"
+	ReplicationService_CompareHashTreeRootsMulti_FullMethodName = "/clusterapi.ReplicationService/CompareHashTreeRootsMulti"
+	ReplicationService_CountObjects_FullMethodName              = "/clusterapi.ReplicationService/CountObjects"
+	ReplicationService_CreateAsyncCheckpoint_FullMethodName     = "/clusterapi.ReplicationService/CreateAsyncCheckpoint"
+	ReplicationService_DeleteAsyncCheckpoint_FullMethodName     = "/clusterapi.ReplicationService/DeleteAsyncCheckpoint"
+	ReplicationService_GetAsyncCheckpointStatus_FullMethodName  = "/clusterapi.ReplicationService/GetAsyncCheckpointStatus"
 )
 
 // ReplicationServiceClient is the client API for ReplicationService service.
@@ -68,6 +69,7 @@ type ReplicationServiceClient interface {
 	FindUUIDs(ctx context.Context, in *FindUUIDsRequest, opts ...grpc.CallOption) (*FindUUIDsResponse, error)
 	HashTreeLevel(ctx context.Context, in *HashTreeLevelRequest, opts ...grpc.CallOption) (*HashTreeLevelResponse, error)
 	CompareHashTreeRoots(ctx context.Context, in *CompareHashTreeRootsRequest, opts ...grpc.CallOption) (*CompareHashTreeRootsResponse, error)
+	CompareHashTreeRootsMulti(ctx context.Context, in *CompareHashTreeRootsMultiRequest, opts ...grpc.CallOption) (*CompareHashTreeRootsMultiResponse, error)
 	CountObjects(ctx context.Context, in *CountObjectsRequest, opts ...grpc.CallOption) (*CountObjectsResponse, error)
 	// Async-checkpoint control plane; mirrors /replicas/indices/{class}/async-checkpoint.
 	CreateAsyncCheckpoint(ctx context.Context, in *CreateAsyncCheckpointRequest, opts ...grpc.CallOption) (*CreateAsyncCheckpointResponse, error)
@@ -253,6 +255,16 @@ func (c *replicationServiceClient) CompareHashTreeRoots(ctx context.Context, in 
 	return out, nil
 }
 
+func (c *replicationServiceClient) CompareHashTreeRootsMulti(ctx context.Context, in *CompareHashTreeRootsMultiRequest, opts ...grpc.CallOption) (*CompareHashTreeRootsMultiResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CompareHashTreeRootsMultiResponse)
+	err := c.cc.Invoke(ctx, ReplicationService_CompareHashTreeRootsMulti_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *replicationServiceClient) CountObjects(ctx context.Context, in *CountObjectsRequest, opts ...grpc.CallOption) (*CountObjectsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(CountObjectsResponse)
@@ -319,6 +331,7 @@ type ReplicationServiceServer interface {
 	FindUUIDs(context.Context, *FindUUIDsRequest) (*FindUUIDsResponse, error)
 	HashTreeLevel(context.Context, *HashTreeLevelRequest) (*HashTreeLevelResponse, error)
 	CompareHashTreeRoots(context.Context, *CompareHashTreeRootsRequest) (*CompareHashTreeRootsResponse, error)
+	CompareHashTreeRootsMulti(context.Context, *CompareHashTreeRootsMultiRequest) (*CompareHashTreeRootsMultiResponse, error)
 	CountObjects(context.Context, *CountObjectsRequest) (*CountObjectsResponse, error)
 	// Async-checkpoint control plane; mirrors /replicas/indices/{class}/async-checkpoint.
 	CreateAsyncCheckpoint(context.Context, *CreateAsyncCheckpointRequest) (*CreateAsyncCheckpointResponse, error)
@@ -383,6 +396,9 @@ func (UnimplementedReplicationServiceServer) HashTreeLevel(context.Context, *Has
 }
 func (UnimplementedReplicationServiceServer) CompareHashTreeRoots(context.Context, *CompareHashTreeRootsRequest) (*CompareHashTreeRootsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CompareHashTreeRoots not implemented")
+}
+func (UnimplementedReplicationServiceServer) CompareHashTreeRootsMulti(context.Context, *CompareHashTreeRootsMultiRequest) (*CompareHashTreeRootsMultiResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CompareHashTreeRootsMulti not implemented")
 }
 func (UnimplementedReplicationServiceServer) CountObjects(context.Context, *CountObjectsRequest) (*CountObjectsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CountObjects not implemented")
@@ -722,6 +738,24 @@ func _ReplicationService_CompareHashTreeRoots_Handler(srv interface{}, ctx conte
 	return interceptor(ctx, in, info, handler)
 }
 
+func _ReplicationService_CompareHashTreeRootsMulti_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CompareHashTreeRootsMultiRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ReplicationServiceServer).CompareHashTreeRootsMulti(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: ReplicationService_CompareHashTreeRootsMulti_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ReplicationServiceServer).CompareHashTreeRootsMulti(ctx, req.(*CompareHashTreeRootsMultiRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _ReplicationService_CountObjects_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CountObjectsRequest)
 	if err := dec(in); err != nil {
@@ -868,6 +902,10 @@ var ReplicationService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "CompareHashTreeRoots",
 			Handler:    _ReplicationService_CompareHashTreeRoots_Handler,
+		},
+		{
+			MethodName: "CompareHashTreeRootsMulti",
+			Handler:    _ReplicationService_CompareHashTreeRootsMulti_Handler,
 		},
 		{
 			MethodName: "CountObjects",

--- a/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
+++ b/adapters/handlers/rest/clusterapi/grpc/protocol/replication.proto
@@ -25,6 +25,7 @@ service ReplicationService {
   rpc FindUUIDs (FindUUIDsRequest) returns (FindUUIDsResponse);
   rpc HashTreeLevel (HashTreeLevelRequest) returns (HashTreeLevelResponse);
   rpc CompareHashTreeRoots (CompareHashTreeRootsRequest) returns (CompareHashTreeRootsResponse);
+  rpc CompareHashTreeRootsMulti (CompareHashTreeRootsMultiRequest) returns (CompareHashTreeRootsMultiResponse);
   rpc CountObjects (CountObjectsRequest) returns (CountObjectsResponse);
 
   // Async-checkpoint control plane; mirrors /replicas/indices/{class}/async-checkpoint.
@@ -295,6 +296,28 @@ message CompareHashTreeRootsRequest {
 
 message CompareHashTreeRootsResponse {
   repeated string diverging_shards = 1;
+}
+
+// CompareHashTreeRootsMulti is the cross-class form of CompareHashTreeRoots: one
+// request carries every class's due shard roots for this target node.
+message ClassShardRootDigests {
+  string index = 1;
+  repeated ShardRootDigest shard_root_digests = 2;
+}
+
+message CompareHashTreeRootsMultiRequest {
+  repeated ClassShardRootDigests classes = 1;
+}
+
+// error set means the class could not be compared; the sender descends its shards.
+message ClassDivergingShards {
+  string index = 1;
+  repeated string diverging_shards = 2;
+  string error = 3;
+}
+
+message CompareHashTreeRootsMultiResponse {
+  repeated ClassDivergingShards classes = 1;
 }
 
 // CountObjects fetches hash tree level digests.

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service.go
@@ -334,6 +334,36 @@ func (s *ReplicationService) CompareHashTreeRoots(ctx context.Context, req *pb.C
 	return &pb.CompareHashTreeRootsResponse{DivergingShards: diverging}, nil
 }
 
+// CompareHashTreeRootsMulti classifies per class; a failed class carries its error so the rest still classify.
+func (s *ReplicationService) CompareHashTreeRootsMulti(ctx context.Context, req *pb.CompareHashTreeRootsMultiRequest) (*pb.CompareHashTreeRootsMultiResponse, error) {
+	total := 0
+	for _, cls := range req.GetClasses() {
+		total += len(cls.GetShardRootDigests())
+	}
+	if total > replica.CompareHashTreeRootsMaxShardsPerRequest {
+		return nil, status.Errorf(codes.InvalidArgument, "too many shards: %d exceeds maximum %d",
+			total, replica.CompareHashTreeRootsMaxShardsPerRequest)
+	}
+
+	resp := &pb.CompareHashTreeRootsMultiResponse{
+		Classes: make([]*pb.ClassDivergingShards, 0, len(req.GetClasses())),
+	}
+	for _, cls := range req.GetClasses() {
+		shards := cls.GetShardRootDigests()
+		roots := make(map[string]hashtree.Digest, len(shards))
+		for _, sr := range shards {
+			roots[sr.GetShard()] = hashtree.Digest{sr.GetRootHashHigh(), sr.GetRootHashLow()}
+		}
+		diverging, err := s.server.CompareHashTreeRoots(ctx, cls.GetIndex(), roots)
+		if err != nil {
+			resp.Classes = append(resp.Classes, &pb.ClassDivergingShards{Index: cls.GetIndex(), Error: err.Error()})
+			continue
+		}
+		resp.Classes = append(resp.Classes, &pb.ClassDivergingShards{Index: cls.GetIndex(), DivergingShards: diverging})
+	}
+	return resp, nil
+}
+
 func (s *ReplicationService) CountObjects(ctx context.Context, req *pb.CountObjectsRequest) (*pb.CountObjectsResponse, error) {
 	count, err := s.server.CountObjects(ctx, req.GetIndex(), req.GetShard())
 	if err != nil {

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -234,6 +234,62 @@ func TestCompareHashTreeRootsRoundTrip(t *testing.T) {
 	})
 }
 
+func TestCompareHashTreeRootsMultiRoundTrip(t *testing.T) {
+	t.Run("classifies per class and isolates per-class errors", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		mockReplicator.EXPECT().
+			CompareHashTreeRoots(mock.Anything, "ClassA", map[string]hashtree.Digest{"a1": {1, 2}, "a2": {3, 4}}).
+			Return([]string{"a2"}, nil)
+		mockReplicator.EXPECT().
+			CompareHashTreeRoots(mock.Anything, "ClassB", map[string]hashtree.Digest{"b1": {5, 6}}).
+			Return(nil, errors.New("index not loaded"))
+
+		resp, err := svc.CompareHashTreeRootsMulti(context.Background(), &pb.CompareHashTreeRootsMultiRequest{
+			Classes: []*pb.ClassShardRootDigests{
+				{Index: "ClassA", ShardRootDigests: []*pb.ShardRootDigest{
+					{Shard: "a1", RootHashHigh: 1, RootHashLow: 2},
+					{Shard: "a2", RootHashHigh: 3, RootHashLow: 4},
+				}},
+				{Index: "ClassB", ShardRootDigests: []*pb.ShardRootDigest{
+					{Shard: "b1", RootHashHigh: 5, RootHashLow: 6},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.GetClasses(), 2)
+		byIndex := map[string]*pb.ClassDivergingShards{}
+		for _, cls := range resp.GetClasses() {
+			byIndex[cls.GetIndex()] = cls
+		}
+		assert.Equal(t, []string{"a2"}, byIndex["ClassA"].GetDivergingShards())
+		assert.Empty(t, byIndex["ClassA"].GetError())
+		assert.Contains(t, byIndex["ClassB"].GetError(), "index not loaded")
+	})
+
+	t.Run("rejects a request exceeding the total shard cap without calling the replicator", func(t *testing.T) {
+		mockReplicator := replicaTypes.NewMockReplicator(t)
+		svc := &ReplicationService{server: mockReplicator}
+
+		perClass := replica.CompareHashTreeRootsMaxShardsPerRequest/2 + 1
+		classes := make([]*pb.ClassShardRootDigests, 2)
+		for c := range classes {
+			shards := make([]*pb.ShardRootDigest, perClass)
+			for i := range shards {
+				shards[i] = &pb.ShardRootDigest{Shard: fmt.Sprintf("shard-%d", i)}
+			}
+			classes[c] = &pb.ClassShardRootDigests{Index: fmt.Sprintf("Class%d", c), ShardRootDigests: shards}
+		}
+
+		_, err := svc.CompareHashTreeRootsMulti(context.Background(), &pb.CompareHashTreeRootsMultiRequest{Classes: classes})
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
 func TestCompareDigestsEncoding(t *testing.T) {
 	const index, shard = "MyClass", "myshard"
 	source := []routerTypes.RepairDigest{

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -138,6 +138,14 @@ func (i *replicatedIndices) handleRequest(w http.ResponseWriter, r *http.Request
 	// NOTE if you update any of these handler methods/paths, also update the indices_replicas_test.go
 	// TestMaintenanceModeReplicatedIndices test to include the new methods/paths.
 	switch {
+	case path == shared.CompareHashTreeRootsMultiPath:
+		if r.Method == http.MethodPost {
+			i.postCompareHashTreeRootsMulti().ServeHTTP(w, r)
+			return
+		}
+
+		http.Error(w, "405 Method not Allowed", http.StatusMethodNotAllowed)
+		return
 	case regxObjectsDigest.MatchString(path):
 		if r.Method == http.MethodGet {
 			i.getObjectsDigest().ServeHTTP(w, r)
@@ -524,6 +532,51 @@ func (i *replicatedIndices) getHashTreeLevel() http.Handler {
 		}
 
 		writeHashTreeLevelResponse(w, r, results)
+	})
+}
+
+func (i *replicatedIndices) postCompareHashTreeRootsMulti() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+
+		var req replica.CompareHashTreeRootsMultiReq
+		body := http.MaxBytesReader(w, r.Body, maxDecompressedReplicaBody)
+		if err := json.NewDecoder(body).Decode(&req); err != nil {
+			http.Error(w, "unmarshal compare hashtree roots multi request: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		total := 0
+		for _, wireRoots := range req.Classes {
+			total += len(wireRoots)
+		}
+		if total > replica.CompareHashTreeRootsMaxShardsPerRequest {
+			http.Error(w, fmt.Sprintf("too many shards: %d exceeds maximum %d",
+				total, replica.CompareHashTreeRootsMaxShardsPerRequest), http.StatusBadRequest)
+			return
+		}
+
+		resp := replica.CompareHashTreeRootsMultiResp{
+			Classes: make(map[string]replica.CompareHashTreeRootsMultiClassResp, len(req.Classes)),
+		}
+		for class, wireRoots := range req.Classes {
+			roots := make(map[string]hashtree.Digest, len(wireRoots))
+			for shard, root := range wireRoots {
+				roots[shard] = hashtree.Digest(root)
+			}
+			diverging, err := i.replicator.CompareHashTreeRoots(r.Context(), class, roots)
+			if err != nil {
+				resp.Classes[class] = replica.CompareHashTreeRootsMultiClassResp{Error: err.Error()}
+				continue
+			}
+			resp.Classes[class] = replica.CompareHashTreeRootsMultiClassResp{DivergingShards: diverging}
+		}
+
+		resBytes, err := json.Marshal(resp)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Write(resBytes) //nolint:errcheck
 	})
 }
 

--- a/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_multi_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_multi_test.go
@@ -20,13 +20,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/clients"
-	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
 	"github.com/weaviate/weaviate/usecases/replica"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
@@ -39,22 +37,8 @@ type crossClassClient interface {
 
 func newMultiPrefilterTestServer(t *testing.T, replicator replicaTypes.Replicator) (crossClassClient, string) {
 	t.Helper()
-	logger, _ := test.NewNullLogger()
-	indices := clusterapi.NewReplicatedIndices(
-		replicator,
-		clusterapi.NewNoopAuthHandler(),
-		func() bool { return false },
-		logger,
-		func() bool { return true },
-	)
-	mux := http.NewServeMux()
-	mux.Handle("/replicas/indices/", indices.Indices())
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-
-	client, err := clients.NewReplicationClient(&http.Client{})
-	require.NoError(t, err)
-	return client, strings.TrimPrefix(server.URL, "http://")
+	client, host := newPrefilterTestServer(t, replicator)
+	return client.(crossClassClient), host
 }
 
 // TestCompareHashTreeRootsMultiRESTRoundTrip proves the real REST client+handler classify per class and isolate per-class errors.

--- a/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_multi_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_prefilter_multi_test.go
@@ -1,0 +1,130 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clusterapi_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/clients"
+	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
+)
+
+type crossClassClient interface {
+	CompareHashTreeRootsMulti(ctx context.Context, host string,
+		classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
+}
+
+func newMultiPrefilterTestServer(t *testing.T, replicator replicaTypes.Replicator) (crossClassClient, string) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	indices := clusterapi.NewReplicatedIndices(
+		replicator,
+		clusterapi.NewNoopAuthHandler(),
+		func() bool { return false },
+		logger,
+		func() bool { return true },
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/replicas/indices/", indices.Indices())
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client, err := clients.NewReplicationClient(&http.Client{})
+	require.NoError(t, err)
+	return client, strings.TrimPrefix(server.URL, "http://")
+}
+
+// TestCompareHashTreeRootsMultiRESTRoundTrip proves the real REST client+handler classify per class and isolate per-class errors.
+func TestCompareHashTreeRootsMultiRESTRoundTrip(t *testing.T) {
+	d := func(hi, lo uint64) hashtree.Digest { return hashtree.Digest{hi, lo} }
+	payload := map[string]map[string]hashtree.Digest{
+		"ClassA": {"a1": d(1, 1), "a2": d(0xFFFFFFFFFFFFFFFF, 2)},
+		"ClassB": {"b1": d(3, 0xDEADBEEFCAFEBABE)},
+		"ClassC": {"c1": d(4, 4)},
+	}
+
+	mockReplicator := replicaTypes.NewMockReplicator(t)
+	received := map[string]map[string]hashtree.Digest{}
+	mockReplicator.EXPECT().
+		CompareHashTreeRoots(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, class string, roots map[string]hashtree.Digest) ([]string, error) {
+			received[class] = roots
+			switch class {
+			case "ClassA":
+				return []string{"a2"}, nil
+			case "ClassB":
+				return nil, nil
+			default:
+				return nil, errors.New("index not loaded")
+			}
+		})
+
+	client, host := newMultiPrefilterTestServer(t, mockReplicator)
+	resp, err := client.CompareHashTreeRootsMulti(context.Background(), host, payload)
+	require.NoError(t, err)
+	require.Len(t, resp.Classes, 3)
+
+	assert.Equal(t, payload, received)
+	assert.Equal(t, []string{"a2"}, resp.Classes["ClassA"].DivergingShards)
+	assert.Empty(t, resp.Classes["ClassA"].Error)
+	assert.Empty(t, resp.Classes["ClassB"].DivergingShards)
+	assert.Empty(t, resp.Classes["ClassB"].Error)
+	assert.Contains(t, resp.Classes["ClassC"].Error, "index not loaded")
+}
+
+// TestCompareHashTreeRootsMultiUnsupportedPeer pins the 404→Unsupported fallback for peers without the route.
+func TestCompareHashTreeRootsMultiUnsupportedPeer(t *testing.T) {
+	server := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(server.Close)
+
+	client, err := clients.NewReplicationClient(&http.Client{})
+	require.NoError(t, err)
+
+	_, err = client.CompareHashTreeRootsMulti(context.Background(),
+		strings.TrimPrefix(server.URL, "http://"),
+		map[string]map[string]hashtree.Digest{"C": {"s": {1, 2}}})
+	assert.ErrorIs(t, err, replica.ErrCompareHashTreeRootsUnsupported)
+}
+
+// TestCompareHashTreeRootsMultiShardCap rejects requests whose total shard count exceeds the receiver cap.
+func TestCompareHashTreeRootsMultiShardCap(t *testing.T) {
+	mockReplicator := replicaTypes.NewMockReplicator(t)
+	client, host := newMultiPrefilterTestServer(t, mockReplicator)
+
+	oversized := map[string]map[string]hashtree.Digest{}
+	perClass := replica.CompareHashTreeRootsMaxShardsPerRequest / 4
+	for c := range 5 {
+		shards := map[string]hashtree.Digest{}
+		for s := range perClass {
+			shards[fmt.Sprintf("s%d", s)] = hashtree.Digest{uint64(c), uint64(s)}
+		}
+		oversized[fmt.Sprintf("Class%d", c)] = shards
+	}
+
+	_, err := client.CompareHashTreeRootsMulti(context.Background(), host, oversized)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too many shards")
+}

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -74,6 +74,15 @@ func TestMaintenanceModeReplicatedIndices(t *testing.T) {
 			assert.True(t, res.StatusCode == maintenanceModeExpectedHTTPStatus, "expected %d, got %d", maintenanceModeExpectedHTTPStatus, res.StatusCode)
 		})
 	}
+
+	t.Run("POST on the cross-class root compare returns maintenance mode status", func(t *testing.T) {
+		req, err := http.NewRequest("POST", server.URL+shared.CompareHashTreeRootsMultiPath, nil)
+		assert.Nil(t, err)
+		res, err := http.DefaultClient.Do(req)
+		assert.Nil(t, err)
+		defer res.Body.Close()
+		assert.Equal(t, maintenanceModeExpectedHTTPStatus, res.StatusCode)
+	})
 }
 
 func newOverwriteServer(t *testing.T) (*httptest.Server, string) {

--- a/adapters/handlers/rest/clusterapi/shared/util.go
+++ b/adapters/handlers/rest/clusterapi/shared/util.go
@@ -20,6 +20,9 @@ import (
 	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
+// CompareHashTreeRootsMultiPath is node-level; the leading underscore cannot collide with a class segment.
+const CompareHashTreeRootsMultiPath = "/replicas/indices/_compareHashTreeRootsMulti"
+
 func LocalIndexNotReady(resp replica.SimpleResponse) bool {
 	if err := resp.FirstError(); err != nil {
 		var replicaErr *replicaerrors.Error

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -77,6 +77,21 @@ var asyncRepDispatchSeam func(*asyncSchedulerEntry)
 // asyncRepPrefilterSeam replaces the replicator root-compare in tests; nil outside tests.
 var asyncRepPrefilterSeam func(ctx context.Context, roots map[string]hashtree.Digest) map[string]struct{}
 
+// prefilterCoalesceWindow delays due entries so cross-class batches can form; var so tests can shrink it.
+var prefilterCoalesceWindow = time.Second
+
+// asyncRepTargetHostsSeam replaces per-shard target resolution in tests; nil outside tests.
+var asyncRepTargetHostsSeam func(*Shard) ([]string, error)
+
+// asyncRepPerClassFallbackSeam replaces the per-class fallback pre-filter in tests; nil outside tests.
+var asyncRepPerClassFallbackSeam func(context.Context, map[string]hashtree.Digest) (map[string]struct{}, replica.PrefilterStats)
+
+// crossClassRootComparer is the narrow client surface for the node-level root compare.
+type crossClassRootComparer interface {
+	CompareHashTreeRootsMulti(ctx context.Context, host string,
+		classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
+}
+
 func init() {
 	asyncRepRebuildBaseBackoff.Store(int64(30 * time.Second))
 }
@@ -574,8 +589,11 @@ type AsyncReplicationScheduler struct {
 
 	// batchPool recycles the []*asyncSchedulerEntry slices sent on workCh.
 	batchPool sync.Pool
-	// dispatchBuckets groups due entries by index during one dispatch pass; dispatcher-owned, emptied at the end of every pass.
-	dispatchBuckets map[*Index][]*asyncSchedulerEntry
+	// dispatchPending accumulates due entries during one dispatch pass; dispatcher-owned, emptied at the end of every pass.
+	dispatchPending []*asyncSchedulerEntry
+
+	// crossClassComparer is the node-level root-compare client; nil falls back to the per-class pre-filter.
+	crossClassComparer crossClassRootComparer
 
 	metrics asyncReplicationSchedulerMetrics
 	logger  logrus.FieldLogger
@@ -599,12 +617,18 @@ type AsyncReplicationScheduler struct {
 //
 // AsyncReplicationHashtreeInitConcurrency is read once here to size the init
 // semaphore; later changes to its DynamicValue have no effect.
+// crossClassComparer is optional: absent (or nil) falls back to the per-class pre-filter.
 func NewAsyncReplicationScheduler(
 	ctx context.Context,
 	replicationCfg replication.GlobalConfig,
 	prom *monitoring.PrometheusMetrics,
 	logger logrus.FieldLogger,
+	crossClassComparer ...crossClassRootComparer,
 ) (*AsyncReplicationScheduler, error) {
+	var comparer crossClassRootComparer
+	if len(crossClassComparer) > 0 {
+		comparer = crossClassComparer[0]
+	}
 	// Guard against nil DynamicValue pointers (zero-valued GlobalConfig in tests).
 	maxWorkersConfig := replicationCfg.AsyncReplicationSchedulerWorkers
 	if maxWorkersConfig == nil {
@@ -673,7 +697,7 @@ func NewAsyncReplicationScheduler(
 		removeCh:                 make(chan removeRequest),
 		asyncReplicationDisabled: asyncReplicationDisabled,
 		rootPrefilterBatchSize:   rootPrefilterBatchSize,
-		dispatchBuckets:          make(map[*Index][]*asyncSchedulerEntry),
+		crossClassComparer:       comparer,
 		hashtreeInitSem:          semaphore.NewWeighted(int64(hashtreeInitConcurrency)),
 		metrics:                  m,
 		logger:                   logger,
@@ -982,6 +1006,13 @@ func (sched *AsyncReplicationScheduler) timeUntilNextLocked() time.Duration {
 	}
 	d := time.Until(sched.h[0].nextRunAt)
 	if d < minDispatchInterval {
+		if !sched.coalesceElapsedLocked(time.Now()) {
+			// Sleep out the coalesce window instead of spinning at minDispatchInterval.
+			if w := time.Until(sched.h[0].nextRunAt.Add(prefilterCoalesceWindow)); w > minDispatchInterval {
+				return w
+			}
+			return minDispatchInterval
+		}
 		// Entry is due now. If the channel is full (all workers busy), use the
 		// larger backoff so the dispatcher yields instead of spinning.
 		if len(sched.workCh) == cap(sched.workCh) {
@@ -1050,6 +1081,9 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 		return
 	}
 	now := time.Now()
+	if !sched.coalesceElapsedLocked(now) {
+		return
+	}
 
 	full := false
 	for len(sched.h) > 0 && !sched.h[0].nextRunAt.After(now) && !full {
@@ -1090,44 +1124,68 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 			continue
 		}
 
-		idx := entry.shard.index
-
 		// Add(1) before send so Deregister+asyncRepWg.Wait() catches the cycle; pop to advance.
 		entry.shard.asyncRepWg.Add(1)
 		entry.pendingDone.Store(true)
 		entry.inFlight = true
 		heap.Pop(&sched.h)
 
-		sched.dispatchBuckets[idx] = append(sched.dispatchBuckets[idx], entry)
+		sched.dispatchPending = append(sched.dispatchPending, entry)
 		if asyncRepDispatchSeam != nil {
 			asyncRepDispatchSeam(entry)
 		}
-		if len(sched.dispatchBuckets[idx]) >= sched.effectiveBatchSize() {
-			if !sched.trySendBatchLocked(sched.dispatchBuckets[idx]) {
-				for _, e := range sched.dispatchBuckets[idx] {
+		if len(sched.dispatchPending) >= sched.effectiveBatchSize() {
+			if !sched.trySendBatchLocked(sched.dispatchPending) {
+				for _, e := range sched.dispatchPending {
 					sched.rollbackReservedLocked(e)
 				}
 				full = true
 			}
-			sched.dispatchBuckets[idx] = sched.dispatchBuckets[idx][:0]
+			clear(sched.dispatchPending)
+			sched.dispatchPending = sched.dispatchPending[:0]
 		}
 	}
 
-	// Flush partial buckets: a bucket below the cap ships as a smaller batch, or
-	// rolls back on a full channel. Keys are deleted so a dropped index (and the
-	// stale entry pointers in its bucket's backing array) is never pinned.
-	for idx, entries := range sched.dispatchBuckets {
-		if len(entries) > 0 {
-			if full || !sched.trySendBatchLocked(entries) {
-				for _, e := range entries {
-					sched.rollbackReservedLocked(e)
-				}
-				full = true
+	// Flush the partial batch; cleared so dropped indexes are never pinned by stale tails.
+	if len(sched.dispatchPending) > 0 {
+		if full || !sched.trySendBatchLocked(sched.dispatchPending) {
+			for _, e := range sched.dispatchPending {
+				sched.rollbackReservedLocked(e)
 			}
 		}
-		delete(sched.dispatchBuckets, idx)
+		clear(sched.dispatchPending)
+		sched.dispatchPending = sched.dispatchPending[:0]
 	}
 	sched.metrics.setQueueDepth(len(sched.h))
+}
+
+// coalesceElapsedLocked reports whether due entries should dispatch now or keep
+// accumulating: a full batch, a head past the window, or a diverging head fire
+// immediately. mu must be held.
+func (sched *AsyncReplicationScheduler) coalesceElapsedLocked(now time.Time) bool {
+	if len(sched.h) == 0 || sched.h[0].nextRunAt.After(now) {
+		return true
+	}
+	batch := sched.effectiveBatchSize()
+	if batch <= 1 {
+		return true
+	}
+	head := sched.h[0]
+	if head.descendDirect {
+		return true
+	}
+	if !head.nextRunAt.After(now.Add(-prefilterCoalesceWindow)) {
+		return true
+	}
+	due := 0
+	for _, e := range sched.h {
+		if !e.nextRunAt.After(now) {
+			if due++; due >= batch {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // onResultLocked re-enqueues a shard after a cycle completes (or discards
@@ -1237,17 +1295,16 @@ func (sched *AsyncReplicationScheduler) onRemoveLocked(s *Shard) {
 	sched.metrics.setQueueDepth(len(sched.h))
 }
 
-// settleDispatchBucketsOnExit settles reservations stranded in dispatchBuckets by a mid-dispatch panic: they sit in no channel and no heap.
+// settleDispatchBucketsOnExit settles reservations stranded in dispatchPending by a mid-dispatch panic: they sit in no channel and no heap.
 func (sched *AsyncReplicationScheduler) settleDispatchBucketsOnExit() {
 	sched.mu.Lock()
 	defer sched.mu.Unlock()
-	for idx, entries := range sched.dispatchBuckets {
-		for _, entry := range entries {
-			entry.inFlight = false
-			entry.settleDone()
-		}
-		delete(sched.dispatchBuckets, idx)
+	for _, entry := range sched.dispatchPending {
+		entry.inFlight = false
+		entry.settleDone()
 	}
+	clear(sched.dispatchPending)
+	sched.dispatchPending = sched.dispatchPending[:0]
 }
 
 // drainWorkChOnExit empties workCh after the dispatcher returned, settling each
@@ -1273,23 +1330,34 @@ func (sched *AsyncReplicationScheduler) drainWorkChOnExit() {
 
 // batchScratch holds a worker's reusable classify maps, reset per batch: no
 // per-batch allocs and no cross-worker sharing.
+// prefilterGroup tracks one class's eligible shards through the cross-class pre-filter.
+type prefilterGroup struct {
+	index   *Index
+	roots   map[string]hashtree.Digest
+	entries map[string]*asyncSchedulerEntry
+	// waiting counts outstanding per-host confirmations; a shard skips only at zero with no diverge.
+	waiting map[string]int
+	diverge map[string]bool
+}
+
 type batchScratch struct {
-	roots    map[string]hashtree.Digest
-	eligible map[string]*asyncSchedulerEntry
-	skip     map[*asyncSchedulerEntry]bool
+	classes map[string]*prefilterGroup
+	// byHost: host → class → shard → root; per-host tuples ≤ batch size (≤4096) so one RPC always fits the receiver's cap.
+	byHost map[string]map[string]map[string]hashtree.Digest
+	skip   map[*asyncSchedulerEntry]bool
 }
 
 func newBatchScratch() *batchScratch {
 	return &batchScratch{
-		roots:    make(map[string]hashtree.Digest),
-		eligible: make(map[string]*asyncSchedulerEntry),
-		skip:     make(map[*asyncSchedulerEntry]bool),
+		classes: make(map[string]*prefilterGroup),
+		byHost:  make(map[string]map[string]map[string]hashtree.Digest),
+		skip:    make(map[*asyncSchedulerEntry]bool),
 	}
 }
 
 func (bs *batchScratch) reset() {
-	clear(bs.roots)
-	clear(bs.eligible)
+	clear(bs.classes)
+	clear(bs.byHost)
 	clear(bs.skip)
 }
 
@@ -1505,19 +1573,25 @@ func (sched *AsyncReplicationScheduler) deferDescent(entry *asyncSchedulerEntry)
 	sched.resultCh <- asyncSchedulerResult{entry: entry, deferDescent: true}
 }
 
-// prefilterCtx builds the context for one batched pre-filter. It must abort when
-// the index closes: index.drop() cancels closingCtx etc.
+// prefilterCtx aborts when the scheduler stops, the timeout fires, or any involved index closes.
 func (sched *AsyncReplicationScheduler) prefilterCtx(
-	idx *Index, timeout time.Duration,
+	timeout time.Duration, indexes ...*Index,
 ) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithTimeout(sched.ctx, timeout)
-
-	if idx == nil || idx.closingCtx == nil {
+	stops := make([]func() bool, 0, len(indexes))
+	for _, idx := range indexes {
+		if idx == nil || idx.closingCtx == nil {
+			continue
+		}
+		stops = append(stops, context.AfterFunc(idx.closingCtx, cancel))
+	}
+	if len(stops) == 0 {
 		return ctx, cancel
 	}
-	stop := context.AfterFunc(idx.closingCtx, cancel)
 	return ctx, func() {
-		stop()
+		for _, stop := range stops {
+			stop()
+		}
 		cancel()
 	}
 }
@@ -1535,6 +1609,7 @@ func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEnt
 		}
 	}()
 
+	total := 0
 	for _, entry := range batch {
 		s := entry.shard
 		if sched.hasTargetNodeOverrides(s) {
@@ -1544,32 +1619,174 @@ func (sched *AsyncReplicationScheduler) classifyBatch(batch []*asyncSchedulerEnt
 		if !ok {
 			continue
 		}
-		scratch.roots[s.name] = root
-		scratch.eligible[s.name] = entry
+		cls := s.index.Config.ClassName.String()
+		g := scratch.classes[cls]
+		if g == nil {
+			g = &prefilterGroup{
+				index:   s.index,
+				roots:   make(map[string]hashtree.Digest),
+				entries: make(map[string]*asyncSchedulerEntry),
+				waiting: make(map[string]int),
+				diverge: make(map[string]bool),
+			}
+			scratch.classes[cls] = g
+		}
+		g.roots[s.name] = root
+		g.entries[s.name] = entry
+		total++
 	}
-	if len(scratch.roots) == 0 {
+	if total == 0 {
 		return
 	}
 
-	s0 := batch[0].shard
-	cfg := sched.effectiveConfig(s0)
-	ctx, cancel := sched.prefilterCtx(s0.index, cfg.diffPerNodeTimeout)
-	// defer so the timer is released even if PrefilterShardRoots panics (an inline
-	// cancel() would be skipped, leaking it until the parent is done).
-	defer cancel()
-	var needFull map[string]struct{}
-	if asyncRepPrefilterSeam != nil {
-		needFull = asyncRepPrefilterSeam(ctx, scratch.roots)
-	} else {
-		var stats replica.PrefilterStats
-		needFull, stats = s0.index.replicator.PrefilterShardRoots(ctx, scratch.roots)
-		sched.metrics.addRootCompareRPC(stats.OK, stats.Errored, stats.Unsupported)
+	cfg := sched.effectiveConfig(batch[0].shard)
+	indexes := make([]*Index, 0, len(scratch.classes))
+	for _, g := range scratch.classes {
+		indexes = append(indexes, g.index)
 	}
-	sched.metrics.observeRootPrefilterBatch(len(scratch.roots))
+	ctx, cancel := sched.prefilterCtx(cfg.diffPerNodeTimeout, indexes...)
+	// defer so the timer is released even if a compare panics.
+	defer cancel()
 
-	for name, entry := range scratch.eligible {
-		if _, diverges := needFull[name]; !diverges {
-			scratch.skip[entry] = true
+	if asyncRepPrefilterSeam != nil {
+		for _, g := range scratch.classes {
+			needFull := asyncRepPrefilterSeam(ctx, g.roots)
+			for name, entry := range g.entries {
+				if _, diverges := needFull[name]; !diverges {
+					scratch.skip[entry] = true
+				}
+			}
+		}
+		sched.metrics.observeRootPrefilterBatch(total)
+		return
+	}
+
+	sched.classifyCrossClass(ctx, scratch)
+	sched.metrics.observeRootPrefilterBatch(total)
+}
+
+// classifyCrossClass resolves per-shard targets, issues one root-compare RPC per host,
+// and marks confirmed-in-sync entries in scratch.skip; every failure path leaves
+// entries on the conservative full-descent side.
+func (sched *AsyncReplicationScheduler) classifyCrossClass(ctx context.Context, scratch *batchScratch) {
+	for cls, g := range scratch.classes {
+		for name, entry := range g.entries {
+			var hosts []string
+			var err error
+			if asyncRepTargetHostsSeam != nil {
+				hosts, err = asyncRepTargetHostsSeam(entry.shard)
+			} else {
+				hosts, err = g.index.replicator.TargetHostAddrsForShard(name)
+			}
+			if err != nil {
+				g.diverge[name] = true
+				continue
+			}
+			if len(hosts) == 0 {
+				scratch.skip[entry] = true
+				continue
+			}
+			g.waiting[name] = len(hosts)
+			for _, h := range hosts {
+				perClass := scratch.byHost[h]
+				if perClass == nil {
+					perClass = make(map[string]map[string]hashtree.Digest)
+					scratch.byHost[h] = perClass
+				}
+				sub := perClass[cls]
+				if sub == nil {
+					sub = make(map[string]hashtree.Digest, len(g.roots))
+					perClass[cls] = sub
+				}
+				sub[name] = g.roots[name]
+			}
+		}
+	}
+
+	var ok, errored, unsupported int
+	fallbackDone := make(map[string]bool)
+	for host, classes := range scratch.byHost {
+		if sched.crossClassComparer == nil {
+			sched.fallbackPerClass(ctx, classes, scratch, &ok, &errored, &unsupported, fallbackDone)
+			continue
+		}
+		resp, err := sched.crossClassComparer.CompareHashTreeRootsMulti(ctx, host, classes)
+		switch {
+		case errors.Is(err, replica.ErrCompareHashTreeRootsUnsupported):
+			unsupported++
+			sched.fallbackPerClass(ctx, classes, scratch, &ok, &errored, &unsupported, fallbackDone)
+		case err != nil:
+			errored++
+			for cls, shards := range classes {
+				g := scratch.classes[cls]
+				for name := range shards {
+					g.diverge[name] = true
+				}
+			}
+		default:
+			ok++
+			for cls, shards := range classes {
+				g := scratch.classes[cls]
+				cr, found := resp.Classes[cls]
+				if !found || cr.Error != "" {
+					for name := range shards {
+						g.diverge[name] = true
+					}
+					continue
+				}
+				for _, name := range cr.DivergingShards {
+					g.diverge[name] = true
+				}
+				for name := range shards {
+					if !g.diverge[name] && g.waiting[name] > 0 {
+						g.waiting[name]--
+					}
+				}
+			}
+		}
+	}
+	sched.metrics.addRootCompareRPC(ok, errored, unsupported)
+
+	for _, g := range scratch.classes {
+		for name, entry := range g.entries {
+			if _, resolved := g.waiting[name]; !resolved {
+				continue
+			}
+			if !g.diverge[name] && g.waiting[name] == 0 {
+				scratch.skip[entry] = true
+			}
+		}
+	}
+}
+
+// fallbackPerClass reruns the per-class pre-filter (all hosts) for classes whose peer
+// lacks the cross-class RPC; its result is authoritative for those classes.
+func (sched *AsyncReplicationScheduler) fallbackPerClass(ctx context.Context,
+	classes map[string]map[string]hashtree.Digest, scratch *batchScratch,
+	ok, errored, unsupported *int, done map[string]bool,
+) {
+	for cls := range classes {
+		if done[cls] {
+			continue
+		}
+		done[cls] = true
+		g := scratch.classes[cls]
+		var needFull map[string]struct{}
+		var stats replica.PrefilterStats
+		if asyncRepPerClassFallbackSeam != nil {
+			needFull, stats = asyncRepPerClassFallbackSeam(ctx, g.roots)
+		} else {
+			needFull, stats = g.index.replicator.PrefilterShardRoots(ctx, g.roots)
+		}
+		*ok += stats.OK
+		*errored += stats.Errored
+		*unsupported += stats.Unsupported
+		for name := range g.entries {
+			if _, diverges := needFull[name]; diverges {
+				g.diverge[name] = true
+			} else if _, resolved := g.waiting[name]; resolved {
+				g.waiting[name] = 0
+			}
 		}
 	}
 }

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/entities/replication"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/replica"
 	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
@@ -2284,7 +2285,6 @@ func durationPtr(d time.Duration) *time.Duration { return &d }
 func newBareScheduler(batchSize, workChCap int) *AsyncReplicationScheduler {
 	s := &AsyncReplicationScheduler{
 		entries:                  make(map[*Shard]*asyncSchedulerEntry),
-		dispatchBuckets:          make(map[*Index][]*asyncSchedulerEntry),
 		workCh:                   make(chan *[]*asyncSchedulerEntry, workChCap),
 		asyncReplicationDisabled: configRuntime.NewDynamicValue(false),
 		rootPrefilterBatchSize:   configRuntime.NewDynamicValue(batchSize),
@@ -2516,8 +2516,7 @@ func TestClassifyBatchExcludesIneligible(t *testing.T) {
 
 	sched.classifyBatch(batch, scratch)
 
-	assert.Empty(t, scratch.roots, "no eligible shard ⇒ no roots collected")
-	assert.Empty(t, scratch.eligible)
+	assert.Empty(t, scratch.classes, "no eligible shard ⇒ no roots collected")
 	for _, e := range batch {
 		assert.False(t, scratch.skip[e], "ineligible shards must take the full descent")
 	}
@@ -2563,7 +2562,7 @@ func TestPrefilterCtxCancelledByIndexClose(t *testing.T) {
 			idx, closeIndex := newIndex()
 			defer closeIndex()
 			// time.Hour: a done ctx can only mean a stop signal propagated.
-			ctx, cancel := sched.prefilterCtx(idx, time.Hour)
+			ctx, cancel := sched.prefilterCtx(time.Hour, idx)
 			defer cancel()
 			require.NoError(t, ctx.Err())
 
@@ -2594,7 +2593,7 @@ func TestPrefilterCtxHonoursTimeout(t *testing.T) {
 	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
 	defer idx.closingCancel()
 
-	ctx, cancel := sched.prefilterCtx(idx, 50*time.Millisecond)
+	ctx, cancel := sched.prefilterCtx(50*time.Millisecond, idx)
 	defer cancel()
 
 	select {
@@ -2613,7 +2612,7 @@ func TestPrefilterCtxNilIndex(t *testing.T) {
 
 	idx := &Index{Config: IndexConfig{ClassName: "C"}}
 
-	ctx, cancel := sched.prefilterCtx(idx, time.Hour)
+	ctx, cancel := sched.prefilterCtx(time.Hour, idx)
 	defer cancel()
 	require.NoError(t, ctx.Err())
 
@@ -2670,7 +2669,10 @@ func TestDispatchDueCoalescing(t *testing.T) {
 		assert.ElementsMatch(t, []int{1, 1, 1, 1}, drainBatchSizes(sched.workCh))
 	})
 
-	t.Run("distinct indexes are batched separately", func(t *testing.T) {
+	t.Run("distinct indexes merge into one cross-class batch", func(t *testing.T) {
+		prev := prefilterCoalesceWindow
+		prefilterCoalesceWindow = 0
+		t.Cleanup(func() { prefilterCoalesceWindow = prev })
 		sched := newBareScheduler(512, 16)
 		a := &Index{Config: IndexConfig{ClassName: "A"}}
 		b := &Index{Config: IndexConfig{ClassName: "B"}}
@@ -2683,7 +2685,7 @@ func TestDispatchDueCoalescing(t *testing.T) {
 
 		sched.dispatchDueLocked()
 
-		assert.ElementsMatch(t, []int{3, 2}, drainBatchSizes(sched.workCh))
+		assert.ElementsMatch(t, []int{5}, drainBatchSizes(sched.workCh))
 	})
 
 	t.Run("full channel rolls unsent entries back into the heap", func(t *testing.T) {
@@ -2706,6 +2708,9 @@ func TestDispatchDueCoalescing(t *testing.T) {
 // TestDeferDescentReDispatchesSingletons: a coalesced batch of diverging shards is
 // deferred and re-dispatched as singletons so descent spreads across the pool.
 func TestDeferDescentReDispatchesSingletons(t *testing.T) {
+	prev := prefilterCoalesceWindow
+	prefilterCoalesceWindow = 0
+	t.Cleanup(func() { prefilterCoalesceWindow = prev })
 	sched := newBareScheduler(512, 16)
 	sched.ctx = context.Background()
 	sched.resultCh = make(chan asyncSchedulerResult, 32)
@@ -2792,6 +2797,9 @@ func TestDeregisterSettlesQueuedDone(t *testing.T) {
 		{name: "descendDirect dispatch", descendDirect: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			prev := prefilterCoalesceWindow
+			prefilterCoalesceWindow = 0
+			t.Cleanup(func() { prefilterCoalesceWindow = prev })
 			sched := newBareScheduler(512, 4)
 			sched.ctx = context.Background()
 			sched.resultCh = make(chan asyncSchedulerResult, 8)
@@ -2833,6 +2841,9 @@ func TestDrainSkipsSettledDones(t *testing.T) {
 
 // TestStaleBatchDroppedAfterReRegister: a previous registration's stranded batch is dropped; the new one runs once.
 func TestStaleBatchDroppedAfterReRegister(t *testing.T) {
+	prev := prefilterCoalesceWindow
+	prefilterCoalesceWindow = 0
+	t.Cleanup(func() { prefilterCoalesceWindow = prev })
 	sched := newBareScheduler(512, 4)
 	sched.ctx = context.Background()
 	sched.resultCh = make(chan asyncSchedulerResult, 8)
@@ -3034,7 +3045,7 @@ func TestDispatcherPanicSettlesReservationsAndUnblocks(t *testing.T) {
 	}
 }
 
-// TestSettleDispatchBucketsOnExit: reservations stranded in dispatchBuckets are settled and cleared.
+// TestSettleDispatchBucketsOnExit: reservations stranded in dispatchPending are settled and cleared.
 func TestSettleDispatchBucketsOnExit(t *testing.T) {
 	sched := newBareScheduler(512, 1)
 	idx := &Index{Config: IndexConfig{ClassName: "C"}}
@@ -3042,17 +3053,20 @@ func TestSettleDispatchBucketsOnExit(t *testing.T) {
 	s.asyncRepWg.Add(1)
 	entry := &asyncSchedulerEntry{shard: s, inFlight: true}
 	entry.pendingDone.Store(true)
-	sched.dispatchBuckets[idx] = append(sched.dispatchBuckets[idx], entry)
+	sched.dispatchPending = append(sched.dispatchPending, entry)
 
 	sched.settleDispatchBucketsOnExit()
 
-	awaitAsyncRepWg(t, s, "stranded bucket reservation must settle")
+	awaitAsyncRepWg(t, s, "stranded pending reservation must settle")
 	assert.False(t, entry.inFlight)
-	assert.Empty(t, sched.dispatchBuckets)
+	assert.Empty(t, sched.dispatchPending)
 }
 
-// TestDispatchBucketsEmptiedEveryPass: no *Index key may survive a dispatch pass, or dropped collections stay pinned forever.
+// TestDispatchBucketsEmptiedEveryPass: no entry pointer may survive a dispatch pass, or dropped collections stay pinned forever.
 func TestDispatchBucketsEmptiedEveryPass(t *testing.T) {
+	prev := prefilterCoalesceWindow
+	prefilterCoalesceWindow = 0
+	t.Cleanup(func() { prefilterCoalesceWindow = prev })
 	tests := []struct {
 		name           string
 		batchSize      int
@@ -3061,7 +3075,7 @@ func TestDispatchBucketsEmptiedEveryPass(t *testing.T) {
 		wantBatchSizes []int
 		wantHeapLen    int
 	}{
-		{"after coalesced dispatch", 512, 16, map[string]int{"A": 3, "B": 2}, []int{3, 2}, 0},
+		{"after cross-class merged dispatch", 512, 16, map[string]int{"A": 3, "B": 2}, []int{5}, 0},
 		{"after mid-pass full batch", 2, 16, map[string]int{"C": 4}, []int{2, 2}, 0},
 		{"after full-channel rollback", 512, 0, map[string]int{"C": 3}, nil, 3},
 	}
@@ -3079,7 +3093,7 @@ func TestDispatchBucketsEmptiedEveryPass(t *testing.T) {
 
 			assert.ElementsMatch(t, tc.wantBatchSizes, drainBatchSizes(sched.workCh))
 			assert.Len(t, sched.h, tc.wantHeapLen)
-			assert.Empty(t, sched.dispatchBuckets)
+			assert.Empty(t, sched.dispatchPending)
 		})
 	}
 }
@@ -3168,4 +3182,200 @@ func TestRecordRootPrefilterNoDiffCancelRaceLeavesStatsEmpty(t *testing.T) {
 	<-done
 
 	require.Empty(t, s.getAsyncReplicationStats(context.Background()))
+}
+
+type fakeCrossClassComparer func(ctx context.Context, host string, classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
+
+func (f fakeCrossClassComparer) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	return f(ctx, host, classes)
+}
+
+func newPrefilterShard(t *testing.T, class, name string) *asyncSchedulerEntry {
+	ht, err := hashtree.NewHashTree(1)
+	require.NoError(t, err)
+	s := &Shard{index: &Index{Config: IndexConfig{ClassName: entschema.ClassName(class)}}, class: &models.Class{Class: class}, name: name}
+	s.hashtree = ht
+	s.hashtreeFullyInitialized = true
+	return &asyncSchedulerEntry{shard: s}
+}
+
+// TestClassifyCrossClass covers skip/descend outcomes across hosts, classes, and fallback paths.
+func TestClassifyCrossClass(t *testing.T) {
+	okAll := func(classes map[string]map[string]hashtree.Digest) *replica.CompareHashTreeRootsMultiResp {
+		resp := &replica.CompareHashTreeRootsMultiResp{Classes: map[string]replica.CompareHashTreeRootsMultiClassResp{}}
+		for cls := range classes {
+			resp.Classes[cls] = replica.CompareHashTreeRootsMultiClassResp{}
+		}
+		return resp
+	}
+	type shardSpec struct{ class, name string }
+	type responder func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
+	tests := []struct {
+		name        string
+		shards      []shardSpec
+		hosts       map[string][]string
+		hostErrs    map[string]error
+		respond     map[string]responder
+		fallback    func(map[string]hashtree.Digest) map[string]struct{}
+		nilComparer bool
+		wantSkip    map[string]bool
+	}{
+		{
+			name:     "all hosts report in sync",
+			shards:   []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:    map[string][]string{"s1": {"h1", "h2"}, "s2": {"h1", "h2"}},
+			wantSkip: map[string]bool{"s1": true, "s2": true},
+		},
+		{
+			name:   "diverging shard descends",
+			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond: map[string]responder{
+				"h1": func(classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					resp := okAll(classes)
+					resp.Classes["A"] = replica.CompareHashTreeRootsMultiClassResp{DivergingShards: []string{"s1"}}
+					return resp, nil
+				},
+			},
+			wantSkip: map[string]bool{"s1": false, "s2": true},
+		},
+		{
+			name:   "class error descends only that class",
+			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond: map[string]responder{
+				"h1": func(classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					resp := okAll(classes)
+					resp.Classes["A"] = replica.CompareHashTreeRootsMultiClassResp{Error: "index not loaded"}
+					return resp, nil
+				},
+			},
+			wantSkip: map[string]bool{"s1": false, "s2": true},
+		},
+		{
+			name:   "class missing from response descends",
+			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond: map[string]responder{
+				"h1": func(classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					resp := okAll(classes)
+					delete(resp.Classes, "B")
+					return resp, nil
+				},
+			},
+			wantSkip: map[string]bool{"s1": true, "s2": false},
+		},
+		{
+			name:   "transport error descends the host tuples",
+			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond: map[string]responder{
+				"h1": func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					return nil, errors.New("connection refused")
+				},
+			},
+			wantSkip: map[string]bool{"s1": false, "s2": false},
+		},
+		{
+			name:   "one healthy and one erroring host descends",
+			shards: []shardSpec{{"A", "s1"}},
+			hosts:  map[string][]string{"s1": {"h1", "h2"}},
+			respond: map[string]responder{
+				"h2": func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					return nil, errors.New("connection refused")
+				},
+			},
+			wantSkip: map[string]bool{"s1": false},
+		},
+		{
+			name:   "unsupported peer falls back per class",
+			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond: map[string]responder{
+				"h1": func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					return nil, replica.ErrCompareHashTreeRootsUnsupported
+				},
+			},
+			fallback: func(roots map[string]hashtree.Digest) map[string]struct{} {
+				if _, ok := roots["s1"]; ok {
+					return map[string]struct{}{"s1": {}}
+				}
+				return nil
+			},
+			wantSkip: map[string]bool{"s1": false, "s2": true},
+		},
+		{
+			name:        "nil comparer falls back per class",
+			shards:      []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:       map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			nilComparer: true,
+			fallback:    func(map[string]hashtree.Digest) map[string]struct{} { return nil },
+			wantSkip:    map[string]bool{"s1": true, "s2": true},
+		},
+		{
+			name:     "no remote targets skips",
+			shards:   []shardSpec{{"A", "s1"}},
+			hosts:    map[string][]string{"s1": {}},
+			wantSkip: map[string]bool{"s1": true},
+		},
+		{
+			name:     "host resolution error descends",
+			shards:   []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:    map[string][]string{"s2": {"h1"}},
+			hostErrs: map[string]error{"s1": errors.New("no routing plan")},
+			wantSkip: map[string]bool{"s1": false, "s2": true},
+		},
+		{
+			name:   "responder panic forces full descent",
+			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond: map[string]responder{
+				"h1": func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					panic("boom")
+				},
+			},
+			wantSkip: map[string]bool{"s1": false, "s2": false},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			asyncRepTargetHostsSeam = func(s *Shard) ([]string, error) {
+				if err := tc.hostErrs[s.name]; err != nil {
+					return nil, err
+				}
+				return tc.hosts[s.name], nil
+			}
+			t.Cleanup(func() { asyncRepTargetHostsSeam = nil })
+			if tc.fallback != nil {
+				asyncRepPerClassFallbackSeam = func(_ context.Context, roots map[string]hashtree.Digest) (map[string]struct{}, replica.PrefilterStats) {
+					return tc.fallback(roots), replica.PrefilterStats{OK: 1}
+				}
+				t.Cleanup(func() { asyncRepPerClassFallbackSeam = nil })
+			}
+			sched := newBareScheduler(512, 1)
+			sched.ctx = context.Background()
+			if !tc.nilComparer {
+				sched.crossClassComparer = fakeCrossClassComparer(func(_ context.Context, host string, classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+					if r := tc.respond[host]; r != nil {
+						return r(classes)
+					}
+					return okAll(classes), nil
+				})
+			}
+			batch := make([]*asyncSchedulerEntry, 0, len(tc.shards))
+			byName := map[string]*asyncSchedulerEntry{}
+			for _, sp := range tc.shards {
+				entry := newPrefilterShard(t, sp.class, sp.name)
+				batch = append(batch, entry)
+				byName[sp.name] = entry
+			}
+			scratch := newBatchScratch()
+			sched.classifyBatch(batch, scratch)
+			for name, want := range tc.wantSkip {
+				assert.Equal(t, want, scratch.skip[byName[name]], name)
+			}
+		})
+	}
 }

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -2278,6 +2278,14 @@ func TestSchedulerClose_BoundedAndCancelsContextsWhenShardsStillRegistered(t *te
 	assert.True(t, errorLogged, "Close() must log an error when shards are still registered")
 }
 
+// zeroCoalesceWindow disables dispatch coalescing for tests that expect immediate batches.
+func zeroCoalesceWindow(t *testing.T) {
+	t.Helper()
+	prev := prefilterCoalesceWindow
+	prefilterCoalesceWindow = 0
+	t.Cleanup(func() { prefilterCoalesceWindow = prev })
+}
+
 // durationPtr is a helper that returns a pointer to a time.Duration value.
 func durationPtr(d time.Duration) *time.Duration { return &d }
 
@@ -2670,9 +2678,7 @@ func TestDispatchDueCoalescing(t *testing.T) {
 	})
 
 	t.Run("distinct indexes merge into one cross-class batch", func(t *testing.T) {
-		prev := prefilterCoalesceWindow
-		prefilterCoalesceWindow = 0
-		t.Cleanup(func() { prefilterCoalesceWindow = prev })
+		zeroCoalesceWindow(t)
 		sched := newBareScheduler(512, 16)
 		a := &Index{Config: IndexConfig{ClassName: "A"}}
 		b := &Index{Config: IndexConfig{ClassName: "B"}}
@@ -2708,9 +2714,7 @@ func TestDispatchDueCoalescing(t *testing.T) {
 // TestDeferDescentReDispatchesSingletons: a coalesced batch of diverging shards is
 // deferred and re-dispatched as singletons so descent spreads across the pool.
 func TestDeferDescentReDispatchesSingletons(t *testing.T) {
-	prev := prefilterCoalesceWindow
-	prefilterCoalesceWindow = 0
-	t.Cleanup(func() { prefilterCoalesceWindow = prev })
+	zeroCoalesceWindow(t)
 	sched := newBareScheduler(512, 16)
 	sched.ctx = context.Background()
 	sched.resultCh = make(chan asyncSchedulerResult, 32)
@@ -2841,9 +2845,7 @@ func TestDrainSkipsSettledDones(t *testing.T) {
 
 // TestStaleBatchDroppedAfterReRegister: a previous registration's stranded batch is dropped; the new one runs once.
 func TestStaleBatchDroppedAfterReRegister(t *testing.T) {
-	prev := prefilterCoalesceWindow
-	prefilterCoalesceWindow = 0
-	t.Cleanup(func() { prefilterCoalesceWindow = prev })
+	zeroCoalesceWindow(t)
 	sched := newBareScheduler(512, 4)
 	sched.ctx = context.Background()
 	sched.resultCh = make(chan asyncSchedulerResult, 8)
@@ -3064,9 +3066,7 @@ func TestSettleDispatchBucketsOnExit(t *testing.T) {
 
 // TestDispatchBucketsEmptiedEveryPass: no entry pointer may survive a dispatch pass, or dropped collections stay pinned forever.
 func TestDispatchBucketsEmptiedEveryPass(t *testing.T) {
-	prev := prefilterCoalesceWindow
-	prefilterCoalesceWindow = 0
-	t.Cleanup(func() { prefilterCoalesceWindow = prev })
+	zeroCoalesceWindow(t)
 	tests := []struct {
 		name           string
 		batchSize      int

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -3212,6 +3212,9 @@ func TestClassifyCrossClass(t *testing.T) {
 	}
 	type shardSpec struct{ class, name string }
 	type responder func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
+	refuse := func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+		return nil, errors.New("connection refused")
+	}
 	tests := []struct {
 		name        string
 		shards      []shardSpec
@@ -3268,25 +3271,17 @@ func TestClassifyCrossClass(t *testing.T) {
 			wantSkip: map[string]bool{"s1": true, "s2": false},
 		},
 		{
-			name:   "transport error descends the host tuples",
-			shards: []shardSpec{{"A", "s1"}, {"B", "s2"}},
-			hosts:  map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
-			respond: map[string]responder{
-				"h1": func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
-					return nil, errors.New("connection refused")
-				},
-			},
+			name:     "transport error descends the host tuples",
+			shards:   []shardSpec{{"A", "s1"}, {"B", "s2"}},
+			hosts:    map[string][]string{"s1": {"h1"}, "s2": {"h1"}},
+			respond:  map[string]responder{"h1": refuse},
 			wantSkip: map[string]bool{"s1": false, "s2": false},
 		},
 		{
-			name:   "one healthy and one erroring host descends",
-			shards: []shardSpec{{"A", "s1"}},
-			hosts:  map[string][]string{"s1": {"h1", "h2"}},
-			respond: map[string]responder{
-				"h2": func(map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
-					return nil, errors.New("connection refused")
-				},
-			},
+			name:     "one healthy and one erroring host descends",
+			shards:   []shardSpec{{"A", "s1"}},
+			hosts:    map[string][]string{"s1": {"h1", "h2"}},
+			respond:  map[string]responder{"h2": refuse},
 			wantSkip: map[string]bool{"s1": false},
 		},
 		{

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -317,11 +317,14 @@ func New(logger logrus.FieldLogger, localNodeName string, config Config,
 	// resume any .deleteme cleanup that didn't finish before the last shutdown
 	scanAndAsyncDeletePending(config.RootPath, logger)
 
+	// Fakes without the cross-class RPC leave the comparer nil → per-class pre-filter fallback.
+	crossClassComparer, _ := replicaClient.(crossClassRootComparer)
 	asyncReplicationScheduler, err := NewAsyncReplicationScheduler(
 		context.Background(),
 		config.Replication,
 		promMetrics,
 		logger,
+		crossClassComparer,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create async replication scheduler: %w", err)

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -577,6 +577,11 @@ func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 	return hosts, nil
 }
 
+// TargetHostAddrsForShard exposes per-shard replica host resolution for the scheduler's cross-class pre-filter.
+func (f *Finder) TargetHostAddrsForShard(shardName string) ([]string, error) {
+	return f.targetHostAddrsForShard(shardName)
+}
+
 // prefilterMaxShardsPerRPC caps shards per CompareHashTreeRoots request to bound
 // gRPC/REST message size.
 const prefilterMaxShardsPerRPC = 1000

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -94,6 +94,21 @@ type CompareHashTreeRootsResp struct {
 	DivergingShards []string `json:"divergingShards,omitempty"`
 }
 
+// CompareHashTreeRootsMultiReq is the cross-class root pre-filter payload: class → shard → raw [high,low] root.
+type CompareHashTreeRootsMultiReq struct {
+	Classes map[string]map[string][2]uint64 `json:"classes"`
+}
+
+type CompareHashTreeRootsMultiResp struct {
+	Classes map[string]CompareHashTreeRootsMultiClassResp `json:"classes"`
+}
+
+// CompareHashTreeRootsMultiClassResp: Error set ⇒ receiver could not compare this class, sender descends its shards.
+type CompareHashTreeRootsMultiClassResp struct {
+	DivergingShards []string `json:"divergingShards,omitempty"`
+	Error           string   `json:"error,omitempty"`
+}
+
 // WClient is the client used to write to replicas
 type WClient interface {
 	PutObject(ctx context.Context, host, index, shard, requestID string,


### PR DESCRIPTION
## Motivation

Follow-up to #12759. On fleets of many small single-tenant collections, the root pre-filter can never amortize its cost: the scheduler batches per index, so single-shard collections always dispatch as singletons — and singleton batches bypass the pre-filter entirely, running a full per-target hashbeat descent every cycle even when replicas are provably in sync.

Profiled on a local 3-node cluster with 1,150 tiny in-sync collections (1,000 single-shard + 150 three-shard, RF=3), steady state **per node** on the current release line: ~2,200 hashbeat descents/min, ~4,600 replication RPCs/min, ~65 MB/min of async-replication-attributable allocations (~63% of process CPU and ~73% of allocation churn vs an async-disabled control). The remaining cost after #12759–#12762 is RPC volume × per-RPC fixed overhead, not any single allocation site.

## Approach

Batch the level-0 root compare **across classes**, one RPC per target node:

- The dispatcher accumulates due entries into a single cross-class pending slice (previously per-`*Index` buckets) and coalesces for up to 1 s (`prefilterCoalesceWindow`) so batches can form — dispatch fires immediately when a full batch is due or the head entry is a diverging `descendDirect`. The dispatcher sleeps out the window rather than polling.
- A new node-level route `POST /replicas/indices/_compareHashTreeRootsMulti` carries `class → shard → root` and returns per-class results (`divergingShards` / `error`), so one unloadable class descends alone without forcing the whole batch down the descent path. Total shards per request are capped by the existing `CompareHashTreeRootsMaxShardsPerRequest`; per-host tuples are bounded by the batch-size cap (≤4096), so a single request always fits.
- `classifyCrossClass` resolves target hosts per shard, requires every host to confirm equality before skipping (per-shard waiting count), and treats every failure — resolution error, transport error, per-class error, missing class in the response, panic — as a conservative full descent.
- **Mixed-version fallback**: peers without the route return 404 (REST) or Unimplemented (gRPC) → the existing `ErrCompareHashTreeRootsUnsupported` sentinel → the per-class `PrefilterShardRoots` path runs for the affected classes, reproducing today's behavior exactly.
- **gRPC parity**: the replication protocol gains `CompareHashTreeRootsMulti` (additive; per-class result granularity mirrors the REST payload), so gRPC-enabled clusters get the same optimization; verified live with `REPLICATION_GRPC_ENABLED=true` on the same fleet (zero unsupported-fallbacks, ~49 shards per compare RPC, zero diffs).
- The scheduler consumes a narrow `crossClassRootComparer` interface via an optional variadic constructor parameter — `RClient`, its mocks, and all existing constructor call sites are untouched. The pre-filter context now aborts when **any** involved index closes (generalizing the pinned index-close invariant).

## Measured effect (same 1,150-collection in-sync fleet, per node)

| | before (with #12759–#12762) | after | async disabled |
|---|---|---|---|
| Allocations | 101–110 MB/min | 51–63 MB/min | 35–42 MB/min |
| CPU | 7.4–8.2% of a core | 4.3–5.1% | 3.8% |
| Hashbeat descents | ~2,200 / 65 s | 0–4 | — |
| Outbound root-compare RPCs | ~430 / 65 s (+ ~4,000 level RPCs) | 48–56, ~50 shards each | — |

Async-attributable allocations drop ~75%; CPU lands within ~1 point of async-off. A live mixed-version cluster (one upgraded node, two peers on the previous build) converged with zero divergence; the fallback restores per-class RPC volume for the transition window only.

## Key areas for review

- `classifyCrossClass` conservative-descend matrix: waiting-count semantics, per-class error isolation, panic recovery clearing the skip set.
- Coalescing gate (`coalesceElapsedLocked`) interaction with `timeUntilNextLocked` — no spin, no missed wake, `descendDirect` never delayed behind the window.
- Done-ownership through the new dispatch path: pending slice settle-on-panic, rollback on full channel, `clear()` before truncate so dropped indexes are never pinned.
- Handler/route: exact-path match dispatched before the per-class regexes; a class segment cannot start with `_`.
- gRPC service method mirrors the REST handler (total-shard cap, per-class error isolation); wire messages are additive.

## Risks and mitigations

- **Rolling upgrade**: additive route and additive proto RPC; old peers hit the 404/Unimplemented fallback (verified live). During the mixed window the fallback re-compares affected classes against all hosts — RPC volume matches the pre-change steady state, transient.
- **Hashbeat latency**: cycles start up to 1 s later than scheduled (bounded; diverging shards bypass the window). Batch size 1 (the existing pre-filter kill switch) also disables coalescing and preserves direct-descent semantics.
- **Index drop during a batch**: entries stay settleable by Deregister throughout; the batch context aborts when any involved index closes.

## Testing

- New table-driven classify matrix (11 cases: multi-host skip, diverge, per-class error, missing class, transport error, partial-host failure, unsupported→fallback, nil comparer, zero targets, resolution error, responder panic).
- REST round-trip against the real client+handler (per-class classification and error isolation), 404→Unsupported, shard-cap rejection; maintenance-mode path coverage extended.
- gRPC service round-trip (per-class classification, error isolation, total-shard cap) and live end-to-end validation over the gRPC transport.
- Existing dispatch/settle/deregister tests adapted to cross-class semantics; `-race` green on the db, clusterapi (+grpc/+shared), clients, and replica packages; scheduler integration tests green; golangci-lint and the goroutine linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
