### PR TITLE
fix(db): report COLD status for inactive tenant shards [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4106,6 +4106,13 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 						status := shard.GetStatus().String()
 						oneNodeStatus.Store(status)
 						perNodeStatus[nodeName] = status
+					} else if err == nil {
+						// Shard is not loaded on this node. For multi-tenant
+						// collections this is expected when the tenant is
+						// inactive. Report it as COLD so the shard still shows
+						// a meaningful status instead of an empty entry.
+						perNodeStatus[nodeName] = models.TenantActivityStatusCOLD
+						oneNodeStatus.CompareAndSwap(nil, models.TenantActivityStatusCOLD)
 					}
 					release()
 				} else {
@@ -4145,7 +4152,11 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 	defer release()
 
 	if shard == nil {
-		return "", fmt.Errorf("local %s shard not found", shardName)
+		// Shard is not loaded on this node. For multi-tenant collections
+		// this is expected when the tenant is inactive (COLD, FROZEN, etc.).
+		// Return "COLD" so the caller can report the shard status rather
+		// than failing the entire request with a 500 error.
+		return models.TenantActivityStatusCOLD, nil
 	}
 
 	if err := i.ensureShardLocallyReady(shard); err != nil {

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -392,6 +392,137 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	require.Equal(t, wantLegacy, gotLegacy, "legacy statuses")
 }
 
+// TestIndex_getShardsStatus_InactiveTenant ensures an inactive tenant whose
+// shard is not loaded on any node is reported as COLD instead of failing the
+// whole listing with a 500 / "local shard not found". Regression test for
+// https://github.com/weaviate/weaviate/issues/12764.
+func TestIndex_getShardsStatus_InactiveTenant(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	clusterNodes := []string{"node-0", "node-1", "node-2"}
+	targetNode := clusterNodes[0]
+	// shard_loaded is a regular loaded shard; shard_inactive has no local
+	// shard and no remote status - exactly what an INACTIVE tenant looks like.
+	shardReplicas := map[string][]string{
+		"shard_loaded":   clusterNodes,
+		"shard_inactive": clusterNodes,
+	}
+	shardStatus := map[string]map[string]string{
+		"shard_loaded": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusReady.String(),
+			"node-2": storagestate.StatusReady.String(),
+		},
+		// shard_inactive has no loaded shard anywhere: remote replicas report
+		// COLD (post-fix IncomingGetShardStatus), the local one has no shard.
+		"shard_inactive": {
+			"node-1": models.TenantActivityStatusCOLD,
+			"node-2": models.TenantActivityStatusCOLD,
+		},
+	}
+
+	want := map[string]map[string]string{
+		"shard_loaded": {
+			"node-0": storagestate.StatusReady.String(),
+			"node-1": storagestate.StatusReady.String(),
+			"node-2": storagestate.StatusReady.String(),
+		},
+		"shard_inactive": {
+			"node-0": models.TenantActivityStatusCOLD,
+			"node-1": models.TenantActivityStatusCOLD,
+			"node-2": models.TenantActivityStatusCOLD,
+		},
+	}
+
+	wantLegacy := map[string]string{
+		"shard_loaded":   storagestate.StatusReady.String(),
+		"shard_inactive": models.TenantActivityStatusCOLD,
+	}
+
+	var replicas []types.Replica
+	for shard, nodes := range shardReplicas {
+		for _, node := range nodes {
+			replicas = append(replicas, types.Replica{
+				ShardName: shard,
+				NodeName:  node,
+				HostAddr:  node,
+			})
+		}
+	}
+
+	router := &fakeRouter{
+		readSet: types.ReadReplicaSet{
+			Replicas: replicas,
+		},
+	}
+
+	replicator := &replica.Replicator{
+		Finder: replica.NewFinder(
+			"Songs", nil, nil,
+			targetNode, nil, nil,
+			logger, nil,
+		),
+	}
+
+	schemaReader := schemaUC.NewMockSchemaReader(t)
+	schemaReader.EXPECT().
+		Shards("Songs").
+		RunAndReturn(func(collectionName string) (shards []string, _ error) {
+			for s := range shardReplicas {
+				shards = append(shards, s)
+			}
+			return
+		}).Maybe()
+	schemaReader.EXPECT().
+		ShardReplicas("Songs", mock.Anything).
+		RunAndReturn(func(collectionName, shardName string) ([]string, error) {
+			return shardReplicas[shardName], nil
+		}).Maybe()
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	nodeResolver.EXPECT().
+		NodeHostname(mock.Anything).
+		RunAndReturn(func(s string) (string, bool) { return s, true }).Maybe()
+
+	index := Index{
+		Config:           IndexConfig{ClassName: schema.ClassName("Songs"), ReplicationFactor: 2},
+		getSchema:        &fakeSchemaGetter{nodeName: targetNode},
+		schemaReader:     schemaReader,
+		shardCreateLocks: esync.NewKeyRWLocker(),
+		router:           router,
+		replicator:       replicator,
+		logger:           logger,
+	}
+	index.allShardsReady.Store(true)
+
+	index.remote = sharding.NewRemoteIndex(
+		"Songs",
+		index.getSchema,
+		nodeResolver,
+		&FakeRemoteClient{shardStatus: shardStatus},
+	)
+
+	// Only shard_loaded has a local shard; shard_inactive has none.
+	mockShard := NewMockShardLike(t)
+	mockShard.EXPECT().
+		preventShutdown().
+		Return(func() {}, nil).Maybe()
+	mockShard.EXPECT().
+		Name().
+		Return("shard_loaded").Maybe()
+	mockShard.EXPECT().
+		GetStatus().
+		Return(storagestate.StatusReady).Maybe()
+	index.shards.Store("shard_loaded", mockShard)
+
+	// Act
+	got, gotLegacy, err := index.getShardsStatus(t.Context(), "")
+
+	// Assert
+	assert.NoError(t, err)
+	require.Equal(t, want, got, "shard statuses")
+	require.Equal(t, wantLegacy, gotLegacy, "legacy statuses")
+}
+
 // TestIndex_ShardHasMultipleReplicasWrite_RoutesThroughReplicatorDuringMovement pins the
 // rf=1 scale-out lost-write fix: while a replica movement is active for the shard, a write
 // must be routed through the replicator (so it registers in the in-flight fence and the


### PR DESCRIPTION
### What's being changed:

`GET /v1/schema/{class}/shards` returned **500** whenever a multi-tenant collection had at least one `INACTIVE` tenant. The listing aborted on the first unloaded tenant shard — a single cold tenant hid the status of every other shard.

Root cause: for an inactive tenant the shard is not loaded on any node, so the local lookup returns no shard and the remote `IncomingGetShardStatus` fails with `local <shard> shard not found`. Both the per-shard remote path and the shard-listing loop treated the normally-unloaded state as a fault.

Fixes made:

- **`Index.IncomingGetShardStatus`** — a `nil` shard now returns `COLD` (the tenant activity status) instead of a `local <shard> shard not found` error. An unloaded shard is the *expected* state for an inactive tenant, not a failure.
- **`Index.getShardsStatus`** — when the local lookup succeeds but yields no shard (inactive tenant), the local node now reports `COLD` in the per-node status map instead of leaving an empty entry, and the legacy aggregated status is set via `oneNodeStatus`.

With this, the endpoint lists all shards, reporting inactive tenants as `COLD`, and no longer fails the whole request.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

Regression test added: `TestIndex_getShardsStatus_InactiveTenant` in `adapters/repos/db/index_test.go`, which models an INACTIVE tenant (no local shard, remote replicas reporting COLD) and asserts the listing succeeds with `COLD` statuses.

Fixes #12764