### PR TITLE
Keep a per-namespace collection count and report it as a metric

### DIFF
--- a/cluster/schema/manager_query_test.go
+++ b/cluster/schema/manager_query_test.go
@@ -17,11 +17,14 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -76,6 +79,101 @@ func TestQueryCollectionsCount(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrBadRequest))
 	})
+}
+
+// TestCollectionsCount_ThroughSchemaManager drives the count through the
+// apply path with schemaOnly=true, the mode every node uses replaying the
+// RAFT log at startup. apply skips updateStore in that mode, so a change
+// moving the counter maintenance out of updateSchema would rebuild a wrong
+// count on every restarting node while the direct-call tests stayed green.
+func TestCollectionsCount_ThroughSchemaManager(t *testing.T) {
+	addClass := func(t *testing.T, sm *SchemaManager, name string, version uint64) error {
+		t.Helper()
+		return sm.AddClass(&cmd.ApplyRequest{
+			Type:       cmd.ApplyRequest_TYPE_ADD_CLASS,
+			Class:      name,
+			Version:    version,
+			SubCommand: mustMarshal(t, cmd.AddClassRequest{Class: &models.Class{Class: name}, State: emptyShardingState()}),
+		}, "test-node", true, false)
+	}
+	deleteClass := func(sm *SchemaManager, name string) error {
+		return sm.DeleteClass(&cmd.ApplyRequest{
+			Type:  cmd.ApplyRequest_TYPE_DELETE_CLASS,
+			Class: name,
+		}, true, false)
+	}
+
+	tests := []struct {
+		name   string
+		replay func(t *testing.T, sm *SchemaManager)
+		want   map[string]int
+	}{
+		{
+			name:   "no commands",
+			replay: func(t *testing.T, sm *SchemaManager) {},
+			want:   map[string]int{"": 0, "customer1": 0},
+		},
+		{
+			name: "adds across namespaces",
+			replay: func(t *testing.T, sm *SchemaManager) {
+				require.NoError(t, addClass(t, sm, "customer1:Movies", 1))
+				require.NoError(t, addClass(t, sm, "customer1:Films", 2))
+				require.NoError(t, addClass(t, sm, "customer2:Movies", 3))
+				require.NoError(t, addClass(t, sm, "Unqualified", 4))
+			},
+			want: map[string]int{"": 4, "customer1": 2, "customer2": 1, "customer3": 0},
+		},
+		{
+			name: "a delete frees the namespace's budget",
+			replay: func(t *testing.T, sm *SchemaManager) {
+				require.NoError(t, addClass(t, sm, "customer1:Movies", 1))
+				require.NoError(t, addClass(t, sm, "customer1:Films", 2))
+				require.NoError(t, deleteClass(sm, "customer1:Films"))
+			},
+			want: map[string]int{"": 1, "customer1": 1},
+		},
+		{
+			name: "deleting the last class leaves the namespace empty",
+			replay: func(t *testing.T, sm *SchemaManager) {
+				require.NoError(t, addClass(t, sm, "customer1:Movies", 1))
+				require.NoError(t, deleteClass(sm, "customer1:Movies"))
+			},
+			want: map[string]int{"": 0, "customer1": 0},
+		},
+		{
+			name: "a re-add after a delete counts once",
+			replay: func(t *testing.T, sm *SchemaManager) {
+				require.NoError(t, addClass(t, sm, "customer1:Movies", 1))
+				require.NoError(t, deleteClass(sm, "customer1:Movies"))
+				require.NoError(t, addClass(t, sm, "customer1:Movies", 2))
+			},
+			want: map[string]int{"": 1, "customer1": 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := fakes.NewMockParser()
+			parser.On("ParseClass", mock.Anything).Return(nil)
+			sm := NewSchemaManager("test-node", nil, parser, prometheus.NewPedanticRegistry(), logrus.New())
+
+			tt.replay(t, sm)
+
+			for namespace, want := range tt.want {
+				payload, err := sm.QueryCollectionsCount(&cmd.QueryRequest{
+					SubCommand: mustMarshal(t, cmd.QueryCollectionsCountRequest{Namespace: namespace}),
+				})
+				require.NoError(t, err)
+
+				var resp cmd.QueryCollectionsCountResponse
+				require.NoError(t, json.Unmarshal(payload, &resp))
+				assert.Equal(t, want, resp.Count, "namespace %q", namespace)
+			}
+		})
+	}
+}
+
+func emptyShardingState() *sharding.State {
+	return &sharding.State{Physical: make(map[string]sharding.Physical)}
 }
 
 func mustMarshal(t *testing.T, v any) []byte {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	entSchema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/versioned"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -81,10 +82,15 @@ type schema struct {
 	nodeID      string
 	shardReader shardReader
 
-	// mu protects `classes` and `aliases`
+	// mu protects `classes`, `aliases` and `classCountByNamespace`
 	mu      sync.RWMutex
 	classes map[string]*metaClass
 	aliases map[string]string // key: canonical form all in TitleCase.
+
+	// classCountByNamespace is kept in step with classes by addClass,
+	// deleteClass and replaceClasses, so the per-namespace collection cap is
+	// checked without scanning every class. An emptied namespace has no entry.
+	classCountByNamespace map[string]int
 
 	// metrics
 	// collectionsCount represents the number of collections on this specific node.
@@ -99,10 +105,11 @@ func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer
 	r := promauto.With(reg)
 
 	s := &schema{
-		nodeID:      nodeID,
-		classes:     make(map[string]*metaClass, 128),
-		aliases:     make(map[string]string, 128),
-		shardReader: shardReader,
+		nodeID:                nodeID,
+		classes:               make(map[string]*metaClass, 128),
+		aliases:               make(map[string]string, 128),
+		classCountByNamespace: make(map[string]int),
+		shardReader:           shardReader,
 		collectionsCount: r.NewGauge(prometheus.GaugeOpts{
 			Namespace:   "weaviate",
 			Name:        "schema_collections",
@@ -259,15 +266,7 @@ func (s *schema) CollectionsCount(namespace string) int {
 	if namespace == "" {
 		return len(s.classes)
 	}
-
-	prefix := namespace + entSchema.NamespaceSeparator
-	count := 0
-	for name := range s.classes {
-		if strings.HasPrefix(name, prefix) {
-			count++
-		}
-	}
-	return count
+	return s.classCountByNamespace[namespace]
 }
 
 // ShardOwner returns the node owner of the specified shard
@@ -365,6 +364,9 @@ func (s *schema) addClass(cls *models.Class, ss *sharding.State, v uint64) error
 	}
 
 	s.collectionsCount.Inc()
+	if ns := namespacing.NamespaceFromQualified(cls.Class); ns != "" {
+		s.classCountByNamespace[ns]++
+	}
 
 	for _, shard := range ss.Physical {
 		s.shardsCount.WithLabelValues(shard.Status).Inc()
@@ -407,6 +409,15 @@ func (s *schema) deleteClass(name string) bool {
 	delete(s.classes, name)
 
 	s.collectionsCount.Dec()
+	if ns := namespacing.NamespaceFromQualified(name); ns != "" {
+		s.classCountByNamespace[ns]--
+		// Drop the key at zero: a cluster that churns namespaces would
+		// otherwise keep an entry for every namespace it ever held.
+		if s.classCountByNamespace[ns] == 0 {
+			delete(s.classCountByNamespace, ns)
+		}
+	}
+
 	for status, count := range sc {
 		s.shardsCount.WithLabelValues(status).Sub(float64(count))
 	}
@@ -436,6 +447,7 @@ func (s *schema) replaceClasses(classes map[string]*metaClass) {
 	}
 
 	s.classes = classes
+	s.classCountByNamespace = countClassesByNamespace(classes)
 
 	s.collectionsCount.Add(float64(len(s.classes)))
 
@@ -444,6 +456,18 @@ func (s *schema) replaceClasses(classes map[string]*metaClass) {
 			s.shardsCount.WithLabelValues(shard.Status).Inc()
 		}
 	}
+}
+
+// countClassesByNamespace counts the classes qualified by each namespace. A
+// class with no namespace prefix belongs to no namespace and is left out.
+func countClassesByNamespace(classes map[string]*metaClass) map[string]int {
+	counts := make(map[string]int)
+	for name := range classes {
+		if ns := namespacing.NamespaceFromQualified(name); ns != "" {
+			counts[ns]++
+		}
+	}
+	return counts
 }
 
 // replaceStatesNodeName it update the node name inside sharding states.

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -93,8 +93,11 @@ type schema struct {
 	classCountByNamespace map[string]int
 
 	// metrics
-	// collectionsCount represents the number of collections on this specific node.
-	collectionsCount prometheus.Gauge
+	// collectionsCount is the number of collections in this node's copy of the
+	// schema, split by the namespace owning them; every node applies every schema
+	// change, so the value is the cluster's. Collections with no namespace prefix
+	// are counted under an empty namespace.
+	collectionsCount *prometheus.GaugeVec
 
 	// shardsCount represents the number of shards (of all collections) on this specific node.
 	shardsCount *prometheus.GaugeVec
@@ -110,12 +113,16 @@ func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer
 		aliases:               make(map[string]string, 128),
 		classCountByNamespace: make(map[string]int),
 		shardReader:           shardReader,
-		collectionsCount: r.NewGauge(prometheus.GaugeOpts{
+		collectionsCount: r.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace:   "weaviate",
 			Name:        "schema_collections",
-			Help:        "Number of collections per node",
+			Help:        "Number of collections per node and namespace",
 			ConstLabels: prometheus.Labels{"nodeID": nodeID},
-		}),
+			// Named collection_namespace, not namespace: a Kubernetes scrape
+			// attaches its own namespace label, and Prometheus resolves the
+			// clash by renaming ours to exported_namespace, so a query for
+			// namespace= matches nothing.
+		}, []string{"collection_namespace"}), // empty for a collection with no prefix
 		shardsCount: r.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace:   "weaviate",
 			Name:        "schema_shards",
@@ -123,6 +130,10 @@ func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer
 			ConstLabels: prometheus.Labels{"nodeID": nodeID},
 		}, []string{"status"}), // status: HOT, WARM, COLD, FROZEN
 	}
+
+	// Create the empty-namespace series now so a node with no collections reports
+	// zero instead of omitting the metric until its first collection arrives.
+	s.collectionsCount.WithLabelValues("")
 
 	return s
 }
@@ -363,8 +374,9 @@ func (s *schema) addClass(cls *models.Class, ss *sharding.State, v uint64) error
 		Class: *cls, Sharding: *ss, ClassVersion: v, ShardVersion: v,
 	}
 
-	s.collectionsCount.Inc()
-	if ns := namespacing.NamespaceFromQualified(cls.Class); ns != "" {
+	ns := namespacing.NamespaceFromQualified(cls.Class)
+	s.collectionsCount.WithLabelValues(ns).Inc()
+	if ns != "" {
 		s.classCountByNamespace[ns]++
 	}
 
@@ -408,13 +420,15 @@ func (s *schema) deleteClass(name string) bool {
 
 	delete(s.classes, name)
 
-	s.collectionsCount.Dec()
-	if ns := namespacing.NamespaceFromQualified(name); ns != "" {
+	ns := namespacing.NamespaceFromQualified(name)
+	s.collectionsCount.WithLabelValues(ns).Dec()
+	if ns != "" {
 		s.classCountByNamespace[ns]--
-		// Drop the key at zero: a cluster that churns namespaces would
-		// otherwise keep an entry for every namespace it ever held.
+		// Drop the key and its series at zero: a cluster that churns namespaces
+		// would otherwise keep an entry for every namespace it ever held.
 		if s.classCountByNamespace[ns] == 0 {
 			delete(s.classCountByNamespace, ns)
+			s.collectionsCount.DeleteLabelValues(ns)
 		}
 	}
 
@@ -439,21 +453,41 @@ func (s *schema) replaceClasses(classes map[string]*metaClass) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.collectionsCount.Sub(float64(len(s.classes)))
 	for _, ss := range s.classes {
 		for _, shard := range ss.Sharding.Physical {
 			s.shardsCount.WithLabelValues(shard.Status).Dec()
 		}
 	}
 
+	previousNamespaces := s.classCountByNamespace
+
 	s.classes = classes
 	s.classCountByNamespace = countClassesByNamespace(classes)
-
-	s.collectionsCount.Add(float64(len(s.classes)))
+	s.republishCollectionsCount(previousNamespaces)
 
 	for _, ss := range s.classes {
 		for _, shard := range ss.Sharding.Physical {
 			s.shardsCount.WithLabelValues(shard.Status).Inc()
+		}
+	}
+}
+
+// republishCollectionsCount rewrites one series per classCountByNamespace entry,
+// puts the remaining classes on the empty-namespace series, and drops namespaces
+// the new set no longer holds. Refresh classCountByNamespace from s.classes first,
+// or the empty-namespace count goes negative. Overwriting rather than resetting
+// keeps the metric present for a concurrent scrape. Callers hold s.mu.
+func (s *schema) republishCollectionsCount(previousNamespaces map[string]int) {
+	namespaced := 0
+	for ns, count := range s.classCountByNamespace {
+		s.collectionsCount.WithLabelValues(ns).Set(float64(count))
+		namespaced += count
+	}
+	s.collectionsCount.WithLabelValues("").Set(float64(len(s.classes) - namespaced))
+
+	for ns := range previousNamespaces {
+		if _, ok := s.classCountByNamespace[ns]; !ok {
+			s.collectionsCount.DeleteLabelValues(ns)
 		}
 	}
 }

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -13,6 +13,7 @@ package schema
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -76,21 +77,26 @@ func Test_schemaCollectionMetrics(t *testing.T) {
 		},
 	}
 
-	// Collection metrics
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount))
+	// Collection metrics. These classes carry no namespace, so they land on
+	// the empty-namespace series.
+	unnamespaced := func() float64 {
+		return testutil.ToFloat64(s.collectionsCount.WithLabelValues(""))
+	}
+
+	assert.Equal(t, float64(0), unnamespaced())
 	require.NoError(t, s.addClass(c1, ss, 0)) // adding c1 collection
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.collectionsCount))
+	assert.Equal(t, float64(1), unnamespaced())
 
 	require.NoError(t, s.addClass(c2, ss, 0)) // adding c2 collection
-	assert.Equal(t, float64(2), testutil.ToFloat64(s.collectionsCount))
+	assert.Equal(t, float64(2), unnamespaced())
 
 	// delete c2
 	s.deleteClass("collection2")
-	assert.Equal(t, float64(1), testutil.ToFloat64(s.collectionsCount))
+	assert.Equal(t, float64(1), unnamespaced())
 
 	// delete c1
 	s.deleteClass("collection1")
-	assert.Equal(t, float64(0), testutil.ToFloat64(s.collectionsCount))
+	assert.Equal(t, float64(0), unnamespaced())
 }
 
 func Test_schemaShardMetrics(t *testing.T) {
@@ -555,6 +561,24 @@ func (p *fixedParser) ParseClass(*models.Class) error { return nil }
 
 func (p *fixedParser) ParseClassUpdate(_, _ *models.Class) (*models.Class, error) {
 	return p.updated, nil
+}
+
+type failingParser struct{}
+
+func (failingParser) ParseClass(*models.Class) error { return errors.New("corrupt class") }
+
+func (failingParser) ParseClassUpdate(_, _ *models.Class) (*models.Class, error) {
+	return nil, nil
+}
+
+// restoreClasses restores a snapshot holding exactly the named classes.
+func restoreClasses(t *testing.T, sc *schema, names ...string) {
+	t.Helper()
+	classes := make(map[string]*metaClass, len(names))
+	for _, name := range names {
+		classes[name] = &metaClass{Class: models.Class{Class: name}}
+	}
+	require.NoError(t, sc.Restore(mustMarshal(t, classes), &fixedParser{}))
 }
 
 // Test_UpdateClass_MovementRejection verifies that an UpdateClass which would rewrite on-disk
@@ -1269,12 +1293,7 @@ func TestCollectionsCount_Namespaced(t *testing.T) {
 				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
 				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, newState(), 2))
 
-				data, err := json.Marshal(map[string]*metaClass{
-					"customer2:Books": {Class: models.Class{Class: "customer2:Books"}},
-					"Global":          {Class: models.Class{Class: "Global"}},
-				})
-				require.NoError(t, err)
-				require.NoError(t, sc.Restore(data, &fixedParser{}))
+				restoreClasses(t, sc, "customer2:Books", "Global")
 			},
 			want: map[string]int{"": 2, "customer1": 0, "customer2": 1},
 		},
@@ -1283,9 +1302,7 @@ func TestCollectionsCount_Namespaced(t *testing.T) {
 			setup: func(t *testing.T, sc *schema) {
 				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
 
-				data, err := json.Marshal(map[string]*metaClass{})
-				require.NoError(t, err)
-				require.NoError(t, sc.Restore(data, &fixedParser{}))
+				restoreClasses(t, sc)
 			},
 			want: map[string]int{"": 0, "customer1": 0},
 		},
@@ -1314,10 +1331,132 @@ func TestClassCountByNamespace_DropsEmptyNamespace(t *testing.T) {
 	assert.Empty(t, sc.classCountByNamespace, "after the last class is deleted")
 
 	require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Books"}, ss, 2))
-	data, err := json.Marshal(map[string]*metaClass{})
-	require.NoError(t, err)
-	require.NoError(t, sc.Restore(data, &fixedParser{}))
+	restoreClasses(t, sc)
 	assert.Empty(t, sc.classCountByNamespace, "after an empty snapshot is restored")
+}
+
+// A snapshot the parser rejects must leave the previous classes and their gauge
+// series untouched: replaceClasses runs only after every class has parsed.
+func TestRestore_RejectedSnapshotLeavesStateIntact(t *testing.T) {
+	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+
+	data := mustMarshal(t, map[string]*metaClass{
+		"customer2:Books": {Class: models.Class{Class: "customer2:Books"}},
+	})
+	require.Error(t, sc.Restore(data, failingParser{}))
+
+	assert.Equal(t, 2, testutil.CollectAndCount(sc.collectionsCount))
+	assert.Equal(t, float64(1), testutil.ToFloat64(sc.collectionsCount.WithLabelValues("customer1")))
+	assert.Equal(t, 1, sc.CollectionsCount("customer1"))
+	assert.Equal(t, 0, sc.CollectionsCount("customer2"))
+}
+
+// TestCollectionsGauge_ByNamespace pins the observable half of the count: the
+// per-namespace series an operator reads to explain a rejected create, and the
+// pruning that keeps a namespace-churning cluster from growing series without
+// bound.
+func TestCollectionsGauge_ByNamespace(t *testing.T) {
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+
+	tests := []struct {
+		name   string
+		setup  func(t *testing.T, sc *schema)
+		want   map[string]float64
+		series int
+	}{
+		{
+			name:   "a fresh schema publishes zero, not nothing",
+			setup:  func(t *testing.T, sc *schema) {},
+			want:   map[string]float64{"": 0},
+			series: 1,
+		},
+		{
+			name: "each namespace gets its own series and unqualified classes share one",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, ss, 2))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Movies"}, ss, 3))
+				require.NoError(t, sc.addClass(&models.Class{Class: "Unqualified"}, ss, 4))
+			},
+			want:   map[string]float64{"": 1, "customer1": 2, "customer2": 1},
+			series: 3,
+		},
+		{
+			name: "emptying a namespace drops its series",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Movies"}, ss, 2))
+				require.True(t, sc.deleteClass("customer1:Movies"))
+			},
+			want:   map[string]float64{"": 0, "customer2": 1},
+			series: 2,
+		},
+		{
+			name: "deleting the last unqualified class keeps its series at zero",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "Unqualified"}, ss, 1))
+				require.True(t, sc.deleteClass("Unqualified"))
+			},
+			want:   map[string]float64{"": 0},
+			series: 1,
+		},
+		{
+			name: "a rejected duplicate add does not move the series",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+				require.ErrorIs(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 2), ErrClassExists)
+			},
+			want:   map[string]float64{"": 0, "customer1": 1},
+			series: 2,
+		},
+		{
+			name: "deleting a class that is not there leaves the series alone",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+				require.False(t, sc.deleteClass("customer1:Missing"))
+				require.False(t, sc.deleteClass("customer2:Missing"))
+			},
+			want:   map[string]float64{"": 0, "customer1": 1},
+			series: 2,
+		},
+		{
+			name: "a restore republishes the series and discards the old ones",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+				restoreClasses(t, sc, "customer2:Books", "Unqualified")
+			},
+			want:   map[string]float64{"": 1, "customer2": 1},
+			series: 2,
+		},
+		{
+			name: "a restore of an empty snapshot leaves only the zero series",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+				restoreClasses(t, sc)
+			},
+			want:   map[string]float64{"": 0},
+			series: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+			tt.setup(t, sc)
+
+			// Counted before any read below: WithLabelValues creates the series
+			// it names, so reading first would manufacture the very series this
+			// asserts on.
+			assert.Equal(t, tt.series, testutil.CollectAndCount(sc.collectionsCount),
+				"no series beyond the ones asserted")
+
+			for namespace, want := range tt.want {
+				assert.Equal(t, want, testutil.ToFloat64(sc.collectionsCount.WithLabelValues(namespace)),
+					"namespace %q", namespace)
+			}
+		})
+	}
 }
 
 // The count is read under a read lock, so all three writers of the map must

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sync"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -1183,16 +1184,189 @@ func TestAliasNamespacePrefixPreserved(t *testing.T) {
 }
 
 func TestCollectionsCount_Namespaced(t *testing.T) {
+	newState := func() *sharding.State {
+		return &sharding.State{Physical: make(map[string]sharding.Physical)}
+	}
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, sc *schema)
+		// want maps a namespace onto the count CollectionsCount must report;
+		// the empty namespace is the cluster-global total.
+		want map[string]int
+	}{
+		{
+			name:  "no classes",
+			setup: func(*testing.T, *schema) {},
+			want:  map[string]int{"": 0, "customer1": 0},
+		},
+		{
+			name: "classes across namespaces alongside an unqualified class",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, newState(), 2))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Movies"}, newState(), 3))
+				require.NoError(t, sc.addClass(&models.Class{Class: "Global"}, newState(), 4))
+			},
+			want: map[string]int{"": 4, "customer1": 2, "customer2": 1, "unknown": 0},
+		},
+		{
+			name: "a namespace that prefixes another does not absorb its classes",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer:Movies"}, newState(), 1))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 2))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, newState(), 3))
+			},
+			want: map[string]int{"": 3, "customer": 1, "customer1": 2},
+		},
+		{
+			name: "a rejected duplicate add is not counted twice",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.ErrorIs(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 2), ErrClassExists)
+			},
+			want: map[string]int{"": 1, "customer1": 1},
+		},
+		{
+			name: "delete removes the class from its namespace only",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, newState(), 2))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Movies"}, newState(), 3))
+				require.True(t, sc.deleteClass("customer1:Movies"))
+			},
+			want: map[string]int{"": 2, "customer1": 1, "customer2": 1},
+		},
+		{
+			name: "deleting the last class empties the namespace",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.True(t, sc.deleteClass("customer1:Movies"))
+			},
+			want: map[string]int{"": 0, "customer1": 0},
+		},
+		{
+			name: "deleting a class that is not there leaves the count alone",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.False(t, sc.deleteClass("customer1:Missing"))
+				require.False(t, sc.deleteClass("customer2:Missing"))
+			},
+			want: map[string]int{"": 1, "customer1": 1, "customer2": 0},
+		},
+		{
+			name: "re-adding a deleted class counts it once",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.True(t, sc.deleteClass("customer1:Movies"))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 2))
+			},
+			want: map[string]int{"": 1, "customer1": 1},
+		},
+		{
+			name: "restoring a snapshot replaces the counts of the namespaces it had",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, newState(), 2))
+
+				data, err := json.Marshal(map[string]*metaClass{
+					"customer2:Books": {Class: models.Class{Class: "customer2:Books"}},
+					"Global":          {Class: models.Class{Class: "Global"}},
+				})
+				require.NoError(t, err)
+				require.NoError(t, sc.Restore(data, &fixedParser{}))
+			},
+			want: map[string]int{"": 2, "customer1": 0, "customer2": 1},
+		},
+		{
+			name: "restoring an empty snapshot clears every namespace",
+			setup: func(t *testing.T, sc *schema) {
+				require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, newState(), 1))
+
+				data, err := json.Marshal(map[string]*metaClass{})
+				require.NoError(t, err)
+				require.NoError(t, sc.Restore(data, &fixedParser{}))
+			},
+			want: map[string]int{"": 0, "customer1": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+			tt.setup(t, sc)
+
+			for namespace, want := range tt.want {
+				assert.Equal(t, want, sc.CollectionsCount(namespace), "namespace %q", namespace)
+			}
+		})
+	}
+}
+
+// A namespace that loses its last class must leave no entry behind: a cluster
+// that churns namespaces would otherwise grow the map for the life of the node.
+func TestClassCountByNamespace_DropsEmptyNamespace(t *testing.T) {
 	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
 	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
 
 	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
-	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, ss, 2))
-	require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Movies"}, ss, 3))
-	require.NoError(t, sc.addClass(&models.Class{Class: "Global"}, ss, 4))
+	require.True(t, sc.deleteClass("customer1:Movies"))
+	assert.Empty(t, sc.classCountByNamespace, "after the last class is deleted")
 
-	assert.Equal(t, 4, sc.CollectionsCount(""), "empty namespace returns total")
-	assert.Equal(t, 2, sc.CollectionsCount("customer1"))
+	require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Books"}, ss, 2))
+	data, err := json.Marshal(map[string]*metaClass{})
+	require.NoError(t, err)
+	require.NoError(t, sc.Restore(data, &fixedParser{}))
+	assert.Empty(t, sc.classCountByNamespace, "after an empty snapshot is restored")
+}
+
+// The count is read under a read lock, so all three writers of the map must
+// write it under the lock that guards s.classes. Run with -race.
+func TestCollectionsCount_ConcurrentAccess(t *testing.T) {
+	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+
+	snapshot, err := json.Marshal(map[string]*metaClass{
+		"customer2:Books": {Class: models.Class{Class: "customer2:Books"}},
+	})
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			sc.CollectionsCount("customer1")
+			sc.CollectionsCount("")
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		// Adds its own class before deleting it, so deleteClass reaches the
+		// counter every iteration instead of returning early once the names
+		// the other goroutines write are gone.
+		for i := 0; i < 2000; i++ {
+			name := fmt.Sprintf("customer3:C%d", i)
+			assert.NoError(t, sc.addClass(&models.Class{Class: name}, ss, uint64(i)))
+			sc.deleteClass(name)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			// assert, not require: only the test goroutine may call FailNow.
+			assert.NoError(t, sc.Restore(snapshot, &fixedParser{}))
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		require.NoError(t, sc.addClass(&models.Class{Class: fmt.Sprintf("customer1:C%d", i)}, ss, uint64(i)))
+	}
+	wg.Wait()
+
+	// The racing writers leave an arbitrary map; a final restore settles it so
+	// the counts are deterministic.
+	require.NoError(t, sc.Restore(snapshot, &fixedParser{}))
 	assert.Equal(t, 1, sc.CollectionsCount("customer2"))
-	assert.Equal(t, 0, sc.CollectionsCount("unknown"))
+	assert.Equal(t, 0, sc.CollectionsCount("customer1"))
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -194,8 +194,27 @@ This document is the single source of truth for Prometheus metrics exposed by We
 #### Schema Management Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|
-| `weaviate_schema_collections` | Number of collections per node | `Gauge` | `nodeID` | - Low 
+| `weaviate_schema_collections` | Number of collections in a node's copy of the schema, split by namespace. See the notes below. | `Gauge` | `nodeID, collection_namespace` | - Medium (one series per populated namespace, plus one) 
 | `weaviate_schema_shards` | Number of shards per node with corresponding status | `Gauge` | `nodeID, status` | - Low 
+
+##### Notes on `weaviate_schema_collections`
+
+- **Every node holds the whole schema**, so `sum without(collection_namespace)` — which keeps
+  `nodeID` — is the total. `sum by (collection_namespace)` multiplies by the node count.
+- **Collections with no namespace are counted under an empty `collection_namespace`.** That series is
+  always present, so a fresh node reports zero rather than omitting the metric. The series count is
+  therefore one per populated namespace *plus one*.
+- **The `collection_namespace` label is new.** A query written against the earlier unlabelled gauge
+  returns one series per namespace once namespaced collections exist, and has to be wrapped in
+  `sum without(collection_namespace)`. Before any namespaced collection exists it still returns a
+  single series carrying the same value as before, so the break only surfaces on a namespaces cluster.
+- **The label is deliberately not called `namespace`.** A Kubernetes scrape stamps a `namespace`
+  target label of its own, and at the default `honorLabels: false` a scraped `namespace` would be
+  rewritten to `exported_namespace` — breaking every query naming it, silently.
+- **A namespace's series is deleted when its last collection is**, so
+  `{collection_namespace="x"} == 0` never matches. Use `absent()` to detect an empty namespace.
+- **Namespace names are tenant identifiers** served on the unauthenticated monitoring port. Keep that
+  port on a trusted network.
 
 #### Runtime Config Metrics
 | Name | Description | Type | Labels | High Cardinality |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,6 +27,7 @@ This document is the single source of truth for Prometheus metrics exposed by We
 - Prefer counters/gauges with a small, bounded label set
 - Avoid per-tenant/per-class/per-route label explosions unless essential for operations
 - Move exploratory or wide-label analytics to logs, traces, or external stores
+- Rate a label Medium where its values are unbounded in principle but few in practice: one series per active value, worth watching rather than avoiding
 
 ### Change management
 
@@ -211,8 +212,11 @@ This document is the single source of truth for Prometheus metrics exposed by We
 - **The label is deliberately not called `namespace`.** A Kubernetes scrape stamps a `namespace`
   target label of its own, and at the default `honorLabels: false` a scraped `namespace` would be
   rewritten to `exported_namespace` — breaking every query naming it, silently.
-- **A namespace's series is deleted when its last collection is**, so
-  `{collection_namespace="x"} == 0` never matches. Use `absent()` to detect an empty namespace.
+- **A named namespace's series is deleted when its last collection is**, so
+  `{collection_namespace="customer1"} == 0` never matches. Use `absent()` to detect an empty
+  namespace. The always-present empty-namespace series is the exception and can read zero. On a
+  namespaces cluster it always reads zero, because such a node refuses to start while it holds a
+  collection with no namespace.
 - **Namespace names are tenant identifiers** served on the unauthenticated monitoring port. Keep that
   port on a trusted network.
 

--- a/test/acceptance/schema/namespace_collection_limit_test.go
+++ b/test/acceptance/schema/namespace_collection_limit_test.go
@@ -67,9 +67,11 @@ func TestNamespacedCollectionCountLimit(t *testing.T) {
 	helper.AssignRoleToUser(t, adminKey, "admin", "customer1:"+u1Subject)
 	defer helper.RevokeRoleFromUser(t, adminKey, "admin", "customer1:"+u1Subject)
 
-	// First class in customer1 uses up that namespace's budget.
+	// First class in customer1 uses up that namespace's budget. The
+	// freed-budget arm below deletes it mid-test, so the cleanup is
+	// best-effort rather than asserted.
 	helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, u1Key)
-	defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+	defer helper.DeleteClassWithoutAssert(t, "customer1:Movies", adminKey)
 
 	// Second class in the same namespace hits the per-namespace cap.
 	_, err = helper.CreateClassAuthWithReturn(t, &models.Class{Class: "Films"}, u1Key)
@@ -81,6 +83,20 @@ func TestNamespacedCollectionCountLimit(t *testing.T) {
 	assert.Equal(t, "USAGE_LIMIT_EXCEEDED", tooMany.Payload.ErrorCode)
 	assert.Equal(t, "collections", tooMany.Payload.Limit)
 	assert.Equal(t, int64(1), tooMany.Payload.Value)
+
+	// Deleting a collection gives the namespace its budget back, so the create
+	// the cap just rejected now succeeds. This is the only end-to-end proof of
+	// the decrement: the cluster-global cap short-circuits on the class total
+	// and never consults the per-namespace count.
+	helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+	helper.CreateClassAuth(t, &models.Class{Class: "Films"}, u1Key)
+	defer helper.DeleteClassAuth(t, "customer1:Films", adminKey)
+
+	// The budget is spent again, not switched off.
+	_, err = helper.CreateClassAuthWithReturn(t, &models.Class{Class: "Shows"}, u1Key)
+	require.Error(t, err)
+	require.True(t, errors.As(err, &tooMany),
+		"expected SchemaObjectsCreateTooManyRequests after the recreate, got %T: %v", err, err)
 
 	// A different namespace has its own budget and can still create a class.
 	helper.CreateNamespace(t, "customer2", adminKey)

--- a/usecases/schema/async_replication_config_validation_test.go
+++ b/usecases/schema/async_replication_config_validation_test.go
@@ -46,7 +46,6 @@ func Test_AddClass_AsyncReplicationConfigValidation(t *testing.T) {
 				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncConfig: tt.asyncConfig},
 			}
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 			_, _, err := handler.AddClass(context.Background(), nil, &class)
 			if tt.wantErr == "" {
@@ -80,7 +79,6 @@ func Test_UpdateClass_AsyncReplicationConfigValidation(t *testing.T) {
 				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 			}
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
 			fakeSchemaManager.On("ReadOnlyClass", "AsyncCfgClass", mock.Anything).Return(initial)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -184,27 +184,31 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 		return nil, 0, err
 	}
 
-	// On namespace-enabled clusters the cap is enforced per namespace.
-	// QualifyForCreate above already required principal.Namespace for this
-	// flow, so it is the correct selector here.
-	countNamespace := ""
-	if h.config.Namespaces.Enabled {
-		countNamespace = principal.Namespace
-	}
-
-	existingCollectionsCount, err := h.schemaManager.QueryCollectionsCount(countNamespace)
-	if err != nil {
-		h.logger.WithField("namespace", countNamespace).Errorf("could not query the collections count: %v", err)
-	}
-
+	// Read the limit before the count: no cap is the default, and the count
+	// costs a round trip to the leader whose answer an uncapped cluster
+	// discards.
 	limit := h.schemaConfig.MaximumAllowedCollectionsCount.Get()
+	if limit != config.DefaultMaximumAllowedCollectionsCount {
+		// On namespace-enabled clusters the cap is enforced per namespace.
+		// QualifyForCreate above already required principal.Namespace for this
+		// flow, so it is the correct selector here.
+		countNamespace := ""
+		if h.config.Namespaces.Enabled {
+			countNamespace = principal.Namespace
+		}
 
-	if limit != config.DefaultMaximumAllowedCollectionsCount && existingCollectionsCount >= limit {
-		// Migrated from a free-text 422 to a typed 429 / RESOURCE_EXHAUSTED
-		// in the usage-limits work; see docs/usage_limits.md for the wire
-		// contract.
-		return nil, 0, usagelimits.NewLimitExceededError(
-			h.errorMessageTemplate(), usagelimits.LimitCollections, int64(limit))
+		existingCollectionsCount, err := h.schemaManager.QueryCollectionsCount(countNamespace)
+		if err != nil {
+			h.logger.WithField("namespace", countNamespace).Errorf("could not query the collections count: %v", err)
+		}
+
+		if existingCollectionsCount >= limit {
+			// Migrated from a free-text 422 to a typed 429 / RESOURCE_EXHAUSTED
+			// in the usage-limits work; see docs/usage_limits.md for the wire
+			// contract.
+			return nil, 0, usagelimits.NewLimitExceededError(
+				h.errorMessageTemplate(), usagelimits.LimitCollections, int64(limit))
+		}
 	}
 
 	candidates, err := h.namespaceCandidates(cls.Class)

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -61,7 +61,6 @@ func Test_AddClass_ObjectTTL_InvertedIndex(t *testing.T) {
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 	classValidated, _, err := handler.AddClass(ctx, nil, class)
 	assert.NoError(t, err)
@@ -93,7 +92,6 @@ func Test_AddClass(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 		_, _, err := handler.AddClass(ctx, nil, class)
 		assert.Nil(t, err)
@@ -120,7 +118,6 @@ func Test_AddClass(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 		_, _, err := handler.AddClass(ctx, nil, class)
 		require.NoError(t, err)
@@ -254,7 +251,6 @@ func Test_AddClass(t *testing.T) {
 			UsingBlockMaxWAND:      config.DefaultUsingBlockMaxWAND,
 		}
 		fakeSchemaManager.On("AddClass", expectedClass, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
 		fakeSchemaManager.AssertExpectations(t)
@@ -289,7 +285,6 @@ func Test_AddClass(t *testing.T) {
 			UsingBlockMaxWAND:      config.DefaultUsingBlockMaxWAND,
 		}
 		fakeSchemaManager.On("AddClass", expectedClass, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
 		fakeSchemaManager.AssertExpectations(t)
@@ -350,7 +345,6 @@ func Test_AddClass(t *testing.T) {
 					// fakeSchemaManager.On("ReadOnlyClass", mock.Anything).Return(&models.Class{Class: classes[tc.dataType[0]].Class, Vectorizer: classes[tc.dataType[0]].Vectorizer})
 					if tc.expectedErrMsg == "" {
 						fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 
 					_, _, err := handler.AddClass(context.Background(), nil, class)
@@ -545,8 +539,11 @@ func Test_AddClassWithLimits(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 
-				// Mock the schema count
-				fakeSchemaManager.On("QueryCollectionsCount", "").Return(tt.existingCount, nil)
+				// An unlimited cap must not ask the leader for a count it would
+				// discard, so the expectation is only set where the cap is on.
+				if tt.maxAllowed != config.DefaultMaximumAllowedCollectionsCount {
+					fakeSchemaManager.On("QueryCollectionsCount", "").Return(tt.existingCount, nil)
+				}
 
 				// Set the max collections limit in config
 				handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(tt.maxAllowed)
@@ -559,7 +556,6 @@ func Test_AddClassWithLimits(t *testing.T) {
 
 				if !tt.expectExceed {
 					fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-					fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				}
 
 				_, _, err := handler.AddClass(ctx, nil, class)
@@ -572,6 +568,9 @@ func Test_AddClassWithLimits(t *testing.T) {
 					assert.NotEmpty(t, le.RenderedMessage)
 				} else {
 					require.Nil(t, err)
+				}
+				if tt.maxAllowed == config.DefaultMaximumAllowedCollectionsCount {
+					fakeSchemaManager.AssertNotCalled(t, "QueryCollectionsCount", "")
 				}
 				fakeSchemaManager.AssertExpectations(t)
 			})
@@ -602,7 +601,6 @@ func Test_AddClassWithLimits(t *testing.T) {
 
 				if tt.expectError == "" {
 					schemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-					schemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					defer schemaManager.AssertExpectations(t)
 				}
 
@@ -730,7 +728,6 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 
 		t.Run("create class with all properties", func(t *testing.T) {
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 			_, _, err := handler.AddClass(ctx, nil, &class)
 			require.Nil(t, err)
@@ -897,7 +894,6 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 		t.Run("create class with all properties", func(t *testing.T) {
 			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			_, _, err := handler.AddClass(ctx, nil, &class)
 			require.Nil(t, err)
 			fakeSchemaManager.AssertExpectations(t)
@@ -1005,7 +1001,6 @@ func Test_AddClass_ObjectTTLConfig(t *testing.T) {
 				handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 				handler.config.ObjectsTTLDeleteSchedule = runtime.NewDynamicValue("@every 1h")
 				fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 				_, _, err := handler.AddClass(context.Background(), nil, collection)
 
@@ -1190,7 +1185,6 @@ func Test_Validation_ClassNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					t.Log(err)
@@ -1212,7 +1206,6 @@ func Test_Validation_ClassNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					t.Log(err)
@@ -1310,7 +1303,6 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 					_, _, err := handler.AddClass(context.Background(), nil, class)
@@ -1336,7 +1328,6 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					t.Log(err)
@@ -1365,7 +1356,6 @@ func Test_Validation_PropertyNames(t *testing.T) {
 					}
 
 					fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-					fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(class)
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					require.Nil(t, err)
@@ -1401,7 +1391,6 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(ctx, nil, class)
 					t.Log(err)
@@ -2362,7 +2351,6 @@ func Test_UpdateClass(t *testing.T) {
 				store.parser = handler.parser
 
 				fakeSchemaManager.On("AddClass", test.initial, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
 				fakeSchemaManager.On("ReadOnlyClass", test.initial.Class, mock.Anything).Return(test.initial)
 				fakeSchemaManager.On("CopyShardingState", mock.Anything).Return(&sharding.State{}, nil)
@@ -2461,7 +2449,6 @@ func Test_UpdateClass_ObjectTTLConfig(t *testing.T) {
 			store.parser = handler.parser
 
 			fakeSchemaManager.On("AddClass", initial, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
 			fakeSchemaManager.On("ReadOnlyClass", initial.Class, mock.Anything).Return(initial)
 
@@ -2532,7 +2519,6 @@ func Test_UpdateClass_ObjectTTLConfig(t *testing.T) {
 				store.parser = handler.parser
 
 				fakeSchemaManager.On("AddClass", initial, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				fakeSchemaManager.On("ReadOnlyClass", initial.Class, mock.Anything).Return(initial)
 
 				handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
@@ -2928,7 +2914,6 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		c, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
@@ -2950,7 +2935,6 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		c, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
@@ -2968,7 +2952,6 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NotNil(t, err)
@@ -2984,7 +2967,6 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NotNil(t, err)

--- a/usecases/schema/handler_test.go
+++ b/usecases/schema/handler_test.go
@@ -59,7 +59,6 @@ func testAddObjectClass(t *testing.T, handler *Handler, fakeSchemaManager *fakeS
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -79,7 +78,6 @@ func testAddObjectClassExplicitVectorizer(t *testing.T, handler *Handler, fakeSc
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -98,7 +96,6 @@ func testAddObjectClassImplicitVectorizer(t *testing.T, handler *Handler, fakeSc
 	}
 
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -154,7 +151,6 @@ func testRemoveObjectClass(t *testing.T, handler *Handler, fakeSchemaManager *fa
 	}
 
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	require.Nil(t, err)
 
@@ -180,7 +176,6 @@ func testCantAddSameClassTwice(t *testing.T, handler *Handler, fakeSchemaManager
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 
@@ -197,7 +192,6 @@ func testCantAddSameClassTwice(t *testing.T, handler *Handler, fakeSchemaManager
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.ExpectedCalls = fakeSchemaManager.ExpectedCalls[:0]
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(ErrNotFound)
 
 	// Add it again
@@ -218,7 +212,6 @@ func testCantAddSameClassTwiceDifferentKinds(t *testing.T, handler *Handler, fak
 		},
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 	_, _, err := handler.AddClass(ctx, nil, class)
 	assert.Nil(t, err)
@@ -293,7 +286,6 @@ func testAddPropertyDuringCreation(t *testing.T, handler *Handler, fakeSchemaMan
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -323,7 +315,6 @@ func testAddPropertyWithTargetVectorConfig(t *testing.T, handler *Handler, fakeS
 		},
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	require.NoError(t, err)
@@ -377,7 +368,6 @@ func testDropProperty(t *testing.T, handler *Handler, fakeSchemaManager *fakeSch
 		Properties:        properties,
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -161,7 +161,6 @@ func TestAddClass(t *testing.T) {
 				sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
 					return c.Class == tt.wantClass
 				}), mock.Anything).Return(nil)
-				sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 			}
 
 			got, _, err := handler.AddClass(context.Background(), tt.principal, class)
@@ -231,7 +230,6 @@ func TestAddClass_PinsShardsToNamespaceHomeNode(t *testing.T) {
 				capturedState = s
 				return true
 			})).Return(nil)
-			sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 
 			class := &models.Class{
 				Class:             tt.inputName,
@@ -295,7 +293,6 @@ func TestAddClass_NamespacePlacementErrors(t *testing.T) {
 			sm.storageCandidates = tt.candidates
 			handler.namespacesExister = tt.exister
 
-			sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 			class := &models.Class{
 				Class:             "Movies",
 				Vectorizer:        "model1",
@@ -336,7 +333,6 @@ func TestAddClass_RejectsExplicitDesiredCount(t *testing.T) {
 			handler.namespacesExister = fakeNamespacesExister{byName: map[string]cmd.Namespace{
 				"customer1": {Name: "customer1", HomeNodes: []string{"node-2"}, State: cmd.NamespaceStateActive},
 			}}
-			sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil).Maybe()
 
 			class := &models.Class{
 				Class:             "Movies",
@@ -365,7 +361,6 @@ func TestAddClass_MTRejectsShardingConfig(t *testing.T) {
 	handler.namespacesExister = fakeNamespacesExister{byName: map[string]cmd.Namespace{
 		"customer1": {Name: "customer1", HomeNodes: []string{"node-2"}, State: cmd.NamespaceStateActive},
 	}}
-	sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil).Maybe()
 
 	class := &models.Class{
 		Class:              "Movies",
@@ -391,7 +386,6 @@ func TestAddClass_AcceptsExplicitDesiredCountOne(t *testing.T) {
 		"customer1": {Name: "customer1", HomeNodes: []string{"node-2"}, State: cmd.NamespaceStateActive},
 	}}
 	sm.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-	sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 
 	class := &models.Class{
 		Class:             "Movies",
@@ -424,7 +418,6 @@ func TestAddClass_OmittedShardingConfigPinsToHomeNode(t *testing.T) {
 		capturedState = s
 		return true
 	})).Return(nil)
-	sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 
 	class := &models.Class{
 		Class:             "Movies",
@@ -476,7 +469,6 @@ func TestAddClass_ShardCapAppliesAfterOverride(t *testing.T) {
 			if !tt.expectExceeds {
 				sm.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 			}
-			sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 
 			class := &models.Class{
 				Class:             "Movies",

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -40,7 +40,6 @@ func TestHandler_AddProperty(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
@@ -99,7 +98,6 @@ func TestHandler_AddProperty(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
@@ -151,7 +149,6 @@ func TestHandler_AddProperty_ReservedSuffix(t *testing.T) {
 					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 				}
 				fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(class)
 				_, _, err := handler.AddClass(ctx, nil, class)
 				require.NoError(t, err)
@@ -209,7 +206,6 @@ func TestHandler_AddProperty_Object(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
@@ -486,7 +482,6 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	}
 	fakeSchemaManager.On("ReadOnlyClass", refClass.Class).Return(&refClass)
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil).Twice()
-	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil).Twice()
 	fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 	_, _, err := handler.AddClass(ctx, nil, &class)
 	require.NoError(t, err)

--- a/usecases/schema/usage_limits_shards_test.go
+++ b/usecases/schema/usage_limits_shards_test.go
@@ -51,7 +51,6 @@ func TestAddClass_WithShardLimit(t *testing.T) {
 			handler.config.UsageLimits.MaxShardsPerCollection = runtime.NewDynamicValue(tt.shardCap)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 
-			fakeMgr.On("QueryCollectionsCount", "").Return(0, nil).Maybe()
 			if !tt.expectExceed {
 				fakeMgr.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 			}


### PR DESCRIPTION
### What's being changed:

Every collection create on a namespaces cluster asked the leader for that namespace's collection count, and the leader scanned every class name for the prefix under the schema read lock.

`schema` now keeps a `classCountByNamespace` map next to `classes`, updated in `addClass`, `deleteClass` and snapshot restore, so `CollectionsCount` answers from a map lookup instead of a scan. Collections with no namespace prefix are not in the map — the unnamespaced total stays `len(classes)`.

The round trip itself is dropped separately: `AddClass` reads the configured cap before it asks for the count, so a cluster with no cap — the default — no longer queries the leader on every create. A capped cluster still queries, and the leader now answers from the map.

Two more related changes:
-`weaviate_schema_collections` gets a `collection_namespace` label
- The label is not called `namespace` because a Kubernetes scrape stamps its own `namespace` target label, and at the default `honorLabels: false` Prometheus renames ours to `exported_namespace` — breaking every query naming it, silently.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->


