### PR TITLE
ci(drop-vector-index): split the cluster and async-indexing jobs in two

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -847,14 +847,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "cluster"
-            test: "--acceptance-drop-vector-index-cluster"
+          - name: "cluster-group1"
+            test: "--acceptance-drop-vector-index-cluster-group1"
+          - name: "cluster-group2"
+            test: "--acceptance-drop-vector-index-cluster-group2"
           - name: "restart-cluster"
             test: "--acceptance-drop-vector-index-restart-cluster"
           - name: "rolling-restart"
             test: "--acceptance-drop-vector-index-rolling-restart"
-          - name: "async-indexing"
-            test: "--acceptance-drop-vector-index-async-indexing"
+          - name: "async-indexing-group1"
+            test: "--acceptance-drop-vector-index-async-indexing-group1"
+          - name: "async-indexing-group2"
+            test: "--acceptance-drop-vector-index-async-indexing-group2"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go

--- a/test/acceptance/drop_vector_index/setup_test.go
+++ b/test/acceptance/drop_vector_index/setup_test.go
@@ -21,54 +21,79 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-func TestDropVectorIndex_Cluster(t *testing.T) {
-	ctx := context.Background()
+func startClusterCompose(ctx context.Context, t *testing.T) *docker.DockerCompose {
+	t.Helper()
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "1").
-		// The cold-tenant test needs the reconcile heal within seconds.
 		WithWeaviateEnv("DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS", "5").
 		Start(ctx)
 	require.NoError(t, err)
-	defer func() {
-		dumpLogsOnFailure(ctx, t, compose)
-		require.NoError(t, compose.Terminate(ctx))
-	}()
-
-	runSuite(t, compose)
-	t.Run("replicated drop", testReplicatedDrop(compose))
-	t.Run("replicated cold tenant", testReplicatedColdTenant(compose))
+	return compose
 }
 
-// TestDropVectorIndex_AsyncIndexing runs the cluster journeys with
-// ASYNC_INDEXING on. That gives every index a vectors_<name>.queue.d the
-// synchronous path never creates, so the disk assertions — unchanged, they read
-// helpers.VectorIndexArtifactsFor — cover an artifact the cluster job cannot.
-// It also owns the dynamic-index journeys: a dynamic vector is refused at class
-// creation unless async indexing is on, so they cannot run in the suite above.
-func TestDropVectorIndex_AsyncIndexing(t *testing.T) {
-	ctx := context.Background()
+func startAsyncCompose(ctx context.Context, t *testing.T) *docker.DockerCompose {
+	t.Helper()
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
+		WithWeaviateExposeGRPCPort().
 		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "1").
 		WithWeaviateEnv("ASYNC_INDEXING", "true").
-		// The dynamic journeys search over gRPC.
-		WithWeaviateExposeGRPCPort().
-		// Flush partial queue chunks promptly, or the drain sits idle.
 		WithWeaviateEnv("ASYNC_INDEXING_STALE_TIMEOUT", "500ms").
 		WithWeaviateEnv("DROP_VECTOR_INDEX_RECONCILE_INTERVAL_SECONDS", "5").
 		Start(ctx)
 	require.NoError(t, err)
+	return compose
+}
+
+func TestDropVectorIndex_Cluster_Group1(t *testing.T) {
+	ctx := context.Background()
+	compose := startClusterCompose(ctx, t)
 	defer func() {
 		dumpLogsOnFailure(ctx, t, compose)
 		require.NoError(t, compose.Terminate(ctx))
 	}()
 
-	runSuite(t, compose)
-	t.Run("replicated drop", testReplicatedDrop(compose))
+	runSuiteGroup1(t, compose)
 	t.Run("replicated cold tenant", testReplicatedColdTenant(compose))
+}
+
+func TestDropVectorIndex_Cluster_Group2(t *testing.T) {
+	ctx := context.Background()
+	compose := startClusterCompose(ctx, t)
+	defer func() {
+		dumpLogsOnFailure(ctx, t, compose)
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	runSuiteGroup2(t, compose)
+	t.Run("replicated drop", testReplicatedDrop(compose))
+}
+
+func TestDropVectorIndex_AsyncIndexing_Group1(t *testing.T) {
+	ctx := context.Background()
+	compose := startAsyncCompose(ctx, t)
+	defer func() {
+		dumpLogsOnFailure(ctx, t, compose)
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	runSuiteGroup1(t, compose)
+	t.Run("replicated cold tenant", testReplicatedColdTenant(compose))
+}
+
+func TestDropVectorIndex_AsyncIndexing_Group2(t *testing.T) {
+	ctx := context.Background()
+	compose := startAsyncCompose(ctx, t)
+	defer func() {
+		dumpLogsOnFailure(ctx, t, compose)
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	runSuiteGroup2(t, compose)
+	t.Run("replicated drop", testReplicatedDrop(compose))
 	t.Run("dynamic upgrade verdict cleared", testDynamicUpgradeVerdictCleared(compose))
 }
 
@@ -115,13 +140,24 @@ func dumpLogsOnFailure(ctx context.Context, t *testing.T, compose *docker.Docker
 	compose.DumpWeaviateLogs(ctx, os.Stderr, 300)
 }
 
-func runSuite(t *testing.T, compose *docker.DockerCompose) {
+func runSuiteGroup1(t *testing.T, compose *docker.DockerCompose) {
 	helper.SetupClient(compose.GetWeaviate().URI())
 	defer helper.ResetClient()
 
 	t.Run("lifecycle", testLifecycle())
-	t.Run("write matrix", testWriteMatrix())
 	t.Run("multi tenant", testMultiTenant())
+	t.Run("tenant mutation during drop", testTenantMutationDuringDrop())
+	t.Run("cold tenant deferred finalize", testColdTenantDeferredFinalize())
+	t.Run("partially cold tenants", testPartiallyColdTenants())
+	t.Run("multi vector", testMultiVector())
+	t.Run("multi vector drop leaves no files on disk", testMultiVectorLeavesNoFilesOnDisk(compose))
+}
+
+func runSuiteGroup2(t *testing.T, compose *docker.DockerCompose) {
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	t.Run("write matrix", testWriteMatrix())
 	t.Run("sustained load", testSustainedLoad(compose))
 	t.Run("concurrent drops", testConcurrentDrops())
 	t.Run("delete class mid-drop", testDeleteClassMidDrop())
@@ -129,14 +165,9 @@ func runSuite(t *testing.T, compose *docker.DockerCompose) {
 	t.Run("zero tenant drop", testZeroTenantDrop())
 	t.Run("all tenants deleted mid-drop", testAllTenantsDeletedMidDrop())
 	t.Run("last vector drop to vectorless", testLastVectorDropToVectorless())
-	t.Run("tenant mutation during drop", testTenantMutationDuringDrop())
-	t.Run("cold tenant deferred finalize", testColdTenantDeferredFinalize())
 	t.Run("deleted cold tenant finalizes without re-clean", testDeletedColdTenantFinalizesWithoutReclean())
-	t.Run("partially cold tenants", testPartiallyColdTenants())
 	t.Run("tenant delete recreate during drop", testTenantDeleteRecreateDuringDrop())
 	t.Run("re-drop after re-create", testRedropAfterRecreate())
-	t.Run("multi vector", testMultiVector())
-	t.Run("multi vector drop leaves no files on disk", testMultiVectorLeavesNoFilesOnDisk(compose))
 	t.Run("hfresh drop leaves no files on disk", testHFreshLeavesNoFilesOnDisk(compose))
 	t.Run("flat drop leaves no files on disk", testFlatLeavesNoFilesOnDisk(compose))
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -60,10 +60,12 @@ function main() {
   run_acceptance_reindex_mt=false
   run_acceptance_reindex_backup=false
   run_acceptance_drop_vector_index=false
-  run_acceptance_drop_vector_index_cluster=false
+  run_acceptance_drop_vector_index_cluster_group1=false
+  run_acceptance_drop_vector_index_cluster_group2=false
   run_acceptance_drop_vector_index_restart_cluster=false
   run_acceptance_drop_vector_index_rolling_restart=false
-  run_acceptance_drop_vector_index_async_indexing=false
+  run_acceptance_drop_vector_index_async_indexing_group1=false
+  run_acceptance_drop_vector_index_async_indexing_group2=false
   run_acceptance_backups=false
 
   while [[ "$#" -gt 0 ]]; do
@@ -124,10 +126,12 @@ function main() {
           --acceptance-reindex-mt|-armt) run_all_tests=false; run_acceptance_reindex_mt=true;;
           --acceptance-reindex-backup|-arb) run_all_tests=false; run_acceptance_reindex_backup=true;;
           --acceptance-drop-vector-index|-advi) run_all_tests=false; run_acceptance_drop_vector_index=true;;
-          --acceptance-drop-vector-index-cluster|-advic) run_all_tests=false; run_acceptance_drop_vector_index_cluster=true;;
+          --acceptance-drop-vector-index-cluster-group1|-advic1) run_all_tests=false; run_acceptance_drop_vector_index_cluster_group1=true;;
+          --acceptance-drop-vector-index-cluster-group2|-advic2) run_all_tests=false; run_acceptance_drop_vector_index_cluster_group2=true;;
           --acceptance-drop-vector-index-restart-cluster|-advirc) run_all_tests=false; run_acceptance_drop_vector_index_restart_cluster=true;;
           --acceptance-drop-vector-index-rolling-restart|-advirr) run_all_tests=false; run_acceptance_drop_vector_index_rolling_restart=true;;
-          --acceptance-drop-vector-index-async-indexing|-advia) run_all_tests=false; run_acceptance_drop_vector_index_async_indexing=true;;
+          --acceptance-drop-vector-index-async-indexing-group1|-advia1) run_all_tests=false; run_acceptance_drop_vector_index_async_indexing_group1=true;;
+          --acceptance-drop-vector-index-async-indexing-group2|-advia2) run_all_tests=false; run_acceptance_drop_vector_index_async_indexing_group2=true;;
           --acceptance-backups|-ab) run_all_tests=false; run_acceptance_backups=true;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
           --cleanup) run_all_tests=false; run_cleanup=true;;
@@ -430,9 +434,14 @@ function main() {
     run_acceptance_drop_vector_index
   fi
 
-  if $run_acceptance_drop_vector_index_cluster; then
-    echo "running drop-vector-index cluster acceptance tests"
-    run_acceptance_drop_vector_index_cluster
+  if $run_acceptance_drop_vector_index_cluster_group1; then
+    echo "running drop-vector-index cluster group 1 acceptance tests"
+    run_acceptance_drop_vector_index_cluster_group1
+  fi
+
+  if $run_acceptance_drop_vector_index_cluster_group2; then
+    echo "running drop-vector-index cluster group 2 acceptance tests"
+    run_acceptance_drop_vector_index_cluster_group2
   fi
 
   if $run_acceptance_drop_vector_index_restart_cluster; then
@@ -445,9 +454,14 @@ function main() {
     run_acceptance_drop_vector_index_rolling_restart
   fi
 
-  if $run_acceptance_drop_vector_index_async_indexing; then
-    echo "running drop-vector-index async-indexing acceptance tests"
-    run_acceptance_drop_vector_index_async_indexing
+  if $run_acceptance_drop_vector_index_async_indexing_group1; then
+    echo "running drop-vector-index async-indexing group 1 acceptance tests"
+    run_acceptance_drop_vector_index_async_indexing_group1
+  fi
+
+  if $run_acceptance_drop_vector_index_async_indexing_group2; then
+    echo "running drop-vector-index async-indexing group 2 acceptance tests"
+    run_acceptance_drop_vector_index_async_indexing_group2
   fi
 
   if $run_acceptance_backups; then
@@ -1077,11 +1091,18 @@ function run_acceptance_drop_vector_index() {
     test/acceptance/drop_vector_index
 }
 
-function run_acceptance_drop_vector_index_cluster() {
+function run_acceptance_drop_vector_index_cluster_group1() {
   build_weaviate_test_image
-  echo_green "acceptance — drop-vector-index-cluster"
-  AOF_GROUP_RUN='^TestDropVectorIndex_Cluster$' \
-    run_aof_group "drop-vector-index-cluster" test/acceptance/drop_vector_index
+  echo_green "acceptance — drop-vector-index-cluster-group1"
+  AOF_GROUP_RUN='^TestDropVectorIndex_Cluster_Group1$' \
+    run_aof_group "drop-vector-index-cluster-group1" test/acceptance/drop_vector_index
+}
+
+function run_acceptance_drop_vector_index_cluster_group2() {
+  build_weaviate_test_image
+  echo_green "acceptance — drop-vector-index-cluster-group2"
+  AOF_GROUP_RUN='^TestDropVectorIndex_Cluster_Group2$' \
+    run_aof_group "drop-vector-index-cluster-group2" test/acceptance/drop_vector_index
 }
 
 function run_acceptance_drop_vector_index_restart_cluster() {
@@ -1091,11 +1112,18 @@ function run_acceptance_drop_vector_index_restart_cluster() {
     run_aof_group "drop-vector-index-restart-cluster" test/acceptance/drop_vector_index
 }
 
-function run_acceptance_drop_vector_index_async_indexing() {
+function run_acceptance_drop_vector_index_async_indexing_group1() {
   build_weaviate_test_image
-  echo_green "acceptance — drop-vector-index-async-indexing"
-  AOF_GROUP_RUN='^TestDropVectorIndex_AsyncIndexing$' \
-    run_aof_group "drop-vector-index-async-indexing" test/acceptance/drop_vector_index
+  echo_green "acceptance — drop-vector-index-async-indexing-group1"
+  AOF_GROUP_RUN='^TestDropVectorIndex_AsyncIndexing_Group1$' \
+    run_aof_group "drop-vector-index-async-indexing-group1" test/acceptance/drop_vector_index
+}
+
+function run_acceptance_drop_vector_index_async_indexing_group2() {
+  build_weaviate_test_image
+  echo_green "acceptance — drop-vector-index-async-indexing-group2"
+  AOF_GROUP_RUN='^TestDropVectorIndex_AsyncIndexing_Group2$' \
+    run_aof_group "drop-vector-index-async-indexing-group2" test/acceptance/drop_vector_index
 }
 
 function run_acceptance_drop_vector_index_rolling_restart() {


### PR DESCRIPTION
### What's being changed:

This PR splits the cluster and async-indexing jobs in two

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
