### PR TITLE
fix(inverted): keep int64 precision when indexing a json.Number

### DIFF
--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -650,6 +650,14 @@ func toInt64(v any) (int64, error) {
 	case int:
 		return int64(val), nil
 	case json.Number:
+		// Int64 keeps every digit. Going through Float64 first rounds anything
+		// past 2^53, and rounds the largest int64 up past its own range, so the
+		// conversion below hands back the smallest int64 instead. A value that
+		// is not integral has no Int64 reading and still goes through Float64,
+		// as before.
+		if i, err := val.Int64(); err == nil {
+			return i, nil
+		}
 		f, err := val.Float64()
 		if err != nil {
 			return 0, err

--- a/adapters/repos/db/inverted/to_int64_test.go
+++ b/adapters/repos/db/inverted/to_int64_test.go
@@ -1,0 +1,61 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToInt64(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     any
+		exp    int64
+		expErr bool
+	}{
+		{name: "int64", in: int64(42), exp: 42},
+		{name: "int", in: 42, exp: 42},
+		{name: "float64", in: float64(42), exp: 42},
+		{name: "int64 max as int64", in: int64(math.MaxInt64), exp: math.MaxInt64},
+
+		// A json.Number carries the digits the client sent, so nothing is lost
+		// before this point. Reading it through Float64 was what lost them.
+		{name: "json.Number small", in: json.Number("42"), exp: 42},
+		{name: "json.Number negative", in: json.Number("-42"), exp: -42},
+		{name: "json.Number int64 max", in: json.Number("9223372036854775807"), exp: math.MaxInt64},
+		{name: "json.Number int64 min", in: json.Number("-9223372036854775808"), exp: math.MinInt64},
+		{name: "json.Number just past 2^53", in: json.Number("9007199254740993"), exp: 9007199254740993},
+
+		// Not integral: no Int64 reading, so the Float64 path still applies.
+		{name: "json.Number with a fraction", in: json.Number("42.7"), exp: 42},
+
+		{name: "json.Number that is not a number", in: json.Number("nope"), expErr: true},
+		{name: "unsupported type", in: "42", expErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := toInt64(test.in)
+			if test.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:


`toInt64` reads a `json.Number` through `Float64()` before converting, so an integer property value past 2^53 is indexed at the wrong number. At the top of the range it does not just round — it flips sign:

| input | before | after |
|---|---|---|
| `json.Number("9223372036854775807")` | **-9223372036854775808** | 9223372036854775807 |
| `json.Number("9007199254740993")` | **9007199254740992** | 9007199254740993 |
| `int64(9223372036854775807)` | 9223372036854775807 | unchanged |

`float64` has 53 bits of mantissa, so `MaxInt64` rounds *up* to 2^63, which is outside int64; the conversion that follows is undefined in Go and yields `MinInt64` on the platforms I ran it on. The value reaching `toInt64` is a `json.Number`, which still carries every digit the client sent, so nothing was lost before this line.

The effect is on the inverted index: the row is written under the wrong key, so range filters and sorts on that property answer from a number the object never had.

## The fix

Try `Int64()` first, which keeps the digits, and fall back to `Float64()` when there is no integer reading — so a non-integral `json.Number` such as `"42.7"` still truncates exactly as before. Eight lines.

Two places in this repository already do it this way, which is what makes this the odd one out rather than a new rule:

- `entities/vectorindex/common/config.go`'s `OptionalIntFromMap` uses `typed.Int64()`, and its comment says why a `json.Number` turns up at all: *"depending on whether we get the results from disk or from the REST API, numbers may be represented slightly differently"*.
- `usecases/objects/validation`'s `intVal` also calls `.Int64()` on a `json.Number` — it then widens to `float64`, which is the separate, larger issue in #11735.

## Scope

This is deliberately **not** a fix for #11735 end to end. That one needs the value to stay integral across validation, storage and serialisation, which is a wider change and a maintainer call. This fixes one link in that chain — the one where a `json.Number` that arrived intact is turned into a different number — and it stands on its own: with the property value already exact, the index should not be the thing that loses it. Marked *Relates to* rather than *Fixes* for that reason.

## Tests

`toInt64` had no test at all. The new one covers each accepted input type, both int64 bounds, the first integer past 2^53, a non-integral `json.Number` (still truncated, unchanged), and the two error cases.

- **Revert-checked**: with `objects.go` restored to `main` and the test kept, exactly the two large-value cases fail, and the failure output is the table above — `-9223372036854775808` for `MaxInt64`.
- `go test ./adapters/repos/db/inverted/` — stated plainly: the package suite does **not** complete on my machine, and it does not complete on a pristine tree either. `TestDocBitmapInvertedRoaringSet_RowMergeBudget` exceeds the timeout on `main` with no change applied, and with that one skipped both trees then stop at `TestDocBitmapContainsBatch_ContainsAnyFold` — **544.377s on the branch against 544.395s on `main`**, i.e. the same wall for both. Every test that does run behaves identically. I could not get a green full-package run to compare against, so I am not claiming one; CI is the check that matters here.
- `gofmt` clean.

Relates to #11735.

---

*Written with assistance from Claude (Opus 5); the diagnosis, the fix and the numbers above were run and checked by me.*

### Review checklist

- [x] Documentation has been updated, if necessary. — not necessary: no public behaviour is added or removed, an existing conversion is corrected.
- [x] Chaos pipeline run or not necessary. — not necessary: single pure function, no scheduling, storage or cluster path touched.
- [x] All new code is covered by tests where it is reasonable. — `toInt64` had no test; the new one covers every branch, both int64 bounds and the error cases.
- [x] Performance tests have been run or not necessary. — not necessary: the added `Int64()` call replaces a `Float64()` call on the same value and only runs for `json.Number` inputs.
