### PR TITLE
Stop retrying a shard unload once its collection is closing

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3322,9 +3322,8 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 		return nil // shard was not found, nothing to unload
 	}
 
-	// The shutdown retries for seconds while enterRead holds the index open, so
-	// it has to give that wait up on a close request rather than leave a
-	// teardown waiting for it to finish.
+	// The shutdown retries for seconds while enterRead holds the index open. A
+	// close request has to end that wait, or the teardown blocks behind it.
 	shutdownCtx, done := i.cancelOnCloseRequested(ctx)
 	defer done()
 
@@ -3337,10 +3336,9 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 				Debugf("shard was already shut or dropped: %v", err)
 			return nil
 		}
-		// backoff reports the aborted wait as a plain cancellation, so only the
-		// close cause names the teardown that stopped the unload. It is joined
-		// rather than substituted: a shutdown that failed on its own can carry a
-		// cancellation too, and that failure is what a caller has to act on.
+		// backoff reports the aborted wait as a plain cancellation, so only
+		// context.Cause names the teardown. The two are joined because a shutdown
+		// that failed on its own also cancels, and that is what to act on.
 		if shutdownCtx.Err() != nil && ctx.Err() == nil && errors.Is(err, context.Canceled) {
 			err = fmt.Errorf("%w: %w", context.Cause(shutdownCtx), err)
 		}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3305,8 +3305,9 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 
 // UnloadLocalShard closes a shard and takes it out of the shard map. A shard
 // that is already gone or already shut is success — the caller wanted it not
-// loaded, and it is not. Every returned error means the shard is still loaded,
-// including the errAlreadyShutdown a closing index refuses with.
+// loaded, and it is not. Every returned error means the shard is still loaded:
+// errAlreadyShutdown once the index is closed, and errIndexShutdown or
+// errIndexDropped while its close is only requested.
 func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 	if err := i.enterRead(); err != nil {
 		return err
@@ -3321,7 +3322,13 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 		return nil // shard was not found, nothing to unload
 	}
 
-	if err := shutdownOrRestoreShard(ctx, &i.shards, shardName, shardLike, i.logger); err != nil {
+	// The shutdown retries for seconds while enterRead holds the index open, so
+	// it has to give that wait up on a close request rather than leave a
+	// teardown waiting for it to finish.
+	shutdownCtx, done := i.cancelOnCloseRequested(ctx)
+	defer done()
+
+	if err := shutdownOrRestoreShard(shutdownCtx, &i.shards, shardName, shardLike, i.logger); err != nil {
 		if errors.Is(err, errAlreadyShutdown) {
 			// The shard is shut, which is the outcome this call asked for. It
 			// is worth a line: reaching it means the shutdown burned its retry
@@ -3329,6 +3336,13 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 			i.logger.WithField("shard", shardName).
 				Debugf("shard was already shut or dropped: %v", err)
 			return nil
+		}
+		// backoff reports the aborted wait as a plain cancellation, so only the
+		// close cause names the teardown that stopped the unload. It is joined
+		// rather than substituted: a shutdown that failed on its own can carry a
+		// cancellation too, and that failure is what a caller has to act on.
+		if shutdownCtx.Err() != nil && ctx.Err() == nil && errors.Is(err, context.Canceled) {
+			err = fmt.Errorf("%w: %w", context.Cause(shutdownCtx), err)
 		}
 		return errors.Wrapf(err, "shutdown shard %q", shardName)
 	}

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -475,6 +475,7 @@ func newDropTestIndex(t *testing.T) (*Index, *test.Hook) {
 		shardCreateLocks: esync.NewKeyRWLocker(),
 		Config:           IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName("Abc")},
 	}
+	idx.closeRequestedCtx, idx.signalCloseRequested = context.WithCancelCause(context.Background())
 	for _, cycle := range testCycles(idx.cycleCallbacks) {
 		cycle.Start()
 	}

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -2810,9 +2810,10 @@ func TestPerformShutdownSkipsDumpWhenStoreShutdownFails(t *testing.T) {
 	}
 	enableAndAwaitAsync(t, ctx, s)
 
-	cancelledCtx, cancel := context.WithCancel(ctx)
-	cancel()
-	require.ErrorContains(t, s.performShutdown(cancelledCtx), "stop lsmkv store",
+	// the store is closed first to make its shutdown fail; the teardown itself
+	// runs to completion whatever the caller's context does
+	require.NoError(t, s.store.Shutdown(ctx))
+	require.ErrorContains(t, s.performShutdown(ctx), "stop lsmkv store",
 		"the store flush itself must have failed for this test to be meaningful")
 	require.Empty(t, htFilesInDir(t, s.pathHashTree()),
 		"no snapshot may be published when the store flush did not complete")

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -2810,7 +2810,7 @@ func TestPerformShutdownSkipsDumpWhenStoreShutdownFails(t *testing.T) {
 	}
 	enableAndAwaitAsync(t, ctx, s)
 
-	// the store is closed first to make its shutdown fail; the teardown itself
+	// the store is closed first to make its shutdown fail. The teardown itself
 	// runs to completion whatever the caller's context does
 	require.NoError(t, s.store.Shutdown(ctx))
 	require.ErrorContains(t, s.performShutdown(ctx), "stop lsmkv store",

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -242,6 +242,18 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.shutdownRequested.Store(false)
 	s.shutCtxCancel(fmt.Errorf("shutdown %q", s.ID()))
 
+	// The teardown below cannot be abandoned: every step of it consumes ctx, and
+	// one that stops after the shut mark leaves the shard torn instead of closed,
+	// with its buckets unflushed and its registry entries uncleared. The caller's
+	// deadline still bounds it; only the cancellation is dropped.
+	if deadline, ok := ctx.Deadline(); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithDeadline(context.WithoutCancel(ctx), deadline)
+		defer cancel()
+	} else {
+		ctx = context.WithoutCancel(ctx)
+	}
+
 	// Track shard unloading: loaded -> unloading
 	// Only update metrics if the shard was properly registered (prevents double-counting
 	// during partial initialization cleanup)

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -242,10 +242,10 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	s.shutdownRequested.Store(false)
 	s.shutCtxCancel(fmt.Errorf("shutdown %q", s.ID()))
 
-	// The teardown below cannot be abandoned: every step of it consumes ctx, and
-	// one that stops after the shut mark leaves the shard torn instead of closed,
-	// with its buckets unflushed and its registry entries uncleared. The caller's
-	// deadline still bounds it; only the cancellation is dropped.
+	// The teardown below cannot be abandoned: every step of it consumes ctx.
+	// Stopping after s.shut is set leaves buckets unflushed and registry entries
+	// uncleared on a shard that already reads as shut. Only the cancellation is
+	// dropped, so the caller's deadline still bounds it.
 	if deadline, ok := ctx.Deadline(); ok {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithDeadline(context.WithoutCancel(ctx), deadline)

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -376,7 +376,58 @@ func TestUnloadLocalShard_ErrorClassification(t *testing.T) {
 			// shut but still holds the handles a failed teardown left open.
 			name: "torn shard stays a failure",
 			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
-				tearShard(t, index.shards.Load(shardName))
+				tearShard(t, index.shards.Load(shardName), errors.New("bucket close failed"))
+				return shardName, context.Background()
+			},
+			wantErr:        errTeardownFailed,
+			wantStillInMap: true,
+		},
+		{
+			// The close is already requested when the unload starts, so the
+			// first refused attempt ends the retry and the unload returns
+			// errIndexShutdown instead of burning 2s to return errShardStillInUse.
+			name: "close request aborts a refused unload",
+			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
+				_, release, err := index.GetShard(context.Background(), shardName)
+				require.NoError(t, err)
+				t.Cleanup(release)
+				index.signalCloseRequested(errIndexShutdown)
+				return shardName, context.Background()
+			},
+			wantErr:        errIndexShutdown,
+			wantStillInMap: true,
+		},
+		{
+			// A close request ends the retry wait, never a teardown already past
+			// the shut mark: every step after that mark consumes ctx, so giving
+			// it up there would leave the shard torn instead of closed.
+			name: "close request does not interrupt an idle shard's teardown",
+			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
+				index.signalCloseRequested(errIndexShutdown)
+				return shardName, context.Background()
+			},
+		},
+		{
+			// A pending close must not relabel a shutdown that failed on its
+			// own: the torn shard is the one state a caller has to act on.
+			name: "close request leaves a torn shard its own error",
+			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
+				tearShard(t, index.shards.Load(shardName), errors.New("bucket close failed"))
+				index.signalCloseRequested(errIndexShutdown)
+				return shardName, context.Background()
+			},
+			wantErr:        errTeardownFailed,
+			wantStillInMap: true,
+		},
+		{
+			// The close cause must not swallow a tear whose own failure carries a
+			// cancellation: matching on the cancellation alone would report the
+			// shard as merely stopped and hide the handles it still holds.
+			name: "close request keeps a cancelled tear matchable",
+			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
+				tearShard(t, index.shards.Load(shardName),
+					fmt.Errorf("stop lsmkv store: %w", context.Canceled))
+				index.signalCloseRequested(errIndexShutdown)
 				return shardName, context.Background()
 			},
 			wantErr:        errTeardownFailed,
@@ -425,8 +476,8 @@ func TestUnloadLocalShard_ErrorClassification(t *testing.T) {
 
 // tearShard puts a loaded shard into the state a shutdown that failed
 // mid-teardown leaves behind: marked shut, but still holding the handles the
-// failure never released.
-func tearShard(t *testing.T, s ShardLike) {
+// failure never released. cause is the failure it stopped on.
+func tearShard(t *testing.T, s ShardLike, cause error) {
 	t.Helper()
 
 	var inner *Shard
@@ -441,5 +492,5 @@ func tearShard(t *testing.T, s ShardLike) {
 	}
 
 	inner.shut.Store(true)
-	inner.teardownErr = errors.New("bucket close failed")
+	inner.teardownErr = cause
 }

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -399,8 +399,8 @@ func TestUnloadLocalShard_ErrorClassification(t *testing.T) {
 		},
 		{
 			// A close request ends the retry wait, never a teardown already past
-			// the shut mark: every step after that mark consumes ctx, so giving
-			// it up there would leave the shard torn instead of closed.
+			// s.shut: every step after that consumes ctx, so giving it up there
+			// would leave buckets unflushed on a shard that reads as shut.
 			name: "close request does not interrupt an idle shard's teardown",
 			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
 				index.signalCloseRequested(errIndexShutdown)
@@ -420,9 +420,9 @@ func TestUnloadLocalShard_ErrorClassification(t *testing.T) {
 			wantStillInMap: true,
 		},
 		{
-			// The close cause must not swallow a tear whose own failure carries a
-			// cancellation: matching on the cancellation alone would report the
-			// shard as merely stopped and hide the handles it still holds.
+			// The cause UnloadLocalShard joins must not hide a tear whose own
+			// failure carries a cancellation: matching on the cancellation alone
+			// reports the shard as stopped and hides the handles it still holds.
 			name: "close request keeps a cancelled tear matchable",
 			setup: func(t *testing.T, index *Index, shardName string) (string, context.Context) {
 				tearShard(t, index.shards.Load(shardName),

--- a/adapters/repos/db/shutdown_test.go
+++ b/adapters/repos/db/shutdown_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -637,31 +638,38 @@ func TestShutdownSignalSurvivesDeadResourceScanner(t *testing.T) {
 	}
 }
 
+// closeRequest is one of the teardowns that asks an index to close before it
+// waits for closeLock, paired with the cause it signals.
+type closeRequest struct {
+	name    string
+	request func(*Index) error
+	cause   error
+}
+
+func closeRequests() []closeRequest {
+	return []closeRequest{
+		{
+			name:    "a shutdown",
+			request: func(idx *Index) error { return idx.Shutdown(context.Background()) },
+			cause:   errIndexShutdown,
+		},
+		{
+			name: "a drop",
+			request: func(idx *Index) error {
+				idx.signalCloseRequested(errIndexDropped)
+				return nil
+			},
+			cause: errIndexDropped,
+		},
+	}
+}
+
 // TestCloseRequestAbortsBackgroundShardLoad pins that the background shard load
 // gives up its wait once a close is requested. It waits for a node-wide load
 // permit while holding the index open, so a load that kept waiting would hold up
 // the teardown for as long as the permit is taken.
 func TestCloseRequestAbortsBackgroundShardLoad(t *testing.T) {
-	tests := []struct {
-		name string
-		// requestClose stands in for the teardown, which asks to close before it
-		// waits for closeLock
-		requestClose func(*Index) error
-	}{
-		{
-			name:         "a shutdown",
-			requestClose: func(idx *Index) error { return idx.Shutdown(context.Background()) },
-		},
-		{
-			name: "a drop",
-			requestClose: func(idx *Index) error {
-				idx.signalCloseRequested(errIndexDropped)
-				return nil
-			},
-		},
-	}
-
-	for _, tt := range tests {
+	for _, tt := range closeRequests() {
 		t.Run(tt.name+" releases the load", func(t *testing.T) {
 			idx := newShutdownTestIndex(t, nil)
 
@@ -671,13 +679,56 @@ func TestCloseRequestAbortsBackgroundShardLoad(t *testing.T) {
 			close(release)
 
 			closeDone := make(chan error, 1)
-			go func() { closeDone <- tt.requestClose(idx) }()
+			go func() { closeDone <- tt.request(idx) }()
 
 			select {
 			case err := <-loadDone:
 				require.ErrorIs(t, err, context.Canceled)
+				require.ErrorIs(t, context.Cause(idx.closeRequestedCtx), tt.cause)
 			case <-time.After(5 * time.Second):
 				t.Fatal("the shard load kept waiting for a permit through the close request")
+			}
+			require.NoError(t, <-closeDone)
+		})
+	}
+}
+
+// TestCloseRequestAbortsShardUnload pins that an unload gives up the shard
+// shutdown it is waiting on once a close is requested. The shutdown retries for
+// seconds while the unload holds the index open, so an unload that kept
+// retrying would hold the teardown behind its own in-flight count.
+func TestCloseRequestAbortsShardUnload(t *testing.T) {
+	for _, tt := range closeRequests() {
+		t.Run(tt.name+" releases the unload", func(t *testing.T) {
+			idx := newShutdownTestIndex(t, nil)
+
+			var parked sync.Once
+			entered := make(chan struct{})
+			shard := NewMockShardLike(t)
+			shard.EXPECT().Name().Return("t1").Maybe()
+			// stands in for Shard.Shutdown's retry loop: a shard in use holds it
+			// until the retries run out or the given context is cancelled
+			shard.EXPECT().Shutdown(mock.Anything).RunAndReturn(func(ctx context.Context) error {
+				parked.Do(func() {
+					close(entered)
+					<-ctx.Done()
+				})
+				return ctx.Err()
+			})
+			idx.shards.Store("t1", shard)
+
+			unloadDone := make(chan error, 1)
+			go func() { unloadDone <- idx.UnloadLocalShard(context.Background(), "t1") }()
+			<-entered
+
+			closeDone := make(chan error, 1)
+			go func() { closeDone <- tt.request(idx) }()
+
+			select {
+			case err := <-unloadDone:
+				require.ErrorIs(t, err, tt.cause)
+			case <-time.After(5 * time.Second):
+				t.Fatal("the unload kept waiting on the shard shutdown through the close request")
 			}
 			require.NoError(t, <-closeDone)
 		})


### PR DESCRIPTION
### What's being changed:

Closes: https://github.com/weaviate/dirk-claude-issues/issues/172 https://linear.app/weaviate/issue/DKF-91/weaviateweaviate-adaptersreposdb-unloadlocalshard-ignores-the-index

This adds the index context in `UnloadLocalShard`, so an unload does not keep retrying in case the collection is shutting down. The retry is not just wasted work: the unload holds the index open through `enterRead`, so the shutdown that asked to close waits behind it until the backoff window runs out, up to 2s per shard.

`performShutdown` also ignores context cancellation (with the exception of a deadline) in the shutdown path, once we start actually shutting down the shard. Otherwise we would end up with half-shutdown shards: the derived context does not stop at the retry, it reaches `performShutdown` too, which marks the shard shut before it closes the buckets and flushes the store. That part is not optional, it is what makes the first one safe. It applies to every shard shutdown and not only to the unload, and the caller's deadline is kept, so no existing timeout changes.

Two smaller things that come with it:
1. An aborted unload now returns the close cause (node shutting down or collection deleted) joined onto the cancellation, instead of a bare context canceled. A shutdown that failed on its own keeps its own error
2. `TestPerformShutdownSkipsDumpWhenStoreShutdownFails` used a cancelled context to make the store shutdown fail, which is exactly what we now ignore. Same assertion, the failure is injected by closing the store first


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

