### PR TITLE
﻿fix(db): preserve the NewShard error chain in LazyLoadShard.Load

### DIFF
--- a/adapters/repos/db/reindex_cancel_cleanup.go
+++ b/adapters/repos/db/reindex_cancel_cleanup.go
@@ -125,10 +125,9 @@ func IsCleanupCollectionDropped(err error) bool {
 // sidecar shutdown hands the context to the bucket's shutdown, whose
 // compaction and flush waits both wrap it. Both are pinned, since a step that
 // started swallowing the cause would silently turn every cancelled run back
-// into a broken shard. A cancellation surfacing deeper, inside NewShard, is
-// flattened to a string in [LazyLoadShard.Load] and reads as a shard failure —
-// an Error-level false alarm on that arm, accepted over masking a real failure
-// as a timeout.
+// into a broken shard. A cancellation surfacing deeper, inside NewShard, is in
+// reach too: [LazyLoadShard.Load] wraps that failure rather than flattening it,
+// so the context checks NewShard makes on its way in reach this guard as well.
 func truncatedByCancellation(reported error) error {
 	if !errors.Is(reported, context.Canceled) && !errors.Is(reported, context.DeadlineExceeded) {
 		return nil

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -148,9 +148,10 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 		l.shardOpts.bitmapBufPool)
 	if err != nil {
 		l.shardOpts.promMetrics.FailLoadingShard()
-		msg := fmt.Sprintf("Unable to load shard %s: %v", l.shardOpts.name, err)
-		l.shardOpts.index.logger.WithField("error", "shard_load").WithError(err).Error(msg)
-		return errors.New(msg)
+		l.shardOpts.index.logger.WithField("error", "shard_load").
+			Errorf("unable to load shard %s: %v", l.shardOpts.name, err)
+		// %w, not a formatted string: callers classify this with errors.Is.
+		return fmt.Errorf("unable to load shard %s: %w", l.shardOpts.name, err)
 	}
 
 	l.shardOpts.promMetrics.FinishLoadingShard()

--- a/adapters/repos/db/shard_lazyloader_load_error_test.go
+++ b/adapters/repos/db/shard_lazyloader_load_error_test.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// A NewShard failure has to reach the caller as a chain: the reindex cleanup
+// sweep's truncation guard reads the cause to tell a run that ran out of time
+// from a shard that broke, and a flattened error answers that with "no".
+// Reproduces https://github.com/weaviate/weaviate/issues/12663.
+func TestLazyLoadShardLoadPreservesTheNewShardErrorChain(t *testing.T) {
+	const (
+		className = "Movies"
+		shardName = "shard-with-an-unopenable-store"
+	)
+
+	ctx := context.Background()
+	_, idx := testShard(t, ctx, className)
+
+	// os.MkdirAll reports a *fs.PathError for an existing non-directory on every
+	// platform, so the cause this test follows is the same everywhere.
+	shardDir := filepath.Join(idx.path(), shardName)
+	require.NoError(t, os.MkdirAll(shardDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(shardDir, "lsm"), []byte("not a directory"), 0o644))
+
+	lazy := &LazyLoadShard{
+		shardOpts:        &deferredShardOpts{name: shardName, index: idx, class: &models.Class{Class: className}},
+		memMonitor:       &loadAttemptMonitor{admitLoad: true},
+		shardLoadLimiter: newSweepLoadLimiter(),
+	}
+
+	loadErr := lazy.Load(ctx)
+	require.Error(t, loadErr)
+
+	var pathErr *fs.PathError
+	require.ErrorAs(t, loadErr, &pathErr,
+		"Load must wrap what NewShard reported, not reformat it into a new error")
+	require.NotNil(t, errors.Unwrap(loadErr))
+	require.ErrorContains(t, loadErr, shardName)
+}


### PR DESCRIPTION
Load reported a NewShard failure as errors.New(fmt.Sprintf(...)), which severs the chain: errors.Is(err, context.Canceled) was false even when a cancelled context was the cause. NewShard checks the caller context at several points and each of those wraps it properly, so the load site was the only break.

The reindex cleanup sweep truncation guard classifies on the chain, so a sweep budget expiring inside NewShard reported as an Error-level shard failure instead of a Warn-level truncated run. The guard godoc paragraph documenting that arm is updated to match.

No caller matched on the old message; the string Unable to load shard appeared only at the site that produced it.

Fixes #12663

### What's being changed:


### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
