### PR TITLE
Back up collections concurrently through one shared worker pool

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -113,7 +113,14 @@ func (db *DB) BackupDescriptors(ctx context.Context, bakid string, classes []str
 ) <-chan backup.ClassDescriptor {
 	ds := make(chan backup.ClassDescriptor, len(classes))
 	f := func() {
+		// The caller drains this channel to close before it releases any index, so
+		// every way out of this goroutine has to leave the channel closed.
+		defer close(ds)
 		for _, c := range classes {
+			if err := ctx.Err(); err != nil {
+				ds <- backup.ClassDescriptor{Name: c, BackupID: bakid, Error: err}
+				return
+			}
 			desc := backup.ClassDescriptor{Name: c, BackupID: bakid}
 			func() {
 				idx := db.GetIndex(schema.ClassName(c))
@@ -147,7 +154,6 @@ func (db *DB) BackupDescriptors(ctx context.Context, bakid string, classes []str
 				break
 			}
 		}
-		close(ds)
 	}
 	enterrors.GoWrapper(f, db.logger)
 	return ds

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -1040,3 +1040,56 @@ func TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks(t *testing.T
 		"shardCreateLocks must be released after preventShutdown failure")
 	idx.shardCreateLocks.RUnlock(shardName)
 }
+
+// TestBackupDescriptorsClosesChannelWhenCancelled pins that the producer closes
+// the descriptor channel on the early return a cancelled context takes. The
+// caller drains that channel to close before it releases any index, so a producer
+// that returns without closing leaves the backup waiting on a channel with no sender.
+func TestBackupDescriptorsClosesChannelWhenCancelled(t *testing.T) {
+	logger, _ := tlog.NewNullLogger()
+	db := &DB{logger: logger, indices: map[string]*Index{}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ch := db.BackupDescriptors(ctx, "backup-1", []string{"Class-A", "Class-B"}, nil)
+
+	var got []backup.ClassDescriptor
+	for {
+		select {
+		case d, ok := <-ch:
+			if !ok {
+				require.Len(t, got, 1, "the cancelled class is the last descriptor sent")
+				assert.Equal(t, "Class-A", got[0].Name)
+				require.Error(t, got[0].Error)
+				assert.ErrorIs(t, got[0].Error, context.Canceled)
+				return
+			}
+			got = append(got, d)
+		case <-time.After(5 * time.Second):
+			t.Fatal("BackupDescriptors never closed the descriptor channel")
+		}
+	}
+}
+
+// TestBackupDescriptorsClosesChannelOnPanic pins the exit that defer close(ds)
+// exists for. GoWrapper recovers a panic and lets the goroutine end, so a close
+// that is not deferred leaves the caller draining a channel with no sender.
+func TestBackupDescriptorsClosesChannelOnPanic(t *testing.T) {
+	logger, _ := tlog.NewNullLogger()
+	// A zero-value Index panics inside descriptor on its nil logger.
+	db := &DB{logger: logger, indices: map[string]*Index{indexID("Class-A"): {}}}
+
+	ch := db.BackupDescriptors(context.Background(), "backup-1", []string{"Class-A"}, nil)
+
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				return
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("BackupDescriptors never closed the descriptor channel after the producer panicked")
+		}
+	}
+}

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -1076,20 +1077,30 @@ func TestBackupDescriptorsClosesChannelWhenCancelled(t *testing.T) {
 // exists for. GoWrapper recovers a panic and lets the goroutine end, so a close
 // that is not deferred leaves the caller draining a channel with no sender.
 func TestBackupDescriptorsClosesChannelOnPanic(t *testing.T) {
-	logger, _ := tlog.NewNullLogger()
+	// The integration suite exports this, which turns GoWrapper's recover off.
+	t.Setenv("DISABLE_RECOVERY_ON_PANIC", "false")
+
+	logger, hook := tlog.NewNullLogger()
 	// A zero-value Index panics inside descriptor on its nil logger.
 	db := &DB{logger: logger, indices: map[string]*Index{indexID("Class-A"): {}}}
 
 	ch := db.BackupDescriptors(context.Background(), "backup-1", []string{"Class-A"}, nil)
 
-	for {
-		select {
-		case _, ok := <-ch:
-			if !ok {
-				return
-			}
-		case <-time.After(5 * time.Second):
-			t.Fatal("BackupDescriptors never closed the descriptor channel after the producer panicked")
-		}
+	select {
+	case d, ok := <-ch:
+		require.False(t, ok, "descriptor %q was sent, so the producer returned instead of panicking", d.Name)
+	case <-time.After(5 * time.Second):
+		t.Fatal("BackupDescriptors never closed the descriptor channel after the producer panicked")
 	}
+
+	// GoWrapper logs the recovery after the deferred close ran. Returning at close
+	// would let t.Setenv restore the flag while the recover is still reading it.
+	require.Eventually(t, func() bool {
+		for _, e := range hook.AllEntries() {
+			if strings.Contains(e.Message, "Recovered from panic") {
+				return true
+			}
+		}
+		return false
+	}, 5*time.Second, 10*time.Millisecond, "the producer goroutine never recovered a panic")
 }

--- a/adapters/repos/db/inverted_reindex_recovery_midproptidy_test.go
+++ b/adapters/repos/db/inverted_reindex_recovery_midproptidy_test.go
@@ -134,9 +134,9 @@ func midPropTidyRunSwapWithRecover(ctx context.Context, task *ShardReindexTaskGe
 
 // midPropTidyRunTidyExpectingPanicError runs tidyBackupBuckets and
 // returns the error it surfaces. When the testHookPostPropTidy hook
-// panics inside one of the goroutines, the wrapper's deferFunc recovers
-// and the error returned from eg.Wait() carries the substring "panic
-// occurred" (see [entities/errors/error_group_wrapper.go] line ~92).
+// panics inside one of the goroutines, the wrapper's recoverPanic
+// returns it as that goroutine's error, and eg.Wait() carries the
+// substring "panic occurred".
 func midPropTidyRunTidyExpectingPanicError(ctx context.Context, task *ShardReindexTaskGeneric,
 	shard *Shard, rt reindexTracker, props []string,
 ) error {

--- a/entities/errors/error_group_wrapper.go
+++ b/entities/errors/error_group_wrapper.go
@@ -28,11 +28,9 @@ import (
 // ErrorGroupWrapper is a custom type that embeds errgroup.Group.
 type ErrorGroupWrapper struct {
 	*errgroup.Group
-	returnError    error
 	variables      []interface{}
 	logger         logrus.FieldLogger
-	deferFunc      func(localVars ...interface{})
-	cancelCtx      func()
+	recoverPanic   func(err *error, localVars ...interface{})
 	routineCounter atomic.Int64
 	includeStack   bool
 	limitSet       int
@@ -41,16 +39,11 @@ type ErrorGroupWrapper struct {
 // NewErrorGroupWrapper creates a new ErrorGroupWrapper.
 func NewErrorGroupWrapper(logger logrus.FieldLogger, vars ...interface{}) *ErrorGroupWrapper {
 	egw := &ErrorGroupWrapper{
-		Group:       new(errgroup.Group),
-		returnError: nil,
-		variables:   vars,
-		logger:      logger,
-
-		// this dummy func makes it safe to call cancelCtx even if a wrapper without a
-		// context is used. Avoids a nil check later on.
-		cancelCtx: func() {},
+		Group:     new(errgroup.Group),
+		variables: vars,
+		logger:    logger,
 	}
-	egw.setDeferFunc()
+	egw.setRecoverPanic()
 
 	if entcfg.Enabled(os.Getenv("LOG_STACK_TRACE_ON_ERROR_GROUP")) {
 		egw.includeStack = true
@@ -60,16 +53,13 @@ func NewErrorGroupWrapper(logger logrus.FieldLogger, vars ...interface{}) *Error
 
 // NewErrorGroupWithContextWrapper creates a new ErrorGroupWrapper
 func NewErrorGroupWithContextWrapper(logger logrus.FieldLogger, ctx context.Context, vars ...interface{}) (*ErrorGroupWrapper, context.Context) {
-	ctx, cancel := context.WithCancel(ctx)
 	eg, ctx := errgroup.WithContext(ctx)
 	egw := &ErrorGroupWrapper{
-		Group:       eg,
-		returnError: nil,
-		variables:   vars,
-		logger:      logger,
-		cancelCtx:   cancel,
+		Group:     eg,
+		variables: vars,
+		logger:    logger,
 	}
-	egw.setDeferFunc()
+	egw.setRecoverPanic()
 
 	if entcfg.Enabled(os.Getenv("LOG_STACK_TRACE_ON_ERROR_GROUP")) {
 		egw.includeStack = true
@@ -78,31 +68,38 @@ func NewErrorGroupWithContextWrapper(logger logrus.FieldLogger, ctx context.Cont
 	return egw, ctx
 }
 
-func (egw *ErrorGroupWrapper) setDeferFunc() {
-	disable := entcfg.Enabled(os.Getenv("DISABLE_RECOVERY_ON_PANIC"))
-	if !disable {
-		egw.deferFunc = func(localVars ...interface{}) {
-			if r := recover(); r != nil {
-				entsentry.Recover(r)
-				egw.logger.WithField("panic", r).Errorf("Recovered from panic: %v, local variables %v, additional localVars %v\n", r, localVars, egw.variables)
-				PrintStack(egw.logger)
-
-				// FIXME(dyma): this is racy if multiple goroutines fail at once.
-				// The errgroup.Group has a errOnce sync.Once guard for that.
-				egw.returnError = fmt.Errorf("panic occurred: %v", r)
-
-				egw.cancelCtx()
-			}
+// setRecoverPanic builds the recovery that Go defers in each goroutine.
+// DISABLE_RECOVERY_ON_PANIC=true makes it a no-op instead, so a panic reaches
+// the runtime.
+func (egw *ErrorGroupWrapper) setRecoverPanic() {
+	if entcfg.Enabled(os.Getenv("DISABLE_RECOVERY_ON_PANIC")) {
+		// never calls recover, so the panic reaches the runtime
+		egw.recoverPanic = func(*error, ...interface{}) {}
+		return
+	}
+	egw.recoverPanic = func(err *error, localVars ...interface{}) {
+		r := recover()
+		if r == nil {
+			return
 		}
-	} else {
-		egw.deferFunc = func(localVars ...interface{}) {}
+		entsentry.Recover(r)
+		egw.logger.WithField("panic", r).Errorf("Recovered from panic: %v, local variables %v, additional localVars %v", r, localVars, egw.variables)
+		PrintStack(egw.logger)
+
+		// The panic becomes the goroutine's error, so errgroup's errOnce records it
+		// and cancels with it. It therefore outranks every error a sibling returns
+		// afterwards, including the context.Canceled that cancellation produces.
+		*err = fmt.Errorf("panic occurred: %v", r)
 	}
 }
 
-// Go overrides the Go method to add panic recovery logic.
+// Go runs f in a new goroutine. A panic in f is recovered and returned as f's
+// error, so Wait reports it as "panic occurred: <value>" and the group's
+// context is cancelled with it. DISABLE_RECOVERY_ON_PANIC lets the panic reach
+// the runtime instead.
 func (egw *ErrorGroupWrapper) Go(f func() error, localVars ...interface{}) {
-	egw.Group.Go(func() error {
-		defer egw.deferFunc(localVars)
+	egw.Group.Go(func() (err error) {
+		defer egw.recoverPanic(&err, localVars...)
 		return f()
 	})
 	egw.routineCounter.Add(1)
@@ -115,7 +112,8 @@ func (egw *ErrorGroupWrapper) SetLimit(limit int) {
 	egw.limitSet = limit
 }
 
-// Wait waits for all goroutines to finish and returns the first non-nil error.
+// Wait waits for all goroutines to finish and returns the first non-nil error,
+// which includes a panic Go recovered.
 func (egw *ErrorGroupWrapper) Wait() error {
 	count := egw.routineCounter.Load()
 	logBase := egw.logger.WithFields(logrus.Fields{
@@ -134,8 +132,5 @@ func (egw *ErrorGroupWrapper) Wait() error {
 
 	logBase.Debugf("Waiting for %d jobs to finish with limit %d", count, egw.limitSet)
 
-	if err := egw.Group.Wait(); err != nil {
-		return err
-	}
-	return egw.returnError
+	return egw.Group.Wait()
 }

--- a/entities/errors/error_group_wrapper.go
+++ b/entities/errors/error_group_wrapper.go
@@ -73,7 +73,7 @@ func NewErrorGroupWithContextWrapper(logger logrus.FieldLogger, ctx context.Cont
 // the runtime.
 func (egw *ErrorGroupWrapper) setRecoverPanic() {
 	if entcfg.Enabled(os.Getenv("DISABLE_RECOVERY_ON_PANIC")) {
-		// never calls recover, so the panic reaches the runtime
+		// the no-op never calls recover, so the panic reaches the runtime
 		egw.recoverPanic = func(*error, ...interface{}) {}
 		return
 	}

--- a/entities/errors/error_group_wrapper_test.go
+++ b/entities/errors/error_group_wrapper_test.go
@@ -14,11 +14,13 @@ package errors
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestErrorGroupWrapper(t *testing.T) {
@@ -42,10 +44,12 @@ func TestErrorGroupWrapper(t *testing.T) {
 				log.SetOutput(os.Stderr)
 			}()
 
-			eg := NewErrorGroupWrapper(log)
+			// the constructor reads the environment, so the value has to be in
+			// place before it runs
 			if tt.set {
 				t.Setenv("DISABLE_RECOVERY_ON_PANIC", tt.env)
 			}
+			eg := NewErrorGroupWrapper(log)
 			eg.Go(func() error {
 				slice := make([]string, 0)
 				slice[0] = "test"
@@ -58,32 +62,120 @@ func TestErrorGroupWrapper(t *testing.T) {
 	}
 }
 
-// The assumption is that the context returned by the group will be cancelled
-// as soon as one goroutine panics
+// The assumption is that the context returned by the group will be cancelled as
+// soon as one goroutine panics, and that Wait reports the panic rather than the
+// cancellation its siblings return because of it.
 func TestErrorGroupWrapperWithContext_Panics(t *testing.T) {
-	var buf bytes.Buffer
-	log := logrus.New()
-	log.SetOutput(&buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
+	cases := []struct {
+		name string
+		// limit, when positive, caps the group so the sibling only starts once the
+		// panicking goroutine has finished.
+		limit           int
+		sibling         func(ctx context.Context) error
+		wantErrContains string
+	}{
+		{name: "no sibling"},
+		{
+			name: "sibling waiting on the group context",
+			sibling: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		},
+		{
+			name:  "sibling starting after the panic",
+			limit: 1,
+			sibling: func(ctx context.Context) error {
+				return ctx.Err()
+			},
+		},
+		{
+			name: "sibling finishing cleanly",
+			sibling: func(context.Context) error {
+				return nil
+			},
+		},
+		{
+			name: "sibling panicking too",
+			sibling: func(context.Context) error {
+				panic("sibling")
+			},
+			wantErrContains: "panic occurred",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := logrus.New()
+			log.SetOutput(&buf)
+			defer func() {
+				log.SetOutput(os.Stderr)
+			}()
 
-	ctx := context.Background()
-	eg, ctx := NewErrorGroupWithContextWrapper(log, ctx)
+			ctx := context.Background()
+			eg, ctx := NewErrorGroupWithContextWrapper(log, ctx)
+			if tt.limit > 0 {
+				eg.SetLimit(tt.limit)
+			}
 
-	eg.Go(func() error {
-		slice := make([]string, 0)
-		slice[0] = "test"
-		return nil
-	})
+			eg.Go(func() error {
+				slice := make([]string, 0)
+				slice[0] = "test"
+				return nil
+			})
+			if tt.sibling != nil {
+				eg.Go(func() error {
+					return tt.sibling(ctx)
+				})
+			}
 
-	// if the wrapper wouldn't cancel the context this line would block forever
-	<-ctx.Done()
-	assert.NotNil(t, ctx.Err())
+			// if the wrapper wouldn't cancel the context this line would block forever
+			<-ctx.Done()
+			assert.NotNil(t, ctx.Err())
 
-	err := eg.Wait()
-	assert.Contains(t, buf.String(), "Recovered from panic")
-	assert.Contains(t, err.Error(), "index out of range")
+			err := eg.Wait()
+			assert.Contains(t, buf.String(), "Recovered from panic")
+			wantErrContains := tt.wantErrContains
+			if wantErrContains == "" {
+				wantErrContains = "index out of range"
+			}
+			require.ErrorContains(t, err, wantErrContains)
+			require.NotErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+// TestErrorGroupWrapperReturnsGoroutineError pins that the deferred recovery
+// leaves the error a goroutine returned by itself, with recovery enabled and
+// with DISABLE_RECOVERY_ON_PANIC turning it into a no-op.
+func TestErrorGroupWrapperReturnsGoroutineError(t *testing.T) {
+	jobErr := errors.New("job failed")
+	cases := []struct {
+		name            string
+		disableRecovery string
+	}{
+		{name: "recovery enabled", disableRecovery: "false"},
+		{name: "recovery disabled", disableRecovery: "true"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			log := logrus.New()
+			log.SetOutput(&buf)
+			defer func() {
+				log.SetOutput(os.Stderr)
+			}()
+
+			t.Setenv("DISABLE_RECOVERY_ON_PANIC", tt.disableRecovery)
+			eg, _ := NewErrorGroupWithContextWrapper(log, context.Background())
+			eg.Go(func() error {
+				return jobErr
+			})
+
+			require.ErrorIs(t, eg.Wait(), jobErr)
+			assert.NotContains(t, buf.String(), "Recovered from panic")
+		})
+	}
 }
 
 // The assumption is that when the goroutine doesn't panic, the context

--- a/entities/errors/error_group_wrapper_test.go
+++ b/entities/errors/error_group_wrapper_test.go
@@ -63,7 +63,7 @@ func TestErrorGroupWrapper(t *testing.T) {
 }
 
 // The assumption is that the context returned by the group will be cancelled as
-// soon as one goroutine panics, and that Wait reports the panic rather than the
+// soon as one goroutine panics. Wait then reports the panic rather than the
 // cancellation its siblings return because of it.
 func TestErrorGroupWrapperWithContext_Panics(t *testing.T) {
 	cases := []struct {

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -273,6 +273,10 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		}
 	}
 	var totalPreCompressionSize int64 // Track total pre-compression bytes
+	// set on the one path that runs the backup to the end, so the defer below can
+	// tell that path from a panic, which leaves err nil on a backup that stopped
+	// somewhere in the middle.
+	var completed bool
 
 	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessBackup)()
 
@@ -284,6 +288,12 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		//  name, so the cancellation check below still reads the operation's
 		//  context rather than this one, which can never be cancelled.
 		metaCtx := context.Background()
+
+		// A panic unwinds through here with err nil, and the success branch would
+		// publish the node as done on a backup that never reached the end.
+		if err == nil && !completed {
+			err = errors.New("backup did not run to completion")
+		}
 
 		// Handle success case first
 		if err == nil {
@@ -348,14 +358,18 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 	// per class could never run wider than that class's shard count, so a node
 	// holding thousands of single-shard collections would upload one shard at a time.
 	poolCtx, cancelPool := context.WithCancel(ctx)
-	defer cancelPool()
 	eg, poolCtx := enterrors.NewErrorGroupWithContextWrapper(u.log, poolCtx)
 	eg.SetLimit(max(u.GoPoolSize, 1))
 	// Releasing an index deletes the class's staging dir, which its shard jobs read
 	// from. Defers run in reverse order, so this one drains the pool before the
-	// release in the defer above it. The normal path already waits below; this is
-	// for a panic or an early return.
-	defer func() { _ = eg.Wait() }()
+	// release in the defer above it. Cancelling first is what bounds the drain: a
+	// shard job runs under storeTimeout, so waiting on jobs nothing has cancelled
+	// parks the backup for a day. The normal path already waits below; this is for
+	// a panic or an early return.
+	defer func() {
+		cancelPool()
+		_ = eg.Wait()
+	}()
 
 	var (
 		uploads []*classUpload
@@ -447,6 +461,7 @@ Loop:
 	desc.Status = backup.Success
 	// After all classes, set desc.PreCompressionSizeBytes as the sum of all class sizes
 	desc.PreCompressionSizeBytes = totalPreCompressionSize
+	completed = true
 	return nil
 }
 

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -259,7 +259,19 @@ func (u *uploader) withCompression(cfg zipConfig) *uploader {
 func (u *uploader) all(ctx context.Context, classes []string, desc *backup.BackupDescriptor, baseDescr []*backup.BackupDescriptor, overrideBucket, overridePath string) (err error) {
 	u.slot.set(backup.Transferring)
 	desc.Status = backup.Transferring
-	ch := u.sourcer.BackupDescriptors(ctx, desc.ID, classes, baseDescr)
+	// all owns the producer's context so it can be stopped before any index is
+	// released. Without that the wait covers every class the backup never reached.
+	producerCtx, stopProducer := context.WithCancel(ctx)
+	ch := u.sourcer.BackupDescriptors(producerCtx, desc.ID, classes, baseDescr)
+	// A class the producer snapshots after the release below stays marked in
+	// progress, and the next backup of that class fails. Draining to close is what
+	// proves it stopped. Draining twice costs nothing, so the normal path calls
+	// this directly and the defer covers a panic or an early return.
+	stopAndDrainProducer := func() {
+		stopProducer()
+		for range ch {
+		}
+	}
 	var totalPreCompressionSize int64 // Track total pre-compression bytes
 
 	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessBackup)()
@@ -318,6 +330,10 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		u.log.Info("finish uploading metadata for cancelled or failed backup")
 	}()
 
+	// Registered after the release above, so reverse order runs it first and no
+	// index is released while the producer can still snapshot its class.
+	defer stopAndDrainProducer()
+
 	contextChecker := func(ctx context.Context) error {
 		ctxerr := ctx.Err()
 		if ctxerr != nil {
@@ -371,6 +387,8 @@ Loop:
 	// and the release deletes it. Every class the loop submitted has already
 	// released itself in finish, so this only covers the ones it never reached.
 	poolErr := eg.Wait()
+
+	stopAndDrainProducer()
 	u.releaseIndexes(classes, desc.ID)
 
 	// uploads is in the order the descriptors arrived, so classes finishing out of
@@ -392,6 +410,11 @@ Loop:
 	}
 	if poolErr != nil {
 		return poolErr
+	}
+	// The producer stopped without saying why, so publishing here would report a
+	// backup that omits every class it never described.
+	if ctx.Err() == nil && len(uploads) != len(classes) {
+		return fmt.Errorf("backup describes %d of %d classes", len(uploads), len(classes))
 	}
 
 	if err := ctx.Err(); err != nil {

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -327,30 +328,70 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		return ctxerr
 	}
 
+	// One pool for the whole backup, shared by the shards of every class. A pool
+	// per class could never run wider than that class's shard count, so a node
+	// holding thousands of single-shard collections would upload one shard at a time.
+	poolCtx, cancelPool := context.WithCancel(ctx)
+	defer cancelPool()
+	eg, poolCtx := enterrors.NewErrorGroupWithContextWrapper(u.log, poolCtx)
+	eg.SetLimit(max(u.GoPoolSize, 1))
+	// Releasing an index deletes the class's staging dir, which its shard jobs read
+	// from. Defers run in reverse order, so this one drains the pool before the
+	// release in the defer above it. The normal path already waits below; this is
+	// for a panic or an early return.
+	defer func() { _ = eg.Wait() }()
+
+	var (
+		uploads []*classUpload
+		descErr error
+	)
+
 Loop:
 	for {
 		select {
 		case cdesc, ok := <-ch:
 			if !ok {
-				u.releaseIndexes(classes, desc.ID)
 				break Loop // we are done
 			}
 			if cdesc.Error != nil {
-				return cdesc.Error
+				descErr = cdesc.Error
+				cancelPool()
+				break Loop
 			}
-			u.log.WithField("class", cdesc.Name).Info("start uploading files")
-			preCompressionSize, err := u.class(ctx, desc.ID, &cdesc, overrideBucket, overridePath)
-			if err != nil {
-				return err
-			}
-			totalPreCompressionSize += preCompressionSize
-			cdesc.PreCompressionSizeBytes = preCompressionSize // Set pre-compression size for this class
-			desc.Classes = append(desc.Classes, cdesc)
-			u.log.WithField("class", cdesc.Name).Info("finish uploading files")
+			uploads = append(uploads, u.submitClass(poolCtx, eg, desc.ID, cdesc, overrideBucket, overridePath))
 
-		case <-ctx.Done():
-			return contextChecker(ctx)
+		// cancelled when the backup is aborted and when the first shard job fails.
+		// Either way there is no point taking more class descriptors.
+		case <-poolCtx.Done():
+			break Loop
 		}
+	}
+
+	// Wait before releasing: a class still in the pool is reading its staging dir,
+	// and the release deletes it. Every class the loop submitted has already
+	// released itself in finish, so this only covers the ones it never reached.
+	poolErr := eg.Wait()
+	u.releaseIndexes(classes, desc.ID)
+
+	// uploads is in the order the descriptors arrived, so classes finishing out of
+	// order does not reorder desc.Classes.
+	for _, cu := range uploads {
+		if !cu.complete() {
+			continue
+		}
+		desc.Classes = append(desc.Classes, cu.desc)
+		totalPreCompressionSize += cu.desc.PreCompressionSizeBytes
+	}
+
+	// descErr first, because it is the real cause. cancelPool has already failed
+	// the in-flight shards with context.Canceled, and the defer above publishes
+	// that as a cancelled backup instead of a failed one. Those shard errors are
+	// not lost: finish logs every class that did not upload in full.
+	if descErr != nil {
+		return descErr
+	}
+	if poolErr != nil {
+		return poolErr
 	}
 
 	if err := ctx.Err(); err != nil {
@@ -409,120 +450,135 @@ func (u *uploader) releaseIndexes(classes []string, bakID string) {
 	}
 }
 
-// class uploads one class
-// Returns the number of bytes written for this class
-func (u *uploader) class(ctx context.Context, id string, desc *backup.ClassDescriptor, overrideBucket, overridePath string) (int64, error) {
-	var err error
-	classLabel := desc.Name
+// classUpload is the state one class's shard jobs share: the descriptor they
+// fill in, and the counters that decide when the class is done and whether it
+// uploaded in full.
+type classUpload struct {
+	desc      backup.ClassDescriptor
+	lastChunk atomic.Int32
+
+	// mu guards the descriptor fields the shard jobs write.
+	mu sync.Mutex
+
+	// pending counts shard jobs that have not returned yet. The job that brings it
+	// to zero runs finish.
+	pending atomic.Int32
+	// shardsDone counts the shards that uploaded. A job bumps it only on its way
+	// out, so one that fails or panics leaves its class incomplete.
+	shardsDone atomic.Int32
+
+	// finish runs once, on whichever shard job returns last.
+	finish func()
+}
+
+// complete reports whether every shard of the class uploaded. Only a complete
+// class may join the backup descriptor: a partial one still lists all its shards
+// but holds chunks for only some, and the restore then skips the rest without
+// reporting anything.
+func (c *classUpload) complete() bool {
+	return int(c.shardsDone.Load()) == len(c.desc.Shards)
+}
+
+// submitClass queues every shard of one class on the shared pool and returns
+// without waiting for them, so the caller can move on to the next class. The
+// returned classUpload is what those jobs write their result into; read it only
+// once the pool has drained.
+func (u *uploader) submitClass(ctx context.Context, eg *enterrors.ErrorGroupWrapper,
+	id string, cdesc backup.ClassDescriptor, overrideBucket, overridePath string,
+) *classUpload {
+	cu := &classUpload{desc: cdesc}
+
+	classLabel := cdesc.Name
 	if monitoring.GetMetrics().Group {
 		classLabel = "n/a"
 	}
-	metric, err := monitoring.GetMetrics().BackupStoreDurations.GetMetricWithLabelValues(getType(u.backend.backend), classLabel)
-	if err == nil {
+	observe := func() {}
+	if metric, err := monitoring.GetMetrics().BackupStoreDurations.
+		GetMetricWithLabelValues(getType(u.backend.backend), classLabel); err == nil {
 		timer := prometheus.NewTimer(metric)
-		defer timer.ObserveDuration()
+		observe = func() { timer.ObserveDuration() }
 	}
-	defer func() {
-		// backups need to be released anyway
-		enterrors.GoWrapper(func() {
-			if err := u.sourcer.ReleaseBackup(context.Background(), id, desc.Name); err != nil {
-				u.log.WithFields(logrus.Fields{
-					"class":    desc.Name,
-					"backupID": id,
-				}).Error("failed to release backup")
-			}
-		}, u.log)
-	}()
-	ctx, cancel := context.WithTimeout(ctx, storeTimeout)
-	defer cancel()
 
+	ctx, cancel := context.WithTimeout(ctx, storeTimeout)
 	u.log.WithFields(logrus.Fields{
 		"action":   "upload_class",
 		"duration": storeTimeout,
 	}).Debug("context.WithTimeout")
 
+	// finish runs when the last shard job of the class has returned. That is the
+	// earliest the index may be released, since releasing it deletes the staging
+	// dir the jobs read from, and late enough for complete to know whether the
+	// class made it into the backup.
+	cu.finish = func() {
+		cancel()
+		observe()
+		u.releaseIndexes([]string{cu.desc.Name}, id)
+		if cu.complete() {
+			u.log.WithField("class", cu.desc.Name).Info("finish uploading files")
+			return
+		}
+		u.log.WithFields(logrus.Fields{
+			"class":       cu.desc.Name,
+			"shards_done": cu.shardsDone.Load(),
+			"shards":      len(cu.desc.Shards),
+		}).Warn("class left out of the backup, not all of its shards uploaded")
+	}
+
 	// Determine source path: use staging dir (hard-linked snapshot) if available,
 	// otherwise fall back to live data path for backward compatibility.
 	sourcePath := u.backend.SourceDataPath()
-	if desc.StagingDir != "" {
-		sourcePath = desc.StagingDir
+	if cdesc.StagingDir != "" {
+		sourcePath = cdesc.StagingDir
 	}
 
-	nShards := len(desc.Shards)
+	u.log.WithField("class", cu.desc.Name).Info("start uploading files")
+
+	nShards := len(cu.desc.Shards)
 	if nShards == 0 {
-		return 0, nil
+		// no jobs to queue, so no job will call finish
+		cu.finish()
+		return cu
 	}
 
-	desc.Chunks = make(map[int32][]string, 1+nShards/2)
-	var (
-		lastChunk atomic.Int32
-		nWorker   = u.GoPoolSize
-	)
-	if nWorker > nShards {
-		nWorker = nShards
-	}
+	cu.desc.Chunks = make(map[int32][]string, 1+nShards/2)
+	cu.pending.Store(int32(nShards))
 
-	// jobs produces work for the processor
-	jobs := func(xs []*backup.ShardDescriptor) <-chan *backup.ShardDescriptor {
-		sendCh := make(chan *backup.ShardDescriptor)
-		f := func() {
-			defer close(sendCh)
-
-			for _, shard := range xs {
-				select {
-				case sendCh <- shard:
-				// cancellation will happen for two reasons:
-				//  - 1. if the whole operation has been aborted,
-				//  - 2. or if the processor routine returns an error
-				case <-ctx.Done():
-					return
+	for _, shard := range cu.desc.Shards {
+		eg.Go(func() error {
+			defer func() {
+				if cu.pending.Add(-1) == 0 {
+					cu.finish()
 				}
-			}
-		}
-		enterrors.GoWrapper(f, u.log)
-		return sendCh
+			}()
+			return u.uploadShard(ctx, cu, shard, overrideBucket, overridePath, sourcePath)
+		})
+	}
+	return cu
+}
+
+// uploadShard compresses one shard into chunks and records them on its class.
+func (u *uploader) uploadShard(ctx context.Context, cu *classUpload, shard *backup.ShardDescriptor,
+	overrideBucket, overridePath, sourcePath string,
+) error {
+	// a failing job cancels ctx, but jobs already queued behind it still start
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
-	incrementalBackupSize := atomic.Int64{}
-
-	// processor
-	processor := func(nWorker int, sender <-chan *backup.ShardDescriptor) <-chan chunkShards {
-		eg, ctx := enterrors.NewErrorGroupWithContextWrapper(u.log, ctx)
-		eg.SetLimit(nWorker)
-		recvCh := make(chan chunkShards, nWorker)
-		f := func() {
-			defer close(recvCh)
-			for i := 0; i < nWorker; i++ {
-				eg.Go(func() error {
-					// operation might have been aborted see comment above
-					if err := ctx.Err(); err != nil {
-						return err
-					}
-					for shard := range sender {
-						incrementalBackupSize.Add(shard.IncrementalBackupInfo.TotalSize)
-						chunks, err := u.processShard(ctx, shard, desc.Name, &lastChunk, overrideBucket, overridePath, sourcePath)
-						if err != nil {
-							return err
-						}
-						for _, c := range chunks {
-							recvCh <- c
-						}
-					}
-					return nil
-				})
-			}
-			err = eg.Wait()
-		}
-		enterrors.GoWrapper(f, u.log)
-		return recvCh
+	chunks, err := u.processShard(ctx, shard, cu.desc.Name, &cu.lastChunk, overrideBucket, overridePath, sourcePath)
+	if err != nil {
+		return err
 	}
 
-	for x := range processor(nWorker, jobs(desc.Shards)) {
-		desc.Chunks[x.chunk] = x.shards
-		desc.PreCompressionSizeBytes += x.preCompressionSize
+	cu.mu.Lock()
+	defer cu.mu.Unlock()
+	for _, c := range chunks {
+		cu.desc.Chunks[c.chunk] = c.shards
+		cu.desc.PreCompressionSizeBytes += c.preCompressionSize
 	}
-	desc.PreCompressionSizeBytes += incrementalBackupSize.Load()
-	return desc.PreCompressionSizeBytes, err
+	cu.desc.PreCompressionSizeBytes += shard.IncrementalBackupInfo.TotalSize
+	cu.shardsDone.Add(1)
+	return nil
 }
 
 type chunkShards struct {

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -474,6 +474,16 @@ func nonEmptyErrMsg(err error) string {
 	return failureWithoutReason
 }
 
+// labelErr names the step err came from, and reports nil for a step that
+// succeeded. Labelling a nil error with %w instead renders "%!w(<nil>)" for the
+// step that worked, in text the status API serves verbatim.
+func labelErr(label string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", label, err)
+}
+
 func (u *uploader) releaseIndexes(classes []string, bakID string) {
 	for _, class := range classes {
 		className := class
@@ -688,9 +698,7 @@ func (u *uploader) compress(ctx context.Context,
 			// Use CloseWithError to signal any producer error to the consumer,
 			// so the consumer's read fails instead of seeing EOF.
 			closeErr := zip.CloseWithError(err)
-			if err != nil || closeErr != nil {
-				err = fmt.Errorf("producer: %w, close: %w", err, closeErr)
-			}
+			err = errors.Join(err, labelErr("close", closeErr))
 		}()
 
 		if err := ctx.Err(); err != nil {
@@ -740,10 +748,8 @@ func (u *uploader) compress(ctx context.Context,
 	// the producer to fail with "closed pipe". We need both errors to show
 	// the actual cause (consumer error), not just the symptom (closed pipe).
 	consumerErr := eg.Wait()
-	if producerErr != nil || consumerErr != nil {
-		return fileSizeExceededInfo, preCompressionSize.Load(), fmt.Errorf("producer: %w, consumer: %w", producerErr, consumerErr)
-	}
-	return fileSizeExceededInfo, preCompressionSize.Load(), nil
+	return fileSizeExceededInfo, preCompressionSize.Load(),
+		errors.Join(labelErr("producer", producerErr), labelErr("consumer", consumerErr))
 }
 
 // calculateShardPreCompressionSize calculates the total size of a shard before compression

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -273,9 +273,9 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		}
 	}
 	var totalPreCompressionSize int64 // Track total pre-compression bytes
-	// set on the one path that runs the backup to the end, so the defer below can
-	// tell that path from a panic, which leaves err nil on a backup that stopped
-	// somewhere in the middle.
+	// completed is set on the one path that runs the backup to the end. The defer
+	// below reads it to tell that path from a panic, which leaves err nil on a
+	// backup that stopped somewhere in the middle.
 	var completed bool
 
 	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessBackup)()
@@ -362,10 +362,10 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 	eg.SetLimit(max(u.GoPoolSize, 1))
 	// Releasing an index deletes the class's staging dir, which its shard jobs read
 	// from. Defers run in reverse order, so this one drains the pool before the
-	// release in the defer above it. Cancelling first is what bounds the drain: a
+	// release in the defer above it. Cancelling first is what bounds the drain. A
 	// shard job runs under storeTimeout, so waiting on jobs nothing has cancelled
-	// parks the backup for a day. The normal path already waits below; this is for
-	// a panic or an early return.
+	// parks the backup for a day. The normal path already waits below. This defer
+	// is for a panic or an early return.
 	defer func() {
 		cancelPool()
 		_ = eg.Wait()
@@ -397,7 +397,7 @@ Loop:
 		}
 	}
 
-	// Wait before releasing: a class still in the pool is reading its staging dir,
+	// Wait before releasing. A class still in the pool is reading its staging dir,
 	// and the release deletes it. Every class the loop submitted has already
 	// released itself in finish, so this only covers the ones it never reached.
 	poolErr := eg.Wait()
@@ -415,10 +415,11 @@ Loop:
 		totalPreCompressionSize += cu.desc.PreCompressionSizeBytes
 	}
 
-	// descErr first, because it is the real cause. cancelPool has already failed
-	// the in-flight shards with context.Canceled, and the defer above publishes
-	// that as a cancelled backup instead of a failed one. Those shard errors are
-	// not lost: finish logs every class that did not upload in full.
+	// descErr is returned first, because it is the real cause. cancelPool has
+	// already failed the in-flight shards with context.Canceled, and the defer
+	// above publishes that as a cancelled backup instead of a failed one. Those
+	// shard errors are not lost, since finish logs every class that did not
+	// upload in full.
 	if descErr != nil {
 		return descErr
 	}
@@ -498,9 +499,9 @@ func (u *uploader) releaseIndexes(classes []string, bakID string) {
 	}
 }
 
-// classUpload is the state one class's shard jobs share: the descriptor they
-// fill in, and the counters that decide when the class is done and whether it
-// uploaded in full.
+// classUpload is the state one class's shard jobs share. It holds the
+// descriptor they fill in, and the counters that decide when the class is done
+// and whether it uploaded in full.
 type classUpload struct {
 	desc      backup.ClassDescriptor
 	lastChunk atomic.Int32
@@ -520,16 +521,16 @@ type classUpload struct {
 }
 
 // complete reports whether every shard of the class uploaded. Only a complete
-// class may join the backup descriptor: a partial one still lists all its shards
-// but holds chunks for only some, and the restore then skips the rest without
-// reporting anything.
+// class may join the backup descriptor. A partial one still lists all its
+// shards but holds chunks for only some. The restore then skips the rest
+// without reporting anything.
 func (c *classUpload) complete() bool {
 	return int(c.shardsDone.Load()) == len(c.desc.Shards)
 }
 
 // submitClass queues every shard of one class on the shared pool and returns
 // without waiting for them, so the caller can move on to the next class. The
-// returned classUpload is what those jobs write their result into; read it only
+// returned classUpload is what those jobs write their result into. Read it only
 // once the pool has drained.
 func (u *uploader) submitClass(ctx context.Context, eg *enterrors.ErrorGroupWrapper,
 	id string, cdesc backup.ClassDescriptor, overrideBucket, overridePath string,
@@ -555,8 +556,8 @@ func (u *uploader) submitClass(ctx context.Context, eg *enterrors.ErrorGroupWrap
 
 	// finish runs when the last shard job of the class has returned. That is the
 	// earliest the index may be released, since releasing it deletes the staging
-	// dir the jobs read from, and late enough for complete to know whether the
-	// class made it into the backup.
+	// dir the jobs read from. It is also late enough for complete to know whether
+	// the class made it into the backup.
 	cu.finish = func() {
 		cancel()
 		observe()
@@ -583,7 +584,7 @@ func (u *uploader) submitClass(ctx context.Context, eg *enterrors.ErrorGroupWrap
 
 	nShards := len(cu.desc.Shards)
 	if nShards == 0 {
-		// no jobs to queue, so no job will call finish
+		// there are no jobs to queue, so no job will call finish
 		cu.finish()
 		return cu
 	}

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -1,0 +1,452 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package backup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// probeTimeout bounds the waits these tests make on the probe's state, so a pool
+// that stops running the work one of them waits on fails an assertion instead of
+// hanging.
+const probeTimeout = 5 * time.Second
+
+// uploadProbe is the sourcer and the backend the shared-pool tests run against.
+// It feeds fixed class descriptors and records what the pool does, and onWrite
+// lets a test hold one chunk open while it inspects what else is running.
+type uploadProbe struct {
+	sourcePath string
+	descs      []backup.ClassDescriptor
+	// onWrite runs while the chunk write is in flight, holding the context that
+	// write was given; returning an error fails it the way a backend rejection does.
+	onWrite   func(ctx context.Context, class, key string) error
+	onRelease func(class string)
+
+	mu sync.Mutex
+	// writing counts the chunk writes of each class that have not returned.
+	writing  map[string]int
+	written  []string
+	releases []string
+	meta     backup.BackupDescriptor
+}
+
+func newUploadProbe(sourcePath string, descs ...backup.ClassDescriptor) *uploadProbe {
+	return &uploadProbe{
+		sourcePath: sourcePath,
+		descs:      descs,
+		writing:    map[string]int{},
+	}
+}
+
+func (p *uploadProbe) ReleaseBackup(_ context.Context, _, class string) error {
+	p.mu.Lock()
+	p.releases = append(p.releases, class)
+	p.mu.Unlock()
+	if p.onRelease != nil {
+		p.onRelease(class)
+	}
+	return nil
+}
+
+func (p *uploadProbe) Backupable(context.Context, []string) error { return nil }
+
+func (p *uploadProbe) BackupDescriptors(_ context.Context, _ string, _ []string, _ []*backup.BackupDescriptor,
+) <-chan backup.ClassDescriptor {
+	ch := make(chan backup.ClassDescriptor, len(p.descs))
+	for _, d := range p.descs {
+		ch <- d
+	}
+	close(ch)
+	return ch
+}
+
+func (p *uploadProbe) Write(ctx context.Context, _, key, _, _ string, r backup.ReadCloserWithError) (n int64, err error) {
+	// mirrors the real backends, which signal their own failure to the producer
+	defer func() { r.CloseWithError(err) }()
+	if n, err = io.Copy(io.Discard, r); err != nil {
+		return n, err
+	}
+
+	class := strings.SplitN(key, "/", 2)[0]
+	p.mu.Lock()
+	p.writing[class]++
+	p.written = append(p.written, key)
+	p.mu.Unlock()
+
+	defer func() {
+		p.mu.Lock()
+		p.writing[class]--
+		p.mu.Unlock()
+	}()
+	if p.onWrite != nil {
+		err = p.onWrite(ctx, class, key)
+	}
+	return n, err
+}
+
+func (p *uploadProbe) PutObject(_ context.Context, _, key, _, _ string, b []byte) error {
+	if key == BackupFile {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return json.Unmarshal(b, &p.meta)
+	}
+	return nil
+}
+
+func (p *uploadProbe) SourceDataPath() string { return p.sourcePath }
+func (p *uploadProbe) IsExternal() bool       { return true }
+func (p *uploadProbe) Name() string           { return "uploadProbe" }
+
+func (p *uploadProbe) HomeDir(_, _, _ string) string { return p.sourcePath }
+
+func (p *uploadProbe) GetObject(context.Context, string, string, string, string) ([]byte, error) {
+	return nil, backup.ErrNotFound{}
+}
+
+func (p *uploadProbe) AllBackups(context.Context) ([]*backup.DistributedBackupDescriptor, error) {
+	return nil, nil
+}
+
+func (p *uploadProbe) Initialize(context.Context, string, string, string) error { return nil }
+
+func (p *uploadProbe) Read(context.Context, string, string, string, string, io.WriteCloser) (int64, error) {
+	return 0, nil
+}
+
+// writingTotal reports how many chunk writes are in flight across all classes.
+func (p *uploadProbe) writingTotal() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n := 0
+	for _, c := range p.writing {
+		n += c
+	}
+	return n
+}
+
+func (p *uploadProbe) snapshot() (written, releases []string, meta backup.BackupDescriptor) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.written...), append([]string(nil), p.releases...), p.meta
+}
+
+// runUpload drives uploader.all over the probe's classes with a pool poolSize wide.
+func runUpload(t *testing.T, ctx context.Context, p *uploadProbe, poolSize int) (*backup.BackupDescriptor, error) {
+	t.Helper()
+	names := make([]string, len(p.descs))
+	for i, d := range p.descs {
+		names[i] = d.Name
+	}
+	logger, _ := test.NewNullLogger()
+	store := nodeStore{objectStore{backend: p, backupId: "backup-1"}}
+	u := newUploader(config.Backup{}, p, nil, nil, nil, nil, store, "backup-1", &backupStat{}, logger).
+		withCompression(zipConfig{Level: int(NoCompression), GoPoolSize: poolSize})
+
+	desc := &backup.BackupDescriptor{ID: "backup-1", Classes: make([]backup.ClassDescriptor, 0, len(names))}
+	return desc, u.all(ctx, names, desc, nil, "", "")
+}
+
+// classDescriptorWithShards returns desc carrying n copies of its shard, so one
+// class can put several shard jobs into the pool at once.
+func classDescriptorWithShards(desc backup.ClassDescriptor, n int) backup.ClassDescriptor {
+	shard := *desc.Shards[0]
+	desc.Shards = make([]*backup.ShardDescriptor, n)
+	for i := range desc.Shards {
+		s := shard
+		s.Name = shard.Name + "-" + string(rune('a'+i))
+		desc.Shards[i] = &s
+	}
+	return desc
+}
+
+// TestUploaderAllUploadsClassesConcurrently pins the two properties one pool for
+// the whole backup buys: every class can be in flight at once even though each
+// holds a single shard, and no class is released while it is still being read.
+func TestUploaderAllUploadsClassesConcurrently(t *testing.T) {
+	classes := []string{"Class-A", "Class-B", "Class-C", "Class-D"}
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
+
+	gate := make(chan struct{})
+	var openGate sync.Once
+	open := func() { openGate.Do(func() { close(gate) }) }
+	p.onWrite = func(context.Context, string, string) error {
+		<-gate
+		return nil
+	}
+
+	var (
+		desc     *backup.BackupDescriptor
+		err      error
+		finished = make(chan struct{})
+	)
+	go func() {
+		defer close(finished)
+		desc, err = runUpload(t, context.Background(), p, len(classes))
+	}()
+	t.Cleanup(func() {
+		open()
+		<-finished
+	})
+
+	require.Eventually(t, func() bool { return p.writingTotal() == len(classes) },
+		probeTimeout, time.Millisecond,
+		"every class should have a chunk in flight at once")
+
+	// Every class is mid-upload for the whole window, and a release would delete
+	// the files those uploads are still reading.
+	assert.Never(t, func() bool {
+		_, releases, _ := p.snapshot()
+		return len(releases) > 0
+	}, 300*time.Millisecond, 5*time.Millisecond,
+		"no class may be released while its chunks are still being written")
+
+	open()
+	select {
+	case <-finished:
+	case <-time.After(probeTimeout):
+		t.Fatal("upload did not finish after the gate opened")
+	}
+	require.NoError(t, err)
+	assert.Equal(t, backup.Success, desc.Status)
+}
+
+// TestUploaderAllKeepsRequestOrder pins that the descriptor lists classes in the
+// order they were requested even when a later class finishes first.
+func TestUploaderAllKeepsRequestOrder(t *testing.T) {
+	classes := []string{"Class-A", "Class-B"}
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
+
+	bReleased := make(chan struct{})
+	var once sync.Once
+	p.onRelease = func(class string) {
+		if class == "Class-B" {
+			once.Do(func() { close(bReleased) })
+		}
+	}
+	p.onWrite = func(_ context.Context, class, _ string) error {
+		if class != "Class-A" {
+			return nil
+		}
+		select {
+		case <-bReleased:
+		case <-time.After(probeTimeout):
+			return errors.New("Class-B never finished while Class-A waited")
+		}
+		return nil
+	}
+
+	desc, err := runUpload(t, context.Background(), p, len(classes))
+	require.NoError(t, err)
+
+	got := make([]string, len(desc.Classes))
+	for i, c := range desc.Classes {
+		got[i] = c.Name
+	}
+	assert.Equal(t, classes, got)
+}
+
+func TestUploaderAllClassDescriptors(t *testing.T) {
+	tests := []struct {
+		name     string
+		shards   []int // shards per class, one entry per class
+		poolSize int
+	}{
+		{name: "one shard per class", shards: []int{1, 1, 1}, poolSize: 4},
+		{name: "several shards of one class share the pool", shards: []int{4}, poolSize: 4},
+		{name: "pool narrower than the work", shards: []int{3, 3}, poolSize: 1},
+		{name: "no classes at all", shards: nil, poolSize: 2},
+		{name: "class without shards is still recorded", shards: []int{0, 1}, poolSize: 2},
+		{name: "unset pool size still runs one worker", shards: []int{2}, poolSize: 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			names := make([]string, len(tc.shards))
+			for i := range tc.shards {
+				names[i] = "Class-" + string(rune('A'+i))
+			}
+			sourcePath := t.TempDir()
+			descs := genClassDescriptions(t, sourcePath, names...)
+			for i, n := range tc.shards {
+				descs[i] = classDescriptorWithShards(descs[i], n)
+			}
+			p := newUploadProbe(sourcePath, descs...)
+
+			desc, err := runUpload(t, context.Background(), p, tc.poolSize)
+			require.NoError(t, err)
+
+			written, _, meta := p.snapshot()
+			require.Len(t, desc.Classes, len(names))
+
+			var total int64
+			for i, c := range desc.Classes {
+				assert.Equal(t, names[i], c.Name)
+				// How many chunks a shard becomes belongs to the zip layer. What the
+				// pool owns is that every chunk it recorded was written and that no
+				// shard's chunks were lost against a concurrent sibling.
+				covered := map[string]bool{}
+				for chunk, shards := range c.Chunks {
+					assert.Contains(t, written, chunkKey(c.Name, chunk))
+					require.Len(t, shards, 1)
+					covered[shards[0]] = true
+				}
+				for _, shard := range c.Shards {
+					assert.True(t, covered[shard.Name], "no chunk recorded for shard %s of %s", shard.Name, c.Name)
+				}
+				total += c.PreCompressionSizeBytes
+			}
+			assert.Equal(t, total, desc.PreCompressionSizeBytes)
+			assert.Len(t, written, countChunks(desc.Classes))
+			assert.Equal(t, backup.Success, meta.Status)
+
+			// Releasing is fire-and-forget, so the set is only complete eventually.
+			assert.Eventually(t, func() bool {
+				_, releases, _ := p.snapshot()
+				return len(dedupe(releases)) == len(names)
+			}, probeTimeout, time.Millisecond, "every class must be released")
+		})
+	}
+}
+
+func countChunks(classes []backup.ClassDescriptor) int {
+	n := 0
+	for _, c := range classes {
+		n += len(c.Chunks)
+	}
+	return n
+}
+
+func dedupe(xs []string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, x := range xs {
+		if !seen[x] {
+			seen[x] = true
+			out = append(out, x)
+		}
+	}
+	return out
+}
+
+func TestUploaderAllFailures(t *testing.T) {
+	const failing = "Class-B"
+	tests := []struct {
+		name      string
+		descError error
+		// failWrites rejects every write of the failing class. failOnPoolCancel
+		// instead waits for the descriptor error to cancel the pool and only then
+		// rejects, so the shards fail with the operation still uncancelled.
+		failWrites       bool
+		failOnPoolCancel bool
+		cancel           bool
+		wantErr          string
+		wantStatus       backup.Status
+	}{
+		{
+			name:       "backend rejects a chunk write",
+			failWrites: true,
+			wantErr:    "backend is full",
+			wantStatus: backup.Failed,
+		},
+		{
+			name:       "descriptor arrives with an error",
+			descError:  errors.New("class vanished"),
+			wantErr:    "class vanished",
+			wantStatus: backup.Failed,
+		},
+		{
+			name:             "shards cancelled by a descriptor error still report a failure",
+			descError:        errors.New("class vanished"),
+			failOnPoolCancel: true,
+			wantErr:          "class vanished",
+			wantStatus:       backup.Failed,
+		},
+		{
+			name:       "operation is cancelled while uploading",
+			cancel:     true,
+			wantErr:    context.Canceled.Error(),
+			wantStatus: backup.Cancelled,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			names := []string{"Class-A", failing}
+			sourcePath := t.TempDir()
+			descs := genClassDescriptions(t, sourcePath, names...)
+			for i := range descs {
+				descs[i] = classDescriptorWithShards(descs[i], 2)
+			}
+			if tc.descError != nil {
+				descs[1] = backup.ClassDescriptor{Name: failing, Error: tc.descError}
+			}
+			p := newUploadProbe(sourcePath, descs...)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tc.cancel {
+				var once sync.Once
+				p.onWrite = func(context.Context, string, string) error {
+					once.Do(cancel)
+					return nil
+				}
+			}
+			if tc.failWrites {
+				p.onWrite = func(_ context.Context, class, _ string) error {
+					if class == failing {
+						return errors.New("backend is full")
+					}
+					return nil
+				}
+			}
+			if tc.failOnPoolCancel {
+				p.onWrite = func(writeCtx context.Context, _, _ string) error {
+					select {
+					case <-writeCtx.Done():
+						return errors.New("backend is full")
+					case <-time.After(probeTimeout):
+						return errors.New("the pool was never cancelled")
+					}
+				}
+			}
+
+			desc, err := runUpload(t, ctx, p, 4)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+			assert.Equal(t, tc.wantStatus, desc.Status)
+
+			for _, c := range desc.Classes {
+				assert.NotEqual(t, failing, c.Name, "a class that did not finish must not be in the descriptor")
+			}
+
+			// Releasing is fire-and-forget, so the set is only complete eventually.
+			assert.Eventually(t, func() bool {
+				_, releases, _ := p.snapshot()
+				return len(dedupe(releases)) == len(names)
+			}, probeTimeout, time.Millisecond, "every class must be released even when the backup fails")
+		})
+	}
+}

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -34,6 +35,9 @@ import (
 // hanging.
 const probeTimeout = 5 * time.Second
 
+// backendFullMsg is the rejection text the probe returns for a class a test fails.
+const backendFullMsg = "backend is full"
+
 // uploadProbe is the sourcer and the backend the shared-pool tests run against.
 // It feeds fixed class descriptors and records what the pool does, and onWrite
 // lets a test hold one chunk open while it inspects what else is running.
@@ -44,20 +48,35 @@ type uploadProbe struct {
 	// write was given; returning an error fails it the way a backend rejection does.
 	onWrite   func(ctx context.Context, class, key string) error
 	onRelease func(class string)
+	// onDescriptor runs before a class is snapshotted, holding the producer's own
+	// context, so a test can keep the producer open while the pool fails around it.
+	onDescriptor func(ctx context.Context, class string)
+	// producerDone closes when the producer stops snapshotting classes, just
+	// before it closes the descriptor channel.
+	producerDone chan struct{}
+	// producerStopsAfter, when positive, ends the producer after that many
+	// descriptors with no error descriptor, as a recovered panic in it would.
+	producerStopsAfter int
 
 	mu sync.Mutex
 	// writing counts the chunk writes of each class that have not returned.
 	writing  map[string]int
 	written  []string
 	releases []string
-	meta     backup.BackupDescriptor
+	// snapshotted names the classes the producer snapshotted, in order.
+	snapshotted []string
+	// snapshottedAfterRelease names the classes the producer snapshotted after
+	// their own index had already been released.
+	snapshottedAfterRelease []string
+	meta                    backup.BackupDescriptor
 }
 
 func newUploadProbe(sourcePath string, descs ...backup.ClassDescriptor) *uploadProbe {
 	return &uploadProbe{
-		sourcePath: sourcePath,
-		descs:      descs,
-		writing:    map[string]int{},
+		sourcePath:   sourcePath,
+		descs:        descs,
+		writing:      map[string]int{},
+		producerDone: make(chan struct{}),
 	}
 }
 
@@ -73,14 +92,59 @@ func (p *uploadProbe) ReleaseBackup(_ context.Context, _, class string) error {
 
 func (p *uploadProbe) Backupable(context.Context, []string) error { return nil }
 
-func (p *uploadProbe) BackupDescriptors(_ context.Context, _ string, _ []string, _ []*backup.BackupDescriptor,
+// BackupDescriptors produces one descriptor at a time from its own goroutine and
+// stops between classes once ctx is cancelled, as DB.BackupDescriptors does, so a
+// test can observe the pool while a later class has not been snapshotted yet.
+func (p *uploadProbe) BackupDescriptors(ctx context.Context, _ string, _ []string, _ []*backup.BackupDescriptor,
 ) <-chan backup.ClassDescriptor {
 	ch := make(chan backup.ClassDescriptor, len(p.descs))
-	for _, d := range p.descs {
-		ch <- d
-	}
-	close(ch)
+	go func() {
+		// producerDone closes before ch, so producerDone is already closed by the
+		// time a consumer draining ch sees it closed.
+		defer func() {
+			close(p.producerDone)
+			close(ch)
+		}()
+		for i, d := range p.descs {
+			if p.producerStopsAfter > 0 && i >= p.producerStopsAfter {
+				return
+			}
+			if err := ctx.Err(); err != nil {
+				ch <- backup.ClassDescriptor{Name: d.Name, Error: err}
+				return
+			}
+			if p.onDescriptor != nil {
+				p.onDescriptor(ctx, d.Name)
+			}
+			p.mu.Lock()
+			p.snapshotted = append(p.snapshotted, d.Name)
+			if slices.Contains(p.releases, d.Name) {
+				p.snapshottedAfterRelease = append(p.snapshottedAfterRelease, d.Name)
+			}
+			p.mu.Unlock()
+
+			ch <- d
+			if d.Error != nil {
+				return
+			}
+		}
+	}()
 	return ch
+}
+
+// classesSnapshotted reports the classes the producer snapshotted, in order.
+func (p *uploadProbe) classesSnapshotted() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.snapshotted...)
+}
+
+// classesSnapshottedAfterRelease reports the classes the producer snapshotted
+// after their own index had already been released.
+func (p *uploadProbe) classesSnapshottedAfterRelease() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.snapshottedAfterRelease...)
 }
 
 func (p *uploadProbe) Write(ctx context.Context, _, key, _, _ string, r backup.ReadCloserWithError) (n int64, err error) {
@@ -369,7 +433,7 @@ func TestUploaderAllFailures(t *testing.T) {
 		{
 			name:       "backend rejects a chunk write",
 			failWrites: true,
-			wantErr:    "backend is full",
+			wantErr:    backendFullMsg,
 			wantStatus: backup.Failed,
 		},
 		{
@@ -417,7 +481,7 @@ func TestUploaderAllFailures(t *testing.T) {
 			if tc.failWrites {
 				p.onWrite = func(_ context.Context, class, _ string) error {
 					if class == failing {
-						return errors.New("backend is full")
+						return errors.New(backendFullMsg)
 					}
 					return nil
 				}
@@ -426,7 +490,7 @@ func TestUploaderAllFailures(t *testing.T) {
 				p.onWrite = func(writeCtx context.Context, _, _ string) error {
 					select {
 					case <-writeCtx.Done():
-						return errors.New("backend is full")
+						return errors.New(backendFullMsg)
 					case <-time.After(probeTimeout):
 						return errors.New("the pool was never cancelled")
 					}
@@ -449,4 +513,139 @@ func TestUploaderAllFailures(t *testing.T) {
 			}, probeTimeout, time.Millisecond, "every class must be released even when the backup fails")
 		})
 	}
+}
+
+// TestUploaderAllWaitsForDescriptorProducer pins that all does not release an
+// index while the descriptor producer can still snapshot it. The producer runs
+// on the operation's context, which cancelling the pool never reaches.
+func TestUploaderAllWaitsForDescriptorProducer(t *testing.T) {
+	const failing = "Class-A"
+	names := []string{failing, "Class-B", "Class-C"}
+	last := names[len(names)-1]
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, names...)...)
+
+	failed := make(chan struct{})
+	var once sync.Once
+	p.onWrite = func(_ context.Context, class, _ string) error {
+		if class != failing {
+			return nil
+		}
+		once.Do(func() { close(failed) })
+		return errors.New(backendFullMsg)
+	}
+	releasedLast := make(chan struct{})
+	var relOnce sync.Once
+	p.onRelease = func(class string) {
+		if class == last {
+			relOnce.Do(func() { close(releasedLast) })
+		}
+	}
+	// onDescriptor holds the last class's snapshot open until all stops the
+	// producer. Whichever of the two arms below wins is the assertion: a release
+	// reaching the held class first is the ordering this test exists to catch.
+	p.onDescriptor = func(ctx context.Context, class string) {
+		if class != last {
+			return
+		}
+		select {
+		case <-failed:
+		case <-time.After(probeTimeout):
+			t.Error("the failing class never failed the pool")
+			return
+		}
+		select {
+		case <-releasedLast:
+			t.Error("the last class's index was released while the producer could still snapshot it")
+		case <-ctx.Done():
+		}
+	}
+
+	desc, err := runUpload(t, context.Background(), p, 4)
+	require.Error(t, err)
+	assert.Equal(t, backup.Failed, desc.Status)
+
+	select {
+	case <-p.producerDone:
+	default:
+		t.Error("all returned while the descriptor producer was still snapshotting classes")
+	}
+
+	select {
+	case <-p.producerDone:
+	case <-time.After(probeTimeout):
+		t.Fatal("the descriptor producer never finished")
+	}
+	assert.Empty(t, p.classesSnapshottedAfterRelease(),
+		"a class snapshotted after its index was released stays marked in progress")
+}
+
+// TestUploaderAllStopsDescriptorProducerOnFailure pins that the drain waits only
+// for the class already being snapshotted. all owns the producer's context, so a
+// failed backup does not wait out a snapshot of every class it never reached.
+func TestUploaderAllStopsDescriptorProducerOnFailure(t *testing.T) {
+	const failing, gated = "Class-A", "Class-C"
+	names := []string{failing, "Class-B", gated, "Class-D"}
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, names...)...)
+
+	p.onWrite = func(_ context.Context, class, _ string) error {
+		if class != failing {
+			return nil
+		}
+		return errors.New(backendFullMsg)
+	}
+	// Holding the gated class until all stops the producer puts one class in flight
+	// at exactly the moment the drain starts, which is the wait the drain bounds.
+	p.onDescriptor = func(ctx context.Context, class string) {
+		if class != gated {
+			return
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(probeTimeout):
+			t.Error("all never stopped the descriptor producer")
+		}
+	}
+
+	desc, err := runUpload(t, context.Background(), p, 4)
+	require.Error(t, err)
+	assert.Equal(t, backup.Failed, desc.Status)
+
+	select {
+	case <-p.producerDone:
+	case <-time.After(probeTimeout):
+		t.Fatal("the descriptor producer never finished")
+	}
+	assert.Equal(t, []string{failing, "Class-B", gated}, p.classesSnapshotted(),
+		"the class after the one in flight must never be snapshotted")
+	assert.Empty(t, p.classesSnapshottedAfterRelease(),
+		"a class snapshotted after its index was released stays marked in progress")
+
+	// The gated class was snapshotted and its descriptor then thrown away by the
+	// drain, which is safe only because the release still covers it.
+	assert.Eventually(t, func() bool {
+		_, releases, _ := p.snapshot()
+		return len(dedupe(releases)) == len(names)
+	}, probeTimeout, time.Millisecond, "every class must be released, described or not")
+}
+
+// TestUploaderAllRejectsPartialDescriptorRun pins that a producer ending without
+// saying why fails the backup. A recovered panic in it closes the channel with no
+// error descriptor, which otherwise reads as "every class was described" and
+// publishes a SUCCESS that omits the classes it never reached.
+func TestUploaderAllRejectsPartialDescriptorRun(t *testing.T) {
+	names := []string{"Class-A", "Class-B", "Class-C"}
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, names...)...)
+	p.producerStopsAfter = 1
+
+	desc, err := runUpload(t, context.Background(), p, 4)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "describes 1 of 3 classes")
+	assert.NotEqual(t, backup.Success, desc.Status)
+
+	_, _, meta := p.snapshot()
+	assert.NotEqual(t, backup.Success, meta.Status,
+		"a backup missing classes must not be published as successful")
 }

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -531,6 +531,8 @@ func TestUploaderAllFailures(t *testing.T) {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantErr)
 			assert.Equal(t, tc.wantStatus, desc.Status)
+			assert.NotContains(t, desc.Error, "%!w(",
+				"a step of the upload that succeeded must not be reported as an error")
 
 			for _, c := range desc.Classes {
 				assert.NotEqual(t, failing, c.Name, "a class that did not finish must not be in the descriptor")

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -718,34 +718,70 @@ func TestUploaderAllCancelsThePoolBeforeDrainingIt(t *testing.T) {
 }
 
 // TestUploaderAllDoesNotPublishSuccessOnPanic pins that a backup that stopped
-// part way through is not published as one that finished. A panic unwinds
-// through the publishing defer with the named error still nil, and a node
-// reporting success is a node the coordinator counts as done.
+// part way through is not published as finished. A node reporting success is a
+// node the coordinator counts as done. A panic in the descriptor loop leaves
+// the named error nil. One in a shard job arrives as the pool's error, which
+// has to name the crash rather than the cancellation its siblings return.
 func TestUploaderAllDoesNotPublishSuccessOnPanic(t *testing.T) {
 	classes := []string{"Class-A", "Class-B"}
-	sourcePath := t.TempDir()
-	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
-	p.panicOnSourcePathCall = 2
-
-	finished := make(chan struct{})
-	u, desc, names, stat := newProbeUploader(t, p, len(classes))
-	go func() {
-		defer close(finished)
-		defer func() { _ = recover() }()
-		_ = u.all(context.Background(), names, desc, nil, "", "")
-	}()
-
-	select {
-	case <-finished:
-	case <-time.After(probeTimeout):
-		t.Fatal("all never returned")
+	tests := []struct {
+		name string
+		// panicIn arranges for the named goroutine to panic.
+		panicIn func(p *uploadProbe)
+		// poolSize 1 leaves the other shard jobs queued, so they start after the
+		// panic and return the cancellation.
+		poolSize int
+		// wantErrContains also names what the injector rests on, so a guard added
+		// against it makes the case fail rather than pass for another reason.
+		wantErrContains []string
+	}{
+		{
+			name:     "descriptor loop",
+			panicIn:  func(p *uploadProbe) { p.panicOnSourcePathCall = 2 },
+			poolSize: len(classes),
+		},
+		{
+			name: "shard job",
+			panicIn: func(p *uploadProbe) {
+				// a nil descriptor panics in createFileList, which runs before compress
+				// installs its own recovery around the consumer goroutine
+				p.descs[0] = classDescriptorWithShards(p.descs[0], 2)
+				p.descs[0].Shards[0] = nil
+			},
+			poolSize:        1,
+			wantErrContains: []string{"panic occurred", "nil pointer"},
+		},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sourcePath := t.TempDir()
+			p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
+			tt.panicIn(p)
 
-	got := stat.get()
-	assert.Equal(t, backup.Failed, got.Status,
-		"a backup that panicked part way through must not be published as successful")
-	assert.NotEmpty(t, got.Err, "the failure has to carry a reason a poll can read")
+			finished := make(chan struct{})
+			u, desc, names, stat := newProbeUploader(t, p, tt.poolSize)
+			go func() {
+				defer close(finished)
+				defer func() { _ = recover() }()
+				_ = u.all(context.Background(), names, desc, nil, "", "")
+			}()
 
-	_, _, meta := p.snapshot()
-	assert.NotEqual(t, backup.Success, meta.Status)
+			select {
+			case <-finished:
+			case <-time.After(probeTimeout):
+				t.Fatal("all never returned")
+			}
+
+			got := stat.get()
+			assert.Equal(t, backup.Failed, got.Status,
+				"a backup that panicked part way through must not be published as successful")
+			assert.NotEmpty(t, got.Err, "the failure has to carry a reason a poll can read")
+			for _, want := range tt.wantErrContains {
+				assert.Contains(t, got.Err, want)
+			}
+
+			_, _, meta := p.snapshot()
+			assert.NotEqual(t, backup.Success, meta.Status)
+		})
+	}
 }

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -46,7 +46,7 @@ type uploadProbe struct {
 	sourcePath string
 	descs      []backup.ClassDescriptor
 	// onWrite runs while the chunk write is in flight, holding the context that
-	// write was given; returning an error fails it the way a backend rejection does.
+	// write was given. Returning an error fails it the way a backend rejection does.
 	onWrite   func(ctx context.Context, class, key string) error
 	onRelease func(class string)
 	// onDescriptor runs before a class is snapshotted, holding the producer's own
@@ -99,8 +99,8 @@ func (p *uploadProbe) ReleaseBackup(_ context.Context, _, class string) error {
 func (p *uploadProbe) Backupable(context.Context, []string) error { return nil }
 
 // BackupDescriptors produces one descriptor at a time from its own goroutine and
-// stops between classes once ctx is cancelled, as DB.BackupDescriptors does, so a
-// test can observe the pool while a later class has not been snapshotted yet.
+// stops between classes once ctx is cancelled, as DB.BackupDescriptors does. A
+// test can then observe the pool while a later class has not been snapshotted yet.
 func (p *uploadProbe) BackupDescriptors(ctx context.Context, _ string, _ []string, _ []*backup.BackupDescriptor,
 ) <-chan backup.ClassDescriptor {
 	ch := make(chan backup.ClassDescriptor, len(p.descs))
@@ -154,7 +154,8 @@ func (p *uploadProbe) classesSnapshottedAfterRelease() []string {
 }
 
 func (p *uploadProbe) Write(ctx context.Context, _, key, _, _ string, r backup.ReadCloserWithError) (n int64, err error) {
-	// mirrors the real backends, which signal their own failure to the producer
+	// CloseWithError mirrors the real backends, which signal their own failure
+	// to the producer
 	defer func() { r.CloseWithError(err) }()
 	if n, err = io.Copy(io.Discard, r); err != nil {
 		return n, err
@@ -246,7 +247,7 @@ func runUploadWithStat(t *testing.T, ctx context.Context, p *uploadProbe, poolSi
 // newProbeUploader builds the uploader the pool tests drive, along with the
 // arguments and the status slot of the upload. A test whose call to all does not
 // return normally still needs to read the slot, which is what a poll for the
-// node reads, so it is handed out before the call rather than after it.
+// node reads. The slot is therefore handed out before the call, not after it.
 func newProbeUploader(t *testing.T, p *uploadProbe, poolSize int) (*uploader, *backup.BackupDescriptor, []string, *backupStat) {
 	t.Helper()
 	names := make([]string, len(p.descs))
@@ -277,8 +278,8 @@ func classDescriptorWithShards(desc backup.ClassDescriptor, n int) backup.ClassD
 }
 
 // TestUploaderAllUploadsClassesConcurrently pins the two properties one pool for
-// the whole backup buys: every class can be in flight at once even though each
-// holds a single shard, and no class is released while it is still being read.
+// the whole backup buys. Every class can be in flight at once even though each
+// holds a single shard. No class is released while it is still being read.
 func TestUploaderAllUploadsClassesConcurrently(t *testing.T) {
 	classes := []string{"Class-A", "Class-B", "Class-C", "Class-D"}
 	sourcePath := t.TempDir()
@@ -574,7 +575,7 @@ func TestUploaderAllWaitsForDescriptorProducer(t *testing.T) {
 		}
 	}
 	// onDescriptor holds the last class's snapshot open until all stops the
-	// producer. Whichever of the two arms below wins is the assertion: a release
+	// producer. Whichever of the two arms below wins is the assertion. A release
 	// reaching the held class first is the ordering this test exists to catch.
 	p.onDescriptor = func(ctx context.Context, class string) {
 		if class != last {
@@ -664,7 +665,7 @@ func TestUploaderAllStopsDescriptorProducerOnFailure(t *testing.T) {
 
 // TestUploaderAllRejectsPartialDescriptorRun pins that a producer ending without
 // saying why fails the backup. A recovered panic in it closes the channel with no
-// error descriptor, which otherwise reads as "every class was described" and
+// error descriptor. That otherwise reads as "every class was described" and
 // publishes a SUCCESS that omits the classes it never reached.
 func TestUploaderAllRejectsPartialDescriptorRun(t *testing.T) {
 	names := []string{"Class-A", "Class-B", "Class-C"}
@@ -690,7 +691,7 @@ func TestUploaderAllCancelsThePoolBeforeDrainingIt(t *testing.T) {
 	classes := []string{"Class-A", "Class-B"}
 	sourcePath := t.TempDir()
 	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
-	// Class-A is submitted and its shard reaches the backend; Class-B panics on
+	// Class-A is submitted and its shard reaches the backend. Class-B panics on
 	// its way into the pool, leaving Class-A in flight.
 	p.panicOnSourcePathCall = 2
 	p.onWrite = func(ctx context.Context, _, _ string) error {

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -19,6 +19,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -57,6 +58,11 @@ type uploadProbe struct {
 	// producerStopsAfter, when positive, ends the producer after that many
 	// descriptors with no error descriptor, as a recovered panic in it would.
 	producerStopsAfter int
+	// panicOnSourcePathCall, when positive, panics on that call to SourceDataPath.
+	// submitClass calls it once per class, so this panics inside the descriptor
+	// loop with the classes before it already running in the pool.
+	panicOnSourcePathCall int
+	sourcePathCalls       atomic.Int64
 
 	mu sync.Mutex
 	// writing counts the chunk writes of each class that have not returned.
@@ -180,9 +186,14 @@ func (p *uploadProbe) PutObject(_ context.Context, _, key, _, _ string, b []byte
 	return nil
 }
 
-func (p *uploadProbe) SourceDataPath() string { return p.sourcePath }
-func (p *uploadProbe) IsExternal() bool       { return true }
-func (p *uploadProbe) Name() string           { return "uploadProbe" }
+func (p *uploadProbe) SourceDataPath() string {
+	if n := p.sourcePathCalls.Add(1); p.panicOnSourcePathCall > 0 && n == int64(p.panicOnSourcePathCall) {
+		panic("uploadProbe: injected panic in the descriptor loop")
+	}
+	return p.sourcePath
+}
+func (p *uploadProbe) IsExternal() bool { return true }
+func (p *uploadProbe) Name() string     { return "uploadProbe" }
 
 func (p *uploadProbe) HomeDir(_, _, _ string) string { return p.sourcePath }
 
@@ -220,17 +231,36 @@ func (p *uploadProbe) snapshot() (written, releases []string, meta backup.Backup
 // runUpload drives uploader.all over the probe's classes with a pool poolSize wide.
 func runUpload(t *testing.T, ctx context.Context, p *uploadProbe, poolSize int) (*backup.BackupDescriptor, error) {
 	t.Helper()
+	desc, _, err := runUploadWithStat(t, ctx, p, poolSize)
+	return desc, err
+}
+
+// runUploadWithStat is runUpload plus the status slot the upload published to,
+// which is what a poll for the node reads.
+func runUploadWithStat(t *testing.T, ctx context.Context, p *uploadProbe, poolSize int) (*backup.BackupDescriptor, *backupStat, error) {
+	t.Helper()
+	u, desc, names, stat := newProbeUploader(t, p, poolSize)
+	return desc, stat, u.all(ctx, names, desc, nil, "", "")
+}
+
+// newProbeUploader builds the uploader the pool tests drive, along with the
+// arguments and the status slot of the upload. A test whose call to all does not
+// return normally still needs to read the slot, which is what a poll for the
+// node reads, so it is handed out before the call rather than after it.
+func newProbeUploader(t *testing.T, p *uploadProbe, poolSize int) (*uploader, *backup.BackupDescriptor, []string, *backupStat) {
+	t.Helper()
 	names := make([]string, len(p.descs))
 	for i, d := range p.descs {
 		names[i] = d.Name
 	}
 	logger, _ := test.NewNullLogger()
 	store := nodeStore{objectStore{backend: p, backupId: "backup-1"}}
-	u := newUploader(config.Backup{}, p, nil, nil, nil, nil, store, "backup-1", &backupStat{}, logger).
+	stat := &backupStat{}
+	u := newUploader(config.Backup{}, p, nil, nil, nil, nil, store, "backup-1", stat, logger).
 		withCompression(zipConfig{Level: int(NoCompression), GoPoolSize: poolSize})
 
 	desc := &backup.BackupDescriptor{ID: "backup-1", Classes: make([]backup.ClassDescriptor, 0, len(names))}
-	return desc, u.all(ctx, names, desc, nil, "", "")
+	return u, desc, names, stat
 }
 
 // classDescriptorWithShards returns desc carrying n copies of its shard, so one
@@ -648,4 +678,74 @@ func TestUploaderAllRejectsPartialDescriptorRun(t *testing.T) {
 	_, _, meta := p.snapshot()
 	assert.NotEqual(t, backup.Success, meta.Status,
 		"a backup missing classes must not be published as successful")
+}
+
+// TestUploaderAllCancelsThePoolBeforeDrainingIt pins the order the pool defers
+// run in when the descriptor loop does not reach its own wait. Draining shard
+// jobs that nothing has cancelled gives each of them the full storeTimeout, so
+// the backup goroutine parks for a day on a backup that is already over.
+func TestUploaderAllCancelsThePoolBeforeDrainingIt(t *testing.T) {
+	classes := []string{"Class-A", "Class-B"}
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
+	// Class-A is submitted and its shard reaches the backend; Class-B panics on
+	// its way into the pool, leaving Class-A in flight.
+	p.panicOnSourcePathCall = 2
+	p.onWrite = func(ctx context.Context, _, _ string) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// the package shadows the any type with a mock.Anything alias, so the
+	// recovered value is reduced to whether there was one
+	var (
+		panicked bool
+		finished = make(chan struct{})
+	)
+	u, desc, names, _ := newProbeUploader(t, p, len(classes))
+	go func() {
+		defer close(finished)
+		defer func() { panicked = recover() != nil }()
+		_ = u.all(context.Background(), names, desc, nil, "", "")
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(probeTimeout):
+		t.Fatal("all never returned: it drained the pool without cancelling it first")
+	}
+	require.True(t, panicked, "the panic must still propagate out of all")
+}
+
+// TestUploaderAllDoesNotPublishSuccessOnPanic pins that a backup that stopped
+// part way through is not published as one that finished. A panic unwinds
+// through the publishing defer with the named error still nil, and a node
+// reporting success is a node the coordinator counts as done.
+func TestUploaderAllDoesNotPublishSuccessOnPanic(t *testing.T) {
+	classes := []string{"Class-A", "Class-B"}
+	sourcePath := t.TempDir()
+	p := newUploadProbe(sourcePath, genClassDescriptions(t, sourcePath, classes...)...)
+	p.panicOnSourcePathCall = 2
+
+	finished := make(chan struct{})
+	u, desc, names, stat := newProbeUploader(t, p, len(classes))
+	go func() {
+		defer close(finished)
+		defer func() { _ = recover() }()
+		_ = u.all(context.Background(), names, desc, nil, "", "")
+	}()
+
+	select {
+	case <-finished:
+	case <-time.After(probeTimeout):
+		t.Fatal("all never returned")
+	}
+
+	got := stat.get()
+	assert.Equal(t, backup.Failed, got.Status,
+		"a backup that panicked part way through must not be published as successful")
+	assert.NotEmpty(t, got.Err, "the failure has to carry a reason a poll can read")
+
+	_, _, meta := p.snapshot()
+	assert.NotEqual(t, backup.Success, meta.Status)
 }

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -1750,8 +1750,8 @@ func returnOrNotFound(fb *fakeBackend, ctx context.Context, backupID, key string
 }
 
 // TestLabelErr pins labelErr's own contract. A step that succeeded has to drop
-// out entirely, since its callers hand the result to errors.Join, and a step
-// that failed has to stay unwrappable: the publishing defer picks cancelled over
+// out entirely, since its callers hand the result to errors.Join. A step that
+// failed has to stay unwrappable. The publishing defer picks cancelled over
 // failed by reading context.Canceled back out.
 func TestLabelErr(t *testing.T) {
 	tests := []struct {

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -16,6 +16,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1746,4 +1747,39 @@ func returnOrNotFound(fb *fakeBackend, ctx context.Context, backupID, key string
 		return
 	}
 	fb.On("GetObject", ctx, backupID, key).Return(body, nil)
+}
+
+// TestLabelErr pins labelErr's own contract. A step that succeeded has to drop
+// out entirely, since its callers hand the result to errors.Join, and a step
+// that failed has to stay unwrappable: the publishing defer picks cancelled over
+// failed by reading context.Canceled back out.
+func TestLabelErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "the step succeeded"},
+		{
+			name: "the step failed",
+			err:  errors.New(backendFullMsg),
+			want: "producer: " + backendFullMsg,
+		},
+		{
+			name: "the step was cancelled",
+			err:  context.Canceled,
+			want: "producer: context canceled",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := labelErr("producer", tt.err)
+			if tt.want == "" {
+				require.NoError(t, got)
+				return
+			}
+			require.EqualError(t, got, tt.want)
+			require.ErrorIs(t, got, tt.err)
+		})
+	}
 }

--- a/usecases/backup/sourcer.go
+++ b/usecases/backup/sourcer.go
@@ -29,9 +29,9 @@ type Sourcer interface { // implemented by the index
 
 	// BackupDescriptors returns a channel of class descriptors, closed on every exit
 	// of the producer, and stops between classes once ctx is cancelled. A descriptor
-	// carrying an error is written before the close when the producer detects one,
-	// but a recovered panic closes the channel silently: a close is not proof that
-	// every class was described. The caller must drain the channel to close before
+	// carrying an error is written before the close when the producer detects one.
+	// A recovered panic instead closes the channel silently, so a close is not
+	// proof that every class was described. The caller must drain the channel to close before
 	// calling ReleaseBackup for any class, since a descriptor produced after a
 	// release leaves that class marked in progress.
 	//

--- a/usecases/backup/sourcer.go
+++ b/usecases/backup/sourcer.go
@@ -27,9 +27,13 @@ type Sourcer interface { // implemented by the index
 	// Backupable returns whether all given class can be backed up.
 	Backupable(_ context.Context, classes []string) error
 
-	// BackupDescriptors returns a channel of class descriptors.
-	// Class descriptor records everything needed to restore a class
-	// If an error happens a descriptor with an error will be written to the channel just before closing it.
+	// BackupDescriptors returns a channel of class descriptors, closed on every exit
+	// of the producer, and stops between classes once ctx is cancelled. A descriptor
+	// carrying an error is written before the close when the producer detects one,
+	// but a recovered panic closes the channel silently: a close is not proof that
+	// every class was described. The caller must drain the channel to close before
+	// calling ReleaseBackup for any class, since a descriptor produced after a
+	// release leaves that class marked in progress.
 	//
 	// BackupDescriptors acquires resources so that a call to ReleaseBackup() is mandatory to free acquired resources.
 	BackupDescriptors(_ context.Context, bakid string, classes []string, baseDescr []*backup.BackupDescriptor,

--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -203,10 +203,7 @@ func (z *zip) CloseWithError(err error) error {
 		}
 		z.zstdEncoder = nil
 	}
-	if err1 != nil || err2 != nil || err3 != nil {
-		return fmt.Errorf("tar: %w, gzip: %w, pw: %w", err1, err2, err3)
-	}
-	return nil
+	return errors.Join(labelErr("tar", err1), labelErr("gzip", err2), labelErr("pw", err3))
 }
 
 // WriteShard writes shard internal files including in memory files stored in sd
@@ -580,11 +577,7 @@ func (u *unzip) Close() (err error) {
 	if u.gzr != nil {
 		err2 = u.gzr.Close()
 	}
-	if err1 != nil || err2 != nil {
-		return fmt.Errorf("close pr: %w, gunzip: %w", err1, err2)
-	}
-
-	return nil
+	return errors.Join(labelErr("close pr", err1), labelErr("gunzip", err2))
 }
 
 func (u *unzip) ReadChunk() (written int64, err error) {

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -2008,3 +2008,37 @@ func newFileList(t *testing.T, sourceDir string, files []string) *backup.FileLis
 		FileSizes: fileSizes,
 	}
 }
+
+// TestUnzipCloseReportsOnlyTheStepThatFailed pins that a chunk whose stream ends
+// early names the decompressor and nothing else. The text reaches the restore's
+// error and from there the status API, where a step that succeeded reported as an
+// error is what a poller reads as a second failure.
+func TestUnzipCloseReportsOnlyTheStepThatFailed(t *testing.T) {
+	var archive bytes.Buffer
+	gw := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gw)
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "f.txt", Mode: 0o644, Size: 4}))
+	_, err := tw.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gw.Close())
+	truncated := archive.Bytes()[:archive.Len()/2]
+
+	uz, wc := NewUnzip(t.TempDir(), backup.CompressionGZIP)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = wc.Write(truncated)
+		wc.Close()
+	}()
+
+	_, readErr := uz.ReadChunk()
+	require.Error(t, readErr, "a truncated chunk must not read as a complete one")
+
+	closeErr := uz.Close()
+	require.Error(t, closeErr)
+	require.NotContains(t, closeErr.Error(), "%!w(",
+		"a close step that succeeded must not be reported as an error")
+	require.Contains(t, closeErr.Error(), "gunzip: ")
+	<-done
+}

--- a/usecases/backup/zip_zstd_test.go
+++ b/usecases/backup/zip_zstd_test.go
@@ -125,7 +125,10 @@ func TestZipZstdEncoderNotPooledAfterFailedClose(t *testing.T) {
 		// consumer goes away while the chunk is still being written
 		require.NoError(t, rc.Close())
 		_, _, _ = z.WriteRegulars(context.Background(), &sd, newFileList(t, dir, files), &atomic.Int64{}, "chunk")
-		require.Error(t, z.CloseWithError(errors.New("consumer gone")))
+		closeErr := z.CloseWithError(errors.New("consumer gone"))
+		require.Error(t, closeErr)
+		require.NotContains(t, closeErr.Error(), "%!w(",
+			"a close step that succeeded must not be reported as an error")
 
 		next, _, err := takeZstdEncoder(level, io.Discard)
 		require.NoError(t, err)


### PR DESCRIPTION
### What's being changed:

Before class uploads were serialized: `uploader.all` took one class descriptor off the channel, uploaded all of its shards, and only then took the next. So a node holding thousands of single-shard collections uploaded one shard at a time no matter how high `GoPoolSize` was set. 

This PR replaces the per-class pool with a single pool for the whole backup: the descriptor loop submits every class's shards and moves on, so shards from different classes upload concurrently up to `GoPoolSize`. Per-class state (chunks, sizes, shard counters) moves into a `classUpload`; a class joins the backup descriptor only once *all* of its shards uploaded, and `uploads` keeps descriptor arrival order so out-of-order completion doesn't reorder `desc.Classes`.

**Also fixed** — concurrency made the index-release ordering load-bearing, which surfaced these latent failure modes:

- Releasing an index deletes the staging dir its shard jobs read from. The pool is now cancelled and drained before any release; cancelling first is what bounds the drain, since a shard job otherwise runs under `storeTimeout`.
- The descriptor producer is now stopped and drained to close before any release. A descriptor produced after a release leaves that class marked in progress, failing the *next* backup of that class.
- `BackupDescriptors` closes its channel on every exit path — previously a recovered panic left it open, which would hang the drain — and stops between classes once its context is cancelled.
- `all` publishes success only on the one path that ran to the end, so a panic unwinding with `err == nil` no longer marks the node's backup done.
- A producer that stops without reporting an error is now an error rather than a backup silently missing every class it never described.

New tests cover the pool behaviour (`backend_pool_test.go`) and the producer contract (`backup_test.go`).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
