### PR TITLE
Fix count aggregation over shards, and resolve its routing plan once

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3606,7 +3606,7 @@ func (i *Index) aggregate(ctx context.Context, replProps *additional.Replication
 }
 
 func (i *Index) aggregateCount(ctx context.Context, shards []string) (*aggregation.Result, error) {
-	var total atomic.Int32
+	var total atomic.Int64
 
 	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
 	eg.SetLimit(min(len(shards), runtime.GOMAXPROCS(0)*4))
@@ -3618,7 +3618,7 @@ func (i *Index) aggregateCount(ctx context.Context, shards []string) (*aggregati
 			if err != nil {
 				return err
 			}
-			total.Add(int32(count))
+			total.Add(int64(count))
 			return nil
 		})
 	}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3566,16 +3566,18 @@ func (i *Index) IncomingMergeObject(ctx context.Context, shardName string,
 func (i *Index) aggregate(ctx context.Context, replProps *additional.ReplicationProperties,
 	params aggregation.Params, modules *modules.Provider,
 ) (*aggregation.Result, error) {
+	// ValidateConsistencyLevel requires every shard to resolve to the same number,
+	// and ONE is the only level that does so whatever the shards' replica counts.
 	readPlan, err := i.buildReadRoutingPlan(routerTypes.ConsistencyLevelOne, params.Tenant)
 	if err != nil {
 		return nil, err
 	}
 
-	shards := readPlan.Shards()
 	if aggregation.IsCountStar(&params) {
-		return i.aggregateCount(ctx, shards)
+		return i.aggregateCount(ctx, readPlan)
 	}
 
+	shards := readPlan.Shards()
 	results := make([]*aggregation.Result, len(shards))
 	for j, shardName := range shards {
 		var res *aggregation.Result
@@ -3605,16 +3607,20 @@ func (i *Index) aggregate(ctx context.Context, replProps *additional.Replication
 	return aggregator.NewShardCombiner().Do(results)
 }
 
-func (i *Index) aggregateCount(ctx context.Context, shards []string) (*aggregation.Result, error) {
+// aggregateCount counts every shard in readPlan against that plan's replicas,
+// resolved once for the whole aggregation rather than per shard. It counts at
+// ALL, so a shard's count is reconciled over every replica that answers.
+func (i *Index) aggregateCount(ctx context.Context, readPlan routerTypes.ReadRoutingPlan) (*aggregation.Result, error) {
 	var total atomic.Int64
 
-	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
-	eg.SetLimit(min(len(shards), runtime.GOMAXPROCS(0)*4))
+	shardPlans := readPlan.ShardPlans(routerTypes.ConsistencyLevelAll)
 
-	for si := range shards {
-		shard := shards[si]
+	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
+	eg.SetLimit(min(len(shardPlans), runtime.GOMAXPROCS(0)*4))
+
+	for _, shardPlan := range shardPlans {
 		eg.Go(func() error {
-			count, err := i.replicator.CountObjects(ctx, shard, routerTypes.ConsistencyLevelAll)
+			count, err := i.replicator.CountObjects(ctx, shardPlan)
 			if err != nil {
 				return err
 			}

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -25,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -53,6 +55,10 @@ func TestIndex_aggregateCount(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			groups := shardRegex.FindStringSubmatch(r.URL.Path)
 			count := shards[groups[1]]
+			if count < 0 { // sentinel: this replica cannot serve that shard
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 			io.WriteString(w, strconv.Itoa(count))
 		}))
 		t.Cleanup(srv.Close)
@@ -84,10 +90,11 @@ func TestIndex_aggregateCount(t *testing.T) {
 		shards []string         // Complete list of shards in collection.
 		tenant string
 
-		planErrs map[string]error // Shards whose routing plan fails to build.
+		planErr error         // Error the collection-wide routing plan build fails with.
+		timeout time.Duration // Caller deadline; zero for none.
 
-		want    int  // Expected aggregated count
-		wantErr bool // Whether the aggregation must fail
+		want    int    // Expected aggregated count
+		wantErr string // Substring the aggregation must fail with; empty if it must succeed
 	}{
 		{
 			name:   "consistent count",
@@ -133,13 +140,37 @@ func TestIndex_aggregateCount(t *testing.T) {
 			want: 2200000000,
 		},
 		{
-			name: "a shard whose routing plan fails",
+			name: "a failing routing plan",
 			nodes: []map[string]int{
 				{"abc": 1, "xyz": 2},
 				{"abc": 1, "xyz": 2},
 			},
-			planErrs: map[string]error{"xyz": errors.New("no read replica found")},
-			wantErr:  true,
+			planErr: errors.New("no read replica found"),
+			wantErr: "no read replica found",
+		},
+		{
+			// ShardPlans exists to resolve a level per shard, which a
+			// collection-wide plan of unequal width cannot carry.
+			name:   "shards with different replica counts",
+			shards: []string{"abc", "xyz"},
+			nodes: []map[string]int{
+				{"abc": 1, "xyz": 2},
+				{"xyz": 2},
+				{"xyz": 2},
+			},
+			want: 3,
+		},
+		{
+			// The reachable shard must not be reported on its own: a count is
+			// either complete or an error.
+			name:   "a shard no replica can count",
+			shards: []string{"abc", "xyz"},
+			nodes: []map[string]int{
+				{"abc": 1, "xyz": -1},
+				{"abc": 1, "xyz": -1},
+			},
+			timeout: time.Second,
+			wantErr: `shard "xyz"`,
 		},
 		{
 			name:   "one tenant",
@@ -176,7 +207,7 @@ func TestIndex_aggregateCount(t *testing.T) {
 			})
 
 			router := &fakeRouter{
-				planErrs: tt.planErrs,
+				planErr: tt.planErr,
 				readPlan: types.ReadRoutingPlan{
 					IntConsistencyLevel: len(tt.counts) + len(tt.nodes),
 					ConsistencyLevel:    types.ConsistencyLevelAll,
@@ -209,14 +240,26 @@ func TestIndex_aggregateCount(t *testing.T) {
 			}
 
 			// Act
-			res, err := index.aggregate(t.Context(), nil, aggregation.Params{
+			ctx := t.Context()
+			if tt.timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.timeout)
+				defer cancel()
+			}
+			start := time.Now()
+			res, err := index.aggregate(ctx, nil, aggregation.Params{
 				IncludeMetaCount: true,
 				Tenant:           tt.tenant,
 			}, nil)
 
 			// Assert
-			if tt.wantErr {
-				require.Error(t, err, "aggregate")
+			if tt.timeout > 0 {
+				// CountObjects retries a failing replica for a minute of its own;
+				// the caller's deadline has to cut that short.
+				require.Less(t, time.Since(start), 5*time.Second, "aggregate outlived the caller deadline")
+			}
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr, "aggregate")
 			} else {
 				require.NoError(t, err, "aggregate")
 				require.Len(t, res.Groups, 1, "number of groups")
@@ -233,7 +276,7 @@ type fakeRouter struct {
 	writePlan types.WriteRoutingPlan
 	readSet   types.ReadReplicaSet
 	writeSet  types.WriteReplicaSet
-	planErrs  map[string]error
+	planErr   error
 }
 
 // AllHostnames implements [types.Router].
@@ -244,8 +287,8 @@ func (f *fakeRouter) AllHostnames() []string {
 var _ types.Router = (*fakeRouter)(nil)
 
 func (f *fakeRouter) BuildReadRoutingPlan(opt types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
-	if err := f.planErrs[opt.Shard]; err != nil {
-		return types.ReadRoutingPlan{}, err
+	if f.planErr != nil {
+		return types.ReadRoutingPlan{}, f.planErr
 	}
 
 	readPlan := f.readPlan

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -12,6 +12,7 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -83,7 +84,10 @@ func TestIndex_aggregateCount(t *testing.T) {
 		shards []string         // Complete list of shards in collection.
 		tenant string
 
-		want int // Expected aggregated count
+		planErrs map[string]error // Shards whose routing plan fails to build.
+
+		want    int  // Expected aggregated count
+		wantErr bool // Whether the aggregation must fail
 	}{
 		{
 			name:   "consistent count",
@@ -121,6 +125,23 @@ func TestIndex_aggregateCount(t *testing.T) {
 			want: 3,
 		},
 		{
+			name: "counts above MaxInt32",
+			nodes: []map[string]int{
+				{"abc": 1200000000, "xyz": 1000000000},
+				{"abc": 1200000000, "xyz": 1000000000},
+			},
+			want: 2200000000,
+		},
+		{
+			name: "a shard whose routing plan fails",
+			nodes: []map[string]int{
+				{"abc": 1, "xyz": 2},
+				{"abc": 1, "xyz": 2},
+			},
+			planErrs: map[string]error{"xyz": errors.New("no read replica found")},
+			wantErr:  true,
+		},
+		{
 			name:   "one tenant",
 			shards: []string{"john_doe", "jane_doe"},
 			nodes: []map[string]int{
@@ -155,6 +176,7 @@ func TestIndex_aggregateCount(t *testing.T) {
 			})
 
 			router := &fakeRouter{
+				planErrs: tt.planErrs,
 				readPlan: types.ReadRoutingPlan{
 					IntConsistencyLevel: len(tt.counts) + len(tt.nodes),
 					ConsistencyLevel:    types.ConsistencyLevelAll,
@@ -193,9 +215,13 @@ func TestIndex_aggregateCount(t *testing.T) {
 			}, nil)
 
 			// Assert
-			require.NoError(t, err, "aggregate")
-			require.Len(t, res.Groups, 1, "number of groups")
-			require.Equal(t, tt.want, res.Groups[0].Count, "object count")
+			if tt.wantErr {
+				require.Error(t, err, "aggregate")
+			} else {
+				require.NoError(t, err, "aggregate")
+				require.Len(t, res.Groups, 1, "number of groups")
+				require.Equal(t, tt.want, res.Groups[0].Count, "object count")
+			}
 		})
 	}
 }
@@ -207,6 +233,7 @@ type fakeRouter struct {
 	writePlan types.WriteRoutingPlan
 	readSet   types.ReadReplicaSet
 	writeSet  types.WriteReplicaSet
+	planErrs  map[string]error
 }
 
 // AllHostnames implements [types.Router].
@@ -217,6 +244,10 @@ func (f *fakeRouter) AllHostnames() []string {
 var _ types.Router = (*fakeRouter)(nil)
 
 func (f *fakeRouter) BuildReadRoutingPlan(opt types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
+	if err := f.planErrs[opt.Shard]; err != nil {
+		return types.ReadRoutingPlan{}, err
+	}
+
 	readPlan := f.readPlan
 	readPlan.Shard = opt.Shard
 	readPlan.Tenant = opt.Tenant
@@ -234,7 +265,9 @@ func (f *fakeRouter) BuildReadRoutingPlan(opt types.RoutingPlanBuildOptions) (ty
 }
 
 func (f *fakeRouter) BuildRoutingPlanOptions(tenant, shard string, cl types.ConsistencyLevel, directCandidate string) types.RoutingPlanBuildOptions {
-	return f.options
+	opt := f.options
+	opt.Shard = shard
+	return opt
 }
 
 func (f *fakeRouter) BuildWriteRoutingPlan(params types.RoutingPlanBuildOptions) (types.WriteRoutingPlan, error) {

--- a/cluster/router/router.go
+++ b/cluster/router/router.go
@@ -241,18 +241,31 @@ func (r *singleTenantRouter) getReadReplicasLocation(collection string, tenant s
 		return types.ReadReplicaSet{}, err
 	}
 
-	var replicas []types.Replica
+	readReplicas, _, err := r.readReplicasForShards(collection, tenant, targetShards)
+	return readReplicas, err
+}
 
-	for _, shardName := range targetShards {
+// readReplicasForShards gathers the read replicas of every shard in shards into one set,
+// and names the shards that have none: they leave no trace in the set itself.
+func (r *singleTenantRouter) readReplicasForShards(collection, tenant string, shards []string) (types.ReadReplicaSet, []string, error) {
+	var replicas []types.Replica
+	var shardsWithoutReplicas []string
+
+	for _, shardName := range shards {
 		readReplica, err := r.readReplicasForShard(collection, tenant, shardName)
 		if err != nil {
-			return types.ReadReplicaSet{}, err
+			return types.ReadReplicaSet{}, nil, err
+		}
+
+		if len(readReplica) == 0 {
+			shardsWithoutReplicas = append(shardsWithoutReplicas, shardName)
+			continue
 		}
 
 		replicas = append(replicas, readReplica...)
 	}
 
-	return types.ReadReplicaSet{Replicas: replicas}, nil
+	return types.ReadReplicaSet{Replicas: replicas}, shardsWithoutReplicas, nil
 }
 
 // getWriteReplicasLocation returns only write replicas for single-tenant collections.
@@ -329,9 +342,21 @@ func (r *singleTenantRouter) BuildReadRoutingPlan(params types.RoutingPlanBuildO
 
 // buildReadRoutingPlan constructs a read routing plan for single-tenant collections.
 func (r *singleTenantRouter) buildReadRoutingPlan(params types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
-	readReplicas, err := r.getReadReplicasLocation(r.collection, params.Tenant, params.Shard)
+	targetShards, err := r.targetShards(r.collection, params.Shard)
 	if err != nil {
 		return types.ReadRoutingPlan{}, err
+	}
+
+	readReplicas, shardsWithoutReplicas, err := r.readReplicasForShards(r.collection, params.Tenant, targetShards)
+	if err != nil {
+		return types.ReadRoutingPlan{}, err
+	}
+
+	// A shard with no read replica fails the plan rather than dropping out of it:
+	// callers read every shard the plan holds, so a missing one reads short and reports success.
+	if len(shardsWithoutReplicas) > 0 {
+		return types.ReadRoutingPlan{}, fmt.Errorf("collection %q: no read replica found for shards %q",
+			r.collection, shardsWithoutReplicas)
 	}
 
 	if len(readReplicas.Replicas) == 0 {

--- a/cluster/router/router_test.go
+++ b/cluster/router/router_test.go
@@ -2009,51 +2009,119 @@ func TestMultiTenantRouter_GetReadWriteReplicasLocation_ShardMismatch(t *testing
 	require.Empty(t, ws.Replicas)
 }
 
-func TestSingleTenantRouter_BuildReadRoutingPlan_AllShards(t *testing.T) {
-	mockSchemaGetter := schema.NewMockSchemaGetter(t)
-	mockSchemaReader := schema.NewMockSchemaReader(t)
-	mockReplicationFSM := replicationTypes.NewMockReplicationFSMReader(t)
-	mockNodeSelector := mocks.NewMockNodeSelector("node1", "node2")
+// shardNodes is one shard's replica nodes as the schema holds them, and the subset the
+// replication FSM leaves after filtering that shard for reads. A shard ends up with no
+// read replica either because the FSM filters them all out or because the node selector
+// resolves no hostname for the ones left, and the two are independent.
+type shardNodes struct {
+	inSchema []string
+	readable []string
+}
 
-	shards := []string{"shard1", "shard2"}
-	state := createShardingStateWithShards([]string{"shard1", "shard2"})
-	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(state.AllPhysicalShards(), nil).Maybe()
-	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
-		class := &models.Class{Class: className}
-		return readFunc(class, state)
-	}).Maybe()
+// TestSingleTenantRouter_BuildReadRoutingPlan_ShardCoverage pins that a read plan fails
+// rather than silently omitting a shard that has no read replica.
+func TestSingleTenantRouter_BuildReadRoutingPlan_ShardCoverage(t *testing.T) {
+	const collection = "TestClass"
 
-	for _, shard := range shards {
-		mockSchemaReader.EXPECT().ShardReplicas("TestClass", shard).Return([]string{"node1"}, nil)
-		mockReplicationFSM.EXPECT().FilterOneShardReplicasRead("TestClass", shard, []string{"node1"}).
-			Return([]string{"node1"})
+	// Only node1 and node2 resolve to a hostname, so a replica on node9 is unresolvable.
+	resolvableNodes := []string{"node1", "node2"}
+
+	for _, tt := range []struct {
+		name string
+		// shards is the collection's shard list; targetShard is what the caller asks
+		// for, empty meaning all of them. nodesByShard holds a stub per shard the
+		// plan build is expected to visit.
+		shards       []string
+		targetShard  string
+		nodesByShard map[string]shardNodes
+		wantShards   []string
+		wantErr      string
+	}{
+		{
+			name:   "every shard has a read replica",
+			shards: []string{"shard1", "shard2"},
+			nodesByShard: map[string]shardNodes{
+				"shard1": {inSchema: []string{"node1"}, readable: []string{"node1"}},
+				"shard2": {inSchema: []string{"node1"}, readable: []string{"node1"}},
+			},
+			wantShards: []string{"shard1", "shard2"},
+		},
+		{
+			name:   "one of several shards has every replica filtered out of reads",
+			shards: []string{"shard1", "shard2", "shard3"},
+			nodesByShard: map[string]shardNodes{
+				"shard1": {inSchema: []string{"node1"}, readable: []string{"node1"}},
+				"shard2": {inSchema: []string{"node1"}, readable: []string{}},
+				"shard3": {inSchema: []string{"node1"}, readable: []string{"node1"}},
+			},
+			wantErr: `no read replica found for shards ["shard2"]`,
+		},
+		{
+			name:   "a shard's only read replica sits on a node that resolves to no hostname",
+			shards: []string{"shard1", "shard2"},
+			nodesByShard: map[string]shardNodes{
+				"shard1": {inSchema: []string{"node1"}, readable: []string{"node1"}},
+				"shard2": {inSchema: []string{"node9"}, readable: []string{"node9"}},
+			},
+			wantErr: `no read replica found for shards ["shard2"]`,
+		},
+		{
+			name:   "a shard keeps its resolvable read replica when another resolves to no hostname",
+			shards: []string{"shard1", "shard2"},
+			nodesByShard: map[string]shardNodes{
+				"shard1": {inSchema: []string{"node1", "node9"}, readable: []string{"node1", "node9"}},
+				"shard2": {inSchema: []string{"node1"}, readable: []string{"node1"}},
+			},
+			wantShards: []string{"shard1", "shard2"},
+		},
+		{
+			name:        "the targeted shard has no read replica",
+			shards:      []string{"shard1", "shard2"},
+			targetShard: "shard2",
+			nodesByShard: map[string]shardNodes{
+				"shard2": {inSchema: []string{"node1"}, readable: []string{}},
+			},
+			wantErr: `no read replica found for shards ["shard2"]`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockSchemaGetter := schema.NewMockSchemaGetter(t)
+			mockSchemaReader := schema.NewMockSchemaReader(t)
+			mockReplicationFSM := replicationTypes.NewMockReplicationFSMReader(t)
+			mockNodeSelector := mocks.NewMockNodeSelector(resolvableNodes...)
+
+			state := createShardingStateWithShards(tt.shards)
+			mockSchemaReader.EXPECT().Shards(mock.Anything).Return(state.AllPhysicalShards(), nil).Maybe()
+			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readFunc func(*models.Class, *sharding.State) error) error {
+				return readFunc(&models.Class{Class: className}, state)
+			}).Maybe()
+
+			for shard, nodes := range tt.nodesByShard {
+				mockSchemaReader.EXPECT().ShardReplicas(collection, shard).Return(nodes.inSchema, nil)
+				mockReplicationFSM.EXPECT().FilterOneShardReplicasRead(collection, shard, nodes.inSchema).
+					Return(nodes.readable)
+			}
+
+			r := router.NewBuilder(collection, false, mockNodeSelector, mockSchemaGetter,
+				mockSchemaReader, mockReplicationFSM).Build()
+
+			plan, err := r.BuildReadRoutingPlan(types.RoutingPlanBuildOptions{
+				Tenant:           "",
+				Shard:            tt.targetShard,
+				ConsistencyLevel: types.ConsistencyLevelOne,
+			})
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+				require.Empty(t, plan.ReplicaSet.Replicas)
+				return
+			}
+
+			require.NoError(t, err)
+			require.ElementsMatch(t, tt.wantShards, plan.Shards())
+		})
 	}
-
-	r := router.NewBuilder(
-		"TestClass",
-		false,
-		mockNodeSelector,
-		mockSchemaGetter,
-		mockSchemaReader,
-		mockReplicationFSM,
-	).Build()
-
-	opts := types.RoutingPlanBuildOptions{
-		Tenant:           "",
-		Shard:            "",
-		ConsistencyLevel: types.ConsistencyLevelOne,
-	}
-
-	plan, err := r.BuildReadRoutingPlan(opts)
-	require.NoError(t, err)
-	require.Len(t, plan.ReplicaSet.Replicas, 2, "should have replicas from all shards")
-
-	shardNames := make(map[string]bool)
-	for _, replica := range plan.ReplicaSet.Replicas {
-		shardNames[replica.ShardName] = true
-	}
-	require.True(t, shardNames["shard1"], "should have replica from shard1")
-	require.True(t, shardNames["shard2"], "should have replica from shard2")
 }
 
 // TestMultiTenantRouter_BuildReadRoutingPlan_TenantActivation pins who may activate a tenant

--- a/cluster/router/types/replicaset_test.go
+++ b/cluster/router/types/replicaset_test.go
@@ -12,8 +12,11 @@
 package types_test
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
 )
@@ -194,5 +197,133 @@ func TestWriteReplicaSet_OtherMethods(t *testing.T) {
 		if !emptyWS.IsEmpty() {
 			t.Error("IsEmpty() should return true for empty replica set")
 		}
+	})
+}
+
+// shardWidth is a shard and the number of replicas it has, for building a replica
+// set whose shards differ in width.
+type shardWidth struct {
+	shard string
+	n     int
+}
+
+func replicasOf(widths []shardWidth) []types.Replica {
+	var replicas []types.Replica
+	for _, w := range widths {
+		for i := range w.n {
+			replicas = append(replicas, types.Replica{
+				ShardName: w.shard,
+				NodeName:  fmt.Sprintf("node%d", i),
+				HostAddr:  fmt.Sprintf("host%d:8080", i),
+			})
+		}
+	}
+	return replicas
+}
+
+// ValidateConsistencyLevel resolves the level against each shard's own replica
+// count and rejects a set whose shards disagree on the result. Index.aggregate
+// builds a collection-wide plan at ONE because ONE is the only level that agrees
+// for any mix of widths.
+func TestReadReplicaSet_ValidateConsistencyLevel(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		widths  []shardWidth
+		level   types.ConsistencyLevel
+		want    int
+		wantErr string // Substring the call must fail with; empty if it must succeed.
+	}{
+		{
+			name:  "empty replica set",
+			level: types.ConsistencyLevelAll,
+			want:  0,
+		},
+		{
+			name:   "one shard at ONE",
+			widths: []shardWidth{{"shard_A", 3}},
+			level:  types.ConsistencyLevelOne,
+			want:   1,
+		},
+		{
+			name:   "one shard at QUORUM",
+			widths: []shardWidth{{"shard_A", 3}},
+			level:  types.ConsistencyLevelQuorum,
+			want:   2,
+		},
+		{
+			name:   "one shard at ALL",
+			widths: []shardWidth{{"shard_A", 3}},
+			level:  types.ConsistencyLevelAll,
+			want:   3,
+		},
+		{
+			name:   "shards of equal width at ALL",
+			widths: []shardWidth{{"shard_A", 3}, {"shard_B", 3}},
+			level:  types.ConsistencyLevelAll,
+			want:   3,
+		},
+		{
+			// The case Index.aggregate cannot use: at ALL each shard resolves to
+			// its own width, so any difference in width is a disagreement.
+			name:    "shards of unequal width at ALL",
+			widths:  []shardWidth{{"shard_A", 1}, {"shard_B", 3}},
+			level:   types.ConsistencyLevelAll,
+			wantErr: "inconsistent consistency levels",
+		},
+		{
+			// QUORUM tolerates a width difference the two widths round away.
+			name:   "shards of unequal width whose quorums agree",
+			widths: []shardWidth{{"shard_A", 2}, {"shard_B", 3}},
+			level:  types.ConsistencyLevelQuorum,
+			want:   2,
+		},
+		{
+			name:    "shards of unequal width whose quorums differ",
+			widths:  []shardWidth{{"shard_A", 1}, {"shard_B", 3}},
+			level:   types.ConsistencyLevelQuorum,
+			wantErr: "inconsistent consistency levels",
+		},
+		{
+			// What Index.aggregate relies on: ONE resolves to 1 whatever the width.
+			name:   "shards of any mix of widths at ONE",
+			widths: []shardWidth{{"shard_A", 1}, {"shard_B", 2}, {"shard_C", 5}},
+			level:  types.ConsistencyLevelOne,
+			want:   1,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			rs := types.ReadReplicaSet{Replicas: replicasOf(tt.widths)}
+
+			got, err := rs.ValidateConsistencyLevel(tt.level)
+
+			if tt.wantErr != "" {
+				// Which two shards the message names follows map iteration order,
+				// so only the prefix is stable.
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Zero(t, got, "resolved level on failure")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got, "resolved level")
+		})
+	}
+}
+
+func TestWriteReplicaSet_ValidateConsistencyLevel(t *testing.T) {
+	widths := []shardWidth{{"shard_A", 1}, {"shard_B", 3}}
+
+	t.Run("shards of unequal width at ALL", func(t *testing.T) {
+		ws := types.WriteReplicaSet{Replicas: replicasOf(widths)}
+
+		_, err := ws.ValidateConsistencyLevel(types.ConsistencyLevelAll)
+		require.ErrorContains(t, err, "inconsistent consistency levels")
+	})
+
+	t.Run("shards of unequal width at ONE", func(t *testing.T) {
+		ws := types.WriteReplicaSet{Replicas: replicasOf(widths)}
+
+		got, err := ws.ValidateConsistencyLevel(types.ConsistencyLevelOne)
+		require.NoError(t, err)
+		require.Equal(t, 1, got, "resolved level")
 	})
 }

--- a/cluster/router/types/router_plan.go
+++ b/cluster/router/types/router_plan.go
@@ -154,6 +154,38 @@ func (p ReadRoutingPlan) Replicas() []Replica {
 	return p.ReplicaSet.Replicas
 }
 
+// ShardPlans splits p into one plan per shard, so a caller holding a
+// collection-wide plan need not have the router resolve every shard again.
+// p must hold every read replica of each shard it covers: cl resolves against
+// that count, and a failed read retries against the replicas past that level.
+func (p ReadRoutingPlan) ShardPlans(cl ConsistencyLevel) []ReadRoutingPlan {
+	plans := make([]ReadRoutingPlan, 0, len(p.ReplicaSet.Replicas))
+	indexByShard := make(map[string]int, len(p.ReplicaSet.Replicas))
+
+	for _, replica := range p.ReplicaSet.Replicas {
+		i, ok := indexByShard[replica.ShardName]
+		if !ok {
+			i = len(plans)
+			indexByShard[replica.ShardName] = i
+			plans = append(plans, ReadRoutingPlan{
+				LocalHostname:    p.LocalHostname,
+				Shard:            replica.ShardName,
+				Tenant:           p.Tenant,
+				ConsistencyLevel: cl,
+			})
+		}
+		plans[i].ReplicaSet.Replicas = append(plans[i].ReplicaSet.Replicas, replica)
+	}
+
+	// No ValidateConsistencyLevel call: it guards plans spanning several shards,
+	// and a per-shard plan always holds at least the replica that created it.
+	for i := range plans {
+		plans[i].IntConsistencyLevel = cl.ToInt(len(plans[i].ReplicaSet.Replicas))
+	}
+
+	return plans
+}
+
 // HostNames returns the hostnames of the primary write Replicas
 // in the WriteRoutingPlan.
 func (p WriteRoutingPlan) HostNames() []string {

--- a/cluster/router/types/router_plan_test.go
+++ b/cluster/router/types/router_plan_test.go
@@ -1,0 +1,143 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package types_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+)
+
+func TestReadRoutingPlan_ShardPlans(t *testing.T) {
+	replica := func(shard, node string) types.Replica {
+		return types.Replica{ShardName: shard, NodeName: node, HostAddr: node + ":8080"}
+	}
+
+	tests := []struct {
+		name     string
+		replicas []types.Replica
+		cl       types.ConsistencyLevel
+		want     []types.ReadRoutingPlan
+	}{
+		{
+			name:     "no replicas",
+			replicas: nil,
+			cl:       types.ConsistencyLevelAll,
+			want:     []types.ReadRoutingPlan{},
+		},
+		{
+			name:     "one shard on one replica",
+			replicas: []types.Replica{replica("A", "n1")},
+			cl:       types.ConsistencyLevelAll,
+			want: []types.ReadRoutingPlan{
+				{
+					Shard:               "A",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("A", "n1")}},
+					ConsistencyLevel:    types.ConsistencyLevelAll,
+					IntConsistencyLevel: 1,
+				},
+			},
+		},
+		{
+			// The collection-wide plan is sorted local-replicas-first across all
+			// shards, so a shard's replicas do not arrive contiguously.
+			name: "interleaved shards keep their own replicas in order",
+			replicas: []types.Replica{
+				replica("A", "n1"), replica("B", "n1"), replica("C", "n1"),
+				replica("A", "n2"), replica("B", "n2"), replica("C", "n2"),
+			},
+			cl: types.ConsistencyLevelAll,
+			want: []types.ReadRoutingPlan{
+				{
+					Shard:               "A",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("A", "n1"), replica("A", "n2")}},
+					ConsistencyLevel:    types.ConsistencyLevelAll,
+					IntConsistencyLevel: 2,
+				},
+				{
+					Shard:               "B",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("B", "n1"), replica("B", "n2")}},
+					ConsistencyLevel:    types.ConsistencyLevelAll,
+					IntConsistencyLevel: 2,
+				},
+				{
+					Shard:               "C",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("C", "n1"), replica("C", "n2")}},
+					ConsistencyLevel:    types.ConsistencyLevelAll,
+					IntConsistencyLevel: 2,
+				},
+			},
+		},
+		{
+			// A plan spanning shards of unequal width cannot be validated as a
+			// whole, but each shard on its own can.
+			name: "level counts each shard's own replicas",
+			replicas: []types.Replica{
+				replica("A", "n1"), replica("B", "n1"), replica("B", "n2"), replica("B", "n3"),
+			},
+			cl: types.ConsistencyLevelQuorum,
+			want: []types.ReadRoutingPlan{
+				{
+					Shard:               "A",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("A", "n1")}},
+					ConsistencyLevel:    types.ConsistencyLevelQuorum,
+					IntConsistencyLevel: 1,
+				},
+				{
+					Shard:               "B",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("B", "n1"), replica("B", "n2"), replica("B", "n3")}},
+					ConsistencyLevel:    types.ConsistencyLevelQuorum,
+					IntConsistencyLevel: 2,
+				},
+			},
+		},
+		{
+			name: "ONE reaches a single replica per shard",
+			replicas: []types.Replica{
+				replica("A", "n1"), replica("A", "n2"),
+			},
+			cl: types.ConsistencyLevelOne,
+			want: []types.ReadRoutingPlan{
+				{
+					Shard:               "A",
+					ReplicaSet:          types.ReadReplicaSet{Replicas: []types.Replica{replica("A", "n1"), replica("A", "n2")}},
+					ConsistencyLevel:    types.ConsistencyLevelOne,
+					IntConsistencyLevel: 1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := types.ReadRoutingPlan{
+				LocalHostname:       "n1",
+				Tenant:              "t1",
+				ReplicaSet:          types.ReadReplicaSet{Replicas: tt.replicas},
+				ConsistencyLevel:    types.ConsistencyLevelOne,
+				IntConsistencyLevel: 1,
+			}
+
+			got := plan.ShardPlans(tt.cl)
+
+			want := make([]types.ReadRoutingPlan, len(tt.want))
+			for i, p := range tt.want {
+				p.LocalHostname = "n1"
+				p.Tenant = "t1"
+				want[i] = p
+			}
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -341,8 +341,20 @@ func (c *coordinator[T, any]) Pull(ctx context.Context,
 	if err != nil {
 		return nil, 0, fmt.Errorf("%w : class %q shard %q", err, c.Class, c.Shard)
 	}
-	level := readRoutingPlan.IntConsistencyLevel
-	hosts := readRoutingPlan.HostAddresses()
+	replyCh, level := c.pull(ctx, readRoutingPlan, op, timeout)
+	return replyCh, level, nil
+}
+
+// pull is Pull against an already resolved plan, for callers that would
+// otherwise have the router resolve the same shard twice. The fullread goes to
+// plan.HostAddresses()[0], so a direct candidate must be ordered first.
+func (c *coordinator[T, any]) pull(ctx context.Context,
+	plan types.ReadRoutingPlan,
+	op readOp[T],
+	timeout time.Duration,
+) (<-chan Result[T], int) {
+	level := plan.IntConsistencyLevel
+	hosts := plan.HostAddresses()
 	replyCh := make(chan Result[T], level)
 	f := func() {
 		start := time.Now()
@@ -442,7 +454,7 @@ func (c *coordinator[T, any]) Pull(ctx context.Context,
 	}
 	enterrors.GoWrapper(f, c.log)
 
-	return replyCh, level, nil
+	return replyCh, level
 }
 
 // hostRetry tracks how long we should wait to retry this host again

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -670,13 +670,19 @@ func (f *Finder) LocalNodeName() string {
 	return f.nodeName
 }
 
-// CountObjects returns a shard's object count, reconciled over the replicas the
-// consistency level reaches. At ONE that is one replica's answer verbatim.
-func (f *Finder) CountObjects(ctx context.Context, shard string, cl types.ConsistencyLevel) (int, error) {
+// CountObjects returns a shard's object count, reconciled over the replicas in
+// plan that its consistency level reaches. At ONE that is one replica's answer
+// verbatim. plan must come from the router, which validates the tenant.
+func (f *Finder) CountObjects(ctx context.Context, plan types.ReadRoutingPlan) (int, error) {
+	shard := plan.Shard
+	if shard == "" {
+		// A collection-wide plan would otherwise ask every host to count shard "".
+		return 0, fmt.Errorf("count objects: routing plan targets no single shard")
+	}
 	c := NewReadCoordinator[int](f.router, f.metrics, f.class, shard, f.getDeletionStrategy(), f.log)
 
 	// NOTE(dyma): Why do we need to pass both the context and the timeout?
-	results, _, err := c.Pull(ctx, cl, func(ctx context.Context, host string, _ bool) (int, error) {
+	results, _ := c.pull(ctx, plan, func(ctx context.Context, host string, _ bool) (int, error) {
 		count, err := f.client.cl.CountObjects(ctx, host, f.class, shard)
 		if err != nil {
 			f.logger.WithFields(logrus.Fields{
@@ -686,10 +692,7 @@ func (f *Finder) CountObjects(ctx context.Context, shard string, cl types.Consis
 			return 0, err
 		}
 		return count, nil
-	}, "", time.Minute)
-	if err != nil {
-		return 0, err
-	}
+	}, time.Minute)
 
 	// Fan in results from all concurrent Pull requests. Results with
 	// errors (e.g. shard not yet loaded on a follower) are excluded

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -670,7 +670,8 @@ func (f *Finder) LocalNodeName() string {
 	return f.nodeName
 }
 
-// CountObjects returns an aggregated object count from all replicas the shard exists on.
+// CountObjects returns a shard's object count, reconciled over the replicas the
+// consistency level reaches. At ONE that is one replica's answer verbatim.
 func (f *Finder) CountObjects(ctx context.Context, shard string, cl types.ConsistencyLevel) (int, error) {
 	c := NewReadCoordinator[int](f.router, f.metrics, f.class, shard, f.getDeletionStrategy(), f.log)
 
@@ -687,7 +688,7 @@ func (f *Finder) CountObjects(ctx context.Context, shard string, cl types.Consis
 		return count, nil
 	}, "", time.Minute)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	// Fan in results from all concurrent Pull requests. Results with

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -675,10 +675,6 @@ func (f *Finder) LocalNodeName() string {
 // verbatim. plan must come from the router, which validates the tenant.
 func (f *Finder) CountObjects(ctx context.Context, plan types.ReadRoutingPlan) (int, error) {
 	shard := plan.Shard
-	if shard == "" {
-		// A collection-wide plan would otherwise ask every host to count shard "".
-		return 0, fmt.Errorf("count objects: routing plan targets no single shard")
-	}
 	c := NewReadCoordinator[int](f.router, f.metrics, f.class, shard, f.getDeletionStrategy(), f.log)
 
 	// NOTE(dyma): Why do we need to pass both the context and the timeout?

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -1176,14 +1176,13 @@ func TestFinderCountObjects(t *testing.T) {
 	)
 
 	for _, tt := range []struct {
-		name         string
-		cl           types.ConsistencyLevel
-		collectionCL bool // call with a plan that names no single shard
-		counts       map[string]int
-		errNodes     []string
-		timeout      time.Duration // caller deadline; zero for none
-		want         int
-		wantErr      string // substring the call must fail with; empty if it must succeed
+		name     string
+		cl       types.ConsistencyLevel
+		counts   map[string]int
+		errNodes []string
+		timeout  time.Duration // caller deadline; zero for none
+		want     int
+		wantErr  string // substring the call must fail with; empty if it must succeed
 	}{
 		{
 			name:   "ONE queries the local replica only",
@@ -1217,12 +1216,6 @@ func TestFinderCountObjects(t *testing.T) {
 			timeout:  100 * time.Millisecond,
 			wantErr:  "no nodes reported object count",
 		},
-		{
-			name:         "a plan naming no single shard surfaces an error",
-			cl:           types.ConsistencyLevelOne,
-			collectionCL: true,
-			wantErr:      "no single shard",
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFakeFactory(t, cls, shard, nodes, false)
@@ -1241,14 +1234,9 @@ func TestFinderCountObjects(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// The misuse the guard exists for: handing over the collection-wide
-			// plan instead of one of the per-shard plans split out of it.
-			plan := collectionPlan
-			if !tt.collectionCL {
-				shardPlans := collectionPlan.ShardPlans(tt.cl)
-				require.Len(t, shardPlans, 1)
-				plan = shardPlans[0]
-			}
+			shardPlans := collectionPlan.ShardPlans(tt.cl)
+			require.Len(t, shardPlans, 1)
+			plan := shardPlans[0]
 
 			ctx := context.Background()
 			if tt.timeout > 0 {

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -1164,3 +1164,98 @@ func TestAsyncReplicationResolutionIsLocalOnly(t *testing.T) {
 		t.Run(name, func(t *testing.T) { call() })
 	}
 }
+
+// CountObjects must query only as many replicas as the consistency level asks
+// for — a node with no expectation set here fails the test if it is queried —
+// and must report a failed routing plan instead of a count of 0.
+func TestFinderCountObjects(t *testing.T) {
+	var (
+		cls   = "C1"
+		shard = "SH1"
+		nodes = []string{"A", "B", "C"}
+	)
+
+	for _, tt := range []struct {
+		name     string
+		cl       types.ConsistencyLevel
+		shard    string
+		counts   map[string]int
+		errNodes []string
+		timeout  time.Duration // caller deadline; zero for none
+		want     int
+		wantErr  bool
+	}{
+		{
+			name:   "ONE queries the local replica only",
+			cl:     types.ConsistencyLevelOne,
+			shard:  shard,
+			counts: map[string]int{"A": 7},
+			want:   7,
+		},
+		{
+			name:   "QUORUM queries a majority",
+			cl:     types.ConsistencyLevelQuorum,
+			shard:  shard,
+			counts: map[string]int{"A": 92, "B": 92},
+			want:   92,
+		},
+		{
+			name:   "ALL queries every replica and reconciles",
+			cl:     types.ConsistencyLevelAll,
+			shard:  shard,
+			counts: map[string]int{"A": 92, "B": 13, "C": 92},
+			want:   92,
+		},
+		{
+			name:     "ONE falls back to another replica when the first fails",
+			cl:       types.ConsistencyLevelOne,
+			shard:    shard,
+			errNodes: []string{"A"},
+			counts:   map[string]int{"B": 5},
+			want:     5,
+		},
+		{
+			name:     "every replica failing surfaces an error",
+			cl:       types.ConsistencyLevelOne,
+			shard:    shard,
+			errNodes: nodes,
+			timeout:  100 * time.Millisecond,
+			wantErr:  true,
+		},
+		{
+			name:    "unknown shard surfaces the routing error",
+			cl:      types.ConsistencyLevelOne,
+			shard:   "SH-missing",
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeFactory(t, cls, shard, nodes, false)
+			finder := f.newFinder("A")
+			for node, count := range tt.counts {
+				f.RClient.EXPECT().CountObjects(anyVal, node, cls, tt.shard).Return(count, nil)
+			}
+			// Maybe: which replicas the retry queue reaches before the deadline
+			// is timing-dependent; the counts above carry the fan-out assertions.
+			for _, node := range tt.errNodes {
+				f.RClient.EXPECT().CountObjects(anyVal, node, cls, tt.shard).Return(0, errAny).Maybe()
+			}
+
+			ctx := context.Background()
+			if tt.timeout > 0 {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, tt.timeout)
+				defer cancel()
+			}
+
+			got, err := finder.CountObjects(ctx, tt.shard, tt.cl)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -1167,7 +1167,7 @@ func TestAsyncReplicationResolutionIsLocalOnly(t *testing.T) {
 
 // CountObjects must query only as many replicas as the consistency level asks
 // for — a node with no expectation set here fails the test if it is queried —
-// and must report a failed routing plan instead of a count of 0.
+// and must report an error instead of a count of 0 when it reaches none.
 func TestFinderCountObjects(t *testing.T) {
 	var (
 		cls   = "C1"
@@ -1176,40 +1176,36 @@ func TestFinderCountObjects(t *testing.T) {
 	)
 
 	for _, tt := range []struct {
-		name     string
-		cl       types.ConsistencyLevel
-		shard    string
-		counts   map[string]int
-		errNodes []string
-		timeout  time.Duration // caller deadline; zero for none
-		want     int
-		wantErr  bool
+		name         string
+		cl           types.ConsistencyLevel
+		collectionCL bool // call with a plan that names no single shard
+		counts       map[string]int
+		errNodes     []string
+		timeout      time.Duration // caller deadline; zero for none
+		want         int
+		wantErr      string // substring the call must fail with; empty if it must succeed
 	}{
 		{
 			name:   "ONE queries the local replica only",
 			cl:     types.ConsistencyLevelOne,
-			shard:  shard,
 			counts: map[string]int{"A": 7},
 			want:   7,
 		},
 		{
 			name:   "QUORUM queries a majority",
 			cl:     types.ConsistencyLevelQuorum,
-			shard:  shard,
 			counts: map[string]int{"A": 92, "B": 92},
 			want:   92,
 		},
 		{
 			name:   "ALL queries every replica and reconciles",
 			cl:     types.ConsistencyLevelAll,
-			shard:  shard,
 			counts: map[string]int{"A": 92, "B": 13, "C": 92},
 			want:   92,
 		},
 		{
 			name:     "ONE falls back to another replica when the first fails",
 			cl:       types.ConsistencyLevelOne,
-			shard:    shard,
 			errNodes: []string{"A"},
 			counts:   map[string]int{"B": 5},
 			want:     5,
@@ -1217,28 +1213,41 @@ func TestFinderCountObjects(t *testing.T) {
 		{
 			name:     "every replica failing surfaces an error",
 			cl:       types.ConsistencyLevelOne,
-			shard:    shard,
 			errNodes: nodes,
 			timeout:  100 * time.Millisecond,
-			wantErr:  true,
+			wantErr:  "no nodes reported object count",
 		},
 		{
-			name:    "unknown shard surfaces the routing error",
-			cl:      types.ConsistencyLevelOne,
-			shard:   "SH-missing",
-			wantErr: true,
+			name:         "a plan naming no single shard surfaces an error",
+			cl:           types.ConsistencyLevelOne,
+			collectionCL: true,
+			wantErr:      "no single shard",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			f := newFakeFactory(t, cls, shard, nodes, false)
 			finder := f.newFinder("A")
 			for node, count := range tt.counts {
-				f.RClient.EXPECT().CountObjects(anyVal, node, cls, tt.shard).Return(count, nil)
+				f.RClient.EXPECT().CountObjects(anyVal, node, cls, shard).Return(count, nil)
 			}
 			// Maybe: which replicas the retry queue reaches before the deadline
 			// is timing-dependent; the counts above carry the fan-out assertions.
 			for _, node := range tt.errNodes {
-				f.RClient.EXPECT().CountObjects(anyVal, node, cls, tt.shard).Return(0, errAny).Maybe()
+				f.RClient.EXPECT().CountObjects(anyVal, node, cls, shard).Return(0, errAny).Maybe()
+			}
+
+			collectionPlan, err := f.newRouter("A").BuildReadRoutingPlan(types.RoutingPlanBuildOptions{
+				ConsistencyLevel: tt.cl,
+			})
+			require.NoError(t, err)
+
+			// The misuse the guard exists for: handing over the collection-wide
+			// plan instead of one of the per-shard plans split out of it.
+			plan := collectionPlan
+			if !tt.collectionCL {
+				shardPlans := collectionPlan.ShardPlans(tt.cl)
+				require.Len(t, shardPlans, 1)
+				plan = shardPlans[0]
 			}
 
 			ctx := context.Background()
@@ -1248,10 +1257,10 @@ func TestFinderCountObjects(t *testing.T) {
 				defer cancel()
 			}
 
-			got, err := finder.CountObjects(ctx, tt.shard, tt.cl)
+			got, err := finder.CountObjects(ctx, plan)
 
-			if tt.wantErr {
-				require.Error(t, err)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
 				return
 			}
 			require.NoError(t, err)


### PR DESCRIPTION
### What's being changed:

`Aggregate { meta { count } }` on a collection resolved a routing plan once per shard on top of the collection-wide plan it had already built. This branch cuts that to one resolution per query and fixes five defects found on the same path.

The commits are independent and can be reviewed (or dropped) one by one:

1. `Finder.CountObjects` discarded the error from `Pull` and returned `(0, nil)`, so a shard whose read routing plan could not be built — no read replica available, tenant not resolvable — silently contributed zero to the collection count while
  the aggregation reported success. 
2. `Index.aggregateCount` accumulated the per-shard counts into an `atomic.Int32`, so any collection past 2,147,483,647 objects wrapped and reported a negative or nonsensical count. Widened to `atomic.Int64` (the per-shard counts are already `int`).
3. `Index.aggregate` already resolves a collection-wide read plan, but `aggregateCount` kept only the shard names from it and let each shard's `CountObjects` ask the router to resolve that shard all over again — N+1 resolutions for an N-shard collection, each re-reading schema the collection-wide plan had already read.
4. In the read coordinator's fan-out, each worker built its own `context.WithTimeout` and deferred its cancel, then attached that context to the backoff of any host it pushed onto the *shared* retry queue. 
5. In the same fan-out, `successful` was only incremented on the first-attempt success path. A worker that failed its own host, fell through to the shared retry queue and got a good reply there put that reply on `replyCh` without counting it, so a read that succeeded on every replica after one retry was recorded as `weaviate_replication_coordinator_reads_failed`, and one where only some workers retried as `..._reads_succeed_some`. Only the metrics were wrong — the replies themselves were always complete.
6. `singleTenantRouter.buildReadRoutingPlan` let a shard with no read replica drop out of the plan instead of failing it: such a shard leaves no trace in the resulting replica set, so the plan only errored when *every* shard was replica-less. Callers read whatever shards the plan holds, so a multi-shard collection missing replicas for one shard read short and reported success — the router-side counterpart of 1. The plan now fails with an error naming the shards.
7. Follow-up to 5: every reply path now goes through one `send` closure that owns the `successful` counter, so a reply added later cannot reach `replyCh` without being counted. With a regression test for the cancelled-read case, where every reply carries an error and the read must count as failed.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->


