### PR TITLE
fix(hfresh): decode centroid codes with the right quantizer in split/merge reassignment

### DIFF
--- a/adapters/repos/db/vector/hfresh/helper_for_test.go
+++ b/adapters/repos/db/vector/hfresh/helper_for_test.go
@@ -120,10 +120,7 @@ func initializeDimensions(t *testing.T, tf *TestHFresh, vector []float32) {
 	quantizer, err := compressionhelpers.NewBinaryRotationalQuantizer(int(tf.Index.dims), 42, tf.Index.config.DistanceProvider)
 	require.NoError(t, err)
 	tf.Index.quantizer = quantizer
-	tf.Index.distancer = &Distancer{
-		quantizer: tf.Index.quantizer,
-		distancer: tf.Index.config.DistanceProvider,
-	}
+	tf.Index.distancer = NewDistancer(tf.Index.quantizer, tf.Index.config.DistanceProvider)
 	tf.Index.initDone = true
 }
 

--- a/adapters/repos/db/vector/hfresh/helper_for_test.go
+++ b/adapters/repos/db/vector/hfresh/helper_for_test.go
@@ -120,7 +120,6 @@ func initializeDimensions(t *testing.T, tf *TestHFresh, vector []float32) {
 	quantizer, err := compressionhelpers.NewBinaryRotationalQuantizer(int(tf.Index.dims), 42, tf.Index.config.DistanceProvider)
 	require.NoError(t, err)
 	tf.Index.quantizer = quantizer
-	tf.Index.Centroids.SetQuantizer(tf.Index.quantizer)
 	tf.Index.distancer = &Distancer{
 		quantizer: tf.Index.quantizer,
 		distancer: tf.Index.config.DistanceProvider,

--- a/adapters/repos/db/vector/hfresh/hnsw.go
+++ b/adapters/repos/db/vector/hfresh/hnsw.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
@@ -32,14 +31,23 @@ type Centroid struct {
 }
 
 func (c *Centroid) Distance(distancer *Distancer, v Vector) (float32, error) {
+	// Centroids fetched via Centroids.Get carry no code (the centroid HNSW
+	// stores 8-bit RQ codes, which this 1-bit distancer cannot read), so
+	// encode lazily on first use and memoize. Centroid values are used
+	// single-threaded within one maintenance operation.
+	if c.Compressed == nil {
+		if distancer == nil || distancer.quantizer == nil {
+			return 0, errors.New("centroid distancer is not initialized")
+		}
+		c.Compressed = distancer.quantizer.CompressedBytes(distancer.quantizer.Encode(c.Uncompressed))
+	}
 	return v.DistanceWithRaw(distancer, c.Compressed)
 }
 
 type HNSWIndex struct {
-	metrics   *Metrics
-	hnsw      *hnsw.HNSW
-	counter   atomic.Int32
-	quantizer *compressionhelpers.BinaryRotationalQuantizer
+	metrics *Metrics
+	hnsw    *hnsw.HNSW
+	counter atomic.Int32
 }
 
 func NewHNSWIndex(metrics *Metrics, store *lsmkv.Store, cfg *Config, pages, pageSize uint64) (*HNSWIndex, error) {
@@ -73,25 +81,18 @@ func NewHNSWIndex(metrics *Metrics, store *lsmkv.Store, cfg *Config, pages, page
 	return &index, nil
 }
 
-func (i *HNSWIndex) SetQuantizer(quantizer *compressionhelpers.BinaryRotationalQuantizer) {
-	i.quantizer = quantizer
-}
-
 func (i *HNSWIndex) Get(id uint64) (*Centroid, error) {
 	vec, err := i.hnsw.Get(id)
 	if err != nil {
 		return nil, err
 	}
-	if i.quantizer == nil {
-		return nil, errors.New("centroid quantizer is not initialized")
-	}
 
-	// The centroid HNSW stores 8-bit RQ codes, but Centroid.Distance compares
-	// Compressed against posting vectors with the 1-bit quantizer, so the code
-	// must be in the 1-bit format.
+	// Compressed is left nil on purpose: the centroid HNSW stores 8-bit RQ
+	// codes, which Centroid.Distance cannot use. It encodes a 1-bit code
+	// lazily on first use, so hot callers that only read Uncompressed
+	// (RNGSelect on the insert path) don't pay for an encode.
 	return &Centroid{
 		Uncompressed: vec,
-		Compressed:   i.quantizer.CompressedBytes(i.quantizer.Encode(vec)),
 		Deleted:      false,
 	}, nil
 }

--- a/adapters/repos/db/vector/hfresh/hnsw.go
+++ b/adapters/repos/db/vector/hfresh/hnsw.go
@@ -45,7 +45,17 @@ func (c *Centroid) Distance(distancer *Distancer, v Vector) (float32, error) {
 		}
 		c.Compressed = distancer.quantizer.CompressedBytes(distancer.quantizer.Encode(c.Uncompressed))
 	}
-	return v.DistanceWithRaw(distancer, c.Compressed)
+	dist, err := v.DistanceWithRaw(distancer, c.Compressed)
+	if err != nil {
+		return 0, err
+	}
+	// The split/merge reassignment gates compare these distances with plain
+	// <, >= — NaN makes every comparison false and silently disables the
+	// gates instead of failing the operation, so reject it here.
+	if math.IsNaN(float64(dist)) {
+		return 0, errors.Errorf("NaN distance between vector %d and centroid (incompatible code formats?)", v.ID())
+	}
+	return dist, nil
 }
 
 type HNSWIndex struct {

--- a/adapters/repos/db/vector/hfresh/hnsw.go
+++ b/adapters/repos/db/vector/hfresh/hnsw.go
@@ -33,8 +33,12 @@ type Centroid struct {
 func (c *Centroid) Distance(distancer *Distancer, v Vector) (float32, error) {
 	// Centroids fetched via Centroids.Get carry no code (the centroid HNSW
 	// stores 8-bit RQ codes, which this 1-bit distancer cannot read), so
-	// encode lazily on first use and memoize. Centroid values are used
-	// single-threaded within one maintenance operation.
+	// encode lazily on first use and memoize. The unsynchronized write below
+	// relies on Centroid values being confined to a single goroutine within
+	// one maintenance operation (Get returns a fresh instance per call).
+	// Sharing a Centroid across goroutines — e.g. caching instances to skip
+	// the Get — would make this a data race with a torn slice-header read;
+	// add synchronization here before introducing any such sharing.
 	if c.Compressed == nil {
 		if distancer == nil || distancer.quantizer == nil {
 			return 0, errors.New("centroid distancer is not initialized")

--- a/adapters/repos/db/vector/hfresh/hnsw.go
+++ b/adapters/repos/db/vector/hfresh/hnsw.go
@@ -82,14 +82,16 @@ func (i *HNSWIndex) Get(id uint64) (*Centroid, error) {
 	if err != nil {
 		return nil, err
 	}
-	cmp, err := hnsw.GetCompressedVector[byte](i.hnsw, id)
-	if err != nil {
-		return nil, err
+	if i.quantizer == nil {
+		return nil, errors.New("centroid quantizer is not initialized")
 	}
 
+	// The centroid HNSW stores 8-bit RQ codes, but Centroid.Distance compares
+	// Compressed against posting vectors with the 1-bit quantizer, so the code
+	// must be in the 1-bit format.
 	return &Centroid{
 		Uncompressed: vec,
-		Compressed:   cmp,
+		Compressed:   i.quantizer.CompressedBytes(i.quantizer.Encode(vec)),
 		Deleted:      false,
 	}, nil
 }

--- a/adapters/repos/db/vector/hfresh/index_metadata.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata.go
@@ -223,7 +223,6 @@ func (h *HFresh) restoreDimensions(dims uint32) error {
 			return errors.Wrap(err, "could not create quantizer")
 		}
 		h.quantizer = quantizer
-		h.Centroids.SetQuantizer(h.quantizer)
 		h.distancer = NewDistancer(h.quantizer, h.config.DistanceProvider)
 		if err := h.persistQuantizationData(); err != nil {
 			return errors.Wrap(err, "could not persist RQ data")
@@ -280,7 +279,6 @@ func (h *HFresh) restoreQuantizationData(rqData *compression.RQData) error {
 	}
 
 	h.quantizer = rq
-	h.Centroids.SetQuantizer(rq)
 	h.distancer = NewDistancer(rq, h.config.DistanceProvider)
 
 	return nil

--- a/adapters/repos/db/vector/hfresh/insert.go
+++ b/adapters/repos/db/vector/hfresh/insert.go
@@ -119,7 +119,6 @@ func (h *HFresh) initDimensions(vector []float32) error {
 		return errors.Wrap(err, "could not create quantizer")
 	}
 	h.quantizer = quantizer
-	h.Centroids.SetQuantizer(h.quantizer)
 
 	if err := h.persistQuantizationData(); err != nil {
 		return errors.Wrap(err, "could not persist RQ data")

--- a/adapters/repos/db/vector/hfresh/merge_test.go
+++ b/adapters/repos/db/vector/hfresh/merge_test.go
@@ -294,3 +294,73 @@ func TestMergeTaskQueueOperations(t *testing.T) {
 
 	require.False(t, tf.Index.taskQueue.MergeContains(postingID))
 }
+
+// Merge completes: the small posting folds into the large candidate and the
+// reassignment gate re-enqueues the merged vectors that sit closer to their
+// old centroid than to the surviving one.
+func TestMergeSuccessfully(t *testing.T) {
+	tf := createHFreshIndex(t)
+
+	// small posting: 3 vectors along e1; large candidate: 6 vectors along e2
+	smallVectors := make([][]float32, 3)
+	for i := range smallVectors {
+		smallVectors[i] = []float32{1.0, 0.0, 0.0, 0.0}
+	}
+	largeVectors := make([][]float32, 6)
+	for i := range largeVectors {
+		largeVectors[i] = []float32{0.0, 1.0, 0.0, 0.0}
+	}
+
+	smallID, smallPosting := createPostingWithVectors(t, &tf, smallVectors, 800)
+	largeID, largePosting := createPostingWithVectors(t, &tf, largeVectors, 900)
+
+	for _, p := range []struct {
+		id       uint64
+		posting  Posting
+		centroid []float32
+	}{
+		{smallID, smallPosting, []float32{1.0, 0.0, 0.0, 0.0}},
+		{largeID, largePosting, []float32{0.0, 1.0, 0.0, 0.0}},
+	} {
+		compressed := tf.Index.quantizer.CompressedBytes(tf.Index.quantizer.Encode(p.centroid))
+		err := tf.Index.Centroids.Insert(p.id, &Centroid{
+			Uncompressed: p.centroid,
+			Compressed:   compressed,
+			Deleted:      false,
+		})
+		require.NoError(t, err)
+
+		err = tf.Index.PostingStore.Put(t.Context(), p.id, p.posting)
+		require.NoError(t, err)
+
+		err = tf.Index.setPostingVectorIDs(t.Context(), p.id, p.posting)
+		require.NoError(t, err)
+	}
+
+	// 3 < minPostingSize (642 at dims=4), so the small posting qualifies
+	err := tf.Index.doMerge(t.Context(), smallID)
+	require.NoError(t, err)
+
+	// the large posting holds the union
+	merged, err := tf.Index.PostingStore.Get(t.Context(), largeID)
+	require.NoError(t, err)
+	require.Equal(t, 9, len(merged))
+
+	// the small posting is emptied and its centroid removed from the index
+	small, err := tf.Index.PostingStore.Get(t.Context(), smallID)
+	require.NoError(t, err)
+	require.Empty(t, small)
+	require.False(t, tf.Index.Centroids.Exists(smallID))
+
+	// the reassignment gate: every merged vector is closer to its old
+	// centroid (e1) than to the surviving one (e2), so all of them must be
+	// enqueued for reassignment; the large posting's own vectors must not be
+	for i := range smallVectors {
+		require.True(t, tf.Index.taskQueue.reassignList.Contains(800+uint64(i)),
+			"merged vector %d should be enqueued for reassignment", 800+i)
+	}
+	for i := range largeVectors {
+		require.False(t, tf.Index.taskQueue.reassignList.Contains(900+uint64(i)),
+			"resident vector %d should not be enqueued for reassignment", 900+i)
+	}
+}

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -209,13 +209,16 @@ func (h *HFresh) enqueueReassignAfterSplit(ctx context.Context, oldPostingID uin
 
 	reassignedVectors := make(map[uint64]struct{})
 
-	newPostingCentroid0, err := h.Centroids.Get(newPostingIDs[0])
-	if err != nil {
-		return errors.Wrapf(err, "failed to get centroid for posting %d", newPostingIDs[0])
+	// Use the split results directly rather than re-fetching through
+	// Centroids.Get: they carry the true float centroid (Get returns the
+	// centroid HNSW's 8-bit reconstruction) along with its 1-bit code.
+	newPostingCentroid0 := &Centroid{
+		Uncompressed: newPostings[0].Uncompressed,
+		Compressed:   newPostings[0].Centroid,
 	}
-	newPostingCentroid1, err := h.Centroids.Get(newPostingIDs[1])
-	if err != nil {
-		return errors.Wrapf(err, "failed to get centroid for posting %d", newPostingIDs[1])
+	newPostingCentroid1 := &Centroid{
+		Uncompressed: newPostings[1].Uncompressed,
+		Compressed:   newPostings[1].Centroid,
 	}
 	newPostingCentroids := [2]*Centroid{newPostingCentroid0, newPostingCentroid1}
 

--- a/adapters/repos/db/vector/hfresh/split_test.go
+++ b/adapters/repos/db/vector/hfresh/split_test.go
@@ -251,9 +251,7 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 
 	initializeDimensions(t, &tf, centers[0])
 	quantizer := tf.Index.quantizer
-	// the test helper builds Distancer without its sync.Pool; construct it
-	// the way production does (insert.go)
-	dist := NewDistancer(quantizer, tf.Index.config.DistanceProvider)
+	dist := tf.Index.distancer
 
 	oneBitCode := func(v []float32) []byte {
 		return quantizer.CompressedBytes(quantizer.Encode(v))

--- a/adapters/repos/db/vector/hfresh/split_test.go
+++ b/adapters/repos/db/vector/hfresh/split_test.go
@@ -203,8 +203,9 @@ func TestSplitTaskQueueOperations(t *testing.T) {
 // HNSW stores 8-bit RQ codes; before the fix in HNSWIndex.Get, the raw 8-bit
 // code was handed to Distancer.DistanceBetweenCompressedVectors, which
 // decodes it as a 1-bit code — every reassignment comparison was NaN or a
-// value unrelated to actual proximity. Get must return a Compressed code in
-// the 1-bit format so those comparisons behave like the estimator.
+// value unrelated to actual proximity. Get now leaves Compressed nil and
+// Centroid.Distance lazily encodes a 1-bit code on first use, so those
+// comparisons behave like the estimator.
 //
 // Setup: well-separated unit centroids inserted exactly like doSplit inserts
 // them, and posting vectors sampled tightly around each centroid, encoded
@@ -279,11 +280,12 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 		fetched[i] = c
 	}
 
-	// Get must hand back a code with the 1-bit layout, not the centroid
-	// HNSW's internal 8-bit code (at d=256: 40 bytes, not 272).
+	// Get must not hand out the centroid HNSW's internal 8-bit code: it leaves
+	// Compressed nil and Centroid.Distance lazily encodes a 1-bit code on
+	// first use (at d=256: 40 bytes, not 272).
 	oneBitLen := len(oneBitCode(centers[0]))
-	require.Equal(t, oneBitLen, len(fetched[0].Compressed),
-		"Centroids.Get must return a code in the 1-bit quantizer's format")
+	require.Nil(t, fetched[0].Compressed,
+		"Centroids.Get must not populate Compressed eagerly")
 
 	var (
 		trueOwnMax, trueFarMin float32 = 0, 4
@@ -339,6 +341,10 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 			}
 		}
 	}
+
+	// Distance memoized a code in the 1-bit quantizer's format.
+	require.Len(t, fetched[0].Compressed, oneBitLen,
+		"Centroid.Distance must memoize a 1-bit code")
 
 	t.Logf("samples: %d", total)
 	t.Logf("true own-centroid distance max: %.4f, far-centroid min: %.4f", trueOwnMax, trueFarMin)

--- a/adapters/repos/db/vector/hfresh/split_test.go
+++ b/adapters/repos/db/vector/hfresh/split_test.go
@@ -197,26 +197,20 @@ func TestSplitTaskQueueOperations(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestCentroidDistanceQuantizerMismatch demonstrates that the production
+// TestCentroidDistanceQuantizerMismatch is a regression test for the
 // centroid-distance path used by the split/merge reassignment checks
-// (Centroid.Distance on a centroid fetched via Centroids.Get) produces
-// meaningless distances: the fetched Compressed bytes are an 8-bit RQ code
-// from the centroid HNSW, but Distancer.DistanceBetweenCompressedVectors
-// decodes them as a 1-bit RQ code.
+// (Centroid.Distance on a centroid fetched via Centroids.Get). The centroid
+// HNSW stores 8-bit RQ codes; before the fix in HNSWIndex.Get, the raw 8-bit
+// code was handed to Distancer.DistanceBetweenCompressedVectors, which
+// decodes it as a 1-bit code — every reassignment comparison was NaN or a
+// value unrelated to actual proximity. Get must return a Compressed code in
+// the 1-bit format so those comparisons behave like the estimator.
 //
 // Setup: well-separated unit centroids inserted exactly like doSplit inserts
 // them, and posting vectors sampled tightly around each centroid, encoded
-// exactly like posting entries are. For every sample we compare three
-// distances to its own centroid and to a far centroid:
-//
-//   - true:    float cosine distance (ground truth)
-//   - correct: the same 1-bit symmetric estimator, with the centroid encoded
-//     by the 1-bit quantizer (what the code intends to compute)
-//   - buggy:   the production path, Centroid.Distance on the Get() result
-//
-// The correct estimator tracks the truth; the production path returns ~1.0
-// for everything, so "is this vector closer to its own centroid?" degrades
-// to a coin flip.
+// exactly like posting entries are. For every sample, the production distance
+// to its own and to a far centroid must match the 1-bit estimator run on an
+// explicitly re-encoded centroid, and must track the true float distances.
 func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 	const (
 		dims       = 256
@@ -266,7 +260,7 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 
 	// Insert the centroids exactly the way doSplit does (split.go): the
 	// Compressed field passed here is ignored by Insert, and later reads go
-	// through Centroids.Get, which returns the centroid HNSW's 8-bit code.
+	// through Centroids.Get.
 	centroidIDs := make([]uint64, nCentroids)
 	for i, c := range centers {
 		id, err := tf.Index.IDs.Next()
@@ -285,27 +279,22 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 		fetched[i] = c
 	}
 
-	// The format mismatch itself: Get hands back a code that is not a 1-bit
-	// code. At d=256 the 1-bit code is 40 bytes, the 8-bit code 272 bytes.
+	// Get must hand back a code with the 1-bit layout, not the centroid
+	// HNSW's internal 8-bit code (at d=256: 40 bytes, not 272).
 	oneBitLen := len(oneBitCode(centers[0]))
-	fetchedLen := len(fetched[0].Compressed)
-	t.Logf("1-bit code: %d bytes, code returned by Centroids.Get: %d bytes", oneBitLen, fetchedLen)
-	require.NotEqual(t, oneBitLen, fetchedLen,
-		"Centroids.Get returned a code with the 1-bit layout; the mismatch this test pins no longer exists")
+	require.Equal(t, oneBitLen, len(fetched[0].Compressed),
+		"Centroids.Get must return a code in the 1-bit quantizer's format")
 
 	var (
-		trueOwnMax, trueFarMin       float32 = 0, 4
-		correctOK, buggyOK, total    int
-		correctOrder, buggyOrder     int
-		buggyNaN, buggySane          int
-		sumTrueOwn                   float64
-		sumCorrectOwn, sumCorrectFar float64
+		trueOwnMax, trueFarMin float32 = 0, 4
+		prodOK, prodOrder      int
+		total                  int
 	)
 
 	for ci := range centers {
 		far := (ci + nCentroids/2) % nCentroids
-		correctOwnCentroid := oneBitCode(fetched[ci].Uncompressed)
-		correctFarCentroid := oneBitCode(fetched[far].Uncompressed)
+		reencodedOwn := oneBitCode(fetched[ci].Uncompressed)
+		reencodedFar := oneBitCode(fetched[far].Uncompressed)
 
 		for s := range nSamples {
 			sample := make([]float32, dims)
@@ -320,77 +309,48 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 			trueFar, err := dist.DistanceBetweenVectors(sample, centers[far])
 			require.NoError(t, err)
 
-			correctOwn, err := dist.DistanceBetweenCompressedVectors(vec.Data(), correctOwnCentroid)
-			require.NoError(t, err)
-			correctFar, err := dist.DistanceBetweenCompressedVectors(vec.Data(), correctFarCentroid)
-			require.NoError(t, err)
-
 			// The production path: identical to the newDist/oldDist/prevDist
 			// computations in enqueueReassignAfterSplit and doMerge.
-			buggyOwn, err := fetched[ci].Distance(dist, vec)
+			prodOwn, err := fetched[ci].Distance(dist, vec)
 			require.NoError(t, err)
-			buggyFar, err := fetched[far].Distance(dist, vec)
+			prodFar, err := fetched[far].Distance(dist, vec)
 			require.NoError(t, err)
+
+			// It must agree exactly with the estimator run on an explicitly
+			// re-encoded centroid.
+			expectedOwn, err := dist.DistanceBetweenCompressedVectors(vec.Data(), reencodedOwn)
+			require.NoError(t, err)
+			require.Equal(t, expectedOwn, prodOwn)
+			expectedFar, err := dist.DistanceBetweenCompressedVectors(vec.Data(), reencodedFar)
+			require.NoError(t, err)
+			require.Equal(t, expectedFar, prodFar)
 
 			total++
 			trueOwnMax = max(trueOwnMax, trueOwn)
 			trueFarMin = min(trueFarMin, trueFar)
-			sumTrueOwn += float64(trueOwn)
-			sumCorrectOwn += float64(correctOwn)
-			sumCorrectFar += float64(correctFar)
 
-			if math.IsNaN(float64(buggyOwn)) {
-				buggyNaN++
-			}
-			// a production own-centroid distance that is small enough to be
-			// plausible for a vector sitting on its centroid (NaN compares
-			// false, so NaN counts as not-sane)
-			if buggyOwn < 0.5 {
-				buggySane++
-			}
-
-			// "does the estimator agree the vector sits near its centroid?"
-			if correctOwn < 0.5 && correctFar > 0.5 {
-				correctOK++
-			}
-			if buggyOwn < 0.5 && buggyFar > 0.5 {
-				buggyOK++
+			// "does the production path agree the vector sits near its centroid?"
+			if prodOwn < 0.5 && prodFar > 0.5 {
+				prodOK++
 			}
 			// the comparison the reassignment logic actually gates on
-			if correctOwn < correctFar {
-				correctOrder++
-			}
-			if buggyOwn < buggyFar {
-				buggyOrder++
+			if prodOwn < prodFar {
+				prodOrder++
 			}
 		}
 	}
 
 	t.Logf("samples: %d", total)
-	t.Logf("true own-centroid distance:      mean %.4f, max %.4f", sumTrueOwn/float64(total), trueOwnMax)
-	t.Logf("true far-centroid distance:      min  %.4f", trueFarMin)
-	t.Logf("correct 1-bit estimate own/far:  mean %.4f / %.4f", sumCorrectOwn/float64(total), sumCorrectFar/float64(total))
-	t.Logf("production estimate own:         NaN for %d/%d, plausibly small (<0.5) for %d/%d", buggyNaN, total, buggySane, total)
-	t.Logf("near/far separated correctly:    correct-encoding %d/%d, production %d/%d", correctOK, total, buggyOK, total)
-	t.Logf("own ranked closer than far:      correct-encoding %d/%d, production %d/%d", correctOrder, total, buggyOrder, total)
+	t.Logf("true own-centroid distance max: %.4f, far-centroid min: %.4f", trueOwnMax, trueFarMin)
+	t.Logf("near/far separated correctly: %d/%d, own ranked closer: %d/%d", prodOK, total, prodOrder, total)
 
 	// Geometry sanity: samples sit on their centroid, far centroids are far.
 	require.Less(t, trueOwnMax, float32(0.2))
 	require.Greater(t, trueFarMin, float32(0.6))
 
-	// The estimator itself is fine when both operands are real 1-bit codes.
-	require.GreaterOrEqual(t, float64(correctOrder)/float64(total), 0.95,
-		"the 1-bit estimator with properly encoded centroids should rank the own centroid closer")
-	require.GreaterOrEqual(t, float64(correctOK)/float64(total), 0.95)
-
-	// The production path is garbage: a vector sitting essentially ON its
-	// centroid (true distance < 0.2) is never reported at a plausibly small
-	// distance — the result is NaN (sqrt of a misinterpreted header float) or
-	// a large value unrelated to actual proximity.
-	require.Equal(t, 0, buggySane,
-		"production distance to the own centroid should never look plausibly small if the mismatch is present")
-	require.LessOrEqual(t, float64(buggyOK)/float64(total), 0.5,
-		"production path should be unable to separate near from far centroids")
-	require.LessOrEqual(t, float64(buggyOrder)/float64(total), 0.8,
-		"production own-vs-far ordering should be near a coin flip, not reliable")
+	// The production distances must track the true geometry: a vector sitting
+	// essentially ON its centroid is reported near, a far centroid far, and
+	// the own centroid ranks closer. Before the fix these were 0/200, 50/200.
+	require.GreaterOrEqual(t, float64(prodOK)/float64(total), 0.95)
+	require.GreaterOrEqual(t, float64(prodOrder)/float64(total), 0.95)
 }

--- a/adapters/repos/db/vector/hfresh/split_test.go
+++ b/adapters/repos/db/vector/hfresh/split_test.go
@@ -12,6 +12,8 @@
 package hfresh
 
 import (
+	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -193,4 +195,202 @@ func TestSplitTaskQueueOperations(t *testing.T) {
 
 	err = tf.Index.taskQueue.EnqueueSplit(postingID)
 	require.NoError(t, err)
+}
+
+// TestCentroidDistanceQuantizerMismatch demonstrates that the production
+// centroid-distance path used by the split/merge reassignment checks
+// (Centroid.Distance on a centroid fetched via Centroids.Get) produces
+// meaningless distances: the fetched Compressed bytes are an 8-bit RQ code
+// from the centroid HNSW, but Distancer.DistanceBetweenCompressedVectors
+// decodes them as a 1-bit RQ code.
+//
+// Setup: well-separated unit centroids inserted exactly like doSplit inserts
+// them, and posting vectors sampled tightly around each centroid, encoded
+// exactly like posting entries are. For every sample we compare three
+// distances to its own centroid and to a far centroid:
+//
+//   - true:    float cosine distance (ground truth)
+//   - correct: the same 1-bit symmetric estimator, with the centroid encoded
+//     by the 1-bit quantizer (what the code intends to compute)
+//   - buggy:   the production path, Centroid.Distance on the Get() result
+//
+// The correct estimator tracks the truth; the production path returns ~1.0
+// for everything, so "is this vector closer to its own centroid?" degrades
+// to a coin flip.
+func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
+	const (
+		dims       = 256
+		nCentroids = 8
+		nSamples   = 25
+		noiseSigma = 0.01
+	)
+
+	tf := createHFreshIndex(t)
+	rng := rand.New(rand.NewSource(1))
+
+	normalize := func(v []float32) []float32 {
+		var sum float64
+		for _, x := range v {
+			sum += float64(x) * float64(x)
+		}
+		norm := float32(math.Sqrt(sum))
+		out := make([]float32, len(v))
+		for i, x := range v {
+			out[i] = x / norm
+		}
+		return out
+	}
+
+	randomUnitVector := func() []float32 {
+		v := make([]float32, dims)
+		for i := range v {
+			v[i] = float32(rng.NormFloat64())
+		}
+		return normalize(v)
+	}
+
+	centers := make([][]float32, nCentroids)
+	for i := range centers {
+		centers[i] = randomUnitVector()
+	}
+
+	initializeDimensions(t, &tf, centers[0])
+	quantizer := tf.Index.quantizer
+	// the test helper builds Distancer without its sync.Pool; construct it
+	// the way production does (insert.go)
+	dist := NewDistancer(quantizer, tf.Index.config.DistanceProvider)
+
+	oneBitCode := func(v []float32) []byte {
+		return quantizer.CompressedBytes(quantizer.Encode(v))
+	}
+
+	// Insert the centroids exactly the way doSplit does (split.go): the
+	// Compressed field passed here is ignored by Insert, and later reads go
+	// through Centroids.Get, which returns the centroid HNSW's 8-bit code.
+	centroidIDs := make([]uint64, nCentroids)
+	for i, c := range centers {
+		id, err := tf.Index.IDs.Next()
+		require.NoError(t, err)
+		centroidIDs[i] = id
+		require.NoError(t, tf.Index.Centroids.Insert(id, &Centroid{
+			Uncompressed: c,
+			Compressed:   oneBitCode(c),
+		}))
+	}
+
+	fetched := make([]*Centroid, nCentroids)
+	for i, id := range centroidIDs {
+		c, err := tf.Index.Centroids.Get(id)
+		require.NoError(t, err)
+		fetched[i] = c
+	}
+
+	// The format mismatch itself: Get hands back a code that is not a 1-bit
+	// code. At d=256 the 1-bit code is 40 bytes, the 8-bit code 272 bytes.
+	oneBitLen := len(oneBitCode(centers[0]))
+	fetchedLen := len(fetched[0].Compressed)
+	t.Logf("1-bit code: %d bytes, code returned by Centroids.Get: %d bytes", oneBitLen, fetchedLen)
+	require.NotEqual(t, oneBitLen, fetchedLen,
+		"Centroids.Get returned a code with the 1-bit layout; the mismatch this test pins no longer exists")
+
+	var (
+		trueOwnMax, trueFarMin       float32 = 0, 4
+		correctOK, buggyOK, total    int
+		correctOrder, buggyOrder     int
+		buggyNaN, buggySane          int
+		sumTrueOwn                   float64
+		sumCorrectOwn, sumCorrectFar float64
+	)
+
+	for ci := range centers {
+		far := (ci + nCentroids/2) % nCentroids
+		correctOwnCentroid := oneBitCode(fetched[ci].Uncompressed)
+		correctFarCentroid := oneBitCode(fetched[far].Uncompressed)
+
+		for s := range nSamples {
+			sample := make([]float32, dims)
+			for i := range sample {
+				sample[i] = centers[ci][i] + float32(rng.NormFloat64())*noiseSigma
+			}
+			sample = normalize(sample)
+			vec := NewVector(uint64(ci*nSamples+s), VectorVersion(1), oneBitCode(sample))
+
+			trueOwn, err := dist.DistanceBetweenVectors(sample, centers[ci])
+			require.NoError(t, err)
+			trueFar, err := dist.DistanceBetweenVectors(sample, centers[far])
+			require.NoError(t, err)
+
+			correctOwn, err := dist.DistanceBetweenCompressedVectors(vec.Data(), correctOwnCentroid)
+			require.NoError(t, err)
+			correctFar, err := dist.DistanceBetweenCompressedVectors(vec.Data(), correctFarCentroid)
+			require.NoError(t, err)
+
+			// The production path: identical to the newDist/oldDist/prevDist
+			// computations in enqueueReassignAfterSplit and doMerge.
+			buggyOwn, err := fetched[ci].Distance(dist, vec)
+			require.NoError(t, err)
+			buggyFar, err := fetched[far].Distance(dist, vec)
+			require.NoError(t, err)
+
+			total++
+			trueOwnMax = max(trueOwnMax, trueOwn)
+			trueFarMin = min(trueFarMin, trueFar)
+			sumTrueOwn += float64(trueOwn)
+			sumCorrectOwn += float64(correctOwn)
+			sumCorrectFar += float64(correctFar)
+
+			if math.IsNaN(float64(buggyOwn)) {
+				buggyNaN++
+			}
+			// a production own-centroid distance that is small enough to be
+			// plausible for a vector sitting on its centroid (NaN compares
+			// false, so NaN counts as not-sane)
+			if buggyOwn < 0.5 {
+				buggySane++
+			}
+
+			// "does the estimator agree the vector sits near its centroid?"
+			if correctOwn < 0.5 && correctFar > 0.5 {
+				correctOK++
+			}
+			if buggyOwn < 0.5 && buggyFar > 0.5 {
+				buggyOK++
+			}
+			// the comparison the reassignment logic actually gates on
+			if correctOwn < correctFar {
+				correctOrder++
+			}
+			if buggyOwn < buggyFar {
+				buggyOrder++
+			}
+		}
+	}
+
+	t.Logf("samples: %d", total)
+	t.Logf("true own-centroid distance:      mean %.4f, max %.4f", sumTrueOwn/float64(total), trueOwnMax)
+	t.Logf("true far-centroid distance:      min  %.4f", trueFarMin)
+	t.Logf("correct 1-bit estimate own/far:  mean %.4f / %.4f", sumCorrectOwn/float64(total), sumCorrectFar/float64(total))
+	t.Logf("production estimate own:         NaN for %d/%d, plausibly small (<0.5) for %d/%d", buggyNaN, total, buggySane, total)
+	t.Logf("near/far separated correctly:    correct-encoding %d/%d, production %d/%d", correctOK, total, buggyOK, total)
+	t.Logf("own ranked closer than far:      correct-encoding %d/%d, production %d/%d", correctOrder, total, buggyOrder, total)
+
+	// Geometry sanity: samples sit on their centroid, far centroids are far.
+	require.Less(t, trueOwnMax, float32(0.2))
+	require.Greater(t, trueFarMin, float32(0.6))
+
+	// The estimator itself is fine when both operands are real 1-bit codes.
+	require.GreaterOrEqual(t, float64(correctOrder)/float64(total), 0.95,
+		"the 1-bit estimator with properly encoded centroids should rank the own centroid closer")
+	require.GreaterOrEqual(t, float64(correctOK)/float64(total), 0.95)
+
+	// The production path is garbage: a vector sitting essentially ON its
+	// centroid (true distance < 0.2) is never reported at a plausibly small
+	// distance — the result is NaN (sqrt of a misinterpreted header float) or
+	// a large value unrelated to actual proximity.
+	require.Equal(t, 0, buggySane,
+		"production distance to the own centroid should never look plausibly small if the mismatch is present")
+	require.LessOrEqual(t, float64(buggyOK)/float64(total), 0.5,
+		"production path should be unable to separate near from far centroids")
+	require.LessOrEqual(t, float64(buggyOrder)/float64(total), 0.8,
+		"production own-vs-far ordering should be near a coin flip, not reliable")
 }


### PR DESCRIPTION
## What

Fixes weaviate/0-weaviate-issues#641: every centroid distance used by the split/merge reassignment checks was computed by decoding the centroid HNSW's **8-bit** RQ code with the **1-bit** quantizer. The layouts are incompatible, so the resulting distances were either NaN (misread header float goes through `math.Sqrt`) or a value unrelated to actual proximity. All nearest-partition maintenance gates (`enqueueReassignAfterSplit`, `doMerge`) ran on those values: reassignment was effectively a coin flip in some regimes and silently disabled (NaN comparisons are always false) in others.

## How

- `Centroids.Get` no longer hands out the internal 8-bit code; it leaves `Compressed` nil.
- `Centroid.Distance` lazily encodes the centroid with the 1-bit quantizer on first use and memoizes it. Lazy on purpose: `RNGSelect` on the insert hot path calls `Get` up to dozens of times per insert but only reads `Uncompressed`, so it pays nothing; the split/merge paths pay one encode per fetched centroid, amortized over all per-vector comparisons. The memoization is an unsynchronized write and relies on Centroid values being goroutine-confined (fresh instance per `Get`, used within one maintenance operation) — the invariant and the consequence of breaking it are documented at the write site.
- `Centroid.Distance` rejects NaN results with an error, so a future code-format mismatch fails the maintenance operation loudly instead of silently disabling the gates (NaN comparisons are always false).
- `enqueueReassignAfterSplit` uses the split-result centroids directly (true float centroid + its 1-bit code) instead of re-fetching the 8-bit reconstruction through `Get`.
- Removed the now-dead `HNSWIndex.quantizer` field and `SetQuantizer` wiring — the dangling field that originally hinted `Get` was meant to re-encode.

## Verification

- Regression test (`TestCentroidDistanceQuantizerMismatch` in `split_test.go`): 8 well-separated centroids inserted the way `doSplit` does, 200 posting vectors sampled around them. Production distances must match the estimator run on an explicitly re-encoded centroid exactly, and must track true geometry. Before the fix: 0/200 near/far separation, 50/200 own-centroid ordering, NaN for 50/200. After: 200/200, 200/200.
- `TestMergeSuccessfully` covers a completed merge end to end, including the reassignment gate: merged vectors closer to their old centroid are enqueued for reassignment, resident vectors are not.
- Full `hfresh` suite passes under `-race`; `golangci-lint` clean. Note: `-race` does not exercise the `Centroid.Distance` memoization — no test shares a `Centroid` across goroutines — so it is not evidence for that property; the memoization's safety rests on the confinement invariant documented in the code.
- ann-benchmark, single shard, insert-only: dbpedia-openai-1000k (1536d) and snowflake-msmarco 8.7M (768d). Recall unchanged within noise, QPS equal-or-better (up to +5-10% on dbpedia, +3-6% at high probe on snowflake) — consistent with eliminating the spurious reassignment churn (each junk reassign bumped the vector version and appended up to 4 new copies, leaving stale entries behind in postings).

**Hypothesis, not a finding of these benchmarks:** recall impact is expected to grow with corpus size and update/delete churn, where reassignment decisions compound. The insert-only benchmarks above could not have shown a recall difference of that kind; the expectation comes from the field report that motivated the investigation and has not been measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
