### PR TITLE
Backport: drain in-flight references before drop tears the shard store down

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -66,6 +66,8 @@ const IdLockPoolSize uint64 = 1024
 var (
 	errAlreadyShutdown    = errors.New("already shut or dropped")
 	errShutdownInProgress = errors.New("shard shutdown in progress")
+	errDropInProgress     = errors.New("shard drop in progress")
+	errShardStillInUse    = errors.New("shard still in use")
 )
 
 type ShardLike interface {
@@ -511,6 +513,8 @@ type Shard struct {
 
 	// shutdownRequested marks shard as requested for shutdown
 	shutdownRequested atomic.Bool
+	// dropRequested marks shard as requested for drop.
+	dropRequested atomic.Bool
 
 	HFreshEnabled bool
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -524,6 +524,9 @@ type Shard struct {
 	// (e.g., NewLoadedShard or FinishLoadingShard was called). This prevents double-counting
 	// or incorrect metric updates during partial initialization cleanup.
 	metricsRegistered atomic.Bool
+
+	// tornStoreReported keeps reportTornStoreAccess to one line per shard
+	tornStoreReported atomic.Bool
 }
 
 func (s *Shard) ID() string {
@@ -643,6 +646,31 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 	enterrors.GoWrapper(f, s.index.logger)
 
 	return err
+}
+
+// objectsBucket returns the shard's objects bucket, or an error once the store
+// is torn down
+func (s *Shard) objectsBucket() (*lsmkv.Bucket, error) {
+	b := s.store.Bucket(helpers.ObjectsBucketLSM)
+	if b == nil {
+		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, errAlreadyShutdown)
+		s.reportTornStoreAccess(err)
+		return nil, err
+	}
+	return b, nil
+}
+
+// reportTornStoreAccess makes an outrun drain visible
+func (s *Shard) reportTornStoreAccess(err error) {
+	if !s.tornStoreReported.CompareAndSwap(false, true) {
+		return
+	}
+	s.index.logger.WithFields(logrus.Fields{
+		"action": "objects_bucket_missing",
+		"class":  s.index.Config.ClassName.String(),
+		"shard":  s.name,
+	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun "+
+		"(further occurrences on this shard are suppressed): %v", err)
 }
 
 // ObjectCount returns the exact count at any moment

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -653,7 +653,7 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 func (s *Shard) objectsBucket() (*lsmkv.Bucket, error) {
 	b := s.store.Bucket(helpers.ObjectsBucketLSM)
 	if b == nil {
-		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, errAlreadyShutdown)
+		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, lsmkv.ErrBucketNotFound)
 		s.reportTornStoreAccess(err)
 		return nil, err
 	}
@@ -669,8 +669,7 @@ func (s *Shard) reportTornStoreAccess(err error) {
 		"action": "objects_bucket_missing",
 		"class":  s.index.Config.ClassName.String(),
 		"shard":  s.name,
-	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun "+
-		"(further occurrences on this shard are suppressed): %v", err)
+	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun, %v", err)
 }
 
 // ObjectCount returns the exact count at any moment

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
@@ -34,6 +35,15 @@ import (
 // If keepFiles==true, all files on disk are kept, only in-memory structures are removed. This is used to allow backups
 // to complete before the files are deleted.
 func (s *Shard) drop(keepFiles bool) (err error) {
+	// Drain before anything is torn down.
+	if drainErr := s.drainRefsForDrop(); drainErr != nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action": "drop_shard",
+			"class":  s.class.Class,
+			"shard":  s.name,
+		}).Errorf("proceeding with drop while references are still held; in-flight requests on this shard will fail: %v", drainErr)
+	}
+
 	s.shutCtxCancel(fmt.Errorf("drop %q", s.ID()))
 	s.reindexer.Stop(s, fmt.Errorf("shard drop"))
 

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -15,8 +15,6 @@ package db
 
 import (
 	"context"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -29,10 +27,11 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-// loadTestShard returns the single-shard test index's shard, loaded, as both
-// the map key and the concrete instance the teardown paths operate on.
+// loadTestShard returns the single-shard test index's shard, loaded, by name
+// and as the concrete instance the teardown paths operate on.
 func loadTestShard(t *testing.T, index *Index) (string, *Shard) {
 	t.Helper()
 
@@ -47,8 +46,8 @@ func loadTestShard(t *testing.T, index *Index) (string, *Shard) {
 	return name, entry.(*LazyLoadShard).shard
 }
 
-// dropTestShard pins the shard — the same pin Index.withShardForWrite holds
-// around a write — and starts a drop() racing it in the background.
+// dropTestShard pins the shard as Index.withShardForWrite does, then races a
+// drop() against it. Returns once that drop is inside its drain.
 func dropTestShard(t *testing.T, index *Index) (shard *Shard, release func(), dropped <-chan error) {
 	t.Helper()
 
@@ -62,6 +61,11 @@ func dropTestShard(t *testing.T, index *Index) (shard *Shard, release func(), dr
 
 	ch := make(chan error, 1)
 	go func() { ch <- shard.drop(false) }()
+
+	// the flag is drainRefsForDrop's first action
+	require.Eventually(t, shard.dropRequested.Load, 10*time.Second, time.Millisecond,
+		"drop never entered its drain")
+
 	return shard, release, ch
 }
 
@@ -85,8 +89,7 @@ func dropTestObject(vec []float32) (*storobj.Object, []byte) {
 
 // TestShardDropWaitsForInFlightReferences pins the race that crashed nodes:
 // drop tore the store down while a pinned write was mid-flight, so
-// Store.Bucket(objects) went nil under it (nil *Bucket -> Get ->
-// GetConsistentView -> SIGSEGV).
+// Store.Bucket(objects) went nil under it.
 func TestShardDropWaitsForInFlightReferences(t *testing.T) {
 	index, cleanup := initIndexAndPopulate(t, t.TempDir())
 	defer cleanup()
@@ -107,10 +110,9 @@ func TestShardDropWaitsForInFlightReferences(t *testing.T) {
 	requireDropped(t, dropped)
 }
 
-// TestShardDropDrainsRealBatchWrite is the end-to-end form. The write paths
-// dereference Store.Bucket unguarded, so the drain is the only thing between
-// this batch and a SIGSEGV — every object must succeed, not merely fail
-// cleanly.
+// TestShardDropDrainsRealBatchWrite is the end-to-end form: every object must
+// succeed, not merely fail cleanly. Asserting success is what keeps the drain
+// responsible for this case rather than objectsBucket's backstop.
 func TestShardDropDrainsRealBatchWrite(t *testing.T) {
 	index, cleanup := initIndexAndPopulate(t, t.TempDir())
 	defer cleanup()
@@ -135,9 +137,7 @@ func TestShardDropDrainsRealBatchWrite(t *testing.T) {
 
 // TestShardDropProceedsWhenDrainTimesOut pins the escape hatch: the drain is
 // bounded on purpose, so a reference held past the window must not wedge the
-// delete — and must be logged, since that line is the only warning preceding
-// the crash TestUnguardedWriteAfterTeardownCrashesProcess documents. Runs for
-// the full drain window (~30s).
+// delete, and must be logged. Runs for the full drain window (~30s).
 func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	index, cleanup := initIndexAndPopulate(t, t.TempDir())
 	defer cleanup()
@@ -150,7 +150,7 @@ func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	defer release()
 
 	requireDropped(t, dropped)
-	// the drain window is ~30s; anything near-instant means it never waited
+	// ~30s window; near-instant means it never waited
 	require.Greater(t, time.Since(start), 10*time.Second, "drop gave up well short of the drain window")
 
 	var warned bool
@@ -161,32 +161,57 @@ func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	require.True(t, warned, "a drop that outran its drain must be logged, not silent")
 }
 
-// TestUnguardedWriteAfterTeardownCrashesProcess pins the known-bad path left
-// open on purpose: the write paths dereference Store.Bucket unguarded, so a
-// write outliving a teardown drain kills the node instead of failing the
-// request. The drain keeps it unreachable in practice; this makes the trade
-// visible in code. Subprocess, because the failure is a process-level SIGSEGV.
-//
-// Reintroducing a nil guard on the write path fails this test — delete it in
-// that same change.
-func TestUnguardedWriteAfterTeardownCrashesProcess(t *testing.T) {
-	if os.Getenv("WEAVIATE_TEST_TORN_STORE_CHILD") == "1" {
-		index, cleanup := initIndexAndPopulate(t, t.TempDir())
-		defer cleanup()
+// TestObjectWritesAfterStoreTeardownReturnErrors covers the backstop: a write
+// outliving the drain must fail on the deregistered bucket rather than
+// dereference nil, and must be reported once.
+func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
 
-		_, shard := loadTestShard(t, index)
-		require.NoError(t, shard.store.Shutdown(context.Background()))
+	logger, hook := test.NewNullLogger()
+	index.logger = logger
 
-		obj, idBytes := dropTestObject(nil)
-		_, _ = shard.putObjectLSM(context.Background(), obj, idBytes)
-		t.Fatal("write against a torn-down store returned instead of crashing")
+	_, shard := loadTestShard(t, index)
+	// the state a teardown that outran its drain leaves behind
+	require.NoError(t, shard.store.Shutdown(context.Background()))
+
+	obj, idBytes := dropTestObject(nil)
+	id := obj.ID()
+	merge := objects.MergeDocument{Class: "Test", ID: id}
+
+	mutations := map[string]func() error{
+		"put": func() error {
+			_, err := shard.putObjectLSM(context.Background(), obj, idBytes)
+			return err
+		},
+		"delete": func() error {
+			_, err := shard.deleteObject(context.Background(), id, time.Now(), false)
+			return err
+		},
+		"batch delete": func() error {
+			return shard.batchDeleteObject(context.Background(), id, time.Now())
+		},
+		"merge": func() error {
+			_, _, err := shard.mergeObjectInStorage(context.Background(), merge, idBytes, index.getClass())
+			return err
+		},
+		"mutable merge": func() error {
+			_, err := shard.mutableMergeObjectLSM(context.Background(), merge, idBytes)
+			return err
+		},
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestUnguardedWriteAfterTeardownCrashesProcess")
-	cmd.Env = append(os.Environ(), "WEAVIATE_TEST_TORN_STORE_CHILD=1")
-	out, err := cmd.CombinedOutput()
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, mutate(), errAlreadyShutdown)
+		})
+	}
 
-	require.Errorf(t, err, "child survived a write against a torn-down store:\n%s", out)
-	require.Contains(t, string(out), "nil pointer dereference")
-	require.Contains(t, string(out), "GetConsistentView")
+	var reports int
+	for _, e := range hook.AllEntries() {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "mutation reached a torn-down store") {
+			reports++
+		}
+	}
+	require.Equal(t, 1, reports, "an outrun drain must be reported exactly once per shard")
 }

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -203,7 +204,7 @@ func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
 
 	for name, mutate := range mutations {
 		t.Run(name, func(t *testing.T) {
-			require.ErrorIs(t, mutate(), errAlreadyShutdown)
+			require.ErrorIs(t, mutate(), lsmkv.ErrBucketNotFound)
 		})
 	}
 

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -1,0 +1,192 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// loadTestShard returns the single-shard test index's shard, loaded, as both
+// the map key and the concrete instance the teardown paths operate on.
+func loadTestShard(t *testing.T, index *Index) (string, *Shard) {
+	t.Helper()
+
+	var name string
+	index.shards.Range(func(n string, _ ShardLike) error {
+		name = n
+		return nil
+	})
+	entry := index.shards.Load(name)
+	require.NotNil(t, entry)
+	require.NoError(t, entry.(*LazyLoadShard).Load(context.Background()))
+	return name, entry.(*LazyLoadShard).shard
+}
+
+// dropTestShard pins the shard — the same pin Index.withShardForWrite holds
+// around a write — and starts a drop() racing it in the background.
+func dropTestShard(t *testing.T, index *Index) (shard *Shard, release func(), dropped <-chan error) {
+	t.Helper()
+
+	name, shard := loadTestShard(t, index)
+
+	_, release, err := index.GetShard(context.Background(), name)
+	require.NoError(t, err)
+
+	// keeps cleanup() from retrying Shutdown on the dropped shard
+	t.Cleanup(func() { index.shards.LoadAndDelete(name) })
+
+	ch := make(chan error, 1)
+	go func() { ch <- shard.drop(false) }()
+	return shard, release, ch
+}
+
+func requireDropped(t *testing.T, dropped <-chan error) {
+	t.Helper()
+	select {
+	case err := <-dropped:
+		require.NoError(t, err)
+	case <-time.After(time.Minute):
+		t.Fatal("drop never completed")
+	}
+}
+
+func dropTestObject(vec []float32) (*storobj.Object, []byte) {
+	id := strfmt.UUID(uuid.New().String())
+	idBytes, _ := uuid.MustParse(id.String()).MarshalBinary()
+	return storobj.FromObject(&models.Object{
+		Class: "Test", ID: id, Properties: map[string]interface{}{},
+	}, vec, nil, nil), idBytes
+}
+
+// TestShardDropWaitsForInFlightReferences pins the race that crashed nodes:
+// drop tore the store down while a pinned write was mid-flight, so
+// Store.Bucket(objects) went nil under it (nil *Bucket -> Get ->
+// GetConsistentView -> SIGSEGV).
+func TestShardDropWaitsForInFlightReferences(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	shard, release, dropped := dropTestShard(t, index)
+
+	select {
+	case err := <-dropped:
+		t.Fatalf("drop completed while a write still held a reference: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// no new writer may sneak in behind the drain either
+	_, err := shard.preventShutdown()
+	require.ErrorIs(t, err, errDropInProgress)
+
+	release()
+	requireDropped(t, dropped)
+}
+
+// TestShardDropDrainsRealBatchWrite is the end-to-end form. The write paths
+// dereference Store.Bucket unguarded, so the drain is the only thing between
+// this batch and a SIGSEGV — every object must succeed, not merely fail
+// cleanly.
+func TestShardDropDrainsRealBatchWrite(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	batch := make([]*storobj.Object, 50)
+	for i := range batch {
+		batch[i], _ = dropTestObject([]float32{float32(i), 1, 2, 3})
+	}
+
+	shard, release, dropped := dropTestShard(t, index)
+
+	errs := func() []error {
+		defer release()
+		return shard.PutObjectBatch(context.Background(), batch)
+	}()
+	for i, err := range errs {
+		require.NoErrorf(t, err, "object %d of a batch in flight during drop", i)
+	}
+
+	requireDropped(t, dropped)
+}
+
+// TestShardDropProceedsWhenDrainTimesOut pins the escape hatch: the drain is
+// bounded on purpose, so a reference held past the window must not wedge the
+// delete — and must be logged, since that line is the only warning preceding
+// the crash TestUnguardedWriteAfterTeardownCrashesProcess documents. Runs for
+// the full drain window (~30s).
+func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	logger, hook := test.NewNullLogger()
+	index.logger = logger
+
+	start := time.Now()
+	_, release, dropped := dropTestShard(t, index) // pin is never released
+	defer release()
+
+	requireDropped(t, dropped)
+	// the drain window is ~30s; anything near-instant means it never waited
+	require.Greater(t, time.Since(start), 10*time.Second, "drop gave up well short of the drain window")
+
+	var warned bool
+	for _, e := range hook.AllEntries() {
+		warned = warned || (e.Level == logrus.ErrorLevel &&
+			strings.Contains(e.Message, "proceeding with drop while references are still held"))
+	}
+	require.True(t, warned, "a drop that outran its drain must be logged, not silent")
+}
+
+// TestUnguardedWriteAfterTeardownCrashesProcess pins the known-bad path left
+// open on purpose: the write paths dereference Store.Bucket unguarded, so a
+// write outliving a teardown drain kills the node instead of failing the
+// request. The drain keeps it unreachable in practice; this makes the trade
+// visible in code. Subprocess, because the failure is a process-level SIGSEGV.
+//
+// Reintroducing a nil guard on the write path fails this test — delete it in
+// that same change.
+func TestUnguardedWriteAfterTeardownCrashesProcess(t *testing.T) {
+	if os.Getenv("WEAVIATE_TEST_TORN_STORE_CHILD") == "1" {
+		index, cleanup := initIndexAndPopulate(t, t.TempDir())
+		defer cleanup()
+
+		_, shard := loadTestShard(t, index)
+		require.NoError(t, shard.store.Shutdown(context.Background()))
+
+		obj, idBytes := dropTestObject(nil)
+		_, _ = shard.putObjectLSM(context.Background(), obj, idBytes)
+		t.Fatal("write against a torn-down store returned instead of crashing")
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestUnguardedWriteAfterTeardownCrashesProcess")
+	cmd.Env = append(os.Environ(), "WEAVIATE_TEST_TORN_STORE_CHILD=1")
+	out, err := cmd.CombinedOutput()
+
+	require.Errorf(t, err, "child survived a write against a torn-down store:\n%s", out)
+	require.Contains(t, string(out), "nil pointer dereference")
+	require.Contains(t, string(out), "GetConsistentView")
+}

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -193,7 +193,7 @@ func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
 			return shard.batchDeleteObject(context.Background(), id, time.Now())
 		},
 		"merge": func() error {
-			_, _, err := shard.mergeObjectInStorage(context.Background(), merge, idBytes, index.getClass())
+			_, _, err := shard.mergeObjectInStorage(context.Background(), merge, idBytes)
 			return err
 		},
 		"mutable merge": func() error {

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -954,7 +954,10 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return err
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return err
+	}
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -199,6 +199,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 
 // drainRefsForDrop blocks new pins and waits for the in-flight ones to finish,
 // so a drop does not tear the store down underneath a running request.
+// Note: this will keep drainRefsForDrop running for 30 seconds.
 func (s *Shard) drainRefsForDrop() error {
 	s.dropRequested.Store(true)
 

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -197,6 +197,22 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	return ec.ToError()
 }
 
+// drainRefsForDrop blocks new pins and waits for the in-flight ones to finish,
+// so a drop does not tear the store down underneath a running request.
+func (s *Shard) drainRefsForDrop() error {
+	s.dropRequested.Store(true)
+
+	return backoff.Retry(func() error {
+		s.shutdownLock.Lock()
+		defer s.shutdownLock.Unlock()
+
+		if inUse := s.inUseCounter.Load(); inUse > 0 {
+			return fmt.Errorf("shard %q holds %d reference(s): %w", s.name, inUse, errShardStillInUse)
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(300*time.Millisecond), 100)) // 30 seconds
+}
+
 const msgReleasedMoreThanOnce = "shard reference released more than once per acquire"
 
 // shutOrDropped reports shard teardown: drop() cancels shutCtx as its first
@@ -212,6 +228,10 @@ func (s *Shard) preventShutdown() (release func(), err error) {
 	}
 	s.shutdownLock.RLock()
 	defer s.shutdownLock.RUnlock()
+
+	if s.dropRequested.Load() {
+		return func() {}, errDropInProgress
+	}
 
 	if s.shut.Load() {
 		return func() {}, errAlreadyShutdown

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -52,7 +52,10 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return false, err
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return false, err
+	}
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
@@ -158,7 +161,11 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 }
 
 func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) error {
-	className, err := s.store.Bucket(helpers.ObjectsBucketLSM).ClassName()
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return err
+	}
+	className, err := bucket.ClassName()
 	if err != nil {
 		return fmt.Errorf("getting bucket class name: %w", err)
 	}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -118,7 +117,10 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte,
 ) (*storobj.Object, objectInsertStatus, error) {
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, objectInsertStatus{}, err
+	}
 
 	var prevObj, obj *storobj.Object
 	var status objectInsertStatus
@@ -217,8 +219,12 @@ func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDoc
 func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte,
 ) (mutableMergeResult, error) {
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	out := mutableMergeResult{}
+
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return out, err
+	}
 
 	// Wait outside the RLock; see shard_write_put.go (calling it under RLock is a recursive read-lock deadlock).
 	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -258,7 +258,10 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 		}
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return status, err
+	}
 	var prevObj *storobj.Object
 
 	// First the object bucket is checked if an object with the same uuid is alreadypresent,


### PR DESCRIPTION
Backport of #12555 to `stable/v1.38`. `stable/v1.39` picks this up through the regular merge-stable-v1.38-into-stable-v1.39 sync; if a 1.39.x release is cut before that sync, it needs a direct cherry-pick instead.

Fixes [weaviate/0-weaviate-issues#643](https://github.com/weaviate/0-weaviate-issues/issues/643) for the 1.38 line.

## Motivation

The nil objects-bucket panic that #12555 fixed on `main` (merged 2026-08-11) reoccurred on v1.38.12 (released 2026-08-25) because the fix was never backported. `Shard.drop()` ignores the shard's in-use refcount, so a tenant/class delete can tear the lsmkv store down under an in-flight batch write; `Store.Bucket(objects)` then returns nil and the write path dereferences it (`putObjectLSM → fetchObject → GetConsistentView` on a nil `*Bucket`). On v1.38 the panic is recovered by the batch errgroup, so the node does not restart — the batch fails and the only evidence is a log line that rotates away. Observed on a WCS load-simulator cluster running 1.38.12 under batch-write load with tenant create/delete churn ([0-weaviate-issues#643](https://github.com/weaviate/0-weaviate-issues/issues/643); original report [0-weaviate-issues#354](https://github.com/weaviate/0-weaviate-issues/issues/354)).

## What's backported

All three commits of #12555, cherry-picked:

- `drop()` drains in-flight shard references before teardown: `dropRequested` blocks new pins, then the drain waits up to ~30s (300ms × 100 retries) for the in-use count to reach zero. On timeout, drop proceeds and logs an error instead of blocking the delete forever.
- A backstop for writes that outlive the drain: the object put/merge/delete paths get the bucket via `objectsBucket()`, which returns an `lsmkv.ErrBucketNotFound` error on a torn-down store instead of a nil pointer; the first occurrence per shard is logged.
- Integration tests: drop waits for a pinned reference; a real batch write racing drop completes fully; drop proceeds after the drain times out; each write path (put, merge, mutable merge, delete, batch delete) fails with the error instead of panicking after teardown.

## Divergence from main

One adaptation commit ([d8d775f](https://github.com/weaviate/weaviate/commit/d8d775f66131e542f2cc2affbd7950c7bf45649a)): `mergeObjectInStorage` takes no `*models.Class` parameter on stable/v1.38, so the test call site drops that argument. The cherry-picks themselves needed only context adjustments (stable/v1.38 lacks main's `errTeardownFailed` var next to the new error definitions).

## Risks

Drop of a busy shard can take up to 30s longer in the worst case (the drain window); the timeout keeps a stuck reference from blocking the delete forever. Same behavior `main` has had since 2026-08-11.

## Testing

All backported tests pass on this branch with `-race`:

```
go test -tags integrationTest -count 1 -race -run 'TestShardDrop|TestObjectWritesAfterStoreTeardown' ./adapters/repos/db/
--- PASS: TestShardDropWaitsForInFlightReferences (0.99s)
--- PASS: TestShardDropDrainsRealBatchWrite (0.68s)
--- PASS: TestShardDropProceedsWhenDrainTimesOut (30.49s)
--- PASS: TestObjectWritesAfterStoreTeardownReturnErrors (0.44s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
