### PR TITLE
security(docker): pin minimum openssl version so cached builds pull CVE fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,8 +55,17 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 ###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)
 FROM alpine:3.24 AS weaviate
-RUN apk upgrade --no-cache libcrypto3 libssl3 openssl musl musl-utils zlib && \
-    apk add --no-cache bc ca-certificates openssl && mkdir ./modules
+# The version pins below are what make this layer's cache key change. A bare
+# `apk upgrade` has a fixed cache key, so CI serves it from the BuildKit cache
+# and keeps shipping the package versions that were current when the cache entry
+# was written -- which is how CVE-2026-14456 and friends survived in the image
+# despite the upgrade. Raise a pin when a scan reports a fix, and add a pin for
+# any package that is not pulled in by one already listed. An unavailable
+# version fails the build rather than silently shipping the vulnerable one.
+# `apk upgrade` still runs first so a busted layer also picks up unrelated fixes.
+# openssl pulls libcrypto3 and libssl3 to the matching version.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache bc ca-certificates "openssl>=3.5.8-r0" && mkdir ./modules
 COPY --from=server_builder /weaviate-server /bin/weaviate
 COPY --from=server_builder /runtime/go-ego/ /go/pkg/mod/github.com/go-ego/
 ENTRYPOINT ["/bin/weaviate"]


### PR DESCRIPTION
### What's being changed:

security(docker): pin minimum openssl version so cached builds pull CVE fixes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
