### PR TITLE
fix(kmeans): compute FitBalanced centers from the balanced membership

### DIFF
--- a/adapters/repos/db/vector/kmeans/kmeans.go
+++ b/adapters/repos/db/vector/kmeans/kmeans.go
@@ -521,6 +521,7 @@ func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
 	for i := range m.K {
 		centroidAssignments[i] = make([]pair, 0, n/m.K)
 	}
+	assigned := false
 	for m.Metrics.Iterations < m.IterationThreshold {
 		for i := range m.K {
 			centroidAssignments[i] = centroidAssignments[i][:0]
@@ -541,8 +542,7 @@ func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
 			metrics.wcss += float64(nearest.distance)
 			metrics.computations += nearest.computations
 		}
-
-		result = m.balanceAssignments(centroidAssignments)
+		assigned = true
 
 		m.Metrics.update(metrics)
 		m.updateCenters(data)
@@ -550,6 +550,16 @@ func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
 			m.Metrics.Termination = ClusterStability
 			break
 		}
+	}
+	// Balancing is applied once, to the final assignment. The balanced labels
+	// are written back before a last call to updateCenters so that the
+	// returned Centers are the means of the membership that is actually
+	// returned. Balancing inside the loop would leave Centers computed from
+	// the pre-balancing assignment.
+	if assigned {
+		result = m.balanceAssignments(centroidAssignments)
+		copy(m.tmp.assignment, result)
+		m.updateCenters(data)
 	}
 	m.cleanupMemory()
 	return result, nil

--- a/adapters/repos/db/vector/kmeans/kmeans_test.go
+++ b/adapters/repos/db/vector/kmeans/kmeans_test.go
@@ -281,6 +281,176 @@ func TestOneCenter(t *testing.T) {
 	}
 }
 
+func repeatVector(v []float32, n int) [][]float32 {
+	data := make([][]float32, n)
+	for i := range data {
+		data[i] = slices.Clone(v)
+	}
+	return data
+}
+
+func constantVector(d int, value float32) []float32 {
+	v := make([]float32, d)
+	for j := range v {
+		v[j] = value
+	}
+	return v
+}
+
+// blobWithOutliers returns a dense blob of normally distributed points
+// followed by nOutliers identical points at distance `offset` per dimension.
+func blobWithOutliers(nBlob int, nOutliers int, d int, offset float32, seed uint64) [][]float32 {
+	data := generateData(nBlob, d, normal, seed)
+	for range nOutliers {
+		data = append(data, constantVector(d, offset))
+	}
+	return data
+}
+
+// assertCentersMatchMembership asserts the core invariant of FitBalanced:
+// for each cluster, the returned center is the mean of the vectors whose
+// returned label points to it. The balanced membership legitimately violates
+// nearest-centroid assignment for the points moved by balancing, so
+// nearest-centroid is deliberately not asserted.
+func assertCentersMatchMembership(t *testing.T, km *KMeans, data [][]float32, labels []uint32) {
+	t.Helper()
+	sums := make([][]float64, km.K)
+	for c := range km.K {
+		sums[c] = make([]float64, km.dimensions)
+	}
+	counts := make([]int, km.K)
+	for i, c := range labels {
+		counts[c]++
+		for j, v := range km.seg(data[i]) {
+			sums[c][j] += float64(v)
+		}
+	}
+	for c := range km.K {
+		if counts[c] == 0 {
+			continue
+		}
+		for j := range km.dimensions {
+			mean := sums[c][j] / float64(counts[c])
+			assert.InDelta(t, mean, float64(km.Centers[c][j]), 1e-3,
+				"cluster %d dimension %d: center must be the mean of the cluster's balanced members", c, j)
+		}
+	}
+}
+
+func balancedClusterSizes(t *testing.T, labels []uint32, k int) []int {
+	t.Helper()
+	counts := make([]int, k)
+	for _, c := range labels {
+		assert.Less(t, int(c), k)
+		counts[c]++
+	}
+	return counts
+}
+
+func TestFitBalancedCentersMatchMembership(t *testing.T) {
+	d := 4
+	k := 2
+
+	cases := []struct {
+		name string
+		data [][]float32
+	}{
+		{
+			name: "normal data",
+			data: generateData(300, d, normal, seed),
+		},
+		{
+			// Most points are copies of one vector, so the initial centers
+			// typically both land on a duplicate and one cluster starts out
+			// empty, leaving its center at the initialization value until the
+			// clusters separate.
+			name: "duplicates with distinct minority",
+			data: append(repeatVector(constantVector(d, 0.1), 194), repeatVector(constantVector(d, 0.9), 6)...),
+		},
+		{
+			// Every point is identical: the second cluster stays empty for the
+			// entire run and updateCenters keeps its initialization center,
+			// while balancing still splits the membership roughly in half.
+			name: "all duplicates",
+			data: repeatVector(constantVector(d, 0.5), 200),
+		},
+	}
+
+	for _, tc := range cases {
+		for _, variant := range kMeansVariants {
+			t.Run(fmt.Sprintf("%s-%v-%v", tc.name, variant.Initialization, variant.Assignment), func(t *testing.T) {
+				km := newDeterministicKMeans(k, d, variant)
+				labels, err := km.FitBalanced(tc.data)
+				assert.NoError(t, err)
+				assert.Len(t, labels, len(tc.data))
+
+				counts := balancedClusterSizes(t, labels, k)
+				assert.LessOrEqual(t, absInt(counts[0]-counts[1]), 10,
+					"membership must be balanced within the threshold")
+
+				assertCentersMatchMembership(t, km, tc.data, labels)
+			})
+		}
+	}
+}
+
+// A dense blob plus two far outliers, sized above the hfresh split floor of
+// 192 vectors. k-means++ initialization places the second center on the
+// outliers, so the outliers form a two-point cluster and balancing then moves
+// roughly half the blob in with them. The returned center for that cluster
+// must be the mean of the balanced membership (roughly offset*2/n per
+// dimension), not the mean of just the two outliers (offset per dimension).
+func TestFitBalancedOutlierBlobSplit(t *testing.T) {
+	d := 4
+	k := 2
+	nBlob := 198
+	nOutliers := 2
+	offset := float32(1000)
+	data := blobWithOutliers(nBlob, nOutliers, d, offset, seed)
+	n := nBlob + nOutliers
+
+	for _, variant := range kMeansVariants {
+		t.Run(fmt.Sprintf("%v-%v", variant.Initialization, variant.Assignment), func(t *testing.T) {
+			km := newDeterministicKMeans(k, d, variant)
+			labels, err := km.FitBalanced(data)
+			assert.NoError(t, err)
+			assert.Len(t, labels, n)
+
+			counts := balancedClusterSizes(t, labels, k)
+			assert.LessOrEqual(t, absInt(counts[0]-counts[1]), 10,
+				"balancing must backfill the outlier cluster from the blob")
+
+			assertCentersMatchMembership(t, km, data, labels)
+		})
+	}
+}
+
+// FitBalanced never runs the assignment loop when IterationThreshold <= 1,
+// because initialization counts as the first iteration. There is then no
+// assignment to balance and the membership is returned as the zero value:
+// every point in cluster 0.
+func TestFitBalancedWithoutIterations(t *testing.T) {
+	n := 100
+	d := 4
+	data := generateData(n, d, normal, seed)
+	for _, variant := range kMeansVariants {
+		for _, iterationThreshold := range []int{0, 1} {
+			km := newDeterministicKMeans(2, d, variant)
+			km.IterationThreshold = iterationThreshold
+			labels, err := km.FitBalanced(data)
+			assert.NoError(t, err)
+			assert.Equal(t, make([]uint32, n), labels)
+		}
+	}
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
 func BenchmarkKMeansFit(b *testing.B) {
 	distribution := []Distribution{normal, uniform}
 	dimensions := []int{4, 8, 16, 32}

--- a/adapters/repos/db/vector/kmeans/kmeans_test.go
+++ b/adapters/repos/db/vector/kmeans/kmeans_test.go
@@ -395,11 +395,11 @@ func TestFitBalancedCentersMatchMembership(t *testing.T) {
 }
 
 // A dense blob plus two far outliers, sized above the hfresh split floor of
-// 192 vectors. k-means++ initialization places the second center on the
-// outliers, so the outliers form a two-point cluster and balancing then moves
-// roughly half the blob in with them. The returned center for that cluster
-// must be the mean of the balanced membership (roughly offset*2/n per
-// dimension), not the mean of just the two outliers (offset per dimension).
+// 192 vectors. Lloyd's iterations isolate the outliers in a two-point cluster,
+// and balancing then moves roughly half the blob in with them. The returned
+// center for that cluster must be the mean of the balanced membership (roughly
+// offset*4/n per dimension because the cluster has about n/2 members), not the
+// mean of just the two outliers (offset per dimension).
 func TestFitBalancedOutlierBlobSplit(t *testing.T) {
 	d := 4
 	k := 2


### PR DESCRIPTION
fix(kmeans): compute FitBalanced centers from the balanced membership

Fixes weaviate/0-weaviate-issues#642.

Targeting stable/v1.37 rather than main: the bug is present and byte-identical
on v1.37, v1.38 and main, and the merge train propagates from here, so this is
the single PR needed.

FitBalanced returned a balanced membership, but m.Centers was computed from
the pre-balancing assignment. balanceAssignments only ever touched its own
local slices, so updateCenters never saw the moved points. The two outputs of
the function described different partitions of the data.

hfresh splitPosting is the only caller: the balanced membership decides what
goes into each new posting, while enc.Centroid(0/1) becomes that posting's
stored centroid for routing and reassignment. So after a skewed split, a
posting's centroid was the mean of a set of points that is not the set it
holds.

The change: balanceAssignments is hoisted out of the iteration loop. The loop
is untouched (assign -> updateCenters -> exit check). After it exits, the
final assignment is balanced once, the balanced labels are written into
m.tmp.assignment, and updateCenters runs once more. Centers are now the means
of the membership that is actually returned.

The returned membership does not change — see the verification section. On a
maintenance branch that is the point: the only output that changes is the
centroids, and only toward being correct.

Deliberately NOT changed here, filed separately:
- #644: balanceAssignments moves the points farthest from their own centroid,
  rather than those with the smallest d(own) - d(other) gap. Also the
  hardcoded imbalance threshold of 10.
- #645: balanceAssignments assumes K=2 and would panic for K>2 — an
  undocumented constraint on an exported method.

Both change the returned membership, which is why they are out of scope here.

Tests (none existed for FitBalanced before):
- TestFitBalancedCentersMatchMembership — the invariant: for each non-empty
  cluster, Centers[c] equals the mean of the members the returned labels put
  there. It does NOT assert that each point is closest to its own centroid;
  balanced k-means violates that by design for the moved points.
- TestFitBalancedOutlierBlobSplit — degenerate case, red without the fix by a
  wide margin.
- TestFitBalancedWithoutIterations — pins the IterationThreshold <= 1 path,
  where the guard keeps behavior identical to before.

Pre-fix max per-dimension centroid error, measured on this branch (4-dim toy
data, illustrative only): 0.108 / 0.194 on N(0,1) with Random / PlusPlus init,
0.749 on a duplicate-heavy set, and 979.16 in a deliberately degenerate
blob-plus-outliers case. Post-fix all are <= 1e-6. What these do not tell you
is how far a centroid moves in a real split — that needs instrumentation on a
live workload, and it stays masked by #641 for as long as centroids are
decoded with the wrong quantizer.