### PR TITLE
Count the objects a shard's shutdown flushes to disk

### DIFF
--- a/adapters/repos/db/index_usage_cache_test.go
+++ b/adapters/repos/db/index_usage_cache_test.go
@@ -44,10 +44,11 @@ func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		name             string
-		savedVersion     int
-		savedFingerprint string
-		wantObjectsCount int64
+		name                string
+		savedVersion        int
+		savedFingerprint    string
+		flushOnlyAtShutdown bool
+		wantObjectsCount    int64
 	}{
 		{
 			name:             "usage of the current version is served",
@@ -74,6 +75,15 @@ func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
 			savedFingerprint: "",
 			wantObjectsCount: populatedObjectsCount,
 		},
+		{
+			// the shard never loads, so its count comes from the count file the
+			// shutdown flush left on disk
+			name:                "objects flushed only at shutdown are recomputed",
+			savedVersion:        types.UsageDiskVersion - 1,
+			savedFingerprint:    currentFingerprint,
+			flushOnlyAtShutdown: true,
+			wantObjectsCount:    populatedObjectsCount,
+		},
 	}
 
 	for _, tt := range tests {
@@ -81,7 +91,7 @@ func TestUnloadedShardUsageSavedToDisk(t *testing.T) {
 			ctx := context.Background()
 			tenantName := "test-tenant"
 
-			index, _ := setupPopulatedLazyIndex(ctx, t, usageIndexParams{})
+			index, _ := setupPopulatedLazyIndex(ctx, t, usageIndexParams{flushOnlyAtShutdown: tt.flushOnlyAtShutdown})
 			t.Cleanup(func() { _ = index.Shutdown(ctx) })
 
 			writeSavedShardUsage(t, index.path(), tenantName, &types.UsageDisk{

--- a/adapters/repos/db/index_usage_hot_cold_test.go
+++ b/adapters/repos/db/index_usage_hot_cold_test.go
@@ -122,6 +122,7 @@ func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
 			require.Len(t, loaded.Shards[0].NamedVectors, len(vectorConfigs))
 			assert.Equal(t, loaded.Shards[0].NamedVectors, unloaded.Shards[0].NamedVectors)
 			assert.Equal(t, loaded.Shards[0].FullShardStorageBytes, unloaded.Shards[0].FullShardStorageBytes)
+			assert.Equal(t, loaded.Shards[0].ObjectsCount, unloaded.Shards[0].ObjectsCount)
 
 			// the first cold report leaves its saved usage in the shard directory, so
 			// a second one walks a directory the loaded shard never has

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -162,6 +162,9 @@ type usageIndexParams struct {
 	// for every object under every configured named vector.
 	vectorDimensions  int
 	dimensionTracking dimensionTracking
+	// flushOnlyAtShutdown leaves the objects in the memtable, so shutting the
+	// index down is what puts them on disk, the way a deactivated tenant does.
+	flushOnlyAtShutdown bool
 }
 
 // setupPopulatedLazyIndex creates an index for a multi-tenant class, populates
@@ -324,11 +327,12 @@ func setupPopulatedLazyIndex(ctx context.Context, t *testing.T, params usageInde
 	shard, release, err := index.GetShard(ctx, tenantName)
 	require.NoError(t, err)
 	require.NotNil(t, shard)
-	// FlushMemtables deactivates the background flush cycle before flushing, so
-	// it cannot race with the cycle's own FlushAndSwitch (which would nil out
-	// b.flushing under the other goroutine and panic). Poking a single bucket's
-	// FlushMemtable directly skips that guard.
-	require.NoError(t, shard.Store().FlushMemtables(ctx))
+	if !params.flushOnlyAtShutdown {
+		// FlushMemtables deactivates the background flush cycle before flushing, so
+		// the cycle cannot start a FlushAndSwitch mid-flush. Poking a single bucket's
+		// FlushMemtable directly skips that guard.
+		require.NoError(t, shard.Store().FlushMemtables(ctx))
+	}
 	release()
 
 	require.NoError(t, index.Shutdown(ctx))

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -187,7 +187,7 @@ type Bucket struct {
 	// Net additions keep track of number of elements stored in bucket (of type replace).
 	// As some buckets don't have to provide Count info (see flat index),
 	// tracking additions can be disabled.
-	// ON by default
+	// OFF by default
 	calcCountNetAdditions bool
 
 	forceCompaction     bool
@@ -1734,6 +1734,15 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.metrics.ObserveBucketShutdownDurationByStrategy(b.strategy, time.Since(start))
 	}()
 
+	// must run before b.disk.shutdown: only FlushAndSwitch writes the count file
+	// an unloaded shard reads, and it needs the previous segments to do so.
+	var countFlushErr error
+	if b.calcCountNetAdditions && b.readOnlyErr() == nil {
+		if err := b.FlushAndSwitch(); err != nil {
+			countFlushErr = err
+		}
+	}
+
 	if err := b.disk.shutdown(ctx); err != nil {
 		return err
 	}
@@ -1776,6 +1785,12 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		}
 	}
 	b.flushLock.Unlock()
+
+	// a failed FlushAndSwitch left b.flushing set and nothing else clears it,
+	// so report the error instead of waiting for it below
+	if countFlushErr != nil {
+		return countFlushErr
+	}
 
 	if b.flushing == nil {
 		// active has flushing, no one else was currently flushing, it's safe to

--- a/adapters/repos/db/lsmkv/bucket_recover_test.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_test.go
@@ -285,7 +285,7 @@ func TestBucketReloadAfterWalDamange(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, count, 2)
 
-	require.NoError(t, b.Shutdown(ctx))
+	crashBucket(t, b)
 	dbFiles, walFiles := countDbAndWalFiles(t, dirName)
 	require.Equal(t, dbFiles, 0)
 	require.Equal(t, walFiles, 1)
@@ -319,7 +319,7 @@ func TestBucketReloadAfterWalDamange(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 4, count)
 
-	require.NoError(t, b.Shutdown(ctx))
+	crashBucket(t, b)
 	dbFiles, walFiles = countDbAndWalFiles(t, dirName)
 	require.Equal(t, dbFiles, 1)
 	require.Equal(t, walFiles, 1)

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
@@ -670,6 +671,108 @@ func verifyFileInfo(t *testing.T, path string, oldEntries []string, segmentInfo 
 	return fileNames
 }
 
+// TestShutdownLeavesObjectsCounted pins what Shutdown leaves on disk for a
+// bucket whose object count is read off disk while its shard is unloaded.
+func TestShutdownLeavesObjectsCounted(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		opts         []BucketOption
+		readOnly     bool
+		putErr       error
+		wantSegments int
+		wantWALs     int
+		wantCounters int
+	}{
+		{
+			name:         "counted bucket flushes a segment carrying its counter",
+			opts:         []BucketOption{WithCalcCountNetAdditions(true)},
+			wantSegments: 1,
+			wantCounters: 1,
+		},
+		{
+			name:     "uncounted bucket keeps its write-ahead log",
+			opts:     []BucketOption{WithCalcCountNetAdditions(false)},
+			wantWALs: 1,
+		},
+		{
+			name:         "read-only counted bucket keeps its write-ahead log",
+			opts:         []BucketOption{WithCalcCountNetAdditions(true)},
+			readOnly:     true,
+			wantWALs:     1,
+			wantCounters: 0,
+		},
+		{
+			// the read-only status refuses FlushAndSwitch, so the segment Shutdown
+			// writes anyway carries no count until the bucket loads again
+			name:         "read-only counted bucket cannot count a segment it must flush",
+			opts:         []BucketOption{WithCalcCountNetAdditions(true), WithMinWalThreshold(0)},
+			readOnly:     true,
+			wantSegments: 1,
+			wantCounters: 0,
+		},
+		{
+			name:         "immutable counted bucket shuts down without flushing",
+			opts:         []BucketOption{WithCalcCountNetAdditions(true), WithImmutable(true)},
+			putErr:       ErrImmutable,
+			wantSegments: 0,
+			wantWALs:     0,
+			wantCounters: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				append(tt.opts, WithStrategy(StrategyReplace))...,
+			)
+			require.NoError(t, err)
+
+			require.ErrorIs(t, b.Put([]byte("hello1"), []byte("world1")), tt.putErr)
+			if tt.readOnly {
+				b.UpdateStatus(storagestate.StatusReadOnly)
+			}
+			require.NoError(t, b.Shutdown(ctx))
+
+			fileTypes := getFileTypeCount(t, dirName)
+			require.Equal(t, tt.wantSegments, fileTypes[".db"])
+			require.Equal(t, tt.wantWALs, fileTypes[".wal"])
+			require.Equal(t, tt.wantCounters, fileTypes[".cna"])
+		})
+	}
+}
+
+// TestShutdownTearsDownWhenCountFlushFails pins that a count flush Shutdown
+// cannot complete still leaves the bucket torn down, and that its caller is
+// told. An unregistered bucket whose segments are never closed outlives the
+// process; a missing count file is recomputed the next time the bucket loads.
+func TestShutdownTearsDownWhenCountFlushFails(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	dirName := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, b.Put([]byte("hello1"), []byte("world1")))
+	require.NoError(t, b.FlushMemtable())
+	require.NoError(t, b.Put([]byte("hello2"), []byte("world2")))
+
+	// a directory that takes no new file fails the segment write
+	require.NoError(t, os.Chmod(dirName, 0o500))
+	t.Cleanup(func() { require.NoError(t, os.Chmod(dirName, 0o700)) })
+
+	require.Error(t, b.Shutdown(ctx))
+	require.Nil(t, b.disk.segments, "SegmentGroup.shutdown clears the list once it has closed every segment")
+}
+
 func TestNetCountComputationAtInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
@@ -699,7 +802,7 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	require.Equal(t, 0, fileTypes[".wal"])
 	require.Equal(t, 4, fileTypes[".cna"])
 
-	// Create a single segment with all deletions - shutdown so the cna files are not written right away, but at startup
+	// Create a single segment with all deletions
 	require.NoError(t, b.Delete([]byte("hello1")))
 	require.NoError(t, b.Delete([]byte("hello2")))
 	require.NoError(t, b.Delete([]byte("hello3")))
@@ -709,7 +812,10 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	fileTypes = getFileTypeCount(t, dirName)
 	require.Equal(t, 5, fileTypes[".db"])
 	require.Equal(t, 0, fileTypes[".wal"])
-	require.Equal(t, 4, fileTypes[".cna"]) // cna file for new segment not yet computed
+	require.Equal(t, 5, fileTypes[".cna"]) // Shutdown's FlushAndSwitch writes the count file
+
+	// a segment whose count file is gone recomputes it when the bucket loads
+	removeFilesWithExt(t, dirName, ".cna")
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace), WithMinWalThreshold(0),
@@ -719,7 +825,7 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	fileTypes = getFileTypeCount(t, dirName)
 	require.Equal(t, 5, fileTypes[".db"])
 	require.Equal(t, 0, fileTypes[".wal"])
-	require.Equal(t, 5, fileTypes[".cna"]) // now computed after startup
+	require.Equal(t, 5, fileTypes[".cna"]) // recomputed when the bucket loaded
 
 	count, err = b.Count(ctx)
 	require.NoError(t, err)
@@ -814,7 +920,7 @@ func TestCountApproximate(t *testing.T) {
 		requireApprox(t, b, 6)
 	})
 
-	t.Run("counter is rebuilt from the WAL on reopen", func(t *testing.T) {
+	t.Run("counter is rebuilt from the WAL after a crash", func(t *testing.T) {
 		dirName := t.TempDir()
 		newFromDir := func() *Bucket {
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
@@ -829,7 +935,8 @@ func TestCountApproximate(t *testing.T) {
 		putKeys(t, b, 3)
 		require.NoError(t, b.Delete([]byte("key-00")))
 		requireApprox(t, b, 2)
-		require.NoError(t, b.Shutdown(ctx))
+
+		crashBucket(t, b)
 		require.Equal(t, 0, getFileTypeCount(t, dirName)[".db"], "data must survive as WAL, not a segment")
 
 		b = newFromDir()
@@ -852,6 +959,26 @@ func getFileTypeCount(t *testing.T, path string) map[string]int {
 		fileTypes[filepath.Ext(entry.Name())] += 1
 	}
 	return fileTypes
+}
+
+// crashBucket abandons a bucket the way a process kill does: its write-ahead log
+// is synced, but nothing flushed the memtable into a segment. Only the registry
+// entry is released, so the same directory can be opened again.
+func crashBucket(t *testing.T, b *Bucket) {
+	t.Helper()
+	require.True(t, b.getAndUpdateWritesSinceLastSync(), "commit log did not sync")
+	GlobalBucketRegistry.Remove(b.registeredPath)
+}
+
+func removeFilesWithExt(t *testing.T, path, ext string) {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ext {
+			require.NoError(t, os.Remove(filepath.Join(path, entry.Name())))
+		}
+	}
 }
 
 // TestBucketReplaceStrategyConsistentView verifies that a Bucket using the

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 func TestShardPathDimensionsLSM(t *testing.T) {
@@ -154,15 +155,44 @@ func TestCalculateUnloadedObjectsMetrics(t *testing.T) {
 	ctx := context.Background()
 	tenantName := "tenant"
 
-	for _, metadata := range []bool{true, false} {
-		t.Run(fmt.Sprintf("metadata=%v", metadata), func(t *testing.T) {
+	tests := []struct {
+		name string
+		// writeMetadata stores the count in a .metadata sidecar instead of a .cna one
+		writeMetadata bool
+		// minWalThreshold decides whether Shutdown keeps the memtable in the
+		// write-ahead log; both values must still leave a counted segment
+		minWalThreshold int64
+	}{
+		{name: "cna sidecar, wal below the reuse threshold", minWalThreshold: config.DefaultPersistenceMaxReuseWalSize},
+		{name: "cna sidecar, wal above the reuse threshold", minWalThreshold: 0},
+		{name: "metadata sidecar, wal below the reuse threshold", writeMetadata: true, minWalThreshold: config.DefaultPersistenceMaxReuseWalSize},
+		{name: "metadata sidecar, wal above the reuse threshold", writeMetadata: true, minWalThreshold: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
 			dirName := t.TempDir()
 			bucketFolder := shardPathObjectsLSM(dirName, tenantName)
 
 			b, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketFolder, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithCalcCountNetAdditions(true), lsmkv.WithWriteMetadata(metadata))
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithCalcCountNetAdditions(true), lsmkv.WithWriteMetadata(tt.writeMetadata), lsmkv.WithMinWalThreshold(tt.minWalThreshold))
 			require.NoError(t, err)
-			defer b.Shutdown(ctx)
+
+			sidecarSuffix := lsmkv.CountNetAdditionsFileSuffix
+			if tt.writeMetadata {
+				sidecarSuffix = lsmkv.MetadataFileSuffix
+			}
+			requireOnDisk := func(segments, wals, sidecars int, count int64) {
+				t.Helper()
+				fileTypes := getFileTypeCount(t, bucketFolder)
+				require.Equal(t, segments, fileTypes[".db"])
+				require.Equal(t, wals, fileTypes[".wal"])
+				require.Equal(t, sidecars, fileTypes[sidecarSuffix])
+
+				metrics, err := CalculateUnloadedObjectsMetrics(logger, dirName, tenantName, true)
+				require.NoError(t, err)
+				require.Equal(t, count, metrics.Count)
+			}
 
 			require.NoError(t, b.Put([]byte("hello1"), []byte("world1")))
 			require.NoError(t, b.FlushMemtable())
@@ -173,34 +203,18 @@ func TestCalculateUnloadedObjectsMetrics(t *testing.T) {
 			require.NoError(t, b.Put([]byte("hello4"), []byte("world4")))
 			require.NoError(t, b.FlushMemtable())
 
-			fileTypes := getFileTypeCount(t, bucketFolder)
-			require.Equal(t, 4, fileTypes[".db"])
-			require.Equal(t, 0, fileTypes[".wal"])
-			if metadata {
-				require.Equal(t, 4, fileTypes[".metadata"])
-			} else {
-				require.Equal(t, 4, fileTypes[".cna"])
-			}
-
-			metrics, err := CalculateUnloadedObjectsMetrics(logger, dirName, "tenant", true)
-			require.NoError(t, err)
-			require.Equal(t, metrics.Count, int64(4))
+			requireOnDisk(4, 0, 4, 4)
 
 			// add another key but dont flush => will not be included in count
 			require.NoError(t, b.Put([]byte("hello5"), []byte("world5")))
 
-			fileTypes = getFileTypeCount(t, bucketFolder)
-			require.Equal(t, 4, fileTypes[".db"])
-			require.Equal(t, 1, fileTypes[".wal"])
-			if metadata {
-				require.Equal(t, 4, fileTypes[".metadata"])
-			} else {
-				require.Equal(t, 4, fileTypes[".cna"])
-			}
+			requireOnDisk(4, 1, 4, 4)
 
-			metrics, err = CalculateUnloadedObjectsMetrics(logger, dirName, "tenant", true)
-			require.NoError(t, err)
-			require.Equal(t, metrics.Count, int64(4))
+			// Shutdown must leave every object in a segment carrying its count, or
+			// a shard that never loads reports fewer objects than it holds
+			require.NoError(t, b.Shutdown(ctx))
+
+			requireOnDisk(5, 0, 5, 5)
 		})
 	}
 }

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -1767,9 +1767,9 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 		require.Len(t, colUsage.Shards, 1)
 		shard := colUsage.Shards[0]
 		require.Equal(t, strings.ToLower(expectedStatus), shard.Status)
-		if expectedStatus == models.TenantActivityStatusACTIVE {
-			require.Equal(t, int64(numObjects), shard.ObjectsCount)
-		}
+		// a deactivated tenant is counted from the segments its shutdown left, so
+		// both paths owe the same number
+		require.Equal(t, int64(numObjects), shard.ObjectsCount)
 		require.Equal(t, expected, namedVectorDimensionalities(t, shard))
 
 		for _, v := range shard.NamedVectors {


### PR DESCRIPTION
### What's being changed:

Compute the .cna files for tenants on shutdown. Otherwise cold tenants would report the wrong object count in billing.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
