### PR TITLE
feat(hfresh): debug endpoint to reassign all vectors in place

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -774,8 +774,9 @@ func setupDebugHandlers(appState *state.State) {
 			stats, err := h.EnqueueReassignAll(context.Background())
 			statsLogger := reassignLogger.
 				WithField("postings", stats.Postings).
-				WithField("entries", stats.Entries).
-				WithField("enqueued", stats.Enqueued)
+				WithField("enqueued", stats.Enqueued).
+				WithField("skippedDeleted", stats.SkippedDeleted).
+				WithField("skippedStale", stats.SkippedStale)
 			if err != nil {
 				statsLogger.Error(err)
 				return

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -761,11 +761,15 @@ func setupDebugHandlers(appState *state.State) {
 		enterrors.GoWrapper(func() {
 			defer release()
 			stats, err := h.EnqueueReassignAll(context.Background())
+			statsLogger := reassignLogger.
+				WithField("postings", stats.Postings).
+				WithField("entries", stats.Entries).
+				WithField("enqueued", stats.Enqueued)
 			if err != nil {
-				reassignLogger.WithField("stats", stats).Error(err)
+				statsLogger.Error(err)
 				return
 			}
-			reassignLogger.WithField("stats", stats).Info("reassign-all enqueue completed")
+			statsLogger.Info("reassign-all enqueue completed")
 		}, reassignLogger)
 
 		reassignLogger.Info("reassign-all enqueue started")

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -760,13 +760,17 @@ func setupDebugHandlers(appState *state.State) {
 			return
 		}
 
+		// The scan needs no shard reference: EnqueueReassignAll also watches
+		// the index's own lifecycle context and stops when the shard shuts
+		// down or is dropped, like the version map warmup does.
+		release()
+
 		reassignLogger := logger.
 			WithField("collection", colName).
 			WithField("shard", shardName).
 			WithField("targetVector", targetVector)
 
 		enterrors.GoWrapper(func() {
-			defer release()
 			stats, err := h.EnqueueReassignAll(context.Background())
 			statsLogger := reassignLogger.
 				WithField("postings", stats.Postings).

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -709,6 +709,13 @@ func setupDebugHandlers(appState *state.State) {
 	// to run on a healthy index. Call via something like:
 	// curl -X POST "localhost:6060/debug/index/reassign/vector?collection=Foo&shard=abc123&vector=default"
 	http.HandleFunc("/debug/index/reassign/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// unlike its read-only siblings, this endpoint starts a corpus-wide
+		// mutating job — do not let a probing GET trigger it
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed, use POST", http.StatusMethodNotAllowed)
+			return
+		}
+
 		colName := r.URL.Query().Get("collection")
 		shardName := r.URL.Query().Get("shard")
 		targetVector := r.URL.Query().Get("vector")

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hfresh"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/cluster/usage"
 	"github.com/weaviate/weaviate/entities/config"
@@ -698,6 +699,76 @@ func setupDebugHandlers(appState *state.State) {
 			WithField("targetVector", targetVector).
 			Info("requantize started")
 
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	// Enqueues a reassignment for every live vector of one shard's hfresh
+	// index, re-routing vectors that earlier maintenance left in the wrong
+	// postings. The reassignment tasks only write for vectors whose current
+	// posting is no longer among their RNG-selected targets, so this is safe
+	// to run on a healthy index. Call via something like:
+	// curl -X POST "localhost:6060/debug/index/reassign/vector?collection=Foo&shard=abc123&vector=default"
+	http.HandleFunc("/debug/index/reassign/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		colName := r.URL.Query().Get("collection")
+		shardName := r.URL.Query().Get("shard")
+		targetVector := r.URL.Query().Get("vector")
+
+		if colName == "" || shardName == "" {
+			http.Error(w, "collection and shard are required", http.StatusBadRequest)
+			return
+		}
+
+		idx := appState.DB.GetIndex(schema.ClassName(colName))
+		if idx == nil {
+			logger.WithField("collection", colName).Error("collection not found")
+			http.Error(w, "collection not found", http.StatusNotFound)
+			return
+		}
+
+		shard, release, err := idx.GetShard(context.Background(), shardName)
+		if err != nil {
+			logger.WithField("shard", shardName).Error(err)
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if shard == nil {
+			release()
+			logger.WithField("shard", shardName).Error("shard not found")
+			http.Error(w, "shard not found", http.StatusNotFound)
+			return
+		}
+
+		vidx, ok := shard.GetVectorIndex(targetVector)
+		if !ok {
+			release()
+			logger.WithField("shard", shardName).Error("vector index not found")
+			http.Error(w, "vector index not found", http.StatusNotFound)
+			return
+		}
+
+		h, ok := vidx.(hfreshReassignAller)
+		if !ok {
+			release()
+			http.Error(w, "not an hfresh index", http.StatusBadRequest)
+			return
+		}
+
+		reassignLogger := logger.
+			WithField("collection", colName).
+			WithField("shard", shardName).
+			WithField("targetVector", targetVector)
+
+		enterrors.GoWrapper(func() {
+			defer release()
+			stats, err := h.EnqueueReassignAll(context.Background())
+			if err != nil {
+				reassignLogger.WithField("stats", stats).Error(err)
+				return
+			}
+			reassignLogger.WithField("stats", stats).Info("reassign-all enqueue completed")
+		}, reassignLogger)
+
+		reassignLogger.Info("reassign-all enqueue started")
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
@@ -1381,6 +1452,10 @@ type MaintenanceMode struct {
 
 type hnswStats interface {
 	Stats() (*hnsw.HnswStats, error)
+}
+
+type hfreshReassignAller interface {
+	EnqueueReassignAll(ctx context.Context) (hfresh.ReassignAllStats, error)
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/adapters/repos/db/vector/hfresh/reassign_all.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all.go
@@ -47,14 +47,13 @@ func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, erro
 		return stats, errors.New("index is not initialized")
 	}
 
-	maxID := h.Centroids.GetMaxID()
-	for postingID := uint64(0); postingID <= maxID; postingID++ {
+	// The posting map enumerates the allocated posting IDs; the posting is
+	// still read from the store because only its entries carry the per-copy
+	// version byte that distinguishes a vector's live copy from stale ones.
+	for postingID := range h.PostingMap.Iter() {
 		err := ctx.Err()
 		if err != nil {
 			return stats, err
-		}
-		if !h.Centroids.Exists(postingID) {
-			continue
 		}
 
 		posting, err := h.PostingStore.Get(ctx, postingID)

--- a/adapters/repos/db/vector/hfresh/reassign_all.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hfresh
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// ReassignAllStats reports what a EnqueueReassignAll scan covered. Enqueued
+// counts enqueue requests, not distinct vectors: a vector stored in several
+// postings is requested once per live copy and deduplicated by the task
+// queue.
+type ReassignAllStats struct {
+	Postings int `json:"postings"`
+	Entries  int `json:"entries"`
+	Enqueued int `json:"enqueued"`
+}
+
+// EnqueueReassignAll walks every posting and enqueues a reassignment task for
+// each live vector entry. The reassignment task re-routes a vector through
+// RNGSelect and aborts before writing anything when the vector's current
+// posting is still among the selected targets, so the write cost of this
+// operation is proportional to how many vectors are actually misplaced, not
+// to the corpus size. Stale entries (version mismatch) and deleted vectors
+// are skipped so each reassignment is anchored to the vector's live copy.
+//
+// This exists to repair placement damage persisted by indexes built before
+// the reassignment-gate fixes: an idle index runs no maintenance that could
+// correct it. It is deliberately not part of the VectorIndex interface and is
+// only reachable through the debug API.
+func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, error) {
+	var stats ReassignAllStats
+
+	_, quantizer := h.loadQuantizer()
+	if quantizer == nil {
+		return stats, errors.New("index is not initialized")
+	}
+
+	maxID := h.Centroids.GetMaxID()
+	for postingID := uint64(0); postingID <= maxID; postingID++ {
+		err := ctx.Err()
+		if err != nil {
+			return stats, err
+		}
+		if !h.Centroids.Exists(postingID) {
+			continue
+		}
+
+		posting, err := h.PostingStore.Get(ctx, postingID)
+		if err != nil {
+			if errors.Is(err, ErrPostingNotFound) {
+				continue
+			}
+			return stats, errors.Wrapf(err, "failed to get posting %d", postingID)
+		}
+		stats.Postings++
+
+		for _, v := range posting {
+			version, err := h.VersionMap.Get(ctx, v.ID())
+			if err != nil {
+				return stats, errors.Wrapf(err, "failed to get version for vector %d", v.ID())
+			}
+			if version.Deleted() || version != v.Version() {
+				continue
+			}
+			stats.Entries++
+
+			err = h.taskQueue.EnqueueReassign(postingID, v.ID())
+			if err != nil {
+				return stats, errors.Wrapf(err, "failed to enqueue reassign for vector %d", v.ID())
+			}
+			stats.Enqueued++
+		}
+	}
+
+	return stats, nil
+}

--- a/adapters/repos/db/vector/hfresh/reassign_all.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all.go
@@ -20,11 +20,14 @@ import (
 // ReassignAllStats reports what an EnqueueReassignAll scan covered. Enqueued
 // counts enqueue requests, not distinct vectors: a vector stored in several
 // postings is requested once per live copy and deduplicated by the task
-// queue.
+// queue. The skipped counters measure index bloat: SkippedStale entries are
+// invalidated copies left behind by earlier reassignments and not yet
+// garbage collected, SkippedDeleted entries belong to deleted vectors.
 type ReassignAllStats struct {
-	Postings int `json:"postings"`
-	Entries  int `json:"entries"`
-	Enqueued int `json:"enqueued"`
+	Postings       int `json:"postings"`
+	Enqueued       int `json:"enqueued"`
+	SkippedDeleted int `json:"skippedDeleted"`
+	SkippedStale   int `json:"skippedStale"`
 }
 
 // EnqueueReassignAll walks every posting and enqueues a reassignment task for
@@ -78,10 +81,14 @@ func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, erro
 			if err != nil {
 				return stats, errors.Wrapf(err, "failed to get version for vector %d", v.ID())
 			}
-			if version.Deleted() || version != v.Version() {
+			if version.Deleted() {
+				stats.SkippedDeleted++
 				continue
 			}
-			stats.Entries++
+			if version != v.Version() {
+				stats.SkippedStale++
+				continue
+			}
 
 			err = h.taskQueue.EnqueueReassign(postingID, v.ID())
 			if err != nil {

--- a/adapters/repos/db/vector/hfresh/reassign_all.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// ReassignAllStats reports what a EnqueueReassignAll scan covered. Enqueued
+// ReassignAllStats reports what an EnqueueReassignAll scan covered. Enqueued
 // counts enqueue requests, not distinct vectors: a vector stored in several
 // postings is requested once per live copy and deduplicated by the task
 // queue.

--- a/adapters/repos/db/vector/hfresh/reassign_all.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all.go
@@ -39,6 +39,11 @@ type ReassignAllStats struct {
 // the reassignment-gate fixes: an idle index runs no maintenance that could
 // correct it. It is deliberately not part of the VectorIndex interface and is
 // only reachable through the debug API.
+//
+// The scan runs without a shard reference, so alongside the caller's ctx it
+// watches the index's own lifecycle context, like the version map warmup: a
+// shard shutdown or drop stops it cooperatively at the next iteration (one
+// in-flight store read or enqueue may race the close, as with warmup).
 func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, error) {
 	var stats ReassignAllStats
 
@@ -52,6 +57,9 @@ func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, erro
 	// version byte that distinguishes a vector's live copy from stale ones.
 	for postingID := range h.PostingMap.Iter() {
 		err := ctx.Err()
+		if err == nil {
+			err = h.ctx.Err()
+		}
 		if err != nil {
 			return stats, err
 		}

--- a/adapters/repos/db/vector/hfresh/reassign_all_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hfresh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnqueueReassignAllUninitialized(t *testing.T) {
+	tf := createHFreshIndex(t)
+
+	_, err := tf.Index.EnqueueReassignAll(t.Context())
+	require.ErrorContains(t, err, "not initialized")
+}
+
+func TestEnqueueReassignAll(t *testing.T) {
+	tf := createHFreshIndex(t)
+
+	vectorsA := createTestVectors(4, 5)
+	postingA, pa := createPostingWithVectors(t, &tf, vectorsA, 100)
+	vectorsB := createTestVectors(4, 3)
+	postingB, pb := createPostingWithVectors(t, &tf, vectorsB, 200)
+
+	for _, p := range []struct {
+		id       uint64
+		posting  Posting
+		centroid []float32
+	}{
+		{postingA, pa, []float32{1.0, 0.0, 0.0, 0.0}},
+		{postingB, pb, []float32{0.0, 1.0, 0.0, 0.0}},
+	} {
+		compressed := tf.Index.quantizer.CompressedBytes(tf.Index.quantizer.Encode(p.centroid))
+		err := tf.Index.Centroids.Insert(p.id, &Centroid{
+			Uncompressed: p.centroid,
+			Compressed:   compressed,
+			Deleted:      false,
+		})
+		require.NoError(t, err)
+
+		err = tf.Index.PostingStore.Put(t.Context(), p.id, p.posting)
+		require.NoError(t, err)
+
+		err = tf.Index.setPostingVectorIDs(t.Context(), p.id, p.posting)
+		require.NoError(t, err)
+	}
+
+	// vector 100 is deleted, vector 200's stored entry is stale (the live
+	// version moved on) — neither may be enqueued
+	_, err := tf.Index.VersionMap.MarkDeleted(t.Context(), 100)
+	require.NoError(t, err)
+	_, err = tf.Index.VersionMap.Increment(t.Context(), 200, VectorVersion(1))
+	require.NoError(t, err)
+
+	stats, err := tf.Index.EnqueueReassignAll(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, 2, stats.Postings)
+	require.Equal(t, 6, stats.Entries, "8 stored entries minus 1 deleted minus 1 stale")
+	require.Equal(t, 6, stats.Enqueued)
+
+	for _, id := range []uint64{101, 102, 103, 104, 201, 202} {
+		require.True(t, tf.Index.taskQueue.reassignList.Contains(id),
+			"live vector %d should be enqueued", id)
+	}
+	for _, id := range []uint64{100, 200} {
+		require.False(t, tf.Index.taskQueue.reassignList.Contains(id),
+			"vector %d should be skipped", id)
+	}
+}

--- a/adapters/repos/db/vector/hfresh/reassign_all_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all_test.go
@@ -85,8 +85,9 @@ func TestEnqueueReassignAll(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, 2, stats.Postings)
-	require.Equal(t, 6, stats.Entries, "8 stored entries minus 1 deleted minus 1 stale")
-	require.Equal(t, 6, stats.Enqueued)
+	require.Equal(t, 6, stats.Enqueued, "8 stored entries minus 1 deleted minus 1 stale")
+	require.Equal(t, 1, stats.SkippedDeleted)
+	require.Equal(t, 1, stats.SkippedStale)
 
 	for _, id := range []uint64{101, 102, 103, 104, 201, 202} {
 		require.True(t, tf.Index.taskQueue.reassignList.Contains(id),

--- a/adapters/repos/db/vector/hfresh/reassign_all_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all_test.go
@@ -12,6 +12,7 @@
 package hfresh
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,24 @@ func TestEnqueueReassignAllUninitialized(t *testing.T) {
 
 	_, err := tf.Index.EnqueueReassignAll(t.Context())
 	require.ErrorContains(t, err, "not initialized")
+}
+
+// The scan runs without a shard reference, so it must stop on the index's
+// own lifecycle context even when the caller's context stays alive.
+func TestEnqueueReassignAllStopsOnIndexShutdown(t *testing.T) {
+	tf := createHFreshIndex(t)
+
+	vectors := createTestVectors(4, 3)
+	postingID, posting := createPostingWithVectors(t, &tf, vectors, 300)
+	err := tf.Index.PostingStore.Put(t.Context(), postingID, posting)
+	require.NoError(t, err)
+	err = tf.Index.setPostingVectorIDs(t.Context(), postingID, posting)
+	require.NoError(t, err)
+
+	tf.Index.cancel()
+
+	_, err = tf.Index.EnqueueReassignAll(t.Context())
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestEnqueueReassignAll(t *testing.T) {


### PR DESCRIPTION
## What

Adds an unofficial debug endpoint that repairs vector placement on an existing hfresh index in place, as an alternative to a full re-ingest:

```
POST /debug/index/reassign/vector?collection=<name>&shard=<shard>[&vector=<target>]
```

Indexes built before #12795 carry persisted placement damage: the split/merge reassignment gates ran on meaningless distances, so vectors ended up in postings their geometry does not justify — and an idle index runs no maintenance that could correct that. Until now the only remedy was a full re-ingest (for a 138M corpus, on the order of a day).

## How

- `HFresh.EnqueueReassignAll(ctx)` (new, deliberately **not** part of the `VectorIndex` interface): enumerates postings via `PostingMap.Iter()`, reads each posting from the store, and enqueues a reassignment task for every **live** entry — deleted vectors and stale copies (stored version ≠ version map) are skipped and counted separately, so each reassignment is anchored to the vector's live copy. Returns `{postings, enqueued, skippedDeleted, skippedStale}`; the skipped counters double as a bloat measure — `skippedStale` is the count of invalidated copies left behind by earlier reassignments and not yet garbage collected.
- The scan runs without holding a shard reference: alongside the caller's context it watches the index's own lifecycle context (the `warmVersionMap` pattern), so a shard shutdown or drop cancels it cooperatively at the next iteration. The debug handler resolves the shard, releases immediately, launches the scan in a background goroutine, and returns `202 Accepted`; completion stats land in the log and repair progress is visible via the pending-reassign-tasks metric. POST only.

**Cost model, stated plainly:** the *write* cost is proportional to how many vectors are actually misplaced — `doReassign` aborts before writing anything when the vector's current posting is still among its RNG-selected targets. The *read* cost is proportional to corpus size regardless: the scan itself is minutes per shard (posting reads + in-memory version checks), and the repair behind it runs `RNGSelect` plus a full-vector fetch for every enqueued vector. Cheaper than a re-ingest, not cheap. Searches stay correct throughout (version filtering hides stale copies), so recall improves progressively while the repair runs.

**Why entries are read from the store and not just the posting map:** only store entries carry the per-copy version byte. The `(posting, vector)` pair enqueued becomes `doReassign`'s abort anchor; anchoring to a stale copy's posting could wrongly abort the repair for exactly the vectors that need it. The map is used for enumeration only.

## Requirements

- **A build carrying both #12795 and #12804** (both merged into stable/v1.37). Anyone running this repair against a damaged index is on an old build by definition, and the repair triggers a split wave: pre-#12795 those splits run the broken reassignment gates and churn damage back in; pre-#12804 every one of them stores a centroid computed from a different partition than the posting it represents.

## Scope and limitations

- Repairs one shard-replica per call (each replica has its own index); run it against every node hosting a replica.
- Repairs placement against the **existing** centroid set; it does not improve centroid positions themselves (see #644 for the remaining balancing-criterion work). A vector with one well-placed live copy and other misplaced copies is left as is — existing `doReassign` abort semantics, unchanged here.
- Moved vectors leave stale entries behind until GC touches their postings; expect temporary posting growth and a split wave, throttled by the task queue.
- Cancellation is cooperative and tied to the index lifecycle; one in-flight store read or enqueue may race a shutdown's close, as with the version map warmup.

## Verification

- `TestEnqueueReassignAll`: two postings, one deleted vector, one stale entry — asserts the exact enqueue/skip split and dedup-list membership. `TestEnqueueReassignAllUninitialized` covers the uninitialized-index guard. `TestEnqueueReassignAllStopsOnIndexShutdown` pins that the scan stops on the index lifecycle context even with a live caller context.
- Full `hfresh` suite passes under `-race`; `golangci-lint` clean.
- Manually exercised against a local node (31,211 postings / 3,995,046 entries scanned; 202 + completion log with discrete stat fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
