### PR TITLE
backup-gcs: default to the gRPC transport

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -61,8 +61,10 @@ const (
 	// 24h timeout. It is a hard timeout on the request rather than a stall
 	// detector, so it must stay well above the time a full chunk takes on a slow
 	// link, and well below chunkRetryDeadline to leave room for retries. Raising
-	// the writer's ChunkSize means revisiting both. HTTP only; the gRPC writer
-	// ignores it.
+	// the writer's ChunkSize means revisiting both. The SDK applies it on the
+	// HTTP transport only, so on the default gRPC transport a stalled chunk is
+	// bounded by the caller's context rather than by this. chunkRetryDeadline
+	// applies on both.
 	chunkTransferTimeout = time.Minute
 )
 
@@ -103,7 +105,7 @@ func storageOptions(ctx context.Context, logger logrus.FieldLogger, transport uc
 		opts = append(opts, option.WithoutAuthentication())
 	}
 
-	if transport.UseGRPC {
+	if transport.UseGRPCOrDefault() {
 		// The SDK exports gRPC client metrics to Cloud Monitoring by default. That
 		// needs monitoring.timeSeries.create and reports its own failures through
 		// the standard library, bypassing our logger.
@@ -135,10 +137,11 @@ func newClient(ctx context.Context, config *clientConfig, dataPath string, logge
 	}
 
 	var client *storage.Client
-	if config.Transport.UseGRPC {
+	if config.Transport.UseGRPCOrDefault() {
 		logger.Infof("backup-gcs: using gRPC transport with a connection pool of %d per client", config.Transport.GRPCConnPool)
 		client, err = storage.NewGRPCClient(ctx, opts...)
 	} else {
+		logger.Info("backup-gcs: using HTTP transport")
 		client, err = storage.NewClient(ctx, opts...)
 	}
 	if err != nil {

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -59,12 +59,18 @@ func TestStorageOptionsTransport(t *testing.T) {
 	}{
 		{
 			name:        "http adds no transport options",
-			transport:   ucfg.BackupGCS{},
+			transport:   ucfg.BackupGCS{UseGRPC: new(false)},
 			wantOptions: []string{"option.withoutAuthentication"},
 		},
 		{
 			name:         "grpc sizes the connection pool and turns client metrics off",
-			transport:    ucfg.BackupGCS{UseGRPC: true, GRPCConnPool: 8},
+			transport:    ucfg.BackupGCS{UseGRPC: new(true), GRPCConnPool: 8},
+			wantOptions:  []string{"option.withoutAuthentication", connPoolOptionType, "*storage.withDisabledClientMetrics"},
+			wantConnPool: 8,
+		},
+		{
+			name:         "an unset transport takes the grpc options",
+			transport:    ucfg.BackupGCS{GRPCConnPool: 8},
 			wantOptions:  []string{"option.withoutAuthentication", connPoolOptionType, "*storage.withDisabledClientMetrics"},
 			wantConnPool: 8,
 		},
@@ -118,13 +124,18 @@ func TestNewClientTransport(t *testing.T) {
 		wantCalls []string
 	}{
 		{
-			name:      "default speaks the json api over http",
-			transport: ucfg.BackupGCS{},
+			name:      "http speaks the json api",
+			transport: ucfg.BackupGCS{UseGRPC: new(false)},
 			wantCalls: []string{"/storage/v1/b/my-bucket"},
 		},
 		{
 			name:      "grpc speaks the storage grpc api",
-			transport: ucfg.BackupGCS{UseGRPC: true, GRPCConnPool: ucfg.DefaultBackupGCSGRPCConnPool},
+			transport: ucfg.BackupGCS{UseGRPC: new(true), GRPCConnPool: ucfg.DefaultBackupGCSGRPCConnPool},
+			wantCalls: []string{"/google.storage.v2.Storage/GetBucket"},
+		},
+		{
+			name:      "an unset transport speaks the storage grpc api",
+			transport: ucfg.BackupGCS{GRPCConnPool: ucfg.DefaultBackupGCSGRPCConnPool},
 			wantCalls: []string{"/google.storage.v2.Storage/GetBucket"},
 		},
 	}

--- a/modules/backup-gcs/module_test.go
+++ b/modules/backup-gcs/module_test.go
@@ -40,7 +40,7 @@ func TestInit_ClientConfigWiring(t *testing.T) {
 		{name: "export only", backupFlag: false, exportFlag: true},
 		{
 			name:      "grpc transport reaches both clients",
-			transport: config.BackupGCS{UseGRPC: true, GRPCConnPool: config.DefaultBackupGCSGRPCConnPool},
+			transport: config.BackupGCS{UseGRPC: new(true), GRPCConnPool: config.DefaultBackupGCSGRPCConnPool},
 		},
 	}
 	for _, tt := range tests {

--- a/test/docker/gcs.go
+++ b/test/docker/gcs.go
@@ -60,6 +60,9 @@ func startGCS(ctx context.Context, networkName string) (*DockerContainer, error)
 	envSettings["GOOGLE_CLOUD_PROJECT"] = projectID
 	envSettings["STORAGE_EMULATOR_HOST"] = fmt.Sprintf("%s:%s", GCS, port.Port())
 	envSettings["BACKUP_GCS_USE_AUTH"] = "false"
+	// The emulator serves the JSON API only, so it cannot answer the gRPC
+	// transport the module otherwise defaults to.
+	envSettings["GCS_MODULE_TRANSPORT"] = "http"
 	endpoints := make(map[EndpointName]endpoint)
 	endpoints[HTTP] = endpoint{port, uri}
 	return &DockerContainer{GCS, endpoints, container, envSettings}, nil

--- a/test/helper/backuptest/gcs.go
+++ b/test/helper/backuptest/gcs.go
@@ -202,6 +202,9 @@ func (b *GCSBackend) GetWeaviateEnv() map[string]string {
 		"BACKUP_GCS_BUCKET":              b.BucketName(),
 		"BACKUP_GCS_USE_AUTH":            "false",
 		"GOOGLE_APPLICATION_CREDENTIALS": "", // Empty for emulator
+		// The emulator serves the JSON API only, so it cannot answer the gRPC
+		// transport the module otherwise defaults to.
+		"GCS_MODULE_TRANSPORT": "http",
 	}
 }
 

--- a/test/modules/backup-gcs/backup_backend_test.go
+++ b/test/modules/backup-gcs/backup_backend_test.go
@@ -41,6 +41,12 @@ const (
 	envGCSUseAuth             = "BACKUP_GCS_USE_AUTH"
 )
 
+// The emulator these tests run against serves the JSON API only, so it cannot
+// answer the gRPC transport the module otherwise defaults to.
+func httpTransport() config.BackupGCS {
+	return config.BackupGCS{UseGRPC: new(false)}
+}
+
 func Test_GcsBackend_Start(t *testing.T) {
 	// Uses the shared GCS emulator from TestMain
 	gCSBackend_Backup(t, "", "")
@@ -90,7 +96,7 @@ func moduleLevelStoreBackupMeta(t *testing.T, overrideBucket, overridePath strin
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
-		params.EXPECT().GetConfig().Return(&config.Config{})
+		params.EXPECT().GetConfig().Return(&config.Config{BackupGCS: httpTransport()})
 		err := gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -184,7 +190,7 @@ func moduleLevelCopyObjects(t *testing.T, overrideBucket, overridePath string) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: t.TempDir()})
-		params.EXPECT().GetConfig().Return(&config.Config{})
+		params.EXPECT().GetConfig().Return(&config.Config{BackupGCS: httpTransport()})
 		err := gcs.Init(testCtx, params)
 		require.Nil(t, err)
 
@@ -237,7 +243,7 @@ func moduleLevelCopyFiles(t *testing.T, overrideBucket, overridePath string) {
 		params := moduletools.NewMockModuleInitParams(t)
 		params.EXPECT().GetLogger().Return(logrus.New())
 		params.EXPECT().GetStorageProvider().Return(&fakeStorageProvider{dataPath: dataDir})
-		params.EXPECT().GetConfig().Return(&config.Config{})
+		params.EXPECT().GetConfig().Return(&config.Config{BackupGCS: httpTransport()})
 		err = gcs.Init(testCtx, params)
 		require.Nil(t, err)
 

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -871,6 +871,7 @@ case $CONFIG in
       GOOGLE_CLOUD_PROJECT=project-id \
       STORAGE_EMULATOR_HOST=localhost:9090 \
       BACKUP_GCS_ENDPOINT=localhost:9090 \
+      GCS_MODULE_TRANSPORT=http \
       BACKUP_GCS_BUCKET=weaviate-backups \
       ENABLE_MODULES="text2vec-contextionary,backup-gcs" \
       CLUSTER_IN_LOCALHOST=true \
@@ -892,6 +893,7 @@ case $CONFIG in
       GOOGLE_CLOUD_PROJECT=project-id \
       STORAGE_EMULATOR_HOST=localhost:9090 \
       BACKUP_GCS_ENDPOINT=localhost:9090 \
+      GCS_MODULE_TRANSPORT=http \
       BACKUP_GCS_BUCKET=weaviate-backups \
       ENABLE_MODULES="text2vec-contextionary,backup-gcs" \
       CLUSTER_IN_LOCALHOST=true \
@@ -916,6 +918,7 @@ case $CONFIG in
       GOOGLE_CLOUD_PROJECT=project-id \
       STORAGE_EMULATOR_HOST=localhost:9090 \
       BACKUP_GCS_ENDPOINT=localhost:9090 \
+      GCS_MODULE_TRANSPORT=http \
       BACKUP_GCS_BUCKET=weaviate-backups \
       ENABLE_MODULES="text2vec-contextionary,backup-gcs" \
       CLUSTER_IN_LOCALHOST=true \
@@ -966,6 +969,7 @@ local-usage-gcs)
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       STORAGE_EMULATOR_HOST=localhost:9090 \
       BACKUP_GCS_ENDPOINT=localhost:9090 \
+      GCS_MODULE_TRANSPORT=http \
       BACKUP_GCS_BUCKET=weaviate-backups \
       USAGE_GCS_BUCKET=weaviate-usage \
       USAGE_GCS_PREFIX=billing-usage \

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -886,16 +886,23 @@ const (
 // GCS_MODULE_ prefix marks it as covering both clients that module builds, the
 // backup one and the export one, unlike the backup-only BACKUP_GCS_BUCKET.
 type BackupGCS struct {
-	// UseGRPC switches from the JSON/HTTP API to the gRPC API. The throughput
-	// gRPC adds comes from DirectPath, which only applies inside GCP, and from
-	// spreading requests over GRPCConnPool channels.
+	// UseGRPC picks the gRPC API over the JSON/HTTP API. The throughput gRPC
+	// adds comes from DirectPath, which only applies inside GCP, and from
+	// spreading requests over GRPCConnPool channels. Nil means unset and falls
+	// back to gRPC; set it to false to go back to HTTP.
 	// Env: GCS_MODULE_TRANSPORT (http or grpc).
-	UseGRPC bool `json:"use_grpc" yaml:"use_grpc"`
+	UseGRPC *bool `json:"use_grpc" yaml:"use_grpc"`
 
 	// GRPCConnPool is how many gRPC channels each client opens. Zero means
 	// unset and falls back to DefaultBackupGCSGRPCConnPool.
 	// Env: GCS_MODULE_GRPC_CONN_POOL.
 	GRPCConnPool int `json:"grpc_conn_pool" yaml:"grpc_conn_pool"`
+}
+
+// UseGRPCOrDefault reports whether the module talks to GCS over gRPC,
+// defaulting to true.
+func (b BackupGCS) UseGRPCOrDefault() bool {
+	return b.UseGRPC == nil || *b.UseGRPC
 }
 
 // Validate bounds a connection pool that came from the config file. Values from

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -277,12 +277,38 @@ func TestConfigParsing(t *testing.T) {
 		weaviateConfig := &WeaviateConfig{}
 		config, err := weaviateConfig.parseConfigFile(file, configFileName)
 		require.NoError(t, err)
-		require.Equal(t, BackupGCS{UseGRPC: true, GRPCConnPool: 32}, config.BackupGCS)
+		require.Equal(t, BackupGCS{UseGRPC: new(true), GRPCConnPool: 32}, config.BackupGCS)
 
 		// LoadConfig reads the file before the environment, so an unset variable
 		// has to leave the parsed value alone.
 		require.NoError(t, FromEnv(&config))
-		assert.Equal(t, BackupGCS{UseGRPC: true, GRPCConnPool: 32}, config.BackupGCS)
+		assert.Equal(t, BackupGCS{UseGRPC: new(true), GRPCConnPool: 32}, config.BackupGCS)
+	})
+
+	t.Run("parse backup_gcs http config and survive the env pass - yaml", func(t *testing.T) {
+		for _, key := range []string{"GCS_MODULE_TRANSPORT", "GCS_MODULE_GRPC_CONN_POOL"} {
+			t.Setenv(key, "")
+		}
+
+		configFileName := "config.yaml"
+		configYaml := `backup_gcs:
+  use_grpc: false
+`
+
+		filepath := fmt.Sprintf("%s/%s", t.TempDir(), configFileName)
+		require.NoError(t, os.WriteFile(filepath, []byte(configYaml), 0o600))
+
+		file, err := os.ReadFile(filepath)
+		require.NoError(t, err)
+		weaviateConfig := &WeaviateConfig{}
+		config, err := weaviateConfig.parseConfigFile(file, configFileName)
+		require.NoError(t, err)
+
+		// gRPC is the default, so an explicit false has to be distinguishable
+		// from an absent key or this config file silently changes transport.
+		require.NoError(t, FromEnv(&config))
+		require.NotNil(t, config.BackupGCS.UseGRPC)
+		assert.False(t, config.BackupGCS.UseGRPCOrDefault())
 	})
 }
 
@@ -524,6 +550,24 @@ func TestConfigValidation_Namespaces(t *testing.T) {
 				assert.NotContains(t, err.Error(), "NAMESPACES_ENABLED=true requires DISABLE_GRAPHQL=true")
 				assert.NotContains(t, err.Error(), "NAMESPACES_ENABLED=true requires RBAC to be enabled")
 			}
+		})
+	}
+}
+
+func TestBackupGCSUseGRPCOrDefault(t *testing.T) {
+	tests := []struct {
+		name    string
+		useGRPC *bool
+		want    bool
+	}{
+		{name: "unset defaults to grpc", useGRPC: nil, want: true},
+		{name: "explicit false selects http", useGRPC: new(false), want: false},
+		{name: "explicit true selects grpc", useGRPC: new(true), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, BackupGCS{UseGRPC: tt.useGRPC}.UseGRPCOrDefault())
 		})
 	}
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -2359,9 +2359,9 @@ func (c *Config) parseBackupGCSConfig() error {
 	switch t := strings.TrimSpace(strings.ToLower(os.Getenv(gcsModuleTransportEnv))); t {
 	case "": // keep the config file value
 	case gcsModuleTransportHTTP:
-		c.BackupGCS.UseGRPC = false
+		c.BackupGCS.UseGRPC = new(false)
 	case gcsModuleTransportGRPC:
-		c.BackupGCS.UseGRPC = true
+		c.BackupGCS.UseGRPC = new(true)
 	default:
 		return fmt.Errorf("%s must be %q or %q. Got: %v",
 			gcsModuleTransportEnv, gcsModuleTransportHTTP, gcsModuleTransportGRPC, t)

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -584,28 +584,28 @@ func TestEnvironmentBackupGCS(t *testing.T) {
 		wantErr  string
 	}{
 		{
-			name:     "unset selects http",
+			name:     "unset leaves the transport unset, which means grpc",
 			expected: BackupGCS{GRPCConnPool: DefaultBackupGCSGRPCConnPool},
 		},
 		{
-			name:     "empty selects http",
+			name:     "empty leaves the transport unset, which means grpc",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": ""},
 			expected: BackupGCS{GRPCConnPool: DefaultBackupGCSGRPCConnPool},
 		},
 		{
 			name:     "http",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "http"},
-			expected: BackupGCS{GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+			expected: BackupGCS{UseGRPC: new(false), GRPCConnPool: DefaultBackupGCSGRPCConnPool},
 		},
 		{
 			name:     "grpc",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: DefaultBackupGCSGRPCConnPool},
 		},
 		{
 			name:     "transport is case insensitive and trimmed",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": " gRPC "},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: DefaultBackupGCSGRPCConnPool},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: DefaultBackupGCSGRPCConnPool},
 		},
 		{
 			name:    "unknown transport is rejected",
@@ -615,17 +615,17 @@ func TestEnvironmentBackupGCS(t *testing.T) {
 		{
 			name:     "connection pool overrides the default",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc", "GCS_MODULE_GRPC_CONN_POOL": "16"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 16},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 16},
 		},
 		{
 			name:     "connection pool of one is accepted",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc", "GCS_MODULE_GRPC_CONN_POOL": "1"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 1},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 1},
 		},
 		{
 			name:     "connection pool at the cap is accepted",
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc", "GCS_MODULE_GRPC_CONN_POOL": "64"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: MaxBackupGCSGRPCConnPool},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: MaxBackupGCSGRPCConnPool},
 		},
 		{
 			name:    "connection pool of zero is rejected",
@@ -654,43 +654,48 @@ func TestEnvironmentBackupGCS(t *testing.T) {
 		},
 		{
 			name:     "unset transport keeps the config file value",
-			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			start:    BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
 		},
 		{
 			name:     "empty transport keeps the config file value",
-			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			start:    BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": ""},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
+		},
+		{
+			name:     "a config file pinned to http stays on http",
+			start:    BackupGCS{UseGRPC: new(false), GRPCConnPool: 32},
+			expected: BackupGCS{UseGRPC: new(false), GRPCConnPool: 32},
 		},
 		{
 			name:     "http overrides the config file transport",
-			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			start:    BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "http"},
-			expected: BackupGCS{GRPCConnPool: 32},
+			expected: BackupGCS{UseGRPC: new(false), GRPCConnPool: 32},
 		},
 		{
 			name:     "grpc overrides the config file transport",
-			start:    BackupGCS{GRPCConnPool: 32},
+			start:    BackupGCS{UseGRPC: new(false), GRPCConnPool: 32},
 			env:      map[string]string{"GCS_MODULE_TRANSPORT": "grpc"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
 		},
 		{
 			name:     "connection pool overrides the config file value",
-			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 32},
+			start:    BackupGCS{UseGRPC: new(true), GRPCConnPool: 32},
 			env:      map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "16"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 16},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 16},
 		},
 		{
 			name:     "config file connection pool out of range is left for validation",
-			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 100},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 100},
+			start:    BackupGCS{UseGRPC: new(true), GRPCConnPool: 100},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 100},
 		},
 		{
 			name:     "connection pool overrides an out of range config file value",
-			start:    BackupGCS{UseGRPC: true, GRPCConnPool: 100},
+			start:    BackupGCS{UseGRPC: new(true), GRPCConnPool: 100},
 			env:      map[string]string{"GCS_MODULE_GRPC_CONN_POOL": "8"},
-			expected: BackupGCS{UseGRPC: true, GRPCConnPool: 8},
+			expected: BackupGCS{UseGRPC: new(true), GRPCConnPool: 8},
 		},
 	}
 


### PR DESCRIPTION
### What's being changed:

Switch the default for uploading to GCS to GRPC

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
