### PR TITLE
Stop holding the collection map lock while counting objects on disk

### DIFF
--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -129,12 +129,11 @@ func (o *nodeWideMetricsObserver) observeShards() {
 }
 
 // Collect and publish the node-wide object_count metric, only when every index
-// reports allShardsReady. A walk an index stops leaves the gauge at its previous
-// value rather than publishing a partial sum, and a collection being deleted
-// counts zero. A single shard whose directory check or object count fails is
-// logged and skipped instead, so the published total is short by that shard.
+// reports allShardsReady. An index whose walk stops leaves the gauge at its
+// previous value instead of a partial sum. A deleted collection counts zero.
+// A shard that fails its directory check or count is left out of the total.
 func (o *nodeWideMetricsObserver) observeObjectCount() {
-	// One copy serves both loops: taking a second for the sum would let an index
+	// One copy serves both loops. Taking a second for the sum would let an index
 	// created in between be counted without its allShardsReady being checked.
 	indices := o.db.copyIndices()
 
@@ -153,14 +152,13 @@ func (o *nodeWideMetricsObserver) observeObjectCount() {
 	for _, index := range indices {
 		count, err := o.indexObjectCount(index)
 		if errors.Is(err, errIndexDropped) {
-			// A collection being deleted really is losing its objects, so the
-			// rest of the node still has a total worth publishing.
+			// A collection being deleted is losing its objects, so the rest of
+			// the node still has a total worth publishing.
 			continue
 		}
 		if err != nil {
 			// Setting ObjectCount to the shards counted so far would report
-			// objects the node never lost. It keeps its previous value instead,
-			// which only this line explains.
+			// objects the node never lost, so the gauge keeps its previous value.
 			o.db.logger.WithFields(logrus.Fields{
 				"action": "skip_observe_node_wide_metrics",
 				"class":  index.Config.ClassName,
@@ -184,13 +182,14 @@ func (o *nodeWideMetricsObserver) observeObjectCount() {
 }
 
 // indexObjectCount sums one index's shard object counts without holding
-// indexLock, because a cold shard reads its count off disk. The walk stops at
-// the next shard once a drop or shutdown is requested: DeleteIndex takes
-// dropIndex while holding indexLock, so a walk that kept dropIndex.RLock would
-// block every index lookup on the node. A stopped walk has no total, and its
-// error carries the cause so the caller can tell a deleted collection from one
-// it must not leave out.
+// indexLock, because a cold shard reads its count off disk. A stopped walk
+// returns no total, and its error names the cause so the caller can tell a
+// delete from a shutdown.
 func (o *nodeWideMetricsObserver) indexObjectCount(index *Index) (int64, error) {
+	// The walk stops at the next shard once a close is requested rather than
+	// holding this across every shard. A long hold parks DeleteIndex on
+	// dropIndex.Lock, and readers taking dropIndex.RLock under indexLock queue
+	// behind it.
 	index.dropIndex.RLock()
 	defer index.dropIndex.RUnlock()
 
@@ -245,8 +244,8 @@ func (o *nodeWideMetricsObserver) indexObjectCount(index *Index) (int64, error) 
 
 	// A callback only checks on entry, so a close request arriving during the
 	// last shard's count has no callback left to stop the walk. Both checks read
-	// the request rather than walkCtx: cancelOnCloseRequested propagates it
-	// through context.AfterFunc, whose goroutine can still be unscheduled here.
+	// closeRequestedCtx rather than walkCtx, whose cancellation runs in a
+	// context.AfterFunc goroutine that may not have been scheduled yet.
 	if index.closeRequestedCtx.Err() != nil {
 		return 0, context.Cause(index.closeRequestedCtx)
 	}

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
@@ -126,12 +128,17 @@ func (o *nodeWideMetricsObserver) observeShards() {
 	}
 }
 
-// Collect and publish aggregated object_count metric iff all indices report allShardsReady=true.
+// Collect and publish the node-wide object_count metric, only when every index
+// reports allShardsReady. A walk an index stops leaves the gauge at its previous
+// value rather than publishing a partial sum, and a collection being deleted
+// counts zero. A single shard whose directory check or object count fails is
+// logged and skipped instead, so the published total is short by that shard.
 func (o *nodeWideMetricsObserver) observeObjectCount() {
-	o.db.indexLock.RLock()
-	defer o.db.indexLock.RUnlock()
+	// One copy serves both loops: taking a second for the sum would let an index
+	// created in between be counted without its allShardsReady being checked.
+	indices := o.db.copyIndices()
 
-	for _, index := range o.db.indices {
+	for _, index := range indices {
 		if !index.allShardsReady.Load() {
 			o.db.logger.WithFields(logrus.Fields{
 				"action": "skip_observe_node_wide_metrics",
@@ -143,33 +150,24 @@ func (o *nodeWideMetricsObserver) observeObjectCount() {
 	start := time.Now()
 
 	totalObjectCount := int64(0)
-	for _, index := range o.db.indices {
-		index.ForEachShard(func(name string, shard ShardLike) error {
-			index.shardCreateLocks.RLock(name)
-			defer index.shardCreateLocks.RUnlock(name)
-			exists, err := index.tenantDirExists(name)
-			if err != nil {
-				o.db.logger.
-					WithField("action", "observe_node_wide_metrics").
-					WithField("shard", name).
-					WithField("class", index.Config.ClassName).
-					Warnf("error while checking if shard exists: %v", err)
-				return nil
-			}
-			if !exists {
-				// shard was deleted in the meantime or is newly created and hasn't been written to disk, skip
-				return nil
-			}
-			objectCount, err := shard.ObjectCountAsync(context.Background())
-			if err != nil {
-				o.db.logger.WithField("action", "observe_node_wide_metrics").
-					WithField("shard", name).
-					WithField("class", index.Config.ClassName).
-					Warnf("error while getting object count for shard: %v", err)
-			}
-			totalObjectCount += objectCount
-			return nil
-		})
+	for _, index := range indices {
+		count, err := o.indexObjectCount(index)
+		if errors.Is(err, errIndexDropped) {
+			// A collection being deleted really is losing its objects, so the
+			// rest of the node still has a total worth publishing.
+			continue
+		}
+		if err != nil {
+			// Setting ObjectCount to the shards counted so far would report
+			// objects the node never lost. It keeps its previous value instead,
+			// which only this line explains.
+			o.db.logger.WithFields(logrus.Fields{
+				"action": "skip_observe_node_wide_metrics",
+				"class":  index.Config.ClassName,
+			}).Warnf("skip node-wide metrics, object count walk stopped: %v", err)
+			return
+		}
+		totalObjectCount += count
 	}
 
 	o.db.promMetrics.ObjectCount.With(prometheus.Labels{
@@ -183,6 +181,76 @@ func (o *nodeWideMetricsObserver) observeObjectCount() {
 		"took":         took,
 		"object_count": totalObjectCount,
 	}).Debug("observed node wide metrics")
+}
+
+// indexObjectCount sums one index's shard object counts without holding
+// indexLock, because a cold shard reads its count off disk. The walk stops at
+// the next shard once a drop or shutdown is requested: DeleteIndex takes
+// dropIndex while holding indexLock, so a walk that kept dropIndex.RLock would
+// block every index lookup on the node. A stopped walk has no total, and its
+// error carries the cause so the caller can tell a deleted collection from one
+// it must not leave out.
+func (o *nodeWideMetricsObserver) indexObjectCount(index *Index) (int64, error) {
+	index.dropIndex.RLock()
+	defer index.dropIndex.RUnlock()
+
+	index.closeLock.RLock()
+	defer index.closeLock.RUnlock()
+
+	if index.closed {
+		err := context.Cause(index.closeRequestedCtx)
+		if err == nil {
+			err = errIndexClosed
+		}
+		return 0, err
+	}
+
+	walkCtx, done := index.cancelOnCloseRequested(context.Background())
+	defer done()
+
+	var total int64
+	err := index.ForEachShard(func(name string, shard ShardLike) error {
+		if index.closeRequestedCtx.Err() != nil {
+			return context.Cause(index.closeRequestedCtx)
+		}
+
+		index.shardCreateLocks.RLock(name)
+		defer index.shardCreateLocks.RUnlock(name)
+		exists, err := index.tenantDirExists(name)
+		if err != nil {
+			o.db.logger.
+				WithField("action", "observe_node_wide_metrics").
+				WithField("shard", name).
+				WithField("class", index.Config.ClassName).
+				Warnf("error while checking if shard exists: %v", err)
+			return nil
+		}
+		if !exists {
+			// shard was deleted in the meantime or is newly created and hasn't been written to disk, skip
+			return nil
+		}
+		objectCount, err := shard.ObjectCountAsync(walkCtx)
+		if err != nil {
+			o.db.logger.WithField("action", "observe_node_wide_metrics").
+				WithField("shard", name).
+				WithField("class", index.Config.ClassName).
+				Warnf("error while getting object count for shard: %v", err)
+		}
+		total += objectCount
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+
+	// A callback only checks on entry, so a close request arriving during the
+	// last shard's count has no callback left to stop the walk. Both checks read
+	// the request rather than walkCtx: cancelOnCloseRequested propagates it
+	// through context.AfterFunc, whose goroutine can still be unscheduled here.
+	if index.closeRequestedCtx.Err() != nil {
+		return 0, context.Cause(index.closeRequestedCtx)
+	}
+	return total, nil
 }
 
 // NOTE(dyma): should this also chech that all indices report allShardsReady == true?

--- a/adapters/repos/db/node_wide_metrics_object_count_test.go
+++ b/adapters/repos/db/node_wide_metrics_object_count_test.go
@@ -1,0 +1,340 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// gaugeUntouched is a value the sum can never produce, so a test that pre-sets
+// the gauge to it can tell "published this total" from "published nothing".
+const gaugeUntouched = -1
+
+// newObjectCountTestIndex builds an index observeObjectCount can walk. It
+// creates each shard's tenant directory, because indexObjectCount skips a shard
+// whose directory is missing.
+func newObjectCountTestIndex(t *testing.T, className string, shards map[string]ShardLike) *Index {
+	t.Helper()
+
+	logger, _ := test.NewNullLogger()
+	index := newActivityTestIndex(className, true)
+	index.logger = logger
+	index.Config.RootPath = t.TempDir()
+	index.closeRequestedCtx, index.signalCloseRequested = context.WithCancelCause(context.Background())
+	index.allShardsReady.Store(true)
+
+	for name, shard := range shards {
+		require.NoError(t, os.MkdirAll(shardPath(index.path(), name), 0o755))
+		index.shards.Store(name, shard)
+	}
+	return index
+}
+
+// newObjectCountObserver returns an observer over the given indices, the DB it
+// reads them from, and the gauge observeObjectCount publishes into, pre-set to
+// gaugeUntouched.
+func newObjectCountObserver(indices ...*Index) (*nodeWideMetricsObserver, *DB, prometheus.Gauge) {
+	logger, _ := test.NewNullLogger()
+	gaugeVec := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "object_count"},
+		[]string{"class_name", "shard_name"})
+	gauge := gaugeVec.WithLabelValues("n/a", "n/a")
+	gauge.Set(gaugeUntouched)
+
+	byName := make(map[string]*Index, len(indices))
+	for _, index := range indices {
+		byName[index.ID()] = index
+	}
+	db := &DB{
+		logger:      logger,
+		indices:     byName,
+		promMetrics: &monitoring.PrometheusMetrics{ObjectCount: gaugeVec},
+	}
+	return newNodeWideMetricsObserver(db), db, gauge
+}
+
+// countingShard reports count and never fails. Maybe() because a walk that
+// stops early leaves the shards behind it uncounted.
+func countingShard(t *testing.T, count int64) *MockShardLike {
+	t.Helper()
+
+	shard := NewMockShardLike(t)
+	shard.EXPECT().ObjectCountAsync(mock.Anything).Return(count, nil).Maybe()
+	return shard
+}
+
+// untouchedShard fails the test if anything asks it for a count, which is what
+// an expectation cannot do: testify caps a call count from above, never at zero.
+func untouchedShard(t *testing.T) *MockShardLike {
+	t.Helper()
+
+	return NewMockShardLike(t)
+}
+
+func TestObserveObjectCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		indices func(t *testing.T) []*Index
+		want    float64
+	}{
+		{
+			name: "sums every shard of every index",
+			indices: func(t *testing.T) []*Index {
+				return []*Index{
+					newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+						"tenant-0": countingShard(t, 3),
+						"tenant-1": countingShard(t, 4),
+					}),
+					newObjectCountTestIndex(t, "Col2", map[string]ShardLike{
+						"tenant-0": countingShard(t, 5),
+					}),
+				}
+			},
+			want: 12,
+		},
+		{
+			name: "no index at all publishes zero",
+			indices: func(t *testing.T) []*Index {
+				return nil
+			},
+			want: 0,
+		},
+		{
+			name: "an index with no shards publishes zero",
+			indices: func(t *testing.T) []*Index {
+				return []*Index{newObjectCountTestIndex(t, "Col1", nil)}
+			},
+			want: 0,
+		},
+		{
+			name: "one index short of ready leaves every shard unread",
+			indices: func(t *testing.T) []*Index {
+				pending := newObjectCountTestIndex(t, "Col2", map[string]ShardLike{
+					"tenant-0": untouchedShard(t),
+				})
+				pending.allShardsReady.Store(false)
+				return []*Index{
+					newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+						"tenant-0": untouchedShard(t),
+					}),
+					pending,
+				}
+			},
+			want: gaugeUntouched,
+		},
+		{
+			name: "a collection closed with no recorded cause skips the tick",
+			indices: func(t *testing.T) []*Index {
+				closed := newObjectCountTestIndex(t, "Col2", map[string]ShardLike{
+					"tenant-0": untouchedShard(t),
+				})
+				closed.closed = true
+				return []*Index{
+					newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+						"tenant-0": countingShard(t, 3),
+					}),
+					closed,
+				}
+			},
+			want: gaugeUntouched,
+		},
+		{
+			name: "a collection closed by a delete counts zero, the rest still count",
+			indices: func(t *testing.T) []*Index {
+				deleted := newObjectCountTestIndex(t, "Col2", map[string]ShardLike{
+					"tenant-0": untouchedShard(t),
+				})
+				deleted.signalCloseRequested(errIndexDropped)
+				deleted.closed = true
+				return []*Index{
+					newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+						"tenant-0": countingShard(t, 3),
+					}),
+					deleted,
+				}
+			},
+			want: 3,
+		},
+		{
+			name: "a shard whose directory is gone is skipped",
+			indices: func(t *testing.T) []*Index {
+				index := newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+					"tenant-0": countingShard(t, 3),
+					"tenant-1": untouchedShard(t),
+				})
+				require.NoError(t, os.RemoveAll(shardPath(index.path(), "tenant-1")))
+				return []*Index{index}
+			},
+			want: 3,
+		},
+		{
+			name: "a shard that fails to report its count contributes zero",
+			indices: func(t *testing.T) []*Index {
+				failing := NewMockShardLike(t)
+				failing.EXPECT().ObjectCountAsync(mock.Anything).
+					Return(0, errors.New("segment metadata unreadable")).Maybe()
+				return []*Index{
+					newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+						"tenant-0": countingShard(t, 3),
+						"tenant-1": failing,
+					}),
+				}
+			},
+			want: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o, _, gauge := newObjectCountObserver(tt.indices(t)...)
+
+			o.observeObjectCount()
+
+			require.Equal(t, tt.want, testutil.ToFloat64(gauge))
+		})
+	}
+}
+
+func TestObserveObjectCountReleasesIndexLock(t *testing.T) {
+	counting := make(chan struct{})
+	release := make(chan struct{})
+	// Deferred as well as called, so a failed assertion below still lets the
+	// walk finish instead of leaving it parked on release.
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	defer releaseOnce()
+
+	shard := NewMockShardLike(t)
+	shard.EXPECT().ObjectCountAsync(mock.Anything).RunAndReturn(
+		func(context.Context) (int64, error) {
+			close(counting)
+			<-release
+			return 3, nil
+		})
+
+	index := newObjectCountTestIndex(t, "Col1", map[string]ShardLike{"tenant-0": shard})
+	o, db, gauge := newObjectCountObserver(index)
+
+	observed := make(chan struct{})
+	go func() {
+		defer close(observed)
+		o.observeObjectCount()
+	}()
+
+	<-counting
+	// The walk takes longer the more tenants the node has, because a cold shard
+	// reads its count off disk. Every index lookup takes indexLock for read and
+	// DeleteIndex takes it for write.
+	require.True(t, db.indexLock.TryLock(), "indexLock must be free while shards are counted")
+	db.indexLock.Unlock()
+
+	releaseOnce()
+	<-observed
+	require.Equal(t, float64(3), testutil.ToFloat64(gauge))
+}
+
+func TestObserveObjectCountWalkStoppedByCloseRequest(t *testing.T) {
+	tests := []struct {
+		name   string
+		cause  error
+		shards []string
+		// countAwaitsCancel holds the shard's count open until the request
+		// reaches walkCtx, which is what a shard honouring its context would do.
+		// Both real ObjectCountAsync implementations ignore it and return at
+		// once, which is the shape the one-shard rows below use.
+		countAwaitsCancel bool
+		want              float64
+	}{
+		{
+			name:              "a collection being deleted counts zero, the rest still publish",
+			cause:             errIndexDropped,
+			shards:            []string{"tenant-0", "tenant-1"},
+			countAwaitsCancel: true,
+			want:              100,
+		},
+		{
+			name:              "a collection shutting down skips the whole tick",
+			cause:             errIndexShutdown,
+			shards:            []string{"tenant-0", "tenant-1"},
+			countAwaitsCancel: true,
+			want:              gaugeUntouched,
+		},
+		// A close during the last shard leaves no callback to observe it, so the
+		// walk has to answer for the cancellation after it returns.
+		{
+			name:   "a delete during the only shard still counts that collection zero",
+			cause:  errIndexDropped,
+			shards: []string{"tenant-0"},
+			want:   100,
+		},
+		{
+			name:   "a shutdown during the only shard still skips the whole tick",
+			cause:  errIndexShutdown,
+			shards: []string{"tenant-0"},
+			want:   gaugeUntouched,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stopping *Index
+			var once sync.Once
+			var counted atomic.Int32
+
+			// Whichever shard the walk reaches first requests the close, so no shard
+			// behind it is counted whichever order the shards come in.
+			requestClose := func(ctx context.Context) (int64, error) {
+				counted.Add(1)
+				once.Do(func() { stopping.signalCloseRequested(tt.cause) })
+				if !tt.countAwaitsCancel {
+					return 5, nil
+				}
+				select {
+				case <-ctx.Done():
+					return 5, nil
+				case <-time.After(2 * time.Second):
+					return 0, errors.New("walk context outlived the close request")
+				}
+			}
+
+			shards := map[string]ShardLike{}
+			for _, name := range tt.shards {
+				shard := NewMockShardLike(t)
+				shard.EXPECT().ObjectCountAsync(mock.Anything).RunAndReturn(requestClose).Maybe()
+				shards[name] = shard
+			}
+			stopping = newObjectCountTestIndex(t, "Col2", shards)
+
+			healthy := newObjectCountTestIndex(t, "Col1", map[string]ShardLike{
+				"tenant-0": countingShard(t, 100),
+			})
+			o, _, gauge := newObjectCountObserver(healthy, stopping)
+
+			o.observeObjectCount()
+
+			require.Equal(t, int32(1), counted.Load(),
+				"the walk must count exactly the shards ahead of the close request")
+			require.Equal(t, tt.want, testutil.ToFloat64(gauge))
+		})
+	}
+}

--- a/adapters/repos/db/node_wide_metrics_object_count_test.go
+++ b/adapters/repos/db/node_wide_metrics_object_count_test.go
@@ -74,8 +74,8 @@ func newObjectCountObserver(indices ...*Index) (*nodeWideMetricsObserver, *DB, p
 	return newNodeWideMetricsObserver(db), db, gauge
 }
 
-// countingShard reports count and never fails. Maybe() because a walk that
-// stops early leaves the shards behind it uncounted.
+// countingShard reports count and never fails. Its expectation is Maybe(),
+// because a walk that stops early leaves the shards behind it uncounted.
 func countingShard(t *testing.T, count int64) *MockShardLike {
 	t.Helper()
 
@@ -84,8 +84,8 @@ func countingShard(t *testing.T, count int64) *MockShardLike {
 	return shard
 }
 
-// untouchedShard fails the test if anything asks it for a count, which is what
-// an expectation cannot do: testify caps a call count from above, never at zero.
+// untouchedShard fails the test if anything asks it for a count. An expectation
+// cannot do that, because testify caps a call count from above, never at zero.
 func untouchedShard(t *testing.T) *MockShardLike {
 	t.Helper()
 
@@ -219,8 +219,8 @@ func TestObserveObjectCount(t *testing.T) {
 func TestObserveObjectCountReleasesIndexLock(t *testing.T) {
 	counting := make(chan struct{})
 	release := make(chan struct{})
-	// Deferred as well as called, so a failed assertion below still lets the
-	// walk finish instead of leaving it parked on release.
+	// releaseOnce is deferred as well as called, so a failed assertion below
+	// still lets the walk finish instead of leaving it parked on release.
 	releaseOnce := sync.OnceFunc(func() { close(release) })
 	defer releaseOnce()
 
@@ -258,10 +258,10 @@ func TestObserveObjectCountWalkStoppedByCloseRequest(t *testing.T) {
 		name   string
 		cause  error
 		shards []string
-		// countAwaitsCancel holds the shard's count open until the request
-		// reaches walkCtx, which is what a shard honouring its context would do.
-		// Both real ObjectCountAsync implementations ignore it and return at
-		// once, which is the shape the one-shard rows below use.
+		// countAwaitsCancel holds the shard's count open until closeRequestedCtx
+		// reaches walkCtx, as a shard honouring its context would. Both real
+		// ObjectCountAsync implementations ignore it and return at once, which is
+		// the shape the one-shard rows below use.
 		countAwaitsCancel bool
 		want              float64
 	}{
@@ -280,7 +280,7 @@ func TestObserveObjectCountWalkStoppedByCloseRequest(t *testing.T) {
 			want:              gaugeUntouched,
 		},
 		// A close during the last shard leaves no callback to observe it, so the
-		// walk has to answer for the cancellation after it returns.
+		// walk checks the close request again after ForEachShard returns.
 		{
 			name:   "a delete during the only shard still counts that collection zero",
 			cause:  errIndexDropped,
@@ -302,7 +302,7 @@ func TestObserveObjectCountWalkStoppedByCloseRequest(t *testing.T) {
 			var counted atomic.Int32
 
 			// Whichever shard the walk reaches first requests the close, so no shard
-			// behind it is counted whichever order the shards come in.
+			// behind it is counted, whatever order the shards come in.
 			requestClose := func(ctx context.Context) (int64, error) {
 				counted.Add(1)
 				once.Do(func() { stopping.signalCloseRequested(tt.cause) })


### PR DESCRIPTION
### What's being changed:

The node-wide `object_count` observer held `DB.indexLock` for the entire duration of its walk, while counting objects on a cold shard reads that count off disk — so a single slow shard blocked every index lookup on the node for as long as the walk took.

This change takes one snapshot of the indices up front (one copy serves both the `allShardsReady` check and the sum, so an index created in between can't be counted without being checked) and moves the per-index shard walk into `indexObjectCount`, which holds only that index's `dropIndex` and `closeLock` read locks.

Because `DeleteIndex` acquires `dropIndex` while holding `indexLock`, the walk deliberately does not keep `dropIndex.RLock` across the whole scan; instead it stops at the next shard once a drop or shutdown is requested, and returns the close cause so the caller can distinguish the two outcomes: a collection being deleted really is losing its objects and counts zero (the rest of the node still publishes a meaningful total), whereas any other interrupted walk leaves the gauge at its previous value rather than publishing a partial sum that would look like data loss.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
