### PR TITLE
Fix shard loaded and unloaded metrics

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3327,7 +3327,7 @@ func (i *Index) UnloadLocalShard(ctx context.Context, shardName string) error {
 	shutdownCtx, done := i.cancelOnCloseRequested(ctx)
 	defer done()
 
-	if err := shutdownOrRestoreShard(shutdownCtx, &i.shards, shardName, shardLike, i.logger); err != nil {
+	if err := shutdownOrRestoreShard(shutdownCtx, i, shardName, shardLike); err != nil {
 		if errors.Is(err, errAlreadyShutdown) {
 			// The shard is shut, which is the outcome this call asked for. It
 			// is worth a line: reaching it means the shutdown burned its retry

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3274,7 +3274,7 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 			return fmt.Errorf("reactivate shard %q: %w", shardName, terr)
 		}
 		if shardKnownShut(shard) {
-			i.shards.LoadAndDelete(shardName)
+			i.evictShutShard(shardName)
 		} else {
 			if mustLoad {
 				lazyShard, ok := shard.(*LazyLoadShard)
@@ -3473,7 +3473,7 @@ func (i *Index) getOptInitLocalShard(ctx context.Context, shardName string, ensu
 		// double check if loaded in the meantime by concurrent call, if not load it
 		shard = i.shards.Load(shardName)
 		if shard != nil && shardKnownShut(shard) {
-			i.shards.LoadAndDelete(shardName)
+			i.evictShutShard(shardName)
 			shard = nil
 		}
 		if shard == nil {

--- a/adapters/repos/db/index_drop_shards_test.go
+++ b/adapters/repos/db/index_drop_shards_test.go
@@ -465,8 +465,15 @@ func newDropTestIndex(t *testing.T) (*Index, *test.Hook) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	// shutdownOrRestoreShard dereferences idx.metrics, so an index without one
+	// panics when a test unloads a shard. Passing nil for prom produces the same
+	// *Metrics a node without monitoring has, one whose baseMetrics is nil.
+	metrics, err := NewMetrics(logger, nil, "Abc", "n/a")
+	require.NoError(t, err)
+
 	idx := &Index{
 		logger:           logger,
+		metrics:          metrics,
 		shards:           shardMap{},
 		closingCtx:       ctx,
 		closingCancel:    cancel,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -365,7 +365,7 @@ func (m *Migrator) ShutdownShard(ctx context.Context, class, shard string) error
 	if !ok {
 		return fmt.Errorf("could not find shard %s", shard)
 	}
-	if err := shutdownOrRestoreShard(ctx, &idx.shards, shard, shardLike, idx.logger); err != nil {
+	if err := shutdownOrRestoreShard(ctx, idx, shard, shardLike); err != nil {
 		if !errors.Is(err, errAlreadyShutdown) {
 			return errors.Wrapf(err, "shutdown shard %q", shard)
 		}
@@ -768,7 +768,7 @@ func (m *Migrator) updateTenants(ctx context.Context, class *models.Class, updat
 
 				m.logger.WithField("shard", name).Debug("starting shutdown")
 
-				if err := shutdownOrRestoreShard(ctx, &idx.shards, name, shard, idx.logger); err != nil {
+				if err := shutdownOrRestoreShard(ctx, idx, name, shard); err != nil {
 					if errors.Is(err, errAlreadyShutdown) {
 						m.logger.WithField("shard", shard.Name()).Debug("already shut down or dropped")
 					} else {

--- a/adapters/repos/db/namespace_guard_test.go
+++ b/adapters/repos/db/namespace_guard_test.go
@@ -500,11 +500,18 @@ func indexForGuardTest(t *testing.T, className string, e namespaces.Exister) *In
 	t.Helper()
 
 	logger, _ := logrustest.NewNullLogger()
+	// shutdownOrRestoreShard dereferences idx.metrics, so an index without one
+	// panics when a test deactivates a tenant. Passing nil for prom produces the
+	// same *Metrics a node without monitoring has, one whose baseMetrics is nil.
+	metrics, err := NewMetrics(logger, nil, className, "n/a")
+	require.NoError(t, err)
+
 	idx := &Index{
 		Config:                 IndexConfig{RootPath: t.TempDir(), ClassName: schema.ClassName(className)},
 		namespace:              namespacing.NamespaceFromQualified(className),
 		namespacesExister:      e,
 		logger:                 logger,
+		metrics:                metrics,
 		shardCreateLocks:       esync.NewKeyRWLocker(),
 		replicaSnapshotOpLocks: esync.NewKeyRWLocker(),
 		backupLock:             esync.NewKeyRWLocker(),

--- a/adapters/repos/db/namespace_guard_test.go
+++ b/adapters/repos/db/namespace_guard_test.go
@@ -1561,6 +1561,12 @@ func indexForBootTest(t *testing.T, className string, e namespaces.Exister, read
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	// shutdownOrRestoreShard dereferences idx.metrics, so an index without one
+	// panics when a test unloads a shard. Passing nil for prom produces the same
+	// *Metrics a node without monitoring has, one whose baseMetrics is nil.
+	metrics, err := NewMetrics(logger, nil, className, "n/a")
+	require.NoError(t, err)
+
 	idx := &Index{
 		Config: IndexConfig{
 			ClassName:            schema.ClassName(className),
@@ -1570,6 +1576,7 @@ func indexForBootTest(t *testing.T, className string, e namespaces.Exister, read
 		namespace:         namespacing.NamespaceFromQualified(className),
 		namespacesExister: e,
 		logger:            logger,
+		metrics:           metrics,
 		schemaReader:      reader,
 		shardCreateLocks:  esync.NewKeyRWLocker(),
 		closingCtx:        ctx,

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -481,7 +481,7 @@ func (i *Index) IncomingReinitShard(ctx context.Context, shardName string) error
 
 		shard, ok := i.shards.LoadAndDelete(shardName)
 		if ok {
-			if err := shutdownOrRestoreShard(ctx, &i.shards, shardName, shard, i.logger); err != nil &&
+			if err := shutdownOrRestoreShard(ctx, i, shardName, shard); err != nil &&
 				!errors.Is(err, errAlreadyShutdown) {
 				return err
 			}

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -35,6 +35,25 @@ import (
 // If keepFiles==true, all files on disk are kept, only in-memory structures are removed. This is used to allow backups
 // to complete before the files are deleted.
 func (s *Shard) drop(keepFiles bool) (err error) {
+	// The shard is out of the shard map before drop runs, so it stops being
+	// counted even when the teardown below fails partway. Claiming the count
+	// under shutdownLock keeps it outside performShutdown's gauge transition.
+	// A shutdown starting mid-drop would otherwise leave it counted as unloading.
+	s.shutdownLock.RLock()
+	wasCounted := s.metricsRegistered.CompareAndSwap(true, false)
+	countedUnloaded := s.shut.Load()
+	s.shutdownLock.RUnlock()
+
+	if wasCounted {
+		defer func() {
+			if countedUnloaded {
+				s.metrics.baseMetrics.DeleteUnloadedShard()
+			} else {
+				s.metrics.baseMetrics.DeleteLoadedShard()
+			}
+		}()
+	}
+
 	// Drain before anything is torn down.
 	if drainErr := s.drainRefsForDrop(); drainErr != nil {
 		s.index.logger.WithFields(logrus.Fields{
@@ -131,7 +150,10 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 		return err
 	}
 
-	if err = s.store.Shutdown(ctx); err != nil {
+	// A shard shut down before the drop closed its store already, which is the
+	// state this step wants. Failing here would abort the drop and leave the
+	// shard's files behind.
+	if err = s.store.Shutdown(ctx); err != nil && !stderrors.Is(err, lsmkv.ErrAlreadyClosed) {
 		return errors.Wrap(err, "stop lsmkv store")
 	}
 
@@ -175,11 +197,6 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 		if deleted != "" {
 			spawnAsyncDelete(deleted, s.index.logger)
 		}
-	}
-
-	// Only update metrics if the shard was properly registered
-	if s.metricsRegistered.Load() {
-		s.metrics.baseMetrics.DeleteLoadedShard()
 	}
 
 	s.index.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -496,6 +496,10 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 	defer l.mutex.Unlock()
 
 	if !l.loaded {
+		// The shard is out of the shard map before drop runs, so it stops being
+		// counted even when the cleanup below fails partway.
+		defer l.shardOpts.promMetrics.DeleteUnloadedShard()
+
 		idx := l.shardOpts.index
 		className := idx.Config.ClassName.String()
 		shardName := l.shardOpts.name
@@ -535,9 +539,6 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 				spawnAsyncDelete(deleted, idx.logger)
 			}
 		}
-
-		// decrement unloaded shard count since this shard is being deleted
-		l.shardOpts.promMetrics.DeleteUnloadedShard()
 
 		return nil
 	}

--- a/adapters/repos/db/shard_lazyloader_metrics_test.go
+++ b/adapters/repos/db/shard_lazyloader_metrics_test.go
@@ -34,29 +34,38 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-// TestLazyLoadShardMetricsLifecycle tests the full lifecycle of shard metrics:
-// 1. Creating a shard increments ShardsUnloaded
-// 2. Loading a shard transitions from Unloaded -> Loading -> Loaded
-// 3. Dropping a shard transitions from Loaded -> Unloading -> Unloaded
-func TestLazyLoadShardMetricsLifecycle(t *testing.T) {
-	ctx := context.Background()
-	dirName := t.TempDir()
-	logger, _ := test.NewNullLogger()
-	className := "TestMetricsLifecycle"
+// shardGauges is a reading of all four shard gauges at one moment, so a test
+// asserts the whole set rather than the one gauge it expects to move.
+type shardGauges struct {
+	loaded    float64
+	loading   float64
+	unloaded  float64
+	unloading float64
+}
 
-	// Get metrics instance
+// shardMetricsHarness is a lazy-loading repo whose shard gauges start at zero,
+// so a test reads them as counts of its own shards.
+type shardMetricsHarness struct {
+	repo         *DB
+	migrator     *Migrator
+	metrics      *monitoring.PrometheusMetrics
+	schemaGetter *fakeSchemaGetter
+}
+
+func newShardMetricsHarness(t *testing.T) *shardMetricsHarness {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+
 	baseMetrics := monitoring.GetMetrics()
 	metricsCopy := *baseMetrics
 	metricsCopy.Registerer = monitoring.NoopRegisterer
 	metrics := &metricsCopy
 
-	// Reset shard metrics to known state
 	metrics.ShardsLoaded.Set(0)
 	metrics.ShardsLoading.Set(0)
 	metrics.ShardsUnloaded.Set(0)
 	metrics.ShardsUnloading.Set(0)
 
-	// Create db with metrics
 	shardState := singleShardState()
 	schemaGetter := &fakeSchemaGetter{
 		schema:     schema.Schema{Objects: &models.Schema{Classes: nil}},
@@ -80,7 +89,7 @@ func TestLazyLoadShardMetricsLifecycle(t *testing.T) {
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
-		RootPath:                  dirName,
+		RootPath:                  t.TempDir(),
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
 		TrackVectorDimensions:     true,
@@ -93,11 +102,172 @@ func TestLazyLoadShardMetricsLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	repo.SetSchemaGetter(schemaGetter)
-	err = repo.WaitForStartup(testCtx())
-	require.NoError(t, err)
-	defer repo.Shutdown(context.Background())
+	require.NoError(t, repo.WaitForStartup(testCtx()))
+	t.Cleanup(func() { repo.Shutdown(context.Background()) })
 
-	migrator := NewMigrator(repo, logger, "node1")
+	return &shardMetricsHarness{
+		repo:         repo,
+		migrator:     NewMigrator(repo, logger, "node1"),
+		metrics:      metrics,
+		schemaGetter: schemaGetter,
+	}
+}
+
+// addClass registers className and returns the name of its only shard, left cold.
+func (h *shardMetricsHarness) addClass(t *testing.T, className string) string {
+	t.Helper()
+	class := &models.Class{
+		Class:               className,
+		VectorIndexConfig:   enthnsw.NewDefaultUserConfig(),
+		InvertedIndexConfig: invertedConfig(),
+	}
+	require.NoError(t, h.migrator.AddClass(context.Background(), class))
+	h.schemaGetter.schema = schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+	var shardName string
+	h.repo.GetIndex(schema.ClassName(className)).shards.Range(func(name string, _ ShardLike) error {
+		shardName = name
+		return nil
+	})
+	require.NotEmpty(t, shardName, "the new class should have registered a shard")
+	return shardName
+}
+
+func (h *shardMetricsHarness) gauges() shardGauges {
+	return shardGauges{
+		loaded:    testutil.ToFloat64(h.metrics.ShardsLoaded),
+		loading:   testutil.ToFloat64(h.metrics.ShardsLoading),
+		unloaded:  testutil.ToFloat64(h.metrics.ShardsUnloaded),
+		unloading: testutil.ToFloat64(h.metrics.ShardsUnloading),
+	}
+}
+
+// TestShardRemovalStopsCountingIt pins that a shard taken out of the shard map
+// leaves the shard gauges. Shutdown alone moves it to unloaded, which is right
+// only while it stays in the map: counted after removal, every tenant
+// deactivation raises shards_unloaded for a shard the node no longer holds.
+func TestShardRemovalStopsCountingIt(t *testing.T) {
+	ctx := context.Background()
+	const className = "TestShardRemovalCounting"
+
+	tests := []struct {
+		name string
+		// loadFirst materializes the shard before it is removed.
+		loadFirst bool
+		remove    func(t *testing.T, h *shardMetricsHarness, shardName string)
+		want      shardGauges
+	}{
+		{
+			name: "ShutdownShard on a cold shard",
+			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				require.NoError(t, h.migrator.ShutdownShard(ctx, className, shardName))
+			},
+		},
+		{
+			name:      "ShutdownShard on a loaded shard",
+			loadFirst: true,
+			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				require.NoError(t, h.migrator.ShutdownShard(ctx, className, shardName))
+			},
+		},
+		{
+			name: "UnloadLocalShard on a cold shard",
+			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				require.NoError(t, h.repo.GetIndex(className).UnloadLocalShard(ctx, shardName))
+			},
+		},
+		{
+			name:      "UnloadLocalShard on a loaded shard",
+			loadFirst: true,
+			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				require.NoError(t, h.repo.GetIndex(className).UnloadLocalShard(ctx, shardName))
+			},
+		},
+		{
+			name:      "IncomingReinitShard counts the shard it puts back once",
+			loadFirst: true,
+			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				require.NoError(t, h.repo.GetIndex(className).IncomingReinitShard(ctx, shardName))
+			},
+			want: shardGauges{unloaded: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newShardMetricsHarness(t)
+			shardName := h.addClass(t, className)
+			require.Equal(t, shardGauges{unloaded: 1}, h.gauges(),
+				"a new lazy shard is counted as unloaded")
+
+			if tt.loadFirst {
+				shard := h.repo.GetIndex(className).shards.Load(shardName)
+				require.NoError(t, shard.(*LazyLoadShard).Load(ctx))
+				require.Equal(t, shardGauges{loaded: 1}, h.gauges())
+			}
+
+			tt.remove(t, h, shardName)
+
+			require.Equal(t, tt.want, h.gauges())
+		})
+	}
+
+	t.Run("a shard put back after a failed shutdown stays counted", func(t *testing.T) {
+		// GetShard holds the shard, so Shutdown gives up after its retries and
+		// shutdownOrRestoreShard puts the live instance back in the map. A shard in
+		// the map is one the node still holds, so it keeps its place in the gauges.
+		h := newShardMetricsHarness(t)
+		shardName := h.addClass(t, className)
+
+		index := h.repo.GetIndex(className)
+		_, release, err := index.GetShard(ctx, shardName)
+		require.NoError(t, err)
+		require.Equal(t, shardGauges{loaded: 1}, h.gauges())
+
+		require.Error(t, index.UnloadLocalShard(ctx, shardName),
+			"a shard in use cannot be shut down")
+		require.Equal(t, shardGauges{loaded: 1}, h.gauges())
+
+		release()
+	})
+
+	t.Run("a name the index does not hold moves no gauge", func(t *testing.T) {
+		h := newShardMetricsHarness(t)
+		h.addClass(t, className)
+
+		require.NoError(t, h.repo.GetIndex(className).UnloadLocalShard(ctx, "no-such-shard"))
+
+		require.Equal(t, shardGauges{unloaded: 1}, h.gauges(),
+			"the class's own shard must keep its count")
+	})
+
+	t.Run("deactivating and activating in turn does not accumulate", func(t *testing.T) {
+		h := newShardMetricsHarness(t)
+		shardName := h.addClass(t, className)
+
+		for range 3 {
+			require.NoError(t, h.migrator.ShutdownShard(ctx, className, shardName))
+			require.Equal(t, shardGauges{}, h.gauges(),
+				"a deactivated shard must leave the gauges every time")
+
+			require.NoError(t, h.migrator.LoadShardForMovement(ctx, className, shardName))
+			require.Equal(t, shardGauges{loaded: 1}, h.gauges(),
+				"an activated shard must be counted once, not once per activation")
+		}
+	})
+}
+
+// TestLazyLoadShardMetricsLifecycle tests the full lifecycle of shard metrics:
+// 1. Creating a shard increments ShardsUnloaded
+// 2. Loading a shard transitions from Unloaded -> Loading -> Loaded
+// 3. Dropping a shard transitions from Loaded -> Unloading -> Unloaded
+func TestLazyLoadShardMetricsLifecycle(t *testing.T) {
+	ctx := context.Background()
+	className := "TestMetricsLifecycle"
+
+	h := newShardMetricsHarness(t)
+	repo, metrics, migrator, schemaGetter := h.repo, h.metrics, h.migrator, h.schemaGetter
+	var err error
 
 	t.Run("create shard increments unloaded count", func(t *testing.T) {
 		// Add class - this creates a shard in unloaded state

--- a/adapters/repos/db/shard_lazyloader_metrics_test.go
+++ b/adapters/repos/db/shard_lazyloader_metrics_test.go
@@ -257,6 +257,62 @@ func TestShardRemovalStopsCountingIt(t *testing.T) {
 	})
 }
 
+// TestReactivationAfterDeferredShutdownCountsOnce pins that a reactivation
+// stops counting the shut shard it evicts. A shutdown that finds the shard in
+// use puts it back in the map and completes later, once the last reference
+// drops; a reactivation then evicts that entry and initializes a fresh shard.
+// Left counted, the evicted entry keeps shards_unloaded standing for a shard
+// the node no longer holds.
+func TestReactivationAfterDeferredShutdownCountsOnce(t *testing.T) {
+	ctx := context.Background()
+	const className = "TestReactivationCounting"
+
+	tests := []struct {
+		name       string
+		reactivate func(t *testing.T, h *shardMetricsHarness, shardName string)
+	}{
+		{
+			name: "load for replica movement",
+			reactivate: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				require.NoError(t, h.migrator.LoadShardForMovement(ctx, className, shardName))
+			},
+		},
+		{
+			name: "write request",
+			reactivate: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				_, release, err := h.repo.GetIndex(className).getOrInitShard(ctx, shardName)
+				require.NoError(t, err)
+				release()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newShardMetricsHarness(t)
+			shardName := h.addClass(t, className)
+			index := h.repo.GetIndex(className)
+
+			// A request holding the shard makes the shutdown give up and put
+			// the shard back in the map.
+			_, release, err := index.GetShard(ctx, shardName)
+			require.NoError(t, err)
+			require.Equal(t, shardGauges{loaded: 1}, h.gauges())
+			require.Error(t, index.UnloadLocalShard(ctx, shardName))
+
+			// The last release completes the shutdown, leaving a shard in the
+			// map that is shut but still counted.
+			release()
+			require.Equal(t, shardGauges{unloaded: 1}, h.gauges())
+
+			tt.reactivate(t, h, shardName)
+
+			require.Equal(t, shardGauges{loaded: 1}, h.gauges(),
+				"the evicted shard must leave the gauges to the one replacing it")
+		})
+	}
+}
+
 // TestLazyLoadShardMetricsLifecycle tests the full lifecycle of shard metrics:
 // 1. Creating a shard increments ShardsUnloaded
 // 2. Loading a shard transitions from Unloaded -> Loading -> Loaded

--- a/adapters/repos/db/shard_lazyloader_metrics_test.go
+++ b/adapters/repos/db/shard_lazyloader_metrics_test.go
@@ -14,7 +14,9 @@ package db
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -24,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -311,6 +314,174 @@ func TestReactivationAfterDeferredShutdownCountsOnce(t *testing.T) {
 				"the evicted shard must leave the gauges to the one replacing it")
 		})
 	}
+}
+
+// TestDropStopsCountingTheShard pins that a dropped shard leaves the gauge it
+// was counted in, and that the drop itself completes. The shard is out of the
+// shard map before drop runs, so a count left behind — or taken off the wrong
+// gauge — stands for a shard the node no longer holds.
+func TestDropStopsCountingTheShard(t *testing.T) {
+	ctx := context.Background()
+	const className = "TestDropCounting"
+
+	tests := []struct {
+		name string
+		// prepare leaves the shard in the state it is dropped from.
+		prepare   func(t *testing.T, h *shardMetricsHarness, shardName string)
+		wantError bool
+	}{
+		{
+			name:    "a cold shard",
+			prepare: func(t *testing.T, h *shardMetricsHarness, shardName string) {},
+		},
+		{
+			name: "a loaded shard",
+			prepare: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				shard := h.repo.GetIndex(className).shards.Load(shardName)
+				require.NoError(t, shard.(*LazyLoadShard).Load(ctx))
+				require.Equal(t, shardGauges{loaded: 1}, h.gauges())
+			},
+		},
+		{
+			name: "a shard shut down while still in the map",
+			prepare: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				// A request holding the shard makes the shutdown give up and
+				// put the shard back; the last release then completes it, so
+				// the drop meets a shard whose store is already closed.
+				index := h.repo.GetIndex(className)
+				_, release, err := index.GetShard(ctx, shardName)
+				require.NoError(t, err)
+				require.Error(t, index.UnloadLocalShard(ctx, shardName))
+				release()
+				require.Equal(t, shardGauges{unloaded: 1}, h.gauges(),
+					"a shut shard in the map is counted as unloaded")
+			},
+		},
+		{
+			name: "a drop that fails partway",
+			prepare: func(t *testing.T, h *shardMetricsHarness, shardName string) {
+				index := h.repo.GetIndex(className)
+				shard := index.shards.Load(shardName)
+				require.NoError(t, shard.(*LazyLoadShard).Load(ctx))
+				// Files removed underneath the shard fail the drop before it
+				// finishes.
+				require.NoError(t, os.RemoveAll(shardPath(index.path(), shardName)))
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newShardMetricsHarness(t)
+			shardName := h.addClass(t, className)
+			require.Equal(t, shardGauges{unloaded: 1}, h.gauges())
+			index := h.repo.GetIndex(className)
+
+			tt.prepare(t, h, shardName)
+
+			err := index.dropShards([]string{shardName})
+			if tt.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NoDirExists(t, shardPath(index.path(), shardName),
+					"a dropped shard must leave no files behind")
+			}
+
+			require.Equal(t, shardGauges{}, h.gauges(),
+				"a dropped shard must leave every gauge")
+		})
+	}
+}
+
+// TestDropDuringDeferredShutdownCountsOnce pins that a shutdown starting while
+// a drop is under way leaves every gauge at zero. Both move the same shard
+// between gauges, so whichever reaches them second has to find the shard
+// already claimed by the first.
+func TestDropDuringDeferredShutdownCountsOnce(t *testing.T) {
+	// The two teardowns differ only in timing, so one round reproduces the
+	// skew about twice in five. Ten rounds keep the odds of missing it under
+	// a percent.
+	const rounds = 10
+
+	h := newShardMetricsHarness(t)
+	for i := 0; i < rounds; i++ {
+		t.Run(fmt.Sprintf("round_%d", i), func(t *testing.T) {
+			dropDuringDeferredShutdown(t, h, fmt.Sprintf("TestDropDuringShutdown%d", i))
+			require.Equal(t, shardGauges{}, h.gauges(),
+				"a shard dropped while a shutdown runs must leave every gauge")
+		})
+	}
+}
+
+// dropDuringDeferredShutdown drops className's only shard while the shutdown
+// that its last reference release triggers is still tearing the shard down.
+func dropDuringDeferredShutdown(t *testing.T, h *shardMetricsHarness, className string) {
+	t.Helper()
+	ctx := context.Background()
+
+	shardName := h.addClass(t, className)
+	index := h.repo.GetIndex(schema.ClassName(className))
+
+	// A request holding the shard makes the unload give up and put the shard
+	// back, leaving shutdownRequested set so the last release completes it.
+	_, release, err := index.GetShard(ctx, shardName)
+	require.NoError(t, err)
+	require.Equal(t, shardGauges{loaded: 1}, h.gauges())
+
+	// A deadline shorter than the shutdown's own retry window ends the wait on
+	// the held reference without changing its outcome.
+	unloadCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	require.Error(t, index.UnloadLocalShard(unloadCtx, shardName))
+
+	lazy, ok := index.shards.Load(shardName).(*LazyLoadShard)
+	require.True(t, ok, "a shard put back after a failed unload stays in the map")
+	shard := lazy.shard
+	require.NotNil(t, shard)
+
+	// Files removed underneath the shard end the drop early, so its metric
+	// bookkeeping runs while the shutdown is still tearing the shard down.
+	require.NoError(t, os.RemoveAll(shardPath(index.path(), shardName)))
+
+	// Both the drop and the shutdown the release triggers queue on
+	// shutdownLock while the test holds it. The drop queues first, so it
+	// reaches the gauges while the shutdown is still waiting.
+	shard.shutdownLock.Lock()
+
+	dropped := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		dropped <- index.dropShards([]string{shardName})
+	}, index.logger)
+
+	// dropShards takes the shard out of the map before drop runs, so this is
+	// the last step observable from here before the drop blocks on the lock.
+	require.Eventually(t, func() bool {
+		return index.shards.Load(shardName) == nil
+	}, 5*time.Second, time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+
+	// The release runs the shutdown on this goroutine, so it blocks too.
+	released := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		release()
+		close(released)
+	}, index.logger)
+	require.Eventually(t, func() bool {
+		return shard.inUseCounter.Load() == 0
+	}, 5*time.Second, time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
+
+	shard.shutdownLock.Unlock()
+
+	select {
+	case err := <-dropped:
+		require.Error(t, err, "the drop should fail on the removed files")
+	case <-time.After(time.Minute):
+		t.Fatal("drop did not finish")
+	}
+	<-released
 }
 
 // TestLazyLoadShardMetricsLifecycle tests the full lifecycle of shard metrics:

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
@@ -143,9 +142,17 @@ func (s *Shard) Shutdown(ctx context.Context) (err error) {
 // leaving a live instance out of the map lets a later (re)load double-open
 // the directory. Callers hold the shard's create lock and classify
 // errAlreadyShutdown themselves (terminal, not a failure).
-func shutdownOrRestoreShard(ctx context.Context, shards *shardMap, name string, shard ShardLike, logger logrus.FieldLogger) error {
+//
+// A shard that stays out of the map stops being counted. Shutdown alone only
+// moves it from loaded to unloaded, which is right while it stays in the map;
+// counted after removal, every tenant deactivation raises shards_unloaded for a
+// shard the node no longer holds.
+func shutdownOrRestoreShard(ctx context.Context, idx *Index, name string, shard ShardLike) error {
+	shards, logger := &idx.shards, idx.logger
+
 	err := shard.Shutdown(ctx)
 	if err == nil || errors.Is(err, errAlreadyShutdown) {
+		idx.metrics.baseMetrics.DeleteUnloadedShard()
 		return err
 	}
 	if restoreShardIfStillAlive(shards, name, shard) {
@@ -166,6 +173,7 @@ func shutdownOrRestoreShard(ctx context.Context, shards *shardMap, name string, 
 	// outcome the caller asked for happened. Report it as the benign
 	// already-shut case, not a failure (a cold-tenant batch would otherwise
 	// fail whole on one racy tenant).
+	idx.metrics.baseMetrics.DeleteUnloadedShard()
 	return errAlreadyShutdown
 }
 

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -46,6 +46,16 @@ func shardKnownShut(s ShardLike) bool {
 	}
 }
 
+// evictShutShard takes a cleanly-shut entry out of the shard map and stops
+// counting it, so the shard that replaces it is the only one counted. A
+// completed shutdown leaves the shard counted as unloaded, which holds only
+// while it stays in the map. Callers hold the shard's create lock.
+func (i *Index) evictShutShard(shardName string) {
+	if _, ok := i.shards.LoadAndDelete(shardName); ok {
+		i.metrics.baseMetrics.DeleteUnloadedShard()
+	}
+}
+
 // teardownError returns the sticky deep-teardown failure, nil when the shard
 // is live or cleanly shut.
 func (s *Shard) teardownError() error {

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -307,7 +307,7 @@ func TestShutdownOrRestoreShard_ConcurrentCompletionIsNotAFailure(t *testing.T) 
 	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 	defer cancel()
 
-	err = shutdownOrRestoreShard(ctx, &index.shards, shardName, shard, index.logger)
+	err = shutdownOrRestoreShard(ctx, index, shardName, shard)
 	require.ErrorIs(t, err, errAlreadyShutdown,
 		"a concurrently-completed shutdown is the requested outcome, not a failure")
 	require.Nil(t, index.shards.Load(shardName), "a cleanly shut shard is not restored")


### PR DESCRIPTION
### What's being changed:

shards_loaded / shards_unloaded drifted upward on nodes that deactivate and reactivate tenants. Every shard removal path left the shard counted, so a node reported shards it no longer held.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
