### PR TITLE
Add weaviate_shards, a shard count by state and eager or lazy loading

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -648,7 +648,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				defer i.shardLoadLimiter.Release()
 
 				newShard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.scheduler,
-					i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool)
+					i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool,
+					monitoring.ShardRegistrationEager)
 				if err != nil {
 					return fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
 				}
@@ -792,7 +793,8 @@ func (i *Index) initShard(ctx context.Context, shardName string, class *models.C
 		defer i.shardLoadLimiter.Release()
 
 		shard, err := NewShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue, i.scheduler,
-			i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool)
+			i.indexCheckpoints, i.shardReindexer, false, i.bitmapBufPool,
+			monitoring.ShardRegistrationEager)
 		if err != nil {
 			return nil, fmt.Errorf("init shard %s of index %s: %w", shardName, i.ID(), err)
 		}

--- a/adapters/repos/db/init_test.go
+++ b/adapters/repos/db/init_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func TestApplyLazyShardAutoDetection(t *testing.T) {
@@ -118,7 +119,7 @@ func TestNewShard_AbortsWhenUsageFileRemovalFails(t *testing.T) {
 
 	_, err := NewShard(ctx, nil, shardName, index, &models.Class{Class: className},
 		index.centralJobQueue, index.scheduler, index.indexCheckpoints,
-		index.shardReindexer, false, index.bitmapBufPool)
+		index.shardReindexer, false, index.bitmapBufPool, monitoring.ShardRegistrationEager)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "remove computed usage file")
 }

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -117,7 +117,8 @@ func TestUpdateIndexTenants(t *testing.T) {
 			require.NoError(t, err)
 
 			shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
-				NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+				NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop(),
+				monitoring.ShardRegistrationEager)
 			require.NoError(t, err)
 
 			index.shards.Store("shard1", shard)
@@ -1065,7 +1066,8 @@ func TestListAndGetFilesWithIntegrityChecking(t *testing.T) {
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
-		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop(),
+		monitoring.ShardRegistrationEager)
 	require.NoError(t, err)
 
 	index.shards.Store("shard1", shard)

--- a/adapters/repos/db/replica_snapshot_concurrent_test.go
+++ b/adapters/repos/db/replica_snapshot_concurrent_test.go
@@ -85,7 +85,8 @@ func TestIncomingCreateReplicaSnapshotConcurrent(t *testing.T) {
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
-		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop(),
+		monitoring.ShardRegistrationEager)
 	require.NoError(t, err)
 	index.shards.Store("shard1", shard)
 

--- a/adapters/repos/db/replica_snapshot_fallback_timer_test.go
+++ b/adapters/repos/db/replica_snapshot_fallback_timer_test.go
@@ -96,7 +96,8 @@ func TestReplicaSnapshotFallbackInactivityTimerIsReset(t *testing.T) {
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
-		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop(),
+		monitoring.ShardRegistrationEager)
 	require.NoError(t, err)
 	index.shards.Store("shard1", shard)
 

--- a/adapters/repos/db/replica_snapshot_shared_halt_test.go
+++ b/adapters/repos/db/replica_snapshot_shared_halt_test.go
@@ -269,7 +269,8 @@ func newSharedHaltTestShard(t *testing.T) (*Index, *Shard) {
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
-		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop(),
+		monitoring.ShardRegistrationEager)
 	require.NoError(t, err)
 	index.shards.Store("shard1", shard)
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -528,6 +528,11 @@ type Shard struct {
 	// or incorrect metric updates during partial initialization cleanup.
 	metricsRegistered atomic.Bool
 
+	// registration is the weaviate_shards series this shard counts against. The
+	// wrapper knows it, this shard does not: shutdown and drop run as methods
+	// here with no way back to the LazyLoadShard that may hold it.
+	registration monitoring.ShardRegistration
+
 	// tornStoreReported keeps reportTornStoreAccess to one line per shard
 	tornStoreReported atomic.Bool
 }

--- a/adapters/repos/db/shard_drop.go
+++ b/adapters/repos/db/shard_drop.go
@@ -47,9 +47,9 @@ func (s *Shard) drop(keepFiles bool) (err error) {
 	if wasCounted {
 		defer func() {
 			if countedUnloaded {
-				s.metrics.baseMetrics.DeleteUnloadedShard()
+				s.metrics.baseMetrics.DeleteUnloadedShard(s.registration)
 			} else {
-				s.metrics.baseMetrics.DeleteLoadedShard()
+				s.metrics.baseMetrics.DeleteLoadedShard(s.registration)
 			}
 		}()
 	}

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -40,6 +40,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	shardName string, index *Index, class *models.Class, jobQueueCh chan job,
 	scheduler *queue.Scheduler, indexCheckpoints *indexcheckpoint.Checkpoints,
 	reindexer ShardReindexerV3, lazyLoadSegments bool, bitmapBufPool roaringset.BitmapBufPool,
+	registration monitoring.ShardRegistration,
 ) (_ *Shard, err error) {
 	start := time.Now()
 	index.logger.WithFields(logrus.Fields{
@@ -94,6 +95,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		bitmapBufPool:                   bitmapBufPool,
 		HFreshEnabled:                   index.HFreshEnabled,
 		lazySegmentLoadingEnabled:       lazyLoadSegments,
+		registration:                    registration,
 	}
 
 	index.metrics.UpdateShardStatus("", storagestate.StatusLoading.String())

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -145,7 +145,7 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	shard, err := NewShard(ctx, l.shardOpts.promMetrics, l.shardOpts.name, l.shardOpts.index,
 		class, l.shardOpts.jobQueueCh, l.shardOpts.scheduler,
 		l.shardOpts.indexCheckpoints, l.shardOpts.shardReindexer, l.lazyLoadSegments,
-		l.shardOpts.bitmapBufPool)
+		l.shardOpts.bitmapBufPool, monitoring.ShardRegistrationLazy)
 	if err != nil {
 		l.shardOpts.promMetrics.FailLoadingShard()
 		msg := fmt.Sprintf("Unable to load shard %s: %v", l.shardOpts.name, err)
@@ -498,7 +498,7 @@ func (l *LazyLoadShard) drop(keepFiles bool) error {
 	if !l.loaded {
 		// The shard is out of the shard map before drop runs, so it stops being
 		// counted even when the cleanup below fails partway.
-		defer l.shardOpts.promMetrics.DeleteUnloadedShard()
+		defer l.shardOpts.promMetrics.DeleteUnloadedShard(monitoring.ShardRegistrationLazy)
 
 		idx := l.shardOpts.index
 		className := idx.Config.ClassName.String()

--- a/adapters/repos/db/shard_lazyloader_metrics_test.go
+++ b/adapters/repos/db/shard_lazyloader_metrics_test.go
@@ -56,6 +56,10 @@ type shardMetricsHarness struct {
 }
 
 func newShardMetricsHarness(t *testing.T) *shardMetricsHarness {
+	return newShardMetricsHarnessWithLazyLoading(t, true)
+}
+
+func newShardMetricsHarnessWithLazyLoading(t *testing.T, lazyLoading bool) *shardMetricsHarness {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 
@@ -68,6 +72,9 @@ func newShardMetricsHarness(t *testing.T) *shardMetricsHarness {
 	metrics.ShardsLoading.Set(0)
 	metrics.ShardsUnloaded.Set(0)
 	metrics.ShardsUnloading.Set(0)
+	for _, labels := range monitoring.AllShardLabels() {
+		metrics.Shards.WithLabelValues(labels...).Set(0)
+	}
 
 	shardState := singleShardState()
 	schemaGetter := &fakeSchemaGetter{
@@ -96,7 +103,7 @@ func newShardMetricsHarness(t *testing.T) *shardMetricsHarness {
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
 		TrackVectorDimensions:     true,
-		EnableLazyLoadShards:      boolPtr(true),
+		EnableLazyLoadShards:      boolPtr(lazyLoading),
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
@@ -116,7 +123,7 @@ func newShardMetricsHarness(t *testing.T) *shardMetricsHarness {
 	}
 }
 
-// addClass registers className and returns the name of its only shard, left cold.
+// addClass registers className and returns the name of its only shard, left unloaded.
 func (h *shardMetricsHarness) addClass(t *testing.T, className string) string {
 	t.Helper()
 	class := &models.Class{
@@ -145,6 +152,82 @@ func (h *shardMetricsHarness) gauges() shardGauges {
 	}
 }
 
+// gaugesFor reads the same four states out of weaviate_shards for one
+// registration, so a test can tell an eagerly-opened shard from a lazy one.
+func (h *shardMetricsHarness) gaugesFor(reg monitoring.ShardRegistration) shardGauges {
+	read := func(state monitoring.ShardState) float64 {
+		return testutil.ToFloat64(h.metrics.Shards.WithLabelValues(string(state), string(reg)))
+	}
+	return shardGauges{
+		loaded:    read(monitoring.ShardStateLoaded),
+		loading:   read(monitoring.ShardStateLoading),
+		unloaded:  read(monitoring.ShardStateUnloaded),
+		unloading: read(monitoring.ShardStateUnloading),
+	}
+}
+
+// TestShardRegistrationSplitsLoadedFromUnloaded pins the question
+// weaviate_shards exists to answer: of the shards a lazy collection holds,
+// which are loaded and which are still unloaded — and that an eager collection
+// never reports a lazy one.
+func TestShardRegistrationSplitsLoadedFromUnloaded(t *testing.T) {
+	ctx := context.Background()
+	const className = "TestShardRegistrationSplit"
+
+	tests := []struct {
+		name        string
+		lazyLoading bool
+		// registration is the series the collection's shards count against.
+		registration monitoring.ShardRegistration
+		// atRest is the split before anything touches the shard.
+		atRest shardGauges
+		// afterAccess is the split once the shard has been opened.
+		afterAccess shardGauges
+	}{
+		{
+			name:         "a lazy collection registers its shard unloaded and opens it on access",
+			lazyLoading:  true,
+			registration: monitoring.ShardRegistrationLazy,
+			atRest:       shardGauges{unloaded: 1},
+			afterAccess:  shardGauges{loaded: 1},
+		},
+		{
+			name:         "an eager collection opens its shard at creation",
+			lazyLoading:  false,
+			registration: monitoring.ShardRegistrationEager,
+			atRest:       shardGauges{loaded: 1},
+			afterAccess:  shardGauges{loaded: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newShardMetricsHarnessWithLazyLoading(t, tt.lazyLoading)
+			shardName := h.addClass(t, className)
+
+			other := monitoring.ShardRegistrationEager
+			if tt.registration == monitoring.ShardRegistrationEager {
+				other = monitoring.ShardRegistrationLazy
+			}
+
+			require.Equal(t, tt.atRest, h.gaugesFor(tt.registration))
+			require.Equal(t, shardGauges{}, h.gaugesFor(other),
+				"the collection must not report shards under the other registration")
+			require.Equal(t, tt.atRest, h.gauges(),
+				"the legacy gauges must agree with the sum over registrations")
+
+			shard := h.repo.GetIndex(className).shards.Load(shardName)
+			if lazyShard, ok := shard.(*LazyLoadShard); ok {
+				require.NoError(t, lazyShard.Load(ctx))
+			}
+
+			require.Equal(t, tt.afterAccess, h.gaugesFor(tt.registration))
+			require.Equal(t, shardGauges{}, h.gaugesFor(other))
+			require.Equal(t, tt.afterAccess, h.gauges())
+		})
+	}
+}
+
 // TestShardRemovalStopsCountingIt pins that a shard taken out of the shard map
 // leaves the shard gauges. Shutdown alone moves it to unloaded, which is right
 // only while it stays in the map: counted after removal, every tenant
@@ -161,7 +244,7 @@ func TestShardRemovalStopsCountingIt(t *testing.T) {
 		want      shardGauges
 	}{
 		{
-			name: "ShutdownShard on a cold shard",
+			name: "ShutdownShard on an unloaded shard",
 			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
 				require.NoError(t, h.migrator.ShutdownShard(ctx, className, shardName))
 			},
@@ -174,7 +257,7 @@ func TestShardRemovalStopsCountingIt(t *testing.T) {
 			},
 		},
 		{
-			name: "UnloadLocalShard on a cold shard",
+			name: "UnloadLocalShard on an unloaded shard",
 			remove: func(t *testing.T, h *shardMetricsHarness, shardName string) {
 				require.NoError(t, h.repo.GetIndex(className).UnloadLocalShard(ctx, shardName))
 			},
@@ -331,7 +414,7 @@ func TestDropStopsCountingTheShard(t *testing.T) {
 		wantError bool
 	}{
 		{
-			name:    "a cold shard",
+			name:    "an unloaded shard",
 			prepare: func(t *testing.T, h *shardMetricsHarness, shardName string) {},
 		},
 		{

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 // shardKnownShut reports whether a map entry points at a shard that CLEANLY
@@ -46,13 +47,29 @@ func shardKnownShut(s ShardLike) bool {
 	}
 }
 
+// shardRegistration reports which weaviate_shards series a shard counts
+// against. A LazyLoadShard is lazy whether or not it currently holds a loaded
+// shard; a bare Shard carries the value it was built with.
+func shardRegistration(s ShardLike) monitoring.ShardRegistration {
+	switch sh := s.(type) {
+	case *LazyLoadShard:
+		return monitoring.ShardRegistrationLazy
+	case *Shard:
+		return sh.registration
+	default:
+		// Unknown wrapper: eager is the value a shard gets when nothing made
+		// it lazy, so an unrecognized one lands where a plain shard would.
+		return monitoring.ShardRegistrationEager
+	}
+}
+
 // evictShutShard takes a cleanly-shut entry out of the shard map and stops
 // counting it, so the shard that replaces it is the only one counted. A
 // completed shutdown leaves the shard counted as unloaded, which holds only
 // while it stays in the map. Callers hold the shard's create lock.
 func (i *Index) evictShutShard(shardName string) {
-	if _, ok := i.shards.LoadAndDelete(shardName); ok {
-		i.metrics.baseMetrics.DeleteUnloadedShard()
+	if shard, ok := i.shards.LoadAndDelete(shardName); ok {
+		i.metrics.baseMetrics.DeleteUnloadedShard(shardRegistration(shard))
 	}
 }
 
@@ -162,7 +179,7 @@ func shutdownOrRestoreShard(ctx context.Context, idx *Index, name string, shard 
 
 	err := shard.Shutdown(ctx)
 	if err == nil || errors.Is(err, errAlreadyShutdown) {
-		idx.metrics.baseMetrics.DeleteUnloadedShard()
+		idx.metrics.baseMetrics.DeleteUnloadedShard(shardRegistration(shard))
 		return err
 	}
 	if restoreShardIfStillAlive(shards, name, shard) {
@@ -183,7 +200,7 @@ func shutdownOrRestoreShard(ctx context.Context, idx *Index, name string, shard 
 	// outcome the caller asked for happened. Report it as the benign
 	// already-shut case, not a failure (a cold-tenant batch would otherwise
 	// fail whole on one racy tenant).
-	idx.metrics.baseMetrics.DeleteUnloadedShard()
+	idx.metrics.baseMetrics.DeleteUnloadedShard(shardRegistration(shard))
 	return errAlreadyShutdown
 }
 
@@ -276,7 +293,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	// Only update metrics if the shard was properly registered (prevents double-counting
 	// during partial initialization cleanup)
 	if s.metricsRegistered.Load() {
-		s.metrics.baseMetrics.StartUnloadingShard()
+		s.metrics.baseMetrics.StartUnloadingShard(s.registration)
 	}
 
 	start := time.Now()
@@ -381,7 +398,7 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 
 	// Track shard unloaded: unloading -> unloaded
 	if s.metricsRegistered.Load() {
-		s.metrics.baseMetrics.FinishUnloadingShard()
+		s.metrics.baseMetrics.FinishUnloadingShard(s.registration)
 	}
 
 	return ec.ToError()

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -144,6 +144,29 @@ This document is the single source of truth for Prometheus metrics exposed by We
 | `weaviate_<module>_operation_latency_seconds` | Latency of usage operations in seconds | `Histogram` | `operation` | - Low 
 | `weaviate_<module>_uploaded_file_size_bytes` | Size of the last uploaded usage file in bytes | `Gauge` | `-` | - Low 
 
+#### Shard Lifecycle Metrics
+| Name | Description | Type | Labels | High Cardinality |
+|---|---|---|---|---|
+| `weaviate_shards` | Number of shards the node holds, by lifecycle state and by whether the collection opens its shards eagerly at creation or lazily on first access. `state` is `loaded`, `unloaded`, `loading` or `unloading`; `registration` is `eager` or `lazy`. A shard is in exactly one state, so `sum(weaviate_shards)` is the number of shards the node holds. See the notes below. | `Gauge` | `state, registration` | - Low (8 series) |
+
+Supersedes `shards_loaded`, `shards_unloaded`, `shards_loading` and `shards_unloading`. Migrate by summing away the `registration` label — `sum by (state) (weaviate_shards)` reproduces each of them exactly:
+
+| Replaces | Equivalent query |
+|---|---|
+| `shards_loaded` | `sum(weaviate_shards{state="loaded"})` |
+| `shards_unloaded` | `sum(weaviate_shards{state="unloaded"})` |
+| `shards_loading` | `sum(weaviate_shards{state="loading"})` |
+| `shards_unloading` | `sum(weaviate_shards{state="unloading"})` |
+
+The split the old gauges could not express is the working set of a lazily-loaded collection — how much of its shard population is actually resident:
+
+```
+weaviate_shards{state="loaded",registration="lazy"}
+  / (weaviate_shards{state="loaded",registration="lazy"} + weaviate_shards{state="unloaded",registration="lazy"})
+```
+
+`registration` is decided per collection when its index is built, so one node can report both. `LAZY_LOAD_SHARD_COUNT_THRESHOLD=0` forces every collection `lazy` and the deprecated `DISABLE_LAZY_LOAD_SHARDS` forces every collection `eager`; with neither set, a collection is `eager` unless it is multi-tenant and its local shard count or on-disk size crosses `LAZY_LOAD_SHARD_COUNT_THRESHOLD` / `LAZY_LOAD_SHARD_SIZE_THRESHOLD_GB`. All eight series are exported from startup, so a node with no lazy collections scrapes zero rather than omitting the series.
+
 #### Shard Load Limiter Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|
@@ -351,10 +374,10 @@ This document is the single source of truth for Prometheus metrics exposed by We
 #### Shard Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|
-| `shards_loaded` | Number of shards loaded | `Gauge` | `-` | - Low 
-| `shards_unloaded` | Number of shards not loaded | `Gauge` | `-` | - Low 
-| `shards_loading` | Number of shards in process of loading | `Gauge` | `-` | - Low 
-| `shards_unloading` | Number of shards in process of unloading | `Gauge` | `-` | - Low 
+| `shards_loaded` | Number of shards loaded. Superseded by `weaviate_shards`; migrate to `sum(weaviate_shards{state="loaded"})` | `Gauge` | `-` | - Low 
+| `shards_unloaded` | Number of shards not loaded. Superseded by `weaviate_shards`; migrate to `sum(weaviate_shards{state="unloaded"})` | `Gauge` | `-` | - Low 
+| `shards_loading` | Number of shards in process of loading. Superseded by `weaviate_shards`; migrate to `sum(weaviate_shards{state="loading"})` | `Gauge` | `-` | - Low 
+| `shards_unloading` | Number of shards in process of unloading. Superseded by `weaviate_shards`; migrate to `sum(weaviate_shards{state="unloading"})` | `Gauge` | `-` | - Low 
 
 #### Tombstone Metrics
 | Name | Description | Type | Labels | High Cardinality |

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -132,6 +132,11 @@ type PrometheusMetrics struct {
 	ShardsLoading   prometheus.Gauge
 	ShardsUnloading prometheus.Gauge
 
+	// Shards supersedes the four gauges above: summing its states reproduces
+	// each of them, and the registration label splits them into the shards
+	// opened at creation and the ones a lazy collection opened on access.
+	Shards *prometheus.GaugeVec
+
 	// ShardHaltForTransferForceResume: non-zero means a transfer was
 	// force-resumed mid-stream — compaction may have raced the transfer.
 	ShardHaltForTransferForceResume *prometheus.CounterVec
@@ -793,6 +798,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "shards_unloading",
 			Help: "Number of shards in process of unloading",
 		}),
+		Shards: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "weaviate_shards",
+			Help: "Number of shards the node holds, by lifecycle state and by whether the collection opens its shards eagerly at creation or lazily on first access",
+		}, []string{"state", "registration"}),
 
 		ShardHaltForTransferForceResume: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "shard_halt_for_transfer_force_resume_total",
@@ -966,6 +975,8 @@ func newPrometheusMetrics() *PrometheusMetrics {
 	if err := m.initObjectsTtl(); err != nil {
 		panic(err)
 	}
+
+	InitGaugeVec(m.Shards, AllShardLabels())
 
 	return m
 }

--- a/usecases/monitoring/shards.go
+++ b/usecases/monitoring/shards.go
@@ -11,7 +11,60 @@
 
 package monitoring
 
-// Move the shard from unloaded to in progress
+// ShardRegistration is the value of the closed `registration` label on
+// weaviate_shards: eager for a shard opened when it was created, lazy for one
+// registered unloaded and opened on first access.
+type ShardRegistration string
+
+const (
+	ShardRegistrationEager ShardRegistration = "eager"
+	ShardRegistrationLazy  ShardRegistration = "lazy"
+)
+
+// ShardState is the value of the closed `state` label on weaviate_shards. A
+// shard the node holds is in exactly one of these, so summing the states gives
+// the number of shards in the shard map.
+type ShardState string
+
+const (
+	ShardStateLoaded    ShardState = "loaded"
+	ShardStateUnloaded  ShardState = "unloaded"
+	ShardStateLoading   ShardState = "loading"
+	ShardStateUnloading ShardState = "unloading"
+)
+
+// AllShardLabels is every combination weaviate_shards can report. A GaugeVec
+// exports no series until a label value is used, so without priming these a
+// node whose collections are all eager omits registration="lazy" entirely
+// instead of scraping zero.
+func AllShardLabels() [][]string {
+	var labels [][]string
+	for _, reg := range []ShardRegistration{ShardRegistrationEager, ShardRegistrationLazy} {
+		for _, state := range []ShardState{ShardStateLoaded, ShardStateUnloaded, ShardStateLoading, ShardStateUnloading} {
+			labels = append(labels, []string{string(state), string(reg)})
+		}
+	}
+	return labels
+}
+
+// enterShardState counts a shard the node did not hold before.
+func (pm *PrometheusMetrics) enterShardState(reg ShardRegistration, state ShardState) {
+	pm.Shards.WithLabelValues(string(state), string(reg)).Inc()
+}
+
+// leaveShardState stops counting a shard the node no longer holds.
+func (pm *PrometheusMetrics) leaveShardState(reg ShardRegistration, state ShardState) {
+	pm.Shards.WithLabelValues(string(state), string(reg)).Dec()
+}
+
+// moveShardState keeps the shard counted while changing which state holds it.
+func (pm *PrometheusMetrics) moveShardState(reg ShardRegistration, from, to ShardState) {
+	pm.leaveShardState(reg, from)
+	pm.enterShardState(reg, to)
+}
+
+// Move the shard from unloaded to in progress. Only a lazy shard loads this
+// way; an eager one is born loaded.
 func (pm *PrometheusMetrics) StartLoadingShard() {
 	if pm == nil {
 		return
@@ -19,6 +72,7 @@ func (pm *PrometheusMetrics) StartLoadingShard() {
 
 	pm.ShardsUnloaded.Dec()
 	pm.ShardsLoading.Inc()
+	pm.moveShardState(ShardRegistrationLazy, ShardStateUnloaded, ShardStateLoading)
 }
 
 // Move the shard from in progress to loaded
@@ -29,6 +83,7 @@ func (pm *PrometheusMetrics) FinishLoadingShard() {
 
 	pm.ShardsLoading.Dec()
 	pm.ShardsLoaded.Inc()
+	pm.moveShardState(ShardRegistrationLazy, ShardStateLoading, ShardStateLoaded)
 }
 
 // Revert shard from loading back to unloaded (when loading fails)
@@ -39,35 +94,39 @@ func (pm *PrometheusMetrics) FailLoadingShard() {
 
 	pm.ShardsLoading.Dec()
 	pm.ShardsUnloaded.Inc()
+	pm.moveShardState(ShardRegistrationLazy, ShardStateLoading, ShardStateUnloaded)
 }
 
 // Move the shard from loaded to in progress
-func (pm *PrometheusMetrics) StartUnloadingShard() {
+func (pm *PrometheusMetrics) StartUnloadingShard(reg ShardRegistration) {
 	if pm == nil {
 		return
 	}
 
 	pm.ShardsLoaded.Dec()
 	pm.ShardsUnloading.Inc()
+	pm.moveShardState(reg, ShardStateLoaded, ShardStateUnloading)
 }
 
 // Move the shard from in progress to unloaded
-func (pm *PrometheusMetrics) FinishUnloadingShard() {
+func (pm *PrometheusMetrics) FinishUnloadingShard(reg ShardRegistration) {
 	if pm == nil {
 		return
 	}
 
 	pm.ShardsUnloading.Dec()
 	pm.ShardsUnloaded.Inc()
+	pm.moveShardState(reg, ShardStateUnloading, ShardStateUnloaded)
 }
 
-// Register a new, unloaded shard
+// Register a new, unloaded shard. Only a lazy shard starts out unloaded.
 func (pm *PrometheusMetrics) NewUnloadedshard() {
 	if pm == nil {
 		return
 	}
 
 	pm.ShardsUnloaded.Inc()
+	pm.enterShardState(ShardRegistrationLazy, ShardStateUnloaded)
 }
 
 // Register a new shard that is immediately loaded (for non-lazy loading path)
@@ -77,24 +136,27 @@ func (pm *PrometheusMetrics) NewLoadedShard() {
 	}
 
 	pm.ShardsLoaded.Inc()
+	pm.enterShardState(ShardRegistrationEager, ShardStateLoaded)
 }
 
 // Unregister a loaded shard (when it's deleted, not unloaded)
-func (pm *PrometheusMetrics) DeleteLoadedShard() {
+func (pm *PrometheusMetrics) DeleteLoadedShard(reg ShardRegistration) {
 	if pm == nil {
 		return
 	}
 
 	pm.ShardsLoaded.Dec()
+	pm.leaveShardState(reg, ShardStateLoaded)
 }
 
 // Unregister an unloaded shard (when it's deleted without ever being loaded)
-func (pm *PrometheusMetrics) DeleteUnloadedShard() {
+func (pm *PrometheusMetrics) DeleteUnloadedShard(reg ShardRegistration) {
 	if pm == nil {
 		return
 	}
 
 	pm.ShardsUnloaded.Dec()
+	pm.leaveShardState(reg, ShardStateUnloaded)
 }
 
 // SetStartupShardProgress publishes the latest eager shard-loading progress

--- a/usecases/monitoring/shards_test.go
+++ b/usecases/monitoring/shards_test.go
@@ -16,169 +16,217 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestShards(t *testing.T) {
+type shardSeries struct {
+	state ShardState
+	reg   ShardRegistration
+}
+
+type shardCounts struct {
+	vec    map[shardSeries]float64
+	legacy map[ShardState]float64
+}
+
+func snapshotShards(m *PrometheusMetrics) shardCounts {
+	c := shardCounts{
+		vec:    map[shardSeries]float64{},
+		legacy: map[ShardState]float64{},
+	}
+	for _, labels := range AllShardLabels() {
+		s := shardSeries{state: ShardState(labels[0]), reg: ShardRegistration(labels[1])}
+		c.vec[s] = testutil.ToFloat64(m.Shards.WithLabelValues(labels...))
+	}
+	c.legacy[ShardStateLoaded] = testutil.ToFloat64(m.ShardsLoaded)
+	c.legacy[ShardStateUnloaded] = testutil.ToFloat64(m.ShardsUnloaded)
+	c.legacy[ShardStateLoading] = testutil.ToFloat64(m.ShardsLoading)
+	c.legacy[ShardStateUnloading] = testutil.ToFloat64(m.ShardsUnloading)
+	return c
+}
+
+// TestShardTransitionsMoveBothMetrics pins every transition against the new
+// weaviate_shards series it moves and the legacy gauge that must move with it,
+// so the two stay reconcilable while consumers migrate.
+func TestShardTransitionsMoveBothMetrics(t *testing.T) {
+	tests := []struct {
+		name       string
+		apply      func(m *PrometheusMetrics)
+		wantVec    map[shardSeries]float64
+		wantLegacy map[ShardState]float64
+	}{
+		{
+			name:  "registering an unloaded shard",
+			apply: func(m *PrometheusMetrics) { m.NewUnloadedshard() },
+			wantVec: map[shardSeries]float64{
+				{ShardStateUnloaded, ShardRegistrationLazy}: 1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateUnloaded: 1},
+		},
+		{
+			name:  "registering a shard that is born loaded",
+			apply: func(m *PrometheusMetrics) { m.NewLoadedShard() },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoaded, ShardRegistrationEager}: 1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoaded: 1},
+		},
+		{
+			name:  "an unloaded shard starts loading",
+			apply: func(m *PrometheusMetrics) { m.StartLoadingShard() },
+			wantVec: map[shardSeries]float64{
+				{ShardStateUnloaded, ShardRegistrationLazy}: -1,
+				{ShardStateLoading, ShardRegistrationLazy}:  1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateUnloaded: -1, ShardStateLoading: 1},
+		},
+		{
+			name:  "a loading shard becomes loaded",
+			apply: func(m *PrometheusMetrics) { m.FinishLoadingShard() },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoading, ShardRegistrationLazy}: -1,
+				{ShardStateLoaded, ShardRegistrationLazy}:  1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoading: -1, ShardStateLoaded: 1},
+		},
+		{
+			name:  "a load that fails returns the shard to unloaded",
+			apply: func(m *PrometheusMetrics) { m.FailLoadingShard() },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoading, ShardRegistrationLazy}:  -1,
+				{ShardStateUnloaded, ShardRegistrationLazy}: 1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoading: -1, ShardStateUnloaded: 1},
+		},
+		{
+			name:  "a loaded lazy shard starts unloading",
+			apply: func(m *PrometheusMetrics) { m.StartUnloadingShard(ShardRegistrationLazy) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoaded, ShardRegistrationLazy}:    -1,
+				{ShardStateUnloading, ShardRegistrationLazy}: 1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoaded: -1, ShardStateUnloading: 1},
+		},
+		{
+			name:  "a loaded eager shard starts unloading",
+			apply: func(m *PrometheusMetrics) { m.StartUnloadingShard(ShardRegistrationEager) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoaded, ShardRegistrationEager}:    -1,
+				{ShardStateUnloading, ShardRegistrationEager}: 1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoaded: -1, ShardStateUnloading: 1},
+		},
+		{
+			name:  "an unloading lazy shard becomes unloaded",
+			apply: func(m *PrometheusMetrics) { m.FinishUnloadingShard(ShardRegistrationLazy) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateUnloading, ShardRegistrationLazy}: -1,
+				{ShardStateUnloaded, ShardRegistrationLazy}:  1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateUnloading: -1, ShardStateUnloaded: 1},
+		},
+		{
+			name:  "an unloading eager shard becomes unloaded",
+			apply: func(m *PrometheusMetrics) { m.FinishUnloadingShard(ShardRegistrationEager) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateUnloading, ShardRegistrationEager}: -1,
+				{ShardStateUnloaded, ShardRegistrationEager}:  1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateUnloading: -1, ShardStateUnloaded: 1},
+		},
+		{
+			name:  "dropping a loaded eager shard",
+			apply: func(m *PrometheusMetrics) { m.DeleteLoadedShard(ShardRegistrationEager) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoaded, ShardRegistrationEager}: -1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoaded: -1},
+		},
+		{
+			name:  "dropping a loaded lazy shard",
+			apply: func(m *PrometheusMetrics) { m.DeleteLoadedShard(ShardRegistrationLazy) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateLoaded, ShardRegistrationLazy}: -1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateLoaded: -1},
+		},
+		{
+			name:  "dropping an unloaded lazy shard",
+			apply: func(m *PrometheusMetrics) { m.DeleteUnloadedShard(ShardRegistrationLazy) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateUnloaded, ShardRegistrationLazy}: -1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateUnloaded: -1},
+		},
+		{
+			name:  "dropping an unloaded eager shard",
+			apply: func(m *PrometheusMetrics) { m.DeleteUnloadedShard(ShardRegistrationEager) },
+			wantVec: map[shardSeries]float64{
+				{ShardStateUnloaded, ShardRegistrationEager}: -1,
+			},
+			wantLegacy: map[ShardState]float64{ShardStateUnloaded: -1},
+		},
+	}
+
 	m := GetMetrics()
 
-	t.Run("start_loading_shard", func(t *testing.T) {
-		// Setting base values
-		mv := m.ShardsLoading
-		mv.Set(1)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := snapshotShards(m)
+			tt.apply(m)
+			after := snapshotShards(m)
 
-		mv = m.ShardsUnloaded
-		mv.Set(1)
+			for s, got := range after.vec {
+				assert.Equal(t, tt.wantVec[s], got-before.vec[s],
+					"weaviate_shards{state=%q,registration=%q}", s.state, s.reg)
+			}
+			for state, got := range after.legacy {
+				assert.Equal(t, tt.wantLegacy[state], got-before.legacy[state],
+					"legacy gauge for state %q", state)
+			}
+		})
+	}
+}
 
-		m.StartLoadingShard()
+// TestShardStatesSumToTheLegacyGauges is the migration contract: a consumer
+// moving off shards_loaded and its siblings gets the same number from
+// sum by (state) over weaviate_shards.
+func TestShardStatesSumToTheLegacyGauges(t *testing.T) {
+	m := GetMetrics()
 
-		loadingCount := testutil.ToFloat64(m.ShardsLoading)
-		unloadedCount := testutil.ToFloat64(m.ShardsUnloaded)
+	// A lazy collection waking two of three shards and putting one back to
+	// sleep, alongside an eager collection that opens its shard at creation.
+	m.NewUnloadedshard()
+	m.NewUnloadedshard()
+	m.NewUnloadedshard()
+	m.NewLoadedShard()
 
-		assert.Equal(t, float64(2), loadingCount)
-		assert.Equal(t, float64(0), unloadedCount)
-	})
+	m.StartLoadingShard()
+	m.FinishLoadingShard()
+	m.StartLoadingShard()
+	m.FinishLoadingShard()
 
-	t.Run("finish_loading_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_loading` should be decremented
-		// 2. `shards_loaded` should be incremented
+	m.StartUnloadingShard(ShardRegistrationLazy)
+	m.FinishUnloadingShard(ShardRegistrationLazy)
 
-		// Setting base values
-		mv := m.ShardsLoading
-		mv.Set(1)
+	counts := snapshotShards(m)
+	for state, legacy := range counts.legacy {
+		sum := counts.vec[shardSeries{state, ShardRegistrationEager}] +
+			counts.vec[shardSeries{state, ShardRegistrationLazy}]
+		assert.Equal(t, legacy, sum, "sum by (state) for %q", state)
+	}
+}
 
-		mv = m.ShardsLoaded
-		mv.Set(1)
+// TestShardsExportsEveryStateAtStartup keeps a node whose collections are all
+// eager from omitting the lazy series instead of scraping zero.
+func TestShardsExportsEveryStateAtStartup(t *testing.T) {
+	m := GetMetrics()
 
-		m.FinishLoadingShard()
+	require.Equal(t, 8, testutil.CollectAndCount(m.Shards))
 
-		loadingCount := testutil.ToFloat64(m.ShardsLoading)
-		loadedCount := testutil.ToFloat64(m.ShardsLoaded)
-
-		assert.Equal(t, float64(0), loadingCount) // dec
-		assert.Equal(t, float64(2), loadedCount)  // inc
-	})
-
-	t.Run("fail_loading_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_loading` should be decremented
-		// 2. `shards_unloaded` should be incremented
-
-		// Setting base values
-		mv := m.ShardsLoading
-		mv.Set(1)
-
-		mv = m.ShardsUnloaded
-		mv.Set(1)
-
-		m.FailLoadingShard()
-
-		loadingCount := testutil.ToFloat64(m.ShardsLoading)
-		unloadedCount := testutil.ToFloat64(m.ShardsUnloaded)
-
-		assert.Equal(t, float64(0), loadingCount)  // dec
-		assert.Equal(t, float64(2), unloadedCount) // inc
-	})
-
-	t.Run("start_unloading_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_loaded` should be decremented
-		// 2. `shards_unloading` should be incremented
-
-		// Setting base values
-		mv := m.ShardsLoaded
-		mv.Set(1)
-
-		mv = m.ShardsUnloading
-		mv.Set(1)
-
-		m.StartUnloadingShard()
-
-		loadedCount := testutil.ToFloat64(m.ShardsLoaded)
-		unloadingCount := testutil.ToFloat64(m.ShardsUnloading)
-
-		assert.Equal(t, float64(0), loadedCount)    // dec
-		assert.Equal(t, float64(2), unloadingCount) // inc
-	})
-
-	t.Run("finish_unloading_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_unloading` should be decremented
-		// 2. `shards_unloaded` should be incremented
-
-		// Setting base values
-		mv := m.ShardsUnloading
-		mv.Set(1)
-
-		mv = m.ShardsUnloaded
-		mv.Set(1)
-
-		m.FinishUnloadingShard()
-
-		unloadingCount := testutil.ToFloat64(m.ShardsUnloading)
-		unloadedCount := testutil.ToFloat64(m.ShardsUnloaded)
-
-		assert.Equal(t, float64(0), unloadingCount) // dec
-		assert.Equal(t, float64(2), unloadedCount)  // inc
-	})
-
-	t.Run("new_unloaded_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_unloaded` should be incremented
-
-		// Setting base values
-		mv := m.ShardsUnloaded
-		mv.Set(1)
-
-		m.NewUnloadedshard()
-
-		unloadedCount := testutil.ToFloat64(m.ShardsUnloaded)
-
-		assert.Equal(t, float64(2), unloadedCount) // inc
-	})
-
-	t.Run("new_loaded_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_loaded` should be incremented
-
-		// Setting base values
-		mv := m.ShardsLoaded
-		mv.Set(1)
-
-		m.NewLoadedShard()
-
-		loadedCount := testutil.ToFloat64(m.ShardsLoaded)
-
-		assert.Equal(t, float64(2), loadedCount) // inc
-	})
-
-	t.Run("delete_loaded_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_loaded` should be decremented
-
-		// Setting base values
-		mv := m.ShardsLoaded
-		mv.Set(2)
-
-		m.DeleteLoadedShard()
-
-		loadedCount := testutil.ToFloat64(m.ShardsLoaded)
-
-		assert.Equal(t, float64(1), loadedCount) // dec
-	})
-
-	t.Run("delete_unloaded_shard", func(t *testing.T) {
-		// invariant:
-		// 1. `shards_unloaded` should be decremented
-
-		// Setting base values
-		mv := m.ShardsUnloaded
-		mv.Set(2)
-
-		m.DeleteUnloadedShard()
-
-		unloadedCount := testutil.ToFloat64(m.ShardsUnloaded)
-
-		assert.Equal(t, float64(1), unloadedCount) // dec
-	})
+	for _, labels := range AllShardLabels() {
+		assert.NotPanics(t, func() {
+			testutil.ToFloat64(m.Shards.WithLabelValues(labels...))
+		}, "series %v must exist", labels)
+	}
 }


### PR DESCRIPTION
Currently, an operator cannot tell how much of a lazily-loaded collection is in memory on a node.

`weaviate_shards` reports the all active shards under two closed labels. state is loaded, unloaded, loading or unloading. `registration` is eager for a shard opened when its collection was created, and lazy for a shard registered unloaded and opened on first access. A shard sits in one state at a time, so sum(weaviate_shards) is the number of shards in the node's shard map.

Example for a lazy collection holding 5 shards and 3 have actually been opened:

```
  weaviate_shards{state="loaded",  registration="lazy"}   # 3 — resident
  weaviate_shards{state="unloaded", registration="lazy"}   # 2 — registered, never opened
  sum(weaviate_shards{registration="lazy"})            # 5 — the population
```