### PR TITLE
Skip vanished files and directories instead of failing shard usage

### DIFF
--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -301,29 +301,35 @@ func CalculateUnloadedObjectsMetrics(logger logrus.FieldLogger, path, shardName 
 	}
 	for file, size := range files {
 		totalDiskSize += size
-
-		if includeCount {
-			filePath := filepath.Join(objectStore, file)
-			// Look for .cna files (net count additions)
-			if strings.HasSuffix(file, lsmkv.CountNetAdditionsFileSuffix) {
-				count, err := lsmkv.ReadCountNetAdditionsFile(filePath)
-				if err != nil {
-					logger.WithField("path", filePath).WithField("shard", shardName).WithError(err).Warn("failed to read .cna file")
-					return types.ObjectUsage{}, err
-				}
-				totalObjectCount += count
-			}
-
-			// Look for .metadata files (bloom filters + count net additions)
-			if strings.HasSuffix(file, lsmkv.MetadataFileSuffix) {
-				count, err := lsmkv.ReadObjectCountFromMetadataFile(filePath)
-				if err != nil {
-					logger.WithField("path", filePath).WithField("shard", shardName).WithError(err).Warn("failed to read .metadata file")
-					return types.ObjectUsage{}, err
-				}
-				totalObjectCount += count
-			}
+		if !includeCount {
+			continue
 		}
+
+		// .cna holds net count additions; .metadata holds those plus bloom filters.
+		var readCount func(string) (int64, error)
+		switch {
+		case strings.HasSuffix(file, lsmkv.CountNetAdditionsFileSuffix):
+			readCount = lsmkv.ReadCountNetAdditionsFile
+		case strings.HasSuffix(file, lsmkv.MetadataFileSuffix):
+			readCount = lsmkv.ReadObjectCountFromMetadataFile
+		default:
+			continue
+		}
+
+		filePath := filepath.Join(objectStore, file)
+		count, err := readCount(filePath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// The listing is a snapshot, so a load or a compaction can drop a
+				// segment before its sidecar is read. Missing that segment beats
+				// failing the whole shard's count.
+				continue
+			}
+			logger.WithField("path", filePath).WithField("shard", shardName).
+				Warnf("failed to read segment sidecar: %v", err)
+			return types.ObjectUsage{}, err
+		}
+		totalObjectCount += count
 	}
 
 	// If we can't determine object count, return the disk size as fallback

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -268,23 +268,33 @@ func CalculateUnloadedVectorsMetrics(lsmPath string, directories []string) (Vect
 	return metrics, nil
 }
 
-// bucketSize sums the sizes of the files in a bucket directory. A bucket that was deleted
-// after the directory listing was taken counts as zero, so dropping one property or vector
-// bucket does not zero out the whole shard's usage.
-func bucketSize(bucketPath string) (uint64, error) {
-	files, _, err := diskio.GetFileWithSizes(bucketPath)
+// listDir lists a directory's files with their sizes and its subdirectory names. A directory that is
+// gone when it is opened lists as empty. One vector index deleted mid-scan is then missing from the
+// total rather than failing the shard's whole usage. A shard's root and its object store are read
+// with diskio.GetFileWithSizes instead, so a shard being dropped still surfaces as an error.
+func listDir(dirPath string) (map[string]int64, []string, error) {
+	files, dirs, err := diskio.GetFileWithSizes(dirPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return 0, nil
+		return nil, nil, nil
 	}
-	if err != nil {
-		return 0, err
-	}
+	return files, dirs, err
+}
 
+func sumSizes(files map[string]int64) uint64 {
 	totalSize := uint64(0)
 	for _, size := range files {
 		totalSize += uint64(size)
 	}
-	return totalSize, nil
+	return totalSize
+}
+
+// bucketSize sums the sizes of the files in a bucket directory, or zero if the bucket is gone.
+func bucketSize(bucketPath string) (uint64, error) {
+	files, _, err := listDir(bucketPath)
+	if err != nil {
+		return 0, err
+	}
+	return sumSizes(files), nil
 }
 
 // CalculateUnloadedObjectsMetrics calculates both object count and storage size from disk
@@ -372,13 +382,18 @@ func CalculateUnloadedIndicesSize(lsmPath string, directories []string) (uint64,
 
 // CalculateNonLSMStorage calculates the full storage used by a shard, including objects, vectors, and indices
 func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
-	var vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize uint64
 	shardPath := filepath.Join(path, shardName)
 
 	files, dirs, err := diskio.GetFileWithSizes(shardPath)
 	if err != nil {
 		return 0, 0, err
 	}
+	return nonLSMStorage(shardPath, files, dirs)
+}
+
+// nonLSMStorage sums a shard's non-LSM storage from a listing of its root taken by the caller.
+func nonLSMStorage(shardPath string, files map[string]int64, dirs []string) (uint64, uint64, error) {
+	var vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize uint64
 
 	// Add sizes of all files in the shard root directory
 	for file, size := range files {
@@ -397,28 +412,20 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 		}
 
 		fullPath := filepath.Join(shardPath, dir)
-		filesSubFolder, subDirs, err := diskio.GetFileWithSizes(fullPath)
+		filesSubFolder, subDirs, err := listDir(fullPath)
 		if err != nil {
 			return 0, 0, err
 		}
 
-		totalSize := uint64(0)
-		for _, size := range filesSubFolder {
-			totalSize += uint64(size)
-		}
+		totalSize := sumSizes(filesSubFolder)
 
 		if strings.HasSuffix(dir, ".hfresh.d") {
 			for _, subDir := range subDirs {
-				subDirPath := filepath.Join(fullPath, subDir)
-				subFiles, _, err := diskio.GetFileWithSizes(subDirPath)
+				subFiles, _, err := listDir(filepath.Join(fullPath, subDir))
 				if err != nil {
 					return 0, 0, err
 				}
-
-				subDirSize := uint64(0)
-				for _, size := range subFiles {
-					subDirSize += uint64(size)
-				}
+				subDirSize := sumSizes(subFiles)
 
 				if strings.HasSuffix(subDir, "commitlog.d") ||
 					strings.HasSuffix(subDir, "snapshot.d") ||

--- a/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
+++ b/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
@@ -12,10 +12,14 @@
 package shardusage
 
 import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 )
@@ -108,4 +112,67 @@ func TestUnloadedSizesSkipVanishedBucket(t *testing.T) {
 func vectorsSize(lsmPath string, directories []string) (uint64, error) {
 	metrics, err := CalculateUnloadedVectorsMetrics(lsmPath, directories)
 	return uint64(metrics.StorageBytes), err
+}
+
+// writeCountNetAdditions writes a .cna file: a little-endian CRC32 of the
+// payload followed by the count.
+func writeCountNetAdditions(t *testing.T, path string, count int64) {
+	t.Helper()
+	buf := make([]byte, 12)
+	binary.LittleEndian.PutUint64(buf[4:], uint64(count))
+	binary.LittleEndian.PutUint32(buf[:4], crc32.ChecksumIEEE(buf[4:]))
+	require.NoError(t, os.WriteFile(path, buf, 0o600))
+}
+
+// A segment's sidecar can be deleted between the objects directory listing and
+// the count read — a load recovering the write-ahead log, or a compaction
+// retiring the segment. Counting the shard without it beats failing the whole
+// count, which reports the shard as empty. Any other read error still surfaces.
+func TestUnloadedObjectsMetricsSkipVanishedSidecar(t *testing.T) {
+	tests := []struct {
+		name string
+		// counts are written as readable .cna files, one per entry.
+		counts []int64
+		// vanished sidecars are listed by the directory read but resolve to nothing.
+		vanished int
+		corrupt  bool
+		want     int64
+		wantErr  bool
+	}{
+		{name: "all sidecars present", counts: []int64{3, 4}, want: 7},
+		{name: "one sidecar vanished", counts: []int64{3, 4}, vanished: 1, want: 7},
+		{name: "every sidecar vanished", vanished: 2},
+		{name: "corrupt sidecar still fails", counts: []int64{3}, corrupt: true, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			indexPath := t.TempDir()
+			objectStore := shardPathObjectsLSM(indexPath, "shard1")
+			require.NoError(t, os.MkdirAll(objectStore, 0o700))
+
+			for i, count := range tc.counts {
+				writeCountNetAdditions(t, filepath.Join(objectStore,
+					fmt.Sprintf("segment-present-%d.cna", i)), count)
+			}
+			// A dangling symlink is listed by Readdir but cannot be opened, which is
+			// what a reader sees when the segment is retired mid-scan.
+			for i := 0; i < tc.vanished; i++ {
+				require.NoError(t, os.Symlink(filepath.Join(objectStore, "gone.db"),
+					filepath.Join(objectStore, fmt.Sprintf("segment-vanished-%d.cna", i))))
+			}
+			if tc.corrupt {
+				require.NoError(t, os.WriteFile(filepath.Join(objectStore, "segment-corrupt.cna"),
+					make([]byte, 12), 0o600))
+			}
+
+			usage, err := CalculateUnloadedObjectsMetrics(logrus.New(), indexPath, "shard1", true)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, usage.Count)
+		})
+	}
 }

--- a/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
+++ b/adapters/repos/db/shard_usage/usage_vanished_bucket_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/diskio"
 )
 
 // A bucket can be deleted between the lsm directory listing and the size calculation, e.g.
@@ -124,13 +125,15 @@ func writeCountNetAdditions(t *testing.T, path string, count int64) {
 	require.NoError(t, os.WriteFile(path, buf, 0o600))
 }
 
-// A segment's sidecar can be deleted between the objects directory listing and
-// the count read — a load recovering the write-ahead log, or a compaction
-// retiring the segment. Counting the shard without it beats failing the whole
-// count, which reports the shard as empty. Any other read error still surfaces.
+// A segment's sidecar can be deleted between the objects directory listing and the count read,
+// by a load recovering the write-ahead log or a compaction retiring the segment. Counting the
+// shard without it beats failing the whole count, which reports the shard as empty. Any other
+// failure to read the store still surfaces.
 func TestUnloadedObjectsMetricsSkipVanishedSidecar(t *testing.T) {
 	tests := []struct {
 		name string
+		// denyStore takes read access from the objects directory before the count.
+		denyStore bool
 		// counts are written as readable .cna files, one per entry.
 		counts []int64
 		// vanished sidecars are listed by the directory read but resolve to nothing.
@@ -143,6 +146,7 @@ func TestUnloadedObjectsMetricsSkipVanishedSidecar(t *testing.T) {
 		{name: "one sidecar vanished", counts: []int64{3, 4}, vanished: 1, want: 7},
 		{name: "every sidecar vanished", vanished: 2},
 		{name: "corrupt sidecar still fails", counts: []int64{3}, corrupt: true, wantErr: true},
+		{name: "unreadable objects directory still fails", denyStore: true, wantErr: true},
 	}
 
 	for _, tc := range tests {
@@ -165,6 +169,9 @@ func TestUnloadedObjectsMetricsSkipVanishedSidecar(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(objectStore, "segment-corrupt.cna"),
 					make([]byte, 12), 0o600))
 			}
+			if tc.denyStore {
+				denyRead(t, objectStore)
+			}
 
 			usage, err := CalculateUnloadedObjectsMetrics(logrus.New(), indexPath, "shard1", true)
 			if tc.wantErr {
@@ -175,4 +182,100 @@ func TestUnloadedObjectsMetricsSkipVanishedSidecar(t *testing.T) {
 			require.Equal(t, tc.want, usage.Count)
 		})
 	}
+}
+
+// denyRead takes read access away from dirPath, so opening it fails with an error that is
+// not fs.ErrNotExist.
+func denyRead(t *testing.T, dirPath string) {
+	t.Helper()
+	if os.Getuid() == 0 {
+		t.Skip("chmod-based permission denial is a no-op for root")
+	}
+	require.NoError(t, os.Chmod(dirPath, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(dirPath, 0o700) })
+}
+
+// A vector index directory can be deleted between the shard root listing and the walk that reads
+// it, e.g. while a named vector is being dropped. Only that directory drops out of the total, and
+// any other failure to open one still surfaces.
+func TestNonLSMStorageSkipVanishedSubdir(t *testing.T) {
+	// These sum the fixture below, in the two buckets the walk reports.
+	const (
+		wantCommitLogs = 1000 + 3000 // main.hnsw.commitlog.d + main.hfresh.d/sub.queue.d
+		wantOther      = 2000 + 4000 // other_dir + the loose file in main.hfresh.d
+	)
+
+	tests := []struct {
+		name string
+		// remove is deleted after the root listing, as a drop racing the walk does.
+		remove string
+		// deny takes read access instead of deleting, for the errors that are not a vanish.
+		deny           string
+		wantCommitLogs uint64
+		wantOther      uint64
+		wantErr        bool
+	}{
+		{
+			name:           "every subdirectory present",
+			wantCommitLogs: wantCommitLogs,
+			wantOther:      wantOther,
+		},
+		{
+			name:           "commit log directory vanished",
+			remove:         "main.hnsw.commitlog.d",
+			wantCommitLogs: wantCommitLogs - 1000,
+			wantOther:      wantOther,
+		},
+		{
+			name:           "plain directory vanished",
+			remove:         "other_dir",
+			wantCommitLogs: wantCommitLogs,
+			wantOther:      wantOther - 2000,
+		},
+		{
+			name:           "hfresh directory vanished with its subdirectories",
+			remove:         "main.hfresh.d",
+			wantCommitLogs: wantCommitLogs - 3000,
+			wantOther:      wantOther - 4000,
+		},
+		{name: "unreadable commit log directory still fails", deny: "main.hnsw.commitlog.d", wantErr: true},
+		{name: "unreadable hfresh subdirectory still fails", deny: "main.hfresh.d/sub.queue.d", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			shardPath := filepath.Join(t.TempDir(), "shard1")
+			writeSizedFile(t, filepath.Join(shardPath, "main.hnsw.commitlog.d", "f"), 1000)
+			writeSizedFile(t, filepath.Join(shardPath, "other_dir", "f"), 2000)
+			writeSizedFile(t, filepath.Join(shardPath, "main.hfresh.d", "sub.queue.d", "f"), 3000)
+			writeSizedFile(t, filepath.Join(shardPath, "main.hfresh.d", "f"), 4000)
+
+			files, dirs, err := diskio.GetFileWithSizes(shardPath)
+			require.NoError(t, err)
+
+			// the listing is already taken, so the walk below meets the shard mid-drop
+			if tc.remove != "" {
+				require.NoError(t, os.RemoveAll(filepath.Join(shardPath, tc.remove)))
+			}
+			if tc.deny != "" {
+				denyRead(t, filepath.Join(shardPath, tc.deny))
+			}
+
+			commitLogs, other, err := nonLSMStorage(shardPath, files, dirs)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantCommitLogs, commitLogs)
+			require.Equal(t, tc.wantOther, other)
+		})
+	}
+}
+
+// writeSizedFile writes a file of the given size, creating its parent directories.
+func writeSizedFile(t *testing.T, path string, size int) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, make([]byte, size), 0o600))
 }


### PR DESCRIPTION
### What's being changed:

Shard usage and the node-wide object count read a shard's files straight off disk: list a directory, then open what the listing named. The listing is a snapshot, and neither read holds anything that keeps those files still:

- `LazyLoadShard.ObjectCountAsync` samples `loaded` under the loading mutex, releases it, and only then reads from disk. `Load` takes that same mutex and nothing else, so any query or write on the tenant hydrates the shard mid-read — segment group init drops leftover `.tmp` and partially compacted segments, and the compactions that follow retire more.
- `CalculateNonLSMStorage` also runs on loaded shards, from `calculateLoadedShardUsage`, where dropping a named vector removes its `.hnsw.commitlog.d` outright.

Both turned the resulting `ErrNotExist` into a hard error for the whole shard, which costs far more than the one file lost: the node-wide `object_count` gauge drops by a whole shard for a cycle, and `usageForShard` catches the error and records the shard as *empty* — zero objects, zero bytes — in the usage report.

The two commits are independent:

1. `CalculateUnloadedObjectsMetrics` skips a segment sidecar (`.cna` / `.metadata`) that is gone when it is opened instead of failing the count — missing one segment beats reporting the shard as empty.
2. `CalculateNonLSMStorage` counts a shard-root subdirectory that vanished mid-walk as zero, the same treatment `bucketSize` already gives an LSM bucket, so one dropped vector index is missing from the total rather than zeroing the shard's usage.

A corrupt sidecar, an unreadable objects directory, and a dropped shard root all still surface as errors.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

