### PR TITLE
Disable background lazy tenant loading for small tenants

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -477,6 +477,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		EnableLazyLoadShards:                appState.ServerConfig.Config.EnableLazyLoadShards,
 		LazyLoadShardCountThreshold:         appState.ServerConfig.Config.LazyLoadShardCountThreshold,
 		LazyLoadShardSizeThresholdGB:        appState.ServerConfig.Config.LazyLoadShardSizeThresholdGB,
+		LazyLoadShardWarmupDisabled:         appState.ServerConfig.Config.LazyLoadShardWarmupDisabled,
 		ForceFullReplicasSearch:             appState.ServerConfig.Config.ForceFullReplicasSearch,
 		TransferInactivityTimeout:           appState.ServerConfig.Config.TransferInactivityTimeout,
 		HaltForTransferTimeout:              appState.ServerConfig.Config.HaltForTransferTimeout,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -477,7 +477,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		EnableLazyLoadShards:                appState.ServerConfig.Config.EnableLazyLoadShards,
 		LazyLoadShardCountThreshold:         appState.ServerConfig.Config.LazyLoadShardCountThreshold,
 		LazyLoadShardSizeThresholdGB:        appState.ServerConfig.Config.LazyLoadShardSizeThresholdGB,
-		LazyLoadShardWarmupDisabled:         appState.ServerConfig.Config.LazyLoadShardWarmupDisabled,
+		LazyLoadShardWarmupMinObjects:       appState.ServerConfig.Config.LazyLoadShardWarmupMinObjects,
 		ForceFullReplicasSearch:             appState.ServerConfig.Config.ForceFullReplicasSearch,
 		TransferInactivityTimeout:           appState.ServerConfig.Config.TransferInactivityTimeout,
 		HaltForTransferTimeout:              appState.ServerConfig.Config.HaltForTransferTimeout,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -709,7 +709,11 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		}
 
 		now := time.Now()
-		var loaded, skipped, failed int
+		tally := map[monitoring.WarmupOutcome]int{}
+		recordOutcome := func(outcome monitoring.WarmupOutcome) {
+			tally[outcome]++
+			promMetrics.RecordWarmupOutcome(outcome)
+		}
 
 		for _, shardName := range hotShardNames {
 			if abortIfClosing() {
@@ -719,8 +723,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 			// The decision comes before the tick so only shards that will load wait a
 			// second. At a positive threshold each skip still costs one directory
 			// listing, unpaced.
-			if !i.warmupCandidate(shardName) {
-				skipped++
+			if shouldWarm, outcome := i.warmupCandidate(shardName); !shouldWarm {
+				recordOutcome(outcome)
 				continue
 			}
 
@@ -732,8 +736,9 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				return
 			}
 
-			if err := i.loadLocalShardIfActive(shardName); err != nil {
-				failed++
+			outcome, err := i.loadLocalShardIfActive(shardName)
+			if err != nil {
+				recordOutcome(monitoring.WarmupFailed)
 				i.logger.
 					WithField("action", "load_shard").
 					WithField("shard_name", shardName).
@@ -744,17 +749,21 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				// rest cold until something touches them.
 				continue
 			}
-			loaded++
+			if outcome != "" {
+				recordOutcome(outcome)
+			}
 		}
 
 		i.logger.
 			WithFields(logrus.Fields{
-				"action":  "load_all_shards",
-				"class":   i.Config.ClassName.String(),
-				"took":    time.Since(now).String(),
-				"loaded":  loaded,
-				"skipped": skipped,
-				"failed":  failed,
+				"action":                  "load_all_shards",
+				"class":                   i.Config.ClassName.String(),
+				"took":                    time.Since(now).String(),
+				"loaded":                  tally[monitoring.WarmupLoaded],
+				"failed":                  tally[monitoring.WarmupFailed],
+				"skipped_not_cold":        tally[monitoring.WarmupSkippedNotCold],
+				"skipped_empty":           tally[monitoring.WarmupSkippedEmpty],
+				"skipped_below_threshold": tally[monitoring.WarmupSkippedBelowThreshold],
 			}).
 			Debug("finished loading all shards")
 	}
@@ -775,29 +784,30 @@ func (i *Index) unloadedShardIsEmpty(shardName string) bool {
 }
 
 // warmupCandidate reports whether the startup sweep should load this shard, and
-// is asked before the sweep spends a tick on it. A count it cannot read answers
-// true: a shard is loaded rather than left cold on a number nobody could take.
-func (i *Index) warmupCandidate(shardName string) bool {
+// where it should not, the outcome naming why. It is asked before the sweep
+// spends a tick on the shard. A count it cannot read answers true: a shard is
+// loaded rather than left cold on a number nobody could take.
+func (i *Index) warmupCandidate(shardName string) (bool, monitoring.WarmupOutcome) {
 	i.shardCreateLocks.Lock(shardName)
 	defer i.shardCreateLocks.Unlock(shardName)
 
 	shard := i.shards.Load(shardName)
 	if shard == nil {
-		return false
+		return false, monitoring.WarmupSkippedNotCold
 	}
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if !ok || lazyShard.isLoaded() {
-		return false
+		return false, monitoring.WarmupSkippedNotCold
 	}
 
 	// avoid footprint of empty shards
 	if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
-		return false
+		return false, monitoring.WarmupSkippedEmpty
 	}
 
 	minObjects := i.Config.LazyLoadShardWarmupMinObjects
 	if minObjects == 0 {
-		return true
+		return true, ""
 	}
 
 	count, err := lazyShard.ObjectCountAsync(i.closingCtx)
@@ -810,10 +820,10 @@ func (i *Index) warmupCandidate(shardName string) bool {
 		} else {
 			entry.Warnf("failed to count objects of unloaded shard, warming it up anyway: %v", err)
 		}
-		return true
+		return true, ""
 	}
 	if count > minObjects {
-		return true
+		return true, ""
 	}
 
 	// The persisted doc-id counter would see the writes the sidecars miss, but it
@@ -828,16 +838,19 @@ func (i *Index) warmupCandidate(shardName string) bool {
 		"object_count":       count,
 		"warmup_min_objects": minObjects,
 	}).Debug("shard holds too few objects to warm up; it loads on first access")
-	return false
+	return false, monitoring.WarmupSkippedBelowThreshold
 }
 
-func (i *Index) loadLocalShardIfActive(shardName string) error {
+// loadLocalShardIfActive loads a shard the startup sweep picked, and reports what
+// the sweep should record for it. An empty outcome means the index refused the
+// load for a reason that says nothing about this shard, so nothing is recorded.
+func (i *Index) loadLocalShardIfActive(shardName string) (monitoring.WarmupOutcome, error) {
 	// Index.Shutdown skips a lazy shard that is not loaded yet, so a build racing
 	// its sweep leaves an open store nothing will ever close. The refcount holds
 	// the index open instead of closeLock, because a teardown queued for the write
 	// lock would park every other reader for the whole build.
 	if err := i.enterRead(); err != nil {
-		return nil // a closed index is not a load failure
+		return "", nil // a closed index is not a load failure
 	}
 	defer i.exitRead()
 
@@ -846,7 +859,7 @@ func (i *Index) loadLocalShardIfActive(shardName string) error {
 	// error would end that loop for every shard behind this one.
 	state, err := i.namespaceState()
 	if err != nil || !namespaces.ShardsShouldBeOpen(state) {
-		return nil
+		return "", nil
 	}
 
 	i.shardCreateLocks.Lock(shardName)
@@ -855,26 +868,34 @@ func (i *Index) loadLocalShardIfActive(shardName string) error {
 	// check if set to inactive in the meantime by concurrent call
 	shard := i.shards.Load(shardName)
 	if shard == nil {
-		return nil
+		return monitoring.WarmupSkippedNotCold, nil
 	}
 
 	lazyShard, ok := shard.(*LazyLoadShard)
-	if ok {
-		// avoid footprint of empty shards
-		if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
-			return nil
-		}
-
-		// The load waits for a permit from the node-wide limiter while the index
-		// is held open, so it has to give that wait up on a close request rather
-		// than leave a teardown waiting for it to finish.
-		ctx, done := i.cancelOnCloseRequested(context.Background())
-		defer done()
-
-		return lazyShard.Load(ctx)
+	if !ok {
+		return monitoring.WarmupSkippedNotCold, nil
 	}
 
-	return nil
+	// avoid footprint of empty shards
+	if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+		return monitoring.WarmupSkippedEmpty, nil
+	}
+
+	// The load waits for a permit from the node-wide limiter while the index
+	// is held open, so it has to give that wait up on a close request rather
+	// than leave a teardown waiting for it to finish.
+	ctx, done := i.cancelOnCloseRequested(context.Background())
+	defer done()
+
+	loaded, err := lazyShard.loadIfCold(ctx)
+	if err != nil {
+		return "", err
+	}
+	if !loaded {
+		return monitoring.WarmupSkippedNotCold, nil
+	}
+
+	return monitoring.WarmupLoaded, nil
 }
 
 // used to init/create shard in different moments of index's lifecycle, therefore it needs to be called

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -686,8 +686,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return nil
 	}
 
-	// Lazy loading is only half lazy: the sweep materializes every hot shard, one
-	// per second, minus what LazyLoadShardWarmupMinObjects leaves out.
+	// Lazy loading is only half lazy: this loads every hot shard above
+	// LazyLoadShardWarmupMinObjects, one per second.
 	initLazyShardsInBackground := func() {
 		// Fires on every exit, a closing index and a failed load included: the
 		// node-wide object count reads a cold shard from disk, and staying false
@@ -697,8 +697,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 
-		// abortIfClosing reports whether the index is closing and logs that the
-		// sweep stopped; the caller is the one that returns.
+		// This only reports and logs. The caller is the one that returns.
 		abortIfClosing := func() bool {
 			err := i.closingCtx.Err()
 			if err == nil {
@@ -722,9 +721,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				return
 			}
 
-			// The decision comes before the tick so only shards that will load wait a
-			// second. At a positive threshold each skip still costs one directory
-			// listing, unpaced.
+			// Checked before the tick so only shards that will load wait a second.
+			// Each skip still costs one unpaced directory listing.
 			if shouldWarm, outcome := i.warmupCandidate(shardName); !shouldWarm {
 				recordOutcome(outcome)
 				continue
@@ -745,10 +743,9 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 					WithField("action", "load_shard").
 					WithField("shard_name", shardName).
 					Errorf("failed to load shard, loading the rest anyway: %v", err)
-				// A failure says nothing about the shards behind this one:
-				// memory pressure is node-wide and transient, anything else
-				// is specific to this shard. Stopping here would leave the
-				// rest cold until something touches them.
+				// A failure says nothing about the shards behind this one: memory
+				// pressure is node-wide and transient, anything else is specific
+				// to this shard. Stopping here would leave the rest cold.
 				continue
 			}
 			if outcome != "" {
@@ -787,9 +784,8 @@ func (i *Index) unloadedShardIsEmpty(shardName string) bool {
 }
 
 // warmupCandidate reports whether the startup sweep should load this shard, and
-// where it should not, the outcome naming why. It is asked before the sweep
-// spends a tick on the shard. A count it cannot read answers true: a shard is
-// loaded rather than left cold on a number nobody could take.
+// where it should not, the outcome naming why. An object count it cannot read
+// answers true, so no shard is left cold on a number nobody could take.
 func (i *Index) warmupCandidate(shardName string) (bool, monitoring.WarmupOutcome) {
 	i.shardCreateLocks.Lock(shardName)
 	defer i.shardCreateLocks.Unlock(shardName)
@@ -830,9 +826,8 @@ func (i *Index) warmupCandidate(shardName string) (bool, monitoring.WarmupOutcom
 	}
 
 	// The persisted doc-id counter would see the writes the sidecars miss, but it
-	// counts allocations rather than objects: deletes never lower it, and an update
-	// that changes a vector raises it. A shard that churned its way down to nothing
-	// would read large forever, so the sweep stays with the count that reads short.
+	// counts allocations rather than objects: deletes never lower it. A shard that
+	// churned its way down to nothing would read large forever.
 
 	i.logger.WithFields(logrus.Fields{
 		"action":             "skip_shard_warmup",
@@ -844,9 +839,9 @@ func (i *Index) warmupCandidate(shardName string) (bool, monitoring.WarmupOutcom
 	return false, monitoring.WarmupSkippedBelowThreshold
 }
 
-// loadLocalShardIfActive loads a shard the startup sweep picked, and reports what
-// the sweep should record for it. An empty outcome means the index refused the
-// load for a reason that says nothing about this shard, so nothing is recorded.
+// loadLocalShardIfActive loads a shard the startup sweep picked and reports the
+// outcome to record. An empty outcome means the index refused the load for a
+// reason that says nothing about this shard.
 func (i *Index) loadLocalShardIfActive(shardName string) (monitoring.WarmupOutcome, error) {
 	// Index.Shutdown skips a lazy shard that is not loaded yet, so a build racing
 	// its sweep leaves an open store nothing will ever close. The refcount holds
@@ -1527,10 +1522,9 @@ type IndexConfig struct {
 	DisableDimensionMetrics *configRuntime.DynamicValue[bool]
 }
 
-// backgroundWarmupEnabled reports whether the startup sweep loads cold shards.
-// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupMinObjects
-// has nothing to gate while EnableLazyLoadShards is false. A negative value turns
-// the sweep off; which shards a non-negative one loads is warmupCandidate's call.
+// backgroundWarmupEnabled reports whether the startup sweep runs at all. Only the
+// lazy-loading path has one, and a negative LazyLoadShardWarmupMinObjects turns it
+// off. Which shards a non-negative value loads is warmupCandidate's call.
 func (c IndexConfig) backgroundWarmupEnabled() bool {
 	return c.EnableLazyLoadShards && c.LazyLoadShardWarmupMinObjects >= 0
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -672,7 +672,7 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return nil
 	}
 
-	if i.Config.LazyLoadShardWarmupDisabled {
+	if !i.Config.backgroundWarmupEnabled() {
 		// Nothing else sets allShardsReady once the sweep is skipped, and
 		// observeObjectCount publishes no node-wide object count while any index
 		// reports false. Cold shards answer it from disk via ObjectCountAsync.
@@ -1420,6 +1420,13 @@ type IndexConfig struct {
 	AutoTenantActivation bool
 
 	DisableDimensionMetrics *configRuntime.DynamicValue[bool]
+}
+
+// backgroundWarmupEnabled reports whether the startup sweep loads cold shards.
+// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupDisabled
+// has nothing to switch off while EnableLazyLoadShards is false.
+func (c IndexConfig) backgroundWarmupEnabled() bool {
+	return c.EnableLazyLoadShards && !c.LazyLoadShardWarmupDisabled
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -672,6 +672,19 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return nil
 	}
 
+	if i.Config.LazyLoadShardWarmupDisabled {
+		// Nothing else sets allShardsReady once the sweep is skipped, and
+		// observeObjectCount publishes no node-wide object count while any index
+		// reports false. Cold shards answer it from disk via ObjectCountAsync.
+		i.allShardsReady.Store(true)
+		i.logger.WithFields(logrus.Fields{
+			"action":     "skip_load_all_shards",
+			"class":      i.Config.ClassName.String(),
+			"hot_shards": len(hotShardNames),
+		}).Debug("background warmup disabled; lazy shards will load on first access")
+		return nil
+	}
+
 	// NOTE(dyma):
 	// 1. So "lazy-loaded" shards are actually loaded "half-eagerly"?
 	// 2. If <-ctx.Done or we fail to load a shard, should allShardsReady still report true?
@@ -1370,6 +1383,7 @@ type IndexConfig struct {
 	AsyncReplicationScheduler           *AsyncReplicationScheduler
 	AvoidMMap                           bool
 	EnableLazyLoadShards                bool
+	LazyLoadShardWarmupDisabled         bool // read only when EnableLazyLoadShards is true
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -816,14 +816,10 @@ func (i *Index) warmupCandidate(shardName string) bool {
 		return true
 	}
 
-	// Segment sidecars miss the segment a shutdown flush writes and everything
-	// still in a write-ahead log, so they can read zero for a large shard that was
-	// merely restarted. The persisted doc-id counter sees both, and a shard left
-	// cold never gets its sidecars derived, so the skip has to convince both.
-	if written, err := indexcounter.Read(shardPath(i.path(), shardName)); err == nil &&
-		int64(written) > minObjects {
-		return true
-	}
+	// The persisted doc-id counter would see the writes the sidecars miss, but it
+	// counts allocations rather than objects: deletes never lower it, and an update
+	// that changes a vector raises it. A shard that churned its way down to nothing
+	// would read large forever, so the sweep stays with the count that reads short.
 
 	i.logger.WithFields(logrus.Fields{
 		"action":             "skip_shard_warmup",

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -694,44 +695,67 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 
+		// abortIfClosing reports whether the index is closing and logs that the
+		// sweep stopped; the caller is the one that returns.
+		abortIfClosing := func() bool {
+			err := i.closingCtx.Err()
+			if err == nil {
+				return false
+			}
+			i.logger.
+				WithField("action", "load_all_shards").
+				Errorf("failed to load all shards: %v", err)
+			return true
+		}
+
 		now := time.Now()
-		var failed int
+		var loaded, skipped, failed int
 
 		for _, shardName := range hotShardNames {
+			if abortIfClosing() {
+				return
+			}
+
+			// The decision comes before the tick so only shards that will load wait a
+			// second. At a positive threshold each skip still costs one directory
+			// listing, unpaced.
+			if !i.warmupCandidate(shardName) {
+				skipped++
+				continue
+			}
+
 			select {
 			case <-i.closingCtx.Done():
-				i.logger.
-					WithField("action", "load_all_shards").
-					Errorf("failed to load all shards: %v", i.closingCtx.Err())
-				return
 			case <-ticker.C:
-				select {
-				case <-i.closingCtx.Done():
-					i.logger.
-						WithField("action", "load_all_shards").
-						Errorf("failed to load all shards: %v", i.closingCtx.Err())
-					return
-				default:
-					if err := i.loadLocalShardIfActive(shardName); err != nil {
-						failed++
-						i.logger.
-							WithField("action", "load_shard").
-							WithField("shard_name", shardName).
-							Errorf("failed to load shard, loading the rest anyway: %v", err)
-						// A failure says nothing about the shards behind this one:
-						// memory pressure is node-wide and transient, anything else
-						// is specific to this shard. Stopping here would leave the
-						// rest cold until something touches them.
-						continue
-					}
-				}
 			}
+			if abortIfClosing() {
+				return
+			}
+
+			if err := i.loadLocalShardIfActive(shardName); err != nil {
+				failed++
+				i.logger.
+					WithField("action", "load_shard").
+					WithField("shard_name", shardName).
+					Errorf("failed to load shard, loading the rest anyway: %v", err)
+				// A failure says nothing about the shards behind this one:
+				// memory pressure is node-wide and transient, anything else
+				// is specific to this shard. Stopping here would leave the
+				// rest cold until something touches them.
+				continue
+			}
+			loaded++
 		}
 
 		i.logger.
-			WithField("action", "load_all_shards").
-			WithField("took", time.Since(now).String()).
-			WithField("failed", failed).
+			WithFields(logrus.Fields{
+				"action":  "load_all_shards",
+				"class":   i.Config.ClassName.String(),
+				"took":    time.Since(now).String(),
+				"loaded":  loaded,
+				"skipped": skipped,
+				"failed":  failed,
+			}).
 			Debug("finished loading all shards")
 	}
 
@@ -748,6 +772,67 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 func (i *Index) unloadedShardIsEmpty(shardName string) bool {
 	count, err := indexcounter.Read(shardPath(i.path(), shardName))
 	return err == nil && count == 0
+}
+
+// warmupCandidate reports whether the startup sweep should load this shard, and
+// is asked before the sweep spends a tick on it. A count it cannot read answers
+// true: a shard is loaded rather than left cold on a number nobody could take.
+func (i *Index) warmupCandidate(shardName string) bool {
+	i.shardCreateLocks.Lock(shardName)
+	defer i.shardCreateLocks.Unlock(shardName)
+
+	shard := i.shards.Load(shardName)
+	if shard == nil {
+		return false
+	}
+	lazyShard, ok := shard.(*LazyLoadShard)
+	if !ok || lazyShard.isLoaded() {
+		return false
+	}
+
+	// avoid footprint of empty shards
+	if i.partitioningEnabled && i.unloadedShardIsEmpty(shardName) {
+		return false
+	}
+
+	minObjects := i.Config.LazyLoadShardWarmupMinObjects
+	if minObjects == 0 {
+		return true
+	}
+
+	count, err := lazyShard.ObjectCountAsync(i.closingCtx)
+	if err != nil {
+		entry := i.logger.
+			WithField("action", "load_shard").
+			WithField("shard_name", shardName)
+		if stderrors.Is(err, fs.ErrNotExist) {
+			entry.Debugf("unloaded shard has no objects bucket yet, warming it up: %v", err)
+		} else {
+			entry.Warnf("failed to count objects of unloaded shard, warming it up anyway: %v", err)
+		}
+		return true
+	}
+	if count > minObjects {
+		return true
+	}
+
+	// Segment sidecars miss the segment a shutdown flush writes and everything
+	// still in a write-ahead log, so they can read zero for a large shard that was
+	// merely restarted. The persisted doc-id counter sees both, and a shard left
+	// cold never gets its sidecars derived, so the skip has to convince both.
+	if written, err := indexcounter.Read(shardPath(i.path(), shardName)); err == nil &&
+		int64(written) > minObjects {
+		return true
+	}
+
+	i.logger.WithFields(logrus.Fields{
+		"action":             "skip_shard_warmup",
+		"class":              i.Config.ClassName.String(),
+		"shard_name":         shardName,
+		"object_count":       count,
+		"warmup_min_objects": minObjects,
+	}).Debug("shard holds too few objects to warm up; it loads on first access")
+	return false
 }
 
 func (i *Index) loadLocalShardIfActive(shardName string) error {
@@ -1383,7 +1468,7 @@ type IndexConfig struct {
 	AsyncReplicationScheduler           *AsyncReplicationScheduler
 	AvoidMMap                           bool
 	EnableLazyLoadShards                bool
-	LazyLoadShardWarmupDisabled         bool // read only when EnableLazyLoadShards is true
+	LazyLoadShardWarmupMinObjects       int64 // read only when EnableLazyLoadShards is true
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration
@@ -1423,10 +1508,11 @@ type IndexConfig struct {
 }
 
 // backgroundWarmupEnabled reports whether the startup sweep loads cold shards.
-// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupDisabled
-// has nothing to switch off while EnableLazyLoadShards is false.
+// The sweep only runs on the lazy-loading path, so LazyLoadShardWarmupMinObjects
+// has nothing to gate while EnableLazyLoadShards is false. A negative value turns
+// the sweep off; which shards a non-negative one loads is warmupCandidate's call.
 func (c IndexConfig) backgroundWarmupEnabled() bool {
-	return c.EnableLazyLoadShards && !c.LazyLoadShardWarmupDisabled
+	return c.EnableLazyLoadShards && c.LazyLoadShardWarmupMinObjects >= 0
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -763,7 +763,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 				"took":                    time.Since(now).String(),
 				"loaded":                  tally[monitoring.WarmupLoaded],
 				"failed":                  tally[monitoring.WarmupFailed],
-				"skipped_not_cold":        tally[monitoring.WarmupSkippedNotCold],
+				"skipped_shard_gone":      tally[monitoring.WarmupSkippedShardGone],
+				"skipped_already_loaded":  tally[monitoring.WarmupSkippedAlreadyLoaded],
 				"skipped_empty":           tally[monitoring.WarmupSkippedEmpty],
 				"skipped_below_threshold": tally[monitoring.WarmupSkippedBelowThreshold],
 			}).
@@ -795,11 +796,11 @@ func (i *Index) warmupCandidate(shardName string) (bool, monitoring.WarmupOutcom
 
 	shard := i.shards.Load(shardName)
 	if shard == nil {
-		return false, monitoring.WarmupSkippedNotCold
+		return false, monitoring.WarmupSkippedShardGone
 	}
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if !ok || lazyShard.isLoaded() {
-		return false, monitoring.WarmupSkippedNotCold
+		return false, monitoring.WarmupSkippedAlreadyLoaded
 	}
 
 	// avoid footprint of empty shards
@@ -870,12 +871,12 @@ func (i *Index) loadLocalShardIfActive(shardName string) (monitoring.WarmupOutco
 	// check if set to inactive in the meantime by concurrent call
 	shard := i.shards.Load(shardName)
 	if shard == nil {
-		return monitoring.WarmupSkippedNotCold, nil
+		return monitoring.WarmupSkippedShardGone, nil
 	}
 
 	lazyShard, ok := shard.(*LazyLoadShard)
 	if !ok {
-		return monitoring.WarmupSkippedNotCold, nil
+		return monitoring.WarmupSkippedAlreadyLoaded, nil
 	}
 
 	// avoid footprint of empty shards
@@ -894,7 +895,7 @@ func (i *Index) loadLocalShardIfActive(shardName string) (monitoring.WarmupOutco
 		return "", err
 	}
 	if !loaded {
-		return monitoring.WarmupSkippedNotCold, nil
+		return monitoring.WarmupSkippedAlreadyLoaded, nil
 	}
 
 	return monitoring.WarmupLoaded, nil

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -336,8 +336,8 @@ type Index struct {
 	closingCtx    context.Context
 	closingCancel context.CancelFunc
 
-	// always true if lazy shard loading is off, in the case of lazy shard
-	// loading will be set to true once the last shard was loaded.
+	// True once the startup sweep is over. Shards it skips or fails to load stay
+	// cold, so this does not mean every shard is loaded.
 	allShardsReady atomic.Bool
 	allocChecker   memwatch.AllocChecker
 
@@ -686,10 +686,12 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return nil
 	}
 
-	// NOTE(dyma):
-	// 1. So "lazy-loaded" shards are actually loaded "half-eagerly"?
-	// 2. If <-ctx.Done or we fail to load a shard, should allShardsReady still report true?
+	// Lazy loading is only half lazy: the sweep materializes every hot shard, one
+	// per second, minus what LazyLoadShardWarmupMinObjects leaves out.
 	initLazyShardsInBackground := func() {
+		// Fires on every exit, a closing index and a failed load included: the
+		// node-wide object count reads a cold shard from disk, and staying false
+		// would suppress it for every index on the node.
 		defer i.allShardsReady.Store(true)
 
 		ticker := time.NewTicker(time.Second)

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -226,8 +226,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 		return nil, fmt.Errorf("tenant exists: %w", err)
 	}
 	if !exists {
-		// no numbers to read from disk, but an active tenant whose lazy shard is not
-		// in memory is marked here the same way a computed one is
+		// no numbers to read from disk, but an unloaded lazy shard is still marked
 		lazyShard, isLazy := shard.(*LazyLoadShard)
 		return emptyShardUsageWithNameAndActivity(shardName, localStatus, isLazy && !lazyShard.isLoaded()), nil
 	}
@@ -239,8 +238,8 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 	switch localStatus {
 	case models.TenantActivityStatusACTIVE, models.TenantActivityStatusHOT:
 		// active tenants can be either fully loaded or lazy loaded. Lazy shards should _not_ be loaded just for
-		// usage calculation, so their usage is read from disk like an inactive shard's — they still report an
-		// active status, marked as unloaded
+		// usage calculation, so their usage is read from disk like an inactive shard's. They
+		// still report an active status, marked as unloaded.
 		lazyShard, isLazy := shard.(*LazyLoadShard)
 		if isLazy {
 			// distinguish between loaded and unloaded lazy shards - make sure that the shard is not loaded
@@ -297,8 +296,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 		return nil, err2
 	}
 	// both fields describe the tenant now, not its files, so neither is left to the
-	// calculations above: one of them saves its result to disk, and a tenant
-	// deactivated later would keep serving whatever was saved with it
+	// calculation above that saves its result to disk and serves it again later
 	shardUsage.Status = strings.ToLower(localStatus)
 	shardUsage.LazyUnloaded = unloadedLazy
 	return shardUsage, nil
@@ -501,8 +499,7 @@ func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
 // calculateUnloadedShardUsage computes usage for a cold shard from disk. vectorConfigs must
 // contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig —
 // and vectorConfigsFingerprint must be their [shardusage.VectorConfigsFingerprint]. The result
-// carries no tenant status: it is saved to disk and served again later, when the tenant may
-// have a different one.
+// carries no tenant status: it is saved to disk and served when the tenant may have changed.
 func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig, vectorConfigsFingerprint string) (*types.ShardUsage, error) {
 	if shardusage.ComputedUsageDataExists(i.path(), shardName) {
 		// usage has been pre-calculated and can be read from disk
@@ -618,8 +615,7 @@ func (i *Index) splitObjectsBucketSize(shardName string, objectsBucketSize, unco
 
 // emptyShardUsageWithNameAndActivity reports zero usage for a shard with no data on disk. Callers
 // pass the schema's upper-case activity constants, while the report spells the status in lower
-// case. lazyUnloaded marks an active shard that is not in memory, the same way a computed one is
-// marked.
+// case. lazyUnloaded marks an active shard that is not in memory, like a computed one.
 func emptyShardUsageWithNameAndActivity(shardName, activity string, lazyUnloaded bool) *types.ShardUsage {
 	return &types.ShardUsage{
 		Name:                shardName,

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -226,15 +226,21 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 		return nil, fmt.Errorf("tenant exists: %w", err)
 	}
 	if !exists {
-		return emptyShardUsageWithNameAndActivity(shardName, localStatus), nil
+		// no numbers to read from disk, but an active tenant whose lazy shard is not
+		// in memory is marked here the same way a computed one is
+		lazyShard, isLazy := shard.(*LazyLoadShard)
+		return emptyShardUsageWithNameAndActivity(shardName, localStatus, isLazy && !lazyShard.isLoaded()), nil
 	}
 
 	var err2 error
 	var shardUsage *types.ShardUsage
+	// true when the usage below was read from disk because the lazy shard is not loaded
+	var unloadedLazy bool
 	switch localStatus {
 	case models.TenantActivityStatusACTIVE, models.TenantActivityStatusHOT:
 		// active tenants can be either fully loaded or lazy loaded. Lazy shards should _not_ be loaded just for
-		// usage calculation and are treated like inactive shards
+		// usage calculation, so their usage is read from disk like an inactive shard's — they still report an
+		// active status, marked as unloaded
 		lazyShard, isLazy := shard.(*LazyLoadShard)
 		if isLazy {
 			// distinguish between loaded and unloaded lazy shards - make sure that the shard is not loaded
@@ -243,6 +249,7 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 				release := lazyShard.blockLoading()
 				defer release()
 
+				unloadedLazy = !lazyShard.loaded
 				if lazyShard.loaded {
 					shardUsage, err2 = i.calculateLoadedShardUsage(ctx, lazyShard.shard, exactObjectCount)
 					if err2 != nil {
@@ -285,10 +292,15 @@ func (i *Index) usageForShard(ctx context.Context, shardName string, exactObject
 				"class": i.Config.ClassName.String(),
 				"shard": shardName,
 			}).Warnf("shard files missing during usage calculation, likely deleted concurrently; recording empty usage: %v", err2)
-			return emptyShardUsageWithNameAndActivity(shardName, localStatus), nil
+			return emptyShardUsageWithNameAndActivity(shardName, localStatus, unloadedLazy), nil
 		}
 		return nil, err2
 	}
+	// both fields describe the tenant now, not its files, so neither is left to the
+	// calculations above: one of them saves its result to disk, and a tenant
+	// deactivated later would keep serving whatever was saved with it
+	shardUsage.Status = strings.ToLower(localStatus)
+	shardUsage.LazyUnloaded = unloadedLazy
 	return shardUsage, nil
 }
 
@@ -338,7 +350,6 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 
 	shardUsage := &types.ShardUsage{
 		Name:                  shard.Name(),
-		Status:                strings.ToLower(models.TenantActivityStatusACTIVE),
 		ObjectsCount:          objectCount,
 		ObjectsStorageBytes:   objectsWithoutVectors,
 		VectorStorageBytes:    uint64(vectorStorageSize) + vectorsInObjects + vectorCommitLogsStorageSize, // lsm/vectors + objects vectors + commit.log folders
@@ -489,7 +500,9 @@ func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
 
 // calculateUnloadedShardUsage computes usage for a cold shard from disk. vectorConfigs must
 // contain only active vectors — a dropped vector's entry carries a nil VectorIndexConfig —
-// and vectorConfigsFingerprint must be their [shardusage.VectorConfigsFingerprint].
+// and vectorConfigsFingerprint must be their [shardusage.VectorConfigsFingerprint]. The result
+// carries no tenant status: it is saved to disk and served again later, when the tenant may
+// have a different one.
 func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName string, vectorConfigs map[string]models.VectorConfig, vectorConfigsFingerprint string) (*types.ShardUsage, error) {
 	if shardusage.ComputedUsageDataExists(i.path(), shardName) {
 		// usage has been pre-calculated and can be read from disk
@@ -575,7 +588,6 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	shardUsage := &types.ShardUsage{
 		Name:                  shardName,
 		ObjectsCount:          objectUsage.Count,
-		Status:                strings.ToLower(models.TenantActivityStatusINACTIVE),
 		ObjectsStorageBytes:   objectsWithoutVectors,
 		VectorStorageBytes:    uint64(vectorMetrics.StorageBytes) + vectorsInObjects + vectorCommitLogsStorageSize,
 		IndexStorageBytes:     indexUsage,
@@ -605,12 +617,14 @@ func (i *Index) splitObjectsBucketSize(shardName string, objectsBucketSize, unco
 }
 
 // emptyShardUsageWithNameAndActivity reports zero usage for a shard with no data on disk. Callers
-// pass the schema's upper-case activity constants, while the report spells the status in lower case
-// like the computed paths do.
-func emptyShardUsageWithNameAndActivity(shardName, activity string) *types.ShardUsage {
+// pass the schema's upper-case activity constants, while the report spells the status in lower
+// case. lazyUnloaded marks an active shard that is not in memory, the same way a computed one is
+// marked.
+func emptyShardUsageWithNameAndActivity(shardName, activity string, lazyUnloaded bool) *types.ShardUsage {
 	return &types.ShardUsage{
 		Name:                shardName,
 		Status:              strings.ToLower(activity),
+		LazyUnloaded:        lazyUnloaded,
 		ObjectsCount:        0,
 		ObjectsStorageBytes: 0,
 		VectorStorageBytes:  0,

--- a/adapters/repos/db/index_usage_cache_test.go
+++ b/adapters/repos/db/index_usage_cache_test.go
@@ -227,9 +227,8 @@ func writeSavedShardUsage(t *testing.T, indexPath, shardName string, saved *type
 	require.NoError(t, os.WriteFile(savedShardUsagePath(indexPath, shardName), data, 0o600))
 }
 
-// markSavedShardUsage stamps savedObjectsCount on the usage a report saved, leaving
-// everything the cache validates untouched.
-func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
+// readSavedShardUsage reads back the file a report saved for a cold shard.
+func readSavedShardUsage(t *testing.T, indexPath, shardName string) *types.UsageDisk {
 	t.Helper()
 
 	data, err := os.ReadFile(savedShardUsagePath(indexPath, shardName))
@@ -237,6 +236,15 @@ func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
 	saved := &types.UsageDisk{}
 	require.NoError(t, json.Unmarshal(data, saved))
 	require.NotNil(t, saved.ShardUsage, "the first report must have saved usage")
+	return saved
+}
+
+// markSavedShardUsage stamps savedObjectsCount on the usage a report saved, leaving
+// everything the cache validates untouched.
+func markSavedShardUsage(t *testing.T, indexPath, shardName string) {
+	t.Helper()
+
+	saved := readSavedShardUsage(t, indexPath, shardName)
 	saved.ShardUsage.ObjectsCount = savedObjectsCount
 	writeSavedShardUsage(t, indexPath, shardName, saved)
 }

--- a/adapters/repos/db/index_usage_hot_cold_test.go
+++ b/adapters/repos/db/index_usage_hot_cold_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"maps"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -133,6 +134,70 @@ func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, recomputed.Shards, 1)
 			assert.Equal(t, loaded.Shards[0].FullShardStorageBytes, recomputed.Shards[0].FullShardStorageBytes)
+		})
+	}
+}
+
+// TestIndex_UsageForCollection_LazyUnloadedShard pins how a hot tenant is reported
+// while its lazy shard sits unloaded: it bills like a loaded one, and only the mark
+// says its numbers came from disk. Without the mark a node that leaves hot tenants
+// unloaded cannot be told apart from one serving them all from memory.
+func TestIndex_UsageForCollection_LazyUnloadedShard(t *testing.T) {
+	active := strings.ToLower(models.TenantActivityStatusACTIVE)
+
+	tests := []struct {
+		name string
+		// load asks for the shard before the report runs, so the lazy shard is loaded
+		load             bool
+		wantLazyUnloaded bool
+	}{
+		{
+			name: "hot tenant whose shard is loaded",
+			load: true,
+		},
+		{
+			name:             "hot tenant whose shard stays unloaded",
+			wantLazyUnloaded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			tenantName := "test-tenant"
+
+			index, vectorConfigs := setupPopulatedLazyIndex(ctx, t, usageIndexParams{})
+			t.Cleanup(func() { _ = index.Shutdown(ctx) })
+
+			release := func() {}
+			if tt.load {
+				var err error
+				_, release, err = index.GetShard(ctx, tenantName)
+				require.NoError(t, err)
+			}
+			usage, err := index.usageForCollection(ctx, semaphore.NewWeighted(1), true, vectorConfigs)
+			release()
+			require.NoError(t, err)
+			require.Len(t, usage.Shards, 1)
+			assert.Equal(t, active, usage.Shards[0].Status, "a hot tenant reports an active shard either way")
+			assert.Equal(t, tt.wantLazyUnloaded, usage.Shards[0].LazyUnloaded)
+			assert.Equal(t, populatedObjectsCount, usage.Shards[0].ObjectsCount)
+
+			if !tt.wantLazyUnloaded {
+				return
+			}
+			// status and mark describe the tenant now, so neither may travel with the
+			// numbers the cold path saved: it may be deactivated before the next report
+			saved := readSavedShardUsage(t, index.path(), tenantName)
+			assert.Empty(t, saved.ShardUsage.Status, "the saved usage must carry no status")
+			assert.False(t, saved.ShardUsage.LazyUnloaded, "the saved usage must not carry the mark")
+
+			// the second report is served from that file and still has to describe the tenant
+			cached, err := index.usageForCollection(ctx, semaphore.NewWeighted(1), true, vectorConfigs)
+			require.NoError(t, err)
+			require.Len(t, cached.Shards, 1)
+			assert.Equal(t, active, cached.Shards[0].Status, "usage served from disk must report the tenant active")
+			assert.True(t, cached.Shards[0].LazyUnloaded, "usage served from disk must carry the mark")
 		})
 	}
 }

--- a/adapters/repos/db/index_usage_hot_cold_test.go
+++ b/adapters/repos/db/index_usage_hot_cold_test.go
@@ -140,8 +140,7 @@ func TestIndex_UsageForCollection_LoadedAndUnloadedAgree(t *testing.T) {
 
 // TestIndex_UsageForCollection_LazyUnloadedShard pins how a hot tenant is reported
 // while its lazy shard sits unloaded: it bills like a loaded one, and only the mark
-// says its numbers came from disk. Without the mark a node that leaves hot tenants
-// unloaded cannot be told apart from one serving them all from memory.
+// separates it from a node serving every tenant from memory.
 func TestIndex_UsageForCollection_LazyUnloadedShard(t *testing.T) {
 	active := strings.ToLower(models.TenantActivityStatusACTIVE)
 

--- a/adapters/repos/db/index_usage_missing_files_test.go
+++ b/adapters/repos/db/index_usage_missing_files_test.go
@@ -129,12 +129,15 @@ func TestIndex_UsageForCollection_MissingShardFiles(t *testing.T) {
 			assert.Equal(t, int64(0), shardUsage.ObjectsCount, "missing shard must be recorded as empty")
 			assert.Equal(t, uint64(0), shardUsage.ObjectsStorageBytes)
 
-			// an empty shard must spell its status the same way a computed one does
+			// an empty shard must spell its status, and mark that it is not in memory,
+			// the same way a computed one does
 			wantStatus := strings.ToLower(models.TenantActivityStatusACTIVE)
 			if tt.loadAndDelete {
 				wantStatus = strings.ToLower(models.TenantActivityStatusINACTIVE)
 			}
 			assert.Equal(t, wantStatus, shardUsage.Status)
+			assert.Equal(t, !tt.loadAndDelete, shardUsage.LazyUnloaded,
+				"an unloaded lazy shard is marked, an inactive one is not")
 		})
 	}
 }

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -229,7 +229,7 @@ func (db *DB) init(ctx context.Context) error {
 				"action":                  "lazy_shard_auto_detection",
 				"class":                   class.Class,
 				"enable_lazy_load_shards": lazyLoadShardEnabled,
-				"background_warmup":       !db.config.LazyLoadShardWarmupDisabled,
+				"background_warmup":       idx.Config.backgroundWarmupEnabled(),
 				"local_shard_count":       localActiveShardsCount,
 				"total_shard_size_bytes":  totalShardSizeBytes,
 				"count_threshold":         db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -173,7 +173,7 @@ func (db *DB) init(ctx context.Context) error {
 					)
 					return lazyLoadShardEnabled
 				}(),
-				LazyLoadShardWarmupDisabled:         db.config.LazyLoadShardWarmupDisabled,
+				LazyLoadShardWarmupMinObjects:       db.config.LazyLoadShardWarmupMinObjects,
 				ForceFullReplicasSearch:             db.config.ForceFullReplicasSearch,
 				TransferInactivityTimeout:           db.config.TransferInactivityTimeout,
 				HaltForTransferTimeout:              db.config.HaltForTransferTimeout,
@@ -230,6 +230,7 @@ func (db *DB) init(ctx context.Context) error {
 				"class":                   class.Class,
 				"enable_lazy_load_shards": lazyLoadShardEnabled,
 				"background_warmup":       idx.Config.backgroundWarmupEnabled(),
+				"warmup_min_objects":      db.config.LazyLoadShardWarmupMinObjects,
 				"local_shard_count":       localActiveShardsCount,
 				"total_shard_size_bytes":  totalShardSizeBytes,
 				"count_threshold":         db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -173,6 +173,7 @@ func (db *DB) init(ctx context.Context) error {
 					)
 					return lazyLoadShardEnabled
 				}(),
+				LazyLoadShardWarmupDisabled:         db.config.LazyLoadShardWarmupDisabled,
 				ForceFullReplicasSearch:             db.config.ForceFullReplicasSearch,
 				TransferInactivityTimeout:           db.config.TransferInactivityTimeout,
 				HaltForTransferTimeout:              db.config.HaltForTransferTimeout,
@@ -228,6 +229,7 @@ func (db *DB) init(ctx context.Context) error {
 				"action":                  "lazy_shard_auto_detection",
 				"class":                   class.Class,
 				"enable_lazy_load_shards": lazyLoadShardEnabled,
+				"background_warmup":       !db.config.LazyLoadShardWarmupDisabled,
 				"local_shard_count":       localActiveShardsCount,
 				"total_shard_size_bytes":  totalShardSizeBytes,
 				"count_threshold":         db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -50,13 +51,15 @@ const (
 
 // newWarmupIndex opens a multi-tenant index over dirName, one lazy shard per
 // tenant, with the startup sweep gated at minObjects. A nil allocChecker gives
-// every load the dummy monitor, which allows all of them.
+// every load the dummy monitor, which allows all of them. The returned hook
+// holds the sweep's own log, which reports what it did with every shard.
 func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
 	allocChecker memwatch.AllocChecker, tenants ...string,
-) *Index {
+) (*Index, *test.Hook) {
 	t.Helper()
 	ctx := context.Background()
-	logger, _ := test.NewNullLogger()
+	logger, hook := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
 
 	class := newClassWithWarmProp(warmupClassName)
 	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
@@ -120,12 +123,45 @@ func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
 		LazyLoadShardWarmupMinObjects: minObjects,
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
-		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{},
+		monitoring.GetMetrics(),
 		class, nil, scheduler, nil, allocChecker,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
 
-	return index
+	return index, hook
+}
+
+// sweepDoneMessage is what the startup sweep logs once it has walked every shard.
+const sweepDoneMessage = "finished loading all shards"
+
+// requireSweepTally asserts how many shards the startup sweep reported under
+// each outcome, waiting for it to finish. An outcome absent from want must have
+// counted nothing.
+func requireSweepTally(t *testing.T, hook *test.Hook, want map[monitoring.WarmupOutcome]int) {
+	t.Helper()
+
+	var tally logrus.Fields
+	require.Eventually(t, func() bool {
+		for _, entry := range hook.AllEntries() {
+			if entry.Message != sweepDoneMessage {
+				continue
+			}
+			tally = entry.Data
+			return true
+		}
+		return false
+	}, 30*time.Second, 50*time.Millisecond, "the sweep should log what it did with every shard")
+
+	for _, outcome := range []monitoring.WarmupOutcome{
+		monitoring.WarmupLoaded,
+		monitoring.WarmupFailed,
+		monitoring.WarmupSkippedNotCold,
+		monitoring.WarmupSkippedEmpty,
+		monitoring.WarmupSkippedBelowThreshold,
+	} {
+		require.Equal(t, want[outcome], tally[string(outcome)], "shards reported as %q", outcome)
+	}
 }
 
 // coldWarmupShard returns a tenant's shard, asserting it is an unloaded lazy one.
@@ -158,7 +194,7 @@ func seedWarmupTenants(t *testing.T, dirName string, seeds map[string]warmupSeed
 		tenants = append(tenants, tenant)
 	}
 
-	index := newWarmupIndex(t, dirName, -1, nil, tenants...)
+	index, _ := newWarmupIndex(t, dirName, -1, nil, tenants...)
 	for tenant, seed := range seeds {
 		writeCountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.counted)
 		if seed.uncounted > 0 {
@@ -185,20 +221,36 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 		// unreadableCount removes the shard's objects bucket directory, so
 		// LazyLoadShard.ObjectCountAsync fails instead of returning a count.
 		unreadableCount bool
-		wantLoaded      bool
+		// wantOutcome is what the sweep should report for the shard. It is empty
+		// where a negative threshold means no sweep runs.
+		wantOutcome monitoring.WarmupOutcome
 	}{
 		{name: "a negative threshold warms nothing", seed: warmupSeed{counted: 3}, minObjects: -1},
-		{name: "the default warms a non-empty shard", seed: warmupSeed{counted: 3}, minObjects: 0, wantLoaded: true},
-		{name: "the default skips an empty shard", minObjects: 0},
-		{name: "a threshold above the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 5},
-		{name: "a threshold at the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 3},
+		{
+			name: "the default warms a non-empty shard",
+			seed: warmupSeed{counted: 3}, minObjects: 0, wantOutcome: monitoring.WarmupLoaded,
+		},
+		{
+			name:       "the default skips an empty shard",
+			minObjects: 0, wantOutcome: monitoring.WarmupSkippedEmpty,
+		},
+		{
+			name: "a threshold above the object count skips the shard",
+			seed: warmupSeed{counted: 3}, minObjects: 5,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
+		},
+		{
+			name: "a threshold at the object count skips the shard",
+			seed: warmupSeed{counted: 3}, minObjects: 3,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
+		},
 		{
 			name: "a threshold below the object count warms the shard",
-			seed: warmupSeed{counted: 3}, minObjects: 2, wantLoaded: true,
+			seed: warmupSeed{counted: 3}, minObjects: 2, wantOutcome: monitoring.WarmupLoaded,
 		},
 		{
 			name: "an unreadable object count warms the shard", seed: warmupSeed{counted: 3}, minObjects: 5,
-			unreadableCount: true, wantLoaded: true,
+			unreadableCount: true, wantOutcome: monitoring.WarmupLoaded,
 		},
 		// Segments a shutdown flush wrote carry no count sidecar, and a shard left
 		// cold never gets one derived, so the sweep weighs a shard by what was
@@ -206,14 +258,16 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 		{
 			name: "unflushed objects do not count towards the threshold",
 			seed: warmupSeed{uncounted: 5}, minObjects: 3,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
 		},
 		{
 			name: "a threshold above the flushed count alone skips the shard",
 			seed: warmupSeed{counted: 2, uncounted: 4}, minObjects: 5,
+			wantOutcome: monitoring.WarmupSkippedBelowThreshold,
 		},
 		{
 			name: "a threshold below the flushed count alone warms the shard",
-			seed: warmupSeed{counted: 6, uncounted: 4}, minObjects: 5, wantLoaded: true,
+			seed: warmupSeed{counted: 6, uncounted: 4}, minObjects: 5, wantOutcome: monitoring.WarmupLoaded,
 		},
 	}
 
@@ -227,17 +281,18 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 					path.Join(shardPathLSM(indexPath, tenant), helpers.ObjectsBucketLSM)))
 			}
 
-			index := newWarmupIndex(t, dirName, tt.minObjects, nil, tenant)
+			index, hook := newWarmupIndex(t, dirName, tt.minObjects, nil, tenant)
 			defer index.Shutdown(ctx)
 
 			lazy := coldWarmupShard(t, index, tenant)
 
-			if tt.wantLoaded {
+			if tt.wantOutcome == monitoring.WarmupLoaded {
 				// The sweep ticks once per second, so allow generous slack.
 				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
 					"background warmup should materialize the shard")
 				require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
 					"allShardsReady should be published once the sweep completes")
+				requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{tt.wantOutcome: 1})
 				return
 			}
 
@@ -246,12 +301,17 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 					"allShardsReady must be published immediately when no sweep runs")
 				require.Never(t, lazy.isLoaded, 2*time.Second, 100*time.Millisecond,
 					"no sweep should run at all")
+				for _, entry := range hook.AllEntries() {
+					require.NotEqual(t, sweepDoneMessage, entry.Message,
+						"a sweep that never runs must report no tally")
+				}
 			} else {
 				require.Eventually(t, index.allShardsReady.Load, 10*time.Second, 50*time.Millisecond,
 					"allShardsReady should be published once the sweep has skipped every shard")
 				// allShardsReady is published from the sweep goroutine's last deferred
 				// call, so it implies the sweep is over and no later load is possible.
 				require.False(t, lazy.isLoaded(), "a shard the sweep leaves out must stay cold")
+				requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{tt.wantOutcome: 1})
 			}
 
 			// Leaving a shard out of the sweep must keep it loadable on demand.
@@ -282,7 +342,7 @@ func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
 	dirName := t.TempDir()
 	tenants := seedWarmupTenants(t, dirName, seeds)
 
-	index := newWarmupIndex(t, dirName, minObjects, nil, tenants...)
+	index, _ := newWarmupIndex(t, dirName, minObjects, nil, tenants...)
 	defer index.Shutdown(ctx)
 
 	// The green path is one tick, so the budget only separates it from a tick per
@@ -406,7 +466,7 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 			tenants := seedWarmupTenants(t, dirName, seeds)
 
 			checker := newRefusingAllocChecker(tt.refuse)
-			index := newWarmupIndex(t, dirName, tt.minObjects, checker, tenants...)
+			index, hook := newWarmupIndex(t, dirName, tt.minObjects, checker, tenants...)
 			defer index.Shutdown(ctx)
 
 			// Published from the sweep goroutine's last deferred call, so it means
@@ -430,6 +490,121 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 				"the sweep must attempt every candidate shard, whatever the ones before it did")
 			require.Equal(t, tt.wantLoaded, loaded,
 				"every candidate the guard allowed must end up loaded")
+			requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{
+				monitoring.WarmupLoaded:                tt.wantLoaded,
+				monitoring.WarmupFailed:                len(tt.refuse),
+				monitoring.WarmupSkippedBelowThreshold: tt.cold,
+			})
+		})
+	}
+}
+
+// TestLazyShardWarmupSkipsShardNoLongerCold pins what the sweep reports for a
+// shard it listed at startup but found nothing to warm: a request loaded it
+// first, or the tenant is gone. A negative threshold keeps the sweep from
+// running, so the decision is read without one racing it.
+func TestLazyShardWarmupSkipsShardNoLongerCold(t *testing.T) {
+	ctx := context.Background()
+
+	const tenant = "busy-tenant"
+
+	tests := []struct {
+		name string
+		// asked is the shard name the sweep would ask about.
+		asked string
+		// loadFirst materializes the tenant's shard before the decision is read.
+		loadFirst bool
+	}{
+		{name: "a shard a request loaded first", asked: tenant, loadFirst: true},
+		{name: "a name the index no longer holds", asked: "vanished-tenant"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			seedWarmupTenants(t, dirName, map[string]warmupSeed{tenant: {counted: 3}})
+
+			index, _ := newWarmupIndex(t, dirName, -1, nil, tenant)
+			defer index.Shutdown(ctx)
+
+			if tt.loadFirst {
+				require.NoError(t, coldWarmupShard(t, index, tenant).Load(ctx))
+			}
+
+			shouldWarm, outcome := index.warmupCandidate(tt.asked)
+
+			require.False(t, shouldWarm, "a shard with nothing left to warm is no candidate")
+			require.Equal(t, monitoring.WarmupSkippedNotCold, outcome)
+		})
+	}
+}
+
+// TestLazyShardWarmupLoadOutcome pins what a load reports back to the startup
+// sweep, so a load the sweep performed is counted apart from one it found
+// nothing to do. A negative threshold keeps the sweep from running, so the
+// outcome is read without one racing it.
+func TestLazyShardWarmupLoadOutcome(t *testing.T) {
+	ctx := context.Background()
+
+	const tenant = "busy-tenant"
+
+	tests := []struct {
+		name string
+		// objects is what the tenant holds on disk before the load is asked for.
+		objects int
+		// asked is the shard name the sweep would load.
+		asked string
+		// loadFirst materializes the tenant's shard first, standing in for a
+		// request that arrived while the sweep was waiting for its tick.
+		loadFirst   bool
+		wantOutcome monitoring.WarmupOutcome
+		wantLoaded  bool
+	}{
+		{
+			name:    "a cold shard is loaded and counted as loaded",
+			objects: 3, asked: tenant,
+			wantOutcome: monitoring.WarmupLoaded, wantLoaded: true,
+		},
+		{
+			name:    "a shard a request took during the tick counts as no load",
+			objects: 3, asked: tenant, loadFirst: true,
+			wantOutcome: monitoring.WarmupSkippedNotCold, wantLoaded: true,
+		},
+		{
+			name:    "a name the index no longer holds counts as no load",
+			objects: 3, asked: "vanished-tenant",
+			wantOutcome: monitoring.WarmupSkippedNotCold,
+		},
+		{
+			name:    "a shard that never held an object counts as empty",
+			objects: 0, asked: tenant,
+			wantOutcome: monitoring.WarmupSkippedEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+			seedWarmupTenants(t, dirName, map[string]warmupSeed{tenant: {counted: tt.objects}})
+
+			index, _ := newWarmupIndex(t, dirName, -1, nil, tenant)
+			defer index.Shutdown(ctx)
+
+			if tt.loadFirst {
+				require.NoError(t, coldWarmupShard(t, index, tenant).Load(ctx))
+			}
+
+			outcome, err := index.loadLocalShardIfActive(tt.asked)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantOutcome, outcome)
+
+			stored := index.shards.Load(tenant)
+			require.NotNil(t, stored, "the tenant's shard must stay registered")
+			lazy, ok := stored.(*LazyLoadShard)
+			require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
+			require.Equal(t, tt.wantLoaded, lazy.isLoaded(),
+				"only a shard the load reported as loaded may end up loaded")
 		})
 	}
 }

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -15,7 +15,10 @@ package db
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -141,6 +144,130 @@ func seedWarmupTenants(t *testing.T, dirName string, tenants ...string) {
 		require.NoError(t, stored.PutObject(ctx, coldTestObject(warmupClassName)))
 	}
 	require.NoError(t, index.Shutdown(ctx))
+}
+
+// TestLazyShardBackgroundWarmup pins both LazyLoadShardWarmupDisabled branches:
+// the sweep loads a HOT tenant a second after init, and disabling it leaves the
+// tenant cold with allShardsReady already published.
+func TestLazyShardBackgroundWarmup(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		className = "TestWarmupClass"
+		nodeName  = "test-node"
+		tenant    = "busy-tenant"
+	)
+
+	tests := []struct {
+		name           string
+		warmupDisabled bool
+	}{
+		{name: "warmup materializes the shard in the background", warmupDisabled: false},
+		{name: "disabled warmup leaves the shard cold", warmupDisabled: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			dirName := t.TempDir()
+
+			class := &models.Class{
+				Class:               className,
+				InvertedIndexConfig: &models.InvertedIndexConfig{},
+				MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
+				ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+			}
+			fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+			shardState := &sharding.State{
+				Physical: map[string]sharding.Physical{
+					tenant: {
+						Name:           tenant,
+						BelongsToNodes: []string{nodeName},
+						Status:         models.TenantActivityStatusHOT,
+					},
+				},
+				PartitioningEnabled: true,
+			}
+			shardState.SetLocalName(nodeName)
+
+			// Write a non-zero indexcount so Index.unloadedShardIsEmpty reports false:
+			// the sweep skips empty tenants, which would make both cases look identical.
+			shardDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant)
+			require.NoError(t, os.MkdirAll(shardDir, os.ModePerm))
+			var buf [8]byte
+			binary.LittleEndian.PutUint64(buf[:], 10)
+			require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
+
+			scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+			mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+				func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
+					return readerFunc(class, shardState)
+				}).Maybe()
+			mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
+
+			mockSchema := schemaUC.NewMockSchemaGetter(t)
+			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+			mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
+			mockSchema.EXPECT().NodeName().Maybe().Return(nodeName)
+			mockSchema.EXPECT().TenantsShards(ctx, className, tenant).Maybe().
+				Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil)
+
+			mockRouter := types.NewMockRouter(t)
+			mockRouter.EXPECT().GetWriteReplicasLocation(className, mock.Anything, tenant).
+				Return(types.WriteReplicaSet{
+					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
+				}, nil).Maybe()
+			mockRouter.EXPECT().GetReadReplicasLocation(className, tenant, tenant).
+				Return(types.ReadReplicaSet{
+					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
+				}, nil).Maybe()
+
+			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
+			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
+
+			index, err := NewIndex(ctx, nil, IndexConfig{
+				RootPath:                    dirName,
+				ClassName:                   schema.ClassName(className),
+				ReplicationFactor:           1,
+				ShardLoadLimiter:            loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+				EnableLazyLoadShards:        true,
+				LazyLoadShardWarmupDisabled: tt.warmupDisabled,
+			}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+				enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
+				mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
+				class, nil, scheduler, nil, nil,
+				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+			require.NoError(t, err)
+			defer index.Shutdown(ctx)
+
+			stored := index.shards.Load(tenant)
+			require.NotNil(t, stored, "shard must be registered after init")
+			lazy, isLazy := stored.(*LazyLoadShard)
+			require.True(t, isLazy, "lazy mode should store a wrapper, got %T", stored)
+			require.False(t, lazy.isLoaded(), "shard must not be loaded during init in lazy mode")
+
+			if !tt.warmupDisabled {
+				// The sweep ticks once per second, so allow generous slack.
+				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
+					"background warmup should materialize the shard")
+				require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
+					"allShardsReady should be published once the sweep completes")
+				return
+			}
+
+			require.True(t, index.allShardsReady.Load(),
+				"allShardsReady must be published immediately when warmup is disabled")
+			require.Never(t, lazy.isLoaded, 3*time.Second, 100*time.Millisecond,
+				"no background sweep should run when warmup is disabled")
+
+			// Disabling the sweep must leave the shard loadable on demand.
+			require.NoError(t, lazy.Load(ctx))
+			require.True(t, lazy.isLoaded())
+		})
+	}
 }
 
 // refusingAllocChecker refuses the load attempts listed in refuse, counted from

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -15,19 +15,18 @@ package db
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"os"
-	"path/filepath"
+	"path"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -49,16 +48,15 @@ const (
 	warmupNodeName  = "test-node"
 )
 
-// newWarmupIndex opens a multi-tenant index over dirName with one hot lazy shard
-// per tenant. A nil allocChecker falls back to the dummy monitor, which allows
-// every load. The returned hook captures the index log, the startup sweep included.
-func newWarmupIndex(t *testing.T, dirName string,
+// newWarmupIndex opens a multi-tenant index over dirName, one lazy shard per
+// tenant, with the startup sweep gated at minObjects. A nil allocChecker gives
+// every load the dummy monitor, which allows all of them.
+func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
 	allocChecker memwatch.AllocChecker, tenants ...string,
-) (*Index, *test.Hook) {
+) *Index {
 	t.Helper()
 	ctx := context.Background()
-	logger, hook := test.NewNullLogger()
-	logger.SetLevel(logrus.DebugLevel)
+	logger, _ := test.NewNullLogger()
 
 	class := newClassWithWarmProp(warmupClassName)
 	class.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
@@ -114,142 +112,122 @@ func newWarmupIndex(t *testing.T, dirName string,
 	shardResolver := resolver.NewShardResolver(warmupClassName, true, schemaGetter)
 
 	index, err := NewIndex(ctx, nil, IndexConfig{
-		RootPath:             dirName,
-		ClassName:            schema.ClassName(warmupClassName),
-		ReplicationFactor:    1,
-		ShardLoadLimiter:     loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
-		EnableLazyLoadShards: true,
+		RootPath:                      dirName,
+		ClassName:                     schema.ClassName(warmupClassName),
+		ReplicationFactor:             1,
+		ShardLoadLimiter:              loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+		EnableLazyLoadShards:          true,
+		LazyLoadShardWarmupMinObjects: minObjects,
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
-		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{},
-		monitoring.GetMetrics(),
+		mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
 		class, nil, scheduler, nil, allocChecker,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
 
-	return index, hook
+	return index
 }
 
-// seedWarmupTenants writes one object per tenant and shuts the index down again,
-// leaving the shards on disk. The sweep skips a tenant shard that was never
-// written to, so a shard has to hold something to be a load candidate.
-func seedWarmupTenants(t *testing.T, dirName string, tenants ...string) {
+// coldWarmupShard returns a tenant's shard, asserting it is an unloaded lazy one.
+func coldWarmupShard(t *testing.T, index *Index, tenant string) *LazyLoadShard {
 	t.Helper()
-	ctx := context.Background()
-
-	index, _ := newWarmupIndex(t, dirName, nil, tenants...)
-	for _, tenant := range tenants {
-		stored := index.shards.Load(tenant)
-		require.NotNil(t, stored, "shard of tenant %q must be registered", tenant)
-		require.NoError(t, stored.PutObject(ctx, coldTestObject(warmupClassName)))
-	}
-	require.NoError(t, index.Shutdown(ctx))
+	stored := index.shards.Load(tenant)
+	require.NotNil(t, stored, "shard of tenant %q must be registered after init", tenant)
+	lazy, ok := stored.(*LazyLoadShard)
+	require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
+	require.False(t, lazy.isLoaded(), "shard of tenant %q must not be loaded during init", tenant)
+	return lazy
 }
 
-// TestLazyShardBackgroundWarmup pins both LazyLoadShardWarmupDisabled branches:
-// the sweep loads a HOT tenant a second after init, and disabling it leaves the
-// tenant cold with allShardsReady already published.
+// warmupSeed is what a tenant holds on disk before the sweep runs.
+type warmupSeed struct {
+	// counted objects sit in a segment with a count sidecar, which
+	// LazyLoadShard.ObjectCountAsync reads without loading the shard.
+	counted int
+	// uncounted objects sit in a segment whose sidecar only the next load writes,
+	// which is what an ordinary shutdown leaves behind.
+	uncounted int
+}
+
+// seedWarmupTenants gives each tenant the objects the map asks for and leaves
+// every shard cold, so a later index sweeps over what is really on disk.
+func seedWarmupTenants(t *testing.T, dirName string, seeds map[string]warmupSeed) []string {
+	t.Helper()
+	tenants := make([]string, 0, len(seeds))
+	for tenant := range seeds {
+		tenants = append(tenants, tenant)
+	}
+
+	index := newWarmupIndex(t, dirName, -1, nil, tenants...)
+	for tenant, seed := range seeds {
+		writeCountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.counted)
+		if seed.uncounted > 0 {
+			writeUncountedObjects(t, coldWarmupShard(t, index, tenant), warmupClassName, seed.uncounted)
+		}
+	}
+	require.NoError(t, index.Shutdown(context.Background()))
+
+	return tenants
+}
+
+// TestLazyShardBackgroundWarmup pins which shards the startup sweep materializes
+// for each range of LazyLoadShardWarmupMinObjects, and that a shard it leaves out
+// still loads on demand.
 func TestLazyShardBackgroundWarmup(t *testing.T) {
 	ctx := context.Background()
 
-	const (
-		className = "TestWarmupClass"
-		nodeName  = "test-node"
-		tenant    = "busy-tenant"
-	)
+	const tenant = "busy-tenant"
 
 	tests := []struct {
-		name           string
-		warmupDisabled bool
+		name       string
+		seed       warmupSeed
+		minObjects int64
+		// unreadableCount removes the shard's objects bucket directory, so
+		// LazyLoadShard.ObjectCountAsync fails instead of returning a count.
+		unreadableCount bool
+		wantLoaded      bool
 	}{
-		{name: "warmup materializes the shard in the background", warmupDisabled: false},
-		{name: "disabled warmup leaves the shard cold", warmupDisabled: true},
+		{name: "a negative threshold warms nothing", seed: warmupSeed{counted: 3}, minObjects: -1},
+		{name: "the default warms a non-empty shard", seed: warmupSeed{counted: 3}, minObjects: 0, wantLoaded: true},
+		{name: "the default skips an empty shard", minObjects: 0},
+		{name: "a threshold above the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 5},
+		{name: "a threshold at the object count skips the shard", seed: warmupSeed{counted: 3}, minObjects: 3},
+		{
+			name: "a threshold below the object count warms the shard",
+			seed: warmupSeed{counted: 3}, minObjects: 2, wantLoaded: true,
+		},
+		{
+			name: "an unreadable object count warms the shard", seed: warmupSeed{counted: 3}, minObjects: 5,
+			unreadableCount: true, wantLoaded: true,
+		},
+		// Segments a shutdown flush wrote carry no count sidecar, so the cold count
+		// reads zero for them and only the doc-id counter sees the objects.
+		{
+			name: "a threshold below the unflushed object count warms the shard",
+			seed: warmupSeed{uncounted: 5}, minObjects: 3, wantLoaded: true,
+		},
+		{
+			name: "a threshold above the unflushed object count skips the shard",
+			seed: warmupSeed{uncounted: 2}, minObjects: 3,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			logger, _ := test.NewNullLogger()
 			dirName := t.TempDir()
-
-			class := &models.Class{
-				Class:               className,
-				InvertedIndexConfig: &models.InvertedIndexConfig{},
-				MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: true},
-				ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+			seedWarmupTenants(t, dirName, map[string]warmupSeed{tenant: tt.seed})
+			if tt.unreadableCount {
+				indexPath := path.Join(dirName, indexID(schema.ClassName(warmupClassName)))
+				require.NoError(t, os.RemoveAll(
+					path.Join(shardPathLSM(indexPath, tenant), helpers.ObjectsBucketLSM)))
 			}
-			fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
 
-			shardState := &sharding.State{
-				Physical: map[string]sharding.Physical{
-					tenant: {
-						Name:           tenant,
-						BelongsToNodes: []string{nodeName},
-						Status:         models.TenantActivityStatusHOT,
-					},
-				},
-				PartitioningEnabled: true,
-			}
-			shardState.SetLocalName(nodeName)
-
-			// Write a non-zero indexcount so Index.unloadedShardIsEmpty reports false:
-			// the sweep skips empty tenants, which would make both cases look identical.
-			shardDir := filepath.Join(dirName, indexID(schema.ClassName(className)), tenant)
-			require.NoError(t, os.MkdirAll(shardDir, os.ModePerm))
-			var buf [8]byte
-			binary.LittleEndian.PutUint64(buf[:], 10)
-			require.NoError(t, os.WriteFile(filepath.Join(shardDir, "indexcount"), buf[:], 0o644))
-
-			scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
-
-			mockSchemaReader := schemaUC.NewMockSchemaReader(t)
-			mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
-				func(_ string, _ bool, readerFunc func(*models.Class, *sharding.State) error) error {
-					return readerFunc(class, shardState)
-				}).Maybe()
-			mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
-
-			mockSchema := schemaUC.NewMockSchemaGetter(t)
-			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
-			mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
-			mockSchema.EXPECT().NodeName().Maybe().Return(nodeName)
-			mockSchema.EXPECT().TenantsShards(ctx, className, tenant).Maybe().
-				Return(map[string]string{tenant: models.TenantActivityStatusHOT}, nil)
-
-			mockRouter := types.NewMockRouter(t)
-			mockRouter.EXPECT().GetWriteReplicasLocation(className, mock.Anything, tenant).
-				Return(types.WriteReplicaSet{
-					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
-				}, nil).Maybe()
-			mockRouter.EXPECT().GetReadReplicasLocation(className, tenant, tenant).
-				Return(types.ReadReplicaSet{
-					Replicas: []types.Replica{{NodeName: nodeName, ShardName: tenant, HostAddr: "10.0.0.1"}},
-				}, nil).Maybe()
-
-			schemaGetter := &fakeSchemaGetter{schema: fakeSchema, shardState: shardState}
-			shardResolver := resolver.NewShardResolver(className, true, schemaGetter)
-
-			index, err := NewIndex(ctx, nil, IndexConfig{
-				RootPath:                    dirName,
-				ClassName:                   schema.ClassName(className),
-				ReplicationFactor:           1,
-				ShardLoadLimiter:            loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
-				EnableLazyLoadShards:        true,
-				LazyLoadShardWarmupDisabled: tt.warmupDisabled,
-			}, inverted.ConfigFromModel(class.InvertedIndexConfig),
-				enthnsw.UserConfig{VectorCacheMaxObjects: 1000}, nil, mockRouter, shardResolver,
-				mockSchema, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil,
-				class, nil, scheduler, nil, nil,
-				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
-			require.NoError(t, err)
+			index := newWarmupIndex(t, dirName, tt.minObjects, nil, tenant)
 			defer index.Shutdown(ctx)
 
-			stored := index.shards.Load(tenant)
-			require.NotNil(t, stored, "shard must be registered after init")
-			lazy, isLazy := stored.(*LazyLoadShard)
-			require.True(t, isLazy, "lazy mode should store a wrapper, got %T", stored)
-			require.False(t, lazy.isLoaded(), "shard must not be loaded during init in lazy mode")
+			lazy := coldWarmupShard(t, index, tenant)
 
-			if !tt.warmupDisabled {
+			if tt.wantLoaded {
 				// The sweep ticks once per second, so allow generous slack.
 				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
 					"background warmup should materialize the shard")
@@ -258,15 +236,63 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 				return
 			}
 
-			require.True(t, index.allShardsReady.Load(),
-				"allShardsReady must be published immediately when warmup is disabled")
-			require.Never(t, lazy.isLoaded, 3*time.Second, 100*time.Millisecond,
-				"no background sweep should run when warmup is disabled")
+			if tt.minObjects < 0 {
+				require.True(t, index.allShardsReady.Load(),
+					"allShardsReady must be published immediately when no sweep runs")
+				require.Never(t, lazy.isLoaded, 2*time.Second, 100*time.Millisecond,
+					"no sweep should run at all")
+			} else {
+				require.Eventually(t, index.allShardsReady.Load, 10*time.Second, 50*time.Millisecond,
+					"allShardsReady should be published once the sweep has skipped every shard")
+				// allShardsReady is published from the sweep goroutine's last deferred
+				// call, so it implies the sweep is over and no later load is possible.
+				require.False(t, lazy.isLoaded(), "a shard the sweep leaves out must stay cold")
+			}
 
-			// Disabling the sweep must leave the shard loadable on demand.
+			// Leaving a shard out of the sweep must keep it loadable on demand.
 			require.NoError(t, lazy.Load(ctx))
 			require.True(t, lazy.isLoaded())
 		})
+	}
+}
+
+// The sweep paces itself at one shard per second, and decides whether to warm a
+// shard before spending that second. With a single shard above the threshold
+// among many below it, the sweep finishes in about a second — spending the tick
+// before the decision would take a second per tenant instead.
+func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		smallTenantCount = 7
+		bigTenant        = "big-tenant"
+		minObjects       = 3
+	)
+
+	seeds := map[string]warmupSeed{bigTenant: {counted: minObjects + 1}}
+	for i := range smallTenantCount {
+		seeds[fmt.Sprintf("small-tenant-%d", i)] = warmupSeed{counted: 1}
+	}
+
+	dirName := t.TempDir()
+	tenants := seedWarmupTenants(t, dirName, seeds)
+
+	index := newWarmupIndex(t, dirName, minObjects, nil, tenants...)
+	defer index.Shutdown(ctx)
+
+	// The green path is one tick, so the budget only separates it from a tick per
+	// shard while there are at least three tenants.
+	sweepBudget := time.Duration(len(tenants)) * time.Second / 2
+	require.Eventually(t, index.allShardsReady.Load, sweepBudget, 50*time.Millisecond,
+		"the sweep must not spend its per-shard tick on the shards it skips")
+
+	for tenant := range seeds {
+		stored := index.shards.Load(tenant)
+		require.NotNil(t, stored)
+		lazy, ok := stored.(*LazyLoadShard)
+		require.True(t, ok, "lazy mode should store a wrapper, got %T", stored)
+		require.Equal(t, tenant == bigTenant, lazy.isLoaded(),
+			"only the tenant above the threshold should be warmed, checked %q", tenant)
 	}
 }
 
@@ -310,66 +336,77 @@ func (c *refusingAllocChecker) attempts() int {
 	return c.calls
 }
 
-// requireSweepFailures waits for the sweep to log the end of its walk and asserts
-// how many loads it counted as failed.
-func requireSweepFailures(t *testing.T, hook *test.Hook, want int) {
-	t.Helper()
-
-	var failed any
-	require.Eventually(t, func() bool {
-		for _, entry := range hook.AllEntries() {
-			if entry.Message != "finished loading all shards" {
-				continue
-			}
-			failed = entry.Data["failed"]
-			return true
-		}
-		return false
-	}, 30*time.Second, 50*time.Millisecond,
-		"the sweep should report the end of its walk, whatever a load did")
-
-	require.Equal(t, want, failed)
-}
-
 // TestLazyShardBackgroundWarmupContinuesAfterFailedLoad pins that a shard failing
 // to load does not end the startup sweep: every shard behind it is still attempted
 // and loaded, and the sweep still reports how many loads failed.
 func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 	ctx := context.Background()
 
-	const tenantCount = 3
+	// Seeded either side of the threshold the skip case uses, so warm tenants are
+	// swept and cold ones are passed over before a load is ever attempted.
+	const (
+		warmObjects = 5
+		coldObjects = 1
+		skipAtFour  = 4
+	)
 
 	tests := []struct {
 		name string
+		// warm tenants sit above the threshold and are load candidates; cold ones
+		// sit below it and the sweep skips them without attempting a load.
+		warm       int
+		cold       int
+		minObjects int64
 		// refuse names the load attempts the memory guard fails, counted from one.
 		// The sweep walks the shards in map order, so a case can pin which attempt
 		// fails, never which tenant.
-		refuse     []int
-		wantLoaded int
+		refuse       []int
+		wantLoaded   int
+		wantAttempts int
 	}{
-		{name: "a failure on the first shard leaves the rest to load", refuse: []int{1}, wantLoaded: 2},
-		{name: "a failure in the middle leaves the rest to load", refuse: []int{2}, wantLoaded: 2},
-		{name: "a failure on the last shard leaves the ones before it loaded", refuse: []int{3}, wantLoaded: 2},
-		{name: "every shard failing still leaves every shard attempted", refuse: []int{1, 2, 3}},
-		{name: "no failure loads every shard", wantLoaded: tenantCount},
+		{
+			name: "a failure on the first shard leaves the rest to load",
+			warm: 3, refuse: []int{1}, wantLoaded: 2, wantAttempts: 3,
+		},
+		{
+			name: "a failure in the middle leaves the rest to load",
+			warm: 3, refuse: []int{2}, wantLoaded: 2, wantAttempts: 3,
+		},
+		{
+			name: "every shard failing still leaves every shard attempted",
+			warm: 3, refuse: []int{1, 2, 3}, wantLoaded: 0, wantAttempts: 3,
+		},
+		{
+			name: "no failure loads every shard",
+			warm: 3, wantLoaded: 3, wantAttempts: 3,
+		},
+		{
+			name: "a failure leaves the shards below the threshold skipped, not attempted",
+			warm: 2, cold: 1, minObjects: skipAtFour, refuse: []int{1},
+			wantLoaded: 1, wantAttempts: 2,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tenants := make([]string, tenantCount)
-			for i := range tenants {
-				tenants[i] = fmt.Sprintf("tenant-%d", i)
+			seeds := map[string]warmupSeed{}
+			for i := range tt.warm {
+				seeds[fmt.Sprintf("warm-tenant-%d", i)] = warmupSeed{counted: warmObjects}
+			}
+			for i := range tt.cold {
+				seeds[fmt.Sprintf("cold-tenant-%d", i)] = warmupSeed{counted: coldObjects}
 			}
 
 			dirName := t.TempDir()
-			seedWarmupTenants(t, dirName, tenants...)
+			tenants := seedWarmupTenants(t, dirName, seeds)
 
 			checker := newRefusingAllocChecker(tt.refuse)
-			index, hook := newWarmupIndex(t, dirName, checker, tenants...)
+			index := newWarmupIndex(t, dirName, tt.minObjects, checker, tenants...)
 			defer index.Shutdown(ctx)
 
-			// The sweep goroutine sets this in a deferred call, so it flips however
-			// the sweep ended, an early return included.
+			// Published from the sweep goroutine's last deferred call, so it means
+			// the sweep is over however it ended — including the abandoning return
+			// this test exists to catch.
 			require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
 				"allShardsReady should be published once the sweep is over")
 
@@ -384,11 +421,10 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 				}
 			}
 
-			require.Equal(t, tenantCount, checker.attempts(),
-				"the sweep must attempt every shard, whatever the ones before it did")
+			require.Equal(t, tt.wantAttempts, checker.attempts(),
+				"the sweep must attempt every candidate shard, whatever the ones before it did")
 			require.Equal(t, tt.wantLoaded, loaded,
-				"every shard the guard allowed must end up loaded")
-			requireSweepFailures(t, hook, len(tt.refuse))
+				"every candidate the guard allowed must end up loaded")
 		})
 	}
 }

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -50,9 +50,8 @@ const (
 )
 
 // newWarmupIndex opens a multi-tenant index over dirName, one lazy shard per
-// tenant, with the startup sweep gated at minObjects. A nil allocChecker gives
-// every load the dummy monitor, which allows all of them. The returned hook
-// holds the sweep's own log, which reports what it did with every shard.
+// tenant, with the startup sweep gated at minObjects. A nil allocChecker allows
+// every load. The returned hook holds the sweep's log of what it did per shard.
 func newWarmupIndex(t *testing.T, dirName string, minObjects int64,
 	allocChecker memwatch.AllocChecker, tenants ...string,
 ) (*Index, *test.Hook) {
@@ -207,9 +206,9 @@ func seedWarmupTenants(t *testing.T, dirName string, seeds map[string]warmupSeed
 	return tenants
 }
 
-// TestLazyShardBackgroundWarmup pins which shards the startup sweep materializes
-// for each range of LazyLoadShardWarmupMinObjects, and that a shard it leaves out
-// still loads on demand.
+// TestLazyShardBackgroundWarmup pins which shards the startup sweep loads for each
+// range of LazyLoadShardWarmupMinObjects, and that a shard it leaves out still
+// loads on demand.
 func TestLazyShardBackgroundWarmup(t *testing.T) {
 	ctx := context.Background()
 
@@ -290,7 +289,7 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 			if tt.wantOutcome == monitoring.WarmupLoaded {
 				// The sweep ticks once per second, so allow generous slack.
 				require.Eventually(t, lazy.isLoaded, 30*time.Second, 50*time.Millisecond,
-					"background warmup should materialize the shard")
+					"background warmup should load the shard")
 				require.Eventually(t, index.allShardsReady.Load, 30*time.Second, 50*time.Millisecond,
 					"allShardsReady should be published once the sweep completes")
 				requireSweepTally(t, hook, map[monitoring.WarmupOutcome]int{tt.wantOutcome: 1})
@@ -322,10 +321,9 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 	}
 }
 
-// The sweep paces itself at one shard per second, and decides whether to warm a
-// shard before spending that second. With a single shard above the threshold
-// among many below it, the sweep finishes in about a second — spending the tick
-// before the decision would take a second per tenant instead.
+// The sweep paces itself at one shard per second and decides before spending it.
+// With one shard above the threshold among many below, the sweep finishes in about
+// a second. Spending the tick first would take a second per tenant.
 func TestLazyShardBackgroundWarmupSkipsSpendNoTick(t *testing.T) {
 	ctx := context.Background()
 
@@ -418,8 +416,8 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 
 	tests := []struct {
 		name string
-		// warm tenants sit above the threshold and are load candidates; cold ones
-		// sit below it and the sweep skips them without attempting a load.
+		// warm tenants sit above the threshold and are load candidates. Cold ones
+		// sit below it, and the sweep skips them without attempting a load.
 		warm       int
 		cold       int
 		minObjects int64
@@ -500,10 +498,9 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 	}
 }
 
-// TestLazyShardWarmupSkipsShardWithNothingToWarm pins what the sweep reports for
-// a shard it listed at startup but found nothing to warm, counting a shard a
-// request took apart from a tenant that is gone. A negative threshold keeps the
-// sweep from running, so the decision is read without one racing it.
+// TestLazyShardWarmupSkipsShardWithNothingToWarm pins what the sweep reports for a
+// shard it listed but found nothing to warm, telling a shard a request took apart
+// from a tenant that is gone. A negative threshold keeps a sweep from racing it.
 func TestLazyShardWarmupSkipsShardWithNothingToWarm(t *testing.T) {
 	ctx := context.Background()
 
@@ -513,7 +510,7 @@ func TestLazyShardWarmupSkipsShardWithNothingToWarm(t *testing.T) {
 		name string
 		// asked is the shard name the sweep would ask about.
 		asked string
-		// loadFirst materializes the tenant's shard before the decision is read.
+		// loadFirst loads the tenant's shard before the decision is read.
 		loadFirst   bool
 		wantOutcome monitoring.WarmupOutcome
 	}{
@@ -548,9 +545,8 @@ func TestLazyShardWarmupSkipsShardWithNothingToWarm(t *testing.T) {
 }
 
 // TestLazyShardWarmupLoadOutcome pins what a load reports back to the startup
-// sweep, so a load the sweep performed is counted apart from one it found
-// nothing to do. A negative threshold keeps the sweep from running, so the
-// outcome is read without one racing it.
+// sweep, so a load it performed counts apart from one that found nothing to do.
+// A negative threshold keeps a sweep from racing it.
 func TestLazyShardWarmupLoadOutcome(t *testing.T) {
 	ctx := context.Background()
 
@@ -562,8 +558,8 @@ func TestLazyShardWarmupLoadOutcome(t *testing.T) {
 		objects int
 		// asked is the shard name the sweep would load.
 		asked string
-		// loadFirst materializes the tenant's shard first, standing in for a
-		// request that arrived while the sweep was waiting for its tick.
+		// loadFirst loads the tenant's shard first, standing in for a request
+		// that arrived while the sweep was waiting for its tick.
 		loadFirst   bool
 		wantOutcome monitoring.WarmupOutcome
 		wantLoaded  bool

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -200,15 +200,20 @@ func TestLazyShardBackgroundWarmup(t *testing.T) {
 			name: "an unreadable object count warms the shard", seed: warmupSeed{counted: 3}, minObjects: 5,
 			unreadableCount: true, wantLoaded: true,
 		},
-		// Segments a shutdown flush wrote carry no count sidecar, so the cold count
-		// reads zero for them and only the doc-id counter sees the objects.
+		// Segments a shutdown flush wrote carry no count sidecar, and a shard left
+		// cold never gets one derived, so the sweep weighs a shard by what was
+		// flushed while it last ran and nothing else.
 		{
-			name: "a threshold below the unflushed object count warms the shard",
-			seed: warmupSeed{uncounted: 5}, minObjects: 3, wantLoaded: true,
+			name: "unflushed objects do not count towards the threshold",
+			seed: warmupSeed{uncounted: 5}, minObjects: 3,
 		},
 		{
-			name: "a threshold above the unflushed object count skips the shard",
-			seed: warmupSeed{uncounted: 2}, minObjects: 3,
+			name: "a threshold above the flushed count alone skips the shard",
+			seed: warmupSeed{counted: 2, uncounted: 4}, minObjects: 5,
+		},
+		{
+			name: "a threshold below the flushed count alone warms the shard",
+			seed: warmupSeed{counted: 6, uncounted: 4}, minObjects: 5, wantLoaded: true,
 		},
 	}
 

--- a/adapters/repos/db/lazy_shard_warmup_integration_test.go
+++ b/adapters/repos/db/lazy_shard_warmup_integration_test.go
@@ -156,7 +156,8 @@ func requireSweepTally(t *testing.T, hook *test.Hook, want map[monitoring.Warmup
 	for _, outcome := range []monitoring.WarmupOutcome{
 		monitoring.WarmupLoaded,
 		monitoring.WarmupFailed,
-		monitoring.WarmupSkippedNotCold,
+		monitoring.WarmupSkippedShardGone,
+		monitoring.WarmupSkippedAlreadyLoaded,
 		monitoring.WarmupSkippedEmpty,
 		monitoring.WarmupSkippedBelowThreshold,
 	} {
@@ -499,11 +500,11 @@ func TestLazyShardBackgroundWarmupContinuesAfterFailedLoad(t *testing.T) {
 	}
 }
 
-// TestLazyShardWarmupSkipsShardNoLongerCold pins what the sweep reports for a
-// shard it listed at startup but found nothing to warm: a request loaded it
-// first, or the tenant is gone. A negative threshold keeps the sweep from
-// running, so the decision is read without one racing it.
-func TestLazyShardWarmupSkipsShardNoLongerCold(t *testing.T) {
+// TestLazyShardWarmupSkipsShardWithNothingToWarm pins what the sweep reports for
+// a shard it listed at startup but found nothing to warm, counting a shard a
+// request took apart from a tenant that is gone. A negative threshold keeps the
+// sweep from running, so the decision is read without one racing it.
+func TestLazyShardWarmupSkipsShardWithNothingToWarm(t *testing.T) {
 	ctx := context.Background()
 
 	const tenant = "busy-tenant"
@@ -513,10 +514,17 @@ func TestLazyShardWarmupSkipsShardNoLongerCold(t *testing.T) {
 		// asked is the shard name the sweep would ask about.
 		asked string
 		// loadFirst materializes the tenant's shard before the decision is read.
-		loadFirst bool
+		loadFirst   bool
+		wantOutcome monitoring.WarmupOutcome
 	}{
-		{name: "a shard a request loaded first", asked: tenant, loadFirst: true},
-		{name: "a name the index no longer holds", asked: "vanished-tenant"},
+		{
+			name: "a shard a request loaded first", asked: tenant, loadFirst: true,
+			wantOutcome: monitoring.WarmupSkippedAlreadyLoaded,
+		},
+		{
+			name: "a name the index no longer holds", asked: "vanished-tenant",
+			wantOutcome: monitoring.WarmupSkippedShardGone,
+		},
 	}
 
 	for _, tt := range tests {
@@ -534,7 +542,7 @@ func TestLazyShardWarmupSkipsShardNoLongerCold(t *testing.T) {
 			shouldWarm, outcome := index.warmupCandidate(tt.asked)
 
 			require.False(t, shouldWarm, "a shard with nothing left to warm is no candidate")
-			require.Equal(t, monitoring.WarmupSkippedNotCold, outcome)
+			require.Equal(t, tt.wantOutcome, outcome)
 		})
 	}
 }
@@ -568,12 +576,12 @@ func TestLazyShardWarmupLoadOutcome(t *testing.T) {
 		{
 			name:    "a shard a request took during the tick counts as no load",
 			objects: 3, asked: tenant, loadFirst: true,
-			wantOutcome: monitoring.WarmupSkippedNotCold, wantLoaded: true,
+			wantOutcome: monitoring.WarmupSkippedAlreadyLoaded, wantLoaded: true,
 		},
 		{
 			name:    "a name the index no longer holds counts as no load",
 			objects: 3, asked: "vanished-tenant",
-			wantOutcome: monitoring.WarmupSkippedNotCold,
+			wantOutcome: monitoring.WarmupSkippedShardGone,
 		},
 		{
 			name:    "a shard that never held an object counts as empty",

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -283,7 +283,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"action":                  "lazy_shard_auto_detection",
 		"class":                   class.Class,
 		"enable_lazy_load_shards": lazyLoadShardEnabled,
-		"background_warmup":       !m.db.config.LazyLoadShardWarmupDisabled,
+		"background_warmup":       idx.Config.backgroundWarmupEnabled(),
 		"local_shard_count":       localActiveShardsCount,
 		"total_shard_size_bytes":  totalShardSizeBytes,
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -197,7 +197,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 				)
 				return lazyLoadShardEnabled
 			}(),
-			LazyLoadShardWarmupDisabled:         m.db.config.LazyLoadShardWarmupDisabled,
+			LazyLoadShardWarmupMinObjects:       m.db.config.LazyLoadShardWarmupMinObjects,
 			ForceFullReplicasSearch:             m.db.config.ForceFullReplicasSearch,
 			TransferInactivityTimeout:           m.db.config.TransferInactivityTimeout,
 			HaltForTransferTimeout:              m.db.config.HaltForTransferTimeout,
@@ -284,6 +284,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"class":                   class.Class,
 		"enable_lazy_load_shards": lazyLoadShardEnabled,
 		"background_warmup":       idx.Config.backgroundWarmupEnabled(),
+		"warmup_min_objects":      m.db.config.LazyLoadShardWarmupMinObjects,
 		"local_shard_count":       localActiveShardsCount,
 		"total_shard_size_bytes":  totalShardSizeBytes,
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -197,6 +197,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 				)
 				return lazyLoadShardEnabled
 			}(),
+			LazyLoadShardWarmupDisabled:         m.db.config.LazyLoadShardWarmupDisabled,
 			ForceFullReplicasSearch:             m.db.config.ForceFullReplicasSearch,
 			TransferInactivityTimeout:           m.db.config.TransferInactivityTimeout,
 			HaltForTransferTimeout:              m.db.config.HaltForTransferTimeout,
@@ -282,6 +283,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		"action":                  "lazy_shard_auto_detection",
 		"class":                   class.Class,
 		"enable_lazy_load_shards": lazyLoadShardEnabled,
+		"background_warmup":       !m.db.config.LazyLoadShardWarmupDisabled,
 		"local_shard_count":       localActiveShardsCount,
 		"total_shard_size_bytes":  totalShardSizeBytes,
 		"count_threshold":         m.db.config.LazyLoadShardCountThreshold,

--- a/adapters/repos/db/namespace_guard_test.go
+++ b/adapters/repos/db/namespace_guard_test.go
@@ -1686,7 +1686,9 @@ func TestGuardBackgroundLoad(t *testing.T) {
 			idx := indexForGuardTest(t, tc.className, tc.exister(t))
 			idx.shards.Store("t1", &LazyLoadShard{memMonitor: failingAllocChecker{}})
 
-			err := idx.loadLocalShardIfActive("t1")
+			outcome, err := idx.loadLocalShardIfActive("t1")
+			require.Empty(t, outcome,
+				"a refused load and a failed one both count against no shard")
 			if tc.wantLoad {
 				require.ErrorIs(t, err, errInjectedMemoryPressure)
 			} else {
@@ -1703,7 +1705,9 @@ func TestGuardBackgroundLoad(t *testing.T) {
 		idx.shards.Store("t1", &LazyLoadShard{memMonitor: failingAllocChecker{}})
 		idx.closed = true
 
-		require.NoError(t, idx.loadLocalShardIfActive("t1"))
+		outcome, err := idx.loadLocalShardIfActive("t1")
+		require.NoError(t, err)
+		require.Empty(t, outcome, "a closing index counts against no shard")
 	})
 
 	// A state that cannot be read refuses the load like a closed namespace does,
@@ -1714,7 +1718,9 @@ func TestGuardBackgroundLoad(t *testing.T) {
 			idx := indexForGuardTest(t, class, tc.exister(t))
 			idx.shards.Store("t1", &LazyLoadShard{memMonitor: failingAllocChecker{}})
 
-			require.NoError(t, idx.loadLocalShardIfActive("t1"))
+			outcome, err := idx.loadLocalShardIfActive("t1")
+			require.NoError(t, err)
+			require.Empty(t, outcome, "an unreadable namespace counts against no shard")
 		})
 	}
 

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -252,9 +252,8 @@ func (o *nodeWideMetricsObserver) indexObjectCount(index *Index) (int64, error) 
 	return total, nil
 }
 
-// NOTE(dyma): should this also chech that all indices report allShardsReady == true?
-// Otherwise getCurrentActivity may end up loading lazy-loaded shards just to check
-// their activity, which is redundant on a cold shard?
+// Needs no allShardsReady check: an unloaded shard reports no activity without
+// being loaded.
 func (o *nodeWideMetricsObserver) observeActivity() {
 	start := time.Now()
 	current := o.getCurrentActivity()

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -420,6 +420,7 @@ type Config struct {
 	EnableLazyLoadShards                *bool
 	LazyLoadShardCountThreshold         int
 	LazyLoadShardSizeThresholdGB        float64
+	LazyLoadShardWarmupDisabled         bool
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -420,7 +420,7 @@ type Config struct {
 	EnableLazyLoadShards                *bool
 	LazyLoadShardCountThreshold         int
 	LazyLoadShardSizeThresholdGB        float64
-	LazyLoadShardWarmupDisabled         bool
+	LazyLoadShardWarmupMinObjects       int64
 	ForceFullReplicasSearch             bool
 	TransferInactivityTimeout           time.Duration
 	HaltForTransferTimeout              time.Duration

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -121,19 +121,27 @@ func (l *LazyLoadShard) mustLoadCtx(ctx context.Context) {
 }
 
 func (l *LazyLoadShard) Load(ctx context.Context) error {
+	_, err := l.loadIfCold(ctx)
+	return err
+}
+
+// loadIfCold builds the shard unless it is loaded already, and reports whether
+// this call is the one that built it. The startup sweep counts only the loads it
+// performed, and a request can take the shard first.
+func (l *LazyLoadShard) loadIfCold(ctx context.Context) (bool, error) {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
 	if l.loaded {
-		return nil
+		return false, nil
 	}
 
 	if err := l.memMonitor.CheckMappingAndReserve(3, int(lsmkv.FlushAfterDirtyDefault.Seconds())); err != nil {
-		return errors.Wrap(err, "memory pressure: cannot load shard")
+		return false, errors.Wrap(err, "memory pressure: cannot load shard")
 	}
 
 	if err := l.shardLoadLimiter.Acquire(ctx); err != nil {
-		return fmt.Errorf("acquiring permit to load shard: %w", err)
+		return false, fmt.Errorf("acquiring permit to load shard: %w", err)
 	}
 	defer l.shardLoadLimiter.Release()
 
@@ -159,7 +167,7 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 		l.shardOpts.promMetrics.FailLoadingShard()
 		msg := fmt.Sprintf("Unable to load shard %s: %v", l.shardOpts.name, err)
 		l.shardOpts.index.logger.WithField("error", "shard_load").WithError(err).Error(msg)
-		return errors.New(msg)
+		return false, errors.New(msg)
 	}
 
 	l.shardOpts.promMetrics.FinishLoadingShard()
@@ -168,7 +176,7 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	l.shard = shard
 	l.loaded = true
 
-	return nil
+	return true, nil
 }
 
 func (l *LazyLoadShard) Index() *Index {

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -71,14 +71,15 @@ type addPropertyLazyFixture struct {
 // It registers no Shutdown cleanup — callers own the repo's lifecycle.
 func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, *fakeSchemaGetter) {
 	t.Helper()
-	repo, migrator, schemaGetter, _ := newLazyLoadRepoWithConfig(t, shardState, true, true)
+	repo, migrator, schemaGetter, _ := newLazyLoadRepoWithConfig(t, shardState, true, -1)
 	return repo, migrator, schemaGetter
 }
 
-// newLazyLoadRepoWithConfig wires a repo with the two lazy-shard knobs set as
-// given, returning the log hook so a test can read what startup logged.
+// newLazyLoadRepoWithConfig wires a repo with EnableLazyLoadShards and
+// LazyLoadShardWarmupMinObjects set as given, returning the log hook so a test
+// can read what startup logged.
 func newLazyLoadRepoWithConfig(t *testing.T, shardState *sharding.State,
-	lazyLoad, warmupDisabled bool,
+	lazyLoad bool, warmupMinObjects int64,
 ) (*DB, *Migrator, *fakeSchemaGetter, *test.Hook) {
 	t.Helper()
 	ctx := testCtx()
@@ -109,11 +110,11 @@ func newLazyLoadRepoWithConfig(t *testing.T, shardState *sharding.State,
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
-		RootPath:                    t.TempDir(),
-		QueryMaximumResults:         10000,
-		MaxImportGoroutinesFactor:   1,
-		EnableLazyLoadShards:        boolPtr(lazyLoad),
-		LazyLoadShardWarmupDisabled: warmupDisabled,
+		RootPath:                      t.TempDir(),
+		QueryMaximumResults:           10000,
+		MaxImportGoroutinesFactor:     1,
+		EnableLazyLoadShards:          boolPtr(lazyLoad),
+		LazyLoadShardWarmupMinObjects: warmupMinObjects,
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
@@ -566,27 +567,29 @@ func TestLazyLoadShard_LoadInvalidatesCachedColdCount(t *testing.T) {
 	}
 }
 
-// background_warmup tells an operator whether this collection's cold shards get
-// loaded by the startup sweep. An eagerly loaded collection has no such sweep,
-// whatever LazyLoadShardWarmupDisabled is set to.
+// background_warmup tells an operator whether this collection runs the startup
+// sweep at all; warmup_min_objects says which shards it then loads. An eagerly
+// loaded collection has no such sweep, whatever LazyLoadShardWarmupMinObjects
+// is set to.
 func TestMigratorAddClass_LogsBackgroundWarmup(t *testing.T) {
 	ctx := testCtx()
 
 	cases := []struct {
-		name           string
-		lazyLoad       bool
-		warmupDisabled bool
-		want           bool
+		name             string
+		lazyLoad         bool
+		warmupMinObjects int64
+		want             bool
 	}{
 		{name: "lazy loading with warmup", lazyLoad: true, want: true},
-		{name: "lazy loading with warmup disabled", lazyLoad: true, warmupDisabled: true},
+		{name: "lazy loading with a threshold", lazyLoad: true, warmupMinObjects: 1000, want: true},
+		{name: "lazy loading with warmup turned off", lazyLoad: true, warmupMinObjects: -1},
 		{name: "eager loading with warmup"},
-		{name: "eager loading with warmup disabled", warmupDisabled: true},
+		{name: "eager loading with warmup turned off", warmupMinObjects: -1},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			repo, migrator, _, hook := newLazyLoadRepoWithConfig(t, singleShardState(), tc.lazyLoad, tc.warmupDisabled)
+			repo, migrator, _, hook := newLazyLoadRepoWithConfig(t, singleShardState(), tc.lazyLoad, tc.warmupMinObjects)
 			t.Cleanup(func() { repo.Shutdown(context.Background()) })
 
 			require.NoError(t, migrator.AddClass(ctx, newClassWithWarmProp("WarmupLogging")))

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -66,12 +66,23 @@ type addPropertyLazyFixture struct {
 	schemaClass *models.Class
 }
 
-// newLazyLoadRepo wires a lazy-load-enabled repo whose shards start cold.
+// newLazyLoadRepo wires a lazy-load-enabled repo whose shards start cold and
+// stay cold, so a test decides when each one loads.
 // It registers no Shutdown cleanup — callers own the repo's lifecycle.
 func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, *fakeSchemaGetter) {
 	t.Helper()
+	repo, migrator, schemaGetter, _ := newLazyLoadRepoWithConfig(t, shardState, true, true)
+	return repo, migrator, schemaGetter
+}
+
+// newLazyLoadRepoWithConfig wires a repo with the two lazy-shard knobs set as
+// given, returning the log hook so a test can read what startup logged.
+func newLazyLoadRepoWithConfig(t *testing.T, shardState *sharding.State,
+	lazyLoad, warmupDisabled bool,
+) (*DB, *Migrator, *fakeSchemaGetter, *test.Hook) {
+	t.Helper()
 	ctx := testCtx()
-	logger, _ := test.NewNullLogger()
+	logger, hook := test.NewNullLogger()
 
 	baseMetrics := monitoring.GetMetrics()
 	metricsCopy := *baseMetrics
@@ -98,10 +109,11 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
-		RootPath:                  t.TempDir(),
-		QueryMaximumResults:       10000,
-		MaxImportGoroutinesFactor: 1,
-		EnableLazyLoadShards:      boolPtr(true),
+		RootPath:                    t.TempDir(),
+		QueryMaximumResults:         10000,
+		MaxImportGoroutinesFactor:   1,
+		EnableLazyLoadShards:        boolPtr(lazyLoad),
+		LazyLoadShardWarmupDisabled: warmupDisabled,
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),
@@ -115,7 +127,7 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	require.NoError(t, repo.init(ctx))
 	repo.startupComplete.Store(true)
 
-	return repo, NewMigrator(repo, logger, "node1"), schemaGetter
+	return repo, NewMigrator(repo, logger, "node1"), schemaGetter, hook
 }
 
 func newAddPropertyLazyFixture(t *testing.T, className string, shardState *sharding.State) *addPropertyLazyFixture {
@@ -550,6 +562,44 @@ func TestLazyLoadShard_LoadInvalidatesCachedColdCount(t *testing.T) {
 				require.EqualValues(t, tc.wantCount, count,
 					"cold count for shard %q after the load attempt", name)
 			}
+		})
+	}
+}
+
+// background_warmup tells an operator whether this collection's cold shards get
+// loaded by the startup sweep. An eagerly loaded collection has no such sweep,
+// whatever LazyLoadShardWarmupDisabled is set to.
+func TestMigratorAddClass_LogsBackgroundWarmup(t *testing.T) {
+	ctx := testCtx()
+
+	cases := []struct {
+		name           string
+		lazyLoad       bool
+		warmupDisabled bool
+		want           bool
+	}{
+		{name: "lazy loading with warmup", lazyLoad: true, want: true},
+		{name: "lazy loading with warmup disabled", lazyLoad: true, warmupDisabled: true},
+		{name: "eager loading with warmup"},
+		{name: "eager loading with warmup disabled", warmupDisabled: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, migrator, _, hook := newLazyLoadRepoWithConfig(t, singleShardState(), tc.lazyLoad, tc.warmupDisabled)
+			t.Cleanup(func() { repo.Shutdown(context.Background()) })
+
+			require.NoError(t, migrator.AddClass(ctx, newClassWithWarmProp("WarmupLogging")))
+
+			// Warnings on the same action carry no background_warmup field.
+			var logged []interface{}
+			for _, entry := range hook.AllEntries() {
+				warmup, ok := entry.Data["background_warmup"]
+				if ok && entry.Data["action"] == "lazy_shard_auto_detection" {
+					logged = append(logged, warmup)
+				}
+			}
+			require.Equal(t, []interface{}{tc.want}, logged)
 		})
 	}
 }

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -568,9 +568,8 @@ func TestLazyLoadShard_LoadInvalidatesCachedColdCount(t *testing.T) {
 }
 
 // background_warmup tells an operator whether this collection runs the startup
-// sweep at all; warmup_min_objects says which shards it then loads. An eagerly
-// loaded collection has no such sweep, whatever LazyLoadShardWarmupMinObjects
-// is set to.
+// sweep at all, and warmup_min_objects which shards it then loads. An eager
+// collection runs no sweep, whatever LazyLoadShardWarmupMinObjects is set to.
 func TestMigratorAddClass_LogsBackgroundWarmup(t *testing.T) {
 	ctx := testCtx()
 

--- a/adapters/repos/db/shutdown_test.go
+++ b/adapters/repos/db/shutdown_test.go
@@ -752,7 +752,10 @@ func startGatedBackgroundLoad(t *testing.T, idx *Index, shardName string) (chan 
 	})
 
 	loadDone := make(chan error, 1)
-	go func() { loadDone <- idx.loadLocalShardIfActive(shardName) }()
+	go func() {
+		_, err := idx.loadLocalShardIfActive(shardName)
+		loadDone <- err
+	}()
 	<-entered
 
 	return release, loadDone

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -265,12 +265,14 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	assert.Equal(t, int64(2), hotShard.ObjectsCount)
 	assert.Equal(t, uint64(612), hotShard.ObjectsStorageBytes)
 	assert.Equal(t, strings.ToLower(models.TenantActivityStatusACTIVE), hotShard.Status)
+	assert.False(t, hotShard.LazyUnloaded, "a loaded shard is not marked as unloaded")
 	assert.Len(t, hotShard.NamedVectors, 1)
 
 	require.NotNil(t, coldShard)
 	assert.Equal(t, int64(0), coldShard.ObjectsCount)
 	assert.Equal(t, uint64(0), coldShard.ObjectsStorageBytes)
 	assert.Equal(t, strings.ToLower(models.TenantActivityStatusINACTIVE), coldShard.Status)
+	assert.False(t, coldShard.LazyUnloaded, "an inactive shard is never loaded, so it carries no mark")
 	assert.Len(t, coldShard.NamedVectors, 1)
 
 	vector := hotShard.NamedVectors[0]

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -73,6 +73,13 @@ type ShardUsage struct {
 	// The status of the shard (ACTIVE, INACTIVE)
 	Status string `json:"status,omitempty"`
 
+	// LazyUnloaded marks an active shard that was not loaded into memory when the
+	// report ran, so everything above was read from disk like a cold shard's. It
+	// separates a lazy shard sitting cold from one serving requests; both are hot
+	// tenants and report the same status. An inactive shard is never loaded, so it
+	// does not carry the mark.
+	LazyUnloaded bool `json:"lazy_unloaded,omitempty"`
+
 	// The number of objects in the shard
 	ObjectsCount int64 `json:"objects_count"`
 

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -73,11 +73,9 @@ type ShardUsage struct {
 	// The status of the shard (ACTIVE, INACTIVE)
 	Status string `json:"status,omitempty"`
 
-	// LazyUnloaded marks an active shard that was not loaded into memory when the
-	// report ran, so everything above was read from disk like a cold shard's. It
-	// separates a lazy shard sitting cold from one serving requests; both are hot
-	// tenants and report the same status. An inactive shard is never loaded, so it
-	// does not carry the mark.
+	// LazyUnloaded marks an active shard that was not in memory when the report ran,
+	// so everything above was read from disk. It tells a lazy shard sitting cold
+	// apart from one serving requests; both report the same active status.
 	LazyUnloaded bool `json:"lazy_unloaded,omitempty"`
 
 	// The number of objects in the shard

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -167,6 +167,11 @@ weaviate_shards{state="loaded",registration="lazy"}
 
 `registration` is decided per collection when its index is built, so one node can report both. `LAZY_LOAD_SHARD_COUNT_THRESHOLD=0` forces every collection `lazy` and the deprecated `DISABLE_LAZY_LOAD_SHARDS` forces every collection `eager`; with neither set, a collection is `eager` unless it is multi-tenant and its local shard count or on-disk size crosses `LAZY_LOAD_SHARD_COUNT_THRESHOLD` / `LAZY_LOAD_SHARD_SIZE_THRESHOLD_GB`. All eight series are exported from startup, so a node with no lazy collections scrapes zero rather than omitting the series.
 
+#### Shard Loading Metrics
+| Name | Description | Type | Labels | High Cardinality |
+|---|---|---|---|---|
+| `weaviate_lazy_shard_warmup_decisions_total` | Number of shards the startup warmup sweep considered, by what it did with each: `loaded`, `failed`, `skipped_not_cold`, `skipped_empty`, `skipped_below_threshold` | `Counter` | `outcome` | - Low 
+
 #### Shard Load Limiter Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -170,7 +170,7 @@ weaviate_shards{state="loaded",registration="lazy"}
 #### Shard Loading Metrics
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|
-| `weaviate_lazy_shard_warmup_decisions_total` | Number of shards the startup warmup sweep considered, by what it did with each: `loaded`, `failed`, `skipped_not_cold`, `skipped_empty`, `skipped_below_threshold` | `Counter` | `outcome` | - Low 
+| `weaviate_lazy_shard_warmup_decisions_total` | Number of shards the startup warmup sweep considered, by what it did with each: `loaded`, `failed`, `skipped_shard_gone`, `skipped_already_loaded`, `skipped_empty`, `skipped_below_threshold` | `Counter` | `outcome` | - Low 
 
 #### Shard Load Limiter Metrics
 | Name | Description | Type | Labels | High Cardinality |

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -533,6 +533,12 @@ func TestRestart(t *testing.T) {
 		WithWeaviateWithDebugPort().
 		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
 		WithWeaviateEnv(entcfg.EnvNestedFilteringPreview, "true").
+		// a count threshold of 0 lazy-loads every multi-tenant collection the node
+		// finds on startup, and the warmup knob leaves those shards unloaded until
+		// something asks for them, so the report after the restart has to measure hot
+		// tenants from disk
+		WithWeaviateEnv("LAZY_LOAD_SHARD_COUNT_THRESHOLD", "0").
+		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "true").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {
@@ -588,8 +594,9 @@ func TestRestart(t *testing.T) {
 
 	// add some data. Only even tenants get nested values, leaving the odd ones as
 	// a baseline with the same schema and object count.
+	const objectsPerTenant = 10
 	for i, tenant := range tenants {
-		objs := make([]*models.Object, 10)
+		objs := make([]*models.Object, objectsPerTenant)
 		for j := range objs {
 			vector := make([]float32, 128)
 			for k := range vector {
@@ -618,44 +625,100 @@ func TestRestart(t *testing.T) {
 		}
 	}
 
-	loaded := strings.ToLower(models.TenantActivityStatusACTIVE)
-	fromDisk := strings.ToLower(models.TenantActivityStatusINACTIVE)
+	hotStatus := strings.ToLower(models.TenantActivityStatusACTIVE)
+	coldStatus := strings.ToLower(models.TenantActivityStatusINACTIVE)
 
 	// collect with concurrent shard readers, compare with the default report after restart
 	usage, err := getDebugUsageWithPort(debug, 4)
 	require.NoError(t, err)
 	require.NotNil(t, usage)
-	assertNestedIndexStorageCounted(t, usage, className, loaded)
+	// writing the objects loaded every shard
+	assertNestedIndexStorageCounted(t, usage, className, hotStatus, false)
 
 	require.NoError(t, compose.Stop(ctx, compose.GetWeaviate().Name(), nil))
 
 	err = compose.Start(ctx, compose.GetWeaviate().Name())
 	require.NoError(t, err)
 
-	usage2, err := getDebugUsageWithPort(compose.GetWeaviate().DebugURI())
+	// the restart gave the container a new mapped port
+	debug = compose.GetWeaviate().DebugURI()
+	c, err = client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
 	require.NoError(t, err)
-	require.NotNil(t, usage2)
-	require.NoError(t, ReportsDifference(usage, usage2))
-	assertNestedIndexStorageCounted(t, usage2, className, loaded)
+
+	// nothing has touched the tenants since the restart and the sweep that would load
+	// them is off, so they stay hot without being in memory. The sweep materializes one
+	// shard per second, so a window this wide fails if the knob stops taking effect.
+	require.Never(t, func() bool {
+		report, err := getDebugUsageWithPort(debug)
+		if err != nil {
+			return false
+		}
+		for _, shard := range shardsForCollection(report, className) {
+			if !shard.LazyUnloaded {
+				return true
+			}
+		}
+		return false
+	}, 15*time.Second, 3*time.Second, "no shard may load while the warmup is disabled")
+
+	unloadedUsage, err := getDebugUsageWithPort(debug)
+	require.NoError(t, err)
+	require.NotNil(t, unloadedUsage)
+	assertNestedIndexStorageCounted(t, unloadedUsage, className, hotStatus, true)
+
+	// reading one tenant loads its shard, and only its shard. Nothing else makes an
+	// unloaded shard observable from outside, so without the mark a node parked in
+	// this mode looks like one serving every tenant from memory.
+	first := tenants[0].Name
+	_, err = c.Data().ObjectsGetter().WithClassName(className).WithTenant(first).Do(ctx)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		report, err := getDebugUsageWithPort(debug)
+		require.NoError(ct, err)
+		shards := shardsForCollection(report, className)
+		require.Len(ct, shards, len(tenants))
+		for _, shard := range shards {
+			if shard.Name == first {
+				assert.False(ct, shard.LazyUnloaded, "the tenant that was read is loaded now")
+				assert.Equal(ct, int64(objectsPerTenant), shard.ObjectsCount)
+				continue
+			}
+			assert.True(ct, shard.LazyUnloaded, "shard %s stays unloaded", shard.Name)
+		}
+	}, 30*time.Second, 500*time.Millisecond)
+
+	// reading the rest brings every shard back into memory, and the report is the one
+	// taken before the restart again
+	for _, tenant := range tenants[1:] {
+		_, err = c.Data().ObjectsGetter().WithClassName(className).WithTenant(tenant.Name).Do(ctx)
+		require.NoError(t, err)
+	}
+
+	var usage2 *usagetypes.Report
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		usage2, err = getDebugUsageWithPort(debug)
+		require.NoError(ct, err)
+		require.NoError(ct, ReportsDifference(usage, usage2))
+	}, 60*time.Second, time.Second)
+	assertNestedIndexStorageCounted(t, usage2, className, hotStatus, false)
 
 	// cold tenants are measured from the bucket directories instead of the shard
 	cold := make([]models.Tenant, len(tenants))
 	for i := range tenants {
 		cold[i] = models.Tenant{Name: tenants[i].Name, ActivityStatus: models.TenantActivityStatusCOLD}
 	}
-	// the restart gave the container a new mapped port
-	c, err = client.NewClient(client.Config{Scheme: "http", Host: compose.GetWeaviate().URI()})
-	require.NoError(t, err)
 	require.NoError(t, c.Schema().TenantsUpdater().WithClassName(className).WithTenants(cold...).Do(ctx))
 
-	usage3, err := getDebugUsageWithPort(compose.GetWeaviate().DebugURI())
+	usage3, err := getDebugUsageWithPort(debug)
 	require.NoError(t, err)
 	require.NotNil(t, usage3)
-	assertNestedIndexStorageCounted(t, usage3, className, fromDisk)
+	// an inactive shard is never loaded, so it carries no mark
+	assertNestedIndexStorageCounted(t, usage3, className, coldStatus, false)
 
 	// shares this container instead of starting its own
 	t.Run("muvera usage", func(t *testing.T) {
-		testUsageMuvera(t, c, compose.GetWeaviate().DebugURI())
+		testUsageMuvera(t, c, debug)
 	})
 }
 
@@ -675,26 +738,37 @@ func nestedCars(tenant, object int) []any {
 func collectionShards(t *testing.T, report *usagetypes.Report, className string) usagetypes.ShardsUsage {
 	t.Helper()
 
+	shards := shardsForCollection(report, className)
+	if shards == nil {
+		require.FailNow(t, "collection missing from usage report: "+className)
+	}
+	return shards
+}
+
+// shardsForCollection returns nil for a collection the report does not carry, so a
+// polling condition can retry instead of failing off the test goroutine.
+func shardsForCollection(report *usagetypes.Report, className string) usagetypes.ShardsUsage {
 	for _, col := range report.Collections {
 		if col != nil && col.Name == className {
 			return col.Shards
 		}
 	}
-	require.FailNow(t, "collection missing from usage report: "+className)
 	return nil
 }
 
 // assertNestedIndexStorageCounted checks that tenants with nested values report more
 // than double the index storage of those without — nested data lives only in the
 // property.nested_ / property.nestedmeta_ buckets, so skipping those makes the two
-// groups equal. wantStatus is active for a loaded shard, inactive for one from disk.
-func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, className, wantStatus string) {
+// groups equal. wantStatus is active for a hot tenant, inactive for a cold one, and
+// wantLazyUnloaded says whether the hot ones were measured from disk.
+func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, className, wantStatus string, wantLazyUnloaded bool) {
 	t.Helper()
 
 	// per shard rather than summed, so one shard reporting nothing cannot hide
 	var smallestNested, largestBaseline uint64
 	for _, shard := range collectionShards(t, report, className) {
 		require.Equal(t, wantStatus, shard.Status, "shard %s", shard.Name)
+		require.Equal(t, wantLazyUnloaded, shard.LazyUnloaded, "shard %s", shard.Name)
 		require.GreaterOrEqual(t, shard.FullShardStorageBytes, shard.IndexStorageBytes,
 			"shard %s full storage must contain its index storage", shard.Name)
 
@@ -1796,7 +1870,8 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	}
 	testAllObjectsIndexed(t, c, className)
 
-	// the status pins which path served the report: active = loaded, inactive = read from disk
+	// the status pins the tenant, not the path: active covers a loaded shard and a lazy
+	// one read from disk, which lazy_unloaded tells apart. inactive means a cold tenant
 	assertUsage := func(t require.TestingT, expectedStatus string) {
 		colUsage, err := getDebugUsageWithPortAndCollection(debug, className)
 		require.NoError(t, err)

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -12,6 +12,7 @@
 package usage
 
 import (
+	"acceptance_tests_with_client/internal/wvhost"
 	"context"
 	"fmt"
 	"math/rand"
@@ -21,8 +22,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"acceptance_tests_with_client/internal/wvhost"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -12,7 +12,6 @@
 package usage
 
 import (
-	"acceptance_tests_with_client/internal/wvhost"
 	"context"
 	"fmt"
 	"math/rand"
@@ -22,6 +21,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"acceptance_tests_with_client/internal/wvhost"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -533,10 +534,9 @@ func TestRestart(t *testing.T) {
 		WithWeaviateWithDebugPort().
 		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
 		WithWeaviateEnv(entcfg.EnvNestedFilteringPreview, "true").
-		// a count threshold of 0 lazy-loads every multi-tenant collection the node
-		// finds on startup, and a negative warmup minimum leaves those shards
-		// unloaded until something asks for them, so the report after the restart
-		// has to measure hot tenants from disk
+		// a count threshold of 0 lazy-loads every multi-tenant collection, and a
+		// negative warmup minimum leaves those shards unloaded until asked for, so
+		// the report after the restart measures hot tenants from disk
 		WithWeaviateEnv("LAZY_LOAD_SHARD_COUNT_THRESHOLD", "0").
 		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", "-1").
 		Start(ctx)
@@ -646,8 +646,8 @@ func TestRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	// nothing has touched the tenants since the restart and the sweep that would load
-	// them is off, so they stay hot without being in memory. The sweep materializes one
-	// shard per second, so a window this wide fails if the knob stops taking effect.
+	// them is off, so they stay hot without being in memory. The sweep loads one shard
+	// per second, so a window this wide fails if the knob stops taking effect.
 	require.Never(t, func() bool {
 		report, err := getDebugUsageWithPort(debug)
 		if err != nil {
@@ -757,10 +757,9 @@ func shardsForCollection(report *usagetypes.Report, className string) usagetypes
 }
 
 // assertNestedIndexStorageCounted checks that tenants with nested values report more
-// than double the index storage of those without — nested data lives only in the
+// than double the index storage of those without. Nested data lives only in the
 // property.nested_ / property.nestedmeta_ buckets, so skipping those makes the two
-// groups equal. wantStatus is active for a hot tenant, inactive for a cold one, and
-// wantLazyUnloaded says whether the hot ones were measured from disk.
+// groups equal. wantLazyUnloaded says whether the hot shards were measured from disk.
 func assertNestedIndexStorageCounted(t *testing.T, report *usagetypes.Report, className, wantStatus string, wantLazyUnloaded bool) {
 	t.Helper()
 
@@ -1870,8 +1869,8 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	}
 	testAllObjectsIndexed(t, c, className)
 
-	// the status pins the tenant, not the path: active covers a loaded shard and a lazy
-	// one read from disk, which lazy_unloaded tells apart. inactive means a cold tenant
+	// the status pins the tenant, not the path: active covers a loaded shard and a
+	// lazy one read from disk, which lazy_unloaded tells apart
 	assertUsage := func(t require.TestingT, expectedStatus string) {
 		colUsage, err := getDebugUsageWithPortAndCollection(debug, className)
 		require.NoError(t, err)

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -534,11 +534,11 @@ func TestRestart(t *testing.T) {
 		WithWeaviateEnv("TRACK_VECTOR_DIMENSIONS", "true").
 		WithWeaviateEnv(entcfg.EnvNestedFilteringPreview, "true").
 		// a count threshold of 0 lazy-loads every multi-tenant collection the node
-		// finds on startup, and the warmup knob leaves those shards unloaded until
-		// something asks for them, so the report after the restart has to measure hot
-		// tenants from disk
+		// finds on startup, and a negative warmup minimum leaves those shards
+		// unloaded until something asks for them, so the report after the restart
+		// has to measure hot tenants from disk
 		WithWeaviateEnv("LAZY_LOAD_SHARD_COUNT_THRESHOLD", "0").
-		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "true").
+		WithWeaviateEnv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", "-1").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -199,9 +199,21 @@ type Config struct {
 	// EnableLazyLoadShards controls lazy shard loading.
 	// nil = auto-detect based on thresholds, true = always lazy-load, false = always eager-load.
 	// DISABLE_LAZY_LOAD_SHARDS=true sets this to false for backward compatibility.
-	EnableLazyLoadShards                *bool                          `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
-	LazyLoadShardCountThreshold         int                            `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
-	LazyLoadShardSizeThresholdGB        float64                        `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
+	EnableLazyLoadShards         *bool   `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
+	LazyLoadShardCountThreshold  int     `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
+	LazyLoadShardSizeThresholdGB float64 `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
+	// LazyLoadShardWarmupDisabled turns off the background sweep that
+	// materializes lazy shards after startup, one shard per second. The zero
+	// value keeps the sweep running. It only takes effect on collections where
+	// lazy loading is active; eager collections never run the sweep.
+	//
+	// A HOT tenant nobody touches then stays unloaded indefinitely, and every
+	// path that reads only loaded shards under-reports or skips it. The two that
+	// change behaviour rather than a number: the TTL sweep does not delete its
+	// expired objects, and async replication does not repair a stale replica of
+	// it. The list is not exhaustive — treat any loaded-shards-only reader as
+	// affected.
+	LazyLoadShardWarmupDisabled         bool                           `json:"lazy_load_shard_warmup_disabled" yaml:"lazy_load_shard_warmup_disabled"`
 	ForceFullReplicasSearch             bool                           `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	TransferInactivityTimeout           time.Duration                  `json:"transfer_inactivity_timeout" yaml:"transfer_inactivity_timeout"`
 	HaltForTransferTimeout              time.Duration                  `json:"halt_for_transfer_timeout" yaml:"halt_for_transfer_timeout"`

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -202,18 +202,23 @@ type Config struct {
 	EnableLazyLoadShards         *bool   `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
 	LazyLoadShardCountThreshold  int     `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
 	LazyLoadShardSizeThresholdGB float64 `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
-	// LazyLoadShardWarmupDisabled turns off the background sweep that
-	// materializes lazy shards after startup, one shard per second. The zero
-	// value keeps the sweep running. It only takes effect on collections where
-	// lazy loading is active; eager collections never run the sweep.
+	// LazyLoadShardWarmupMinObjects gates the background sweep that materializes
+	// lazy shards after startup, one shard per second. A negative value sweeps
+	// nothing. The zero value sweeps every shard that has ever been written to,
+	// minus the empty tenant shards of a multi-tenant collection. A positive value
+	// sweeps only shards holding strictly more than that many objects, counted from
+	// flushed segments — so a shard whose writes are still unflushed reads small and
+	// can be left cold. It only takes effect on collections where lazy loading is
+	// active; eager collections never run the sweep.
 	//
-	// A HOT tenant nobody touches then stays unloaded indefinitely, and every
-	// path that reads only loaded shards under-reports or skips it. The two that
-	// change behaviour rather than a number: the TTL sweep does not delete its
-	// expired objects, and async replication does not repair a stale replica of
-	// it. The list is not exhaustive — treat any loaded-shards-only reader as
-	// affected.
-	LazyLoadShardWarmupDisabled         bool                           `json:"lazy_load_shard_warmup_disabled" yaml:"lazy_load_shard_warmup_disabled"`
+	// A HOT tenant the sweep leaves out and nobody touches stays unloaded
+	// indefinitely, and every path that reads only loaded shards under-reports or
+	// skips it. The two that change behaviour rather than a number: the TTL sweep
+	// does not delete its expired objects, and async replication does not repair a
+	// stale replica of it. MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so a
+	// node admits writes past its cap. The list is not exhaustive — treat any
+	// loaded-shards-only reader as affected.
+	LazyLoadShardWarmupMinObjects       int64                          `json:"lazy_load_shard_warmup_min_objects" yaml:"lazy_load_shard_warmup_min_objects"`
 	ForceFullReplicasSearch             bool                           `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	TransferInactivityTimeout           time.Duration                  `json:"transfer_inactivity_timeout" yaml:"transfer_inactivity_timeout"`
 	HaltForTransferTimeout              time.Duration                  `json:"halt_for_transfer_timeout" yaml:"halt_for_transfer_timeout"`

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -202,22 +202,16 @@ type Config struct {
 	EnableLazyLoadShards         *bool   `json:"enable_lazy_load_shards" yaml:"enable_lazy_load_shards"`
 	LazyLoadShardCountThreshold  int     `json:"lazy_load_shard_count_threshold" yaml:"lazy_load_shard_count_threshold"`
 	LazyLoadShardSizeThresholdGB float64 `json:"lazy_load_shard_size_threshold_gb" yaml:"lazy_load_shard_size_threshold_gb"`
-	// LazyLoadShardWarmupMinObjects gates the background sweep that materializes
-	// lazy shards after startup, one shard per second. A negative value sweeps
-	// nothing. The zero value sweeps every shard that has ever been written to,
-	// minus the empty tenant shards of a multi-tenant collection. A positive value
-	// sweeps only shards holding strictly more than that many objects, counted from
-	// flushed segments — so a shard whose writes are still unflushed reads small and
-	// can be left cold. It only takes effect on collections where lazy loading is
-	// active; eager collections never run the sweep.
+	// LazyLoadShardWarmupMinObjects gates the background sweep that loads lazy
+	// shards after startup, one per second. Negative sweeps nothing, zero sweeps
+	// every shard ever written to, and a positive value sweeps only shards holding
+	// strictly more than that many objects, counted from flushed segments. An eager
+	// collection runs no sweep.
 	//
-	// A HOT tenant the sweep leaves out and nobody touches stays unloaded
-	// indefinitely, and every path that reads only loaded shards under-reports or
-	// skips it. The two that change behaviour rather than a number: the TTL sweep
-	// does not delete its expired objects, and async replication does not repair a
-	// stale replica of it. MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so a
-	// node admits writes past its cap. The list is not exhaustive — treat any
-	// loaded-shards-only reader as affected.
+	// A HOT tenant left out and never touched stays unloaded, and every path that
+	// reads only loaded shards under-reports or skips it: TTL keeps its expired
+	// objects, async replication leaves a stale replica unrepaired, and
+	// MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it.
 	LazyLoadShardWarmupMinObjects       int64                          `json:"lazy_load_shard_warmup_min_objects" yaml:"lazy_load_shard_warmup_min_objects"`
 	ForceFullReplicasSearch             bool                           `json:"force_full_replicas_search" yaml:"force_full_replicas_search"`
 	TransferInactivityTimeout           time.Duration                  `json:"transfer_inactivity_timeout" yaml:"transfer_inactivity_timeout"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -175,17 +175,28 @@ func FromEnv(config *Config) error {
 
 	// Written only when the variable is set, so a value from the config file
 	// survives.
-	if v := os.Getenv("LAZY_LOAD_SHARD_WARMUP_DISABLED"); v != "" {
-		config.LazyLoadShardWarmupDisabled = entcfg.Enabled(v)
+	if v := os.Getenv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS"); v != "" {
+		asInt, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return fmt.Errorf("parse LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS as int: %w", err)
+		}
+		config.LazyLoadShardWarmupMinObjects = asInt
 	}
 	// Eager loading ignores the knob entirely, so warning there would describe a
 	// state no collection on this node is in. Auto-detection is resolved per
 	// collection later, so a nil setting still warns.
-	if config.LazyLoadShardWarmupDisabled &&
+	if minObjects := config.LazyLoadShardWarmupMinObjects; minObjects != 0 &&
 		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
-		logrus.Warn("lazy shard background warmup is disabled; shards stay unloaded until first access. " +
-			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. " +
-			"Async replication also skips it, so a stale replica is not repaired until something loads it.")
+		left := fmt.Sprintf("only shards holding more than %d objects are warmed up", minObjects)
+		if minObjects < 0 {
+			left = "no shard is warmed up"
+		}
+		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so %s; every other shard stays unloaded "+
+			"until first access. "+
+			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. "+
+			"Async replication also skips it, so a stale replica is not repaired until something loads it. "+
+			"MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so this node admits writes past its cap.",
+			minObjects, left)
 	}
 
 	// Lazy load shard size threshold for auto-detection (in GB)

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -173,6 +173,21 @@ func FromEnv(config *Config) error {
 		config.LazyLoadShardCountThreshold = DefaultLazyLoadShardCountThreshold
 	}
 
+	// Written only when the variable is set, so a value from the config file
+	// survives.
+	if v := os.Getenv("LAZY_LOAD_SHARD_WARMUP_DISABLED"); v != "" {
+		config.LazyLoadShardWarmupDisabled = entcfg.Enabled(v)
+	}
+	// Eager loading ignores the knob entirely, so warning there would describe a
+	// state no collection on this node is in. Auto-detection is resolved per
+	// collection later, so a nil setting still warns.
+	if config.LazyLoadShardWarmupDisabled &&
+		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
+		logrus.Warn("lazy shard background warmup is disabled; shards stay unloaded until first access. " +
+			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. " +
+			"Async replication also skips it, so a stale replica is not repaired until something loads it.")
+	}
+
 	// Lazy load shard size threshold for auto-detection (in GB)
 	// Determines at what total shard size auto-detection enables lazy loading
 	if v := os.Getenv("LAZY_LOAD_SHARD_SIZE_THRESHOLD_GB"); v != "" {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -187,12 +187,15 @@ func FromEnv(config *Config) error {
 	// collection later, so a nil setting still warns.
 	if minObjects := config.LazyLoadShardWarmupMinObjects; minObjects != 0 &&
 		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
-		left := fmt.Sprintf("only shards holding more than %d objects are warmed up", minObjects)
+		left := fmt.Sprintf("only shards holding more than %d objects are warmed up, counted "+
+			"from flushed segments — so a shard restarted mid-write reads lower than it "+
+			"holds and can be left out", minObjects)
 		if minObjects < 0 {
 			left = "no shard is warmed up"
 		}
-		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so %s; every other shard stays unloaded "+
-			"until first access. "+
+		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so on a collection using lazy loading %s. "+
+			"Whatever is left out stays unloaded until first access, and an eager collection ignores "+
+			"the setting and loads all of its shards. "+
 			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. "+
 			"Async replication also skips it, so a stale replica is not repaired until something loads it. "+
 			"MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so this node admits writes past its cap.",

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -187,18 +187,15 @@ func FromEnv(config *Config) error {
 	// collection later, so a nil setting still warns.
 	if minObjects := config.LazyLoadShardWarmupMinObjects; minObjects != 0 &&
 		(config.EnableLazyLoadShards == nil || *config.EnableLazyLoadShards) {
-		left := fmt.Sprintf("only shards holding more than %d objects are warmed up, counted "+
-			"from flushed segments — so a shard restarted mid-write reads lower than it "+
-			"holds and can be left out", minObjects)
+		left := fmt.Sprintf("only shards holding more than %d objects are warmed up", minObjects)
 		if minObjects < 0 {
 			left = "no shard is warmed up"
 		}
 		logrus.Warnf("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS is %d, so on a collection using lazy loading %s. "+
-			"Whatever is left out stays unloaded until first access, and an eager collection ignores "+
-			"the setting and loads all of its shards. "+
-			"An untouched HOT tenant keeps its expired objects, because the TTL sweep skips unloaded shards. "+
-			"Async replication also skips it, so a stale replica is not repaired until something loads it. "+
-			"MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so this node admits writes past its cap.",
+			"A HOT tenant left out stays unloaded until first access. "+
+			"While it is unloaded the TTL sweep keeps its expired objects, async replication leaves a "+
+			"stale replica unrepaired, and MAXIMUM_ALLOWED_OBJECTS_COUNT stops counting it, so this "+
+			"node admits writes past its cap.",
 			minObjects, left)
 	}
 

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -749,6 +749,42 @@ func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {
 	}
 }
 
+func TestEnvironmentLazyLoadShardWarmupDisabled(t *testing.T) {
+	tests := []struct {
+		name string
+		// preset mirrors a value coming from the config file, which is parsed
+		// before FromEnv runs.
+		preset   bool
+		value    string
+		expected bool
+	}{
+		{name: "unset keeps warmup running", value: "", expected: false},
+		{name: "true disables", value: "true", expected: true},
+		{name: "on disables", value: "on", expected: true},
+		{name: "1 disables", value: "1", expected: true},
+		{name: "false keeps warmup running", value: "false", expected: false},
+		{name: "unparsable value keeps warmup running", value: "not-a-bool", expected: false},
+		{name: "config file value survives an unset env var", preset: true, value: "", expected: true},
+		{name: "env var overrides the config file", preset: true, value: "false", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Ensure hermetic behavior regardless of outer environment
+			t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "")
+
+			if tt.value != "" {
+				t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", tt.value)
+			}
+
+			conf := Config{LazyLoadShardWarmupDisabled: tt.preset}
+			require.NoError(t, FromEnv(&conf))
+
+			assert.Equal(t, tt.expected, conf.LazyLoadShardWarmupDisabled)
+		})
+	}
+}
+
 func TestEnvironmentHaltForTransferTimeout(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -749,38 +749,44 @@ func TestEnvironmentLazyLoadShardSizeThreshold(t *testing.T) {
 	}
 }
 
-func TestEnvironmentLazyLoadShardWarmupDisabled(t *testing.T) {
+func TestEnvironmentLazyLoadShardWarmupMinObjects(t *testing.T) {
 	tests := []struct {
 		name string
 		// preset mirrors a value coming from the config file, which is parsed
 		// before FromEnv runs.
-		preset   bool
-		value    string
-		expected bool
+		preset      int64
+		value       string
+		expected    int64
+		expectedErr bool
 	}{
-		{name: "unset keeps warmup running", value: "", expected: false},
-		{name: "true disables", value: "true", expected: true},
-		{name: "on disables", value: "on", expected: true},
-		{name: "1 disables", value: "1", expected: true},
-		{name: "false keeps warmup running", value: "false", expected: false},
-		{name: "unparsable value keeps warmup running", value: "not-a-bool", expected: false},
-		{name: "config file value survives an unset env var", preset: true, value: "", expected: true},
-		{name: "env var overrides the config file", preset: true, value: "false", expected: false},
+		{name: "unset keeps the zero value", value: "", expected: 0},
+		{name: "negative turns the sweep off", value: "-1", expected: -1},
+		{name: "zero sweeps every non-empty shard", value: "0", expected: 0},
+		{name: "positive sets a threshold", value: "1000", expected: 1000},
+		{name: "unparsable value is rejected", value: "not-an-int", expectedErr: true},
+		{name: "config file value survives an unset env var", preset: 500, value: "", expected: 500},
+		{name: "env var overrides the config file", preset: 500, value: "-1", expected: -1},
+		{name: "zero overrides a config-file threshold", preset: 500, value: "0", expected: 0},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Ensure hermetic behavior regardless of outer environment
-			t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", "")
+			t.Setenv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", "")
 
 			if tt.value != "" {
-				t.Setenv("LAZY_LOAD_SHARD_WARMUP_DISABLED", tt.value)
+				t.Setenv("LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS", tt.value)
 			}
 
-			conf := Config{LazyLoadShardWarmupDisabled: tt.preset}
-			require.NoError(t, FromEnv(&conf))
+			conf := Config{LazyLoadShardWarmupMinObjects: tt.preset}
+			err := FromEnv(&conf)
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
 
-			assert.Equal(t, tt.expected, conf.LazyLoadShardWarmupDisabled)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, conf.LazyLoadShardWarmupMinObjects)
 		})
 	}
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -137,6 +137,8 @@ type PrometheusMetrics struct {
 	// opened at creation and the ones a lazy collection opened on access.
 	Shards *prometheus.GaugeVec
 
+	LazyShardWarmupDecisions *prometheus.CounterVec
+
 	// ShardHaltForTransferForceResume: non-zero means a transfer was
 	// force-resumed mid-stream — compaction may have raced the transfer.
 	ShardHaltForTransferForceResume *prometheus.CounterVec
@@ -802,6 +804,11 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "weaviate_shards",
 			Help: "Number of shards the node holds, by lifecycle state and by whether the collection opens its shards eagerly at creation or lazily on first access",
 		}, []string{"state", "registration"}),
+
+		LazyShardWarmupDecisions: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "weaviate_lazy_shard_warmup_decisions_total",
+			Help: "Number of shards the startup warmup sweep considered, by what it did with each",
+		}, []string{"outcome"}),
 
 		ShardHaltForTransferForceResume: promauto.NewCounterVec(prometheus.CounterOpts{
 			Name: "shard_halt_for_transfer_force_resume_total",

--- a/usecases/monitoring/shards.go
+++ b/usecases/monitoring/shards.go
@@ -73,9 +73,12 @@ const (
 	WarmupLoaded WarmupOutcome = "loaded"
 	// WarmupFailed: the sweep attempted the load and it failed.
 	WarmupFailed WarmupOutcome = "failed"
-	// WarmupSkippedNotCold: no cold shard was left to warm, the shard having
-	// loaded or been deleted since the sweep listed it.
-	WarmupSkippedNotCold WarmupOutcome = "skipped_not_cold"
+	// WarmupSkippedShardGone: the index no longer holds the shard, its tenant
+	// having been deactivated or deleted since the sweep listed it.
+	WarmupSkippedShardGone WarmupOutcome = "skipped_shard_gone"
+	// WarmupSkippedAlreadyLoaded: something reached the shard before the sweep
+	// did, so there was nothing left to load.
+	WarmupSkippedAlreadyLoaded WarmupOutcome = "skipped_already_loaded"
 	// WarmupSkippedEmpty: the shard has never held an object.
 	WarmupSkippedEmpty WarmupOutcome = "skipped_empty"
 	// WarmupSkippedBelowThreshold: the shard holds too few objects for

--- a/usecases/monitoring/shards.go
+++ b/usecases/monitoring/shards.go
@@ -63,6 +63,35 @@ func (pm *PrometheusMetrics) moveShardState(reg ShardRegistration, from, to Shar
 	pm.enterShardState(reg, to)
 }
 
+// WarmupOutcome is the value of the closed `outcome` label on
+// weaviate_lazy_shard_warmup_decisions_total: what the startup sweep that loads
+// lazy shards did with one of them.
+type WarmupOutcome string
+
+const (
+	// WarmupLoaded: the sweep loaded the shard.
+	WarmupLoaded WarmupOutcome = "loaded"
+	// WarmupFailed: the sweep attempted the load and it failed.
+	WarmupFailed WarmupOutcome = "failed"
+	// WarmupSkippedNotCold: no cold shard was left to warm, the shard having
+	// loaded or been deleted since the sweep listed it.
+	WarmupSkippedNotCold WarmupOutcome = "skipped_not_cold"
+	// WarmupSkippedEmpty: the shard has never held an object.
+	WarmupSkippedEmpty WarmupOutcome = "skipped_empty"
+	// WarmupSkippedBelowThreshold: the shard holds too few objects for
+	// LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS.
+	WarmupSkippedBelowThreshold WarmupOutcome = "skipped_below_threshold"
+)
+
+// RecordWarmupOutcome records what the startup warmup sweep did with one shard.
+func (pm *PrometheusMetrics) RecordWarmupOutcome(outcome WarmupOutcome) {
+	if pm == nil {
+		return
+	}
+
+	pm.LazyShardWarmupDecisions.WithLabelValues(string(outcome)).Inc()
+}
+
 // Move the shard from unloaded to in progress. Only a lazy shard loads this
 // way; an eager one is born loaded.
 func (pm *PrometheusMetrics) StartLoadingShard() {

--- a/usecases/monitoring/shards_test.go
+++ b/usecases/monitoring/shards_test.go
@@ -230,3 +230,53 @@ func TestShardsExportsEveryStateAtStartup(t *testing.T) {
 		}, "series %v must exist", labels)
 	}
 }
+
+// TestWarmupOutcomeCountsOnItsOwnSeries pins each outcome to one series, so a
+// dashboard summing them reads the sweep's decisions without double counting.
+func TestWarmupOutcomeCountsOnItsOwnSeries(t *testing.T) {
+	m := GetMetrics()
+
+	outcomes := []WarmupOutcome{
+		WarmupLoaded,
+		WarmupFailed,
+		WarmupSkippedNotCold,
+		WarmupSkippedEmpty,
+		WarmupSkippedBelowThreshold,
+	}
+
+	readAll := func() map[WarmupOutcome]float64 {
+		counts := make(map[WarmupOutcome]float64, len(outcomes))
+		for _, outcome := range outcomes {
+			counts[outcome] = testutil.ToFloat64(
+				m.LazyShardWarmupDecisions.WithLabelValues(string(outcome)))
+		}
+		return counts
+	}
+
+	for _, recorded := range outcomes {
+		t.Run(string(recorded), func(t *testing.T) {
+			before := readAll()
+
+			m.RecordWarmupOutcome(recorded)
+
+			after := readAll()
+			for _, outcome := range outcomes {
+				want := before[outcome]
+				if outcome == recorded {
+					want++
+				}
+				assert.Equal(t, want, after[outcome], "outcome %q", outcome)
+			}
+		})
+	}
+}
+
+// TestRecordWarmupOutcomeToleratesNilMetrics covers an index built without
+// monitoring, which passes nil here.
+func TestRecordWarmupOutcomeToleratesNilMetrics(t *testing.T) {
+	var nilMetrics *PrometheusMetrics
+
+	assert.NotPanics(t, func() {
+		nilMetrics.RecordWarmupOutcome(WarmupLoaded)
+	})
+}

--- a/usecases/monitoring/shards_test.go
+++ b/usecases/monitoring/shards_test.go
@@ -239,7 +239,8 @@ func TestWarmupOutcomeCountsOnItsOwnSeries(t *testing.T) {
 	outcomes := []WarmupOutcome{
 		WarmupLoaded,
 		WarmupFailed,
-		WarmupSkippedNotCold,
+		WarmupSkippedShardGone,
+		WarmupSkippedAlreadyLoaded,
 		WarmupSkippedEmpty,
 		WarmupSkippedBelowThreshold,
 	}


### PR DESCRIPTION
### What's being changed:

Adds `LAZY_LOAD_SHARD_WARMUP_MIN_OBJECTS` to control the background sweep that loads lazy shards after startup, plus the observability to tell what the sweep actually did.

| Value | Effect |
|---|---|
| `< 0` | Sweep is off entirely — lazy shards load only on first access |
| `0` (default) | Unchanged behavior: warm every hot shard, minus empty tenant shards of an MT collection |
| `> 0` | Warm only shards holding strictly more than N objects, counted from **flushed** segments |

It only applies where lazy loading is active; eager collections ignore it and still load everything. A non-zero value logs a startup warning naming the consequences, because a HOT tenant left cold and never touched stays unloaded indefinitely: the TTL sweep won't delete its expired objects, async replication won't repair a stale replica of it, and `MAXIMUM_ALLOWED_OBJECTS_COUNT` stops counting it (so the node admits writes past its cap). Any loaded-shards-only reader is affected — that list isn't exhaustive.

**Sweep rework** (`Index.initAndStoreShards`)

- The load/skip decision (`warmupCandidate`) now runs *before* the one-second tick, so skipped shards don't consume pacing.
- `allShardsReady` is now stored on every exit path — sweep disabled, index closing, or load failure. It previously implied "all shards loaded"; it now only means "the sweep is over". Without this, `observeObjectCount` would publish no node-wide object count for the whole node.
- `LazyLoadShard.loadIfCold` reports whether *this* call performed the load, so a shard a request grabbed first is counted as skipped rather than loaded.

**Observability**

- New counter `weaviate_lazy_shard_warmup_decisions_total{outcome}` — `loaded`, `failed`, `skipped_shard_gone`, `skipped_already_loaded`, `skipped_empty`, `skipped_below_threshold`.
- Sweep summary log carries the per-outcome tally and the class; index build logs `background_warmup` / `warmup_min_objects`.
- Usage reports gain `lazy_unloaded` on `ShardUsage`, separating an active tenant sitting cold from one serving requests — both report the same status today. Related: `Status` moved out of the computed-usage paths into `usageForShard`, because unloaded usage is persisted to disk and reused, and a tenant deactivated later would otherwise keep serving a stale status.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
