### PR TITLE
Cache object count for lazy shards

### DIFF
--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -57,9 +57,13 @@ import (
 )
 
 type LazyLoadShard struct {
-	shardOpts        *deferredShardOpts
-	shard            *Shard
-	loaded           bool
+	shardOpts *deferredShardOpts
+	shard     *Shard
+	loaded    bool
+	// unloadedCount caches the object count read off disk while the shard is
+	// cold, which a cold shard cannot change without loading first. nil means
+	// not read yet; Load clears it.
+	unloadedCount    *int64
 	mutex            sync.Mutex
 	memMonitor       memwatch.AllocChecker
 	shardLoadLimiter *loadlimiter.LoadLimiter
@@ -141,6 +145,11 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	if class == nil {
 		class = l.shardOpts.class
 	}
+
+	// NewShard writes the segment sidecars a cold count reads and recovers the
+	// write-ahead log into segments, so the cached cold count is stale from here
+	// on — including when the load fails partway and leaves the shard cold.
+	l.unloadedCount = nil
 
 	shard, err := NewShard(ctx, l.shardOpts.promMetrics, l.shardOpts.name, l.shardOpts.index,
 		class, l.shardOpts.jobQueueCh, l.shardOpts.scheduler,
@@ -250,17 +259,30 @@ func (l *LazyLoadShard) ObjectCount(ctx context.Context) (int, error) {
 
 func (l *LazyLoadShard) ObjectCountAsync(ctx context.Context) (int64, error) {
 	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	if l.loaded {
-		l.mutex.Unlock()
 		return l.shard.ObjectCountAsync(ctx)
 	}
-	l.mutex.Unlock()
+	if l.unloadedCount != nil {
+		return *l.unloadedCount, nil
+	}
+
+	// The disk read stays under the lock: a load writes segment sidecars and
+	// recovers the write-ahead log, so a read overlapping one can sum a mix of
+	// old and new segments and then cache the result. Everything else on this
+	// shard waits for one directory listing. A failed read caches nothing, so a
+	// shard whose sidecars stay unreadable repeats that listing on every call.
 	idx := l.shardOpts.index
 	objectUsage, err := shardusage.CalculateUnloadedObjectsMetrics(idx.logger, idx.path(), l.shardOpts.name, true)
 	if err != nil {
 		return 0, fmt.Errorf("error while getting object count for shard %s: %w", l.shardOpts.name, err)
 	}
-	return objectUsage.Count, nil
+
+	count := objectUsage.Count
+	l.unloadedCount = &count
+
+	return count, nil
 }
 
 func (l *LazyLoadShard) GetPropertyLengthTracker() *inverted.JsonShardMetaData {

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -14,8 +14,13 @@ package db
 import (
 	"context"
 	"errors"
+	"os"
+	"path"
 	"testing"
+	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -24,6 +29,7 @@ import (
 	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -352,6 +358,200 @@ func TestGetOrInitShard_InitFailureNamesShard(t *testing.T) {
 	require.ErrorContains(t, err, `init local shard "uninitialized-shard"`)
 	require.ErrorContains(t, err, f.index.ID())
 	require.ErrorContains(t, err, "memory pressure")
+}
+
+// awaitStartupWarmup waits out the background sweep that loads a lazy
+// collection's shards one per second after startup, and shuts down whatever it
+// loaded so every shard is cold again. The sweep walks each shard once, so
+// nothing loads behind a test that waited for it here.
+func (f *addPropertyLazyFixture) awaitStartupWarmup(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, f.index.allShardsReady.Load, 30*time.Second, 20*time.Millisecond,
+		"the startup sweep should finish")
+
+	f.index.shards.Range(func(name string, shard ShardLike) error {
+		lazyShard, ok := shard.(*LazyLoadShard)
+		require.True(t, ok, "shard should be a LazyLoadShard")
+		if lazyShard.isLoaded() {
+			require.NoError(t, lazyShard.Shutdown(testCtx()), "shard %q should go cold again", name)
+		}
+		return nil
+	})
+}
+
+// coldTestObject builds an object for the class newClassWithWarmProp defines.
+func coldTestObject(className string) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:         strfmt.UUID(uuid.NewString()),
+			Class:      className,
+			Properties: map[string]interface{}{"warm": "object count fixture"},
+		},
+	}
+}
+
+// writeCountedObjects writes n objects and returns the shard cold with them in a
+// segment a cold count can read: flushing while the shard runs writes each new
+// segment's sidecar, and the count comes from those sidecars.
+func writeCountedObjects(t *testing.T, shard *LazyLoadShard, className string, n int) {
+	t.Helper()
+	ctx := testCtx()
+	require.NoError(t, shard.Load(ctx))
+	for range n {
+		require.NoError(t, shard.PutObject(ctx, coldTestObject(className)))
+	}
+	require.NoError(t, shard.Store().FlushMemtables(ctx))
+	require.NoError(t, shard.Shutdown(ctx))
+	require.False(t, shard.isLoaded(), "shard %q should be cold again", shard.Name())
+}
+
+// writeUncountedObjects writes n objects and returns the shard cold with them in
+// a segment a cold count cannot read: the shutdown flush writes the segment but
+// not the sidecar holding its object count, which the next load derives.
+func writeUncountedObjects(t *testing.T, shard *LazyLoadShard, className string, n int) {
+	t.Helper()
+	ctx := testCtx()
+	require.NoError(t, shard.Load(ctx))
+	for range n {
+		require.NoError(t, shard.PutObject(ctx, coldTestObject(className)))
+	}
+	require.NoError(t, shard.Shutdown(ctx))
+	require.False(t, shard.isLoaded(), "shard %q should be cold again", shard.Name())
+}
+
+// A cold shard answers ObjectCountAsync by listing its objects directory and
+// reading a sidecar per segment. nodeWideMetricsObserver asks every shard every
+// 30 seconds, and a cold shard cannot move that number without loading first,
+// so the answer is cached.
+func TestLazyLoadShard_ObjectCountAsyncCachesColdCount(t *testing.T) {
+	ctx := testCtx()
+	const className = "ColdObjectCount"
+
+	cases := []struct {
+		name    string
+		objects int
+	}{
+		{name: "empty shard"},
+		{name: "single object", objects: 1},
+		{name: "many objects", objects: 7},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAddPropertyLazyFixture(t, className, singleShardState())
+			f.awaitStartupWarmup(t)
+
+			for name, shard := range f.coldShards(t) {
+				writeCountedObjects(t, shard, className, tc.objects)
+
+				first, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err)
+				require.EqualValues(t, tc.objects, first, "cold read must count what shard %q has on disk", name)
+
+				// A second disk read cannot succeed once the objects directory is gone, so
+				// any answer at all proves the count came from the cache.
+				require.NoError(t, os.RemoveAll(path.Join(shard.pathLSM(), helpers.ObjectsBucketLSM)))
+
+				second, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err, "shard %q re-read the objects directory", name)
+				require.EqualValues(t, tc.objects, second)
+			}
+		})
+	}
+}
+
+// breakProplenTracker makes the shard's next load fail after NewShard has
+// already opened the objects bucket and written its segment sidecars, by
+// putting a directory where initProplenTracker expects a file.
+func breakProplenTracker(t *testing.T, shard *LazyLoadShard) {
+	t.Helper()
+	plPath := path.Join(path.Dir(shard.pathLSM()), "proplengths")
+	require.NoError(t, os.RemoveAll(plPath))
+	require.NoError(t, os.Mkdir(plPath, os.ModePerm))
+}
+
+// A load writes the segment sidecars a cold count reads, so the count cached
+// before it is stale — even when the load fails partway and leaves the shard
+// cold. A load that fails before reaching NewShard has touched nothing, so the
+// cache still holds.
+func TestLazyLoadShard_LoadInvalidatesCachedColdCount(t *testing.T) {
+	ctx := testCtx()
+	const (
+		className = "ColdObjectCountInvalidation"
+		counted   = 5 // objects a cold read counts, because their segment has its sidecar
+		uncounted = 3 // objects whose segment gets its sidecar only at the next load
+	)
+
+	cases := []struct {
+		name      string
+		breakLoad func(t *testing.T, shard *LazyLoadShard)
+		wantErr   bool
+		// wantCached asserts the answer came from the cache, not from disk.
+		wantCached bool
+		wantCount  int64
+	}{
+		{
+			name:      "load succeeds",
+			breakLoad: func(*testing.T, *LazyLoadShard) {},
+			wantCount: counted + uncounted,
+		},
+		{
+			name:      "load fails after touching disk",
+			breakLoad: breakProplenTracker,
+			wantErr:   true,
+			wantCount: counted + uncounted,
+		},
+		{
+			name: "load fails before touching disk",
+			breakLoad: func(_ *testing.T, shard *LazyLoadShard) {
+				shard.memMonitor = failingAllocChecker{}
+			},
+			wantErr:    true,
+			wantCached: true,
+			wantCount:  counted,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newAddPropertyLazyFixture(t, className, singleShardState())
+			f.awaitStartupWarmup(t)
+
+			for name, shard := range f.coldShards(t) {
+				writeCountedObjects(t, shard, className, counted)
+				writeUncountedObjects(t, shard, className, uncounted)
+
+				cold, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err)
+				require.EqualValues(t, counted, cold,
+					"shard %q counts the segments whose sidecar is on disk", name)
+
+				tc.breakLoad(t, shard)
+				loadErr := shard.Load(ctx)
+				if tc.wantErr {
+					require.Error(t, loadErr)
+				} else {
+					require.NoError(t, loadErr)
+				}
+
+				// Go cold again, so the next count comes from the cold path rather than
+				// from the loaded shard.
+				require.NoError(t, shard.Shutdown(ctx))
+
+				if tc.wantCached {
+					// A disk read cannot succeed once the objects directory is gone, so
+					// any answer at all proves the cache survived the failed load.
+					require.NoError(t, os.RemoveAll(path.Join(shard.pathLSM(), helpers.ObjectsBucketLSM)))
+				}
+
+				count, err := shard.ObjectCountAsync(ctx)
+				require.NoError(t, err)
+				require.EqualValues(t, tc.wantCount, count,
+					"cold count for shard %q after the load attempt", name)
+			}
+		})
+	}
 }
 
 // Resuming maintenance cycles after a backup must not force-load cold shards:


### PR DESCRIPTION
### What's being changed:

LazyLoadShard.ObjectCountAsync answers for a cold shard by reading the data from disk. nodeWideMetricsObserver
walks every shard on the node every 30s. So every cold shard paid a full directory listing plus one file read per segment, forever, for a number that cannot change.

This PR adds caching of the object count that is cleared when the lazy shard is actually loaded.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
