### PR TITLE
fix(modulecomponents): skip nil images when an object lacks the requested image property

### DIFF
--- a/modules/generative-cohere/clients/cohere_test.go
+++ b/modules/generative-cohere/clients/cohere_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
+	cohereparams "github.com/weaviate/weaviate/modules/generative-cohere/parameters"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -199,4 +200,57 @@ func (f fakeClassConfig) PropertiesDataTypes() map[string]schema.DataType {
 
 func (f fakeClassConfig) Config() *config.Config {
 	return nil
+}
+
+func TestGenerateWithMissingImageProperty(t *testing.T) {
+	earth := "earth-base64"
+
+	tests := []struct {
+		name             string
+		imageProperties  []string
+		props            []*modulecapabilities.GenerateProperties
+		expectedContents int
+	}{
+		{
+			name:             "requested property is absent from the object",
+			imageProperties:  []string{"thumbnail"},
+			props:            []*modulecapabilities.GenerateProperties{{Text: map[string]string{"prop": "value"}, Blob: map[string]*string{"image": &earth}}},
+			expectedContents: 1,
+		},
+		{
+			name:            "one of two objects is missing the property",
+			imageProperties: []string{"image"},
+			props: []*modulecapabilities.GenerateProperties{
+				{Text: map[string]string{"prop": "value"}, Blob: map[string]*string{"image": &earth}},
+				{Text: map[string]string{"prop": "other"}, Blob: map[string]*string{"other": &earth}},
+			},
+			expectedContents: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPayload generateInput
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				require.NoError(t, json.Unmarshal(body, &gotPayload))
+				w.Write([]byte(`{"message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}`))
+			}))
+			defer server.Close()
+
+			c := New("apiKey", time.Minute, nullLogger())
+			_, err := c.GenerateAllResults(context.Background(), tt.props, "task",
+				cohereparams.Params{ImageProperties: tt.imageProperties}, false, &fakeClassConfig{baseURL: server.URL})
+			require.NoError(t, err)
+
+			require.Len(t, gotPayload.Messages, 1)
+			assert.Len(t, gotPayload.Messages[0].Content, tt.expectedContents)
+			for _, c := range gotPayload.Messages[0].Content {
+				if c.Type == contentTypeImageUrl {
+					require.NotNil(t, c.ImageURL)
+					assert.NotContains(t, c.ImageURL.URL, "base64,%!s(*string=<nil>)")
+				}
+			}
+		})
+	}
 }

--- a/modules/generative-openai/clients/openai_test.go
+++ b/modules/generative-openai/clients/openai_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
@@ -274,4 +275,61 @@ func TestOpenAIApiErrorDecode(t *testing.T) {
 
 func ptString(in string) *string {
 	return &in
+}
+
+func TestGenerateWithMissingImageProperty(t *testing.T) {
+	earth := "earth-base64"
+
+	tests := []struct {
+		name          string
+		imageProps    []string
+		props         []*modulecapabilities.GenerateProperties
+		expectedParts int
+	}{
+		{
+			name:          "requested property is absent from the object",
+			imageProps:    []string{"thumbnail"},
+			props:         []*modulecapabilities.GenerateProperties{{Text: map[string]string{"prop": "value"}, Blob: map[string]*string{"image": &earth}}},
+			expectedParts: 0,
+		},
+		{
+			name:       "one of two objects is missing the property",
+			imageProps: []string{"image"},
+			props: []*modulecapabilities.GenerateProperties{
+				{Text: map[string]string{"prop": "value"}, Blob: map[string]*string{"image": &earth}},
+				{Text: map[string]string{"prop": "other"}, Blob: map[string]*string{"other": &earth}},
+			},
+			expectedParts: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotPayload map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				require.NoError(t, json.Unmarshal(body, &gotPayload))
+				w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+			}))
+			defer server.Close()
+
+			c := New("openAIApiKey", "", "", time.Minute, nullLogger())
+			c.buildUrl = func(isLegacy, isAzure bool, resourceName, deploymentID, baseURL, apiVersion string) (string, error) {
+				return fakeBuildUrl(server.URL, isAzure, isLegacy, resourceName, deploymentID, baseURL, apiVersion)
+			}
+
+			_, err := c.GenerateAllResults(context.Background(), tt.props, "task",
+				openaiparams.Params{Model: "gpt-4o", ImageProperties: tt.imageProps}, false, nil)
+			require.NoError(t, err)
+
+			messages := gotPayload["messages"].([]any)
+			require.Len(t, messages, 1)
+			content := messages[0].(map[string]any)["content"]
+			if tt.expectedParts == 0 {
+				assert.Equal(t, `task: [{"prop":"value"}]`, content)
+				return
+			}
+			assert.Len(t, content, tt.expectedParts)
+		})
+	}
 }

--- a/usecases/modulecomponents/generative/generative.go
+++ b/usecases/modulecomponents/generative/generative.go
@@ -58,7 +58,10 @@ func ParseImageProperties(inputBase64Images []*string, inputImagePropertyNames [
 	if len(storedBase64ImagesArray) > 0 {
 		for _, storedBase64Images := range storedBase64ImagesArray {
 			for _, inputImagePropertyName := range inputImagePropertyNames {
-				images = append(images, storedBase64Images[inputImagePropertyName])
+				// An object that does not carry the requested property contributes no image.
+				if image := storedBase64Images[inputImagePropertyName]; image != nil {
+					images = append(images, image)
+				}
 			}
 		}
 	}

--- a/usecases/modulecomponents/generative/generative_test.go
+++ b/usecases/modulecomponents/generative/generative_test.go
@@ -28,3 +28,60 @@ func Test_MakeSinglePrompt(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, "Create a story based on \"A Grand Day Out\"", prompt)
 }
+
+func Test_ParseImageProperties(t *testing.T) {
+	earth, mars := "earth-base64", "mars-base64"
+
+	tests := []struct {
+		name           string
+		inputImages    []*string
+		propertyNames  []string
+		storedImages   []map[string]*string
+		expectedImages []*string
+	}{
+		{
+			name:           "no images at all",
+			expectedImages: []*string{},
+		},
+		{
+			name:           "user provided images only",
+			inputImages:    []*string{&earth},
+			expectedImages: []*string{&earth},
+		},
+		{
+			name:           "stored image resolved by property name",
+			propertyNames:  []string{"image"},
+			storedImages:   []map[string]*string{{"image": &earth}},
+			expectedImages: []*string{&earth},
+		},
+		{
+			name:           "requested property is not present on the object",
+			propertyNames:  []string{"thumbnail"},
+			storedImages:   []map[string]*string{{"image": &earth}},
+			expectedImages: []*string{},
+		},
+		{
+			name:           "one of several objects is missing the property",
+			propertyNames:  []string{"image"},
+			storedImages:   []map[string]*string{{"image": &earth}, {"other": &mars}},
+			expectedImages: []*string{&earth},
+		},
+		{
+			name:           "stored images come before user provided ones",
+			inputImages:    []*string{&mars},
+			propertyNames:  []string{"image"},
+			storedImages:   []map[string]*string{{"image": &earth}},
+			expectedImages: []*string{&earth, &mars},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			images := ParseImageProperties(tt.inputImages, tt.propertyNames, tt.storedImages)
+			require.Equal(t, tt.expectedImages, images)
+			for i := range images {
+				require.NotNil(t, images[i], "image at index %d must not be nil", i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

`ParseImageProperties` appended a `nil` entry whenever a requested image property was missing from an object's blob map — e.g. `imageProperties: ["image", "thumbnail"]` where only some objects carry `thumbnail`, or a property name that is not a blob at all.

`generative-openai` and `generative-cohere` dereference those pointers directly, so an ordinary user query panics the node. `generative-anthropic`, `-aws`, `-google` and `-ollama` pass them through and send a JSON `null` to the provider.

Fixed at the source: an object that does not carry the requested property now contributes no image.

Tests: a table over the helper, plus one regression test each in the openai and cohere clients. All three fail without the fix (two by panic).

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
