### PR TITLE
test(generative-aws): remove Cohere's Command-R models from tests

### DIFF
--- a/test/modules/generative-aws/generative_aws_test.go
+++ b/test/modules/generative-aws/generative_aws_test.go
@@ -81,15 +81,6 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 				generativeModel: "anthropic.claude-3-haiku-20240307-v1:0",
 				withImages:      true,
 			},
-			// Cohere
-			{
-				name:            "cohere.command-r-v1:0",
-				generativeModel: "cohere.command-r-v1:0",
-			},
-			{
-				name:            "cohere.command-r-plus-v1:0",
-				generativeModel: "cohere.command-r-plus-v1:0",
-			},
 			// Meta
 			{
 				name:            "meta.llama3-8b-instruct-v1:0",


### PR DESCRIPTION
### What's being changed:

This PR removes Cohere's Command-R models from tests, they reach EOL, there no replacements for those models yet available in AWS Bedrock, so removing all of them.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
