### PR TITLE
fix(lsmkv): give test SegmentGroups a logger to stop slow-read nil panic

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -881,6 +881,7 @@ func TestBucketReplaceStrategyConsistentView(t *testing.T) {
 	ctx := context.Background()
 
 	diskSegments := &SegmentGroup{
+		logger:   nullLogger(),
 		strategy: StrategyReplace,
 		segments: []Segment{
 			newFakeReplaceSegment(map[string][]byte{
@@ -1029,6 +1030,7 @@ func TestBucketReplaceStrategyWriteVsFlush(t *testing.T) {
 			"key1": []byte("value1"),
 		}),
 		disk: &SegmentGroup{
+			logger:   nullLogger(),
 			strategy: StrategyReplace,
 			segments: []Segment{},
 		},

--- a/adapters/repos/db/lsmkv/segment_group_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_test.go
@@ -81,6 +81,7 @@ func TestSegmentGroup_Replace_ConsistentViewAcrossSegmentAddition(t *testing.T) 
 		"key1": []byte("value1"),
 	}
 	sg := &SegmentGroup{
+		logger:   nullLogger(),
 		strategy: StrategyReplace,
 		segments: []Segment{newFakeReplaceSegment(segmentData)},
 	}
@@ -770,6 +771,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			"key1": []byte("value1"),
 		}
 		sg := &SegmentGroup{
+			logger:   nullLogger(),
 			strategy: StrategyReplace,
 			segments: []Segment{newFakeReplaceSegment(segmentData)},
 		}
@@ -786,6 +788,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			"key1": []byte("value1"),
 		}
 		sg := &SegmentGroup{
+			logger:   nullLogger(),
 			strategy: StrategyReplace,
 			segments: []Segment{newFakeReplaceSegment(segmentData)},
 		}
@@ -807,6 +810,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			"key1": []byte("new-value"),
 		})
 		sg := &SegmentGroup{
+			logger:   nullLogger(),
 			strategy: StrategyReplace,
 			segments: []Segment{seg1, seg2}, // seg2 is newer (higher index)
 		}
@@ -823,6 +827,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			"key1": []byte("value1"),
 		}
 		sg := &SegmentGroup{
+			logger:   nullLogger(),
 			strategy: StrategyReplace,
 			segments: []Segment{newFakeReplaceSegment(segmentData)},
 		}
@@ -851,6 +856,7 @@ func TestSegmentGroup_ExistsWithSegmentList(t *testing.T) {
 			"key2": []byte("value2"),
 		})
 		sg := &SegmentGroup{
+			logger:   nullLogger(),
 			strategy: StrategyReplace,
 			segments: []Segment{seg1, seg2},
 		}


### PR DESCRIPTION
### What's being changed:

Fixes panic:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered, repanicked]
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd8 pc=0x1518c10]

goroutine 4810 [running]:
testing.tRunner.func1.2({0x19586a0, 0x273a1f0})
	/opt/hostedtoolcache/go/1.26.7/x64/src/testing/testing.go:1974 +0x419
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.26.7/x64/src/testing/testing.go:1977 +0x67f
panic({0x19586a0?, 0x273a1f0?})
	/opt/hostedtoolcache/go/1.26.7/x64/src/runtime/panic.go:860 +0x13a
github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*SegmentGroup).getWithSegmentList(0xc000727380, {0xc000bc99b8, 0x4, 0x8}, {0xc0003bfc40, 0x1, 0x0?})
	/home/runner/work/weaviate/weaviate/adapters/repos/db/lsmkv/segment_group.go:775 +0x390
github.com/weaviate/weaviate/adapters/repos/db/lsmkv.TestBucketReplaceStrategyWriteVsFlush(0xc0003fcfc8)
	/home/runner/work/weaviate/weaviate/adapters/repos/db/lsmkv/bucket_test.go:1083 +0xdfd
testing.tRunner(0xc0003fcfc8, 0x1b76bf0)
	/opt/hostedtoolcache/go/1.26.7/x64/src/testing/testing.go:2036 +0x21d
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.26.7/x64/src/testing/testing.go:2101 +0xb13
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
