### PR TITLE
fix(db): report tenant activity status for inactive shards in getShardsStatus (fix #12764)

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4166,6 +4166,20 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 				}
 			}
 
+			if len(perNodeStatus) == 0 {
+				_ = i.schemaReader.Read(className, true, func(_ *models.Class, state *sharding.State) error {
+					if state != nil {
+						if physical, ok := state.Physical[shardName]; ok && physical.Status != "" {
+							for _, nodeName := range replicas {
+								perNodeStatus[nodeName] = physical.Status
+							}
+							oneNodeStatus.Store(physical.Status)
+						}
+					}
+					return nil
+				})
+			}
+
 			mu.Lock()
 			shardsStatus[shardName] = perNodeStatus
 			if s, ok := oneNodeStatus.Load().(string); ok {
@@ -4187,9 +4201,23 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 	if err != nil {
 		return "", err
 	}
-	defer release()
+	if release != nil {
+		defer release()
+	}
 
 	if shard == nil {
+		var tenantStatus string
+		_ = i.schemaReader.Read(i.Config.ClassName.String(), true, func(_ *models.Class, state *sharding.State) error {
+			if state != nil {
+				if physical, ok := state.Physical[shardName]; ok {
+					tenantStatus = physical.Status
+				}
+			}
+			return nil
+		})
+		if tenantStatus != "" {
+			return tenantStatus, nil
+		}
 		return "", fmt.Errorf("local %s shard not found", shardName)
 	}
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4209,14 +4209,16 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 
 	if shard == nil {
 		var tenantStatus string
-		_ = i.schemaReader.Read(i.Config.ClassName.String(), true, func(_ *models.Class, state *sharding.State) error {
+		if err := i.schemaReader.Read(i.Config.ClassName.String(), true, func(_ *models.Class, state *sharding.State) error {
 			if state != nil {
 				if physical, ok := state.Physical[shardName]; ok {
 					tenantStatus = physical.Status
 				}
 			}
 			return nil
-		})
+		}); err != nil {
+			return "", err
+		}
 		if tenantStatus != "" {
 			return tenantStatus, nil
 		}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4167,7 +4167,7 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 			}
 
 			if len(perNodeStatus) == 0 {
-				_ = i.schemaReader.Read(className, true, func(_ *models.Class, state *sharding.State) error {
+				if err := i.schemaReader.Read(className, true, func(_ *models.Class, state *sharding.State) error {
 					if state != nil {
 						if physical, ok := state.Physical[shardName]; ok && physical.Status != "" {
 							for _, nodeName := range replicas {
@@ -4177,7 +4177,9 @@ func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]
 						}
 					}
 					return nil
-				})
+				}); err != nil {
+					return err
+				}
 			}
 
 			mu.Lock()

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -467,6 +467,98 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	require.Equal(t, wantLegacy, gotLegacy, "legacy statuses")
 }
 
+func TestIndex_getShardsStatusFallback(t *testing.T) {
+	const (
+		className = "Songs"
+		shardName = "shard-0"
+		localNode = "node-0"
+	)
+	fallbackStatus := "COLD"
+	fallbackErr := errors.New("schema read failed")
+
+	tests := []struct {
+		name           string
+		replicas       []string
+		remoteStatuses map[string]string
+		readErr        error
+		wantStatus     string
+		wantErr        error
+	}{
+		{
+			name:       "local shard missing uses physical status",
+			replicas:   []string{localNode},
+			wantStatus: fallbackStatus,
+		},
+		{
+			name:           "all remote replicas unavailable uses physical status",
+			replicas:       []string{"node-1", "node-2"},
+			remoteStatuses: map[string]string{"node-1": NodeUnresponsive, "node-2": NodeUnresponsive},
+			wantStatus:     fallbackStatus,
+		},
+		{
+			name:     "physical status read error is returned",
+			replicas: []string{localNode},
+			readErr:  fallbackErr,
+			wantErr:  fallbackErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			schemaReader := schemaUC.NewMockSchemaReader(t)
+			schemaReader.EXPECT().Shards(className).Return([]string{shardName}, nil)
+			schemaReader.EXPECT().ShardReplicas(className, shardName).Return(tt.replicas, nil)
+			schemaReader.EXPECT().Read(className, true, mock.Anything).RunAndReturn(
+				func(_ string, _ bool, reader func(*models.Class, *sharding.State) error) error {
+					if tt.readErr != nil {
+						return tt.readErr
+					}
+					return reader(nil, &sharding.State{Physical: map[string]sharding.Physical{
+						shardName: {Name: shardName, Status: fallbackStatus},
+					}})
+				},
+			)
+
+			var replicas []types.Replica
+			for _, nodeName := range tt.replicas {
+				replicas = append(replicas, types.Replica{ShardName: shardName, NodeName: nodeName, HostAddr: nodeName})
+			}
+			nodeResolver := cluster.NewMockNodeResolver(t)
+			nodeResolver.EXPECT().NodeHostname(mock.Anything).
+				RunAndReturn(func(nodeName string) (string, bool) { return nodeName, true }).Maybe()
+			index := Index{
+				Config:           IndexConfig{ClassName: schema.ClassName(className), ReplicationFactor: 2},
+				getSchema:        &fakeSchemaGetter{nodeName: localNode},
+				schemaReader:     schemaReader,
+				shardCreateLocks: esync.NewKeyRWLocker(),
+				router:           &fakeRouter{readSet: types.ReadReplicaSet{Replicas: replicas}},
+				replicator:       &replica.Replicator{Finder: replica.NewFinder(className, nil, nil, localNode, nil, nil, logger, nil)},
+				logger:           logger,
+			}
+			index.remote = sharding.NewRemoteIndex(
+				className,
+				index.getSchema,
+				nodeResolver,
+				&FakeRemoteClient{shardStatus: map[string]map[string]string{shardName: tt.remoteStatuses}},
+			)
+
+			got, gotLegacy, err := index.getShardsStatus(t.Context(), "")
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			want := map[string]string{}
+			for _, nodeName := range tt.replicas {
+				want[nodeName] = fallbackStatus
+			}
+			require.Equal(t, map[string]map[string]string{shardName: want}, got)
+			require.Equal(t, map[string]string{shardName: fallbackStatus}, gotLegacy)
+		})
+	}
+}
+
 // TestIndex_ShardHasMultipleReplicasWrite_RoutesThroughReplicatorDuringMovement pins the
 // rf=1 scale-out lost-write fix: while a replica movement is active for the shard, a write
 // must be routed through the replicator (so it registers in the in-flight fence and the

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -490,6 +490,11 @@ func TestIndex_getShardsStatusFallback(t *testing.T) {
 			wantStatus: fallbackStatus,
 		},
 		{
+			name:       "local shard missing uses physical hot status",
+			replicas:   []string{localNode},
+			wantStatus: "HOT",
+		},
+		{
 			name:           "all remote replicas unavailable uses physical status",
 			replicas:       []string{"node-1", "node-2"},
 			remoteStatuses: map[string]string{"node-1": NodeUnresponsive, "node-2": NodeUnresponsive},
@@ -515,7 +520,7 @@ func TestIndex_getShardsStatusFallback(t *testing.T) {
 						return tt.readErr
 					}
 					return reader(nil, &sharding.State{Physical: map[string]sharding.Physical{
-						shardName: {Name: shardName, Status: fallbackStatus},
+						shardName: {Name: shardName, Status: tt.wantStatus},
 					}})
 				},
 			)
@@ -551,10 +556,59 @@ func TestIndex_getShardsStatusFallback(t *testing.T) {
 			require.NoError(t, err)
 			want := map[string]string{}
 			for _, nodeName := range tt.replicas {
-				want[nodeName] = fallbackStatus
+				want[nodeName] = tt.wantStatus
 			}
 			require.Equal(t, map[string]map[string]string{shardName: want}, got)
 			require.Equal(t, map[string]string{shardName: fallbackStatus}, gotLegacy)
+		})
+	}
+}
+
+func TestIndex_IncomingGetShardStatusFallback(t *testing.T) {
+	const (
+		className = "Songs"
+		shardName = "shard-0"
+	)
+	fallbackErr := errors.New("schema read failed")
+
+	tests := []struct {
+		name       string
+		status     string
+		readErr    error
+		wantStatus string
+		wantErr    error
+	}{
+		{name: "cold shard", status: "COLD", wantStatus: "COLD"},
+		{name: "hot shard", status: "HOT", wantStatus: "HOT"},
+		{name: "schema read error", readErr: fallbackErr, wantErr: fallbackErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemaReader := schemaUC.NewMockSchemaReader(t)
+			schemaReader.EXPECT().Read(className, true, mock.Anything).RunAndReturn(
+				func(_ string, _ bool, reader func(*models.Class, *sharding.State) error) error {
+					if tt.readErr != nil {
+						return tt.readErr
+					}
+					return reader(nil, &sharding.State{Physical: map[string]sharding.Physical{
+						shardName: {Name: shardName, Status: tt.status},
+					}})
+				},
+			)
+			index := Index{
+				Config:           IndexConfig{ClassName: schema.ClassName(className)},
+				schemaReader:     schemaReader,
+				shardCreateLocks: esync.NewKeyRWLocker(),
+			}
+
+			got, err := index.IncomingGetShardStatus(t.Context(), shardName)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantStatus, got)
 		})
 	}
 }


### PR DESCRIPTION
Fixes #12764

### Problem
In multi-tenant collections with INACTIVE/cold tenants, GET /v1/schema/{class}/shards (and getShardsStatus) failed with HTTP 500 (local shard not found) because the unloaded tenant shard was not present in runtime memory across nodes, aborting the whole shard listing.

### Solution
- In dapters/repos/db/index.go: When no node reports a runtime active shard for a tenant in getShardsStatus, fall back to checking the schema's sharding state for the tenant's Physical.Status (e.g. COLD/INACTIVE), reporting its activity status gracefully without failing the endpoint.
- In IncomingGetShardStatus: Fall back to checking Physical.Status from sharding state if local shard is nil before erroring.