### PR TITLE
reindex: durable migration record (part 1/2, inert)

### DIFF
--- a/adapters/handlers/rest/handlers_reindex.go
+++ b/adapters/handlers/rest/handlers_reindex.go
@@ -25,14 +25,14 @@ import (
 
 // buildUnitMaps creates per-replica unit IDs and maps from shard ownership.
 // ShardOwnership returns map[nodeName][]shardName (node→shards it owns).
-// Unit ID format: "shardName__nodeName".
+// Unit ID format is [db.MigrationUnitID]: "shardName__nodeName".
 func buildUnitMaps(shardOwnership map[string][]string) (unitIDs []string, unitToShard, unitToNode map[string]string) {
 	unitToShard = make(map[string]string)
 	unitToNode = make(map[string]string)
 
 	for nodeName, shards := range shardOwnership {
 		for _, shardName := range shards {
-			unitID := fmt.Sprintf("%s__%s", shardName, nodeName)
+			unitID := db.MigrationUnitID(shardName, nodeName)
 			unitIDs = append(unitIDs, unitID)
 			unitToShard[unitID] = shardName
 			unitToNode[unitID] = nodeName
@@ -298,7 +298,7 @@ func buildUnitSpecs(shardOwnership map[string][]string) []distributedtask.UnitSp
 	var specs []distributedtask.UnitSpec
 	for nodeName, shards := range shardOwnership {
 		for _, shardName := range shards {
-			unitID := fmt.Sprintf("%s__%s", shardName, nodeName)
+			unitID := db.MigrationUnitID(shardName, nodeName)
 			specs = append(specs, distributedtask.UnitSpec{
 				ID:      unitID,
 				GroupID: shardName,

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -137,22 +137,29 @@ func TestListInactiveLSMFiles(t *testing.T) {
 			},
 		},
 		{
-			name: "migrations tmp leftovers are excluded, checkpoints are not",
+			name: "migrations tmp leftovers are excluded, records and sentinels are not",
 			setup: func(t *testing.T, lsmDir string) {
 				trackerDir := filepath.Join(lsmDir, migrationsDir, "searchable_retokenize_text_1")
+				recordsDir := filepath.Join(lsmDir, migrationsDir, "records")
 				require.NoError(t, os.MkdirAll(trackerDir, 0o755))
-				for _, name := range []string{"started.mig", "properties.mig", "progress.mig.000000001"} {
+				require.NoError(t, os.MkdirAll(recordsDir, 0o755))
+				for _, name := range []string{
+					"payload.mig", "started.mig", "properties.mig", "progress.mig.000000001",
+				} {
 					require.NoError(t, os.WriteFile(filepath.Join(trackerDir, name), []byte("x"), 0o644))
 				}
+				require.NoError(t, os.WriteFile(
+					filepath.Join(recordsDir, "7_searchable_retokenize_shard-1__node-0.json"), []byte("{}"), 0o644))
 
-				// Same call the tracker's atomic properties.mig write makes, so
-				// the name carries the real random infix rather than one the
-				// test picked.
-				leftover, err := os.CreateTemp(trackerDir, "properties.mig.*.tmp")
+				// Same call the record store's atomic write makes, so the name
+				// carries the real random infix rather than one the test picked.
+				leftover, err := os.CreateTemp(recordsDir, "7_searchable_retokenize_shard-1__node-0.json.*.tmp")
 				require.NoError(t, err)
 				require.NoError(t, leftover.Close())
 			},
 			expected: []string{
+				filepath.Join(migrationsDir, "records", "7_searchable_retokenize_shard-1__node-0.json"),
+				filepath.Join(migrationsDir, "searchable_retokenize_text_1", "payload.mig"),
 				filepath.Join(migrationsDir, "searchable_retokenize_text_1", "progress.mig.000000001"),
 				filepath.Join(migrationsDir, "searchable_retokenize_text_1", "properties.mig"),
 				filepath.Join(migrationsDir, "searchable_retokenize_text_1", "started.mig"),

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler.go
@@ -68,10 +68,12 @@ func (r *migrationClusterReconciler) samplers() (unresolved, shuttingDown *logru
 func (r *migrationClusterReconciler) SetTaskSources(ctx context.Context, source MigrationLocalTaskSource,
 	cluster MigrationClusterTaskSource,
 ) {
-	r.mu.Lock()
-	r.local = source
-	r.cluster = cluster
-	r.mu.Unlock()
+	func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.local = source
+		r.cluster = cluster
+	}()
 
 	r.ReconcileLoaded(ctx)
 	r.periodicOnce.Do(func() {
@@ -197,9 +199,11 @@ func (r *migrationClusterReconciler) shardsWithUndecidedRecords() []migrationUnd
 }
 
 func (r *migrationClusterReconciler) LocalTasks() ([]*distributedtask.Task, bool) {
-	r.mu.RLock()
-	source := r.local
-	r.mu.RUnlock()
+	source := func() MigrationLocalTaskSource {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.local
+	}()
 
 	if source == nil {
 		return nil, false
@@ -211,9 +215,11 @@ func (r *migrationClusterReconciler) LocalTasks() ([]*distributedtask.Task, bool
 // unreachable leader cannot hold a pass open. The shard walk after it is
 // not bounded.
 func (r *migrationClusterReconciler) clusterTasksBounded(ctx context.Context) ([]*distributedtask.Task, error) {
-	r.mu.RLock()
-	source := r.cluster
-	r.mu.RUnlock()
+	source := func() MigrationClusterTaskSource {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		return r.cluster
+	}()
 
 	if source == nil {
 		return nil, fmt.Errorf("no cluster-wide reindex task source is installed on this node")

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler.go
@@ -63,8 +63,7 @@ func (r *migrationClusterReconciler) samplers() (unresolved, shuttingDown *logru
 }
 
 // SetTaskSources and the periodic pass run on different goroutines, so the
-// sources are guarded. The pass starts on the first call and only the first;
-// this PR makes none, as the cutover that installs the sources starts it.
+// sources are guarded; periodicOnce starts the pass on the first call only.
 func (r *migrationClusterReconciler) SetTaskSources(ctx context.Context, source MigrationLocalTaskSource,
 	cluster MigrationClusterTaskSource,
 ) {
@@ -117,11 +116,10 @@ func (r *migrationClusterReconciler) ReconcileLoaded(ctx context.Context) {
 	}
 }
 
-// Names, not shards: ForEachLoadedShard's loaded check is advisory, and
-// resolving a shard it already handed over calls Load, which has no shutdown
-// flag to refuse and would rebuild a deactivated tenant outside the shard map,
-// where nothing can ever shut it down. getLoadedShard holds the locks every
-// teardown takes across both the map read and the reference it takes, so a
+// Names, not shards: resolving a shard the walk already handed over would
+// call Load, which has no shutdown flag to refuse and would rebuild a
+// deactivated tenant outside the shard map, where nothing can ever shut it
+// down again. getLoadedShard takes the same locks every teardown does, so a
 // shard torn down since its name was collected reads as absent instead.
 func (r *migrationClusterReconciler) reconcileShard(ctx context.Context, idx *Index, name string,
 	tasks []*distributedtask.Task, unresolved, shuttingDown *logrusext.Sampler,

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler.go
@@ -1,0 +1,232 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/logrusext"
+)
+
+const migrationClusterQueryTimeout = 5 * time.Second
+
+const migrationClusterReconcileInterval = time.Minute
+
+// MigrationLocalTaskSource reads this node's own applied view of the reindex
+// task namespace. ok=false means "not installed", which licenses no discard.
+type MigrationLocalTaskSource func() ([]*distributedtask.Task, bool)
+
+// MigrationClusterTaskSource reads the reindex task namespace from the leader.
+type MigrationClusterTaskSource func(context.Context) ([]*distributedtask.Task, error)
+
+// migrationClusterReconciler decides this node's undecided migration records
+// against the leader's reindex task list.
+type migrationClusterReconciler struct {
+	db *DB
+
+	mu      sync.RWMutex
+	local   MigrationLocalTaskSource
+	cluster MigrationClusterTaskSource
+
+	samplersOnce sync.Once
+	unresolved   *logrusext.Sampler
+	shuttingDown *logrusext.Sampler
+
+	periodicOnce sync.Once
+}
+
+// A node drain fails preventShutdown on every loaded shard at once, and a
+// shard count is a tenant count, so one pass can reach these two lines once
+// per tenant. The pass repeats every interval, so the sampling windows have to
+// span passes: the samplers live on the reconciler, not on a call.
+func (r *migrationClusterReconciler) samplers() (unresolved, shuttingDown *logrusext.Sampler) {
+	r.samplersOnce.Do(func() {
+		r.unresolved = logrusext.NewSampler(r.db.logger, maxReportedErrors, migrationClusterReconcileInterval)
+		r.shuttingDown = logrusext.NewSampler(r.db.logger, maxReportedErrors, migrationClusterReconcileInterval)
+	})
+	return r.unresolved, r.shuttingDown
+}
+
+// SetTaskSources and the periodic pass run on different goroutines, so the
+// sources are guarded. The pass starts on the first call and only the first;
+// this PR makes none, as the cutover that installs the sources starts it.
+func (r *migrationClusterReconciler) SetTaskSources(ctx context.Context, source MigrationLocalTaskSource,
+	cluster MigrationClusterTaskSource,
+) {
+	r.mu.Lock()
+	r.local = source
+	r.cluster = cluster
+	r.mu.Unlock()
+
+	r.ReconcileLoaded(ctx)
+	r.periodicOnce.Do(func() {
+		enterrors.GoWrapper(func() { r.reconcilePeriodically(ctx) }, r.db.logger)
+	})
+}
+
+func (r *migrationClusterReconciler) reconcilePeriodically(ctx context.Context) {
+	ticker := time.NewTicker(migrationClusterReconcileInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.db.shutdown:
+			return
+		case <-ticker.C:
+			r.ReconcileLoaded(ctx)
+		}
+	}
+}
+
+func (r *migrationClusterReconciler) ReconcileLoaded(ctx context.Context) {
+	undecided := r.shardsWithUndecidedRecords()
+	if len(undecided) == 0 {
+		return
+	}
+	tasks, err := r.clusterTasksBounded(ctx)
+	if err != nil {
+		r.db.logger.WithField("action", "reindex_migration_reconcile").Warnf(
+			"the leader's reindex task list is unreachable; deciding nothing this pass: %v", err)
+		return
+	}
+
+	unresolved, shuttingDown := r.samplers()
+
+	for _, found := range undecided {
+		for _, name := range found.names {
+			r.reconcileShard(ctx, found.idx, name, tasks, unresolved, shuttingDown)
+		}
+	}
+}
+
+// Names, not shards: ForEachLoadedShard's loaded check is advisory, and
+// resolving a shard it already handed over calls Load, which has no shutdown
+// flag to refuse and would rebuild a deactivated tenant outside the shard map,
+// where nothing can ever shut it down. getLoadedShard holds the locks every
+// teardown takes across both the map read and the reference it takes, so a
+// shard torn down since its name was collected reads as absent instead.
+func (r *migrationClusterReconciler) reconcileShard(ctx context.Context, idx *Index, name string,
+	tasks []*distributedtask.Task, unresolved, shuttingDown *logrusext.Sampler,
+) {
+	shard, release, err := idx.getLoadedShard(name)
+	if err != nil {
+		shuttingDown.WithSampling(func(l logrus.FieldLogger) {
+			l.WithField("shard", name).Infof(
+				"skipping migration reconciliation on a shard that is shutting down: %v", err)
+		})
+		return
+	}
+	defer release()
+	if shard == nil {
+		return
+	}
+
+	concrete, err := unwrapShard(ctx, shard)
+	if err != nil {
+		unresolved.WithSampling(func(l logrus.FieldLogger) {
+			l.WithField("shard", name).Errorf(
+				"skipping migration reconciliation on a shard that could not be resolved: %v", err)
+		})
+		return
+	}
+	concrete.migrations().ReconcileWithClusterTasks(ctx, tasks)
+}
+
+func loadedShardNames(idx *Index) []string {
+	var names []string
+	idx.ForEachLoadedShard(func(name string, _ ShardLike) error {
+		names = append(names, name)
+		return nil
+	})
+	return names
+}
+
+func (r *migrationClusterReconciler) snapshotIndices() []*Index {
+	r.db.indexLock.RLock()
+	defer r.db.indexLock.RUnlock()
+	indices := make([]*Index, 0, len(r.db.indices))
+	for _, idx := range r.db.indices {
+		indices = append(indices, idx)
+	}
+	return indices
+}
+
+// Shard names, not a boolean: the walk that finds the shards with something to
+// decide is the walk that reconciles them, so a node where one tenant in a
+// hundred thousand holds a record does not pay for the other 99,999 twice.
+type migrationUndecidedShards struct {
+	idx   *Index
+	names []string
+}
+
+func (r *migrationClusterReconciler) shardsWithUndecidedRecords() []migrationUndecidedShards {
+	var found []migrationUndecidedShards
+	for _, idx := range r.snapshotIndices() {
+		var names []string
+		idx.ForEachLoadedShard(func(name string, shard ShardLike) error {
+			store := shard.migrationRecordStore()
+			if store == nil || len(store.Unreadable()) > 0 {
+				return nil
+			}
+			if store.HasUndecided() {
+				names = append(names, name)
+			}
+			return nil
+		})
+		if len(names) > 0 {
+			found = append(found, migrationUndecidedShards{idx: idx, names: names})
+		}
+	}
+	return found
+}
+
+func (r *migrationClusterReconciler) LocalTasks() ([]*distributedtask.Task, bool) {
+	r.mu.RLock()
+	source := r.local
+	r.mu.RUnlock()
+
+	if source == nil {
+		return nil, false
+	}
+	return source()
+}
+
+// clusterTasksBounded puts a timeout on the leader query alone, so an
+// unreachable leader cannot hold a pass open. The shard walk after it is
+// not bounded.
+func (r *migrationClusterReconciler) clusterTasksBounded(ctx context.Context) ([]*distributedtask.Task, error) {
+	r.mu.RLock()
+	source := r.cluster
+	r.mu.RUnlock()
+
+	if source == nil {
+		return nil, fmt.Errorf("no cluster-wide reindex task source is installed on this node")
+	}
+	ctx, cancel := context.WithTimeout(ctx, migrationClusterQueryTimeout)
+	defer cancel()
+	return source(ctx)
+}
+
+// SetMigrationTaskSources installs the two task sources reconciliation reads.
+// The first pass runs before this returns; the repeat runs until ctx ends.
+func (db *DB) SetMigrationTaskSources(ctx context.Context, source MigrationLocalTaskSource,
+	cluster MigrationClusterTaskSource,
+) {
+	db.migrationCluster.SetTaskSources(ctx, source, cluster)
+}

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler.go
@@ -148,15 +148,6 @@ func (r *migrationClusterReconciler) reconcileShard(ctx context.Context, idx *In
 	concrete.migrations().ReconcileWithClusterTasks(ctx, tasks)
 }
 
-func loadedShardNames(idx *Index) []string {
-	var names []string
-	idx.ForEachLoadedShard(func(name string, _ ShardLike) error {
-		names = append(names, name)
-		return nil
-	})
-	return names
-}
-
 func (r *migrationClusterReconciler) snapshotIndices() []*Index {
 	r.db.indexLock.RLock()
 	defer r.db.indexLock.RUnlock()

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler_test.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler_test.go
@@ -154,7 +154,7 @@ func TestTheClusterPassWalksARealLoadedShard(t *testing.T) {
 	rec, ok := shard.migrationRecords.Get(subject.Key)
 	require.True(t, ok)
 	require.Equal(t, MigrationStateMerged, rec.State(),
-		"this build decides nothing: the cutover PR is what makes this record move")
+		"this build decides nothing: the cutover is what makes this record move")
 	hook.Reset()
 
 	// A shard whose shutdown began is skipped and sampled.
@@ -240,4 +240,13 @@ func TestAWedgedRecordStopsCountingAsUndecided(t *testing.T) {
 	require.NoError(t, store.Load())
 	require.True(t, store.HasUndecided(),
 		"a load re-derives the wedge, so the pass that follows it decides the record again")
+}
+
+func loadedShardNames(idx *Index) []string {
+	var names []string
+	idx.ForEachLoadedShard(func(name string, _ ShardLike) error {
+		names = append(names, name)
+		return nil
+	})
+	return names
 }

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler_test.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler_test.go
@@ -1,0 +1,247 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	esync "github.com/weaviate/weaviate/entities/sync"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// The pass walks every loaded shard, and a shard count is a tenant count. A
+// node drain refuses all of them at once and the pass repeats every interval,
+// so a line per shard would repeat the whole tenant list every minute.
+func TestTheClusterPassSamplesItsPerShardRefusals(t *testing.T) {
+	const shards = maxReportedErrors + 5
+
+	logger, hook := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	require.NoError(t, store.Put(NewMigrationRecordMerged(
+		testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title"))))
+	require.NoError(t, store.Load())
+	require.True(t, store.HasUndecided(), "fixture: the pass only runs when something is undecided")
+
+	idx := &Index{logger: logger, shardCreateLocks: esync.NewKeyRWLocker()}
+	for i := 0; i < shards; i++ {
+		name := fmt.Sprintf("shard-%02d", i)
+		shard := NewMockShardLike(t)
+		shard.EXPECT().migrationRecordStore().Return(store).Maybe()
+		shard.EXPECT().Name().Return(name).Maybe()
+		shard.EXPECT().preventShutdown().Return(func() {}, nil).Maybe()
+		idx.shards.Store(name, shard)
+	}
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Books": idx}}
+	db.migrationCluster.db = db
+	db.migrationCluster.local = func() ([]*distributedtask.Task, bool) { return nil, true }
+	db.migrationCluster.cluster = func(context.Context) ([]*distributedtask.Task, error) {
+		return nil, nil
+	}
+
+	db.migrationCluster.ReconcileLoaded(context.Background())
+
+	var refusals int
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == logrus.ErrorLevel {
+			refusals++
+		}
+	}
+	require.Equal(t, maxReportedErrors, refusals,
+		"a mock shard is a shard the pass cannot resolve, and %d of them must not print %d lines", shards, shards)
+}
+
+// Every other fixture shard is a mock, which unwrapShard rejects before the
+// walk takes a reference or reaches the pass body. The real shard's own arm is
+// silent: every verdict is Leave until the cutover PR wires LocalTasks, so a
+// second, unresolvable shard is what makes a running walk observable.
+func TestTheClusterPassWalksARealLoadedShard(t *testing.T) {
+	ctx := context.Background()
+	logger, hook := test.NewNullLogger()
+
+	class := newTestClassWithProps("ClusterPassWalk", []string{"title"})
+	shd, realIdx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false, func(i *Index) { i.logger = logger })
+	shard := shd.(*Shard)
+
+	detectorIdx := &Index{logger: logger, shardCreateLocks: esync.NewKeyRWLocker()}
+	detector := NewMockShardLike(t)
+	detector.EXPECT().Name().Return("detector").Maybe()
+	// The pass walks only the shards that have something undecided, so the
+	// detector needs a record of its own to be reached at all. Empty to begin
+	// with, so the settled-node assertion below still holds.
+	detectorStore := NewMigrationRecordStore(t.TempDir(), logger)
+	detector.EXPECT().migrationRecordStore().Return(detectorStore).Maybe()
+	detector.EXPECT().preventShutdown().Return(func() {}, nil).Maybe()
+	detectorIdx.shards.Store("detector", detector)
+
+	// A loaded shard with nothing to decide. preventShutdown is deliberately
+	// left unstubbed: the pass reconciles the shards the gate named and no
+	// others, and an unexpected call here is what says it walked this one too.
+	settled := NewMockShardLike(t)
+	settled.EXPECT().Name().Return("settled").Maybe()
+	settled.EXPECT().migrationRecordStore().Return(NewMigrationRecordStore(t.TempDir(), logger)).Maybe()
+	detectorIdx.shards.Store("settled", settled)
+
+	db := &DB{logger: logger, indices: map[string]*Index{"Real": realIdx, "Detector": detectorIdx}}
+	db.migrationCluster.db = db
+	leaderQueries := 0
+	db.migrationCluster.cluster = func(context.Context) ([]*distributedtask.Task, error) {
+		leaderQueries++
+		return nil, nil
+	}
+	hook.Reset()
+
+	// A settled node does not query the leader.
+	db.migrationCluster.ReconcileLoaded(ctx)
+	require.Zero(t, leaderQueries, "nothing is undecided, so the leader is not asked")
+
+	// The gate answers for the whole node, so a shard holding a record this
+	// build cannot read must not open it: nothing here can say what that record
+	// decided, undecided sibling or not.
+	require.NoError(t, detectorStore.Put(NewMigrationRecordMerged(
+		testMigrationSubject(43, StrategyCodeEnableFilterable, "title"))))
+	plantUnreadableRecord(t, detectorStore.Dir())
+	require.NoError(t, detectorStore.Load())
+	require.True(t, detectorStore.HasUndecided(), "fixture: the record it could read is undecided")
+	db.migrationCluster.ReconcileLoaded(ctx)
+	require.Zero(t, leaderQueries,
+		"a shard this build cannot read every record of must not open the leader-query gate")
+	require.NoError(t, os.Remove(filepath.Join(detectorStore.Dir(), "99_enable_searchable.json")))
+	require.NoError(t, detectorStore.Load())
+	hook.Reset()
+
+	// A failed leader query walks no shard.
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	subject.Key.UnitID = shard.migrationUnit()
+	require.NoError(t, shard.migrationRecords.Put(NewMigrationRecordMerged(subject)))
+	require.NoError(t, shard.migrationRecords.Load())
+	db.migrationCluster.cluster = func(context.Context) ([]*distributedtask.Task, error) {
+		return nil, fmt.Errorf("no leader")
+	}
+	db.migrationCluster.ReconcileLoaded(ctx)
+	require.Len(t, storeLinesAt(hook, logrus.WarnLevel), 1)
+	require.Contains(t, storeLinesAt(hook, logrus.WarnLevel)[0], "deciding nothing this pass")
+	require.Empty(t, storeLinesAt(hook, logrus.ErrorLevel),
+		"an unreachable leader stops the pass before it walks anything")
+	hook.Reset()
+
+	// A real loaded shard is resolved, reaches the pass body, and its reference
+	// is released.
+	db.migrationCluster.cluster = func(context.Context) ([]*distributedtask.Task, error) { return nil, nil }
+	db.migrationCluster.ReconcileLoaded(ctx)
+	refusals := storeLinesAt(hook, logrus.ErrorLevel)
+	require.Len(t, refusals, 1, "the walk ran, and only the shard it cannot resolve refused")
+	require.Contains(t, refusals[0], "could not be resolved")
+	require.Zero(t, shard.inUseCounter.Load(), "the walk released the reference it took")
+	require.Empty(t, storeLinesAt(hook, logrus.InfoLevel), "a skipped shard says so, and none was skipped")
+	rec, ok := shard.migrationRecords.Get(subject.Key)
+	require.True(t, ok)
+	require.Equal(t, MigrationStateMerged, rec.State(),
+		"this build decides nothing: the cutover PR is what makes this record move")
+	hook.Reset()
+
+	// A shard whose shutdown began is skipped and sampled.
+	shard.shutdownRequested.Store(true)
+	db.migrationCluster.ReconcileLoaded(ctx)
+	shard.shutdownRequested.Store(false)
+	skipped := storeLinesAt(hook, logrus.InfoLevel)
+	require.Len(t, skipped, 1)
+	require.Contains(t, skipped[0], "shutting down")
+	require.Zero(t, shard.inUseCounter.Load(), "a refused preventShutdown takes no reference")
+}
+
+// "No tasks" and "no answer" license opposite dispositions of the same record.
+func TestUninstalledTaskSourcesDecideNothing(t *testing.T) {
+	var r migrationClusterReconciler
+
+	tasks, readable := r.LocalTasks()
+	require.Nil(t, tasks)
+	require.False(t, readable,
+		"an uninstalled local view must not read as readable-and-empty")
+
+	cluster, err := r.clusterTasksBounded(context.Background())
+	require.Error(t, err,
+		"an uninstalled cluster source must not read as an authoritative empty task list")
+	require.Nil(t, cluster)
+}
+
+// The pass collects a shard name and resolves it a moment later, so a tenant
+// torn down in between has to read as gone. Resolving the shard the walk itself
+// handed over instead calls Load, which has no shutdown flag to refuse: it
+// rebuilds the tenant outside the shard map, where nothing can ever shut it
+// down and reactivation fails until the node restarts.
+func TestTheClusterPassDoesNotRebuildAShardTornDownUnderIt(t *testing.T) {
+	const tenant = "torn-down-under-the-pass"
+
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	class := newTestClassWithProps("ClusterPassTeardown", []string{"title"})
+	hot, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false, func(i *Index) { i.logger = logger })
+	defer hot.Shutdown(context.Background())
+
+	cold := NewLazyLoadShard(ctx, nil, tenant, idx, class, idx.centralJobQueue,
+		idx.indexCheckpoints, idx.allocChecker, idx.shardLoadLimiter, idx.shardReindexer,
+		false, idx.bitmapBufPool)
+	require.NoError(t, cold.Load(ctx))
+	idx.shards.Store(tenant, cold)
+	t.Cleanup(func() {
+		if cold.isLoaded() {
+			_ = cold.Shutdown(context.Background())
+		}
+	})
+
+	require.Contains(t, loadedShardNames(idx), tenant,
+		"fixture: the walk collects the tenant while it is still up")
+
+	// What a tenant deactivation does, landing after the name was collected.
+	require.NoError(t, cold.Shutdown(ctx))
+	require.False(t, cold.isLoaded(), "fixture: the tenant is down before the pass resolves it")
+
+	db := &DB{logger: logger, indices: map[string]*Index{class.Class: idx}}
+	db.migrationCluster.db = db
+	unresolved, shuttingDown := db.migrationCluster.samplers()
+
+	db.migrationCluster.reconcileShard(ctx, idx, tenant, nil, unresolved, shuttingDown)
+
+	require.False(t, cold.isLoaded(),
+		"the pass must leave a deactivated tenant down, not rebuild it outside the shard map")
+}
+
+// One record no pass can advance drove a leader query and a walk of every
+// loaded shard, once a minute, for the life of the process, with nothing to
+// show for it. The wedge outlives the reconciler that found it, so the store
+// can answer that this shard has nothing left to decide.
+func TestAWedgedRecordStopsCountingAsUndecided(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	require.NoError(t, store.Put(NewMigrationRecordIterating(subject, MigrationCheckpoint{})))
+	require.True(t, store.HasUndecided(), "fixture: a record before the flip is undecided")
+
+	store.MarkWedged(subject.Key)
+	require.False(t, store.HasUndecided(),
+		"a record nothing here can move must stop driving the periodic pass")
+
+	require.NoError(t, store.Load())
+	require.True(t, store.HasUndecided(),
+		"a load re-derives the wedge, so the pass that follows it decides the record again")
+}

--- a/adapters/repos/db/inverted_reindex_cluster_reconciler_test.go
+++ b/adapters/repos/db/inverted_reindex_cluster_reconciler_test.go
@@ -68,10 +68,9 @@ func TestTheClusterPassSamplesItsPerShardRefusals(t *testing.T) {
 		"a mock shard is a shard the pass cannot resolve, and %d of them must not print %d lines", shards, shards)
 }
 
-// Every other fixture shard is a mock, which unwrapShard rejects before the
-// walk takes a reference or reaches the pass body. The real shard's own arm is
-// silent: every verdict is Leave until the cutover PR wires LocalTasks, so a
-// second, unresolvable shard is what makes a running walk observable.
+// Only a real, resolvable shard proves the walk ran: mocks are rejected
+// before the pass body, and the real shard's own verdict stays Leave until
+// the cutover wires LocalTasks.
 func TestTheClusterPassWalksARealLoadedShard(t *testing.T) {
 	ctx := context.Background()
 	logger, hook := test.NewNullLogger()
@@ -183,11 +182,8 @@ func TestUninstalledTaskSourcesDecideNothing(t *testing.T) {
 	require.Nil(t, cluster)
 }
 
-// The pass collects a shard name and resolves it a moment later, so a tenant
-// torn down in between has to read as gone. Resolving the shard the walk itself
-// handed over instead calls Load, which has no shutdown flag to refuse: it
-// rebuilds the tenant outside the shard map, where nothing can ever shut it
-// down and reactivation fails until the node restarts.
+// A tenant torn down between the pass's name-collect and resolve steps must
+// read as gone, not get rebuilt via Load outside the shard map.
 func TestTheClusterPassDoesNotRebuildAShardTornDownUnderIt(t *testing.T) {
 	const tenant = "torn-down-under-the-pass"
 

--- a/adapters/repos/db/inverted_reindex_promote_canonical_dir_test.go
+++ b/adapters/repos/db/inverted_reindex_promote_canonical_dir_test.go
@@ -1,0 +1,404 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"hash/fnv"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+func fixtureStrategyOf(t *testing.T, trackerName string) (MigrationStrategyCode, ReindexMigrationType) {
+	t.Helper()
+	for _, known := range []struct {
+		prefix string
+		code   MigrationStrategyCode
+		mType  ReindexMigrationType
+	}{
+		{MigrationDirSearchableMapToBlockmax, StrategyCodeSearchableMapToBlockmax, ReindexTypeChangeAlgorithm},
+		{MigrationDirFilterableRoaringsetRefresh, StrategyCodeFilterableRoaringsetRefresh, ReindexTypeRepairFilterable},
+		{MigrationDirPrefixFilterableToRangeable, StrategyCodeFilterableToRangeable, ReindexTypeEnableRangeable},
+		{MigrationDirPrefixSearchableRetokenize, StrategyCodeSearchableRetokenize, ReindexTypeChangeTokenization},
+		{MigrationDirPrefixFilterableRetokenize, StrategyCodeFilterableRetokenize, ReindexTypeChangeTokenizationFilterable},
+		{MigrationDirPrefixEnableFilterable, StrategyCodeEnableFilterable, ReindexTypeEnableFilterable},
+		{MigrationDirPrefixEnableSearchable, StrategyCodeEnableSearchable, ReindexTypeEnableSearchable},
+		{MigrationDirPrefixRebuildSearchable, StrategyCodeRebuildSearchable, ReindexTypeRebuildSearchable},
+	} {
+		if strings.HasPrefix(trackerName, known.prefix) {
+			return known.code, known.mType
+		}
+	}
+	require.FailNowf(t, "no strategy owns this tracker dir name", "%q", trackerName)
+	return "", ""
+}
+
+func fixtureRecordVersion(trackerName string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(trackerName))
+	if v := h.Sum64(); v != 0 {
+		return v
+	}
+	return 1
+}
+
+func fixtureSidecarFor(staged string) string {
+	if reindex := strings.Replace(staged, "_ingest_", "_reindex_", 1); reindex != staged {
+		return reindex
+	}
+	return staged + "__reindex"
+}
+
+func mkMigrationRecordAt(t *testing.T, lsmPath, unitID, trackerName string,
+	staged, canonical map[string]string, state MigrationState,
+) {
+	t.Helper()
+	code, migrationType := fixtureStrategyOf(t, trackerName)
+	subject := MigrationSubject{
+		Key: MigrationRecordKey{
+			TaskVersion:  fixtureRecordVersion(trackerName),
+			StrategyCode: code,
+			UnitID:       unitID,
+		},
+		TaskID:        "fixture:" + trackerName,
+		MigrationType: migrationType,
+		TrackerDir:    trackerName,
+		Props:         map[string]MigrationPropertyDirs{},
+	}
+	for prop, dir := range staged {
+		subject.Props[prop] = MigrationPropertyDirs{
+			Staged: dir, Canonical: canonical[prop], Sidecar: fixtureSidecarFor(dir),
+		}
+	}
+
+	var rec MigrationRecord
+	switch state {
+	case MigrationStateIterating:
+		rec = NewMigrationRecordIterating(subject, MigrationCheckpoint{})
+	case MigrationStateSwapped:
+		rec = NewMigrationRecordSwapped(subject, subject.Properties(), canonical)
+	case MigrationStatePromoted:
+		rec = NewMigrationRecordPromoted(subject, subject.Properties(), canonical)
+	default:
+		require.FailNowf(t, "unsupported fixture state", "%q", state)
+	}
+	logger, _ := test.NewNullLogger()
+	require.NoError(t, NewMigrationRecordStore(lsmPath, logger).Put(rec))
+}
+
+// A shard load re-creates the canonical directory empty, so its presence
+// proves no promotion.
+
+const (
+	promoteRenamedProp = "title"
+	promoteBlockedProp = "body"
+
+	promoteTracker = "rebuild_searchable_pair_1"
+)
+
+func promoteStagedDir(prop string) string {
+	return "property_" + prop + "_searchable__rebuild_searchable_ingest_1"
+}
+
+func aPromoteShard(t *testing.T, ctx context.Context, props []string, vocabulary string) (*Shard, *Index, *models.Class) {
+	t.Helper()
+	className := "Promote" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, props)
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+	for _, obj := range promoteObjects(className, props, vocabulary, 20) {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+	return shard, idx, class
+}
+
+func promoteObjects(className string, props []string, vocabulary string, n int) []*storobj.Object {
+	objs := make([]*storobj.Object, n)
+	for i := range objs {
+		term := vocabulary + string(rune('a'+i%20))
+		properties := map[string]interface{}{}
+		for _, prop := range props {
+			properties[prop] = term
+		}
+		objs[i] = &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:         strfmt.UUID(uuid.NewString()),
+				Class:      className,
+				Properties: properties,
+			},
+			Vector: []float32{float32(i)},
+		}
+	}
+	return objs
+}
+
+func copyDirTree(t *testing.T, from, to string) {
+	t.Helper()
+	require.NoError(t, filepath.WalkDir(from, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(from, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(to, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+		dst, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+		_, err = io.Copy(dst, src)
+		return err
+	}))
+}
+
+// One restart: reconciliation, then the bucket init that re-creates canonical dirs.
+func reloadShardFromDisk(t *testing.T, ctx context.Context, idx *Index, shard *Shard,
+	class *models.Class,
+) *Shard {
+	t.Helper()
+	name := shard.Name()
+	require.NoError(t, shard.Shutdown(ctx))
+	simulateProcessRestartBucketCleanup(t, shard.pathLSM())
+	return openShardFromDisk(t, ctx, idx, class, name)
+}
+
+func openShardFromDisk(t *testing.T, ctx context.Context, idx *Index,
+	class *models.Class, name string,
+) *Shard {
+	t.Helper()
+	loaded, err := idx.initShard(ctx, name, class, nil, true, true)
+	require.NoError(t, err)
+	idx.shards.Store(name, loaded)
+	return loaded.(*Shard)
+}
+
+func migrationRecordStates(t *testing.T, lsmPath string) []MigrationState {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	store := NewMigrationRecordStore(lsmPath, logger)
+	require.NoError(t, store.Load())
+	states := make([]MigrationState, 0, len(store.Records()))
+	for _, rec := range store.Records() {
+		states = append(states, rec.State())
+	}
+	return states
+}
+
+func soleMigrationRecordState(t *testing.T, lsmPath string) MigrationState {
+	t.Helper()
+	states := migrationRecordStates(t, lsmPath)
+	require.Len(t, states, 1, "the fixture plants exactly one record")
+	return states[0]
+}
+
+const deleteBeforeAnyLoad = -1
+
+// Pins two defects: a re-created empty canonical directory must not read as an
+// already-run promotion, and a rename that ran must still count after a WAL flush.
+func TestPromoteDecidesFromTheRecordNotFromTheDirectory(t *testing.T) {
+	tests := []struct {
+		name             string
+		props            []string
+		emptyStaged      bool
+		writeAfterLoad1  string
+		deleteAfterLoad  int
+		loads            int
+		wantRecordSwept  bool
+		wantState        MigrationState
+		wantRenamedTerms string
+		reason           string
+	}{
+		{
+			name:             "an index DELETE took both directories before the rename could run",
+			props:            []string{promoteRenamedProp},
+			deleteAfterLoad:  deleteBeforeAnyLoad,
+			loads:            2,
+			wantState:        MigrationStateSwapped,
+			wantRenamedTerms: "",
+			reason: "the record must not read Promoted over a canonical directory the shard load re-created: " +
+				"no promotion of this property ever started",
+		},
+		{
+			name:             "the staged directory is there to promote",
+			props:            []string{promoteRenamedProp},
+			loads:            1,
+			wantState:        MigrationStatePromoted,
+			wantRenamedTerms: "donor",
+			reason:           "a promotion whose staged directory is present must still run and move its data",
+		},
+		{
+			name:             "an index DELETE took the directory the rename produced",
+			props:            []string{promoteRenamedProp, promoteBlockedProp},
+			deleteAfterLoad:  1,
+			loads:            3,
+			wantState:        MigrationStateSwapped,
+			wantRenamedTerms: "",
+			reason: "the record must not read Promoted over a canonical directory the shard load re-created: " +
+				"the data this migration renamed onto that name is gone",
+		},
+		{
+			name:             "nothing takes the directory the rename produced",
+			props:            []string{promoteRenamedProp, promoteBlockedProp},
+			loads:            3,
+			wantRecordSwept:  true,
+			wantRenamedTerms: "donor",
+			reason:           "a promotion whose renamed data is still under the canonical name must complete and close",
+		},
+		{
+			name:             "an ordinary write lands in the empty bucket the promotion produced",
+			props:            []string{promoteRenamedProp, promoteBlockedProp},
+			emptyStaged:      true,
+			writeAfterLoad1:  "written",
+			loads:            3,
+			wantRecordSwept:  true,
+			wantRenamedTerms: "written",
+			reason:           "a promotion that moved no data must still complete and close",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			shard, idx, class := aPromoteShard(t, ctx, tc.props, "canonical")
+			lsmPath := shard.pathLSM()
+			renamedCanonical := helpers.BucketSearchableFromPropNameLSM(promoteRenamedProp)
+
+			before := fingerprintInvertedBucket(t, shard.store.Bucket(renamedCanonical))
+			require.NotEmpty(t, before, "fixture: the canonical bucket holds terms before anything touches it")
+
+			donor, _, _ := aPromoteShard(t, ctx, tc.props, "donor")
+			donorPath := donor.pathLSM()
+			donorTerms := map[string]map[string][]uint64{}
+			for _, prop := range tc.props {
+				donorTerms[prop] = fingerprintInvertedBucket(t,
+					donor.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop)))
+				require.NotEmpty(t, donorTerms[prop], "fixture: the donor bucket holds terms")
+			}
+			require.NotEqual(t, before, donorTerms[promoteRenamedProp], "fixture: the two vocabularies must differ")
+
+			renamedStagedSource := filepath.Join(donorPath, renamedCanonical)
+			require.NoError(t, donor.Shutdown(ctx))
+
+			require.NoError(t, shard.Shutdown(ctx))
+			simulateProcessRestartBucketCleanup(t, lsmPath)
+
+			renamedStaged := filepath.Join(lsmPath, promoteStagedDir(promoteRenamedProp))
+			if tc.emptyStaged {
+				require.NoError(t, os.MkdirAll(renamedStaged, 0o755))
+			} else {
+				copyDirTree(t, renamedStagedSource, renamedStaged)
+			}
+
+			staged := map[string]string{}
+			canonical := map[string]string{}
+			for _, prop := range tc.props {
+				staged[prop] = promoteStagedDir(prop)
+				canonical[prop] = helpers.BucketSearchableFromPropNameLSM(prop)
+			}
+			mkTrackerDir(t, lsmPath, promoteTracker)
+			mkMigrationRecordAt(t, lsmPath, shard.migrationUnit(), promoteTracker, staged, canonical, MigrationStateSwapped)
+			require.Equal(t, MigrationStateSwapped, soleMigrationRecordState(t, lsmPath), "fixture")
+
+			if tc.deleteAfterLoad == deleteBeforeAnyLoad {
+				require.NoError(t, os.RemoveAll(filepath.Join(lsmPath, renamedCanonical)))
+				require.NoError(t, os.RemoveAll(renamedStaged))
+			}
+
+			current := openShardFromDisk(t, ctx, idx, class, shard.Name())
+			afterFirstLoad := fingerprintInvertedBucket(t, current.store.Bucket(renamedCanonical))
+			if tc.deleteAfterLoad != deleteBeforeAnyLoad && !tc.emptyStaged {
+				require.Equal(t, donorTerms[promoteRenamedProp], afterFirstLoad,
+					"fixture: the first load renames the staged directory onto the canonical name")
+			}
+			if tc.emptyStaged {
+				require.Empty(t, afterFirstLoad,
+					"fixture: a promotion of an empty staged directory leaves an empty bucket")
+			}
+
+			writtenTerms := map[string][]uint64{}
+			if tc.writeAfterLoad1 != "" {
+				for _, obj := range promoteObjects(class.Class, tc.props, tc.writeAfterLoad1, 20) {
+					require.NoError(t, current.PutObject(ctx, obj))
+				}
+				writtenTerms = fingerprintInvertedBucket(t, current.store.Bucket(renamedCanonical))
+				require.NotEmpty(t, writtenTerms, "fixture: the write reaches the promoted bucket")
+			}
+			if tc.deleteAfterLoad == 1 {
+				require.NoError(t, current.removeBucket(ctx, renamedCanonical))
+			}
+
+			for _, prop := range tc.props[1:] {
+				copyDirTree(t,
+					filepath.Join(donorPath, helpers.BucketSearchableFromPropNameLSM(prop)),
+					filepath.Join(lsmPath, promoteStagedDir(prop)))
+			}
+
+			for load := 2; load <= tc.loads; load++ {
+				current = reloadShardFromDisk(t, ctx, idx, current, class)
+			}
+			defer current.Shutdown(ctx)
+
+			got := fingerprintInvertedBucket(t, current.store.Bucket(renamedCanonical))
+			switch tc.wantRenamedTerms {
+			case "":
+				require.Empty(t, got,
+					"fixture: the canonical bucket must hold nothing, or promoting it would lose nothing")
+			case "written":
+				assert.Equal(t, writtenTerms, got,
+					"the canonical bucket must still hold what was written into it after the promotion")
+			default:
+				assert.Equal(t, donorTerms[promoteRenamedProp], got,
+					"the canonical bucket must hold the data the promotion renamed onto it")
+			}
+			for _, prop := range tc.props[1:] {
+				assert.Equal(t, donorTerms[prop],
+					fingerprintInvertedBucket(t, current.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop))),
+					"the sibling's own promotion must still run and move its data")
+			}
+
+			if tc.wantRecordSwept {
+				assert.Empty(t, migrationRecordStates(t, lsmPath), tc.reason)
+				assert.NoDirExists(t, filepath.Join(lsmPath, migrationsDir, promoteTracker),
+					"a record that closes takes its tracker directory with it")
+			} else {
+				assert.Equal(t, tc.wantState, soleMigrationRecordState(t, lsmPath), tc.reason)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/inverted_reindex_reconcile.go
+++ b/adapters/repos/db/inverted_reindex_reconcile.go
@@ -172,10 +172,10 @@ func (r *migrationReconciler) Reconcile(ctx context.Context) error {
 			return nil
 		}
 		if err := r.reconcileOne(ctx, rec, someRecordsUnreadable); err != nil {
-			// One migration must not be able to keep a shard from loading. Not
-			// marked on the store: a refused reclaim, a directory that would not
-			// go and a cancelled activation all arrive here, and the record is
-			// kept precisely so a later pass retries them.
+			// One migration must not keep a shard from loading. Not marked on the
+			// store: a refused reclaim, a directory that would not go and a
+			// cancelled activation keep the record for a later pass; a failure
+			// past its unlink leaves nothing to retry.
 			r.countWedged(rec.Subject().Key)
 			r.logger.WithField("record", rec.Subject().Key.String()).Errorf("reconcile migration record: %v", err)
 		}
@@ -430,6 +430,9 @@ func (r *migrationReconciler) promoteSealed(ctx context.Context, rec MigrationRe
 		r.logger.WithField("record", subject.Key.String()).
 			WithField("property_count", len(subject.Props)).
 			Errorf("promote the properties of a migration: %v", err)
+		// Returned as well as logged: the caller counts the record as wedged, so
+		// the shard does not read as settled over a promotion that did not run.
+		return err
 	}
 
 	// A Promoted record is read as "this rename happened". A pass that renamed

--- a/adapters/repos/db/inverted_reindex_reconcile.go
+++ b/adapters/repos/db/inverted_reindex_reconcile.go
@@ -1,0 +1,981 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// Must run before the directory is removed, or mmaps and compactions leak.
+// Takes directories rather than a record, so the caller closes only what it has
+// already decided it may remove: a shutdown deregisters the bucket and nothing
+// reopens it before the next shard load, so closing a directory the caller then
+// leaves in place stops that data serving with no record left to answer for it.
+type migrationStagedBucketCloser interface {
+	ShutdownStagedBucketsAt(ctx context.Context, dirs []string) error
+}
+
+type migrationReconcileDeps struct {
+	LocalTasks func() ([]*distributedtask.Task, bool)
+
+	SealUnit func(distributedtask.TaskDescriptor, string) (func(), bool)
+
+	Class func() *models.Class
+
+	Buckets migrationStagedBucketCloser
+}
+
+type migrationReconciler struct {
+	store      *MigrationRecordStore
+	lsmPath    string
+	wedgedKeys map[MigrationRecordKey]bool
+	logger     logrus.FieldLogger
+	deps       migrationReconcileDeps
+}
+
+func newMigrationReconciler(store *MigrationRecordStore, lsmPath string,
+	logger logrus.FieldLogger, deps migrationReconcileDeps,
+) *migrationReconciler {
+	return &migrationReconciler{store: store, lsmPath: lsmPath, logger: logger, deps: deps}
+}
+
+type migrationVerdict uint8
+
+const (
+	migrationVerdictLeave migrationVerdict = iota
+	migrationVerdictCommit
+	migrationVerdictDiscard
+	// Keep the record and its data, and stop asking: the leader has answered
+	// that the owning task is gone and no schema reading will ever confirm or
+	// deny this migration, so every later pass reaches the same answer.
+	migrationVerdictWedge
+)
+
+const migrationWedgeRemedy = "Submit a new migration covering every property this record names; " +
+	"once its flip is durable it supersedes this record, and the next shard load " +
+	"reclaims the record and its directories."
+
+// Supersession keys on the canonical directory name, which is the very thing
+// this record does not name, so a new migration could never take it over.
+const migrationWedgeRemedyNoCanonical = "Once you have confirmed which directory holds " +
+	"the property's data, remove this record by hand; no new migration can supersede a " +
+	"record that names no canonical directory."
+
+// A property list is user-chosen and unbounded, so it never reaches a log line
+// whole: the count goes in a field and the names go through the shared cap.
+func migrationReportedNames(names []string) []string {
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		set[name] = struct{}{}
+	}
+	return reportedShardNames(set)
+}
+
+// Counts the record against this pass and no further. A refusal, a filesystem
+// fault and a cancellation all land here, and the periodic pass is the only
+// thing that retries any of them.
+func (r *migrationReconciler) countWedged(key MigrationRecordKey) {
+	if r.wedgedKeys == nil {
+		r.wedgedKeys = map[MigrationRecordKey]bool{}
+	}
+	r.wedgedKeys[key] = true
+}
+
+// The reconciler lives for one pass, so a wedge it diagnosed also goes to the
+// store, which is what the periodic pass asks whether this shard has anything
+// left to decide. Only for a record no pass on this build could advance: a
+// record that merely did not settle this time has to be asked again.
+func (r *migrationReconciler) markWedged(key MigrationRecordKey) {
+	r.countWedged(key)
+	r.store.MarkWedged(key)
+}
+
+func (r *migrationReconciler) wedged(subject MigrationSubject, remedy, format string, args ...any) {
+	r.markWedged(subject.Key)
+	r.logger.WithField("record", subject.Key.String()).
+		WithField("property_count", len(subject.Props)).
+		Errorf(format+" "+remedy, args...)
+}
+
+// Debug, not Info: a Leave repeats on every shard load for the life of the
+// record, and only one that never resolves is worth finding.
+func (r *migrationReconciler) leftStanding(subject MigrationSubject, why string) {
+	r.logger.WithField("record", subject.Key.String()).Debugf(
+		"leaving the migration record standing: %s", why)
+}
+
+// Error, not Warn: one wedged record is cleared by resubmitting one migration,
+// while this withholds every promoting and destructive action of the pass for
+// the life of the shard.
+func (r *migrationReconciler) freezeNotice() {
+	unreadable := r.store.Unreadable()
+	// A store-scope fault read no record, so a count and a per-file remedy would
+	// both name something that does not exist.
+	for _, u := range unreadable {
+		if u.Scope == MigrationRecordFaultStore {
+			r.logger.WithField("path", r.store.Dir()).Errorf(
+				"the migration record store cannot answer for this shard (%s): withholding every "+
+					"destructive and promoting action this migration-record pass takes here until the cause is cleared",
+				u.Reason)
+			return
+		}
+	}
+	r.logger.WithField("path", r.store.Dir()).Errorf(
+		"%d migration record(s) not understood: withholding every destructive and promoting action "+
+			"this migration-record pass takes on this shard. This is normally a downgrade: run the build "+
+			"that wrote them, or remove the files the record store named once you have confirmed what they claim",
+		len(unreadable))
+}
+
+func (r *migrationReconciler) WedgedCount() int { return len(r.wedgedKeys) }
+
+func (r *migrationReconciler) Reconcile(ctx context.Context) error {
+	if err := r.store.Load(); err != nil {
+		// The load's own fault is recorded as unreadable, so the freeze this
+		// return causes is announced on this path too.
+		r.freezeNotice()
+		return fmt.Errorf("load migration records: %w", err)
+	}
+
+	someRecordsUnreadable := len(r.store.Unreadable()) > 0
+	if someRecordsUnreadable {
+		r.freezeNotice()
+	}
+
+	r.wedgedKeys = nil
+	r.RetireSuperseded(ctx)
+
+	for _, rec := range r.store.Records() {
+		// The pass renames and removes whole property indexes, and it runs on
+		// the RAFT apply loop, where every further apply queues behind it.
+		if err := ctx.Err(); err != nil {
+			r.logger.Errorf("stopping the migration-record pass on this shard: %v", err)
+			return nil
+		}
+		if err := r.reconcileOne(ctx, rec, someRecordsUnreadable); err != nil {
+			// One migration must not be able to keep a shard from loading. Not
+			// marked on the store: a refused reclaim, a directory that would not
+			// go and a cancelled activation all arrive here, and the record is
+			// kept precisely so a later pass retries them.
+			r.countWedged(rec.Subject().Key)
+			r.logger.WithField("record", rec.Subject().Key.String()).Errorf("reconcile migration record: %v", err)
+		}
+	}
+	return nil
+}
+
+// someUnreadable: an unreadable record's properties count as unreadable, so
+// withholding must cover the whole shard, not just those.
+func (r *migrationReconciler) reconcileOne(ctx context.Context, rec MigrationRecord,
+	someUnreadable bool,
+) error {
+	switch typed := rec.(type) {
+	case MigrationRecordIterating, MigrationRecordIterated:
+		return r.reconcileUncommitted(ctx, rec, someUnreadable)
+	case MigrationRecordMerged:
+		return r.reconcileMerged(ctx, typed, someUnreadable)
+	case MigrationRecordSwapped:
+		return r.reconcileSwapped(ctx, typed, someUnreadable)
+	case MigrationRecordPromoted:
+		return r.reconcilePromoted(ctx, typed, someUnreadable)
+	default:
+		return fmt.Errorf("no reconciliation for record variant %T", rec)
+	}
+}
+
+// Discard runs before the reverse edge: restarting when directories are
+// gone would arm a live mirror nothing will ever recreate them for.
+func (r *migrationReconciler) reconcileUncommitted(ctx context.Context, rec MigrationRecord,
+	someUnreadable bool,
+) error {
+	subject := rec.Subject()
+
+	if someUnreadable {
+		_, err := r.restartIfRebuiltDataGone(subject)
+		return err
+	}
+
+	verdict, why := r.localVerdict(subject)
+	switch verdict {
+	case migrationVerdictDiscard:
+		return r.discard(ctx, subject, why)
+	case migrationVerdictCommit:
+		// Above the restart edge, not below it: a migration the cluster
+		// committed can never be finished here, so restarting its rebuild
+		// would restart it on every load and the record would never terminate.
+		r.wedged(subject, migrationWedgeRemedy,
+			"migration is %s locally but the cluster reports it committed (%s), so no load here can finish it. "+
+				"Properties: %s.",
+			rec.State(), why, strings.Join(migrationReportedNames(subject.Properties()), ", "))
+		return nil
+	case migrationVerdictLeave:
+	default:
+		return fmt.Errorf("unhandled verdict %d", verdict)
+	}
+
+	restarted, err := r.restartIfRebuiltDataGone(subject)
+	if err != nil || restarted {
+		return err
+	}
+	r.leftStanding(subject, why)
+	return nil
+}
+
+// A missing owned directory means the rebuild never reached disk, so
+// resuming would swap in an incomplete bucket.
+func (r *migrationReconciler) restartIfRebuiltDataGone(subject MigrationSubject) (bool, error) {
+	for _, dir := range migrationOwnedDirs(subject) {
+		there, err := r.dirExists(dir)
+		if err != nil {
+			return false, err
+		}
+		if there {
+			continue
+		}
+
+		restarted := subject
+		restarted.IterationCutoff = migrationHorizonEverything
+
+		r.logger.WithField("record", subject.Key.String()).Warnf(
+			"rebuilt data at %q is gone; restarting the rebuild from the beginning and re-covering the horizon the mirror held", dir)
+		return true, r.store.Put(NewMigrationRecordIterating(restarted, MigrationCheckpoint{}))
+	}
+	return false, nil
+}
+
+func (r *migrationReconciler) reconcileMerged(ctx context.Context, rec MigrationRecordMerged,
+	someUnreadable bool,
+) error {
+	if someUnreadable {
+		return nil
+	}
+	subject := rec.Subject()
+	verdict, why := r.localVerdict(subject)
+
+	switch verdict {
+	case migrationVerdictLeave:
+		r.leftStanding(subject, why)
+		return nil
+	case migrationVerdictDiscard:
+		return r.discard(ctx, subject, why)
+	case migrationVerdictCommit:
+	default:
+		return fmt.Errorf("unhandled verdict %d", verdict)
+	}
+
+	swapped, err := r.commitMerged(subject, why)
+	if err != nil {
+		return err
+	}
+	return r.reconcileSwapped(ctx, swapped, someUnreadable)
+}
+
+// Skips a superseded property the way promoteSealed does: retirement deletes
+// that property's staged directory, and demanding it back here would wedge the
+// record for good.
+func (r *migrationReconciler) commitMerged(subject MigrationSubject,
+	why string,
+) (MigrationRecordSwapped, error) {
+	all := r.store.Records()
+	props := subject.Properties()
+	for _, prop := range props {
+		if migrationPropertySuperseded(all, subject, prop) {
+			continue
+		}
+		staged, canonical := subject.Props[prop].Staged, subject.Props[prop].Canonical
+		if staged == "" || canonical == "" {
+			return MigrationRecordSwapped{}, fmt.Errorf(
+				"refusing to commit the flip: property %q names no staged or canonical directory, "+
+					"so the flip it would record could never be promoted", prop)
+		}
+		there, err := r.dirExists(staged)
+		if err != nil {
+			return MigrationRecordSwapped{}, err
+		}
+		if !there {
+			return MigrationRecordSwapped{}, fmt.Errorf(
+				"refusing to commit the flip: property %q names no staged directory %q to promote", prop, staged)
+		}
+	}
+
+	displaced := make(map[string]string, len(props))
+	for _, prop := range props {
+		displaced[prop] = subject.Props[prop].Canonical
+	}
+	swapped := NewMigrationRecordSwapped(subject, props, displaced)
+	if err := r.store.Put(swapped); err != nil {
+		return swapped, fmt.Errorf("record the flip decision: %w", err)
+	}
+	r.logger.WithField("record", subject.Key.String()).Infof("committing merged migration: %s", why)
+	return swapped, nil
+}
+
+// ReconcileWithClusterTasks settles the dispositions a shard load withheld.
+// The leader's task list is an argument so a shard load never blocks on it.
+func (r *migrationReconciler) ReconcileWithClusterTasks(ctx context.Context, tasks []*distributedtask.Task) {
+	if len(r.store.Unreadable()) > 0 {
+		return
+	}
+	for _, rec := range r.store.Records() {
+		if ctx.Err() != nil {
+			return
+		}
+		subject := rec.Subject()
+		if rec.PointerSwapped() || r.store.Wedged(subject.Key) {
+			continue
+		}
+		verdict, why := r.clusterVerdict(subject, tasks)
+		switch {
+		case verdict == migrationVerdictWedge:
+			r.wedged(subject, migrationWedgeRemedy, "%s.", why)
+		case verdict == migrationVerdictDiscard:
+			if err := r.discard(ctx, subject, why); err != nil {
+				r.logger.WithField("record", subject.Key.String()).Errorf(
+					"discard a migration the leader's task list settled: %v", err)
+			}
+		case verdict == migrationVerdictCommit && rec.State() == MigrationStateMerged:
+			if _, err := r.commitMerged(subject, why); err != nil {
+				r.logger.WithField("record", subject.Key.String()).Errorf(
+					"commit a merged migration the leader's task list settled: %v", err)
+				continue
+			}
+			r.logger.WithField("record", subject.Key.String()).Info(
+				"the staged data is the data; the next shard load promotes it onto the canonical name")
+		}
+	}
+	monitoring.GetMetrics().AddMigrationRecordsWedged(r.WedgedCount(), 0)
+}
+
+// As destructive as discard (removes directories before renaming), so
+// sealed the same way.
+func (r *migrationReconciler) reconcileSwapped(ctx context.Context, rec MigrationRecordSwapped,
+	someUnreadable bool,
+) error {
+	if someUnreadable {
+		return nil
+	}
+	return r.withSealedUnit(rec.Subject(), "its promotion", func() error {
+		return r.promoteSealed(ctx, rec)
+	})
+}
+
+func (r *migrationReconciler) promoteSealed(ctx context.Context, rec MigrationRecordSwapped) error {
+	subject := rec.Subject()
+	all := r.store.Records()
+	settled := true
+	promotedAny := false
+	// One line per record, not one per property: a single I/O fault fails every
+	// property, and a failure between the rename and its sync yields two.
+	promoting := errorcompounder.New()
+	var noHandles []string
+
+	for _, prop := range subject.Properties() {
+		// Between Put(started) and the rename there is no check: those two are
+		// what make an interrupted promotion readable, so they stay together.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if migrationPropertySuperseded(all, subject, prop) {
+			continue
+		}
+
+		staged, canonical := subject.Props[prop].Staged, subject.Props[prop].Canonical
+		if staged == "" || canonical == "" {
+			settled = false
+			noHandles = append(noHandles, prop)
+			continue
+		}
+
+		displaced, _ := rec.DisplacedDir(prop)
+		updated, promoted, err := r.promoteProperty(rec, prop,
+			promotionDirs{staged: staged, canonical: canonical, displaced: displaced})
+		rec = updated
+		if err != nil {
+			settled = false
+			promoting.AddWrapf(err, "promote property %q", prop)
+			continue
+		}
+		if !promoted {
+			settled = false
+			continue
+		}
+		promotedAny = true
+	}
+
+	if len(noHandles) > 0 {
+		r.wedged(subject, migrationWedgeRemedyNoCanonical,
+			"cannot promote %d propert(y/ies): the record names no staged or canonical directory for %s.",
+			len(noHandles), strings.Join(migrationReportedNames(noHandles), ", "))
+	}
+	if err := promoting.ToErrorLimited(maxReportedErrors); err != nil {
+		r.logger.WithField("record", subject.Key.String()).
+			WithField("property_count", len(subject.Props)).
+			Errorf("promote the properties of a migration: %v", err)
+	}
+
+	// A Promoted record is read as "this rename happened". A pass that renamed
+	// nothing must not write one; a fully superseded record is retired instead.
+	if !settled || !promotedAny {
+		return nil
+	}
+	return r.store.Put(NewMigrationRecordPromoted(subject, rec.Flipped(), rec.displacedDirs))
+}
+
+// Directory presence can't prove a rename ran (canonical is pre-created
+// empty either way), so the record brackets it with a start/finish write.
+func (r *migrationReconciler) promoteProperty(rec MigrationRecordSwapped,
+	prop string, dirs promotionDirs,
+) (MigrationRecordSwapped, bool, error) {
+	subject := rec.Subject()
+	staged, canonical, displaced := dirs.staged, dirs.canonical, dirs.displaced
+	switch rec.PromotionOf(prop) {
+	case migrationPromotionFinished:
+		return r.confirmPromotionSurvives(rec, prop, canonical)
+	case migrationPromotionLost:
+		r.wedged(subject, migrationWedgeRemedy,
+			"property %q was promoted onto %q and that directory is gone; preserving the record and promoting nothing.",
+			prop, canonical)
+		return rec, false, nil
+	default:
+	}
+	stagedThere, err := r.dirExists(staged)
+	if err != nil {
+		return rec, false, err
+	}
+	if !stagedThere {
+		return r.settleInterruptedPromotion(rec, prop, staged, canonical)
+	}
+
+	// Dormant here: every flip this build writes displaces the canonical name
+	// itself, and the cutover PR is what writes a different one.
+	if displaced != "" && displaced != canonical {
+		if cleared, err := r.clearForPromotion(displaced, "the displaced directory"); err != nil || !cleared {
+			return rec, false, err
+		}
+	}
+	if cleared, err := r.clearForPromotion(canonical, "the canonical directory"); err != nil || !cleared {
+		return rec, false, err
+	}
+
+	started := rec.WithPromotionAt(prop, migrationPromotionStarted)
+	if err := r.store.Put(started); err != nil {
+		return rec, false, fmt.Errorf(
+			"record the promotion of property %q before renaming %q onto %q: %w", prop, staged, canonical, err)
+	}
+	rec = started
+
+	if err := r.rename(staged, canonical); err != nil {
+		return r.abandonPromotion(rec, prop, staged), false, err
+	}
+
+	finished := rec.WithPromotionAt(prop, migrationPromotionFinished)
+	if err := r.store.Put(finished); err != nil {
+		r.logger.WithField("record", subject.Key.String()).Errorf(
+			"record the finished promotion of property %q: %v", prop, err)
+		return rec, true, nil
+	}
+	return finished, true, nil
+}
+
+func (r *migrationReconciler) clearForPromotion(dir, what string) (cleared bool, err error) {
+	there, err := r.dirExists(dir)
+	if err != nil {
+		return false, err
+	}
+	if !there {
+		return true, nil
+	}
+	if err := r.removeDir(r.lsmPath, dir, what+" the promotion replaces"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func (r *migrationReconciler) confirmPromotionSurvives(rec MigrationRecordSwapped,
+	prop, canonical string,
+) (MigrationRecordSwapped, bool, error) {
+	there, err := r.dirExists(canonical)
+	if err != nil {
+		return rec, false, err
+	}
+	if there {
+		return rec, true, nil
+	}
+	r.wedged(rec.Subject(), migrationWedgeRemedy,
+		"property %q was promoted onto %q and that directory is gone, so the data this migration renamed onto it is gone; "+
+			"preserving the record and promoting nothing.", prop, canonical)
+	lost := rec.WithPromotionAt(prop, migrationPromotionLost)
+	if err := r.store.Put(lost); err != nil {
+		r.logger.WithField("record", rec.Subject().Key.String()).Errorf(
+			"record that the promoted directory of property %q is gone: %v", prop, err)
+		return rec, false, nil
+	}
+	return lost, false, nil
+}
+
+func (r *migrationReconciler) settleInterruptedPromotion(rec MigrationRecordSwapped,
+	prop, staged, canonical string,
+) (MigrationRecordSwapped, bool, error) {
+	subject := rec.Subject()
+	if rec.PromotionOf(prop) != migrationPromotionStarted {
+		r.wedged(subject, migrationWedgeRemedy,
+			"property %q lost its staged directory %q to something that is not its promotion, which never started; "+
+				"preserving the record and promoting nothing.", prop, staged)
+		return rec, false, nil
+	}
+	canonicalThere, err := r.dirExists(canonical)
+	if err != nil {
+		return rec, false, err
+	}
+	if !canonicalThere {
+		r.wedged(subject, migrationWedgeRemedy,
+			"property %q has neither its staged directory %q nor its canonical directory %q, so its rename never ran; "+
+				"preserving the record and promoting nothing.", prop, staged, canonical)
+		abandoned := rec.WithPromotionAbandoned(prop)
+		if err := r.store.Put(abandoned); err != nil {
+			r.logger.WithField("record", subject.Key.String()).Errorf(
+				"take back the started promotion of property %q whose rename never ran: %v", prop, err)
+			return rec, false, nil
+		}
+		return abandoned, false, nil
+	}
+	finished := rec.WithPromotionAt(prop, migrationPromotionFinished)
+	if err := r.store.Put(finished); err != nil {
+		return rec, false, fmt.Errorf("record the finished promotion of property %q: %w", prop, err)
+	}
+	return finished, true, nil
+}
+
+// [diskio.RenameAndSync] renames before it syncs, so a sync error can follow a
+// rename that already ran. Taking the mark back then makes every later pass
+// read the promoted canonical directory as unpromoted.
+func (r *migrationReconciler) abandonPromotion(rec MigrationRecordSwapped, prop, staged string) MigrationRecordSwapped {
+	stagedThere, err := r.dirExists(staged)
+	if err != nil {
+		r.logger.WithField("record", rec.Subject().Key.String()).Errorf(
+			"cannot tell whether the staged directory %q of property %q survived its failed rename, "+
+				"so its started promotion mark is left standing: %v", staged, prop, err)
+		return rec
+	}
+	if !stagedThere {
+		return rec
+	}
+	abandoned := rec.WithPromotionAbandoned(prop)
+	if err := r.store.Put(abandoned); err != nil {
+		r.logger.WithField("record", rec.Subject().Key.String()).Errorf(
+			"take back the started promotion of property %q after its rename failed: %v", prop, err)
+		return rec
+	}
+	return abandoned
+}
+
+// One value, not three strings: two of these reach os.RemoveAll and the
+// third holds the only copy, so swapping any two at a call site deletes data.
+type promotionDirs struct {
+	staged    string
+	canonical string
+	displaced string
+}
+
+func (r *migrationReconciler) reconcilePromoted(ctx context.Context, rec MigrationRecordPromoted,
+	someUnreadable bool,
+) error {
+	if someUnreadable {
+		return nil
+	}
+	return r.withSealedUnit(rec.Subject(), "its closure sweep", func() error {
+		return r.reconcilePromotedSealed(ctx, rec)
+	})
+}
+
+func (r *migrationReconciler) reconcilePromotedSealed(ctx context.Context, rec MigrationRecordPromoted) error {
+	subject := rec.Subject()
+	all := r.store.Records()
+
+	if err := r.repromoteWhatTheRecordOutran(ctx, all, subject); err != nil {
+		return err
+	}
+
+	remaining := r.reclaimOwnedDirs(ctx, subject)
+	if len(remaining) > 0 {
+		r.logger.WithField("record", subject.Key.String()).Warnf(
+			"%d directory/directories of a promoted migration could not be reclaimed yet", len(remaining))
+		return nil
+	}
+
+	class := r.deps.Class()
+	if class == nil {
+		r.logger.WithField("record", subject.Key.String()).Warn(
+			"a promoted migration's collection is not in the schema, so nothing here can confirm its effect; keeping the record")
+		return nil
+	}
+	if effect, missing := migrationEffectStatus(class, subject); effect == migrationEffectPending {
+		r.logger.WithField("record", subject.Key.String()).WithField("properties_pending", len(missing)).Warn(
+			"this shard promoted a migration whose effect is not in the schema; keeping the record, " +
+				"which is what answers for the property until the effect lands")
+		return nil
+	}
+	if older, sole := migrationSoleSupersessorOf(all, subject); sole {
+		r.logger.WithField("record", subject.Key.String()).Warnf(
+			"keeping this promoted migration's record: it is the only thing superseding record %s, "+
+				"and removing it would let the next load promote that record's older staged data over "+
+				"the directory this one's data lives in. The next pass retires that record first", older)
+		return nil
+	}
+	if err := r.removeTrackerDir(subject); err != nil {
+		return err
+	}
+	return r.store.Remove(subject.Key)
+}
+
+func (r *migrationReconciler) repromoteWhatTheRecordOutran(ctx context.Context, all []MigrationRecord,
+	subject MigrationSubject,
+) error {
+	var ambiguous, repromoted []string
+	// One line per record, not one per property: this runs on every load of a
+	// promoted record, and one interrupted pass leaves every property behind.
+	// Deferred, so a rename that fails partway still reports what it ran.
+	defer func() {
+		if len(repromoted) == 0 {
+			return
+		}
+		r.logger.WithField("record", subject.Key.String()).
+			WithField("property_count", len(subject.Props)).
+			Errorf("%d propert(y/ies) recorded as promoted still hold their data at the staged name: %s; "+
+				"re-running the promotion", len(repromoted), strings.Join(migrationReportedNames(repromoted), ", "))
+	}()
+
+	for _, prop := range subject.Properties() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		staged, canonical := subject.Props[prop].Staged, subject.Props[prop].Canonical
+		if staged == "" || canonical == "" {
+			continue
+		}
+		if migrationPropertySuperseded(all, subject, prop) {
+			continue
+		}
+		stagedThere, err := r.dirExists(staged)
+		if err != nil {
+			return err
+		}
+		if !stagedThere {
+			continue
+		}
+		canonicalThere, err := r.dirExists(canonical)
+		if err != nil {
+			return err
+		}
+		if canonicalThere {
+			ambiguous = append(ambiguous, prop)
+			continue
+		}
+
+		repromoted = append(repromoted, prop)
+		if err := r.rename(staged, canonical); err != nil {
+			return err
+		}
+	}
+	if len(ambiguous) > 0 {
+		r.wedged(subject, migrationWedgeRemedy,
+			"%d propert(y/ies) recorded as promoted hold a directory at both their staged and canonical names: %s; "+
+				"nothing here can tell which one the promotion produced, so the record and both directories are preserved.",
+			len(ambiguous), strings.Join(migrationReportedNames(ambiguous), ", "))
+		return fmt.Errorf(
+			"%d property/properties hold a directory at both their staged and canonical names: %s; "+
+				"nothing here can tell which one the promotion produced, so the record and both directories are preserved",
+			len(ambiguous), strings.Join(migrationReportedNames(ambiguous), ", "))
+	}
+	return nil
+}
+
+const migrationTaskMapUnreadable = "this node's task map cannot be read yet"
+
+// Not installed and installed-but-not-applied-yet read the same here: neither
+// licenses a decision.
+func (r *migrationReconciler) localTasks() ([]*distributedtask.Task, bool) {
+	if r.deps.LocalTasks == nil {
+		return nil, false
+	}
+	return r.deps.LocalTasks()
+}
+
+func (r *migrationReconciler) localVerdict(subject MigrationSubject) (migrationVerdict, string) {
+	tasks, readable := r.localTasks()
+	if !readable {
+		return migrationVerdictLeave, migrationTaskMapUnreadable
+	}
+	return r.verdictFrom(subject, tasks, taskListMayLag)
+}
+
+func (r *migrationReconciler) clusterVerdict(subject MigrationSubject, tasks []*distributedtask.Task) (migrationVerdict, string) {
+	local, readable := r.localTasks()
+	if !readable {
+		return migrationVerdictLeave, migrationTaskMapUnreadable
+	}
+	if task := findMigrationTask(subject, local); task != nil {
+		return migrationVerdictForTask(task)
+	}
+	return r.verdictFrom(subject, tasks, taskListIsComplete)
+}
+
+func (r *migrationReconciler) sealUnit(subject MigrationSubject) (func(), bool) {
+	if r.deps.SealUnit == nil {
+		return func() {}, false
+	}
+	return r.deps.SealUnit(
+		distributedtask.TaskDescriptor{ID: subject.TaskID, Version: subject.Key.TaskVersion},
+		subject.Key.UnitID)
+}
+
+// A live worker keeps writing through pointers taken before its phase
+// began, into what the teardown would remove; decline and retry next pass.
+func (r *migrationReconciler) withSealedUnit(subject MigrationSubject, what string, run func() error) error {
+	release, sealed := r.sealUnit(subject)
+	if !sealed {
+		r.logger.WithField("record", subject.Key.String()).Infof(
+			"a local unit of this migration is still running, so %s waits for the next pass", what)
+		return nil
+	}
+	defer release()
+	return run()
+}
+
+type taskListCompleteness bool
+
+const (
+	taskListMayLag     taskListCompleteness = false
+	taskListIsComplete taskListCompleteness = true
+)
+
+func (r *migrationReconciler) verdictFrom(subject MigrationSubject, tasks []*distributedtask.Task,
+	completeness taskListCompleteness,
+) (migrationVerdict, string) {
+	if task := findMigrationTask(subject, tasks); task != nil {
+		return migrationVerdictForTask(task)
+	}
+
+	class := r.deps.Class()
+	if class == nil {
+		return migrationVerdictLeave, "collection is not in the locally applied schema"
+	}
+	if migrationEffectConfirmsCommit(class, subject) {
+		return migrationVerdictCommit, "owning task is gone and the schema shows its effect"
+	}
+	if migrationEffectIsNeverObservable(subject.MigrationType) {
+		why := fmt.Sprintf("the schema never shows the effect of a %s migration, "+
+			"so it can neither confirm nor deny this one", subject.MigrationType)
+		if completeness == taskListMayLag {
+			return migrationVerdictLeave, why
+		}
+		// Every later pass reads this same answer, so leaving the record
+		// standing costs a leader query and a shard walk a minute, forever.
+		return migrationVerdictWedge, why + ", and the leader's list no longer holds the owning task"
+	}
+	if effect, _ := migrationEffectStatus(class, subject); effect == migrationEffectUnobservable {
+		return migrationVerdictLeave, "the locally applied schema does not hold every property this record names yet"
+	}
+	if completeness == taskListMayLag {
+		return migrationVerdictLeave, "this node can see neither the owning task nor its effect, which a node still applying its log cannot tell from a task that is gone"
+	}
+	return migrationVerdictDiscard, "owning task is gone and the schema does not show its effect"
+}
+
+func migrationVerdictForTask(task *distributedtask.Task) (migrationVerdict, string) {
+	switch task.Status {
+	case distributedtask.TaskStatusFinished:
+		return migrationVerdictCommit, "owning task finished"
+	case distributedtask.TaskStatusCancelled, distributedtask.TaskStatusFailed:
+		return migrationVerdictDiscard, fmt.Sprintf("owning task %s", task.Status)
+	default:
+		// Active, or a status this build does not recognize.
+		return migrationVerdictLeave, fmt.Sprintf("owning task is %s", task.Status)
+	}
+}
+
+func findMigrationTask(subject MigrationSubject, tasks []*distributedtask.Task) *distributedtask.Task {
+	for _, task := range tasks {
+		if task != nil && task.ID == subject.TaskID && task.Version == subject.Key.TaskVersion {
+			return task
+		}
+	}
+	return nil
+}
+
+// Can't wait for a live worker instead: shard load runs on the RAFT apply
+// loop, and waiting there would stall the whole cluster.
+func (r *migrationReconciler) discard(ctx context.Context, subject MigrationSubject, why string) error {
+	return r.withSealedUnit(subject, "the discard of its staged data", func() error {
+		return r.discardSealed(ctx, subject, why)
+	})
+}
+
+func (r *migrationReconciler) discardSealed(ctx context.Context, subject MigrationSubject, why string) error {
+	r.logger.WithField("record", subject.Key.String()).Infof("discarding staged migration data: %s", why)
+	return r.reclaimRecordAndDirs(ctx, subject)
+}
+
+// The record answers for every directory it names, so it goes last of all.
+func (r *migrationReconciler) reclaimRecordAndDirs(ctx context.Context, subject MigrationSubject) error {
+	if remaining := r.reclaimOwnedDirs(ctx, subject); len(remaining) > 0 {
+		return fmt.Errorf("%d owned directory/directories survived", len(remaining))
+	}
+	if err := r.removeTrackerDir(subject); err != nil {
+		return err
+	}
+	return r.store.Remove(subject.Key)
+}
+
+func (r *migrationReconciler) closeStagedBuckets(ctx context.Context, dirs ...string) error {
+	if r.deps.Buckets == nil {
+		return nil
+	}
+	if err := r.deps.Buckets.ShutdownStagedBucketsAt(ctx, dirs); err != nil {
+		return fmt.Errorf("shut down the staged buckets at %s: %w",
+			strings.Join(migrationReportedNames(dirs), ", "), err)
+	}
+	return nil
+}
+
+// Reports a failed removal, which leaves a directory nothing else attributes:
+// the caller must keep its record so the next load retries.
+func (r *migrationReconciler) removeTrackerDir(subject MigrationSubject) error {
+	if err := r.removeDir(r.migrationsPath(), subject.TrackerDir, "the migration's tracker directory"); err != nil {
+		r.logger.WithField("dir", subject.TrackerDir).Errorf("%v", err)
+		return err
+	}
+	return nil
+}
+
+// A directory a later-versioned record claims as displaced is that claimer's
+// only copy; removing it here loses the successor's data.
+// One line per record, not one per directory: a single filesystem fault fails
+// the removal and the confirming stat of every directory the record names.
+func (r *migrationReconciler) reclaimOwnedDirs(ctx context.Context,
+	subject MigrationSubject,
+) []string {
+	var remaining []string
+	owned := migrationOwnedDirs(subject)
+	all := r.store.Records()
+	reclaiming := errorcompounder.New()
+	for _, dir := range owned {
+		if err := ctx.Err(); err != nil {
+			reclaiming.Add(err)
+			remaining = append(remaining, dir)
+			break
+		}
+		if migrationDirClaimedAsDisplaced(all, subject, dir) {
+			continue
+		}
+		if err := r.closeStagedBuckets(ctx, dir); err != nil {
+			reclaiming.Add(err)
+			remaining = append(remaining, dir)
+			continue
+		}
+		reclaiming.Add(r.removeDir(r.lsmPath, dir, "a migration directory"))
+		there, err := r.dirExists(dir)
+		if err != nil {
+			reclaiming.AddWrapf(err, "confirm migration directory %q is gone", dir)
+		}
+		if there || err != nil {
+			remaining = append(remaining, dir)
+		}
+	}
+	if err := reclaiming.ToErrorLimited(maxReportedErrors); err != nil {
+		r.logger.WithField("record", subject.Key.String()).
+			WithField("directory_count", len(owned)).
+			Errorf("reclaim the directories of a migration: %v", err)
+	}
+	return remaining
+}
+
+func migrationOwnedDirs(subject MigrationSubject) []string {
+	dirs := make([]string, 0, 2*len(subject.Props))
+	for _, prop := range subject.Properties() {
+		dirs = append(dirs, migrationOwnCopyDirs(subject, prop)...)
+	}
+	return dirs
+}
+
+// Refused here, not at each caller: joining an empty or escaping handle
+// onto root resolves to root itself, and callers remove or rename the result.
+func (r *migrationReconciler) path(root, dir, what string) (string, error) {
+	if !migrationHandleIsOneElement(dir) {
+		return "", fmt.Errorf("refusing to act on %s %q: it does not name a single directory under %q",
+			what, dir, root)
+	}
+	return filepath.Join(root, dir), nil
+}
+
+func (r *migrationReconciler) removeDir(root, dir, what string) error {
+	if dir == "" {
+		return nil
+	}
+	path, err := r.path(root, dir, what)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(path); err != nil {
+		return fmt.Errorf("remove %s %q: %w", what, dir, err)
+	}
+	return nil
+}
+
+func (r *migrationReconciler) migrationsPath() string {
+	return filepath.Join(r.lsmPath, migrationsDir)
+}
+
+func (r *migrationReconciler) dirExists(dir string) (bool, error) {
+	if dir == "" {
+		return false, nil
+	}
+	path, err := r.path(r.lsmPath, dir, "a recorded directory")
+	if err != nil {
+		return false, err
+	}
+	// Any stat failure besides ENOENT must stop the caller, or a promotion
+	// probe could take "cannot see it" as proof a rename already ran.
+	there, err := diskio.DirExists(path)
+	if err != nil {
+		return false, fmt.Errorf("stat migration directory %q: %w", path, err)
+	}
+	return there, nil
+}
+
+// The Promoted record written on this rename's strength is durable, so the
+// rename must be too, or a crash leaves it naming a path that was never made.
+func (r *migrationReconciler) rename(from, to string) error {
+	fromPath, err := r.path(r.lsmPath, from, "the directory to promote")
+	if err != nil {
+		return err
+	}
+	toPath, err := r.path(r.lsmPath, to, "the name to promote onto")
+	if err != nil {
+		return err
+	}
+	if err := diskio.RenameAndSync(fromPath, toPath); err != nil {
+		return fmt.Errorf("promote %q to %q: %w", from, to, err)
+	}
+	return nil
+}

--- a/adapters/repos/db/inverted_reindex_reconcile.go
+++ b/adapters/repos/db/inverted_reindex_reconcile.go
@@ -27,10 +27,9 @@ import (
 )
 
 // Must run before the directory is removed, or mmaps and compactions leak.
-// Takes directories rather than a record, so the caller closes only what it has
-// already decided it may remove: a shutdown deregisters the bucket and nothing
-// reopens it before the next shard load, so closing a directory the caller then
-// leaves in place stops that data serving with no record left to answer for it.
+// Takes directories, not a record, so the caller closes only what it has
+// already decided to remove — closing one it means to keep would stop that
+// data serving with no record left to account for it.
 type migrationStagedBucketCloser interface {
 	ShutdownStagedBucketsAt(ctx context.Context, dirs []string) error
 }
@@ -467,7 +466,7 @@ func (r *migrationReconciler) promoteProperty(rec MigrationRecordSwapped,
 	}
 
 	// Dormant here: every flip this build writes displaces the canonical name
-	// itself, and the cutover PR is what writes a different one.
+	// itself, and the cutover is what writes a different one.
 	if displaced != "" && displaced != canonical {
 		if cleared, err := r.clearForPromotion(displaced, "the displaced directory"); err != nil || !cleared {
 			return rec, false, err

--- a/adapters/repos/db/inverted_reindex_reconcile_test.go
+++ b/adapters/repos/db/inverted_reindex_reconcile_test.go
@@ -968,13 +968,15 @@ func TestAPromotionThatCannotRecordItsStartDoesNotRename(t *testing.T) {
 	f.put(NewMigrationRecordSwapped(subject, []string{"title"}, map[string]string{"title": "property_title_searchable"}))
 	f.blockRecordWrites()
 
-	f.reconcile()
+	r := f.reconcile()
 
 	require.True(t, f.exists("property_title__g42_ingest"),
 		"the rename must not run before the record says it started")
 	state, present := f.state(subject.Key)
 	require.True(t, present)
 	require.Equal(t, MigrationStateSwapped, state, "and no promotion is recorded")
+	require.Equal(t, 1, r.WedgedCount(),
+		"a promotion that could not run counts, or the shard reads as settled")
 }
 
 func wedgeEntry(t *testing.T, f *reconcileFixture) *logrus.Entry {
@@ -1894,9 +1896,8 @@ func TestARecordTheAppliedSchemaHasNotCaughtUpWithIsAskedAgain(t *testing.T) {
 	}
 }
 
-// A name a migration mints carries its own task version, so two records can
-// only claim one directory if something outside this build wrote them. Nothing
-// here can tell which one the data belongs to, so both are refused.
+// Nothing here can tell which of two records claiming one directory the data
+// belongs to, so both are refused.
 func TestTwoRecordsClaimingOneDirectoryAreBothRefused(t *testing.T) {
 	f := newReconcileFixture(t)
 	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")

--- a/adapters/repos/db/inverted_reindex_reconcile_test.go
+++ b/adapters/repos/db/inverted_reindex_reconcile_test.go
@@ -1,0 +1,1971 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+type fakeBucketCloser struct {
+	closed []string
+	err    error
+}
+
+func (f *fakeBucketCloser) ShutdownStagedBucketsAt(_ context.Context, dirs []string) error {
+	f.closed = append(f.closed, dirs...)
+	return f.err
+}
+
+type liveUnitKey struct {
+	desc   distributedtask.TaskDescriptor
+	unitID string
+}
+
+func liveUnitOf(subject MigrationSubject) *liveUnitKey {
+	return &liveUnitKey{
+		desc:   distributedtask.TaskDescriptor{ID: subject.TaskID, Version: subject.Key.TaskVersion},
+		unitID: subject.Key.UnitID,
+	}
+}
+
+type reconcileFixture struct {
+	t             *testing.T
+	lsmPath       string
+	planted       []MigrationSubject
+	store         *MigrationRecordStore
+	buckets       *fakeBucketCloser
+	tasks         []*distributedtask.Task
+	tasksReadable bool
+	liveUnit      *liveUnitKey
+	asked         []liveUnitKey
+	sealed        []liveUnitKey
+	sealsReleased int
+	class         *models.Class
+	logger        *logrus.Logger
+	logs          *test.Hook
+}
+
+func newReconcileFixture(t *testing.T) *reconcileFixture {
+	t.Helper()
+	return newReconcileFixtureAt(t, t.TempDir())
+}
+
+func newReconcileFixtureAt(t *testing.T, lsmPath string) *reconcileFixture {
+	t.Helper()
+	logger, hook := test.NewNullLogger()
+	require.NoError(t, os.MkdirAll(lsmPath, 0o777))
+	return &reconcileFixture{
+		t:             t,
+		tasksReadable: true,
+		lsmPath:       lsmPath,
+		store:         NewMigrationRecordStore(lsmPath, logger),
+		buckets:       &fakeBucketCloser{},
+		logger:        logger,
+		logs:          hook,
+	}
+}
+
+func (f *reconcileFixture) logged(want string) bool {
+	for _, entry := range f.logs.AllEntries() {
+		if strings.Contains(entry.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *reconcileFixture) errorLines(contains string) []string {
+	var lines []string
+	for _, entry := range f.logs.AllEntries() {
+		if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, contains) {
+			lines = append(lines, entry.Message)
+		}
+	}
+	return lines
+}
+
+func manyMigrationProps(n int) []string {
+	props := make([]string, n)
+	for i := range props {
+		props[i] = fmt.Sprintf("prop_%02d", i)
+	}
+	return props
+}
+
+func (f *reconcileFixture) warned(want string) bool {
+	for _, entry := range f.logs.AllEntries() {
+		if entry.Level == logrus.WarnLevel && strings.Contains(entry.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *reconcileFixture) reconcile() *migrationReconciler {
+	f.t.Helper()
+	r := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps())
+	require.NoError(f.t, r.Reconcile(context.Background()))
+	f.requireMigrationDirsTrackRecords()
+	return r
+}
+
+func (f *reconcileFixture) deps() migrationReconcileDeps {
+	return migrationReconcileDeps{
+		LocalTasks: func() ([]*distributedtask.Task, bool) { return f.tasks, f.tasksReadable },
+		SealUnit: func(desc distributedtask.TaskDescriptor, unitID string) (func(), bool) {
+			f.asked = append(f.asked, liveUnitKey{desc, unitID})
+			if f.liveUnit != nil && *f.liveUnit == (liveUnitKey{desc, unitID}) {
+				return nil, false
+			}
+			f.sealed = append(f.sealed, liveUnitKey{desc, unitID})
+			return func() { f.sealsReleased++ }, true
+		},
+		Class:   func() *models.Class { return f.class },
+		Buckets: f.buckets,
+	}
+}
+
+func TestOnlyAHandleNamingOneDirectoryBecomesAPath(t *testing.T) {
+	tests := []struct {
+		name             string
+		dir              string
+		refusedAsPath    bool
+		refusedAsRemoval bool
+	}{
+		{name: "names none", dir: "", refusedAsPath: true, refusedAsRemoval: false},
+		{name: "the root itself", dir: ".", refusedAsPath: true, refusedAsRemoval: true},
+		{name: "the parent of the root", dir: "..", refusedAsPath: true, refusedAsRemoval: true},
+		{name: "a join back to the root", dir: "x/..", refusedAsPath: true, refusedAsRemoval: true},
+		{name: "a nested path", dir: "sub/dir", refusedAsPath: true, refusedAsRemoval: true},
+		{name: "an absolute path", dir: "/etc", refusedAsPath: true, refusedAsRemoval: true},
+		{name: "one directory", dir: "property_title_searchable", refusedAsPath: false, refusedAsRemoval: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.mkdirs(helpers.ObjectsBucketLSM, "property_title_searchable")
+			r := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps())
+
+			path, err := r.path(f.lsmPath, tt.dir, "a recorded directory")
+			if tt.refusedAsPath {
+				require.Error(t, err)
+				require.Empty(t, path)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, filepath.Join(f.lsmPath, tt.dir), path)
+			}
+
+			err = r.removeDir(f.lsmPath, tt.dir, "a recorded directory")
+			if tt.refusedAsRemoval {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.DirExists(t, f.lsmPath, "the shard's LSM directory")
+			require.True(t, f.exists(helpers.ObjectsBucketLSM), "the shard's object store")
+			require.Equal(t, tt.refusedAsPath, f.exists("property_title_searchable"),
+				"only a handle that names one directory removes one")
+		})
+	}
+}
+
+func (f *reconcileFixture) mkdirs(names ...string) {
+	f.t.Helper()
+	for _, name := range names {
+		require.NoError(f.t, os.MkdirAll(filepath.Join(f.lsmPath, name), 0o777))
+		require.NoError(f.t, os.WriteFile(filepath.Join(f.lsmPath, name, "segment-1.db"), []byte(name), 0o600))
+	}
+}
+
+func (f *reconcileFixture) exists(name string) bool {
+	info, err := os.Stat(filepath.Join(f.lsmPath, name))
+	return err == nil && info.IsDir()
+}
+
+func denyDirectoryWrites(t *testing.T, path string) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("root writes into a directory whatever its mode says")
+	}
+	require.NoError(t, os.Chmod(path, 0o500))
+	t.Cleanup(func() { os.Chmod(path, 0o700) })
+}
+
+func (f *reconcileFixture) blockRemoval(name string) {
+	f.t.Helper()
+	denyDirectoryWrites(f.t, filepath.Join(f.lsmPath, name))
+}
+
+func (f *reconcileFixture) blockTrackerRemoval(subject MigrationSubject) {
+	f.t.Helper()
+	denyDirectoryWrites(f.t, filepath.Join(f.lsmPath, migrationsDir, subject.TrackerDir))
+}
+
+func (f *reconcileFixture) blockRecordWrites() {
+	f.t.Helper()
+	denyDirectoryWrites(f.t, f.store.Dir())
+}
+
+func (f *reconcileFixture) allowRecordWrites() {
+	f.t.Helper()
+	require.NoError(f.t, os.Chmod(f.store.Dir(), 0o700))
+}
+
+// A file no build can decode, which is what withholds every destructive action
+// on the shard whose record store holds it.
+func plantUnreadableRecord(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o777))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "99_enable_searchable.json"), []byte("{"), 0o600))
+}
+
+// Writes the file without the writer's own bookkeeping, which is the only way
+// a record claiming another record's directory can get onto a shard.
+func (f *reconcileFixture) plantRecordFile(rec MigrationRecord) {
+	f.t.Helper()
+	data, err := encodeMigrationRecord(rec)
+	require.NoError(f.t, err)
+	require.NoError(f.t, os.MkdirAll(f.store.Dir(), 0o777))
+	require.NoError(f.t, os.WriteFile(
+		filepath.Join(f.store.Dir(), rec.Subject().Key.fileName()), data, 0o600))
+}
+
+func (f *reconcileFixture) contentOf(name string) string {
+	data, err := os.ReadFile(filepath.Join(f.lsmPath, name, "segment-1.db"))
+	require.NoError(f.t, err)
+	return string(data)
+}
+
+func (f *reconcileFixture) put(rec MigrationRecord) {
+	f.t.Helper()
+	subject := rec.Subject()
+	require.NoError(f.t, f.store.Put(rec))
+	f.planted = append(f.planted, subject)
+	path := filepath.Join(f.lsmPath, migrationsDir, subject.TrackerDir)
+	require.NoError(f.t, os.MkdirAll(path, 0o777))
+	require.NoError(f.t, os.WriteFile(filepath.Join(path, "payload.mig"), []byte(subject.TaskID), 0o600))
+}
+
+func (f *reconcileFixture) trackerDirExists(subject MigrationSubject) bool {
+	info, err := os.Stat(filepath.Join(f.lsmPath, migrationsDir, subject.TrackerDir))
+	return err == nil && info.IsDir()
+}
+
+// A tracker directory on disk means its record is live: the startup finalize
+// path acts on tracker directories by name, so one with no record is an
+// ownerless instruction handed to another subsystem. The other direction is
+// weaker on purpose. Removal takes the directories, then the tracker, then the
+// record, so a record can outlive its tracker, and only once nothing it named
+// is left for it to remove.
+func (f *reconcileFixture) requireMigrationDirsTrackRecords() {
+	f.t.Helper()
+	surviving := f.store.Records()
+	for _, subject := range f.planted {
+		_, hasRecord := f.store.Get(subject.Key)
+		trackerThere := f.trackerDirExists(subject)
+		if trackerThere {
+			require.True(f.t, hasRecord, "tracker directory of %s survives with no record", subject.Key)
+		}
+
+		for _, dir := range migrationOwnedDirs(subject) {
+			if !f.exists(dir) {
+				continue
+			}
+			require.True(f.t, attributedToSomeRecord(surviving, dir),
+				"directory %q survives with no record owning or claiming it", dir)
+			require.True(f.t, trackerThere || !hasRecord ||
+				migrationDirClaimedAsDisplaced(surviving, subject, dir),
+				"record %s outlived its tracker directory while %q is still its own to remove",
+				subject.Key, dir)
+		}
+	}
+}
+
+func attributedToSomeRecord(records []MigrationRecord, dir string) bool {
+	for _, rec := range records {
+		if rec.OwnsBucket(dir) {
+			return true
+		}
+		if displacer, ok := rec.(migrationDisplacer); ok {
+			if _, claimed := displacer.displacedFor(dir); claimed {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (f *reconcileFixture) state(key MigrationRecordKey) (MigrationState, bool) {
+	rec, ok := f.store.Get(key)
+	if !ok {
+		return "", false
+	}
+	return rec.State(), true
+}
+
+func (f *reconcileFixture) swapped(t *testing.T, key MigrationRecordKey) MigrationRecordSwapped {
+	t.Helper()
+	rec, ok := f.store.Get(key)
+	require.True(t, ok)
+	swapped, ok := rec.(MigrationRecordSwapped)
+	require.True(t, ok)
+	return swapped
+}
+
+func testTask(id string, version uint64, status distributedtask.TaskStatus) *distributedtask.Task {
+	return &distributedtask.Task{
+		Namespace:      ReindexNamespace,
+		TaskDescriptor: distributedtask.TaskDescriptor{ID: id, Version: version},
+		Status:         status,
+	}
+}
+
+func testClassWithTokenization(tokenization string, props ...string) *models.Class {
+	class := &models.Class{Class: "Books"}
+	for _, name := range props {
+		class.Properties = append(class.Properties, &models.Property{Name: name, Tokenization: tokenization})
+	}
+	return class
+}
+
+func TestCommitMergedRefusesARecordItCouldNeverPromote(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	setMigrationDir(&subject, "title", func(d *MigrationPropertyDirs) { d.Canonical = "" })
+	f.mkdirs("property_title__g42_ingest")
+	f.tasks = []*distributedtask.Task{testTask(subject.TaskID, 42, distributedtask.TaskStatusFinished)}
+	f.put(NewMigrationRecordMerged(subject))
+
+	for pass := 1; pass <= 3; pass++ {
+		f.reconcile()
+		state, present := f.state(subject.Key)
+		require.True(t, present)
+		require.Equal(t, MigrationStateMerged, state,
+			"pass %d wrote a flip whose promotion can never run", pass)
+	}
+	require.True(t, f.logged("refusing to commit the flip"),
+		"the refusal has to say why, or an operator sees a migration that simply stops")
+	require.Equal(t, "property_title__g42_ingest", f.contentOf("property_title__g42_ingest"),
+		"and the staged data the flip would have promoted is untouched")
+}
+
+func TestReconcileMergedDisposition(t *testing.T) {
+	const taskID = "Books:change-tokenization:title:ab12"
+	const bodySidecar = "property_body__s42_reindex"
+
+	tests := []struct {
+		name            string
+		task            *distributedtask.Task
+		tasksUnreadable bool
+		noStagedDir     bool
+		// A second property the record names one directory for, and only a
+		// sidecar: a property does not have to reach the staging phase.
+		secondProperty bool
+		class          *models.Class
+		wantState      MigrationState
+		wantRecord     bool
+		wantStagedGone bool
+		wantCanonical  string
+	}{
+		{
+			name:          "task still running: record and directories survive the load untouched",
+			task:          testTask(taskID, 42, distributedtask.TaskStatusStarted),
+			class:         testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantState:     MigrationStateMerged,
+			wantRecord:    true,
+			wantCanonical: "property_title_searchable",
+		},
+		{
+			name:           "task finished: commit and promote",
+			task:           testTask(taskID, 42, distributedtask.TaskStatusFinished),
+			class:          testClassWithTokenization(models.PropertyTokenizationLowercase, "title"),
+			wantState:      MigrationStatePromoted,
+			wantRecord:     true,
+			wantStagedGone: true,
+			wantCanonical:  "property_title__g42_ingest",
+		},
+		{
+			name:           "task cancelled: discard the staged copy, leave the canonical bucket alone",
+			task:           testTask(taskID, 42, distributedtask.TaskStatusCancelled),
+			class:          testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantRecord:     false,
+			wantStagedGone: true,
+			wantCanonical:  "property_title_searchable",
+		},
+		{
+			name:           "task failed",
+			task:           testTask(taskID, 42, distributedtask.TaskStatusFailed),
+			class:          testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantRecord:     false,
+			wantStagedGone: true,
+			wantCanonical:  "property_title_searchable",
+		},
+		{
+			name:           "task cancelled: the discard takes every directory the record names",
+			task:           testTask(taskID, 42, distributedtask.TaskStatusCancelled),
+			class:          testClassWithTokenization(models.PropertyTokenizationWord, "title", "body"),
+			secondProperty: true,
+			wantRecord:     false,
+			wantStagedGone: true,
+			wantCanonical:  "property_title_searchable",
+		},
+		{
+			name:          "a status this build does not recognize is left for whoever does",
+			task:          testTask(taskID, 42, distributedtask.TaskStatus("QUIESCING")),
+			class:         testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantState:     MigrationStateMerged,
+			wantRecord:    true,
+			wantCanonical: "property_title_searchable",
+		},
+		{
+			name:          "same task ID at a different version is a different run and says nothing",
+			task:          testTask(taskID, 43, distributedtask.TaskStatusFinished),
+			class:         testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantState:     MigrationStateMerged,
+			wantRecord:    true,
+			wantCanonical: "property_title_searchable",
+		},
+		{
+			name:           "task gone and the schema shows the effect: commit",
+			class:          testClassWithTokenization(models.PropertyTokenizationLowercase, "title"),
+			wantState:      MigrationStatePromoted,
+			wantRecord:     true,
+			wantStagedGone: true,
+			wantCanonical:  "property_title__g42_ingest",
+		},
+		{
+			name:          "neither the task nor its effect is visible here: leave it to the pass that asks the leader",
+			class:         testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantState:     MigrationStateMerged,
+			wantRecord:    true,
+			wantCanonical: "property_title_searchable",
+		},
+		{
+			name:            "the task map is not readable yet, so an absent task proves nothing",
+			tasksUnreadable: true,
+			class:           testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantState:       MigrationStateMerged,
+			wantRecord:      true,
+			wantCanonical:   "property_title_searchable",
+		},
+		{
+			name:           "task finished but the staged data is gone: freeze rather than stamp it complete",
+			task:           testTask(taskID, 42, distributedtask.TaskStatusFinished),
+			noStagedDir:    true,
+			class:          testClassWithTokenization(models.PropertyTokenizationLowercase, "title"),
+			wantState:      MigrationStateMerged,
+			wantRecord:     true,
+			wantStagedGone: true,
+			wantCanonical:  "property_title_searchable",
+		},
+		{
+			name:          "collection missing from the applied schema is an anomaly, not a licence to delete",
+			class:         nil,
+			wantState:     MigrationStateMerged,
+			wantRecord:    true,
+			wantCanonical: "property_title_searchable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = tt.class
+			f.tasksReadable = !tt.tasksUnreadable
+			if tt.task != nil {
+				f.tasks = []*distributedtask.Task{tt.task}
+			}
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			subject.TaskID = taskID
+			if tt.noStagedDir {
+				f.mkdirs("property_title__s42_reindex", "property_title_searchable")
+			} else {
+				f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable")
+			}
+			if tt.secondProperty {
+				setMigrationDir(&subject, "body", func(d *MigrationPropertyDirs) { d.Sidecar = bodySidecar })
+				f.mkdirs(bodySidecar)
+			}
+			f.put(NewMigrationRecordMerged(subject))
+
+			f.reconcile()
+
+			state, present := f.state(subject.Key)
+			require.Equal(t, tt.wantRecord, present)
+			if tt.wantRecord {
+				require.Equal(t, tt.wantState, state)
+			}
+			require.Equal(t, !tt.wantStagedGone, f.exists("property_title__g42_ingest"))
+			require.True(t, f.exists("property_title_searchable"), "the canonical bucket must survive every disposition")
+			require.Equal(t, tt.wantCanonical, f.contentOf("property_title_searchable"))
+			if tt.secondProperty {
+				require.False(t, f.exists(bodySidecar),
+					"a directory the record names is the record's own to remove")
+				require.Empty(t, f.store.Records(), "and the discard leaves the store empty")
+			}
+		})
+	}
+}
+
+func TestReconcileSwappedProbe(t *testing.T) {
+	tests := []struct {
+		name             string
+		present          []string
+		promotion        map[string]migrationPromotionMark
+		wantState        MigrationState
+		wantCanonical    string
+		wantCanonicalDir bool
+		wantMark         migrationPromotionMark
+	}{
+		{
+			name:             "both present: whether or not the crash beat the first flip, the probe reads the same two handles",
+			present:          []string{"property_title__g42_ingest", "property_title_searchable"},
+			wantState:        MigrationStatePromoted,
+			wantCanonical:    "property_title__g42_ingest",
+			wantCanonicalDir: true,
+		},
+		{
+			name:             "staged only: the displaced directory is already gone, promote",
+			present:          []string{"property_title__g42_ingest"},
+			wantState:        MigrationStatePromoted,
+			wantCanonical:    "property_title__g42_ingest",
+			wantCanonicalDir: true,
+		},
+		{
+			name:             "canonical only, a start recorded and no finish: settle the rename that ran",
+			present:          []string{"property_title_searchable"},
+			promotion:        map[string]migrationPromotionMark{"title": migrationPromotionStarted},
+			wantState:        MigrationStatePromoted,
+			wantCanonical:    "property_title_searchable",
+			wantCanonicalDir: true,
+		},
+		{
+			name:             "neither, a start recorded and no finish: the rename never ran, promote nothing",
+			promotion:        map[string]migrationPromotionMark{"title": migrationPromotionStarted},
+			wantState:        MigrationStateSwapped,
+			wantCanonicalDir: false,
+			wantMark:         "",
+		},
+		{
+			name:             "a finish recorded and the directory holds files no rename of this property produced: promote",
+			present:          []string{"property_title_searchable"},
+			promotion:        map[string]migrationPromotionMark{"title": migrationPromotionFinished},
+			wantState:        MigrationStatePromoted,
+			wantCanonical:    "property_title_searchable",
+			wantCanonicalDir: true,
+		},
+		{
+			name:             "a finish recorded and the directory is gone: promote nothing, and say so durably",
+			promotion:        map[string]migrationPromotionMark{"title": migrationPromotionFinished},
+			wantState:        MigrationStateSwapped,
+			wantCanonicalDir: false,
+			wantMark:         migrationPromotionLost,
+		},
+		{
+			name:             "canonical only, no promotion recorded: something else took the staged directory, promote nothing",
+			present:          []string{"property_title_searchable"},
+			wantState:        MigrationStateSwapped,
+			wantCanonical:    "property_title_searchable",
+			wantCanonicalDir: true,
+		},
+		{
+			name:             "neither: preserve the record and promote nothing",
+			present:          nil,
+			wantState:        MigrationStateSwapped,
+			wantCanonicalDir: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			f.mkdirs(tt.present...)
+			rec := NewMigrationRecordSwapped(subject, []string{"title"}, map[string]string{"title": "property_title_searchable"})
+			for prop, mark := range tt.promotion {
+				rec = rec.WithPromotionAt(prop, mark)
+			}
+			f.put(rec)
+
+			f.reconcile()
+
+			state, present := f.state(subject.Key)
+			require.True(t, present, "a swapped record is never discarded")
+			require.Equal(t, tt.wantState, state)
+			require.Equal(t, tt.wantCanonicalDir, f.exists("property_title_searchable"))
+			if tt.wantState == MigrationStateSwapped && len(tt.promotion) > 0 {
+				require.Equal(t, tt.wantMark, f.swapped(t, subject.Key).PromotionOf("title"))
+			}
+			if tt.wantCanonical != "" {
+				require.Equal(t, tt.wantCanonical, f.contentOf("property_title_searchable"))
+			}
+		})
+	}
+}
+
+// A sync error can follow a rename that already ran; taking the mark back
+// wedges Swapped forever.
+func TestAbandonPromotionKeepsARenameThatAlreadyMoved(t *testing.T) {
+	tests := []struct {
+		name        string
+		drive       func(t *testing.T, f *reconcileFixture, rec MigrationRecordSwapped) MigrationRecordSwapped
+		stagedThere bool
+		wantKept    bool
+		reason      string
+	}{
+		{
+			name: "the staged directory is still there, so the rename did not move it",
+			drive: func(t *testing.T, f *reconcileFixture, rec MigrationRecordSwapped) MigrationRecordSwapped {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(f.lsmPath, "property_title_searchable"), []byte("not a directory"), 0o600))
+				r := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps())
+				updated, promoted, err := r.promoteProperty(rec, "title",
+					promotionDirs{staged: "property_title__g42_ingest", canonical: "property_title_searchable"})
+				require.Error(t, err, "fixture: the rename has to fail for there to be anything to take back")
+				require.False(t, promoted)
+				return updated
+			},
+			stagedThere: true,
+			wantKept:    false,
+			reason:      "a rename that moved nothing leaves nothing to recognize later",
+		},
+		{
+			name: "the staged directory is gone, so the rename moved it before failing",
+			drive: func(t *testing.T, f *reconcileFixture, rec MigrationRecordSwapped) MigrationRecordSwapped {
+				r := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps())
+				return r.abandonPromotion(rec, "title", "property_title__g42_ingest")
+			},
+			wantKept: true,
+			reason:   "only the record says which directory under the canonical name this promotion produced",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			if tt.stagedThere {
+				f.mkdirs("property_title__g42_ingest")
+			}
+			rec := NewMigrationRecordSwapped(subject, []string{"title"},
+				map[string]string{"title": "property_title_searchable"}).
+				WithPromotionAt("title", migrationPromotionStarted)
+			f.put(rec)
+
+			kept := tt.drive(t, f, rec).PromotionOf("title") != ""
+			require.Equal(t, tt.wantKept, kept, tt.reason)
+
+			require.NoError(t, f.store.Load())
+			onDisk, ok := f.store.Records()[0].(MigrationRecordSwapped)
+			require.True(t, ok)
+			keptOnDisk := onDisk.PromotionOf("title") != ""
+			require.Equal(t, tt.wantKept, keptOnDisk, tt.reason)
+		})
+	}
+}
+
+func TestReconcileReverseEdge(t *testing.T) {
+	checkpointed := func(subject MigrationSubject) MigrationRecord {
+		return NewMigrationRecordIterating(subject, MigrationCheckpoint{
+			LastProcessedKey: []byte("halfway"),
+		})
+	}
+
+	uncheckpointed := func(subject MigrationSubject) MigrationRecord {
+		return NewMigrationRecordIterating(subject, MigrationCheckpoint{})
+	}
+
+	tests := []struct {
+		name              string
+		plant             func(MigrationSubject) MigrationRecord
+		present           []string
+		taskStatus        distributedtask.TaskStatus
+		unreadableSibling bool
+		wantState         MigrationState
+		wantRestart       bool
+		wantGone          bool
+		wantWedged        bool
+	}{
+		{
+			name:      "iterated with every owned directory on disk: stay iterated",
+			plant:     func(s MigrationSubject) MigrationRecord { return NewMigrationRecordIterated(s) },
+			present:   []string{"property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable"},
+			wantState: MigrationStateIterated,
+		},
+		{
+			name:        "iterated and the directory the rebuild wrote into is gone",
+			plant:       func(s MigrationSubject) MigrationRecord { return NewMigrationRecordIterated(s) },
+			present:     []string{"property_title__g42_ingest", "property_title_searchable"},
+			wantState:   MigrationStateIterating,
+			wantRestart: true,
+		},
+		{
+			name:        "iterated and the directory the mirror writes into is gone",
+			plant:       func(s MigrationSubject) MigrationRecord { return NewMigrationRecordIterated(s) },
+			present:     []string{"property_title__s42_reindex", "property_title_searchable"},
+			wantState:   MigrationStateIterating,
+			wantRestart: true,
+		},
+		{
+			name:      "a checkpoint with every owned directory on disk keeps its place",
+			plant:     checkpointed,
+			present:   []string{"property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable"},
+			wantState: MigrationStateIterating,
+		},
+		{
+			name:        "a checkpoint whose rebuild directory is gone restarts",
+			plant:       checkpointed,
+			present:     []string{"property_title__g42_ingest", "property_title_searchable"},
+			wantState:   MigrationStateIterating,
+			wantRestart: true,
+		},
+		{
+			name:        "a checkpoint whose mirror directory is gone restarts",
+			plant:       checkpointed,
+			present:     []string{"property_title__s42_reindex", "property_title_searchable"},
+			wantState:   MigrationStateIterating,
+			wantRestart: true,
+		},
+		{
+			name:      "no checkpoint with every owned directory on disk keeps its place",
+			plant:     uncheckpointed,
+			present:   []string{"property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable"},
+			wantState: MigrationStateIterating,
+		},
+		{
+			name:        "no checkpoint and the directory the mirror writes into is gone",
+			plant:       uncheckpointed,
+			present:     []string{"property_title__s42_reindex", "property_title_searchable"},
+			wantState:   MigrationStateIterating,
+			wantRestart: true,
+		},
+		{
+			name:        "no checkpoint and the directory the rebuild writes into is gone",
+			plant:       uncheckpointed,
+			present:     []string{"property_title__g42_ingest", "property_title_searchable"},
+			wantState:   MigrationStateIterating,
+			wantRestart: true,
+		},
+		{
+			// The restart writes, and a store nobody could read in full must
+			// not take a write: it would reset a live migration's checkpoint
+			// on evidence this build cannot see.
+			name:              "an unreadable sibling record withholds the reverse edge too",
+			plant:             checkpointed,
+			present:           []string{"property_title_searchable"},
+			unreadableSibling: true,
+			wantState:         MigrationStateIterating,
+		},
+		{
+			name:       "a committed migration whose rebuilt data is gone wedges instead of restarting",
+			plant:      uncheckpointed,
+			present:    []string{"property_title_searchable"},
+			taskStatus: distributedtask.TaskStatusFinished,
+			wantState:  MigrationStateIterating,
+			wantWedged: true,
+		},
+		{
+			name:       "a cancelled migration whose directories are gone is discarded, not restarted",
+			plant:      uncheckpointed,
+			present:    []string{"property_title_searchable"},
+			taskStatus: distributedtask.TaskStatusCancelled,
+			wantGone:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			status := tt.taskStatus
+			if status == "" {
+				status = distributedtask.TaskStatusStarted
+			}
+			f.tasks = []*distributedtask.Task{testTask(subject.TaskID, 42, status)}
+			f.mkdirs(tt.present...)
+			f.put(tt.plant(subject))
+			if tt.unreadableSibling {
+				plantUnreadableRecord(t, f.store.Dir())
+			}
+
+			r := f.reconcile()
+
+			state, present := f.state(subject.Key)
+			if tt.wantGone {
+				require.False(t, present, "a cancelled migration with no data left has nothing to resume")
+				return
+			}
+			require.True(t, present)
+			require.Equal(t, tt.wantState, state)
+			if tt.wantWedged {
+				require.Equal(t, 1, r.WedgedCount(),
+					"a record no load here can finish has to terminate as wedged")
+				require.False(t, f.store.HasUndecided(),
+					"and the wedge outlives this pass, or the record asks the leader once a minute forever")
+			}
+
+			rec, _ := f.store.Get(subject.Key)
+			if !tt.wantRestart {
+				require.Equal(t, subject.IterationCutoff, rec.Subject().IterationCutoff,
+					"a rebuild that was not restarted keeps the horizon it armed with")
+				return
+			}
+
+			require.Equal(t, MigrationCheckpoint{}, rec.(MigrationRecordIterating).Checkpoint(),
+				"the checkpoint has to clear with the state, or the rebuild resumes past data it never wrote")
+
+			require.True(t, rec.Subject().IterationCutoff.After(time.Now()),
+				"a restarted rebuild must skip nothing: the mirror it delegated to is gone")
+		})
+	}
+}
+
+// A record this build cannot read may name the directory another record's
+// disposition removes or renames over, so one unreadable file withholds every
+// destructive arm on the shard at once.
+func TestAnUnreadableRecordWithholdsEveryDestructiveArm(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title", "body", "note", "tag")
+
+	discarding := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	promoting := testMigrationSubject(50, StrategyCodeSearchableRetokenize, "body")
+	closing := testMigrationSubject(60, StrategyCodeSearchableRetokenize, "note")
+	retiring := testMigrationSubject(70, StrategyCodeSearchableRetokenize, "tag")
+
+	f.tasks = []*distributedtask.Task{testTask(discarding.TaskID, 42, distributedtask.TaskStatusCancelled)}
+	f.mkdirs("property_title__g42_ingest", "property_body__g50_ingest", "property_note__s60_reindex",
+		"property_tag__g70_ingest", "property_tag__g80_ingest", "property_title_searchable",
+		"property_body_searchable", "property_note_searchable", "property_tag_searchable")
+	f.put(NewMigrationRecordMerged(discarding))
+	f.put(NewMigrationRecordSwapped(promoting, []string{"body"},
+		map[string]string{"body": "property_body_searchable"}))
+	f.put(NewMigrationRecordPromoted(closing, []string{"note"},
+		map[string]string{"note": "property_note_searchable"}))
+	f.put(NewMigrationRecordMerged(retiring))
+	f.put(swappedOn(80, "tag"))
+	plantUnreadableRecord(t, f.store.Dir())
+	require.NoError(t, f.store.Load())
+	require.NotEmpty(t, f.store.Unreadable(), "fixture: the load has to refuse a file")
+
+	// Retirement has two entry points, the standalone sweep and the load's own
+	// pass, and both have to withhold.
+	newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).RetireSuperseded(context.Background())
+	f.reconcile()
+
+	require.True(t, f.exists("property_title__g42_ingest"), "a discard removes a directory an unreadable record may name")
+	require.True(t, f.exists("property_body__g50_ingest"), "a promotion renames over one")
+	require.True(t, f.exists("property_note__s60_reindex"), "a closure sweep reclaims one")
+	require.True(t, f.exists("property_tag__g70_ingest"), "and a retirement takes one")
+	require.Len(t, f.store.Records(), 5, "so no record is settled")
+}
+
+// An unreadable records directory holds no record and names no file to remove,
+// so the notice must report the store's own fault instead of a record count.
+func TestReconcileNotUnderstoodNamesTheDirectoryWhenItIsUnreadable(t *testing.T) {
+	lsmPath := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(lsmPath, migrationsDir), 0o777))
+	// A regular file where the directory belongs: unlike a mode change it still fails for root.
+	require.NoError(t, os.WriteFile(filepath.Join(lsmPath, migrationsDir, migrationRecordsDirName), nil, 0o600))
+
+	f := newReconcileFixtureAt(t, lsmPath)
+	r := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps())
+	require.Error(t, r.Reconcile(context.Background()))
+
+	require.Len(t, f.logs.AllEntries(), 1)
+	notice := f.logs.AllEntries()[0]
+	require.Equal(t, logrus.ErrorLevel, notice.Level)
+	require.Contains(t, notice.Message, "read migration records dir")
+	require.Contains(t, notice.Message, "not a directory", "the errno the store recorded reaches the operator")
+	require.NotContains(t, notice.Message, "not understood", "no record was read, so none can be miscounted")
+	require.NotContains(t, notice.Message, "downgrade", "no older build reads a file that is not there")
+	require.NotContains(t, notice.Message, "remove the files", "there is no file to remove")
+}
+
+// A pass that renamed nothing must not write a Promoted record, and must not
+// read the record it left standing as an ambiguity on the next load.
+func TestAPromotionThatPromotedNothingDoesNotRecordOne(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+
+	f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_title_searchable")
+	f.put(swappedOn(10, "title"))
+	f.put(swappedOn(20, "title"))
+	f.blockRemoval("property_title__g10_ingest")
+
+	f.reconcile()
+	key := MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"}
+	state, present := f.state(key)
+	require.True(t, present, "the record is preserved")
+	require.Equal(t, MigrationStateSwapped, state)
+
+	r := f.reconcile()
+	require.Zero(t, r.WedgedCount(), "a record that promoted nothing must not wedge the next load")
+	require.False(t, f.logged("nothing here can tell which one the promotion produced"),
+		"the ambiguity this reports does not exist")
+}
+
+func TestARecordWhoseFlipDoesNotCoverEveryPropertyIsRefused(t *testing.T) {
+	subject := testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")
+	partial := NewMigrationRecordSwapped(subject, []string{"title"},
+		map[string]string{"title": "property_title_searchable", "body": "property_body_searchable"})
+
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title", "body")
+	f.mkdirs("property_title__g10_ingest", "property_body__g10_ingest", "property_title_searchable", "property_body_searchable")
+	writeRawMigrationRecord(t, f.store, partial.toEnvelope())
+
+	f.reconcile()
+
+	require.Equal(t, "property_body_searchable", f.contentOf("property_body_searchable"),
+		"the canonical bucket is the only complete copy of a property the flip does not cover")
+	require.NotEmpty(t, f.store.Unreadable(), "the loader refuses the record rather than acting on it")
+
+	_, err := encodeMigrationRecord(partial)
+	require.ErrorContains(t, err, "which its flip does not cover", "and the writer cannot produce one")
+}
+
+// The rename is replayable only because a start mark is durable before it and
+// a finish mark after it. Renaming without the start mark leaves a missing
+// staged directory that the next load cannot tell from data loss.
+func TestAPromotionThatCannotRecordItsStartDoesNotRename(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	f.mkdirs("property_title__g42_ingest", "property_title_searchable")
+	f.put(NewMigrationRecordSwapped(subject, []string{"title"}, map[string]string{"title": "property_title_searchable"}))
+	f.blockRecordWrites()
+
+	f.reconcile()
+
+	require.True(t, f.exists("property_title__g42_ingest"),
+		"the rename must not run before the record says it started")
+	state, present := f.state(subject.Key)
+	require.True(t, present)
+	require.Equal(t, MigrationStateSwapped, state, "and no promotion is recorded")
+}
+
+func wedgeEntry(t *testing.T, f *reconcileFixture) *logrus.Entry {
+	t.Helper()
+	for _, entry := range f.logs.AllEntries() {
+		if entry.Level == logrus.ErrorLevel && strings.Contains(entry.Message, "the cluster reports it committed") {
+			return entry
+		}
+	}
+	require.FailNow(t, "no wedge line was logged")
+	return nil
+}
+
+// A wedged record is preserved, so its line re-emits on every load for the life
+// of the shard, and the property list it names comes from the user's request.
+func TestAWedgedRecordNamesABoundedNumberOfProperties(t *testing.T) {
+	const over = maxReportedErrors + 2
+
+	props := manyMigrationProps(over)
+
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, props...)
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, props...)
+	f.mkdirs(migrationOwnedDirs(subject)...)
+	f.put(NewMigrationRecordIterated(subject))
+	f.tasks = []*distributedtask.Task{testTask(subject.TaskID, 42, distributedtask.TaskStatusFinished)}
+
+	r := f.reconcile()
+	require.Equal(t, 1, r.WedgedCount())
+
+	entry := wedgeEntry(t, f)
+	require.Equal(t, over, entry.Data["property_count"],
+		"the count is a field, so the names never have to be complete")
+	require.NotContains(t, entry.Data, "properties",
+		"and the whole list must not reach a field either")
+	require.Contains(t, entry.Message, "(and 2 more)", "the names it does print are capped")
+	for _, prop := range props[maxReportedErrors:] {
+		require.NotContains(t, entry.Message, prop)
+	}
+}
+
+// Each of these walks a record's properties, or the directories those name,
+// and a record names as many as the request that started it asked for. One
+// fault reaches every item, so the report is one line per record.
+func TestTheReconcilerReportsOneLinePerRecordNotOnePerProperty(t *testing.T) {
+	const over = maxReportedErrors + 2
+
+	tests := []struct {
+		name    string
+		line    string
+		arrange func(f *reconcileFixture, props []string)
+	}{
+		{
+			name: "owned directories a discard cannot remove",
+			line: "reclaim the directories of a migration",
+			arrange: func(f *reconcileFixture, props []string) {
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, props...)
+				owned := migrationOwnedDirs(subject)
+				f.mkdirs(owned...)
+				f.put(NewMigrationRecordIterating(subject, MigrationCheckpoint{}))
+				f.tasks = []*distributedtask.Task{
+					testTask(subject.TaskID, subject.Key.TaskVersion, distributedtask.TaskStatusCancelled),
+				}
+				for _, dir := range owned {
+					f.blockRemoval(dir)
+				}
+			},
+		},
+		{
+			name: "promotions that cannot clear the canonical directory",
+			line: "promote the properties of a migration",
+			arrange: func(f *reconcileFixture, props []string) {
+				f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, props...)
+				rec := swappedOn(42, props...)
+				f.mkdirs(migrationOwnedDirs(rec.Subject())...)
+				for _, prop := range props {
+					f.mkdirs(rec.Subject().Props[prop].Canonical)
+					f.blockRemoval(rec.Subject().Props[prop].Canonical)
+				}
+				f.put(rec)
+			},
+		},
+		{
+			name: "superseded properties a retirement cannot reclaim",
+			line: "retire the superseded properties",
+			arrange: func(f *reconcileFixture, props []string) {
+				predecessor := swappedOn(10, props...)
+				successor := swappedOn(20, props...)
+				f.mkdirs(migrationOwnedDirs(predecessor.Subject())...)
+				f.mkdirs(migrationOwnedDirs(successor.Subject())...)
+				f.put(predecessor)
+				f.put(successor)
+				for _, prop := range props {
+					f.blockRemoval(predecessor.Subject().Props[prop].Staged)
+				}
+			},
+		},
+		{
+			name: "properties a promoted record outran its rename on",
+			line: "still hold their data at the staged name",
+			arrange: func(f *reconcileFixture, props []string) {
+				f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, props...)
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, props...)
+				displaced := make(map[string]string, len(props))
+				for _, prop := range props {
+					f.mkdirs(subject.Props[prop].Staged)
+					displaced[prop] = subject.Props[prop].Canonical
+				}
+				f.put(NewMigrationRecordPromoted(subject, props, displaced))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props := manyMigrationProps(over)
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationWord, props...)
+			tt.arrange(f, props)
+
+			f.reconcile()
+
+			lines := f.errorLines(tt.line)
+			require.Len(t, lines, 1, "%d properties have to cost one line, not one each", over)
+			require.Contains(t, lines[0], " more)", "and the items that one line names are capped")
+		})
+	}
+}
+
+func TestReconcilePromotedClosure(t *testing.T) {
+	tests := []struct {
+		name       string
+		leftovers  []string
+		class      *models.Class
+		wantRecord bool
+		wantWarn   string
+	}{
+		{
+			name:       "directories gone and the effect visible: the record has nothing left to answer",
+			class:      testClassWithTokenization(models.PropertyTokenizationLowercase, "title"),
+			wantRecord: false,
+		},
+		{
+			name:       "directories gone but the effect is not visible yet: keep the record",
+			class:      testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantRecord: true,
+			wantWarn:   "effect is not in the schema",
+		},
+		{
+			name:       "a leftover with the effect still not visible: reclaim it and keep the record",
+			leftovers:  []string{"property_title__s42_reindex"},
+			class:      testClassWithTokenization(models.PropertyTokenizationWord, "title"),
+			wantRecord: true,
+			wantWarn:   "effect is not in the schema",
+		},
+		{
+			name:       "a leftover from a retirement that partly failed is reclaimed, then the record goes",
+			leftovers:  []string{"property_title__s42_reindex"},
+			class:      testClassWithTokenization(models.PropertyTokenizationLowercase, "title"),
+			wantRecord: false,
+		},
+		{
+			name:       "the property was deleted after promotion, which takes the effect's carrier with it",
+			class:      &models.Class{Class: "Books"},
+			wantRecord: false,
+		},
+		{
+			name:       "the collection is not in the applied schema: decide nothing",
+			class:      nil,
+			wantRecord: true,
+			wantWarn:   "collection is not in the schema",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = tt.class
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			f.mkdirs(append([]string{"property_title_searchable"}, tt.leftovers...)...)
+			f.put(NewMigrationRecordPromoted(subject, []string{"title"}, map[string]string{"title": "property_title_searchable"}))
+
+			f.reconcile()
+
+			_, present := f.state(subject.Key)
+			require.Equal(t, tt.wantRecord, present)
+			require.True(t, f.exists("property_title_searchable"), "the closure sweep must never reach the live data")
+			require.Equal(t, "property_title_searchable", f.contentOf("property_title_searchable"))
+			for _, leftover := range tt.leftovers {
+				require.False(t, f.exists(leftover), "an owned leftover has to be reclaimed")
+			}
+			if tt.wantWarn == "" {
+				require.False(t, f.warned("promoted"),
+					"an arm that settles cleanly has nothing to tell an operator")
+			} else {
+				require.True(t, f.warned(tt.wantWarn),
+					"a promoted record kept for a reason no load can resolve has to say so")
+			}
+		})
+	}
+}
+
+// The record is durable before its rename, so a crash can strand staged data.
+func TestReconcilePromotedRepairsATornPromotion(t *testing.T) {
+	tests := []struct {
+		name            string
+		stagedThere     bool
+		canonicalThere  bool
+		propertyDeleted bool
+		wantContentAt   string
+		wantStagedGone  bool
+		wantRecordGone  bool
+	}{
+		{
+			name:           "the rename never reached disk: re-promote, do not reclaim",
+			stagedThere:    true,
+			wantContentAt:  "property_title__g42_ingest",
+			wantStagedGone: true,
+			wantRecordGone: true,
+		},
+		{
+			name:           "both names present: nothing here can tell which one holds the promoted data",
+			stagedThere:    true,
+			canonicalThere: true,
+			wantContentAt:  "property_title_searchable",
+			wantStagedGone: false,
+			wantRecordGone: false,
+		},
+		{
+			name:           "the ordinary aftermath of a promotion that completed",
+			canonicalThere: true,
+			wantContentAt:  "property_title_searchable",
+			wantStagedGone: true,
+			wantRecordGone: true,
+		},
+		{
+			name:           "neither name present",
+			wantStagedGone: true,
+			wantRecordGone: true,
+		},
+		{
+			name:            "the property was deleted after promotion, directory and all",
+			propertyDeleted: true,
+			wantStagedGone:  true,
+			wantRecordGone:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+			if tt.propertyDeleted {
+				f.class = &models.Class{Class: "Books"}
+			}
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			var planted []string
+			if tt.stagedThere {
+				planted = append(planted, "property_title__g42_ingest")
+			}
+			if tt.canonicalThere {
+				planted = append(planted, "property_title_searchable")
+			}
+			f.mkdirs(planted...)
+			f.put(NewMigrationRecordPromoted(subject, []string{"title"}, map[string]string{"title": "property_title_searchable"}))
+
+			f.reconcile()
+
+			require.Equal(t, !tt.wantStagedGone, f.exists("property_title__g42_ingest"))
+			if tt.wantContentAt == "" {
+				require.False(t, f.exists("property_title_searchable"))
+			} else {
+				require.True(t, f.exists("property_title_searchable"), "the promoted property must have its data")
+				require.Equal(t, tt.wantContentAt, f.contentOf("property_title_searchable"),
+					"the canonical name must hold the data the record promoted")
+			}
+
+			_, present := f.state(subject.Key)
+			require.Equal(t, !tt.wantRecordGone, present)
+		})
+	}
+}
+
+// Swapped is durable before any destructive step, so a crash resumes instead
+// of re-deciding.
+func TestReconcileCommitEdgeWritesItsVerdictFirst(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	f.mkdirs("property_title__g42_ingest", "property_title_searchable")
+	f.put(NewMigrationRecordMerged(subject))
+
+	require.NoError(t, os.RemoveAll(filepath.Join(f.lsmPath, "property_title_searchable")))
+	require.NoError(t, os.WriteFile(filepath.Join(f.lsmPath, "property_title_searchable"), []byte("not a directory"), 0o600))
+
+	f.reconcile()
+
+	state, present := f.state(subject.Key)
+	require.True(t, present)
+	require.Equal(t, MigrationStateSwapped, state,
+		"the verdict is durable even though the action that follows it did not complete")
+
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+	f.tasks = []*distributedtask.Task{testTask(subject.TaskID, 42, distributedtask.TaskStatusCancelled)}
+	f.reconcile()
+
+	state, present = f.state(subject.Key)
+	require.True(t, present, "a decided flip is never re-decided, whatever the cluster later says")
+	require.Equal(t, MigrationStateSwapped, state)
+}
+
+func TestReconcilePerShardDivergentStatesConverge(t *testing.T) {
+	const taskID = "Books:change-tokenization:title:ab12"
+	root := t.TempDir()
+
+	shards := []struct {
+		name       string
+		arrange    func(f *reconcileFixture)
+		wantState  MigrationState
+		wantRecord bool
+		wantStaged bool
+		wantLive   string
+	}{
+		{
+			name: "flipped before the restart: promote",
+			arrange: func(f *reconcileFixture) {
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+				subject.TaskID = taskID
+				f.mkdirs("property_title__g42_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordSwapped(subject, []string{"title"},
+					map[string]string{"title": "property_title_searchable"}))
+			},
+			wantState:  MigrationStatePromoted,
+			wantRecord: true,
+			wantLive:   "property_title__g42_ingest",
+		},
+		{
+			name: "still merged when the task finished: commit, then promote",
+			arrange: func(f *reconcileFixture) {
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+				subject.TaskID = taskID
+				f.mkdirs("property_title__g42_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(subject))
+			},
+			wantState:  MigrationStatePromoted,
+			wantRecord: true,
+			wantLive:   "property_title__g42_ingest",
+		},
+		{
+			name: "rebuild never finished: the cluster's verdict does not complete it",
+			arrange: func(f *reconcileFixture) {
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+				subject.TaskID = taskID
+				f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable")
+				f.put(NewMigrationRecordIterating(subject, MigrationCheckpoint{}))
+			},
+			wantState:  MigrationStateIterating,
+			wantRecord: true,
+			wantStaged: true,
+			wantLive:   "property_title_searchable",
+		},
+		{
+			name: "the migration never reached this shard",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title_searchable")
+			},
+			wantLive: "property_title_searchable",
+		},
+	}
+
+	fixtures := make([]*reconcileFixture, len(shards))
+	for i, sh := range shards {
+		f := newReconcileFixtureAt(t, filepath.Join(root, fmt.Sprintf("shard-%d", i), "lsm"))
+		f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+		f.tasks = []*distributedtask.Task{testTask(taskID, 42, distributedtask.TaskStatusFinished)}
+		sh.arrange(f)
+		fixtures[i] = f
+	}
+
+	for _, f := range fixtures {
+		f.reconcile()
+	}
+
+	for i, sh := range shards {
+		t.Run(sh.name, func(t *testing.T) {
+			f := fixtures[i]
+			state, present := f.state(MigrationRecordKey{
+				TaskVersion: 42, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0",
+			})
+			require.Equal(t, sh.wantRecord, present)
+			if sh.wantRecord {
+				require.Equal(t, sh.wantState, state)
+			}
+			require.Equal(t, sh.wantStaged, f.exists("property_title__g42_ingest"))
+			require.Equal(t, sh.wantLive, f.contentOf("property_title_searchable"),
+				"each shard serves what its own records and directories say")
+		})
+	}
+}
+
+func TestPromotionWithholdsOnADirectoryItCannotStat(t *testing.T) {
+	tests := []struct {
+		name      string
+		stagedDir func(f *reconcileFixture) string
+		wantState MigrationState
+	}{
+		{
+			name:      "a staged directory that stats cleanly promotes",
+			stagedDir: func(*reconcileFixture) string { return "property_title__g20_ingest" },
+			wantState: MigrationStatePromoted,
+		},
+		{
+			name: "a staged directory that cannot be stat'd promotes nothing",
+			stagedDir: func(*reconcileFixture) string {
+				return "property_p__" + strings.Repeat("m", 300-len("property_p__")-len("_ingest")) + "_ingest"
+			},
+			wantState: MigrationStateSwapped,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+			f.mkdirs("property_title__g20_ingest", "property_title_searchable")
+
+			subject := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")
+			setMigrationDir(&subject, "title", func(d *MigrationPropertyDirs) { d.Staged = tt.stagedDir(f) })
+			displaced := map[string]string{"title": subject.Props["title"].Canonical}
+			f.put(NewMigrationRecordSwapped(subject, []string{"title"}, displaced))
+
+			f.reconcile()
+
+			state, present := f.state(subject.Key)
+			require.True(t, present, "the record survives either way")
+			assert.Equal(t, tt.wantState, state)
+			assert.True(t, f.exists("property_title_searchable"),
+				"the canonical directory is never removed on a withheld promotion")
+			assert.False(t, f.store.Wedged(subject.Key),
+				"a stat that could not answer is transient: wedging it stops the periodic pass ever retrying")
+		})
+	}
+}
+
+// The probe every recorded directory is resolved through. A stat that could
+// not answer must not read as an absent directory: the promotion probe would
+// take "cannot see it" as proof the rename already ran.
+func TestDirExistsSeparatesAbsentFromUnreadable(t *testing.T) {
+	tests := []struct {
+		name     string
+		dir      string
+		sealRoot bool
+		want     bool
+		wantErr  bool
+	}{
+		{name: "a directory that is there", dir: "property_title_searchable", want: true},
+		{name: "nothing at that name", dir: "property_gone_searchable"},
+		{name: "a regular file is not a directory", dir: "afile"},
+		{name: "a handle naming none reads as absent, not as an error", dir: ""},
+		{name: "a handle that does not name one directory under the shard", dir: "sub/dir", wantErr: true},
+		{
+			name: "a directory the process may not stat is not an absent one",
+			dir:  "property_title_searchable", sealRoot: true, wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.mkdirs("property_title_searchable")
+			require.NoError(t, os.WriteFile(filepath.Join(f.lsmPath, "afile"), []byte("x"), 0o600))
+			if tt.sealRoot {
+				if os.Geteuid() == 0 {
+					t.Skip("root traverses a 0o000 directory, so the permission error cannot arise")
+				}
+				require.NoError(t, os.Chmod(f.lsmPath, 0o000))
+				t.Cleanup(func() { os.Chmod(f.lsmPath, 0o700) })
+			}
+
+			there, err := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).dirExists(tt.dir)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.False(t, there, "a probe that could not answer must not report a directory")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, there)
+		})
+	}
+}
+
+// A record whose flip is durable is never re-decided. The cluster pass reaches
+// records a shard load left standing, and the leader can report the owning task
+// cancelled long after the flip: discarding then takes the only copy there is.
+func TestTheClusterPassNeverReDecidesAFlippedRecord(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	f.mkdirs("property_title__g42_ingest", "property_title_searchable")
+	f.put(NewMigrationRecordSwapped(subject, []string{"title"},
+		map[string]string{"title": "property_title_searchable"}))
+
+	newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).ReconcileWithClusterTasks(
+		context.Background(),
+		[]*distributedtask.Task{testTask(subject.TaskID, 42, distributedtask.TaskStatusCancelled)})
+
+	state, present := f.state(subject.Key)
+	require.True(t, present, "a cancelled task must never delete data a flip already committed")
+	require.Equal(t, MigrationStateSwapped, state)
+	require.True(t, f.exists("property_title__g42_ingest"))
+	require.Equal(t, "property_title_searchable", f.contentOf("property_title_searchable"))
+}
+
+func TestEveryTeardownArmSealsTheUnit(t *testing.T) {
+	const taskID = "Books:change-tokenization:title:ab12"
+	subjectOf := func(version uint64) MigrationSubject {
+		subject := testMigrationSubject(version, StrategyCodeSearchableRetokenize, "title")
+		subject.TaskID = taskID
+		return subject
+	}
+
+	tests := []struct {
+		name     string
+		arrange  func(f *reconcileFixture)
+		heldDirs []string
+	}{
+		{
+			name: "the discard arm",
+			arrange: func(f *reconcileFixture) {
+				f.tasks = []*distributedtask.Task{testTask(taskID, 42, distributedtask.TaskStatusCancelled)}
+				f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(subjectOf(42)))
+			},
+			heldDirs: []string{"property_title__g42_ingest", "property_title__s42_reindex"},
+		},
+		{
+			name: "the promotion arm, which removes the displaced directory before it renames",
+			arrange: func(f *reconcileFixture) {
+				subject := subjectOf(42)
+				f.mkdirs("property_title__g42_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordSwapped(subject, []string{"title"},
+					map[string]string{"title": "property_title_searchable"}))
+			},
+			heldDirs: []string{"property_title__g42_ingest"},
+		},
+		{
+			name: "the promoted closure sweep",
+			arrange: func(f *reconcileFixture) {
+				subject := subjectOf(42)
+				f.mkdirs("property_title__s42_reindex", "property_title_searchable")
+				f.put(NewMigrationRecordPromoted(subject, []string{"title"},
+					map[string]string{"title": "property_title_searchable"}))
+			},
+			heldDirs: []string{"property_title__s42_reindex"},
+		},
+		{
+			name: "supersession's per-property retirement",
+			arrange: func(f *reconcileFixture) {
+				f.tasks = []*distributedtask.Task{testTask(taskID, 10, distributedtask.TaskStatusStarted)}
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex", "property_title__g20_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(subjectOf(10)))
+				f.put(swappedOn(20, "title"))
+			},
+			heldDirs: []string{"property_title__g10_ingest", "property_title__s10_reindex"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			live := newReconcileFixture(t)
+			live.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+			tt.arrange(live)
+			live.liveUnit = liveUnitOf(live.planted[0])
+			live.reconcile()
+			for _, dir := range tt.heldDirs {
+				require.True(t, live.exists(dir),
+					"a live worker writes into %s through a pointer it already holds", dir)
+			}
+			require.Contains(t, live.asked, *live.liveUnit,
+				"the arm must take the seal of the unit whose directories it is about to remove")
+
+			free := newReconcileFixture(t)
+			free.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+			tt.arrange(free)
+			free.reconcile()
+			for _, dir := range tt.heldDirs {
+				require.False(t, free.exists(dir),
+					"with no worker running, %s is the arm's own work and must be done", dir)
+			}
+			require.Contains(t, free.sealed, *liveUnitOf(free.planted[0]),
+				"the arm holds the unit while it works")
+			require.Equal(t, len(free.sealed), free.sealsReleased,
+				"and lets it go again: a leaked seal refuses this unit for the life of the process")
+		})
+	}
+}
+
+// A restored archive could name the migration tree, which sweeps hand to os.RemoveAll.
+func TestAPoisonedRecordCannotSweepTheMigrationTree(t *testing.T) {
+	tests := []struct {
+		name    string
+		poison  func(*MigrationSubject)
+		serving string
+	}{
+		{
+			name: "a staged directory naming the migrations tree",
+			poison: func(s *MigrationSubject) {
+				setMigrationDir(s, "title", func(d *MigrationPropertyDirs) { d.Staged = migrationsDir })
+			},
+		},
+		{
+			name: "a sidecar directory naming the migrations tree",
+			poison: func(s *MigrationSubject) {
+				setMigrationDir(s, "title", func(d *MigrationPropertyDirs) { d.Sidecar = migrationsDir })
+			},
+		},
+		{
+			name:   "a tracker directory naming the record store",
+			poison: func(s *MigrationSubject) { s.TrackerDir = migrationRecordsDirName },
+		},
+		{
+			name: "a staged directory naming the object store",
+			poison: func(s *MigrationSubject) {
+				setMigrationDir(s, "title", func(d *MigrationPropertyDirs) { d.Staged = "objects" })
+			},
+			serving: "objects",
+		},
+		{
+			name: "a staged directory naming a live bucket of another property",
+			poison: func(s *MigrationSubject) {
+				setMigrationDir(s, "title", func(d *MigrationPropertyDirs) { d.Staged = "property_body_searchable" })
+			},
+			serving: "property_body_searchable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+
+			bystander := testMigrationSubject(50, StrategyCodeEnableFilterable, "title")
+			f.mkdirs("property_title__g50_ingest", "property_title_searchable")
+			f.put(NewMigrationRecordMerged(bystander))
+
+			poisoned := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			tt.poison(&poisoned)
+			if tt.serving != "" {
+				mkSidecarWithData(t, f.lsmPath, tt.serving)
+			}
+			writeRawMigrationRecord(t, f.store, migrationRecordEnvelope{
+				FormatVersion: migrationRecordFormatVersion,
+				State:         MigrationStatePromoted,
+				Subject:       poisoned,
+				Flip:          &migrationFlipEnvelope{Flipped: []string{"title"}},
+			})
+
+			f.reconcile()
+
+			require.Len(t, f.store.Unreadable(), 1,
+				"a record naming the migration tree as its own must read as not understood")
+			require.DirExists(t, filepath.Join(f.lsmPath, migrationsDir),
+				"the shard's migration tree must survive the record that named it")
+			_, present := f.state(bystander.Key)
+			require.True(t, present, "and so must every other record on the shard")
+			require.True(t, f.trackerDirExists(bystander))
+			if tt.serving != "" {
+				require.Equal(t, sidecarDataFor(tt.serving), readSidecarData(t, f.lsmPath, tt.serving),
+					"the store this record named must still hold its data")
+			}
+		})
+	}
+}
+
+func sidecarDataFor(dir string) string {
+	return "segment-of-" + dir
+}
+
+func mkSidecarWithData(t *testing.T, lsmPath, name string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(lsmPath, name), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(lsmPath, name, "segment-0.db"),
+		[]byte(sidecarDataFor(name)), 0o644))
+}
+
+func readSidecarData(t *testing.T, lsmPath, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(lsmPath, name, "segment-0.db"))
+	if err != nil {
+		return "<gone: " + err.Error() + ">"
+	}
+	return string(data)
+}
+
+func writeRawMigrationRecord(t *testing.T, store *MigrationRecordStore, env migrationRecordEnvelope) {
+	t.Helper()
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(store.Dir(), 0o777))
+	require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), env.Subject.Key.fileName()), data, 0o600))
+}
+
+func TestReconcilePromotedRepairsEveryPropertyItCan(t *testing.T) {
+	tests := []struct {
+		name  string
+		props []string
+	}{
+		{name: "the undecidable property comes first", props: []string{"title", "body"}},
+		{name: "the undecidable property comes last", props: []string{"body", "title"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, tt.props...)
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, tt.props...)
+			f.mkdirs("property_title__g42_ingest", "property_title_searchable", "property_body__g42_ingest")
+			f.put(NewMigrationRecordPromoted(subject, tt.props,
+				map[string]string{"title": "property_title_searchable", "body": "property_body_searchable"}))
+
+			f.reconcile()
+
+			require.True(t, f.exists("property_body_searchable"), "the sibling's repair rename must still run")
+			require.Equal(t, "property_body__g42_ingest", f.contentOf("property_body_searchable"),
+				"and it must move the sibling's own data, not an empty bucket")
+			require.False(t, f.exists("property_body__g42_ingest"), "which leaves nothing at the staged name")
+
+			require.True(t, f.exists("property_title__g42_ingest"), "the undecidable property keeps both its directories")
+			require.True(t, f.exists("property_title_searchable"))
+			_, present := f.state(subject.Key)
+			require.True(t, present, "and the record that attributes them survives")
+			require.True(t, f.logged(
+				"1 property/properties hold a directory at both their staged and canonical names: title"),
+				"an operator has to be told which property the sweep is waiting on")
+		})
+	}
+}
+
+// The pass renames and removes whole property indexes, and a shard load runs on
+// the RAFT apply loop, where every schema change and every tenant activation in
+// the cluster queues behind it. A caller that gave up has to be able to stop it.
+func TestACancelledPassRemovesNothing(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable")
+	f.tasks = append(f.tasks, testTask(subject.TaskID, 42, distributedtask.TaskStatusCancelled))
+	f.put(NewMigrationRecordIterated(subject))
+
+	// A second record whose disposition writes rather than removes, so the
+	// per-record check is what has to stop it and not the per-directory one.
+	committing := testMigrationSubject(50, StrategyCodeSearchableRetokenize, "body")
+	f.mkdirs("property_body__g50_ingest", "property_body__s50_reindex", "property_body_searchable")
+	f.tasks = append(f.tasks, testTask(committing.TaskID, 50, distributedtask.TaskStatusFinished))
+	f.put(NewMigrationRecordMerged(committing))
+
+	// A superseded pair, so retirement has something to retire.
+	retirable := testMigrationSubject(60, StrategyCodeSearchableRetokenize, "note")
+	successor := testMigrationSubject(70, StrategyCodeSearchableRetokenize, "note")
+	f.mkdirs("property_note__g60_ingest", "property_note__s60_reindex",
+		"property_note__g70_ingest", "property_note_searchable")
+	f.put(NewMigrationRecordSwapped(retirable, retirable.Properties(),
+		map[string]string{"note": "property_note_searchable"}))
+	f.put(NewMigrationRecordSwapped(successor, successor.Properties(),
+		map[string]string{"note": "property_note_searchable"}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	r := newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps())
+	require.NoError(t, r.Reconcile(ctx),
+		"a shard load must not fail because the activation that drove it was cancelled")
+
+	_, present := f.state(subject.Key)
+	require.True(t, present, "a pass that stopped decided nothing")
+	require.True(t, f.exists("property_title__g42_ingest"),
+		"and removed nothing: the discard this record was due never ran")
+
+	state, present := f.state(committing.Key)
+	require.True(t, present)
+	require.Equal(t, MigrationStateMerged, state,
+		"and wrote no verdict either: the pass has to stop between records, not only inside one")
+
+	// Cancellation reaching the pass mid-record has to stop the per-property
+	// work too: one record names as many directories as its request asked for,
+	// and the loop-top check in Reconcile only fires between records.
+	all := f.store.Records()
+	left := r.reclaimOwnedDirs(ctx, subject)
+	require.NotEmpty(t, left, "a cancelled reclaim reports the directories it left standing")
+	require.True(t, f.exists("property_title__g42_ingest"))
+	require.True(t, f.exists("property_title__s42_reindex"))
+
+	flip := NewMigrationRecordSwapped(committing, committing.Properties(),
+		map[string]string{"body": "property_body_searchable"})
+	require.ErrorIs(t, r.promoteSealed(ctx, flip), context.Canceled,
+		"a promotion stops between properties")
+	require.Equal(t, "property_body__g50_ingest", f.contentOf("property_body__g50_ingest"),
+		"so the rename it would have run never ran")
+
+	require.ErrorIs(t, r.repromoteWhatTheRecordOutran(ctx, all, committing), context.Canceled,
+		"and so does the sweep that re-runs a promotion the record outran")
+	require.Equal(t, "property_body__g50_ingest", f.contentOf("property_body__g50_ingest"))
+
+	r.RetireSuperseded(ctx)
+	_, present = f.state(retirable.Key)
+	require.True(t, present, "and retirement stops between records")
+	require.True(t, f.exists("property_note__g60_ingest"),
+		"so the directory it would have reclaimed is still there")
+
+	// The commit this pass would write is the assertion, not the discard: a
+	// discard stops at the cancelled reclaim whether or not the loop checked.
+	r.ReconcileWithClusterTasks(ctx, f.tasks)
+	state, present = f.state(committing.Key)
+	require.True(t, present)
+	require.Equal(t, MigrationStateMerged, state,
+		"and the periodic pass decides nothing either: it runs on a context the caller can end")
+}
+
+// A transient fault leaves the record standing so a later pass can act on it.
+// The periodic pass is the only thing that comes back, so reading a fault as
+// "nothing here can ever move this" shuts the only door out.
+func TestARecordThisPassCouldNotSettleIsRetriedByTheNext(t *testing.T) {
+	const contested = "property_title__g42_ingest"
+
+	tests := []struct {
+		name string
+		// Returns what clears the blocker, so the retry has something to settle.
+		block func(f *reconcileFixture) func()
+	}{
+		{
+			name: "a directory this node could not remove",
+			block: func(f *reconcileFixture) func() {
+				f.blockRemoval(contested)
+				return func() {
+					require.NoError(f.t, os.Chmod(filepath.Join(f.lsmPath, contested), 0o700))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			setMigrationDir(&subject, "title", func(d *MigrationPropertyDirs) { d.Sidecar = "" })
+			f.mkdirs(contested, "property_title_searchable")
+			f.tasks = append(f.tasks, testTask(subject.TaskID, 42, distributedtask.TaskStatusCancelled))
+			f.put(NewMigrationRecordIterated(subject))
+
+			clear := tt.block(f)
+			r := f.reconcile()
+
+			_, present := f.state(subject.Key)
+			require.True(t, present, "the discard did not run, so its record stays")
+			require.True(t, f.exists(contested), "and so does the directory that record answers for")
+			require.True(t, f.store.HasUndecided(),
+				"the periodic pass is the only thing that retries this, so it has to keep seeing the shard")
+
+			clear()
+			r.ReconcileWithClusterTasks(context.Background(), f.tasks)
+
+			_, present = f.state(subject.Key)
+			require.False(t, present, "once the blocker is gone the retry settles the record")
+			require.False(t, f.exists(contested))
+		})
+	}
+}
+
+// The submit gate rejects a property the class does not hold and Weaviate never
+// removes one, so a schema that does not hold every property a record names is
+// a schema that is behind, whether it is short of one of them or of all.
+func TestARecordTheAppliedSchemaHasNotCaughtUpWithIsAskedAgain(t *testing.T) {
+	tests := []struct {
+		name string
+		// What the class holds while it is still behind.
+		holds []string
+	}{
+		{name: "the schema holds neither property"},
+		{name: "the schema holds one of the two properties", holds: []string{"title"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, tt.holds...)
+
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title", "body")
+			f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable",
+				"property_body__g42_ingest", "property_body__s42_reindex", "property_body_searchable")
+			f.put(NewMigrationRecordMerged(subject))
+
+			newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).
+				ReconcileWithClusterTasks(context.Background(), nil)
+
+			state, present := f.state(subject.Key)
+			require.True(t, present)
+			require.Equal(t, MigrationStateMerged, state,
+				"committing here would flip on the evidence of the properties the schema does hold")
+			require.True(t, f.store.HasUndecided(), "so the record keeps driving the periodic pass")
+
+			f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title", "body")
+			newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).
+				ReconcileWithClusterTasks(context.Background(), nil)
+
+			state, _ = f.state(subject.Key)
+			require.Equal(t, MigrationStateSwapped, state,
+				"and the pass after the schema catches up commits it")
+		})
+	}
+}
+
+// A name a migration mints carries its own task version, so two records can
+// only claim one directory if something outside this build wrote them. Nothing
+// here can tell which one the data belongs to, so both are refused.
+func TestTwoRecordsClaimingOneDirectoryAreBothRefused(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+
+	const contested = "property_title__g42_ingest"
+	first := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	second := testMigrationSubject(43, StrategyCodeEnableFilterable, "title")
+	setMigrationDir(&second, "title", func(d *MigrationPropertyDirs) { d.Staged = contested })
+	f.mkdirs(contested, "property_title_searchable")
+	f.plantRecordFile(NewMigrationRecordIterated(first))
+	f.plantRecordFile(NewMigrationRecordIterated(second))
+	f.tasks = []*distributedtask.Task{
+		testTask(first.TaskID, 42, distributedtask.TaskStatusCancelled),
+		testTask(second.TaskID, 43, distributedtask.TaskStatusCancelled),
+	}
+
+	f.reconcile()
+
+	require.Len(t, f.store.Unreadable(), 2, "each file is refused, and the reason names the other")
+	require.True(t, f.exists(contested),
+		"the discard both records were due would have taken the data one of them holds")
+	require.FileExists(t, filepath.Join(f.store.Dir(), first.Key.fileName()))
+	require.FileExists(t, filepath.Join(f.store.Dir(), second.Key.fileName()))
+	require.True(t, f.logged("withholding every destructive and promoting action"),
+		"an operator has to be told why this shard stopped")
+}
+
+// One wedged record beside one that is still undecided. The store keeps saying
+// this shard has something to decide, so the periodic pass keeps coming back,
+// and the wedged record is read off the store rather than diagnosed again.
+func TestAWedgedRecordIsDiagnosedOncePerLoadedStore(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+
+	stuck := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	stuck.MigrationType = ReindexTypeRepairFilterable
+	f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable")
+	f.put(NewMigrationRecordMerged(stuck))
+
+	waiting := testMigrationSubject(43, StrategyCodeEnableFilterable, "ghost")
+	f.mkdirs("property_ghost__g43_ingest", "property_ghost__s43_reindex")
+	f.put(NewMigrationRecordMerged(waiting))
+
+	f.reconcile()
+	require.True(t, f.store.HasUndecided(),
+		"a shard load reads a task list that may lag, so it may not call this settled")
+
+	// A fresh reconciler per pass, as the periodic pass builds one per shard.
+	diagnose := func() float64 {
+		before := testutil.ToFloat64(monitoring.GetMetrics().MigrationRecordsWedged)
+		newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).
+			ReconcileWithClusterTasks(context.Background(), nil)
+		return testutil.ToFloat64(monitoring.GetMetrics().MigrationRecordsWedged) - before
+	}
+
+	require.Equal(t, float64(1), diagnose(), "the pass that wedges a record is the pass that reports it")
+	require.True(t, f.store.HasUndecided(),
+		"fixture: the second record has to be what keeps the periodic pass coming back")
+	require.Len(t, f.errorLines("the schema never shows the effect"), 1)
+
+	require.Equal(t, float64(0), diagnose(),
+		"the store holds the verdict, so a later pass reads it instead of deriving it again")
+	require.Len(t, f.errorLines("the schema never shows the effect"), 1,
+		"and the operator is not told the same thing every minute for the life of the process")
+
+	state, present := f.state(stuck.Key)
+	require.True(t, present, "the wedged record answers for staged data nothing else attributes")
+	require.Equal(t, MigrationStateMerged, state, "and nothing promoted or discarded it")
+	require.True(t, f.exists("property_title__g42_ingest"), "its staged data is untouched")
+}

--- a/adapters/repos/db/inverted_reindex_reconcile_test.go
+++ b/adapters/repos/db/inverted_reindex_reconcile_test.go
@@ -279,12 +279,10 @@ func (f *reconcileFixture) trackerDirExists(subject MigrationSubject) bool {
 	return err == nil && info.IsDir()
 }
 
-// A tracker directory on disk means its record is live: the startup finalize
-// path acts on tracker directories by name, so one with no record is an
-// ownerless instruction handed to another subsystem. The other direction is
-// weaker on purpose. Removal takes the directories, then the tracker, then the
-// record, so a record can outlive its tracker, and only once nothing it named
-// is left for it to remove.
+// A tracker directory implies a live record: the finalize path acts on
+// trackers by name, so an orphaned one hands another subsystem a stale
+// instruction. The reverse isn't required — removal order is directories,
+// then tracker, then record, so a record may briefly outlive its tracker.
 func (f *reconcileFixture) requireMigrationDirsTrackRecords() {
 	f.t.Helper()
 	surviving := f.store.Records()

--- a/adapters/repos/db/inverted_reindex_record.go
+++ b/adapters/repos/db/inverted_reindex_record.go
@@ -249,7 +249,7 @@ func NewMigrationRecordPromoted(subject MigrationSubject, flipped []string, disp
 	return MigrationRecordPromoted{migrationRecordBase{subject}, migrationFlipBlock{flipped, displacedDirs}}
 }
 
-// Read by the cutover PR, which resumes an interrupted rebuild from it.
+// Read by the cutover to resume an interrupted rebuild.
 func (r MigrationRecordIterating) Checkpoint() MigrationCheckpoint { return r.checkpoint }
 
 func (r MigrationRecordIterating) State() MigrationState { return MigrationStateIterating }
@@ -363,11 +363,9 @@ func validateMigrationEnvelope(e migrationRecordEnvelope) error {
 	return validateCanonicalNamesOwnBucket(e)
 }
 
-// Promotion renames over every property the record names, and before the flip
-// a property's canonical bucket is its complete primary copy. A flip that
-// covers fewer properties than the record names would take one of those, and
-// one that displaces a directory for a property outside the list claims a
-// directory no reader here would ever reclaim or hand back.
+// A flip must cover every property the record names and rename only their
+// canonical buckets: covering fewer would drop one, and displacing a
+// directory for a property outside the list would orphan it beyond reclaim.
 func validateFlipCoversEveryProperty(e migrationRecordEnvelope) error {
 	if e.Flip == nil {
 		return nil

--- a/adapters/repos/db/inverted_reindex_record.go
+++ b/adapters/repos/db/inverted_reindex_record.go
@@ -1,0 +1,692 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+)
+
+type MigrationState string
+
+const (
+	MigrationStateIterating MigrationState = "iterating"
+	MigrationStateIterated  MigrationState = "iterated"
+	MigrationStateMerged    MigrationState = "merged"
+	MigrationStateSwapped   MigrationState = "swapped"
+	MigrationStatePromoted  MigrationState = "promoted"
+)
+
+// Values land in record file names, so they're a durable on-disk format:
+// never rename one, and never reuse a retired one.
+type MigrationStrategyCode string
+
+const (
+	StrategyCodeSearchableMapToBlockmax     MigrationStrategyCode = MigrationDirSearchableMapToBlockmax
+	StrategyCodeFilterableRoaringsetRefresh MigrationStrategyCode = MigrationDirFilterableRoaringsetRefresh
+	StrategyCodeFilterableToRangeable       MigrationStrategyCode = MigrationDirPrefixFilterableToRangeable
+	StrategyCodeSearchableRetokenize        MigrationStrategyCode = MigrationDirPrefixSearchableRetokenize
+	StrategyCodeFilterableRetokenize        MigrationStrategyCode = MigrationDirPrefixFilterableRetokenize
+	StrategyCodeEnableFilterable            MigrationStrategyCode = MigrationDirPrefixEnableFilterable
+	StrategyCodeEnableSearchable            MigrationStrategyCode = MigrationDirPrefixEnableSearchable
+	StrategyCodeRebuildSearchable           MigrationStrategyCode = MigrationDirPrefixRebuildSearchable
+)
+
+func (c MigrationStrategyCode) valid() bool {
+	switch c {
+	case StrategyCodeSearchableMapToBlockmax, StrategyCodeFilterableRoaringsetRefresh,
+		StrategyCodeFilterableToRangeable, StrategyCodeSearchableRetokenize,
+		StrategyCodeFilterableRetokenize, StrategyCodeEnableFilterable,
+		StrategyCodeEnableSearchable, StrategyCodeRebuildSearchable:
+		return true
+	default:
+		return false
+	}
+}
+
+// TaskVersion is not the generation: that's a separate per-node counter
+// nodes routinely disagree on.
+type MigrationRecordKey struct {
+	TaskVersion  uint64                `json:"taskVersion"`
+	StrategyCode MigrationStrategyCode `json:"strategyCode"`
+	UnitID       string                `json:"unitID"`
+}
+
+// MigrationUnitID composes the ID of the reindex task unit that covers one
+// shard replica. The submit path names units with it, and a shard derives its
+// own with it, so a record found under a shard can be told apart from one a
+// backup or a shard copy landed there from another replica.
+func MigrationUnitID(shardName, nodeName string) string {
+	return shardName + "__" + nodeName
+}
+
+// The unit is in the name because backup and shard copy land a foreign node's
+// record here; without it the names collide and the next local write destroys it.
+func (k MigrationRecordKey) fileName() string {
+	return fmt.Sprintf("%d_%s_%s.json", k.TaskVersion, k.StrategyCode, k.UnitID)
+}
+
+func (k MigrationRecordKey) String() string {
+	return fmt.Sprintf("%d/%s/%s", k.TaskVersion, k.StrategyCode, k.UnitID)
+}
+
+func (k MigrationRecordKey) valid() bool {
+	return k.TaskVersion > 0 && k.StrategyCode.valid() && migrationHandleIsOneElement(k.UnitID)
+}
+
+type MigrationCheckpoint struct {
+	LastProcessedKey []byte    `json:"lastProcessedKey,omitempty"`
+	UpdatedAt        time.Time `json:"updatedAt"`
+}
+
+type MigrationPropertyDirs struct {
+	Staged    string `json:"staged,omitempty"`
+	Canonical string `json:"canonical,omitempty"`
+	Sidecar   string `json:"sidecar,omitempty"`
+}
+
+// Carries enough to name every directory it touches, so no reader ever
+// re-derives one from a property name or a generation number. Naming a
+// directory is what lists its property, so a directory for a property the
+// record does not cover is unwritable.
+type MigrationSubject struct {
+	Key                  MigrationRecordKey   `json:"key"`
+	TaskID               string               `json:"taskID"`
+	MigrationType        ReindexMigrationType `json:"migrationType"`
+	TargetTokenization   string               `json:"targetTokenization,omitempty"`
+	OriginalTokenization string               `json:"originalTokenization,omitempty"`
+
+	// Fixed at first write, never re-derived from a moved clock.
+	IterationCutoff time.Time `json:"iterationCutoff"`
+
+	TrackerDir string `json:"trackerDir,omitempty"`
+
+	Props map[string]MigrationPropertyDirs `json:"props,omitempty"`
+}
+
+// Sorted, so every pass over a record's properties reaches them in one order.
+func (s MigrationSubject) Properties() []string { return slices.Sorted(maps.Keys(s.Props)) }
+
+func migrationStagedOf(d MigrationPropertyDirs) string    { return d.Staged }
+func migrationCanonicalOf(d MigrationPropertyDirs) string { return d.Canonical }
+func migrationSidecarOf(d MigrationPropertyDirs) string   { return d.Sidecar }
+
+func (s MigrationSubject) dirsInRole(read func(MigrationPropertyDirs) string) map[string]string {
+	out := make(map[string]string, len(s.Props))
+	for prop, dirs := range s.Props {
+		out[prop] = read(dirs)
+	}
+	return out
+}
+
+var migrationHorizonEverything = time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC)
+
+// A record is a value: whoever holds one must not mutate it or anything
+// reachable from it, since the store hands the same value to every reader.
+type MigrationRecord interface {
+	State() MigrationState
+	Subject() MigrationSubject
+	migrationRecordQuestions
+
+	toEnvelope() migrationRecordEnvelope
+}
+
+type migrationRecordBase struct {
+	subject MigrationSubject
+}
+
+func (b migrationRecordBase) Subject() MigrationSubject { return b.subject }
+
+type migrationFlipBlock struct {
+	flipped       []string
+	displacedDirs map[string]string
+}
+
+func (f migrationFlipBlock) Flipped() []string { return f.flipped }
+
+func (f migrationFlipBlock) DisplacedDir(prop string) (string, bool) {
+	dir, ok := f.displacedDirs[prop]
+	return dir, ok
+}
+
+type MigrationRecordIterating struct {
+	migrationRecordBase
+	checkpoint MigrationCheckpoint
+}
+
+type MigrationRecordIterated struct {
+	migrationRecordBase
+}
+
+type MigrationRecordMerged struct {
+	migrationRecordBase
+}
+
+type MigrationRecordSwapped struct {
+	migrationRecordBase
+	migrationFlipBlock
+	promotion map[string]migrationPromotionMark
+}
+
+type migrationPromotionMark string
+
+const (
+	migrationPromotionStarted  migrationPromotionMark = "started"
+	migrationPromotionFinished migrationPromotionMark = "finished"
+	migrationPromotionLost     migrationPromotionMark = "lost"
+)
+
+func migrationPromotionMarkKnown(m migrationPromotionMark) bool {
+	switch m {
+	case migrationPromotionStarted, migrationPromotionFinished, migrationPromotionLost:
+		return true
+	}
+	return false
+}
+
+type MigrationRecordPromoted struct {
+	migrationRecordBase
+	migrationFlipBlock
+}
+
+func NewMigrationRecordIterating(subject MigrationSubject, checkpoint MigrationCheckpoint) MigrationRecordIterating {
+	return MigrationRecordIterating{migrationRecordBase{subject}, checkpoint}
+}
+
+func NewMigrationRecordIterated(subject MigrationSubject) MigrationRecordIterated {
+	return MigrationRecordIterated{migrationRecordBase{subject}}
+}
+
+func NewMigrationRecordMerged(subject MigrationSubject) MigrationRecordMerged {
+	return MigrationRecordMerged{migrationRecordBase{subject}}
+}
+
+func NewMigrationRecordSwapped(subject MigrationSubject, flipped []string, displacedDirs map[string]string) MigrationRecordSwapped {
+	return MigrationRecordSwapped{migrationRecordBase{subject}, migrationFlipBlock{flipped, displacedDirs}, nil}
+}
+
+func (r MigrationRecordSwapped) PromotionOf(prop string) migrationPromotionMark {
+	return r.promotion[prop]
+}
+
+func (r MigrationRecordSwapped) WithPromotionAt(prop string, mark migrationPromotionMark) MigrationRecordSwapped {
+	next := make(map[string]migrationPromotionMark, len(r.promotion)+1)
+	maps.Copy(next, r.promotion)
+	next[prop] = mark
+	r.promotion = next
+	return r
+}
+
+func (r MigrationRecordSwapped) WithPromotionAbandoned(prop string) MigrationRecordSwapped {
+	if _, marked := r.promotion[prop]; !marked {
+		return r
+	}
+	next := make(map[string]migrationPromotionMark, len(r.promotion))
+	maps.Copy(next, r.promotion)
+	delete(next, prop)
+	r.promotion = next
+	return r
+}
+
+func NewMigrationRecordPromoted(subject MigrationSubject, flipped []string, displacedDirs map[string]string) MigrationRecordPromoted {
+	return MigrationRecordPromoted{migrationRecordBase{subject}, migrationFlipBlock{flipped, displacedDirs}}
+}
+
+// Read by the cutover PR, which resumes an interrupted rebuild from it.
+func (r MigrationRecordIterating) Checkpoint() MigrationCheckpoint { return r.checkpoint }
+
+func (r MigrationRecordIterating) State() MigrationState { return MigrationStateIterating }
+func (r MigrationRecordIterated) State() MigrationState  { return MigrationStateIterated }
+func (r MigrationRecordMerged) State() MigrationState    { return MigrationStateMerged }
+func (r MigrationRecordSwapped) State() MigrationState   { return MigrationStateSwapped }
+func (r MigrationRecordPromoted) State() MigrationState  { return MigrationStatePromoted }
+
+// Bumped only for changes a previous release can't read: a bump freezes
+// every record already on the shard as NotUnderstood on the other build.
+const migrationRecordFormatVersion = 1
+
+type migrationFlipEnvelope struct {
+	Flipped       []string          `json:"flipped,omitempty"`
+	DisplacedDirs map[string]string `json:"displacedDirs,omitempty"`
+	// Its own key, not one an earlier shape wrote: a build that reads only the
+	// other key then promotes nothing rather than promoting on a claim it cannot check.
+	Promotion map[string]migrationPromotionMark `json:"promotion,omitempty"`
+}
+
+type migrationRecordEnvelope struct {
+	FormatVersion int                    `json:"formatVersion"`
+	State         MigrationState         `json:"state"`
+	Subject       MigrationSubject       `json:"subject"`
+	Checkpoint    *MigrationCheckpoint   `json:"checkpoint,omitempty"`
+	Flip          *migrationFlipEnvelope `json:"flip,omitempty"`
+}
+
+func newMigrationRecordEnvelope(state MigrationState, subject MigrationSubject) migrationRecordEnvelope {
+	return migrationRecordEnvelope{FormatVersion: migrationRecordFormatVersion, State: state, Subject: subject}
+}
+
+func (f migrationFlipBlock) toEnvelope() *migrationFlipEnvelope {
+	return &migrationFlipEnvelope{Flipped: f.flipped, DisplacedDirs: f.displacedDirs}
+}
+
+func (r MigrationRecordIterating) toEnvelope() migrationRecordEnvelope {
+	env := newMigrationRecordEnvelope(MigrationStateIterating, r.subject)
+	cp := r.checkpoint
+	env.Checkpoint = &cp
+	return env
+}
+
+func (r MigrationRecordIterated) toEnvelope() migrationRecordEnvelope {
+	return newMigrationRecordEnvelope(MigrationStateIterated, r.subject)
+}
+
+func (r MigrationRecordMerged) toEnvelope() migrationRecordEnvelope {
+	return newMigrationRecordEnvelope(MigrationStateMerged, r.subject)
+}
+
+func (r MigrationRecordSwapped) toEnvelope() migrationRecordEnvelope {
+	env := newMigrationRecordEnvelope(MigrationStateSwapped, r.subject)
+	env.Flip = r.migrationFlipBlock.toEnvelope()
+	env.Flip.Promotion = r.promotion
+	return env
+}
+
+func (r MigrationRecordPromoted) toEnvelope() migrationRecordEnvelope {
+	env := newMigrationRecordEnvelope(MigrationStatePromoted, r.subject)
+	env.Flip = r.migrationFlipBlock.toEnvelope()
+	return env
+}
+
+func encodeMigrationRecord(rec MigrationRecord) ([]byte, error) {
+	env := rec.toEnvelope()
+	if err := validateMigrationEnvelope(env); err != nil {
+		return nil, err
+	}
+	// Writer-side only: nothing acts on such a record, so refusing it at decode
+	// would freeze a shard over a record that can do nothing.
+	if len(env.Subject.Props) == 0 {
+		return nil, fmt.Errorf("record %q names no properties, so nothing could ever act on it", env.Subject.Key)
+	}
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxMigrationRecordBytes {
+		return nil, fmt.Errorf("record %q holds %d bytes, bound is %d",
+			env.Subject.Key, len(data), maxMigrationRecordBytes)
+	}
+	return data, nil
+}
+
+func validateMigrationEnvelope(e migrationRecordEnvelope) error {
+	if e.FormatVersion != migrationRecordFormatVersion {
+		return fmt.Errorf("unknown record format version %d", e.FormatVersion)
+	}
+	if !e.Subject.Key.valid() {
+		return fmt.Errorf("record key %q is incomplete or names an unknown strategy", e.Subject.Key)
+	}
+	if e.Subject.TaskID == "" {
+		return fmt.Errorf("record %q has no task ID", e.Subject.Key)
+	}
+	if !migrationTypeKnown(e.Subject.MigrationType) {
+		return fmt.Errorf("record %q names unknown migration type %q", e.Subject.Key, e.Subject.MigrationType)
+	}
+	if err := validateMigrationHandles(e); err != nil {
+		return err
+	}
+	if err := validatePromotion(e); err != nil {
+		return err
+	}
+	if err := validateFlipCoversEveryProperty(e); err != nil {
+		return err
+	}
+	if err := validateOneOwnerPerDirectory(e); err != nil {
+		return err
+	}
+	return validateCanonicalNamesOwnBucket(e)
+}
+
+// Promotion renames over every property the record names, and before the flip
+// a property's canonical bucket is its complete primary copy. A flip that
+// covers fewer properties than the record names would take one of those, and
+// one that displaces a directory for a property outside the list claims a
+// directory no reader here would ever reclaim or hand back.
+func validateFlipCoversEveryProperty(e migrationRecordEnvelope) error {
+	if e.Flip == nil {
+		return nil
+	}
+	flipped := make(map[string]struct{}, len(e.Flip.Flipped))
+	for _, prop := range e.Flip.Flipped {
+		flipped[prop] = struct{}{}
+	}
+	for _, prop := range e.Subject.Properties() {
+		if _, covered := flipped[prop]; !covered {
+			return fmt.Errorf("record %q names property %q, which its flip does not cover", e.Subject.Key, prop)
+		}
+		delete(flipped, prop)
+	}
+	if len(flipped) > 0 {
+		return fmt.Errorf("record %q flips %d property/properties it does not name", e.Subject.Key, len(flipped))
+	}
+	for _, prop := range slices.Sorted(maps.Keys(e.Flip.DisplacedDirs)) {
+		if _, named := e.Subject.Props[prop]; !named {
+			return fmt.Errorf("record %q displaces a directory for property %q, which it does not name",
+				e.Subject.Key, prop)
+		}
+	}
+	return nil
+}
+
+// Not a shape test: the promotion renames the staged directory over this one,
+// so a canonical handle naming any other bucket renames over data no migration
+// here built. Empty stays legal; the record then promotes nothing.
+func validateCanonicalNamesOwnBucket(e migrationRecordEnvelope) error {
+	for _, prop := range e.Subject.Properties() {
+		canonical := e.Subject.Props[prop].Canonical
+		want := sourceBucketNameFor(e.Subject.Key.StrategyCode, prop)
+		if canonical != "" && canonical != want {
+			return fmt.Errorf("record %q names %q as the canonical directory of property %q, but its strategy reads %q",
+				e.Subject.Key, canonical, prop, want)
+		}
+	}
+	return nil
+}
+
+// [TestEveryStrategyReadsTheMainBucketThisNames] pins this against the eight
+// strategies' own SourceBucketName. No default arm, so the linter refuses a
+// ninth code that names no bucket; a valid key never reaches the last return.
+func sourceBucketNameFor(code MigrationStrategyCode, prop string) string {
+	switch code {
+	case StrategyCodeSearchableMapToBlockmax, StrategyCodeEnableSearchable,
+		StrategyCodeRebuildSearchable, StrategyCodeSearchableRetokenize:
+		return helpers.BucketSearchableFromPropNameLSM(prop)
+	case StrategyCodeFilterableToRangeable:
+		return helpers.BucketRangeableFromPropNameLSM(prop)
+	case StrategyCodeFilterableRoaringsetRefresh, StrategyCodeFilterableRetokenize,
+		StrategyCodeEnableFilterable:
+		return helpers.BucketFromPropNameLSM(prop)
+	}
+	return ""
+}
+
+func validatePromotion(e migrationRecordEnvelope) error {
+	if e.Flip == nil {
+		return nil
+	}
+	if len(e.Flip.Promotion) > 0 && e.State != MigrationStateSwapped {
+		return fmt.Errorf("record %q in state %q carries promotion marks, which only a swapped record does",
+			e.Subject.Key, e.State)
+	}
+	for _, prop := range slices.Sorted(maps.Keys(e.Flip.Promotion)) {
+		if _, named := e.Subject.Props[prop]; !named {
+			return fmt.Errorf("record %q records a promotion of property %q, which it does not name",
+				e.Subject.Key, prop)
+		}
+		if !migrationPromotionMarkKnown(e.Flip.Promotion[prop]) {
+			return fmt.Errorf("record %q records unknown promotion mark %q for property %q",
+				e.Subject.Key, e.Flip.Promotion[prop], prop)
+		}
+	}
+	return nil
+}
+
+// Each actor acts on one property's handles, so a directory a second property
+// also names gets closed or deleted while that property is still serving from it.
+func validateOneOwnerPerDirectory(e migrationRecordEnvelope) error {
+	type claim struct{ role, prop string }
+	owner := map[string]claim{}
+
+	for _, group := range migrationHandleGroups {
+		if group.dirs == nil {
+			continue
+		}
+		dirs := group.dirs(e)
+		for _, prop := range slices.Sorted(maps.Keys(dirs)) {
+			dir := dirs[prop]
+			if dir == "" || (group.displacesCanonical && dir == e.Subject.Props[prop].Canonical) {
+				continue
+			}
+			if held, taken := owner[dir]; taken {
+				return fmt.Errorf(
+					"record %q names directory %q as both the %s of property %q and the %s of property %q",
+					e.Subject.Key, dir, held.role, held.prop, group.field, prop)
+			}
+			owner[dir] = claim{group.field, prop}
+		}
+	}
+	return nil
+}
+
+func decodeMigrationRecord(data []byte) (MigrationRecord, error) {
+	var env migrationRecordEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("decode record: %w", err)
+	}
+	if err := validateMigrationEnvelope(env); err != nil {
+		return nil, err
+	}
+
+	switch env.State {
+	case MigrationStateIterating:
+		if err := env.requireBlocks(migrationBlocks{checkpoint: true}); err != nil {
+			return nil, err
+		}
+		return NewMigrationRecordIterating(env.Subject, *env.Checkpoint), nil
+	case MigrationStateIterated:
+		if err := env.requireBlocks(migrationBlocks{}); err != nil {
+			return nil, err
+		}
+		return NewMigrationRecordIterated(env.Subject), nil
+	case MigrationStateMerged:
+		if err := env.requireBlocks(migrationBlocks{}); err != nil {
+			return nil, err
+		}
+		return NewMigrationRecordMerged(env.Subject), nil
+	case MigrationStateSwapped:
+		if err := env.requireBlocks(migrationBlocks{flip: true}); err != nil {
+			return nil, err
+		}
+		swapped := NewMigrationRecordSwapped(env.Subject, env.Flip.Flipped, env.Flip.DisplacedDirs)
+		swapped.promotion = env.Flip.Promotion
+		return swapped, nil
+	case MigrationStatePromoted:
+		if err := env.requireBlocks(migrationBlocks{flip: true}); err != nil {
+			return nil, err
+		}
+		return NewMigrationRecordPromoted(env.Subject, env.Flip.Flipped, env.Flip.DisplacedDirs), nil
+	default:
+		return nil, fmt.Errorf("record %q names unknown state %q", env.Subject.Key, env.State)
+	}
+}
+
+// [filepath.IsLocal] isn't this test: it accepts ".", "x/.." and
+// "a/b/../..", each of which Join resolves back to the shard root.
+func migrationHandleIsOneElement(h string) bool {
+	if h == "" || h == "." || h == ".." || filepath.IsAbs(h) {
+		return false
+	}
+	return !strings.ContainsRune(h, '/') && !strings.ContainsRune(h, os.PathSeparator)
+}
+
+// [TestEveryDirectoryRoleUnderTheShardRootCarriesAShapeRule] refuses a role
+// whose shape is neither the sidecar nor the property-bucket rule.
+type migrationHandleShape uint8
+
+const (
+	migrationShapeUnchecked migrationHandleShape = iota
+	migrationShapeSidecar
+	migrationShapePropertyBucket
+)
+
+type migrationHandleGroup struct {
+	field string
+
+	dirs func(e migrationRecordEnvelope) map[string]string
+
+	envelopeHandles func(e migrationRecordEnvelope) []string
+
+	displacesCanonical bool
+	// namesDirectory separates handles a sweep hands to os.RemoveAll from
+	// property names, which are user-chosen and not checked against the
+	// reserved set.
+	namesDirectory bool
+
+	underMigrationsDir bool
+
+	shape migrationHandleShape
+}
+
+func (g migrationHandleGroup) handles(e migrationRecordEnvelope) []string {
+	if g.dirs == nil {
+		return g.envelopeHandles(e)
+	}
+	dirs := g.dirs(e)
+	out := make([]string, 0, len(dirs))
+	for _, prop := range slices.Sorted(maps.Keys(dirs)) {
+		out = append(out, dirs[prop])
+	}
+	return out
+}
+
+var migrationHandleGroups = []migrationHandleGroup{
+	{
+		field:          "tracker directory",
+		namesDirectory: true, underMigrationsDir: true,
+		envelopeHandles: func(e migrationRecordEnvelope) []string { return []string{e.Subject.TrackerDir} },
+	},
+	{
+		field:          string(migrationRoleStaged),
+		dirs:           func(e migrationRecordEnvelope) map[string]string { return e.Subject.dirsInRole(migrationStagedOf) },
+		namesDirectory: true, shape: migrationShapeSidecar,
+	},
+	{
+		field: "property",
+		envelopeHandles: func(e migrationRecordEnvelope) []string {
+			return slices.Concat(
+				e.Subject.Properties(),
+				slices.Sorted(maps.Keys(e.displacedDirs())),
+				e.flippedProps())
+		},
+	},
+	{
+		field:          string(migrationRoleCanonical),
+		dirs:           func(e migrationRecordEnvelope) map[string]string { return e.Subject.dirsInRole(migrationCanonicalOf) },
+		namesDirectory: true, shape: migrationShapePropertyBucket,
+	},
+	{
+		field:          string(migrationRoleSidecar),
+		dirs:           func(e migrationRecordEnvelope) map[string]string { return e.Subject.dirsInRole(migrationSidecarOf) },
+		namesDirectory: true, shape: migrationShapeSidecar,
+	},
+	{
+		field:              "displaced directory",
+		dirs:               func(e migrationRecordEnvelope) map[string]string { return e.displacedDirs() },
+		namesDirectory:     true,
+		shape:              migrationShapePropertyBucket,
+		displacesCanonical: true,
+	},
+}
+
+func (e migrationRecordEnvelope) displacedDirs() map[string]string {
+	if e.Flip == nil {
+		return nil
+	}
+	return e.Flip.DisplacedDirs
+}
+
+func (e migrationRecordEnvelope) flippedProps() []string {
+	if e.Flip == nil {
+		return nil
+	}
+	return e.Flip.Flipped
+}
+
+func validateMigrationHandles(e migrationRecordEnvelope) error {
+	for _, group := range migrationHandleGroups {
+		for _, handle := range group.handles(e) {
+			if handle == "" && group.namesDirectory {
+				continue
+			}
+			if !migrationHandleIsOneElement(handle) {
+				return fmt.Errorf("record %q names %s %q, which is not a single directory inside the shard",
+					e.Subject.Key, group.field, handle)
+			}
+			if group.namesDirectory && migrationReservedDirName(handle) {
+				return fmt.Errorf("record %q names %s %q, which is a directory no migration may own",
+					e.Subject.Key, group.field, handle)
+			}
+			switch group.shape {
+			case migrationShapeUnchecked:
+			case migrationShapeSidecar:
+				if !migrationHandleIsSidecarShaped(handle) {
+					return fmt.Errorf("record %q names %s %q, which is not shaped like a sidecar of a property bucket",
+						e.Subject.Key, group.field, handle)
+				}
+			case migrationShapePropertyBucket:
+				if !strings.HasPrefix(handle, migrationPropertyBucketPrefix) {
+					return fmt.Errorf("record %q names %s %q, which is not a property bucket",
+						e.Subject.Key, group.field, handle)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ".migrations"/"records" would let a teardown remove the tracker/record
+// store; "objects" is the shard's whole object store.
+func migrationReservedDirName(h string) bool {
+	return h == migrationsDir || h == migrationRecordsDirName || h == helpers.ObjectsBucketLSM
+}
+
+// A positive shape rule, not a denylist, so it refuses stores added later
+// too. Deliberately as weak as [isSidecarDirOf]: weaviate/weaviate#12621.
+func migrationHandleIsSidecarShaped(h string) bool {
+	tail, ok := strings.CutPrefix(h, migrationPropertyBucketPrefix)
+	if !ok {
+		return false
+	}
+	i := strings.Index(tail, "__")
+	if i < 0 {
+		return false
+	}
+	return slices.Contains(sidecarRoleWords, sidecarRoleWord(tail[i+2:]))
+}
+
+// TestEveryPropertyBucketCarriesTheMigrationPrefix pins this against the
+// helpers that build those names.
+const migrationPropertyBucketPrefix = "property_"
+
+type migrationBlocks struct {
+	checkpoint bool
+	flip       bool
+}
+
+func (e migrationRecordEnvelope) requireBlocks(want migrationBlocks) error {
+	if (e.Checkpoint != nil) != want.checkpoint {
+		return fmt.Errorf("record %q in state %q: checkpoint block present=%v, wanted=%v",
+			e.Subject.Key, e.State, e.Checkpoint != nil, want.checkpoint)
+	}
+	if (e.Flip != nil) != want.flip {
+		return fmt.Errorf("record %q in state %q: flip block present=%v, wanted=%v",
+			e.Subject.Key, e.State, e.Flip != nil, want.flip)
+	}
+	return nil
+}

--- a/adapters/repos/db/inverted_reindex_record_atomic_publish_test.go
+++ b/adapters/repos/db/inverted_reindex_record_atomic_publish_test.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// A reader must see the old record or the new one, never half of either.
+func TestPutPublishesTheRecordByReplacingTheFile(t *testing.T) {
+	lsm := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	store := NewMigrationRecordStore(lsm, logger)
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	require.NoError(t, store.Put(NewMigrationRecordMerged(subject)))
+
+	target := filepath.Join(store.Dir(), subject.Key.fileName())
+	before, err := os.ReadFile(target)
+	require.NoError(t, err)
+	beforeInfo, err := os.Stat(target)
+	require.NoError(t, err)
+
+	// A second name for the file the old record occupies: an in-place write
+	// shows through it, a replacement cannot.
+	witness := filepath.Join(lsm, "witness")
+	require.NoError(t, os.Link(target, witness))
+
+	require.NoError(t, store.Put(NewMigrationRecordSwapped(subject,
+		[]string{"title"}, map[string]string{"title": "property_title_searchable"})))
+
+	after, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.NotEqual(t, before, after, "the fixture must actually publish something new")
+
+	witnessed, err := os.ReadFile(witness)
+	require.NoError(t, err)
+	require.Equal(t, before, witnessed, "the file the old record occupied must still hold it whole")
+
+	afterInfo, err := os.Stat(target)
+	require.NoError(t, err)
+	require.False(t, os.SameFile(beforeInfo, afterInfo),
+		"publishing must leave a different file at the name")
+}
+
+// No other test catches a deleted content sync: it only shows after a crash. The
+// directory sync past the rename is pinned by diskio's TestRenameAndSync.
+func TestWriteFileAtomicSyncsTheContentBeforeItPublishesTheName(t *testing.T) {
+	dir := t.TempDir()
+	const name = "record.mig"
+	target := filepath.Join(dir, name)
+
+	var synced []string
+	sync := func(f *os.File) error {
+		got, err := os.ReadFile(f.Name())
+		require.NoError(t, err)
+		require.Equal(t, "payload", string(got), "the bytes have to be written before the sync")
+		require.NoFileExists(t, target, "and the name must not be published before it")
+		synced = append(synced, f.Name())
+		return f.Sync()
+	}
+
+	require.NoError(t, writeFileAtomicWithSync(dir, name, []byte("payload"), sync))
+
+	require.Len(t, synced, 1, "the content is synced exactly once, before the rename")
+	require.FileExists(t, target, "and the rename then publishes the name")
+	got, err := os.ReadFile(target)
+	require.NoError(t, err)
+	require.Equal(t, "payload", string(got))
+}

--- a/adapters/repos/db/inverted_reindex_record_atomic_publish_test.go
+++ b/adapters/repos/db/inverted_reindex_record_atomic_publish_test.go
@@ -57,8 +57,7 @@ func TestPutPublishesTheRecordByReplacingTheFile(t *testing.T) {
 		"publishing must leave a different file at the name")
 }
 
-// No other test catches a deleted content sync: it only shows after a crash. The
-// directory sync past the rename is pinned by diskio's TestRenameAndSync.
+// No other test catches a deleted content sync: it only shows after a crash.
 func TestWriteFileAtomicSyncsTheContentBeforeItPublishesTheName(t *testing.T) {
 	dir := t.TempDir()
 	const name = "record.mig"

--- a/adapters/repos/db/inverted_reindex_record_questions.go
+++ b/adapters/repos/db/inverted_reindex_record_questions.go
@@ -20,8 +20,8 @@ type migrationRecordQuestions interface {
 	// acknowledged writes the old copy never received.
 	PointerSwapped() bool
 
-	// Both read by the cutover PR: the first before it hands a shard's writes
-	// to the staged copy, the second before it opens a bucket at a directory a
+	// Both read by the cutover: the first before it hands a shard's writes to
+	// the staged copy, the second before it opens a bucket at a directory a
 	// record may be about to rename or remove.
 	IterationComplete() bool
 	OwnsBucket(dir string) bool

--- a/adapters/repos/db/inverted_reindex_record_questions.go
+++ b/adapters/repos/db/inverted_reindex_record_questions.go
@@ -1,0 +1,50 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import "slices"
+
+type migrationRecordQuestions interface {
+	StagedDataComplete() bool
+
+	// From here the migration is irreversible: the new buckets may hold
+	// acknowledged writes the old copy never received.
+	PointerSwapped() bool
+
+	// Both read by the cutover PR: the first before it hands a shard's writes
+	// to the staged copy, the second before it opens a bucket at a directory a
+	// record may be about to rename or remove.
+	IterationComplete() bool
+	OwnsBucket(dir string) bool
+}
+
+func (b migrationRecordBase) OwnsBucket(dir string) bool {
+	return slices.Contains(migrationOwnedDirs(b.subject), dir)
+}
+
+func (r MigrationRecordIterating) StagedDataComplete() bool { return false }
+func (r MigrationRecordIterated) StagedDataComplete() bool  { return false }
+func (r MigrationRecordMerged) StagedDataComplete() bool    { return true }
+func (r MigrationRecordSwapped) StagedDataComplete() bool   { return true }
+func (r MigrationRecordPromoted) StagedDataComplete() bool  { return true }
+
+func (r MigrationRecordIterating) IterationComplete() bool { return false }
+func (r MigrationRecordIterated) IterationComplete() bool  { return true }
+func (r MigrationRecordMerged) IterationComplete() bool    { return true }
+func (r MigrationRecordSwapped) IterationComplete() bool   { return true }
+func (r MigrationRecordPromoted) IterationComplete() bool  { return true }
+
+func (r MigrationRecordIterating) PointerSwapped() bool { return false }
+func (r MigrationRecordIterated) PointerSwapped() bool  { return false }
+func (r MigrationRecordMerged) PointerSwapped() bool    { return false }
+func (r MigrationRecordSwapped) PointerSwapped() bool   { return true }
+func (r MigrationRecordPromoted) PointerSwapped() bool  { return true }

--- a/adapters/repos/db/inverted_reindex_record_questions_test.go
+++ b/adapters/repos/db/inverted_reindex_record_questions_test.go
@@ -1,0 +1,119 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testQuestionRecords() (iterating, iterated, merged, swapped, promoted MigrationRecord) {
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title", "body")
+	flipped := []string{"title", "body"}
+	displaced := map[string]string{"title": "property_title_searchable", "body": "property_body_searchable"}
+
+	return NewMigrationRecordIterating(subject, MigrationCheckpoint{LastProcessedKey: []byte("halfway")}),
+		NewMigrationRecordIterated(subject),
+		NewMigrationRecordMerged(subject),
+		NewMigrationRecordSwapped(subject, flipped, displaced),
+		NewMigrationRecordPromoted(subject, flipped, displaced)
+}
+
+func TestMigrationRecordQuestions(t *testing.T) {
+	iterating, iterated, merged, swapped, promoted := testQuestionRecords()
+
+	tests := []struct {
+		name               string
+		record             MigrationRecord
+		wantState          MigrationState
+		wantStagedComplete bool
+		wantPointerSwapped bool
+		wantIterationDone  bool
+	}{
+		{
+			name:               "iterating: rebuilding into staging, canonical still primary",
+			record:             iterating,
+			wantState:          MigrationStateIterating,
+			wantStagedComplete: false,
+			wantPointerSwapped: false,
+			wantIterationDone:  false,
+		},
+		{
+			name:               "iterated: rebuild durable, still discardable",
+			record:             iterated,
+			wantState:          MigrationStateIterated,
+			wantStagedComplete: false,
+			wantPointerSwapped: false,
+			wantIterationDone:  true,
+		},
+		{
+			name:               "merged: the staged data is complete, the flip decision has not been made",
+			record:             merged,
+			wantState:          MigrationStateMerged,
+			wantStagedComplete: true,
+			wantPointerSwapped: false,
+			wantIterationDone:  true,
+		},
+		{
+			name:               "swapped: the flip decision is durable, so the migration is irreversible",
+			record:             swapped,
+			wantState:          MigrationStateSwapped,
+			wantStagedComplete: true,
+			wantPointerSwapped: true,
+			wantIterationDone:  true,
+		},
+		{
+			name:               "promoted: committed and swapped, same answers as swapped",
+			record:             promoted,
+			wantState:          MigrationStatePromoted,
+			wantStagedComplete: true,
+			wantPointerSwapped: true,
+			wantIterationDone:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantState, tt.record.State())
+			require.Equal(t, tt.wantStagedComplete, tt.record.StagedDataComplete())
+			require.Equal(t, tt.wantPointerSwapped, tt.record.PointerSwapped())
+			require.Equal(t, tt.wantIterationDone, tt.record.IterationComplete())
+		})
+	}
+}
+
+func TestMigrationRecordOwnsBucket(t *testing.T) {
+	_, _, merged, _, _ := testQuestionRecords()
+
+	tests := []struct {
+		name string
+		dir  string
+		want bool
+	}{
+		{name: "a staged directory of a covered property", dir: "property_title__g42_ingest", want: true},
+		{name: "a staged directory of the other covered property", dir: "property_body__g42_ingest", want: true},
+		{name: "a sidecar directory the migration created", dir: "property_title__s42_reindex", want: true},
+		{
+			name: "the canonical directory, which predates the migration and must never be reclaimed by it",
+			dir:  "property_title_searchable", want: false,
+		},
+		{name: "another migration's directory", dir: "property_title__g43_ingest", want: false},
+		{name: "no directory at all", dir: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, merged.OwnsBucket(tt.dir))
+		})
+	}
+}

--- a/adapters/repos/db/inverted_reindex_record_read_bound_test.go
+++ b/adapters/repos/db/inverted_reindex_record_read_bound_test.go
@@ -1,0 +1,94 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// Load runs inside the RAFT apply of UpdateTenants, so an oversized record
+// must be refused rather than decoded.
+func TestOversizedMigrationRecordIsRefusedNotParsed(t *testing.T) {
+	tests := []struct {
+		name        string
+		bytes       int64
+		wantOutcome MigrationRecordLoadOutcome
+	}{
+		{
+			name:        "under the bound: read and understood",
+			bytes:       maxMigrationRecordBytes / 2,
+			wantOutcome: MigrationRecordLoaded,
+		},
+		{
+			name:        "over the bound: refused, and refused reads as not understood",
+			bytes:       maxMigrationRecordBytes + (1 << 20),
+			wantOutcome: MigrationRecordNotUnderstood,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lsm := t.TempDir()
+			logger, _ := test.NewNullLogger()
+			store := NewMigrationRecordStore(lsm, logger)
+
+			key := plantRecordOfSize(t, store, tc.bytes)
+			target := filepath.Join(store.Dir(), key.fileName())
+
+			rec, outcome, err := loadMigrationRecordFile(target)
+			require.Equal(t, tc.wantOutcome, outcome)
+
+			require.NoError(t, store.Load())
+			if tc.wantOutcome == MigrationRecordLoaded {
+				require.NoError(t, err)
+				require.NotNil(t, rec)
+				require.Len(t, store.Records(), 1)
+				require.Empty(t, store.Unreadable())
+				return
+			}
+
+			require.Error(t, err)
+			require.Empty(t, store.Records(), "a record nobody read is not a record")
+			require.Len(t, store.Unreadable(), 1)
+			require.Equal(t, key.fileName(), store.Unreadable()[0].FileName)
+
+			require.Error(t, store.Put(NewMigrationRecordMerged(
+				testMigrationSubject(key.TaskVersion, key.StrategyCode, "title"))),
+				"a record this build refused to read must not be written over")
+		})
+	}
+}
+
+func plantRecordOfSize(t *testing.T, store *MigrationRecordStore, size int64) MigrationRecordKey {
+	t.Helper()
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	padMigrationSubject(&subject, size)
+	writeRawMigrationRecord(t, store, NewMigrationRecordMerged(subject).toEnvelope())
+	return subject.Key
+}
+
+// One padding shape for the loader's bound and the writer's, so the two cannot
+// drift into testing different records.
+func padMigrationSubject(subject *MigrationSubject, size int64) {
+	const dirLen = 200
+	for i := 0; int64(i)*(dirLen+8) < size; i++ {
+		subject.Props[fmt.Sprintf("pad_%06d", i)] = MigrationPropertyDirs{
+			Sidecar: fmt.Sprintf("property_pad__g42%06d%s_ingest", i, strings.Repeat("x", dirLen)),
+		}
+	}
+}

--- a/adapters/repos/db/inverted_reindex_record_store.go
+++ b/adapters/repos/db/inverted_reindex_record_store.go
@@ -416,11 +416,10 @@ func (s *MigrationRecordStore) Put(rec MigrationRecord) error {
 	return nil
 }
 
-// [diskio.RenameAndSync] renames before it syncs, so a failed write can follow a
-// rename that already published the record under its final name. Nothing
-// re-reads the store in-process, so memory has to be settled against the file
-// here, or it answers with the older record for the life of the process while
-// the next load answers with the newer one.
+// [diskio.RenameAndSync] renames before it syncs, so a failed write can follow
+// a rename that already published the record. Nothing else re-reads the
+// store, so memory must be settled against the file here or it serves the
+// older record for the life of the process.
 func (s *MigrationRecordStore) adoptIfPublished(rec MigrationRecord, data []byte) {
 	published, err := os.ReadFile(s.path(rec.Subject().Key))
 	if err != nil || !bytes.Equal(published, data) {

--- a/adapters/repos/db/inverted_reindex_record_store.go
+++ b/adapters/repos/db/inverted_reindex_record_store.go
@@ -449,10 +449,12 @@ func (s *MigrationRecordStore) removeSynced(key MigrationRecordKey, sync func(st
 		return fmt.Errorf("remove migration record %q: %w", key, removed)
 	}
 
-	s.mu.Lock()
-	delete(s.records, key)
-	delete(s.wedged, key)
-	s.mu.Unlock()
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		delete(s.records, key)
+		delete(s.wedged, key)
+	}()
 
 	if removed != nil {
 		return nil
@@ -497,12 +499,15 @@ func (s *MigrationRecordStore) Get(key MigrationRecordKey) (MigrationRecord, boo
 // slices.SortFunc is not stable, so the order has to cover the whole key or
 // two passes over one store disagree.
 func (s *MigrationRecordStore) Records() []MigrationRecord {
-	s.mu.RLock()
-	out := make([]MigrationRecord, 0, len(s.records))
-	for _, rec := range s.records {
-		out = append(out, rec)
-	}
-	s.mu.RUnlock()
+	out := func() []MigrationRecord {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		out := make([]MigrationRecord, 0, len(s.records))
+		for _, rec := range s.records {
+			out = append(out, rec)
+		}
+		return out
+	}()
 
 	slices.SortFunc(out, func(a, b MigrationRecord) int {
 		ak, bk := a.Subject().Key, b.Subject().Key

--- a/adapters/repos/db/inverted_reindex_record_store.go
+++ b/adapters/repos/db/inverted_reindex_record_store.go
@@ -1,0 +1,606 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"bytes"
+	"cmp"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/entities/diskio"
+)
+
+const migrationRecordsDirName = "records"
+
+type MigrationRecordLoadOutcome uint8
+
+const (
+	MigrationRecordLoaded MigrationRecordLoadOutcome = iota
+	MigrationRecordAbsent
+	MigrationRecordNotUnderstood
+)
+
+type MigrationRecordFaultScope uint8
+
+const (
+	MigrationRecordFaultFile MigrationRecordFaultScope = iota
+	MigrationRecordFaultStore
+)
+
+type MigrationRecordUnreadable struct {
+	FileName string
+	Reason   string
+	Scope    MigrationRecordFaultScope
+}
+
+// A record this build could not read holds whatever a hand edit or a restore
+// put in it, and a decode refusal quotes the handle it refused. Only the 8 MiB
+// read cap bounds that, and the reason reaches a log line the freeze re-emits
+// on every load of the shard.
+const maxMigrationFaultReasonBytes = 512
+
+// Both ends, because the quoted handle sits in the middle: the head says which
+// record and which role, the tail says what is wrong with it.
+func migrationFaultReason(err error) string {
+	reason := err.Error()
+	if len(reason) <= maxMigrationFaultReasonBytes {
+		return reason
+	}
+	const half = maxMigrationFaultReasonBytes / 2
+	return strings.ToValidUTF8(reason[:half], "") + "…(truncated)…" +
+		strings.ToValidUTF8(reason[len(reason)-half:], "")
+}
+
+// Readers are served from the map: activating a tenant loads its shard on
+// the RAFT apply loop, where a read that went to disk would hold up the log.
+type MigrationRecordStore struct {
+	dir string
+	// The unit whose records are this shard's own. Empty where the caller
+	// cannot name one, which reads every record as local, as before.
+	unitID string
+	logger logrus.FieldLogger
+
+	// Separate from mu: mu must never be held across an fsync, or a reader
+	// on the apply loop would queue behind the disk.
+	writeMu sync.Mutex
+
+	mu         sync.RWMutex
+	records    map[MigrationRecordKey]MigrationRecord
+	unreadable []MigrationRecordUnreadable
+	// Records no pass on this build could advance. Cleared on every load, since
+	// the pass that follows a load re-derives it.
+	wedged map[MigrationRecordKey]bool
+}
+
+// The store names no unit, so every record it loads reads as local. Callers
+// that can name the unit owning this shard's records use
+// NewMigrationRecordStoreForUnit, which is what tells a foreign one apart.
+func NewMigrationRecordStore(lsmPath string, logger logrus.FieldLogger) *MigrationRecordStore {
+	return NewMigrationRecordStoreForUnit(lsmPath, "", logger)
+}
+
+func NewMigrationRecordStoreForUnit(lsmPath, unitID string, logger logrus.FieldLogger) *MigrationRecordStore {
+	return &MigrationRecordStore{
+		dir:     filepath.Join(lsmPath, migrationsDir, migrationRecordsDirName),
+		unitID:  unitID,
+		logger:  logger,
+		records: map[MigrationRecordKey]MigrationRecord{},
+	}
+}
+
+func (s *MigrationRecordStore) Dir() string { return s.dir }
+
+// Two levels, not MkdirAll: a write racing a collection DELETE, which renames
+// the class directory away, would otherwise re-materialize the deleted tree.
+func (s *MigrationRecordStore) mkdir() error {
+	return s.mkdirSynced(diskio.Fsync)
+}
+
+// The sync is a parameter for the same reason writeFileAtomicWithSync takes
+// one: a test can assert a created directory's own name is on disk before a
+// record is written into it.
+func (s *MigrationRecordStore) mkdirSynced(sync func(string) error) error {
+	for _, dir := range []string{filepath.Dir(s.dir), s.dir} {
+		if err := os.Mkdir(dir, 0o777); err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return err
+		}
+		// The record's own fsync does not publish the directory entry holding
+		// it. Without this a crash leaves the record synced into a directory
+		// that is gone, and Load then reports no records at all rather than an
+		// unreadable one, which is the reading the freeze cannot see.
+		if err := sync(filepath.Dir(dir)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *MigrationRecordStore) path(key MigrationRecordKey) string {
+	return filepath.Join(s.dir, key.fileName())
+}
+
+// Kept out of Load: any store may Load over a directory the owning shard is
+// writing to, and removing its scratch file breaks that shard's rename. Only
+// the owning shard calls this, once, before load.
+func (s *MigrationRecordStore) SweepTempFiles() {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			s.logger.WithField("path", s.dir).Warnf("sweep stale migration record temp files: %v", err)
+		}
+		return
+	}
+	var failed int
+	var example string
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, tmpExt) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(s.dir, name)); err != nil && !os.IsNotExist(err) {
+			failed++
+			if example == "" {
+				example = fmt.Sprintf("%s: %v", name, err)
+			}
+		}
+	}
+	if failed > 0 {
+		s.logger.WithField("path", s.dir).WithField("file_count", failed).Warnf(
+			"could not remove %d stale migration record temp file(s), for example %s", failed, example)
+	}
+}
+
+func (s *MigrationRecordStore) Load() error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			s.publish(map[MigrationRecordKey]MigrationRecord{}, nil)
+			return nil
+		}
+		s.publish(map[MigrationRecordKey]MigrationRecord{}, []MigrationRecordUnreadable{{
+			FileName: migrationRecordsDirName,
+			Reason:   fmt.Sprintf("read migration records dir: %v", err),
+			Scope:    MigrationRecordFaultStore,
+		}})
+		return fmt.Errorf("read migration records dir %q: %w", s.dir, err)
+	}
+
+	records := make(map[MigrationRecordKey]MigrationRecord, len(entries))
+	var unreadable, foreign []MigrationRecordUnreadable
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, tmpExt) {
+			continue
+		}
+
+		rec, outcome, err := loadMigrationRecordFile(filepath.Join(s.dir, name))
+		switch outcome {
+		case MigrationRecordLoaded:
+			if got := rec.Subject().Key.fileName(); got != name {
+				unreadable = append(unreadable, MigrationRecordUnreadable{
+					FileName: name,
+					Reason:   fmt.Sprintf("content names record file %q", got),
+					Scope:    MigrationRecordFaultFile,
+				})
+				continue
+			}
+			if s.foreignUnit(rec.Subject().Key) {
+				foreign = append(foreign, MigrationRecordUnreadable{
+					FileName: name,
+					Reason:   fmt.Sprintf("unit %q is not this shard's own", rec.Subject().Key.UnitID),
+					Scope:    MigrationRecordFaultFile,
+				})
+				continue
+			}
+			records[rec.Subject().Key] = rec
+		case MigrationRecordAbsent:
+			continue
+		case MigrationRecordNotUnderstood:
+			unreadable = append(unreadable, MigrationRecordUnreadable{
+				FileName: name, Reason: migrationFaultReason(err), Scope: MigrationRecordFaultFile,
+			})
+		}
+	}
+
+	unreadable = append(unreadable, refuseRecordsOfSeveralUnits(records)...)
+	unreadable = append(unreadable, refuseRecordsOfDuplicateClaims(records)...)
+	s.reportForeign(foreign)
+
+	// One line per load, not one per file: Load runs on every shard load, which
+	// on a multi-tenant collection is once per tenant. Error, not Warn: this
+	// withholds every destructive action on the shard until someone acts.
+	if len(unreadable) > 0 {
+		names := make([]string, 0, len(unreadable))
+		for _, u := range unreadable {
+			names = append(names, u.FileName)
+		}
+		s.logger.WithField("path", s.dir).WithField("file_count", len(unreadable)).Errorf(
+			"%d migration record(s) not understood, preserving them and withholding destructive work; "+
+				"files: %s; first reason: %s",
+			len(unreadable), strings.Join(migrationReportedNames(names), ", "), unreadable[0].Reason)
+	}
+
+	s.publish(records, unreadable)
+	return nil
+}
+
+// A backup restore and a replica move both land another replica's record file
+// under this shard, where nothing else tells it apart from a local one: it is
+// granted a seal no local worker holds and is then reconciled as local work.
+// Set aside rather than adopted, and left on disk for whoever put it there.
+func (s *MigrationRecordStore) foreignUnit(key MigrationRecordKey) bool {
+	return s.unitID != "" && key.UnitID != s.unitID
+}
+
+// One line per load, not one per file: Load runs once per tenant on a
+// multi-tenant collection, and a restore lands every replica's records at once.
+func (s *MigrationRecordStore) reportForeign(foreign []MigrationRecordUnreadable) {
+	if len(foreign) == 0 {
+		return
+	}
+	names := make([]string, 0, len(foreign))
+	for _, f := range foreign {
+		names = append(names, f.FileName)
+	}
+	s.logger.WithField("path", s.dir).WithField("file_count", len(foreign)).Warnf(
+		"%d migration record(s) here belong to another replica of this shard and are ignored; "+
+			"they were most likely left by a restore or a replica move, and the directories they "+
+			"name are not this shard's to reclaim. Files: %s",
+		len(foreign), strings.Join(migrationReportedNames(names), ", "))
+}
+
+// A fault, not a preference: a teardown always seals a foreign unit, so
+// dropping foreign records would strand their directories for reclaimers.
+func refuseRecordsOfSeveralUnits(records map[MigrationRecordKey]MigrationRecord) []MigrationRecordUnreadable {
+	units := map[string]struct{}{}
+	for key := range records {
+		units[key.UnitID] = struct{}{}
+	}
+	if len(units) < 2 {
+		return nil
+	}
+	named := make([]string, 0, len(units))
+	for unit := range units {
+		named = append(named, unit)
+	}
+	slices.Sort(named)
+	return []MigrationRecordUnreadable{{
+		FileName: migrationRecordsDirName,
+		Reason: fmt.Sprintf(
+			"records of %d units are here (%s); this node cannot tell which is its own, "+
+				"and sealing a foreign one would not hold back a live local worker. "+
+				"Move or remove the record files whose unit is not this shard's, and leave this shard's own in place",
+			len(named), strings.Join(migrationReportedNames(named), ", ")),
+		Scope: MigrationRecordFaultStore,
+	}}
+}
+
+// A tracker directory sits under .migrations and every other claim at the shard
+// root, so the two are kept apart here or one name shared across them reads as a
+// collision over a directory that does not exist.
+func migrationExclusiveClaims(subject MigrationSubject) []string {
+	claims := migrationOwnedDirs(subject)
+	if subject.TrackerDir != "" {
+		claims = append(claims, filepath.Join(migrationsDir, subject.TrackerDir))
+	}
+	return claims
+}
+
+// A directory name a migration mints carries its own task version, so only a
+// hand-edited or restore-landed file can claim a directory another record
+// claims. Both claimants leave the live set: nothing here can tell which one
+// the data belongs to, and either answer would delete the other's only copy.
+func refuseRecordsOfDuplicateClaims(records map[MigrationRecordKey]MigrationRecord) []MigrationRecordUnreadable {
+	keys := slices.SortedFunc(maps.Keys(records), func(a, b MigrationRecordKey) int {
+		return cmp.Compare(a.fileName(), b.fileName())
+	})
+	// Per unit, because two replicas of one shard name the same directories on
+	// their own shards. Records of several units under one shard is its own
+	// fault, above, and this shard's own records are all of one unit.
+	type claimedBy struct{ unit, dir string }
+	held := map[claimedBy]MigrationRecordKey{}
+	shared := map[MigrationRecordKey]string{}
+	against := map[MigrationRecordKey]MigrationRecordKey{}
+	for _, key := range keys {
+		for _, dir := range migrationExclusiveClaims(records[key].Subject()) {
+			claim := claimedBy{key.UnitID, dir}
+			first, taken := held[claim]
+			if !taken {
+				held[claim] = key
+				continue
+			}
+			shared[first], against[first] = dir, key
+			shared[key], against[key] = dir, first
+		}
+	}
+
+	refused := make([]MigrationRecordUnreadable, 0, len(shared))
+	for _, key := range keys {
+		claim, collided := shared[key]
+		if !collided {
+			continue
+		}
+		delete(records, key)
+		refused = append(refused, MigrationRecordUnreadable{
+			FileName: key.fileName(),
+			Reason: fmt.Sprintf(
+				"this record and %q both claim directory %q, and this node cannot tell which one holds "+
+					"its data. Confirm which migration the directory belongs to, then move or remove the "+
+					"record file of the other one",
+				against[key].fileName(), claim),
+			Scope: MigrationRecordFaultFile,
+		})
+	}
+	return refused
+}
+
+func (s *MigrationRecordStore) publish(records map[MigrationRecordKey]MigrationRecord, unreadable []MigrationRecordUnreadable) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = records
+	s.unreadable = unreadable
+	s.wedged = nil
+}
+
+// MarkWedged records that nothing this build runs can move this record on. The
+// reconciler holding that knowledge lives for one pass, so without this one
+// wedged record costs a leader query and a walk of every loaded shard on the
+// node, once a minute, for the life of the process, and never progresses.
+func (s *MigrationRecordStore) MarkWedged(key MigrationRecordKey) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.wedged == nil {
+		s.wedged = map[MigrationRecordKey]bool{}
+	}
+	s.wedged[key] = true
+}
+
+// Read by every later pass in this incarnation. The reconciler that diagnosed
+// the wedge lives for one pass, so without this the next pass derives the same
+// verdict, logs it again and counts it again, once a minute, forever.
+func (s *MigrationRecordStore) Wedged(key MigrationRecordKey) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.wedged[key]
+}
+
+func (s *MigrationRecordStore) Put(rec MigrationRecord) error {
+	data, err := encodeMigrationRecord(rec)
+	if err != nil {
+		return fmt.Errorf("encode migration record %q: %w", rec.Subject().Key, err)
+	}
+
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	if err := s.mayWrite(rec.Subject().Key); err != nil {
+		return err
+	}
+	if err := s.mkdir(); err != nil {
+		return fmt.Errorf("create migration records dir %q: %w", s.dir, err)
+	}
+	if err := writeFileAtomic(s.dir, rec.Subject().Key.fileName(), data); err != nil {
+		s.adoptIfPublished(rec, data)
+		return fmt.Errorf("write migration record %q: %w", rec.Subject().Key, err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[rec.Subject().Key] = rec
+	return nil
+}
+
+// [diskio.RenameAndSync] renames before it syncs, so a failed write can follow a
+// rename that already published the record under its final name. Nothing
+// re-reads the store in-process, so memory has to be settled against the file
+// here, or it answers with the older record for the life of the process while
+// the next load answers with the newer one.
+func (s *MigrationRecordStore) adoptIfPublished(rec MigrationRecord, data []byte) {
+	published, err := os.ReadFile(s.path(rec.Subject().Key))
+	if err != nil || !bytes.Equal(published, data) {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records[rec.Subject().Key] = rec
+}
+
+func (s *MigrationRecordStore) Remove(key MigrationRecordKey) error {
+	return s.removeSynced(key, diskio.Fsync)
+}
+
+// The sync is a parameter for the same reason mkdirSynced takes one: a test can
+// assert the unlink's own directory entry reached disk.
+func (s *MigrationRecordStore) removeSynced(key MigrationRecordKey, sync func(string) error) error {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+
+	if err := s.mayWrite(key); err != nil {
+		return err
+	}
+	removed := os.Remove(s.path(key))
+	if removed != nil && !os.IsNotExist(removed) {
+		return fmt.Errorf("remove migration record %q: %w", key, removed)
+	}
+
+	s.mu.Lock()
+	delete(s.records, key)
+	delete(s.wedged, key)
+	s.mu.Unlock()
+
+	if removed != nil {
+		return nil
+	}
+	// The unlink survives a crash only once the directory holding it is synced.
+	// Without this a retired record comes back on the next load, naming
+	// directories the pass that retired it already removed.
+	if err := sync(s.dir); err != nil {
+		return fmt.Errorf("publish the removal of migration record %q: %w", key, err)
+	}
+	return nil
+}
+
+// Any fault at all holds back every write, not only one naming this record's
+// own file. A record this build could not read may name the same directories,
+// so a write decided without it is decided on a state nobody here can see.
+func (s *MigrationRecordStore) mayWrite(key MigrationRecordKey) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.unreadable) == 0 {
+		return nil
+	}
+	name := key.fileName()
+	for _, u := range s.unreadable {
+		if u.Scope == MigrationRecordFaultFile && u.FileName == name {
+			return fmt.Errorf("refusing to write migration record %q over a file this build could not read: %s",
+				key, u.Reason)
+		}
+	}
+	u := s.unreadable[0]
+	return fmt.Errorf("refusing to write migration record %q: this build could not read %q, "+
+		"so it cannot tell what is already recorded here: %s", key, u.FileName, u.Reason)
+}
+
+func (s *MigrationRecordStore) Get(key MigrationRecordKey) (MigrationRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	rec, ok := s.records[key]
+	return rec, ok
+}
+
+// slices.SortFunc is not stable, so the order has to cover the whole key or
+// two passes over one store disagree.
+func (s *MigrationRecordStore) Records() []MigrationRecord {
+	s.mu.RLock()
+	out := make([]MigrationRecord, 0, len(s.records))
+	for _, rec := range s.records {
+		out = append(out, rec)
+	}
+	s.mu.RUnlock()
+
+	slices.SortFunc(out, func(a, b MigrationRecord) int {
+		ak, bk := a.Subject().Key, b.Subject().Key
+		if c := cmp.Compare(ak.TaskVersion, bk.TaskVersion); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(ak.StrategyCode, bk.StrategyCode); c != 0 {
+			return c
+		}
+		return cmp.Compare(ak.UnitID, bk.UnitID)
+	})
+	return out
+}
+
+// HasUndecided reports whether any understood record is still pre-swap and
+// still movable. A wedged one is neither, and asking again about it is what
+// makes the periodic pass repeat forever with nothing to show for it.
+func (s *MigrationRecordStore) HasUndecided() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for key, rec := range s.records {
+		if !rec.PointerSwapped() && !s.wedged[key] {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *MigrationRecordStore) Unreadable() []MigrationRecordUnreadable {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return slices.Clone(s.unreadable)
+}
+
+// Load runs inside the RAFT apply of UpdateTenants, holding the FSM loop
+// cluster-wide, so this bound is load-bearing; see
+// TestTheLargestRecordTheWriterCanBuildFitsTheLoadersBound.
+const maxMigrationRecordBytes = 8 << 20
+
+func loadMigrationRecordFile(path string) (MigrationRecord, MigrationRecordLoadOutcome, error) {
+	// An over-bound file reads as not-understood, not absent: unread, it may
+	// name directories that must not be reclaimed.
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, MigrationRecordAbsent, nil
+		}
+		return nil, MigrationRecordNotUnderstood, fmt.Errorf("stat %q: %w", filepath.Base(path), err)
+	}
+	if info.Size() > maxMigrationRecordBytes {
+		return nil, MigrationRecordNotUnderstood, fmt.Errorf(
+			"record %q holds %d bytes, bound is %d", filepath.Base(path), info.Size(), maxMigrationRecordBytes)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, MigrationRecordAbsent, nil
+		}
+		return nil, MigrationRecordNotUnderstood, fmt.Errorf("read %q: %w", filepath.Base(path), err)
+	}
+
+	rec, err := decodeMigrationRecord(data)
+	if err != nil {
+		return nil, MigrationRecordNotUnderstood, err
+	}
+	return rec, MigrationRecordLoaded, nil
+}
+
+func writeFileAtomic(dir, name string, content []byte) error {
+	return writeFileAtomicWithSync(dir, name, content, (*os.File).Sync)
+}
+
+// The sync is a parameter so a test can assert it runs after the bytes and
+// before the rename publishes the name.
+func writeFileAtomicWithSync(dir, name string, content []byte, sync func(*os.File) error) (err error) {
+	tmp, err := os.CreateTemp(dir, name+".*"+tmpExt)
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		if err != nil {
+			tmp.Close()
+			os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err = tmp.Write(content); err != nil {
+		return err
+	}
+	// Bytes must reach disk before the name does, or a crash can publish the
+	// new name over content that never landed.
+	if err = sync(tmp); err != nil {
+		return err
+	}
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+	return diskio.RenameAndSync(tmpPath, filepath.Join(dir, name))
+}

--- a/adapters/repos/db/inverted_reindex_record_store.go
+++ b/adapters/repos/db/inverted_reindex_record_store.go
@@ -117,16 +117,13 @@ func (s *MigrationRecordStore) mkdir() error {
 // record is written into it.
 func (s *MigrationRecordStore) mkdirSynced(sync func(string) error) error {
 	for _, dir := range []string{filepath.Dir(s.dir), s.dir} {
-		if err := os.Mkdir(dir, 0o777); err != nil {
-			if os.IsExist(err) {
-				continue
-			}
+		if err := os.Mkdir(dir, 0o777); err != nil && !os.IsExist(err) {
 			return err
 		}
-		// The record's own fsync does not publish the directory entry holding
-		// it. Without this a crash leaves the record synced into a directory
-		// that is gone, and Load then reports no records at all rather than an
-		// unreadable one, which is the reading the freeze cannot see.
+		// The record's own fsync does not publish the directory entry holding it: a
+		// crash without this leaves the record synced into a directory that is gone.
+		// Unconditional, because whoever created an already-present directory may
+		// have died before syncing it.
 		if err := sync(filepath.Dir(dir)); err != nil {
 			return err
 		}
@@ -312,10 +309,8 @@ func migrationExclusiveClaims(subject MigrationSubject) []string {
 	return claims
 }
 
-// A directory name a migration mints carries its own task version, so only a
-// hand-edited or restore-landed file can claim a directory another record
-// claims. Both claimants leave the live set: nothing here can tell which one
-// the data belongs to, and either answer would delete the other's only copy.
+// Both claimants leave the live set: nothing here can tell which one the data
+// belongs to, and either answer would delete the other's only copy.
 func refuseRecordsOfDuplicateClaims(records map[MigrationRecordKey]MigrationRecord) []MigrationRecordUnreadable {
 	keys := slices.SortedFunc(maps.Keys(records), func(a, b MigrationRecordKey) int {
 		return cmp.Compare(a.fileName(), b.fileName())

--- a/adapters/repos/db/inverted_reindex_record_test.go
+++ b/adapters/repos/db/inverted_reindex_record_test.go
@@ -1516,11 +1516,8 @@ func TestARecordCarryingTheRetiredCheckpointCountersStillLoads(t *testing.T) {
 		"and the one field still read survives the two that are gone")
 }
 
-// The write publishes the record by renaming and only then syncs the directory
-// holding the new name, so a failed write may or may not have published. Same
-// file name either way, and only its contents tell the two apart. Nothing
-// re-reads the store in-process, so memory has to be settled against the file,
-// or the store answers with a record no later load agrees with.
+// A failed Put must adopt exactly the record the file holds after a
+// rename-then-sync race, not stale in-memory state.
 func TestAFailedPutAdoptsOnlyTheRecordTheFileHolds(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/adapters/repos/db/inverted_reindex_record_test.go
+++ b/adapters/repos/db/inverted_reindex_record_test.go
@@ -1,0 +1,1658 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func testMigrationSubject(version uint64, code MigrationStrategyCode, props ...string) MigrationSubject {
+	subject := MigrationSubject{
+		Key:                  MigrationRecordKey{TaskVersion: version, StrategyCode: code, UnitID: "shard-1__node-0"},
+		TaskID:               "Books:change-tokenization:title:ab12",
+		MigrationType:        ReindexTypeChangeTokenization,
+		TargetTokenization:   models.PropertyTokenizationLowercase,
+		OriginalTokenization: models.PropertyTokenizationWord,
+		TrackerDir:           fmt.Sprintf("m_%d_tracker", version),
+		IterationCutoff:      time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC),
+	}
+	if len(props) == 0 {
+		return subject
+	}
+
+	subject.Props = map[string]MigrationPropertyDirs{}
+	for _, prop := range props {
+		subject.Props[prop] = MigrationPropertyDirs{
+			Staged:    fmt.Sprintf("property_%s__g%d_ingest", prop, version),
+			Canonical: sourceBucketNameFor(code, prop),
+			Sidecar:   fmt.Sprintf("property_%s__s%d_reindex", prop, version),
+		}
+	}
+	return subject
+}
+
+// Rewrites one role of one property, which a struct value cannot take in place.
+func setMigrationDir(subject *MigrationSubject, prop string, set func(*MigrationPropertyDirs)) {
+	dirs := subject.Props[prop]
+	set(&dirs)
+	if subject.Props == nil {
+		subject.Props = map[string]MigrationPropertyDirs{}
+	}
+	subject.Props[prop] = dirs
+}
+
+func TestMigrationRecordRoundTrip(t *testing.T) {
+	checkpoint := MigrationCheckpoint{
+		LastProcessedKey: []byte{0xDE, 0xAD, 0xBE, 0xEF},
+		UpdatedAt:        time.Date(2026, 8, 21, 10, 0, 0, 123456789, time.UTC),
+	}
+	displaced := map[string]string{"title": "property_title"}
+	nilDirMaps := testMigrationSubject(7, StrategyCodeSearchableMapToBlockmax, "title")
+	nilDirMaps.Props = map[string]MigrationPropertyDirs{"title": {}}
+
+	tests := []struct {
+		name      string
+		record    MigrationRecord
+		wantState MigrationState
+	}{
+		{
+			name:      "iterating carries the checkpoint",
+			record:    NewMigrationRecordIterating(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title"), checkpoint),
+			wantState: MigrationStateIterating,
+		},
+		{
+			name:      "iterated",
+			record:    NewMigrationRecordIterated(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")),
+			wantState: MigrationStateIterated,
+		},
+		{
+			name:      "merged",
+			record:    NewMigrationRecordMerged(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title", "body")),
+			wantState: MigrationStateMerged,
+		},
+		{
+			name:      "swapped carries the flip set and the displaced handles",
+			record:    NewMigrationRecordSwapped(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title"), []string{"title"}, displaced),
+			wantState: MigrationStateSwapped,
+		},
+		{
+			name: "swapped carries the promotion it started, which is the only thing that makes a missing staged dir readable",
+			record: NewMigrationRecordSwapped(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title"),
+				[]string{"title"}, displaced).WithPromotionAt("title", migrationPromotionStarted),
+			wantState: MigrationStateSwapped,
+		},
+		{
+			name:      "promoted keeps the flip block so a partly failed retirement is still attributable",
+			record:    NewMigrationRecordPromoted(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title"), []string{"title"}, displaced),
+			wantState: MigrationStatePromoted,
+		},
+		{
+			name:      "a record naming no directories keeps its nil maps nil",
+			record:    NewMigrationRecordMerged(nilDirMaps),
+			wantState: MigrationStateMerged,
+		},
+		{
+			name: "two properties that displaced nothing still name one owner each",
+			record: NewMigrationRecordSwapped(testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title", "body"),
+				[]string{"title", "body"}, map[string]string{"title": "", "body": ""}),
+			wantState: MigrationStateSwapped,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encoded, err := encodeMigrationRecord(tt.record)
+			require.NoError(t, err)
+			require.True(t, bytes.Contains(encoded, []byte("\n  ")), "records are indented so an operator can read one with cat")
+
+			decoded, err := decodeMigrationRecord(encoded)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantState, decoded.State())
+			require.Equal(t, tt.record, decoded)
+		})
+	}
+}
+
+// A round trip cannot catch a renamed JSON tag; on disk it decodes at zero.
+func TestTheRecordsWireNamesAreTheCompatibilityContract(t *testing.T) {
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+
+	keysOf := func(t *testing.T, data []byte, path ...string) []string {
+		t.Helper()
+		var block map[string]any
+		require.NoError(t, json.Unmarshal(data, &block))
+		for _, step := range path {
+			require.Contains(t, block, step)
+			block = block[step].(map[string]any)
+		}
+		return slices.Sorted(maps.Keys(block))
+	}
+
+	swapped, err := encodeMigrationRecord(NewMigrationRecordSwapped(subject,
+		[]string{"title"}, map[string]string{"title": "property_title"}).
+		WithPromotionAt("title", migrationPromotionFinished))
+	require.NoError(t, err)
+	iterating, err := encodeMigrationRecord(NewMigrationRecordIterating(subject,
+		MigrationCheckpoint{LastProcessedKey: []byte{1}}))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"flip", "formatVersion", "state", "subject"},
+		keysOf(t, swapped))
+	require.Equal(t, []string{
+		"iterationCutoff", "key", "migrationType", "originalTokenization",
+		"props", "targetTokenization", "taskID", "trackerDir",
+	}, keysOf(t, swapped, "subject"))
+	require.Equal(t, []string{"canonical", "sidecar", "staged"},
+		keysOf(t, swapped, "subject", "props", "title"))
+	require.Equal(t, []string{"strategyCode", "taskVersion", "unitID"},
+		keysOf(t, swapped, "subject", "key"))
+	require.Equal(t, []string{"displacedDirs", "flipped", "promotion"},
+		keysOf(t, swapped, "flip"))
+	require.Equal(t, []string{"lastProcessedKey", "updatedAt"},
+		keysOf(t, iterating, "checkpoint"))
+
+	codes := map[MigrationStrategyCode]string{
+		StrategyCodeSearchableMapToBlockmax:     "searchable_map_to_blockmax",
+		StrategyCodeFilterableRoaringsetRefresh: "filterable_roaringset_refresh",
+		StrategyCodeFilterableToRangeable:       "filterable_to_rangeable",
+		StrategyCodeSearchableRetokenize:        "searchable_retokenize",
+		StrategyCodeFilterableRetokenize:        "filterable_retokenize",
+		StrategyCodeEnableFilterable:            "enable_filterable",
+		StrategyCodeEnableSearchable:            "enable_searchable",
+		StrategyCodeRebuildSearchable:           "rebuild_searchable",
+	}
+	require.Len(t, codes, 8, "two codes now render the same string, so their records share a file name")
+	for code, onDisk := range codes {
+		require.Equal(t, onDisk, string(code))
+	}
+}
+
+func TestAFlipKeyThisBuildDoesNotKnowStillDecodes(t *testing.T) {
+	subject := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+	swapped := NewMigrationRecordSwapped(subject, []string{"title"},
+		map[string]string{"title": "property_title"})
+
+	encoded, err := encodeMigrationRecord(swapped)
+	require.NoError(t, err)
+	env := map[string]any{}
+	require.NoError(t, json.Unmarshal(encoded, &env))
+	env["flip"].(map[string]any)["someLaterBuildsBlock"] = map[string]any{"title": "whatever"}
+	data, err := json.Marshal(env)
+	require.NoError(t, err)
+
+	decoded, err := decodeMigrationRecord(data)
+	require.NoError(t, err)
+	require.Equal(t, swapped, decoded)
+	require.Empty(t, decoded.(MigrationRecordSwapped).PromotionOf("title"),
+		"a key this build cannot read licenses no promotion")
+}
+
+func TestMigrationRecordNotUnderstood(t *testing.T) {
+	propDirs := func(env map[string]any, prop string) map[string]any {
+		props := env["subject"].(map[string]any)["props"].(map[string]any)
+		if props[prop] == nil {
+			props[prop] = map[string]any{}
+		}
+		return props[prop].(map[string]any)
+	}
+
+	valid := func(mutate func(env map[string]any)) []byte {
+		encoded, err := encodeMigrationRecord(NewMigrationRecordMerged(testMigrationSubject(42, StrategyCodeEnableFilterable, "title")))
+		require.NoError(t, err)
+		env := map[string]any{}
+		require.NoError(t, json.Unmarshal(encoded, &env))
+		mutate(env)
+		out, err := json.Marshal(env)
+		require.NoError(t, err)
+		return out
+	}
+
+	type propReader func(prop string) map[string]any
+
+	twoProperties := func(mutate func(dirs propReader, env map[string]any)) []byte {
+		return valid(func(env map[string]any) {
+			body := propDirs(env, "body")
+			body["staged"] = "property_body__g42_ingest"
+			body["canonical"] = "property_body"
+			body["sidecar"] = "property_body__s42_reindex"
+			mutate(func(prop string) map[string]any { return propDirs(env, prop) }, env)
+		})
+	}
+
+	tests := []struct {
+		name    string
+		data    []byte
+		wantErr string
+	}{
+		{
+			name: "not json at all", data: []byte("this is not a record"),
+			wantErr: "decode record:",
+		},
+		{
+			name: "truncated mid-write", data: []byte(`{"formatVersion":1,"state":"mer`),
+			wantErr: "unexpected end of JSON input",
+		},
+		{name: "empty file", data: nil, wantErr: "unexpected end of JSON input"},
+		{
+			name:    "format version from a future build",
+			data:    valid(func(env map[string]any) { env["formatVersion"] = 99 }),
+			wantErr: "unknown record format version 99",
+		},
+		{
+			name:    "state this build does not know",
+			data:    valid(func(env map[string]any) { env["state"] = "tidied" }),
+			wantErr: "names unknown state \"tidied\"",
+		},
+		{
+			name: "migration type this build does not know",
+			data: valid(func(env map[string]any) {
+				env["subject"].(map[string]any)["migrationType"] = "reticulate-splines"
+			}),
+			wantErr: "names unknown migration type \"reticulate-splines\"",
+		},
+		{
+			name:    "task ID missing",
+			data:    valid(func(env map[string]any) { env["subject"].(map[string]any)["taskID"] = "" }),
+			wantErr: "has no task ID",
+		},
+		{
+			name: "checkpoint on a state that has none",
+			data: valid(func(env map[string]any) {
+				env["checkpoint"] = map[string]any{"processedCount": 1}
+			}),
+			wantErr: "in state \"merged\": checkpoint block present=true, wanted=false",
+		},
+		{
+			name: "flip block on a state that has none",
+			data: valid(func(env map[string]any) {
+				env["flip"] = map[string]any{"flipped": []string{"title"}}
+			}),
+			wantErr: "in state \"merged\": flip block present=true, wanted=false",
+		},
+		{
+			name:    "iterating without its checkpoint",
+			data:    valid(func(env map[string]any) { env["state"] = string(MigrationStateIterating) }),
+			wantErr: "in state \"iterating\": checkpoint block present=false, wanted=true",
+		},
+		{
+			name:    "swapped without its flip block",
+			data:    valid(func(env map[string]any) { env["state"] = string(MigrationStateSwapped) }),
+			wantErr: "in state \"swapped\": flip block present=false, wanted=true",
+		},
+		{
+			name:    "promoted without its flip block",
+			data:    valid(func(env map[string]any) { env["state"] = string(MigrationStatePromoted) }),
+			wantErr: "in state \"promoted\": flip block present=false, wanted=true",
+		},
+		{
+			name: "a flip that displaced the directory it staged",
+			data: valid(func(env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title"},
+					"displacedDirs": map[string]any{"title": propDirs(env, "title")["staged"]},
+				}
+			}),
+			wantErr: `names directory "property_title__g42_ingest" as both the staged directory of property "title" and the displaced directory of property "title"`,
+		},
+		{
+			name: "a flip that displaced another property's staged directory",
+			data: valid(func(env map[string]any) {
+				body := propDirs(env, "body")
+				body["staged"] = "property_body__g42_ingest"
+				body["canonical"] = "property_body"
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title", "body"},
+					"displacedDirs": map[string]any{"title": body["staged"]},
+				}
+			}),
+			wantErr: `names directory "property_body__g42_ingest" as both the staged directory of property "body" and the displaced directory of property "title"`,
+		},
+		{
+			name: "two properties naming the same sidecar directory",
+			data: valid(func(env map[string]any) {
+				propDirs(env, "body")["sidecar"] = propDirs(env, "title")["sidecar"]
+			}),
+			wantErr: `names directory "property_title__s42_reindex" as both the sidecar directory of property "body" and the sidecar directory of property "title"`,
+		},
+		{
+			name: "a displaced directory recorded for a property the record does not name",
+			data: valid(func(env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title"},
+					"displacedDirs": map[string]any{"body": "property_body"},
+				}
+			}),
+			wantErr: `displaces a directory for property "body", which it does not name`,
+		},
+		{
+			name: "a promotion recorded for a property the record does not name",
+			data: valid(func(env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title"},
+					"displacedDirs": map[string]any{"title": "property_title"},
+					"promotion":     map[string]any{"body": "started"},
+				}
+			}),
+			wantErr: `records a promotion of property "body", which it does not name`,
+		},
+		{
+			name: "a promotion mark on a state that has no promotion to be part way through",
+			data: valid(func(env map[string]any) {
+				env["state"] = string(MigrationStatePromoted)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title"},
+					"displacedDirs": map[string]any{"title": "property_title"},
+					"promotion":     map[string]any{"title": "finished"},
+				}
+			}),
+			wantErr: `in state "promoted" carries promotion marks, which only a swapped record does`,
+		},
+		{
+			name: "a promotion mark this build does not know",
+			data: valid(func(env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title"},
+					"displacedDirs": map[string]any{"title": "property_title"},
+					"promotion":     map[string]any{"title": "bogus"},
+				}
+			}),
+			wantErr: `records unknown promotion mark "bogus" for property "title"`,
+		},
+		{
+			name: "two properties naming the same staged directory",
+			data: twoProperties(func(dirs propReader, _ map[string]any) {
+				dirs("body")["staged"] = dirs("title")["staged"]
+			}),
+			wantErr: `names directory "property_title__g42_ingest" as both the staged directory of property "body" and the staged directory of property "title"`,
+		},
+		{
+			name: "a property staged into another property's sidecar directory",
+			data: twoProperties(func(dirs propReader, _ map[string]any) {
+				dirs("body")["staged"] = dirs("title")["sidecar"]
+			}),
+			wantErr: `names directory "property_title__s42_reindex" as both the staged directory of property "body" and the sidecar directory of property "title"`,
+		},
+		{
+			name: "a property staged into its own sidecar directory",
+			data: twoProperties(func(dirs propReader, _ map[string]any) {
+				dirs("title")["staged"] = dirs("title")["sidecar"]
+			}),
+			wantErr: `names directory "property_title__s42_reindex" as both the staged directory of property "title" and the sidecar directory of property "title"`,
+		},
+		{
+			name: "two properties naming the same canonical directory",
+			data: twoProperties(func(dirs propReader, _ map[string]any) {
+				dirs("body")["canonical"] = dirs("title")["canonical"]
+			}),
+			wantErr: `names directory "property_title" as both the canonical directory of property "body" and the canonical directory of property "title"`,
+		},
+		{
+			name: "a property staged into another property's canonical directory",
+			data: twoProperties(func(dirs propReader, _ map[string]any) {
+				dirs("title")["canonical"] = "property_title__retokenize_ingest_1"
+				dirs("body")["staged"] = dirs("title")["canonical"]
+			}),
+			wantErr: `names directory "property_title__retokenize_ingest_1" as both the staged directory of property "body" and the canonical directory of property "title"`,
+		},
+		{
+			name: "a sidecar that is another property's canonical directory",
+			data: twoProperties(func(dirs propReader, _ map[string]any) {
+				dirs("title")["canonical"] = "property_title__retokenize_ingest_1"
+				dirs("body")["sidecar"] = dirs("title")["canonical"]
+			}),
+			wantErr: `names directory "property_title__retokenize_ingest_1" as both the canonical directory of property "title" and the sidecar directory of property "body"`,
+		},
+		{
+			name: "a flip that displaced a sidecar directory",
+			data: twoProperties(func(dirs propReader, env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title", "body"},
+					"displacedDirs": map[string]any{"title": dirs("body")["sidecar"]},
+				}
+			}),
+			wantErr: `names directory "property_body__s42_reindex" as both the sidecar directory of property "body" and the displaced directory of property "title"`,
+		},
+		{
+			name: "a flip that displaced another property's canonical directory",
+			data: twoProperties(func(dirs propReader, env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title", "body"},
+					"displacedDirs": map[string]any{"title": dirs("body")["canonical"]},
+				}
+			}),
+			wantErr: `names directory "property_body" as both the canonical directory of property "body" and the displaced directory of property "title"`,
+		},
+		{
+			name: "two properties displacing the same directory",
+			data: twoProperties(func(_ propReader, env map[string]any) {
+				env["state"] = string(MigrationStateSwapped)
+				env["flip"] = map[string]any{
+					"flipped":       []string{"title", "body"},
+					"displacedDirs": map[string]any{"title": "property_shared__g41_ingest", "body": "property_shared__g41_ingest"},
+				}
+			}),
+			wantErr: `names directory "property_shared__g41_ingest" as both the displaced directory of property "body" and the displaced directory of property "title"`,
+		},
+		{
+			// Every other role is covered by
+			// [TestNoStoreTheShardServesFromCanBeNamedInAnyDirectoryRole]; the
+			// tracker directory is the one that does not sit at the shard root.
+			name: "a tracker directory that is the record store",
+			data: valid(func(env map[string]any) {
+				env["subject"].(map[string]any)["trackerDir"] = migrationRecordsDirName
+			}),
+			wantErr: `names tracker directory "records", which is a directory no migration may own`,
+		},
+		{
+			name: "a unit the record file name could not carry",
+			data: valid(func(env map[string]any) {
+				env["subject"].(map[string]any)["key"].(map[string]any)["unitID"] = "../shard-2__node-0"
+			}),
+			wantErr: "record key \"42/enable_filterable/../shard-2__node-0\" is incomplete",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec, err := decodeMigrationRecord(tt.data)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantErr)
+			require.Nil(t, rec)
+		})
+	}
+}
+
+func TestMigrationRecordKey(t *testing.T) {
+	tests := []struct {
+		name      string
+		key       MigrationRecordKey
+		wantFile  string
+		wantValid bool
+	}{
+		{
+			name:      "searchable half of a change-tokenization fan-out",
+			key:       MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"},
+			wantFile:  "42_searchable_retokenize_shard-1__node-0.json",
+			wantValid: true,
+		},
+		{
+			name:      "filterable half of the same fan-out, same task and unit",
+			key:       MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeFilterableRetokenize, UnitID: "shard-1__node-0"},
+			wantFile:  "42_filterable_retokenize_shard-1__node-0.json",
+			wantValid: true,
+		},
+		{
+			name:      "a later generation on the same strategy",
+			key:       MigrationRecordKey{TaskVersion: 43, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"},
+			wantFile:  "43_searchable_retokenize_shard-1__node-0.json",
+			wantValid: true,
+		},
+		{
+			name:      "generation zero is never allocated by raft",
+			key:       MigrationRecordKey{TaskVersion: 0, StrategyCode: StrategyCodeEnableSearchable, UnitID: "shard-1__node-0"},
+			wantFile:  "0_enable_searchable_shard-1__node-0.json",
+			wantValid: false,
+		},
+		{
+			name:      "unknown strategy code",
+			key:       MigrationRecordKey{TaskVersion: 42, StrategyCode: "quantum_reindex", UnitID: "shard-1__node-0"},
+			wantFile:  "42_quantum_reindex_shard-1__node-0.json",
+			wantValid: false,
+		},
+		{
+			name:      "no unit",
+			key:       MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeRebuildSearchable},
+			wantFile:  "42_rebuild_searchable_.json",
+			wantValid: false,
+		},
+		{
+			name:      "the same task and strategy on another unit",
+			key:       MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-1"},
+			wantFile:  "42_searchable_retokenize_shard-1__node-1.json",
+			wantValid: true,
+		},
+		{
+			name:      "a unit that would escape the records directory",
+			key:       MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeEnableFilterable, UnitID: "../shard-2__node-0"},
+			wantFile:  "42_enable_filterable_../shard-2__node-0.json",
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.wantFile, tt.key.fileName())
+			require.Equal(t, tt.wantValid, tt.key.valid())
+		})
+	}
+}
+
+func TestMigrationRecordStore(t *testing.T) {
+	// Two strategies of one submission share its task version, and production
+	// tells their directories apart by the strategy word the name carries.
+	merged := func(version uint64, code MigrationStrategyCode) MigrationRecord {
+		subject := testMigrationSubject(version, code, "title")
+		subject.TrackerDir = fmt.Sprintf("%s_%d_tracker", code, version)
+		setMigrationDir(&subject, "title", func(d *MigrationPropertyDirs) {
+			d.Staged = fmt.Sprintf("property_title__%s_%d_ingest", code, version)
+			d.Sidecar = fmt.Sprintf("property_title__%s_%d_reindex", code, version)
+		})
+		return NewMigrationRecordMerged(subject)
+	}
+
+	tests := []struct {
+		name        string
+		arrange     func(t *testing.T, s *MigrationRecordStore)
+		assert      func(t *testing.T, s *MigrationRecordStore)
+		wantLoadErr bool
+	}{
+		{
+			name:    "a shard that never ran a migration loads empty",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Empty(t, s.Records())
+				require.Empty(t, s.Unreadable())
+			},
+		},
+		{
+			name: "a written record survives a reload",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				got, ok := s.Get(MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeEnableFilterable, UnitID: "shard-1__node-0"})
+				require.True(t, ok)
+				require.Equal(t, merged(42, StrategyCodeEnableFilterable), got)
+			},
+		},
+		{
+			name: "a file this build cannot place is surfaced, not deleted",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				plantUnreadableRecord(t, s.Dir())
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Len(t, s.Unreadable(), 1)
+				require.Equal(t, "99_enable_searchable.json", s.Unreadable()[0].FileName)
+				_, err := os.Stat(filepath.Join(s.Dir(), "99_enable_searchable.json"))
+				require.NoError(t, err, "an unreadable record must survive the load that could not read it")
+			},
+		},
+		{
+			name: "one unreadable file does not hide the readable ones",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+				plantUnreadableRecord(t, s.Dir())
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Len(t, s.Records(), 1)
+				require.Len(t, s.Unreadable(), 1)
+			},
+		},
+		{
+			name: "a record whose content names a different file is not trusted",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+				require.NoError(t, os.Rename(
+					filepath.Join(s.Dir(), "42_enable_filterable_shard-1__node-0.json"),
+					filepath.Join(s.Dir(), "43_enable_filterable_shard-1__node-0.json")))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Empty(t, s.Records())
+				require.Len(t, s.Unreadable(), 1)
+			},
+		},
+		{
+			name: "removing a record twice is not an error",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				key := MigrationRecordKey{TaskVersion: 42, StrategyCode: StrategyCodeEnableFilterable, UnitID: "shard-1__node-0"}
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+				require.NoError(t, s.Remove(key))
+				require.NoError(t, s.Remove(key))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Empty(t, s.Records())
+			},
+		},
+		{
+			name: "a write racing a collection DELETE fails instead of re-creating the tree",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, os.RemoveAll(filepath.Dir(filepath.Dir(s.Dir()))))
+				require.Error(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				_, err := os.Stat(filepath.Dir(filepath.Dir(s.Dir())))
+				require.True(t, os.IsNotExist(err),
+					"the deleted collection's directory tree must stay deleted")
+			},
+		},
+		{
+			name: "a scratch file another writer owns survives a load and only the owner sweeps it",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, os.MkdirAll(s.Dir(), 0o777))
+				require.NoError(t, os.WriteFile(filepath.Join(s.Dir(), "42_enable_filterable.json.1234"+tmpExt), []byte("half"), 0o600))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				scratch := filepath.Join(s.Dir(), "42_enable_filterable.json.1234"+tmpExt)
+				require.Empty(t, s.Records())
+				require.Empty(t, s.Unreadable(), "a scratch file is not a record this build failed to read")
+
+				logger, _ := test.NewNullLogger()
+				foreign := NewMigrationRecordStore(filepath.Dir(filepath.Dir(s.Dir())), logger)
+				require.NoError(t, foreign.Load())
+				_, err := os.Stat(scratch)
+				require.NoError(t, err, "a foreign reader must not delete a scratch file it does not own")
+
+				s.SweepTempFiles()
+				left, err := os.ReadDir(s.Dir())
+				require.NoError(t, err)
+				require.Empty(t, left, "the owning store sweeps what a crash left behind")
+			},
+		},
+		{
+			name: "a record this build cannot read refuses every write, not only its own key",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, os.MkdirAll(s.Dir(), 0o777))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(s.Dir(), "42_enable_filterable_shard-1__node-0.json"), []byte("{torn"), 0o600))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Len(t, s.Unreadable(), 1)
+				require.Error(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+
+				kept, err := os.ReadFile(filepath.Join(s.Dir(), "42_enable_filterable_shard-1__node-0.json"))
+				require.NoError(t, err)
+				require.Equal(t, "{torn", string(kept))
+
+				require.Error(t, s.Put(merged(43, StrategyCodeEnableFilterable)),
+					"the record nobody could read may name the same directories, so no key can be decided here")
+			},
+		},
+		{
+			name: "a records directory that cannot be read leaves the whole set unreadable, not clean",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, os.MkdirAll(filepath.Dir(s.Dir()), 0o777))
+				require.NoError(t, os.WriteFile(s.Dir(), []byte("not a directory"), 0o600))
+			},
+			wantLoadErr: true,
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Empty(t, s.Records())
+				require.NotEmpty(t, s.Unreadable(),
+					"a directory nobody could read must withhold, not report a clean shard")
+			},
+		},
+		{
+			name: "a records directory that could not be read freezes every write, not one file name",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+				require.NoError(t, os.Rename(s.Dir(), s.Dir()+".aside"))
+				require.NoError(t, os.WriteFile(s.Dir(), []byte("not a directory"), 0o600))
+			},
+			wantLoadErr: true,
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, os.Remove(s.Dir()))
+				require.NoError(t, os.Rename(s.Dir()+".aside", s.Dir()))
+
+				before, err := os.ReadFile(filepath.Join(s.Dir(), "42_enable_filterable_shard-1__node-0.json"))
+				require.NoError(t, err)
+
+				require.Error(t, s.Put(NewMigrationRecordIterating(
+					testMigrationSubject(42, StrategyCodeEnableFilterable, "title"), MigrationCheckpoint{})),
+					"a build that cannot tell what is recorded here must not demote a flip record")
+				require.Error(t, s.Remove(MigrationRecordKey{
+					TaskVersion: 42, StrategyCode: StrategyCodeEnableFilterable, UnitID: "shard-1__node-0",
+				}), "the freeze that preserves a record must not be undone by removing it")
+
+				after, err := os.ReadFile(filepath.Join(s.Dir(), "42_enable_filterable_shard-1__node-0.json"))
+				require.NoError(t, err)
+				require.Equal(t, before, after)
+			},
+		},
+		{
+			name: "a file this build cannot read refuses every removal, whatever key it names",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, s.Put(merged(43, StrategyCodeEnableFilterable)))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(s.Dir(), "42_enable_filterable_shard-1__node-0.json"), []byte("{torn"), 0o600))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Error(t, s.Remove(MigrationRecordKey{
+					TaskVersion: 42, StrategyCode: StrategyCodeEnableFilterable, UnitID: "shard-1__node-0",
+				}), "the record this build could not read")
+				require.Error(t, s.Remove(MigrationRecordKey{
+					TaskVersion: 43, StrategyCode: StrategyCodeEnableFilterable, UnitID: "shard-1__node-0",
+				}), "and the one it could: retiring it decides a shard nobody here can read")
+
+				for _, name := range []string{
+					"42_enable_filterable_shard-1__node-0.json",
+					"43_enable_filterable_shard-1__node-0.json",
+				} {
+					require.FileExists(t, filepath.Join(s.Dir(), name))
+				}
+			},
+		},
+		{
+			name: "a foreign unit's record is neither answered for nor overwritten",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				foreign := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+				foreign.Key.UnitID = "shard-1__node-9"
+				require.NoError(t, s.Put(NewMigrationRecordMerged(foreign)))
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Len(t, s.Records(), 2)
+				for _, unit := range []string{"shard-1__node-0", "shard-1__node-9"} {
+					_, ok := s.Get(MigrationRecordKey{
+						TaskVersion: 42, StrategyCode: StrategyCodeEnableFilterable, UnitID: unit,
+					})
+					require.True(t, ok, "unit %q lost its record", unit)
+				}
+			},
+		},
+		{
+			name: "two units on one shard freeze it rather than being acted on",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				foreign := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+				foreign.Key.UnitID = "shard-1__node-9"
+				require.NoError(t, s.Put(NewMigrationRecordMerged(foreign)))
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				require.Len(t, s.Unreadable(), 1)
+				require.Equal(t, MigrationRecordFaultStore, s.Unreadable()[0].Scope)
+				require.Contains(t, s.Unreadable()[0].Reason, "shard-1__node-9")
+
+				require.Error(t, s.Put(merged(43, StrategyCodeEnableFilterable)),
+					"a frozen store must not take a write it cannot place among the records it could not attribute")
+			},
+		},
+		{
+			name: "records come back in ascending task-version order, then strategy code",
+			arrange: func(t *testing.T, s *MigrationRecordStore) {
+				require.NoError(t, s.Put(merged(43, StrategyCodeEnableFilterable)))
+				require.NoError(t, s.Put(merged(7, StrategyCodeEnableFilterable)))
+				require.NoError(t, s.Put(merged(42, StrategyCodeFilterableRetokenize)))
+				require.NoError(t, s.Put(merged(42, StrategyCodeEnableFilterable)))
+			},
+			assert: func(t *testing.T, s *MigrationRecordStore) {
+				var got []string
+				for _, rec := range s.Records() {
+					got = append(got, rec.Subject().Key.fileName())
+				}
+				require.Equal(t, []string{
+					"7_enable_filterable_shard-1__node-0.json",
+					"42_enable_filterable_shard-1__node-0.json",
+					"42_filterable_retokenize_shard-1__node-0.json",
+					"43_enable_filterable_shard-1__node-0.json",
+				}, got)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			store := NewMigrationRecordStore(t.TempDir(), logger)
+			tt.arrange(t, store)
+
+			err := store.Load()
+			if tt.wantLoadErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			tt.assert(t, store)
+		})
+	}
+}
+
+func TestMigrationRecordStoreConcurrentAccess(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	lsmPath := t.TempDir()
+	store := NewMigrationRecordStore(lsmPath, logger)
+
+	const writers, readers = 8, 8
+	var wg sync.WaitGroup
+	for i := range writers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for gen := 1; gen <= 8; gen++ {
+				subject := testMigrationSubject(uint64(i*8+gen), StrategyCodeEnableFilterable, "title")
+				if err := store.Put(NewMigrationRecordMerged(subject)); err != nil {
+					t.Errorf("put record: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 64 {
+				for _, rec := range store.Records() {
+					_, _ = store.Get(rec.Subject().Key)
+				}
+				_ = store.Unreadable()
+			}
+		}()
+	}
+	for range readers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 64 {
+				_ = NewMigrationRecordStore(lsmPath, logger).Load()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Len(t, store.Records(), writers*8,
+		"every put publishes into the map the readers were walking")
+	require.NoError(t, store.Load())
+	require.Len(t, store.Records(), writers*8)
+}
+
+func TestDecodeMigrationRecordRejectsEscapingHandles(t *testing.T) {
+	tests := []struct {
+		name   string
+		place  func(*MigrationSubject, *migrationFlipEnvelope, string)
+		handle string
+		// A record with no flip leaves the handle check the only rule that can
+		// refuse what place writes.
+		noFlip    bool
+		wantErr   bool
+		wantField string
+	}{
+		{
+			name:   "tracker directory",
+			place:  func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) { s.TrackerDir = h },
+			handle: "../../../../etc", wantErr: true,
+		},
+		{
+			name: "staged directory",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Staged: h}}
+			},
+			handle: "/var/lib/weaviate", wantErr: true, wantField: "staged directory",
+		},
+		{
+			name: "canonical directory",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Canonical: h}}
+			},
+			handle: "../sibling_shard/property_title", wantErr: true, wantField: "canonical directory",
+		},
+		{
+			name: "sidecar directory",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Sidecar: h}}
+			},
+			handle: "..", wantErr: true, wantField: "sidecar directory",
+		},
+		{
+			name: "displaced directory",
+			place: func(_ *MigrationSubject, f *migrationFlipEnvelope, h string) {
+				f.DisplacedDirs = map[string]string{"title": h}
+			},
+			handle: "/", wantErr: true, wantField: "displaced directory",
+		},
+		{
+			name: "a handle that only looks like an escape stays inside",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Staged: h}}
+			},
+			handle: "property_..title__g42_ingest",
+		},
+		{
+			name: "a nested handle names no directory a writer can produce",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Sidecar: h}}
+			},
+			handle: "property_tracker__g42_ingest/searchable/title", wantErr: true,
+		},
+		{
+			name:   "an empty handle is the ordinary names-none",
+			place:  func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) { s.TrackerDir = h },
+			handle: "",
+		},
+		{
+			name: "the current directory",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Sidecar: h}}
+			},
+			handle: ".", wantErr: true,
+		},
+		{
+			name:   "a descent and an ascent that cancel",
+			place:  func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) { s.TrackerDir = h },
+			handle: "x/..", wantErr: true,
+		},
+		{
+			name: "a property name that escapes",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{h: {}}
+			},
+			handle: "x/../../../../etc", noFlip: true, wantErr: true, wantField: "property",
+		},
+		{
+			name: "an empty property name, which composes into another property's bucket",
+			place: func(s *MigrationSubject, _ *migrationFlipEnvelope, h string) {
+				s.Props = map[string]MigrationPropertyDirs{h: {}}
+			},
+			handle: "", noFlip: true, wantErr: true, wantField: "property",
+		},
+		{
+			name: "a poisoned displaced-dirs key",
+			place: func(_ *MigrationSubject, f *migrationFlipEnvelope, h string) {
+				f.DisplacedDirs = map[string]string{h: "property_title__g42_ingest"}
+			},
+			handle: "../../evil", wantErr: true, wantField: "property",
+		},
+		{
+			name: "a poisoned flipped-properties entry",
+			place: func(_ *MigrationSubject, f *migrationFlipEnvelope, h string) {
+				f.Flipped = []string{h}
+			},
+			handle: "../../evil", wantErr: true, wantField: "property",
+		},
+		{
+			name: "an ordinary property name decodes",
+			place: func(s *MigrationSubject, f *migrationFlipEnvelope, h string) {
+				s.Props, f.Flipped = map[string]MigrationPropertyDirs{h: {}}, []string{h}
+			},
+			handle: "title_2",
+		},
+		{
+			name: "a property named after the record store decodes",
+			place: func(s *MigrationSubject, f *migrationFlipEnvelope, h string) {
+				s.Props, f.Flipped = map[string]MigrationPropertyDirs{h: {}}, []string{h}
+			},
+			handle: migrationRecordsDirName,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+			subject.TrackerDir = ""
+			subject.Props = map[string]MigrationPropertyDirs{"title": {}}
+			flip := migrationFlipEnvelope{Flipped: []string{"title"}}
+			tt.place(&subject, &flip, tt.handle)
+
+			env := migrationRecordEnvelope{
+				FormatVersion: migrationRecordFormatVersion,
+				State:         MigrationStateSwapped,
+				Subject:       subject,
+				Flip:          &flip,
+			}
+			if tt.noFlip {
+				env.State, env.Flip = MigrationStateIterated, nil
+			}
+			data, err := json.Marshal(env)
+			require.NoError(t, err)
+
+			rec, err := decodeMigrationRecord(data)
+			if tt.wantErr {
+				require.Error(t, err, "a handle that leaves the shard root must not decode")
+				require.Nil(t, rec)
+				if tt.wantField != "" {
+					require.Contains(t, err.Error(),
+						fmt.Sprintf("names %s %q, which is not a single directory inside the shard",
+							tt.wantField, tt.handle),
+						"the handle check has to be the rule that refuses this, not one that names the same handle")
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, rec)
+		})
+	}
+}
+
+// A record only the writer accepts wedges that key until fixed by hand.
+func TestTheWriterRefusesWhatTheLoaderWouldReject(t *testing.T) {
+	tests := []struct {
+		name    string
+		mangle  func(*MigrationSubject)
+		because string
+		wantErr string
+	}{
+		{
+			name:    "a tracker directory that leaves the shard root",
+			mangle:  func(s *MigrationSubject) { s.TrackerDir = "../../../etc" },
+			because: "the tracker directory is joined onto the shard and handed to a recursive delete",
+			wantErr: "names tracker directory \"../../../etc\"",
+		},
+		{
+			name: "a staged directory that is a live bucket of another property",
+			mangle: func(s *MigrationSubject) {
+				s.Props = map[string]MigrationPropertyDirs{"title": {Staged: "property_body_searchable"}}
+			},
+			because: "a staged handle is reclaimed on every teardown path, so a live bucket named there is deleted",
+			wantErr: `names staged directory "property_body_searchable", which is not shaped like a sidecar of a property bucket`,
+		},
+		{
+			name:    "a strategy code outside the known set",
+			mangle:  func(s *MigrationSubject) { s.Key.StrategyCode = "bogus" },
+			because: "the code is in the file name, so the loader refuses a file the writer chose",
+			wantErr: "record key \"42/bogus/shard-1__node-0\" is incomplete or names an unknown strategy",
+		},
+		{
+			name:    "a record over the size bound the loader enforces",
+			mangle:  func(s *MigrationSubject) { padMigrationSubject(s, maxMigrationRecordBytes) },
+			because: "the loader refuses a file over the bound, so the writer must not build one",
+			wantErr: "bound is",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+			tt.mangle(&subject)
+			rec := NewMigrationRecordMerged(subject)
+
+			_, err := encodeMigrationRecord(rec)
+			require.Error(t, err, tt.because)
+			require.Contains(t, err.Error(), tt.wantErr)
+
+			logger, _ := test.NewNullLogger()
+			store := NewMigrationRecordStore(t.TempDir(), logger)
+			require.Error(t, store.Put(rec), "and Put refuses it for the same reason")
+			require.Empty(t, store.Records(), "nothing a load would refuse reaches the map either")
+		})
+	}
+}
+
+// Guards a per-property field that grows with data instead of property count:
+// the largest buildable record would then stop fitting.
+func TestTheLargestRecordTheWriterCanBuildFitsTheLoadersBound(t *testing.T) {
+	const maxDirEntryNameBytes = 255
+
+	longest := func(role string, i int) string {
+		s := fmt.Sprintf("%s_%d_", role, i)
+		return s + strings.Repeat("x", maxDirEntryNameBytes-len(s))
+	}
+	longestSidecar := func(role string, i int) string {
+		s := fmt.Sprintf("property_%s_%d__", role, i)
+		const tail = "_ingest"
+		return s + strings.Repeat("x", maxDirEntryNameBytes-len(s)-len(tail)) + tail
+	}
+	longestBucket := func(role string, i int) string {
+		s := fmt.Sprintf("property_%s_%d_", role, i)
+		return s + strings.Repeat("x", maxDirEntryNameBytes-len(s))
+	}
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize)
+	subject.TrackerDir = longest("tracker", 0)
+	subject.Props = make(map[string]MigrationPropertyDirs, maxReindexPropertiesPerTask)
+	displaced := map[string]string{}
+	for i := 0; i < maxReindexPropertiesPerTask; i++ {
+		prop := longest("property", i)
+		subject.Props[prop] = MigrationPropertyDirs{
+			Staged:    longestSidecar("staged", i),
+			Canonical: sourceBucketNameFor(subject.Key.StrategyCode, prop),
+			Sidecar:   longestSidecar("sidecar", i),
+		}
+		displaced[prop] = longestBucket("displaced", i)
+	}
+
+	swapped := NewMigrationRecordSwapped(subject, subject.Properties(), displaced)
+	for _, prop := range subject.Properties() {
+		swapped = swapped.WithPromotionAt(prop, migrationPromotionFinished)
+	}
+
+	iterating := NewMigrationRecordIterating(subject, MigrationCheckpoint{
+		LastProcessedKey: bytes.Repeat([]byte{0xff}, 16),
+	})
+
+	for _, rec := range []MigrationRecord{swapped, iterating} {
+		t.Run(string(rec.State()), func(t *testing.T) {
+			data, err := encodeMigrationRecord(rec)
+			require.NoError(t, err)
+			require.Less(t, len(data), maxMigrationRecordBytes,
+				"the writer must not be able to build a record the loader refuses")
+
+			logger, _ := test.NewNullLogger()
+			store := NewMigrationRecordStore(t.TempDir(), logger)
+			require.NoError(t, store.Put(rec))
+			require.NoError(t, store.Load())
+			require.Len(t, store.Records(), 1)
+			require.Empty(t, store.Unreadable())
+		})
+	}
+}
+
+func TestARecordNamingNoPropertiesIsRefusedByTheWriterAndToleratedByTheLoader(t *testing.T) {
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize)
+	rec := NewMigrationRecordMerged(subject)
+
+	_, err := encodeMigrationRecord(rec)
+	require.ErrorContains(t, err, "names no properties")
+
+	logger, _ := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	require.Error(t, store.Put(rec), "and Put refuses it for the same reason")
+
+	writeRawMigrationRecord(t, store, rec.toEnvelope())
+
+	require.NoError(t, store.Load())
+	require.Len(t, store.Records(), 1, "the loader reads it")
+	require.Empty(t, store.Unreadable(), "and withholds nothing on its account")
+}
+
+func storeLinesAt(hook *test.Hook, level logrus.Level) []string {
+	var out []string
+	for _, entry := range hook.AllEntries() {
+		if entry.Level == level {
+			out = append(out, entry.Message)
+		}
+	}
+	return out
+}
+
+// Load runs on every shard load, which on a multi-tenant collection is once
+// per tenant, and the number of files it cannot read is not bounded by
+// anything this node controls.
+func TestALoadWithManyUnreadableRecordsReportsOneLine(t *testing.T) {
+	const over = maxReportedErrors + 2
+
+	logger, hook := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	require.NoError(t, os.MkdirAll(store.Dir(), 0o777))
+	for i := 0; i < over; i++ {
+		name := fmt.Sprintf("bad_%02d.mig", i)
+		require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), name), []byte("not a record"), 0o600))
+	}
+
+	require.NoError(t, store.Load())
+	require.Len(t, store.Unreadable(), over)
+
+	lines := storeLinesAt(hook, logrus.ErrorLevel)
+	require.Len(t, lines, 1, "one line per load, not one per file")
+	require.Contains(t, lines[0], "(and 2 more)", "and the files it names are capped")
+}
+
+// The freeze notice quotes the reason a decode gave back, and a decode refusal
+// quotes the handle it refused. A record file is bounded only by the 8 MiB read
+// cap, and the notice re-emits on every load of the shard.
+func TestAnUnreadableRecordsReasonIsBounded(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	require.NoError(t, os.MkdirAll(store.Dir(), 0o777))
+
+	huge := migrationPropertyBucketPrefix + strings.Repeat("x", 1<<16)
+	subject := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+	setMigrationDir(&subject, "title", func(d *MigrationPropertyDirs) { d.Staged = huge })
+	data, err := json.Marshal(newMigrationRecordEnvelope(MigrationStateMerged, subject))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), subject.Key.fileName()), data, 0o600))
+
+	require.NoError(t, store.Load())
+
+	require.Len(t, store.Unreadable(), 1, "fixture: the handle has to be one this build refuses")
+	reason := store.Unreadable()[0].Reason
+	require.Less(t, len(reason), maxMigrationFaultReasonBytes+32)
+	require.Contains(t, reason, "names staged directory",
+		"the bound must keep the part of the reason that says which record and which role")
+	require.Contains(t, reason, "not shaped like a sidecar",
+		"and the part that says what is wrong with it")
+
+	lines := storeLinesAt(hook, logrus.ErrorLevel)
+	require.Len(t, lines, 1)
+	require.Less(t, len(lines[0]), 4096, "so the line an operator's log holds is bounded too")
+}
+
+// The sweep runs once per shard load too, over a directory whose temp files
+// are one per interrupted write.
+func TestSweepingTempFilesItCannotRemoveReportsOneLine(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	require.NoError(t, os.MkdirAll(store.Dir(), 0o777))
+	for i := 0; i < 2; i++ {
+		name := fmt.Sprintf("rec_%d.mig%s", i, tmpExt)
+		require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), name), []byte("x"), 0o600))
+	}
+	denyDirectoryWrites(t, store.Dir())
+
+	store.SweepTempFiles()
+
+	lines := storeLinesAt(hook, logrus.WarnLevel)
+	require.Len(t, lines, 1, "one line per sweep, not one per file")
+	require.Contains(t, lines[0], "2 stale migration record temp file(s)")
+}
+
+func TestEveryPropertyBucketCarriesTheMigrationPrefix(t *testing.T) {
+	for _, bucket := range []string{
+		helpers.BucketFromPropNameLSM("title"),
+		helpers.BucketSearchableFromPropNameLSM("title"),
+		helpers.BucketRangeableFromPropNameLSM("title"),
+	} {
+		require.True(t, strings.HasPrefix(bucket, migrationPropertyBucketPrefix), bucket)
+		require.False(t, migrationHandleIsSidecarShaped(bucket),
+			"a property's own bucket must never pass as a migration's staged copy")
+	}
+}
+
+// Names come from the helpers, not a literal list, so a store added later fails.
+func TestNoStoreTheShardServesFromCanBeNamedInAnyDirectoryRole(t *testing.T) {
+	stores := []string{
+		helpers.ObjectsBucketLSM,
+		helpers.DimensionsBucketLSM,
+		migrationsDir,
+		migrationRecordsDirName,
+	}
+	for _, targetVector := range []string{"", "myNamedVector"} {
+		stores = append(stores, helpers.VectorIndexArtifactsFor(targetVector, nil).LSMBuckets...)
+	}
+
+	liveBuckets := []string{
+		helpers.BucketFromPropNameLSM("title"),
+		helpers.BucketSearchableFromPropNameLSM("title"),
+		helpers.BucketRangeableFromPropNameLSM("title"),
+	}
+
+	for _, role := range migrationShardRootDirectoryRoles(t) {
+		refused := stores
+		if role.shape == migrationShapeSidecar {
+			refused = slices.Concat(stores, liveBuckets)
+		}
+		for _, store := range refused {
+			t.Run(role.field+"/"+store, func(t *testing.T) {
+				env := migrationRecordEnvelope{
+					Subject:    testMigrationSubject(1, StrategyCodeSearchableRetokenize, "title"),
+					State:      MigrationStateIterating,
+					Checkpoint: &MigrationCheckpoint{},
+				}
+				migrationDirectoryRolePlacers[role.field](&env, "title", store)
+				err := validateMigrationHandles(env)
+				require.Errorf(t, err, "a record naming this as its %s hands it to os.RemoveAll", role.field)
+				require.Contains(t, err.Error(), store)
+			})
+		}
+	}
+}
+
+var migrationDirectoryRolePlacers = map[string]func(env *migrationRecordEnvelope, prop, handle string){
+	"staged directory": func(env *migrationRecordEnvelope, prop, handle string) {
+		setMigrationDir(&env.Subject, prop, func(d *MigrationPropertyDirs) { d.Staged = handle })
+	},
+	"sidecar directory": func(env *migrationRecordEnvelope, prop, handle string) {
+		setMigrationDir(&env.Subject, prop, func(d *MigrationPropertyDirs) { d.Sidecar = handle })
+	},
+	"canonical directory": func(env *migrationRecordEnvelope, prop, handle string) {
+		setMigrationDir(&env.Subject, prop, func(d *MigrationPropertyDirs) { d.Canonical = handle })
+	},
+	"displaced directory": func(env *migrationRecordEnvelope, prop, handle string) {
+		env.Flip = &migrationFlipEnvelope{
+			Flipped:       []string{prop},
+			DisplacedDirs: map[string]string{prop: handle},
+		}
+	},
+}
+
+func migrationShardRootDirectoryRoles(t *testing.T) []migrationHandleGroup {
+	t.Helper()
+	var out []migrationHandleGroup
+	for _, group := range migrationHandleGroups {
+		if !group.namesDirectory || group.underMigrationsDir {
+			continue
+		}
+		require.Containsf(t, migrationDirectoryRolePlacers, group.field,
+			"the %s role has no placer here, so no test below covers it", group.field)
+		out = append(out, group)
+	}
+	return out
+}
+
+func TestEveryDirectoryRoleUnderTheShardRootCarriesAShapeRule(t *testing.T) {
+	for _, group := range migrationShardRootDirectoryRoles(t) {
+		t.Run(group.field, func(t *testing.T) {
+			require.Containsf(t,
+				[]migrationHandleShape{migrationShapeSidecar, migrationShapePropertyBucket},
+				group.shape,
+				"the %s role reaches os.RemoveAll in the shard's LSM directory, so its handle has to take either the sidecar shape or the property-bucket rule",
+				group.field)
+		})
+	}
+}
+
+func TestEveryWriterEmittedSidecarNameIsAccepted(t *testing.T) {
+	props := []string{"title", "a__b", "x_ingest", "a__reindex"}
+
+	strategiesFor := func(prop string, generation int) []MigrationStrategy {
+		return []MigrationStrategy{
+			&MapToBlockmaxStrategy{generation: generation},
+			&RoaringSetRefreshStrategy{generation: generation},
+			&FilterableToRangeableStrategy{propNames: []string{prop}, generation: generation},
+			&SearchableRetokenizeStrategy{propName: prop, generation: generation},
+			&FilterableRetokenizeStrategy{propName: prop, generation: generation},
+			&EnableFilterableStrategy{propNames: []string{prop}, generation: generation},
+			&EnableSearchableStrategy{propNames: []string{prop}, generation: generation},
+			&RebuildSearchableStrategy{propNames: []string{prop}, generation: generation},
+		}
+	}
+	require.Len(t, strategiesFor("title", 1), len(strategiesByMigrationDir(1)))
+
+	for _, generation := range []int{1, 2, 11} {
+		for _, prop := range props {
+			for _, strategy := range strategiesFor(prop, generation) {
+				main := strategy.SourceBucketName(prop)
+				requireAcceptedInPromoteRoles(t, main)
+				for _, suffix := range []string{
+					strategy.ReindexSuffix(), strategy.IngestSuffix(), strategy.BackupSuffix(),
+				} {
+					name := main + suffix
+					require.Truef(t, migrationHandleIsSidecarShaped(name),
+						"%T emits %q, and refusing it refuses the migration", strategy, name)
+					requireAcceptedInPromoteRoles(t, name)
+				}
+			}
+		}
+	}
+	for _, prop := range props {
+		for _, indexType := range []string{"filterable", "searchable", "rangeable"} {
+			main, ok := mainBucketForPropertyIndex(prop, indexType)
+			require.True(t, ok, indexType)
+			requireAcceptedInPromoteRoles(t, main)
+		}
+	}
+}
+
+func requireAcceptedInPromoteRoles(t *testing.T, handle string) {
+	t.Helper()
+	for _, role := range migrationShardRootDirectoryRoles(t) {
+		if role.shape != migrationShapePropertyBucket {
+			continue
+		}
+		env := migrationRecordEnvelope{
+			Subject:    testMigrationSubject(1, StrategyCodeSearchableRetokenize, "title"),
+			State:      MigrationStateIterating,
+			Checkpoint: &MigrationCheckpoint{},
+		}
+		migrationDirectoryRolePlacers[role.field](&env, "title", handle)
+		require.NoErrorf(t, validateMigrationHandles(env),
+			"a writer puts %q in the %s role", handle, role.field)
+	}
+}
+
+func TestEveryStrategyReadsTheMainBucketThisNames(t *testing.T) {
+	const prop = "title"
+	byCode := map[MigrationStrategyCode]MigrationStrategy{
+		StrategyCodeSearchableMapToBlockmax:     &MapToBlockmaxStrategy{},
+		StrategyCodeFilterableRoaringsetRefresh: &RoaringSetRefreshStrategy{},
+		StrategyCodeFilterableToRangeable:       &FilterableToRangeableStrategy{propNames: []string{prop}},
+		StrategyCodeSearchableRetokenize:        &SearchableRetokenizeStrategy{propName: prop},
+		StrategyCodeFilterableRetokenize:        &FilterableRetokenizeStrategy{propName: prop},
+		StrategyCodeEnableFilterable:            &EnableFilterableStrategy{propNames: []string{prop}},
+		StrategyCodeEnableSearchable:            &EnableSearchableStrategy{propNames: []string{prop}},
+		StrategyCodeRebuildSearchable:           &RebuildSearchableStrategy{propNames: []string{prop}},
+	}
+	require.Len(t, byCode, len(strategiesByMigrationDir(1)), "every strategy carries a record code")
+
+	for code, strategy := range byCode {
+		t.Run(string(code), func(t *testing.T) {
+			require.True(t, code.valid())
+			require.Equal(t, strategy.SourceBucketName(prop), sourceBucketNameFor(code, prop),
+				"a record's canonical handle is derived from its code, so the two have to agree")
+		})
+	}
+}
+
+func TestACanonicalHandleMustBeTheRecordsOwnMainBucket(t *testing.T) {
+	inRole := func(role, handle string) error {
+		env := newMigrationRecordEnvelope(MigrationStateIterating,
+			testMigrationSubject(1, StrategyCodeSearchableRetokenize, "title"))
+		migrationDirectoryRolePlacers[role](&env, "title", handle)
+		return validateMigrationEnvelope(env)
+	}
+
+	for _, tt := range []struct {
+		name   string
+		handle string
+	}{
+		{name: "the shard's own id index", handle: helpers.BucketFromPropNameLSM(filters.InternalPropID)},
+		{name: "a property length index", handle: helpers.BucketFromPropNameLengthLSM("title")},
+		{name: "another property's bucket", handle: helpers.BucketFromPropNameLSM("body")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Error(t, inRole(string(migrationRoleCanonical), tt.handle),
+				"a canonical handle is the bucket this record's own property and strategy name")
+			require.NoError(t, inRole("displaced directory", tt.handle),
+				"a flip moves aside whatever was there, so any property bucket is a legal displaced handle")
+		})
+	}
+}
+
+// A record fsynced into a directory whose own name never reached disk reads
+// after a crash as no record at all, which is the one outcome the freeze
+// cannot see: the shard proceeds as if the migration had never run.
+func TestTheRecordsDirectoryIsOnDiskBeforeARecordLandsInIt(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	lsmPath := t.TempDir()
+	store := NewMigrationRecordStore(lsmPath, logger)
+
+	var synced []string
+	record := func(path string) error {
+		synced = append(synced, path)
+		return nil
+	}
+
+	require.NoError(t, store.mkdirSynced(record))
+	require.Equal(t, []string{lsmPath, filepath.Join(lsmPath, migrationsDir)}, synced,
+		"each directory this call created has to have its own name published by its parent")
+
+	synced = nil
+	require.NoError(t, store.mkdirSynced(record))
+	require.Empty(t, synced, "a directory that was already there was not created, so nothing was published")
+
+	fresh := NewMigrationRecordStore(t.TempDir(), logger)
+	require.Equal(t, assert.AnError, fresh.mkdirSynced(func(string) error { return assert.AnError }),
+		"a directory whose name did not reach disk must not read as a store ready to be written to")
+}
+
+// The two counters were persisted but never written or read. Retiring them
+// only holds if a record an older build wrote still loads: a record this build
+// cannot decode withholds every destructive action on its shard.
+func TestARecordCarryingTheRetiredCheckpointCountersStillLoads(t *testing.T) {
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	data, err := json.Marshal(migrationRecordEnvelope{
+		// A literal, not the constant: an older build stamped the version it
+		// knew, so bumping the constant has to red this test rather than move
+		// the fixture along with it.
+		FormatVersion: 1,
+		State:         MigrationStateIterating,
+		Subject:       subject,
+		Checkpoint:    &MigrationCheckpoint{LastProcessedKey: []byte("halfway")},
+	})
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	checkpoint := raw["checkpoint"].(map[string]any)
+	checkpoint["processedCount"], checkpoint["indexedCount"] = 1200, 980
+	asOlderBuildsWroteIt, err := json.Marshal(raw)
+	require.NoError(t, err)
+
+	rec, err := decodeMigrationRecord(asOlderBuildsWroteIt)
+	require.NoError(t, err, "a record an older build wrote must not read as one this build cannot place")
+	require.Equal(t, MigrationStateIterating, rec.State())
+	require.Equal(t, []byte("halfway"), rec.(MigrationRecordIterating).Checkpoint().LastProcessedKey,
+		"and the one field still read survives the two that are gone")
+}
+
+// The write publishes the record by renaming and only then syncs the directory
+// holding the new name, so a failed write may or may not have published. Same
+// file name either way, and only its contents tell the two apart. Nothing
+// re-reads the store in-process, so memory has to be settled against the file,
+// or the store answers with a record no later load agrees with.
+func TestAFailedPutAdoptsOnlyTheRecordTheFileHolds(t *testing.T) {
+	tests := []struct {
+		name        string
+		onDisk      func(MigrationSubject) MigrationRecord
+		wantAdopted bool
+	}{
+		{
+			name: "the rename ran, so the file already holds what the write was publishing",
+			onDisk: func(s MigrationSubject) MigrationRecord {
+				return NewMigrationRecordSwapped(s, s.Properties(), map[string]string{"title": "property_title"})
+			},
+			wantAdopted: true,
+		},
+		{
+			name:   "the rename never ran, so the file still holds the older record",
+			onDisk: func(s MigrationSubject) MigrationRecord { return NewMigrationRecordMerged(s) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			store := NewMigrationRecordStore(t.TempDir(), logger)
+			require.NoError(t, os.MkdirAll(store.Dir(), 0o777))
+
+			subject := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+			planted, err := encodeMigrationRecord(tt.onDisk(subject))
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(store.Dir(), subject.Key.fileName()), planted, 0o600))
+
+			denyDirectoryWrites(t, store.Dir())
+			writing := NewMigrationRecordSwapped(subject, subject.Properties(),
+				map[string]string{"title": "property_title"})
+			require.Error(t, store.Put(writing), "the write could not finish, so it has to report a failure")
+
+			got, present := store.Get(subject.Key)
+			require.Equal(t, tt.wantAdopted, present,
+				"the store has to answer with what the file holds, not with what the write intended")
+			if tt.wantAdopted {
+				require.Equal(t, MigrationStateSwapped, got.State())
+			}
+
+			kept, err := os.ReadFile(filepath.Join(store.Dir(), subject.Key.fileName()))
+			require.NoError(t, err)
+			require.Equal(t, planted, kept, "and a publish that failed leaves the file it found")
+		})
+	}
+}
+
+// Put syncs the directory that publishes a record's name. Without the same
+// sync on the unlink, a crash brings a retired record back, naming directories
+// the pass that retired it already removed.
+func TestRemovingARecordPublishesTheRemoval(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	key := testMigrationSubject(42, StrategyCodeEnableFilterable, "title").Key
+	put := func() {
+		require.NoError(t, store.Put(NewMigrationRecordMerged(
+			testMigrationSubject(42, StrategyCodeEnableFilterable, "title"))))
+	}
+
+	put()
+	var synced []string
+	require.NoError(t, store.removeSynced(key, func(dir string) error {
+		require.NoFileExists(t, filepath.Join(store.Dir(), key.fileName()),
+			"the sync has to follow the unlink it makes durable")
+		synced = append(synced, dir)
+		return nil
+	}))
+	require.Equal(t, []string{store.Dir()}, synced,
+		"the directory that held the record's name is what publishes its absence")
+
+	synced = nil
+	require.NoError(t, store.removeSynced(key, func(dir string) error {
+		synced = append(synced, dir)
+		return nil
+	}))
+	require.Empty(t, synced, "a removal that found no file has nothing to publish")
+
+	put()
+	require.Error(t, store.removeSynced(key, func(string) error { return assert.AnError }),
+		"a removal whose absence did not reach disk must not read as done")
+	require.Empty(t, store.Records(), "the file is gone either way, so memory has to agree")
+}
+
+// The wedge belongs to the record the key named, not to the key. A record
+// re-created under a removed key would inherit it and stay hidden from the
+// periodic pass for the life of the process.
+func TestRemovingARecordTakesItsWedgeWithIt(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	store := NewMigrationRecordStore(t.TempDir(), logger)
+	subject := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+
+	require.NoError(t, store.Put(NewMigrationRecordMerged(subject)))
+	store.MarkWedged(subject.Key)
+	require.False(t, store.HasUndecided(), "fixture: a wedged record stops driving the pass")
+
+	require.NoError(t, store.Remove(subject.Key))
+	require.NoError(t, store.Put(NewMigrationRecordMerged(subject)))
+
+	require.False(t, store.Wedged(subject.Key))
+	require.True(t, store.HasUndecided(),
+		"the re-created record has never been decided, so the pass has to come back for it")
+}
+
+// A restore or a replica move lands another replica's record file under this
+// shard. Adopted, it is granted a seal no local worker holds and is reconciled
+// as local work, and this shard's own record then puts two units in one
+// directory, which freezes every write until someone deletes a file by hand.
+func TestALoneForeignRecordIsSetAsideRatherThanAdopted(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	lsmPath := t.TempDir()
+	const own = "shard-1__node-0"
+
+	foreign := testMigrationSubject(42, StrategyCodeEnableFilterable, "title")
+	foreign.Key.UnitID = "shard-1__node-9"
+	require.NoError(t, NewMigrationRecordStore(lsmPath, logger).Put(NewMigrationRecordMerged(foreign)))
+
+	local := NewMigrationRecordStoreForUnit(lsmPath, own, logger)
+	require.NoError(t, local.Load())
+	require.Empty(t, local.Records(), "another replica's record is not this shard's work to reconcile")
+	require.Empty(t, local.Unreadable(), "and it is not a fault, so nothing on this shard is withheld")
+
+	mine := testMigrationSubject(43, StrategyCodeEnableFilterable, "title")
+	require.Equal(t, own, mine.Key.UnitID, "fixture: the second record is this shard's own")
+	require.NoError(t, local.Put(NewMigrationRecordMerged(mine)))
+
+	require.NoError(t, local.Load())
+	require.Len(t, local.Records(), 1, "only this shard's own record")
+	require.Empty(t, local.Unreadable(),
+		"a shard that knows its own unit must not freeze over a file another replica left")
+
+	_, err := os.Stat(filepath.Join(local.Dir(), foreign.Key.fileName()))
+	require.NoError(t, err, "the foreign file is left on disk for whoever put it there")
+}

--- a/adapters/repos/db/inverted_reindex_record_test.go
+++ b/adapters/repos/db/inverted_reindex_record_test.go
@@ -1479,7 +1479,8 @@ func TestTheRecordsDirectoryIsOnDiskBeforeARecordLandsInIt(t *testing.T) {
 
 	synced = nil
 	require.NoError(t, store.mkdirSynced(record))
-	require.Empty(t, synced, "a directory that was already there was not created, so nothing was published")
+	require.Equal(t, []string{lsmPath, filepath.Join(lsmPath, migrationsDir)}, synced,
+		"a directory an earlier process left unsynced is published again, not assumed durable")
 
 	fresh := NewMigrationRecordStore(t.TempDir(), logger)
 	require.Equal(t, assert.AnError, fresh.mkdirSynced(func(string) error { return assert.AnError }),

--- a/adapters/repos/db/inverted_reindex_schema_effect.go
+++ b/adapters/repos/db/inverted_reindex_schema_effect.go
@@ -1,0 +1,132 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import "github.com/weaviate/weaviate/entities/models"
+
+type migrationEffect int
+
+const (
+	migrationEffectPending migrationEffect = iota
+	migrationEffectVisible
+	migrationEffectUnobservable
+)
+
+// The one place a migration type is answered for: the predicate that reads its
+// effect off a property, or nil where the post-condition equals the
+// pre-condition and no schema read can confirm or deny it. No default arm, so
+// the linter names a tenth type that answers here for neither.
+func migrationEffectReader(migrationType ReindexMigrationType) (
+	visible func(MigrationSubject, *models.Property) bool, known bool,
+) {
+	switch migrationType {
+	case ReindexTypeChangeTokenization, ReindexTypeChangeTokenizationFilterable:
+		return func(s MigrationSubject, p *models.Property) bool {
+			return propertyTokenizationAtTarget(p, s.TargetTokenization)
+		}, true
+	case ReindexTypeEnableFilterable:
+		return func(_ MigrationSubject, p *models.Property) bool { return propertyFilterableEnabled(p) }, true
+	case ReindexTypeEnableSearchable:
+		return func(s MigrationSubject, p *models.Property) bool {
+			return propertySearchableAtTarget(p, s.TargetTokenization)
+		}, true
+	case ReindexTypeChangeAlgorithm:
+		return func(_ MigrationSubject, p *models.Property) bool { return propertyBlockmaxStamped(p) }, true
+	case ReindexTypeEnableRangeable:
+		return func(_ MigrationSubject, p *models.Property) bool { return propertyRangeableEnabled(p) }, true
+	case ReindexTypeRepairFilterable, ReindexTypeRebuildSearchable, ReindexTypeRepairRangeable:
+		return nil, true
+	}
+	return nil, false
+}
+
+func migrationTypeKnown(migrationType ReindexMigrationType) bool {
+	_, known := migrationEffectReader(migrationType)
+	return known
+}
+
+// Asked of the type alone, because migrationEffectStatus reports the same
+// answer for a record the applied schema is behind on, which is a different thing.
+func migrationEffectIsNeverObservable(migrationType ReindexMigrationType) bool {
+	visible, known := migrationEffectReader(migrationType)
+	return known && visible == nil
+}
+
+func migrationEffectStatus(class *models.Class, subject MigrationSubject) (migrationEffect, []string) {
+	if migrationEffectIsNeverObservable(subject.MigrationType) {
+		return migrationEffectUnobservable, nil
+	}
+
+	if len(subject.Props) == 0 {
+		return migrationEffectPending, nil
+	}
+
+	byName := make(map[string]*models.Property, len(class.Properties))
+	for _, prop := range class.Properties {
+		byName[prop.Name] = prop
+	}
+
+	var missing []string
+	for _, name := range subject.Properties() {
+		prop, present := byName[name]
+		if !present {
+			// Submit rejects a property the class does not hold and Weaviate
+			// never removes one, so a schema short of any of them is behind.
+			// One missing or all missing is the same condition and reads alike.
+			return migrationEffectUnobservable, nil
+		}
+		if !migrationPropertyEffectVisible(subject, prop) {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		return migrationEffectPending, missing
+	}
+	return migrationEffectVisible, nil
+}
+
+// Reading an unobservable effect as proof of commit would permanently
+// promote a cancelled migration.
+func migrationEffectConfirmsCommit(class *models.Class, subject MigrationSubject) bool {
+	effect, _ := migrationEffectStatus(class, subject)
+	return effect == migrationEffectVisible
+}
+
+// Mirrors the conditions under which the schema writer sets these flags. Where
+// the writer narrows and this does not, reconcilePromotedSealed reads the
+// effect as pending and never removes the promoted record's tracker directory.
+func migrationPropertyEffectVisible(subject MigrationSubject, prop *models.Property) bool {
+	visible, _ := migrationEffectReader(subject.MigrationType)
+	return visible != nil && visible(subject, prop)
+}
+
+func propertyTokenizationAtTarget(prop *models.Property, target string) bool {
+	return prop.Tokenization == target
+}
+
+func propertyFilterableEnabled(prop *models.Property) bool {
+	return prop.IndexFilterable != nil && *prop.IndexFilterable
+}
+
+func propertySearchableAtTarget(prop *models.Property, target string) bool {
+	return prop.IndexSearchable != nil && *prop.IndexSearchable &&
+		propertyTokenizationAtTarget(prop, target) &&
+		propertyBlockmaxStamped(prop)
+}
+
+func propertyBlockmaxStamped(prop *models.Property) bool {
+	return prop.SearchableBlockmax != nil && *prop.SearchableBlockmax
+}
+
+func propertyRangeableEnabled(prop *models.Property) bool {
+	return prop.IndexRangeFilters != nil && *prop.IndexRangeFilters
+}

--- a/adapters/repos/db/inverted_reindex_schema_effect_test.go
+++ b/adapters/repos/db/inverted_reindex_schema_effect_test.go
@@ -1,0 +1,173 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestMigrationEffectStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		mtype       ReindexMigrationType
+		target      string
+		properties  []string
+		class       *models.Class
+		want        migrationEffect
+		wantMissing []string
+	}{
+		{
+			name: "change-tokenization: the property carries the target tokenization", mtype: ReindexTypeChangeTokenization,
+			target: models.PropertyTokenizationLowercase, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "title", Tokenization: models.PropertyTokenizationLowercase}}},
+			want:  migrationEffectVisible,
+		},
+		{
+			name: "change-tokenization: the property still carries the old one", mtype: ReindexTypeChangeTokenization,
+			target: models.PropertyTokenizationLowercase, properties: []string{"title"},
+			class:       &models.Class{Properties: []*models.Property{{Name: "title", Tokenization: models.PropertyTokenizationWord}}},
+			want:        migrationEffectPending,
+			wantMissing: []string{"title"},
+		},
+		{
+			name: "change-tokenization: one of two properties has not flipped", mtype: ReindexTypeChangeTokenization,
+			target: models.PropertyTokenizationLowercase, properties: []string{"title", "body"},
+			class: &models.Class{Properties: []*models.Property{
+				{Name: "title", Tokenization: models.PropertyTokenizationLowercase},
+				{Name: "body", Tokenization: models.PropertyTokenizationWord},
+			}},
+			want:        migrationEffectPending,
+			wantMissing: []string{"body"},
+		},
+		{
+			name: "change-tokenization-filterable", mtype: ReindexTypeChangeTokenizationFilterable,
+			target: models.PropertyTokenizationField, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "title", Tokenization: models.PropertyTokenizationField}}},
+			want:  migrationEffectVisible,
+		},
+		{
+			name: "enable-filterable: flag on", mtype: ReindexTypeEnableFilterable, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "title", IndexFilterable: boolPtr(true)}}},
+			want:  migrationEffectVisible,
+		},
+		{
+			name: "enable-filterable: flag unset reads as not yet committed", mtype: ReindexTypeEnableFilterable, properties: []string{"title"},
+			class:       &models.Class{Properties: []*models.Property{{Name: "title"}}},
+			want:        migrationEffectPending,
+			wantMissing: []string{"title"},
+		},
+		{
+			name: "enable-searchable: all three parts of the effect are visible", mtype: ReindexTypeEnableSearchable,
+			target: models.PropertyTokenizationWord, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{
+				Name: "title", IndexSearchable: boolPtr(true), SearchableBlockmax: boolPtr(true),
+				Tokenization: models.PropertyTokenizationWord,
+			}}},
+			want: migrationEffectVisible,
+		},
+		{
+			name: "enable-searchable: the blockmax stamp is missing", mtype: ReindexTypeEnableSearchable,
+			target: models.PropertyTokenizationWord, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{
+				Name: "title", IndexSearchable: boolPtr(true), Tokenization: models.PropertyTokenizationWord,
+			}}},
+			want:        migrationEffectPending,
+			wantMissing: []string{"title"},
+		},
+		{
+			name: "change-algorithm: the per-property stamp", mtype: ReindexTypeChangeAlgorithm, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "title", SearchableBlockmax: boolPtr(true)}}},
+			want:  migrationEffectVisible,
+		},
+		{
+			// The class flag has a writer outside the migration and defaults to
+			// true, so it cannot answer for an unstamped property.
+			name: "change-algorithm: the class flag does not answer for an unstamped property", mtype: ReindexTypeChangeAlgorithm, properties: []string{"title"},
+			class: &models.Class{
+				InvertedIndexConfig: &models.InvertedIndexConfig{UsingBlockMaxWAND: true},
+				Properties:          []*models.Property{{Name: "title"}},
+			},
+			want:        migrationEffectPending,
+			wantMissing: []string{"title"},
+		},
+		{
+			name: "enable-rangeable", mtype: ReindexTypeEnableRangeable, properties: []string{"price"},
+			class: &models.Class{Properties: []*models.Property{{Name: "price", IndexRangeFilters: boolPtr(true)}}},
+			want:  migrationEffectVisible,
+		},
+		{
+			name: "enable-rangeable: flag not set", mtype: ReindexTypeEnableRangeable, properties: []string{"price"},
+			class:       &models.Class{Properties: []*models.Property{{Name: "price"}}},
+			want:        migrationEffectPending,
+			wantMissing: []string{"price"},
+		},
+		{
+			// IndexRangeFilters is what put the repair on the list, and the
+			// repair writes no other flag, so reading it back proves nothing.
+			name: "repair-rangeable reads its own entry condition, so no schema read settles it", mtype: ReindexTypeRepairRangeable, properties: []string{"price"},
+			class: &models.Class{Properties: []*models.Property{{Name: "price", IndexRangeFilters: boolPtr(true)}}},
+			want:  migrationEffectUnobservable,
+		},
+		{
+			name: "repair-filterable has no flag anywhere, so no schema read settles it", mtype: ReindexTypeRepairFilterable, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "title"}}},
+			want:  migrationEffectUnobservable,
+		},
+		{
+			name: "rebuild-searchable has none either", mtype: ReindexTypeRebuildSearchable, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "title"}}},
+			want:  migrationEffectUnobservable,
+		},
+		{
+			name: "the only property is not in the applied schema yet", mtype: ReindexTypeEnableFilterable, properties: []string{"title"},
+			class: &models.Class{Properties: []*models.Property{{Name: "body", IndexFilterable: boolPtr(true)}}},
+			want:  migrationEffectUnobservable,
+		},
+		{
+			name: "one property not in the applied schema yet, the other not flipped", mtype: ReindexTypeEnableFilterable, properties: []string{"title", "body"},
+			class: &models.Class{Properties: []*models.Property{{Name: "body"}}},
+			want:  migrationEffectUnobservable,
+		},
+		{
+			name: "change-algorithm: every property deleted, so the stamp is gone with them", mtype: ReindexTypeChangeAlgorithm, properties: []string{"title"},
+			class: &models.Class{
+				InvertedIndexConfig: &models.InvertedIndexConfig{UsingBlockMaxWAND: true},
+			},
+			want: migrationEffectUnobservable,
+		},
+		{
+			name: "no properties and a type whose effect is per property: nothing to read", mtype: ReindexTypeEnableFilterable,
+			class: &models.Class{}, want: migrationEffectPending,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			subject := MigrationSubject{
+				MigrationType:      tt.mtype,
+				TargetTokenization: tt.target,
+			}
+			for _, prop := range tt.properties {
+				setMigrationDir(&subject, prop, func(*MigrationPropertyDirs) {})
+			}
+			effect, missing := migrationEffectStatus(tt.class, subject)
+			require.Equal(t, tt.want, effect)
+			require.Equal(t, tt.wantMissing, missing,
+				"the properties a pending read blamed")
+			require.Equal(t, tt.want == migrationEffectVisible,
+				migrationEffectConfirmsCommit(tt.class, subject))
+		})
+	}
+}

--- a/adapters/repos/db/inverted_reindex_shard_migrations.go
+++ b/adapters/repos/db/inverted_reindex_shard_migrations.go
@@ -18,14 +18,9 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// shardMigrations is one shard's side of migration-record reconciliation. A
-// shard detached from its index answers with each dependency's own safe
-// default rather than failing: no readable local task list, and a seal nobody
-// is contending.
-//
-// Shard.migrationReconciler wires neither node-level answer in this PR: it
-// leaves LocalTasks nil and grants every seal, so every cluster verdict
-// leaves records standing until the cutover wires them.
+// shardMigrations is one shard's side of migration-record reconciliation.
+// Detached from its index, or before the cutover installs real answers, it
+// falls back to safe defaults: no local task list, and every seal granted.
 type shardMigrations struct {
 	shard *Shard
 }

--- a/adapters/repos/db/inverted_reindex_shard_migrations.go
+++ b/adapters/repos/db/inverted_reindex_shard_migrations.go
@@ -1,0 +1,68 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// shardMigrations is one shard's side of migration-record reconciliation. A
+// shard detached from its index answers with each dependency's own safe
+// default rather than failing: no readable local task list, and a seal nobody
+// is contending.
+//
+// Shard.migrationReconciler wires neither node-level answer in this PR: it
+// leaves LocalTasks nil and grants every seal, so every cluster verdict
+// leaves records standing until the cutover wires them.
+type shardMigrations struct {
+	shard *Shard
+}
+
+func (s *Shard) migrations() shardMigrations { return shardMigrations{shard: s} }
+
+func (m shardMigrations) ReconcileWithClusterTasks(ctx context.Context, tasks []*distributedtask.Task) {
+	if m.shard.migrationRecords == nil {
+		return
+	}
+	m.liveReconciler().ReconcileWithClusterTasks(ctx, tasks)
+}
+
+func (m shardMigrations) RetireSuperseded(ctx context.Context) {
+	if m.shard.migrationRecords == nil {
+		return
+	}
+	m.liveReconciler().RetireSuperseded(ctx)
+}
+
+func (m shardMigrations) liveReconciler() *migrationReconciler {
+	className := m.shard.index.Config.ClassName.String()
+	return m.shard.migrationReconciler(func() *models.Class {
+		return m.shard.index.getSchema.ReadOnlyClass(className)
+	})
+}
+
+func (m shardMigrations) LocalTasks() ([]*distributedtask.Task, bool) {
+	if m.shard.index == nil || m.shard.index.db == nil {
+		return nil, false
+	}
+	return m.shard.index.db.migrationCluster.LocalTasks()
+}
+
+func (m shardMigrations) SealUnit(desc distributedtask.TaskDescriptor, unitID string) (func(), bool) {
+	if m.shard.index == nil || m.shard.index.db == nil {
+		return func() {}, true
+	}
+	return m.shard.index.db.migrationSeals.SealUnit(desc, unitID)
+}

--- a/adapters/repos/db/inverted_reindex_shard_wiring.go
+++ b/adapters/repos/db/inverted_reindex_shard_wiring.go
@@ -20,11 +20,9 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-// Every step of a shard load that renames or removes a migration directory, in
-// the order they run. Both must stay ahead of bucket loading, or a bucket opens
-// at a name one of them is about to move. They read ownership from different
-// evidence, the tracker tree and the record store, so keeping them together is
-// what makes their agreement reviewable.
+// Every step of a shard load that renames or removes a migration directory,
+// in the order they run: both must stay ahead of bucket loading, or a bucket
+// opens at a name one of them is about to move.
 func (s *Shard) settleMigrationDirectories(ctx context.Context, class *models.Class) {
 	FinalizeCompletedMigrations(s.pathLSM(), s.index.logger)
 	s.reconcileMigrationRecords(ctx, class)
@@ -59,7 +57,7 @@ func (s *Shard) migrationReconciler(class func() *models.Class) *migrationReconc
 			Class:   class,
 			Buckets: s,
 			// A grant nobody contends: no task writes a record on this
-			// build. The cutover PR wires the real worker registry here.
+			// build. The cutover wires the real worker registry here.
 			SealUnit: func(distributedtask.TaskDescriptor, string) (func(), bool) {
 				return func() {}, true
 			},
@@ -68,8 +66,8 @@ func (s *Shard) migrationReconciler(class func() *models.Class) *migrationReconc
 
 // Resolves the record's own copy of the property and closes that. The
 // reconciler names directories instead, because it has to decide before it
-// closes; both land on ShutdownStagedBucketsAt. Called by the cutover PR,
-// where a worker closes the copy it is done writing.
+// closes; both land on ShutdownStagedBucketsAt. Called by the cutover, where
+// a worker closes the copy it is done writing.
 func (s *Shard) ShutdownStagedBuckets(ctx context.Context, key MigrationRecordKey, prop string) error {
 	if s.migrationRecords == nil {
 		return nil

--- a/adapters/repos/db/inverted_reindex_shard_wiring.go
+++ b/adapters/repos/db/inverted_reindex_shard_wiring.go
@@ -40,9 +40,9 @@ func (s *Shard) reconcileMigrationRecords(ctx context.Context, class *models.Cla
 		reconciler.WedgedCount(), len(s.migrationRecords.Unreadable()))
 }
 
-// Empty where the node name is not wired: reading every record as local is what
-// this store did before it could tell them apart, and a shard that cannot name
-// its own unit must not set its own records aside.
+// Empty where the index or schema getter is missing: reading every record as
+// local is what this store did before it could tell them apart. An unwired
+// node name is not caught and reaches MigrationUnitID.
 func (s *Shard) migrationUnit() string {
 	if s.index == nil || s.index.getSchema == nil {
 		return ""

--- a/adapters/repos/db/inverted_reindex_shard_wiring.go
+++ b/adapters/repos/db/inverted_reindex_shard_wiring.go
@@ -1,0 +1,112 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// Every step of a shard load that renames or removes a migration directory, in
+// the order they run. Both must stay ahead of bucket loading, or a bucket opens
+// at a name one of them is about to move. They read ownership from different
+// evidence, the tracker tree and the record store, so keeping them together is
+// what makes their agreement reviewable.
+func (s *Shard) settleMigrationDirectories(ctx context.Context, class *models.Class) {
+	FinalizeCompletedMigrations(s.pathLSM(), s.index.logger)
+	s.reconcileMigrationRecords(ctx, class)
+}
+
+func (s *Shard) reconcileMigrationRecords(ctx context.Context, class *models.Class) {
+	s.migrationRecords = NewMigrationRecordStoreForUnit(s.pathLSM(), s.migrationUnit(), s.index.logger)
+	s.migrationRecords.SweepTempFiles()
+
+	reconciler := s.migrationReconciler(func() *models.Class { return class })
+	if err := reconciler.Reconcile(ctx); err != nil {
+		s.index.logger.WithField("shard", s.ID()).Errorf("reconcile migration records: %v", err)
+	}
+	monitoring.GetMetrics().AddMigrationRecordsWedged(
+		reconciler.WedgedCount(), len(s.migrationRecords.Unreadable()))
+}
+
+// Empty where the node name is not wired: reading every record as local is what
+// this store did before it could tell them apart, and a shard that cannot name
+// its own unit must not set its own records aside.
+func (s *Shard) migrationUnit() string {
+	if s.index == nil || s.index.getSchema == nil {
+		return ""
+	}
+	return MigrationUnitID(s.name, s.index.getSchema.NodeName())
+}
+
+func (s *Shard) migrationReconciler(class func() *models.Class) *migrationReconciler {
+	return newMigrationReconciler(s.migrationRecords, s.pathLSM(),
+		s.index.logger.WithField("shard", s.ID()),
+		migrationReconcileDeps{
+			Class:   class,
+			Buckets: s,
+			// A grant nobody contends: no task writes a record on this
+			// build. The cutover PR wires the real worker registry here.
+			SealUnit: func(distributedtask.TaskDescriptor, string) (func(), bool) {
+				return func() {}, true
+			},
+		})
+}
+
+// Resolves the record's own copy of the property and closes that. The
+// reconciler names directories instead, because it has to decide before it
+// closes; both land on ShutdownStagedBucketsAt. Called by the cutover PR,
+// where a worker closes the copy it is done writing.
+func (s *Shard) ShutdownStagedBuckets(ctx context.Context, key MigrationRecordKey, prop string) error {
+	if s.migrationRecords == nil {
+		return nil
+	}
+	rec, ok := s.migrationRecords.Get(key)
+	if !ok {
+		return nil
+	}
+	return s.ShutdownStagedBucketsAt(ctx, migrationOwnCopyDirs(rec.Subject(), prop))
+}
+
+func (s *Shard) ShutdownStagedBucketsAt(ctx context.Context, dirs []string) error {
+	if s.store == nil {
+		return nil
+	}
+	for _, dir := range dirs {
+		if s.store.Bucket(dir) == nil {
+			continue
+		}
+		if err := s.store.ShutdownBucket(ctx, dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Shard) migrationRecordStore() *MigrationRecordStore { return s.migrationRecords }
+
+// Reports no store rather than loading a cold shard: a shard with no records
+// on disk has nothing to reconcile, and loading one to find that out would
+// resurrect a shard that was deliberately unloaded.
+func (l *LazyLoadShard) migrationRecordStore() *MigrationRecordStore {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if !l.loaded {
+		return nil
+	}
+	return l.shard.migrationRecordStore()
+}

--- a/adapters/repos/db/inverted_reindex_shard_wiring_test.go
+++ b/adapters/repos/db/inverted_reindex_shard_wiring_test.go
@@ -1,0 +1,281 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// The registry grants when it has nobody to ask and refuses only on a real
+// refusal, so a deployment that never wires a seal provider up can still
+// reclaim a migration's directories.
+func TestMigrationUnitSealsDisposition(t *testing.T) {
+	desc := distributedtask.TaskDescriptor{ID: "Books:change-tokenization:title:ab12", Version: 42}
+	const unitID = "shard-1__node-0"
+
+	tests := []struct {
+		name       string
+		builder    ReindexUnitSealBuilder
+		wantSealed bool
+	}{
+		{name: "no builder installed", wantSealed: true},
+		{
+			name:       "a builder that produces no seal",
+			builder:    func() ReindexUnitSeal { return nil },
+			wantSealed: true,
+		},
+		{
+			name: "an installed seal refuses while a worker still holds the unit",
+			builder: func() ReindexUnitSeal {
+				return func(d distributedtask.TaskDescriptor, u string) (func(), bool) {
+					require.Equal(t, desc, d, "the seal must answer for the unit the teardown named")
+					require.Equal(t, unitID, u)
+					return nil, false
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seals migrationUnitSeals
+			seals.Install(tt.builder)
+
+			release, sealed := seals.SealUnit(desc, unitID)
+			require.Equal(t, tt.wantSealed, sealed)
+			if tt.wantSealed {
+				require.NotNil(t, release, "a granted seal must hand back a release the teardown can call")
+				release()
+			}
+		})
+	}
+}
+
+// The properties a predecessor still owns must keep serving while one is retired.
+func TestShutdownStagedBucketsClosesOnlyTheNamedProperty(t *testing.T) {
+	const propA, propB = "title", "author"
+
+	tests := []struct {
+		name  string
+		prop  string
+		other string
+	}{
+		{name: "retiring the first property", prop: propA, other: propB},
+		{name: "retiring the second property", prop: propB, other: propA},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testCtx()
+			className := "WiringStagedScope_" + uuid.NewString()[:8]
+			shd, _ := testShardWithSettings(t, ctx, newTestClassWithProps(className, []string{propA, propB}),
+				enthnsw.UserConfig{Skip: true}, false, false, false)
+			shard := shd.(*Shard)
+			defer shard.Shutdown(context.Background())
+
+			subject := testMigrationSubject(42, StrategyCodeEnableFilterable, propA, propB)
+
+			for _, dir := range migrationOwnedDirs(subject) {
+				require.NoError(t, shard.store.CreateOrLoadBucket(ctx, dir,
+					lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+				require.NotNil(t, shard.store.Bucket(dir), "the fixture has to open %q", dir)
+			}
+			require.NoError(t, shard.migrationRecords.Put(
+				NewMigrationRecordIterating(subject, MigrationCheckpoint{})))
+
+			require.NoError(t, shard.ShutdownStagedBuckets(ctx, subject.Key, tt.prop))
+
+			assert.Nil(t, shard.store.Bucket(subject.Props[tt.prop].Staged),
+				"the staged bucket of the retired property")
+			assert.Nil(t, shard.store.Bucket(subject.Props[tt.prop].Sidecar),
+				"the sidecar bucket of the retired property")
+			assert.NotNil(t, shard.store.Bucket(subject.Props[tt.other].Staged),
+				"the staged bucket of the property still in use")
+			assert.NotNil(t, shard.store.Bucket(subject.Props[tt.other].Sidecar),
+				"the sidecar bucket of the property still in use")
+		})
+	}
+}
+
+// The accessor reads l.shard, which the loader writes under l.mutex. Taking the
+// same mutex on the read side is what makes the pair safe, and dropping it makes
+// this test fail under -race.
+func TestLazyLoadShardMigrationRecordStoreLocksAgainstTheLoader(t *testing.T) {
+	const tenant = "record-store-reader"
+
+	ctx := testCtx()
+	className := "WiringRecordStoreRace_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"title"})
+	hot, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	defer hot.Shutdown(context.Background())
+
+	cold := NewLazyLoadShard(ctx, nil, tenant, idx, class, idx.centralJobQueue,
+		idx.indexCheckpoints, idx.allocChecker, idx.shardLoadLimiter, idx.shardReindexer,
+		false, idx.bitmapBufPool)
+	defer func() {
+		if cold.isLoaded() {
+			require.NoError(t, cold.Shutdown(context.Background()))
+		}
+	}()
+
+	// The reader is already spinning when the load starts and keeps spinning
+	// until it has returned, so the write to l.shard lands inside the window the
+	// reader is reading in. No timing assumption sits between the two.
+	spinning, loadDone := make(chan struct{}), make(chan struct{})
+	var readers sync.WaitGroup
+	readers.Add(1)
+	go func() {
+		defer readers.Done()
+		close(spinning)
+		for {
+			cold.migrationRecordStore()
+			select {
+			case <-loadDone:
+				return
+			default:
+			}
+		}
+	}()
+
+	<-spinning
+	loadErr := cold.Load(ctx)
+	close(loadDone)
+	readers.Wait()
+
+	require.NoError(t, loadErr)
+	require.NotNil(t, cold.migrationRecordStore(),
+		"a loaded shard reconciles its records at init, so the accessor has to see a store")
+}
+
+// The whole safety argument for this PR is that a shard load decides nothing.
+// The record pass runs on every load, but it is wired with no task source, so
+// the only disposition it can reach is to leave the record standing. A load
+// has to hand back the record, and every directory it names, as it found them
+// — even when the schema already shows the migration's effect, which is the
+// one reading that would otherwise license a commit.
+func TestAShardLoadLeavesAnUndecidedRecordExactlyAsItFoundIt(t *testing.T) {
+	ctx := testCtx()
+	className := "WiringInertLoad_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"title"})
+	class.Properties[0].Tokenization = models.PropertyTokenizationLowercase
+
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true}, false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(context.Background())
+
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	subject.Key.UnitID = shard.migrationUnit()
+	require.Equal(t, models.PropertyTokenizationLowercase, subject.TargetTokenization,
+		"fixture: the schema has to already show this migration's effect")
+	require.NoError(t, shard.migrationRecords.Put(NewMigrationRecordMerged(subject)))
+
+	named := append(migrationOwnedDirs(subject), subject.Props["title"].Canonical)
+	for _, dir := range named {
+		require.NoError(t, os.MkdirAll(filepath.Join(shard.pathLSM(), dir), 0o777))
+	}
+	tracker := filepath.Join(shard.pathLSM(), migrationsDir, subject.TrackerDir)
+	require.NoError(t, os.MkdirAll(tracker, 0o777))
+
+	shard.reconcileMigrationRecords(ctx, class)
+
+	rec, ok := shard.migrationRecords.Get(subject.Key)
+	require.True(t, ok, "a load must not retire a record it has no task list to decide against")
+	require.Equal(t, MigrationStateMerged, rec.State(),
+		"and it must not move it: no disposition on this build is reachable from a shard load")
+	for _, dir := range named {
+		require.DirExists(t, filepath.Join(shard.pathLSM(), dir),
+			"every directory the record names survives a load that decided nothing")
+	}
+	require.DirExists(t, tracker, "and so does its tracker directory")
+}
+
+// The counters answer two different operator questions, and the call site is
+// the only place that decides which count goes where. Both move on every
+// faulted load, so a swap of the two arguments shows up nowhere unless a test
+// drives a real load and gives the two counts different values.
+func TestAShardLoadCountsWedgedAndUnreadableRecordsInTheirOwnCounters(t *testing.T) {
+	ctx := testCtx()
+	className := "WiringRecordCounters_" + uuid.NewString()[:8]
+	class := newTestClassWithProps(className, []string{"title"})
+	class.Properties[0].Tokenization = models.PropertyTokenizationLowercase
+
+	shd, _ := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true}, false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(context.Background())
+
+	// One record the load cannot place: its rebuilt data is gone, so the pass
+	// tries to restart it, and the freeze the unreadable files raise refuses
+	// that write.
+	subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+	subject.Key.UnitID = shard.migrationUnit()
+	require.NoError(t, shard.migrationRecords.Put(
+		NewMigrationRecordIterating(subject, MigrationCheckpoint{})))
+
+	// Two files, not one: equal counts would survive the swap this test exists
+	// to catch.
+	records := shard.migrationRecords.Dir()
+	for _, version := range []uint64{7, 8} {
+		key := testMigrationSubject(version, StrategyCodeSearchableRetokenize, "title").Key
+		key.UnitID = shard.migrationUnit()
+		require.NoError(t, os.WriteFile(filepath.Join(records, key.fileName()),
+			[]byte("a record this build cannot decode"), 0o600))
+	}
+
+	// Deltas, not absolutes: the counters are node-wide and every shard load in
+	// this package adds to the same two.
+	m := monitoring.GetMetrics()
+	wedgedBefore := testutil.ToFloat64(m.MigrationRecordsWedged)
+	notUnderstoodBefore := testutil.ToFloat64(m.MigrationRecordsNotUnderstood)
+
+	shard.reconcileMigrationRecords(ctx, class)
+
+	require.Equal(t, float64(1), testutil.ToFloat64(m.MigrationRecordsWedged)-wedgedBefore,
+		"the one record this load left standing belongs in the wedged counter")
+	require.Equal(t, float64(2), testutil.ToFloat64(m.MigrationRecordsNotUnderstood)-notUnderstoodBefore,
+		"and the two files it could not read belong in the other")
+}
+
+// The store sets aside every record whose unit is not this shard's own, so the
+// shard has to arrive at the exact ID the submit path assigns. Both sides are
+// stated here rather than read back out of migrationUnit(), which is what every
+// other fixture does: a divergence would set aside every record on every shard,
+// and that reads as a node that quietly stopped reconciling, not as a fault.
+func TestAShardNamesItsOwnUnitTheWayTheSubmitPathDoes(t *testing.T) {
+	require.Equal(t, "shard-1__node-0", MigrationUnitID("shard-1", "node-0"),
+		"the unit ID is the shard name, two underscores, then the node name")
+
+	ctx := testCtx()
+	className := "WiringUnitID_" + uuid.NewString()[:8]
+	shd, _ := testShardWithSettings(t, ctx, newTestClassWithProps(className, []string{"title"}),
+		enthnsw.UserConfig{Skip: true}, false, false, false)
+	shard := shd.(*Shard)
+	defer shard.Shutdown(context.Background())
+
+	require.Equal(t, shard.name+"__node1", shard.migrationUnit(),
+		"and the shard composes it from its own name and the name of the node it runs on")
+}

--- a/adapters/repos/db/inverted_reindex_shard_wiring_test.go
+++ b/adapters/repos/db/inverted_reindex_shard_wiring_test.go
@@ -172,12 +172,9 @@ func TestLazyLoadShardMigrationRecordStoreLocksAgainstTheLoader(t *testing.T) {
 		"a loaded shard reconciles its records at init, so the accessor has to see a store")
 }
 
-// The whole safety argument for this PR is that a shard load decides nothing.
-// The record pass runs on every load, but it is wired with no task source, so
-// the only disposition it can reach is to leave the record standing. A load
-// has to hand back the record, and every directory it names, as it found them
-// — even when the schema already shows the migration's effect, which is the
-// one reading that would otherwise license a commit.
+// A shard load must decide nothing: with no task source wired, it can only
+// leave the record standing exactly as found, even when the schema already
+// shows the migration's effect.
 func TestAShardLoadLeavesAnUndecidedRecordExactlyAsItFoundIt(t *testing.T) {
 	ctx := testCtx()
 	className := "WiringInertLoad_" + uuid.NewString()[:8]
@@ -260,11 +257,9 @@ func TestAShardLoadCountsWedgedAndUnreadableRecordsInTheirOwnCounters(t *testing
 		"and the two files it could not read belong in the other")
 }
 
-// The store sets aside every record whose unit is not this shard's own, so the
-// shard has to arrive at the exact ID the submit path assigns. Both sides are
-// stated here rather than read back out of migrationUnit(), which is what every
-// other fixture does: a divergence would set aside every record on every shard,
-// and that reads as a node that quietly stopped reconciling, not as a fault.
+// Pins the unit ID format independently of migrationUnit(): the store sets
+// aside every record whose unit isn't this shard's own, so a divergence there
+// would silently set aside every record on every shard.
 func TestAShardNamesItsOwnUnitTheWayTheSubmitPathDoes(t *testing.T) {
 	require.Equal(t, "shard-1__node-0", MigrationUnitID("shard-1", "node-0"),
 		"the unit ID is the shard name, two underscores, then the node name")

--- a/adapters/repos/db/inverted_reindex_strategy_rangeable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rangeable.go
@@ -239,7 +239,7 @@ func (s *FilterableToRangeableStrategy) OnMigrationComplete(ctx context.Context,
 	_, err := applyPerPropertySchemaUpdate(ctx, s.schemaManager, className, s.propNames,
 		[]string{api.PropertyFieldIndexRangeFilters},
 		func(prop *models.Property) bool {
-			if prop.IndexRangeFilters != nil && *prop.IndexRangeFilters {
+			if propertyRangeableEnabled(prop) {
 				return false // already enabled
 			}
 			prop.IndexRangeFilters = &trueVal

--- a/adapters/repos/db/inverted_reindex_supersession.go
+++ b/adapters/repos/db/inverted_reindex_supersession.go
@@ -1,0 +1,229 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+)
+
+type migrationDisplacer interface {
+	displacedFor(dir string) (string, bool)
+	DisplacedDir(prop string) (string, bool)
+}
+
+func (f migrationFlipBlock) displacedFor(dir string) (string, bool) {
+	if dir == "" {
+		return "", false
+	}
+	for prop, displaced := range f.displacedDirs {
+		if displaced == dir {
+			return prop, true
+		}
+	}
+	return "", false
+}
+
+// The bar is Swapped, not Merged: a staged-but-undecided successor may still
+// be cancelled, and treating it as settled would withhold a promotion.
+func migrationPropertySuperseded(all []MigrationRecord, subject MigrationSubject, prop string) bool {
+	return migrationPropertySupersededExcept(all, subject, prop, MigrationRecordKey{})
+}
+
+// except names a record the caller is about to remove, so the answer is what
+// supersession would read as once that record is gone.
+func migrationPropertySupersededExcept(all []MigrationRecord, subject MigrationSubject,
+	prop string, except MigrationRecordKey,
+) bool {
+	canonical := subject.Props[prop].Canonical
+	if canonical == "" {
+		return false
+	}
+	for _, other := range all {
+		if other.Subject().Key == except {
+			continue
+		}
+		if migrationSupersedes(other, subject) && other.Subject().Props[prop].Canonical == canonical {
+			return true
+		}
+	}
+	return false
+}
+
+// Removing a record while it is the only thing superseding an older one
+// un-supersedes that older record, and the next load then promotes the older
+// record's staged data over the directory this record's data lives in.
+func migrationSoleSupersessorOf(all []MigrationRecord, subject MigrationSubject) (MigrationRecordKey, bool) {
+	for _, other := range all {
+		older := other.Subject()
+		if older.Key == subject.Key {
+			continue
+		}
+		for _, prop := range older.Properties() {
+			if migrationPropertySuperseded(all, older, prop) &&
+				!migrationPropertySupersededExcept(all, older, prop, subject.Key) {
+				return older.Key, true
+			}
+		}
+	}
+	return MigrationRecordKey{}, false
+}
+
+func migrationSupersedes(candidate MigrationRecord, subject MigrationSubject) bool {
+	key := candidate.Subject().Key
+	return key != subject.Key && key.TaskVersion > subject.Key.TaskVersion && candidate.PointerSwapped()
+}
+
+type migrationDirRole string
+
+const (
+	migrationRoleCanonical migrationDirRole = "canonical directory"
+	migrationRoleStaged    migrationDirRole = "staged directory"
+	migrationRoleSidecar   migrationDirRole = "sidecar directory"
+)
+
+// The canonical directory is the property's live bucket, never one of these.
+func migrationOwnCopyDirs(subject MigrationSubject, prop string) []string {
+	own := subject.Props[prop]
+	dirs := make([]string, 0, 2)
+	for _, dir := range []string{own.Staged, own.Sidecar} {
+		if dir != "" {
+			dirs = append(dirs, dir)
+		}
+	}
+	return dirs
+}
+
+func migrationDirClaimedAsDisplaced(all []MigrationRecord, subject MigrationSubject, dir string) bool {
+	for _, other := range all {
+		if !migrationSupersedes(other, subject) {
+			continue
+		}
+		displacer, ok := other.(migrationDisplacer)
+		if !ok {
+			continue
+		}
+		claimedFor, ok := displacer.displacedFor(dir)
+		if _, named := other.Subject().Props[claimedFor]; !ok || !named {
+			continue
+		}
+		if migrationPropertySuperseded(all, other.Subject(), claimedFor) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func (r *migrationReconciler) RetireSuperseded(ctx context.Context) {
+	if len(r.store.Unreadable()) > 0 {
+		return
+	}
+	for _, rec := range r.store.Records() {
+		if ctx.Err() != nil {
+			return
+		}
+		subject := rec.Subject()
+		if len(subject.Props) == 0 {
+			continue
+		}
+
+		// Read at this record's turn, not once for the whole sweep: a record
+		// retired earlier here answers for nothing any more, and a list taken
+		// before the sweep began still counts its claims.
+		all := r.store.Records()
+		superseded := supersededProperties(all, subject)
+		if len(superseded) == 0 {
+			continue
+		}
+		if !migrationRetirable(rec, superseded) {
+			continue
+		}
+
+		_ = r.withSealedUnit(subject, "its retirement", func() error {
+			r.retireOneSealed(ctx, all, subject, superseded)
+			return nil
+		})
+	}
+}
+
+// An unflipped record may retire too, but only once every property is
+// superseded — otherwise a superseded-but-unflipped record wedges forever,
+// its tracker dragging cold tenants into hydration.
+func migrationRetirable(rec MigrationRecord, superseded []string) bool {
+	if rec.StagedDataComplete() {
+		return true
+	}
+	return !rec.PointerSwapped() && len(superseded) == len(rec.Subject().Props)
+}
+
+func supersededProperties(all []MigrationRecord, subject MigrationSubject) []string {
+	var out []string
+	for _, prop := range subject.Properties() {
+		if migrationPropertySuperseded(all, subject, prop) {
+			out = append(out, prop)
+		}
+	}
+	return out
+}
+
+func (r *migrationReconciler) retireOneSealed(ctx context.Context, all []MigrationRecord,
+	subject MigrationSubject, superseded []string,
+) {
+	// One line per record, not one per property: retirement runs on every shard
+	// load and a record names as many properties as its request asked for.
+	retiring := errorcompounder.New()
+	for _, prop := range superseded {
+		retiring.Add(r.retireProperty(ctx, all, subject, prop))
+	}
+	if err := retiring.ToErrorLimited(maxReportedErrors); err != nil {
+		r.logger.WithField("record", subject.Key.String()).
+			WithField("properties_superseded", len(superseded)).
+			Errorf("retire the superseded properties of a migration: %v", err)
+		return
+	}
+	if len(superseded) != len(subject.Props) {
+		return
+	}
+	if err := r.reclaimRecordAndDirs(ctx, subject); err != nil {
+		r.logger.WithField("record", subject.Key.String()).
+			Errorf("reclaim a superseded migration: %v", err)
+		return
+	}
+	r.logger.WithField("record", subject.Key.String()).
+		WithField("properties_retired", len(superseded)).
+		Info("a newer migration took over every property of this one, so its record and directories are reclaimed")
+}
+
+// Closes after deciding, not before: a bucket this pass shuts down is
+// deregistered until the shard next loads, so closing one whose directory is
+// then left in place stops that data serving with nothing to reopen it.
+func (r *migrationReconciler) retireProperty(ctx context.Context, all []MigrationRecord,
+	subject MigrationSubject, prop string,
+) error {
+	// Every directory holding this record's own copy of the property, not the
+	// staged one alone: the record stops answering for the property here, and a
+	// sidecar left behind is data at a name nothing attributes any more.
+	for _, dir := range migrationOwnCopyDirs(subject, prop) {
+		if migrationDirClaimedAsDisplaced(all, subject, dir) {
+			continue
+		}
+		if err := r.closeStagedBuckets(ctx, dir); err != nil {
+			return err
+		}
+		if err := r.removeDir(r.lsmPath, dir, "a directory of a superseded migration"); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/adapters/repos/db/inverted_reindex_supersession_test.go
+++ b/adapters/repos/db/inverted_reindex_supersession_test.go
@@ -1,0 +1,590 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// One submission fans out into two strategies, which carry its task version
+// under one unit. Read as ">=", each would supersede the other, and the
+// retirement that follows would take both their staged directories.
+func TestTwoStrategiesOfOneSubmissionDoNotSupersedeEachOther(t *testing.T) {
+	searchable := swappedOn(42, "title")
+	subject := testMigrationSubject(42, StrategyCodeFilterableRetokenize, "title")
+	filterable := NewMigrationRecordSwapped(subject, []string{"title"},
+		map[string]string{"title": subject.Props["title"].Canonical})
+
+	require.Equal(t, searchable.Subject().Key.TaskVersion, filterable.Subject().Key.TaskVersion,
+		"fixture: the two halves of one submission share its task version")
+	require.Equal(t, searchable.Subject().Key.UnitID, filterable.Subject().Key.UnitID,
+		"fixture: and they run on one unit")
+	require.NotEqual(t, searchable.Subject().Key, filterable.Subject().Key)
+
+	require.False(t, migrationSupersedes(searchable, filterable.Subject()))
+	require.False(t, migrationSupersedes(filterable, searchable.Subject()))
+}
+
+func swappedOn(version uint64, props ...string) MigrationRecordSwapped {
+	subject := testMigrationSubject(version, StrategyCodeSearchableRetokenize, props...)
+	displaced := make(map[string]string, len(props))
+	for _, prop := range props {
+		displaced[prop] = subject.Props[prop].Canonical
+	}
+	return NewMigrationRecordSwapped(subject, props, displaced)
+}
+
+func TestReconcileSupersession(t *testing.T) {
+	tests := []struct {
+		name    string
+		arrange func(f *reconcileFixture)
+		assert  func(t *testing.T, f *reconcileFixture)
+	}{
+		{
+			name: "a swapped successor retires its predecessor on the shared property",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex", "property_title__g20_ingest", "property_title__s20_reindex", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title")))
+				f.put(swappedOn(20, "title"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				_, present := f.state(MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.False(t, present, "the superseded record is retired")
+				require.False(t, f.exists("property_title__g10_ingest"))
+				require.False(t, f.exists("property_title__s10_reindex"))
+				require.Equal(t, "property_title__g20_ingest", f.contentOf("property_title_searchable"), "the successor's data is now canonical")
+			},
+		},
+		{
+			name: "a successor that has only merged is not a witness",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title")))
+				f.put(NewMigrationRecordMerged(testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.exists("property_title__g10_ingest"), "a successor that may still be cancelled retires nothing")
+				require.True(t, f.exists("property_title__g20_ingest"))
+			},
+		},
+		{
+			name: "a successor on a different index type does not displace anything",
+			arrange: func(f *reconcileFixture) {
+				predecessor := testMigrationSubject(10, StrategyCodeFilterableRetokenize, "title")
+				f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_title_searchable", "property_title")
+				f.put(NewMigrationRecordMerged(predecessor))
+				f.put(swappedOn(20, "title"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.exists("property_title__g10_ingest"))
+				require.True(t, f.exists("property_title"))
+			},
+		},
+		{
+			name: "one multi-property successor retires two single-property predecessors",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_body__g11_ingest", "property_title__g30_ingest", "property_body__g30_ingest", "property_title_searchable", "property_body_searchable")
+				f.put(NewMigrationRecordMerged(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title")))
+				f.put(NewMigrationRecordMerged(testMigrationSubject(11, StrategyCodeSearchableRetokenize, "body")))
+				f.put(swappedOn(30, "title", "body"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.False(t, f.exists("property_title__g10_ingest"))
+				require.False(t, f.exists("property_body__g11_ingest"))
+				require.Equal(t, "property_title__g30_ingest", f.contentOf("property_title_searchable"))
+				require.Equal(t, "property_body__g30_ingest", f.contentOf("property_body_searchable"))
+			},
+		},
+		{
+			name: "a partial overlap retires only the shared property, and the record survives for the rest",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_body__g10_ingest", "property_title__s10_reindex", "property_title__g20_ingest", "property_title_searchable", "property_body_searchable")
+				f.put(NewMigrationRecordMerged(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")))
+				f.put(swappedOn(20, "title"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				state, present := f.state(MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.True(t, present, "retiring the whole record would discard committed data on its unshared property")
+				require.Equal(t, MigrationStateMerged, state)
+				require.False(t, f.exists("property_title__g10_ingest"))
+				require.True(t, f.exists("property_body__g10_ingest"))
+			},
+		},
+		{
+			name: "a partially superseded record that has not staged its data whole retires nothing",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_body__g10_ingest",
+					"property_title__s10_reindex", "property_body__s10_reindex",
+					"property_title__g20_ingest", "property_title_searchable", "property_body_searchable")
+				f.put(NewMigrationRecordIterated(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")))
+				f.put(swappedOn(20, "title"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.exists("property_title__g10_ingest"),
+					"an unflipped record retires only once every property it names is superseded")
+			},
+		},
+		{
+			name: "three migrations on one property: only the newest survives, whatever order they are processed in",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_title__g30_ingest", "property_title_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(swappedOn(20, "title"))
+				f.put(swappedOn(30, "title"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.False(t, f.exists("property_title__g10_ingest"))
+				require.False(t, f.exists("property_title__g20_ingest"))
+				require.Equal(t, "property_title__g30_ingest", f.contentOf("property_title_searchable"))
+
+				remaining := f.store.Records()
+				require.Len(t, remaining, 1)
+				require.EqualValues(t, 30, remaining[0].Subject().Key.TaskVersion)
+			},
+		},
+		{
+			name: "a directory a successor claims as displaced is removed by that successor, not by retirement",
+			arrange: func(f *reconcileFixture) {
+				successor := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")
+				f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_title_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(NewMigrationRecordSwapped(successor, []string{"title"}, map[string]string{"title": "property_title__g10_ingest"}))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.False(t, f.exists("property_title__g10_ingest"))
+				require.False(t, f.exists("property_title__g20_ingest"))
+				require.Equal(t, "property_title__g20_ingest", f.contentOf("property_title_searchable"))
+			},
+		},
+		{
+			name: "the successor cannot promote, so the directory it displaced stays the last copy there is",
+			arrange: func(f *reconcileFixture) {
+				successor := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")
+				f.mkdirs("property_title__g10_ingest")
+				f.put(swappedOn(10, "title"))
+				f.put(NewMigrationRecordSwapped(successor, []string{"title"}, map[string]string{"title": "property_title__g10_ingest"}))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.exists("property_title__g10_ingest"),
+					"nothing but the claim can spare the directory holding the only copy of the property")
+				_, present := f.state(MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.False(t, present, "and the superseded record it belonged to is still retired")
+				state, present := f.state(MigrationRecordKey{TaskVersion: 20, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.True(t, present)
+				require.Equal(t, MigrationStateSwapped, state)
+			},
+		},
+		{
+			name: "a claim lapses with the claimer's own property, not with its whole record",
+			arrange: func(f *reconcileFixture) {
+				claimer := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title", "body")
+				f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_body__g20_ingest", "property_title__g30_ingest",
+					"property_title_searchable", "property_body_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(NewMigrationRecordSwapped(claimer, []string{"title", "body"},
+					map[string]string{"title": "property_title__g10_ingest"}))
+				f.put(swappedOn(30, "title"))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.False(t, f.exists("property_title__g10_ingest"),
+					"honoring a lapsed claim strands the directory at a name no surviving record holds")
+				require.False(t, f.exists("property_title__g20_ingest"))
+				require.Equal(t, "property_title__g30_ingest", f.contentOf("property_title_searchable"))
+				require.Equal(t, "property_body__g20_ingest", f.contentOf("property_body_searchable"),
+					"the claimer's unshared property is promoted, not retired")
+
+				_, present := f.state(MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.False(t, present)
+				_, present = f.state(MigrationRecordKey{TaskVersion: 20, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.True(t, present, "a record with an unsuperseded property still has something to answer for")
+			},
+		},
+		{
+			name: "the closure sweep of a promoted record leaves a successor's displaced claim alone",
+			arrange: func(f *reconcileFixture) {
+				predecessor := testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")
+				successor := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex", "property_body_searchable")
+				f.put(NewMigrationRecordPromoted(predecessor, []string{"title", "body"},
+					map[string]string{"title": "property_title_searchable", "body": "property_body_searchable"}))
+				f.put(NewMigrationRecordSwapped(successor, []string{"title"},
+					map[string]string{"title": "property_title__g10_ingest"}))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.exists("property_title__g10_ingest"),
+					"the successor cannot promote, so the directory it displaced is the only copy of the property")
+				state, present := f.state(MigrationRecordKey{TaskVersion: 20, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.True(t, present)
+				require.Equal(t, MigrationStateSwapped, state)
+			},
+		},
+		{
+			name: "a chain of displacements retires end to end without stranding a directory",
+			arrange: func(f *reconcileFixture) {
+				middle := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")
+				newest := testMigrationSubject(30, StrategyCodeSearchableRetokenize, "title")
+				f.mkdirs("property_title__g10_ingest", "property_title__g20_ingest", "property_title__g30_ingest", "property_title_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(NewMigrationRecordSwapped(middle, []string{"title"}, map[string]string{"title": "property_title__g10_ingest"}))
+				f.put(NewMigrationRecordSwapped(newest, []string{"title"}, map[string]string{"title": "property_title__g20_ingest"}))
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.False(t, f.exists("property_title__g10_ingest"))
+				require.False(t, f.exists("property_title__g20_ingest"))
+				require.Equal(t, "property_title__g30_ingest", f.contentOf("property_title_searchable"))
+
+				remaining := f.store.Records()
+				require.Len(t, remaining, 1)
+				require.EqualValues(t, 30, remaining[0].Subject().Key.TaskVersion)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title", "body")
+			tt.arrange(f)
+
+			for _, rec := range f.store.Records() {
+				f.tasks = append(f.tasks, testTask(rec.Subject().TaskID, rec.Subject().Key.TaskVersion, distributedtask.TaskStatusStarted))
+			}
+
+			f.reconcile()
+			tt.assert(t, f)
+
+			before := f.store.Records()
+			f.reconcile()
+			require.Equal(t, before, f.store.Records(), "a second reconciliation moved something")
+			tt.assert(t, f)
+		})
+	}
+}
+
+// A record stops answering for a property when that property retires, so
+// retirement has to take every directory holding the record's own copy of it.
+// A sidecar left behind is data at a name nothing attributes any more.
+func TestRetiringOnePropertyTakesItsSidecarWithIt(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title", "body")
+
+	partial := testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")
+	f.mkdirs(migrationOwnedDirs(partial)...)
+	f.mkdirs("property_title__g20_ingest", "property_title_searchable", "property_body_searchable")
+	f.put(NewMigrationRecordMerged(partial))
+	f.put(swappedOn(20, "title"))
+
+	f.reconcile()
+
+	require.False(t, f.exists("property_title__g10_ingest"), "the staged copy of the retired property")
+	require.False(t, f.exists("property_title__s10_reindex"), "and its sidecar, which holds the same property")
+	require.True(t, f.exists("property_body__g10_ingest"), "the property nothing took over keeps its own copy")
+	require.True(t, f.exists("property_body__s10_reindex"))
+	_, present := f.state(partial.Key)
+	require.True(t, present, "and the record survives to answer for it")
+}
+
+// Drop the record and nothing attributes the directory, so no later load retries.
+func TestAFailedRemovalKeepsTheRecordThatNamesTheDirectory(t *testing.T) {
+	tests := []struct {
+		name    string
+		arrange func(f *reconcileFixture) MigrationRecordKey
+		assert  func(t *testing.T, f *reconcileFixture)
+	}{
+		{
+			name: "a superseded record whose sidecar directory cannot be removed",
+			arrange: func(f *reconcileFixture) MigrationRecordKey {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex",
+					"property_title__g20_ingest", "property_title_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(swappedOn(20, "title"))
+				f.blockRemoval("property_title__s10_reindex")
+				return MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"}
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.exists("property_title__s10_reindex"), "the directory is still there to attribute")
+			},
+		},
+		{
+			name: "a superseded record whose tracker directory cannot be removed",
+			arrange: func(f *reconcileFixture) MigrationRecordKey {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex",
+					"property_title__g20_ingest", "property_title_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(swappedOn(20, "title"))
+				f.blockTrackerRemoval(f.planted[0])
+				return f.planted[0].Key
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.trackerDirExists(f.planted[0]), "the directory is still there to attribute")
+			},
+		},
+		{
+			name: "a superseded record whose own record file cannot be removed",
+			arrange: func(f *reconcileFixture) MigrationRecordKey {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex",
+					"property_title__g20_ingest", "property_title_searchable")
+				f.put(swappedOn(10, "title"))
+				f.put(swappedOn(20, "title"))
+				f.blockRecordWrites()
+				return MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"}
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.False(t, f.logged("its record and directories are reclaimed"),
+					"a record still on disk must not be reported as reclaimed")
+
+				f.allowRecordWrites()
+				f.reconcile()
+				_, present := f.state(MigrationRecordKey{TaskVersion: 10, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0"})
+				require.False(t, present, "the next pass finishes the removal the blocked one could not")
+			},
+		},
+		{
+			name: "a promoted record whose tracker directory cannot be removed",
+			arrange: func(f *reconcileFixture) MigrationRecordKey {
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+				f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+				f.mkdirs("property_title_searchable")
+				f.put(NewMigrationRecordPromoted(subject, []string{"title"}, map[string]string{"title": "property_title_searchable"}))
+				f.blockTrackerRemoval(subject)
+				return subject.Key
+			},
+			assert: func(t *testing.T, f *reconcileFixture) {
+				require.True(t, f.trackerDirExists(f.planted[0]), "the directory is still there to attribute")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+			key := tt.arrange(f)
+
+			f.reconcile()
+
+			_, present := f.state(key)
+			require.True(t, present, "the record that names the surviving directory has to stay")
+			tt.assert(t, f)
+		})
+	}
+}
+
+// An open bucket's directory leaks mmaps and in-flight compactions.
+func TestShutdownFailureHoldsBackRemoval(t *testing.T) {
+	key := func(version uint64) MigrationRecordKey {
+		return MigrationRecordKey{
+			TaskVersion: version, StrategyCode: StrategyCodeSearchableRetokenize,
+			UnitID: "shard-1__node-0",
+		}
+	}
+
+	tests := []struct {
+		name       string
+		arrange    func(f *reconcileFixture)
+		key        MigrationRecordKey
+		dir        string
+		wantWedged bool
+	}{
+		{
+			name: "the cancel edge keeps the staged copy it could not close",
+			arrange: func(f *reconcileFixture) {
+				subject := testMigrationSubject(42, StrategyCodeSearchableRetokenize, "title")
+				f.mkdirs("property_title__g42_ingest", "property_title__s42_reindex", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(subject))
+				f.tasks = []*distributedtask.Task{testTask(subject.TaskID, 42, distributedtask.TaskStatusCancelled)}
+			},
+			key:        key(42),
+			dir:        "property_title__g42_ingest",
+			wantWedged: true,
+		},
+		{
+			name: "the supersession edge keeps the predecessor that still names it",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex", "property_title__g20_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title")))
+				f.put(swappedOn(20, "title"))
+			},
+			key: key(10),
+			dir: "property_title__g10_ingest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			f.class = testClassWithTokenization(models.PropertyTokenizationWord, "title")
+			tt.arrange(f)
+			f.buckets.err = errors.New("bucket shutdown refused")
+
+			r := f.reconcile()
+
+			assert.True(t, f.exists(tt.dir), "the directory of a bucket that is still open")
+			_, present := f.state(tt.key)
+			assert.True(t, present, "the record that names the directory has to outlive a failed removal")
+			if tt.wantWedged {
+				assert.Equal(t, 1, r.WedgedCount(),
+					"a record whose reconciliation errored is as stuck as one the pass wedged")
+			}
+		})
+	}
+}
+
+// Must ask what's superseded before sealing: sealing first would refuse
+// against the very worker running this pass, from inside its own unit.
+func TestRetirementAsksWhatIsSupersededBeforeItSeals(t *testing.T) {
+	predecessor := testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title")
+
+	tests := []struct {
+		name        string
+		arrange     func(f *reconcileFixture)
+		liveFor     *MigrationSubject
+		dir         string
+		wantGone    bool
+		wantSeals   int
+		wantWaiting bool
+	}{
+		{
+			name: "nothing supersedes the record the swap just wrote",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g20_ingest", "property_title_searchable")
+				f.put(swappedOn(20, "title"))
+			},
+			liveFor: subjectPtr(swappedOn(20, "title").Subject()),
+			dir:     "property_title__g20_ingest",
+		},
+		{
+			name: "a superseded predecessor is retired from inside the successor's unit",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex", "property_title__g20_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(predecessor))
+				f.put(swappedOn(20, "title"))
+			},
+			liveFor:   subjectPtr(swappedOn(20, "title").Subject()),
+			dir:       "property_title__g10_ingest",
+			wantGone:  true,
+			wantSeals: 1,
+		},
+		{
+			// Retiring it would take the staged data of the property nothing
+			// took over, and no successor would ever rebuild it.
+			name: "an unflipped record whose successor took only one of its properties",
+			arrange: func(f *reconcileFixture) {
+				partial := testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")
+				f.mkdirs("property_title__g10_ingest", "property_body__g10_ingest",
+					"property_title__g20_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordIterating(partial, MigrationCheckpoint{}))
+				f.put(swappedOn(20, "title"))
+			},
+			dir: "property_title__g10_ingest",
+		},
+		{
+			name: "the superseded record's own worker is still running",
+			arrange: func(f *reconcileFixture) {
+				f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex", "property_title__g20_ingest", "property_title_searchable")
+				f.put(NewMigrationRecordMerged(predecessor))
+				f.put(swappedOn(20, "title"))
+			},
+			liveFor:     subjectPtr(predecessor),
+			dir:         "property_title__g10_ingest",
+			wantWaiting: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newReconcileFixture(t)
+			tt.arrange(f)
+			if tt.liveFor != nil {
+				f.liveUnit = liveUnitOf(*tt.liveFor)
+			}
+
+			newMigrationReconciler(f.store, f.lsmPath, f.logger, f.deps()).
+				RetireSuperseded(context.Background())
+
+			require.Len(t, f.sealed, tt.wantSeals,
+				"a record with no superseded property is no teardown and seals nothing")
+			require.Equal(t, len(f.sealed), f.sealsReleased)
+			require.Equal(t, tt.wantWaiting, f.logged("waits for the next pass"),
+				"a retirement is reported as waiting only when one was owed and refused")
+			require.Equal(t, !tt.wantGone, f.exists(tt.dir), "the staged directory %s", tt.dir)
+		})
+	}
+}
+
+func subjectPtr(subject MigrationSubject) *MigrationSubject { return &subject }
+
+func promotedOn(version uint64, props ...string) MigrationRecordPromoted {
+	subject := testMigrationSubject(version, StrategyCodeSearchableRetokenize, props...)
+	displaced := make(map[string]string, len(props))
+	for _, prop := range props {
+		displaced[prop] = subject.Props[prop].Canonical
+	}
+	return NewMigrationRecordPromoted(subject, props, displaced)
+}
+
+// The older record is only superseded while the newer one is on disk, so
+// removing the newer one hands the older record's staged data a promotion over
+// the directory the newer one's data lives in.
+func TestAPromotedRecordSurvivesWhileItIsAnotherRecordsOnlySupersessor(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title")
+	f.mkdirs("property_title__g10_ingest", "property_title__s10_reindex",
+		"property_title__s20_reindex", "property_title_searchable")
+	f.put(NewMigrationRecordMerged(testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title")))
+	f.put(promotedOn(20, "title"))
+	f.blockRemoval("property_title__g10_ingest")
+
+	f.reconcile()
+	_, present := f.state(MigrationRecordKey{
+		TaskVersion: 20, StrategyCode: StrategyCodeSearchableRetokenize, UnitID: "shard-1__node-0",
+	})
+	require.True(t, present,
+		"the record that could not retire is still superseded only by this one, which must stay")
+
+	f.reconcile()
+	require.Equal(t, "property_title_searchable", f.contentOf("property_title_searchable"),
+		"the older record's staged data must not be promoted over the directory the newer one filled")
+}
+
+// The pass removes records as it goes, so what supersedes what has to be read
+// off the store at each record's turn. Read once for the whole pass, a record
+// already removed still counts, and the record it names is kept for nothing.
+func TestARecordRemovedEarlierInThePassStopsSupersedingAnything(t *testing.T) {
+	f := newReconcileFixture(t)
+	f.class = testClassWithTokenization(models.PropertyTokenizationLowercase, "title", "body")
+
+	older := testMigrationSubject(10, StrategyCodeSearchableRetokenize, "title", "body")
+	newer := testMigrationSubject(20, StrategyCodeSearchableRetokenize, "title")
+	f.mkdirs("property_title_searchable", "property_body_searchable")
+	f.put(NewMigrationRecordPromoted(older, older.Properties(),
+		map[string]string{"title": "property_title_searchable", "body": "property_body_searchable"}))
+	f.put(NewMigrationRecordPromoted(newer, newer.Properties(),
+		map[string]string{"title": "property_title_searchable"}))
+
+	f.reconcile()
+
+	_, present := f.state(older.Key)
+	require.False(t, present, "fixture: the older record has to be the one this pass removes first")
+	_, present = f.state(newer.Key)
+	require.False(t, present,
+		"the record it was the sole supersessor of is gone, so this one has nothing left to hold it back")
+	require.False(t, f.trackerDirExists(newer),
+		"and its tracker directory goes with it, instead of hydrating this tenant on every load")
+}

--- a/adapters/repos/db/inverted_reindex_tracker.go
+++ b/adapters/repos/db/inverted_reindex_tracker.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/entities/diskio"
 )
 
 // -----------------------------------------------------------------------------
@@ -335,41 +334,8 @@ func (t *fileReindexTracker) createFile(filename string, content []byte) error {
 // none — never a truncated one. Unlike [fileReindexTracker.createFile] it
 // overwrites, which is what lets a caller repair a torn file. Use it wherever
 // a reader keys off the file's content rather than its mere existence.
-func (t *fileReindexTracker) createFileAtomic(filename string, content []byte) (err error) {
-	// Same directory as the target, or the rename would cross filesystems.
-	// Nothing sweeps a temp file a crash leaves behind, so it stays out of
-	// backups by its .tmp extension alone — every walk that reaches this
-	// directory has to skip that extension.
-	tmp, err := os.CreateTemp(t.config.migrationPath, filename+".*.tmp")
-	if err != nil {
-		return err
-	}
-	tmpPath := tmp.Name()
-	defer func() {
-		if err != nil {
-			tmp.Close()
-			os.Remove(tmpPath)
-		}
-	}()
-
-	if _, err = tmp.Write(content); err != nil {
-		return err
-	}
-	// The bytes have to reach the disk before the name does, or a machine
-	// crash can publish the new name over content that never landed.
-	if err = tmp.Sync(); err != nil {
-		return err
-	}
-	// Close reports write errors the Write above can still be holding.
-	if err = tmp.Close(); err != nil {
-		return err
-	}
-	if err = os.Rename(tmpPath, t.filepath(filename)); err != nil {
-		return err
-	}
-	// The rename is itself a directory entry, and survives a machine crash
-	// only once the directory holding it is synced.
-	return diskio.Fsync(t.config.migrationPath)
+func (t *fileReindexTracker) createFileAtomic(filename string, content []byte) error {
+	return writeFileAtomic(t.config.migrationPath, filename, content)
 }
 
 func (t *fileReindexTracker) removeFile(filename string) error {

--- a/adapters/repos/db/inverted_reindex_unit_seals.go
+++ b/adapters/repos/db/inverted_reindex_unit_seals.go
@@ -1,0 +1,56 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync"
+
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+)
+
+// migrationUnitSeals holds the seal every teardown takes before it removes a
+// migration's directories. This PR installs no builder, so SealUnit grants
+// every seal until the cutover installs one.
+type migrationUnitSeals struct {
+	mu      sync.RWMutex
+	builder ReindexUnitSealBuilder
+}
+
+func (s *migrationUnitSeals) Install(builder ReindexUnitSealBuilder) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.builder = builder
+}
+
+// SealUnit reserves a (task, unit) for teardown. The returned bool is false
+// only when a worker still holds the unit; every uninstalled or nil-seal case
+// reports success with a no-op release.
+func (s *migrationUnitSeals) SealUnit(desc distributedtask.TaskDescriptor, unitID string) (func(), bool) {
+	s.mu.RLock()
+	builder := s.builder
+	s.mu.RUnlock()
+
+	if builder == nil {
+		return func() {}, true
+	}
+	seal := builder()
+	if seal == nil {
+		return func() {}, true
+	}
+	return seal(desc, unitID)
+}
+
+// SetReindexUnitSeal installs the seal a teardown takes before it removes a
+// migration's directories. This PR ships the installer, not a call to it.
+func (db *DB) SetReindexUnitSeal(builder ReindexUnitSealBuilder) {
+	db.migrationSeals.Install(builder)
+}

--- a/adapters/repos/db/inverted_reindex_unit_seals.go
+++ b/adapters/repos/db/inverted_reindex_unit_seals.go
@@ -35,9 +35,11 @@ func (s *migrationUnitSeals) Install(builder ReindexUnitSealBuilder) {
 // only when a worker still holds the unit; every uninstalled or nil-seal case
 // reports success with a no-op release.
 func (s *migrationUnitSeals) SealUnit(desc distributedtask.TaskDescriptor, unitID string) (func(), bool) {
-	s.mu.RLock()
-	builder := s.builder
-	s.mu.RUnlock()
+	builder := func() ReindexUnitSealBuilder {
+		s.mu.RLock()
+		defer s.mu.RUnlock()
+		return s.builder
+	}()
 
 	if builder == nil {
 		return func() {}, true

--- a/adapters/repos/db/inverted_reindex_unit_seals.go
+++ b/adapters/repos/db/inverted_reindex_unit_seals.go
@@ -18,8 +18,8 @@ import (
 )
 
 // migrationUnitSeals holds the seal every teardown takes before it removes a
-// migration's directories. This PR installs no builder, so SealUnit grants
-// every seal until the cutover installs one.
+// migration's directories. With no builder installed, SealUnit grants every
+// seal until the cutover installs one.
 type migrationUnitSeals struct {
 	mu      sync.RWMutex
 	builder ReindexUnitSealBuilder
@@ -52,7 +52,7 @@ func (s *migrationUnitSeals) SealUnit(desc distributedtask.TaskDescriptor, unitI
 }
 
 // SetReindexUnitSeal installs the seal a teardown takes before it removes a
-// migration's directories. This PR ships the installer, not a call to it.
+// migration's directories.
 func (db *DB) SetReindexUnitSeal(builder ReindexUnitSealBuilder) {
 	db.migrationSeals.Install(builder)
 }

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -4789,6 +4789,53 @@ func (_c *MockShardLike_isReadOnly_Call) RunAndReturn(run func() error) *MockSha
 	return _c
 }
 
+// migrationRecordStore provides a mock function with no fields
+func (_m *MockShardLike) migrationRecordStore() *MigrationRecordStore {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for migrationRecordStore")
+	}
+
+	var r0 *MigrationRecordStore
+	if rf, ok := ret.Get(0).(func() *MigrationRecordStore); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*MigrationRecordStore)
+		}
+	}
+
+	return r0
+}
+
+// MockShardLike_migrationRecordStore_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'migrationRecordStore'
+type MockShardLike_migrationRecordStore_Call struct {
+	*mock.Call
+}
+
+// migrationRecordStore is a helper method to define mock.On call
+func (_e *MockShardLike_Expecter) migrationRecordStore() *MockShardLike_migrationRecordStore_Call {
+	return &MockShardLike_migrationRecordStore_Call{Call: _e.mock.On("migrationRecordStore")}
+}
+
+func (_c *MockShardLike_migrationRecordStore_Call) Run(run func()) *MockShardLike_migrationRecordStore_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockShardLike_migrationRecordStore_Call) Return(_a0 *MigrationRecordStore) *MockShardLike_migrationRecordStore_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardLike_migrationRecordStore_Call) RunAndReturn(run func() *MigrationRecordStore) *MockShardLike_migrationRecordStore_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // mutableMergeObjectLSM provides a mock function with given fields: ctx, merge, idBytes
 func (_m *MockShardLike) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error) {
 	ret := _m.Called(ctx, merge, idBytes)
@@ -5797,7 +5844,8 @@ func (_c *MockShardLike_updateVectorIndexesIgnoreDelete_Call) RunAndReturn(run f
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockShardLike {
+},
+) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -322,6 +322,15 @@ func (p *ReindexProvider) claimActiveWorker(desc distributedtask.TaskDescriptor,
 	return true
 }
 
+// ReindexUnitSeal reserves one (task, unit) for teardown. It reports false
+// while a worker still holds the unit; otherwise the caller must call the
+// returned func to release it.
+type ReindexUnitSeal func(desc distributedtask.TaskDescriptor, unitID string) (func(), bool)
+
+// ReindexUnitSealBuilder returns the current seal, or nil where the provider
+// has none. Called per seal rather than held.
+type ReindexUnitSealBuilder func() ReindexUnitSeal
+
 func (p *ReindexProvider) releaseActiveWorker(desc distributedtask.TaskDescriptor, unitID string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -2412,7 +2421,7 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 		missing, err := applyPerPropertySchemaUpdate(ctx, p.schemaManager, payload.Collection, payload.Properties,
 			[]string{api.PropertyFieldTokenization},
 			func(prop *models.Property) bool {
-				if prop.Tokenization == payload.TargetTokenization {
+				if propertyTokenizationAtTarget(prop, payload.TargetTokenization) {
 					return false
 				}
 				prop.Tokenization = payload.TargetTokenization
@@ -2436,7 +2445,7 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 		_, err := applyPerPropertySchemaUpdate(ctx, p.schemaManager, payload.Collection, payload.Properties,
 			[]string{api.PropertyFieldIndexFilterable},
 			func(prop *models.Property) bool {
-				if prop.IndexFilterable != nil && *prop.IndexFilterable {
+				if propertyFilterableEnabled(prop) {
 					return false
 				}
 				prop.IndexFilterable = &trueVal
@@ -2460,9 +2469,7 @@ func (p *ReindexProvider) flipSemanticMigrationSchema(
 		_, err := applyPerPropertySchemaUpdate(ctx, p.schemaManager, payload.Collection, payload.Properties,
 			[]string{api.PropertyFieldIndexSearchable, api.PropertyFieldTokenization, api.PropertyFieldSearchableBlockmax},
 			func(prop *models.Property) bool {
-				if prop.IndexSearchable != nil && *prop.IndexSearchable &&
-					prop.Tokenization == payload.TargetTokenization &&
-					prop.SearchableBlockmax != nil && *prop.SearchableBlockmax {
+				if propertySearchableAtTarget(prop, payload.TargetTokenization) {
 					return false
 				}
 				prop.IndexSearchable = &trueVal
@@ -2519,7 +2526,7 @@ func (p *ReindexProvider) stampSearchableBlockmax(ctx context.Context, collectio
 	_, err := applyPerPropertySchemaUpdate(ctx, p.schemaManager, collection, propNames,
 		[]string{api.PropertyFieldSearchableBlockmax},
 		func(prop *models.Property) bool {
-			if prop.SearchableBlockmax != nil && *prop.SearchableBlockmax {
+			if propertyBlockmaxStamped(prop) {
 				return false
 			}
 			prop.SearchableBlockmax = &trueVal

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -135,6 +135,11 @@ type DB struct {
 	shardReindexActivityLookupBuilder  ShardReindexActivityLookupBuilder
 	reindexCleanupInProgressLookupBldr CleanupInProgressLookupBuilder
 
+	// Both carry their own lock; see [migrationUnitSeals] and
+	// [migrationClusterReconciler].
+	migrationSeals   migrationUnitSeals
+	migrationCluster migrationClusterReconciler
+
 	bitmapBufPool      roaringset.BitmapBufPool
 	bitmapBufPoolClose func()
 
@@ -354,6 +359,9 @@ func New(logger logrus.FieldLogger, localNodeName string, config Config,
 	// Serve replication calls targeting the local node in-process instead of
 	// over a loopback round-trip.
 	db.replicaClient = newRoutingReplicationClient(replicaClient, db, nodeResolver, localNodeName)
+
+	// The reconciler walks this node's loaded shards, so it needs a way back.
+	db.migrationCluster.db = db
 
 	if db.maxNumberGoroutines == 0 {
 		return db, errors.New("no workers to add batch-jobs configured.")

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -149,6 +149,7 @@ type ShardLike interface {
 
 	isReadOnly() error
 	pathLSM() string
+	migrationRecordStore() *MigrationRecordStore
 
 	preparePutObject(context.Context, string, *storobj.Object) replica.SimpleResponse
 	preparePutObjects(context.Context, string, []*storobj.Object) replica.SimpleResponse
@@ -506,6 +507,8 @@ type Shard struct {
 	// path; registration/arm/disarm publish a fresh copy under the mutex.
 	propValueIndexState           atomic.Value // *propValueIndexState
 	propertyValueIndexCallbacksMu sync.Mutex
+
+	migrationRecords *MigrationRecordStore
 	// stores names of properties that are searchable and use buckets of
 	// inverted strategy. for such properties delta analyzer should avoid
 	// computing delta between previous and current values of properties

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -158,10 +158,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, fmt.Errorf("init shard's %q store: %w", s.ID(), err)
 	}
 
-	// Finalize any completed migrations whose directory renames were deferred
-	// from a runtime swap. This must run before bucket loading (initNonVector)
-	// so that buckets are found at their canonical directory names.
-	FinalizeCompletedMigrations(s.pathLSM(), s.index.logger)
+	s.settleMigrationDirectories(ctx, class)
 
 	// Pessimistically mark any in-flight enable-rangeable / repair-rangeable
 	// migration's target property as "not locally ready" on this shard.
@@ -327,27 +324,29 @@ const unboundedRecoveryPayload = 0
 // parsed, so a refusal is not counted as a read: it cost a stat.
 var errRecoveryPayloadTooLarge = errors.New("recovery payload exceeds the parse bound")
 
-// readRecoveryPropertyNames extracts the `Properties` slice from a
-// migration tracker dir's payload.mig sentinel file (see
-// ShardReindexTaskGeneric.SaveRecoveryPayload). The error keeps a missing
-// payload (os.IsNotExist) distinguishable from an unreadable or unparseable
-// one: [migrationDirScope.inScopeFailingOpen] treats only the former as "the task recorded
-// nothing", while the latter makes the unloaded-shard gate and the recovery
-// probe ([hasUntidiedTracker]) fail open.
-//
-// maxBytes refuses a larger payload before opening it;
-// [unboundedRecoveryPayload] reads any size.
+func refuseOversizedRecoveryPayload(path string, bound int64) error {
+	if bound <= unboundedRecoveryPayload {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.Size() > bound {
+		return fmt.Errorf("%w: %s holds %d bytes, bound is %d",
+			errRecoveryPayloadTooLarge, reindexRecoveryPayloadFile, info.Size(), bound)
+	}
+	return nil
+}
+
+// readRecoveryPropertyNames reads the property list a task saved in its
+// payload.mig. A missing payload (os.IsNotExist) must stay distinguishable
+// from an unreadable one: readTaskProps reads only the former as "the task
+// recorded nothing", and fails the unloaded-shard gate open on the latter.
 func readRecoveryPropertyNames(migDir string, maxBytes int64) ([]string, error) {
 	path := filepath.Join(migDir, reindexRecoveryPayloadFile)
-	if maxBytes > unboundedRecoveryPayload {
-		info, err := os.Stat(path)
-		if err != nil {
-			return nil, err
-		}
-		if info.Size() > maxBytes {
-			return nil, fmt.Errorf("%w: %s holds %d bytes, bound is %d",
-				errRecoveryPayloadTooLarge, reindexRecoveryPayloadFile, info.Size(), maxBytes)
-		}
+	if err := refuseOversizedRecoveryPayload(path, maxBytes); err != nil {
+		return nil, err
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/entities/diskio/files.go
+++ b/entities/diskio/files.go
@@ -67,6 +67,26 @@ func Fsync(path string) error {
 	return f.Sync()
 }
 
+// A crash keeps the rename only once the directory holding the new name is
+// synced (and the old one too, where they differ).
+func RenameAndSync(from, to string) error {
+	return renameAndSync(from, to, Fsync)
+}
+
+func renameAndSync(from, to string, sync func(string) error) error {
+	if err := os.Rename(from, to); err != nil {
+		return err
+	}
+	toDir := filepath.Dir(to)
+	if err := sync(toDir); err != nil {
+		return err
+	}
+	if fromDir := filepath.Dir(from); fromDir != toDir {
+		return sync(fromDir)
+	}
+	return nil
+}
+
 // GetFileWithSizes gets all files in a directory including their filesize. Symlinks are not
 // followed. Callers that only need the subdirectory names should use GetSubdirNames, which
 // avoids a stat per entry.

--- a/entities/diskio/files_test.go
+++ b/entities/diskio/files_test.go
@@ -12,6 +12,7 @@
 package diskio
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -154,6 +155,78 @@ func TestSanitizeFilePathJoin(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, filepath.Join(rootPath, "sub", "file.txt"), got)
+		})
+	}
+}
+
+func TestRenameAndSync(t *testing.T) {
+	tests := []struct {
+		name          string
+		from, to      string
+		missingSource bool
+		wantSyncs     []string
+		syncFails     bool
+		wantErr       bool
+		// Set only where the rename succeeded and just the sync failed.
+		wantPublished bool
+	}{
+		{name: "within one directory", from: "a.tmp", to: "a", wantSyncs: []string{"."}},
+		{name: "across two directories", from: "a.tmp", to: "d/a", wantSyncs: []string{"d", "."}},
+		{name: "over an existing name", from: "a.tmp", to: "taken", wantSyncs: []string{"."}},
+		{name: "source is not there", from: "gone.tmp", to: "a", missingSource: true, wantErr: true},
+		{name: "target directory is not there", from: "a.tmp", to: "absent/a", wantErr: true},
+		{
+			name: "a sync that fails fails the rename", from: "a.tmp", to: "a",
+			syncFails: true, wantSyncs: []string{"."}, wantErr: true, wantPublished: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			require.NoError(t, os.Mkdir(filepath.Join(root, "d"), 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(root, "taken"), []byte("old"), 0o600))
+			from, to := filepath.Join(root, tc.from), filepath.Join(root, tc.to)
+			if !tc.missingSource {
+				require.NoError(t, os.WriteFile(from, []byte("new"), 0o600))
+			}
+
+			var synced []string
+			publishedBeforeFirstSync := false
+			err := renameAndSync(from, to, func(dir string) error {
+				if len(synced) == 0 {
+					_, statErr := os.Stat(to)
+					publishedBeforeFirstSync = statErr == nil
+				}
+				rel, relErr := filepath.Rel(root, dir)
+				require.NoError(t, relErr)
+				synced = append(synced, rel)
+				if tc.syncFails {
+					return errors.New("no space")
+				}
+				return nil
+			})
+
+			require.Equal(t, tc.wantSyncs, synced,
+				"a rename is durable only once the directories holding its names are synced")
+			if len(tc.wantSyncs) > 0 {
+				require.True(t, publishedBeforeFirstSync,
+					"the sync has to follow the rename it makes durable")
+			}
+
+			if tc.wantErr {
+				require.Error(t, err)
+				_, statErr := os.Stat(to)
+				require.Equal(t, tc.wantPublished, statErr == nil,
+					"only a post-rename failure may leave the target name published")
+				return
+			}
+			require.NoError(t, err)
+			moved, err := os.ReadFile(to)
+			require.NoError(t, err)
+			require.Equal(t, "new", string(moved), "the target must hold what the source held")
+			_, statErr := os.Stat(from)
+			require.True(t, os.IsNotExist(statErr), "the source name must be gone")
 		})
 	}
 }

--- a/test/acceptance/distributed_tasks/unit_tracking_test.go
+++ b/test/acceptance/distributed_tasks/unit_tracking_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	tcexec "github.com/testcontainers/testcontainers-go/exec"
+	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/docker"
 )
@@ -674,7 +675,7 @@ func buildPerReplicaUnits(placements []shardPlacement) (unitIDs []string, shardM
 	shardMap = make(map[string]string, len(placements))
 	nodeMap = make(map[string]string, len(placements))
 	for _, p := range placements {
-		suID := fmt.Sprintf("%s__%s", p.ShardName, p.NodeName)
+		suID := db.MigrationUnitID(p.ShardName, p.NodeName)
 		unitIDs = append(unitIDs, suID)
 		shardMap[suID] = p.ShardName
 		nodeMap[suID] = p.NodeName

--- a/usecases/monitoring/migration_records_test.go
+++ b/usecases/monitoring/migration_records_test.go
@@ -1,0 +1,48 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// The two counters answer different operator questions: one says a record
+// needs a decision no later load can make, the other that a build could not
+// read a record at all. Swapped, both still move, and each shard load moves
+// them again, so nothing downstream would show the mix-up.
+func TestMigrationRecordCountersEachCountTheirOwnRecords(t *testing.T) {
+	m := &PrometheusMetrics{
+		MigrationRecordsWedged: prometheus.NewCounter(
+			prometheus.CounterOpts{Name: "migration_records_wedged_total"}),
+		MigrationRecordsNotUnderstood: prometheus.NewCounter(
+			prometheus.CounterOpts{Name: "migration_records_not_understood_total"}),
+	}
+
+	m.AddMigrationRecordsWedged(2, 3)
+	require.Equal(t, float64(2), testutil.ToFloat64(m.MigrationRecordsWedged),
+		"the records this load left standing are the first argument")
+	require.Equal(t, float64(3), testutil.ToFloat64(m.MigrationRecordsNotUnderstood),
+		"and the records it could not read are the second")
+
+	m.AddMigrationRecordsWedged(1, 0)
+	require.Equal(t, float64(3), testutil.ToFloat64(m.MigrationRecordsWedged),
+		"every load adds what it found, so the total sums over loads")
+	require.Equal(t, float64(3), testutil.ToFloat64(m.MigrationRecordsNotUnderstood),
+		"and a load with nothing unreadable adds nothing to the other")
+
+	require.NotPanics(t, func() { (*PrometheusMetrics)(nil).AddMigrationRecordsWedged(1, 1) },
+		"a shard still loads on a build with metrics switched off")
+}

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -75,6 +75,8 @@ type PrometheusMetrics struct {
 
 	// Reindex metrics
 	RangeableInMemoryRebuildDegraded *prometheus.CounterVec
+	MigrationRecordsWedged           prometheus.Counter
+	MigrationRecordsNotUnderstood    prometheus.Counter
 
 	// Backup/Restore metrics
 	BackupRestoreDurations            *prometheus.SummaryVec
@@ -598,6 +600,14 @@ func newPrometheusMetrics() *PrometheusMetrics {
 			Name: "rangeable_inmemory_rebuild_degraded_total",
 			Help: "Number of times the rangeable in-memory rebuild at reindex finalize degraded to disk serving instead of activating in-memory acceleration",
 		}, []string{"class_name", "shard_name", "property"}),
+		MigrationRecordsWedged: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "migration_records_wedged_total",
+			Help: "Reindex migration records a reconciliation pass left standing, either wedged for a reason no later load can change or with a reconciliation that errored. A shard load counts every one it found, and a periodic pass counts only the ones it newly wedged, so the total is a sum of diagnoses rather than a count of distinct records; the log line for each names the record and the shard.",
+		}),
+		MigrationRecordsNotUnderstood: promauto.NewCounter(prometheus.CounterOpts{
+			Name: "migration_records_not_understood_total",
+			Help: "Reindex migration records a shard load could not place: one it could not stat or read, one over the size bound, one it could not decode, one whose content names a different file, records naming more than one migration unit, or a records directory it could not read at all. Each withholds every promoting and destructive reindex action on its shard; the log line names the file and the reason.",
+		}),
 
 		// Queue metrics
 		QueueSize: promauto.NewGaugeVec(prometheus.GaugeOpts{
@@ -1048,6 +1058,22 @@ func (m *PrometheusMetrics) initObjectsTtl() error {
 	}
 
 	return nil
+}
+
+// Node-wide and unlabelled: class and shard names are user-chosen, so a
+// per-shard series is one series per tenant, which the metricsCount acceptance
+// test forbids. Counters, not gauges: an unlabelled gauge no healed shard can
+// reset would report its last non-zero value forever.
+func (m *PrometheusMetrics) AddMigrationRecordsWedged(wedged, notUnderstood int) {
+	if m == nil {
+		return
+	}
+	if wedged > 0 {
+		m.MigrationRecordsWedged.Add(float64(wedged))
+	}
+	if notUnderstood > 0 {
+		m.MigrationRecordsNotUnderstood.Add(float64(notUnderstood))
+	}
 }
 
 func (m *PrometheusMetrics) IncRangeableInMemoryRebuildDegraded(className, shardName, propName string) {


### PR DESCRIPTION
Adds the migration-record representation for runtime reindexing. Fully additive: nothing writes a record yet, so behavior on the existing path is unchanged.

- **Record format and store**: one JSON file per (task, strategy, unit) under `<shard>/lsm/.migrations/records/`, written atomically. A record this build cannot read freezes the store instead of being guessed at.
- **Load-time reconciliation**, wired in `NewShard` before buckets open: drives each record to a terminal state — commit or discard staged data, promote recorded renames, retire superseded generations.
- **Supersession ordering, schema-effect reads, and the record's passive queries**, shared by the reconciler and later consumers.
- **Metrics**: node-wide counters for wedged and unreadable records.

The preserve set, cleanup sweeps and unloaded-shard gate are unchanged from v1.39. weaviate/weaviate#12848 makes tasks write records and moves the sweeps onto them.

**Test coverage**: unit and integration tests ship here. End-to-end acceptance tests land in a separate follow-up PR — deliberately, and not a condition of this one shipping.

Part 1 of 2. Replaces weaviate/weaviate#12763, split because its diff exceeded GitHub's 20,000-line render limit.

### Deliberately out of scope

Runtime reindexing is in Preview. This boundary is intentional, not an oversight — please don't ask for these; they are what the PR was trimmed to remove.

- **Backups** — deferred until the backup subsystem's v1.40 rework lands. Backup-related reindex issues are tracked separately.
- **Upgrading while a migration is running or partially finished** — unsupported in Preview. Operators drain and finalize before upgrading, so this adds no mid-migration upgrade compatibility.
- **A partially flipped schema** — cannot happen. A migration carries exactly one property: the only submission path builds a single-element list, so there is no partial set to flip. Schema-flip ordering is separately corrected by weaviate/weaviate#12700, which defers the cluster-wide announcement until every shard has finished. Handling it here would widen an unrelated PR rather than add coverage.
- **Rolling-upgrade state inconsistency** — mixed-version nodes may briefly disagree about migration state; accepted for Preview. No double-handling, no fallbacks, no inferring which build wrote a given piece of state.

