### PR TITLE
fix: reject ASCII controls in text properties

### DIFF
--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"regexp"
 	"time"
+	"unicode"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/entities/models"
@@ -263,7 +264,7 @@ func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName
 			return nil, fmt.Errorf("invalid cref: %w", err)
 		}
 	case schema.DataTypeText:
-		data, err = stringVal(pv)
+		data, err = textVal(pv)
 		if err != nil {
 			return nil, fmt.Errorf("invalid text property '%s' on class '%s': %w", propertyName, className, err)
 		}
@@ -313,7 +314,7 @@ func (v *Validator) extractAndValidateProperty(ctx context.Context, propertyName
 			return nil, fmt.Errorf("invalid blobHash property '%s' on class '%s': %w", propertyName, className, err)
 		}
 	case schema.DataTypeTextArray:
-		data, err = stringArrayVal(pv, "text")
+		data, err = textArrayVal(pv)
 		if err != nil {
 			return nil, fmt.Errorf("invalid text array property '%s' on class '%s': %w", propertyName, className, err)
 		}
@@ -398,6 +399,35 @@ func stringVal(val interface{}) (string, error) {
 	}
 
 	return typed, nil
+}
+
+func textVal(val interface{}) (string, error) {
+	typed, err := stringVal(val)
+	if err != nil {
+		return "", err
+	}
+	for _, r := range typed {
+		if r <= 0x1f && unicode.IsControl(r) && r != '\t' && r != '\n' && r != '\r' {
+			return "", fmt.Errorf("contains ASCII control character U+%04X", r)
+		}
+	}
+	return typed, nil
+}
+
+func textArrayVal(val interface{}) ([]string, error) {
+	typed, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("not a text array, but %T", val)
+	}
+	data := make([]string, len(typed))
+	for i := range typed {
+		var err error
+		data[i], err = textVal(typed[i])
+		if err != nil {
+			return nil, fmt.Errorf("invalid text array value: %s", val)
+		}
+	}
+	return data, nil
 }
 
 func boolVal(val interface{}) (bool, error) {

--- a/usecases/objects/validation/properties_validation.go
+++ b/usecases/objects/validation/properties_validation.go
@@ -424,7 +424,7 @@ func textArrayVal(val interface{}) ([]string, error) {
 		var err error
 		data[i], err = textVal(typed[i])
 		if err != nil {
-			return nil, fmt.Errorf("invalid text array value: %s", val)
+			return nil, fmt.Errorf("invalid text array value at index %d: %w", i, err)
 		}
 	}
 	return data, nil

--- a/usecases/objects/validation/properties_validation_test.go
+++ b/usecases/objects/validation/properties_validation_test.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,12 +31,28 @@ import (
 )
 
 func TestTextValRejectsASCIIControlCharacters(t *testing.T) {
-	if _, err := textVal("abc\x01\x02\x03def"); err == nil {
-		t.Fatal("expected ASCII control characters to be rejected")
+	for _, r := range []rune{'\x00', '\x01', '\x02', '\x03', '\x04', '\x1f'} {
+		r := r
+		t.Run(fmt.Sprintf("rejects U+%04X", r), func(t *testing.T) {
+			if _, err := textVal(string([]rune{'a', r, 'b'})); err == nil {
+				t.Fatalf("expected U+%04X to be rejected", r)
+			}
+		})
 	}
-	if got, err := textVal("hello\nworld"); err != nil || got != "hello\nworld" {
-		t.Fatalf("expected newline to remain valid, got %q, err %v", got, err)
+	for _, r := range []rune{'\t', '\n', '\r'} {
+		r := r
+		t.Run(fmt.Sprintf("allows U+%04X", r), func(t *testing.T) {
+			if _, err := textVal(string([]rune{'a', r, 'b'})); err != nil {
+				t.Fatalf("expected U+%04X to remain valid: %v", r, err)
+			}
+		})
 	}
+	t.Run("rejects array element and preserves index detail", func(t *testing.T) {
+		_, err := textArrayVal([]interface{}{"ok", "bad\x03value"})
+		if err == nil || !strings.Contains(err.Error(), "index 1") || !strings.Contains(err.Error(), "U+0003") {
+			t.Fatalf("expected indexed control-character error, got %v", err)
+		}
+	})
 }
 
 func TestValidator_extractAndValidateProperty(t *testing.T) {

--- a/usecases/objects/validation/properties_validation_test.go
+++ b/usecases/objects/validation/properties_validation_test.go
@@ -29,6 +29,15 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
+func TestTextValRejectsASCIIControlCharacters(t *testing.T) {
+	if _, err := textVal("abc\x01\x02\x03def"); err == nil {
+		t.Fatal("expected ASCII control characters to be rejected")
+	}
+	if got, err := textVal("hello\nworld"); err != nil || got != "hello\nworld" {
+		t.Fatalf("expected newline to remain valid, got %q, err %v", got, err)
+	}
+}
+
 func TestValidator_extractAndValidateProperty(t *testing.T) {
 	type fields struct {
 		schema schema.Schema


### PR DESCRIPTION
## Issue

Closes #11745

## Background

Text properties accepted ASCII C0 control characters such as SOH, STX, and ETX, allowing invisible bytes into indexed text.

## Changes

- Validate text values and text arrays at the object property boundary.
- Reject ASCII control characters other than tab, newline, and carriage return.
- Add a regression test for SOH/STX/ETX and preserve ordinary multiline text.

## Compatibility

Existing human-readable text, including tabs and line breaks, remains valid. Text containing other ASCII C0 controls now returns the existing invalid-property validation error.

## Validation

- `go test ./usecases/objects/validation` — passed
- `gofmt` on changed Go files — passed
- `git diff --check` — passed

## Limitations

The full repository test suite and Docker API reproduction were not run locally; the focused unit test covers the shared object text validation path.
