### PR TITLE
fix(kmeans): replace FitBalanced's post-hoc balancing with in-loop size-constrained assignment

### DIFF
--- a/adapters/repos/db/vector/kmeans/kmeans.go
+++ b/adapters/repos/db/vector/kmeans/kmeans.go
@@ -496,19 +496,31 @@ func (m *KMeans) Fit(data [][]float32) error {
 	return nil
 }
 
-type pair struct {
-	distance float32
-	index    uint32
-}
-
+// FitBalanced clusters the data into exactly two groups whose sizes both hold
+// at least ceil(n/4) of the points, so a posting split always makes bounded
+// progress: neither child receives more than n - ceil(n/4) entries.
+//
+// It runs Lloyd's algorithm with a size-constrained assignment step: whenever
+// plain nearest-centroid assignment already satisfies the floor, it is used
+// unchanged; otherwise the points with the smallest relative preference are
+// moved across the boundary (see balancedAssignment). Because the constraint
+// lives inside the loop, centroids are recomputed from the constrained
+// membership and adapt to it. For the squared-L2 objective, each constrained
+// assignment minimizes WCSS for fixed centers under the size constraint and
+// each center recomputation minimizes WCSS for fixed membership, so the
+// constrained objective is non-increasing across iterations; ties can
+// plateau, which the iteration threshold bounds.
+//
+// The returned centers are always the means of the returned membership. The
+// returned membership is NOT guaranteed to be nearest-centroid with respect
+// to the returned centers: the floor violates that by design, and any run can
+// end one recomputation after its last assignment.
 func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
+	if m.K != 2 {
+		return nil, errors.New("balanced k-means requires exactly 2 clusters")
+	}
 	if len(data) < m.K {
 		return nil, errors.New("not enough data to fit k-means")
-	}
-
-	if m.K == 1 {
-		m.computeCentroid(data)
-		return nil, nil
 	}
 
 	n := len(data)
@@ -517,32 +529,39 @@ func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
 	m.Metrics.Termination = MaxIterations
 
 	result := make([]uint32, n)
-	centroidAssignments := make([][]pair, m.K)
-	for i := range m.K {
-		centroidAssignments[i] = make([]pair, 0, n/m.K)
-	}
-	assigned := false
+	deltas := make([]float32, n)
+	rightDists := make([]float32, n)
+	offsets := make([]int, n)
+	minCount := (n + 3) / 4
+
 	for m.Metrics.Iterations < m.IterationThreshold {
-		for i := range m.K {
-			centroidAssignments[i] = centroidAssignments[i][:0]
-		}
 		var metrics IterationMetrics
-		if m.Assignment == GraphPruning {
-			m.updateCenterNeighbors()
-			metrics.computations += m.K * m.K / 2
-		}
+
+		// The assignment needs both distances for every point, so the
+		// GraphPruning machinery (which exists to avoid computing the second
+		// distance) does not apply here.
 		for i, x := range data {
-			prevCenterIdx := m.tmp.assignment[i]
-			nearest := m.nearest(x, prevCenterIdx)
-			if nearest.index != prevCenterIdx {
-				metrics.changes++
-				m.tmp.assignment[i] = nearest.index
-			}
-			centroidAssignments[nearest.index] = append(centroidAssignments[nearest.index], pair{distance: nearest.distance, index: uint32(i)})
-			metrics.wcss += float64(nearest.distance)
-			metrics.computations += nearest.computations
+			p := m.seg(x)
+			d0 := m.l2squared(p, m.Centers[0])
+			d1 := m.l2squared(p, m.Centers[1])
+			deltas[i] = d0 - d1
+			rightDists[i] = d1
 		}
-		assigned = true
+		metrics.computations += 2 * n
+
+		balancedAssignment(deltas, minCount, offsets, result)
+
+		for i := range data {
+			if result[i] != m.tmp.assignment[i] {
+				metrics.changes++
+				m.tmp.assignment[i] = result[i]
+			}
+			if result[i] == 0 {
+				metrics.wcss += float64(deltas[i] + rightDists[i])
+			} else {
+				metrics.wcss += float64(rightDists[i])
+			}
+		}
 
 		m.Metrics.update(metrics)
 		m.updateCenters(data)
@@ -551,50 +570,62 @@ func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
 			break
 		}
 	}
-	// Balancing is applied once, to the final assignment. The balanced labels
-	// are written back before a last call to updateCenters so that the
-	// returned Centers are the means of the membership that is actually
-	// returned. Balancing inside the loop would leave Centers computed from
-	// the pre-balancing assignment.
-	if assigned {
-		result = m.balanceAssignments(centroidAssignments)
-		copy(m.tmp.assignment, result)
-		m.updateCenters(data)
-	}
 	m.cleanupMemory()
 	return result, nil
 }
 
-func (m *KMeans) balanceAssignments(centroidAssignments [][]pair) []uint32 {
-	slices.SortFunc(centroidAssignments[0], func(a, b pair) int {
-		return cmp.Compare(b.distance, a.distance)
+// balancedAssignment assigns each point to the closer of two centers, subject
+// to each side holding at least minCount points. deltas[i] is the point's
+// distance to the left center minus its distance to the right center. When
+// plain nearest-centroid assignment (delta < 0 goes left) already satisfies
+// the floor, it is returned unchanged. Otherwise the points are stable-sorted
+// by delta and the sorted order is cut at the clamped boundary — for fixed
+// centers this is the minimum-WCSS assignment satisfying the size constraint,
+// and the points that cross the boundary are those with the smallest regret.
+// Ties keep input order via the stable sort, which makes degenerate inputs
+// (all deltas equal) deterministic. offsets and labels are caller-provided
+// buffers of length len(deltas).
+func balancedAssignment(deltas []float32, minCount int, offsets []int, labels []uint32) {
+	n := len(deltas)
+
+	naturalLeft := 0
+	for _, delta := range deltas {
+		if delta < 0 {
+			naturalLeft++
+		}
+	}
+
+	if naturalLeft >= minCount && n-naturalLeft >= minCount {
+		for i, delta := range deltas {
+			if delta < 0 {
+				labels[i] = 0
+			} else {
+				labels[i] = 1
+			}
+		}
+		return
+	}
+
+	leftCount := naturalLeft
+	if leftCount < minCount {
+		leftCount = minCount
+	} else {
+		leftCount = n - minCount
+	}
+
+	for i := range offsets {
+		offsets[i] = i
+	}
+	slices.SortStableFunc(offsets, func(a, b int) int {
+		return cmp.Compare(deltas[a], deltas[b])
 	})
-	slices.SortFunc(centroidAssignments[1], func(a, b pair) int {
-		return cmp.Compare(b.distance, a.distance)
-	})
-	threshold := 10
-
-	// balance the assignments, if the difference between the two clusters is greater than the threshold,
-	// we need to move some points from the larger cluster to the smaller cluster starting from the
-	// furthest point in the larger cluster.
-
-	for len(centroidAssignments[0])-len(centroidAssignments[1]) > threshold {
-		centroidAssignments[1] = append(centroidAssignments[1], centroidAssignments[0][0])
-		centroidAssignments[0] = centroidAssignments[0][1:]
+	for i, offset := range offsets {
+		if i < leftCount {
+			labels[offset] = 0
+		} else {
+			labels[offset] = 1
+		}
 	}
-
-	for len(centroidAssignments[1])-len(centroidAssignments[0]) > threshold {
-		centroidAssignments[0] = append(centroidAssignments[0], centroidAssignments[1][0])
-		centroidAssignments[1] = centroidAssignments[1][1:]
-	}
-	result := make([]uint32, len(centroidAssignments[0])+len(centroidAssignments[1]))
-	for _, v := range centroidAssignments[0] {
-		result[v.index] = 0
-	}
-	for _, v := range centroidAssignments[1] {
-		result[v.index] = 1
-	}
-	return result
 }
 
 func (m *KMeans) DisableDeltaThreshold() {

--- a/adapters/repos/db/vector/kmeans/kmeans.go
+++ b/adapters/repos/db/vector/kmeans/kmeans.go
@@ -534,7 +534,12 @@ func (m *KMeans) FitBalanced(data [][]float32) ([]uint32, error) {
 	offsets := make([]int, n)
 	minCount := (n + 3) / 4
 
-	for m.Metrics.Iterations < m.IterationThreshold {
+	// Unlike Fit, FitBalanced returns memberships: the size floor and the
+	// centers-match-membership guarantees require at least one constrained
+	// assignment and center update, even when the iteration threshold is
+	// consumed by initialization alone.
+	iterationThreshold := max(m.IterationThreshold, m.Metrics.Iterations+1)
+	for m.Metrics.Iterations < iterationThreshold {
 		var metrics IterationMetrics
 
 		// The assignment needs both distances for every point, so the

--- a/adapters/repos/db/vector/kmeans/kmeans_test.go
+++ b/adapters/repos/db/vector/kmeans/kmeans_test.go
@@ -556,13 +556,14 @@ func TestFitBalancedMetricsUseActualAssignment(t *testing.T) {
 	}
 }
 
-// FitBalanced never runs the assignment loop when IterationThreshold <= 1,
-// because initialization counts as the first iteration. There is then no
-// assignment to balance and the membership is returned as the zero value:
-// every point in cluster 0.
+// FitBalanced always runs at least one constrained assignment pass, even when
+// the iteration threshold is consumed by initialization alone: the size floor
+// and the centers-matching-membership guarantee both require the loop body to
+// have executed.
 func TestFitBalancedWithoutIterations(t *testing.T) {
 	n := 100
 	d := 4
+	floor := (n + 3) / 4
 	data := generateData(n, d, normal, seed)
 	for _, variant := range kMeansVariants {
 		for _, iterationThreshold := range []int{0, 1} {
@@ -570,7 +571,14 @@ func TestFitBalancedWithoutIterations(t *testing.T) {
 			km.IterationThreshold = iterationThreshold
 			labels, err := km.FitBalanced(data)
 			assert.NoError(t, err)
-			assert.Equal(t, make([]uint32, n), labels)
+			assert.Len(t, labels, n)
+			assert.Equal(t, iterationThreshold+1, km.Metrics.Iterations,
+				"exactly one constrained pass beyond the threshold")
+
+			counts := balancedClusterSizes(t, labels, 2)
+			assert.GreaterOrEqual(t, min(counts[0], counts[1]), floor)
+			assert.LessOrEqual(t, max(counts[0], counts[1]), n-floor)
+			assertCentersMatchMembership(t, km, data, labels)
 		}
 	}
 }

--- a/adapters/repos/db/vector/kmeans/kmeans_test.go
+++ b/adapters/repos/db/vector/kmeans/kmeans_test.go
@@ -384,9 +384,11 @@ func TestFitBalancedCentersMatchMembership(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Len(t, labels, len(tc.data))
 
+				n := len(tc.data)
+				floor := (n + 3) / 4
 				counts := balancedClusterSizes(t, labels, k)
-				assert.LessOrEqual(t, absInt(counts[0]-counts[1]), 10,
-					"membership must be balanced within the threshold")
+				assert.GreaterOrEqual(t, counts[0], floor, "left child must hold at least ceil(n/4) vectors")
+				assert.GreaterOrEqual(t, counts[1], floor, "right child must hold at least ceil(n/4) vectors")
 
 				assertCentersMatchMembership(t, km, tc.data, labels)
 			})
@@ -395,11 +397,11 @@ func TestFitBalancedCentersMatchMembership(t *testing.T) {
 }
 
 // A dense blob plus two far outliers, sized above the hfresh split floor of
-// 192 vectors. Lloyd's iterations isolate the outliers in a two-point cluster,
-// and balancing then moves roughly half the blob in with them. The returned
-// center for that cluster must be the mean of the balanced membership (roughly
-// offset*4/n per dimension because the cluster has about n/2 members), not the
-// mean of just the two outliers (offset per dimension).
+// 192 vectors. Lloyd's iterations isolate the outliers in a two-point cluster;
+// the size floor then tops that cluster up to exactly ceil(n/4) members with
+// the blob points that have the lowest assignment regret. The returned center
+// for that cluster must be the mean of the constrained membership, not the
+// mean of just the two outliers.
 func TestFitBalancedOutlierBlobSplit(t *testing.T) {
 	d := 4
 	k := 2
@@ -408,6 +410,7 @@ func TestFitBalancedOutlierBlobSplit(t *testing.T) {
 	offset := float32(1000)
 	data := blobWithOutliers(nBlob, nOutliers, d, offset, seed)
 	n := nBlob + nOutliers
+	floor := (n + 3) / 4
 
 	for _, variant := range kMeansVariants {
 		t.Run(fmt.Sprintf("%v-%v", variant.Initialization, variant.Assignment), func(t *testing.T) {
@@ -417,11 +420,139 @@ func TestFitBalancedOutlierBlobSplit(t *testing.T) {
 			assert.Len(t, labels, n)
 
 			counts := balancedClusterSizes(t, labels, k)
-			assert.LessOrEqual(t, absInt(counts[0]-counts[1]), 10,
-				"balancing must backfill the outlier cluster from the blob")
+			assert.Equal(t, floor, min(counts[0], counts[1]),
+				"the outlier cluster must be topped up to exactly the size floor")
 
 			assertCentersMatchMembership(t, km, data, labels)
 		})
+	}
+}
+
+// Two well-separated groups whose natural split satisfies the size floor:
+// the constrained assignment must not interfere — every point stays with its
+// own group.
+func TestFitBalancedNaturalSplitUntouched(t *testing.T) {
+	d := 4
+	nA, nB := 140, 60
+
+	data := append(repeatVector(constantVector(d, 0.0), nA), repeatVector(constantVector(d, 10.0), nB)...)
+
+	for _, variant := range kMeansVariants {
+		t.Run(fmt.Sprintf("%v-%v", variant.Initialization, variant.Assignment), func(t *testing.T) {
+			km := newDeterministicKMeans(2, d, variant)
+			labels, err := km.FitBalanced(data)
+			assert.NoError(t, err)
+
+			counts := balancedClusterSizes(t, labels, 2)
+			assert.ElementsMatch(t, []int{nA, nB}, counts,
+				"a natural 70/30 split satisfies the floor and must be returned unchanged")
+
+			for i := 1; i < nA; i++ {
+				assert.Equal(t, labels[0], labels[i], "group A must stay together")
+			}
+			for i := nA + 1; i < nA+nB; i++ {
+				assert.Equal(t, labels[nA], labels[i], "group B must stay together")
+			}
+			assert.NotEqual(t, labels[0], labels[nA], "the two groups must be separated")
+
+			assertCentersMatchMembership(t, km, data, labels)
+		})
+	}
+}
+
+// When every vector is identical, all distance differences tie: the floor
+// assigns exactly ceil(n/4) vectors to one side, deterministically in input
+// order, with no vector dropped and no empty cluster.
+func TestFitBalancedAllIdenticalDeterministic(t *testing.T) {
+	d := 4
+	n := 200
+	floor := (n + 3) / 4
+	data := repeatVector(constantVector(d, 0.5), n)
+
+	for _, variant := range kMeansVariants {
+		t.Run(fmt.Sprintf("%v-%v", variant.Initialization, variant.Assignment), func(t *testing.T) {
+			km := newDeterministicKMeans(2, d, variant)
+			labels, err := km.FitBalanced(data)
+			assert.NoError(t, err)
+			assert.Len(t, labels, n)
+
+			counts := balancedClusterSizes(t, labels, 2)
+			assert.Equal(t, floor, min(counts[0], counts[1]))
+
+			// ties break by input order: the floor side is a contiguous prefix
+			minority := labels[0]
+			for i := range floor {
+				assert.Equal(t, minority, labels[i], "floor side must be the input-order prefix")
+			}
+			for i := floor; i < n; i++ {
+				assert.NotEqual(t, minority, labels[i])
+			}
+		})
+	}
+}
+
+// Small odd sizes: the floor is ceil(n/4), mathematically at least 25%.
+func TestFitBalancedSmallOddSizes(t *testing.T) {
+	d := 4
+	for _, n := range []int{2, 3, 5, 7, 9} {
+		floor := (n + 3) / 4
+		data := repeatVector(constantVector(d, 1.0), n)
+		km := newDeterministicKMeans(2, d, kMeansVariants[0])
+		labels, err := km.FitBalanced(data)
+		assert.NoError(t, err)
+		counts := balancedClusterSizes(t, labels, 2)
+		assert.GreaterOrEqual(t, min(counts[0], counts[1]), floor, "n=%d", n)
+		assert.LessOrEqual(t, max(counts[0], counts[1]), n-floor, "n=%d", n)
+	}
+}
+
+// FitBalanced supports exactly two clusters; other K values must error rather
+// than panic (the balancing logic is two-way by construction).
+func TestFitBalancedRequiresTwoClusters(t *testing.T) {
+	d := 4
+	data := generateData(20, d, normal, seed)
+	for _, k := range []int{1, 3, 4} {
+		km := newDeterministicKMeans(k, d, kMeansVariants[0])
+		_, err := km.FitBalanced(data)
+		assert.ErrorContains(t, err, "exactly 2 clusters", "k=%d", k)
+	}
+}
+
+// The metrics must describe the constrained algorithm: two distance
+// computations per vector per assignment iteration, and WCSS computed from
+// the assignment actually returned. When the run ends in a stable iteration
+// (no changes), the recorded WCSS must equal the sum of squared distances of
+// each vector to the center of its returned cluster.
+func TestFitBalancedMetricsUseActualAssignment(t *testing.T) {
+	d := 4
+	nBlob := 198
+	nOutliers := 2
+	data := blobWithOutliers(nBlob, nOutliers, d, float32(1000), seed)
+	n := nBlob + nOutliers
+
+	km := newDeterministicKMeans(2, d, kMeansVariants[0])
+	labels, err := km.FitBalanced(data)
+	assert.NoError(t, err)
+
+	// entry 0 is initialization; every assignment iteration computes both
+	// distances for every vector
+	for i := 1; i < len(km.Metrics.Computations); i++ {
+		assert.Equal(t, 2*n, km.Metrics.Computations[i], "iteration %d", i)
+	}
+
+	if km.Metrics.Termination == ClusterStability && km.Metrics.Changes[len(km.Metrics.Changes)-1] == 0 {
+		var expected float64
+		for i, x := range data {
+			var sum float64
+			for j := range x {
+				diff := float64(x[j] - km.Centers[labels[i]][j])
+				sum += diff * diff
+			}
+			expected += sum
+		}
+		got := km.Metrics.WCSS[len(km.Metrics.WCSS)-1]
+		assert.InEpsilon(t, expected, got, 1e-3,
+			"WCSS must reflect the returned constrained assignment")
 	}
 }
 
@@ -444,11 +575,61 @@ func TestFitBalancedWithoutIterations(t *testing.T) {
 	}
 }
 
-func absInt(x int) int {
-	if x < 0 {
-		return -x
+// The assignment step in isolation: deltas[i] = d(i, left) - d(i, right).
+func TestBalancedAssignment(t *testing.T) {
+	cases := []struct {
+		name     string
+		deltas   []float32
+		minCount int
+		expected []uint32
+	}{
+		{
+			name:     "natural split above floor is untouched",
+			deltas:   []float32{-1, -2, 3, 4},
+			minCount: 1,
+			expected: []uint32{0, 0, 1, 1},
+		},
+		{
+			name:     "natural split exactly at floor is untouched",
+			deltas:   []float32{-1, -2, 3, 4},
+			minCount: 2,
+			expected: []uint32{0, 0, 1, 1},
+		},
+		{
+			name:     "floor binds on the left",
+			deltas:   []float32{1, 2, 3, 4},
+			minCount: 1,
+			expected: []uint32{0, 1, 1, 1},
+		},
+		{
+			name:     "floor binds on the right",
+			deltas:   []float32{-1, -2, -3, -4},
+			minCount: 1,
+			expected: []uint32{1, 0, 0, 0},
+		},
+		{
+			name:     "forced movers are the lowest-regret vectors",
+			deltas:   []float32{5, 1, 3, -2},
+			minCount: 2,
+			expected: []uint32{1, 0, 1, 0},
+		},
+		{
+			name:     "ties break by input order",
+			deltas:   []float32{0, 0, 0, 0},
+			minCount: 1,
+			expected: []uint32{0, 1, 1, 1},
+		},
 	}
-	return x
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			n := len(tc.deltas)
+			labels := make([]uint32, n)
+			offsets := make([]int, n)
+			balancedAssignment(tc.deltas, tc.minCount, offsets, labels)
+			assert.Equal(t, tc.expected, labels)
+		})
+	}
 }
 
 func BenchmarkKMeansFit(b *testing.B) {


### PR DESCRIPTION
## What

Fixes weaviate/0-weaviate-issues#644 and weaviate/0-weaviate-issues#645.

`FitBalanced` — used by the hfresh posting split — ran ordinary k-means and then force-balanced the two clusters after the fact: it repeatedly moved the vectors *farthest from their own centroid* until the sizes differed by at most an absolute 10. That criterion never looks at the distance to the destination, so a vector could be moved into the cluster it is even *farther* from, and hfresh routing assumes the opposite: that a posting's membership is geometrically described by its centroid. The near-50/50 requirement also forced far more moves than progress requires.

## How

The post-hoc balancing is replaced by a **size-constrained assignment step inside the k-means loop**:

- Each iteration computes both distances per vector and the signed difference `d0 − d1`. If plain nearest-centroid assignment already gives each side at least `ceil(n/4)`, it is used unchanged — the common path, zero forced moves.
- Otherwise the vectors are stable-sorted by the difference and the sorted order is cut at the clamped boundary. For fixed centroids this is the minimum-WCSS assignment satisfying the size constraint: the vectors that cross the boundary are exactly the ones with the least to lose. Ties keep input order, so degenerate inputs (e.g. a posting of identical vectors) split deterministically.
- Because the constraint lives inside the loop, centroids are recomputed from the constrained membership every iteration and adapt to it. For the squared-L2 objective both alternating steps are optimal for their sub-problem, so the constrained objective is non-increasing; ties can plateau, which the existing iteration threshold bounds.
- Metrics describe the actual algorithm: changes and WCSS are computed from the post-constraint assignment, and computations are `2n` per iteration (the assignment needs both distances, so the GraphPruning machinery no longer applies here — with two centroids it bought nothing anyway).
- `K != 2` now returns an error instead of panicking in the balancing code — the constraint is validated, which closes weaviate/0-weaviate-issues#645.

### Guarantees (all covered by unit tests)

- each child holds at least `ceil(n/4)` and at most `n − ceil(n/4)` vectors — every split makes bounded progress (a per-split clustering guarantee, not a system-level termination claim: a live index can regrow postings);
- no vectors are ever dropped, including all-identical postings, which split deterministically;
- returned centroids are always the means of the returned membership (preserving the #12804 invariant through the new code path);
- unconstrained assignment steps are pure nearest-centroid; when the floor activates, the assignment is the minimum-cost feasible one for that step's centroids.

Deliberately **not** guaranteed: every returned vector being nearest its returned centroid — the floor violates that by design, and any run can end one centroid recomputation after its last assignment.

## Scope

- `FitBalanced` only. Its single production caller is the hfresh posting split.
- `Fit` — used by HNSW/PQ training — and every shared helper are untouched; HNSW behavior is byte-identical.
- The post-split reassignment gates are deliberately untouched, so a recall A/B against this change is attributable to the clustering/membership algorithm alone.

Named follow-ups (separate PRs, only if benchmarks warrant): revisit `FitBalanced`'s stopping criterion (the generic 1% `DeltaThreshold` can stop while the remaining movers are boundary vectors; the constrained step costs only `2n` distance computations per iteration), and whether floor-forced members need special handling in post-split maintenance. The 25% floor is a starting point; 20/25/33 is a cheap benchmark dimension.

## Verification

- New unit tests pin the whole contract: the assignment step in isolation (natural splits untouched at and above the floor, floor binding in both directions, movers are the lowest-regret vectors, input-order ties), floor bounds on normal/duplicate-heavy/all-identical data, deterministic identical-vector splits, exact preservation of a natural 70/30 split, small odd sizes, the `K != 2` error, and the metrics contract (per-iteration computations; WCSS equal to the recomputed sum over the returned membership when the run ends stable).
- Full `-race` passes on `kmeans`, `compressionhelpers`, and `hfresh` (including its split and recall tests); `golangci-lint` clean.
- ann-benchmark, dbpedia-openai-1000k-angular, hfresh single shard, before → after (same base, same machine):

| searchProbe | recall before | recall after | Δ | QPS before | QPS after |
|---|---|---|---|---|---|
| 16 | 0.8038 | 0.8232 | +1.9 pt | 2900 | 2896 |
| 24 | 0.8341 | 0.8512 | +1.7 | 2650 | 2715 |
| 32 | 0.8521 | 0.8679 | +1.6 | 2518 | 2480 |
| 48 | 0.8729 | 0.8870 | +1.4 | 2192 | 2173 |
| 64 | 0.8853 | 0.8981 | +1.3 | 1937 | 1898 |
| 96 | 0.9111 | 0.9229 | +1.2 | 1527 | 1529 |
| 128 | 0.9278 | 0.9369 | +0.9 | 1234 | 1248 |
| 256 | 0.9562 | 0.9624 | +0.6 | 751 | 739 |
| 512 | 0.9759 | 0.9793 | +0.3 | 438 | 442 |

Recall improves in every cell at unchanged QPS, with the gain largest at low probe and decaying smoothly — the signature of better placement: correct posting membership matters most when few postings are probed, and deep probing papers over placement mistakes. NDCG moves in lockstep.

<img width="959" height="703" alt="output" src="https://github.com/user-attachments/assets/6b758ea6-a715-40c0-999e-0639f1578f8f" />

