### PR TITLE
Shut down test indexes so background flush cannot race TempDir cleanup

### DIFF
--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"log"
 	"math/rand"
 	"os"
@@ -649,4 +650,14 @@ func newTestIndex(t *testing.T, logger logrus.FieldLogger, className string,
 		idx.shards.Store(name, shard)
 	}
 	return idx
+}
+
+// shutdownIndexOnCleanup stops the index's cycle goroutines before t.TempDir's RemoveAll; tolerates a mid-test shutdown.
+func shutdownIndexOnCleanup(t *testing.T, index *Index) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := index.Shutdown(context.Background()); err != nil && !errors.Is(err, errAlreadyShutdown) {
+			t.Errorf("shutdown index: %v", err)
+		}
+	})
 }

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -115,6 +115,7 @@ func TestUpdateIndexTenants(t *testing.T) {
 				hnsw.NewDefaultUserConfig(), nil, nil, shardResolver, mockSchemaGetter, mockSchemaReader, nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
 				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 			require.NoError(t, err)
+			shutdownIndexOnCleanup(t, index)
 
 			shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,
 				NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
@@ -558,6 +559,7 @@ func TestUpdateIndexShards(t *testing.T) {
 				hnsw.NewDefaultUserConfig(), nil, nil, shardResolver, mockSchemaGetter, mockSchemaReader, nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, memwatch.NewDummyMonitor(),
 				NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 			require.NoError(t, err)
+			shutdownIndexOnCleanup(t, index)
 
 			// Initialize shards
 			for _, shardName := range tt.initialShards {
@@ -992,6 +994,7 @@ func TestListAndGetFilesWithIntegrityChecking(t *testing.T) {
 		hnsw.NewDefaultUserConfig(), nil, nil, shardResolver, mockSchemaGetter, mockSchemaReader, nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
+	shutdownIndexOnCleanup(t, index)
 	// HaltForTransfer's backup-gate would refuse the test's
 	// IncomingPauseFileActivity call without a wired lookup; install
 	// the no-live-reindex stub so the gate is satisfied.

--- a/adapters/repos/db/replica_snapshot_concurrent_test.go
+++ b/adapters/repos/db/replica_snapshot_concurrent_test.go
@@ -82,6 +82,7 @@ func TestIncomingCreateReplicaSnapshotConcurrent(t *testing.T) {
 		nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
+	shutdownIndexOnCleanup(t, index)
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,

--- a/adapters/repos/db/replica_snapshot_fallback_timer_test.go
+++ b/adapters/repos/db/replica_snapshot_fallback_timer_test.go
@@ -93,6 +93,7 @@ func TestReplicaSnapshotFallbackInactivityTimerIsReset(t *testing.T) {
 		nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
+	shutdownIndexOnCleanup(t, index)
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,

--- a/adapters/repos/db/replica_snapshot_shared_halt_test.go
+++ b/adapters/repos/db/replica_snapshot_shared_halt_test.go
@@ -266,6 +266,7 @@ func newSharedHaltTestShard(t *testing.T) (*Index, *Shard) {
 		nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
 	require.NoError(t, err)
+	shutdownIndexOnCleanup(t, index)
 	index.db = stubDBWithNoLiveReindex()
 
 	shard, err := NewShard(context.Background(), nil, "shard1", index, class, nil, scheduler, nil,


### PR DESCRIPTION
## Motivation

`TestListAndGetFilesWithIntegrityChecking` flaked in CI with `unlinkat: directory not empty` plus "flush and switch failed" log noise. The test builds a real `Index`+`Shard` over `t.TempDir()` and returns without shutting anything down, but `NewIndex` starts a memtable-flush cycle that only `Index.Shutdown` stops ([index.go#L550](https://github.com/weaviate/weaviate/blob/74b6e62b5d/adapters/repos/db/index.go#L550)). The leaked flush callback raced the test framework's `TempDir` `RemoveAll`, recreating files mid-removal on the deleted tree.

## Approach

Register `t.Cleanup(index.Shutdown)` immediately after every `NewIndex` in the tests sharing the pattern — `TestUpdateIndexTenants`, `TestUpdateIndexShards`, `TestListAndGetFilesWithIntegrityChecking`, and the three replica-snapshot tests (concurrent, fallback-timer, shared-halt) — not just the one that flaked. LIFO cleanup order guarantees the flush cycle is drained before the `TempDir` removal runs. No production code changes.

## Risks and mitigations

- **Double shutdown**: some of these tests shut down or deliberately break individual shards themselves; `Index.Shutdown` treats `errAlreadyShutdown` per shard as benign and stops the cycle managers regardless ([index.go#L3625](https://github.com/weaviate/weaviate/blob/74b6e62b5d/adapters/repos/db/index.go#L3625)), so the cleanup's `require.NoError` holds in every case.

## Testing

All touched tests pass under `-race -count 20`; the fix is structural (a cleanup-ordering guarantee), not a timing tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
