### PR TITLE
gh-12621 match the whole sidecar suffix against the strategy registry, not its trailing role word

### DIFF
--- a/adapters/repos/db/inverted_reindex_record.go
+++ b/adapters/repos/db/inverted_reindex_record.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/schema"
 )
 
 type MigrationState string
@@ -655,7 +656,9 @@ func migrationReservedDirName(h string) bool {
 }
 
 // A positive shape rule, not a denylist, so it refuses stores added later
-// too. Deliberately as weak as [isSidecarDirOf]: weaviate/weaviate#12621.
+// too. Still matches on the role word alone, so it stays weaker than
+// [isSidecarDirOf] now that the sweep reads whole suffixes out of the
+// strategy registry: weaviate/weaviate#12621.
 func migrationHandleIsSidecarShaped(h string) bool {
 	tail, ok := strings.CutPrefix(h, migrationPropertyBucketPrefix)
 	if !ok {
@@ -665,7 +668,7 @@ func migrationHandleIsSidecarShaped(h string) bool {
 	if i < 0 {
 		return false
 	}
-	return slices.Contains(sidecarRoleWords, sidecarRoleWord(tail[i+2:]))
+	return slices.Contains(schema.SidecarRoleWords, schema.SidecarRoleWord(tail[i+2:]))
 }
 
 // TestEveryPropertyBucketCarriesTheMigrationPrefix pins this against the

--- a/adapters/repos/db/reindex_cancel_cleanup_unloaded_shards_test.go
+++ b/adapters/repos/db/reindex_cancel_cleanup_unloaded_shards_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
@@ -1229,7 +1230,8 @@ func sweptMigrationDirPrefixes() []string {
 }
 
 // Every migration strategy's sidecar suffix must be recognized by
-// [isSidecarDirOf]; extend [sidecarRoleWords] if a new one is added.
+// [isSidecarDirOf]. It reads them out of [buildSidecarSuffixes], so a new
+// strategy is covered as soon as the registry knows it.
 func TestEverySidecarSuffixIsASidecar(t *testing.T) {
 	const main = "property_category"
 
@@ -1270,9 +1272,13 @@ func TestIsSidecarDirOfRejectsOtherPropertiesBuckets(t *testing.T) {
 		{name: "a property whose name carries the separator", dir: main + "__extra"},
 		{name: "a generation-suffixed main bucket", dir: main + "__gen2"},
 		{name: "a longer property's main bucket", dir: main + "_x"},
+		// Also property "category__enable_filterable_ingest_1"'s own main
+		// bucket, which PropertyNameRegex admits. The two are byte-for-byte
+		// identical, so no filename rule separates them; closing that residual
+		// needs the sweep to consult the class's live properties. #12621
 		{name: "a sidecar", dir: main + "__enable_filterable_ingest_1", want: true},
-		{name: "category__reindex's own bucket, wrongly accepted", dir: main + "__reindex", want: true},
-		{name: "category__ingest_0's own bucket, wrongly accepted", dir: main + "__ingest_0", want: true},
+		{name: "category__reindex's own bucket", dir: main + "__reindex"},
+		{name: "category__ingest_0's own bucket", dir: main + "__ingest_0"},
 		{name: "a property named after a number", dir: main + "__12", want: false},
 		{name: "a blockmax backup sidecar", dir: main + "__blockmax_map_3", want: true},
 		{name: "a property whose name extends a role word", dir: main + "__ingest_x", want: false},
@@ -1284,14 +1290,45 @@ func TestIsSidecarDirOfRejectsOtherPropertiesBuckets(t *testing.T) {
 			name: "the dir a crashed bucket replacement left behind",
 			dir:  main + lsmkv.ReplacedBucketDirSuffix, want: true,
 		},
-		// weaviate/weaviate#12621: "category__<word>_<role>" is a property's own
-		// main bucket on every index type, and sweeping "category" deletes it.
-		{name: "a property whose name ends in a role word", dir: main + "__ingest", want: true},
+		// weaviate/weaviate#12621: every one of these is a property's own main
+		// bucket that the role-word match read as a sidecar of "category".
+		{name: "a property whose name ends in a role word", dir: main + "__ingest"},
+		{name: "a property whose name ends in the backup role word", dir: main + "__backup"},
+		{name: "a property whose name ends in the map role word", dir: main + "__map"},
+		{name: "a property whose name ends in a role word after a word", dir: main + "__data_ingest"},
+		{name: "a property whose name ends in the reindex role word after a word", dir: main + "__x_reindex"},
+		{name: "a property whose name ends in a role word and a generation", dir: main + "__ingest_2"},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, tc.want, isSidecarDirOf(tc.dir, main))
+		})
+	}
+}
+
+// weaviate/weaviate#12621 reaches all three index types, because the main
+// bucket name is the only thing that differs between them and the role-word
+// match never looked past it.
+func TestIsSidecarDirOfRejectsRoleWordPropertiesOnEveryIndexType(t *testing.T) {
+	cases := map[string]struct {
+		mainBucket    func(string) string
+		sidecarSuffix string
+	}{
+		"filterable": {helpers.BucketFromPropNameLSM, "__enable_filterable_ingest_1"},
+		"searchable": {helpers.BucketSearchableFromPropNameLSM, "__enable_searchable_ingest_1"},
+		"rangeable":  {helpers.BucketRangeableFromPropNameLSM, "__rangeable_ingest_1"},
+	}
+
+	for indexType, tc := range cases {
+		t.Run(indexType, func(t *testing.T) {
+			main := tc.mainBucket("category")
+			victim := strings.TrimPrefix(main, "property_") + "__ingest"
+			require.False(t, isSidecarDirOf(helpers.BucketFromPropNameLSM(victim), main),
+				"sweeping %q must not reach property %q's filterable bucket",
+				"category", victim)
+			require.True(t, isSidecarDirOf(main+tc.sidecarSuffix, main),
+				"a real sidecar of %q still has to be swept", main)
 		})
 	}
 }

--- a/adapters/repos/db/reindex_cancel_cleanup_unloaded_shards_test.go
+++ b/adapters/repos/db/reindex_cancel_cleanup_unloaded_shards_test.go
@@ -1238,7 +1238,7 @@ func TestEverySidecarSuffixIsASidecar(t *testing.T) {
 	require.ElementsMatch(t, sweptMigrationDirPrefixes(),
 		slices.Collect(maps.Keys(strategiesByMigrationDir(1))),
 		"a strategy the cleanup sweeps but this test does not instantiate would "+
-			"never have its suffix checked against the role words")
+			"never have its suffix checked against the registry")
 
 	// Generation 0 is the canonical post-finalize bucket, which carries no
 	// sidecar suffix at all; live migrations start at 1 (see genSuffix).

--- a/adapters/repos/db/reindex_cleanup_live_property_guard_test.go
+++ b/adapters/repos/db/reindex_cleanup_live_property_guard_test.go
@@ -1,0 +1,142 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// The property whose main bucket wears a sidecar's name. Sweeping "category"
+// looks for exactly "property_category__enable_filterable_ingest_1", and that
+// is byte-for-byte this property's own filterable bucket.
+const (
+	liveVictimProp = "category__enable_filterable_ingest_1"
+	// A cancelled attempt's real leftovers, at a generation no property
+	// claims. Present so a guard that simply stopped sweeping would fail
+	// these tests rather than pass them.
+	staleSidecarDir = "property_category__enable_filterable_ingest_2"
+)
+
+func liveVictimBucket() string {
+	return helpers.BucketFromPropNameLSM(liveVictimProp)
+}
+
+// weaviate/weaviate#12621, the half no filename rule can close: matching the
+// whole suffix against the strategy registry stops the sweep at properties
+// whose names merely end in a role word, but a property named after a whole
+// suffix still collides exactly. The sweep has to ask the class who owns the
+// dir before it removes it.
+//
+// Without the guard this test fails twice over: the bucket is shut down in
+// step 1 and its directory — the property's live data — is removed in step 2.
+func TestCleanStalePartialReindexStateKeepsALivePropertysOwnMainBucket(t *testing.T) {
+	ctx := testCtx()
+	className := "LivePropGuard" + uuid.NewString()[:8]
+	shd, _ := testShardWithSettings(t, ctx,
+		newTestClassWithProps(className, []string{"category", liveVictimProp}),
+		enthnsw.UserConfig{Skip: true}, false, false)
+	shard := shd.(*Shard)
+	t.Cleanup(func() { shard.Shutdown(testCtx()) })
+
+	victimPath := filepath.Join(shard.pathLSM(), liveVictimBucket())
+	require.DirExists(t, victimPath,
+		"fixture: the colliding property has to own a bucket before the sweep can take it")
+	require.NotNil(t, shard.store.Bucket(liveVictimBucket()),
+		"fixture: that bucket has to be loaded, so step 1 has something to shut down")
+
+	sidecarPath := filepath.Join(shard.pathLSM(), staleSidecarDir)
+	require.NoError(t, os.MkdirAll(sidecarPath, 0o755))
+	mkTrackerDir(t, shard.pathLSM(), "enable_filterable_category_2", "started.mig")
+
+	_, err := shard.CleanStalePartialReindexState(ctx, "category", "filterable")
+	require.NoError(t, err)
+
+	require.DirExists(t, victimPath,
+		"the sweep removed a live property's own main bucket dir: #12621 data loss")
+	require.NotNil(t, shard.store.Bucket(liveVictimBucket()),
+		"the sweep shut down a live property's own main bucket")
+	require.NoDirExists(t, sidecarPath,
+		"the guard cannot buy safety by refusing to sweep: a real stale sidecar still goes")
+}
+
+// The DELETE path (updatePropertyBuckets → cleanStaleSidecarDirs) sweeps the
+// same dirs with the same matcher, so it needs the same guard. Exercised
+// through the helper both callers share.
+func TestCleanStaleSidecarDirsKeepsALivePropertysOwnMainBucket(t *testing.T) {
+	ctx := testCtx()
+	className := "LivePropGuardDelete" + uuid.NewString()[:8]
+	shd, _ := testShardWithSettings(t, ctx,
+		newTestClassWithProps(className, []string{"category", liveVictimProp}),
+		enthnsw.UserConfig{Skip: true}, false, false)
+	shard := shd.(*Shard)
+	t.Cleanup(func() { shard.Shutdown(testCtx()) })
+
+	victimPath := filepath.Join(shard.pathLSM(), liveVictimBucket())
+	require.DirExists(t, victimPath)
+
+	sidecarPath := filepath.Join(shard.pathLSM(), staleSidecarDir)
+	require.NoError(t, os.MkdirAll(sidecarPath, 0o755))
+
+	shard.cleanStaleSidecarDirs(helpers.BucketFromPropNameLSM("category"), shard.liveMainBuckets())
+
+	require.DirExists(t, victimPath,
+		"the DELETE-path sweep removed a live property's own main bucket dir")
+	require.NoDirExists(t, sidecarPath,
+		"the DELETE-path sweep still has to remove a real stale sidecar")
+}
+
+// The guard reads the class, so what it collects out of one is worth pinning
+// on its own: every bucket name a property owns, whatever its index flags
+// currently say, because the guarantee is about the property existing.
+func TestMainBucketNamesOfCollectsEveryBucketAPropertyOwns(t *testing.T) {
+	names := mainBucketNamesOf(&models.Class{
+		Class:      "Article",
+		Properties: []*models.Property{{Name: "title"}, nil},
+	})
+
+	for _, want := range []string{
+		helpers.BucketFromPropNameLSM("title"),
+		helpers.BucketSearchableFromPropNameLSM("title"),
+		helpers.BucketRangeableFromPropNameLSM("title"),
+		helpers.BucketFromPropNameLengthLSM("title"),
+		helpers.BucketFromPropNameNullLSM("title"),
+		helpers.BucketFromPropNameMetaCountLSM("title"),
+	} {
+		require.Truef(t, names[want], "%q is a live property's bucket and must be excluded", want)
+	}
+	require.False(t, names[helpers.BucketFromPropNameLSM("other")],
+		"a property the class does not have owns nothing")
+}
+
+// An unreadable class is told apart from a class with no properties, and the
+// sweep then behaves as it did before the guard. Failing closed instead would
+// leave the slate dirty for the next submit, which is the Sev 1 the sweep
+// exists to prevent; an unreadable class here means the class is going away.
+func TestTheLiveBucketGuardFailsOpenOnAnUnreadableClass(t *testing.T) {
+	require.Nil(t, mainBucketNamesOf(nil),
+		"an unreadable class has to be distinguishable from one with no properties")
+	require.NotNil(t, mainBucketNamesOf(&models.Class{Class: "Empty"}),
+		"a class with no properties is readable, and excludes nothing")
+
+	guard := &liveMainBuckets{built: true, names: mainBucketNamesOf(nil)}
+	require.False(t, guard.has(helpers.BucketFromPropNameLSM("anything")),
+		"with no class to consult the sweep goes ahead, as it did before the guard")
+}

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -478,8 +478,8 @@ func mainBucketForPropertyIndex(propName, indexType string) (string, bool) {
 // fresh main into __backup.
 //
 // Sidecar names are <mainBucket>__<strategy>_<role>[_<gen>]; see
-// [isSidecarDirOf] for why matching on the role word (not the whole suffix)
-// avoids reading a property's own name as a sidecar.
+// [isSidecarDirOf] for why the whole suffix has to come from the strategy
+// registry before a dir is read as a sidecar.
 //
 // In addition to removing the on-disk dirs, this function ALSO drops the
 // dir's entry from [lsmkv.GlobalBucketRegistry]. Background: a successful
@@ -539,44 +539,74 @@ func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preser
 	}
 }
 
-// sidecarRoleWords are the words every migration sidecar suffix ends in, once
-// the numeric generation tail is off. Keep in lockstep with the strategies'
-// ReindexSuffix / IngestSuffix / BackupSuffix; [TestEverySidecarSuffixIsASidecar]
-// pins that a new strategy either reuses one of these or extends the list.
-var sidecarRoleWords = schema.SidecarRoleWords
+// sidecarSuffixes are the whole suffixes a migration sidecar dir carries,
+// before [genSuffix] appends "_<gen>". Read out of the strategy registry
+// rather than listed by hand so a new strategy cannot add a suffix the sweep
+// fails to recognize; [TestEverySidecarSuffixIsASidecar] pins that.
+var sidecarSuffixes = buildSidecarSuffixes()
+
+func buildSidecarSuffixes() []string {
+	var suffixes []string
+	for _, indexType := range []string{"filterable", "searchable", "rangeable"} {
+		migDirs := migrationDirPrefixesForIndexType(indexType)
+		if classDir, ok := classLevelMigrationDirForIndexType(indexType); ok {
+			migDirs = append(migDirs, classDir)
+		}
+		for _, migDir := range migDirs {
+			if recipe := migrationSuffixes(migDir); recipe != nil {
+				suffixes = append(suffixes, recipe.ingestSuffix, recipe.backupSuffix)
+			}
+			if reindex := reindexSuffixForFinalize(migDir); reindex != "" {
+				suffixes = append(suffixes, reindex)
+			}
+		}
+	}
+	slices.Sort(suffixes)
+	return slices.Compact(suffixes)
+}
 
 // isSidecarDirOf reports whether name is a per-property sidecar of
 // mainBucketName. "__" alone isn't enough: property names may contain "__"
-// too, so "property_a__b" is "a__b"'s own main bucket, not a sidecar of "a"
-// — the trailing role word decides instead. Shared with
+// too, so "property_a__b" is "a__b"'s own main bucket, not a sidecar of "a".
+// The whole suffix has to be one the strategy registry can name, which is
+// what [sidecarDirsForOrphan] already requires of the audit path. Shared with
 // [hasStalePartialReindexState] for the same hydrate-or-skip decision.
 //
 // The dir a crashed [lsmkv.Store.ReplaceBuckets] leaves behind is matched by
-// whole name, since "del" is no migration role word. It is swept here because
+// whole name, since no strategy names "___del". It is swept here because
 // nothing else removes it, and it can never be preserved: the preserve set
 // holds migration suffixes only ([completedMigrationSidecarSuffixes]).
 //
-// Still too weak: a property named "a__<word>_<role>" (or "a___del") reads as
-// a sidecar of "a" on all three index types, so sweeping "a" deletes that
-// property's live bucket. Whole-suffix matching against [migrationSuffixes]
-// ([sidecarDirsForOrphan] does this) would close it without an on-disk
-// rename. weaviate/weaviate#12621
+// Residual, narrower than weaviate/weaviate#12621 but not closed by it: a
+// property literally named "a__blockmax_ingest" still reads as a sidecar of
+// "a". Only a check against the class's live properties closes that, and the
+// sweep would have to reach them without loading a shard.
 func isSidecarDirOf(name, mainBucketName string) bool {
 	if name == mainBucketName+lsmkv.ReplacedBucketDirSuffix {
 		return true
 	}
-	suffix, ok := strings.CutPrefix(name, mainBucketName+"__")
+	suffix, ok := strings.CutPrefix(name, mainBucketName)
 	if !ok {
 		return false
 	}
-	return slices.Contains(sidecarRoleWords, sidecarRoleWord(suffix))
+	return slices.Contains(sidecarSuffixes, trimGenSuffix(suffix))
 }
 
-// sidecarRoleWord returns a sidecar suffix's trailing word, ignoring the
-// "_<gen>" tail [genSuffix] appends. Shared with the property-name check that
-// refuses a name of this shape at creation time.
-func sidecarRoleWord(suffix string) string {
-	return schema.SidecarRoleWord(suffix)
+// trimGenSuffix drops the "_<gen>" tail [genSuffix] appends.
+//
+// Only an all-digit tail is dropped: a non-numeric tail is part of the
+// property's own name, not a generation. This also covers generation 0,
+// which a buggy writer could leave even though [parseMigrationDirName] only
+// accepts generations >= 1.
+func trimGenSuffix(suffix string) string {
+	if i := strings.LastIndexByte(suffix, '_'); i >= 0 && isAllDigits(suffix[i+1:]) {
+		return suffix[:i]
+	}
+	return suffix
+}
+
+func isAllDigits(s string) bool {
+	return s != "" && strings.TrimLeft(s, "0123456789") == ""
 }
 
 func (s *Shard) removeBucket(ctx context.Context, bucketName string) error {

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -173,6 +173,10 @@ func (s *Shard) updatePropertyBuckets(ctx context.Context,
 		// twice costs megabytes inside the RAFT apply.
 		props := &taskPropsCache{}
 		defer func() { payloadReads.Add(int64(props.count())) }()
+		// One live-property memo for the whole loop, for the same reason the
+		// tracker memo above is shared: the sweep runs once per disabled index
+		// type and each build is a schema read inside the RAFT apply.
+		live := s.liveMainBuckets()
 		for _, indexType := range disabledIndexTypes(prop) {
 			// The whole loop runs inside the RAFT apply, once per shard. Every
 			// shard still queued for it drops out here rather than walking its
@@ -188,7 +192,7 @@ func (s *Shard) updatePropertyBuckets(ctx context.Context,
 				return fmt.Errorf("cannot remove %s index for %s property: %w", indexType, prop.Name, err)
 			}
 			s.cleanStaleMigrationDirs(ctx, prop.Name, indexType, props)
-			s.cleanStaleSidecarDirs(mainBucket)
+			s.cleanStaleSidecarDirs(mainBucket, live)
 		}
 		return nil
 	})
@@ -386,6 +390,9 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 	})
 
 	props := &taskPropsCache{}
+	// Read at most once, and only if a name below matches: a sweep with
+	// nothing to remove must not pay a schema read.
+	live := s.liveMainBuckets()
 	// Preserve sidecars of completed-but-deferred migrations: they back the
 	// live in-memory bucket pointer; wiping them is #10675-shape data loss.
 	scope := migrationDirsOf(s.pathLSM(), nil, propName, indexType).cachingProps(props)
@@ -395,6 +402,13 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 	var shutDown []string
 	for bucketName := range loaded {
 		if !isSidecarDirOf(bucketName, mainBucketName) {
+			continue
+		}
+		// A name match alone cannot authorize a shutdown: this bucket may be
+		// a live property's own main bucket wearing a sidecar-shaped name.
+		if live.has(bucketName) {
+			logger.WithField("bucket", bucketName).
+				Warn("partial-reindex cleanup: keeping bucket that is a live property's own main bucket")
 			continue
 		}
 		// Skip live sidecar buckets backing a completed-but-deferred
@@ -424,7 +438,7 @@ func (s *Shard) CleanStalePartialReindexState(ctx context.Context, propName, ind
 	// Steps 2 + 3: remove sidecar dirs and migration dir. The helpers log
 	// per-directory removal failures rather than fail; preserved suffixes
 	// survive.
-	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, preserveSidecars)
+	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, preserveSidecars, live)
 	if err := cleanStaleMigrationDirsIn(ctx, scope, s.index.logger); err != nil {
 		return props.count(), err
 	}
@@ -496,15 +510,23 @@ func mainBucketForPropertyIndex(propName, indexType string) (string, bool) {
 // the same hazard if any ShutdownBucket call along the way was skipped);
 // belt-and-suspenders is the right posture for a leak that produces
 // "FAILED" status on a follow-up migration with no clear remediation.
-func (s *Shard) cleanStaleSidecarDirs(mainBucketName string) {
-	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, nil)
+func (s *Shard) cleanStaleSidecarDirs(mainBucketName string, live *liveMainBuckets) {
+	s.cleanStaleSidecarDirsWithPreserved(mainBucketName, nil, live)
 }
 
 // cleanStaleSidecarDirsWithPreserved removes matching sidecar dirs except
 // those in `preserveSidecars` (from [completedMigrationSidecarSuffixes]):
 // they back live completed-but-deferred migrations; wiping them is
 // #10675-shape silent data loss. Pass nil to wipe everything.
-func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preserveSidecars map[string]bool) {
+func (s *Shard) cleanStaleSidecarDirsWithPreserved(
+	mainBucketName string, preserveSidecars map[string]bool, live *liveMainBuckets,
+) {
+	if live == nil {
+		// A caller with no memo to share still gets the guard, never a nil
+		// dereference and never a silent hole: building one costs a single
+		// schema read, and only if a name below matches.
+		live = s.liveMainBuckets()
+	}
 	entries, err := os.ReadDir(s.pathLSM())
 	if err != nil {
 		s.index.logger.WithField("path", s.pathLSM()).
@@ -516,6 +538,13 @@ func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preser
 			continue
 		}
 		if !isSidecarDirOf(entry.Name(), mainBucketName) {
+			continue
+		}
+		// The name says sidecar; the class says whose dir it actually is.
+		// A live property's own main bucket is never this sweep's to remove.
+		if live.has(entry.Name()) {
+			s.index.logger.WithField("path", filepath.Join(s.pathLSM(), entry.Name())).
+				Warn("partial-reindex cleanup: keeping dir that is a live property's own main bucket")
 			continue
 		}
 		if suffix := strings.TrimPrefix(entry.Name(), mainBucketName); preserveSidecars[suffix] {
@@ -577,10 +606,12 @@ func buildSidecarSuffixes() []string {
 // nothing else removes it, and it can never be preserved: the preserve set
 // holds migration suffixes only ([completedMigrationSidecarSuffixes]).
 //
-// Residual, narrower than weaviate/weaviate#12621 but not closed by it: a
-// property literally named "a__blockmax_ingest" still reads as a sidecar of
-// "a". Only a check against the class's live properties closes that, and the
-// sweep would have to reach them without loading a shard.
+// The filename is all this sees, so it proposes and does not dispose: a
+// property literally named "a__blockmax_ingest" owns
+// "property_a__blockmax_ingest", which is byte-for-byte the name a sweep of
+// "a" looks for, and no rule over filenames can separate the two. Every
+// caller that goes on to shut down or remove what this matched has to put
+// the name past [liveMainBuckets.has] first. weaviate/weaviate#12621.
 func isSidecarDirOf(name, mainBucketName string) bool {
 	if name == mainBucketName+lsmkv.ReplacedBucketDirSuffix {
 		return true
@@ -590,6 +621,88 @@ func isSidecarDirOf(name, mainBucketName string) bool {
 		return false
 	}
 	return slices.Contains(sidecarSuffixes, trimGenSuffix(suffix))
+}
+
+// liveMainBuckets answers "is this dir a live property's own main bucket?"
+// for the length of one sweep.
+//
+// It is the half of the sidecar decision [isSidecarDirOf] cannot make: the
+// name match reads a dir's shape, this reads the class. Without it a class
+// holding a property named "a__blockmax_ingest" loses that property's data
+// the first time anything sweeps property "a", because the two names are
+// identical. weaviate/weaviate#12621.
+//
+// Built on first use, not at construction: a sweep that matches no sidecar —
+// the common case — never reads the schema, which keeps the DELETE path's
+// per-shard cost inside the RAFT apply where it was.
+type liveMainBuckets struct {
+	shard *Shard
+	names map[string]bool
+	built bool
+}
+
+func (s *Shard) liveMainBuckets() *liveMainBuckets {
+	return &liveMainBuckets{shard: s}
+}
+
+// has reports whether name is one of the class's live properties' own
+// buckets, and so is never this sweep's to shut down or remove.
+//
+// Fails open on a class it cannot read, logging once. Refusing to sweep is
+// not the safe side here: leaving the slate dirty is the Sev 1 this file's
+// header describes (the next submit short-circuits and reports success
+// against a partial bucket), while an unreadable class in these paths means
+// the class itself is going away, where removing its dirs is right anyway.
+func (l *liveMainBuckets) has(name string) bool {
+	if !l.built {
+		l.names = mainBucketNamesOf(l.shard.index.getClass())
+		l.built = true
+		if l.names == nil {
+			l.shard.index.logger.WithFields(map[string]any{
+				"shard": l.shard.Name(),
+				"class": l.shard.index.Config.ClassName.String(),
+			}).Error("partial-reindex cleanup: class not readable from the schema; " +
+				"sidecar sweep cannot exclude live properties' own main buckets")
+		}
+	}
+	return l.names[name]
+}
+
+// mainBucketNamesOf collects every LSM bucket name the class's properties
+// own. Returns nil, distinguishably from an empty set, for a class that
+// could not be read.
+//
+// Every name a property could own, not just the ones its current index
+// flags say exist: the guarantee wanted here is that no live property's
+// bucket is removed by a sidecar sweep, and a flag read at sweep time is a
+// weaker thing to rest that on than the property's existence.
+//
+// The cost is that a genuinely stale sidecar whose name collides with a live
+// property's bucket leaks instead of being removed. That is the safe side of
+// the name-collision family weaviate/weaviate#12574 tracks: a leaked dir
+// announces itself as "file exists" on the next swap, a deleted one is
+// silent data loss.
+func mainBucketNamesOf(class *models.Class) map[string]bool {
+	if class == nil {
+		return nil
+	}
+	names := make(map[string]bool, len(class.Properties)*6)
+	for _, prop := range class.Properties {
+		if prop == nil {
+			continue
+		}
+		for _, name := range []string{
+			helpers.BucketFromPropNameLSM(prop.Name),
+			helpers.BucketSearchableFromPropNameLSM(prop.Name),
+			helpers.BucketRangeableFromPropNameLSM(prop.Name),
+			helpers.BucketFromPropNameLengthLSM(prop.Name),
+			helpers.BucketFromPropNameNullLSM(prop.Name),
+			helpers.BucketFromPropNameMetaCountLSM(prop.Name),
+		} {
+			names[name] = true
+		}
+	}
+	return names
 }
 
 // trimGenSuffix drops the "_<gen>" tail [genSuffix] appends.


### PR DESCRIPTION
Fixes #12621. `isSidecarDirOf` matched a sidecar by its trailing role word, so another property's own bucket, `property_a__ingest`, read as a sidecar of `a` and the cleanup sweep removed it. `sidecarRoleWord` reached `category__data_ingest`, `category__x_reindex` and `category__ingest_2` the same way, on all three index types.

Now it matches the whole suffix, modulo the `_<gen>` tail, against what the strategy registry can name. `buildSidecarSuffixes` reads that set out of the registry instead of a hand-written list, so a new strategy doesn't need remembering. `sidecarRoleWord` becomes `trimGenSuffix`, and the `___del` dir a crashed `ReplaceBuckets` leaves behind still matches by whole name.

One thing this doesn't close: a property named exactly `a__blockmax_ingest` is still ambiguous with a real sidecar of `a`, since the two bucket names are identical and `PropertyNameRegex` admits it. That needs the class's live properties, the optional second step in #12621. It's pinned in the table test and named in the godoc.

`TestIsSidecarDirOfRejectsOtherPropertiesBuckets` had three cases pinning this as accepted; those flip, along with the rest of the issue's table, and the eight subtests fail before the change and pass after. `TestIsSidecarDirOfRejectsRoleWordPropertiesOnEveryIndexType` is new. `TestEverySidecarSuffixIsASidecar` is untouched and still green at generations 1 and 7, so nothing that was swept before is missed.

`go test -count 1 ./adapters/repos/db/` at base `837e1d8` has one failure, `TestListAndGetFilesWithIntegrityChecking`. It fails the same way on a clean checkout of that commit with this branch stashed, so it isn't mine.
