### PR TITLE
Bound backup status descriptor reads

### DIFF
--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -501,8 +501,11 @@ func (c *coordinator) OnStatus(ctx context.Context, store coordStore, req *Statu
 		filename = GlobalRestoreFile
 	}
 
-	// The backup might have been already created.
-	meta, err := store.Meta(ctx, filename, store.bucket, store.path)
+	// The backup might have been already created. Bounded read: a status poll
+	// must not hang for as long as the backend is unreachable.
+	readCtx, cancel := context.WithTimeout(ctx, metaReadTimeout)
+	defer cancel()
+	meta, err := store.Meta(readCtx, filename, store.bucket, store.path)
 	if err != nil {
 		path := st.Path
 		if errors.As(err, &backup.ErrNotFound{}) {

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -735,11 +735,11 @@ func TestSchedulerBackupStatusServesTheReasonOfAFailedBackup(t *testing.T) {
 	fs.client.On("Abort", mock.Anything, node, mock.Anything).Return(nil)
 	fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("bucket/" + backupID)
 	fs.backend.On("Initialize", ctx, backupID).Return(nil)
-	fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
+	fs.backend.On("GetObject", mock.Anything, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
 	// No backup under this id yet, then the descriptor written when the
 	// operation started, which is all the failed write leaves behind.
-	fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{}).Once()
-	fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).
+	fs.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{}).Once()
+	fs.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).
 		Return(marshalCoordinatorMeta(backup.DistributedBackupDescriptor{
 			ID: backupID, Status: backup.Started,
 		}), nil)

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -346,7 +346,10 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.Principal, verb string,
 	store coordStore, filename, overrideBucket, overridePath string,
 ) error {
-	meta, err := store.Meta(ctx, filename, overrideBucket, overridePath)
+	// Bounded: an unreachable backend must fail a status/cancel fast, not hang the request.
+	readCtx, cancel := context.WithTimeout(ctx, metaReadTimeout)
+	defer cancel()
+	meta, err := store.Meta(readCtx, filename, overrideBucket, overridePath)
 	if err != nil {
 		// A read concurrent with a write yields a partial file that fails to
 		// unmarshal; treat it as not-found so a mid-write status poll retries.
@@ -360,6 +363,9 @@ func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.P
 }
 
 const metaReadAttempts = 3
+
+// metaReadTimeout bounds descriptor reads on the status/authz paths; var for tests.
+var metaReadTimeout = 15 * time.Second
 
 // metaWithRetry reads the backup meta, retrying briefly on a partial file mid-write
 // (json.SyntaxError) so a class-scoped caller can resolve the real classes for a

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -364,7 +364,7 @@ func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.P
 
 const metaReadAttempts = 3
 
-// metaReadTimeout bounds descriptor reads on the status/authz paths; var for tests.
+// metaReadTimeout bounds descriptor reads on the status/authz paths.
 var metaReadTimeout = 15 * time.Second
 
 // metaWithRetry reads the backup meta, retrying briefly on a partial file mid-write

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -3079,25 +3079,54 @@ func TestRestoreIgnoresNodeMappingForUnknownNode(t *testing.T) {
 	}
 }
 
-// TestBackupStatusBoundedWhenBackendUnreachable pins that status polls fail fast instead of hanging with the backend down.
+// TestBackupStatusBoundedWhenBackendUnreachable pins that both descriptor reads
+// of a status poll — the authz read and the coordinator read — fail fast instead
+// of hanging with the backend down.
 func TestBackupStatusBoundedWhenBackendUnreachable(t *testing.T) {
 	old := metaReadTimeout
 	metaReadTimeout = 100 * time.Millisecond
 	defer func() { metaReadTimeout = old }()
-	fs := newFakeScheduler(nil)
-	fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("home/")
-	fs.backend.On("GetObject", mock.Anything, mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) { <-args.Get(0).(context.Context).Done() }).
-		Return(nil, errors.New("backend unreachable"))
-	s := fs.scheduler()
-
-	t0 := time.Now()
-	_, err := s.BackupStatus(context.Background(), nil, "s3", "bounded-status", "", "")
-	require.Error(t, err)
-	require.Less(t, time.Since(t0), 3*time.Second, "backup status must be bounded when the backend hangs")
-
-	t0 = time.Now()
-	_, err = s.RestorationStatus(context.Background(), nil, "s3", "bounded-status", "", "")
-	require.Error(t, err)
-	require.Less(t, time.Since(t0), 3*time.Second, "restore status must be bounded when the backend hangs")
+	id := "bounded-status"
+	authzMeta := marshalCoordinatorMeta(backup.DistributedBackupDescriptor{
+		StartedAt: time.Now().UTC(),
+		Nodes:     map[string]*backup.NodeDescriptor{"N1": {Classes: []string{"C1"}}},
+		Status:    backup.Success,
+	})
+	backupStatus := func(s *Scheduler) error {
+		_, err := s.BackupStatus(context.Background(), nil, "s3", id, "", "")
+		return err
+	}
+	restoreStatus := func(s *Scheduler) error {
+		_, err := s.RestorationStatus(context.Background(), nil, "s3", id, "", "")
+		return err
+	}
+	tests := []struct {
+		name      string
+		filename  string
+		authzMeta []byte
+		status    func(*Scheduler) error
+	}{
+		{"BackupAuthzReadBlocks", GlobalBackupFile, nil, backupStatus},
+		{"BackupCoordinatorReadBlocks", GlobalBackupFile, authzMeta, backupStatus},
+		{"RestoreAuthzReadBlocks", GlobalRestoreFile, nil, restoreStatus},
+		{"RestoreCoordinatorReadBlocks", GlobalRestoreFile, authzMeta, restoreStatus},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fs := newFakeScheduler(nil)
+			fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("home/")
+			if tc.authzMeta != nil {
+				fs.backend.On("GetObject", mock.Anything, id, tc.filename).Return(tc.authzMeta, nil).Once()
+			}
+			fs.backend.On("GetObject", mock.Anything, id, tc.filename).
+				Run(func(args mock.Arguments) { <-args.Get(0).(context.Context).Done() }).
+				Return(nil, errors.New("backend unreachable"))
+			fs.backend.On("GetObject", mock.Anything, id, BackupFile).Return(nil, backup.ErrNotFound{})
+			t0 := time.Now()
+			err := tc.status(fs.scheduler())
+			require.Error(t, err)
+			require.ErrorContains(t, err, "backend unreachable")
+			require.Less(t, time.Since(t0), 3*time.Second, "status must be bounded when the backend hangs")
+		})
+	}
 }

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -221,8 +221,8 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		// In-flight backup: meta has not yet been persisted, so the meta read
 		// that backs authorizeBackupByID returns ErrNotFound and is a no-op.
 		// OnStatus then short-circuits on lastOp.
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
-		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, BackupFile).Return(nil, backup.ErrNotFound{})
 		st, err := s.BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -239,8 +239,8 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		}
 		// A status poll racing an in-progress meta write reads a partial file
 		// that fails to unmarshal; authz must tolerate it so the poll succeeds.
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return([]byte("{"), nil)
-		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, GlobalBackupFile).Return([]byte("{"), nil)
+		fs.backend.On("GetObject", mock.Anything, id, BackupFile).Return(nil, backup.ErrNotFound{})
 		st, err := s.BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -255,8 +255,8 @@ func TestSchedulerBackupStatus(t *testing.T) {
 
 	t.Run("MetadataNotFound", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
-		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, BackupFile).Return(nil, backup.ErrNotFound{})
 
 		_, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.NotNil(t, err)
@@ -270,8 +270,8 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		// A transient/operational read failure propagates raw so the handler
 		// default arm maps it to 500 instead of misclassifying as 404.
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
-		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", mock.Anything, id, GlobalBackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", mock.Anything, id, BackupFile).Return(nil, ErrAny)
 
 		_, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.ErrorIs(t, err, ErrAny, "underlying backend error should propagate unwrapped")
@@ -293,7 +293,7 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		want.CompletedAt = completedAt
 		want.Status = backup.Success
 		want.Size = 2.5
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(bytes, nil)
+		fs.backend.On("GetObject", mock.Anything, id, GlobalBackupFile).Return(bytes, nil)
 		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		got, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
@@ -309,8 +309,8 @@ func TestSchedulerBackupStatus(t *testing.T) {
 				Status:      backup.Success,
 			},
 		)
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
-		fs.backend.On("GetObject", ctx, id, BackupFile).Return(bytes, nil)
+		fs.backend.On("GetObject", mock.Anything, id, GlobalBackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", mock.Anything, id, BackupFile).Return(bytes, nil)
 		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		got, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
 		require.ErrorIs(t, err, errLegacySingleNode)
@@ -346,7 +346,7 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 		// In-flight restore: meta has not yet been persisted, so the meta read
 		// that backs authorizeBackupByID returns ErrNotFound and is a no-op.
 		// OnStatus then short-circuits on lastOp.
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
 		st, err := s.RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -363,7 +363,7 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 		}
 		// A status poll racing an in-progress meta write reads a partial file
 		// that fails to unmarshal; authz must tolerate it so the poll succeeds.
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return([]byte("{"), nil)
+		fs.backend.On("GetObject", mock.Anything, id, GlobalRestoreFile).Return([]byte("{"), nil)
 		st, err := s.RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -378,7 +378,7 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 
 	t.Run("MetadataNotFound", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", mock.Anything, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
 		_, err := fs.scheduler().RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.NotNil(t, err)
 		nerr := backup.ErrNotFound{}
@@ -391,7 +391,7 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 		// A transient/operational read failure propagates raw so the handler
 		// default arm maps it to 500 instead of misclassifying as 404.
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", mock.Anything, id, GlobalRestoreFile).Return(nil, ErrAny)
 		_, err := fs.scheduler().RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.ErrorIs(t, err, ErrAny, "underlying backend error should propagate unwrapped")
 	})
@@ -403,7 +403,7 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 		want := want
 		want.CompletedAt = completedAt
 		want.Status = backup.Success
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(bytes, nil)
+		fs.backend.On("GetObject", mock.Anything, id, GlobalRestoreFile).Return(bytes, nil)
 		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		got, err := fs.scheduler().RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
@@ -3077,4 +3077,27 @@ func TestRestoreIgnoresNodeMappingForUnknownNode(t *testing.T) {
 			fs.client.AssertNotCalled(t, "CanCommit", mock.Anything, newNode, mock.Anything)
 		})
 	}
+}
+
+// TestBackupStatusBoundedWhenBackendUnreachable pins that status polls fail fast instead of hanging with the backend down.
+func TestBackupStatusBoundedWhenBackendUnreachable(t *testing.T) {
+	old := metaReadTimeout
+	metaReadTimeout = 100 * time.Millisecond
+	defer func() { metaReadTimeout = old }()
+	fs := newFakeScheduler(nil)
+	fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("home/")
+	fs.backend.On("GetObject", mock.Anything, mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) { <-args.Get(0).(context.Context).Done() }).
+		Return(nil, errors.New("backend unreachable"))
+	s := fs.scheduler()
+
+	t0 := time.Now()
+	_, err := s.BackupStatus(context.Background(), nil, "s3", "bounded-status", "", "")
+	require.Error(t, err)
+	require.Less(t, time.Since(t0), 3*time.Second, "backup status must be bounded when the backend hangs")
+
+	t0 = time.Now()
+	_, err = s.RestorationStatus(context.Background(), nil, "s3", "bounded-status", "", "")
+	require.Error(t, err)
+	require.Less(t, time.Since(t0), 3*time.Second, "restore status must be bounded when the backend hangs")
 }


### PR DESCRIPTION
## What

A backup/restore status GET reads the global descriptor from the backend twice — once for authorization scoping (`authorizeBackupByID`) and once in `coordinator.OnStatus` — with no deadline on either read. With the backend unreachable (network partition, S3 outage), every status poll hangs until the server write-timeout, for in-flight and completed backups alike. Measured live on a 3-node cluster with the backend paused: all status probes blocked past a 15s client timeout for the entire outage and recovered in 0.1s the moment the backend resumed.

## How

Both descriptor reads now run under a 15s bound (`metaReadTimeout`); on an unreachable backend the poll fails fast with the real error instead of hanging. In-flight ops on the coordinating node still answer from memory before any read, unchanged.

`TestBackupStatusBoundedWhenBackendUnreachable` pins it with a backend mock that blocks until ctx cancellation: without the bound the test hangs to the framework timeout; with it both status paths return in milliseconds. The three status tests that pinned `GetObject` to the literal request context now match it loosely — the wrapped deadline context no longer compares identical, and ctx identity was never what they pinned.

Found during the live battle test of #12815 (status polling through a paused-backend window); pre-existing on main and independent of that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

