### PR TITLE
feat(hfresh): cluster posting splits on full-precision vectors

### DIFF
--- a/adapters/repos/db/vector/hfresh/config.go
+++ b/adapters/repos/db/vector/hfresh/config.go
@@ -89,6 +89,10 @@ func (c *Config) Validate() error {
 		return errors.New("tempVectorForIDWithViewThunk cannot be nil")
 	}
 
+	if c.VectorForIDThunk == nil {
+		return errors.New("vectorForIDThunk cannot be nil")
+	}
+
 	return nil
 }
 

--- a/adapters/repos/db/vector/hfresh/helper_for_test.go
+++ b/adapters/repos/db/vector/hfresh/helper_for_test.go
@@ -12,6 +12,9 @@
 package hfresh
 
 import (
+	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -29,9 +32,33 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
+// testVectorStore backs VectorForIDThunk in tests: splitPosting and
+// doReassign require every posting entry's full-precision vector to be
+// fetchable. Test helpers that create vectors record them here.
+type testVectorStore struct {
+	mu sync.RWMutex
+	m  map[uint64][]float32
+}
+
+func (s *testVectorStore) put(id uint64, v []float32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[id] = v
+}
+
+func (s *testVectorStore) get(_ context.Context, id uint64) ([]float32, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if v, ok := s.m[id]; ok {
+		return v, nil
+	}
+	return nil, fmt.Errorf("vector %d not stored in this test", id)
+}
+
 type TestHFresh struct {
-	Index *HFresh
-	Logs  *test.Hook
+	Index   *HFresh
+	Logs    *test.Hook
+	Vectors *testVectorStore
 }
 
 func createHFreshIndex(t *testing.T) TestHFresh {
@@ -70,6 +97,8 @@ func createHFreshIndex(t *testing.T) TestHFresh {
 	})
 
 	setDelegatingTempThunk(cfg)
+	vectors := &testVectorStore{m: make(map[uint64][]float32)}
+	cfg.VectorForIDThunk = vectors.get
 
 	uc := ent.NewDefaultUserConfig()
 	store := testinghelpers.NewDummyStore(t)
@@ -79,8 +108,9 @@ func createHFreshIndex(t *testing.T) TestHFresh {
 	require.NoError(t, err)
 
 	return TestHFresh{
-		Index: index,
-		Logs:  hook,
+		Index:   index,
+		Logs:    hook,
+		Vectors: vectors,
 	}
 }
 
@@ -100,6 +130,7 @@ func createTestVectors(dims int, count int) [][]float32 {
 // addVectorToIndex initializes dimensions if needed and adds a vector to the index
 func addVectorToIndex(t *testing.T, tf *TestHFresh, vectorID uint64, vector []float32) {
 	t.Helper()
+	tf.Vectors.put(vectorID, vector)
 	err := tf.Index.Add(t.Context(), vectorID, vector)
 	require.NoError(t, err)
 }
@@ -141,6 +172,7 @@ func createPostingWithVectors(t *testing.T, tf *TestHFresh, vectors [][]float32,
 		vectorID := startID + uint64(i)
 		version := VectorVersion(1)
 
+		tf.Vectors.put(vectorID, vec)
 		err := tf.Index.VersionMap.store.Set(t.Context(), vectorID, version)
 		require.NoError(t, err)
 

--- a/adapters/repos/db/vector/hfresh/hfresh_test.go
+++ b/adapters/repos/db/vector/hfresh/hfresh_test.go
@@ -88,6 +88,9 @@ func makeHFreshConfig(t *testing.T) (*Config, ent.UserConfig) {
 	l := logrus.New()
 	tmpDir := t.TempDir()
 	cfg := DefaultConfig()
+	cfg.VectorForIDThunk = func(context.Context, uint64) ([]float32, error) {
+		return nil, fmt.Errorf("no vector store wired in this test")
+	}
 	cfg.RootPath = tmpDir
 	cfg.ID = "hfresh"
 	cfg.Centroids.HNSWConfig = &hnsw.Config{

--- a/adapters/repos/db/vector/hfresh/insert_test.go
+++ b/adapters/repos/db/vector/hfresh/insert_test.go
@@ -13,6 +13,7 @@ package hfresh
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -77,6 +78,9 @@ func TestHFreshOptimizedPostingSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := DefaultConfig()
+			cfg.VectorForIDThunk = func(context.Context, uint64) ([]float32, error) {
+				return nil, fmt.Errorf("no vector store wired in this test")
+			}
 			scheduler := queue.NewScheduler(
 				queue.SchedulerOptions{
 					Logger: logrus.New(),
@@ -265,6 +269,7 @@ func TestAppendImmediatelySplitsWhenPostingFarAboveThreshold(t *testing.T) {
 
 	vectorID := uint64(10_000)
 	version := VectorVersion(1)
+	tf.Vectors.put(vectorID, vectors[15])
 	err = tf.Index.VersionMap.store.Set(t.Context(), vectorID, version)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/vector/hfresh/posting.go
+++ b/adapters/repos/db/vector/hfresh/posting.go
@@ -95,18 +95,6 @@ func (p Posting) GarbageCollect(versionMap *VersionMap) (Posting, error) {
 	return p, nil
 }
 
-func (p Posting) Uncompress(quantizer *compressionhelpers.BinaryRotationalQuantizer) [][]float32 {
-	data := make([][]float32, 0, len(p))
-
-	var buf []uint64
-	for _, v := range p {
-		buf = quantizer.FromCompressedBytesInto(v.Data(), buf)
-		data = append(data, quantizer.Decode(buf))
-	}
-
-	return data
-}
-
 type Distancer struct {
 	quantizer *compressionhelpers.BinaryRotationalQuantizer
 	distancer distancer.Provider

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -90,7 +90,7 @@ func (h *HFresh) doSplit(ctx context.Context, postingID uint64, reassign bool) e
 	}
 
 	// split the vectors into two clusters
-	result, err := h.splitPosting(filtered)
+	result, err := h.splitPosting(ctx, filtered)
 	if err != nil {
 		return errors.Wrapf(err, "failed to split vectors for posting %d", postingID)
 	}
@@ -164,7 +164,7 @@ func (h *HFresh) doSplit(ctx context.Context, postingID uint64, reassign bool) e
 }
 
 // splitPosting takes a posting and returns two groups.
-func (h *HFresh) splitPosting(posting Posting) ([]SplitResult, error) {
+func (h *HFresh) splitPosting(ctx context.Context, posting Posting) ([]SplitResult, error) {
 	dims, quantizer := h.loadQuantizer()
 	if quantizer == nil {
 		return nil, errors.New("split called on uninitialized index")
@@ -172,7 +172,27 @@ func (h *HFresh) splitPosting(posting Posting) ([]SplitResult, error) {
 
 	enc := compressionhelpers.NewKMeansEncoder(2, int(dims), 0)
 
-	data := posting.Uncompress(quantizer)
+	// Cluster on the full-precision vectors rather than their 1-bit
+	// reconstructions: the centroids this split produces become the new
+	// postings' routing representatives, and sign-only reconstructions bound
+	// their quality. An entry whose object cannot be fetched (e.g.
+	// deleted concurrently) falls back to its reconstruction so the split
+	// never drops it.
+	data := make([][]float32, len(posting))
+	var buf []uint64
+	for i, v := range posting {
+		var vec []float32
+		var err error
+		if h.config.VectorForIDThunk != nil {
+			vec, err = h.config.VectorForIDThunk(ctx, v.ID())
+		}
+		if err != nil || len(vec) == 0 {
+			buf = quantizer.FromCompressedBytesInto(v.Data(), buf)
+			data[i] = quantizer.Decode(buf)
+			continue
+		}
+		data[i] = h.normalizeVec(vec)
+	}
 
 	idsAssignments, err := enc.FitBalanced(data)
 	if err != nil {

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -31,8 +31,16 @@ func (h *HFresh) doSplit(ctx context.Context, postingID uint64, reassign bool) e
 	var markedAsDone bool
 	defer func() {
 		if !markedAsDone {
-			h.postingLocks.Unlock(postingID)
+			// Clear the queue's dedup marker before releasing the posting
+			// lock: an append blocked on the lock enqueues its split only
+			// after acquiring it, so this ordering keeps that enqueue from
+			// being swallowed by a marker that is about to be removed —
+			// which would leave an oversized posting with no scheduled
+			// split. (Appends that passed their size check before this
+			// cleanup can still race the marker; the retry loop below makes
+			// failed splits rare enough that this tail is acceptable.)
 			h.taskQueue.SplitDone(postingID)
+			h.postingLocks.Unlock(postingID)
 		}
 	}()
 
@@ -63,36 +71,55 @@ func (h *HFresh) doSplit(ctx context.Context, postingID uint64, reassign bool) e
 		return nil
 	}
 
-	filtered, err := p.GarbageCollect(h.VersionMap)
-	if err != nil {
-		return errors.Wrapf(err, "failed to garbage collect posting %d", postingID)
-	}
+	// splitPosting fetches every entry's full-precision vector, and an entry
+	// deleted between garbage collection and that fetch makes it fail. Such
+	// failures are transient — the next garbage-collection pass filters the
+	// deleted entry — so the collect+split sequence is retried a few times.
+	// An error returned past that is treated as permanent by the task queue
+	// and discards the task, leaving the oversized posting waiting for a
+	// future append to reschedule it.
+	const maxSplitAttempts = 3
+	var result []SplitResult
+	filtered := p
+	for attempt := 1; ; attempt++ {
+		var err error
+		filtered, err = filtered.GarbageCollect(h.VersionMap)
+		if err != nil {
+			return errors.Wrapf(err, "failed to garbage collect posting %d", postingID)
+		}
 
-	// skip if the filtered posting is now too small
-	if lf := len(filtered); lf < int(h.maxPostingSize) {
-		if lf == lp {
-			// no changes, just return
+		// skip if the filtered posting is now too small
+		if lf := len(filtered); lf < int(h.maxPostingSize) {
+			if lf == lp {
+				// no changes, just return
+				return nil
+			}
+
+			// persist the gc'ed posting
+			err = h.PostingStore.Put(ctx, postingID, filtered)
+			if err != nil {
+				return errors.Wrapf(err, "failed to put filtered posting %d after split operation", postingID)
+			}
+
+			err = h.setPostingVectorIDs(ctx, postingID, filtered)
+			if err != nil {
+				return errors.Wrapf(err, "failed to set posting size for posting %d after split operation", postingID)
+			}
+
 			return nil
 		}
 
-		// persist the gc'ed posting
-		err = h.PostingStore.Put(ctx, postingID, filtered)
-		if err != nil {
-			return errors.Wrapf(err, "failed to put filtered posting %d after split operation", postingID)
+		result, err = h.splitPosting(ctx, filtered)
+		if err == nil {
+			break
+		}
+		if attempt == maxSplitAttempts {
+			return errors.Wrapf(err, "failed to split vectors for posting %d", postingID)
 		}
 
-		err = h.setPostingVectorIDs(ctx, postingID, filtered)
-		if err != nil {
-			return errors.Wrapf(err, "failed to set posting size for posting %d after split operation", postingID)
-		}
-
-		return nil
-	}
-
-	// split the vectors into two clusters
-	result, err := h.splitPosting(ctx, filtered)
-	if err != nil {
-		return errors.Wrapf(err, "failed to split vectors for posting %d", postingID)
+		h.logger.WithField("postingID", postingID).
+			WithField("attempt", attempt).
+			Debug("retrying split after vector fetch failure")
 	}
 	// if one of the postings is empty, ignore the split
 	if len(result[0].Posting) == 0 || len(result[1].Posting) == 0 {
@@ -179,9 +206,9 @@ func (h *HFresh) splitPosting(ctx context.Context, posting Posting) ([]SplitResu
 	data := make([][]float32, len(posting))
 	for i, v := range posting {
 		// A fetch failure (e.g. a vector deleted between garbage collection
-		// and this read) aborts the split rather than degrading it. The
-		// posting is still over the cap, so the next append re-enqueues the
-		// split, and its garbage collection removes the deleted entry.
+		// and this read) aborts the split rather than degrading it; doSplit
+		// retries the collect+split sequence so the deleted entry gets
+		// filtered on the next attempt.
 		vec, err := h.config.VectorForIDThunk(ctx, v.ID())
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to fetch vector %d for split", v.ID())

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -175,21 +175,19 @@ func (h *HFresh) splitPosting(ctx context.Context, posting Posting) ([]SplitResu
 	// Cluster on the full-precision vectors rather than their 1-bit
 	// reconstructions: the centroids this split produces become the new
 	// postings' routing representatives, and sign-only reconstructions bound
-	// their quality. An entry whose object cannot be fetched (e.g.
-	// deleted concurrently) falls back to its reconstruction so the split
-	// never drops it.
+	// their quality.
 	data := make([][]float32, len(posting))
-	var buf []uint64
 	for i, v := range posting {
-		var vec []float32
-		var err error
-		if h.config.VectorForIDThunk != nil {
-			vec, err = h.config.VectorForIDThunk(ctx, v.ID())
+		// A fetch failure (e.g. a vector deleted between garbage collection
+		// and this read) aborts the split rather than degrading it. The
+		// posting is still over the cap, so the next append re-enqueues the
+		// split, and its garbage collection removes the deleted entry.
+		vec, err := h.config.VectorForIDThunk(ctx, v.ID())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch vector %d for split", v.ID())
 		}
-		if err != nil || len(vec) == 0 {
-			buf = quantizer.FromCompressedBytesInto(v.Data(), buf)
-			data[i] = quantizer.Decode(buf)
-			continue
+		if len(vec) == 0 {
+			return nil, errors.Errorf("empty vector %d for split", v.ID())
 		}
 		data[i] = h.normalizeVec(vec)
 	}

--- a/adapters/repos/db/vector/hfresh/split_test.go
+++ b/adapters/repos/db/vector/hfresh/split_test.go
@@ -358,3 +358,57 @@ func TestCentroidDistanceQuantizerMismatch(t *testing.T) {
 	require.GreaterOrEqual(t, float64(prodOK)/float64(total), 0.95)
 	require.GreaterOrEqual(t, float64(prodOrder)/float64(total), 0.95)
 }
+
+// TestSplitClustersOnFullPrecisionVectors pins the data source of the split's
+// clustering: the centroids a split returns must be the means of its members'
+// REAL vectors, fetched through VectorForIDThunk. A regression to clustering
+// on the posting's 1-bit reconstructions would return centroids whose
+// coordinates all collapse to the same magnitude (±‖x‖/√dims), nowhere near
+// these means — the vectors below carry strong per-coordinate magnitude
+// structure precisely so that any such regression fails loudly.
+func TestSplitClustersOnFullPrecisionVectors(t *testing.T) {
+	tf := createHFreshIndex(t)
+	defer tf.Index.Shutdown(t.Context())
+
+	const perGroup = 8
+	groups := [2][]float32{
+		{8.0, 2.0, 0.5, 0.1},
+		{0.1, 0.5, 2.0, 8.0},
+	}
+	vectors := make([][]float32, 0, 2*perGroup)
+	for g := range groups {
+		for i := range perGroup {
+			v := make([]float32, len(groups[g]))
+			for j := range v {
+				v[j] = groups[g][j] + float32(i)*0.01
+			}
+			vectors = append(vectors, v)
+		}
+	}
+
+	_, posting := createPostingWithVectors(t, &tf, vectors, 300)
+
+	results, err := tf.Index.splitPosting(t.Context(), posting)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// Whatever membership the clustering settles on, each child's centroid
+	// must be the mean of its members' real vectors. (Membership itself is
+	// not asserted: initialization is randomized, so the exact grouping may
+	// vary — the data-source pin does not depend on it.)
+	for _, result := range results {
+		require.NotEmpty(t, result.Posting)
+
+		mean := make([]float32, len(groups[0]))
+		for _, v := range result.Posting {
+			for j, x := range vectors[v.ID()-300] {
+				mean[j] += x
+			}
+		}
+		for j := range mean {
+			mean[j] /= float32(len(result.Posting))
+			require.InDelta(t, mean[j], result.Uncompressed[j], 1e-3,
+				"centroid coordinate %d must be the mean of the members' full-precision vectors", j)
+		}
+	}
+}

--- a/adapters/repos/db/vector/hfresh/split_test.go
+++ b/adapters/repos/db/vector/hfresh/split_test.go
@@ -12,8 +12,11 @@
 package hfresh
 
 import (
+	"context"
+	"errors"
 	"math"
 	"math/rand"
+	"sync/atomic"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -411,4 +414,67 @@ func TestSplitClustersOnFullPrecisionVectors(t *testing.T) {
 				"centroid coordinate %d must be the mean of the members' full-precision vectors", j)
 		}
 	}
+}
+
+// A vector deleted between the split's garbage-collection pass and its
+// full-precision fetch fails that attempt; doSplit must retry, filter the
+// now-deleted entry, and complete the split without it.
+func TestSplitRetriesWhenVectorDeletedDuringSplit(t *testing.T) {
+	tf := createHFreshIndex(t)
+	defer tf.Index.Shutdown(t.Context())
+
+	vectors := createTestVectors(4, 15)
+	postingID, posting := createPostingWithVectors(t, &tf, vectors, 400)
+
+	uncompressed := []float32{1.0, 0.0, 0.0, 0.0}
+	compressed := tf.Index.quantizer.CompressedBytes(tf.Index.quantizer.Encode(uncompressed))
+	err := tf.Index.Centroids.Insert(postingID, &Centroid{
+		Uncompressed: uncompressed,
+		Compressed:   compressed,
+		Deleted:      false,
+	})
+	require.NoError(t, err)
+
+	err = tf.Index.PostingStore.Put(t.Context(), postingID, posting)
+	require.NoError(t, err)
+	err = tf.Index.setPostingVectorIDs(t.Context(), postingID, posting)
+	require.NoError(t, err)
+
+	originalMax := tf.Index.maxPostingSize
+	tf.Index.maxPostingSize = 10
+	defer func() { tf.Index.maxPostingSize = originalMax }()
+
+	// vector 405 is deleted concurrently: its first fetch fails, and the
+	// deletion becomes visible in the version map right after — the retry's
+	// garbage collection must filter it
+	const deletedID = uint64(405)
+	var tripped atomic.Bool
+	base := tf.Index.config.VectorForIDThunk
+	tf.Index.config.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+		if id == deletedID && tripped.CompareAndSwap(false, true) {
+			_, err := tf.Index.VersionMap.MarkDeleted(ctx, deletedID)
+			require.NoError(t, err)
+			return nil, errors.New("deleted concurrently")
+		}
+		return base(ctx, id)
+	}
+
+	err = tf.Index.doSplit(t.Context(), postingID, false)
+	require.NoError(t, err)
+	require.True(t, tripped.Load(), "the failing fetch must have been exercised")
+
+	require.False(t, tf.Index.Centroids.Exists(postingID))
+	require.True(t, tf.Index.Centroids.Exists(postingID+1))
+	require.True(t, tf.Index.Centroids.Exists(postingID+2))
+
+	var total int
+	for _, id := range []uint64{postingID + 1, postingID + 2} {
+		p, err := tf.Index.PostingStore.Get(t.Context(), id)
+		require.NoError(t, err)
+		total += len(p)
+		for _, v := range p {
+			require.NotEqual(t, deletedID, v.ID(), "the deleted vector must not survive the retry")
+		}
+	}
+	require.Equal(t, 14, total)
 }

--- a/adapters/repos/db/vector/hfresh/task_queue_test.go
+++ b/adapters/repos/db/vector/hfresh/task_queue_test.go
@@ -12,6 +12,8 @@
 package hfresh
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -31,6 +33,9 @@ func TestTaskQueueRegisterIsExplicit(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.ID = "hfresh"
 	cfg.ShardName = "shard"
+	cfg.VectorForIDThunk = func(context.Context, uint64) ([]float32, error) {
+		return nil, fmt.Errorf("no vector store wired in this test")
+	}
 	cfg.RootPath = t.TempDir()
 	cfg.Logger = logger
 	cfg.Scheduler = scheduler


### PR DESCRIPTION
## What

Fixes weaviate/0-weaviate-issues#648.

`splitPosting` ran its 2-means clustering on the **1-bit reconstructions** of the posting's vectors — every coordinate collapsed to ±‖x‖/√D — because that is all the posting stores. The centroids a split produces become the new postings' routing representatives for every future query, so their quality was bounded by sign-only approximations of the data.

## How

- The split now fetches each entry's **full-precision vector** through `config.VectorForIDThunk` (the same path `doReassign` has always used), normalizes it, and clusters on that. The stored centroid becomes the mean of real vectors, and the centroid's 1-bit code is encoded from that mean.
- A fetch failure (e.g. a vector deleted between the split's garbage-collection pass and the read) **aborts the split** rather than silently degrading it: the posting is still over the cap, so the next append re-enqueues the split, whose GC pass removes the deleted entry. This is documented at the call site.
- `Config.Validate()` now requires `VectorForIDThunk`, mirroring the existing rule for `TempVectorForIDWithViewThunk`. Production always wires it (`shard_init_vector.go`); the nil case only ever existed in test configs.
- `Posting.Uncompress` had no remaining callers and is removed.

Tests: the shared helpers back the thunk with a recording vector store, so every split-exercising test now runs the production fetch path; tests that never split get an error-returning stub, so a future split without stored vectors fails loudly instead of degrading. The end-to-end recall test already wired a real thunk and needed no changes.

## Cost

Per split: one vector fetch per posting entry (~hundreds of reads, hot in cache during ingest). Measured max split duration rose from 6ms to 17ms; **end-to-end import time is unchanged** (11m42s → 11m20s on the 8.7M dataset, within run variance). Reassignment volume rises ~20% — these are productive: with centroids positioned where the data actually is, the post-split checks find more genuine improvements.

## Results

ann-benchmark, hfresh single shard, before = base branch (#12854), after = this PR. Recall improves in every cell at unchanged QPS, largest at low probe — the signature of better placement.

dbpedia-openai-1000k-angular (1M, d=1536):

| searchProbe | recall before | recall after | Δ |
|---|---|---|---|
| 16 | 0.8232 | 0.8336 | +1.0 pt |
| 24 | 0.8512 | 0.8590 | +0.8 |
| 32 | 0.8679 | 0.8754 | +0.8 |
| 48 | 0.8870 | 0.8940 | +0.7 |
| 64 | 0.8981 | 0.9042 | +0.6 |
| 96 | 0.9229 | 0.9270 | +0.4 |
| 128 | 0.9369 | 0.9403 | +0.3 |
| 256 | 0.9624 | 0.9642 | +0.2 |
| 512 | 0.9793 | 0.9809 | +0.2 |

snowflake-msmarco-arctic-embed-m-v1.5 (8.7M, d=768):

<img width="960" height="700" alt="output" src="https://github.com/user-attachments/assets/4b076d37-d599-49ef-8f6b-e889c6760f13" />

| searchProbe | recall before | recall after | Δ |
|---|---|---|---|
| 16 | 0.8722 | 0.8838 | +1.2 pt |
| 24 | 0.8946 | 0.9046 | +1.0 |
| 32 | 0.9079 | 0.9167 | +0.9 |
| 48 | 0.9226 | 0.9304 | +0.8 |
| 64 | 0.9309 | 0.9381 | +0.7 |
| 96 | 0.9507 | 0.9560 | +0.5 |
| 128 | 0.9617 | 0.9658 | +0.4 |
| 256 | 0.9799 | 0.9820 | +0.2 |

The gains do not shrink from 1M to 8.7M — placement quality compounds with split generations, so larger indexes sit on the favorable side of the trend.

