### PR TITLE
fix(db): fail queries on a deregistered bucket instead of dereferencing nil

### DIFF
--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -42,6 +42,18 @@ func GetVectorsBucketName(targetVector string) string {
 	return VectorsBucketLSM
 }
 
+// MuveraBucketName is the bucket an HNSW index stores its MUVERA-encoded
+// vectors in, keyed by doc id.
+func MuveraBucketName(indexID string) string {
+	return indexID + "_muvera_vectors"
+}
+
+// MVMappingsBucketName is the bucket an HNSW index stores its multi-vector
+// node-id to doc-id mappings in.
+func MVMappingsBucketName(indexID string) string {
+	return indexID + "_mv_mappings"
+}
+
 func GetHNSWCommitLogDirName(targetVector string) string {
 	if targetVector != "" {
 		return fmt.Sprintf("%s.hnsw.commitlog.d", GetVectorsBucketName(targetVector))

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -772,10 +772,15 @@ func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard 
 		wrapper := func(object *storobj.Object) error {
 			return cb(i, shard, object)
 		}
-		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		// pinned for the whole iteration: the cursor underneath reads the
+		// bucket's segments, and an unpinned pointer can be shut down between
+		// the lookup and the scan
+		bucket, release := shard.Store().AcquireBucketForRead(helpers.ObjectsBucketLSM)
 		if bucket == nil {
 			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
 		}
+		defer release()
+
 		return bucket.IterateObjects(ctx, wrapper)
 	})
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -773,6 +773,9 @@ func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard 
 			return cb(i, shard, object)
 		}
 		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		if bucket == nil {
+			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
+		}
 		return bucket.IterateObjects(ctx, wrapper)
 	})
 }

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1542,7 +1542,11 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	for _, prop := range props {
 		propExtraction.Add(prop)
 		bucketName := t.reindexBucketName(prop)
-		bucketsByPropName[prop] = store.Bucket(bucketName)
+		bucket := store.Bucket(bucketName)
+		if bucket == nil {
+			return time.Time{}, false, fmt.Errorf("reindex bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
+		}
+		bucketsByPropName[prop] = bucket
 	}
 
 	breakCh := make(chan bool, 1)

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -2894,7 +2894,16 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 		// where data is parked in `b.flushing` invisible to the
 		// segment cursor — the original race that the
 		// flushAndSwitchMu lock was added to close.
-		cursor := shard.Store().Bucket(helpers.ObjectsBucketLSM).CursorOnDisk()
+		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		if bucket == nil {
+			startedCh <- time.Now()
+			mdCh <- &migrationData{err: fmt.Errorf("objects bucket of shard %q: %w",
+				shard.Name(), lsmkv.ErrBucketNotFound)}
+			close(mdCh)
+			return
+		}
+
+		cursor := bucket.CursorOnDisk()
 		defer cursor.Close()
 
 		startedCh <- time.Now() // after cursor created (necessary locks acquired)

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1539,10 +1539,24 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	store := shard.Store()
 	propExtraction := storobj.NewPropExtraction()
 	bucketsByPropName := map[string]*lsmkv.Bucket{}
+	// Every reindex bucket stays pinned while this chunk writes to it: the
+	// writes run long after the lookup, and an unpinned pointer can be shut
+	// down in between. The pins are dropped explicitly once the last write is
+	// durable — runtimePrepare below shuts these very buckets down, and
+	// Bucket.Shutdown waits on exactly these pins — with the defer as the
+	// backstop for the error paths in between.
+	var releaseBuckets []func()
+	releaseReindexBuckets := sync.OnceFunc(func() {
+		for _, release := range releaseBuckets {
+			release()
+		}
+	})
+	defer releaseReindexBuckets()
 	for _, prop := range props {
 		propExtraction.Add(prop)
 		bucketName := t.reindexBucketName(prop)
-		bucket := store.Bucket(bucketName)
+		bucket, release := store.AcquireBucketForRead(bucketName)
+		releaseBuckets = append(releaseBuckets, release)
 		if bucket == nil {
 			return time.Time{}, false, fmt.Errorf("reindex bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
 		}
@@ -1564,9 +1578,11 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	// the segment-only Cursor() the iteration uses, producing a
 	// per-replica `path = N/M` divergence on rows that were in flight
 	// at iteration start.
-	objectsBucket := store.Bucket(helpers.ObjectsBucketLSM)
+	objectsBucket, releaseObjectsBucket := store.AcquireBucketForRead(helpers.ObjectsBucketLSM)
 	if objectsBucket != nil {
-		if err = objectsBucket.FlushAndSwitch(); err != nil {
+		err = objectsBucket.FlushAndSwitch()
+		releaseObjectsBucket()
+		if err != nil {
 			err = fmt.Errorf("flushing objects bucket before reindex: %w", err)
 			return zerotime, false, err
 		}
@@ -1680,6 +1696,8 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 				return zerotime, false, err
 			}
 		}
+		releaseReindexBuckets()
+
 		if err = rt.markReindexed(); err != nil {
 			err = fmt.Errorf("marking reindexed: %w", err)
 			return zerotime, false, err
@@ -2898,7 +2916,11 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 		// where data is parked in `b.flushing` invisible to the
 		// segment cursor — the original race that the
 		// flushAndSwitchMu lock was added to close.
-		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		// pinned for the cursor's whole life: the segments it reads are
+		// mmap'd, and a teardown between this lookup and the last Next would
+		// unmap them underneath the scan
+		bucket, release := shard.Store().AcquireBucketForRead(helpers.ObjectsBucketLSM)
+		defer release()
 		if bucket == nil {
 			startedCh <- time.Now()
 			mdCh <- &migrationData{err: fmt.Errorf("objects bucket of shard %q: %w",

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -150,6 +150,9 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 		}
 		tempBucketName := helpers.TempBucketFromBucketName(bucketsToReindex[i])
 		tempBucket := r.shard.Store().Bucket(tempBucketName)
+		if tempBucket == nil {
+			return fmt.Errorf("temp bucket %q: %w", tempBucketName, lsmkv.ErrBucketNotFound)
+		}
 		tempBucket.FlushMemtable()
 		tempBucket.UpdateStatus(storagestate.StatusReadOnly)
 

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -149,12 +149,18 @@ func (r *ShardInvertedReindexer) doTask(ctx context.Context, task ShardInvertedR
 			return err
 		}
 		tempBucketName := helpers.TempBucketFromBucketName(bucketsToReindex[i])
-		tempBucket := r.shard.Store().Bucket(tempBucketName)
+		tempBucket, releaseTempBucket := r.shard.Store().AcquireBucketForRead(tempBucketName)
 		if tempBucket == nil {
 			return fmt.Errorf("temp bucket %q: %w", tempBucketName, lsmkv.ErrBucketNotFound)
 		}
 		tempBucket.FlushMemtable()
 		tempBucket.UpdateStatus(storagestate.StatusReadOnly)
+		// released before the rename/replace below: both take
+		// bucketAccessLock for write, and the store's order is
+		// bucketAccessLock OUTER -> lifetimeLock INNER. Holding the pin
+		// across them inverts it, which is exactly what the teardown
+		// invariant on AcquireBucketForRead exists to rule out.
+		releaseTempBucket()
 
 		if reindexProperties[i].NewIndex {
 			if err := r.shard.Store().RenameBucket(ctx, tempBucketName, bucketsToReindex[i]); err != nil {

--- a/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
+++ b/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 type shardInvertedReindexTaskMissingTextFilterable struct {
@@ -120,5 +122,11 @@ func (t *shardInvertedReindexTaskMissingTextFilterable) OnPostResumeStore(ctx co
 }
 
 func (t *shardInvertedReindexTaskMissingTextFilterable) ObjectsIterator(shard ShardLike) objectsIterator {
-	return shard.Store().Bucket(helpers.ObjectsBucketLSM).IterateObjects
+	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
+		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		if bucket == nil {
+			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
+		}
+		return bucket.IterateObjects(ctx, fn)
+	}
 }

--- a/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
+++ b/adapters/repos/db/inverted_reindexer_missing_text_filterable.go
@@ -123,10 +123,15 @@ func (t *shardInvertedReindexTaskMissingTextFilterable) OnPostResumeStore(ctx co
 
 func (t *shardInvertedReindexTaskMissingTextFilterable) ObjectsIterator(shard ShardLike) objectsIterator {
 	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
-		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		// pinned for the whole iteration: the cursor underneath reads the
+		// bucket's segments, and an unpinned pointer can be shut down between
+		// the lookup and the scan
+		bucket, release := shard.Store().AcquireBucketForRead(helpers.ObjectsBucketLSM)
 		if bucket == nil {
 			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
 		}
+		defer release()
+
 		return bucket.IterateObjects(ctx, fn)
 	}
 }

--- a/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
+++ b/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
@@ -80,10 +80,15 @@ func (t *ShardInvertedReindexTaskSetToRoaringSet) OnPostResumeStore(ctx context.
 
 func (t *ShardInvertedReindexTaskSetToRoaringSet) ObjectsIterator(shard ShardLike) objectsIterator {
 	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
-		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		// pinned for the whole iteration: the cursor underneath reads the
+		// bucket's segments, and an unpinned pointer can be shut down between
+		// the lookup and the scan
+		bucket, release := shard.Store().AcquireBucketForRead(helpers.ObjectsBucketLSM)
 		if bucket == nil {
 			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
 		}
+		defer release()
+
 		return bucket.IterateObjects(ctx, fn)
 	}
 }

--- a/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
+++ b/adapters/repos/db/inverted_reindexer_set_to_roaringset.go
@@ -13,10 +13,12 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 type ShardInvertedReindexTaskSetToRoaringSet struct{}
@@ -77,5 +79,11 @@ func (t *ShardInvertedReindexTaskSetToRoaringSet) OnPostResumeStore(ctx context.
 }
 
 func (t *ShardInvertedReindexTaskSetToRoaringSet) ObjectsIterator(shard ShardLike) objectsIterator {
-	return shard.Store().Bucket(helpers.ObjectsBucketLSM).IterateObjects
+	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
+		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		if bucket == nil {
+			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
+		}
+		return bucket.IterateObjects(ctx, fn)
+	}
 }

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -136,11 +136,14 @@ func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLik
 
 	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
 		// resolved per call, not once at wiring time: a teardown between the
-		// two would leave this closure holding a bucket that no longer exists
-		objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		// two would leave this closure holding a bucket that no longer exists.
+		// Pinned for the whole cursor, so a teardown starting mid-scan waits
+		// rather than unmapping the segments the cursor reads.
+		objectsBucket, release := shard.Store().AcquireBucketForRead(helpers.ObjectsBucketLSM)
 		if objectsBucket == nil {
 			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
 		}
+		defer release()
 
 		cursor := objectsBucket.Cursor()
 		defer cursor.Close()

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -134,8 +134,14 @@ func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLik
 		PropertyPaths: propertyPaths,
 	}
 
-	objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
 	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
+		// resolved per call, not once at wiring time: a teardown between the
+		// two would leave this closure holding a bucket that no longer exists
+		objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
+		if objectsBucket == nil {
+			return fmt.Errorf("objects bucket of shard %q: %w", shard.Name(), lsmkv.ErrBucketNotFound)
+		}
+
 		cursor := objectsBucket.Cursor()
 		defer cursor.Close()
 		className, err := objectsBucket.ClassName()

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -646,7 +646,12 @@ type BucketConsistentView struct {
 	Bucket   *Bucket
 }
 
+// ReleaseView is a no-op on the zero view, which the query paths hand out
+// when the store no longer holds the bucket.
 func (cv BucketConsistentView) ReleaseView() {
+	if cv.release == nil {
+		return
+	}
 	cv.release()
 }
 

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -115,6 +115,30 @@ func (s *Store) AcquireBucketForRead(name string) (*Bucket, func()) {
 	return b, b.lifetimeLock.RUnlock
 }
 
+// AcquireBucketConsistentViewForRead returns a consistent view of the named
+// bucket with the bucket itself pinned for the view's whole lifetime:
+// [BucketConsistentView.ReleaseView] drops the segment references and the
+// lifetime pin together, so a concurrent [Bucket.Shutdown] cannot unmap the
+// segments the view still points at.
+//
+// A name the store no longer holds yields the zero view. Its Bucket field is
+// nil — callers that need to report the miss check it — and releasing it is a
+// no-op.
+func (s *Store) AcquireBucketConsistentViewForRead(name string) BucketConsistentView {
+	bucket, release := s.AcquireBucketForRead(name)
+	if bucket == nil {
+		return BucketConsistentView{}
+	}
+
+	view := bucket.GetConsistentView()
+	releaseSegments := view.release
+	view.release = func() {
+		releaseSegments()
+		release()
+	}
+	return view
+}
+
 func (s *Store) UpdateBucketsStatus(targetStatus storagestate.Status) error {
 	s.closeLock.RLock()
 	defer s.closeLock.RUnlock()

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -669,7 +669,7 @@ func (s *Shard) reportTornStoreAccess(err error) {
 		"action": "objects_bucket_missing",
 		"class":  s.index.Config.ClassName.String(),
 		"shard":  s.name,
-	}).Warnf("mutation reached a torn-down store, a teardown drain was outrun, %v", err)
+	}).Warnf("request reached a torn-down store, a teardown drain was outrun, %v", err)
 }
 
 // ObjectCount returns the exact count at any moment

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -648,16 +648,19 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 	return err
 }
 
-// objectsBucket returns the shard's objects bucket, or an error once the store
-// is torn down
-func (s *Shard) objectsBucket() (*lsmkv.Bucket, error) {
-	b := s.store.Bucket(helpers.ObjectsBucketLSM)
+// objectsBucket returns the shard's objects bucket pinned for the caller's
+// operation, or an error once the store is torn down. The release closure is
+// always non-nil and must be called exactly once: it drops the lifetime pin
+// that keeps a concurrent [lsmkv.Bucket.Shutdown] from unmapping the segments
+// the operation is reading.
+func (s *Shard) objectsBucket() (*lsmkv.Bucket, func(), error) {
+	b, release := s.store.AcquireBucketForRead(helpers.ObjectsBucketLSM)
 	if b == nil {
 		err := fmt.Errorf("objects bucket of shard %q: %w", s.name, lsmkv.ErrBucketNotFound)
 		s.reportTornStoreAccess(err)
-		return nil, err
+		return nil, release, err
 	}
-	return b, nil
+	return b, release, nil
 }
 
 // reportTornStoreAccess makes an outrun drain visible

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -16,6 +16,7 @@ package db
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -317,4 +318,58 @@ func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, reports, "an outrun drain must be reported exactly once per shard")
+}
+
+// TestInFlightObjectReadHoldsOffBucketTeardown is the read matrix's mirror
+// image. The matrix covers the read that arrives once teardown has finished,
+// which only exercises the nil-bucket guards. This covers the read that
+// resolved its bucket first: the lifetime pin it holds must make
+// Bucket.Shutdown wait, because a teardown that ran anyway would unmap the
+// segments the read is still in.
+func TestInFlightObjectReadHoldsOffBucketTeardown(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	_, shard := loadTestShard(t, index)
+
+	reading := make(chan struct{})
+	resume := make(chan struct{})
+	iterated := make(chan error, 1)
+
+	go func() {
+		var once sync.Once
+		iterated <- index.IterateObjects(context.Background(),
+			func(*Index, ShardLike, *storobj.Object) error {
+				once.Do(func() {
+					close(reading)
+					<-resume
+				})
+				return nil
+			})
+	}()
+
+	select {
+	case <-reading:
+	case err := <-iterated:
+		t.Fatalf("iteration finished without reading an object: %v", err)
+	}
+
+	torn := make(chan error, 1)
+	go func() { torn <- shard.store.Shutdown(context.Background()) }()
+
+	select {
+	case err := <-torn:
+		t.Fatalf("teardown completed while a read still held the objects bucket: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(resume)
+	require.NoError(t, <-iterated)
+
+	select {
+	case err := <-torn:
+		require.NoError(t, err)
+	case <-time.After(time.Minute):
+		t.Fatal("teardown never completed after the read released its pin")
+	}
 }

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -26,7 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
@@ -196,6 +200,55 @@ func TestObjectReadsAfterStoreTeardownReturnErrors(t *testing.T) {
 		},
 		"multi vector by doc id": func() error {
 			_, err := shard.multiVectorByIndexID(context.Background(), 0, "")
+			return err
+		},
+		"object by id": func() error {
+			_, err := shard.ObjectByID(context.Background(), id, nil, additional.Properties{})
+			return err
+		},
+		"multi object by id": func() error {
+			_, err := shard.MultiObjectByID(context.Background(), []multi.Identifier{{ID: id.String()}})
+			return err
+		},
+		"multi object raw by id": func() error {
+			_, err := shard.MultiObjectRawByID(context.Background(), []strfmt.UUID{id})
+			return err
+		},
+		"object digests": func() error {
+			_, err := shard.ObjectDigests(context.Background(), []multi.Identifier{{ID: id.String()}})
+			return err
+		},
+		"compare digests": func() error {
+			_, err := shard.CompareDigests(context.Background(),
+				[]types.RepairDigest{{ID: uuid.MustParse(id.String())}})
+			return err
+		},
+		"object by doc id with props": func() error {
+			_, err := shard.objectByIndexIDWithProps(context.Background(), 0, nil)
+			return err
+		},
+		"uuid from doc id": func() error {
+			_, err := shard.uuidFromDocID(0)
+			return err
+		},
+		"object list": func() error {
+			_, err := shard.ObjectList(context.Background(), 10, nil, nil, additional.Properties{},
+				shard.index.Config.ClassName)
+			return err
+		},
+		"cursor object list": func() error {
+			_, err := shard.cursorObjectList(context.Background(), &filters.Cursor{Limit: 10},
+				additional.Properties{}, shard.index.Config.ClassName)
+			return err
+		},
+		"was deleted": func() error {
+			_, _, err := shard.WasDeleted(context.Background(), id)
+			return err
+		},
+		"object vector search": func() error {
+			_, _, err := shard.ObjectVectorSearch(context.Background(),
+				[]models.Vector{[]float32{1, 2, 3, 4}}, []string{""}, 0, 10, nil, nil, nil,
+				additional.Properties{}, nil, nil)
 			return err
 		},
 	}

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -162,6 +162,55 @@ func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
 	require.True(t, warned, "a drop that outran its drain must be logged, not silent")
 }
 
+// TestObjectReadsAfterStoreTeardownReturnErrors is the read-side sibling: a
+// query outliving the drain reads the objects bucket through the same
+// deregistered-bucket window. The bucket view has no error to return, so it
+// yields the zero view and the reads taken against it fail individually.
+func TestObjectReadsAfterStoreTeardownReturnErrors(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	_, shard := loadTestShard(t, index)
+	require.NoError(t, shard.store.Shutdown(context.Background()))
+
+	obj, _ := dropTestObject(nil)
+	id := obj.ID()
+
+	reads := map[string]func() error{
+		"exists": func() error {
+			_, err := shard.Exists(context.Background(), id)
+			return err
+		},
+		"object digest": func() error {
+			_, err := shard.ObjectDigestErrDeleted(context.Background(), id)
+			return err
+		},
+		"object digests in range": func() error {
+			end := strfmt.UUID(uuid.Max.String())
+			_, err := shard.ObjectDigestsInRange(context.Background(), id, end, 10)
+			return err
+		},
+		"vector by doc id": func() error {
+			_, err := shard.vectorByIndexID(context.Background(), 0, "")
+			return err
+		},
+		"multi vector by doc id": func() error {
+			_, err := shard.multiVectorByIndexID(context.Background(), 0, "")
+			return err
+		},
+	}
+
+	for name, read := range reads {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, read(), lsmkv.ErrBucketNotFound)
+		})
+	}
+
+	t.Run("releasing the zero bucket view", func(t *testing.T) {
+		require.NotPanics(t, func() { shard.GetObjectsBucketView().ReleaseView() })
+	})
+}
+
 // TestObjectWritesAfterStoreTeardownReturnErrors covers the backstop: a write
 // outliving the drain must fail on the deregistered bucket rather than
 // dereference nil, and must be reported once.
@@ -210,7 +259,7 @@ func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
 
 	var reports int
 	for _, e := range hook.AllEntries() {
-		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "mutation reached a torn-down store") {
+		if e.Level == logrus.WarnLevel && strings.Contains(e.Message, "request reached a torn-down store") {
 			reports++
 		}
 	}

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -547,7 +547,11 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 			return err
 		}
 
-		if actualStrategy := s.store.Bucket(bucketName).Strategy(); actualStrategy == lsmkv.StrategyInverted {
+		bucket := s.store.Bucket(bucketName)
+		if bucket == nil {
+			return fmt.Errorf("searchable bucket %q of shard %q: %w", bucketName, s.name, lsmkv.ErrBucketNotFound)
+		}
+		if actualStrategy := bucket.Strategy(); actualStrategy == lsmkv.StrategyInverted {
 			s.markSearchableBlockmaxProperties(prop.Name)
 		}
 	}

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -547,11 +547,13 @@ func (s *Shard) createPropertyValueIndex(ctx context.Context, prop *models.Prope
 			return err
 		}
 
-		bucket := s.store.Bucket(bucketName)
+		bucket, release := s.store.AcquireBucketForRead(bucketName)
 		if bucket == nil {
 			return fmt.Errorf("searchable bucket %q of shard %q: %w", bucketName, s.name, lsmkv.ErrBucketNotFound)
 		}
-		if actualStrategy := bucket.Strategy(); actualStrategy == lsmkv.StrategyInverted {
+		actualStrategy := bucket.Strategy()
+		release()
+		if actualStrategy == lsmkv.StrategyInverted {
 			s.markSearchableBlockmaxProperties(prop.Name)
 		}
 	}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -80,7 +80,10 @@ func (s *Shard) ObjectByID(ctx context.Context, id strfmt.UUID, props search.Sel
 		return nil, err
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 
 	className, err := bucket.ClassName()
 	if err != nil {
@@ -118,7 +121,10 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 		ids[i] = idBytes
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 
 	className, err := bucket.ClassName()
 	if err != nil {
@@ -156,7 +162,10 @@ func (s *Shard) MultiObjectRawByID(ctx context.Context, ids []strfmt.UUID) ([][]
 	s.activityTrackerRead.Add(1)
 	out := make([][]byte, len(ids))
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 	for i, id := range ids {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -187,7 +196,10 @@ func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]
 	// Replication-internal operation: do not count as user read activity.
 	objects := make([]types.RepairResponse, len(query))
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 	for i, q := range query {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -295,7 +307,10 @@ func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.Repair
 		return nil, nil
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 
 	firstUUID := sourceDigests[0].ID
 	lastUUID := sourceDigests[len(sourceDigests)-1].ID
@@ -383,7 +398,10 @@ func (s *Shard) objectByIndexIDWithProps(ctx context.Context, indexID uint64,
 	keyBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(keyBuf, indexID)
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 
 	className, err := bucket.ClassName()
 	if err != nil {
@@ -819,7 +837,10 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors []models.V
 
 	beforeObjects := time.Now()
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, nil, err
+	}
 	objs, err := storobj.ObjectsByDocID(bucket, idsCombined, additional, properties, s.index.logger)
 	if err != nil {
 		return nil, nil, err
@@ -843,7 +864,10 @@ func (s *Shard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, 
 			return nil, err
 		}
 		helpers.AnnotateSlowQueryLog(ctx, "sort_took", time.Since(beforeSort))
-		bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+		bucket, err := s.objectsBucket()
+		if err != nil {
+			return nil, err
+		}
 
 		beforeObjects := time.Now()
 		defer func() {
@@ -863,7 +887,10 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor,
 	additional additional.Properties,
 	className schema.ClassName,
 ) ([]*storobj.Object, error) {
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
 
 	bucketClassName, err := bucket.ClassName()
 	if err != nil {
@@ -949,9 +976,9 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 }
 
 func (s *Shard) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
-	if bucket == nil {
-		return "", errors.Errorf("objects bucket not found")
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return "", err
 	}
 
 	docIDBytes := make([]byte, 8)
@@ -1059,6 +1086,9 @@ func (s *Shard) WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time
 		return false, time.Time{}, err
 	}
 
-	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return false, time.Time{}, err
+	}
 	return bucket.WasDeleted(idBytes)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -50,7 +50,12 @@ func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (typ
 		return types.RepairResponse{}, err
 	}
 
-	bytes, err := s.store.Bucket(helpers.ObjectsBucketLSM).GetErrDeleted(idBytes)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return types.RepairResponse{}, err
+	}
+
+	bytes, err := bucket.GetErrDeleted(idBytes)
 	if err != nil {
 		return types.RepairResponse{}, err
 	}
@@ -229,9 +234,14 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 		return nil, fmt.Errorf("invalid final UUID %q: %w", finalUUID, err)
 	}
 
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
+
 	// Digest mode: only the header is read below, so skip the full value copy.
-	cursor := s.store.Bucket(helpers.ObjectsBucketLSM).
-		CursorReplaceDigestReusableRange(storobj.MarshallerV1HeaderLen, initialUUID16[:], finalUUID16[:])
+	cursor := bucket.CursorReplaceDigestReusableRange(
+		storobj.MarshallerV1HeaderLen, initialUUID16[:], finalUUID16[:])
 	defer cursor.Close()
 
 	return collectObjectDigests(ctx, cursor, initialUUID16[:], finalUUID16[:], limit)
@@ -344,7 +354,12 @@ func (s *Shard) Exists(ctx context.Context, id strfmt.UUID) (bool, error) {
 		return false, err
 	}
 
-	bytes, err := s.store.Bucket(helpers.ObjectsBucketLSM).Get(idBytes)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return false, err
+	}
+
+	bytes, err := bucket.Get(idBytes)
 	if err != nil {
 		return false, errors.Wrap(err, "read request")
 	}
@@ -410,8 +425,12 @@ func (s *Shard) multiVectorByIndexID(ctx context.Context, indexID uint64, target
 func (s *Shard) readMultiVectorByIndexIDIntoSlice(ctx context.Context, indexID uint64, container *common.VectorSlice, targetVector string) ([][]float32, error) {
 	binary.LittleEndian.PutUint64(container.Buff8, indexID)
 
-	bytes, newBuff, err := s.store.Bucket(helpers.ObjectsBucketLSM).
-		GetBySecondaryWithBuffer(ctx, 0, container.Buff8, container.Buff)
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, err
+	}
+
+	bytes, newBuff, err := bucket.GetBySecondaryWithBuffer(ctx, 0, container.Buff8, container.Buff)
 	if err != nil {
 		return nil, err
 	}
@@ -435,8 +454,17 @@ func (s *Shard) readMultiVectorByIndexIDIntoSlice(ctx context.Context, indexID u
 
 // GetObjectsBucketView returns a consistent view of the objects bucket that can
 // be reused for multiple reads without acquiring locks for each read.
+//
+// On a torn-down store it returns the zero view instead of failing: the thunk
+// signature every vector index shares has no error to report, so the reads
+// taken against the view fail individually (they check the view's bucket)
+// while releasing the zero view stays a no-op.
 func (s *Shard) GetObjectsBucketView() common.BucketView {
-	return s.store.Bucket(helpers.ObjectsBucketLSM).GetConsistentView()
+	bucket, err := s.objectsBucket()
+	if err != nil {
+		return lsmkv.BucketConsistentView{}
+	}
+	return bucket.GetConsistentView()
 }
 
 func (s *Shard) readVectorByIndexIDIntoSliceWithView(ctx context.Context, indexID uint64, container *common.VectorSlice, targetVector string, view common.BucketView) ([]float32, error) {
@@ -445,6 +473,9 @@ func (s *Shard) readVectorByIndexIDIntoSliceWithView(ctx context.Context, indexI
 	bucketView, ok := view.(lsmkv.BucketConsistentView)
 	if !ok {
 		return nil, fmt.Errorf("invalid view type: expected BucketConsistentView, got %T", view)
+	}
+	if bucketView.Bucket == nil {
+		return nil, fmt.Errorf("objects bucket of shard %q: %w", s.name, lsmkv.ErrBucketNotFound)
 	}
 
 	bytes, newBuff, err := bucketView.Bucket.
@@ -476,6 +507,9 @@ func (s *Shard) readMultiVectorByIndexIDIntoSliceWithView(ctx context.Context, i
 	bucketView, ok := view.(lsmkv.BucketConsistentView)
 	if !ok {
 		return nil, fmt.Errorf("invalid view type: expected BucketConsistentView, got %T", view)
+	}
+	if bucketView.Bucket == nil {
+		return nil, fmt.Errorf("objects bucket of shard %q: %w", s.name, lsmkv.ErrBucketNotFound)
 	}
 
 	bytes, newBuff, err := bucketView.Bucket.GetBySecondaryWithBufferAndView(ctx, 0, container.Buff8, container.Buff, bucketView)

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -50,10 +50,11 @@ func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (typ
 		return types.RepairResponse{}, err
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return types.RepairResponse{}, err
 	}
+	defer release()
 
 	bytes, err := bucket.GetErrDeleted(idBytes)
 	if err != nil {
@@ -80,10 +81,11 @@ func (s *Shard) ObjectByID(ctx context.Context, id strfmt.UUID, props search.Sel
 		return nil, err
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	className, err := bucket.ClassName()
 	if err != nil {
@@ -121,10 +123,11 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 		ids[i] = idBytes
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	className, err := bucket.ClassName()
 	if err != nil {
@@ -162,10 +165,11 @@ func (s *Shard) MultiObjectRawByID(ctx context.Context, ids []strfmt.UUID) ([][]
 	s.activityTrackerRead.Add(1)
 	out := make([][]byte, len(ids))
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	for i, id := range ids {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -196,10 +200,11 @@ func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]
 	// Replication-internal operation: do not count as user read activity.
 	objects := make([]types.RepairResponse, len(query))
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	for i, q := range query {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -246,10 +251,11 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 		return nil, fmt.Errorf("invalid final UUID %q: %w", finalUUID, err)
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	// Digest mode: only the header is read below, so skip the full value copy.
 	cursor := bucket.CursorReplaceDigestReusableRange(
@@ -307,10 +313,11 @@ func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.Repair
 		return nil, nil
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	firstUUID := sourceDigests[0].ID
 	lastUUID := sourceDigests[len(sourceDigests)-1].ID
@@ -369,10 +376,11 @@ func (s *Shard) Exists(ctx context.Context, id strfmt.UUID) (bool, error) {
 		return false, err
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return false, err
 	}
+	defer release()
 
 	bytes, err := bucket.Get(idBytes)
 	if err != nil {
@@ -398,10 +406,11 @@ func (s *Shard) objectByIndexIDWithProps(ctx context.Context, indexID uint64,
 	keyBuf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(keyBuf, indexID)
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	className, err := bucket.ClassName()
 	if err != nil {
@@ -443,10 +452,11 @@ func (s *Shard) multiVectorByIndexID(ctx context.Context, indexID uint64, target
 func (s *Shard) readMultiVectorByIndexIDIntoSlice(ctx context.Context, indexID uint64, container *common.VectorSlice, targetVector string) ([][]float32, error) {
 	binary.LittleEndian.PutUint64(container.Buff8, indexID)
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	bytes, newBuff, err := bucket.GetBySecondaryWithBuffer(ctx, 0, container.Buff8, container.Buff)
 	if err != nil {
@@ -471,18 +481,21 @@ func (s *Shard) readMultiVectorByIndexIDIntoSlice(ctx context.Context, indexID u
 }
 
 // GetObjectsBucketView returns a consistent view of the objects bucket that can
-// be reused for multiple reads without acquiring locks for each read.
+// be reused for multiple reads without acquiring locks for each read. The
+// bucket stays pinned until ReleaseView, so a teardown that starts while the
+// view is in flight waits for it rather than unmapping the segments under it.
 //
 // On a torn-down store it returns the zero view instead of failing: the thunk
 // signature every vector index shares has no error to report, so the reads
 // taken against the view fail individually (they check the view's bucket)
 // while releasing the zero view stays a no-op.
 func (s *Shard) GetObjectsBucketView() common.BucketView {
-	bucket, err := s.objectsBucket()
-	if err != nil {
-		return lsmkv.BucketConsistentView{}
+	view := s.store.AcquireBucketConsistentViewForRead(helpers.ObjectsBucketLSM)
+	if view.Bucket == nil {
+		s.reportTornStoreAccess(fmt.Errorf("objects bucket of shard %q: %w",
+			s.name, lsmkv.ErrBucketNotFound))
 	}
-	return bucket.GetConsistentView()
+	return view
 }
 
 func (s *Shard) readVectorByIndexIDIntoSliceWithView(ctx context.Context, indexID uint64, container *common.VectorSlice, targetVector string, view common.BucketView) ([]float32, error) {
@@ -837,10 +850,11 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors []models.V
 
 	beforeObjects := time.Now()
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer release()
 	objs, err := storobj.ObjectsByDocID(bucket, idsCombined, additional, properties, s.index.logger)
 	if err != nil {
 		return nil, nil, err
@@ -864,10 +878,11 @@ func (s *Shard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, 
 			return nil, err
 		}
 		helpers.AnnotateSlowQueryLog(ctx, "sort_took", time.Since(beforeSort))
-		bucket, err := s.objectsBucket()
+		bucket, release, err := s.objectsBucket()
 		if err != nil {
 			return nil, err
 		}
+		defer release()
 
 		beforeObjects := time.Now()
 		defer func() {
@@ -887,10 +902,11 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor,
 	additional additional.Properties,
 	className schema.ClassName,
 ) ([]*storobj.Object, error) {
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 
 	bucketClassName, err := bucket.ClassName()
 	if err != nil {
@@ -976,10 +992,11 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 }
 
 func (s *Shard) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return "", err
 	}
+	defer release()
 
 	docIDBytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(docIDBytes, docID)
@@ -1011,10 +1028,11 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return err
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return err
 	}
+	defer release()
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
@@ -1086,9 +1104,10 @@ func (s *Shard) WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time
 		return false, time.Time{}, err
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return false, time.Time{}, err
 	}
+	defer release()
 	return bucket.WasDeleted(idBytes)
 }

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -52,10 +52,11 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return false, err
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return false, err
 	}
+	defer release()
 
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
@@ -161,10 +162,11 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 }
 
 func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) error {
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return err
 	}
+	defer release()
 	className, err := bucket.ClassName()
 	if err != nil {
 		return fmt.Errorf("getting bucket class name: %w", err)

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -117,10 +117,11 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte,
 ) (*storobj.Object, objectInsertStatus, error) {
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, objectInsertStatus{}, err
 	}
+	defer release()
 
 	var prevObj, obj *storobj.Object
 	var status objectInsertStatus
@@ -221,10 +222,11 @@ func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDo
 ) (mutableMergeResult, error) {
 	out := mutableMergeResult{}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return out, err
 	}
+	defer release()
 
 	// Wait outside the RLock; see shard_write_put.go (calling it under RLock is a recursive read-lock deadlock).
 	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -257,10 +257,11 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 		}
 	}
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
 		return status, err
 	}
+	defer release()
 	var prevObj *storobj.Object
 
 	// First the object bucket is checked if an object with the same uuid is alreadypresent,

--- a/adapters/repos/db/sorter/inverted_sorter.go
+++ b/adapters/repos/db/sorter/inverted_sorter.go
@@ -123,11 +123,14 @@ func (is *invertedSorter) sortDocIDsWithNesting(
 		return nil, err
 	}
 
+	// pinned for the whole sort: the bucket backs every cursor opened below,
+	// and an unpinned pointer can be shut down between the lookup and the scan
 	bucketName := helpers.BucketFromPropNameLSM(propNames[0])
-	bucket := is.store.Bucket(bucketName)
+	bucket, release := is.store.AcquireBucketForRead(bucketName)
 	if bucket == nil {
 		return nil, fmt.Errorf("bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
 	}
+	defer release()
 	if bucket.Strategy() != lsmkv.StrategyRoaringSet {
 		// this should never happen, the query planner should already have chosen
 		// another strategy
@@ -378,8 +381,9 @@ func (is *invertedSorter) quantileKeysForDescSort(ctx context.Context, limit int
 	// a torn-down store leaves no bucket to count; fall through to the full
 	// index scan below rather than dereferencing nil
 	totalCount := 0
-	if ob := is.store.Bucket(helpers.ObjectsBucketLSM); ob != nil {
+	if ob, release := is.store.AcquireBucketForRead(helpers.ObjectsBucketLSM); ob != nil {
 		totalCount = ob.CountAsync()
+		release()
 	}
 	if totalCount == 0 {
 		// no objects, likely no disk segments yet, force a full index scan

--- a/adapters/repos/db/sorter/inverted_sorter.go
+++ b/adapters/repos/db/sorter/inverted_sorter.go
@@ -123,7 +123,11 @@ func (is *invertedSorter) sortDocIDsWithNesting(
 		return nil, err
 	}
 
-	bucket := is.store.Bucket(helpers.BucketFromPropNameLSM(propNames[0]))
+	bucketName := helpers.BucketFromPropNameLSM(propNames[0])
+	bucket := is.store.Bucket(bucketName)
+	if bucket == nil {
+		return nil, fmt.Errorf("bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
+	}
 	if bucket.Strategy() != lsmkv.StrategyRoaringSet {
 		// this should never happen, the query planner should already have chosen
 		// another strategy
@@ -369,10 +373,14 @@ func (is *invertedSorter) startNestedSort(
 func (is *invertedSorter) quantileKeysForDescSort(ctx context.Context, limit int,
 	ids helpers.AllowList, invertedBucket *lsmkv.Bucket, nesting int,
 ) [][]byte {
-	ob := is.store.Bucket(helpers.ObjectsBucketLSM)
-	totalCount := ob.CountAsync()
 	zeroByte := [][]byte{{0x00}}
 
+	// a torn-down store leaves no bucket to count; fall through to the full
+	// index scan below rather than dereferencing nil
+	totalCount := 0
+	if ob := is.store.Bucket(helpers.ObjectsBucketLSM); ob != nil {
+		totalCount = ob.CountAsync()
+	}
 	if totalCount == 0 {
 		// no objects, likely no disk segments yet, force a full index scan
 		return zeroByte

--- a/adapters/repos/db/sorter/query_planner.go
+++ b/adapters/repos/db/sorter/query_planner.go
@@ -107,10 +107,12 @@ func (s *queryPlanner) EstimateCosts(ctx context.Context, ids helpers.AllowList,
 	sort []filters.Sort,
 ) (float64, float64) {
 	// a torn-down store leaves no bucket to count; fall through to the
-	// no-segments estimate below rather than dereferencing nil
+	// no-segments estimate below rather than dereferencing nil. The pin keeps
+	// the count from racing a teardown that starts right after the lookup.
 	totalObjects := 0
-	if bucket := s.store.Bucket(helpers.ObjectsBucketLSM); bucket != nil {
+	if bucket, release := s.store.AcquireBucketForRead(helpers.ObjectsBucketLSM); bucket != nil {
 		totalObjects = bucket.CountAsync()
+		release()
 	}
 	var matches int
 	if ids == nil {

--- a/adapters/repos/db/sorter/query_planner.go
+++ b/adapters/repos/db/sorter/query_planner.go
@@ -106,7 +106,12 @@ func NewQueryPlanner(store *lsmkv.Store, dataTypesHelper *dataTypesHelper,
 func (s *queryPlanner) EstimateCosts(ctx context.Context, ids helpers.AllowList, limit int,
 	sort []filters.Sort,
 ) (float64, float64) {
-	totalObjects := s.store.Bucket(helpers.ObjectsBucketLSM).CountAsync()
+	// a torn-down store leaves no bucket to count; fall through to the
+	// no-segments estimate below rather than dereferencing nil
+	totalObjects := 0
+	if bucket := s.store.Bucket(helpers.ObjectsBucketLSM); bucket != nil {
+		totalObjects = bucket.CountAsync()
+	}
 	var matches int
 	if ids == nil {
 		matches = totalObjects

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -783,14 +783,15 @@ func (dynamic *dynamic) doUpgrade() error {
 	dynamic.status.Upgraded()
 
 	var errs []error
-	bDir := dynamic.store.Bucket(dynamic.getBucketName()).GetDir()
-	err = dynamic.store.ShutdownBucket(dynamic.ctx, dynamic.getBucketName())
-	if err != nil {
+	if bDir, err := dynamic.bucketDir(dynamic.getBucketName()); err != nil {
 		errs = append(errs, err)
-	}
-	err = os.RemoveAll(bDir)
-	if err != nil {
-		errs = append(errs, err)
+	} else {
+		if err := dynamic.store.ShutdownBucket(dynamic.ctx, dynamic.getBucketName()); err != nil {
+			errs = append(errs, err)
+		}
+		if err := os.RemoveAll(bDir); err != nil {
+			errs = append(errs, err)
+		}
 	}
 	// Due to the potential for a different quantizer using a different endianness
 	// we remove the bucket here if needed
@@ -802,14 +803,15 @@ func (dynamic *dynamic) doUpgrade() error {
 	}
 
 	if removeCompressedBucket {
-		bDir = dynamic.store.Bucket(dynamic.getCompressedBucketName()).GetDir()
-		err = dynamic.store.ShutdownBucket(dynamic.ctx, dynamic.getCompressedBucketName())
-		if err != nil {
+		if bDir, err := dynamic.bucketDir(dynamic.getCompressedBucketName()); err != nil {
 			errs = append(errs, err)
-		}
-		err = os.RemoveAll(bDir)
-		if err != nil {
-			errs = append(errs, err)
+		} else {
+			if err := dynamic.store.ShutdownBucket(dynamic.ctx, dynamic.getCompressedBucketName()); err != nil {
+				errs = append(errs, err)
+			}
+			if err := os.RemoveAll(bDir); err != nil {
+				errs = append(errs, err)
+			}
 		}
 	}
 	if len(errs) > 0 {
@@ -838,15 +840,27 @@ func (dynamic *dynamic) cleanupAbortedUpgrade(index VectorIndex) {
 	}
 }
 
+// bucketDir resolves a bucket's on-disk directory. The upgrade's cleanup runs
+// on a background goroutine, so a shard teardown can deregister the bucket
+// first — in which case there is nothing left to shut down or delete, and the
+// lookup must report that instead of dereferencing nil. The pin is dropped
+// before returning: the caller's next step is a Shutdown of this same bucket,
+// which drains the very pin we would otherwise still hold.
+func (dynamic *dynamic) bucketDir(name string) (string, error) {
+	bucket, release := dynamic.store.AcquireBucketForRead(name)
+	if bucket == nil {
+		return "", fmt.Errorf("dynamic index: bucket %q: %w", name, lsmkv.ErrBucketNotFound)
+	}
+	defer release()
+
+	return bucket.GetDir(), nil
+}
+
 // Loop over the store and add each vector to the HNSW.
 // This can take a while, so we use short-lived cursors to not block
 // other operations on the KV store (e.g. flush)
 func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 	bucketName := dynamic.getBucketName()
-	bucket := dynamic.store.Bucket(bucketName)
-	if bucket == nil {
-		return fmt.Errorf("copy vectors to hnsw: bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
-	}
 
 	var k, v []byte
 
@@ -856,6 +870,14 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 	for {
 		ids = ids[:0]
 		vectors = vectors[:0]
+
+		// re-acquired per batch, released with the cursor: a pin spanning the
+		// whole copy would hold off a teardown for as long as the upgrade
+		// runs, which is exactly what the short-lived cursors avoid
+		bucket, release := dynamic.store.AcquireBucketForRead(bucketName)
+		if bucket == nil {
+			return fmt.Errorf("copy vectors to hnsw: bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
+		}
 
 		cursor := bucket.Cursor()
 
@@ -869,6 +891,7 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 		for k != nil && i < batchSize {
 			if err := dynamic.ctx.Err(); err != nil {
 				cursor.Close()
+				release()
 				// context was cancelled, stop processing
 				return err
 			}
@@ -885,6 +908,7 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 		}
 
 		cursor.Close()
+		release()
 
 		if err := index.AddBatch(dynamic.ctx, ids, vectors); err != nil {
 			return errors.Wrap(err, "add vectors to upgraded index")

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -842,7 +842,11 @@ func (dynamic *dynamic) cleanupAbortedUpgrade(index VectorIndex) {
 // This can take a while, so we use short-lived cursors to not block
 // other operations on the KV store (e.g. flush)
 func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
-	bucket := dynamic.store.Bucket(dynamic.getBucketName())
+	bucketName := dynamic.getBucketName()
+	bucket := dynamic.store.Bucket(bucketName)
+	if bucket == nil {
+		return fmt.Errorf("copy vectors to hnsw: bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
+	}
 
 	var k, v []byte
 

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -133,27 +133,34 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 	return index, nil
 }
 
-// getBucket returns the named bucket, or an error if the store no longer holds
-// it. A shard teardown deregisters every bucket up front and drains in-flight
-// requests afterwards, and DropVectorIndex removes a single vector's buckets
-// from a shard that stays alive; either way an operation that is already
-// running finds no bucket under the name it resolved.
-func (index *flat) getBucket(name string) (*lsmkv.Bucket, error) {
-	bucket := index.store.Bucket(name)
+// getBucket returns the named bucket pinned for the caller's operation, or an
+// error if the store no longer holds it. A shard teardown deregisters every
+// bucket up front and drains in-flight requests afterwards, and
+// DropVectorIndex removes a single vector's buckets from a shard that stays
+// alive; either way an operation that is already running finds no bucket under
+// the name it resolved.
+//
+// The release closure is always non-nil and must be called exactly once. It
+// holds off the bucket's Shutdown for the operation's duration, so a teardown
+// racing a lookup that already succeeded cannot unmap the segments underneath
+// it.
+func (index *flat) getBucket(name string) (*lsmkv.Bucket, func(), error) {
+	bucket, release := index.store.AcquireBucketForRead(name)
 	if bucket == nil {
-		return nil, fmt.Errorf("flat index %q: bucket %q: %w", index.id, name, lsmkv.ErrBucketNotFound)
+		return nil, release, fmt.Errorf("flat index %q: bucket %q: %w", index.id, name, lsmkv.ErrBucketNotFound)
 	}
-	return bucket, nil
+	return bucket, release, nil
 }
 
 func (flat *flat) getUint64QuantizedVector(ctx context.Context, id uint64) ([]uint64, error) {
 	key := flat.pool.byteSlicePool.Get(8)
 	defer flat.pool.byteSlicePool.Put(key)
 	binary.BigEndian.PutUint64(key.slice, id)
-	bucket, err := flat.getBucket(flat.getCompressedBucketName())
+	bucket, release, err := flat.getBucket(flat.getCompressedBucketName())
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	bytes, err := bucket.Get(key.slice)
 	if err != nil {
 		return nil, err
@@ -168,10 +175,11 @@ func (flat *flat) getByteQuantizedVector(ctx context.Context, id uint64) ([]byte
 	key := flat.pool.byteSlicePool.Get(8)
 	defer flat.pool.byteSlicePool.Put(key)
 	binary.BigEndian.PutUint64(key.slice, id)
-	bucket, err := flat.getBucket(flat.getCompressedBucketName())
+	bucket, release, err := flat.getBucket(flat.getCompressedBucketName())
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	bytes, err := bucket.Get(key.slice)
 	if err != nil {
 		return nil, err
@@ -233,10 +241,11 @@ func (index *flat) storeVector(id uint64, vector []byte) error {
 }
 
 func (index *flat) storeGenericVector(id uint64, vector []byte, bucketName string) error {
-	bucket, err := index.getBucket(bucketName)
+	bucket, release, err := index.getBucket(bucketName)
 	if err != nil {
 		return err
 	}
+	defer release()
 	idBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(idBytes, id)
 	return bucket.Put(idBytes, vector)
@@ -309,10 +318,11 @@ func (index *flat) initBuckets(ctx context.Context, cfg Config) error {
 		}
 	}
 
-	bucket, err := index.getBucket(index.getBucketName())
+	bucket, release, err := index.getBucket(index.getBucketName())
 	if err != nil {
 		return err
 	}
+	defer release()
 	atomic.StoreUint64(&index.count, uint64(bucket.CountAsync()))
 
 	return nil
@@ -435,25 +445,39 @@ func (index *flat) Delete(ids ...uint64) error {
 		idBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(idBytes, ids[i])
 
-		bucket, err := index.getBucket(index.getBucketName())
-		if err != nil {
+		if err := index.deleteFromBuckets(idBytes); err != nil {
 			return err
-		}
-		if err := bucket.Delete(idBytes); err != nil {
-			return err
-		}
-
-		if index.Compressed() {
-			compressed, err := index.getBucket(index.getCompressedBucketName())
-			if err != nil {
-				return err
-			}
-			if err := compressed.Delete(idBytes); err != nil {
-				return err
-			}
 		}
 	}
 	return nil
+}
+
+// deleteFromBuckets drops one id from the vector bucket and, when the index is
+// compressed, from the compressed bucket. Split out of [flat.Delete] so each
+// id's bucket pins are released as its iteration ends rather than piling up
+// for the whole batch.
+func (index *flat) deleteFromBuckets(idBytes []byte) error {
+	bucket, release, err := index.getBucket(index.getBucketName())
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	if err := bucket.Delete(idBytes); err != nil {
+		return err
+	}
+
+	if !index.Compressed() {
+		return nil
+	}
+
+	compressed, releaseCompressed, err := index.getBucket(index.getCompressedBucketName())
+	if err != nil {
+		return err
+	}
+	defer releaseCompressed()
+
+	return compressed.Delete(idBytes)
 }
 
 func (index *flat) searchTimeRescore(k int) int {
@@ -483,10 +507,11 @@ func (index *flat) searchByVector(ctx context.Context, vector []float32, k int, 
 
 	vector = index.normalized(vector)
 
-	bucket, err := index.getBucket(index.getBucketName())
+	bucket, release, err := index.getBucket(index.getBucketName())
 	if err != nil {
 		return nil, nil, err
 	}
+	defer release()
 
 	if err := index.findTopVectors(heap, allow, k,
 		bucket.Cursor,
@@ -531,10 +556,11 @@ func (index *flat) searchByVectorQuantized(ctx context.Context, vector []float32
 			return nil, nil, err
 		}
 	} else {
-		bucket, err := index.getBucket(index.getCompressedBucketName())
+		bucket, release, err := index.getBucket(index.getCompressedBucketName())
 		if err != nil {
 			return nil, nil, err
 		}
+		defer release()
 
 		if err := index.findTopVectors(heap, allow, rescore,
 			bucket.Cursor,
@@ -631,10 +657,11 @@ func (index *flat) vectorById(id uint64) ([]byte, error) {
 	defer index.pool.byteSlicePool.Put(idSlice)
 
 	binary.BigEndian.PutUint64(idSlice.slice, id)
-	bucket, err := index.getBucket(index.getBucketName())
+	bucket, release, err := index.getBucket(index.getBucketName())
 	if err != nil {
 		return nil, err
 	}
+	defer release()
 	return bucket.Get(idSlice.slice)
 }
 
@@ -984,11 +1011,12 @@ func (index *flat) PostStartup(ctx context.Context) {
 	// one additional struct per vector while loading. Should be negligible)
 
 	before := time.Now()
-	bucket, err := index.getBucket(index.getCompressedBucketName())
+	bucket, release, err := index.getBucket(index.getCompressedBucketName())
 	if err != nil {
 		index.logger.Errorf("preload vectors of flat index %q: %v", index.id, err)
 		return
 	}
+	defer release()
 	// we expect to be IO-bound, so more goroutines than CPUs is fine, we do
 	// however want some kind of relationship to the machine size, so
 	// 2*GOMAXPROCS seems like a good default.
@@ -1173,10 +1201,11 @@ func (index *flat) ContainsDoc(id uint64) bool {
 		bucketName = index.getBucketName()
 	}
 
-	bucket, err := index.getBucket(bucketName)
+	bucket, release, err := index.getBucket(bucketName)
 	if err != nil {
 		return false
 	}
+	defer release()
 
 	idBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(idBytes, id)
@@ -1199,11 +1228,12 @@ func (index *flat) Iterate(fn func(docID uint64) bool) {
 		bucketName = index.getBucketName()
 	}
 
-	bucket, err := index.getBucket(bucketName)
+	bucket, release, err := index.getBucket(bucketName)
 	if err != nil {
 		index.logger.Errorf("iterate flat index %q: %v", index.id, err)
 		return
 	}
+	defer release()
 
 	cursor := bucket.Cursor()
 	defer cursor.Close()

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -133,11 +133,28 @@ func New(cfg Config, uc flatent.UserConfig, store *lsmkv.Store) (*flat, error) {
 	return index, nil
 }
 
+// getBucket returns the named bucket, or an error if the store no longer holds
+// it. A shard teardown deregisters every bucket up front and drains in-flight
+// requests afterwards, and DropVectorIndex removes a single vector's buckets
+// from a shard that stays alive; either way an operation that is already
+// running finds no bucket under the name it resolved.
+func (index *flat) getBucket(name string) (*lsmkv.Bucket, error) {
+	bucket := index.store.Bucket(name)
+	if bucket == nil {
+		return nil, fmt.Errorf("flat index %q: bucket %q: %w", index.id, name, lsmkv.ErrBucketNotFound)
+	}
+	return bucket, nil
+}
+
 func (flat *flat) getUint64QuantizedVector(ctx context.Context, id uint64) ([]uint64, error) {
 	key := flat.pool.byteSlicePool.Get(8)
 	defer flat.pool.byteSlicePool.Put(key)
 	binary.BigEndian.PutUint64(key.slice, id)
-	bytes, err := flat.store.Bucket(flat.getCompressedBucketName()).Get(key.slice)
+	bucket, err := flat.getBucket(flat.getCompressedBucketName())
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := bucket.Get(key.slice)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +168,11 @@ func (flat *flat) getByteQuantizedVector(ctx context.Context, id uint64) ([]byte
 	key := flat.pool.byteSlicePool.Get(8)
 	defer flat.pool.byteSlicePool.Put(key)
 	binary.BigEndian.PutUint64(key.slice, id)
-	bytes, err := flat.store.Bucket(flat.getCompressedBucketName()).Get(key.slice)
+	bucket, err := flat.getBucket(flat.getCompressedBucketName())
+	if err != nil {
+		return nil, err
+	}
+	bytes, err := bucket.Get(key.slice)
 	if err != nil {
 		return nil, err
 	}
@@ -203,18 +224,22 @@ func extractCache(uc flatent.UserConfig) (bool, QuantizerType) {
 	return false, 0
 }
 
-func (index *flat) storeCompressedVector(id uint64, vector []byte) {
-	index.storeGenericVector(id, vector, index.getCompressedBucketName())
+func (index *flat) storeCompressedVector(id uint64, vector []byte) error {
+	return index.storeGenericVector(id, vector, index.getCompressedBucketName())
 }
 
-func (index *flat) storeVector(id uint64, vector []byte) {
-	index.storeGenericVector(id, vector, index.getBucketName())
+func (index *flat) storeVector(id uint64, vector []byte) error {
+	return index.storeGenericVector(id, vector, index.getBucketName())
 }
 
-func (index *flat) storeGenericVector(id uint64, vector []byte, bucket string) {
+func (index *flat) storeGenericVector(id uint64, vector []byte, bucketName string) error {
+	bucket, err := index.getBucket(bucketName)
+	if err != nil {
+		return err
+	}
 	idBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(idBytes, id)
-	index.store.Bucket(bucket).Put(idBytes, vector)
+	return bucket.Put(idBytes, vector)
 }
 
 func (index *flat) Cached() bool {
@@ -284,8 +309,11 @@ func (index *flat) initBuckets(ctx context.Context, cfg Config) error {
 		}
 	}
 
-	count := index.store.Bucket(index.getBucketName()).CountAsync()
-	atomic.StoreUint64(&index.count, uint64(count))
+	bucket, err := index.getBucket(index.getBucketName())
+	if err != nil {
+		return err
+	}
+	atomic.StoreUint64(&index.count, uint64(bucket.CountAsync()))
 
 	return nil
 }
@@ -381,9 +409,13 @@ func (index *flat) Add(ctx context.Context, id uint64, vector []float32) error {
 
 	vector = index.normalized(vector)
 	slice := make([]byte, len(vector)*4)
-	index.storeVector(id, byteSliceFromFloat32Slice(vector, slice))
+	if err := index.storeVector(id, byteSliceFromFloat32Slice(vector, slice)); err != nil {
+		return err
+	}
 
-	index.Preload(id, vector)
+	if err := index.preload(id, vector); err != nil {
+		return err
+	}
 
 	for {
 		oldCount := atomic.LoadUint64(&index.count)
@@ -403,12 +435,20 @@ func (index *flat) Delete(ids ...uint64) error {
 		idBytes := make([]byte, 8)
 		binary.BigEndian.PutUint64(idBytes, ids[i])
 
-		if err := index.store.Bucket(index.getBucketName()).Delete(idBytes); err != nil {
+		bucket, err := index.getBucket(index.getBucketName())
+		if err != nil {
+			return err
+		}
+		if err := bucket.Delete(idBytes); err != nil {
 			return err
 		}
 
 		if index.Compressed() {
-			if err := index.store.Bucket(index.getCompressedBucketName()).Delete(idBytes); err != nil {
+			compressed, err := index.getBucket(index.getCompressedBucketName())
+			if err != nil {
+				return err
+			}
+			if err := compressed.Delete(idBytes); err != nil {
 				return err
 			}
 		}
@@ -443,8 +483,13 @@ func (index *flat) searchByVector(ctx context.Context, vector []float32, k int, 
 
 	vector = index.normalized(vector)
 
+	bucket, err := index.getBucket(index.getBucketName())
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if err := index.findTopVectors(heap, allow, k,
-		index.store.Bucket(index.getBucketName()).Cursor,
+		bucket.Cursor,
 		index.createDistanceCalc(vector),
 	); err != nil {
 		return nil, nil, err
@@ -486,8 +531,13 @@ func (index *flat) searchByVectorQuantized(ctx context.Context, vector []float32
 			return nil, nil, err
 		}
 	} else {
+		bucket, err := index.getBucket(index.getCompressedBucketName())
+		if err != nil {
+			return nil, nil, err
+		}
+
 		if err := index.findTopVectors(heap, allow, rescore,
-			index.store.Bucket(index.getCompressedBucketName()).Cursor,
+			bucket.Cursor,
 			index.createDistanceCalcQuantized(vector),
 		); err != nil {
 			return nil, nil, err
@@ -581,7 +631,11 @@ func (index *flat) vectorById(id uint64) ([]byte, error) {
 	defer index.pool.byteSlicePool.Put(idSlice)
 
 	binary.BigEndian.PutUint64(idSlice.slice, id)
-	return index.store.Bucket(index.getBucketName()).Get(idSlice.slice)
+	bucket, err := index.getBucket(index.getBucketName())
+	if err != nil {
+		return nil, err
+	}
+	return bucket.Get(idSlice.slice)
 }
 
 // populates given heap with smallest distances and corresponding ids calculated by
@@ -880,26 +934,35 @@ func (index *flat) ValidateBeforeInsert(vector []float32) error {
 }
 
 func (index *flat) Preload(id uint64, vector []float32) {
-	if index.Compressed() {
-		if index.quantizer.Type() == ByteQuantizer {
-			// For byte quantizer
-			vectorQuantized := index.quantizer.EncodeBytes(vector)
-			if index.Cached() {
-				index.cache.Grow(id)
-				index.cache.PreloadBytes(id, vectorQuantized)
-			}
-			index.storeCompressedVector(id, vectorQuantized)
-		} else if index.quantizer.Type() == Uint64Quantizer {
-			// For uint64 quantizer
-			vectorQuantized := index.quantizer.EncodeUint64(vector)
-			if index.Cached() {
-				index.cache.Grow(id)
-				index.cache.PreloadUint64(id, vectorQuantized)
-			}
-			slice := make([]byte, len(vectorQuantized)*8)
-			index.storeCompressedVector(id, byteSliceFromUint64Slice(vectorQuantized, slice))
-		}
+	if err := index.preload(id, vector); err != nil {
+		index.logger.Errorf("preload vector %d into flat index %q: %v", id, index.id, err)
 	}
+}
+
+func (index *flat) preload(id uint64, vector []float32) error {
+	if !index.Compressed() {
+		return nil
+	}
+
+	switch index.quantizer.Type() {
+	case ByteQuantizer:
+		vectorQuantized := index.quantizer.EncodeBytes(vector)
+		if index.Cached() {
+			index.cache.Grow(id)
+			index.cache.PreloadBytes(id, vectorQuantized)
+		}
+		return index.storeCompressedVector(id, vectorQuantized)
+	case Uint64Quantizer:
+		vectorQuantized := index.quantizer.EncodeUint64(vector)
+		if index.Cached() {
+			index.cache.Grow(id)
+			index.cache.PreloadUint64(id, vectorQuantized)
+		}
+		slice := make([]byte, len(vectorQuantized)*8)
+		return index.storeCompressedVector(id, byteSliceFromUint64Slice(vectorQuantized, slice))
+	}
+
+	return nil
 }
 
 func (index *flat) PostStartup(ctx context.Context) {
@@ -921,7 +984,11 @@ func (index *flat) PostStartup(ctx context.Context) {
 	// one additional struct per vector while loading. Should be negligible)
 
 	before := time.Now()
-	bucket := index.store.Bucket(index.getCompressedBucketName())
+	bucket, err := index.getBucket(index.getCompressedBucketName())
+	if err != nil {
+		index.logger.Errorf("preload vectors of flat index %q: %v", index.id, err)
+		return
+	}
 	// we expect to be IO-bound, so more goroutines than CPUs is fine, we do
 	// however want some kind of relationship to the machine size, so
 	// 2*GOMAXPROCS seems like a good default.
@@ -1106,9 +1173,14 @@ func (index *flat) ContainsDoc(id uint64) bool {
 		bucketName = index.getBucketName()
 	}
 
+	bucket, err := index.getBucket(bucketName)
+	if err != nil {
+		return false
+	}
+
 	idBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(idBytes, id)
-	v, err := index.store.Bucket(bucketName).Get(idBytes)
+	v, err := bucket.Get(idBytes)
 	if v == nil || errors.Is(err, entlsmkv.NotFound) {
 		return false
 	}
@@ -1127,7 +1199,12 @@ func (index *flat) Iterate(fn func(docID uint64) bool) {
 		bucketName = index.getBucketName()
 	}
 
-	bucket := index.store.Bucket(bucketName)
+	bucket, err := index.getBucket(bucketName)
+	if err != nil {
+		index.logger.Errorf("iterate flat index %q: %v", index.id, err)
+		return
+	}
+
 	cursor := bucket.Cursor()
 	defer cursor.Close()
 

--- a/adapters/repos/db/vector/flat/torn_store_test.go
+++ b/adapters/repos/db/vector/flat/torn_store_test.go
@@ -14,7 +14,9 @@ package flat
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
@@ -180,5 +182,81 @@ func TestFlatOperationsOnTornDownStore(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.NotPanics(t, op)
 		})
+	}
+}
+
+// TestFlatIterationHoldsBucketAgainstTeardown covers the other half of the
+// race. The cases above start after teardown has finished, so they only prove
+// the nil-bucket guards. This one resolves the bucket first and then lets the
+// teardown in: the lifetime pin the operation holds must make Bucket.Shutdown
+// wait, because a teardown that ran anyway would unmap the segments the scan
+// is still walking.
+func TestFlatIterationHoldsBucketAgainstTeardown(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	dir := t.TempDir()
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+
+	index, err := New(Config{
+		ID:                "pinned-store",
+		RootPath:          dir,
+		Logger:            logger,
+		DistanceProvider:  distancer.NewL2SquaredProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, flatent.UserConfig{VectorCacheMaxObjects: 1_000}, store)
+	require.Nil(t, err)
+
+	ids := make([]uint64, 100)
+	vectors := make([][]float32, 100)
+	for i := range vectors {
+		ids[i] = uint64(i)
+		vectors[i] = []float32{float32(i), float32(i) + 1, float32(i) + 2, float32(i) + 3}
+	}
+	require.Nil(t, index.AddBatch(ctx, ids, vectors))
+
+	scanning := make(chan struct{})
+	resume := make(chan struct{})
+	scanned := make(chan struct{})
+
+	go func() {
+		defer close(scanned)
+		var once sync.Once
+		index.Iterate(func(uint64) bool {
+			once.Do(func() {
+				close(scanning)
+				<-resume
+			})
+			return true
+		})
+	}()
+
+	select {
+	case <-scanning:
+	case <-scanned:
+		t.Fatal("iteration finished without visiting a vector")
+	}
+
+	torn := make(chan error, 1)
+	go func() { torn <- store.Shutdown(context.Background()) }()
+
+	select {
+	case err := <-torn:
+		t.Fatalf("teardown completed while an iteration still held the bucket: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	close(resume)
+	<-scanned
+
+	select {
+	case err := <-torn:
+		require.NoError(t, err)
+	case <-time.After(time.Minute):
+		t.Fatal("teardown never completed after the iteration released its pin")
 	}
 }

--- a/adapters/repos/db/vector/flat/torn_store_test.go
+++ b/adapters/repos/db/vector/flat/torn_store_test.go
@@ -1,0 +1,184 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package flat
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+)
+
+func shutdownStore(t *testing.T, store *lsmkv.Store) {
+	require.Nil(t, store.Shutdown(context.Background()))
+}
+
+// A shard teardown deregisters every bucket before the query paths are drained,
+// so Store.Bucket returns nil to a search that is still running. The search must
+// fail with an error instead of dereferencing the nil bucket.
+func TestFlatSearchOnTornDownStore(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	tests := []struct {
+		name     string
+		uc       flatent.UserConfig
+		teardown func(t *testing.T, store *lsmkv.Store)
+	}{
+		{
+			name:     "uncompressed",
+			uc:       flatent.UserConfig{VectorCacheMaxObjects: 1_000},
+			teardown: shutdownStore,
+		},
+		{
+			name: "bq without cache",
+			uc: flatent.UserConfig{
+				VectorCacheMaxObjects: 1_000,
+				BQ:                    flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 100},
+			},
+			teardown: shutdownStore,
+		},
+		{
+			name: "bq with cache",
+			uc: flatent.UserConfig{
+				VectorCacheMaxObjects: 1_000,
+				BQ:                    flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 100, Cache: true},
+			},
+			teardown: shutdownStore,
+		},
+		{
+			// what DropVectorIndex and the dynamic flat->hnsw upgrade do: the
+			// shard lives on, only this vector's raw bucket is deregistered.
+			// The quantized phase is served from the cache, so the search
+			// reaches the rescoring step and reads the raw vectors.
+			name: "raw bucket removed under a cached bq search",
+			uc: flatent.UserConfig{
+				VectorCacheMaxObjects: 1_000,
+				BQ:                    flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 100, Cache: true},
+			},
+			teardown: func(t *testing.T, store *lsmkv.Store) {
+				require.Nil(t, store.ShutdownBucket(context.Background(), helpers.VectorsBucketLSM))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := lsmkv.New(dir, dir, logger, nil, nil,
+				cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop())
+			require.Nil(t, err)
+
+			index, err := New(Config{
+				ID:                "torn-store",
+				RootPath:          dir,
+				Logger:            logger,
+				DistanceProvider:  distancer.NewL2SquaredProvider(),
+				MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+			}, test.uc, store)
+			require.Nil(t, err)
+
+			// mirrors production: an empty index is prefilled at startup, so the
+			// cache stays complete through the inserts below
+			index.PostStartup(ctx)
+
+			ids := make([]uint64, 100)
+			vectors := make([][]float32, 100)
+			for i := range vectors {
+				ids[i] = uint64(i)
+				vectors[i] = []float32{float32(i), float32(i) + 1, float32(i) + 2, float32(i) + 3}
+			}
+			require.Nil(t, index.AddBatch(ctx, ids, vectors))
+
+			test.teardown(t, store)
+
+			var searchErr error
+			require.NotPanics(t, func() {
+				_, _, searchErr = index.SearchByVector(ctx, []float32{1, 2, 3, 4}, 10, nil)
+			})
+			require.Error(t, searchErr)
+			require.False(t, strings.Contains(searchErr.Error(), "panic"),
+				"search must fail with an error, got a recovered panic: %v", searchErr)
+		})
+	}
+}
+
+// The write and iteration paths share the search path's exposure: they resolve
+// the same buckets by name, so a teardown reaches them the same way.
+func TestFlatOperationsOnTornDownStore(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	dir := t.TempDir()
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.Nil(t, err)
+
+	index, err := New(Config{
+		ID:                "torn-store",
+		RootPath:          dir,
+		Logger:            logger,
+		DistanceProvider:  distancer.NewL2SquaredProvider(),
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, flatent.UserConfig{
+		VectorCacheMaxObjects: 1_000,
+		BQ:                    flatent.CompressionUserConfig{Enabled: true, RescoreLimit: 100, Cache: true},
+	}, store)
+	require.Nil(t, err)
+
+	index.PostStartup(ctx)
+	require.Nil(t, index.AddBatch(ctx, []uint64{0}, [][]float32{{1, 2, 3, 4}}))
+	require.Nil(t, store.Shutdown(ctx))
+
+	failing := map[string]func() error{
+		"add": func() error {
+			return index.Add(ctx, 1, []float32{4, 3, 2, 1})
+		},
+		"add batch": func() error {
+			return index.AddBatch(ctx, []uint64{2}, [][]float32{{4, 3, 2, 1}})
+		},
+		"delete": func() error {
+			return index.Delete(0)
+		},
+	}
+	for name, op := range failing {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, op(), lsmkv.ErrBucketNotFound)
+		})
+	}
+
+	// these report through their return value or a log line, so all that is
+	// owed here is that they do not crash
+	silent := map[string]func(){
+		"preload":      func() { index.Preload(3, []float32{1, 1, 1, 1}) },
+		"contains doc": func() { require.False(t, index.ContainsDoc(0)) },
+		"iterate":      func() { index.Iterate(func(uint64) bool { return true }) },
+		"post startup": func() { index.PostStartup(ctx) },
+	}
+	for name, op := range silent {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, op)
+		})
+	}
+}

--- a/adapters/repos/db/vector/hfresh/index_metadata.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata.go
@@ -69,6 +69,10 @@ func NewSharedBucket(store *lsmkv.Store, indexID string, cfg StoreConfig) (*lsmk
 	}
 
 	bucket := store.Bucket(bName)
+	if bucket == nil {
+		return nil, errors.Wrapf(lsmkv.ErrBucketNotFound, "shared bucket %s", bName)
+	}
+
 	err = cleanupLegacyReassignBucket(bucket)
 	if err != nil {
 		return nil, err

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -238,10 +239,15 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 }
 
 // objectsBucketView returns a consistent view of the objects bucket, valid
-// until ReleaseView. A missing objects bucket is a wiring bug — the shard
-// creates it before any vector index — and panics rather than degrading.
+// until ReleaseView. A torn-down store yields the zero view: releasing it is a
+// no-op and the reads taken against it fail individually, which is all this
+// signature can report.
 func (h *HFresh) objectsBucketView() common.BucketView {
-	return h.store.Bucket(helpers.ObjectsBucketLSM).GetConsistentView()
+	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
+	if bucket == nil {
+		return lsmkv.BucketConsistentView{}
+	}
+	return bucket.GetConsistentView()
 }
 
 // fetchNormalizedVector reads the full vector for id into the pooled slice

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -239,15 +238,15 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 }
 
 // objectsBucketView returns a consistent view of the objects bucket, valid
-// until ReleaseView. A torn-down store yields the zero view: releasing it is a
-// no-op and the reads taken against it fail individually, which is all this
-// signature can report.
+// until ReleaseView. The bucket stays pinned for the view's lifetime, so a
+// teardown starting while the search workers still hold the view waits for
+// them instead of unmapping the segments they read from.
+//
+// A torn-down store yields the zero view: releasing it is a no-op and the
+// reads taken against it fail individually, which is all this signature can
+// report.
 func (h *HFresh) objectsBucketView() common.BucketView {
-	bucket := h.store.Bucket(helpers.ObjectsBucketLSM)
-	if bucket == nil {
-		return lsmkv.BucketConsistentView{}
-	}
-	return bucket.GetConsistentView()
+	return h.store.AcquireBucketConsistentViewForRead(helpers.ObjectsBucketLSM)
 }
 
 // fetchNormalizedVector reads the full vector for id into the pooled slice

--- a/adapters/repos/db/vector/hfresh/store.go
+++ b/adapters/repos/db/vector/hfresh/store.go
@@ -67,9 +67,14 @@ func NewPostingStore(store *lsmkv.Store, sharedBucket *lsmkv.Bucket, metrics *Me
 		return nil, errors.Wrapf(err, "failed to create or load bucket %s", bName)
 	}
 
+	bucket := store.Bucket(bName)
+	if bucket == nil {
+		return nil, errors.Wrapf(lsmkv.ErrBucketNotFound, "posting store bucket %s", bName)
+	}
+
 	return &PostingStore{
 		store:    store,
-		bucket:   store.Bucket(bName),
+		bucket:   bucket,
 		locks:    common.NewDefaultShardedRWLocks(),
 		metrics:  metrics,
 		versions: versions,

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -126,12 +126,9 @@ func (h *hnsw) DeleteMulti(docIDs ...uint64) error {
 			}
 			idBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(idBytes, id)
-			bucket, err := h.getBucket(h.id + "_mv_mappings")
-			if err != nil {
-				return err
-			}
-			if err := bucket.Delete(idBytes); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("failed to delete %s_mv_mappings from the bucket", h.id))
+			mappings := helpers.MVMappingsBucketName(h.id)
+			if err := h.deleteFromBucket(mappings, idBytes); err != nil {
+				return errors.Wrapf(err, "failed to delete %s from the bucket", mappings)
 			}
 		}
 		h.Lock()
@@ -958,10 +955,7 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 			binary.BigEndian.PutUint64(idBytes, id)
 			// no early return: the node teardown below must run, and
 			// resetLock is held until after it
-			bucket, err := h.getBucket(h.id + "_muvera_vectors")
-			if err == nil {
-				err = bucket.Delete(idBytes)
-			}
+			err := h.deleteFromBucket(helpers.MuveraBucketName(h.id), idBytes)
 			if err != nil {
 				h.logger.WithFields(logrus.Fields{
 					"action": "muvera_delete",

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -126,7 +126,11 @@ func (h *hnsw) DeleteMulti(docIDs ...uint64) error {
 			}
 			idBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(idBytes, id)
-			if err := h.store.Bucket(h.id + "_mv_mappings").Delete(idBytes); err != nil {
+			bucket, err := h.getBucket(h.id + "_mv_mappings")
+			if err != nil {
+				return err
+			}
+			if err := bucket.Delete(idBytes); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to delete %s_mv_mappings from the bucket", h.id))
 			}
 		}
@@ -952,12 +956,17 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 		if h.muvera.Load() {
 			idBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(idBytes, id)
-			if err := h.store.Bucket(h.id + "_muvera_vectors").Delete(idBytes); err != nil {
+			// no early return: the node teardown below must run, and
+			// resetLock is held until after it
+			bucket, err := h.getBucket(h.id + "_muvera_vectors")
+			if err == nil {
+				err = bucket.Delete(idBytes)
+			}
+			if err != nil {
 				h.logger.WithFields(logrus.Fields{
 					"action": "muvera_delete",
 					"id":     id,
-				}).WithError(err).
-					Warnf("cannot delete vector from muvera bucket")
+				}).Warnf("cannot delete vector from muvera bucket: %v", err)
 			}
 		}
 		if err := h.commitLog.DeleteNode(id); err != nil {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -1124,6 +1124,18 @@ func (h *hnsw) Stats() (*HnswStats, error) {
 	return &stats, nil
 }
 
+// getBucket returns the named bucket, or an error if the store no longer holds
+// it. A shard teardown deregisters every bucket up front and drains in-flight
+// requests afterwards, so an operation that is already running finds no bucket
+// under the name it resolved.
+func (h *hnsw) getBucket(name string) (*lsmkv.Bucket, error) {
+	bucket := h.store.Bucket(name)
+	if bucket == nil {
+		return nil, fmt.Errorf("hnsw index %q: bucket %q: %w", h.id, name, lsmkv.ErrBucketNotFound)
+	}
+	return bucket, nil
+}
+
 func (h *hnsw) Type() common.IndexType {
 	return common.IndexTypeHNSW
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -313,14 +313,14 @@ func New(cfg Config, uc ent.UserConfig,
 			muveraEncoder = multivector.NewMuveraEncoder(uc.Multivector.MuveraConfig, store)
 			err := store.CreateOrLoadBucket(
 				context.Background(),
-				cfg.ID+"_muvera_vectors",
+				helpers.MuveraBucketName(cfg.ID),
 				cfg.MakeBucketOptions(lsmkv.StrategyReplace)...,
 			)
 			if err != nil {
 				return nil, errors.Wrapf(err, "Create or load bucket (muvera store)")
 			}
 			muveraVectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
-				return muveraEncoder.GetMuveraVectorForID(id, cfg.ID+"_muvera_vectors")
+				return muveraEncoder.GetMuveraVectorForID(id, helpers.MuveraBucketName(cfg.ID))
 			}
 			vectorCache = cache.NewShardedFloat32LockCache(
 				muveraVectorForID, cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects, 1, cfg.Logger,
@@ -441,7 +441,7 @@ func New(cfg Config, uc ent.UserConfig,
 		if !uc.Multivector.MuveraEnabled() {
 			err := index.store.CreateOrLoadBucket(
 				context.Background(),
-				cfg.ID+"_mv_mappings",
+				helpers.MVMappingsBucketName(cfg.ID),
 				cfg.MakeBucketOptions(lsmkv.StrategyReplace)...,
 			)
 			if err != nil {
@@ -1124,16 +1124,46 @@ func (h *hnsw) Stats() (*HnswStats, error) {
 	return &stats, nil
 }
 
-// getBucket returns the named bucket, or an error if the store no longer holds
-// it. A shard teardown deregisters every bucket up front and drains in-flight
-// requests afterwards, so an operation that is already running finds no bucket
-// under the name it resolved.
-func (h *hnsw) getBucket(name string) (*lsmkv.Bucket, error) {
-	bucket := h.store.Bucket(name)
+// getBucket returns the named bucket pinned for the caller's operation, or an
+// error if the store no longer holds it. A shard teardown deregisters every
+// bucket up front and drains in-flight requests afterwards, so an operation
+// that is already running finds no bucket under the name it resolved.
+//
+// The release closure is always non-nil and must be called exactly once. It
+// holds off the bucket's Shutdown for the operation's duration, so a teardown
+// racing a lookup that already succeeded cannot unmap the segments underneath
+// it. Prefer [hnsw.putInBucket] / [hnsw.deleteFromBucket], which pair the pin
+// with its release for a single operation.
+func (h *hnsw) getBucket(name string) (*lsmkv.Bucket, func(), error) {
+	bucket, release := h.store.AcquireBucketForRead(name)
 	if bucket == nil {
-		return nil, fmt.Errorf("hnsw index %q: bucket %q: %w", h.id, name, lsmkv.ErrBucketNotFound)
+		return nil, release, fmt.Errorf("hnsw index %q: bucket %q: %w", h.id, name, lsmkv.ErrBucketNotFound)
 	}
-	return bucket, nil
+	return bucket, release, nil
+}
+
+// putInBucket writes one entry to the named bucket under a lifetime pin held
+// for exactly that write. Callers write inside per-vector loops, where a
+// deferred release would pile pins up until the whole batch is done.
+func (h *hnsw) putInBucket(name string, key, value []byte) error {
+	bucket, release, err := h.getBucket(name)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return bucket.Put(key, value)
+}
+
+// deleteFromBucket is [hnsw.putInBucket]'s counterpart for removals.
+func (h *hnsw) deleteFromBucket(name string, key []byte) error {
+	bucket, release, err := h.getBucket(name)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return bucket.Delete(key)
 }
 
 func (h *hnsw) Type() common.IndexType {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -299,12 +299,9 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docIDs[i])
 			muveraBytes := multivector.MuveraBytesFromFloat32(processedVectors[i])
-			bucket, err := h.getBucket(h.id + "_muvera_vectors")
-			if err != nil {
-				return err
-			}
-			if err := bucket.Put(docIDBytes, muveraBytes); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("failed to put %s_muvera_vectors into the bucket", h.id))
+			muveraVectors := helpers.MuveraBucketName(h.id)
+			if err := h.putInBucket(muveraVectors, docIDBytes, muveraBytes); err != nil {
+				return errors.Wrapf(err, "failed to put into the %s bucket", muveraVectors)
 			}
 		}
 		// Replace original vectors with processed ones
@@ -425,15 +422,12 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			binary.BigEndian.PutUint64(nodeIDBytes, nodeId)
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docID)
-			bucket, err := h.getBucket(h.id + "_mv_mappings")
-			if err != nil {
-				return err
-			}
-			if err := bucket.Put(nodeIDBytes, docIDBytes); err != nil {
-				return errors.Wrap(err, fmt.Sprintf("failed to put %s_mv_mappings into the bucket", h.id))
+			mappings := helpers.MVMappingsBucketName(h.id)
+			if err := h.putInBucket(mappings, nodeIDBytes, docIDBytes); err != nil {
+				return errors.Wrapf(err, "failed to put into the %s bucket", mappings)
 			}
 
-			err = h.addOne(ctx, vector, node)
+			err := h.addOne(ctx, vector, node)
 			if err != nil {
 				return err
 			}

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -299,7 +299,11 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docIDs[i])
 			muveraBytes := multivector.MuveraBytesFromFloat32(processedVectors[i])
-			if err := h.store.Bucket(h.id+"_muvera_vectors").Put(docIDBytes, muveraBytes); err != nil {
+			bucket, err := h.getBucket(h.id + "_muvera_vectors")
+			if err != nil {
+				return err
+			}
+			if err := bucket.Put(docIDBytes, muveraBytes); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to put %s_muvera_vectors into the bucket", h.id))
 			}
 		}
@@ -421,8 +425,11 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 			binary.BigEndian.PutUint64(nodeIDBytes, nodeId)
 			docIDBytes := make([]byte, 8)
 			binary.BigEndian.PutUint64(docIDBytes, docID)
-			err := h.store.Bucket(h.id+"_mv_mappings").Put(nodeIDBytes, docIDBytes)
+			bucket, err := h.getBucket(h.id + "_mv_mappings")
 			if err != nil {
+				return err
+			}
+			if err := bucket.Put(nodeIDBytes, docIDBytes); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to put %s_mv_mappings into the bucket", h.id))
 			}
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -369,14 +370,15 @@ func (h *hnsw) restoreDocMappings() error {
 	maxDocID := uint64(0)
 	buf := make([]byte, 8)
 
-	// Get the mappings bucket - handle case where it might be nil
-	bucket := h.store.Bucket(h.id + "_mv_mappings")
-	if bucket == nil {
-		err := errors.New("multivector mappings bucket not found")
+	// pinned for the whole scan below: without it a teardown racing this
+	// lookup could unmap the segments the Gets read from
+	bucket, release, err := h.getBucket(helpers.MVMappingsBucketName(h.id))
+	if err != nil {
 		h.logger.WithField("action", "restore_doc_mappings").
-			WithError(err)
-		return err
+			Errorf("multivector mappings bucket not found: %v", err)
+		return errors.Wrap(err, "multivector mappings bucket not found")
 	}
+	defer release()
 
 	for _, node := range h.nodes {
 		if node == nil {

--- a/adapters/repos/db/vector/multivector/muvera.go
+++ b/adapters/repos/db/vector/multivector/muvera.go
@@ -223,10 +223,13 @@ func MuveraFromBytes(bytes []byte) []float32 {
 }
 
 func (e *MuveraEncoder) GetMuveraVectorForID(id uint64, bucketName string) ([]float32, error) {
-	bucket := e.muveraStore.Bucket(bucketName)
+	// pinned for the read: an unpinned pointer can be shut down between the
+	// lookup and the Get, unmapping the segments underneath it
+	bucket, release := e.muveraStore.AcquireBucketForRead(bucketName)
 	if bucket == nil {
 		return nil, fmt.Errorf("muvera bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
 	}
+	defer release()
 
 	idBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(idBytes, id)

--- a/adapters/repos/db/vector/multivector/muvera.go
+++ b/adapters/repos/db/vector/multivector/muvera.go
@@ -222,10 +222,15 @@ func MuveraFromBytes(bytes []byte) []float32 {
 	return vec
 }
 
-func (e *MuveraEncoder) GetMuveraVectorForID(id uint64, bucket string) ([]float32, error) {
+func (e *MuveraEncoder) GetMuveraVectorForID(id uint64, bucketName string) ([]float32, error) {
+	bucket := e.muveraStore.Bucket(bucketName)
+	if bucket == nil {
+		return nil, fmt.Errorf("muvera bucket %q: %w", bucketName, lsmkv.ErrBucketNotFound)
+	}
+
 	idBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(idBytes, id)
-	muveraBytes, err := e.muveraStore.Bucket(bucket).Get(idBytes)
+	muveraBytes, err := bucket.Get(idBytes)
 	if err != nil {
 		return nil, fmt.Errorf("getting vector for id: %w", err)
 	}


### PR DESCRIPTION
### What's being changed:

Fixes this type of panics:
```
goroutine 1170276 [running]:
runtime/debug.Stack()
	runtime/debug/stack.go:26 +0x5e
github.com/weaviate/weaviate/entities/errors.PrintStack({0x4d9c4d0?, 0x1fb45d61bc00?})
	github.com/weaviate/weaviate/entities/errors/panics_logger.go:21 +0x4c
github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).setRecoverPanic.func2(0x1fb4896a2e20, {0x0, 0x0, 0x0})
	github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:87 +0x185
panic({0x3507ec0?, 0x8e6af50?})
	runtime/panic.go:860 +0x13a
sync/atomic.(*Int32).Add(...)
	sync/atomic/type.go:94
sync.(*RWMutex).RLock(...)
	sync/rwmutex.go:72
github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).GetConsistentView(0x0)
	github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:834 +0x61
github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).get(0x0, {0x1fb4a3038b60, 0x8, 0xc8})
	github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:902 +0x6c
github.com/weaviate/weaviate/adapters/repos/db/lsmkv.(*Bucket).Get(0x3c3bfd3?, {0x1fb4a3038b60?, 0x1fb4b2ea0e38?, 0x2?})
	github.com/weaviate/weaviate/adapters/repos/db/lsmkv/bucket.go:872 +0x18
github.com/weaviate/weaviate/adapters/repos/db/vector/flat.(*flat).vectorById(0x1fb45e520000, 0x3d2434)
	github.com/weaviate/weaviate/adapters/repos/db/vector/flat/index.go:584 +0x1a7
github.com/weaviate/weaviate/adapters/repos/db/vector/flat.(*flat).searchByVectorQuantized.func1()
	github.com/weaviate/weaviate/adapters/repos/db/vector/flat/index.go:514 +0x89
github.com/weaviate/weaviate/entities/errors.(*ErrorGroupWrapper).Go.func1()
	github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:103 +0xc9
golang.org/x/sync/errgroup.(*Group).Go.func1()
	golang.org/x/sync@v0.21.0/errgroup/errgroup.go:93 +0x50
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1160819
	golang.org/x/sync@v0.21.0/errgroup/errgroup.go:78 +0x95
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
