### PR TITLE
fix(db): drain in-flight references before dropping a vector index

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -274,6 +274,18 @@ type Shard struct {
 	queue         *VectorIndexQueue
 	vectorIndexes map[string]VectorIndex
 	queues        map[string]*VectorIndexQueue
+	// vectorIndexRefs counts the in-flight users of one vector index, so
+	// DropVectorIndex can wait for them the way drop() waits for shard
+	// references. Keyed by the legacy-normalized target name (see
+	// [Shard.pinVectorIndex]); a counter is removed with its vector.
+	vectorIndexRefs sync.Map // string -> *atomic.Int64
+	// vectorIndexDropping counts the drops claimed per target: no new
+	// reference may be taken while the count is above zero. Guarded by
+	// vectorIndexMu, which is what orders a claim against an in-flight pin. A
+	// count rather than a flag because a re-enqueued drop can overlap the one
+	// it retries, and the first to finish must not re-open the target the
+	// other is still draining for.
+	vectorIndexDropping map[string]int
 
 	geoQueues map[string]*VectorIndexQueue
 

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -15,6 +15,7 @@ package db
 
 import (
 	"maps"
+	"sync/atomic"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -103,6 +104,73 @@ func (s *Shard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
 
 	index, ok := s.vectorIndexes[targetVector]
 	return index, ok
+}
+
+const msgVectorRefReleasedMoreThanOnce = "vector index reference released more than once per pin"
+
+// pinVectorIndex resolves targetVector like [Shard.GetVectorIndex] and, in the
+// same critical section, pins it for the caller's whole operation:
+// [Shard.DropVectorIndex] waits for every pin to be released before it removes
+// the index and the buckets it reads from. Resolving without pinning is what
+// let a drop pull those buckets out from under a running search.
+//
+// Taking the reference under the same RLock as the map read is what makes the
+// pin airtight: a drop claims its target under vectorIndexMu.Lock, so a pin
+// either completes before the claim and is seen by the drain, or observes the
+// claim and is refused.
+//
+// release is never nil, including when the index is not found, and must be
+// called exactly once — defer it at the call site.
+func (s *Shard) pinVectorIndex(targetVector string) (VectorIndex, func(), bool) {
+	s.vectorIndexMu.RLock()
+	defer s.vectorIndexMu.RUnlock()
+
+	var (
+		key   string
+		index VectorIndex
+		ok    bool
+	)
+	if s.isTargetVectorLegacyWithLock(targetVector) {
+		key, index, ok = "", s.vectorIndex, s.vectorIndex != nil
+	} else {
+		key = targetVector
+		index, ok = s.vectorIndexes[targetVector]
+	}
+	if !ok {
+		return nil, func() {}, false
+	}
+	if s.vectorIndexDropping[key] > 0 {
+		return nil, func() {}, false
+	}
+
+	refs := s.vectorIndexRefsFor(key)
+	refs.Add(1)
+
+	// Releasing more than once per pin would drive the counter negative and
+	// disable the drain, so absorb it and report it.
+	var released atomic.Bool
+	return index, func() {
+		if !released.CompareAndSwap(false, true) {
+			s.index.logger.
+				WithField("action", "vector_index_ref_count").
+				WithField("shard", s.name).
+				WithField("target_vector", key).
+				Error(msgVectorRefReleasedMoreThanOnce)
+			return
+		}
+		refs.Add(-1)
+	}, true
+}
+
+// vectorIndexRefsFor returns the reference counter of one target vector,
+// creating it on first use. Callers hold at least vectorIndexMu.RLock, so the
+// counters live in a sync.Map rather than a plain map guarded by it.
+func (s *Shard) vectorIndexRefsFor(key string) *atomic.Int64 {
+	if refs, ok := s.vectorIndexRefs.Load(key); ok {
+		return refs.(*atomic.Int64)
+	}
+	refs, _ := s.vectorIndexRefs.LoadOrStore(key, &atomic.Int64{})
+	return refs.(*atomic.Int64)
 }
 
 func (s *Shard) isTargetVectorLegacyWithLock(targetVector string) bool {

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -25,10 +25,12 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params, module
 
 	// we only need the index queue for vector search
 	if params.NearObject != nil || params.NearVector != nil || params.Hybrid != nil || params.SearchVector != nil {
-		idx, ok := s.GetVectorIndex(params.TargetVector)
+		idx, release, ok := s.pinVectorIndex(params.TargetVector)
 		if !ok {
 			return nil, fmt.Errorf("no vector index for target vector %q", params.TargetVector)
 		}
+		defer release()
+
 		vectorIndex = idx
 	}
 

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -76,13 +76,14 @@ func (s *Shard) FillQueue(targetVector string, from uint64) error {
 
 	var counter int
 
-	vectorIndex, ok := s.GetVectorIndex(targetVector)
+	vectorIndex, release, ok := s.pinVectorIndex(targetVector)
 	if !ok {
 		s.index.logger.WithField("targetVector", targetVector).Warn("preload queue: vector index not found")
 		// shard was never initialized, possibly because of a failed shard
 		// initialization. No op.
 		return nil
 	}
+	defer release()
 
 	q, ok := s.GetVectorIndexQueue(targetVector)
 	if !ok {
@@ -277,7 +278,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 	className := s.index.Config.ClassName.String()
 	shardName := s.Name()
 
-	vectorIndex, ok := s.GetVectorIndex(targetVector)
+	vectorIndex, release, ok := s.pinVectorIndex(targetVector)
 	if !ok {
 		s.index.logger.
 			WithField("class", className).
@@ -288,6 +289,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 		// initialization. No op.
 		return nil
 	}
+	defer release()
 
 	// if it's HNSW, trigger a tombstone cleanup
 	if hnsw.IsHNSWIndex(vectorIndex) {
@@ -552,13 +554,14 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 func (s *Shard) RequantizeIndex(ctx context.Context, targetVector string) error {
 	start := time.Now()
 
-	vectorIndex, ok := s.GetVectorIndex(targetVector)
+	vectorIndex, release, ok := s.pinVectorIndex(targetVector)
 	if !ok {
 		s.index.logger.WithField("targetVector", targetVector).WithField("action", "requantize").Warn("requantize index: vector index not found")
 		// shard was never initialized, possibly because of a failed shard
 		// initialization. No op.
 		return nil
 	}
+	defer release()
 
 	if !vectorIndex.Compressed() {
 		s.index.logger.WithField("targetVector", targetVector).WithField("action", "requantize").Info("vector index is not compressed, skipping requantizing")

--- a/adapters/repos/db/shard_drop_vector_index_refcount_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_refcount_test.go
@@ -1,0 +1,175 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// dropVectorIndexInBackground starts the drop and returns the channel its
+// result lands on.
+func dropVectorIndexInBackground(ctx context.Context, shard *Shard, targetVector string) chan error {
+	dropped := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		dropped <- shard.DropVectorIndex(ctx, targetVector)
+	}, shard.index.logger)
+	return dropped
+}
+
+// requireVectorIndexPinnable asserts whether a reference can be taken on
+// targetVector right now, releasing it either way.
+func requireVectorIndexPinnable(t *testing.T, shard *Shard, targetVector string, want bool) {
+	t.Helper()
+
+	_, release, ok := shard.pinVectorIndex(targetVector)
+	release()
+	require.Equal(t, want, ok)
+}
+
+func requireVectorIndexDropped(t *testing.T, dropped chan error) {
+	t.Helper()
+	select {
+	case err := <-dropped:
+		require.NoError(t, err)
+	case <-time.After(time.Minute): // the drain window plus the teardown behind it
+		t.Fatal("drop never completed")
+	}
+}
+
+// TestDropVectorIndexWaitsForInFlightReferences is the point of the drain: a
+// search that resolved the index before the drop keeps working on it, and the
+// drop waits rather than removing the buckets underneath it.
+func TestDropVectorIndexWaitsForInFlightReferences(t *testing.T) {
+	ctx := testCtx()
+	shard, _ := setupDropVectorShard(t, ctx)
+	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "a", true)))
+
+	index, release, ok := shard.pinVectorIndex("foo")
+	require.True(t, ok)
+
+	dropped := dropVectorIndexInBackground(ctx, shard, "foo")
+
+	select {
+	case err := <-dropped:
+		t.Fatalf("drop completed while a reference was still held: %v", err)
+	case <-time.After(500 * time.Millisecond):
+	}
+
+	// the whole point: the pinned index still reads its own buckets
+	ids, _, err := index.SearchByVector(ctx, []float32{1, 2, 3}, 1, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	// and no new reference may sneak in behind the drain
+	requireVectorIndexPinnable(t, shard, "foo", false)
+
+	release()
+	requireVectorIndexDropped(t, dropped)
+
+	requireVectorIndexPinnable(t, shard, "foo", false)
+}
+
+// TestDropVectorIndexProceedsWhenDrainTimesOut pins the escape hatch: the drain
+// is bounded on purpose, so a reference held past the window must not wedge the
+// drop, and must be logged. Runs for the full drain window (~30s).
+func TestDropVectorIndexProceedsWhenDrainTimesOut(t *testing.T) {
+	ctx := testCtx()
+	shard, _ := setupDropVectorShard(t, ctx)
+	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "a", true)))
+
+	logger, hook := test.NewNullLogger()
+	shard.index.logger = logger
+
+	_, release, ok := shard.pinVectorIndex("foo") // never released before the drop
+	require.True(t, ok)
+	defer release()
+
+	start := time.Now()
+	requireVectorIndexDropped(t, dropVectorIndexInBackground(ctx, shard, "foo"))
+	// ~30s window; near-instant means it never waited
+	require.Greater(t, time.Since(start), 10*time.Second, "drop gave up well short of the drain window")
+
+	var warned bool
+	for _, e := range hook.AllEntries() {
+		warned = warned || (e.Level == logrus.ErrorLevel &&
+			strings.Contains(e.Message, "proceeding with drop while references are still held"))
+	}
+	require.True(t, warned, "a drop that outran its drain must be logged, not silent")
+}
+
+// TestVectorIndexDropClaimIsReleased covers the states a claim must not
+// outlive: a claim blocks every reference to its target, so one left behind
+// would leave a live vector unqueryable.
+func TestVectorIndexDropClaimIsReleased(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(t *testing.T, ctx context.Context, shard *Shard)
+	}{
+		{
+			name: "vector re-created after a completed drop",
+			run: func(t *testing.T, ctx context.Context, shard *Shard) {
+				require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
+				require.NoError(t, shard.initTargetVector(ctx, "foo", hnsw.NewDefaultUserConfig(), false))
+			},
+		},
+		{
+			// the release a drop runs when it gives up before the vector is
+			// gone. Checked on the claim itself: since the teardown got its own
+			// budget, no caller-side input reaches that path any more.
+			name: "claim released",
+			run: func(t *testing.T, ctx context.Context, shard *Shard) {
+				_, release := shard.claimVectorIndexDrop("foo")
+				requireVectorIndexPinnable(t, shard, "foo", false)
+				release()
+			},
+		},
+		{
+			// a re-enqueued drop overlapping the one it retries: the first to
+			// finish must not re-open a target the other is still draining for
+			name: "one of two overlapping claims released",
+			run: func(t *testing.T, ctx context.Context, shard *Shard) {
+				_, releaseFirst := shard.claimVectorIndexDrop("foo")
+				_, releaseSecond := shard.claimVectorIndexDrop("foo")
+
+				releaseFirst()
+				requireVectorIndexPinnable(t, shard, "foo", false)
+
+				releaseSecond()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := testCtx()
+			shard, _ := setupDropVectorShard(t, ctx)
+
+			test.run(t, ctx, shard)
+
+			_, release, ok := shard.pinVectorIndex("foo")
+			defer release()
+			require.True(t, ok, "vector must be usable again")
+		})
+	}
+}

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -15,7 +15,10 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync/atomic"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"go.etcd.io/bbolt"
 
@@ -427,11 +430,87 @@ func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
 	return index.Drop(ctx, false)
 }
 
+// claimVectorIndexDrop marks targetVector as being dropped, so no new
+// reference can be taken on it, and returns the key its references are counted
+// under plus the release for that claim. Every exit path must release: a claim
+// left behind would leave a live vector unqueryable, and one released early
+// re-opens a target another drop is still draining for.
+func (s *Shard) claimVectorIndexDrop(targetVector string) (key string, release func()) {
+	s.vectorIndexMu.Lock()
+	defer s.vectorIndexMu.Unlock()
+
+	key = targetVector
+	if s.isTargetVectorLegacyWithLock(targetVector) {
+		key = ""
+	}
+	if s.vectorIndexDropping == nil {
+		s.vectorIndexDropping = map[string]int{}
+	}
+	s.vectorIndexDropping[key]++
+
+	var released atomic.Bool
+	return key, func() {
+		if !released.CompareAndSwap(false, true) {
+			return
+		}
+		s.vectorIndexMu.Lock()
+		defer s.vectorIndexMu.Unlock()
+		if s.vectorIndexDropping[key]--; s.vectorIndexDropping[key] <= 0 {
+			delete(s.vectorIndexDropping, key)
+		}
+	}
+}
+
+// drainVectorIndexRefs waits for the in-flight users of one vector index to
+// finish, so its drop does not remove the index and its buckets underneath a
+// running request. The caller must have claimed the target first, or new
+// references keep arriving.
+//
+// Bounded like the shard-level drain: on timeout the caller proceeds and the
+// stragglers fail on the deregistered bucket, rather than one stuck reference
+// blocking the drop forever.
+func (s *Shard) drainVectorIndexRefs(key string) error {
+	return backoff.Retry(func() error {
+		if refs := s.vectorIndexRefsFor(key).Load(); refs > 0 {
+			return fmt.Errorf("vector %q of shard %q holds %d reference(s): %w",
+				key, s.name, refs, errShardStillInUse)
+		}
+		return nil
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(300*time.Millisecond), 100)) // 30 seconds
+}
+
 // DropVectorIndex shuts down and removes the named vector index and its queue
 // from this shard, deleting associated files from disk. It also removes the
 // LSM buckets that store the raw and compressed vector data.
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
-	if err := s.dropVectorIndexArtifacts(ctx, targetVector); err != nil {
+	key, releaseClaim := s.claimVectorIndexDrop(targetVector)
+	defer releaseClaim()
+
+	// Before the drain, not after: the queue holds the index for as long as it
+	// indexes, so a live queue would keep the reference count above zero until
+	// the window runs out.
+	if err := s.dropVectorIndexQueue(ctx, targetVector); err != nil {
+		return err
+	}
+
+	if drainErr := s.drainVectorIndexRefs(key); drainErr != nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action":        "drop_vector_index",
+			"class":         s.index.Config.ClassName.String(),
+			"shard":         s.name,
+			"target_vector": targetVector,
+		}).Errorf("proceeding with drop while references are still held; in-flight requests on this vector will fail: %v", drainErr)
+	}
+
+	// A fresh budget for the teardown, started after the drain rather than
+	// before it: the wait above can consume a whole caller deadline, and a
+	// half-dropped vector — queue gone, index and buckets still there — is the
+	// worst outcome of the two. Same reasoning as the fresh shutdown context
+	// in [Shard.drop].
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 20*time.Second)
+	defer cancel()
+
+	if err := s.dropVectorIndexArtifacts(ctx, targetVector, key); err != nil {
 		return err
 	}
 
@@ -444,16 +523,9 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 	return nil
 }
 
-func (s *Shard) dropVectorIndexArtifacts(ctx context.Context, targetVector string) error {
+func (s *Shard) dropVectorIndexArtifacts(ctx context.Context, targetVector, key string) error {
 	s.vectorIndexMu.Lock()
 	defer s.vectorIndexMu.Unlock()
-
-	if queue, ok := s.queues[targetVector]; ok && queue != nil {
-		if err := queue.Drop(ctx); err != nil {
-			return fmt.Errorf("drop queue for vector %q: %w", targetVector, err)
-		}
-		delete(s.queues, targetVector)
-	}
 
 	if index, ok := s.vectorIndexes[targetVector]; ok && index != nil {
 		if err := dropOneVectorIndex(ctx, index); err != nil {
@@ -487,6 +559,29 @@ func (s *Shard) dropVectorIndexArtifacts(ctx context.Context, targetVector strin
 			return fmt.Errorf("delete checkpoint for vector %q: %w", targetVector, err)
 		}
 	}
+
+	// The vector is gone, so its reference counter has nothing left to guard.
+	// The claim is released by the deferred call, after this lock.
+	s.vectorIndexRefs.Delete(key)
+
+	return nil
+}
+
+// dropVectorIndexQueue stops and forgets targetVector's queue. Split out of
+// DropVectorIndex because it must run before the reference drain, outside the
+// lock the rest of the drop holds.
+func (s *Shard) dropVectorIndexQueue(ctx context.Context, targetVector string) error {
+	s.vectorIndexMu.Lock()
+	defer s.vectorIndexMu.Unlock()
+
+	queue, ok := s.queues[targetVector]
+	if !ok || queue == nil {
+		return nil
+	}
+	if err := queue.Drop(ctx); err != nil {
+		return fmt.Errorf("drop queue for vector %q: %w", targetVector, err)
+	}
+	delete(s.queues, targetVector)
 
 	return nil
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -657,20 +657,25 @@ func (s *Shard) VectorDistanceForQuery(ctx context.Context, docId uint64, search
 
 	distances := make([]float32, len(targetVectors))
 	for j, target := range targetVectors {
-		index, ok := s.GetVectorIndex(target)
-		if !ok {
-			return nil, fmt.Errorf("index %s not found", target)
-		}
-		var distancer common.QueryVectorDistancer
-		switch v := searchVectors[j].(type) {
-		case []float32:
-			distancer = index.QueryVectorDistancer(v)
-		case [][]float32:
-			distancer = index.(VectorIndexMulti).QueryMultiVectorDistancer(v)
-		default:
-			return nil, fmt.Errorf("unsupported vector type: %T", v)
-		}
-		dist, err := distancer.DistanceToNode(docId)
+		// one pin per target, released before the next one is taken
+		dist, err := func() (float32, error) {
+			index, release, ok := s.pinVectorIndex(target)
+			if !ok {
+				return 0, fmt.Errorf("index %s not found", target)
+			}
+			defer release()
+
+			var distancer common.QueryVectorDistancer
+			switch v := searchVectors[j].(type) {
+			case []float32:
+				distancer = index.QueryVectorDistancer(v)
+			case [][]float32:
+				distancer = index.(VectorIndexMulti).QueryMultiVectorDistancer(v)
+			default:
+				return 0, fmt.Errorf("unsupported vector type: %T", v)
+			}
+			return distancer.DistanceToNode(docId)
+		}()
 		if err != nil {
 			return nil, err
 		}
@@ -736,10 +741,11 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors []models.V
 				err   error
 			)
 
-			vidx, ok := s.GetVectorIndex(targetVector)
+			vidx, release, ok := s.pinVectorIndex(targetVector)
 			if !ok {
 				return fmt.Errorf("index for target vector %q not found", targetVector)
 			}
+			defer release()
 
 			if limit < 0 {
 				switch searchVector := searchVectors[i].(type) {


### PR DESCRIPTION
### What's being changed:

This PR drains in-flight references before dropping a vector index.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
