### PR TITLE
Refuse property names that collide with migration directories

### DIFF
--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -27,6 +27,7 @@ package rest
 //     match "foo" against "foobar")
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -411,6 +412,77 @@ func TestValidateRangeableProperties(t *testing.T) {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "already")
 	})
+}
+
+// -----------------------------------------------------------------------------
+// validateNoSidecarShapedProperties — a property whose own bucket reads as a
+// migration working directory blocks migrations on the whole collection.
+// -----------------------------------------------------------------------------
+
+func TestValidateNoSidecarShapedProperties(t *testing.T) {
+	cases := []struct {
+		name         string
+		propNames    []string
+		wantOffender string
+	}{
+		{
+			name:      "plain names, including ones that merely contain a role word",
+			propNames: []string{"title", "myreindex", "a_reindex", "a__foo"},
+		},
+		{
+			name:         "offender is a property the migration request never names",
+			propNames:    []string{"title", "title__enable_filterable_ingest_3"},
+			wantOffender: "title__enable_filterable_ingest_3",
+		},
+		{
+			name:         "generation tail",
+			propNames:    []string{"a__reindex_2"},
+			wantOffender: "a__reindex_2",
+		},
+		{
+			name:         "multi-word strategy before the role word",
+			propNames:    []string{"a__foo_reindex"},
+			wantOffender: "a__foo_reindex",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			class := &models.Class{Class: "C"}
+			for _, n := range tc.propNames {
+				class.Properties = append(class.Properties, &models.Property{Name: n})
+			}
+			err := validateNoSidecarShapedProperties(class)
+			if tc.wantOffender == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantOffender)
+			assert.Contains(t, err.Error(), "no migration can start")
+		})
+	}
+}
+
+// TestSubmitReindexTask_RefusesSidecarShapedProperty pins the refusal on the
+// submit path itself, and that it is class-wide: the request migrates "title",
+// while the offending property is one it never names.
+func TestSubmitReindexTask_RefusesSidecarShapedProperty(t *testing.T) {
+	class := &models.Class{
+		Class: "C",
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+			{Name: "title__enable_filterable_ingest_3", DataType: []string{"text"}},
+		},
+	}
+
+	resp := admissionHandler().submitReindexTask(context.Background(), nil, class, "C", "title",
+		upsertPlan{migrationType: db.ReindexTypeEnableFilterable}, nil, nil)
+
+	code, body := statusOf(t, resp)
+	require.Equal(t, http.StatusBadRequest, code)
+	require.Len(t, body.Error, 1)
+	assert.Contains(t, body.Error[0].Message, "title__enable_filterable_ingest_3")
 }
 
 func TestValidateRebuildRangeableProperty(t *testing.T) {

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -414,10 +414,8 @@ func TestValidateRangeableProperties(t *testing.T) {
 	})
 }
 
-// -----------------------------------------------------------------------------
 // validateNoSidecarShapedProperties — a property whose own bucket reads as a
 // migration working directory blocks migrations on the whole collection.
-// -----------------------------------------------------------------------------
 
 func TestValidateNoSidecarShapedProperties(t *testing.T) {
 	cases := []struct {

--- a/adapters/handlers/rest/handlers_indexes_upsert.go
+++ b/adapters/handlers/rest/handlers_indexes_upsert.go
@@ -648,6 +648,12 @@ func (h *indexesHandlers) validateTenantScope(ctx context.Context, principal *mo
 // task. Returns 202 STARTED or the mapped error, reusing the caller's RAFT
 // snapshot (reindexTasks) so check-and-submit sees one consistent view.
 func (h *indexesHandlers) submitReindexTask(ctx context.Context, principal *models.Principal, class *models.Class, collection, propertyName string, plan upsertPlan, tenants []string, reindexTasks []*distributedtask.Task) middleware.Responder {
+	// The one funnel both upsert and rebuild reach to start a task. A NO_OP
+	// returns before this and is deliberately not refused: it starts nothing.
+	if err := validateNoSidecarShapedProperties(class); err != nil {
+		return jsonResponder(http.StatusBadRequest, errorResponse(principal, err.Error()))
+	}
+
 	if h.appState.ClusterService == nil {
 		return jsonResponder(http.StatusServiceUnavailable, errorResponse(principal,
 			"cluster service unavailable; cannot submit reindex task"))

--- a/adapters/handlers/rest/handlers_reindex.go
+++ b/adapters/handlers/rest/handlers_reindex.go
@@ -78,6 +78,24 @@ func filterableIndexOn(prop *models.Property) bool {
 	}
 }
 
+// validateNoSidecarShapedProperties refuses a migration on a collection holding
+// a property whose own bucket reads as a working directory some migration
+// derives from a different property's name; the two would share a directory.
+//
+// Every property is checked, not just the ones the request names: a migration
+// on "title" collides with a property called
+// "title__enable_filterable_ingest_3" the request never mentions. Such a name
+// can no longer be created; a collection that already has one keeps serving.
+func validateNoSidecarShapedProperties(class *models.Class) error {
+	for _, prop := range class.Properties {
+		if entschema.PropertyNameIsSidecarShaped(prop.Name) {
+			return fmt.Errorf("collection %q has property %q, whose name collides with the working directories a migration derives from another property; no migration can start on this collection until that property is removed",
+				class.Class, prop.Name)
+		}
+	}
+	return nil
+}
+
 // validateRangeableProperties validates that the named properties are
 // eligible for enable-rangeable: numeric type, not already rangeable.
 // Whether the property currently has a filterable index is deliberately

--- a/adapters/handlers/rest/handlers_reindex.go
+++ b/adapters/handlers/rest/handlers_reindex.go
@@ -78,14 +78,6 @@ func filterableIndexOn(prop *models.Property) bool {
 	}
 }
 
-// validateNoSidecarShapedProperties refuses a migration on a collection holding
-// a property whose own bucket reads as a working directory some migration
-// derives from a different property's name; the two would share a directory.
-//
-// Every property is checked, not just the ones the request names: a migration
-// on "title" collides with a property called
-// "title__enable_filterable_ingest_3" the request never mentions. Such a name
-// can no longer be created; a collection that already has one keeps serving.
 func validateNoSidecarShapedProperties(class *models.Class) error {
 	for _, prop := range class.Properties {
 		if entschema.PropertyNameIsSidecarShaped(prop.Name) {

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -543,9 +543,6 @@ func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preser
 // the numeric generation tail is off. Keep in lockstep with the strategies'
 // ReindexSuffix / IngestSuffix / BackupSuffix; [TestEverySidecarSuffixIsASidecar]
 // pins that a new strategy either reuses one of these or extends the list.
-//
-// The list lives in entities/schema because property-name validation refuses a
-// name that would give a property this shape.
 var sidecarRoleWords = schema.SidecarRoleWords
 
 // isSidecarDirOf reports whether name is a per-property sidecar of

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -543,7 +543,10 @@ func (s *Shard) cleanStaleSidecarDirsWithPreserved(mainBucketName string, preser
 // the numeric generation tail is off. Keep in lockstep with the strategies'
 // ReindexSuffix / IngestSuffix / BackupSuffix; [TestEverySidecarSuffixIsASidecar]
 // pins that a new strategy either reuses one of these or extends the list.
-var sidecarRoleWords = []string{"reindex", "ingest", "backup", "map"}
+//
+// The list lives in entities/schema because property-name validation refuses a
+// name that would give a property this shape.
+var sidecarRoleWords = schema.SidecarRoleWords
 
 // isSidecarDirOf reports whether name is a per-property sidecar of
 // mainBucketName. "__" alone isn't enough: property names may contain "__"
@@ -573,21 +576,10 @@ func isSidecarDirOf(name, mainBucketName string) bool {
 }
 
 // sidecarRoleWord returns a sidecar suffix's trailing word, ignoring the
-// "_<gen>" tail [genSuffix] appends.
-//
-// Only an all-digit tail is dropped: a non-numeric tail is part of the
-// property's own name, not a generation. This also covers generation 0,
-// which a buggy writer could leave even though [parseMigrationDirName] only
-// accepts generations >= 1.
+// "_<gen>" tail [genSuffix] appends. Shared with the property-name check that
+// refuses a name of this shape at creation time.
 func sidecarRoleWord(suffix string) string {
-	if i := strings.LastIndexByte(suffix, '_'); i >= 0 && isAllDigits(suffix[i+1:]) {
-		suffix = suffix[:i]
-	}
-	return suffix[strings.LastIndexByte(suffix, '_')+1:]
-}
-
-func isAllDigits(s string) bool {
-	return s != "" && strings.TrimLeft(s, "0123456789") == ""
+	return schema.SidecarRoleWord(suffix)
 }
 
 func (s *Shard) removeBucket(ctx context.Context, bucketName string) error {

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -286,8 +287,10 @@ func ValidateReservedPropertyName(name string) error {
 	return nil
 }
 
-// ValidateReservedPropertyNameSuffix rejects property names whose suffix would
-// collide with internal bucket/directory names derived from other properties.
+// ValidateReservedPropertyNameSuffix rejects property names that would collide
+// with an internal bucket or directory name derived from another property: a
+// reserved suffix, or the shape a migration gives its own working directories
+// ([PropertyNameIsSidecarShaped]).
 // Only applied on creation paths — existing schemas (backup restore, startup)
 // must continue to load even if they contain legacy names matching these suffixes.
 func ValidateReservedPropertyNameSuffix(name string) error {
@@ -296,7 +299,41 @@ func ValidateReservedPropertyNameSuffix(name string) error {
 			return fmt.Errorf("'%s' is not a valid property name: suffix '%s' is reserved for internal indices", name, suffix)
 		}
 	}
+	if PropertyNameIsSidecarShaped(name) {
+		return fmt.Errorf("'%s' is not a valid property name: it reads as a working directory a migration derives from another property's name", name)
+	}
 	return nil
+}
+
+// SidecarRoleWords are the words every migration sidecar suffix ends in, once
+// the numeric generation tail is off. Kept here so this name check and
+// adapters/repos/db, which builds and sweeps those directories, read one list.
+var SidecarRoleWords = []string{"reindex", "ingest", "backup", "map"}
+
+// PropertyNameIsSidecarShaped reports whether a property called name would own
+// a bucket ("property_<name>") that reads as a working directory some other
+// property's migration derives, e.g. "title__enable_filterable_ingest_3" is
+// where a migration on "title" works.
+func PropertyNameIsSidecarShaped(name string) bool {
+	i := strings.Index(name, "__")
+	if i < 0 {
+		return false
+	}
+	return slices.Contains(SidecarRoleWords, SidecarRoleWord(name[i+2:]))
+}
+
+// SidecarRoleWord returns a sidecar suffix's trailing word, ignoring the
+// "_<gen>" generation tail. Only an all-digit tail is dropped: a non-numeric
+// tail is part of the property's own name, not a generation.
+func SidecarRoleWord(suffix string) string {
+	if i := strings.LastIndexByte(suffix, '_'); i >= 0 && isAllDigits(suffix[i+1:]) {
+		suffix = suffix[:i]
+	}
+	return suffix[strings.LastIndexByte(suffix, '_')+1:]
+}
+
+func isAllDigits(s string) bool {
+	return s != "" && strings.TrimLeft(s, "0123456789") == ""
 }
 
 // AssertValidClassName assert that this string is a valid class name or

--- a/entities/schema/validation_test.go
+++ b/entities/schema/validation_test.go
@@ -154,6 +154,21 @@ func TestValidateReservedPropertyNameSuffix(t *testing.T) {
 		{name: "reject _nullState", input: "foo_nullState", wantErr: true},
 		{name: "reject when suffix is the whole prefix of name", input: "bar_temp", wantErr: true},
 		{name: "reject name equal to suffix only", input: "_temp", wantErr: true},
+
+		// A migration on property "a" works in directories called
+		// "property_a__<strategy>_<role>_<gen>". A property whose own main
+		// bucket has that shape would share the directory.
+		{name: "reject sidecar shape", input: "a__reindex", wantErr: true},
+		{name: "reject sidecar shape with generation tail", input: "a__reindex_2", wantErr: true},
+		{name: "reject sidecar shape with multi-word strategy", input: "a__foo_reindex", wantErr: true},
+		{name: "reject real derived name", input: "title__enable_filterable_ingest_3", wantErr: true},
+		{name: "reject map role word", input: "a__blockmax_map_1", wantErr: true},
+		{name: "reject backup role word", input: "a__roaringset_backup", wantErr: true},
+		{name: "ok role word without the double underscore", input: "myreindex", wantErr: false},
+		{name: "ok role word as a plain suffix", input: "a_reindex", wantErr: false},
+		{name: "ok double underscore without a role word", input: "a__foo", wantErr: false},
+		{name: "ok role word not in trailing position", input: "a__reindex_foo", wantErr: false},
+		{name: "ok non-numeric tail after the role word", input: "a__reindex_v2", wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
A migration derives its working-directory names from the property it migrates:
`property_<prop>__<strategy>_<role>_<gen>`. A *different* property named so that
its own main bucket has that shape ends up sharing a directory on disk with that
migration.

Two rules close it:

- **A new property cannot be created with such a name.** A new arm of
  `ValidateReservedPropertyNameSuffix`, which both creation paths already call.
  It reuses the existing shape test rather than a suffix match, so `myreindex`
  stays valid while `a__reindex_2` and `a__foo_reindex` do not.
- **A collection that already holds such a property cannot start a migration.**
  The check walks every property of the class, not only the ones the request
  names: the colliding property is one the request never mentions.

The role-word list (`reindex`, `ingest`, `backup`, `map`) moves into
`entities/schema`, so the name check and the directory sweeper in
`adapters/repos/db` read one list.

Existing schemas keep loading and serving unchanged. The only new refusal a
collection with a legacy name sees is that a migration cannot start.
