### PR TITLE
perf(hfresh): fetch split vectors through a single bucket view

### DIFF
--- a/adapters/repos/db/vector/hfresh/hfresh_test.go
+++ b/adapters/repos/db/vector/hfresh/hfresh_test.go
@@ -13,6 +13,7 @@ package hfresh
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"log"
 	"net/http"
@@ -132,6 +133,10 @@ func makeHFreshConfig(t *testing.T) (*Config, ent.UserConfig) {
 // the caller may normalize the returned slice in place.
 func setDelegatingTempThunk(cfg *Config) {
 	cfg.TempVectorForIDWithViewThunk = func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+		// Mirror the production thunk (Shard.readVectorByIndexIDIntoSliceWithView),
+		// which writes the ID into Buff8 unconditionally: a caller passing a
+		// container without pool-initialized buffers must fail tests too.
+		binary.LittleEndian.PutUint64(container.Buff8, id)
 		vec, err := cfg.VectorForIDThunk(ctx, id)
 		if err != nil {
 			return nil, err

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 )
 
@@ -211,14 +210,19 @@ func (h *HFresh) splitPosting(ctx context.Context, posting Posting) ([]SplitResu
 	view := h.objectsBucketView()
 	defer view.ReleaseView()
 
-	var slice common.VectorSlice
+	// The pooled container is required, not just an optimization: the
+	// production thunk writes the vector ID into the container's Buff8,
+	// which only the pool initializes.
+	slice := h.tempVectors.Get(int(dims))
+	defer h.tempVectors.Put(slice)
+
 	data := make([][]float32, len(posting))
 	for i, v := range posting {
 		// A fetch failure (e.g. a vector deleted between garbage collection
 		// and this read) aborts the split rather than degrading it; doSplit
 		// retries the collect+split sequence so the deleted entry gets
 		// filtered on the next attempt.
-		vec, err := h.fetchNormalizedVector(ctx, v.ID(), &slice, view)
+		vec, err := h.fetchNormalizedVector(ctx, v.ID(), slice, view)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to fetch vector %d for split", v.ID())
 		}

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -13,9 +13,11 @@ package hfresh
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 )
 
@@ -119,6 +121,7 @@ func (h *HFresh) doSplit(ctx context.Context, postingID uint64, reassign bool) e
 
 		h.logger.WithField("postingID", postingID).
 			WithField("attempt", attempt).
+			WithField("error", err).
 			Debug("retrying split after vector fetch failure")
 	}
 	// if one of the postings is empty, ignore the split
@@ -202,21 +205,29 @@ func (h *HFresh) splitPosting(ctx context.Context, posting Posting) ([]SplitResu
 	// Cluster on the full-precision vectors rather than their 1-bit
 	// reconstructions: the centroids this split produces become the new
 	// postings' routing representatives, and sign-only reconstructions bound
-	// their quality.
+	// their quality. All reads go through a single bucket view and a pooled
+	// slice — the split holds the posting lock, so per-vector view churn
+	// would extend the time appends to this posting stay blocked.
+	view := h.objectsBucketView()
+	defer view.ReleaseView()
+
+	var slice common.VectorSlice
 	data := make([][]float32, len(posting))
 	for i, v := range posting {
 		// A fetch failure (e.g. a vector deleted between garbage collection
 		// and this read) aborts the split rather than degrading it; doSplit
 		// retries the collect+split sequence so the deleted entry gets
 		// filtered on the next attempt.
-		vec, err := h.config.VectorForIDThunk(ctx, v.ID())
+		vec, err := h.fetchNormalizedVector(ctx, v.ID(), &slice, view)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to fetch vector %d for split", v.ID())
 		}
 		if len(vec) == 0 {
 			return nil, errors.Errorf("empty vector %d for split", v.ID())
 		}
-		data[i] = h.normalizeVec(vec)
+		// vec aliases the pooled slice and the next fetch overwrites it;
+		// clustering needs every vector at once, so copy it out.
+		data[i] = slices.Clone(vec)
 	}
 
 	idsAssignments, err := enc.FitBalanced(data)


### PR DESCRIPTION
### What's being changed:

Follow-up to #12863, addressing two review findings on the split path:

- **One bucket view per split instead of one per vector.** `splitPosting` fetched each entry's full-precision vector through `VectorForIDThunk`, which lands in `Shard.vectorByIndexID` and acquires/releases a fresh objects-bucket view plus a per-call key allocation. The split holds the posting lock for its whole duration, so with postings of hundreds to thousands of entries this churn extends the window during which appends to that posting are blocked. Vectors are now read through a single consistent view with a pooled slice (`fetchNormalizedVector`, the same path search rescoring uses), and each vector is copied out into the clustering buffer. This also makes the fetch loop read from one consistent snapshot.
- **Split retry log now carries the error.** The retry in `doSplit` logged the attempt but dropped the fetch error, so recovered failures left no diagnosable trace (the error only surfaced if all attempts failed).

No behavior change: same vectors, same clustering, same retry semantics.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.