### PR TITLE
fix(replica): bounds-check read repair, guard group-by objects bucket

### DIFF
--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
@@ -30,7 +29,11 @@ func (s *Shard) groupResults(ctx context.Context, ids []uint64,
 	dists []float32, groupBy *searchparams.GroupBy,
 	additional additional.Properties, properties []string,
 ) ([]*storobj.Object, []float32, error) {
-	objsBucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	objsBucket, err := s.objectsBucket()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	className := s.index.Config.ClassName
 	class := s.index.getSchema.ReadOnlyClass(className.String())
 	if class == nil {

--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -29,10 +29,11 @@ func (s *Shard) groupResults(ctx context.Context, ids []uint64,
 	dists []float32, groupBy *searchparams.GroupBy,
 	additional additional.Properties, properties []string,
 ) ([]*storobj.Object, []float32, error) {
-	objsBucket, err := s.objectsBucket()
+	objsBucket, release, err := s.objectsBucket()
 	if err != nil {
 		return nil, nil, err
 	}
+	defer release()
 
 	className := s.index.Config.ClassName
 	class := s.index.getSchema.ReadOnlyClass(className.String())

--- a/adapters/repos/db/shard_group_by_torn_store_test.go
+++ b/adapters/repos/db/shard_group_by_torn_store_test.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/searchparams"
+)
+
+// groupResults reaches the objects bucket to hydrate each group's hits, so a
+// teardown that outran its drain must fail it rather than dereference nil.
+func TestGroupResultsAfterStoreTeardownReturnsError(t *testing.T) {
+	index, cleanup := initIndexAndPopulate(t, t.TempDir())
+	defer cleanup()
+
+	_, shard := loadTestShard(t, index)
+	// the state a teardown that outran its drain leaves behind
+	require.NoError(t, shard.store.Shutdown(context.Background()))
+
+	_, _, err := shard.groupResults(context.Background(), nil, nil,
+		&searchparams.GroupBy{Property: "name", Groups: 1, ObjectsPerGroup: 1},
+		additional.Properties{}, nil)
+	require.ErrorIs(t, err, lsmkv.ErrBucketNotFound)
+}

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
@@ -88,19 +89,11 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
-<<<<<<< HEAD
 		RootPath:                  t.TempDir(),
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
+		MemtablesFlushDirtyAfter:  int(time.Hour.Seconds()),
 		EnableLazyLoadShards:      boolPtr(true),
-=======
-		RootPath:                      t.TempDir(),
-		QueryMaximumResults:           10000,
-		MaxImportGoroutinesFactor:     1,
-		MemtablesFlushDirtyAfter:      int(time.Hour.Seconds()),
-		EnableLazyLoadShards:          boolPtr(lazyLoad),
-		LazyLoadShardWarmupMinObjects: warmupMinObjects,
->>>>>>> ec9666116f (fix(replica): bounds-check read repair, guard group-by objects bucket)
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),

--- a/adapters/repos/db/shard_lazyloader_coldshard_test.go
+++ b/adapters/repos/db/shard_lazyloader_coldshard_test.go
@@ -88,10 +88,19 @@ func newLazyLoadRepo(t *testing.T, shardState *sharding.State) (*DB, *Migrator, 
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 
 	repo, err := New(logger, "node1", Config{
+<<<<<<< HEAD
 		RootPath:                  t.TempDir(),
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
 		EnableLazyLoadShards:      boolPtr(true),
+=======
+		RootPath:                      t.TempDir(),
+		QueryMaximumResults:           10000,
+		MaxImportGoroutinesFactor:     1,
+		MemtablesFlushDirtyAfter:      int(time.Hour.Seconds()),
+		EnableLazyLoadShards:          boolPtr(lazyLoad),
+		LazyLoadShardWarmupMinObjects: warmupMinObjects,
+>>>>>>> ec9666116f (fix(replica): bounds-check read repair, guard group-by objects bucket)
 	},
 		&FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{},
 		&FakeReplicationClient{}, metrics, memwatch.NewDummyMonitor(),

--- a/adapters/repos/db/shard_lock_test.go
+++ b/adapters/repos/db/shard_lock_test.go
@@ -14,6 +14,7 @@
 package db
 
 import (
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -114,6 +115,9 @@ func TestShardLock_DocIdDeadlock(t *testing.T) {
 
 // this method tests the bucket_lock_debug.go methods using a real shard
 // it is set here instead of lsmkv to reuse shard creation methods dependencies
+//
+// Only publishing a segment takes the maintenance lock, so the flushes the
+// assertion needs are forced rather than left to background maintenance.
 func TestShardLock_ObjectsMaintenanceLock(t *testing.T) {
 	amount := 1000
 	ctx := testCtx()
@@ -121,22 +125,52 @@ func TestShardLock_ObjectsMaintenanceLock(t *testing.T) {
 	shd, _ := testShard(t, ctx, className)
 
 	ids := createDataForLockTests(t, shd, className, amount)
+	objectsBucket := shd.Store().Bucket(helpers.ObjectsBucketLSM)
+	require.NotNil(t, objectsBucket)
+
 	eg := enterrors.NewErrorGroupWrapper(logrus.New())
+
+	// set by the poller once it samples the lock held
+	var observed atomic.Bool
 
 	finished := make(chan struct{})
 	eg.Go(func() error {
-		t.Run("delete data from shard", func(t *testing.T) {
-			deleteDataForLockTests(t, shd, ids)
-		})
-		close(finished)
+		defer close(finished)
+
+		const flushEvery = 100
+		for i, id := range ids {
+			require.NoError(t, shd.batchDeleteObject(ctx, id, time.Now()))
+			if i%flushEvery == flushEvery-1 {
+				require.NoError(t, objectsBucket.FlushAndSwitch())
+			}
+		}
+
+		objs, err := shd.ObjectList(ctx, len(ids), nil, nil, additional.Properties{},
+			shd.Index().Config.ClassName)
+		require.NoError(t, err)
+		require.Equal(t, 0, len(objs))
+
+		// the poller is not synchronised with the flushes above; keep publishing
+		// segments, bounded, until one is actually observed
+		deadline := time.Now().Add(30 * time.Second)
+		for !observed.Load() && time.Now().Before(deadline) {
+			require.NoError(t, shd.PutObject(ctx, testObject(className)))
+			require.NoError(t, objectsBucket.FlushAndSwitch())
+		}
 		return nil
 	})
 
 	changes := 0
 	timeLocked := 0
-	objectsBucket := shd.Store().Bucket(helpers.ObjectsBucketLSM)
+	sampleLock := func() (bool, error) {
+		locked, err := objectsBucket.DebugGetSegmentGroupLockStatus()
+		if locked {
+			observed.Store(true)
+		}
+		return locked, err
+	}
 	eg.Go(func() error {
-		timeLocked, changes = testLock(t, finished, objectsBucket.DebugGetSegmentGroupLockStatus)
+		timeLocked, changes = testLock(t, finished, sampleLock)
 		return nil
 	})
 

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -41,7 +41,8 @@ type repairer struct {
 }
 
 // repairOne repairs a single object (used by Finder::GetOne).
-// contentIdx is -1 when no reply carried the full object.
+// contentIdx is -1 when no reply carried the full object, which only the
+// content-fetching paths need.
 func (r *repairer) repairOne(ctx context.Context,
 	shard string,
 	id strfmt.UUID,
@@ -56,10 +57,6 @@ func (r *repairer) repairOne(ctx context.Context,
 		}
 		r.metrics.ObserveReadRepairDuration(time.Since(start))
 	}(time.Now())
-
-	if contentIdx < 0 || contentIdx >= len(votes) {
-		return nil, fmt.Errorf("no reply identified as the caller's copy among %d replies", len(votes))
-	}
 
 	var (
 		deleted          bool
@@ -116,6 +113,13 @@ func (r *repairer) repairOne(ctx context.Context,
 
 	if deleted && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
 		return nil, replicaerrors.ErrConflictExistOrDeleted
+	}
+
+	// Only the paths below need the caller's copy; the delete-only exits above
+	// repair from the digest votes alone, so the check belongs here and not at
+	// the top of the function.
+	if contentIdx < 0 || contentIdx >= len(votes) {
+		return nil, fmt.Errorf("no reply identified as the caller's copy among %d replies", len(votes))
 	}
 
 	// fetch most recent object

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -40,7 +40,8 @@ type repairer struct {
 	logger              logrus.FieldLogger
 }
 
-// repairOne repairs a single object (used by Finder::GetOne)
+// repairOne repairs a single object (used by Finder::GetOne).
+// contentIdx is -1 when no reply carried the full object.
 func (r *repairer) repairOne(ctx context.Context,
 	shard string,
 	id strfmt.UUID,
@@ -55,6 +56,10 @@ func (r *repairer) repairOne(ctx context.Context,
 		}
 		r.metrics.ObserveReadRepairDuration(time.Since(start))
 	}(time.Now())
+
+	if contentIdx < 0 || contentIdx >= len(votes) {
+		return nil, fmt.Errorf("no reply identified as the caller's copy among %d replies", len(votes))
+	}
 
 	var (
 		deleted          bool
@@ -205,6 +210,10 @@ func (r *repairer) repairExist(ctx context.Context,
 		}
 		r.metrics.ObserveReadRepairDuration(time.Since(start))
 	}(time.Now())
+
+	if len(votes) == 0 {
+		return false, fmt.Errorf("no replies to repair from")
+	}
 
 	var (
 		deleted          bool

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // TestRepairBatchPartTimeBasedLiveWinnerFailedRefetch pins that a live winner whose refetch fails does not nil-deref under TimeBasedResolution (regression for the repairBatchPart guard).
@@ -275,7 +276,8 @@ func TestRepairOneWithoutCallerCopy(t *testing.T) {
 			strategy:   models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
 		},
 		{
-			// the delete branches run before the content lookup
+			// time-based resolution falls past the delete-only exits and does
+			// need the caller's copy
 			name:       "no reply carried content, deleted replica",
 			votes:      []ObjTuple{{Sender: "A", UTime: 100, O: Replica{ID: id, LastUpdateTimeUnixMilli: 100, Deleted: true}}},
 			contentIdx: -1,
@@ -308,6 +310,63 @@ func TestRepairOneWithoutCallerCopy(t *testing.T) {
 			require.Nil(t, obj)
 		})
 	}
+}
+
+// TestRepairOneDeleteOnlyPathsNeedNoCallerCopy is the one-object counterpart of
+// TestRepairBatchPartDeleteOnConflictSkipsContentFetch: a tombstone is resolved
+// from the digest votes alone, so losing the full-content reply must not stop
+// the repair. Guarding contentIdx at the top of repairOne would have left the
+// live replica unrepaired here.
+func TestRepairOneDeleteOnlyPathsNeedNoCallerCopy(t *testing.T) {
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	// one replica holds the tombstone, the other is stale and must be overwritten
+	votes := []ObjTuple{
+		{Sender: "A", UTime: 200, O: Replica{ID: id, LastUpdateTimeUnixMilli: 200, Deleted: true}},
+		{Sender: "B", UTime: 100, O: Replica{ID: id, LastUpdateTimeUnixMilli: 100}},
+	}
+
+	t.Run("delete on conflict repairs from digests", func(t *testing.T) {
+		rc := NewMockRClient(t)
+		var overwritten []string
+		rc.EXPECT().OverwriteObjects(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(_ context.Context, host, _, _ string, _ []*objects.VObject) ([]types.RepairResponse, error) {
+				overwritten = append(overwritten, host)
+				return nil, nil
+			}).Maybe()
+
+		r := &repairer{
+			class:               "C1",
+			getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyDeleteOnConflict },
+			client:              NewFinderClient(rc, logger),
+			metrics:             metrics,
+			logger:              logger,
+		}
+
+		obj, err := r.repairOne(context.Background(), "S1", id, votes, -1)
+		require.NoError(t, err, "a tombstone repair needs no full-content reply")
+		require.Nil(t, obj)
+		require.Equal(t, []string{"B"}, overwritten, "only the stale replica is overwritten")
+	})
+
+	t.Run("no automated resolution reports the conflict", func(t *testing.T) {
+		r := &repairer{
+			class:               "C1",
+			getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyNoAutomatedResolution },
+			client:              NewFinderClient(NewMockRClient(t), logger),
+			metrics:             metrics,
+			logger:              logger,
+		}
+
+		obj, err := r.repairOne(context.Background(), "S1", id, votes, -1)
+		require.ErrorIs(t, err, replicaerrors.ErrConflictExistOrDeleted,
+			"the conflict is known from the digests, not from the caller's copy")
+		require.Nil(t, obj)
+	})
 }
 
 // TestRepairExistWithoutReplies pins that an empty vote slice is reported

--- a/usecases/replica/repairer_internal_test.go
+++ b/usecases/replica/repairer_internal_test.go
@@ -237,3 +237,100 @@ func TestRepairBatchPartWithoutCallerCopy(t *testing.T) {
 	require.ErrorContains(t, err, "no reply identified as the caller's copy")
 	require.Equal(t, []bool{false}, resolved)
 }
+
+// TestRepairOneWithoutCallerCopy pins that a missing caller copy is reported
+// instead of indexing votes[-1]. Counterpart to TestRepairBatchPartWithoutCallerCopy.
+func TestRepairOneWithoutCallerCopy(t *testing.T) {
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	newRepairer := func(strategy string) *repairer {
+		return &repairer{
+			class:               "C1",
+			getDeletionStrategy: func() string { return strategy },
+			client:              NewFinderClient(NewMockRClient(t), logger),
+			metrics:             metrics,
+			logger:              logger,
+		}
+	}
+
+	digestOnly := []ObjTuple{
+		{Sender: "A", UTime: 100, O: Replica{ID: id, LastUpdateTimeUnixMilli: 100}},
+		{Sender: "B", UTime: 200, O: Replica{ID: id, LastUpdateTimeUnixMilli: 200}},
+	}
+
+	cases := []struct {
+		name       string
+		votes      []ObjTuple
+		contentIdx int
+		strategy   string
+	}{
+		{
+			name:       "no reply carried content",
+			votes:      digestOnly,
+			contentIdx: -1,
+			strategy:   models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+		},
+		{
+			// the delete branches run before the content lookup
+			name:       "no reply carried content, deleted replica",
+			votes:      []ObjTuple{{Sender: "A", UTime: 100, O: Replica{ID: id, LastUpdateTimeUnixMilli: 100, Deleted: true}}},
+			contentIdx: -1,
+			strategy:   models.ReplicationConfigDeletionStrategyTimeBasedResolution,
+		},
+		{
+			name:       "every reply was lost",
+			votes:      nil,
+			contentIdx: -1,
+			strategy:   models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+		},
+		{
+			name:       "content index past the surviving replies",
+			votes:      digestOnly,
+			contentIdx: len(digestOnly),
+			strategy:   models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRepairer(tc.strategy)
+
+			var obj *storobj.Object
+			var err error
+			require.NotPanics(t, func() {
+				obj, err = r.repairOne(context.Background(), "S1", id, tc.votes, tc.contentIdx)
+			})
+			require.ErrorContains(t, err, "no reply identified as the caller's copy")
+			require.Nil(t, obj)
+		})
+	}
+}
+
+// TestRepairExistWithoutReplies pins that an empty vote slice is reported
+// instead of indexing votes[0].
+func TestRepairExistWithoutReplies(t *testing.T) {
+	id := strfmt.UUID("00000000-0000-0000-0000-000000000abc")
+
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+	logger, _ := test.NewNullLogger()
+
+	r := &repairer{
+		class:               "C1",
+		getDeletionStrategy: func() string { return models.ReplicationConfigDeletionStrategyNoAutomatedResolution },
+		client:              NewFinderClient(NewMockRClient(t), logger),
+		metrics:             metrics,
+		logger:              logger,
+	}
+
+	var exists bool
+	require.NotPanics(t, func() {
+		exists, err = r.repairExist(context.Background(), "S1", id, nil)
+	})
+	require.ErrorContains(t, err, "no replies to repair from")
+	require.False(t, exists)
+}


### PR DESCRIPTION
### What's being changed:
A tenant delete tears the store down under in-flight reads, leaving `Store.Bucket(objects)` nil: `Shard.WasDeleted` dereferenced it, and repairOne indexed votes[-1] once the swallowed reply left contentIdx unset.

Route every objects-bucket read through `Shard.objectsBucket()`, return a `tornBucketView` from the two view getters that have no error to report through, and bounds-check repairOne/repairExist.

Also unflakes `TestShardLock_ObjectsMaintenanceLock` and the lazy-load cold count fixture, which left MemtablesFlushDirtyAfter at 0 so every cycle tick flushed the memtable.

Refs: weaviate/0-weaviate-issues#647

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
