### PR TITLE
fix(reindex): only checkpoint reindex progress once the data is durable

### DIFF
--- a/adapters/repos/db/inverted_reindex_progress_durability_test.go
+++ b/adapters/repos/db/inverted_reindex_progress_durability_test.go
@@ -34,8 +34,7 @@ const (
 	durabilityCheckpointAt = 20
 )
 
-// interruptingRetokenizeStrategy delegates to FilterableRetokenizeStrategy and
-// cancels the reindex run's context after a fixed number of writes.
+// interruptingRetokenizeStrategy cancels the reindex run's context after a fixed number of writes.
 type interruptingRetokenizeStrategy struct {
 	FilterableRetokenizeStrategy
 	writes      int
@@ -56,11 +55,7 @@ func (s *interruptingRetokenizeStrategy) WriteToReindexBucket(shard ShardLike, b
 	return nil
 }
 
-// TestReindexProgressCheckpointDurability covers both markProgress call sites in
-// OnAfterLsmInitAsync: a checkpoint may only certify postings that are already
-// durable. Each case drives one site, snapshots the reindex bucket the way a
-// SIGKILL would (bytes the kernel already holds are copied, the commit log's
-// user-space buffer is not) and replays that snapshot the way a restart does.
+// TestReindexProgressCheckpointDurability pins that a reindex checkpoint never certifies postings that a crash could still lose.
 func TestReindexProgressCheckpointDurability(t *testing.T) {
 	tests := []struct {
 		name               string
@@ -152,9 +147,8 @@ func TestReindexProgressCheckpointDurability(t *testing.T) {
 	}
 }
 
-// copyBucketDir snapshots a live bucket directory into a fresh temp dir. The
-// copy sees every byte already handed to the kernel and nothing still held in
-// the process, which is what a SIGKILL leaves on disk.
+// copyBucketDir copies a live bucket dir via read/write, keeping only bytes
+// already flushed to the kernel — what survives a SIGKILL.
 func copyBucketDir(t *testing.T, src string) string {
 	t.Helper()
 	dst := t.TempDir()

--- a/adapters/repos/db/inverted_reindex_progress_durability_test.go
+++ b/adapters/repos/db/inverted_reindex_progress_durability_test.go
@@ -1,0 +1,169 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/models"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+const (
+	durabilityProp         = "title"
+	durabilityCheckpointAt = 20
+)
+
+// interruptingRetokenizeStrategy delegates to FilterableRetokenizeStrategy and
+// cancels the reindex run's context after a fixed number of writes.
+type interruptingRetokenizeStrategy struct {
+	FilterableRetokenizeStrategy
+	writes      int
+	cancelAfter int
+	cancel      context.CancelFunc
+}
+
+func (s *interruptingRetokenizeStrategy) WriteToReindexBucket(shard ShardLike, bucket *lsmkv.Bucket,
+	docID uint64, prop inverted.Property,
+) error {
+	if err := s.FilterableRetokenizeStrategy.WriteToReindexBucket(shard, bucket, docID, prop); err != nil {
+		return err
+	}
+	s.writes++
+	if s.writes == s.cancelAfter {
+		s.cancel()
+	}
+	return nil
+}
+
+// TestReindexProgressCheckpointDurability covers both markProgress call sites in
+// OnAfterLsmInitAsync: a checkpoint may only certify postings that are already
+// durable. Each case drives one site, snapshots the reindex bucket the way a
+// SIGKILL would (bytes the kernel already holds are copied, the commit log's
+// user-space buffer is not) and replays that snapshot the way a restart does.
+func TestReindexProgressCheckpointDurability(t *testing.T) {
+	tests := []struct {
+		name               string
+		processingDuration time.Duration
+		checkEvery         int
+		cancelAfter        int
+	}{
+		{
+			name:               "error path checkpoints while unwinding",
+			processingDuration: 10 * time.Minute,
+			checkEvery:         1000,
+			cancelAfter:        durabilityCheckpointAt,
+		},
+		{
+			name:       "time slice path checkpoints on normal return",
+			checkEvery: durabilityCheckpointAt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testCtx()
+			runCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			className := "ReindexCheckpointDurability_" + uuid.NewString()[:8]
+			shd, idx := testShardWithSettings(t, ctx,
+				newTestClassWithProps(className, []string{durabilityProp}),
+				enthnsw.UserConfig{Skip: true}, false, false, false)
+			shard := shd.(*Shard)
+			defer shard.Shutdown(ctx)
+
+			for _, obj := range makeConvergenceTestObjects(t, 50, className) {
+				require.NoError(t, shard.PutObject(ctx, obj))
+			}
+
+			strategy := &interruptingRetokenizeStrategy{
+				FilterableRetokenizeStrategy: FilterableRetokenizeStrategy{
+					propName:           durabilityProp,
+					targetTokenization: models.PropertyTokenizationField,
+					className:          className,
+					generation:         1,
+				},
+				cancelAfter: tt.cancelAfter,
+				cancel:      cancel,
+			}
+			task := NewShardReindexTaskGeneric("FilterableRetokenize", idx.logger, strategy,
+				reindexTaskConfig{
+					concurrency:                   2,
+					memtableOptFactor:             4,
+					backupMemtableOptFactor:       1,
+					pauseDuration:                 time.Second,
+					processingDuration:            tt.processingDuration,
+					checkProcessingEveryNoObjects: tt.checkEvery,
+				},
+				&UuidKeyParser{}, uuidObjectsIteratorAsync)
+
+			require.NoError(t, task.OnAfterLsmInit(ctx, shard))
+			_, _, err := task.OnAfterLsmInitAsync(runCtx, shard)
+			require.Equal(t, tt.cancelAfter > 0, err != nil, "unexpected run outcome: %v", err)
+			require.Equal(t, durabilityCheckpointAt, strategy.writes,
+				"the site under test must be reached after exactly %d objects", durabilityCheckpointAt)
+
+			rt, err := task.newReindexTracker(shard.pathLSM())
+			require.NoError(t, err)
+			lastKey, _, err := rt.GetProgress()
+			require.NoError(t, err)
+			require.NotEmpty(t, lastKey.Bytes(), "the site under test must have written a checkpoint")
+
+			snapshot := copyBucketDir(t, filepath.Join(shard.pathLSM(),
+				task.reindexBucketName(durabilityProp)))
+			logger, _ := test.NewNullLogger()
+			recovered, err := lsmkv.NewBucketCreator().NewBucket(ctx, snapshot, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
+			require.NoError(t, err)
+			defer recovered.Shutdown(ctx)
+
+			docIDs := map[uint64]struct{}{}
+			for _, ids := range fingerprintRoaringSetBucket(t, recovered) {
+				for _, id := range ids {
+					docIDs[id] = struct{}{}
+				}
+			}
+			require.Len(t, docIDs, durabilityCheckpointAt,
+				"the checkpoint certifies %d objects, so the recovered bucket must hold all of them",
+				durabilityCheckpointAt)
+		})
+	}
+}
+
+// copyBucketDir snapshots a live bucket directory into a fresh temp dir. The
+// copy sees every byte already handed to the kernel and nothing still held in
+// the process, which is what a SIGKILL leaves on disk.
+func copyBucketDir(t *testing.T, src string) string {
+	t.Helper()
+	dst := t.TempDir()
+	entries, err := os.ReadDir(src)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(src, entry.Name()))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(dst, entry.Name()), data, 0o600))
+	}
+	return dst
+}

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1114,6 +1114,20 @@ func (t *ShardReindexTaskGeneric) newReindexTrackerGuarded(shard ShardLike) (rei
 	return rt, nil
 }
 
+// flushReindexBuckets makes buffered reindex writes durable, so a checkpoint
+// written after it can never certify rows a crash would discard.
+func (t *ShardReindexTaskGeneric) flushReindexBuckets(buckets map[string]*lsmkv.Bucket, action string) error {
+	for propName, bucket := range buckets {
+		if bucket == nil {
+			continue
+		}
+		if err := bucket.FlushAndSwitch(); err != nil {
+			return fmt.Errorf("flushing reindex bucket for prop %q before %s: %w", propName, action, err)
+		}
+	}
+	return nil
+}
+
 func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard ShardLike,
 ) (rerunAt time.Time, reloadShard bool, err error) {
 	collectionName := shard.Index().Config.ClassName.String()
@@ -1233,13 +1247,6 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		}
 	}
 
-	defer func() {
-		if err != nil && !bytes.Equal(lastStoredKey.Bytes(), lastProcessedKey.Bytes()) {
-			logger.WithField("last_processed_key", lastProcessedKey).Debug("marking progress on error")
-			rt.markProgress(lastProcessedKey, processedCount, indexedCount)
-		}
-	}()
-
 	store := shard.Store()
 	propExtraction := storobj.NewPropExtraction()
 	bucketsByPropName := map[string]*lsmkv.Bucket{}
@@ -1248,6 +1255,17 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		bucketName := t.reindexBucketName(prop)
 		bucketsByPropName[prop] = store.Bucket(bucketName)
 	}
+
+	defer func() {
+		if err != nil && !bytes.Equal(lastStoredKey.Bytes(), lastProcessedKey.Bytes()) {
+			if ferr := t.flushReindexBuckets(bucketsByPropName, "checkpointing on error"); ferr != nil {
+				logger.WithError(ferr).Warn("skipping reindex progress checkpoint: buckets not durable")
+				return
+			}
+			logger.WithField("last_processed_key", lastProcessedKey).Debug("marking progress on error")
+			rt.markProgress(lastProcessedKey, processedCount, indexedCount)
+		}
+	}()
 
 	breakCh := make(chan bool, 1)
 	breakCh <- false
@@ -1335,6 +1353,9 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 		}
 	}
 	if !bytes.Equal(lastStoredKey.Bytes(), lastProcessedKey.Bytes()) {
+		if err = t.flushReindexBuckets(bucketsByPropName, "marking progress"); err != nil {
+			return zerotime, false, err
+		}
 		if err := rt.markProgress(lastProcessedKey, processedCount, indexedCount); err != nil {
 			err = fmt.Errorf("marking reindex progress: %w", err)
 			return zerotime, false, err

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1259,7 +1259,7 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	defer func() {
 		if err != nil && !bytes.Equal(lastStoredKey.Bytes(), lastProcessedKey.Bytes()) {
 			if ferr := t.flushReindexBuckets(bucketsByPropName, "checkpointing on error"); ferr != nil {
-				logger.WithError(ferr).Warn("skipping reindex progress checkpoint: buckets not durable")
+logger.Warnf("skipping reindex progress checkpoint: buckets not durable: %v", ferr)
 				return
 			}
 			logger.WithField("last_processed_key", lastProcessedKey).Debug("marking progress on error")

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1259,7 +1259,7 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	defer func() {
 		if err != nil && !bytes.Equal(lastStoredKey.Bytes(), lastProcessedKey.Bytes()) {
 			if ferr := t.flushReindexBuckets(bucketsByPropName, "checkpointing on error"); ferr != nil {
-logger.Warnf("skipping reindex progress checkpoint: buckets not durable: %v", ferr)
+				logger.Warnf("skipping reindex progress checkpoint: buckets not durable: %v", ferr)
 				return
 			}
 			logger.WithField("last_processed_key", lastProcessedKey).Debug("marking progress on error")


### PR DESCRIPTION
A node killed mid-reindex can come back permanently short of rows, and
filtered queries on that replica silently under-return. Only the node that
restarts first is affected; the one that restarts last rebuilds from scratch.

The resume checkpoint is a plain file write and reaches disk immediately. The
reindex postings it vouches for sit in a memtable whose write-ahead log is
buffered in user space. A SIGKILL discards that buffer, WAL recovery drops the
torn tail, and the resume then seeks past a range that was never indexed.

The fix flushes every per-property reindex bucket before writing the
checkpoint, at both progress call sites in OnAfterLsmInitAsync. On flush
failure the checkpoint is skipped entirely: a checkpoint whose data is not
durable is the defect itself, and skipping costs only re-processing a range,
which the resume design already tolerates. A third certifier, markReindexed,
already had this barrier; this completes the pattern at the other two. The
ongoing cost is one extra segment per property per ten-minute time slice.

Tests: TestReindexProgressCheckpointDurability in adapters/repos/db. Both
subtests fail on stable/v1.39 with the checkpoint present and the recovered
bucket completely empty.

### Deliberately out of scope

Runtime reindexing is in Preview. This boundary is intentional, not an oversight — please don't ask for these; they are what the PR was trimmed to remove.

- **Backups** — deferred until the backup subsystem's v1.40 rework lands. Backup-related reindex issues are tracked separately.
- **Upgrading while a migration is running or partially finished** — unsupported in Preview. Operators drain and finalize before upgrading, so this adds no mid-migration upgrade compatibility.
- **Rolling-upgrade state inconsistency** — mixed-version nodes may briefly disagree about migration state; accepted for Preview. No double-handling, no fallbacks, no inferring which build wrote a given piece of state.
