### PR TITLE
fix(aggregation-pr1): return scan errors rather than partial results or panics

### DIFF
--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -109,6 +109,9 @@ func Test_Aggregations(t *testing.T) {
 	t.Run("date aggregations with filters",
 		testDateAggregationsWithFilters(repo))
 
+	t.Run("filtered aggregation reports a failing object",
+		testFilteredAggregationSurfacesScanError(repo, schemaGetter))
+
 	t.Run("clean up",
 		cleanupCompanyTestSchemaAndData(repo, migrator))
 }
@@ -2344,4 +2347,59 @@ func mustStringToTime(s string) time.Time {
 		panic(fmt.Sprintf("failed to parse time: %s, %s", s, err))
 	}
 	return asTime
+}
+
+// The scan's callback fails on an object whose stored type no longer matches
+// the declared one, which a schema change can leave behind. That failure is
+// where a swallowed error left a plausible partial result: aggregates over
+// every other object and nothing to say one was skipped.
+func testFilteredAggregationSurfacesScanError(repo *DB,
+	schemaGetter *fakeSchemaGetter,
+) func(t *testing.T) {
+	return func(t *testing.T) {
+		drifted := *companyClass
+		drifted.Properties = make([]*models.Property, len(companyClass.Properties))
+		for i, p := range companyClass.Properties {
+			if p.Name == "listedInIndex" {
+				redeclared := *p
+				redeclared.DataType = []string{"number"}
+				drifted.Properties[i] = &redeclared
+				continue
+			}
+			drifted.Properties[i] = p
+		}
+
+		classes := schemaGetter.schema.Objects.Classes
+		for i, c := range classes {
+			if c.Class == companyClass.Class {
+				classes[i] = &drifted
+				t.Cleanup(func() { classes[i] = companyClass })
+				break
+			}
+		}
+
+		params := aggregation.Params{
+			ClassName: schema.ClassName(companyClass.Class),
+			Filters: &filters.LocalFilter{
+				Root: &filters.Clause{
+					Operator: filters.OperatorGreaterThan,
+					Value: &filters.Value{
+						Type:  schema.DataTypeInt,
+						Value: -5, // price is positive everywhere, so every object matches
+					},
+					On: &filters.Path{Property: "price"},
+				},
+			},
+			Properties: []aggregation.ParamProperty{
+				{
+					Name:        schema.PropertyName("listedInIndex"),
+					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
+				},
+			},
+		}
+
+		res, err := repo.Aggregate(context.Background(), params, nil)
+		require.Error(t, err, "an object the scan could not analyse must fail the aggregation")
+		require.Nil(t, res, "a partial result is worse than an error: it looks complete")
+	}
 }

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -132,7 +132,7 @@ func (fa *filteredAggregator) properties(ctx context.Context,
 		return nil, errors.Wrap(err, "prepare aggregators for props")
 	}
 
-	scan := func(properties *models.PropertySchema, docID uint64) error {
+	scan := func(ctx context.Context, properties *models.PropertySchema, docID uint64) error {
 		if err := fa.AnalyzeObject(ctx, properties, propAggs); err != nil {
 			return errors.Wrapf(err, "analyze object %d", docID)
 		}
@@ -143,7 +143,7 @@ func (fa *filteredAggregator) properties(ctx context.Context,
 		propertyNames = append(propertyNames, k)
 	}
 
-	err = docid.ScanObjectsLSM(fa.store, ids, scan, propertyNames, fa.logger)
+	err = docid.ScanObjectsLSM(ctx, fa.store, ids, scan, propertyNames, fa.logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "properties view tx")
 	}

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -64,7 +64,7 @@ func (g *grouper) Do(ctx context.Context) ([]group, error) {
 }
 
 func (g *grouper) groupAll(ctx context.Context) ([]group, error) {
-	err := ScanAllLSM(ctx, g.store, func(prop *models.PropertySchema, docID uint64) error {
+	err := ScanAllLSM(ctx, g.store, func(_ context.Context, prop *models.PropertySchema, docID uint64) error {
 		return g.addElementById(prop, docID)
 	}, &storobj.PropertyExtraction{
 		PropertyPaths: [][]string{{g.params.GroupBy.Property.String()}},
@@ -82,8 +82,11 @@ func (g *grouper) groupFiltered(ctx context.Context) ([]group, error) {
 		return nil, err
 	}
 
-	if err := docid.ScanObjectsLSM(g.store, ids,
-		func(prop *models.PropertySchema, docID uint64) error {
+	if err := docid.ScanObjectsLSM(ctx, g.store, ids,
+		func(ctx context.Context, prop *models.PropertySchema, docID uint64) error {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			return g.addElementById(prop, docID)
 		}, []string{g.params.GroupBy.Property.String()}, g.logger); err != nil {
 		return nil, err
@@ -303,9 +306,8 @@ func ScanAllLSM(ctx context.Context, store *lsmkv.Store, scan docid.ObjectScanFn
 				return errors.Wrapf(err, "unmarshal data object")
 			}
 
-			// scanAll has no abort, so we can ignore the first arg
 			properties := elem.Properties()
-			if err := scan(&properties, elem.DocID); err != nil {
+			if err := scan(ctx, &properties, elem.DocID); err != nil {
 				return err
 			}
 		}

--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -31,7 +31,7 @@ import (
 
 const contextCheckInterval = 50 // check context every 50 iterations, every iteration adds too much overhead
 
-// ObjectScanFn is called once per object, if false or an error is returned,
+// ObjectScanFn is called once per object, if an error is returned,
 // the scanning will stop
 type ObjectScanFn func(prop *models.PropertySchema, docID uint64) error
 
@@ -136,14 +136,14 @@ func (os *objectScannerLSM) scan() error {
 
 				// majority of time is spend reading the objects => do the analyses sequentially to not cause races
 				// when analysing the results
-				if func() error {
+				if err := func() error {
 					lock.Lock()
 					defer lock.Unlock()
 					if err := os.scanFn(&properties, id); err != nil {
-						return errors.Wrapf(err, "scan")
+						return errors.Wrapf(err, "scan object %d", id)
 					}
 					return nil
-				}() != nil {
+				}(); err != nil {
 					return err
 				}
 			}

--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -29,18 +29,19 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
-const contextCheckInterval = 50 // check context every 50 iterations, every iteration adds too much overhead
+func scanConcurrency() int { return 2 * runtime.GOMAXPROCS(0) }
 
-// ObjectScanFn is called once per object, if an error is returned,
-// the scanning will stop
-type ObjectScanFn func(prop *models.PropertySchema, docID uint64) error
+// ObjectScanFn is called once per object with the context the scan runs under,
+// which is cancelled whenever the caller's is. If an error is returned, the
+// scanning will stop.
+type ObjectScanFn func(ctx context.Context, prop *models.PropertySchema, docID uint64) error
 
 // ScanObjectsLSM calls the provided scanFn on each object for the
 // specified pointer. If a pointer does not resolve to an object-id, the item
 // will be skipped. The number of times scanFn is called can therefore be
 // smaller than the input length of pointers.
-func ScanObjectsLSM(store *lsmkv.Store, pointers []uint64, scan ObjectScanFn, properties []string, logger logrus.FieldLogger) error {
-	return newObjectScannerLSM(store, pointers, scan, properties, logger).Do()
+func ScanObjectsLSM(ctx context.Context, store *lsmkv.Store, pointers []uint64, scan ObjectScanFn, properties []string, logger logrus.FieldLogger) error {
+	return newObjectScannerLSM(store, pointers, scan, properties, logger).Do(ctx)
 }
 
 type objectScannerLSM struct {
@@ -64,12 +65,12 @@ func newObjectScannerLSM(store *lsmkv.Store, pointers []uint64,
 	}
 }
 
-func (os *objectScannerLSM) Do() error {
+func (os *objectScannerLSM) Do(ctx context.Context) error {
 	if err := os.init(); err != nil {
 		return errors.Wrap(err, "init object scanner")
 	}
 
-	if err := os.scan(); err != nil {
+	if err := os.scan(ctx); err != nil {
 		return errors.Wrap(err, "scan")
 	}
 
@@ -86,7 +87,11 @@ func (os *objectScannerLSM) init() error {
 	return nil
 }
 
-func (os *objectScannerLSM) scan() error {
+func (os *objectScannerLSM) scan(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Preallocate property paths needed for json unmarshalling
 	propertyPaths := make([][]string, len(os.properties))
 	for i := range os.properties {
@@ -94,9 +99,8 @@ func (os *objectScannerLSM) scan() error {
 	}
 
 	lock := sync.Mutex{}
-	// the context of the user request is checked in the scanFn function
-	eg, newContext := enterrors.NewErrorGroupWithContextWrapper(os.logger, context.Background())
-	concurrency := 2 * runtime.GOMAXPROCS(0)
+	eg, groupCtx := enterrors.NewErrorGroupWithContextWrapper(os.logger, ctx)
+	concurrency := scanConcurrency()
 	stride := int(math.Ceil(max(float64(len(os.pointers))/float64(concurrency), 1)))
 	for i := 0; i < concurrency; i++ {
 		start := i * stride
@@ -111,12 +115,17 @@ func (os *objectScannerLSM) scan() error {
 			// The typed properties are needed for extraction from json
 			var properties models.PropertySchema
 
-			for j, id := range os.pointers[start:end] {
-				if j%contextCheckInterval == 0 && newContext.Err() != nil {
-					return newContext.Err()
+			// checked per doc ID rather than every nth: a worker's range is only
+			// len(pointers)/concurrency long, so an interval skips short ranges
+			// outright. BenchmarkScanObjectsLSM sweeps what the check costs.
+			for _, id := range os.pointers[start:end] {
+				if err := groupCtx.Err(); err != nil {
+					return err
 				}
 				binary.LittleEndian.PutUint64(docIDBytes, id)
-				res, err := os.objectsBucket.GetBySecondary(context.TODO(), 0, docIDBytes) // TODO: Context!
+				// GetBySecondary reads ctx for slow-query annotation only, so a worker
+				// already inside this read is not interrupted by a cancellation.
+				res, err := os.objectsBucket.GetBySecondary(groupCtx, 0, docIDBytes)
 				if err != nil {
 					return err
 				}
@@ -139,7 +148,7 @@ func (os *objectScannerLSM) scan() error {
 				if err := func() error {
 					lock.Lock()
 					defer lock.Unlock()
-					if err := os.scanFn(&properties, id); err != nil {
+					if err := os.scanFn(groupCtx, &properties, id); err != nil {
 						return errors.Wrapf(err, "scan object %d", id)
 					}
 					return nil

--- a/adapters/repos/db/docid/scan_test.go
+++ b/adapters/repos/db/docid/scan_test.go
@@ -58,14 +58,14 @@ func TestScanObjectsLSM(t *testing.T) {
 			store, pointers := storeWithObjects(t, tt.objectCount, logger)
 
 			var calls atomic.Int64
-			scan := func(_ *models.PropertySchema, _ uint64) error {
+			scan := func(_ context.Context, _ *models.PropertySchema, _ uint64) error {
 				if int(calls.Add(1)) == tt.failOnCall {
 					return errScanFn
 				}
 				return nil
 			}
 
-			err := ScanObjectsLSM(store, pointers, scan, []string{"name"}, logger)
+			err := ScanObjectsLSM(context.Background(), store, pointers, scan, []string{"name"}, logger)
 
 			if tt.failOnCall == 0 {
 				require.NoError(t, err)
@@ -77,21 +77,144 @@ func TestScanObjectsLSM(t *testing.T) {
 	}
 }
 
+func TestScanObjectsLSMCancellation(t *testing.T) {
+	const someObjects = 100
+
+	// ten doc IDs per worker, so the first worker's range holds the whole of what
+	// the two part-way rows observe and no other worker can reach scanFn
+	tenPerWorker := 10 * scanConcurrency()
+
+	tests := []struct {
+		name string
+		// doc IDs beyond storedObjects resolve to no object, so the loop skips
+		// them without ever reaching scanFn
+		storedObjects int
+		pointerCount  int
+		// otherwise the first scanFn call cancels, part way through the scan
+		cancelBeforeScan bool
+		maxScanCalls     int
+	}{
+		{
+			name:             "cancelled before the scan, every doc ID resolves",
+			storedObjects:    someObjects,
+			pointerCount:     someObjects,
+			cancelBeforeScan: true,
+			maxScanCalls:     0,
+		},
+		{
+			name:             "cancelled before the scan, no doc ID resolves",
+			storedObjects:    0,
+			pointerCount:     someObjects,
+			cancelBeforeScan: true,
+			maxScanCalls:     0,
+		},
+		{
+			name:             "cancelled before the scan, no doc IDs at all",
+			storedObjects:    0,
+			pointerCount:     0,
+			cancelBeforeScan: true,
+			maxScanCalls:     0,
+		},
+		{
+			// only the first worker's range resolves, so it alone reaches scanFn and
+			// the count below is its own behaviour rather than a race between workers
+			name:          "cancelled part way through, every doc ID resolves",
+			storedObjects: 10,
+			pointerCount:  tenPerWorker,
+			maxScanCalls:  1,
+		},
+		{
+			name:          "cancelled part way through, only the first doc ID resolves",
+			storedObjects: 1,
+			pointerCount:  tenPerWorker,
+			maxScanCalls:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			store, pointers := storeWithObjects(t, tt.storedObjects, logger)
+			for i := len(pointers); i < tt.pointerCount; i++ {
+				pointers = append(pointers, uint64(i))
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancelBeforeScan {
+				cancel()
+			}
+
+			var calls atomic.Int64
+			var sawCancel atomic.Bool
+			scan := func(scanCtx context.Context, _ *models.PropertySchema, _ uint64) error {
+				calls.Add(1)
+				cancel()
+				// cancelling the caller's context propagates to children before it
+				// returns, so a scanCtx derived from it is already cancelled here
+				sawCancel.Store(scanCtx.Err() != nil)
+				return nil
+			}
+
+			err := ScanObjectsLSM(ctx, store, pointers, scan, []string{"name"}, logger)
+
+			require.ErrorIs(t, err, context.Canceled)
+			require.LessOrEqual(t, calls.Load(), int64(tt.maxScanCalls))
+			if calls.Load() > 0 {
+				require.True(t, sawCancel.Load(), "scanFn was handed a context the caller cannot cancel")
+			}
+		})
+	}
+}
+
+// Sweeps what the per-doc-ID context poll in scan costs, on the two shapes the
+// loop takes: every doc ID resolving to an object, and none of them resolving.
+func BenchmarkScanObjectsLSM(b *testing.B) {
+	const docIDCount = 50000
+
+	benchmarks := []struct {
+		name          string
+		storedObjects int
+	}{
+		{name: "every doc ID resolves", storedObjects: docIDCount},
+		{name: "no doc ID resolves", storedObjects: 0},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			logger, _ := test.NewNullLogger()
+			store, pointers := storeWithObjects(b, bm.storedObjects, logger)
+			for i := len(pointers); i < docIDCount; i++ {
+				pointers = append(pointers, uint64(i))
+			}
+			scan := func(_ context.Context, _ *models.PropertySchema, _ uint64) error { return nil }
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := ScanObjectsLSM(context.Background(), store, pointers, scan,
+					[]string{"name"}, logger); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 // storeWithObjects returns a store holding count objects keyed by their UUID,
 // with the docID secondary index ScanObjectsLSM resolves pointers through, and
 // the docIDs of those objects.
-func storeWithObjects(t *testing.T, count int, logger logrus.FieldLogger) (*lsmkv.Store, []uint64) {
+func storeWithObjects(tb testing.TB, count int, logger logrus.FieldLogger) (*lsmkv.Store, []uint64) {
 	ctx := context.Background()
-	dir := t.TempDir()
+	dir := tb.TempDir()
 
 	store, err := lsmkv.New(dir, dir, logger, nil, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop())
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, store.Shutdown(ctx)) })
+	require.NoError(tb, err)
+	tb.Cleanup(func() { require.NoError(tb, store.Shutdown(ctx)) })
 
-	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
+	require.NoError(tb, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
 		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1)))
 	bucket := store.Bucket(helpers.ObjectsBucketLSM)
 
@@ -105,15 +228,15 @@ func storeWithObjects(t *testing.T, count int, logger logrus.FieldLogger) (*lsmk
 		obj.SetID(strfmt.UUID(id.String()))
 		obj.Object.Properties = map[string]interface{}{"name": fmt.Sprintf("object-%d", i)}
 		objBytes, err := obj.MarshalBinary()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 
 		// the shard write path keys objects by the UUID's 16 raw bytes
 		idBytes, err := id.MarshalBinary()
-		require.NoError(t, err)
+		require.NoError(tb, err)
 
 		docIDBytes := make([]byte, 8)
 		binary.LittleEndian.PutUint64(docIDBytes, docID)
-		require.NoError(t, bucket.Put(idBytes, objBytes,
+		require.NoError(tb, bucket.Put(idBytes, objBytes,
 			lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)))
 	}
 

--- a/adapters/repos/db/docid/scan_test.go
+++ b/adapters/repos/db/docid/scan_test.go
@@ -1,0 +1,121 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package docid
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+var errScanFn = errors.New("scan fn failed")
+
+func TestScanObjectsLSM(t *testing.T) {
+	// enough objects that the scan splits them across several concurrent workers
+	const manyObjects = 100
+
+	tests := []struct {
+		name        string
+		objectCount int
+		// the scanFn call that returns errScanFn, counted from one; 0 lets every
+		// call succeed
+		failOnCall int
+	}{
+		{name: "no objects", objectCount: 0, failOnCall: 0},
+		{name: "every call succeeds", objectCount: manyObjects, failOnCall: 0},
+		{name: "the only object fails", objectCount: 1, failOnCall: 1},
+		{name: "the first scan call fails", objectCount: manyObjects, failOnCall: 1},
+		{name: "a mid-scan call fails", objectCount: manyObjects, failOnCall: manyObjects / 2},
+		{name: "the last scan call fails", objectCount: manyObjects, failOnCall: manyObjects},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			store, pointers := storeWithObjects(t, tt.objectCount, logger)
+
+			var calls atomic.Int64
+			scan := func(_ *models.PropertySchema, _ uint64) error {
+				if int(calls.Add(1)) == tt.failOnCall {
+					return errScanFn
+				}
+				return nil
+			}
+
+			err := ScanObjectsLSM(store, pointers, scan, []string{"name"}, logger)
+
+			if tt.failOnCall == 0 {
+				require.NoError(t, err)
+				require.Equal(t, int64(tt.objectCount), calls.Load())
+				return
+			}
+			require.ErrorIs(t, err, errScanFn)
+		})
+	}
+}
+
+// storeWithObjects returns a store holding count objects keyed by their UUID,
+// with the docID secondary index ScanObjectsLSM resolves pointers through, and
+// the docIDs of those objects.
+func storeWithObjects(t *testing.T, count int, logger logrus.FieldLogger) (*lsmkv.Store, []uint64) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	store, err := lsmkv.New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Shutdown(ctx)) })
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM,
+		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1)))
+	bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+	pointers := make([]uint64, count)
+	for i := range pointers {
+		docID := uint64(i)
+		pointers[i] = docID
+
+		id := uuid.New()
+		obj := storobj.New(docID)
+		obj.SetID(strfmt.UUID(id.String()))
+		obj.Object.Properties = map[string]interface{}{"name": fmt.Sprintf("object-%d", i)}
+		objBytes, err := obj.MarshalBinary()
+		require.NoError(t, err)
+
+		// the shard write path keys objects by the UUID's 16 raw bytes
+		idBytes, err := id.MarshalBinary()
+		require.NoError(t, err)
+
+		docIDBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(docIDBytes, docID)
+		require.NoError(t, bucket.Put(idBytes, objBytes,
+			lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)))
+	}
+
+	return store, pointers
+}


### PR DESCRIPTION
First of a series from a profiling audit of the aggregation read path; the rest is performance work, stacked behind it. Two commits, one bug each — the commit messages carry the mechanism.

## Motivation

`docid.ScanObjectsLSM` could not report failure. Its worker returned a nil loop-scoped error rather than the callback's, and its error group was rooted at `context.Background()` rather than the caller's. A cancelled filtered aggregation therefore answered 200 with an aggregate over however many objects it had reached — a plausible smaller number, indistinguishable from the real one.

## Approach

The context is threaded rather than worked around: `ObjectScanFn` takes the scan's context, so a callback reads the context that is actually cancelled rather than one it closed over. Passing it to `GetBySecondary` does **not** make the read interruptible, and the comment there says so.

`contextCheckInterval = 50` is removed rather than retuned: it indexed a *worker's own* slice, so below `interval × 2 × GOMAXPROCS` doc IDs it ran exactly once. `BenchmarkScanObjectsLSM` sweeps what checking per doc ID costs.

## Risks

An aggregation that returned a partial result as a success now returns an error. Intended, user-visible, and worth a release note.

## Testing

`docid/scan_test.go` is new — the package had no test file at all, much of why this drifted. It covers the callback error, cancellation before and part-way through, and doc IDs resolving to no object; each row was mutation-tested.

`Test_Aggregations` covers the production boundary through a property whose stored type no longer matches the declared one. A cancelled request cannot stand in for that: cancelling one fails earlier, in the searcher that resolves the doc IDs, and never reaches the scan.
