### PR TITLE
gh-12658 exclude LSM scratch files from the offload-s3 shard upload

### DIFF
--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -307,14 +307,6 @@ func (m *Module) Upload(ctx context.Context, className, shardName, nodeName stri
 	// Only mark real uploads as active: the empty-shard shortcut above is a no-op.
 	defer monitoring.GetBackgroundProcessMetrics().Started(monitoring.ProcessOffload)()
 
-	cmd := []string{
-		fmt.Sprintf("--endpoint-url=%s", m.Endpoint),
-		"cp",
-		fmt.Sprintf("--concurrency=%s", fmt.Sprintf("%d", m.Concurrency)),
-		fmt.Sprintf("%s/*", localPath),
-		fmt.Sprintf("s3://%s/%s/%s/%s/", m.Bucket, strings.ToLower(className), shardName, nodeName),
-	}
-
 	var err error
 	defer func() {
 		// Update few useful metrics
@@ -327,8 +319,25 @@ func (m *Module) Upload(ctx context.Context, className, shardName, nodeName stri
 		m.metrics.OpsDuration.WithLabelValues("upload", status).Observe(time.Since(start).Seconds())
 	}()
 
-	err = m.newApp().RunContext(ctx, cmd)
+	err = m.newApp().RunContext(ctx, m.uploadArgs(localPath, className, shardName, nodeName))
 	return err
+}
+
+// uploadArgs builds the s5cmd invocation for a shard upload. s5cmd expands
+// the source wildcard recursively, so without --exclude it also ships the
+// .tmp scratch a shard keeps when it is frozen without ever being loaded.
+// lsmkv.Bucket.listFiles and listInactiveLSMFiles already skip those; this
+// path builds an argv instead of walking the tree, so it needs its own rule.
+// .wal stays in, the shard needs it to recover on the next reactivation.
+func (m *Module) uploadArgs(localPath, className, shardName, nodeName string) []string {
+	return []string{
+		fmt.Sprintf("--endpoint-url=%s", m.Endpoint),
+		"cp",
+		fmt.Sprintf("--concurrency=%s", fmt.Sprintf("%d", m.Concurrency)),
+		"--exclude=*.tmp",
+		fmt.Sprintf("%s/*", localPath),
+		fmt.Sprintf("s3://%s/%s/%s/%s/", m.Bucket, strings.ToLower(className), shardName, nodeName),
+	}
 }
 
 // Download downloads the content of a shard to desired node from

--- a/modules/offload-s3/module_test.go
+++ b/modules/offload-s3/module_test.go
@@ -73,6 +73,31 @@ func TestUpload_ConcurrentNoFlagRedefinedPanic(t *testing.T) {
 	}
 }
 
+func TestUploadArgs_SkipsScratchFiles(t *testing.T) {
+	// Constructed directly: New() registers Prometheus collectors, and the
+	// suite already has one module registered.
+	m := &Module{
+		Endpoint:    "http://127.0.0.1:1",
+		Bucket:      "weaviate-offload-test",
+		Concurrency: 4,
+	}
+
+	args := m.uploadArgs("/var/lib/weaviate/testclass/tenant-0", "TestClass", "tenant-0", "node1")
+
+	// Exact argv, because position matters: s5cmd stops reading flags at the
+	// first positional, so an --exclude placed after the source wildcard
+	// becomes a third positional and cp fails with "expected source and
+	// destination arguments".
+	require.Equal(t, []string{
+		"--endpoint-url=http://127.0.0.1:1",
+		"cp",
+		"--concurrency=4",
+		"--exclude=*.tmp",
+		"/var/lib/weaviate/testclass/tenant-0/*",
+		"s3://weaviate-offload-test/testclass/tenant-0/node1/",
+	}, args)
+}
+
 func shardName(i int) string {
 	return fmt.Sprintf("tenant-%d", i)
 }


### PR DESCRIPTION
Fixes #12658

`offload-s3` uploads with `s5cmd cp <shardPath>/* s3://…`. s5cmd compiles `*` to `.*`, which crosses `/`, so the copy is recursive and unfiltered: every `.tmp` under the shard reaches object storage, including interrupted memtable flushes, compaction and cleanup leftovers, and precomputed `*.bloom.tmp`.

Loaded shards normally lose those files during `segment_group` init. Unloaded shards don't: `(*Migrator).freezeTenants` uses `idx.GetShard`, which doesn't materialize one, so freezing an unloaded tenant uploads the on-disk tree left by the last crash. Other shard walks already exclude this material: `lsmkv.Bucket.listFiles` skips `.wal` and `.tmp` (`adapters/repos/db/lsmkv/bucket_backup.go:85`), while `listInactiveLSMFiles` skips `tmpExt` (`adapters/repos/db/backup.go:929`).

Add `--exclude=*.tmp` to `cp`, the first option from the issue. I didn't replace the glob with an explicit backup-walk file list because that is a larger change and would also address residue directories, which #12644 covers separately. `.wal` remains included: backups exclude it because they need immutable files, but a frozen shard needs its WAL for recovery after reactivation.

The argv is now built by `uploadArgs`, allowing `TestUploadArgs_SkipsScratchFiles` to assert it without an S3 endpoint. `Upload` is otherwise unchanged. `go test ./modules/offload-s3/` passes at `4a216cb`; without the flag, the test fails with:

```
[]string{"--endpoint-url=…", "cp", "--concurrency=4", "…/tenant-0/*", "s3://…/node1/"} does not contain "--exclude=*.tmp"
```

The test asserts exact argv ordering because position matters. With vendored s5cmd v2.0.1, moving `--exclude` after the source wildcard gives `expected source and destination arguments`; `--exclude-nope` gives `flag provided but not defined: -exclude-nope`; `--exclude=*.tmp` parses and reaches the S3 call, failing only on the unreachable endpoint.

This doesn't prove s5cmd's recursive exclusion. I couldn't add or run a MinIO-backed journey test under `test/modules/offload-s3/` without Docker. The matching is in `isObjectExcluded` (`command/wildcard.go:50`): `WildCardToRegexp` compiles `*.tmp` to `^.*\.tmp$` and matches the object path after trimming the source prefix.

`DownloadToPath` still copies the whole remote prefix. Tenants offloaded by an earlier version therefore retain and restore remote `.tmp` files on thaw; filtering or cleaning those is a compatibility decision outside this fix.