### PR TITLE
[Bug] gRPC can't read geo/phone-shaped object props, unchanged PUTs always rewrite

### DIFF
--- a/adapters/handlers/grpc/v1/mapping.go
+++ b/adapters/handlers/grpc/v1/mapping.go
@@ -108,14 +108,23 @@ func (m *Mapper) NewNestedValue(v interface{}, dt schema.DataType, parent schema
 	}
 	switch dt {
 	case schema.DataTypeObject:
-		if _, ok := v.(map[string]interface{}); !ok {
+		obj, ok := v.(map[string]interface{})
+		if !ok {
+			// the disk read path enriches geo/phone-shaped object maps into
+			// their struct forms; turn them back into maps so they serialize
+			// like any other object property
+			if shaped, err := shapeStructToMap(v); err == nil {
+				obj, ok = shaped.(map[string]interface{})
+			}
+		}
+		if !ok {
 			return nil, protoimpl.X.NewError("invalid type: %T expected map[string]interface{}", v)
 		}
-		obj, err := m.newObject(v.(map[string]interface{}), parent, prop)
+		val, err := m.newObject(obj, parent, prop)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating nested object")
 		}
-		return NewObjectValue(obj), nil
+		return NewObjectValue(val), nil
 	case schema.DataTypeObjectArray:
 		if _, ok := v.([]interface{}); !ok {
 			return nil, protoimpl.X.NewError("invalid type: %T expected []map[string]interface{}", v)
@@ -381,7 +390,37 @@ func newPhoneNumberValue(v *models.PhoneNumber) *pb.Value {
 	}}
 }
 
-// NewNilValue constructs a new nil Value.
+// NewNilValue constructs a nil Value.
 func (m *Mapper) NewNilValue() *pb.Value {
 	return &pb.Value{Kind: &pb.Value_NullValue{}}
+}
+
+// shapeStructToMap converts the enriched disk forms of geo/phone-shaped object
+// properties back into their map representation, mirroring what the request
+// path produces. Other values are returned unchanged (with a nil error).
+func shapeStructToMap(v interface{}) (interface{}, error) {
+	switch val := v.(type) {
+	case *models.GeoCoordinates:
+		out := map[string]interface{}{}
+		if val.Latitude != nil {
+			out["latitude"] = float64(*val.Latitude)
+		}
+		if val.Longitude != nil {
+			out["longitude"] = float64(*val.Longitude)
+		}
+		return out, nil
+	case *models.PhoneNumber:
+		out := map[string]interface{}{
+			"input":                  val.Input,
+			"internationalFormatted": val.InternationalFormatted,
+			"nationalFormatted":      val.NationalFormatted,
+			"national":               float64(val.National),
+			"countryCode":            float64(val.CountryCode),
+			"defaultCountry":         val.DefaultCountry,
+			"valid":                  val.Valid,
+		}
+		return out, nil
+	default:
+		return nil, protoimpl.X.NewError("unexpected type: %T", v)
+	}
 }

--- a/adapters/handlers/grpc/v1/mapping_test.go
+++ b/adapters/handlers/grpc/v1/mapping_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/search"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
@@ -182,4 +183,81 @@ func TestNewPrimitiveValue(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestNewNestedValueGeoAndPhoneShapedObjects(t *testing.T) {
+	float32p := func(f float32) *float32 { return &f }
+
+	geoParent := &Property{Property: &models.Property{
+		Name: "location",
+		NestedProperties: []*models.NestedProperty{
+			{Name: "latitude", DataType: []string{"number"}},
+			{Name: "longitude", DataType: []string{"number"}},
+		},
+	}}
+	geoSelect := search.SelectProperty{
+		Name:     "location",
+		IsObject: true,
+		Props: []search.SelectProperty{
+			{Name: "latitude", IsPrimitive: true},
+			{Name: "longitude", IsPrimitive: true},
+		},
+	}
+
+	phoneParent := &Property{Property: &models.Property{
+		Name: "phone",
+		NestedProperties: []*models.NestedProperty{
+			{Name: "input", DataType: []string{"string"}},
+			{Name: "internationalFormatted", DataType: []string{"string"}},
+			{Name: "nationalFormatted", DataType: []string{"string"}},
+			{Name: "national", DataType: []string{"number"}},
+			{Name: "countryCode", DataType: []string{"number"}},
+			{Name: "valid", DataType: []string{"boolean"}},
+		},
+	}}
+	phoneSelect := search.SelectProperty{
+		Name:     "phone",
+		IsObject: true,
+		Props: []search.SelectProperty{
+			{Name: "input", IsPrimitive: true},
+			{Name: "internationalFormatted", IsPrimitive: true},
+			{Name: "nationalFormatted", IsPrimitive: true},
+			{Name: "national", IsPrimitive: true},
+			{Name: "countryCode", IsPrimitive: true},
+			{Name: "valid", IsPrimitive: true},
+		},
+	}
+
+	t.Run("geo-shaped object property stored as GeoCoordinates", func(t *testing.T) {
+		m := NewMapping()
+		in := &models.GeoCoordinates{Latitude: float32p(45.67), Longitude: float32p(-12.34)}
+		out, err := m.NewNestedValue(in, schema.DataTypeObject, geoParent, geoSelect)
+		require.NoError(t, err)
+		require.NotNil(t, out.GetObjectValue())
+		fields := out.GetObjectValue().GetFields()
+		require.Equal(t, float64(*in.Latitude), fields["latitude"].GetNumberValue())
+		require.Equal(t, float64(*in.Longitude), fields["longitude"].GetNumberValue())
+	})
+
+	t.Run("phone-shaped object property stored as PhoneNumber", func(t *testing.T) {
+		m := NewMapping()
+		in := &models.PhoneNumber{
+			Input:                  "123456789",
+			InternationalFormatted: "+48 12 345 67 89",
+			NationalFormatted:      "12 345 67 89",
+			National:               123456789,
+			CountryCode:            48,
+			Valid:                  true,
+		}
+		out, err := m.NewNestedValue(in, schema.DataTypeObject, phoneParent, phoneSelect)
+		require.NoError(t, err)
+		require.NotNil(t, out.GetObjectValue())
+		fields := out.GetObjectValue().GetFields()
+		require.Equal(t, in.Input, fields["input"].GetTextValue())
+		require.Equal(t, in.InternationalFormatted, fields["internationalFormatted"].GetTextValue())
+		require.Equal(t, in.NationalFormatted, fields["nationalFormatted"].GetTextValue())
+		require.Equal(t, float64(in.National), fields["national"].GetNumberValue())
+		require.Equal(t, float64(in.CountryCode), fields["countryCode"].GetNumberValue())
+		require.Equal(t, in.Valid, fields["valid"].GetBoolValue())
+	})
 }

--- a/adapters/repos/db/shard_skip_vector_reindex_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_test.go
@@ -390,6 +390,28 @@ func TestPropsEqual(t *testing.T) {
 
 	prevProps := createPrevProps(1)
 	nextProps := createNextProps(1)
+
+	// shared fixtures for the shaped geo/phone property cases below
+	geoStruct := &models.GeoCoordinates{
+		Latitude:  ptrFloat32(45.67),
+		Longitude: ptrFloat32(-12.34),
+	}
+	phoneStruct := &models.PhoneNumber{
+		Input:                  "123456789",
+		InternationalFormatted: "+48 12 345 67 89",
+		NationalFormatted:      "12 345 67 89",
+		National:               123456789,
+		CountryCode:            48,
+		Valid:                  true,
+	}
+	phoneMap := map[string]interface{}{
+		"input":                  "123456789",
+		"internationalFormatted": "+48 12 345 67 89",
+		"nationalFormatted":      "12 345 67 89",
+		"national":               float64(123456789),
+		"countryCode":            float64(48),
+		"valid":                  true,
+	}
 	testCases := []testCase{
 		{
 			prevProps:     nil,
@@ -715,80 +737,60 @@ func TestPropsEqual(t *testing.T) {
 		// disk but arrives as a map in the request; unchanged values must
 		// still compare equal
 		{
-			prevProps: map[string]interface{}{
-				"geoObj": &models.GeoCoordinates{
-					Latitude:  ptrFloat32(45.67),
-					Longitude: ptrFloat32(-12.34),
-				},
-			},
-			nextProps: map[string]interface{}{
-				"geoObj": map[string]interface{}{
-					"latitude":  float64(45.67),
-					"longitude": float64(-12.34),
-				},
-			},
+			prevProps: map[string]interface{}{"geoObj": geoStruct},
+			nextProps: map[string]interface{}{"geoObj": map[string]interface{}{
+				"latitude":  float64(45.67),
+				"longitude": float64(-12.34),
+			}},
 			expectedEqual: true,
 		},
 		{
+			prevProps: map[string]interface{}{"geoObj": geoStruct},
+			nextProps: map[string]interface{}{"geoObj": map[string]interface{}{
+				"latitude":  float64(45.67),
+				"longitude": float64(100.0),
+			}},
+			expectedEqual: false,
+		},
+		// nested properties are never geo/phone-shaped on the disk read path,
+		// so nested maps must not be shaped during comparison either; shaping
+		// would collapse sub-float32 differences and silently skip a real
+		// update
+		{
 			prevProps: map[string]interface{}{
-				"geoObj": &models.GeoCoordinates{
-					Latitude:  ptrFloat32(45.67),
-					Longitude: ptrFloat32(-12.34),
+				"outer": map[string]interface{}{
+					"inner": map[string]interface{}{
+						"latitude":  float64(45.6700001),
+						"longitude": float64(-12.34),
+					},
 				},
 			},
 			nextProps: map[string]interface{}{
-				"geoObj": map[string]interface{}{
-					"latitude":  float64(45.67),
-					"longitude": float64(100.0),
+				"outer": map[string]interface{}{
+					"inner": map[string]interface{}{
+						"latitude":  float64(45.6700002),
+						"longitude": float64(-12.34),
+					},
 				},
 			},
 			expectedEqual: false,
 		},
 		// same for a phone-shaped object property
 		{
-			prevProps: map[string]interface{}{
-				"phoneObj": &models.PhoneNumber{
-					Input:                  "123456789",
-					InternationalFormatted: "+48 12 345 67 89",
-					NationalFormatted:      "12 345 67 89",
-					National:               123456789,
-					CountryCode:            48,
-					Valid:                  true,
-				},
-			},
-			nextProps: map[string]interface{}{
-				"phoneObj": map[string]interface{}{
-					"input":                  "123456789",
-					"internationalFormatted": "+48 12 345 67 89",
-					"nationalFormatted":      "12 345 67 89",
-					"national":               float64(123456789),
-					"countryCode":            float64(48),
-					"valid":                  true,
-				},
-			},
+			prevProps:     map[string]interface{}{"phoneObj": phoneStruct},
+			nextProps:     map[string]interface{}{"phoneObj": phoneMap},
 			expectedEqual: true,
 		},
 		{
-			prevProps: map[string]interface{}{
-				"phoneObj": &models.PhoneNumber{
-					Input:                  "123456789",
-					InternationalFormatted: "+48 12 345 67 89",
-					NationalFormatted:      "12 345 67 89",
-					National:               123456789,
-					CountryCode:            48,
-					Valid:                  true,
-				},
-			},
-			nextProps: map[string]interface{}{
-				"phoneObj": map[string]interface{}{
-					"input":                  "000000000",
-					"internationalFormatted": "+48 12 345 67 89",
-					"nationalFormatted":      "12 345 67 89",
-					"national":               float64(123456789),
-					"countryCode":            float64(48),
-					"valid":                  true,
-				},
-			},
+			prevProps: map[string]interface{}{"phoneObj": phoneStruct},
+			nextProps: map[string]interface{}{"phoneObj": map[string]interface{}{
+				"input":                  "000000000",
+				"internationalFormatted": "+48 12 345 67 89",
+				"nationalFormatted":      "12 345 67 89",
+				"national":               float64(123456789),
+				"countryCode":            float64(48),
+				"valid":                  true,
+			}},
 			expectedEqual: false,
 		},
 	}

--- a/adapters/repos/db/shard_skip_vector_reindex_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_test.go
@@ -690,6 +690,107 @@ func TestPropsEqual(t *testing.T) {
 			}(),
 			expectedEqual: false,
 		},
+		// empty typed arrays on the request side must compare equal to the
+		// []interface{}{} placeholder the disk read path produces
+		{
+			prevProps: map[string]interface{}{
+				"texts":    []interface{}{},
+				"ints":     []interface{}{},
+				"numbers":  []interface{}{},
+				"booleans": []interface{}{},
+				"uuids":    []interface{}{},
+				"dates":    []interface{}{},
+			},
+			nextProps: map[string]interface{}{
+				"texts":    []string{},
+				"ints":     []float64{},
+				"numbers":  []float64{},
+				"booleans": []bool{},
+				"uuids":    []uuid.UUID{},
+				"dates":    []time.Time{},
+			},
+			expectedEqual: true,
+		},
+		// a geo-shaped object property is stored as *models.GeoCoordinates on
+		// disk but arrives as a map in the request; unchanged values must
+		// still compare equal
+		{
+			prevProps: map[string]interface{}{
+				"geoObj": &models.GeoCoordinates{
+					Latitude:  ptrFloat32(45.67),
+					Longitude: ptrFloat32(-12.34),
+				},
+			},
+			nextProps: map[string]interface{}{
+				"geoObj": map[string]interface{}{
+					"latitude":  float64(45.67),
+					"longitude": float64(-12.34),
+				},
+			},
+			expectedEqual: true,
+		},
+		{
+			prevProps: map[string]interface{}{
+				"geoObj": &models.GeoCoordinates{
+					Latitude:  ptrFloat32(45.67),
+					Longitude: ptrFloat32(-12.34),
+				},
+			},
+			nextProps: map[string]interface{}{
+				"geoObj": map[string]interface{}{
+					"latitude":  float64(45.67),
+					"longitude": float64(100.0),
+				},
+			},
+			expectedEqual: false,
+		},
+		// same for a phone-shaped object property
+		{
+			prevProps: map[string]interface{}{
+				"phoneObj": &models.PhoneNumber{
+					Input:                  "123456789",
+					InternationalFormatted: "+48 12 345 67 89",
+					NationalFormatted:      "12 345 67 89",
+					National:               123456789,
+					CountryCode:            48,
+					Valid:                  true,
+				},
+			},
+			nextProps: map[string]interface{}{
+				"phoneObj": map[string]interface{}{
+					"input":                  "123456789",
+					"internationalFormatted": "+48 12 345 67 89",
+					"nationalFormatted":      "12 345 67 89",
+					"national":               float64(123456789),
+					"countryCode":            float64(48),
+					"valid":                  true,
+				},
+			},
+			expectedEqual: true,
+		},
+		{
+			prevProps: map[string]interface{}{
+				"phoneObj": &models.PhoneNumber{
+					Input:                  "123456789",
+					InternationalFormatted: "+48 12 345 67 89",
+					NationalFormatted:      "12 345 67 89",
+					National:               123456789,
+					CountryCode:            48,
+					Valid:                  true,
+				},
+			},
+			nextProps: map[string]interface{}{
+				"phoneObj": map[string]interface{}{
+					"input":                  "000000000",
+					"internationalFormatted": "+48 12 345 67 89",
+					"nationalFormatted":      "12 345 67 89",
+					"national":               float64(123456789),
+					"countryCode":            float64(48),
+					"valid":                  true,
+				},
+			},
+			expectedEqual: false,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -658,6 +658,8 @@ func compareObjsForInsertStatus(prevObj, nextObj *storobj.Object) (preserve, ski
 	if !ok {
 		return false, false
 	}
+	prevProps = canonicalizePropsForComparison(prevProps)
+	nextProps = canonicalizePropsForComparison(nextProps)
 	if !geoPropsEqual(prevProps, nextProps) {
 		return false, false
 	}
@@ -769,7 +771,58 @@ func addPropsEqual(prevAddProps, nextAddProps models.AdditionalProperties) bool 
 	return reflect.DeepEqual(prevAddProps, nextAddProps)
 }
 
+// canonicalizePropsForComparison normalizes property maps so that values
+// originating from an incoming request and values read back from disk can be
+// compared. Request validation and the disk read path (storobj enrich) produce
+// different Go types for the same logical value: typed empty arrays become
+// []interface{}{} on disk, and geo/phone-shaped object maps are stored as
+// *models.GeoCoordinates / *models.PhoneNumber. Without this, an unchanged
+// object never compares equal and every PUT is rewritten.
+func canonicalizePropsForComparison(props map[string]interface{}) map[string]interface{} {
+	if props == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(props))
+	for name, value := range props {
+		out[name] = canonicalizeValueForComparison(value)
+	}
+	return out
+}
+
+func canonicalizeValueForComparison(value interface{}) interface{} {
+	switch val := value.(type) {
+	case []string:
+		if len(val) == 0 {
+			return []interface{}{}
+		}
+	case []float64:
+		if len(val) == 0 {
+			return []interface{}{}
+		}
+	case []bool:
+		if len(val) == 0 {
+			return []interface{}{}
+		}
+	case []time.Time:
+		if len(val) == 0 {
+			return []interface{}{}
+		}
+	case []uuid.UUID:
+		if len(val) == 0 {
+			return []interface{}{}
+		}
+	case map[string]interface{}:
+		if shaped, err := storobj.ShapeConvertMap(val); err == nil {
+			return shaped
+		}
+	}
+	return value
+}
+
 func propsEqual(prevProps, nextProps map[string]interface{}) bool {
+	prevProps = canonicalizePropsForComparison(prevProps)
+	nextProps = canonicalizePropsForComparison(nextProps)
+
 	if len(prevProps) != len(nextProps) {
 		return false
 	}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -658,8 +658,8 @@ func compareObjsForInsertStatus(prevObj, nextObj *storobj.Object) (preserve, ski
 	if !ok {
 		return false, false
 	}
-	prevProps = canonicalizePropsForComparison(prevProps)
-	nextProps = canonicalizePropsForComparison(nextProps)
+	prevProps = canonicalizePropsForComparison(prevProps, false)
+	nextProps = canonicalizePropsForComparison(nextProps, false)
 	if !geoPropsEqual(prevProps, nextProps) {
 		return false, false
 	}
@@ -778,18 +778,23 @@ func addPropsEqual(prevAddProps, nextAddProps models.AdditionalProperties) bool 
 // []interface{}{} on disk, and geo/phone-shaped object maps are stored as
 // *models.GeoCoordinates / *models.PhoneNumber. Without this, an unchanged
 // object never compares equal and every PUT is rewritten.
-func canonicalizePropsForComparison(props map[string]interface{}) map[string]interface{} {
+//
+// Shaping is only applied to top-level properties (nested == false). The disk
+// read path explicitly skips geo/phone shaping for nested properties, so
+// shaping nested maps here would collapse sub-float32 differences and silently
+// skip a real update.
+func canonicalizePropsForComparison(props map[string]interface{}, nested bool) map[string]interface{} {
 	if props == nil {
 		return nil
 	}
 	out := make(map[string]interface{}, len(props))
 	for name, value := range props {
-		out[name] = canonicalizeValueForComparison(value)
+		out[name] = canonicalizeValueForComparison(value, nested)
 	}
 	return out
 }
 
-func canonicalizeValueForComparison(value interface{}) interface{} {
+func canonicalizeValueForComparison(value interface{}, nested bool) interface{} {
 	switch val := value.(type) {
 	case []string:
 		if len(val) == 0 {
@@ -812,16 +817,22 @@ func canonicalizeValueForComparison(value interface{}) interface{} {
 			return []interface{}{}
 		}
 	case map[string]interface{}:
-		if shaped, err := storobj.ShapeConvertMap(val); err == nil {
-			return shaped
+		if !nested {
+			if shaped, err := storobj.ShapeConvertMap(val); err == nil {
+				return shaped
+			}
 		}
 	}
 	return value
 }
 
 func propsEqual(prevProps, nextProps map[string]interface{}) bool {
-	prevProps = canonicalizePropsForComparison(prevProps)
-	nextProps = canonicalizePropsForComparison(nextProps)
+	return propsEqualNested(prevProps, nextProps, false)
+}
+
+func propsEqualNested(prevProps, nextProps map[string]interface{}, nested bool) bool {
+	prevProps = canonicalizePropsForComparison(prevProps, nested)
+	nextProps = canonicalizePropsForComparison(nextProps, nested)
 
 	if len(prevProps) != len(nextProps) {
 		return false
@@ -876,7 +887,7 @@ func propsEqual(prevProps, nextProps map[string]interface{}) bool {
 			if !ok {
 				return false
 			}
-			if !propsEqual(prevVal, nextVal) {
+			if !propsEqualNested(prevVal, nextVal, true) {
 				return false
 			}
 
@@ -897,7 +908,7 @@ func propsEqual(prevProps, nextProps map[string]interface{}) bool {
 				if !ok {
 					return false
 				}
-				if !propsEqual(prevValI, nextValI) {
+				if !propsEqualNested(prevValI, nextValI, true) {
 					return false
 				}
 			}

--- a/usecases/modulecomponents/vectorizer/object_texts.go
+++ b/usecases/modulecomponents/vectorizer/object_texts.go
@@ -19,6 +19,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	entcfg "github.com/weaviate/weaviate/entities/config"
 
 	"github.com/weaviate/weaviate/entities/models"
@@ -100,6 +102,25 @@ func (v *ObjectVectorizer) TextsWithTitleProperty(ctx context.Context, object *m
 			case string:
 				corpi, titlePropertyValue = v.insertValue(val, propName,
 					toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
+			case []time.Time:
+				// the disk read path stores date[] values as strings; keep the
+				// request form consistent so embeddings don't depend on whether
+				// the value came from a request or from disk
+				for i := range val {
+					corpi, titlePropertyValue = v.insertValue(val[i].Format(time.RFC3339), propName,
+						toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
+				}
+			case time.Time:
+				corpi, titlePropertyValue = v.insertValue(val.Format(time.RFC3339), propName,
+					toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
+			case []uuid.UUID:
+				for i := range val {
+					corpi, titlePropertyValue = v.insertValue(val[i].String(), propName,
+						toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
+				}
+			case uuid.UUID:
+				corpi, titlePropertyValue = v.insertValue(val.String(), propName,
+					toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
 			default:
 				// do nothing
 			}
@@ -112,9 +133,6 @@ func (v *ObjectVectorizer) TextsWithTitleProperty(ctx context.Context, object *m
 						toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
 				case json.Number:
 					corpi, titlePropertyValue = v.insertValue(val.String(), propName,
-						toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
-				case time.Time:
-					corpi, titlePropertyValue = v.insertValue(val.Format(time.RFC3339), propName,
 						toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
 				case []any:
 					if len(val) > 0 {

--- a/usecases/modulecomponents/vectorizer/object_texts.go
+++ b/usecases/modulecomponents/vectorizer/object_texts.go
@@ -105,13 +105,14 @@ func (v *ObjectVectorizer) TextsWithTitleProperty(ctx context.Context, object *m
 			case []time.Time:
 				// the disk read path stores date[] values as strings; keep the
 				// request form consistent so embeddings don't depend on whether
-				// the value came from a request or from disk
+				// the value came from a request or from disk. JSON persistence
+				// keeps fractional seconds, so they must be kept here too.
 				for i := range val {
-					corpi, titlePropertyValue = v.insertValue(val[i].Format(time.RFC3339), propName,
+					corpi, titlePropertyValue = v.insertValue(val[i].Format(time.RFC3339Nano), propName,
 						toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
 				}
 			case time.Time:
-				corpi, titlePropertyValue = v.insertValue(val.Format(time.RFC3339), propName,
+				corpi, titlePropertyValue = v.insertValue(val.Format(time.RFC3339Nano), propName,
 					toLowerCase, isPropertyNameVectorizable, isTitleProperty, corpi, titlePropertyValue)
 			case []uuid.UUID:
 				for i := range val {

--- a/usecases/modulecomponents/vectorizer/object_texts_test.go
+++ b/usecases/modulecomponents/vectorizer/object_texts_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/models"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
@@ -202,6 +203,40 @@ func TestVectorizingObjects_AllPropertyTypes(t *testing.T) {
 			}},
 			vectorizableProperties: []string{"date_prop"},
 			wantCorpi:              "2011-05-05T07:16:30+02:00",
+		},
+		{
+			name: "date property as time.Time without source properties",
+			object: &models.Object{Class: className, Properties: map[string]any{
+				"date_prop": asTime("2011-05-05T07:16:30+02:00"),
+			}},
+			wantCorpi: "2011-05-05T07:16:30+02:00",
+		},
+		{
+			name: "date array property as []time.Time",
+			object: &models.Object{Class: className, Properties: map[string]any{
+				"date_array_prop": []time.Time{asTime("2011-05-05T07:16:30+02:00"), asTime("2011-05-06T07:16:30+02:00")},
+			}},
+			vectorizableProperties: []string{"date_array_prop"},
+			wantCorpi:              "2011-05-05T07:16:30+02:00 2011-05-06T07:16:30+02:00",
+		},
+		{
+			name: "uuid property as uuid.UUID",
+			object: &models.Object{Class: className, Properties: map[string]any{
+				"uuid_prop": uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"),
+			}},
+			vectorizableProperties: []string{"uuid_prop"},
+			wantCorpi:              "550e8400-e29b-41d4-a716-446655440000",
+		},
+		{
+			name: "uuid array property as []uuid.UUID",
+			object: &models.Object{Class: className, Properties: map[string]any{
+				"uuid_array_prop": []uuid.UUID{
+					uuid.MustParse("550e8400-e29b-41d4-a716-446655440000"),
+					uuid.MustParse("550e8400-e29b-41d4-a716-446655440001"),
+				},
+			}},
+			vectorizableProperties: []string{"uuid_array_prop"},
+			wantCorpi:              "550e8400-e29b-41d4-a716-446655440000 550e8400-e29b-41d4-a716-446655440001",
 		},
 	}
 	for _, tt := range tests {

--- a/usecases/modulecomponents/vectorizer/object_texts_test.go
+++ b/usecases/modulecomponents/vectorizer/object_texts_test.go
@@ -28,7 +28,7 @@ func TestVectorizingObjects_AllPropertyTypes(t *testing.T) {
 	className := "TestClass"
 	var nilAnyArray []any
 	asTime := func(date string) time.Time {
-		if asTime, err := time.Parse(time.RFC3339, date); err == nil {
+		if asTime, err := time.Parse(time.RFC3339Nano, date); err == nil {
 			return asTime
 		}
 		// fallback to current time, this will surely fail tests
@@ -210,6 +210,25 @@ func TestVectorizingObjects_AllPropertyTypes(t *testing.T) {
 				"date_prop": asTime("2011-05-05T07:16:30+02:00"),
 			}},
 			wantCorpi: "2011-05-05T07:16:30+02:00",
+		},
+		{
+			name: "date property as time.Time keeps fractional seconds",
+			object: &models.Object{Class: className, Properties: map[string]any{
+				"date_prop": asTime("2011-05-05T07:16:30.123+02:00"),
+			}},
+			vectorizableProperties: []string{"date_prop"},
+			wantCorpi:              "2011-05-05T07:16:30.123+02:00",
+		},
+		{
+			name: "date array property as []time.Time keeps fractional seconds",
+			object: &models.Object{Class: className, Properties: map[string]any{
+				"date_array_prop": []time.Time{
+					asTime("2011-05-05T07:16:30.123+02:00"),
+					asTime("2011-05-06T07:16:30.456+02:00"),
+				},
+			}},
+			vectorizableProperties: []string{"date_array_prop"},
+			wantCorpi:              "2011-05-05T07:16:30.123+02:00 2011-05-06T07:16:30.456+02:00",
 		},
 		{
 			name: "date array property as []time.Time",


### PR DESCRIPTION
I kept running into the same class of weirdness described in #12809: the same property value is a different Go type depending on whether it just arrived in a request or was read back from disk. The issue lists four places this bites. #11789 already fixed the comparator, but three are still open, and I hit two of them from the outside:

1. Fetching an object whose `object` property is shaped `{latitude, longitude}` over gRPC dies with `proto: invalid type: *models.GeoCoordinates expected map[string]interface{}`. The disk read path enriches geo/phone-shaped maps into their struct forms, and the gRPC mapper only knew the map form. Same story for phone-shaped objects.

2. A PUT of an unchanged object is basically never skipped. `propsEqual` compares request forms against disk forms and the two don't line up: empty arrays come in as `[]string{}` / `[]float64{}` etc. but are stored as `[]interface{}{}`, and geo/phone-shaped object properties arrive as maps but are stored as structs. So every update of an unchanged object rewrites the row and everything downstream of a real write runs again.

3. The vectorizer text builder treats the two forms differently too: a date is vectorized when it's a string from disk, but a `time.Time` from the request only when source properties are set, and `[]time.Time` / `uuid.UUID` request values weren't handled at all. So after a PATCH merges disk and request values, the embedding can include values the original insert never vectorized.

What I changed:

- gRPC: `NewNestedValue` converts the enriched `*models.GeoCoordinates` / `*models.PhoneNumber` forms back into maps before serializing, so it emits the same thing REST/GraphQL emit for the same object.
- `propsEqual`: canonicalizes both sides before comparing (typed empty arrays to `[]interface{}{}`, geo/phone-shaped maps to structs via the existing `storobj.ShapeConvertMap`). Also applied in `compareObjsForInsertStatus`, so `geoPropsEqual` sees the canonical forms and doesn't bail out early.
- Vectorizer: request-side `time.Time`, `[]time.Time`, `uuid.UUID`, `[]uuid.UUID` now vectorize exactly like their disk-side string forms.

Tests: new propsEqual cases for the empty-array and geo/phone-shaped object forms (equal and unequal variants), a gRPC mapping test for geo/phone-shaped object properties, and vectorizer cases pinning the request forms to the same corpus as the disk forms.

One thing I'm not 100% sure about: the vectorizer change means date/uuid values are now always vectorized, matching the disk path, even when no source properties are configured. If that's not the desired request-time behavior, the alternative is to make the disk path skip them instead, but that changes search behavior for existing data, so I aligned on the disk behavior.

### What's being changed:

See above; three production files plus tests, all related to the request/disk type-form mismatch tracked in #12809.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary, no user-facing behavior change beyond bug fixes
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

closes #12809
