### PR TITLE
fix(db): crash-safe delete ordering — inverted cleanup durable before row delete

### DIFF
--- a/adapters/repos/db/docid_reuse.go
+++ b/adapters/repos/db/docid_reuse.go
@@ -1,0 +1,30 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+
+	entcfg "github.com/weaviate/weaviate/entities/config"
+)
+
+// docIDReuseEnabled gates the docID-reuse feature. When ON, a delete's
+// inverted-index cleanup must be made durable (fsynced) BEFORE the object row
+// delete, because an orphaned posting would later resolve to a DIFFERENT
+// object once its docID is reused. When OFF (the default), deletes keep
+// today's cheaper page-cache WAL flush.
+//
+// Read per call rather than cached: deletes are not so hot that one Getenv
+// matters, and tests toggle it via t.Setenv.
+func docIDReuseEnabled() bool {
+	return entcfg.Enabled(os.Getenv("DOCID_REUSE_ENABLED"))
+}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2493,6 +2493,19 @@ func (b *Bucket) WriteWAL() error {
 	return b.active.writeWAL()
 }
 
+// SyncWAL is WriteWAL's durable sibling: it flushes the active memtable's
+// commit-log buffers AND fsyncs the WAL file, so every write acknowledged
+// before the call survives a crash. Writes that already rotated into the
+// flushing memtable are made durable by the flush cycle itself (its commit
+// log is flushed+fsynced via close() at the start of the memtable flush);
+// like WriteWAL, this only touches the currently active memtable.
+func (b *Bucket) SyncWAL() error {
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+
+	return b.active.syncWAL()
+}
+
 func (b *Bucket) DocPointerWithScoreList(ctx context.Context, key []byte, propBoost float32, cfgs ...MapListOption) ([]terms.DocPointerWithScore, error) {
 	view := b.GetConsistentView()
 	defer view.ReleaseView()

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -2493,15 +2493,29 @@ func (b *Bucket) WriteWAL() error {
 	return b.active.writeWAL()
 }
 
-// SyncWAL is WriteWAL's durable sibling: it flushes the active memtable's
-// commit-log buffers AND fsyncs the WAL file, so every write acknowledged
-// before the call survives a crash. Writes that already rotated into the
-// flushing memtable are made durable by the flush cycle itself (its commit
-// log is flushed+fsynced via close() at the start of the memtable flush);
-// like WriteWAL, this only touches the currently active memtable.
+// SyncWAL is WriteWAL's durable sibling: it flushes the commit-log buffers
+// AND fsyncs the WAL file, so every write acknowledged before the call
+// survives a crash.
+//
+// It must cover the FLUSHING memtable as well as the active one: a write can
+// rotate into b.flushing (atomicallySwitchMemtable) at any point before this
+// call, and the flush cycle only fsyncs that memtable's commit log later, at
+// commitlog.close() inside Memtable.flush — after waitForZeroWriters, i.e.
+// potentially hundreds of milliseconds after the switch. Syncing only the
+// active memtable in that window would report durability the rotated writes
+// don't have. Writers can even still be appending to the rotated memtable
+// (they hold only a writer count, not flushLock, during the append), which
+// the per-memtable lock inside syncWAL serializes against. If the flush
+// cycle already closed the commit log, syncWAL is a no-op — close() fsyncs.
 func (b *Bucket) SyncWAL() error {
 	b.flushLock.RLock()
 	defer b.flushLock.RUnlock()
+
+	if b.flushing != nil {
+		if err := b.flushing.syncWAL(); err != nil {
+			return err
+		}
+	}
 
 	return b.active.syncWAL()
 }

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -181,6 +181,15 @@ type commitLogger struct {
 	n      atomic.Int64
 	path   string
 
+	// mu serializes flushBuffers/sync/close against each other and guards
+	// closed. A durability barrier (Bucket.SyncWAL) may sync the FLUSHING
+	// memtable's log concurrently with the flush cycle closing it; the
+	// memtable's own lock cannot arbitrate that without also blocking
+	// readers (m.RLock) for the duration of close()'s fsync. Appends don't
+	// take mu: they are serialized by the memtable lock and can no longer
+	// happen once close() is reachable (waitForZeroWriters ran).
+	mu sync.Mutex
+
 	checksumWriter integrity.ChecksumWriter
 
 	bufNode *bytes.Buffer
@@ -396,9 +405,12 @@ func (cl *commitLogger) size() int64 {
 }
 
 func (cl *commitLogger) sync() error {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
 	// a closed log was already flushed and fsynced by close(); syncing again
 	// would fail on the closed file while the durability it asks for is
-	// already guaranteed. Callers serialize with close() via the memtable lock.
+	// already guaranteed
 	if cl.closed {
 		return nil
 	}
@@ -406,6 +418,9 @@ func (cl *commitLogger) sync() error {
 }
 
 func (cl *commitLogger) close() error {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
 	if cl.closed {
 		return nil
 	}
@@ -445,6 +460,9 @@ func (cl *commitLogger) delete() error {
 }
 
 func (cl *commitLogger) flushBuffers() error {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+
 	// see sync(): close() already flushed everything a closed log buffered
 	if cl.closed {
 		return nil

--- a/adapters/repos/db/lsmkv/commitlogger.go
+++ b/adapters/repos/db/lsmkv/commitlogger.go
@@ -396,6 +396,12 @@ func (cl *commitLogger) size() int64 {
 }
 
 func (cl *commitLogger) sync() error {
+	// a closed log was already flushed and fsynced by close(); syncing again
+	// would fail on the closed file while the durability it asks for is
+	// already guaranteed. Callers serialize with close() via the memtable lock.
+	if cl.closed {
+		return nil
+	}
 	return cl.file.Sync()
 }
 
@@ -439,6 +445,10 @@ func (cl *commitLogger) delete() error {
 }
 
 func (cl *commitLogger) flushBuffers() error {
+	// see sync(): close() already flushed everything a closed log buffered
+	if cl.closed {
+		return nil
+	}
 	err := cl.writer.Flush()
 	if err != nil {
 		return fmt.Errorf("flushing WAL %q: %w", cl.path, err)

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -62,6 +62,7 @@ type memtable interface {
 	commitlogWalPath() string
 
 	writeWAL() error
+	syncWAL() error
 	flushWAL() error
 	flush() (string, error)
 	setAveragePropertyLength(avgPropLength float64, propLengthCount uint64)
@@ -688,6 +689,21 @@ func (m *Memtable) writeWAL() error {
 	defer m.Unlock()
 
 	return m.commitlog.flushBuffers()
+}
+
+// syncWAL goes one step further than writeWAL: after flushing the commit
+// logger's in-memory buffers to the OS, it also fsyncs the WAL file. Use it
+// when the caller needs a durability barrier, i.e. a guarantee that every
+// prior write to this memtable survives a crash, not just a process exit.
+func (m *Memtable) syncWAL() error {
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.commitlog.flushBuffers(); err != nil {
+		return err
+	}
+
+	return m.commitlog.sync()
 }
 
 // ReadOnlyTombstones returns a shared, immutable snapshot of the memtable's tombstones.

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -26,13 +26,7 @@ import (
 )
 
 func (m *Memtable) flushWAL() error {
-	// under the memtable lock: Bucket.SyncWAL may concurrently sync this
-	// memtable's commit log (it also syncs the flushing memtable, see
-	// SyncWAL), and close() swaps the log into its closed state
-	m.Lock()
-	err := m.commitlog.close()
-	m.Unlock()
-	if err != nil {
+	if err := m.commitlog.close(); err != nil {
 		return err
 	}
 
@@ -77,13 +71,11 @@ func (m *Memtable) flush() (segmentPath string, rerr error) {
 	// (indicated by a successful close of the flush file - which indicates a
 	// successful fsync)
 
-	// under the memtable lock: Bucket.SyncWAL may concurrently sync this
-	// (flushing) memtable's commit log, and close() must not race its
-	// flushBuffers/sync calls
-	m.Lock()
-	err := m.commitlog.close()
-	m.Unlock()
-	if err != nil {
+	// racing a concurrent Bucket.SyncWAL on this (flushing) memtable is
+	// safe: close, sync and flushBuffers serialize on the commit logger's
+	// own mutex, deliberately NOT the memtable lock — holding that across
+	// close()'s fsync would block every reader of this memtable
+	if err := m.commitlog.close(); err != nil {
 		return "", errors.Wrap(err, "close commit log file")
 	}
 

--- a/adapters/repos/db/lsmkv/memtable_flush.go
+++ b/adapters/repos/db/lsmkv/memtable_flush.go
@@ -26,7 +26,13 @@ import (
 )
 
 func (m *Memtable) flushWAL() error {
-	if err := m.commitlog.close(); err != nil {
+	// under the memtable lock: Bucket.SyncWAL may concurrently sync this
+	// memtable's commit log (it also syncs the flushing memtable, see
+	// SyncWAL), and close() swaps the log into its closed state
+	m.Lock()
+	err := m.commitlog.close()
+	m.Unlock()
+	if err != nil {
 		return err
 	}
 
@@ -41,8 +47,7 @@ func (m *Memtable) flushWAL() error {
 	}
 
 	// fsync parent directory
-	err := diskio.Fsync(filepath.Dir(m.path))
-	if err != nil {
+	if err := diskio.Fsync(filepath.Dir(m.path)); err != nil {
 		return err
 	}
 
@@ -72,7 +77,13 @@ func (m *Memtable) flush() (segmentPath string, rerr error) {
 	// (indicated by a successful close of the flush file - which indicates a
 	// successful fsync)
 
-	if err := m.commitlog.close(); err != nil {
+	// under the memtable lock: Bucket.SyncWAL may concurrently sync this
+	// (flushing) memtable's commit log, and close() must not race its
+	// flushBuffers/sync calls
+	m.Lock()
+	err := m.commitlog.close()
+	m.Unlock()
+	if err != nil {
 		return "", errors.Wrap(err, "close commit log file")
 	}
 

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -355,6 +355,69 @@ func (s *Store) WriteWALs() error {
 	return nil
 }
 
+// SyncWALs makes the WALs of the named buckets durable: for each bucket it
+// flushes the active memtable's commit-log buffers and fsyncs the WAL file
+// (Bucket.SyncWAL). Use it as a crash-durability barrier when later writes
+// (e.g. deleting an object row) must not become durable before the named
+// buckets' earlier writes are.
+//
+// An unknown bucket name is an ERROR, not a no-op: callers use this as a
+// durability barrier, and silently skipping a misnamed bucket would void the
+// guarantee the caller depends on.
+func (s *Store) SyncWALs(ctx context.Context, bucketNames ...string) error {
+	s.closeLock.RLock()
+	defer s.closeLock.RUnlock()
+
+	if s.closed {
+		return fmt.Errorf("%w: syncing wals of store %q", ErrAlreadyClosed, s.dir)
+	}
+
+	s.bucketAccessLock.RLock()
+	defer s.bucketAccessLock.RUnlock()
+
+	for _, name := range bucketNames {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("sync wals of store %q: %w", s.dir, err)
+		}
+		bucket := s.bucketNoLock(name)
+		if bucket == nil {
+			return fmt.Errorf("sync wal: bucket %q of store %q: %w", name, s.dir, ErrBucketNotFound)
+		}
+		if err := bucket.SyncWAL(); err != nil {
+			return errors.Wrapf(err, "sync wal of bucket %q", name)
+		}
+	}
+
+	return nil
+}
+
+// SyncAllWALs is SyncWALs over every bucket currently registered in the
+// store. It exists for callers that cannot enumerate which buckets an opaque
+// write path touched (e.g. migration double-write callbacks) and must fall
+// back to a conservative full barrier.
+func (s *Store) SyncAllWALs(ctx context.Context) error {
+	s.closeLock.RLock()
+	defer s.closeLock.RUnlock()
+
+	if s.closed {
+		return fmt.Errorf("%w: syncing wals of store %q", ErrAlreadyClosed, s.dir)
+	}
+
+	s.bucketAccessLock.RLock()
+	defer s.bucketAccessLock.RUnlock()
+
+	for name, bucket := range s.bucketsByName {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("sync wals of store %q: %w", s.dir, err)
+		}
+		if err := bucket.SyncWAL(); err != nil {
+			return errors.Wrapf(err, "sync wal of bucket %q", name)
+		}
+	}
+
+	return nil
+}
+
 // bucketJobStatus is used to safely track the status of
 // a job applied to each of a store's buckets when run
 // in parallel

--- a/adapters/repos/db/lsmkv/store_sync_wals_test.go
+++ b/adapters/repos/db/lsmkv/store_sync_wals_test.go
@@ -90,6 +90,57 @@ func TestStore_SyncWALs(t *testing.T) {
 	})
 }
 
+// TestBucket_SyncWAL_CoversRotatedMemtable pins the rotation window: a write
+// can rotate into the flushing memtable (atomicallySwitchMemtable) at any
+// point before the barrier, and the flush cycle only flushes+fsyncs that
+// memtable's commit log later, at commitlog.close() inside Memtable.flush.
+// SyncWAL called inside that window must cover the rotated memtable's WAL —
+// syncing only the active memtable would report durability the rotated
+// write does not have.
+func TestBucket_SyncWAL_CoversRotatedMemtable(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Shutdown(ctx)
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_rot", WithStrategy(StrategyReplace)))
+	b := store.Bucket("bucket_rot")
+	require.NotNil(t, b)
+
+	require.NoError(t, b.Put([]byte("key"), []byte("value")))
+
+	// rotate active -> flushing WITHOUT running the flush cycle, freezing the
+	// window between the switch and the flush's commitlog.close()
+	switched, err := b.atomicallySwitchMemtable(b.createNewActiveMemtable)
+	require.NoError(t, err)
+	require.True(t, switched)
+	require.NotNil(t, b.flushing)
+
+	walSize := func(mt memtable) int64 {
+		info, err := os.Stat(mt.commitlogWalPath())
+		if os.IsNotExist(err) {
+			return 0
+		}
+		require.NoError(t, err)
+		return info.Size()
+	}
+
+	// precondition: the rotated write still sits in the flushing memtable's
+	// in-memory commit-log buffer, nothing reached its WAL file yet
+	require.Zero(t, walSize(b.flushing),
+		"rotated write expected to still be buffered")
+
+	require.NoError(t, b.SyncWAL())
+
+	require.Positive(t, walSize(b.flushing),
+		"SyncWAL must flush the rotated (flushing) memtable's WAL, not only the active one")
+
+	// drain the leftover flushing memtable through the regular flush cycle:
+	// its commitlog.close() must tolerate the barrier having synced first,
+	// and a SyncWAL after the close must be a no-op, not an error
+	require.NoError(t, b.FlushAndSwitch())
+	require.NoError(t, b.SyncWAL())
+}
+
 // TestStore_SyncWALs_ClosedStore pins the error contract on an already-closed
 // store, matching WriteWALs.
 func TestStore_SyncWALs_ClosedStore(t *testing.T) {

--- a/adapters/repos/db/lsmkv/store_sync_wals_test.go
+++ b/adapters/repos/db/lsmkv/store_sync_wals_test.go
@@ -1,0 +1,103 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package lsmkv
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStore_SyncWALs covers the durability barrier primitive: syncing a named
+// bucket must flush that bucket's commit-log buffers to its WAL file on disk
+// (plus fsync), while a bucket that was NOT named must not be required to
+// flush. An unknown bucket name is an error (documented on SyncWALs): callers
+// use this as a crash-safety barrier, so silently skipping a misnamed bucket
+// would void the guarantee.
+func TestStore_SyncWALs(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	defer store.Shutdown(ctx)
+
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_a", WithStrategy(StrategyReplace)))
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_b", WithStrategy(StrategyReplace)))
+
+	bucketA := store.Bucket("bucket_a")
+	bucketB := store.Bucket("bucket_b")
+	require.NotNil(t, bucketA)
+	require.NotNil(t, bucketB)
+
+	// walSize reports the on-disk size of the bucket's active WAL file. A
+	// missing file counts as 0: the commit logger is lazily initialized and
+	// small writes sit in its in-memory buffer until flushed.
+	walSize := func(t *testing.T, b *Bucket) int64 {
+		t.Helper()
+		info, err := os.Stat(b.active.commitlogWalPath())
+		if os.IsNotExist(err) {
+			return 0
+		}
+		require.NoError(t, err)
+		return info.Size()
+	}
+
+	require.NoError(t, bucketA.Put([]byte("key-a"), []byte("value-a")))
+	require.NoError(t, bucketB.Put([]byte("key-b"), []byte("value-b")))
+
+	// Both writes are small enough to still sit in the commit loggers'
+	// in-memory buffers, i.e. nothing has reached the WAL files yet. This is
+	// the precondition that makes the flush observable below.
+	require.Zero(t, walSize(t, bucketA), "write to bucket_a expected to still be buffered")
+	require.Zero(t, walSize(t, bucketB), "write to bucket_b expected to still be buffered")
+
+	t.Run("sync flushes exactly the named bucket's WAL to disk", func(t *testing.T) {
+		require.NoError(t, store.SyncWALs(ctx, "bucket_a"))
+
+		require.Positive(t, walSize(t, bucketA),
+			"bucket_a's WAL must contain the record after SyncWALs")
+		require.Zero(t, walSize(t, bucketB),
+			"bucket_b was not named, its buffer must not be required to flush")
+	})
+
+	t.Run("unknown bucket name is an error", func(t *testing.T) {
+		err := store.SyncWALs(ctx, "bucket_a", "no_such_bucket")
+		require.ErrorIs(t, err, ErrBucketNotFound)
+	})
+
+	t.Run("canceled context aborts", func(t *testing.T) {
+		canceledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := store.SyncWALs(canceledCtx, "bucket_b")
+		require.ErrorIs(t, err, context.Canceled)
+		require.Zero(t, walSize(t, bucketB))
+	})
+
+	t.Run("SyncAllWALs flushes every bucket", func(t *testing.T) {
+		require.NoError(t, store.SyncAllWALs(ctx))
+		require.Positive(t, walSize(t, bucketB))
+	})
+}
+
+// TestStore_SyncWALs_ClosedStore pins the error contract on an already-closed
+// store, matching WriteWALs.
+func TestStore_SyncWALs_ClosedStore(t *testing.T) {
+	ctx := context.Background()
+	store := newTestStore(t)
+	require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_a", WithStrategy(StrategyReplace)))
+	require.NoError(t, store.Shutdown(ctx))
+
+	require.ErrorIs(t, store.SyncWALs(ctx, "bucket_a"), ErrAlreadyClosed)
+	require.ErrorIs(t, store.SyncAllWALs(ctx), ErrAlreadyClosed)
+}

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -4158,6 +4158,208 @@ func (_c *MockShardLike_batchDeleteObject_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
+// prepareBatchDelete provides a mock function with given fields: ctx, id, deletionTime
+func (_m *MockShardLike) prepareBatchDelete(ctx context.Context, id strfmt.UUID, deletionTime time.Time) (*preparedBatchDelete, error) {
+	ret := _m.Called(ctx, id, deletionTime)
+
+	if len(ret) == 0 {
+		panic("no return value specified for prepareBatchDelete")
+	}
+
+	var r0 *preparedBatchDelete
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, time.Time) (*preparedBatchDelete, error)); ok {
+		return rf(ctx, id, deletionTime)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, time.Time) *preparedBatchDelete); ok {
+		r0 = rf(ctx, id, deletionTime)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*preparedBatchDelete)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, strfmt.UUID, time.Time) error); ok {
+		r1 = rf(ctx, id, deletionTime)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_prepareBatchDelete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'prepareBatchDelete'
+type MockShardLike_prepareBatchDelete_Call struct {
+	*mock.Call
+}
+
+// prepareBatchDelete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id strfmt.UUID
+//   - deletionTime time.Time
+func (_e *MockShardLike_Expecter) prepareBatchDelete(ctx interface{}, id interface{}, deletionTime interface{}) *MockShardLike_prepareBatchDelete_Call {
+	return &MockShardLike_prepareBatchDelete_Call{Call: _e.mock.On("prepareBatchDelete", ctx, id, deletionTime)}
+}
+
+func (_c *MockShardLike_prepareBatchDelete_Call) Run(run func(ctx context.Context, id strfmt.UUID, deletionTime time.Time)) *MockShardLike_prepareBatchDelete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(strfmt.UUID), args[2].(time.Time))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_prepareBatchDelete_Call) Return(_a0 *preparedBatchDelete, _a1 error) *MockShardLike_prepareBatchDelete_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockShardLike_prepareBatchDelete_Call) RunAndReturn(run func(context.Context, strfmt.UUID, time.Time) (*preparedBatchDelete, error)) *MockShardLike_prepareBatchDelete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// finalizeBatchDelete provides a mock function with given fields: ctx, prep, deletionTime
+func (_m *MockShardLike) finalizeBatchDelete(ctx context.Context, prep *preparedBatchDelete, deletionTime time.Time) error {
+	ret := _m.Called(ctx, prep, deletionTime)
+
+	if len(ret) == 0 {
+		panic("no return value specified for finalizeBatchDelete")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *preparedBatchDelete, time.Time) error); ok {
+		r0 = rf(ctx, prep, deletionTime)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockShardLike_finalizeBatchDelete_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'finalizeBatchDelete'
+type MockShardLike_finalizeBatchDelete_Call struct {
+	*mock.Call
+}
+
+// finalizeBatchDelete is a helper method to define mock.On call
+//   - ctx context.Context
+//   - prep *preparedBatchDelete
+//   - deletionTime time.Time
+func (_e *MockShardLike_Expecter) finalizeBatchDelete(ctx interface{}, prep interface{}, deletionTime interface{}) *MockShardLike_finalizeBatchDelete_Call {
+	return &MockShardLike_finalizeBatchDelete_Call{Call: _e.mock.On("finalizeBatchDelete", ctx, prep, deletionTime)}
+}
+
+func (_c *MockShardLike_finalizeBatchDelete_Call) Run(run func(ctx context.Context, prep *preparedBatchDelete, deletionTime time.Time)) *MockShardLike_finalizeBatchDelete_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*preparedBatchDelete), args[2].(time.Time))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_finalizeBatchDelete_Call) Return(_a0 error) *MockShardLike_finalizeBatchDelete_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardLike_finalizeBatchDelete_Call) RunAndReturn(run func(context.Context, *preparedBatchDelete, time.Time) error) *MockShardLike_finalizeBatchDelete_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// invertedDeleteBarrier provides a mock function with given fields: ctx, touched
+func (_m *MockShardLike) invertedDeleteBarrier(ctx context.Context, touched *touchedBuckets) error {
+	ret := _m.Called(ctx, touched)
+
+	if len(ret) == 0 {
+		panic("no return value specified for invertedDeleteBarrier")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *touchedBuckets) error); ok {
+		r0 = rf(ctx, touched)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockShardLike_invertedDeleteBarrier_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'invertedDeleteBarrier'
+type MockShardLike_invertedDeleteBarrier_Call struct {
+	*mock.Call
+}
+
+// invertedDeleteBarrier is a helper method to define mock.On call
+//   - ctx context.Context
+//   - touched *touchedBuckets
+func (_e *MockShardLike_Expecter) invertedDeleteBarrier(ctx interface{}, touched interface{}) *MockShardLike_invertedDeleteBarrier_Call {
+	return &MockShardLike_invertedDeleteBarrier_Call{Call: _e.mock.On("invertedDeleteBarrier", ctx, touched)}
+}
+
+func (_c *MockShardLike_invertedDeleteBarrier_Call) Run(run func(ctx context.Context, touched *touchedBuckets)) *MockShardLike_invertedDeleteBarrier_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(*touchedBuckets))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_invertedDeleteBarrier_Call) Return(_a0 error) *MockShardLike_invertedDeleteBarrier_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardLike_invertedDeleteBarrier_Call) RunAndReturn(run func(context.Context, *touchedBuckets) error) *MockShardLike_invertedDeleteBarrier_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// batchExtendInvertedIndexItemsLSMNoFrequency provides a mock function with given fields: b, item
+func (_m *MockShardLike) batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error {
+	ret := _m.Called(b, item)
+
+	if len(ret) == 0 {
+		panic("no return value specified for batchExtendInvertedIndexItemsLSMNoFrequency")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*lsmkv.Bucket, inverted.MergeItem) error); ok {
+		r0 = rf(b, item)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'batchExtendInvertedIndexItemsLSMNoFrequency'
+type MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call struct {
+	*mock.Call
+}
+
+// batchExtendInvertedIndexItemsLSMNoFrequency is a helper method to define mock.On call
+//   - b *lsmkv.Bucket
+//   - item inverted.MergeItem
+func (_e *MockShardLike_Expecter) batchExtendInvertedIndexItemsLSMNoFrequency(b interface{}, item interface{}) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
+	return &MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call{Call: _e.mock.On("batchExtendInvertedIndexItemsLSMNoFrequency", b, item)}
+}
+
+func (_c *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call) Run(run func(b *lsmkv.Bucket, item inverted.MergeItem)) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*lsmkv.Bucket), args[1].(inverted.MergeItem))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call) Return(_a0 error) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call) RunAndReturn(run func(*lsmkv.Bucket, inverted.MergeItem) error) *MockShardLike_batchExtendInvertedIndexItemsLSMNoFrequency_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // commitReplication provides a mock function with given fields: _a0, _a1
 func (_m *MockShardLike) commitReplication(_a0 context.Context, _a1 string) interface{} {
 	ret := _m.Called(_a0, _a1)

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -379,6 +379,11 @@ type Shard struct {
 	// intermediate state; production code never sets it.
 	testDeletePhaseHook func(phase string)
 
+	// testPutPhaseHook is testDeletePhaseHook's sibling for the crash-safe
+	// docID-retiring phases of an UPDATE that changes the docID (see
+	// retireOldDocIDLocked). Test-only; production code never sets it.
+	testPutPhaseHook func(phase string)
+
 	// Indicates whether searchable buckets should be used
 	// when filterable buckets are missing for text/text[] properties
 	// This can happen for db created before v1.19, where

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -177,6 +177,9 @@ type ShardLike interface {
 	setFallbackToSearchable(fallback bool)
 	addJobToQueue(job job)
 	batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error
+	prepareBatchDelete(ctx context.Context, id strfmt.UUID, deletionTime time.Time) (*preparedBatchDelete, error)
+	finalizeBatchDelete(ctx context.Context, prep *preparedBatchDelete, deletionTime time.Time) error
+	invertedDeleteBarrier(ctx context.Context, touched *touchedBuckets) error
 	putObjectLSM(ctx context.Context, object *storobj.Object, idBytes []byte) (objectInsertStatus, error)
 	mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error)
 	updatePropertySpecificIndices(ctx context.Context, object *storobj.Object, status objectInsertStatus) error

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -370,6 +370,12 @@ type Shard struct {
 	// replication
 	replicationMap pendingReplicaTasks
 
+	// testDeletePhaseHook, when non-nil, is invoked after each phase of the
+	// crash-safe delete sequence (see deleteObjectCrashSafeLocked). It exists
+	// ONLY so tests can assert the no-orphan-posting invariant at every
+	// intermediate state; production code never sets it.
+	testDeletePhaseHook func(phase string)
+
 	// Indicates whether searchable buckets should be used
 	// when filterable buckets are missing for text/text[] properties
 	// This can happen for db created before v1.19, where

--- a/adapters/repos/db/shard_delete_crash_safe_test.go
+++ b/adapters/repos/db/shard_delete_crash_safe_test.go
@@ -1,0 +1,575 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// The crash-safe delete tests cover the delete ordering required for docID
+// reuse: inverted-index posting removals must happen (and be made durable)
+// BEFORE the object row delete, because an orphaned posting (docID in a
+// posting, no object row) is unrepairable — the row's bytes are the only
+// source of which postings to remove — and, once docIDs are reused, resolves
+// to a DIFFERENT object.
+
+const (
+	crashSafeTextProp = "description"
+	crashSafeIntProp  = "points"
+)
+
+func crashSafeDeleteClass(className string) *models.Class {
+	vTrue := true
+	return &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:            crashSafeTextProp,
+				DataType:        schema.DataTypeText.PropString(),
+				Tokenization:    models.PropertyTokenizationWhitespace,
+				IndexFilterable: &vTrue,
+				IndexSearchable: &vTrue,
+			},
+			{
+				Name:              crashSafeIntProp,
+				DataType:          schema.DataTypeInt.PropString(),
+				IndexFilterable:   &vTrue,
+				IndexRangeFilters: &vTrue,
+			},
+		},
+		InvertedIndexConfig: crashSafeInvertedConfig(),
+	}
+}
+
+func crashSafeInvertedConfig() *models.InvertedIndexConfig {
+	cfg := invertedConfig()
+	cfg.IndexTimestamps = true
+	return cfg
+}
+
+// crashSafeConcreteShard unwraps the ShardLike returned by the fixtures into
+// the concrete *Shard the phase-level tests drive.
+func crashSafeConcreteShard(t *testing.T, ctx context.Context, s ShardLike) *Shard {
+	t.Helper()
+	switch sh := s.(type) {
+	case *Shard:
+		return sh
+	case *LazyLoadShard:
+		require.NoError(t, sh.Load(ctx))
+		return sh.shard
+	default:
+		t.Fatalf("unexpected shard type %T", s)
+		return nil
+	}
+}
+
+func crashSafeTestShard(t *testing.T, ctx context.Context, className string) *Shard {
+	t.Helper()
+	shd, _ := testShardWithSettings(t, ctx, crashSafeDeleteClass(className),
+		enthnsw.UserConfig{Skip: true}, false, false, false)
+	return crashSafeConcreteShard(t, ctx, shd)
+}
+
+func crashSafeTestObject(className string) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:    strfmt.UUID(uuid.NewString()),
+			Class: className,
+			Properties: map[string]interface{}{
+				crashSafeTextProp: "alpha bravo",
+				crashSafeIntProp:  float64(42),
+			},
+		},
+	}
+}
+
+// crashSafeObjectState reads everything the assertions below need about a
+// stored object: its row bytes, docID and the analyzed inverted properties.
+type crashSafeObjectState struct {
+	idBytes  []byte
+	row      []byte
+	docID    uint64
+	props    []inverted.Property
+	nilProps []inverted.NilProperty
+}
+
+func crashSafeReadObjectState(t *testing.T, s *Shard, id strfmt.UUID) *crashSafeObjectState {
+	t.Helper()
+
+	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
+	require.NoError(t, err)
+
+	bucket, err := s.objectsBucket()
+	require.NoError(t, err)
+
+	row, err := bucket.Get(idBytes)
+	require.NoError(t, err)
+	require.NotNil(t, row, "object row must exist")
+
+	docID, _, err := storobj.DocIDAndTimeFromBinary(row)
+	require.NoError(t, err)
+
+	className, err := bucket.ClassName()
+	require.NoError(t, err)
+	obj, err := storobj.FromBinaryDisk(row, className)
+	require.NoError(t, err)
+
+	props, nilProps, _, err := s.AnalyzeObject(obj)
+	require.NoError(t, err)
+
+	return &crashSafeObjectState{
+		idBytes:  idBytes,
+		row:      row,
+		docID:    docID,
+		props:    props,
+		nilProps: nilProps,
+	}
+}
+
+func crashSafeRowPresent(t *testing.T, s *Shard, idBytes []byte) bool {
+	t.Helper()
+	bucket, err := s.objectsBucket()
+	require.NoError(t, err)
+	row, err := bucket.Get(idBytes)
+	require.NoError(t, err)
+	return row != nil
+}
+
+// crashSafeSetBucketContains reports whether docID is a member of key's
+// posting in a Set/RoaringSet-strategy bucket.
+func crashSafeSetBucketContains(t *testing.T, ctx context.Context, b *lsmkv.Bucket, key []byte, docID uint64) bool {
+	t.Helper()
+	switch b.Strategy() {
+	case lsmkv.StrategySetCollection:
+		list, err := b.SetList(key)
+		require.NoError(t, err)
+		docIDBytes := make([]byte, 8)
+		binary.LittleEndian.PutUint64(docIDBytes, docID)
+		for _, v := range list {
+			if bytes.Equal(v, docIDBytes) {
+				return true
+			}
+		}
+		return false
+	case lsmkv.StrategyRoaringSet:
+		bm, release, err := b.RoaringSetGet(ctx, key)
+		require.NoError(t, err)
+		defer release()
+		return bm.Contains(docID)
+	default:
+		t.Fatalf("unexpected set bucket strategy %q", b.Strategy())
+		return false
+	}
+}
+
+// crashSafePostingsForDocID reports which inverted structures still contain a
+// posting for docID, keyed by a human-readable structure descriptor. It
+// covers filterable, searchable, rangeable, null and property-length indexes
+// for every analyzed property (timestamp props included via IndexTimestamps).
+func crashSafePostingsForDocID(t *testing.T, ctx context.Context, s *Shard,
+	st *crashSafeObjectState,
+) map[string]bool {
+	t.Helper()
+	found := map[string]bool{}
+
+	for _, prop := range st.props {
+		if prop.HasFilterableIndex {
+			b := s.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
+			require.NotNil(t, b, "filterable bucket for %q", prop.Name)
+			for _, item := range prop.Items {
+				if crashSafeSetBucketContains(t, ctx, b, item.Data, st.docID) {
+					found["filterable/"+prop.Name] = true
+				}
+			}
+		}
+
+		if prop.HasSearchableIndex {
+			b := s.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop.Name))
+			require.NotNil(t, b, "searchable bucket for %q", prop.Name)
+			for _, item := range prop.Items {
+				pointers, err := b.DocPointerWithScoreList(ctx, item.Data, 1)
+				require.NoError(t, err)
+				for _, ptr := range pointers {
+					if ptr.Id == st.docID && ptr.Frequency > 0 {
+						found["searchable/"+prop.Name] = true
+					}
+				}
+			}
+		}
+
+		if prop.HasRangeableIndex {
+			b := s.store.Bucket(helpers.BucketRangeableFromPropNameLSM(prop.Name))
+			require.NotNil(t, b, "rangeable bucket for %q", prop.Name)
+			for _, item := range prop.Items {
+				reader := b.ReaderRoaringSetRange()
+				bm, release, err := reader.Read(ctx, binary.BigEndian.Uint64(item.Data), filters.OperatorEqual)
+				require.NoError(t, err)
+				if bm.Contains(st.docID) {
+					found["rangeable/"+prop.Name] = true
+				}
+				release()
+				reader.Close()
+			}
+		}
+
+		if isMetaCountProperty(prop) || isInternalProperty(prop) {
+			continue
+		}
+
+		if s.index.invertedIndexConfig.IndexPropertyLength && prop.Length >= 0 {
+			b := s.store.Bucket(helpers.BucketFromPropNameLengthLSM(prop.Name))
+			require.NotNil(t, b, "length bucket for %q", prop.Name)
+			key, err := bucketKeyPropertyLength(prop.Length)
+			require.NoError(t, err)
+			if crashSafeSetBucketContains(t, ctx, b, key, st.docID) {
+				found["length/"+prop.Name] = true
+			}
+		}
+
+		if s.index.invertedIndexConfig.IndexNullState {
+			b := s.store.Bucket(helpers.BucketFromPropNameNullLSM(prop.Name))
+			require.NotNil(t, b, "null bucket for %q", prop.Name)
+			key, err := bucketKeyPropertyNull(prop.Length == 0)
+			require.NoError(t, err)
+			if crashSafeSetBucketContains(t, ctx, b, key, st.docID) {
+				found["null/"+prop.Name] = true
+			}
+		}
+	}
+
+	return found
+}
+
+func crashSafeAnyPostingPresent(t *testing.T, ctx context.Context, s *Shard,
+	st *crashSafeObjectState,
+) bool {
+	t.Helper()
+	return len(crashSafePostingsForDocID(t, ctx, s, st)) > 0
+}
+
+// TestDeleteCrashSafe_NoOrphanPostingAtAnyPhase walks every phase of the
+// single-object delete and asserts THE invariant that makes deletes
+// crash-safe for docID reuse: at no intermediate state may an inverted
+// posting reference a docID whose object row is gone. The old ordering (row
+// delete first, inverted cleanup after) violates this between the row delete
+// and the cleanup.
+func TestDeleteCrashSafe_NoOrphanPostingAtAnyPhase(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "DeleteCrashSafeInvariant")
+
+	obj := crashSafeTestObject("DeleteCrashSafeInvariant")
+	require.NoError(t, s.PutObject(ctx, obj))
+	st := crashSafeReadObjectState(t, s, obj.ID())
+
+	// Sanity: postings exist while the row exists.
+	require.True(t, crashSafeAnyPostingPresent(t, ctx, s, st))
+
+	var phases []string
+	s.testDeletePhaseHook = func(phase string) {
+		phases = append(phases, phase)
+		if crashSafeAnyPostingPresent(t, ctx, s, st) {
+			require.True(t, crashSafeRowPresent(t, s, st.idBytes),
+				"after phase %q: inverted posting present for docID %d but object row is gone (orphan posting)",
+				phase, st.docID)
+		}
+	}
+	defer func() { s.testDeletePhaseHook = nil }()
+
+	require.NoError(t, s.DeleteObject(ctx, obj.ID(), time.Time{}))
+
+	require.Equal(t,
+		[]string{deletePhasePrepared, deletePhaseCleanedUp, deletePhaseBarrier, deletePhaseRowDeleted},
+		phases, "delete phases must run in the crash-safe order")
+
+	require.False(t, crashSafeRowPresent(t, s, st.idBytes))
+	require.False(t, crashSafeAnyPostingPresent(t, ctx, s, st))
+}
+
+// TestDeleteCrashSafe_RetryAfterCrashBeforeRowDelete simulates a crash in the
+// window the new ordering leaves open: the inverted cleanup ran and was made
+// durable, but the process died before the row delete. The state is
+// row-without-postings, and retrying the delete through the public API must
+// converge (row gone, postings gone) with no error.
+func TestDeleteCrashSafe_RetryAfterCrashBeforeRowDelete(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "DeleteCrashSafeRetry")
+
+	obj := crashSafeTestObject("DeleteCrashSafeRetry")
+	require.NoError(t, s.PutObject(ctx, obj))
+	st := crashSafeReadObjectState(t, s, obj.ID())
+
+	// Run the delete only up to (and including) the barrier — the row delete
+	// never happens, simulating a crash right before it.
+	touched, err := s.cleanupInvertedIndexOnDelete(st.row, st.docID)
+	require.NoError(t, err)
+	require.NoError(t, s.invertedDeleteBarrier(ctx, touched))
+
+	require.True(t, crashSafeRowPresent(t, s, st.idBytes),
+		"simulated crash: row must still exist")
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st),
+		"simulated crash: postings must already be removed")
+
+	// Retry through the public API: must converge with no error.
+	require.NoError(t, s.DeleteObject(ctx, obj.ID(), time.Time{}))
+
+	require.False(t, crashSafeRowPresent(t, s, st.idBytes))
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st))
+}
+
+// TestDeleteCrashSafe_CleanupIdempotentPerStructure pins that a partially
+// completed cleanup (crash mid-cleanup) does not break the retry: for each
+// inverted structure, remove the object's posting once at the lsm level, then
+// run the full delete — it must succeed and converge.
+func TestDeleteCrashSafe_CleanupIdempotentPerStructure(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "DeleteCrashSafeIdempotent")
+
+	propByName := func(st *crashSafeObjectState, name string) *inverted.Property {
+		for i := range st.props {
+			if st.props[i].Name == name {
+				return &st.props[i]
+			}
+		}
+		return nil
+	}
+
+	tests := []struct {
+		name string
+		// preDelete removes exactly one structure's posting(s), simulating a
+		// crash that happened right after that removal.
+		preDelete func(t *testing.T, st *crashSafeObjectState)
+	}{
+		{
+			name: "filterable (roaringset/set)",
+			preDelete: func(t *testing.T, st *crashSafeObjectState) {
+				prop := propByName(st, crashSafeTextProp)
+				require.NotNil(t, prop)
+				b := s.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
+				require.NotNil(t, b)
+				for _, item := range prop.Items {
+					require.NoError(t, s.deleteFromPropertySetBucket(b, st.docID, item.Data))
+				}
+			},
+		},
+		{
+			name: "searchable (map/inverted)",
+			preDelete: func(t *testing.T, st *crashSafeObjectState) {
+				prop := propByName(st, crashSafeTextProp)
+				require.NotNil(t, prop)
+				b := s.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop.Name))
+				require.NotNil(t, b)
+				for _, item := range prop.Items {
+					require.NoError(t, s.deleteInvertedIndexItemWithFrequencyLSM(b, item, st.docID))
+				}
+			},
+		},
+		{
+			name: "rangeable (roaringsetrange)",
+			preDelete: func(t *testing.T, st *crashSafeObjectState) {
+				prop := propByName(st, crashSafeIntProp)
+				require.NotNil(t, prop)
+				b := s.store.Bucket(helpers.BucketRangeableFromPropNameLSM(prop.Name))
+				require.NotNil(t, b)
+				for _, item := range prop.Items {
+					require.NoError(t, s.deleteFromPropertyRangeBucket(b, st.docID, item.Data))
+				}
+			},
+		},
+		{
+			name: "null index",
+			preDelete: func(t *testing.T, st *crashSafeObjectState) {
+				prop := propByName(st, crashSafeTextProp)
+				require.NotNil(t, prop)
+				require.NoError(t, s.deleteFromPropertyNullIndex(prop.Name, st.docID, prop.Length == 0, nil))
+			},
+		},
+		{
+			name: "prop-length index",
+			preDelete: func(t *testing.T, st *crashSafeObjectState) {
+				prop := propByName(st, crashSafeTextProp)
+				require.NotNil(t, prop)
+				require.NoError(t, s.deleteFromPropertyLengthIndex(prop.Name, st.docID, prop.Length, nil))
+			},
+		},
+		{
+			name: "timestamp buckets",
+			preDelete: func(t *testing.T, st *crashSafeObjectState) {
+				prop := propByName(st, filters.InternalPropCreationTimeUnix)
+				require.NotNil(t, prop, "timestamp prop must be analyzed (IndexTimestamps on)")
+				b := s.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
+				require.NotNil(t, b)
+				for _, item := range prop.Items {
+					require.NoError(t, s.deleteFromPropertySetBucket(b, st.docID, item.Data))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := crashSafeTestObject("DeleteCrashSafeIdempotent")
+			require.NoError(t, s.PutObject(ctx, obj))
+			st := crashSafeReadObjectState(t, s, obj.ID())
+
+			tt.preDelete(t, st)
+
+			// The full delete re-runs the cleanup including the structure
+			// already emptied above; it must not error and must converge.
+			require.NoError(t, s.DeleteObject(ctx, obj.ID(), time.Time{}))
+
+			require.False(t, crashSafeRowPresent(t, s, st.idBytes))
+			require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st))
+		})
+	}
+}
+
+// TestDeleteCrashSafe_BarrierRespectsDocIDReuseFlag pins the barrier
+// dispatch: with DOCID_REUSE_ENABLED the barrier syncs (fsync) exactly the
+// touched buckets via Store.SyncWALs — observable because SyncWALs errors on
+// an unknown bucket name — and without the flag it stays on the WriteWALs
+// page-cache flush, which never looks at the names.
+func TestDeleteCrashSafe_BarrierRespectsDocIDReuseFlag(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "DeleteCrashSafeFlag")
+
+	obj := crashSafeTestObject("DeleteCrashSafeFlag")
+	require.NoError(t, s.PutObject(ctx, obj))
+	st := crashSafeReadObjectState(t, s, obj.ID())
+
+	t.Run("cleanup reports every touched bucket name", func(t *testing.T) {
+		touched, err := s.cleanupInvertedIndexOnDelete(st.row, st.docID)
+		require.NoError(t, err)
+
+		expected := []string{
+			helpers.BucketFromPropNameLSM(crashSafeTextProp),
+			helpers.BucketSearchableFromPropNameLSM(crashSafeTextProp),
+			helpers.BucketFromPropNameLSM(crashSafeIntProp),
+			helpers.BucketRangeableFromPropNameLSM(crashSafeIntProp),
+			helpers.BucketFromPropNameNullLSM(crashSafeTextProp),
+			helpers.BucketFromPropNameLengthLSM(crashSafeTextProp),
+			helpers.BucketFromPropNameLSM(filters.InternalPropCreationTimeUnix),
+			helpers.BucketFromPropNameLSM(filters.InternalPropLastUpdateTimeUnix),
+		}
+		require.Subset(t, touched.list(), expected)
+		require.False(t, touched.all)
+	})
+
+	t.Run("flag on routes the touched names into SyncWALs", func(t *testing.T) {
+		t.Setenv("DOCID_REUSE_ENABLED", "true")
+
+		bogus := newTouchedBuckets()
+		bogus.add("no_such_bucket")
+		err := s.invertedDeleteBarrier(ctx, bogus)
+		require.ErrorIs(t, err, lsmkv.ErrBucketNotFound,
+			"an unknown touched bucket must surface SyncWALs' error — proving the names reach SyncWALs")
+
+		real := newTouchedBuckets()
+		real.add(helpers.BucketFromPropNameLSM(crashSafeTextProp))
+		require.NoError(t, s.invertedDeleteBarrier(ctx, real))
+	})
+
+	t.Run("flag off stays on the WriteWALs path", func(t *testing.T) {
+		t.Setenv("DOCID_REUSE_ENABLED", "false")
+
+		bogus := newTouchedBuckets()
+		bogus.add("no_such_bucket")
+		require.NoError(t, s.invertedDeleteBarrier(ctx, bogus),
+			"without the flag the barrier must not consult bucket names (WriteWALs path)")
+	})
+
+	t.Run("flag on, full delete end to end", func(t *testing.T) {
+		t.Setenv("DOCID_REUSE_ENABLED", "true")
+
+		obj2 := crashSafeTestObject("DeleteCrashSafeFlag")
+		require.NoError(t, s.PutObject(ctx, obj2))
+		st2 := crashSafeReadObjectState(t, s, obj2.ID())
+
+		require.NoError(t, s.DeleteObject(ctx, obj2.ID(), time.Time{}))
+		require.False(t, crashSafeRowPresent(t, s, st2.idBytes))
+		require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st2))
+	})
+}
+
+// TestDeleteCrashSafe_DeleteByFilterViaBatch covers the delete-by-filter
+// funnel: filter-matched uuids are resolved (FindUUIDs) and deleted through
+// DeleteObjectBatch — the same crash-safe batch path — leaving rows AND
+// postings gone for matches and intact for non-matches.
+func TestDeleteCrashSafe_DeleteByFilterViaBatch(t *testing.T) {
+	ctx := testCtx()
+	className := "DeleteCrashSafeByFilter"
+	s := crashSafeTestShard(t, ctx, className)
+
+	matching1 := crashSafeTestObject(className)
+	matching2 := crashSafeTestObject(className)
+	nonMatching := crashSafeTestObject(className)
+	nonMatching.Object.Properties = map[string]interface{}{
+		crashSafeTextProp: "charlie delta",
+		crashSafeIntProp:  float64(7),
+	}
+
+	for _, obj := range []*storobj.Object{matching1, matching2, nonMatching} {
+		require.NoError(t, s.PutObject(ctx, obj))
+	}
+
+	states := map[strfmt.UUID]*crashSafeObjectState{}
+	for _, obj := range []*storobj.Object{matching1, matching2, nonMatching} {
+		states[obj.ID()] = crashSafeReadObjectState(t, s, obj.ID())
+	}
+
+	filter := &filters.LocalFilter{Root: &filters.Clause{
+		Operator: filters.OperatorEqual,
+		On: &filters.Path{
+			Class:    schema.ClassName(className),
+			Property: schema.PropertyName(crashSafeIntProp),
+		},
+		Value: &filters.Value{Value: 42, Type: schema.DataTypeInt},
+	}}
+
+	uuids, err := s.FindUUIDs(ctx, filter, 100)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []strfmt.UUID{matching1.ID(), matching2.ID()}, uuids)
+
+	result := s.DeleteObjectBatch(ctx, uuids, time.Time{}, false)
+	for _, r := range result {
+		require.NoError(t, r.Err)
+	}
+
+	for _, obj := range []*storobj.Object{matching1, matching2} {
+		st := states[obj.ID()]
+		require.False(t, crashSafeRowPresent(t, s, st.idBytes), "matched object row must be gone")
+		require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st), "matched object postings must be gone")
+	}
+
+	st := states[nonMatching.ID()]
+	require.True(t, crashSafeRowPresent(t, s, st.idBytes), "non-matching object must survive")
+	require.NotEmpty(t, crashSafePostingsForDocID(t, ctx, s, st))
+}

--- a/adapters/repos/db/shard_delete_crash_safe_test.go
+++ b/adapters/repos/db/shard_delete_crash_safe_test.go
@@ -115,11 +115,12 @@ func crashSafeTestObject(className string) *storobj.Object {
 // crashSafeObjectState reads everything the assertions below need about a
 // stored object: its row bytes, docID and the analyzed inverted properties.
 type crashSafeObjectState struct {
-	idBytes  []byte
-	row      []byte
-	docID    uint64
-	props    []inverted.Property
-	nilProps []inverted.NilProperty
+	idBytes    []byte
+	row        []byte
+	docID      uint64
+	updateTime int64
+	props      []inverted.Property
+	nilProps   []inverted.NilProperty
 }
 
 func crashSafeReadObjectState(t *testing.T, s *Shard, id strfmt.UUID) *crashSafeObjectState {
@@ -135,7 +136,7 @@ func crashSafeReadObjectState(t *testing.T, s *Shard, id strfmt.UUID) *crashSafe
 	require.NoError(t, err)
 	require.NotNil(t, row, "object row must exist")
 
-	docID, _, err := storobj.DocIDAndTimeFromBinary(row)
+	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(row)
 	require.NoError(t, err)
 
 	className, err := bucket.ClassName()
@@ -147,11 +148,12 @@ func crashSafeReadObjectState(t *testing.T, s *Shard, id strfmt.UUID) *crashSafe
 	require.NoError(t, err)
 
 	return &crashSafeObjectState{
-		idBytes:  idBytes,
-		row:      row,
-		docID:    docID,
-		props:    props,
-		nilProps: nilProps,
+		idBytes:    idBytes,
+		row:        row,
+		docID:      docID,
+		updateTime: updateTime,
+		props:      props,
+		nilProps:   nilProps,
 	}
 }
 
@@ -572,4 +574,106 @@ func TestDeleteCrashSafe_DeleteByFilterViaBatch(t *testing.T) {
 	st := states[nonMatching.ID()]
 	require.True(t, crashSafeRowPresent(t, s, st.idBytes), "non-matching object must survive")
 	require.NotEmpty(t, crashSafePostingsForDocID(t, ctx, s, st))
+}
+
+// TestDeleteCrashSafe_BatchRevalidationRace pins the batcher's phase-2
+// revalidation: when a concurrent put replaces the object between phase 1
+// (inverted cleanup) and phase 2 (row delete), phase 2 must NOT just delete
+// the row — that would orphan the put's fresh postings. It must fall back to
+// the full crash-safe single-object delete, leaving row AND fresh postings
+// gone.
+func TestDeleteCrashSafe_BatchRevalidationRace(t *testing.T) {
+	ctx := testCtx()
+	className := "DeleteCrashSafeBatchRace"
+	s := crashSafeTestShard(t, ctx, className)
+
+	obj := crashSafeTestObject(className)
+	require.NoError(t, s.PutObject(ctx, obj))
+	stOld := crashSafeReadObjectState(t, s, obj.ID())
+
+	// phase 1: postings cleaned, row stays
+	prep, err := s.prepareBatchDelete(ctx, obj.ID(), time.Time{})
+	require.NoError(t, err)
+	require.True(t, prep.found)
+	require.Equal(t, stOld.docID, prep.docID)
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, stOld))
+	require.True(t, crashSafeRowPresent(t, s, stOld.idBytes))
+
+	// a concurrent put wins the race between the phases: same uuid, fresh
+	// properties -> fresh postings under a fresh docID
+	updated := &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:    obj.ID(),
+			Class: className,
+			Properties: map[string]interface{}{
+				crashSafeTextProp: "charlie delta",
+				crashSafeIntProp:  float64(7),
+			},
+		},
+	}
+	require.NoError(t, s.PutObject(ctx, updated))
+	stNew := crashSafeReadObjectState(t, s, obj.ID())
+	// NOTE: a props-only update PRESERVES the docID (a fresh docID is only
+	// assigned when vectors/geo change), and updateTime has millisecond
+	// resolution — the revalidation therefore also fingerprints the row
+	// bytes. Assert the row content really did change.
+	require.False(t, bytes.Equal(stOld.row, stNew.row),
+		"concurrent put must change the row bytes")
+	require.NotEmpty(t, crashSafePostingsForDocID(t, ctx, s, stNew),
+		"the put's fresh postings must exist before phase 2")
+
+	// barrier + phase 2: must detect the changed row and fall back to the
+	// full crash-safe delete of the FRESH row
+	require.NoError(t, s.invertedDeleteBarrier(ctx, prep.touched))
+	require.NoError(t, s.finalizeBatchDelete(ctx, prep, time.Time{}))
+
+	require.False(t, crashSafeRowPresent(t, s, stNew.idBytes))
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, stNew),
+		"phase 2 fallback must remove the concurrent put's fresh postings (no orphans)")
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, stOld))
+}
+
+// TestDeleteCrashSafe_BatchRetryAfterCrashBetweenPhases simulates a crash
+// after the batch barrier but before any phase-2 row delete: rows present,
+// postings gone. Retrying the whole batch through the public API must
+// converge with no error.
+func TestDeleteCrashSafe_BatchRetryAfterCrashBetweenPhases(t *testing.T) {
+	ctx := testCtx()
+	className := "DeleteCrashSafeBatchRetry"
+	s := crashSafeTestShard(t, ctx, className)
+
+	obj1 := crashSafeTestObject(className)
+	obj2 := crashSafeTestObject(className)
+	require.NoError(t, s.PutObject(ctx, obj1))
+	require.NoError(t, s.PutObject(ctx, obj2))
+	st1 := crashSafeReadObjectState(t, s, obj1.ID())
+	st2 := crashSafeReadObjectState(t, s, obj2.ID())
+
+	// phase 1 for both objects + one barrier over the union — then "crash"
+	// before phase 2
+	union := newTouchedBuckets()
+	for _, id := range []strfmt.UUID{obj1.ID(), obj2.ID()} {
+		prep, err := s.prepareBatchDelete(ctx, id, time.Time{})
+		require.NoError(t, err)
+		require.True(t, prep.found)
+		union.merge(prep.touched)
+	}
+	require.NoError(t, s.invertedDeleteBarrier(ctx, union))
+
+	for _, st := range []*crashSafeObjectState{st1, st2} {
+		require.True(t, crashSafeRowPresent(t, s, st.idBytes))
+		require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st))
+	}
+
+	// retry through the public batch API
+	result := s.DeleteObjectBatch(ctx, []strfmt.UUID{obj1.ID(), obj2.ID()}, time.Time{}, false)
+	for _, r := range result {
+		require.NoError(t, r.Err)
+	}
+
+	for _, st := range []*crashSafeObjectState{st1, st2} {
+		require.False(t, crashSafeRowPresent(t, s, st.idBytes))
+		require.Empty(t, crashSafePostingsForDocID(t, ctx, s, st))
+	}
 }

--- a/adapters/repos/db/shard_delete_crash_safe_test.go
+++ b/adapters/repos/db/shard_delete_crash_safe_test.go
@@ -94,7 +94,7 @@ func crashSafeConcreteShard(t *testing.T, ctx context.Context, s ShardLike) *Sha
 func crashSafeTestShard(t *testing.T, ctx context.Context, className string) *Shard {
 	t.Helper()
 	shd, _ := testShardWithSettings(t, ctx, crashSafeDeleteClass(className),
-		enthnsw.UserConfig{Skip: true}, false, false, false)
+		enthnsw.UserConfig{Skip: true}, false, false)
 	return crashSafeConcreteShard(t, ctx, shd)
 }
 
@@ -129,8 +129,9 @@ func crashSafeReadObjectState(t *testing.T, s *Shard, id strfmt.UUID) *crashSafe
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	require.NoError(t, err)
 
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	require.NoError(t, err)
+	defer release()
 
 	row, err := bucket.Get(idBytes)
 	require.NoError(t, err)
@@ -159,8 +160,9 @@ func crashSafeReadObjectState(t *testing.T, s *Shard, id strfmt.UUID) *crashSafe
 
 func crashSafeRowPresent(t *testing.T, s *Shard, idBytes []byte) bool {
 	t.Helper()
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	require.NoError(t, err)
+	defer release()
 	row, err := bucket.Get(idBytes)
 	require.NoError(t, err)
 	return row != nil

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -1007,6 +1007,27 @@ func (l *LazyLoadShard) batchDeleteObject(ctx context.Context, id strfmt.UUID, d
 	return l.shard.batchDeleteObject(ctx, id, deletionTime)
 }
 
+func (l *LazyLoadShard) prepareBatchDelete(ctx context.Context, id strfmt.UUID, deletionTime time.Time) (*preparedBatchDelete, error) {
+	if err := l.Load(ctx); err != nil {
+		return nil, err
+	}
+	return l.shard.prepareBatchDelete(ctx, id, deletionTime)
+}
+
+func (l *LazyLoadShard) finalizeBatchDelete(ctx context.Context, prep *preparedBatchDelete, deletionTime time.Time) error {
+	if err := l.Load(ctx); err != nil {
+		return err
+	}
+	return l.shard.finalizeBatchDelete(ctx, prep, deletionTime)
+}
+
+func (l *LazyLoadShard) invertedDeleteBarrier(ctx context.Context, touched *touchedBuckets) error {
+	if err := l.Load(ctx); err != nil {
+		return err
+	}
+	return l.shard.invertedDeleteBarrier(ctx, touched)
+}
+
 func (l *LazyLoadShard) putObjectLSM(ctx context.Context, object *storobj.Object, idBytes []byte) (objectInsertStatus, error) {
 	l.mustLoad()
 	return l.shard.putObjectLSM(ctx, object, idBytes)

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -14,6 +14,7 @@ package db
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	stderrors "errors"
 	"fmt"
@@ -1025,11 +1026,57 @@ func (s *Shard) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
 	return strfmt.UUID(prop[0]), nil
 }
 
+// batchDeleteObject deletes a single object in the crash-safe order (inverted
+// cleanup -> barrier -> row delete), leaving the WAL flushing to the caller
+// (the batcher flushes once per batch). Retained as the standalone entry the
+// batchers' phases compose; callers that batch many objects should instead
+// run prepareBatchDelete for all of them, one invertedDeleteBarrier, then
+// finalizeBatchDelete — see deleteObjectsBatcher.
 func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
+	prep, err := s.prepareBatchDelete(ctx, id, deletionTime)
+	if err != nil {
+		return err
+	}
+	if !prep.found {
+		// nothing to do
+		return nil
+	}
+	if err := s.invertedDeleteBarrier(ctx, prep.touched); err != nil {
+		return errors.Wrap(err, "inverted delete barrier")
+	}
+	return s.finalizeBatchDelete(ctx, prep, deletionTime)
+}
+
+// preparedBatchDelete carries phase-1 state of a batched delete between the
+// cleanup phase and the row-delete phase.
+type preparedBatchDelete struct {
+	uuid    strfmt.UUID
+	idBytes []byte
+	// found reports whether a live row existed in phase 1; when false the
+	// remaining fields (except uuid/idBytes) are zero and phase 2 is a no-op.
+	found      bool
+	docID      uint64
+	updateTime int64
+	// rowHash fingerprints the row bytes read in phase 1. docID+updateTime
+	// alone cannot detect every concurrent put: a props-only update PRESERVES
+	// the docID, and updateTime has millisecond resolution, so a put landing
+	// in the same millisecond would be invisible to them.
+	rowHash [sha256.Size]byte
+	touched *touchedBuckets
+}
+
+// prepareBatchDelete is phase 1 of a batched delete: under the object's
+// docIdLock it reads the row and removes the docID from every inverted
+// posting — but does NOT delete the row. The caller must run
+// invertedDeleteBarrier over the union of all touched buckets before any
+// finalizeBatchDelete, so a crash between the phases can only ever leave
+// row-without-postings (repairable by retry), never an orphan posting.
+func (s *Shard) prepareBatchDelete(ctx context.Context, id strfmt.UUID, deletionTime time.Time,
+) (*preparedBatchDelete, error) {
 	// Wait outside RLock: initAsyncReplication holds the write lock while
 	// initialising, so blocking under RLock here would deadlock.
 	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {
-		return err
+		return nil, err
 	}
 
 	s.asyncReplicationRWMux.RLock()
@@ -1037,12 +1084,12 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	bucket, release, err := s.objectsBucket()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer release()
 
@@ -1052,52 +1099,98 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 	lock.Lock()
 	defer lock.Unlock()
 
-	existing, err := bucket.Get(idBytes)
+	prep, err := s.prepareObjectDeletionLocked(bucket, idBytes, deletionTime, false)
 	if err != nil {
-		return errors.Wrap(err, "unexpected error on previous lookup")
+		return nil, err
+	}
+	if prep == nil {
+		return &preparedBatchDelete{uuid: id, idBytes: idBytes}, nil
 	}
 
-	if existing == nil {
-		// nothing to do
+	touched, err := s.cleanupInvertedIndexOnDelete(prep.existing, prep.docID)
+	if err != nil {
+		return nil, errors.Wrap(err, "delete inverted postings of object")
+	}
+
+	return &preparedBatchDelete{
+		uuid:       id,
+		idBytes:    idBytes,
+		found:      true,
+		docID:      prep.docID,
+		updateTime: prep.updateTime,
+		rowHash:    sha256.Sum256(prep.existing),
+		touched:    touched,
+	}, nil
+}
+
+// finalizeBatchDelete is phase 2 of a batched delete: after the barrier made
+// phase 1's posting removals durable, it re-validates the row under the
+// object's docIdLock and deletes it.
+//
+//   - Row unchanged since phase 1 (same docID, updateTime and row-content
+//     hash): delete the row (+changelog/hashtree) and remove the docID from
+//     the vector/geo queues.
+//   - Row gone: a concurrent delete won; nothing left to do.
+//   - Row changed (a concurrent put won the race between the phases): the
+//     put's FRESH postings landed after phase 1's cleanup, so deleting the row
+//     now would orphan them. Fall back to the full crash-safe single-object
+//     delete under the held lock — re-clean, re-barrier for this one object,
+//     then delete the row.
+func (s *Shard) finalizeBatchDelete(ctx context.Context, prep *preparedBatchDelete, deletionTime time.Time) error {
+	if !prep.found {
 		return nil
 	}
 
-	// we need the doc ID so we can clean up inverted indices currently
-	// pointing to this object
-	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
+	if err := s.waitForMinimalHashTreeInitialization(ctx); err != nil {
+		return err
+	}
+
+	s.asyncReplicationRWMux.RLock()
+	defer s.asyncReplicationRWMux.RUnlock()
+
+	bucket, release, err := s.objectsBucket()
 	if err != nil {
-		return errors.Wrap(err, "get existing doc id from object binary")
+		return err
 	}
+	defer release()
 
-	docIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(docIDBytes, docID)
-	withSecondary := lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)
-	if deletionTime.IsZero() {
-		err = bucket.Delete(idBytes, withSecondary)
-	} else {
-		err = bucket.DeleteWith(idBytes, deletionTime, withSecondary)
-	}
+	lock := &s.docIdLock[s.uuidToIdLockPoolId(prep.idBytes)]
+
+	lock.Lock()
+	defer lock.Unlock()
+
+	cur, err := s.prepareObjectDeletionLocked(bucket, prep.idBytes, deletionTime, false)
 	if err != nil {
-		return errors.Wrap(err, "delete object from bucket")
+		return err
+	}
+	if cur == nil {
+		// row gone — a concurrent delete already converged this object
+		return nil
 	}
 
-	logTime := updateTime
-	if !deletionTime.IsZero() {
-		logTime = deletionTime.UnixMilli()
-	}
-	s.AppendChangeLogDelete(idBytes, logTime)
-
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime, logTime); err != nil {
-		return errors.Wrap(err, "object deletion in hashtree")
+	if cur.docID == prep.docID && cur.updateTime == prep.updateTime &&
+		sha256.Sum256(cur.existing) == prep.rowHash {
+		if err := s.deleteObjectRowLocked(bucket, cur, deletionTime); err != nil {
+			return err
+		}
+		return s.deleteFromVectorAndGeoQueues(cur.docID)
 	}
 
-	_, err = s.cleanupInvertedIndexOnDelete(existing, docID)
-	if err != nil {
-		return errors.Wrap(err, "delete object from bucket")
+	// concurrent put between the phases: run the full crash-safe delete for
+	// the fresh row
+	docID, deleted, err := s.deleteObjectCrashSafeLocked(ctx, bucket, prep.idBytes, deletionTime, false)
+	if err != nil || !deleted {
+		return err
 	}
+	return s.deleteFromVectorAndGeoQueues(docID)
+}
 
-	err = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
-		if err = queue.Delete(docID); err != nil {
+// deleteFromVectorAndGeoQueues removes docID from every vector and geo index
+// queue; the caller is responsible for flushing the queues (the batcher does
+// so once per batch).
+func (s *Shard) deleteFromVectorAndGeoQueues(docID uint64) error {
+	err := s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
+		if err := queue.Delete(docID); err != nil {
 			return fmt.Errorf("delete from vector index queue of vector %q: %w", targetVector, err)
 		}
 		return nil
@@ -1106,17 +1199,12 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return err
 	}
 
-	err = s.ForEachGeoQueue(func(propName string, queue *VectorIndexQueue) error {
-		if err = queue.Delete(docID); err != nil {
+	return s.ForEachGeoQueue(func(propName string, queue *VectorIndexQueue) error {
+		if err := queue.Delete(docID); err != nil {
 			return fmt.Errorf("delete from geo index queue of prop %q: %w", propName, err)
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (s *Shard) WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) {

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -1091,7 +1091,7 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return errors.Wrap(err, "object deletion in hashtree")
 	}
 
-	err = s.cleanupInvertedIndexOnDelete(existing, docID)
+	_, err = s.cleanupInvertedIndexOnDelete(existing, docID)
 	if err != nil {
 		return errors.Wrap(err, "delete object from bucket")
 	}

--- a/adapters/repos/db/shard_update_crash_safe_test.go
+++ b/adapters/repos/db/shard_update_crash_safe_test.go
@@ -1,0 +1,166 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+// The crash-safe update tests mirror the crash-safe delete tests for the
+// update path that CHANGES the docID: the row rewrite retires the old docID
+// exactly like a delete retires it, so the old docID's inverted cleanup must
+// be durable before the rewritten row can be. Without that ordering a crash
+// can leave orphan postings for a docID that later reaches the free list.
+
+// crashSafeUpdatedVersion builds a new version of obj with different props
+// AND a different vector. The vector change is what forces a docID change
+// (compareObjsForInsertStatus treats a prop-only change as docID-preserved).
+func crashSafeUpdatedVersion(obj *storobj.Object, className string) *storobj.Object {
+	updated := crashSafeTestObject(className)
+	updated.Object.ID = obj.ID()
+	updated.Object.Properties = map[string]interface{}{
+		crashSafeTextProp: "charlie delta",
+		crashSafeIntProp:  float64(7),
+	}
+	updated.Vector = []float32{0.9, 0.8, 0.7}
+	return updated
+}
+
+// TestUpdateCrashSafe_NoOrphanPostingAtAnyPhase walks every phase of a
+// docID-changing update and asserts the same invariant as the delete tests,
+// transposed: at no intermediate state may an inverted posting reference the
+// OLD docID once the object row no longer does. The old ordering (row
+// rewrite first, inverted cleanup after, no barrier) violates this between
+// the row write and the cleanup.
+func TestUpdateCrashSafe_NoOrphanPostingAtAnyPhase(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "UpdateCrashSafeInvariant")
+
+	obj := crashSafeTestObject("UpdateCrashSafeInvariant")
+	obj.Vector = []float32{0.1, 0.2, 0.3}
+	require.NoError(t, s.PutObject(ctx, obj))
+	prevSt := crashSafeReadObjectState(t, s, obj.ID())
+
+	// Sanity: postings exist for the initial docID.
+	require.True(t, crashSafeAnyPostingPresent(t, ctx, s, prevSt))
+
+	currentDocID := func() uint64 {
+		return crashSafeReadObjectState(t, s, obj.ID()).docID
+	}
+
+	var phases []string
+	s.testPutPhaseHook = func(phase string) {
+		phases = append(phases, phase)
+		// A posting for the outgoing docID may only exist while the row
+		// still references that docID. Once the row was rewritten under the
+		// new docID, a surviving old posting is an orphan.
+		if crashSafeAnyPostingPresent(t, ctx, s, prevSt) {
+			require.Equal(t, prevSt.docID, currentDocID(),
+				"after phase %q: posting for retired docID %d present but the row no longer references it (orphan posting)",
+				phase, prevSt.docID)
+		}
+	}
+	defer func() { s.testPutPhaseHook = nil }()
+
+	require.NoError(t, s.PutObject(ctx, crashSafeUpdatedVersion(obj, "UpdateCrashSafeInvariant")))
+
+	require.Equal(t,
+		[]string{putPhaseRetireCleanedUp, putPhaseRetireBarrier, putPhaseRowWritten},
+		phases, "docID-retiring update phases must run in the crash-safe order")
+
+	newSt := crashSafeReadObjectState(t, s, obj.ID())
+	require.NotEqual(t, prevSt.docID, newSt.docID,
+		"the updated vector must have forced a docID change")
+	require.False(t, crashSafeAnyPostingPresent(t, ctx, s, prevSt),
+		"no posting may remain for the retired docID")
+	require.True(t, crashSafeAnyPostingPresent(t, ctx, s, newSt),
+		"postings must exist for the new docID")
+}
+
+// TestUpdateCrashSafe_RetryAfterCrashBeforeRowWrite simulates a crash in the
+// window the new ordering leaves open: the old docID's cleanup ran and was
+// made durable, but the process died before the row rewrite. The state is
+// old-row-without-postings, and retrying the update through the public API
+// must converge (row under the new docID, postings only for the new docID)
+// with no error — the retire cleanup is idempotent.
+func TestUpdateCrashSafe_RetryAfterCrashBeforeRowWrite(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "UpdateCrashSafeRetry")
+
+	obj := crashSafeTestObject("UpdateCrashSafeRetry")
+	obj.Vector = []float32{0.1, 0.2, 0.3}
+	require.NoError(t, s.PutObject(ctx, obj))
+	prevSt := crashSafeReadObjectState(t, s, obj.ID())
+
+	// Run the update only up to (and including) the barrier — the row write
+	// never happens, simulating a crash right before it.
+	bucket, err := s.objectsBucket()
+	require.NoError(t, err)
+	className, err := bucket.ClassName()
+	require.NoError(t, err)
+	prevObj, err := storobj.FromBinaryDisk(prevSt.row, className)
+	require.NoError(t, err)
+	require.NoError(t, s.retireOldDocIDLocked(ctx, prevObj, prevSt.docID))
+
+	require.True(t, crashSafeRowPresent(t, s, prevSt.idBytes),
+		"simulated crash: the old row must still exist")
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, prevSt),
+		"simulated crash: the old docID's postings must already be removed")
+
+	// Retry through the public API: must converge with no error.
+	require.NoError(t, s.PutObject(ctx, crashSafeUpdatedVersion(obj, "UpdateCrashSafeRetry")))
+
+	newSt := crashSafeReadObjectState(t, s, obj.ID())
+	require.NotEqual(t, prevSt.docID, newSt.docID)
+	require.Empty(t, crashSafePostingsForDocID(t, ctx, s, prevSt))
+	require.True(t, crashSafeAnyPostingPresent(t, ctx, s, newSt))
+}
+
+// TestUpdateCrashSafe_PreservedDocIDSkipsRetire pins the boundary of the new
+// ordering: a prop-only update keeps its docID, so the row rewrite retires
+// nothing and no retire phases (and no barrier) may run.
+func TestUpdateCrashSafe_PreservedDocIDSkipsRetire(t *testing.T) {
+	ctx := testCtx()
+	s := crashSafeTestShard(t, ctx, "UpdateCrashSafePreserved")
+
+	obj := crashSafeTestObject("UpdateCrashSafePreserved")
+	obj.Vector = []float32{0.1, 0.2, 0.3}
+	require.NoError(t, s.PutObject(ctx, obj))
+	prevSt := crashSafeReadObjectState(t, s, obj.ID())
+
+	var phases []string
+	s.testPutPhaseHook = func(phase string) { phases = append(phases, phase) }
+	defer func() { s.testPutPhaseHook = nil }()
+
+	// same vector, changed props: docID-preserved update
+	updated := crashSafeTestObject("UpdateCrashSafePreserved")
+	updated.Object.ID = obj.ID()
+	updated.Object.Properties = map[string]interface{}{
+		crashSafeTextProp: "echo foxtrot",
+		crashSafeIntProp:  float64(9),
+	}
+	updated.Vector = []float32{0.1, 0.2, 0.3}
+	require.NoError(t, s.PutObject(ctx, updated))
+
+	require.Equal(t, []string{putPhaseRowWritten}, phases,
+		"a docID-preserving update must not run the retire phases")
+
+	newSt := crashSafeReadObjectState(t, s, obj.ID())
+	require.Equal(t, prevSt.docID, newSt.docID)
+	require.True(t, crashSafeAnyPostingPresent(t, ctx, s, newSt))
+}

--- a/adapters/repos/db/shard_update_crash_safe_test.go
+++ b/adapters/repos/db/shard_update_crash_safe_test.go
@@ -109,8 +109,9 @@ func TestUpdateCrashSafe_RetryAfterCrashBeforeRowWrite(t *testing.T) {
 
 	// Run the update only up to (and including) the barrier — the row write
 	// never happens, simulating a crash right before it.
-	bucket, err := s.objectsBucket()
+	bucket, release, err := s.objectsBucket()
 	require.NoError(t, err)
+	defer release()
 	className, err := bucket.ClassName()
 	require.NoError(t, err)
 	prevObj, err := storobj.FromBinaryDisk(prevSt.row, className)

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -59,6 +59,20 @@ func (b *deleteObjectsBatcher) delete(ctx context.Context, uuids []strfmt.UUID, 
 	b.objects = b.deleteSingleBatchInLSM(ctx, uuids, deletionTime, dryRun)
 }
 
+// deleteSingleBatchInLSM deletes the batch in two phases so the whole batch
+// shares ONE durability barrier:
+//
+//	phase 1 (concurrent): per object, read the row and remove its inverted
+//	  postings (prepareBatchDelete) — no row deletes yet.
+//	barrier (once): make every phase-1 posting removal durable over the
+//	  union of touched buckets (invertedDeleteBarrier).
+//	phase 2 (concurrent): per object, re-validate and delete the row
+//	  (finalizeBatchDelete); a row changed by a concurrent put between the
+//	  phases falls back to a full per-object crash-safe delete.
+//
+// This order guarantees no crash can leave an orphan posting (docID in a
+// posting, no object row), which — once docIDs are reused — would resolve to
+// a different object.
 func (b *deleteObjectsBatcher) deleteSingleBatchInLSM(ctx context.Context,
 	batch []strfmt.UUID, deletionTime time.Time, dryRun bool,
 ) objects.BatchSimpleObjects {
@@ -76,10 +90,15 @@ func (b *deleteObjectsBatcher) deleteSingleBatchInLSM(ctx context.Context,
 		return result
 	}
 
+	// phase 1: concurrent inverted cleanups, accumulating the union of
+	// touched buckets; rows stay in place
+	preps := make([]*preparedBatchDelete, len(batch))
+	touchedUnion := newTouchedBuckets()
+
 	eg := enterrors.NewErrorGroupWrapper(b.shard.Index().logger)
 	eg.SetLimit(_NUMCPU) // prevent unbounded concurrency
 
-	lastDeleted := -1
+	lastScheduled := -1
 outer:
 	for i, uuid := range batch {
 		select {
@@ -89,39 +108,88 @@ outer:
 		}
 
 		f := func() error {
-			// perform delete
-			obj := b.deleteObjectOfBatchInLSM(ctx, uuid, deletionTime, dryRun)
+			obj, prep := b.prepareObjectOfBatchInLSM(ctx, uuid, deletionTime, dryRun)
 			objLock.Lock()
 			result[i] = obj
+			if prep != nil {
+				preps[i] = prep
+				touchedUnion.merge(prep.touched)
+			}
 			objLock.Unlock()
 			return nil
 		}
 		eg.Go(f, i, uuid)
-		lastDeleted = i
+		lastScheduled = i
 
 	}
 	// safe to ignore error, as the internal routines never return an error
 	eg.Wait()
 
 	ctxErr := ctx.Err()
-	for i, count := lastDeleted+1, len(batch); i < count; i++ {
+	for i, count := lastScheduled+1, len(batch); i < count; i++ {
 		result[i] = objects.BatchSimpleObject{UUID: batch[i], Err: ctxErr}
 	}
+
+	// barrier: phase 1's posting removals must be durable before ANY row
+	// delete below can possibly become durable
+	anyPrepared := false
+	for i := range preps {
+		if preps[i] != nil && preps[i].found && result[i].Err == nil {
+			anyPrepared = true
+			break
+		}
+	}
+	if anyPrepared {
+		if err := b.shard.invertedDeleteBarrier(ctx, touchedUnion); err != nil {
+			// rows were not deleted; every prepared object converges on retry
+			err = errors.Wrap(err, "inverted delete barrier")
+			for i := range preps {
+				if preps[i] != nil && preps[i].found && result[i].Err == nil {
+					result[i] = objects.BatchSimpleObject{UUID: batch[i], Err: err}
+				}
+			}
+			return result
+		}
+	}
+
+	// phase 2: concurrent re-validation + row deletes
+	eg = enterrors.NewErrorGroupWrapper(b.shard.Index().logger)
+	eg.SetLimit(_NUMCPU)
+	for i := range preps {
+		if preps[i] == nil || !preps[i].found || result[i].Err != nil {
+			continue
+		}
+		prep := preps[i]
+		f := func() error {
+			err := b.shard.finalizeBatchDelete(ctx, prep, deletionTime)
+			objLock.Lock()
+			result[i] = objects.BatchSimpleObject{UUID: prep.uuid, Err: err}
+			objLock.Unlock()
+			return nil
+		}
+		eg.Go(f, i, prep.uuid)
+	}
+	eg.Wait()
 
 	return result
 }
 
-func (b *deleteObjectsBatcher) deleteObjectOfBatchInLSM(ctx context.Context,
+// prepareObjectOfBatchInLSM runs phase 1 for one object of the batch. The
+// returned prep is nil for dry runs and failures.
+func (b *deleteObjectsBatcher) prepareObjectOfBatchInLSM(ctx context.Context,
 	uuid strfmt.UUID, deletionTime time.Time, dryRun bool,
-) objects.BatchSimpleObject {
+) (objects.BatchSimpleObject, *preparedBatchDelete) {
 	before := time.Now()
 	defer b.shard.Metrics().BatchDelete(before, "shard_delete_individual_total")
 	if !dryRun {
-		err := b.shard.batchDeleteObject(ctx, uuid, deletionTime)
-		return objects.BatchSimpleObject{UUID: uuid, Err: err}
+		prep, err := b.shard.prepareBatchDelete(ctx, uuid, deletionTime)
+		if err != nil {
+			return objects.BatchSimpleObject{UUID: uuid, Err: err}, nil
+		}
+		return objects.BatchSimpleObject{UUID: uuid, Err: nil}, prep
 	}
 
-	return objects.BatchSimpleObject{UUID: uuid, Err: nil}
+	return objects.BatchSimpleObject{UUID: uuid, Err: nil}, nil
 }
 
 func (b *deleteObjectsBatcher) flushWALs(ctx context.Context) {

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -25,12 +26,116 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
+// Phases of the crash-safe delete sequence, reported to the test-only
+// phase hook so tests can assert invariants at every intermediate state.
+const (
+	deletePhasePrepared   = "prepared"
+	deletePhaseCleanedUp  = "cleaned-up"
+	deletePhaseBarrier    = "barrier"
+	deletePhaseRowDeleted = "row-deleted"
+)
+
+func (s *Shard) fireDeletePhaseHook(phase string) {
+	if h := s.testDeletePhaseHook; h != nil {
+		h(phase)
+	}
+}
+
+// touchedBuckets collects the names of the LSM buckets an inverted-index
+// cleanup wrote to, so the delete barrier can sync exactly those WALs. All
+// methods are nil-receiver safe: write paths that don't need the barrier
+// (e.g. the put path's old-posting cleanup) pass nil.
+type touchedBuckets struct {
+	names map[string]struct{}
+	// all marks that an opaque write path (migration double-write callbacks)
+	// may have written to buckets we cannot enumerate; the barrier must then
+	// conservatively cover every bucket in the store.
+	all bool
+}
+
+func newTouchedBuckets() *touchedBuckets {
+	return &touchedBuckets{names: map[string]struct{}{}}
+}
+
+func (tb *touchedBuckets) add(name string) {
+	if tb == nil {
+		return
+	}
+	tb.names[name] = struct{}{}
+}
+
+func (tb *touchedBuckets) markAll() {
+	if tb == nil {
+		return
+	}
+	tb.all = true
+}
+
+// merge folds other into tb (used to build a batch-wide union).
+func (tb *touchedBuckets) merge(other *touchedBuckets) {
+	if tb == nil || other == nil {
+		return
+	}
+	tb.all = tb.all || other.all
+	for name := range other.names {
+		tb.names[name] = struct{}{}
+	}
+}
+
+// list returns the collected names, sorted for deterministic sync order.
+func (tb *touchedBuckets) list() []string {
+	if tb == nil {
+		return nil
+	}
+	names := make([]string, 0, len(tb.names))
+	for name := range tb.names {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// invertedDeleteBarrier makes a delete's inverted-index removals durable
+// before the object row delete may become durable. With docID reuse ON an
+// orphaned posting (docID in a posting, no object row) would later resolve to
+// a DIFFERENT object, so the removals are fsynced via SyncWALs on exactly the
+// touched buckets. With the flag OFF we keep today's cheap page-cache flush
+// (WriteWALs), which preserves the write ordering without paying an fsync per
+// delete. Note the objects bucket is deliberately NOT part of the barrier:
+// the row is deleted after it.
+func (s *Shard) invertedDeleteBarrier(ctx context.Context, touched *touchedBuckets) error {
+	if !docIDReuseEnabled() {
+		return s.store.WriteWALs()
+	}
+	if touched != nil && touched.all {
+		return s.store.SyncAllWALs(ctx)
+	}
+	return s.store.SyncWALs(ctx, touched.list()...)
+}
+
+// deletePreparation captures everything read from the object row that the
+// later delete phases need, so they never have to re-read it.
+type deletePreparation struct {
+	idBytes    []byte
+	existing   []byte
+	docID      uint64
+	updateTime int64
+}
+
 func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
 	_, err := s.deleteObject(ctx, id, deletionTime, fromChangeLogReplay(ctx))
 	return err
 }
 
 // deleteObject tombstones the object (reporting whether it did); with skipIfLocalNewer it keeps a live copy at least as new as deletionTime, since lsmkv does not timestamp-arbitrate and an older repair tombstone would otherwise clobber a newer write.
+//
+// Crash-safety: the phases run in an order that guarantees no crash can leave
+// an ORPHAN POSTING (docID present in an inverted posting while the object
+// row is gone) — see deleteObjectCrashSafeLocked. A crash at any point leaves
+// either both row and postings, or row-without-postings; both converge on
+// retrying the delete, whereas an orphan posting is unrepairable (the row's
+// bytes are the only source of which postings to remove) and, once docIDs are
+// reused, resolves to a different object.
 func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time,
 	skipIfLocalNewer bool,
 ) (bool, error) {
@@ -64,54 +169,9 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 	lock.Lock()
 	defer lock.Unlock()
 
-	existing, err := bucket.Get([]byte(idBytes))
-	if err != nil {
-		return false, fmt.Errorf("unexpected error on previous lookup: %w", err)
-	}
-
-	if existing == nil {
-		// nothing to do
-		return false, nil
-	}
-
-	// we need the doc ID so we can clean up inverted indices currently
-	// pointing to this object
-	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
-	if err != nil {
-		return false, fmt.Errorf("get existing doc id from object binary: %w", err)
-	}
-
-	if skipIfLocalNewer && !deletionTime.IsZero() && updateTime >= deletionTime.UnixMilli() {
-		return false, nil // live local object is newer; keep it (TimeBased)
-	}
-
-	docIDBytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(docIDBytes, docID)
-	withSecondary := lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)
-	if deletionTime.IsZero() {
-		err = bucket.Delete(idBytes, withSecondary)
-	} else {
-		err = bucket.DeleteWith(idBytes, deletionTime, withSecondary)
-	}
-	if err != nil {
-		return false, fmt.Errorf("delete object from bucket: %w", err)
-	}
-
-	// Never time.Now() — the target's LWW replay compares this against its
-	// local object's updateTime.
-	logTime := updateTime
-	if !deletionTime.IsZero() {
-		logTime = deletionTime.UnixMilli()
-	}
-	s.AppendChangeLogDelete(idBytes, logTime)
-
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime, logTime); err != nil {
-		return false, fmt.Errorf("object deletion in hashtree: %w", err)
-	}
-
-	err = s.cleanupInvertedIndexOnDelete(existing, docID)
-	if err != nil {
-		return false, fmt.Errorf("delete object from bucket: %w", err)
+	docID, deleted, err := s.deleteObjectCrashSafeLocked(ctx, bucket, idBytes, deletionTime, skipIfLocalNewer)
+	if err != nil || !deleted {
+		return false, err
 	}
 
 	if err = s.store.WriteWALs(); err != nil {
@@ -161,28 +221,147 @@ func (s *Shard) deleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 	return true, nil
 }
 
-func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) error {
+// deleteObjectCrashSafeLocked runs the LSM part of an object delete in the
+// crash-safe order. The caller must hold the object's docIdLock. Reports the
+// deleted object's docID and whether a live row was actually deleted.
+//
+// Order (each step only after the previous one):
+//
+//  1. prepare: read the row and evaluate guards.
+//  2. cleanup: remove the docID from every inverted posting the row's
+//     properties point to.
+//  3. barrier: make those removals durable (invertedDeleteBarrier) BEFORE the
+//     row delete below can possibly become durable.
+//  4. row delete (+docID secondary key), change-log append, hashtree update.
+//
+// A crash before 4 leaves the row in place; retrying the delete re-runs the
+// (idempotent) cleanup and converges. The reverse order could leave a posting
+// pointing at a row that no longer exists, which a retry cannot repair.
+func (s *Shard) deleteObjectCrashSafeLocked(ctx context.Context, bucket *lsmkv.Bucket,
+	idBytes []byte, deletionTime time.Time, skipIfLocalNewer bool,
+) (uint64, bool, error) {
+	prep, err := s.prepareObjectDeletionLocked(bucket, idBytes, deletionTime, skipIfLocalNewer)
+	if err != nil || prep == nil {
+		return 0, false, err
+	}
+	s.fireDeletePhaseHook(deletePhasePrepared)
+
+	touched, err := s.cleanupInvertedIndexOnDelete(prep.existing, prep.docID)
+	if err != nil {
+		return 0, false, fmt.Errorf("delete inverted postings of object: %w", err)
+	}
+	s.fireDeletePhaseHook(deletePhaseCleanedUp)
+
+	if err := s.invertedDeleteBarrier(ctx, touched); err != nil {
+		return 0, false, fmt.Errorf("inverted delete barrier: %w", err)
+	}
+	s.fireDeletePhaseHook(deletePhaseBarrier)
+
+	if err := s.deleteObjectRowLocked(bucket, prep, deletionTime); err != nil {
+		return 0, false, err
+	}
+	s.fireDeletePhaseHook(deletePhaseRowDeleted)
+
+	return prep.docID, true, nil
+}
+
+// prepareObjectDeletionLocked reads the object row and evaluates the delete
+// guards. Returns (nil, nil) when there is nothing to do (no row, or the
+// local row is newer than an incoming repair tombstone). Caller must hold the
+// object's docIdLock.
+func (s *Shard) prepareObjectDeletionLocked(bucket *lsmkv.Bucket, idBytes []byte,
+	deletionTime time.Time, skipIfLocalNewer bool,
+) (*deletePreparation, error) {
+	existing, err := bucket.Get(idBytes)
+	if err != nil {
+		return nil, fmt.Errorf("unexpected error on previous lookup: %w", err)
+	}
+
+	if existing == nil {
+		// nothing to do
+		return nil, nil
+	}
+
+	// we need the doc ID so we can clean up inverted indices currently
+	// pointing to this object
+	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
+	if err != nil {
+		return nil, fmt.Errorf("get existing doc id from object binary: %w", err)
+	}
+
+	if skipIfLocalNewer && !deletionTime.IsZero() && updateTime >= deletionTime.UnixMilli() {
+		return nil, nil // live local object is newer; keep it (TimeBased)
+	}
+
+	return &deletePreparation{
+		idBytes:    idBytes,
+		existing:   existing,
+		docID:      docID,
+		updateTime: updateTime,
+	}, nil
+}
+
+// deleteObjectRowLocked deletes the object row (with its docID secondary
+// key), appends the change-log delete and updates the hashtree. It must only
+// run AFTER the inverted cleanup and its barrier. Caller must hold the
+// object's docIdLock.
+func (s *Shard) deleteObjectRowLocked(bucket *lsmkv.Bucket, prep *deletePreparation,
+	deletionTime time.Time,
+) error {
+	docIDBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(docIDBytes, prep.docID)
+	withSecondary := lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)
+
+	var err error
+	if deletionTime.IsZero() {
+		err = bucket.Delete(prep.idBytes, withSecondary)
+	} else {
+		err = bucket.DeleteWith(prep.idBytes, deletionTime, withSecondary)
+	}
+	if err != nil {
+		return fmt.Errorf("delete object from bucket: %w", err)
+	}
+
+	// Never time.Now() — the target's LWW replay compares this against its
+	// local object's updateTime.
+	logTime := prep.updateTime
+	if !deletionTime.IsZero() {
+		logTime = deletionTime.UnixMilli()
+	}
+	s.AppendChangeLogDelete(prep.idBytes, logTime)
+
+	if err = s.mayDeleteObjectHashTree(prep.idBytes, prep.updateTime, logTime); err != nil {
+		return fmt.Errorf("object deletion in hashtree: %w", err)
+	}
+
+	return nil
+}
+
+// cleanupInvertedIndexOnDelete removes docID from every inverted structure
+// the row's properties point to. It reports the names of the buckets it wrote
+// to so the caller can run a durability barrier over exactly those WALs.
+func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) (*touchedBuckets, error) {
 	bucket, release, err := s.objectsBucket()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer release()
 	className, err := bucket.ClassName()
 	if err != nil {
-		return fmt.Errorf("getting bucket class name: %w", err)
+		return nil, fmt.Errorf("getting bucket class name: %w", err)
 	}
 	previousObject, err := storobj.FromBinaryDisk(previous, className)
 	if err != nil {
-		return fmt.Errorf("unmarshal previous object: %w", err)
+		return nil, fmt.Errorf("unmarshal previous object: %w", err)
 	}
 
 	previousProps, previousNilProps, previousNestedProps, err := s.AnalyzeObject(previousObject)
 	if err != nil {
-		return fmt.Errorf("analyze previous object: %w", err)
+		return nil, fmt.Errorf("analyze previous object: %w", err)
 	}
 
 	if err = s.subtractPropLengths(previousProps); err != nil {
-		return fmt.Errorf("subtract prop lengths: %w", err)
+		return nil, fmt.Errorf("subtract prop lengths: %w", err)
 	}
 
 	// Removing the old docId from the factory solves an issue,
@@ -192,20 +371,29 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 	// For any NotEquals filter, we do an Equals filter and invert it's results.
 	s.bitmapFactory.RemoveIds(docID)
 
+	touched := newTouchedBuckets()
+
 	st := s.loadPropValueIndexState()
-	err = s.deleteFromInvertedIndicesLSM(previousProps, previousNilProps, docID, st)
+	if len(st.del) > 0 || len(st.scope.props) > 0 {
+		// Migration double-write callbacks resolve their target buckets
+		// dynamically (sidecar or swap fallback), so we cannot enumerate
+		// them here; be conservative.
+		touched.markAll()
+	}
+
+	err = s.deleteFromInvertedIndicesLSM(previousProps, previousNilProps, docID, st, touched)
 	if err != nil {
-		return fmt.Errorf("put inverted indices props: %w", err)
+		return nil, fmt.Errorf("put inverted indices props: %w", err)
 	}
 
 	// Mirrors the delete into the ingest bucket for scope props suppressed
-	// above; no-op absent a migration.
+	// above; no-op absent a migration. (Bucket-wise covered by markAll.)
 	if err = s.migrationDoubleWriteDelete(st, previousObject, docID); err != nil {
-		return fmt.Errorf("migration double-write delete: %w", err)
+		return nil, fmt.Errorf("migration double-write delete: %w", err)
 	}
 
-	if err = s.deleteNestedInvertedIndicesLSM(previousNestedProps, docID); err != nil {
-		return fmt.Errorf("delete nested inverted indices: %w", err)
+	if err = s.deleteNestedInvertedIndicesLSM(previousNestedProps, docID, touched); err != nil {
+		return nil, fmt.Errorf("delete nested inverted indices: %w", err)
 	}
 
 	if s.index.Config.TrackVectorDimensions {
@@ -213,14 +401,15 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 			if err = s.removeDimensionsLSM(dims, docID, targetVector); err != nil {
 				return fmt.Errorf("remove dimension tracking for vector %q: %w", targetVector, err)
 			}
+			touched.add(helpers.DimensionsBucketLSM)
 			return nil
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return touched, nil
 }
 
 func (s *Shard) mayDeleteObjectHashTree(uuidBytes []byte, updateTime, deletionEventMs int64) error {

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -355,6 +355,17 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) (*to
 		return nil, fmt.Errorf("unmarshal previous object: %w", err)
 	}
 
+	return s.cleanupInvertedIndexForRetiredDocID(previousObject, docID)
+}
+
+// cleanupInvertedIndexForRetiredDocID is cleanupInvertedIndexOnDelete's core
+// for callers that already hold the unmarshaled previous object: the delete
+// path reaches it from the row bytes, the update path (docID change) directly
+// with the previous object version it fetched. In both cases docID is being
+// RETIRED — no row will reference it afterwards — so every posting removal
+// below must be made durable (invertedDeleteBarrier over the returned
+// touched set) before the retiring row write may become durable.
+func (s *Shard) cleanupInvertedIndexForRetiredDocID(previousObject *storobj.Object, docID uint64) (*touchedBuckets, error) {
 	previousProps, previousNilProps, previousNestedProps, err := s.AnalyzeObject(previousObject)
 	if err != nil {
 		return nil, fmt.Errorf("analyze previous object: %w", err)

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -21,14 +21,21 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
+// deleteFromInvertedIndicesLSM removes docID's postings for the given props.
+// Every bucket written to is reported into touched (nil-safe), so a delete's
+// durability barrier can sync exactly those WALs.
 func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps []inverted.NilProperty,
-	docID uint64, st *propValueIndexState,
+	docID uint64, st *propValueIndexState, touched *touchedBuckets,
 ) error {
 	for _, prop := range props {
 		if prop.HasFilterableIndex {
-			bucket := s.store.Bucket(helpers.BucketFromPropNameLSM(prop.Name))
+			bucketName := helpers.BucketFromPropNameLSM(prop.Name)
+			bucket := s.store.Bucket(bucketName)
 			if bucket == nil {
 				return fmt.Errorf("no bucket for prop '%s' found", prop.Name)
+			}
+			if len(prop.Items) > 0 {
+				touched.add(bucketName)
 			}
 
 			for _, item := range prop.Items {
@@ -40,9 +47,13 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 		}
 
 		if prop.HasSearchableIndex {
-			bucket := s.store.Bucket(helpers.BucketSearchableFromPropNameLSM(prop.Name))
+			bucketName := helpers.BucketSearchableFromPropNameLSM(prop.Name)
+			bucket := s.store.Bucket(bucketName)
 			if bucket == nil {
 				return fmt.Errorf("no bucket searchable for prop '%s' found", prop.Name)
+			}
+			if len(prop.Items) > 0 {
+				touched.add(bucketName)
 			}
 
 			for _, item := range prop.Items {
@@ -55,9 +66,13 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 		}
 
 		if prop.HasRangeableIndex {
-			bucket := s.store.Bucket(helpers.BucketRangeableFromPropNameLSM(prop.Name))
+			bucketName := helpers.BucketRangeableFromPropNameLSM(prop.Name)
+			bucket := s.store.Bucket(bucketName)
 			if bucket == nil {
 				return fmt.Errorf("no bucket rangeable for prop %q found", prop.Name)
+			}
+			if len(prop.Items) > 0 {
+				touched.add(bucketName)
 			}
 			for _, item := range prop.Items {
 				if err := s.deleteFromPropertyRangeBucket(bucket, docID, item.Data); err != nil {
@@ -82,13 +97,13 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 
 		// properties where defining a length does not make sense (floats etc.) have a negative entry as length
 		if s.index.invertedIndexConfig.IndexPropertyLength && prop.Length >= 0 {
-			if err := s.deleteFromPropertyLengthIndex(prop.Name, docID, prop.Length); err != nil {
+			if err := s.deleteFromPropertyLengthIndex(prop.Name, docID, prop.Length, touched); err != nil {
 				return errors.Wrap(err, "add indexed property length")
 			}
 		}
 
 		if s.index.invertedIndexConfig.IndexNullState {
-			if err := s.deleteFromPropertyNullIndex(prop.Name, docID, prop.Length == 0); err != nil {
+			if err := s.deleteFromPropertyNullIndex(prop.Name, docID, prop.Length == 0, touched); err != nil {
 				return errors.Wrap(err, "add indexed null state")
 			}
 		}
@@ -97,13 +112,13 @@ func (s *Shard) deleteFromInvertedIndicesLSM(props []inverted.Property, nilProps
 	// remove nil properties from the nullstate and property length inverted index
 	for _, nilProperty := range nilProps {
 		if s.index.invertedIndexConfig.IndexPropertyLength && nilProperty.AddToPropertyLength {
-			if err := s.deleteFromPropertyLengthIndex(nilProperty.Name, docID, 0); err != nil {
+			if err := s.deleteFromPropertyLengthIndex(nilProperty.Name, docID, 0, touched); err != nil {
 				return errors.Wrap(err, "add indexed property length")
 			}
 		}
 
 		if s.index.invertedIndexConfig.IndexNullState {
-			if err := s.deleteFromPropertyNullIndex(nilProperty.Name, docID, true); err != nil {
+			if err := s.deleteFromPropertyNullIndex(nilProperty.Name, docID, true, touched); err != nil {
 				return errors.Wrap(err, "add indexed null state")
 			}
 		}
@@ -129,8 +144,9 @@ func (s *Shard) deleteInvertedIndexItemWithFrequencyLSM(bucket *lsmkv.Bucket,
 	return bucket.MapDeleteKey(item.Data, docIDBytes)
 }
 
-func (s *Shard) deleteFromPropertyLengthIndex(propName string, docID uint64, length int) error {
-	bucketLength := s.store.Bucket(helpers.BucketFromPropNameLengthLSM(propName))
+func (s *Shard) deleteFromPropertyLengthIndex(propName string, docID uint64, length int, touched *touchedBuckets) error {
+	bucketName := helpers.BucketFromPropNameLengthLSM(propName)
+	bucketLength := s.store.Bucket(bucketName)
 	if bucketLength == nil {
 		return errors.Errorf("no bucket for prop '%s' length found", propName)
 	}
@@ -142,11 +158,13 @@ func (s *Shard) deleteFromPropertyLengthIndex(propName string, docID uint64, len
 	if err := s.deleteFromPropertySetBucket(bucketLength, docID, key); err != nil {
 		return errors.Wrapf(err, "failed adding to prop '%s' length bucket", propName)
 	}
+	touched.add(bucketName)
 	return nil
 }
 
-func (s *Shard) deleteFromPropertyNullIndex(propName string, docID uint64, isNull bool) error {
-	bucketNull := s.store.Bucket(helpers.BucketFromPropNameNullLSM(propName))
+func (s *Shard) deleteFromPropertyNullIndex(propName string, docID uint64, isNull bool, touched *touchedBuckets) error {
+	bucketName := helpers.BucketFromPropNameNullLSM(propName)
+	bucketNull := s.store.Bucket(bucketName)
 	if bucketNull == nil {
 		return errors.Errorf("no bucket for prop '%s' null found", propName)
 	}
@@ -158,6 +176,7 @@ func (s *Shard) deleteFromPropertyNullIndex(propName string, docID uint64, isNul
 	if err := s.deleteFromPropertySetBucket(bucketNull, docID, key); err != nil {
 		return errors.Wrapf(err, "failed adding to prop '%s' null bucket", propName)
 	}
+	touched.add(bucketName)
 	return nil
 }
 

--- a/adapters/repos/db/shard_write_inverted_lsm_nested.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_nested.go
@@ -20,26 +20,31 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
-func (s *Shard) deleteNestedInvertedIndicesLSM(nestedProps []inverted.NestedProperty, docID uint64) error {
+func (s *Shard) deleteNestedInvertedIndicesLSM(nestedProps []inverted.NestedProperty, docID uint64,
+	touched *touchedBuckets,
+) error {
 	for _, np := range nestedProps {
-		if err := s.deleteNestedFilterableIndex(np, docID); err != nil {
+		if err := s.deleteNestedFilterableIndex(np, docID, touched); err != nil {
 			return err
 		}
 		// TODO: delete nested searchable index (Phase 2)
 		// TODO: delete nested rangeable index (Phase 3)
-		if err := s.deleteNestedMetaIndex(np, docID); err != nil {
+		if err := s.deleteNestedMetaIndex(np, docID, touched); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (s *Shard) deleteNestedFilterableIndex(np inverted.NestedProperty, docID uint64) error {
+func (s *Shard) deleteNestedFilterableIndex(np inverted.NestedProperty, docID uint64,
+	touched *touchedBuckets,
+) error {
 	if !np.HasFilterableIndex {
 		return nil
 	}
 
-	bucket := s.store.Bucket(helpers.BucketNestedFromPropNameLSM(np.Name))
+	bucketName := helpers.BucketNestedFromPropNameLSM(np.Name)
+	bucket := s.store.Bucket(bucketName)
 	if bucket == nil {
 		return fmt.Errorf("nested prop %q: no filterable value bucket found", np.Name)
 	}
@@ -47,15 +52,19 @@ func (s *Shard) deleteNestedFilterableIndex(np inverted.NestedProperty, docID ui
 	if err := bucket.RoaringSetRemoveBatch(nestedFilterableEntries(np, docID)); err != nil {
 		return fmt.Errorf("nested prop %q: remove filterable values: %w", np.Name, err)
 	}
+	touched.add(bucketName)
 	return nil
 }
 
-func (s *Shard) deleteNestedMetaIndex(np inverted.NestedProperty, docID uint64) error {
+func (s *Shard) deleteNestedMetaIndex(np inverted.NestedProperty, docID uint64,
+	touched *touchedBuckets,
+) error {
 	if len(np.Idx) == 0 && len(np.Exists) == 0 {
 		return nil
 	}
 
-	bucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(np.Name))
+	bucketName := helpers.BucketNestedMetaFromPropNameLSM(np.Name)
+	bucket := s.store.Bucket(bucketName)
 	if bucket == nil {
 		return fmt.Errorf("nested prop %q: no meta bucket found", np.Name)
 	}
@@ -63,6 +72,7 @@ func (s *Shard) deleteNestedMetaIndex(np inverted.NestedProperty, docID uint64) 
 	if err := bucket.RoaringSetRemoveBatch(nestedMetaEntries(np, docID)); err != nil {
 		return fmt.Errorf("nested prop %q: remove meta entries: %w", np.Name, err)
 	}
+	touched.add(bucketName)
 	return nil
 }
 

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -196,6 +196,14 @@ func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDoc
 			return nil
 		}
 
+		// docID change: retire the old docID crash-safely BEFORE the row
+		// write below — same reasoning as putObjectLSM.
+		if status.docIDChanged {
+			if err := s.retireOldDocIDLocked(ctx, prevObj, status.oldDocID); err != nil {
+				return err
+			}
+		}
+
 		objBytes, err := obj.MarshalBinaryDisk(s.index.Config.SkipWriteClassNameOnDisk)
 		if err != nil {
 			return errors.Wrapf(err, "marshal object %s to binary", obj.ID())

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -602,10 +602,12 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 
 	if prevObject != nil {
 		// TODO: metrics
-		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID, st); err != nil {
+		// nil touched-bucket collector: the put path replaces the row rather
+		// than deleting it, so it needs no inverted-delete durability barrier
+		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID, st, nil); err != nil {
 			return fmt.Errorf("delete inverted indices props: %w", err)
 		}
-		if err := s.deleteNestedInvertedIndicesLSM(prevNestedProps, status.oldDocID); err != nil {
+		if err := s.deleteNestedInvertedIndicesLSM(prevNestedProps, status.oldDocID, nil); err != nil {
 			return fmt.Errorf("delete nested inverted indices: %w", err)
 		}
 		if s.index.Config.TrackVectorDimensions {

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -237,6 +237,51 @@ func fetchObject(bucket *lsmkv.Bucket, idBytes []byte) (*storobj.Object, error) 
 	return obj, nil
 }
 
+// Phases of the crash-safe docID retirement inside an update, reported to
+// the test-only put phase hook (mirrors the delete phase constants).
+const (
+	putPhaseRetireCleanedUp = "retire-cleaned-up"
+	putPhaseRetireBarrier   = "retire-barrier"
+	putPhaseRowWritten      = "row-written"
+)
+
+func (s *Shard) firePutPhaseHook(phase string) {
+	if h := s.testPutPhaseHook; h != nil {
+		h(phase)
+	}
+}
+
+// retireOldDocIDLocked is the update-path mirror of the delete path's
+// cleanup+barrier phases (deleteObjectCrashSafeLocked steps 2-3). When an
+// update changes the docID, the row rewrite retires the old docID exactly
+// like a delete retires it: afterwards no row references it, so a crash that
+// loses part of the old docID's inverted cleanup while the rewritten row
+// survives leaves orphan postings for a docID that will later reach the free
+// list. Cleaning up and syncing BEFORE the row write is issued guarantees
+// the cleanup is durable before the rewrite can possibly be.
+//
+// A crash after the barrier but before the row write leaves the old row with
+// its postings already removed — the same convergent state as a delete
+// crashing before its row delete: the object is temporarily invisible to
+// filters and the next put (or delete) of the object re-runs the idempotent
+// cleanup.
+//
+// Caller must hold the object's docIdLock and pass status.docIDChanged.
+func (s *Shard) retireOldDocIDLocked(ctx context.Context, prevObj *storobj.Object, oldDocID uint64) error {
+	touched, err := s.cleanupInvertedIndexForRetiredDocID(prevObj, oldDocID)
+	if err != nil {
+		return fmt.Errorf("cleanup inverted postings of old docID %d: %w", oldDocID, err)
+	}
+	s.firePutPhaseHook(putPhaseRetireCleanedUp)
+
+	if err := s.invertedDeleteBarrier(ctx, touched); err != nil {
+		return fmt.Errorf("inverted delete barrier for old docID %d: %w", oldDocID, err)
+	}
+	s.firePutPhaseHook(putPhaseRetireBarrier)
+
+	return nil
+}
+
 func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes []byte,
 ) (status objectInsertStatus, err error) {
 	before := time.Now()
@@ -327,6 +372,16 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 			return nil
 		}
 
+		// docID change: retire the old docID crash-safely BEFORE the row
+		// write below — see retireOldDocIDLocked. (docIDChanged implies
+		// prevObj != nil; determineInsertStatus decided the docID above, so
+		// the gate is exact, not conservative.)
+		if status.docIDChanged {
+			if err := s.retireOldDocIDLocked(ctx, prevObj, status.oldDocID); err != nil {
+				return err
+			}
+		}
+
 		var objBinary []byte
 		if obj.PrecomputedDiskBinary != nil {
 			// raw path: persist source bytes verbatim, only patching our docID.
@@ -342,6 +397,7 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 		if err := s.upsertObjectDataLSM(bucket, idBytes, objBinary, status.docID); err != nil {
 			return errors.Wrap(err, "upsert object data")
 		}
+		s.firePutPhaseHook(putPhaseRowWritten)
 		s.metrics.PutObjectUpsertObject(before)
 
 		// Tee before hashtree: the bucket is the SSOT for movement catchup.
@@ -546,33 +602,30 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 	}
 
 	// One snapshot for the whole write, so the double-write pass below sees
-	// the same {add,del,scope} as the inline suppression above.
+	// the same {add,del,scope} as the inline suppression above. (When the
+	// docID changed, the old docID's cleanup already ran with its own
+	// snapshot in retireOldDocIDLocked — the same two-snapshot split a
+	// delete-then-put would have.)
 	st := s.loadPropValueIndexState()
 
 	var prevProps []inverted.Property
 	var prevNilprops []inverted.NilProperty
 	var prevNestedProps []inverted.NestedProperty
 
-	if prevObject != nil {
+	// Only the docID-PRESERVED update still needs the previous version here,
+	// for the delta cleanup below. The docID-CHANGED update retired the old
+	// docID — full inverted cleanup, prop-length subtraction, bitmap-factory
+	// removal, dimension tracking, migration delete mirror, and a durability
+	// barrier — in retireOldDocIDLocked, BEFORE the new row was written.
+	if prevObject != nil && status.docIDPreserved {
 		prevProps, prevNilprops, prevNestedProps, err = s.AnalyzeObject(prevObject)
 		if err != nil {
 			return fmt.Errorf("analyze previous object: %w", err)
 		}
-	}
-	// if object updated (with or without docID changed)
-	if status.docIDChanged || status.docIDPreserved {
-		if err := s.subtractPropLengths(prevProps); err != nil {
-			s.index.logger.WithField("action", "subtractPropLengths").WithError(err).Error("could not subtract prop lengths")
-		}
-	}
 
-	// Removing the old docId from the factory solves an issue,
-	// where, if using a NotEquals filter on a property,
-	// there is a possible time period where that docId has been deleted from the inverted index,
-	// but is still present in HNSW or other vector indices.
-	// For any NotEquals filter, we do an Equals filter and invert it's results.
-	if status.docIDChanged {
-		s.bitmapFactory.RemoveIds(status.oldDocID)
+		if err := s.subtractPropLengths(prevProps); err != nil {
+			s.index.logger.WithField("action", "subtractPropLengths").Errorf("could not subtract prop lengths: %v", err)
+		}
 	}
 
 	if err := s.SetPropertyLengths(props); err != nil {
@@ -595,15 +648,14 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		nilpropsToDel = deltaNil.ToDelete
 	} else {
 		propsToAdd = inverted.DedupItems(props)
-		propsToDel = inverted.DedupItems(prevProps)
 		nilpropsToAdd = nilprops
-		nilpropsToDel = prevNilprops
 	}
 
-	if prevObject != nil {
+	if prevObject != nil && status.docIDPreserved {
 		// TODO: metrics
-		// nil touched-bucket collector: the put path replaces the row rather
-		// than deleting it, so it needs no inverted-delete durability barrier
+		// nil touched-bucket collector: the docID lives on (the row still
+		// references it after the rewrite), so this delta cleanup cannot
+		// orphan a to-be-reused docID and needs no durability barrier
 		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID, st, nil); err != nil {
 			return fmt.Errorf("delete inverted indices props: %w", err)
 		}
@@ -645,8 +697,14 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 	}
 
 	// Mirrors this write into the ingest bucket under the TARGET analysis for
-	// scope props suppressed above; no-op absent a migration.
-	if err := s.migrationDoubleWrite(st, object, prevObject, status); err != nil {
+	// scope props suppressed above; no-op absent a migration. When the docID
+	// changed, the previous version's delete mirror already ran (durably) in
+	// retireOldDocIDLocked, so only the add side remains here.
+	prevForMigration := prevObject
+	if status.docIDChanged {
+		prevForMigration = nil
+	}
+	if err := s.migrationDoubleWrite(st, object, prevForMigration, status); err != nil {
 		return fmt.Errorf("migration double-write: %w", err)
 	}
 


### PR DESCRIPTION
## What

First PR of the docID-reuse series (targets `integration/docid-reuse`). The delete path is synchronous but non-transactional across LSM buckets: today the object row is deleted FIRST, then the inverted postings are removed. A crash in between leaves an orphan posting (docID in a posting, no object row) that a retry cannot repair — the row's bytes are the only source of which postings to remove. With docID reuse, an orphan posting later resolves to a different object, so filters return objects that don't match.

Three commits:

1. **`lsmkv.SyncWALs`** — new durability-barrier primitive: `Store.SyncWALs(ctx, names...)` / `SyncAllWALs` → `Bucket.SyncWAL()` → active memtable's commit logger flush **+ fsync**. Unknown bucket name is an error (a barrier must not silently skip). Mirrors `WriteWAL`'s locking discipline.
2. **Single delete reorder** — `deleteObject` now runs: read row + guards → inverted cleanup (returns the set of touched bucket names) → **barrier** → row delete (+secondary key, changelog, hashtree) → WriteWALs → vector/geo queue deletes. The barrier is `SyncWALs(touched)` when `DOCID_REUSE_ENABLED` is on (same env flag that will gate the whole reuse feature; default off), today's `WriteWALs` otherwise — write *ordering* is always the new one; the fsync cost is opt-in.
3. **Batch delete, one barrier per batch** — phase 1 (concurrent): read + cleanup per object, union of touched buckets; one barrier; phase 2 (concurrent, per-uuid lock): revalidate the row (docID + updateTime + **sha256 of the phase-1 row bytes**) and delete it; on mismatch (a concurrent put won the race between phases) fall back to the full single-object crash-safe delete so the put's fresh postings can't be orphaned. Delete-by-filter funnels through this same path (covered by test).

Crash at any intermediate point now leaves either row+postings or row-without-postings; both converge on retry. An orphan posting can no longer be produced.

## Also fixed (found during the work)

- Revalidation by (docID, updateTime) alone is insufficient — a props-only put preserves the docID and updateTime has ms resolution; phase 2 additionally compares a sha256 of the row bytes.
- Pre-existing bug: the batch delete path never enqueued the delete on **geo** queues (only vector) — batch-deleted objects lingered in geo indexes. Single delete always did both; batch now does too (`deleteFromVectorAndGeoQueues`).

## Tests

- `TestStore_SyncWALs` (+closed-store): on-disk WAL assertions, per-name selectivity, unknown-name error, ctx cancel.
- `TestDeleteCrashSafe_NoOrphanPostingAtAnyPhase`: steps through every phase asserting the invariant "posting present ⇒ row present". Red against the old order (`orphan posting` at phase row-deleted), green after the reorder.
- `TestDeleteCrashSafe_RetryAfterCrashBeforeRowDelete`, `_CleanupIdempotentPerStructure` (table: filterable/searchable/rangeable/null/prop-length/timestamps), `_BarrierRespectsDocIDReuseFlag`, `_DeleteByFilterViaBatch`, `_BatchRevalidationRace`, `_BatchRetryAfterCrashBetweenPhases`.

Suites: `go test -race -count 1 ./adapters/repos/db/{,lsmkv/}` unit + `-tags integrationTest` all green; `linter_go_routines.sh` clean; gofumpt clean.

## Notes

- PropertyLengthTracker durability in single delete is a known separate issue, deliberately untouched here.
- Legacy `StrategySetCollection` shards are not in the idempotency table (needs an old-format fixture); the delete ops are strategy-agnostic and idempotent for both strategies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4r4MLtZ5BtUhMHfirHa2N

## Updates

- Rebased-by-merge onto the refreshed `integration/docid-reuse` (arena cache adapted to current main — occupied-slot counting + `PreloadIfAbsent`).
- The geo-queue omission in batch delete turned out to be a general bug and is fixed on stable as #12889; the equivalent change here (needed by phase 2 anyway) is its forward-port and will reconcile via the normal stable→main merge train.
- Why phase 2 compares a sha256 instead of `bytes.Equal`: phase 1 deliberately does NOT retain the row bytes between phases — a large batch would otherwise hold thousands of KB-sized rows in memory for the whole barrier window; the 32-byte fingerprint is kept instead.


## Review round 2

- **Update path with a docID change is now retire-safe.** The nil touched-collector rationale in `updateInvertedIndexLSM` only held for docID-preserving puts. A docID-changing update retires the old docID exactly like a delete, so `putObjectLSM`/`mergeObjectInStorage` now run the delete path's cleanup + barrier (`retireOldDocIDLocked`) BEFORE the row rewrite is issued (`determineInsertStatus` fixes the docID before the write, so the gate is exact, not conservative). Covered by `TestUpdateCrashSafe_*`, red against the old order at phase row-written.
- **SyncWAL rotation window: confirmed real, closed.** Between `atomicallySwitchMemtable` and the flush's `commitlog.close()` (which runs only after `waitForZeroWriters`), `SyncWAL` synced the new active memtable and reported durability the rotated writes didn't have. `SyncWAL` now also syncs the flushing memtable; close/sync/flushBuffers serialize on a commitLogger-internal mutex (NOT the memtable lock — holding that across close()'s fsync stalls readers, which CI caught on the first attempt) and a closed commit log treats `flushBuffers`/`sync` as durable no-ops. Covered by `TestBucket_SyncWAL_CoversRotatedMemtable`.
- **Flag OFF cost note:** with `DOCID_REUSE_ENABLED` off, a single delete now runs `WriteWALs` twice (the barrier's page-cache flush plus the pre-existing tail flush), and a docID-changing update runs one extra `WriteWALs`. Both are buffered flushes, no fsync; kept for ordering symmetry with the flag-on path.
- **`bitmapFactory.RemoveIds` follow-up:** with reuse enabled, `RemoveIds` on a since-reused docID would remove the NEW object from the filter universe. Its removal is its own upcoming PR in this series (it is NOT yet tracked by an issue — flagging here so the series carries the TODO).

- **Base-branch CI note:** `vulnerability check` fails on grpc `v1.82.1` (CVE-2026-84304, published this week; fixed in 1.83.1). `main` already carries `v1.83.2` — `integration/docid-reuse` needs a merge-down from main; not addressable from this PR.
