### PR TITLE
fix(db): batch delete never removed objects from geo index queues

### DIFF
--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -558,6 +559,67 @@ func TestInitGeoPropConcurrent(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1}, found)
+}
+
+// TestDeleteRemovesFromGeoIndex pins that every delete path removes the object
+// from the shard's geo indexes, not only from its vector indexes. A path that
+// skips the geo queues leaves deleted doc IDs served by geo filters until an
+// unrelated write to the same prop happens to tombstone them.
+func TestDeleteRemovesFromGeoIndex(t *testing.T) {
+	tests := []struct {
+		name   string
+		delete func(t *testing.T, ctx context.Context, s *Shard, id strfmt.UUID)
+	}{
+		{
+			name: "single-object delete",
+			delete: func(t *testing.T, ctx context.Context, s *Shard, id strfmt.UUID) {
+				require.NoError(t, s.DeleteObject(ctx, id, time.Time{}))
+			},
+		},
+		{
+			name: "batch delete",
+			delete: func(t *testing.T, ctx context.Context, s *Shard, id strfmt.UUID) {
+				for _, result := range s.DeleteObjectBatch(ctx, []strfmt.UUID{id}, time.Time{}, false) {
+					require.NoError(t, result.Err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			s := testGeoPropShard(t, ctx)
+
+			obj := &storobj.Object{
+				MarshallerVersion: 1,
+				Object: models.Object{
+					ID:         strfmt.UUID(uuid.NewString()),
+					Class:      geoPropClass,
+					Properties: map[string]interface{}{"location": munichCoordinates()},
+				},
+				Vector: []float32{1, 2, 3},
+			}
+			require.NoError(t, s.PutObject(ctx, obj))
+
+			idx, _ := geoIndexAndQueue(t, s, "location")
+			withinRange := func() []uint64 {
+				found, err := idx.WithinRange(ctx, filters.GeoRange{
+					GeoCoordinates: munichCoordinates(),
+					Distance:       10000,
+				})
+				require.NoError(t, err)
+				return found
+			}
+			require.Equal(t, []uint64{obj.DocID}, withinRange(),
+				"sanity: the object must be geo-indexed before the delete")
+
+			test.delete(t, ctx, s, obj.Object.ID)
+
+			require.Empty(t, withinRange(),
+				"the deleted object must be gone from the geo index")
+		})
+	}
 }
 
 // blockGeoQueueDir puts a regular file where propName's queue directory belongs,

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -1015,6 +1015,16 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 		return err
 	}
 
+	err = s.ForEachGeoQueue(func(propName string, queue *VectorIndexQueue) error {
+		if err = queue.Delete(docID); err != nil {
+			return fmt.Errorf("delete from geo index queue of prop %q: %w", propName, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## What

`batchDeleteObject` (the path behind `DeleteObjectBatch`, including delete-by-filter) enqueued the delete on every **vector** index queue but never on the **geo** property queues, so batch-deleted objects lingered in geo indexes and kept matching `WithinGeoRange` queries. The single-object delete path has always done both. Verified present on stable/v1.39, v1.38 and v1.37.

Fix mirrors the single-delete's geo-queue handling (`ForEachGeoQueue` delete loop) in `batchDeleteObject`. No flush added there: the batcher's `flushWALs` already flushes geo queues once per batch, same as vector queues.

## Test

`TestDeleteRemovesFromGeoIndex` (table-driven: single delete / batch delete): puts an object with geo coordinates, asserts the geo index finds its docID, deletes, asserts it is gone. Red before the fix on the batch case only (`Should be empty, but was [0]`) — the single-delete case passed, isolating the batch path.

Suites: `go test -race -count 1 ./adapters/repos/db/` and full `-tags integrationTest` both green.

## Backport note

Dry-run cherry-picks: **v1.38 clean** (both files auto-merge). **v1.37**: the fix hunk in `shard_read.go` auto-merges cleanly; the test file's neighbors don't exist there, so the test needs a small port (helpers exist with `*testing.T`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4r4MLtZ5BtUhMHfirHa2N