### PR TITLE
fix(aggregator): filtered meta count included deleted objects after restart

### DIFF
--- a/adapters/repos/db/aggregate_filtered_deleted_integration_test.go
+++ b/adapters/repos/db/aggregate_filtered_deleted_integration_test.go
@@ -140,3 +140,125 @@ func TestFilteredAggregateMetaCountSkipsDeletedIDs(t *testing.T) {
 		})
 	}
 }
+
+// TestGroupedAggregateCountSkipsDeletedIDs is the GroupBy mirror of
+// TestFilteredAggregateMetaCountSkipsDeletedIDs. The grouped path receives
+// the same deleted-id-polluted allow list from a negated filter, but its
+// per-group counts self-correct BY CONSTRUCTION: grouping requires reading
+// each object's grouped-by value (grouper.groupFiltered →
+// docid.ScanObjectsLSM), the scan skips ids that no longer resolve to a
+// stored object, and each group's Count is the number of ids that actually
+// resolved — a deleted id can never be grouped. This test pins that
+// property so a future refactor (e.g. counting the raw allow list per
+// group) cannot silently reintroduce the overcount the filtered meta count
+// had.
+func TestGroupedAggregateCountSkipsDeletedIDs(t *testing.T) {
+	const (
+		keepTotal   = 5
+		keepDeleted = 2
+		dropTotal   = 3
+		dropDeleted = 1
+	)
+
+	limit := 5
+	tests := []struct {
+		name   string
+		filter *filters.LocalFilter
+	}{
+		{
+			// both groups survive the NotEqual "other" filter; each must
+			// count only its live objects
+			name:   "negated filter",
+			filter: aggCategoryFilter(filters.OperatorNotEqual, "other"),
+		},
+		{
+			name:   "positive filter (control)",
+			filter: aggCategoryFilter(filters.OperatorEqual, "keep"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			class := &models.Class{
+				Class: aggDeletedIDsClass,
+				Properties: []*models.Property{{
+					Name:         "category",
+					DataType:     schema.DataTypeText.PropString(),
+					Tokenization: models.PropertyTokenizationWhitespace,
+				}},
+			}
+			shardLike, _ := testShardWithSettings(t, ctx, class,
+				hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, false)
+			s := concreteShard(t, shardLike)
+
+			put := func(category string) strfmt.UUID {
+				obj := &storobj.Object{
+					MarshallerVersion: 1,
+					Object: models.Object{
+						ID:         strfmt.UUID(uuid.NewString()),
+						Class:      aggDeletedIDsClass,
+						Properties: map[string]interface{}{"category": category},
+					},
+					Vector: []float32{1, 2, 3},
+				}
+				require.NoError(t, s.PutObject(ctx, obj))
+				return obj.Object.ID
+			}
+
+			keepIDs := make([]strfmt.UUID, keepTotal)
+			for i := range keepIDs {
+				keepIDs[i] = put("keep")
+			}
+			dropIDs := make([]strfmt.UUID, dropTotal)
+			for i := range dropIDs {
+				dropIDs[i] = put("drop")
+			}
+			for i := 0; i < keepDeleted; i++ {
+				require.NoError(t, s.DeleteObject(ctx, keepIDs[i], time.Time{}))
+			}
+			for i := 0; i < dropDeleted; i++ {
+				require.NoError(t, s.DeleteObject(ctx, dropIDs[i], time.Time{}))
+			}
+
+			// mimic a restart: shard init prefills the bitmap factory's universe
+			// from the doc id counter's high-water mark (shard_init_lsm.go), which
+			// brings the deleted doc ids back into the universe
+			s.bitmapFactory = roaringset.NewBitmapFactory(s.bitmapBufPool,
+				func() uint64 { return s.counter.Get() - 1 })
+
+			res, err := s.Aggregate(ctx, aggregation.Params{
+				ClassName:        schema.ClassName(aggDeletedIDsClass),
+				Filters:          test.filter,
+				IncludeMetaCount: true,
+				GroupBy: &filters.Path{
+					Class:    schema.ClassName(aggDeletedIDsClass),
+					Property: schema.PropertyName("category"),
+				},
+				Properties: []aggregation.ParamProperty{{
+					Name:        schema.PropertyName("category"),
+					Aggregators: []aggregation.Aggregator{aggregation.NewTopOccurrencesAggregator(&limit)},
+				}},
+			}, nil)
+			require.NoError(t, err)
+
+			countsByGroup := map[interface{}]int{}
+			propOccursByGroup := map[interface{}]int{}
+			for _, g := range res.Groups {
+				countsByGroup[g.GroupedBy.Value] = g.Count
+				items := g.Properties["category"].TextAggregation.Items
+				require.Len(t, items, 1)
+				propOccursByGroup[g.GroupedBy.Value] = items[0].Occurs
+			}
+
+			expected := map[interface{}]int{"keep": keepTotal - keepDeleted}
+			if test.filter.Root.Operator == filters.OperatorNotEqual {
+				expected["drop"] = dropTotal - dropDeleted
+			}
+			require.Equal(t, expected, countsByGroup,
+				"each group must count only its live objects")
+			require.Equal(t, expected, propOccursByGroup,
+				"each group's property aggregation must only include live objects")
+		})
+	}
+}

--- a/adapters/repos/db/aggregate_filtered_deleted_integration_test.go
+++ b/adapters/repos/db/aggregate_filtered_deleted_integration_test.go
@@ -1,0 +1,142 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/aggregation"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+const aggDeletedIDsClass = "AggregateDeletedIDs"
+
+func aggCategoryFilter(operator filters.Operator, value string) *filters.LocalFilter {
+	return &filters.LocalFilter{Root: &filters.Clause{
+		Operator: operator,
+		On: &filters.Path{
+			Class:    schema.ClassName(aggDeletedIDsClass),
+			Property: schema.PropertyName("category"),
+		},
+		Value: &filters.Value{Value: value, Type: schema.DataTypeText},
+	}}
+}
+
+// TestFilteredAggregateMetaCountSkipsDeletedIDs pins that the meta count of a
+// filtered aggregation only counts live objects. A negated filter builds its
+// allow list by subtracting the matches from the bitmap factory's universe,
+// and after a restart that universe is prefilled from the doc id counter's
+// high-water mark — so it contains every deleted doc id. Counting the raw
+// allow list therefore overcounts by the number of deleted objects.
+func TestFilteredAggregateMetaCountSkipsDeletedIDs(t *testing.T) {
+	const total, deleted = 5, 2
+
+	limit := 5
+	tests := []struct {
+		name      string
+		filter    *filters.LocalFilter
+		withProps bool
+	}{
+		{
+			name:   "negated filter, meta count only",
+			filter: aggCategoryFilter(filters.OperatorNotEqual, "other"),
+		},
+		{
+			name:      "negated filter, with property aggregation",
+			filter:    aggCategoryFilter(filters.OperatorNotEqual, "other"),
+			withProps: true,
+		},
+		{
+			name:   "positive filter (control)",
+			filter: aggCategoryFilter(filters.OperatorEqual, "keep"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			class := &models.Class{
+				Class: aggDeletedIDsClass,
+				Properties: []*models.Property{{
+					Name:         "category",
+					DataType:     schema.DataTypeText.PropString(),
+					Tokenization: models.PropertyTokenizationWhitespace,
+				}},
+			}
+			shardLike, _ := testShardWithSettings(t, ctx, class,
+				hnsw.UserConfig{Distance: common.DefaultDistanceMetric}, false, false, false)
+			s := concreteShard(t, shardLike)
+
+			ids := make([]strfmt.UUID, total)
+			for i := range ids {
+				obj := &storobj.Object{
+					MarshallerVersion: 1,
+					Object: models.Object{
+						ID:         strfmt.UUID(uuid.NewString()),
+						Class:      aggDeletedIDsClass,
+						Properties: map[string]interface{}{"category": "keep"},
+					},
+					Vector: []float32{1, 2, 3},
+				}
+				require.NoError(t, s.PutObject(ctx, obj))
+				ids[i] = obj.Object.ID
+			}
+			for i := 0; i < deleted; i++ {
+				require.NoError(t, s.DeleteObject(ctx, ids[i], time.Time{}))
+			}
+
+			// mimic a restart: shard init prefills the bitmap factory's universe
+			// from the doc id counter's high-water mark (shard_init_lsm.go), which
+			// brings the deleted doc ids back into the universe
+			s.bitmapFactory = roaringset.NewBitmapFactory(s.bitmapBufPool,
+				func() uint64 { return s.counter.Get() - 1 })
+
+			params := aggregation.Params{
+				ClassName:        schema.ClassName(aggDeletedIDsClass),
+				Filters:          test.filter,
+				IncludeMetaCount: true,
+			}
+			if test.withProps {
+				params.Properties = []aggregation.ParamProperty{{
+					Name:        schema.PropertyName("category"),
+					Aggregators: []aggregation.Aggregator{aggregation.NewTopOccurrencesAggregator(&limit)},
+				}}
+			}
+
+			res, err := s.Aggregate(ctx, params, nil)
+			require.NoError(t, err)
+			require.Len(t, res.Groups, 1)
+			require.Equal(t, total-deleted, res.Groups[0].Count,
+				"the meta count must only include live objects")
+
+			if test.withProps {
+				items := res.Groups[0].Properties["category"].TextAggregation.Items
+				require.Len(t, items, 1)
+				require.Equal(t, total-deleted, items[0].Occurs,
+					"the property aggregation must only include live objects")
+			}
+		})
+	}
+}

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -124,15 +124,22 @@ func (fa *filteredAggregator) filtered(ctx context.Context) (*aggregation.Result
 	return fa.prepareResult(ctx, foundIDs)
 }
 
+// properties runs the property aggregations over ids. It also returns how
+// many of the ids resolved to a stored object: ids can contain doc ids of
+// deleted objects (see prepareResult), which the scan skips.
 func (fa *filteredAggregator) properties(ctx context.Context,
 	ids []uint64,
-) (map[string]aggregation.Property, error) {
+) (map[string]aggregation.Property, int, error) {
 	propAggs, err := fa.prepareAggregatorsForProps()
 	if err != nil {
-		return nil, errors.Wrap(err, "prepare aggregators for props")
+		return nil, 0, errors.Wrap(err, "prepare aggregators for props")
 	}
 
+	// only invoked for ids that resolved to a live object; the scanner
+	// serializes the calls, so the count needs no synchronization of its own
+	liveCount := 0
 	scan := func(properties *models.PropertySchema, docID uint64) error {
+		liveCount++
 		if err := fa.AnalyzeObject(ctx, properties, propAggs); err != nil {
 			return errors.Wrapf(err, "analyze object %d", docID)
 		}
@@ -145,10 +152,15 @@ func (fa *filteredAggregator) properties(ctx context.Context,
 
 	err = docid.ScanObjectsLSM(fa.store, ids, scan, propertyNames, fa.logger)
 	if err != nil {
-		return nil, errors.Wrap(err, "properties view tx")
+		return nil, 0, errors.Wrap(err, "properties view tx")
 	}
 
-	return propAggs.results()
+	props, err := propAggs.results()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return props, liveCount, nil
 }
 
 func (fa *filteredAggregator) AnalyzeObject(ctx context.Context,
@@ -333,13 +345,19 @@ func (fa *filteredAggregator) prepareResult(ctx context.Context, foundIDs []uint
 	// without grouping there is always exactly one group
 	out.Groups = make([]aggregation.Group, 1)
 
-	if fa.params.IncludeMetaCount {
-		out.Groups[0].Count = len(foundIDs)
-	}
-
-	props, err := fa.properties(ctx, foundIDs)
+	props, liveCount, err := fa.properties(ctx, foundIDs)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregate properties")
+	}
+
+	if fa.params.IncludeMetaCount {
+		// foundIDs can contain doc ids of deleted objects: a negated filter
+		// builds its allow list by subtracting the matches from the bitmap
+		// factory's universe, which is prefilled from the doc id counter's
+		// high-water mark on shard init and therefore contains every doc id
+		// deleted before the last restart. Count only the ids that still
+		// resolved to a stored object.
+		out.Groups[0].Count = liveCount
 	}
 
 	out.Groups[0].Properties = props

--- a/adapters/repos/db/aggregator/grouped.go
+++ b/adapters/repos/db/aggregator/grouped.go
@@ -73,6 +73,10 @@ func (ga *groupedAggregator) aggregateGroup(ctx context.Context,
 ) (aggregation.Group, error) {
 	out := in
 	fa := newFilteredAggregator(ga.Aggregator)
+	// the live count is deliberately discarded: in.Count was built by the
+	// grouper from ids that resolved to a stored object during the group
+	// scan (a deleted id resolves to nothing and cannot be grouped), so it
+	// is already live-only — see TestGroupedAggregateCountSkipsDeletedIDs
 	props, _, err := fa.properties(ctx, ids)
 	if err != nil {
 		return out, errors.Wrap(err, "aggregate properties")

--- a/adapters/repos/db/aggregator/grouped.go
+++ b/adapters/repos/db/aggregator/grouped.go
@@ -73,7 +73,7 @@ func (ga *groupedAggregator) aggregateGroup(ctx context.Context,
 ) (aggregation.Group, error) {
 	out := in
 	fa := newFilteredAggregator(ga.Aggregator)
-	props, err := fa.properties(ctx, ids)
+	props, _, err := fa.properties(ctx, ids)
 	if err != nil {
 		return out, errors.Wrap(err, "aggregate properties")
 	}


### PR DESCRIPTION
## What

Filtered aggregations with a negation-style filter (`NotEqual`, deny-list inversion) overcount deleted objects in `meta { count }`. The deny-list allowList is built as prefilled-universe `AndNot` matches, and the universe is re-prefilled from the docID counter high-water at startup — so after **any restart** it contains every deleted docID. `prepareResult` in `aggregator/filtered.go` set `Count = len(foundIDs)` on the raw allowList without resolving objects, counting the deleted ids. Per-property aggregations were already correct (they resolve via `docid.ScanObjectsLSM`, which skips missing rows) — only the meta count was wrong.

Fix: the meta count now comes from the resolution pass the aggregation already performs — `properties()` counts ids that resolve to a stored object inside the `ScanObjectsLSM` callback (which only fires for live rows), and `prepareResult` uses that live count instead of `len(foundIDs)`. AllowList construction is untouched; no extra resolution pass is added.

Side effect worth noting: the meta count now reflects live objects on all filtered paths (vector/hybrid ids also flow through `prepareResult`); those resolve to live objects anyway, so values only change where they were wrong.

## Test

`TestFilteredAggregateMetaCountSkipsDeletedIDs` (table-driven): inserts 5, deletes 2, rebuilds the `bitmapFactory` exactly as shard init does (honest post-restart state), then aggregates with `IncludeMetaCount`: NotEqual meta-only, NotEqual + property aggregation, Equal control. Red before the fix (`expected: 3, actual: 5`) on both negated cases; the control passed and only the meta count was wrong, matching the diagnosis.

Suites: `./adapters/repos/db/aggregator/...`, `./adapters/repos/db/` and full `-tags integrationTest` all green.

## Backport note

Dry-run cherry-picks: **v1.38 fully clean** (aggregator files identical). **v1.37**: `filtered.go` diverged (hybrid path/imports) — needs manual re-application of the `properties`/`prepareResult` change; `grouped.go` and the test apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K4r4MLtZ5BtUhMHfirHa2N