### PR TITLE
perf(aggregation-pr2): reuse one object buffer per scan worker

### DIFF
--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -31,6 +31,10 @@ import (
 
 func scanConcurrency() int { return 2 * runtime.GOMAXPROCS(0) }
 
+// A worker carries its largest object between reads, so this bounds what one
+// outsized object pins. A normal object with its vectors fits under it.
+const maxRetainedBufferBytes = 1 << 20 // 1MB
+
 // ObjectScanFn is called once per object with the context the scan runs under,
 // which is cancelled whenever the caller's is. If an error is returned, the
 // scanning will stop.
@@ -112,6 +116,10 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 			// each object is scanned one after the other, so we can reuse the same memory allocations for all objects
 			docIDBytes := make([]byte, 8)
 
+			// Grown to the largest object this worker reads, up to maxRetainedBufferBytes.
+			// Safe to reuse: UnmarshalPropertiesFromObject retains no slice into it.
+			var objBuf []byte
+
 			// The typed properties are needed for extraction from json
 			var properties models.PropertySchema
 
@@ -123,12 +131,13 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 					return err
 				}
 				binary.LittleEndian.PutUint64(docIDBytes, id)
-				// GetBySecondary reads ctx for slow-query annotation only, so a worker
-				// already inside this read is not interrupted by a cancellation.
-				res, err := os.objectsBucket.GetBySecondary(groupCtx, 0, docIDBytes)
+				// GetBySecondaryWithBuffer reads ctx for slow-query annotation only, so a
+				// worker already inside this read is not interrupted by a cancellation.
+				res, newBuf, err := os.objectsBucket.GetBySecondaryWithBuffer(groupCtx, 0, docIDBytes, objBuf)
 				if err != nil {
 					return err
 				}
+				objBuf = newBuf
 
 				if res == nil {
 					continue
@@ -154,6 +163,10 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 					return nil
 				}(); err != nil {
 					return err
+				}
+
+				if cap(objBuf) > maxRetainedBufferBytes {
+					objBuf = nil
 				}
 			}
 			return nil

--- a/adapters/repos/db/docid/scan_test.go
+++ b/adapters/repos/db/docid/scan_test.go
@@ -16,6 +16,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -55,7 +59,7 @@ func TestScanObjectsLSM(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := test.NewNullLogger()
-			store, pointers := storeWithObjects(t, tt.objectCount, logger)
+			store, pointers := storeWithObjects(t, tt.objectCount, logger, false)
 
 			var calls atomic.Int64
 			scan := func(_ context.Context, _ *models.PropertySchema, _ uint64) error {
@@ -134,7 +138,7 @@ func TestScanObjectsLSMCancellation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger, _ := test.NewNullLogger()
-			store, pointers := storeWithObjects(t, tt.storedObjects, logger)
+			store, pointers := storeWithObjects(t, tt.storedObjects, logger, false)
 			for i := len(pointers); i < tt.pointerCount; i++ {
 				pointers = append(pointers, uint64(i))
 			}
@@ -167,8 +171,101 @@ func TestScanObjectsLSMCancellation(t *testing.T) {
 	}
 }
 
-// Sweeps what the per-doc-ID context poll in scan costs, on the two shapes the
-// loop takes: every doc ID resolving to an object, and none of them resolving.
+// A worker's payload buffer is grown to the largest object it has read, so a
+// smaller object is parsed out of a buffer whose spare capacity still holds a
+// larger one. These rows pin the values scanFn is handed under that reuse.
+func TestScanObjectsLSMPropertyValues(t *testing.T) {
+	const (
+		objectCount = 200
+		sizeStep    = 64
+	)
+	propertyNames := []string{"name", "count", "flag", "tags", "scores", "meta"}
+
+	tests := []struct {
+		name string
+		// largest object first, so the later ones meet an over-sized buffer
+		descending bool
+		// every nth pointer resolves to no object; 0 inserts none
+		missingEvery int
+		// every nth object is padded past maxRetainedBufferBytes; 0 pads none
+		oversizedEvery int
+	}{
+		{name: "sizes descending", descending: true},
+		{name: "sizes ascending", descending: false},
+		{name: "sizes descending, doc IDs missing mid-scan", descending: true, missingEvery: 7},
+		{name: "objects past the retained buffer cap", oversizedEvery: 13},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			props := make([]map[string]interface{}, objectCount)
+			for i := range props {
+				padding := (i + 1) * sizeStep
+				if tt.descending {
+					padding = (objectCount - i) * sizeStep
+				}
+				if tt.oversizedEvery > 0 && i%tt.oversizedEvery == 0 {
+					padding = maxRetainedBufferBytes + sizeStep
+				}
+				props[i] = objectProperties(i, padding)
+			}
+
+			logger, _ := test.NewNullLogger()
+			store, stored := storeWithProperties(t, logger, true, props)
+
+			pointers := stored
+			if tt.missingEvery > 0 {
+				pointers = nil
+				for i, id := range stored {
+					if i%tt.missingEvery == 0 {
+						pointers = append(pointers, uint64(objectCount+i))
+					}
+					pointers = append(pointers, id)
+				}
+			}
+			require.Greater(t, len(pointers), scanConcurrency(),
+				"a worker must read more than one object or its buffer is never reused")
+
+			var lock sync.Mutex
+			scanned := map[uint64]interface{}{}
+			scan := func(_ context.Context, prop *models.PropertySchema, docID uint64) error {
+				lock.Lock()
+				defer lock.Unlock()
+				scanned[docID] = *prop
+				return nil
+			}
+
+			require.NoError(t, ScanObjectsLSM(context.Background(), store, pointers, scan,
+				propertyNames, logger))
+
+			require.Len(t, scanned, objectCount)
+			for i, want := range props {
+				require.Equal(t, want, scanned[uint64(i)], "properties of object %d", i)
+			}
+		})
+	}
+}
+
+// objectProperties returns properties already in the shape UnmarshalProperties
+// decodes them back into, so the fixture doubles as the expected value.
+func objectProperties(i, padding int) map[string]interface{} {
+	tags := make([]interface{}, 0, padding/512+1)
+	for j := 0; j <= padding/512; j++ {
+		tags = append(tags, fmt.Sprintf("tag-%d-%d", i, j))
+	}
+	return map[string]interface{}{
+		"name":   strings.Repeat("x", padding),
+		"count":  float64(i),
+		"flag":   i%2 == 0,
+		"tags":   tags,
+		"scores": []interface{}{float64(i) + 0.5, float64(i) + 1.5},
+		"meta":   map[string]interface{}{"owner": fmt.Sprintf("owner-%d", i), "rank": float64(i)},
+	}
+}
+
+// Sweeps what the per-doc-ID context poll and the reused payload buffer cost,
+// on the two shapes the loop takes: every doc ID resolving to an object, and
+// none of them resolving.
 func BenchmarkScanObjectsLSM(b *testing.B) {
 	const docIDCount = 50000
 
@@ -183,12 +280,13 @@ func BenchmarkScanObjectsLSM(b *testing.B) {
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			logger, _ := test.NewNullLogger()
-			store, pointers := storeWithObjects(b, bm.storedObjects, logger)
+			store, pointers := storeWithObjects(b, bm.storedObjects, logger, true)
 			for i := len(pointers); i < docIDCount; i++ {
 				pointers = append(pointers, uint64(i))
 			}
 			scan := func(_ context.Context, _ *models.PropertySchema, _ uint64) error { return nil }
 
+			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if err := ScanObjectsLSM(context.Background(), store, pointers, scan,
@@ -203,7 +301,20 @@ func BenchmarkScanObjectsLSM(b *testing.B) {
 // storeWithObjects returns a store holding count objects keyed by their UUID,
 // with the docID secondary index ScanObjectsLSM resolves pointers through, and
 // the docIDs of those objects.
-func storeWithObjects(tb testing.TB, count int, logger logrus.FieldLogger) (*lsmkv.Store, []uint64) {
+func storeWithObjects(tb testing.TB, count int, logger logrus.FieldLogger, flush bool) (*lsmkv.Store, []uint64) {
+	props := make([]map[string]interface{}, count)
+	for i := range props {
+		props[i] = map[string]interface{}{"name": fmt.Sprintf("object-%d", i)}
+	}
+	return storeWithProperties(tb, logger, flush, props)
+}
+
+// storeWithProperties returns a store holding one object per entry in props and
+// the docIDs of those objects. flush is what puts them in a disk segment, the
+// only path on which GetBySecondaryWithBuffer fills the caller's buffer.
+func storeWithProperties(tb testing.TB, logger logrus.FieldLogger, flush bool,
+	props []map[string]interface{},
+) (*lsmkv.Store, []uint64) {
 	ctx := context.Background()
 	dir := tb.TempDir()
 
@@ -218,7 +329,7 @@ func storeWithObjects(tb testing.TB, count int, logger logrus.FieldLogger) (*lsm
 		lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithSecondaryIndices(1)))
 	bucket := store.Bucket(helpers.ObjectsBucketLSM)
 
-	pointers := make([]uint64, count)
+	pointers := make([]uint64, len(props))
 	for i := range pointers {
 		docID := uint64(i)
 		pointers[i] = docID
@@ -226,7 +337,7 @@ func storeWithObjects(tb testing.TB, count int, logger logrus.FieldLogger) (*lsm
 		id := uuid.New()
 		obj := storobj.New(docID)
 		obj.SetID(strfmt.UUID(id.String()))
-		obj.Object.Properties = map[string]interface{}{"name": fmt.Sprintf("object-%d", i)}
+		obj.Object.Properties = props[i]
 		objBytes, err := obj.MarshalBinary()
 		require.NoError(tb, err)
 
@@ -240,5 +351,23 @@ func storeWithObjects(tb testing.TB, count int, logger logrus.FieldLogger) (*lsm
 			lsmkv.WithSecondaryKey(helpers.ObjectsBucketLSMDocIDSecondaryIndex, docIDBytes)))
 	}
 
+	if flush && len(props) > 0 {
+		require.NoError(tb, bucket.FlushMemtable())
+		requireSegmentOnDisk(tb, bucket.GetDir())
+	}
+
 	return store, pointers
+}
+
+// requireSegmentOnDisk fails unless the bucket wrote a segment; without one a
+// scan answers from the memtable and never reuses the buffer.
+func requireSegmentOnDisk(tb testing.TB, dir string) {
+	entries, err := os.ReadDir(dir)
+	require.NoError(tb, err)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".db" {
+			return
+		}
+	}
+	require.Fail(tb, "no segment file in "+dir)
 }

--- a/adapters/repos/db/lsmkv/segment_replace_strategy.go
+++ b/adapters/repos/db/lsmkv/segment_replace_strategy.go
@@ -92,12 +92,15 @@ func (s *segment) getBySecondary(pos int, key []byte, buffer []byte) ([]byte, []
 	// invalid memory without the copy, thus leading to a SEGFAULT.
 	// Similar approach was used to fix SEGFAULT in collection strategy
 	// https://github.com/weaviate/weaviate/issues/1837
-	var contentsCopy []byte
-	if uint64(cap(buffer)) >= end-start {
-		contentsCopy = buffer[:end-start]
-	} else {
-		contentsCopy = make([]byte, end-start)
+	//
+	// The copy's capacity stops at the node, so a length read out of the payload
+	// cannot slice into what a reused buffer holds of a larger node. buffer is
+	// returned instead, keeping the capacity the caller grew.
+	nodeSize := end - start
+	if uint64(cap(buffer)) < nodeSize {
+		buffer = make([]byte, nodeSize)
 	}
+	contentsCopy := buffer[:nodeSize:nodeSize]
 	if err = s.copyNode(contentsCopy, nodeOffset{start, end}); err != nil {
 		return nil, nil, nil, err
 	}
@@ -107,7 +110,7 @@ func (s *segment) getBySecondary(pos int, key []byte, buffer []byte) ([]byte, []
 		return nil, nil, nil, err
 	}
 
-	return primaryKey, currContent, contentsCopy, err
+	return primaryKey, currContent, buffer, err
 }
 
 func (s *segment) replaceStratParseData(in []byte) ([]byte, []byte, error) {

--- a/adapters/repos/db/lsmkv/segment_replace_strategy_test.go
+++ b/adapters/repos/db/lsmkv/segment_replace_strategy_test.go
@@ -1,0 +1,154 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+// A caller threading its buffer forward hands getBySecondary one grown to the
+// largest record it has read, whose spare capacity holds that record's bytes.
+// Both lengths a record carries are read back out of it and used to slice.
+func TestSegmentGetBySecondaryReusedBuffer(t *testing.T) {
+	widestValue := bytes.Repeat([]byte("F"), 512)
+	hitValue := []byte("hit-value")
+
+	// declares more primary-key bytes than it stores
+	corruptPKRecord := replaceRecordDeclaring([]byte("corrupt"), []byte("corrupt-pk"), 7, 200)
+	// a tombstone with no value behind it, declaring 64 bytes of one
+	corruptTombstone := append([]byte{0x01}, make([]byte, 8)...)
+	binary.LittleEndian.PutUint64(corruptTombstone[1:9], 64)
+
+	seg := segmentWithSecondaryRecords(t, []secondaryRecord{
+		{secKey: []byte("sec-widest"), record: replaceRecord(widestValue, []byte("widest-pk"))},
+		{secKey: []byte("sec-hit"), record: replaceRecord(hitValue, []byte("hit-pk"))},
+		{secKey: []byte("sec-corrupt-pk"), record: corruptPKRecord},
+		{secKey: []byte("sec-deleted"), record: append([]byte{0x01}, make([]byte, 8)...)},
+		{secKey: []byte("sec-corrupt-tombstone"), record: corruptTombstone},
+	})
+
+	tests := []struct {
+		name           string
+		secKey         []byte
+		wantValue      []byte
+		wantPrimaryKey []byte
+		wantErr        error
+		// the parse must fail rather than answer out of the buffer's spare bytes
+		wantOverReadBlocked bool
+	}{
+		{
+			name:           "hit",
+			secKey:         []byte("sec-hit"),
+			wantValue:      hitValue,
+			wantPrimaryKey: []byte("hit-pk"),
+		},
+		{
+			name:    "miss",
+			secKey:  []byte("sec-absent"),
+			wantErr: lsmkv.NotFound,
+		},
+		{
+			name:    "tombstoned key",
+			secKey:  []byte("sec-deleted"),
+			wantErr: lsmkv.Deleted,
+		},
+		{
+			name:                "record declaring a primary key past its end",
+			secKey:              []byte("sec-corrupt-pk"),
+			wantOverReadBlocked: true,
+		},
+		{
+			name:                "tombstone declaring a value past its end",
+			secKey:              []byte("sec-corrupt-tombstone"),
+			wantOverReadBlocked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, buffer, err := seg.getBySecondary(0, []byte("sec-widest"), nil)
+			require.NoError(t, err)
+			require.Greater(t, cap(buffer), len(corruptPKRecord),
+				"the reused buffer must outsize the records under test")
+			require.Equal(t, byte('F'), buffer[len(corruptPKRecord)],
+				"the bytes past the records under test must be the widest record's value")
+			bufferCap := cap(buffer)
+
+			if tt.wantOverReadBlocked {
+				require.Panics(t, func() { seg.getBySecondary(0, tt.secKey, buffer) },
+					"a length past the record must not be answered out of the reused buffer")
+				return
+			}
+
+			primaryKey, value, gotBuffer, err := seg.getBySecondary(0, tt.secKey, buffer)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValue, value)
+			require.Equal(t, tt.wantPrimaryKey, primaryKey)
+			require.Equal(t, bufferCap, cap(gotBuffer),
+				"the returned buffer must keep the capacity the caller grew")
+		})
+	}
+}
+
+type secondaryRecord struct {
+	secKey []byte
+	record []byte
+}
+
+// segmentWithSecondaryRecords returns a segment reading the given records from
+// memory, indexed at secondary position 0 in the order given.
+func segmentWithSecondaryRecords(t *testing.T, records []secondaryRecord) *segment {
+	t.Helper()
+
+	var contents []byte
+	nodes := make(segmentindex.Nodes, 0, len(records))
+	for _, r := range records {
+		start := uint64(len(contents))
+		contents = append(contents, r.record...)
+		nodes = append(nodes, segmentindex.Node{Key: r.secKey, Start: start, End: uint64(len(contents))})
+	}
+
+	tree := segmentindex.NewBalanced(nodes)
+	index, err := tree.MarshalBinary()
+	require.NoError(t, err)
+
+	return &segment{
+		strategy:         segmentindex.StrategyReplace,
+		readFromMemory:   true,
+		contents:         contents,
+		secondaryIndices: []diskIndex{segmentindex.NewDiskTree(index)},
+	}
+}
+
+func replaceRecord(value, primaryKey []byte) []byte {
+	return replaceRecordDeclaring(value, primaryKey, uint64(len(value)), uint32(len(primaryKey)))
+}
+
+// replaceRecordDeclaring takes the two header lengths rather than reading them
+// off value and primaryKey, so a caller can build a torn record.
+func replaceRecordDeclaring(value, primaryKey []byte, declaredValueLength uint64, declaredPKLength uint32) []byte {
+	record := make([]byte, 9, 9+len(value)+4+len(primaryKey))
+	binary.LittleEndian.PutUint64(record[1:9], declaredValueLength)
+	record = append(record, value...)
+	record = binary.LittleEndian.AppendUint32(record, declaredPKLength)
+	return append(record, primaryKey...)
+}

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1368,6 +1368,7 @@ func UnmarshalPropertiesFromObject(data []byte, resultProperties map[string]inte
 }
 
 // UnmarshalProperties accepts serialized properties as data and populates resultProperties map with the properties specified by propertyPaths.
+// Every value it writes is copied out of data, which the caller may then overwrite.
 func UnmarshalProperties(data []byte, properties map[string]interface{}, propertyPaths [][]string) error {
 	var returnError error
 	jsonparser.EachKey(data, func(idx int, value []byte, dataType jsonparser.ValueType, err error) {
@@ -1394,7 +1395,7 @@ func UnmarshalProperties(data []byte, properties map[string]interface{}, propert
 				// there can be more than one
 				var beacons []interface{}
 				handler := func(beaconByte []byte, dataType jsonparser.ValueType, offset int, err error) {
-					beaconVal, err2 := jsonparser.GetString(beaconByte, "beacon") // this points to the underlying memory
+					beaconVal, err2 := jsonparser.GetString(beaconByte, "beacon")
 					returnError = err2
 					beacons = append(beacons, map[string]interface{}{"beacon": beaconVal})
 				}


### PR DESCRIPTION
Stacked on #12883. Review that one first; this diff is only the top two commits.

## Motivation

`docid.ScanObjectsLSM` reads each object through `GetBySecondary`, which is `GetBySecondaryWithBuffer(…, nil)`. A nil buffer sends `segment.getBySecondary` down its allocating branch, so every object in a scan gets a fresh slice sized to its record. Profiling the aggregation read path made that one `make` the dominant source of allocated bytes in the process.

## Approach

One `[]byte` per worker, threaded across its range — the shape `sorter/lsm_sorter.go` already uses. A `sync.Pool` was considered and rejected: a per-worker slice already turns one allocation per object into roughly two per CPU, and the pool would cost an exported API on a published module, process-lifetime retention (`Put` has no size cap), and a buffer shared across queries that nothing zeroes.

A worker drops its buffer once its capacity passes `maxRetainedBufferBytes`, so one outsized object cannot pin that much per worker for the length of the scan — the ceiling is otherwise `2*GOMAXPROCS × largest matched object`, which grows with the core count of the node. The constant is reasoned rather than measured: 1 MB clears a normal object and its vectors (a 2048-dim float32 vector is 8 KiB, ten named vectors 80 KiB) and sits below the multi-vector and document-sized cases. Above the cap each read allocates, so the cap forfeits the reuse for those collections rather than regressing anything.

Reuse is safe only because nothing retains a pointer into the buffer past the iteration — every value `UnmarshalProperties` writes is copied out of the data it parses. Its godoc now says so, because the obvious next optimisation is swapping `GetString` for the `GetUnsafeString` four lines above it, and the comment that should have stopped you claimed the opposite of the truth.

The second commit closes what reuse opens. `replaceStratParseData` slices by lengths read out of the record, and a slice expression is bounded by capacity; a reused buffer's capacity is the largest record that caller has read. Capping the copy introduces no new failure mode — it puts the buffer-reusing callers back where `segment.get` and every `GetBySecondary` caller already sit.

## Where to look

- `docid/scan.go` — `objBuf = newBuf` sits after the error check, and the declaration is outside the loop; `:=` inside it compiles and silently reuses nothing.
- `docid/scan.go` — the buffer reset sits after `scanFn` returns, because the value handed to it aliases `objBuf`. It is skipped on the miss path, which is safe: a miss returns the buffer ungrown, so the capacity stays under the cap at the top of every iteration.
- `lsmkv/segment_replace_strategy.go` — `buffer` is returned rather than the capped copy, or every larger object reallocates.
- `lsmkv/segment_replace_strategy_test.go` — the two over-read rows. A corrupt value length panics either way, so only the primary-key and tombstone lengths pin the cap.

## Risks

- A torn record read through a reused buffer fails rather than returning a neighbouring object's bytes. That failure is the panic `make([]byte, nodeSize)` already produces, since `len == cap` there; `shard_group_by`, the LSM sorter and the inverted searcher move onto that same footing. Bounds-checking the declared lengths so a torn record returns an error instead is a pre-existing gap — `in[1:9]` is unguarded on the non-tombstone path with or without a buffer — and belongs in its own change.
- The scan's error group recovers a panic into an error; those three run on the request goroutine and depend on the REST panic middleware. `DISABLE_RECOVERY_ON_PANIC` disables both.
- A collection whose *typical* object exceeds the cap resets on every read, so it gets no reuse while still paying the check. Multi-vector and document-sized collections are that shape.

## Testing

`BenchmarkScanObjectsLSM` gains `ReportAllocs` and a flushed-segment fixture — on a memtable hit the bucket hands the buffer back untouched, so an unflushed one proves nothing. The scan test covers objects ordered large-then-small across several datatypes, the shape an aliasing bug shows in; ascending does not. Both were mutation-tested: aliasing `parseValues`' string arm fails the descending rows only, and dropping the cap returns foreign bytes.

`TestScanObjectsLSMPropertyValues` gains a row padding every 13th object past `maxRetainedBufferBytes`, pinning that a buffer dropped mid-range does not corrupt the objects read after it. It does not pin the memory bound, and nothing does — the cap's only effect is retained bytes, which no unit test here can assert. Replacing the reset with a panic confirms the new row reaches it and the three pre-existing rows do not.
