### PR TITLE
test(cluster): fix snapshot-restore flake racing the cluster-ID commit

### DIFF
--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -142,6 +142,14 @@ func TestSnapshotRestoreReloadsDBBeforeWaitToRestoreDB(t *testing.T) {
 	require.NoError(t, srv.WaitUntilDBRestored(ctx, time.Second, make(chan struct{})))
 	require.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 
+	// With telemetry on, onLeaderFound commits a cluster-ID entry up to a second
+	// after leadership. Let it land before the snapshot.
+	if m.cfg.TelemetryEnabled {
+		require.True(t, tryNTimesWithWait(30, time.Millisecond*200, func() bool {
+			return srv.store.ClusterID() != ""
+		}), "background cluster-ID command was never committed")
+	}
+
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
 	m.indexer.On("AddClass", Anything).Return(nil)
 	m.parser.On("ParseClass", mock.Anything).Return(nil)
@@ -152,6 +160,11 @@ func TestSnapshotRestoreReloadsDBBeforeWaitToRestoreDB(t *testing.T) {
 
 	require.NoError(t, srv.store.raft.Barrier(2*time.Second).Error())
 	require.NoError(t, srv.store.raft.Snapshot().Error())
+
+	lastCmd, err := srv.store.LastAppliedCommand()
+	require.NoError(t, err)
+	require.LessOrEqual(t, lastCmd, lastSnapshotIndex(srv.store.snapshotStore),
+		"a command was committed after the snapshot, so the reopen would take the log-replay path")
 
 	m.indexer.On("Close", Anything).Return(nil)
 	require.NoError(t, srv.Close(ctx))


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
