### PR TITLE
config: remove the dead HFreshEnabled flag

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -533,7 +533,6 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		LazyPropertyLengthsEnabled:   appState.ServerConfig.Config.LazyPropertyLengthsEnabled,
 		MaintenanceModeEnabled:       appState.Cluster.MaintenanceModeEnabledForLocalhost,
 		AsyncIndexingEnabled:         appState.ServerConfig.Config.AsyncIndexingEnabled,
-		HFreshEnabled:                appState.ServerConfig.Config.HFreshEnabled,
 		OperationalMode:              appState.ServerConfig.Config.OperationalMode,
 		DisableDimensionMetrics:      appState.ServerConfig.Config.DisableDimensionMetrics,
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics, appState.MemWatch, nil, nil, nil, appState.NamespacesController) // TODO client

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -515,7 +515,6 @@ func setupTestShardWithSettings(t testing.TB, ctx context.Context, class *models
 		shardLoadLimiter:       loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
 		shardReindexer:         NewShardReindexerV3Noop(),
 		bitmapBufPool:          roaringset.NewBitmapBufPoolNoop(),
-		HFreshEnabled:          true,
 		replicator:             replicator,
 		router:                 mockRouter,
 		db:                     repo,

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -266,7 +266,6 @@ type Index struct {
 	vectorIndexUserConfigLock sync.Mutex
 	vectorIndexUserConfig     schemaConfig.VectorIndexConfig
 	vectorIndexUserConfigs    map[string]schemaConfig.VectorIndexConfig
-	HFreshEnabled             bool
 
 	partitioningEnabled  bool
 	AsyncIndexingEnabled bool
@@ -504,7 +503,6 @@ func NewIndex(
 		router:                  router,
 		shardResolver:           shardResolver,
 		bitmapBufPool:           bitmapBufPool,
-		HFreshEnabled:           cfg.HFreshEnabled,
 		tenantsManager:          tenantsManager,
 	}
 	index.closeRequestedCtx, index.signalCloseRequested = context.WithCancelCause(context.Background())
@@ -1570,8 +1568,6 @@ type IndexConfig struct {
 	QueryBatchedContainsEnabled *configRuntime.DynamicValue[bool]
 	LazyPropertyLengthsEnabled  *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled      func() bool
-
-	HFreshEnabled bool
 
 	AutoTenantActivation bool
 

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -206,7 +206,6 @@ func (db *DB) init(ctx context.Context) error {
 				QueryBatchedContainsEnabled:  db.config.QueryBatchedContainsEnabled,
 				LazyPropertyLengthsEnabled:   db.config.LazyPropertyLengthsEnabled,
 				MaintenanceModeEnabled:       db.config.MaintenanceModeEnabled,
-				HFreshEnabled:                db.config.HFreshEnabled,
 				AutoTenantActivation:         schema.AutoTenantActivationEnabled(class),
 				DisableDimensionMetrics:      db.config.DisableDimensionMetrics,
 			},

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -229,7 +229,6 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			QueryBatchedContainsEnabled:  m.db.config.QueryBatchedContainsEnabled,
 			LazyPropertyLengthsEnabled:   m.db.config.LazyPropertyLengthsEnabled,
 			MaintenanceModeEnabled:       m.db.config.MaintenanceModeEnabled,
-			HFreshEnabled:                m.db.config.HFreshEnabled,
 			AutoTenantActivation:         schema.AutoTenantActivationEnabled(class),
 		},
 		// no backward-compatibility check required, since newly added classes will
@@ -893,9 +892,6 @@ func (m *Migrator) ValidateVectorIndexConfigUpdate(
 	case vectorindex.VectorIndexTypeDYNAMIC:
 		return dynamic.ValidateUserConfigUpdate(old, updated)
 	case vectorindex.VectorIndexTypeHFresh:
-		if !m.db.config.HFreshEnabled {
-			return errors.New("hfresh index is available only in experimental mode")
-		}
 		return hfresh.ValidateUserConfigUpdate(old, updated)
 	}
 	return fmt.Errorf("invalid index type: %s", old.IndexType())

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -461,7 +461,6 @@ type Config struct {
 	MaintenanceModeEnabled      func() bool
 	AsyncIndexingEnabled        bool
 
-	HFreshEnabled   bool
 	OperationalMode *configRuntime.DynamicValue[string]
 
 	DisableDimensionMetrics *configRuntime.DynamicValue[bool]

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -507,8 +507,6 @@ type Shard struct {
 	// dropRequested marks shard as requested for drop.
 	dropRequested atomic.Bool
 
-	HFreshEnabled bool
-
 	lazySegmentLoadingEnabled bool
 
 	// metricsRegistered tracks whether this shard was registered with shard lifecycle metrics

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -93,7 +93,6 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		reindexer:                       reindexer,
 		usingBlockMaxWAND:               index.invertedIndexConfig.UsingBlockMaxWAND,
 		bitmapBufPool:                   bitmapBufPool,
-		HFreshEnabled:                   index.HFreshEnabled,
 		lazySegmentLoadingEnabled:       lazyLoadSegments,
 		registration:                    registration,
 	}

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -231,9 +231,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		}
 		vectorIndex = vi
 	case vectorindex.VectorIndexTypeHFresh:
-		if !s.index.HFreshEnabled {
-			return nil, errors.New("hfresh index is available only in experimental mode")
-		}
 		userConfig, ok := vectorIndexUserConfig.(hfreshent.UserConfig)
 		if !ok {
 			return nil, errors.Errorf("hfresh vector index: config is not hfresh.UserConfig: %T",

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -22,7 +22,6 @@ export CLUSTER_HOSTNAME=${CLUSTER_HOSTNAME:-"weaviate-0"}
 export GPT4ALL_INFERENCE_API="http://localhost:8010"
 export DISABLE_TELEMETRY=true # disable telemetry for local development
 export PERSISTENCE_HNSW_SNAPSHOT_INTERVAL_SECONDS=${PERSISTENCE_HNSW_SNAPSHOT_INTERVAL_SECONDS:-"300"}
-export EXPERIMENTAL_HFRESH_ENABLED=true
 export DEBUG_ENDPOINTS_ENABLED=true
 
 # inject build info into binaries.

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -241,7 +241,6 @@ type Config struct {
 	DistributedTasks                    DistributedTasksConfig         `json:"distributed_tasks" yaml:"distributed_tasks"`
 	ReplicationEngineMaxWorkers         int                            `json:"replication_engine_max_workers" yaml:"replication_engine_max_workers"`
 	ReplicationEngineFileCopyWorkers    int                            `json:"replication_engine_file_copy_workers" yaml:"replication_engine_file_copy_workers"`
-	HFreshEnabled                       bool                           `json:"hfresh_enabled" yaml:"hfresh_enabled"`
 	ReplicationEngineFileCopyChunkSize  int                            `json:"replication_engine_file_copy_chunk_size" yaml:"replication_engine_file_copy_chunk_size"`
 	// Raft Specific configuration
 	// TODO-RAFT: Do we want to be able to specify these with config file as well ?

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -657,8 +657,6 @@ func FromEnv(config *Config) error {
 	}
 	config.DefaultShardingCount = configRuntime.NewDynamicValue(defaultShardingCount)
 
-	config.HFreshEnabled = true
-
 	if entcfg.Enabled(os.Getenv("INDEX_RANGEABLE_IN_MEMORY")) {
 		config.Persistence.IndexRangeableInMemory = true
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -1749,7 +1749,7 @@ func (h *Handler) validateVectorizer(vectorizer string) error {
 }
 
 // validateVectorIndexTypeBasic is the per-type correctness gate
-// (async-indexing for dynamic, experimental flag for hfresh, known name).
+// (async-indexing for dynamic, known name).
 // Runs unconditionally — these are invariants, not policy.
 func (h *Handler) validateVectorIndexTypeBasic(vectorIndexType string) error {
 	switch vectorIndexType {
@@ -1761,9 +1761,6 @@ func (h *Handler) validateVectorIndexTypeBasic(vectorIndexType string) error {
 		}
 		return nil
 	case vectorindex.VectorIndexTypeHFresh:
-		if !h.config.HFreshEnabled {
-			return fmt.Errorf("the hfresh index is available only in experimental mode")
-		}
 		return nil
 	default:
 		return errors.Errorf("unrecognized or unsupported vectorIndexType %q",

--- a/usecases/schema/class_muvera_bounds_test.go
+++ b/usecases/schema/class_muvera_bounds_test.go
@@ -38,7 +38,6 @@ func newTestHandlerWithRealVectorConfigParser(t *testing.T) *Handler {
 	cfg := config.Config{
 		DefaultVectorizerModule:     config.VectorizerModuleNone,
 		DefaultVectorDistanceMetric: "cosine",
-		HFreshEnabled:               true,
 	}
 	fakeClusterState := fakes.NewFakeClusterState()
 	fakeValidator := &fakeValidator{}

--- a/usecases/schema/class_restrictions_test.go
+++ b/usecases/schema/class_restrictions_test.go
@@ -73,7 +73,6 @@ func TestValidateVectorIndexType_AllowList(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, _ := newTestHandler(t, &fakeDB{})
-			handler.config.HFreshEnabled = true
 			handler.asyncIndexingEnabled = true
 			if tt.allow != nil {
 				handler.config.Restrictions.AllowedVectorIndexTypes = runtime.NewDynamicValue(tt.allow)
@@ -105,7 +104,6 @@ func TestValidateVectorIndexType_AllowList(t *testing.T) {
 // must still match the canonical lowercase comparison.
 func TestValidateVectorIndexType_RuntimeOverrideNormalization(t *testing.T) {
 	handler, _ := newTestHandler(t, &fakeDB{})
-	handler.config.HFreshEnabled = true
 	dv := runtime.NewDynamicValue([]string{"HNSW", " FLAT ", "Bogus", "hnsw"})
 	handler.config.Restrictions.AllowedVectorIndexTypes = dv
 
@@ -248,7 +246,6 @@ func TestValidateVectorSettingsAgainst_GrandfatherUnchanged_NamedVector(t *testi
 func newHandlerWithAllowList(t *testing.T, vectorAllow, compressionAllow []string) *Handler {
 	t.Helper()
 	handler, _ := newTestHandler(t, &fakeDB{})
-	handler.config.HFreshEnabled = true
 	handler.asyncIndexingEnabled = true
 	if vectorAllow != nil {
 		handler.config.Restrictions.AllowedVectorIndexTypes = runtime.NewDynamicValue(vectorAllow)
@@ -318,7 +315,6 @@ func classWithNamedVector(t *testing.T, name, indexType, compression string) *mo
 
 func TestValidateVectorIndexType_AllowListUsesOperatorTemplate(t *testing.T) {
 	handler, _ := newTestHandler(t, &fakeDB{})
-	handler.config.HFreshEnabled = true
 	handler.config.Restrictions.AllowedVectorIndexTypes = runtime.NewDynamicValue([]string{"hfresh"})
 	handler.config.Restrictions.ErrorMessage = runtime.NewDynamicValue(
 		"Invalid config: {value} is not allowed for {restriction} (allowed: {allowed})",
@@ -340,7 +336,6 @@ func TestValidateVectorIndexType_AllowListUsesOperatorTemplate(t *testing.T) {
 // them at the client version.
 func TestValidateVectorIndexType_NamedVectorHNSWHasClientHint(t *testing.T) {
 	handler, _ := newTestHandler(t, &fakeDB{})
-	handler.config.HFreshEnabled = true
 	handler.config.Restrictions.AllowedVectorIndexTypes = runtime.NewDynamicValue([]string{"hfresh"})
 
 	t.Run("named-vector rejection appends client hint", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

`HFreshEnabled` has been unfalsifiable since 4ed049f5c5 ("Move HFresh out of experimental", #10339), which replaced the `EXPERIMENTAL_HFRESH_ENABLED` env lookup with an unconditional `config.HFreshEnabled = true` in `FromEnv`. Nothing else assigned it outside tests, so the flag was dead weight. This removes it.

Gone with it:

- **Three unreachable gates**, each returning `"hfresh index is available only in experimental mode"`: class creation (`usecases/schema/class.go`), vector index config update validation (`adapters/repos/db/migrator.go`), and shard vector index init (`adapters/repos/db/shard_init_vector.go`).
- **The plumbing**: the field on `config.Config`, `db.Config`, `db.IndexConfig`, `Index` and `Shard`, plus every assignment threading it from `configure_api.go` → `repo` → `init.go`/`migrator.go` → `shard_init.go`. `Shard.HFreshEnabled` was write-only — the one read site went through `s.index`.
- **`export EXPERIMENTAL_HFRESH_ENABLED=true`** in `tools/dev/run_dev_server.sh`, which nothing had read since #10339.
- The `hfresh_enabled` JSON/YAML config-file key, and the test-side setters.

`ALLOWED_VECTOR_INDEX_TYPES` remains the supported way to restrict hfresh, which is what `docs/usage_limits.md` already documents.

**On dropping the config-file key:** removing the tag could in principle break boot for an operator whose config file carries `hfresh_enabled`. It doesn't — `config_handler.go` uses plain `json.Unmarshal`/`yaml.Unmarshal` with no `DisallowUnknownFields`/`KnownFields`, so the key is silently ignored. That matches the previous behavior, where `FromEnv` overwrote whatever the file said anyway.

Verification: `go build ./...` and `go build -tags integrationTest ./...` clean; `go test ./usecases/schema/... ./usecases/config/... ./adapters/repos/db/` pass; `go vet` clean on the acceptance packages touching hfresh (`vector_index_restrictions`, `drop_vector_index`, `schema`) — none referenced the env var; `golangci-lint run` on the changed packages surfaces only a pre-existing finding in `executor_test.go`.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: not necessary — `EXPERIMENTAL_HFRESH_ENABLED` was never documented, and `docs/usage_limits.md` already describes `ALLOWED_VECTOR_INDEX_TYPES` as the restriction mechanism.
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary — pure dead-code removal, no behavior change.
- [x] All new code is covered by tests where it is reasonable. No new code; existing schema/db suites cover the touched paths.
- [x] Performance tests have been run or not necessary.
