### PR TITLE
test(python): pin weaviate-client python dependency to 4.23 version

### DIFF
--- a/test/acceptance_with_python/requirements.txt
+++ b/test/acceptance_with_python/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/weaviate/weaviate-python-client.git@3106d23afe83c6ef74d022268fce7ba3cd88ab23
+weaviate-client~=4.23
 pytest>=8.0.1,<9.0.0
 pytest-xdist==3.6.1
 pytest-benchmark==4.0.0

--- a/test/acceptance_with_python/test_filter.py
+++ b/test/acceptance_with_python/test_filter.py
@@ -7,32 +7,18 @@ from weaviate.collections.classes.filters import Filter, _FilterValue
 from .conftest import CollectionFactory
 
 
-# bug in client + not supported in weaviate for filter by empty list
 @pytest.mark.parametrize(
-    "weaviate_filter,results,skip",
+    "weaviate_filter,results",
     [
-        (
-            Filter.by_property("textArray").equal([]),
-            [1],
-            True,
-        ),
-        (Filter.by_property("textArray", length=True).equal(0), [1], False),
-        (
-            Filter.by_property("textArray").not_equal([]),
-            [0],
-            True,
-        ),
-        (Filter.by_property("textArray", length=True).not_equal(0), [0], False),
+        (Filter.by_property("textArray", length=True).equal(0), [1]),
+        (Filter.by_property("textArray", length=True).not_equal(0), [0]),
     ],
 )
 def test_empty_list_filter(
     collection_factory: CollectionFactory,
     weaviate_filter: _FilterValue,
     results: List[int],
-    skip: bool,
 ) -> None:
-    if skip:
-        pytest.skip("Not supported in this version")
     collection = collection_factory(
         vectorizer_config=Configure.Vectorizer.none(),
         properties=[Property(name="textArray", data_type=DataType.TEXT_ARRAY)],


### PR DESCRIPTION
### What's being changed:

This PR pins weaviate-client python dependency to >=4.23.0 version.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
