### PR TITLE
perf(aggregation-pr5): read a segment node straight into the caller's buffer

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_targeted_scan.go
+++ b/adapters/repos/db/lsmkv/bucket_targeted_scan.go
@@ -16,7 +16,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -383,25 +382,15 @@ func (s *segment) readRange(offset nodeOffset, operation string, buf *[]byte) ([
 	if s.readFromMemory {
 		return s.contents[offset.start:offset.end:offset.end], nil
 	}
-	if s.contentFile == nil {
-		return nil, fmt.Errorf("targeted scan: nil contentFile for segment at %s", s.path)
-	}
-
 	need := offset.end - offset.start
 	if uint64(cap(*buf)) < need {
 		*buf = make([]byte, need)
 	}
 	b := (*buf)[:need:need]
 
-	// ReadAt reports an error whenever it returns short, so it carries io.ReadFull's
-	// guarantee without the wrapper
-	observe := readObserver.GetOrCreate(readMetricName(operation), s.metrics)
-	start := time.Now()
-	n, err := s.contentFile.ReadAt(b, int64(offset.start))
-	if err != nil {
-		return nil, errors.Wrap(err, "targeted scan: read range")
+	if err := s.preadInto(b, offset.start, operation); err != nil {
+		return nil, err
 	}
-	observe(int64(n), time.Since(start).Nanoseconds())
 	return b, nil
 }
 

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -809,18 +809,25 @@ func (s *segment) copyNode(b []byte, offset nodeOffset) error {
 		copy(b, s.contents[offset.start:offset.end])
 		return nil
 	}
+	return s.preadInto(b, offset.start, copyNodeOp)
+}
 
+// preadInto fills b from the segment file at off and meters what came off disk.
+// The caller owns the buffer and the range it covers; this is the pread half
+// copyNode and readRange share, and the operation names both the metric label
+// and the error.
+func (s *segment) preadInto(b []byte, off uint64, operation string) error {
 	if s.contentFile == nil {
-		return fmt.Errorf("copyNode: nil contentFile for segment at %s", s.path)
+		return fmt.Errorf("%s: nil contentFile for segment at %s", operation, s.path)
 	}
 
 	readStart := time.Now()
 	// ReadAt errors on a short read; all io.ReadFull adds is io.ErrUnexpectedEOF in place of io.EOF
-	n, err := s.contentFile.ReadAt(b, int64(offset.start))
+	n, err := s.contentFile.ReadAt(b, int64(off))
 	if err != nil {
-		return fmt.Errorf("copyNode: %w", err)
+		return fmt.Errorf("%s: %w", operation, err)
 	}
-	observe := readObserver.GetOrCreate(readMetricName(copyNodeOp), s.metrics)
+	observe := readObserver.GetOrCreate(readMetricName(operation), s.metrics)
 	observe(int64(n), time.Since(readStart).Nanoseconds())
 	return nil
 }

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -764,11 +765,13 @@ type nodeOffset struct {
 	start, end uint64
 }
 
-// readMetricName is the sync.Map key bufferedReaderAt meters under. Joining it
-// per call allocates, and read paths that fetch a few bytes per row do this once
-// a row, so the operations used there are pre-joined.
+// readMetricName is the sync.Map key bufferedReaderAt and copyNode meter under.
+// Joining it per call allocates, so the operations the switch lists are joined
+// at compile time; the rest join per call in the default arm.
 func readMetricName(operation string) string {
 	switch operation {
+	case copyNodeOp:
+		return "ReadFromSegment" + copyNodeOp
 	case targetedScanPeekOp:
 		return "ReadFromSegment" + targetedScanPeekOp
 	case targetedScanRangeOp:
@@ -799,19 +802,27 @@ func (s *segment) newNodeReader(offset nodeOffset, operation string) (*nodeReade
 	return &nodeReader{r: r, releaseFn: release}, nil
 }
 
+const copyNodeOp = "copyNode"
+
 func (s *segment) copyNode(b []byte, offset nodeOffset) error {
 	if s.readFromMemory {
 		copy(b, s.contents[offset.start:offset.end])
 		return nil
 	}
-	n, err := s.newNodeReader(offset, "copyNode")
-	if err != nil {
-		return fmt.Errorf("copy node: %w", err)
-	}
-	defer n.Release()
 
-	_, err = io.ReadFull(n, b)
-	return err
+	if s.contentFile == nil {
+		return fmt.Errorf("copyNode: nil contentFile for segment at %s", s.path)
+	}
+
+	readStart := time.Now()
+	// ReadAt errors on a short read; all io.ReadFull adds is io.ErrUnexpectedEOF in place of io.EOF
+	n, err := s.contentFile.ReadAt(b, int64(offset.start))
+	if err != nil {
+		return fmt.Errorf("copyNode: %w", err)
+	}
+	observe := readObserver.GetOrCreate(readMetricName(copyNodeOp), s.metrics)
+	observe(int64(n), time.Since(readStart).Nanoseconds())
+	return nil
 }
 
 func (s *segment) bytesReaderFrom(in []byte) (*bytes.Reader, error) {

--- a/adapters/repos/db/lsmkv/segment_copy_node_test.go
+++ b/adapters/repos/db/lsmkv/segment_copy_node_test.go
@@ -1,0 +1,209 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// Spelled out rather than derived from readMetricName, which would move this
+// with the code it checks.
+const copyNodeMetricName = "ReadFromSegmentcopyNode"
+
+// The observer cache is global, so the entry is removed again afterwards.
+func recordCopyNodeReads(tb testing.TB) *[]int64 {
+	tb.Helper()
+
+	var observed []int64
+	readObserver.Store(copyNodeMetricName, BytesReadObserver(func(n, nanoseconds int64) {
+		observed = append(observed, n)
+		assert.Positive(tb, nanoseconds, "the elapsed time must be measured, not passed as a zero")
+	}))
+	tb.Cleanup(func() { readObserver.Delete(copyNodeMetricName) })
+	return &observed
+}
+
+// The byte at i is the low byte of i, so a read at any offset has an expected
+// value.
+func preadSegmentFile(tb testing.TB, size int) (*os.File, []byte) {
+	tb.Helper()
+
+	contents := make([]byte, size)
+	for i := range contents {
+		contents[i] = byte(i)
+	}
+	path := filepath.Join(tb.TempDir(), "segment.db")
+	require.NoError(tb, os.WriteFile(path, contents, 0o644))
+
+	f, err := os.Open(path)
+	require.NoError(tb, err)
+	tb.Cleanup(func() { require.NoError(tb, f.Close()) })
+	return f, contents
+}
+
+func TestSegmentCopyNodeFromFile(t *testing.T) {
+	const fileSize = 8192
+
+	tests := []struct {
+		name   string
+		start  uint64
+		length int
+		// contentFile is nil only where readFromMemory is set, so this state is
+		// built here rather than reached from newSegment
+		noContentFile bool
+		wantErr       error
+		wantErrText   []string
+		wantObserved  []int64
+	}{
+		{
+			name:         "header-sized read fetches only the bytes asked for",
+			start:        0,
+			length:       18,
+			wantObserved: []int64{18},
+		},
+		{
+			name:         "read spanning more than one page",
+			start:        100,
+			length:       4200,
+			wantObserved: []int64{4200},
+		},
+		{
+			name:         "read reaching the last byte of the file",
+			start:        fileSize - 64,
+			length:       64,
+			wantObserved: []int64{64},
+		},
+		{
+			name:        "read running past the end of the file",
+			start:       fileSize - 192,
+			length:      4096,
+			wantErr:     io.EOF,
+			wantErrText: []string{"copyNode"},
+		},
+		{
+			name:    "read starting past the end of the file",
+			start:   fileSize,
+			length:  16,
+			wantErr: io.EOF,
+		},
+		{
+			name:          "segment with no content file",
+			length:        18,
+			noContentFile: true,
+			// naming the segment is the whole point of the guard
+			wantErrText: []string{"copyNode", "nil contentFile", "segment.db"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, contents := preadSegmentFile(t, fileSize)
+			observed := recordCopyNodeReads(t)
+			seg := &segment{contentFile: f, size: fileSize, path: f.Name()}
+			if tt.noContentFile {
+				seg.contentFile = nil
+			}
+
+			b := make([]byte, tt.length)
+			err := seg.copyNode(b, nodeOffset{tt.start, tt.start + uint64(tt.length)})
+
+			for _, want := range tt.wantErrText {
+				require.ErrorContains(t, err, want)
+			}
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr,
+					"a short read must be reported, not passed off as a filled buffer")
+			} else if len(tt.wantErrText) == 0 {
+				require.NoError(t, err)
+				require.Equal(t, contents[tt.start:tt.start+uint64(tt.length)], b)
+			}
+			require.Equal(t, tt.wantObserved, *observed,
+				"the read size summary must see the bytes that actually came off disk")
+		})
+	}
+}
+
+func TestSegmentCopyNodeServesBucketReads(t *testing.T) {
+	ctx := context.Background()
+
+	// one size and no subtest: copyNode branches on neither length nor page
+	// boundary, and what this test alone kills is a segment served from memory
+	const valueSize = 4200
+
+	logger, _ := test.NewNullLogger()
+	bucket, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithStrategy(StrategyReplace), WithSecondaryIndices(1),
+		WithPread(true), WithMinMMapSize(0))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, bucket.Shutdown(ctx)) })
+
+	key, secondary := []byte("primary"), []byte("secondary")
+	value := make([]byte, valueSize)
+	for i := range value {
+		value[i] = byte(i)
+	}
+	require.NoError(t, bucket.Put(key, value, WithSecondaryKey(0, secondary)))
+	require.NoError(t, bucket.FlushMemtable())
+
+	segments, release := bucket.disk.getConsistentViewOfSegments()
+	t.Cleanup(release)
+	require.Len(t, segments, 1)
+	seg, ok := segments[0].(*segment)
+	require.True(t, ok)
+	// reading from memory would return before copyNode reaches the file
+	require.False(t, seg.readFromMemory)
+
+	got, err := bucket.Get(key)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+
+	got, err = bucket.GetBySecondary(ctx, 0, secondary)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+}
+
+func BenchmarkSegmentCopyNode(b *testing.B) {
+	const fileSize = 1024 * 1024
+
+	metrics := benchIOReadMetrics(b)
+
+	// seed the global cache, which a test in the same binary may have filled
+	readObserver.Store(copyNodeMetricName, metrics.ReadObserver(copyNodeMetricName))
+	b.Cleanup(func() { readObserver.Delete(copyNodeMetricName) })
+
+	for _, length := range []int{18, 4200} {
+		b.Run(fmt.Sprintf("%dB", length), func(b *testing.B) {
+			f, _ := preadSegmentFile(b, fileSize)
+			seg := &segment{contentFile: f, size: fileSize, path: f.Name(), metrics: metrics}
+			buf := make([]byte, length)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := seg.copyNode(buf, nodeOffset{0, uint64(length)}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_inverted.go
@@ -61,7 +61,7 @@ func (s *segment) loadTombstones() (*sroar.Bitmap, error) {
 
 	buffer := make([]byte, 8)
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.TombstoneOffset, s.invertedHeader.TombstoneOffset + 8}); err != nil {
-		return nil, fmt.Errorf("copy node: %w", err)
+		return nil, err
 	}
 	bitmapSize := binary.LittleEndian.Uint64(buffer)
 
@@ -72,7 +72,7 @@ func (s *segment) loadTombstones() (*sroar.Bitmap, error) {
 
 	buffer = make([]byte, bitmapSize)
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.TombstoneOffset + 8, s.invertedHeader.TombstoneOffset + 8 + bitmapSize}); err != nil {
-		return nil, fmt.Errorf("copy node: %w", err)
+		return nil, err
 	}
 
 	bitmap := sroar.FromBuffer(buffer)
@@ -98,7 +98,7 @@ func (s *segment) loadPropertyLengthsStats() error {
 
 	buffer := make([]byte, 8*3)
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.PropertyLengthsOffset, s.invertedHeader.PropertyLengthsOffset + 8*3}); err != nil {
-		return fmt.Errorf("copy node: %w", err)
+		return err
 	}
 
 	s.invertedData.avgPropertyLengthsAvg = math.Float64frombits(binary.LittleEndian.Uint64(buffer))
@@ -140,7 +140,7 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 	buffer := make([]byte, 8*3)
 
 	if err := s.copyNode(buffer, nodeOffset{s.invertedHeader.PropertyLengthsOffset, s.invertedHeader.PropertyLengthsOffset + 8*3}); err != nil {
-		return nil, 0, nil, nil, fmt.Errorf("copy node: %w", err)
+		return nil, 0, nil, nil, err
 	}
 
 	// don't re-write stats already set at open: readers access them unlocked
@@ -161,7 +161,7 @@ func (s *segment) loadPropertyLengthsLocked() ([]uint32, uint64, []uint64, []uin
 
 	buffer = make([]byte, propertyLengthsSize)
 	if err := s.copyNode(buffer, nodeOffset{propertyLengthsStart, propertyLengthsEnd}); err != nil {
-		return nil, 0, nil, nil, fmt.Errorf("copy node: %w", err)
+		return nil, 0, nil, nil, err
 	}
 	ids, lens, err := gobenc.DecodePairs(buffer)
 	if err != nil {

--- a/adapters/repos/db/lsmkv/segment_reader_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/segment_reader_benchmark_test.go
@@ -28,20 +28,10 @@ func BenchmarkSegmentReader(b *testing.B) {
 	f.Write(make([]byte, 1024*1024)) // Write 1MB of data
 	f.Sync()
 
-	reg := prometheus.NewRegistry()
-
-	ioRead := prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Name: "test_file_io_reads_total_bytes",
-		Help: "Total number of bytes read from disk",
-	}, []string{"operation"})
-
-	err = reg.Register(ioRead)
-	require.NoError(b, err)
-
 	segment := &segment{
 		contentFile: f,
 		size:        1024 * 1024,
-		metrics:     &Metrics{IORead: ioRead},
+		metrics:     benchIOReadMetrics(b),
 	}
 
 	b.ReportAllocs()
@@ -50,4 +40,17 @@ func BenchmarkSegmentReader(b *testing.B) {
 		_, release, _ := segment.bufferedReaderAt(0, "some op")
 		release()
 	}
+}
+
+// benchIOReadMetrics is the read-byte summary the segment benchmarks meter into,
+// registered privately so two of them in one binary do not collide.
+func benchIOReadMetrics(tb testing.TB) *Metrics {
+	tb.Helper()
+
+	ioRead := prometheus.NewSummaryVec(prometheus.SummaryOpts{
+		Name: "test_file_io_reads_total_bytes",
+		Help: "Total number of bytes read from disk",
+	}, []string{"operation"})
+	require.NoError(tb, prometheus.NewRegistry().Register(ioRead))
+	return &Metrics{IORead: ioRead}
 }


### PR DESCRIPTION
Stacked on #12913. Review that one first; this diff is only the top two commits.

## Motivation

`copyNode` sizes its buffer from the segment index before it reads, and still built a metered reader, a section reader and a pooled `bufio.Reader` for every node, torn down again after a single `io.ReadFull`.

## Approach

A buffered reader amortises one syscall across several reads from the same reader, which is what the segment cursors need — they are handed only a start offset and discover each node's extent field by field as they parse it. `copyNode` reads once and releases, so there is nothing to amortise. Only it changes; the cursors keep the buffered path.

It reads through the file's positional read instead. `io.ReaderAt` errors on any short read, so all `io.ReadFull` added was `io.ErrUnexpectedEOF` in place of `io.EOF`, which nothing in the package reads.

`file_io_reads_total_bytes{operation="ReadFromSegmentcopyNode"}` keeps its name and label and changes what it counts: a sub-page read reports its own size where it reported the 4 KiB `bufio` fill, so operators graphing it see a step down at deploy. It still counts only reads that succeeded, matching `readRange` and `diskio.MeteredReader`.

The second commit removes the copy that first produced. `readRange` reads a byte range out of a segment for the targeted scan, and `copyNode` now does the same thing beside it — the nil `contentFile` guard, the timestamp, the positional read, the observer lookup, the observe call and the comment justifying no wrapper, all written twice. The two had already disagreed on whether a failed read is metered, which is the divergence a reader migrating off `newNodeReader` would inherit at random. Only the pread half is shared: the mmap arms are opposites, since `readRange` hands back a capacity-clamped window into the mapped contents while `copyNode` copies out of it, so each keeps its own fast path. `readRange`'s read errors now name the operation they were read under rather than a fixed prefix, which is also the label their bytes are metered under.

## Testing

`BenchmarkSegmentCopyNode` covers a header-sized read and one crossing a page boundary; a second test exercises a real pread bucket end to end. Every new assertion was mutation-tested.
