### PR TITLE
fix(raft-cluster): barrier a new leader's FSM before it judges proposes

### DIFF
--- a/cluster/raft_apply_endpoints.go
+++ b/cluster/raft_apply_endpoints.go
@@ -338,6 +338,10 @@ func (s *Raft) Execute(ctx context.Context, req *cmd.ApplyRequest) (uint64, erro
 			if errors.Is(err, raft.ErrNotLeader) || errors.Is(err, raft.ErrLeadershipLost) {
 				return err
 			}
+			// Transient by construction, so retry instead of failing the client.
+			if errors.Is(err, types.ErrFSMNotCaughtUp) {
+				return err
+			}
 			return backoff.Permanent(err)
 		}
 

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -237,7 +237,8 @@ func toRPCError(err error) error {
 		// leader-local apply would otherwise reach the follower as
 		// codes.Internal and render 500.
 		ec = NotLeaderRPCCode
-	case errors.Is(err, types.ErrNotOpen):
+	case errors.Is(err, types.ErrNotOpen),
+		errors.Is(err, types.ErrFSMNotCaughtUp):
 		ec = codes.Unavailable
 	case errors.Is(err, namespaces.ErrNamespaceGone),
 		errors.Is(err, namespaces.ErrNotFound):

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -508,3 +508,17 @@ func (m *MockExecutor) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.Q
 	}
 	return &cmd.QueryResponse{}, nil
 }
+
+// A leader whose FSM has not caught up is transient.
+var applyRetryableCodes = []codes.Code{codes.Aborted, codes.ResourceExhausted, codes.Unavailable}
+
+func TestToRPCError_FSMNotCaughtUpIsRetryable(t *testing.T) {
+	wrapped := fmt.Errorf("waiting for leader FSM: %w", types.ErrFSMNotCaughtUp)
+
+	st, ok := status.FromError(toRPCError(wrapped))
+	assert.True(t, ok)
+	assert.NotEqual(t, codes.Internal, st.Code(),
+		"Internal is not retried by the Apply retry policy")
+	assert.Contains(t, applyRetryableCodes, st.Code(),
+		"must map to a code Apply's retryPolicy retries")
+}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -245,6 +245,10 @@ type Store struct {
 	// applyTimeout timeout limit the amount of time raft waits for a command to be applied
 	applyTimeout time.Duration
 
+	// fsmCaughtUpTerm is the leader term a barrier has confirmed; see
+	// [Store.waitLeaderFSMCaughtUp].
+	fsmCaughtUpTerm atomic.Uint64
+
 	// raft snapshot store
 	snapshotStore *raft.FileSnapshotStore
 
@@ -312,6 +316,10 @@ type storeMetrics struct {
 	// fsmStartupAppliedIndex represents previous applied index of the cluster store FSM in local node
 	// that any restart would try to catch up
 	fsmStartupAppliedIndex prometheus.Gauge
+
+	// leaderFSMBarriers counts catch-up barriers. Once per leadership change
+	// when healthy, so a climbing rate reads as leadership churn.
+	leaderFSMBarriers prometheus.Counter
 }
 
 // newStoreMetrics cretes and registers the store related metrics on
@@ -343,6 +351,11 @@ func newStoreMetrics(nodeID string, reg prometheus.Registerer) *storeMetrics {
 		fsmStartupAppliedIndex: r.NewGauge(prometheus.GaugeOpts{
 			Name:        "weaviate_cluster_store_fsm_startup_applied_index",
 			Help:        "Previous applied index of the cluster store FSM in local node that any restart would try to catch up",
+			ConstLabels: prometheus.Labels{"nodeID": nodeID},
+		}),
+		leaderFSMBarriers: r.NewCounter(prometheus.CounterOpts{
+			Name:        "weaviate_cluster_store_leader_fsm_barriers_total",
+			Help:        "Catch-up barriers issued by this node after winning an election",
 			ConstLabels: prometheus.Labels{"nodeID": nodeID},
 		}),
 	}
@@ -1029,6 +1042,39 @@ func (st *Store) reloadDBFromSchema() {
 	val := max(lastSnapshotIndex(st.snapshotStore), lastLogApplied)
 	st.lastAppliedIndexToDB.Store(val)
 	st.metrics.fsmStartupAppliedIndex.Set(float64(val))
+}
+
+// waitLeaderFSMCaughtUp blocks until this node's FSM has applied what it
+// inherited from the previous term. Memoised per term, so steady state is one
+// atomic load.
+//
+// raft reports Leader as soon as the vote is won: the log holds every committed
+// entry, the state machine may hold none of them. raft.Barrier waits out that
+// difference; VerifyLeader appends nothing, so it waits for nothing.
+func (st *Store) waitLeaderFSMCaughtUp() error {
+	if st.raft == nil {
+		return nil
+	}
+
+	term := st.raft.CurrentTerm()
+	if st.fsmCaughtUpForTerm(term) {
+		return nil
+	}
+
+	st.metrics.leaderFSMBarriers.Inc()
+	if err := st.raft.Barrier(st.applyTimeout).Error(); err != nil {
+		st.log.Warnf("leader FSM catch-up barrier failed on term %d: %v", term, err)
+		return fmt.Errorf("%w: %w", types.ErrFSMNotCaughtUp, err)
+	}
+
+	// Terms only climb, so a stamp staled by a new term costs one extra barrier.
+	st.fsmCaughtUpTerm.Store(term)
+	return nil
+}
+
+// fsmCaughtUpForTerm reports whether a barrier has confirmed term.
+func (st *Store) fsmCaughtUpForTerm(term uint64) bool {
+	return term != 0 && st.fsmCaughtUpTerm.Load() == term
 }
 
 func (st *Store) FSMHasCaughtUp() bool {

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -246,7 +247,10 @@ type Store struct {
 	applyTimeout time.Duration
 
 	// fsmCaughtUpTerm is the leader term a barrier has confirmed; see
-	// [Store.waitLeaderFSMCaughtUp].
+	// [Store.waitLeaderFSMCaughtUp]. Written under fsmCatchUpMu, which is what
+	// keeps the check, the barrier and the stamp one unit; atomic so a future
+	// lock-free reader can peek it.
+	fsmCatchUpMu    sync.Mutex
 	fsmCaughtUpTerm atomic.Uint64
 
 	// raft snapshot store
@@ -1055,6 +1059,9 @@ func (st *Store) waitLeaderFSMCaughtUp() error {
 	if st.raft == nil {
 		return nil
 	}
+
+	st.fsmCatchUpMu.Lock()
+	defer st.fsmCatchUpMu.Unlock()
 
 	term := st.raft.CurrentTerm()
 	if st.fsmCaughtUpForTerm(term) {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -33,19 +33,21 @@ func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 		"class": req.Class,
 	}).Debug("server.execute")
 
-	// PreApplyFilter below judges against in-memory FSM state, so a leader that
-	// has not drained what it inherited must not judge yet. Ahead of the tenant
-	// lock, not worth holding across a barrier round-trip.
-	if err := st.waitLeaderFSMCaughtUp(); err != nil {
-		return 0, err
-	}
-
 	// Serialize AddTenants per class so the pre-commit cap check can't race the
 	// apply that increments the count (Execute blocks until apply). Skipped when
 	// the cap is unlimited — nothing to make race-free.
 	if req.Type == api.ApplyRequest_TYPE_ADD_TENANT && st.schemaManager.TenantLimitEnforced() {
 		st.tenantAddLocks.Lock(req.Class)
 		defer st.tenantAddLocks.Unlock(req.Class)
+	}
+
+	// PreApplyFilter below judges against in-memory FSM state, so a leader that
+	// has not drained what it inherited must not judge yet. After the tenant
+	// lock, not before: that lock is held across the apply, so a caller can wait
+	// on it long enough for leadership to turn over, and a term confirmed before
+	// the wait says nothing about the term it wakes up in.
+	if err := st.waitLeaderFSMCaughtUp(); err != nil {
+		return 0, err
 	}
 
 	// Parse the underlying command before pre execute filtering to avoid queryinf the schema is the underlying command

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -33,6 +33,13 @@ func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
 		"class": req.Class,
 	}).Debug("server.execute")
 
+	// PreApplyFilter below judges against in-memory FSM state, so a leader that
+	// has not drained what it inherited must not judge yet. Ahead of the tenant
+	// lock, not worth holding across a barrier round-trip.
+	if err := st.waitLeaderFSMCaughtUp(); err != nil {
+		return 0, err
+	}
+
 	// Serialize AddTenants per class so the pre-commit cap check can't race the
 	// apply that increments the count (Execute blocks until apply). Skipped when
 	// the cap is unlimited — nothing to make race-free.

--- a/cluster/store_propose_barrier_test.go
+++ b/cluster/store_propose_barrier_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -168,4 +169,31 @@ func TestProposeBarrier_TermZeroDoesNotShortCircuit(t *testing.T) {
 	st.fsmCaughtUpTerm.Store(7)
 	require.True(t, st.fsmCaughtUpForTerm(7))
 	require.False(t, st.fsmCaughtUpForTerm(8), "a later term must re-barrier")
+}
+
+// Concurrent first-of-term proposes must share one barrier. Each is a
+// replicated log entry, and they land on the hottest failover path.
+func TestProposeBarrier_ConcurrentCallersShareOneBarrier(t *testing.T) {
+	srv, _ := newBarrierTestStore(t)
+	st := srv.store
+
+	const callers = 50
+	before := barrierCount(t, st)
+	st.fsmCaughtUpTerm.Store(0)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			require.NoError(t, st.waitLeaderFSMCaughtUp())
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	require.Equal(t, float64(1), barrierCount(t, st)-before,
+		"%d concurrent first-of-term callers appended one barrier each", callers)
 }

--- a/cluster/store_propose_barrier_test.go
+++ b/cluster/store_propose_barrier_test.go
@@ -197,3 +197,54 @@ func TestProposeBarrier_ConcurrentCallersShareOneBarrier(t *testing.T) {
 	require.Equal(t, float64(1), barrierCount(t, st)-before,
 		"%d concurrent first-of-term callers appended one barrier each", callers)
 }
+
+// The tenant lock is held across the apply, so a caller can wait on it long
+// enough for leadership to turn over. A term confirmed before that wait says
+// nothing about the term it wakes up in, so the gate must run after the lock.
+//
+// Red if the gate moves back above the tenant lock: the caller passes it on the
+// memo while the term is still current, and issues no barrier once the
+// confirmation is invalidated under it.
+func TestProposeBarrier_ReconfirmsAfterWaitingOnTheTenantLock(t *testing.T) {
+	srv, m := newBarrierTestStore(t)
+	st := srv.store
+	m.indexer.On("AddTenants", mock.Anything, mock.Anything).Return(nil).Maybe()
+	st.schemaManager.SetTenantLimit(func() int { return 100 }, nil)
+
+	const class = "Docs"
+	sub, err := proto.Marshal(&command.AddTenantsRequest{
+		ClusterNodes: []string{st.cfg.NodeID},
+		Tenants:      []*command.Tenant{{Name: "t1", Status: "HOT"}},
+	})
+	require.NoError(t, err)
+	addTenants := &command.ApplyRequest{
+		Type: command.ApplyRequest_TYPE_ADD_TENANT, Class: class, SubCommand: sub,
+	}
+
+	// Confirm the term first, so a gate above the lock would find the memo warm
+	// and issue nothing. Without this the two orderings are indistinguishable.
+	require.NoError(t, st.waitLeaderFSMCaughtUp())
+
+	st.tenantAddLocks.Lock(class)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = st.Execute(addTenants)
+	}()
+
+	// Let the caller reach the lock, then invalidate the confirmation it would
+	// have been travelling on — this stands in for the leadership turnover.
+	time.Sleep(300 * time.Millisecond)
+	st.fsmCaughtUpTerm.Store(0)
+	before := barrierCount(t, st)
+
+	st.tenantAddLocks.Unlock(class)
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Execute never returned")
+	}
+
+	require.Equal(t, float64(1), barrierCount(t, st)-before,
+		"a stale confirmation must be re-established after the tenant-lock wait")
+}

--- a/cluster/store_propose_barrier_test.go
+++ b/cluster/store_propose_barrier_test.go
@@ -1,0 +1,171 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/utils"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/cluster/mocks"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// Telemetry off so only the test moves the log index.
+func newBarrierTestStore(t *testing.T) (*Raft, *MockStore) {
+	t.Helper()
+
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	m.cfg.TelemetryEnabled = false
+	m.store.cfg.TelemetryEnabled = false
+
+	m.indexer.On("Open", mock.Anything).Return(nil)
+	m.indexer.On("Close", mock.Anything).Return(nil)
+	m.indexer.On("AddClass", mock.Anything).Return(nil)
+	m.indexer.On("UpdateClass", mock.Anything).Return(nil)
+	m.indexer.On("DeleteClass", mock.Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+	m.parser.On("ParseClass", mock.Anything).Return(nil)
+	m.replicationFSM.EXPECT().
+		HasActiveReplicationForCollection(mock.Anything).Return(false).Maybe()
+
+	srv := NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
+	ctx := context.Background()
+	require.Nil(t, srv.Open(ctx, m.indexer))
+	t.Cleanup(func() { srv.Close(ctx) })
+
+	addr := fmt.Sprintf("%s:%d", m.cfg.Host, m.cfg.RaftPort)
+	require.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
+	require.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second, make(chan struct{})))
+	require.True(t, tryNTimesWithWait(40, 200*time.Millisecond, srv.store.IsLeader),
+		"node never became leader")
+	return srv, &m
+}
+
+func addClassCmd(t *testing.T, name string) *command.ApplyRequest {
+	t.Helper()
+	sub, err := json.Marshal(&command.AddClassRequest{
+		Class: &models.Class{Class: name}, State: &sharding.State{},
+	})
+	require.NoError(t, err)
+	return &command.ApplyRequest{
+		Type: command.ApplyRequest_TYPE_ADD_CLASS, Class: name, SubCommand: sub,
+	}
+}
+
+// settledLogIndex waits out the configuration entry bootstrap appends around
+// the election, so the delta measured after it belongs to the barrier alone.
+func settledLogIndex(t *testing.T, st *Store) uint64 {
+	t.Helper()
+	last := st.raft.LastIndex()
+	stable := 0
+	for i := 0; i < 100; i++ {
+		time.Sleep(20 * time.Millisecond)
+		if cur := st.raft.LastIndex(); cur != last {
+			last, stable = cur, 0
+			continue
+		}
+		if stable++; stable == 5 {
+			return last
+		}
+	}
+	t.Fatal("raft log index never settled")
+	return 0
+}
+
+func barrierCount(t *testing.T, st *Store) float64 {
+	t.Helper()
+	return testutil.ToFloat64(st.metrics.leaderFSMBarriers)
+}
+
+// Red if the gate becomes any leadership-only check.
+func TestProposeBarrier_WaitsForTheFSMNotJustTheLog(t *testing.T) {
+	srv, m := newBarrierTestStore(t)
+	st := srv.store
+
+	var applied atomic.Bool
+	m.indexer.ExpectedCalls = nil
+	m.indexer.On("Open", mock.Anything).Return(nil)
+	m.indexer.On("Close", mock.Anything).Return(nil)
+	m.indexer.On("TriggerSchemaUpdateCallbacks").Return()
+	m.indexer.On("AddClass", mock.Anything).
+		Run(func(mock.Arguments) {
+			// Hold the FSM so the log runs ahead of the state machine.
+			time.Sleep(300 * time.Millisecond)
+			applied.Store(true)
+		}).Return(nil)
+
+	// Append without waiting, so the entry is in flight.
+	cmdBytes, err := proto.Marshal(addClassCmd(t, "InFlight"))
+	require.NoError(t, err)
+	fut := st.raft.Apply(cmdBytes, st.applyTimeout)
+
+	// A fresh leader has stamped no term yet.
+	st.fsmCaughtUpTerm.Store(0)
+	require.NoError(t, st.waitLeaderFSMCaughtUp())
+
+	require.True(t, applied.Load(),
+		"barrier returned while the FSM was still behind its log")
+	require.NoError(t, fut.Error())
+}
+
+// A barrier is a log entry. Red at 0 if the gate goes, at 3 if the memo goes.
+func TestProposeBarrier_OnePerLeaderTerm(t *testing.T) {
+	srv, _ := newBarrierTestStore(t)
+	st := srv.store
+
+	before := barrierCount(t, st)
+	for i := 0; i < 3; i++ {
+		_, err := st.Execute(addClassCmd(t, fmt.Sprintf("Memoised%d", i)))
+		require.NoError(t, err)
+	}
+	require.Equal(t, float64(1), barrierCount(t, st)-before,
+		"expected exactly one barrier for the term")
+}
+
+// Red if Barrier is swapped for VerifyLeader, which appends nothing.
+func TestProposeBarrier_IsACatchUpBarrierNotALeadershipCheck(t *testing.T) {
+	srv, _ := newBarrierTestStore(t)
+	st := srv.store
+
+	st.fsmCaughtUpTerm.Store(0)
+	before := settledLogIndex(t, st)
+	require.NoError(t, st.waitLeaderFSMCaughtUp())
+	require.Equal(t, uint64(1), st.raft.LastIndex()-before,
+		"a catch-up barrier is a log entry")
+}
+
+// Without the term != 0 guard the two zeros match and the gate reports caught
+// up having never run.
+func TestProposeBarrier_TermZeroDoesNotShortCircuit(t *testing.T) {
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	st := m.store
+
+	require.Equal(t, uint64(0), st.fsmCaughtUpTerm.Load())
+	require.False(t, st.fsmCaughtUpForTerm(0),
+		"term 0 must never read as caught up")
+
+	st.fsmCaughtUpTerm.Store(7)
+	require.True(t, st.fsmCaughtUpForTerm(7))
+	require.False(t, st.fsmCaughtUpForTerm(8), "a later term must re-barrier")
+}

--- a/cluster/types/errs.go
+++ b/cluster/types/errs.go
@@ -27,6 +27,9 @@ var (
 	// ErrDeadlineExceeded represents an error returned when the deadline for waiting for a specific update is exceeded.
 	ErrDeadlineExceeded = errors.New("deadline exceeded for waiting for update")
 	ErrNotFound         = errors.New("not found")
+	// ErrFSMNotCaughtUp means this node is leader but its FSM has not applied
+	// what it inherited. Always transient: it catches up, or loses leadership.
+	ErrFSMNotCaughtUp = errors.New("leader FSM has not caught up with its log")
 )
 
 // IsNoLeader reports whether err means the operation could not reach a


### PR DESCRIPTION
### What's being changed:
Before it appends anything to the log, `Store.Execute` validates the request against the schema it holds in memory. That's only sound if this node's FSM is current  and `IsLeader()` doesn't tell you that. It's a bare `raft.State() == raft.Leader`, which flips the instant a candidate wins the vote, before `runLeader` has even started. So a node can be leader while entries it has already committed are still sitting unapplied, and it validates against a stale picture.

Wait for the FSM to catch up first: one `raft.Barrier` per leader term, cached after that.

Fixes weaviate/dirk-claude-issues#158.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
