### PR TITLE
chore: bake vector index identity into its logger

### DIFF
--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -478,6 +478,53 @@ func TestInitGeoPropNamesItsShard(t *testing.T) {
 	}
 }
 
+// TestVectorIndexLoggerCarriesIdentity pins the contract that lets storage-layer
+// entities (compressors, commit loggers, queues) log without ever being told
+// the logical target-vector name: the shard bakes both identities - the
+// logical name for operators and the physical id for storage - into the
+// logger it hands to initVectorIndex, once, and every implementation
+// (hnsw/flat/dynamic/hfresh) and everything it constructs inherits that
+// logger unchanged.
+func TestVectorIndexLoggerCarriesIdentity(t *testing.T) {
+	ctx := context.Background()
+
+	vic := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
+	vic.SetDefaults()
+	shd, idx := testShardWithNamedVector(t, ctx, "LoggerIdentityNamed", vic)
+	s := shd.(*Shard)
+	defer removeRootPath(t, idx)
+	defer func() { require.NoError(t, idx.drop()) }()
+
+	// hooking the shard's own logger rather than replacing it: the field is read
+	// unsynchronized from background goroutines the shard already started
+	logger, ok := s.index.logger.(*logrus.Logger)
+	require.True(t, ok, "the test shard no longer carries a hookable logger")
+	hook := test.NewLocal(logger)
+	logger.SetLevel(logrus.DebugLevel)
+
+	// Force a fresh construction of the named vector's index while the hook is
+	// attached. hnsw.New unconditionally logs a line ("restored data from
+	// disk") as part of its startup, through the identified logger baked in
+	// at construction time - a deterministic way to observe the identity
+	// without depending on cache-prefill timing or async goroutines.
+	require.NoError(t, s.DropVectorIndex(ctx, "title"))
+	require.NoError(t, s.initTargetVector(ctx, "title", vic, false))
+
+	var sawIdentifiedLine bool
+	for _, entry := range hook.AllEntries() {
+		targetVector, ok := entry.Data["target_vector"]
+		if !ok {
+			continue
+		}
+		sawIdentifiedLine = true
+		require.Equalf(t, "title", targetVector, "line %q", entry.Message)
+		require.Equalf(t, "vectors_title", entry.Data["index_id"], "line %q", entry.Message)
+		require.Equalf(t, "LoggerIdentityNamed", entry.Data["class"], "line %q", entry.Message)
+		require.Equalf(t, s.name, entry.Data["shard"], "line %q", entry.Message)
+	}
+	require.True(t, sawIdentifiedLine, "no log line under the recreated index carried target_vector")
+}
+
 // TestInitGeoPropQueueFailureIsRetryable pins that a failed queue build leaves
 // no index registered. Keeping it would make the guard skip the retry, so the
 // prop would serve reads with an index nothing ever drains into.

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/common"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -476,6 +477,24 @@ func TestInitGeoPropNamesItsShard(t *testing.T) {
 		require.NotZerof(t, namedPerProp[geoPropID(prop)],
 			"prop %q logged no line naming its class and shard", prop)
 	}
+}
+
+// testShardWithNamedVector builds a shard whose only vector index is the named
+// vector "title" with the given config (async indexing on, as dynamic needs).
+func testShardWithNamedVector(t *testing.T, ctx context.Context, className string,
+	vic schemaConfig.VectorIndexConfig,
+) (ShardLike, *Index) {
+	t.Helper()
+	return testShardWithSettings(t, ctx, &models.Class{Class: className}, nil, false, true, true,
+		func(i *Index) {
+			i.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{"title": vic}
+		},
+	)
+}
+
+func removeRootPath(t *testing.T, idx *Index) {
+	t.Helper()
+	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
 }
 
 // TestVectorIndexLoggerCarriesIdentity pins the contract that lets storage-layer

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -88,6 +88,24 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		makeBucketOptions = s.overwrittenMakeDefaultBucketOptions(lsmkv.WithLazySegmentLoading(lazyLoadSegments))
 	}
 
+	// a shard can actually have multiple vector indexes:
+	// - the main index, which is used for all normal object vectors
+	// - a geo property index for each geo prop in the schema
+	//
+	// here we label the main vector index as such.
+	vecIdxID := s.vectorIndexID(targetVector)
+
+	// Every log line under this index carries both identities: the logical
+	// name for operators ("which vector?") and the physical id for storage
+	// ("which files?"). Implementations and the entities they own (compressors,
+	// commit loggers, queues) inherit it and add nothing of their own.
+	logger := s.index.logger.WithFields(logrus.Fields{
+		"class":         s.index.Config.ClassName.String(),
+		"shard":         s.name,
+		"target_vector": targetVector,
+		"index_id":      vecIdxID,
+	})
+
 	switch vectorIndexUserConfig.IndexType() {
 	case vectorindex.VectorIndexTypeHNSW:
 		hnswUserConfig, ok := vectorIndexUserConfig.(hnswent.UserConfig)
@@ -103,15 +121,8 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 			s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 			s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
-			// a shard can actually have multiple vector indexes:
-			// - the main index, which is used for all normal object vectors
-			// - a geo property index for each geo prop in the schema
-			//
-			// here we label the main vector index as such.
-			vecIdxID := s.vectorIndexID(targetVector)
-
 			vi, err := hnsw.New(hnsw.Config{
-				Logger:                            s.index.logger,
+				Logger:                            logger,
 				RootPath:                          s.path(),
 				ID:                                vecIdxID,
 				ShardName:                         s.name,
@@ -156,18 +167,11 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		}
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 
-		// a shard can actually have multiple vector indexes:
-		// - the main index, which is used for all normal object vectors
-		// - a geo property index for each geo prop in the schema
-		//
-		// here we label the main vector index as such.
-		vecIdxID := s.vectorIndexID(targetVector)
-
 		vi, err := flat.New(flat.Config{
 			ID:                vecIdxID,
 			TargetVector:      targetVector,
 			RootPath:          s.path(),
-			Logger:            s.index.logger,
+			Logger:            logger,
 			DistanceProvider:  distProv,
 			AllocChecker:      s.index.allocChecker,
 			MakeBucketOptions: makeBucketOptions,
@@ -185,13 +189,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
-		// a shard can actually have multiple vector indexes:
-		// - the main index, which is used for all normal object vectors
-		// - a geo property index for each geo prop in the schema
-		//
-		// here we label the main vector index as such.
-		vecIdxID := s.vectorIndexID(targetVector)
-
 		metaDB, err := s.getOrInitMetadataDB()
 		if err != nil {
 			return nil, errors.Wrapf(err, "init shard %q: dynamic index", s.ID())
@@ -200,7 +197,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		vi, err := dynamic.New(dynamic.Config{
 			ID:                           vecIdxID,
 			TargetVector:                 targetVector,
-			Logger:                       s.index.logger,
+			Logger:                       logger,
 			DistanceProvider:             distProv,
 			RootPath:                     s.path(),
 			ShardName:                    s.name,
@@ -240,11 +237,11 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
-		hfreshConfigID := s.vectorIndexID(targetVector)
+		hfreshConfigID := vecIdxID
 		rootPath := filepath.Join(s.path(), helpers.HFreshDirName(hfreshConfigID))
 
 		hfreshConfig := &hfresh.Config{
-			Logger:            s.index.logger,
+			Logger:            logger,
 			Scheduler:         s.index.scheduler,
 			DistanceProvider:  distProv,
 			RootPath:          rootPath,
@@ -262,7 +259,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 			TombstoneCallbacks:           s.cycleCallbacks.vectorTombstoneCleanupCallbacks,
 			Centroids: hfresh.CentroidConfig{
 				HNSWConfig: &hnsw.Config{
-					Logger:                            s.index.logger,
+					Logger:                            logger,
 					RootPath:                          rootPath,
 					ID:                                hfreshConfigID + "_centroids",
 					ShardName:                         s.name,

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -678,14 +678,14 @@ func (dynamic *dynamic) Upgrade(callback func()) error {
 				dynamic.status.Reset()
 			}
 		}()
-		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW started")
+		dynamic.logger.Debugf("upgrade to HNSW started")
 
 		err := dynamic.upgradeFn()
 		if err != nil {
 			dynamic.logger.Errorf("failed to upgrade index: %v", err)
 			return
 		}
-		dynamic.logger.WithField("shard", dynamic.shardName).WithField("class", dynamic.className).Debugf("upgrade to HNSW completed")
+		dynamic.logger.Debugf("upgrade to HNSW completed")
 	}, dynamic.logger)
 
 	return nil

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1052,10 +1052,9 @@ func (index *flat) PostStartup(ctx context.Context) {
 		}
 		if <-abortedCh {
 			index.logger.WithFields(logrus.Fields{
-				"action":   "preload_cache",
-				"count":    len(vecs),
-				"took":     time.Since(before),
-				"index_id": index.id,
+				"action": "preload_cache",
+				"count":  len(vecs),
+				"took":   time.Since(before),
 			}).Warn("preload vectors aborted")
 			return
 		}
@@ -1093,10 +1092,9 @@ func (index *flat) PostStartup(ctx context.Context) {
 		}
 		if <-abortedCh {
 			index.logger.WithFields(logrus.Fields{
-				"action":   "preload_cache",
-				"count":    len(vecs),
-				"took":     time.Since(before),
-				"index_id": index.id,
+				"action": "preload_cache",
+				"count":  len(vecs),
+				"took":   time.Since(before),
 			}).Warn("preload vectors aborted")
 			return
 		}
@@ -1146,10 +1144,9 @@ func (index *flat) PostStartup(ctx context.Context) {
 		}
 		if <-abortedCh {
 			index.logger.WithFields(logrus.Fields{
-				"action":   "preload_cache",
-				"count":    count,
-				"took":     time.Since(before),
-				"index_id": index.id,
+				"action": "preload_cache",
+				"count":  count,
+				"took":   time.Since(before),
 			}).Warn("preload vectors aborted")
 			return
 		}
@@ -1169,10 +1166,9 @@ func (index *flat) PostStartup(ctx context.Context) {
 		}
 		if <-abortedCh {
 			index.logger.WithFields(logrus.Fields{
-				"action":   "preload_cache",
-				"count":    count,
-				"took":     time.Since(before),
-				"index_id": index.id,
+				"action": "preload_cache",
+				"count":  count,
+				"took":   time.Since(before),
 			}).Warn("preload vectors aborted")
 			return
 		}
@@ -1182,11 +1178,10 @@ func (index *flat) PostStartup(ctx context.Context) {
 
 	took := time.Since(before)
 	index.logger.WithFields(logrus.Fields{
-		"action":   "preload_cache",
-		"type":     index.compressionType.String(),
-		"count":    count,
-		"took":     took,
-		"index_id": index.id,
+		"action": "preload_cache",
+		"type":   index.compressionType.String(),
+		"count":  count,
+		"took":   took,
 	}).Debugf("pre-loaded %d vectors in %s", count, took)
 }
 

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -101,12 +101,9 @@ func NewIndex(config Config,
 		return nil, errors.Errorf("geo index %q: coordinatesFromObject is required alongside a store", config.ID)
 	}
 
-	// hnsw no longer bakes class/shard/target_vector into the logger it's
-	// handed — the shard does that for its own vector indexes, but a geo
-	// index is built outside that path, so it must do so itself here.
-	// index_id is the key its prefill lines already give this id, which also
-	// names the files on disk; target_vector is left out since a geo index
-	// has no object-vector identity of its own.
+	// A geo index is built outside the shard's vector-index path, so it
+	// identifies its own log lines. No target_vector: a geo index has no
+	// object-vector identity.
 	config.Logger = config.Logger.WithFields(logrus.Fields{
 		"class":    config.ClassName,
 		"shard":    config.ShardName,

--- a/adapters/repos/db/vector/geo/geo.go
+++ b/adapters/repos/db/vector/geo/geo.go
@@ -101,10 +101,17 @@ func NewIndex(config Config,
 		return nil, errors.Errorf("geo index %q: coordinatesFromObject is required alongside a store", config.ID)
 	}
 
-	// the underlying index identifies its lines by class, shard and target
-	// vector, and a geo index leaves the target vector empty. index_id is the key
-	// its prefill lines already give this id, which also names the files on disk.
-	config.Logger = config.Logger.WithField("index_id", config.ID)
+	// hnsw no longer bakes class/shard/target_vector into the logger it's
+	// handed — the shard does that for its own vector indexes, but a geo
+	// index is built outside that path, so it must do so itself here.
+	// index_id is the key its prefill lines already give this id, which also
+	// names the files on disk; target_vector is left out since a geo index
+	// has no object-vector identity of its own.
+	config.Logger = config.Logger.WithFields(logrus.Fields{
+		"class":    config.ClassName,
+		"shard":    config.ShardName,
+		"index_id": config.ID,
+	})
 
 	var vectorFromObject hnsw.VectorFromObject
 	if config.CoordinatesFromObject != nil {

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -167,10 +167,9 @@ func (h *hnsw) UpdateUserConfig(updated config.VectorIndexConfig, callback func(
 
 func (h *hnsw) Upgrade(callback func()) error {
 	h.logger.WithFields(logrus.Fields{
-		"action":       "compress",
-		"shard":        h.shardName,
-		"collection":   h.className,
-		"targetVector": h.getTargetVector(),
+		"action":     "compress",
+		"shard":      h.shardName,
+		"collection": h.className,
 	}).Info("switching to compressed vectors")
 
 	err := ent.ValidatePQConfig(h.pqConfig)
@@ -203,17 +202,15 @@ func (h *hnsw) compressThenCallback(callback func()) {
 	}
 	if err := h.compress(uc); err != nil {
 		h.logger.WithFields(logrus.Fields{
-			"action":       "compress",
-			"shard":        h.shardName,
-			"collection":   h.className,
-			"targetVector": h.getTargetVector(),
-		}).WithError(err).Error("vector compression failed")
+			"action":     "compress",
+			"shard":      h.shardName,
+			"collection": h.className,
+		}).Errorf("vector compression failed: %v", err)
 		return
 	}
 	h.logger.WithFields(logrus.Fields{
-		"action":       "compress",
-		"shard":        h.shardName,
-		"collection":   h.className,
-		"targetVector": h.getTargetVector(),
+		"action":     "compress",
+		"shard":      h.shardName,
+		"collection": h.className,
 	}).Info("vector compression complete")
 }

--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -205,7 +205,7 @@ func (h *hnsw) compressThenCallback(callback func()) {
 			"action":     "compress",
 			"shard":      h.shardName,
 			"collection": h.className,
-		}).Errorf("vector compression failed: %v", err)
+		}).WithError(err).Error("vector compression failed")
 		return
 	}
 	h.logger.WithFields(logrus.Fields{

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -409,14 +409,6 @@ func New(cfg Config, uc ent.UserConfig,
 		makeBucketOptions: cfg.MakeBucketOptions,
 		fs:                common.NewOSFS(),
 	}
-	// shard/class/target_vector are already baked into cfg.Logger by the
-	// caller (the shard, for the main index; geo/hfresh callers that build
-	// their own hnsw indexes do the same). index_id is the one thing hnsw
-	// itself must override: a centroid graph or geo index shares an (often
-	// empty) logical target-vector name with its owning index, so only the
-	// physical ID told to us here — not the inherited one — distinguishes
-	// them. WithField/WithFields is last-write-wins, so this line always
-	// wins over whatever index_id the caller's logger already carried.
 	index.logger = cfg.Logger.WithField("index_id", index.id)
 	index.acornSearch.Store(uc.FilterStrategy == ent.FilterStrategyAcorn)
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -409,11 +409,15 @@ func New(cfg Config, uc ent.UserConfig,
 		makeBucketOptions: cfg.MakeBucketOptions,
 		fs:                common.NewOSFS(),
 	}
-	index.logger = cfg.Logger.WithFields(logrus.Fields{
-		"shard":        cfg.ShardName,
-		"class":        cfg.ClassName,
-		"targetVector": index.getTargetVector(),
-	})
+	// shard/class/target_vector are already baked into cfg.Logger by the
+	// caller (the shard, for the main index; geo/hfresh callers that build
+	// their own hnsw indexes do the same). index_id is the one thing hnsw
+	// itself must override: a centroid graph or geo index shares an (often
+	// empty) logical target-vector name with its owning index, so only the
+	// physical ID told to us here — not the inherited one — distinguishes
+	// them. WithField/WithFields is last-write-wins, so this line always
+	// wins over whatever index_id the caller's logger already carried.
+	index.logger = cfg.Logger.WithField("index_id", index.id)
 	index.acornSearch.Store(uc.FilterStrategy == ent.FilterStrategyAcorn)
 
 	index.multivector.Store(uc.Multivector.Enabled)

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -100,17 +100,15 @@ func (pf *vectorCachePrefiller[T]) logLevel(level, count int, before time.Time) 
 		"hnsw_level": level,
 		"count":      count,
 		"took":       time.Since(before),
-		"index_id":   pf.index.id,
 	}).Debug("prefilled level in vector cache")
 }
 
 func (pf *vectorCachePrefiller[T]) logTotal(count, limit int, before time.Time) {
 	pf.logger.WithFields(logrus.Fields{
-		"action":   "hnsw_vector_cache_prefill",
-		"limit":    limit,
-		"count":    count,
-		"took":     time.Since(before),
-		"index_id": pf.index.id,
+		"action": "hnsw_vector_cache_prefill",
+		"limit":  limit,
+		"count":  count,
+		"took":   time.Since(before),
 	}).Info("prefilled vector cache")
 }
 

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_parallel.go
@@ -116,7 +116,6 @@ func (h *hnsw) prefillCacheParallel(ctx context.Context) error {
 		"action":   "hnsw_vector_cache_prefill",
 		"count":    loaded.Load(),
 		"took":     time.Since(before),
-		"index_id": h.id,
 		"parallel": true,
 	}).Info("prefilled vector cache")
 	return nil


### PR DESCRIPTION
### What's being changed:

Every log line emitted under a vector index now carries the vector's identity, without the index implementations (or the compressors, commit loggers and prefillers they own) having to know the logical target-vector name themselves.

- The shard builds the logger once in `initVectorIndex` with `class`, `shard`, `target_vector` (the logical name, for operators) and `index_id` (the physical ID, `main` / `vectors_<name>`, which names the files on disk) and hands it to hnsw, flat, dynamic, hfresh and hfresh's centroid graph.
- hnsw keeps only its own `index_id` override (so a centroid graph or geo index, which shares an often-empty logical name with its owner, is still distinguishable) and drops the `shard`/`class`/camelCase `targetVector` fields it used to add itself. flat and dynamic drop their hand-rolled `index_id`/`shard`/`class` fields.
- geo builds its hnsw index outside the shard path, so it now bakes `class`/`shard`/`index_id` into its own logger (previously only `index_id`).
- Pinned by `TestVectorIndexLoggerCarriesIdentity`: recreating a named vector's index while a logrus hook is attached must yield lines carrying all four fields with the expected values.

Log-shape change worth knowing: hnsw's `targetVector` log key becomes `target_vector` (snake_case, consistent with the other shard-level fields).

This is the first of the split-out pieces of #12903 (logical-to-physical vector index mapping RFC, step 2); it is independent of the naming changes there.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.