### PR TITLE
fix(db): keep multi-target candidates when a named vector is missing (#12916)

### DIFF
--- a/adapters/repos/db/shard_combine_multi_target.go
+++ b/adapters/repos/db/shard_combine_multi_target.go
@@ -124,8 +124,6 @@ func CombineMultiTargetResults(ctx context.Context, shard DistanceForVector, log
 			weights[i] = float64(targetCombination.Weights[i])
 		}
 
-		scoresToRemove := make(map[uint64]struct{})
-
 		fusionInput := make([][]*search.Result, len(results))
 		for i := range results {
 			localIDs := make(map[uint64]struct{}, len(allIDs))
@@ -144,26 +142,8 @@ func CombineMultiTargetResults(ctx context.Context, shard DistanceForVector, log
 			if err := getScoresOfMissingResults(ctx, shard, logger, missingIDs, &resultContainer, targetCombination.Weights); err != nil {
 				return nil, nil, err
 			}
-			for key := range resultContainer.IDsToRemove {
-				scoresToRemove[key] = struct{}{}
-			}
 			fusionInput[i] = resultContainer.ResultsIn
 			clear(missingIDs) // each target vector is handled separately for hybrid
-		}
-
-		// remove objects that have missing target vectors
-		if len(scoresToRemove) > 0 {
-			for i := range fusionInput {
-				for j := len(fusionInput[i]) - 1; j >= 0; j-- {
-					if _, ok := scoresToRemove[*fusionInput[i][j].DocID]; ok {
-						if j < len(fusionInput[i])-1 {
-							fusionInput[i] = append(fusionInput[i][:j], fusionInput[i][j+1:]...)
-						} else {
-							fusionInput[i] = fusionInput[i][:j]
-						}
-					}
-				}
-			}
 		}
 
 		joined := hybrid.FusionRelativeScore(weights, fusionInput, targetVectors, false)
@@ -291,8 +271,12 @@ func getScoresOfMissingResults(ctx context.Context, shard DistanceForVector, log
 			mutex.Lock()
 			defer mutex.Unlock()
 			if err != nil {
-				// when we cannot look up missing distances for an object, it will be removed from the result list
-				combinedResults.RemoveIdFromResult(id)
+				// Missing named vectors (or other per-object distance lookup
+				// failures) must not drop an object that already qualified in
+				// another selected target space. Keep the partial score and
+				// skip only the unavailable component.
+				logger.WithError(err).WithField("id", id).
+					Debug("skipping unavailable target vector distance in multi-target join")
 			} else {
 				combinedResults.AddScores(id, targets.target, distances, targets.weights)
 			}

--- a/adapters/repos/db/shard_combine_multi_target_test.go
+++ b/adapters/repos/db/shard_combine_multi_target_test.go
@@ -109,7 +109,8 @@ func TestCombiner(t *testing.T) {
 			targets:         []string{"target1", "target2"},
 			joinMethod:      &dto.TargetCombination{Weights: []float32{1, 1}},
 			in:              [][]search.Result{{res(0, 0.5), res(1, 0.6)}, {res(0, 0.5)}},
-			out:             []search.Result{res(0, 1)},
+			// Doc 1 lacks target2; keep the partial target1 score instead of dropping it.
+			out:             []search.Result{res(1, 0.6), res(0, 1)},
 			missingElements: map[uint64][]string{1: {"target2"}},
 		},
 		{
@@ -125,7 +126,8 @@ func TestCombiner(t *testing.T) {
 			targets:         []string{"target1", "target2"},
 			joinMethod:      &dto.TargetCombination{Type: dto.RelativeScore, Weights: []float32{0.5, 0.5}},
 			in:              [][]search.Result{{res(0, 0.5), res(1, 0.6)}, {res(0, 0.5)}},
-			out:             []search.Result{res(0, 1)},
+			// Doc 1 lacks target2 but still qualifies via target1.
+			out:             []search.Result{res(0, 0.5), res(1, 0.5)},
 			missingElements: map[uint64][]string{1: {"target2"}},
 		},
 		{
@@ -163,7 +165,8 @@ func TestCombiner(t *testing.T) {
 				{res(1, 0.2), res(2, 0.4), res(3, 0.6), res(4, 0.8)},
 				{res(6, 0.1), res(0, 0.3), res(2, 0.7), res(3, 0.9)},
 			},
-			out:             []search.Result{res(1, 0.95), res(2, 1.27)},
+			// Doc 0 lacks target3; keep partial score 0.5 + 0.5*0.4 + 0.1*0.3 = 0.73.
+			out:             []search.Result{res(0, 0.73), res(1, 0.95), res(2, 1.27)},
 			missingElements: map[uint64][]string{0: {"target3"}},
 		},
 		{
@@ -199,7 +202,16 @@ func TestCombiner(t *testing.T) {
 				4: {"target1": 1, "target2": 1.1, "target4": 1.2},
 				5: {"target1": 1, "target3": 1.2, "target4": 1.3},
 			},
-			out:             []search.Result{res(1, 0.28), res(0, 0.3), res(2, 0.89), res(3, 1.46), res(5, 1.65), res(4, 1.69)},
+			// Doc 6 lacks target3; keep it with a partial relative score instead of dropping it.
+			out: []search.Result{
+				res(1, 0.15000002),
+				res(0, 0.27222225),
+				res(2, 0.41111115),
+				res(3, 0.7111111),
+				res(4, 0.82500005),
+				res(5, 0.85),
+				res(6, 1.5),
+			},
 			missingElements: map[uint64][]string{6: {"target3"}},
 		},
 		{
@@ -223,7 +235,15 @@ func TestCombiner(t *testing.T) {
 				{res(1, 0.2), res(3, 0.6), res(4, 0.8)},
 				{res(6, 0.1), res(0, 0.3), res(2, 0.7), res(3, 0.9)},
 			},
-			out:             []search.Result{res(3, 1.85)}, // score is 1 for each if there is only one result, multiplied by the weight
+			out: []search.Result{
+				res(6, 0),
+				res(4, 0.083333336),
+				res(0, 0.26052633),
+				res(5, 0.32142857),
+				res(1, 0.35000008),
+				res(2, 0.781579),
+				res(3, 1.5976609),
+			}, // partial-target candidates remain in the union
 			missingElements: map[uint64][]string{0: {"target2"}, 1: {"target2"}, 2: {"target3"}, 4: {"target1", "target2", "target4"}, 5: {"target1", "target2", "target4"}, 6: {"target1", "target2", "target3"}},
 		},
 	}


### PR DESCRIPTION
## Summary
- `sum` / `average` / `relative_score` multi-target joins no longer drop objects that lack one selected named vector.
- Unavailable target-vector distance lookups are skipped so partial scores remain, matching the documented any-target union behavior.
- Unit expectations in `TestCombiner` updated for the new contract.

Fixes #12916

## Test plan
- [x] `go test ./adapters/repos/db/ -run TestCombiner` (pass)


Made with [Cursor](https://cursor.com)