### PR TITLE
dynamic: Derive dynamic index storage names and state key from the physical ID

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -451,7 +451,7 @@ func (i *Index) unloadedVectorState(shardName, targetVector string,
 	}
 	if vectorConfig.VectorIndexType == common.IndexTypeDynamic {
 		upgraded, err := dynamic.UpgradedOnDisk(shardPath(i.path(), shardName),
-			vectorIndexID(targetVector), targetVector)
+			vectorIndexID(targetVector))
 		if err != nil {
 			i.logger.WithFields(logrus.Fields{
 				"class":         i.Config.ClassName.String(),

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -202,7 +202,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 
 		vi, err := dynamic.New(dynamic.Config{
 			ID:                           vecIdxID,
-			TargetVector:                 targetVector,
 			Logger:                       logger,
 			DistanceProvider:             distProv,
 			RootPath:                     s.path(),

--- a/adapters/repos/db/vector/dynamic/config.go
+++ b/adapters/repos/db/vector/dynamic/config.go
@@ -30,7 +30,6 @@ import (
 
 type Config struct {
 	ID                           string
-	TargetVector                 string
 	Logger                       logrus.FieldLogger
 	RootPath                     string
 	ShardName                    string

--- a/adapters/repos/db/vector/dynamic/drop_target_vector_test.go
+++ b/adapters/repos/db/vector/dynamic/drop_target_vector_test.go
@@ -44,7 +44,6 @@ func newDynamicForDrop(t *testing.T, meta *shardmeta.DB, rootPath, targetVector 
 
 	idx, err := New(Config{
 		AllocChecker:          memwatch.NewDummyMonitor(),
-		TargetVector:          targetVector,
 		RootPath:              rootPath,
 		ID:                    "vectors_" + targetVector,
 		MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -279,18 +279,21 @@ func (dynamic *dynamic) Type() common.IndexType {
 }
 
 func (dynamic *dynamic) dbKey() []byte {
-	return dbKey(dynamic.targetVector)
+	return dbKeyForID(dynamic.id)
 }
 
-func dbKey(targetVector string) []byte {
-	if targetVector == "" {
+// dbKeyForID derives the upgrade-verdict key from a physical index ID: the
+// bare key for the legacy "main" index, "<key>_<suffix>" for "vectors_<suffix>".
+func dbKeyForID(physicalID string) []byte {
+	suffix := helpers.PhysicalIDSuffix(physicalID)
+	if suffix == "" {
 		return []byte(composerUpgradedKey)
 	}
 
-	key := make([]byte, 0, len(composerUpgradedKey)+len(targetVector)+1)
+	key := make([]byte, 0, len(composerUpgradedKey)+len(suffix)+1)
 	key = append(key, composerUpgradedKey...)
 	key = append(key, '_')
-	key = append(key, targetVector...)
+	key = append(key, suffix...)
 	return key
 }
 
@@ -305,7 +308,8 @@ func dbKey(targetVector string) []byte {
 // loaded shard owns the key and deletes it through its own handle (both
 // baked into shardmeta.DeleteOffline).
 func RemoveStateKey(rootPath, targetVector string) error {
-	if err := shardmeta.DeleteOffline(rootPath, StateNamespace, dbKey(targetVector)); err != nil {
+	key := dbKeyForID(helpers.VectorIndexIDForTarget(targetVector))
+	if err := shardmeta.DeleteOffline(rootPath, StateNamespace, key); err != nil {
 		return fmt.Errorf("delete dynamic state for %q: %w", targetVector, err)
 	}
 	return nil
@@ -319,14 +323,14 @@ func RemoveStateKey(rootPath, targetVector string) error {
 //
 // State that could not be read returns false along with the error, so a
 // caller can tell that answer apart from a shard positively known to be flat.
-func UpgradedOnDisk(rootPath, id, targetVector string) (bool, error) {
+func UpgradedOnDisk(rootPath, id string) (bool, error) {
 	upgradedWithoutStateKey := false
-	if targetVector != "" {
+	if helpers.PhysicalIDSuffix(id) != "" {
 		_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
 		upgradedWithoutStateKey = err == nil
 	}
 
-	v, ok, err := shardmeta.GetOffline(rootPath, StateNamespace, dbKey(targetVector))
+	v, ok, err := shardmeta.GetOffline(rootPath, StateNamespace, dbKeyForID(id))
 	if err != nil {
 		return false, fmt.Errorf("read dynamic state: %w", err)
 	}
@@ -341,11 +345,7 @@ func UpgradedOnDisk(rootPath, id, targetVector string) (bool, error) {
 }
 
 func (dynamic *dynamic) getBucketName() string {
-	if dynamic.targetVector != "" {
-		return fmt.Sprintf("%s_%s", helpers.VectorsBucketLSM, dynamic.targetVector)
-	}
-
-	return helpers.VectorsBucketLSM
+	return helpers.VectorsBucketNameForID(dynamic.id)
 }
 
 func (dynamic *dynamic) init(cfg *Config) (bool, error) {
@@ -367,10 +367,10 @@ func (dynamic *dynamic) init(cfg *Config) (bool, error) {
 		// a stored empty value reads back non-nil, so length is what says
 		// whether a state was recorded
 		upgraded = v[0] != 0
-	case cfg.TargetVector != "":
-		// a bug in earlier versions caused target vectors to all use the same
+	case helpers.PhysicalIDSuffix(cfg.ID) != "":
+		// a bug in earlier versions caused named vectors to all use the same
 		// key. this is a mitigation to preserve existing upgraded state and
-		// migrate to target-vector-specific keys going forward: no recorded
+		// migrate to per-vector keys going forward: no recorded
 		// state means the verdict is inferred from the existence of the HNSW
 		// dir and recorded under this vector's own key.
 		verdict := []byte{0}
@@ -399,7 +399,7 @@ func (dynamic *dynamic) init(cfg *Config) (bool, error) {
 }
 
 func (dynamic *dynamic) getCompressedBucketName() string {
-	return helpers.GetCompressedBucketName(dynamic.targetVector)
+	return helpers.CompressedBucketNameForID(dynamic.id)
 }
 
 func (dynamic *dynamic) Compressed() bool {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -151,7 +151,6 @@ func (s *status) TryUpgrading() bool {
 type dynamic struct {
 	sync.RWMutex
 	id                           string
-	targetVector                 string
 	store                        *lsmkv.Store
 	logger                       logrus.FieldLogger
 	rootPath                     string
@@ -205,7 +204,6 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 
 	index := &dynamic{
 		id:                           cfg.ID,
-		targetVector:                 cfg.TargetVector,
 		logger:                       cfg.Logger,
 		rootPath:                     cfg.RootPath,
 		shardName:                    cfg.ShardName,
@@ -488,7 +486,7 @@ func (dynamic *dynamic) Drop(ctx context.Context, keepFiles bool) error {
 
 	if !keepFiles {
 		if err := dynamic.state.Delete(dynamic.dbKey()); err != nil && !shardmeta.IsClosed(err) {
-			return fmt.Errorf("delete dynamic state for %q: %w", dynamic.targetVector, err)
+			return fmt.Errorf("delete dynamic state for %q: %w", dynamic.id, err)
 		}
 	}
 
@@ -516,7 +514,7 @@ func (dynamic *dynamic) DropTargetVector(ctx context.Context) error {
 	defer dynamic.Unlock()
 
 	if err := dynamic.state.Delete(dynamic.dbKey()); err != nil {
-		return fmt.Errorf("delete dynamic state for %q: %w", dynamic.targetVector, err)
+		return fmt.Errorf("delete dynamic state for %q: %w", dynamic.id, err)
 	}
 
 	// keepFiles=false: the underlying index's own files go, but the SHARED

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -222,7 +222,6 @@ func TestDynamicWithTargetVectors(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		dynamic, err := New(Config{
 			AllocChecker:          memwatch.NewDummyMonitor(),
-			TargetVector:          "target_" + strconv.Itoa(i),
 			RootPath:              rootPath,
 			ID:                    helpers.VectorIndexIDForTarget("target_" + strconv.Itoa(i)),
 			MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,
@@ -715,7 +714,6 @@ func TestDynamicUpgradeCompression(t *testing.T) {
 
 			config := Config{
 				AllocChecker: memwatch.NewDummyMonitor(),
-				TargetVector: "",
 				RootPath:     rootPath,
 				ID:           "vector-test_0",
 				MakeCommitLoggerThunk: func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
@@ -980,7 +978,6 @@ func TestDynamicStoreMigrationBug(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		dynamic, err := New(Config{
-			TargetVector:          "target_" + strconv.Itoa(i),
 			RootPath:              rootPath,
 			ID:                    helpers.VectorIndexIDForTarget("target_" + strconv.Itoa(i)),
 			AllocChecker:          memwatch.NewDummyMonitor(),
@@ -1052,7 +1049,6 @@ func TestDynamicStoreMigrationBug(t *testing.T) {
 	// open them again to ensure the state is correct
 	for i := 0; i < 5; i++ {
 		dynamic, err := New(Config{
-			TargetVector:          "target_" + strconv.Itoa(i),
 			RootPath:              rootPath,
 			ID:                    helpers.VectorIndexIDForTarget("target_" + strconv.Itoa(i)),
 			AllocChecker:          memwatch.NewDummyMonitor(),
@@ -1117,7 +1113,6 @@ func TestDynamicStoreMigrationBug(t *testing.T) {
 	// in this scenario, we must not lose the upgraded state
 	for i := 0; i < 5; i++ {
 		dynamic, err := New(Config{
-			TargetVector:          "target_" + strconv.Itoa(i),
 			RootPath:              rootPath,
 			ID:                    helpers.VectorIndexIDForTarget("target_" + strconv.Itoa(i)),
 			AllocChecker:          memwatch.NewDummyMonitor(),
@@ -1315,7 +1310,7 @@ func TestDynamicStaleCommitLogCleanedOnRestart(t *testing.T) {
 // newUpgradeTestDynamic builds a dynamic index for tests around the
 // flat->HNSW upgrade path. The caller controls the commit logger thunk so
 // tests can observe the on-disk HNSW commit log directory.
-func newUpgradeTestDynamic(t *testing.T, rootPath, id, targetVector string,
+func newUpgradeTestDynamic(t *testing.T, rootPath, id string,
 	meta *shardmeta.DB, vectors [][]float32, thunk hnsw.MakeCommitLogger,
 ) *dynamic {
 	t.Helper()
@@ -1334,7 +1329,6 @@ func newUpgradeTestDynamic(t *testing.T, rootPath, id, targetVector string,
 		AllocChecker:          memwatch.NewDummyMonitor(),
 		RootPath:              rootPath,
 		ID:                    id,
-		TargetVector:          targetVector,
 		MakeCommitLoggerThunk: thunk,
 		DistanceProvider:      distancer,
 		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
@@ -1378,7 +1372,7 @@ func TestDynamicCopyToVectorIndexPropagatesAddBatchError(t *testing.T) {
 	})
 
 	vectors, _ := testinghelpers.RandomVecs(100, 0, 8)
-	idx := newUpgradeTestDynamic(t, t.TempDir(), "copy-err-test", "", meta, vectors, hnsw.MakeNoopCommitLogger)
+	idx := newUpgradeTestDynamic(t, t.TempDir(), "copy-err-test", meta, vectors, hnsw.MakeNoopCommitLogger)
 
 	for i := range vectors {
 		require.NoError(t, idx.Add(ctx, uint64(i), vectors[i]))
@@ -1401,7 +1395,7 @@ func TestDynamicAbortedUpgradeCleansPartialCommitLog(t *testing.T) {
 	})
 
 	vectors, _ := testinghelpers.RandomVecs(1_000, 0, 20)
-	idx := newUpgradeTestDynamic(t, rootPath, id, "", meta, vectors, func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
+	idx := newUpgradeTestDynamic(t, rootPath, id, meta, vectors, func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
 		return hnsw.NewCommitLogger(rootPath, id, logger, cyclemanager.NewCallbackGroupNoop())
 	})
 
@@ -1444,7 +1438,7 @@ func TestDynamicUpgradeStatePersistFailureCleansPartialCommitLog(t *testing.T) {
 	require.NoError(t, err)
 
 	vectors, _ := testinghelpers.RandomVecs(200, 0, 8)
-	idx := newUpgradeTestDynamic(t, rootPath, id, "", meta, vectors, func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
+	idx := newUpgradeTestDynamic(t, rootPath, id, meta, vectors, func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
 		return hnsw.NewCommitLogger(rootPath, id, logger, cyclemanager.NewCallbackGroupNoop())
 	})
 	t.Cleanup(func() {
@@ -1553,7 +1547,7 @@ func TestDynamicStaleCommitLogCleanedOnInit(t *testing.T) {
 			}
 
 			vectors, _ := testinghelpers.RandomVecs(10, 0, 8)
-			idx := newUpgradeTestDynamic(t, rootPath, id, tt.targetVector, meta, vectors, hnsw.MakeNoopCommitLogger)
+			idx := newUpgradeTestDynamic(t, rootPath, id, meta, vectors, hnsw.MakeNoopCommitLogger)
 			t.Cleanup(func() {
 				idx.Shutdown(context.Background())
 			})
@@ -1568,15 +1562,12 @@ func TestDynamicStaleCommitLogCleanedOnInit(t *testing.T) {
 	}
 }
 
-// TestStorageNamesDeriveFromID pins that the buckets and the state key
-// derive from the physical ID, never from the logical target vector. The
-// mismatched case is the regression: canonical pairs would pass even if a
-// name silently reverted to deriving from the target vector.
+// TestStorageNamesDeriveFromID pins the buckets and the state key for the
+// two shipped ID shapes; the index has no other name to derive them from.
 func TestStorageNamesDeriveFromID(t *testing.T) {
 	tests := []struct {
 		name           string
 		id             string
-		targetVector   string
 		wantBucket     string
 		wantCompressed string
 		wantStateKey   string
@@ -1589,20 +1580,11 @@ func TestStorageNamesDeriveFromID(t *testing.T) {
 			wantStateKey:   "upgraded",
 		},
 		{
-			name:           "named canonical",
+			name:           "named",
 			id:             "vectors_title",
-			targetVector:   "title",
 			wantBucket:     "vectors_title",
 			wantCompressed: "vectors_compressed_title",
 			wantStateKey:   "upgraded_title",
-		},
-		{
-			name:           "id and target vector differ",
-			id:             "vectors_physical",
-			targetVector:   "logical",
-			wantBucket:     "vectors_physical",
-			wantCompressed: "vectors_compressed_physical",
-			wantStateKey:   "upgraded_physical",
 		},
 	}
 	for _, tt := range tests {
@@ -1612,7 +1594,7 @@ func TestStorageNamesDeriveFromID(t *testing.T) {
 			t.Cleanup(func() { meta.Close() })
 
 			vectors, _ := testinghelpers.RandomVecs(10, 0, 4)
-			idx := newUpgradeTestDynamic(t, t.TempDir(), tt.id, tt.targetVector, meta, vectors, hnsw.MakeNoopCommitLogger)
+			idx := newUpgradeTestDynamic(t, t.TempDir(), tt.id, meta, vectors, hnsw.MakeNoopCommitLogger)
 			t.Cleanup(func() { idx.Shutdown(context.Background()) })
 
 			assert.Equal(t, tt.wantBucket, idx.getBucketName())

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -1481,8 +1481,6 @@ func TestDynamicUpgradeStatePersistFailureCleansPartialCommitLog(t *testing.T) {
 // unless the vector is positively marked as upgraded — otherwise the partial
 // state gets replayed into the rebuilt index.
 func TestDynamicStaleCommitLogCleanedOnInit(t *testing.T) {
-	const id = "stale-commitlog-test"
-
 	tests := []struct {
 		name         string
 		targetVector string
@@ -1532,6 +1530,7 @@ func TestDynamicStaleCommitLogCleanedOnInit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rootPath := t.TempDir()
+			id := helpers.VectorIndexIDForTarget(tt.targetVector)
 
 			meta, err := shardmeta.Open(t.TempDir(), time.Second)
 			require.NoError(t, err)
@@ -1565,6 +1564,61 @@ func TestDynamicStaleCommitLogCleanedOnInit(t *testing.T) {
 			} else {
 				require.True(t, os.IsNotExist(err), "stale commit log dir should have been removed")
 			}
+		})
+	}
+}
+
+// TestStorageNamesDeriveFromID pins that the buckets and the state key
+// derive from the physical ID, never from the logical target vector. The
+// mismatched case is the regression: canonical pairs would pass even if a
+// name silently reverted to deriving from the target vector.
+func TestStorageNamesDeriveFromID(t *testing.T) {
+	tests := []struct {
+		name           string
+		id             string
+		targetVector   string
+		wantBucket     string
+		wantCompressed string
+		wantStateKey   string
+	}{
+		{
+			name:           "legacy",
+			id:             "main",
+			wantBucket:     "vectors",
+			wantCompressed: "vectors_compressed",
+			wantStateKey:   "upgraded",
+		},
+		{
+			name:           "named canonical",
+			id:             "vectors_title",
+			targetVector:   "title",
+			wantBucket:     "vectors_title",
+			wantCompressed: "vectors_compressed_title",
+			wantStateKey:   "upgraded_title",
+		},
+		{
+			name:           "id and target vector differ",
+			id:             "vectors_physical",
+			targetVector:   "logical",
+			wantBucket:     "vectors_physical",
+			wantCompressed: "vectors_compressed_physical",
+			wantStateKey:   "upgraded_physical",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta, err := shardmeta.Open(t.TempDir(), time.Second)
+			require.NoError(t, err)
+			t.Cleanup(func() { meta.Close() })
+
+			vectors, _ := testinghelpers.RandomVecs(10, 0, 4)
+			idx := newUpgradeTestDynamic(t, t.TempDir(), tt.id, tt.targetVector, meta, vectors, hnsw.MakeNoopCommitLogger)
+			t.Cleanup(func() { idx.Shutdown(context.Background()) })
+
+			assert.Equal(t, tt.wantBucket, idx.getBucketName())
+			assert.Equal(t, tt.wantCompressed, idx.getCompressedBucketName())
+			assert.Equal(t, []byte(tt.wantStateKey), idx.dbKey())
+			assert.Equal(t, []byte(tt.wantStateKey), dbKeyForID(tt.id))
 		})
 	}
 }

--- a/adapters/repos/db/vector/dynamic/remove_state_key_test.go
+++ b/adapters/repos/db/vector/dynamic/remove_state_key_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	bbolt "go.etcd.io/bbolt"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 )
 
@@ -36,7 +37,7 @@ func writeVerdicts(t *testing.T, rootPath string, targets ...string) {
 			return err
 		}
 		for _, target := range targets {
-			if err := b.Put(dbKey(target), []byte{1}); err != nil {
+			if err := b.Put(dbKeyForID(helpers.VectorIndexIDForTarget(target)), []byte{1}); err != nil {
 				return err
 			}
 		}
@@ -46,7 +47,7 @@ func writeVerdicts(t *testing.T, rootPath string, targets ...string) {
 
 func hasVerdict(t *testing.T, rootPath, target string) bool {
 	t.Helper()
-	upgraded, err := UpgradedOnDisk(rootPath, "vectors_"+target, target)
+	upgraded, err := UpgradedOnDisk(rootPath, helpers.VectorIndexIDForTarget(target))
 	require.NoError(t, err)
 	return upgraded
 }

--- a/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_legacy_integration_test.go
@@ -74,7 +74,6 @@ func TestRestoreUpgradedLegacyDynamic(t *testing.T) {
 			AllocChecker:     memwatch.NewDummyMonitor(),
 			RootPath:         root,
 			ID:               indexID,
-			TargetVector:     "", // legacy / default vector — the bug's trigger
 			Logger:           logger,
 			DistanceProvider: dp,
 			MakeCommitLoggerThunk: func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {

--- a/adapters/repos/db/vector/dynamic/upgrade_state_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_state_test.go
@@ -169,7 +169,7 @@ func TestUpgradedOnDisk(t *testing.T) {
 			}
 			setUpStateDB(t, rootPath, tt.db, tt.storedKey, tt.storedValue)
 
-			upgraded, err := UpgradedOnDisk(rootPath, id, tt.targetVector)
+			upgraded, err := UpgradedOnDisk(rootPath, id)
 			if tt.wantErr {
 				require.Error(t, err)
 			} else {


### PR DESCRIPTION
### What's being changed:

Second per-index PR of the logical-to-physical vector index mapping RFC (context: #12881, #12919; helpers + flat: #12924; layout pin: #12923). **Stacked on #12924**, so its diff shows up here until that one merges.

Dynamic now names everything it stores from its **physical ID** (`cfg.ID`: `main` for the legacy vector, `vectors_<name>` for a named vector), the way its inner flat does since #12924:

- the raw and compressed buckets come from `VectorsBucketNameForID` / `CompressedBucketNameForID`;
- the upgrade-verdict key in the shard's `index.db` comes from `dbKeyForID` (bare `upgraded` for `main`, `upgraded_<suffix>` for `vectors_<suffix>`), and the no-state-key migration branch in `init` keys off the ID too;
- `UpgradedOnDisk` no longer takes the target vector; `RemoveStateKey` keeps taking it (the drop path only knows the logical name) and derives the canonical ID itself.

Dynamic's `TargetVector` config field is gone: its inner flat no longer takes it and the two state-key error messages name the physical ID, so nothing read it; the shard stops passing it.

Tests: `TestStorageNamesDeriveFromID` pins the buckets and the state key for the legacy, canonical named, and a deliberately mismatched ID/target-vector pair, the case that would still pass if any name reverted to the target vector. The stale-commit-log fixture pairs its ID with its target vector the way the shard does; with ID-based derivation its fixed non-canonical ID read as the legacy vector.

**No byte on disk changes.** For the canonical pairs the shard always builds, every produced string and key is byte-identical; the golden table in #12924, dynamic's unmodified state-key tests, and #12923's layout pin guard it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

