### PR TITLE
perf(asyncrep): prune the scheduler due-count scan via the heap invariant

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -182,6 +182,21 @@ func (h *asyncSchedulerHeap) Pop() any {
 	return e
 }
 
+// countDue counts entries due at now, capped at limit; heap order (parent <= child) prunes non-due subtrees.
+func (h asyncSchedulerHeap) countDue(now time.Time, limit int) int {
+	return h.countDueFrom(0, now, limit)
+}
+
+func (h asyncSchedulerHeap) countDueFrom(i int, now time.Time, limit int) int {
+	if limit <= 0 || i >= len(h) || h[i].nextRunAt.After(now) {
+		return 0
+	}
+	n := 1
+	n += h.countDueFrom(2*i+1, now, limit-n)
+	n += h.countDueFrom(2*i+2, now, limit-n)
+	return n
+}
+
 // asyncSchedulerResult carries the outcome of a single runHashbeatCycle call
 // back to the dispatcher goroutine.
 type asyncSchedulerResult struct {
@@ -1177,15 +1192,7 @@ func (sched *AsyncReplicationScheduler) coalesceElapsedLocked(now time.Time) boo
 	if !head.nextRunAt.After(now.Add(-prefilterCoalesceWindow)) {
 		return true
 	}
-	due := 0
-	for _, e := range sched.h {
-		if !e.nextRunAt.After(now) {
-			if due++; due >= batch {
-				return true
-			}
-		}
-	}
-	return false
+	return sched.h.countDue(now, batch) >= batch
 }
 
 // onResultLocked re-enqueues a shard after a cycle completes (or discards

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -2716,6 +2717,140 @@ func TestDispatchDueCoalescing(t *testing.T) {
 		}
 	})
 }
+
+func TestHeapCountDue(t *testing.T) {
+	now := time.Now()
+	ms := time.Millisecond
+	mkHeap := func(offsets ...time.Duration) asyncSchedulerHeap {
+		h := make(asyncSchedulerHeap, 0, len(offsets))
+		for i, off := range offsets {
+			h = append(h, &asyncSchedulerEntry{nextRunAt: now.Add(off), seq: uint64(i)})
+		}
+		heap.Init(&h)
+		return h
+	}
+
+	tests := []struct {
+		name  string
+		h     asyncSchedulerHeap
+		limit int
+		want  int
+	}{
+		{"empty heap", mkHeap(), 4, 0},
+		{"single due", mkHeap(-ms), 4, 1},
+		{"single future", mkHeap(ms), 4, 0},
+		{"due at exactly now", mkHeap(0), 4, 1},
+		{"due below limit", mkHeap(-3*ms, -2*ms, ms, 2*ms), 4, 2},
+		{"due exactly at limit", mkHeap(-3*ms, -2*ms, -ms, ms), 3, 3},
+		{"due above limit caps at limit", mkHeap(-5*ms, -4*ms, -3*ms, -2*ms, -ms), 2, 2},
+		{"all due under limit", mkHeap(-4*ms, -3*ms, -2*ms, -ms), 10, 4},
+		{"limit zero", mkHeap(-ms), 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.h.countDue(now, tt.limit))
+		})
+	}
+}
+
+func TestHeapCountDueMatchesNaiveScan(t *testing.T) {
+	now := time.Now()
+	rng := rand.New(rand.NewPCG(7, 13))
+	for _, size := range []int{1, 2, 7, 100, 5000} {
+		for _, density := range []float64{0, 0.002, 0.05, 0.5, 1} {
+			for _, limit := range []int{1, 2, 128} {
+				h := make(asyncSchedulerHeap, 0, size)
+				for i := range size {
+					off := time.Duration(rng.Int64N(int64(time.Second))) + time.Millisecond
+					if rng.Float64() < density {
+						off = -time.Duration(rng.Int64N(int64(time.Second)))
+						if rng.IntN(10) == 0 {
+							off = 0
+						}
+					}
+					h = append(h, &asyncSchedulerEntry{nextRunAt: now.Add(off), seq: uint64(i)})
+				}
+				heap.Init(&h)
+				naive := 0
+				for _, e := range h {
+					if !e.nextRunAt.After(now) {
+						naive++
+					}
+				}
+				assert.Equal(t, min(naive, limit), h.countDue(now, limit),
+					"size=%d density=%v limit=%d", size, density, limit)
+			}
+		}
+	}
+}
+
+func TestCoalesceElapsedLocked(t *testing.T) {
+	now := time.Now()
+	ms := time.Millisecond
+	tests := []struct {
+		name       string
+		batch      int
+		offsets    []time.Duration
+		directHead bool
+		want       bool
+	}{
+		{"empty heap", 4, nil, false, true},
+		{"head not yet due", 4, []time.Duration{time.Minute}, false, true},
+		{"batch size 1 dispatches immediately", 1, []time.Duration{-ms}, false, true},
+		{"fewer than batch due within window", 4, []time.Duration{-2 * ms, -ms, time.Minute}, false, false},
+		{"batch count due fires", 2, []time.Duration{-2 * ms, -ms, time.Minute}, false, true},
+		{"head past window fires", 4, []time.Duration{-2 * prefilterCoalesceWindow}, false, true},
+		{"diverging head fires", 4, []time.Duration{-ms}, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched := newBareScheduler(tt.batch, 1)
+			for i, off := range tt.offsets {
+				sched.h = append(sched.h, &asyncSchedulerEntry{nextRunAt: now.Add(off), seq: uint64(i)})
+			}
+			heap.Init(&sched.h)
+			if tt.directHead {
+				sched.h[0].descendDirect = true
+			}
+			assert.Equal(t, tt.want, sched.coalesceElapsedLocked(now))
+		})
+	}
+}
+
+func BenchmarkCoalesceElapsed(b *testing.B) {
+	now := time.Now()
+	const total, due = 50_000, 50
+	sched := newBareScheduler(128, 1)
+	for i := range total {
+		off := time.Duration(i+1) * time.Second
+		if i < due {
+			off = -time.Duration(i+1) * time.Microsecond
+		}
+		sched.h = append(sched.h, &asyncSchedulerEntry{nextRunAt: now.Add(off), seq: uint64(i)})
+	}
+	heap.Init(&sched.h)
+
+	b.Run("pruned", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			sched.coalesceElapsedLocked(now)
+		}
+	})
+	b.Run("naiveScan", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			n := 0
+			for _, e := range sched.h {
+				if !e.nextRunAt.After(now) {
+					n++
+				}
+			}
+			benchCoalesceSink += n
+		}
+	})
+}
+
+var benchCoalesceSink int
 
 // TestDeferDescentReDispatchesSingletons: a coalesced batch of diverging shards is
 // deferred and re-dispatched as singletons so descent spreads across the pool.

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -2784,6 +2784,55 @@ func TestHeapCountDueMatchesNaiveScan(t *testing.T) {
 	}
 }
 
+// Pins countDue equivalence on heap shapes built by interleaved ops (production surgery), not just heap.Init.
+func TestHeapCountDueInterleavedOps(t *testing.T) {
+	now := time.Now()
+	rng := rand.New(rand.NewPCG(21, 42))
+	var h asyncSchedulerHeap
+	var seq uint64
+
+	randOffset := func() time.Duration {
+		switch rng.IntN(5) {
+		case 0:
+			return 0
+		case 1, 2:
+			return -time.Duration(rng.Int64N(int64(time.Second)))
+		default:
+			return time.Duration(rng.Int64N(int64(time.Second)))
+		}
+	}
+	push := func() {
+		heap.Push(&h, &asyncSchedulerEntry{nextRunAt: now.Add(randOffset()), seq: seq})
+		seq++
+	}
+
+	for i := range 5000 {
+		switch op := rng.IntN(10); {
+		case len(h) == 0 || op < 4:
+			push()
+		case op < 6:
+			heap.Pop(&h)
+		case op < 8:
+			heap.Remove(&h, rng.IntN(len(h)))
+		default:
+			e := heap.Pop(&h).(*asyncSchedulerEntry)
+			e.nextRunAt = now.Add(randOffset())
+			e.seq = seq
+			seq++
+			heap.Push(&h, e)
+		}
+		naive := 0
+		for _, e := range h {
+			if !e.nextRunAt.After(now) {
+				naive++
+			}
+		}
+		for _, limit := range []int{1, 3, 128} {
+			require.Equal(t, min(naive, limit), h.countDue(now, limit), "iter=%d len=%d limit=%d", i, len(h), limit)
+		}
+	}
+}
+
 func TestCoalesceElapsedLocked(t *testing.T) {
 	now := time.Now()
 	ms := time.Millisecond


### PR DESCRIPTION
## Motivation

`coalesceElapsedLocked` decides on essentially every dispatcher wakeup whether due shards should dispatch now or keep accumulating into a cross-class batch. It counted due entries with a linear scan over the entire scheduler heap — one entry per registered shard — while holding `sched.mu`. On a 50k+ tenant cluster, pprof attributed ~3.5% of total CPU to this scan alone, all under the same lock every register/deregister/result path contends on. The existing early exit (stop once `batch` due entries are found) does not help in the common steady state: when fewer than `batch` entries are due, the scan runs to the end.

## Approach

The heap is a min-heap on `nextRunAt`, so parent ≤ child: if a node is not yet due, its entire subtree is not due. The due-count therefore becomes a pruned DFS over the array-embedded heap, capped at `batch` — at most ~`2·batch+1` node visits instead of `len(heap)`, independent of fleet size. No new state, no behavior change; the predicate result is identical to the old scan.

Incremental bookkeeping (a maintained due-counter) was rejected: "due" is a function of the wall clock, not of heap mutations, so a counter cannot stay correct without periodic re-scans — the invariant-based prune gets the same win with zero state.

## Key areas for review

- [`async_replication_scheduler.go:186` (`countDue`/`countDueFrom`)](https://github.com/weaviate/weaviate/blob/bdd97efbf5798b19a4206be3f92324ec5953257c/adapters/repos/db/async_replication_scheduler.go#L186) — the prune and the limit threading: `n` starts at 1 for the counted node and the remaining budget flows through both subtree calls. Recursion only descends into due nodes, so depth is bounded by the count itself.
- [`async_replication_scheduler.go:1195` (`coalesceElapsedLocked`)](https://github.com/weaviate/weaviate/blob/bdd97efbf5798b19a4206be3f92324ec5953257c/adapters/repos/db/async_replication_scheduler.go#L1195) — the call site; verify the boundary semantics (`!After(now)` = due at exactly `now`) match the replaced loop.

## Risks and mitigations

- **A silent miscount would stall coalescing or fire batches early**: pinned by `TestHeapCountDueMatchesNaiveScan`, which cross-checks the pruned count against the naive scan over randomized heaps (sizes 1–5000, due densities 0–100%, limits 1–128), plus boundary tables (due at exactly `now`, limit 0, count capped at limit). `TestHeapCountDueInterleavedOps` extends the cross-check to heap shapes produced by interleaved production-style surgery, not just `heap.Init`.
- **Recursion depth**: bounded by the number of counted due nodes, which is capped at `batch` ≤ `MaxAsyncReplicationRootPrefilterBatchSize` (4096) — trivial stack usage, zero allocations.

## Testing

- `TestHeapCountDue` — table-driven boundary cases (empty heap, exactly-now, limit 0, at/above/below limit).
- `TestHeapCountDueMatchesNaiveScan` — randomized equivalence with the naive linear scan.
- `TestHeapCountDueInterleavedOps` — 5000 iterations of interleaved `Push` / head-`Pop` / arbitrary-index `Remove` / pop-mutate-repush ops (mirroring dispatch, deregister, and re-enqueue), cross-checking against the naive scan after every op.
- `TestCoalesceElapsedLocked` — pins the surrounding predicate: empty heap, head not yet due, batch=1 bypass, sub-batch inside the window holds, full batch fires, head past window fires, diverging head fires.
- `BenchmarkCoalesceElapsed` (50k entries, 50 due, batch 128): ~87µs → ~390ns per call, 0 allocs.
- New and adjacent scheduler tests (`TestDispatchDueCoalescing`, `TestDeferDescentReDispatchesSingletons`, full scheduler test file) pass with `-race`.

No breaking changes.

