### PR TITLE
shard: protect the legacy vector's artifacts when dropping a named vector

### DIFF
--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -103,7 +103,7 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 		// what stops a drop deleting a live vector whose own bucket happens to
 		// share a name with one of this target's artifacts.
 		if err := helper.removeVectorIndexFiles(idx.path(), shardName, target,
-			otherTargetVectors(class, target)); err != nil {
+			siblingVectors(class, target)); err != nil {
 			return err
 		}
 	}

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -197,6 +197,17 @@ func vectorIndexArtifactNames(targetVector string) VectorIndexArtifacts {
 	}
 }
 
+// SiblingVector is a live vector whose artifacts a drop must not touch.
+// Quantized says whether its index can own a compressed bucket at all: only
+// an index with a quantizer configured ever writes one, so protecting it for
+// an uncompressed sibling would leak the raw bucket of a vector whose name
+// collides with it, and a re-created vector of that name would then open
+// stale data.
+type SiblingVector struct {
+	Name      string
+	Quantized bool
+}
+
 // VectorIndexArtifactsFor lists what dropping targetVector has to remove. It is
 // the single source of truth for that set: the live drop, the file sweep and
 // the tests all read it, because three hand-maintained copies is exactly how
@@ -207,23 +218,28 @@ func vectorIndexArtifactNames(targetVector string) VectorIndexArtifacts {
 // back to decide would miss an index that failed to load, or one whose config
 // changed since it was written.
 //
-// otherTargetVectors is not optional. TargetVectorNameRegex permits names like
+// siblings is not optional. TargetVectorNameRegex permits names like
 // "<other>_muvera_vectors" or "<other>_centroids", which make one of THIS
 // target's artifacts byte-identical to a bucket a live sibling owns. Any
-// artifact a sibling claims is therefore dropped from the list: leaking beats
+// artifact a sibling can own is therefore dropped from the list: leaking beats
 // deleting data that is still in use.
-func VectorIndexArtifactsFor(targetVector string, otherTargetVectors []string) VectorIndexArtifacts {
+func VectorIndexArtifactsFor(targetVector string, siblings []SiblingVector) VectorIndexArtifacts {
 	artifacts := vectorIndexArtifactNames(targetVector)
 
 	// Skipping the target itself is what keeps its OWN artifacts in the list,
 	// for a caller that passes the whole schema rather than filtering first.
 	protected := map[string]struct{}{}
-	for _, other := range otherTargetVectors {
-		if other == targetVector {
+	for _, sibling := range siblings {
+		if sibling.Name == targetVector {
 			continue
 		}
-		for _, name := range vectorIndexArtifactNames(other).All() {
+		for _, name := range vectorIndexArtifactNames(sibling.Name).All() {
 			protected[name] = struct{}{}
+		}
+		if !sibling.Quantized {
+			for _, name := range compressedArtifactNames(sibling.Name) {
+				delete(protected, name)
+			}
 		}
 	}
 	if len(protected) == 0 {
@@ -245,6 +261,16 @@ func VectorIndexArtifactsFor(targetVector string, otherTargetVectors []string) V
 	}
 	artifacts.LSMBuckets = keptBuckets
 	return artifacts
+}
+
+// compressedArtifactNames is the subset of vectorIndexArtifactNames that only
+// a quantized index writes: its own compressed bucket and, for hfresh, the
+// centroid graph's.
+func compressedArtifactNames(targetVector string) []string {
+	return []string{
+		GetCompressedBucketName(targetVector),
+		CompressedBucketNameForID(VectorIndexIDForTarget(targetVector) + "_centroids"),
+	}
 }
 
 func GetHNSWCommitLogDirName(targetVector string) string {

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -158,23 +158,27 @@ func (a VectorIndexArtifacts) All() []string {
 // vectorIndexArtifactNames is the raw, unfiltered artifact set for a target
 // vector. Split out from VectorIndexArtifactsFor so the sibling-collision guard
 // can compute what OTHER vectors own without recursing through the filter.
+//
+// Names the indexes key on their physical ID use VectorIndexIDForTarget, which
+// is the raw bucket name for a named vector but "main" for the legacy one:
+// keyed on the bucket name instead, the legacy vector's list named buckets and
+// directories that never exist ("vectors_muvera_vectors", "vectors.hfresh.d")
+// and so protected nothing of what it really owns.
 func vectorIndexArtifactNames(targetVector string) VectorIndexArtifacts {
-	indexID := GetVectorsBucketName(targetVector)
+	indexID := VectorIndexIDForTarget(targetVector)
 	return VectorIndexArtifacts{
 		LSMBuckets: []string{
-			indexID,                               // raw vectors
+			GetVectorsBucketName(targetVector),    // raw vectors
 			GetCompressedBucketName(targetVector), // BQ/PQ/SQ/RQ
 			MuveraBucketName(indexID),             // multivector + muvera
 			MVMappingsBucketName(indexID),         // multivector without muvera
 			HFreshPostingsBucketName(indexID),     // hfresh
 			HFreshSharedBucketName(indexID),       // hfresh
-			// hfresh runs a nested centroids HNSW whose id is
-			// "<indexID>_centroids"; hnsw derives its compressed bucket from
-			// that id with the "vectors_" prefix stripped, so it lands in the
-			// shard's lsm dir under this name. Its commitlog and snapshot dirs
-			// do NOT need listing — they live inside the .hfresh.d directory
-			// below, which goes wholesale.
-			GetCompressedBucketName(targetVector + "_centroids"),
+			// hfresh runs a nested centroids HNSW with the ID "<indexID>_centroids"
+			// whose compressed bucket lands in the shard's lsm dir under the name
+			// that ID yields. Its commitlog and snapshot dirs do NOT need listing —
+			// they live inside the .hfresh.d directory below, which goes wholesale.
+			CompressedBucketNameForID(indexID + "_centroids"),
 		},
 		ShardDirs: []string{
 			GetHNSWCommitLogDirName(targetVector),

--- a/adapters/repos/db/helpers/vector_index_artifacts_test.go
+++ b/adapters/repos/db/helpers/vector_index_artifacts_test.go
@@ -81,7 +81,7 @@ func TestVectorIndexArtifactsFor_NeverTakesASiblingsArtifact(t *testing.T) {
 			require.Contains(t, unguarded.LSMBuckets, tc.clash,
 				"precondition: dropping foo does target this name when no siblings are declared")
 
-			got := VectorIndexArtifactsFor("foo", []string{tc.sibling})
+			got := VectorIndexArtifactsFor("foo", []SiblingVector{{Name: tc.sibling, Quantized: true}})
 			assert.NotContains(t, got.LSMBuckets, tc.clash,
 				"a live sibling's bucket must never be removed")
 
@@ -97,7 +97,7 @@ func TestVectorIndexArtifactsFor_NeverTakesASiblingsArtifact(t *testing.T) {
 // caller passes the target itself in the sibling list, which is easy to do by
 // looping over the whole schema.
 func TestVectorIndexArtifactsFor_KeepsItsOwnPrimaryBucket(t *testing.T) {
-	got := VectorIndexArtifactsFor("vec", []string{"vec", "other"})
+	got := VectorIndexArtifactsFor("vec", []SiblingVector{{Name: "vec", Quantized: true}, {Name: "other", Quantized: true}})
 	assert.Contains(t, got.LSMBuckets, "vectors_vec",
 		"the dropped vector's own bucket must still be removed")
 	assert.Contains(t, got.LSMBuckets, "vectors_vec_mv_mappings")
@@ -114,7 +114,7 @@ func TestVectorIndexArtifactsFor_UnrelatedSiblingsChangeNothing(t *testing.T) {
 	require.NotEmpty(t, plain.LSMBuckets)
 	require.NotEmpty(t, plain.ShardDirs)
 
-	withSiblings := VectorIndexArtifactsFor("vec", []string{"vec2", "other", "vec_extra"})
+	withSiblings := VectorIndexArtifactsFor("vec", []SiblingVector{{Name: "vec2", Quantized: true}, {Name: "other"}, {Name: "vec_extra", Quantized: true}})
 	assert.Equal(t, plain.LSMBuckets, withSiblings.LSMBuckets)
 	assert.Equal(t, plain.ShardDirs, withSiblings.ShardDirs)
 }
@@ -153,7 +153,7 @@ func TestVectorIndexArtifactsFor_LegacyVectorNamesWhatItOwns(t *testing.T) {
 func TestVectorIndexArtifactsFor_NeverTakesTheLegacyVectorsArtifact(t *testing.T) {
 	// A named vector called "compressed" owns raw bucket "vectors_compressed",
 	// byte-identical to the legacy vector's quantized bucket.
-	got := VectorIndexArtifactsFor("compressed", []string{""})
+	got := VectorIndexArtifactsFor("compressed", []SiblingVector{{Name: "", Quantized: true}})
 	assert.NotContains(t, got.LSMBuckets, "vectors_compressed",
 		"the legacy vector's quantized bucket must survive dropping a named vector called compressed")
 	assert.Contains(t, got.LSMBuckets, "vectors_compressed_compressed",
@@ -163,8 +163,64 @@ func TestVectorIndexArtifactsFor_NeverTakesTheLegacyVectorsArtifact(t *testing.T
 	// raw bucket: leaking it would hand a re-created vector of the same name
 	// stale data.
 	for _, name := range []string{"muvera_vectors", "mv_mappings", "compressed_centroids"} {
-		got := VectorIndexArtifactsFor(name, []string{""})
+		got := VectorIndexArtifactsFor(name, []SiblingVector{{Name: "", Quantized: true}})
 		assert.Contains(t, got.LSMBuckets, "vectors_"+name,
 			"dropping %q next to the legacy vector must still remove its own raw bucket", name)
+	}
+}
+
+// Only a quantized index ever writes a compressed bucket, so an unquantized
+// sibling must not protect one: the raw bucket of a vector whose name
+// collides with it would leak into a re-created vector of that name.
+func TestVectorIndexArtifactsFor_ProtectsOnlyWhatASiblingCanOwn(t *testing.T) {
+	tests := []struct {
+		name      string
+		target    string
+		sibling   SiblingVector
+		bucket    string // the target's artifact that collides with the sibling's
+		protected bool
+	}{
+		{
+			name:    "quantized named sibling keeps its compressed bucket",
+			target:  "compressed_x",
+			sibling: SiblingVector{Name: "x", Quantized: true},
+			bucket:  "vectors_compressed_x", protected: true,
+		},
+		{
+			name:    "unquantized named sibling never wrote a compressed bucket",
+			target:  "compressed_x",
+			sibling: SiblingVector{Name: "x"},
+			bucket:  "vectors_compressed_x", protected: false,
+		},
+		{
+			name:    "quantized legacy sibling keeps its compressed bucket",
+			target:  "compressed",
+			sibling: SiblingVector{Name: "", Quantized: true},
+			bucket:  "vectors_compressed", protected: true,
+		},
+		{
+			name:    "unquantized legacy sibling never wrote a compressed bucket",
+			target:  "compressed",
+			sibling: SiblingVector{Name: ""},
+			bucket:  "vectors_compressed", protected: false,
+		},
+		{
+			name:    "a raw bucket is protected whatever the sibling's compression",
+			target:  "foo",
+			sibling: SiblingVector{Name: "foo_muvera_vectors"},
+			bucket:  "vectors_foo_muvera_vectors", protected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Contains(t, VectorIndexArtifactsFor(tt.target, nil).LSMBuckets, tt.bucket,
+				"precondition: dropping %s targets %s when nothing is protected", tt.target, tt.bucket)
+			got := VectorIndexArtifactsFor(tt.target, []SiblingVector{tt.sibling})
+			if tt.protected {
+				assert.NotContains(t, got.LSMBuckets, tt.bucket)
+			} else {
+				assert.Contains(t, got.LSMBuckets, tt.bucket)
+			}
+		})
 	}
 }

--- a/adapters/repos/db/helpers/vector_index_artifacts_test.go
+++ b/adapters/repos/db/helpers/vector_index_artifacts_test.go
@@ -118,3 +118,53 @@ func TestVectorIndexArtifactsFor_UnrelatedSiblingsChangeNothing(t *testing.T) {
 	assert.Equal(t, plain.LSMBuckets, withSiblings.LSMBuckets)
 	assert.Equal(t, plain.ShardDirs, withSiblings.ShardDirs)
 }
+
+// The legacy vector's list is only ever used for protection (it cannot be
+// dropped), so it has to name what the legacy index really writes: its ID is
+// "main", not its raw bucket name "vectors".
+func TestVectorIndexArtifactsFor_LegacyVectorNamesWhatItOwns(t *testing.T) {
+	got := VectorIndexArtifactsFor("", nil)
+
+	assert.Subset(t, got.LSMBuckets, []string{
+		"vectors",              // raw vectors
+		"vectors_compressed",   // BQ/PQ/SQ/RQ, and the centroid HNSW of a legacy hfresh
+		"main_muvera_vectors",  // multivector + muvera
+		"main_mv_mappings",     // multivector without muvera
+		"hfresh_postings_main", // hfresh postings
+		"hfresh_shared_main",   // hfresh shared metadata
+	})
+	assert.ElementsMatch(t, []string{
+		"main.hnsw.commitlog.d",
+		"main.hnsw.snapshot.d",
+		"main.hfresh.d",
+		"main.queue.d",
+		"meta.db",
+	}, got.ShardDirs)
+
+	for _, never := range []string{
+		"vectors_muvera_vectors", "vectors_mv_mappings", "hfresh_postings_vectors",
+		"hfresh_shared_vectors", "vectors_compressed__centroids",
+		"vectors.hfresh.d", "vectors.queue.d",
+	} {
+		assert.NotContains(t, got.All(), never, "no legacy index ever writes %q", never)
+	}
+}
+
+func TestVectorIndexArtifactsFor_NeverTakesTheLegacyVectorsArtifact(t *testing.T) {
+	// A named vector called "compressed" owns raw bucket "vectors_compressed",
+	// byte-identical to the legacy vector's quantized bucket.
+	got := VectorIndexArtifactsFor("compressed", []string{""})
+	assert.NotContains(t, got.LSMBuckets, "vectors_compressed",
+		"the legacy vector's quantized bucket must survive dropping a named vector called compressed")
+	assert.Contains(t, got.LSMBuckets, "vectors_compressed_compressed",
+		"the dropped vector's own quantized bucket still goes")
+
+	// Names that only collided with the misnamed legacy list keep their own
+	// raw bucket: leaking it would hand a re-created vector of the same name
+	// stale data.
+	for _, name := range []string{"muvera_vectors", "mv_mappings", "compressed_centroids"} {
+		got := VectorIndexArtifactsFor(name, []string{""})
+		assert.Contains(t, got.LSMBuckets, "vectors_"+name,
+			"dropping %q next to the legacy vector must still remove its own raw bucket", name)
+	}
+}

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -20,6 +20,10 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
+	"github.com/weaviate/weaviate/entities/vectorindex"
+	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 type vectorDropIndexHelper struct{}
@@ -41,7 +45,7 @@ func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
 			continue
 		}
 		if err := h.removeVectorIndexFiles(indexPath, shardName, name,
-			otherTargetVectors(class, name)); err != nil {
+			siblingVectors(class, name)); err != nil {
 			return fmt.Errorf("failed to remove dropped vector index %q files for class %s: %w",
 				name, class.Class, err)
 		}
@@ -51,16 +55,16 @@ func (h *vectorDropIndexHelper) ensureFilesAreRemovedForDroppedVectorIndexes(
 
 // removeVectorIndexFiles removes every on-disk artifact of a named vector index
 // (see helpers.VectorIndexArtifactsFor for the set and why it is centralised).
-// otherTargetVectors are the collection's remaining vector names, needed so a
-// sibling whose own bucket collides with one of this target's artifact names is
-// not deleted along with it.
+// siblings are the collection's remaining vectors, needed so a sibling whose
+// own bucket collides with one of this target's artifact names is not deleted
+// along with it.
 func (h *vectorDropIndexHelper) removeVectorIndexFiles(
-	indexPath, shardName, targetVector string, otherTargetVectors []string,
+	indexPath, shardName, targetVector string, siblings []helpers.SiblingVector,
 ) error {
 	lsmDir := filepath.Join(indexPath, shardName, "lsm")
 	shardDir := filepath.Join(indexPath, shardName)
 
-	artifacts := helpers.VectorIndexArtifactsFor(targetVector, otherTargetVectors)
+	artifacts := helpers.VectorIndexArtifactsFor(targetVector, siblings)
 
 	var dirs []string
 	for _, bucket := range artifacts.LSMBuckets {
@@ -91,9 +95,9 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 	return nil
 }
 
-// otherTargetVectors lists the collection's vector names except `exclude` —
-// the siblings whose artifacts a drop must not touch. Every artifact a sibling
-// owns is protected, not just its primary bucket.
+// siblingVectors lists the collection's vectors except `exclude` — the
+// siblings whose artifacts a drop must not touch — each marked with whether
+// its index can own a compressed bucket.
 //
 // The legacy vector ("") is a sibling too, although it never appears in
 // VectorConfig: a class that gained named vectors next to its legacy one can
@@ -101,20 +105,57 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 // one called "compressed" owns the raw bucket "vectors_compressed", which is
 // the legacy vector's quantized bucket. Left out, the legacy vector's data
 // went with such a drop.
-func otherTargetVectors(class *models.Class, exclude string) []string {
+func siblingVectors(class *models.Class, exclude string) []helpers.SiblingVector {
 	if class == nil {
 		// Nothing to protect, so the drop runs unfiltered: a name collision
 		// with a live sibling takes that sibling's bucket with it.
 		return nil
 	}
-	others := make([]string, 0, len(class.VectorConfig)+1)
+	siblings := make([]helpers.SiblingVector, 0, len(class.VectorConfig)+1)
 	if exclude != "" && modelsext.ClassHasLegacyVectorIndex(class) {
-		others = append(others, "")
+		siblings = append(siblings, helpers.SiblingVector{
+			Quantized: canOwnCompressedBucket(class.VectorIndexType, class.VectorIndexConfig),
+		})
 	}
-	for name := range class.VectorConfig {
+	for name, cfg := range class.VectorConfig {
 		if name != exclude {
-			others = append(others, name)
+			siblings = append(siblings, helpers.SiblingVector{
+				Name:      name,
+				Quantized: canOwnCompressedBucket(cfg.VectorIndexType, cfg.VectorIndexConfig),
+			})
 		}
 	}
-	return others
+	return siblings
+}
+
+// canOwnCompressedBucket reports whether an index with this configuration can
+// have written a compressed bucket: hnsw, flat and dynamic only with a
+// quantizer enabled (compression cannot be switched off again, so a config
+// without one means the bucket was never written), hfresh always, through its
+// centroid graph. A configuration this cannot read is treated as quantized:
+// leaking beats deleting.
+func canOwnCompressedBucket(indexType string, cfg interface{}) bool {
+	switch indexType {
+	case vectorindex.VectorIndexTypeHNSW:
+		if uc, ok := cfg.(hnswent.UserConfig); ok {
+			return hnswQuantized(uc)
+		}
+	case vectorindex.VectorIndexTypeFLAT:
+		if uc, ok := cfg.(flatent.UserConfig); ok {
+			return flatQuantized(uc)
+		}
+	case vectorindex.VectorIndexTypeDYNAMIC:
+		if uc, ok := cfg.(dynamicent.UserConfig); ok {
+			return flatQuantized(uc.FlatUC) || hnswQuantized(uc.HnswUC)
+		}
+	}
+	return true
+}
+
+func hnswQuantized(uc hnswent.UserConfig) bool {
+	return uc.PQ.Enabled || uc.BQ.Enabled || uc.SQ.Enabled || uc.RQ.Enabled
+}
+
+func flatQuantized(uc flatent.UserConfig) bool {
+	return uc.PQ.Enabled || uc.BQ.Enabled || uc.SQ.Enabled || uc.RQ.Enabled
 }

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -94,13 +94,23 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 // otherTargetVectors lists the collection's vector names except `exclude` —
 // the siblings whose artifacts a drop must not touch. Every artifact a sibling
 // owns is protected, not just its primary bucket.
+//
+// The legacy vector ("") is a sibling too, although it never appears in
+// VectorConfig: a class that gained named vectors next to its legacy one can
+// hold a named vector whose artifacts collide with the legacy vector's, e.g.
+// one called "compressed" owns the raw bucket "vectors_compressed", which is
+// the legacy vector's quantized bucket. Left out, the legacy vector's data
+// went with such a drop.
 func otherTargetVectors(class *models.Class, exclude string) []string {
 	if class == nil {
 		// Nothing to protect, so the drop runs unfiltered: a name collision
 		// with a live sibling takes that sibling's bucket with it.
 		return nil
 	}
-	others := make([]string, 0, len(class.VectorConfig))
+	others := make([]string, 0, len(class.VectorConfig)+1)
+	if exclude != "" && modelsext.ClassHasLegacyVectorIndex(class) {
+		others = append(others, "")
+	}
 	for name := range class.VectorConfig {
 		if name != exclude {
 			others = append(others, name)

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -343,3 +343,117 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 		require.NoError(t, err)
 	})
 }
+
+func TestOtherTargetVectors(t *testing.T) {
+	named := map[string]models.VectorConfig{
+		"a": {VectorIndexType: "hnsw"},
+		"b": {VectorIndexType: "flat"},
+	}
+	tests := []struct {
+		name    string
+		class   *models.Class
+		exclude string
+		want    []string
+	}{
+		{name: "nil class protects nothing", class: nil, exclude: "a", want: nil},
+		{
+			name:    "named vectors only",
+			class:   &models.Class{VectorConfig: named},
+			exclude: "a",
+			want:    []string{"b"},
+		},
+		{
+			name:    "legacy vector next to named vectors is a sibling",
+			class:   &models.Class{VectorIndexType: "hnsw", VectorConfig: named},
+			exclude: "a",
+			want:    []string{"", "b"},
+		},
+		{
+			name:    "the legacy vector is never its own sibling",
+			class:   &models.Class{VectorIndexType: "hnsw", VectorConfig: named},
+			exclude: "",
+			want:    []string{"a", "b"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tt.want, otherTargetVectors(tt.class, tt.exclude))
+		})
+	}
+}
+
+// TestVectorDropIndexHelper_SweepSparesTheLegacyVector pins the data-loss
+// journey: a class with a legacy vector gains a named vector whose artifacts
+// collide with the legacy vector's, then drops it. The sweep must take only
+// what the named vector owns.
+func TestVectorDropIndexHelper_SweepSparesTheLegacyVector(t *testing.T) {
+	h := newVectorDropIndexHelper()
+
+	mixedClass := func(dropped string) *models.Class {
+		return &models.Class{
+			Class:           "Mixed",
+			VectorIndexType: "hnsw",
+			VectorConfig: map[string]models.VectorConfig{
+				dropped: {VectorIndexType: vectorindex.VectorIndexTypeNone},
+			},
+		}
+	}
+	pathExists := func(p string) bool {
+		_, err := os.Stat(p)
+		return err == nil
+	}
+	mkdirs := func(t *testing.T, base string, names ...string) []string {
+		t.Helper()
+		paths := make([]string, 0, len(names))
+		for _, name := range names {
+			p := filepath.Join(base, name)
+			require.NoError(t, os.MkdirAll(p, 0o755))
+			require.NoError(t, os.WriteFile(filepath.Join(p, "segment.db"), []byte("live"), 0o644))
+			paths = append(paths, p)
+		}
+		return paths
+	}
+
+	tests := []struct {
+		name       string
+		dropped    string
+		legacyLSM  []string // buckets the legacy index owns that must survive
+		droppedLSM []string // buckets the dropped vector owns that must go
+	}{
+		{
+			// "vectors_compressed" is both the named vector's raw bucket and
+			// the legacy vector's quantized bucket: it stays, the rest goes
+			name:       "named vector called compressed",
+			dropped:    "compressed",
+			legacyLSM:  []string{"vectors", "vectors_compressed"},
+			droppedLSM: []string{"vectors_compressed_compressed"},
+		},
+		{
+			// no real collision: the legacy muvera bucket is main_muvera_vectors
+			name:       "named vector called muvera_vectors",
+			dropped:    "muvera_vectors",
+			legacyLSM:  []string{"vectors", "vectors_compressed", "main_muvera_vectors"},
+			droppedLSM: []string{"vectors_muvera_vectors", "vectors_compressed_muvera_vectors"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			indexPath, shardName := t.TempDir(), "shard1"
+			lsm := filepath.Join(indexPath, shardName, "lsm")
+			legacy := mkdirs(t, lsm, tt.legacyLSM...)
+			legacy = append(legacy, mkdirs(t, filepath.Join(indexPath, shardName), "main.hnsw.commitlog.d", "main.queue.d")...)
+			gone := mkdirs(t, lsm, tt.droppedLSM...)
+			gone = append(gone, mkdirs(t, filepath.Join(indexPath, shardName),
+				"vectors_"+tt.dropped+".hnsw.commitlog.d", "vectors_"+tt.dropped+".queue.d")...)
+
+			require.NoError(t, h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, mixedClass(tt.dropped)))
+
+			for _, p := range legacy {
+				assert.True(t, pathExists(p), "%s belongs to the legacy vector and must survive", p)
+			}
+			for _, p := range gone {
+				assert.False(t, pathExists(p), "%s belongs to the dropped vector and must go", p)
+			}
+		})
+	}
+}

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -22,6 +22,10 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/vectorindex"
+	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	hfreshent "github.com/weaviate/weaviate/entities/vectorindex/hfresh"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
 func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
@@ -138,7 +142,7 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 			require.NoError(t, os.WriteFile(filepath.Join(siblingBucket, "segment.db"), []byte("live"), 0o644))
 			require.NoError(t, os.MkdirAll(ownBucket, 0o755))
 
-			require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, dropped, []string{sibling}))
+			require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, dropped, []helpers.SiblingVector{{Name: sibling}}))
 
 			assert.True(t, pathExists(siblingBucket),
 				"%s is %s's live vectors bucket and must survive dropping %s",
@@ -344,40 +348,74 @@ func TestVectorDropIndexHelper_EnsureFilesAreRemovedForDroppedVectorIndexes(t *t
 	})
 }
 
-func TestOtherTargetVectors(t *testing.T) {
+func TestSiblingVectors(t *testing.T) {
+	bq := hnswent.UserConfig{BQ: hnswent.BQConfig{Enabled: true}}
 	named := map[string]models.VectorConfig{
-		"a": {VectorIndexType: "hnsw"},
-		"b": {VectorIndexType: "flat"},
+		"a": {VectorIndexType: "hnsw", VectorIndexConfig: hnswent.UserConfig{}},
+		"b": {VectorIndexType: "flat", VectorIndexConfig: flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}}},
 	}
 	tests := []struct {
 		name    string
 		class   *models.Class
 		exclude string
-		want    []string
+		want    []helpers.SiblingVector
 	}{
 		{name: "nil class protects nothing", class: nil, exclude: "a", want: nil},
 		{
 			name:    "named vectors only",
 			class:   &models.Class{VectorConfig: named},
 			exclude: "a",
-			want:    []string{"b"},
+			want:    []helpers.SiblingVector{{Name: "b", Quantized: true}},
 		},
 		{
 			name:    "legacy vector next to named vectors is a sibling",
-			class:   &models.Class{VectorIndexType: "hnsw", VectorConfig: named},
+			class:   &models.Class{VectorIndexType: "hnsw", VectorIndexConfig: bq, VectorConfig: named},
 			exclude: "a",
-			want:    []string{"", "b"},
+			want:    []helpers.SiblingVector{{Name: "", Quantized: true}, {Name: "b", Quantized: true}},
 		},
 		{
 			name:    "the legacy vector is never its own sibling",
-			class:   &models.Class{VectorIndexType: "hnsw", VectorConfig: named},
+			class:   &models.Class{VectorIndexType: "hnsw", VectorIndexConfig: bq, VectorConfig: named},
 			exclude: "",
-			want:    []string{"a", "b"},
+			want:    []helpers.SiblingVector{{Name: "a"}, {Name: "b", Quantized: true}},
+		},
+		{
+			name:    "an uncompressed legacy hnsw cannot own a compressed bucket",
+			class:   &models.Class{VectorIndexType: "hnsw", VectorIndexConfig: hnswent.UserConfig{}, VectorConfig: named},
+			exclude: "b",
+			want:    []helpers.SiblingVector{{Name: ""}, {Name: "a"}},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.ElementsMatch(t, tt.want, otherTargetVectors(tt.class, tt.exclude))
+			assert.ElementsMatch(t, tt.want, siblingVectors(tt.class, tt.exclude))
+		})
+	}
+}
+
+func TestCanOwnCompressedBucket(t *testing.T) {
+	tests := []struct {
+		name      string
+		indexType string
+		cfg       interface{}
+		want      bool
+	}{
+		{"hnsw without a quantizer", "hnsw", hnswent.UserConfig{}, false},
+		{"hnsw with pq", "hnsw", hnswent.UserConfig{PQ: hnswent.PQConfig{Enabled: true}}, true},
+		{"hnsw with rq", "hnsw", hnswent.UserConfig{RQ: hnswent.RQConfig{Enabled: true}}, true},
+		{"flat without a quantizer", "flat", flatent.UserConfig{}, false},
+		{"flat with rq", "flat", flatent.UserConfig{RQ: flatent.RQUserConfig{Enabled: true}}, true},
+		{"dynamic without a quantizer", "dynamic", dynamicent.UserConfig{}, false},
+		{"dynamic whose hnsw stage has sq", "dynamic", dynamicent.UserConfig{HnswUC: hnswent.UserConfig{SQ: hnswent.SQConfig{Enabled: true}}}, true},
+		{"dynamic whose flat stage has bq", "dynamic", dynamicent.UserConfig{FlatUC: flatent.UserConfig{BQ: flatent.CompressionUserConfig{Enabled: true}}}, true},
+		{"hfresh always runs a quantized centroid graph", "hfresh", hfreshent.UserConfig{}, true},
+		{"unreadable config is treated as quantized", "hnsw", map[string]interface{}{}, true},
+		{"nil config is treated as quantized", "hnsw", nil, true},
+		{"unknown index type is treated as quantized", "none", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, canOwnCompressedBucket(tt.indexType, tt.cfg))
 		})
 	}
 }
@@ -389,15 +427,17 @@ func TestOtherTargetVectors(t *testing.T) {
 func TestVectorDropIndexHelper_SweepSparesTheLegacyVector(t *testing.T) {
 	h := newVectorDropIndexHelper()
 
-	mixedClass := func(dropped string) *models.Class {
+	mixedClass := func(dropped string, legacyConfig hnswent.UserConfig) *models.Class {
 		return &models.Class{
-			Class:           "Mixed",
-			VectorIndexType: "hnsw",
+			Class:             "Mixed",
+			VectorIndexType:   "hnsw",
+			VectorIndexConfig: legacyConfig,
 			VectorConfig: map[string]models.VectorConfig{
 				dropped: {VectorIndexType: vectorindex.VectorIndexTypeNone},
 			},
 		}
 	}
+	bq := hnswent.UserConfig{BQ: hnswent.BQConfig{Enabled: true}}
 	pathExists := func(p string) bool {
 		_, err := os.Stat(p)
 		return err == nil
@@ -417,21 +457,33 @@ func TestVectorDropIndexHelper_SweepSparesTheLegacyVector(t *testing.T) {
 	tests := []struct {
 		name       string
 		dropped    string
+		legacy     hnswent.UserConfig
 		legacyLSM  []string // buckets the legacy index owns that must survive
 		droppedLSM []string // buckets the dropped vector owns that must go
 	}{
 		{
 			// "vectors_compressed" is both the named vector's raw bucket and
-			// the legacy vector's quantized bucket: it stays, the rest goes
-			name:       "named vector called compressed",
+			// the quantized legacy vector's compressed bucket: it stays, the
+			// rest goes
+			name:       "named vector called compressed next to a quantized legacy vector",
 			dropped:    "compressed",
+			legacy:     bq,
 			legacyLSM:  []string{"vectors", "vectors_compressed"},
 			droppedLSM: []string{"vectors_compressed_compressed"},
+		},
+		{
+			// an uncompressed legacy hnsw never wrote "vectors_compressed", so
+			// the bucket is the named vector's alone and has to go with it
+			name:       "named vector called compressed next to an uncompressed legacy vector",
+			dropped:    "compressed",
+			legacyLSM:  []string{"vectors"},
+			droppedLSM: []string{"vectors_compressed", "vectors_compressed_compressed"},
 		},
 		{
 			// no real collision: the legacy muvera bucket is main_muvera_vectors
 			name:       "named vector called muvera_vectors",
 			dropped:    "muvera_vectors",
+			legacy:     bq,
 			legacyLSM:  []string{"vectors", "vectors_compressed", "main_muvera_vectors"},
 			droppedLSM: []string{"vectors_muvera_vectors", "vectors_compressed_muvera_vectors"},
 		},
@@ -446,7 +498,7 @@ func TestVectorDropIndexHelper_SweepSparesTheLegacyVector(t *testing.T) {
 			gone = append(gone, mkdirs(t, filepath.Join(indexPath, shardName),
 				"vectors_"+tt.dropped+".hnsw.commitlog.d", "vectors_"+tt.dropped+".queue.d")...)
 
-			require.NoError(t, h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, mixedClass(tt.dropped)))
+			require.NoError(t, h.ensureFilesAreRemovedForDroppedVectorIndexes(indexPath, shardName, mixedClass(tt.dropped, tt.legacy)))
 
 			for _, p := range legacy {
 				assert.True(t, pathExists(p), "%s belongs to the legacy vector and must survive", p)

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -463,7 +463,7 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 	// other vector names is what stops a sibling being deleted when its own
 	// bucket collides with one of this target's artifact names.
 	artifacts := helpers.VectorIndexArtifactsFor(targetVector,
-		otherTargetVectors(s.class, targetVector))
+		siblingVectors(s.class, targetVector))
 	for _, bucket := range artifacts.LSMBuckets {
 		if err := s.removeBucket(ctx, bucket); err != nil {
 			return fmt.Errorf("drop bucket %q for vector %q: %w", bucket, targetVector, err)

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -643,7 +643,7 @@ func (l *LazyLoadShard) dropUnloadedVectorIndex(targetVector string) error {
 	}
 	if err := newVectorDropIndexHelper().removeVectorIndexFiles(
 		l.shardOpts.index.path(), l.shardOpts.name, targetVector,
-		otherTargetVectors(class, targetVector)); err != nil {
+		siblingVectors(class, targetVector)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What's being changed:

Data-loss fix on the vector index drop path, split out of the logical-to-physical mapping work (#12881, #12919, #12924, #12925, #12928) because it stands on its own.

**The bug.** Dropping a named vector removes every artifact the index owns, minus anything a live sibling also owns. The sibling list was built from `VectorConfig` alone, which never holds the legacy (unnamed) vector. A class that had a legacy vector and later gained named vectors, which is legal through a class update, could therefore hold a named vector whose artifacts collide with the legacy vector's: one called `compressed` owns the raw bucket `vectors_compressed`, byte-identical to the legacy vector's quantized bucket. Dropping it deleted the legacy vector's quantized data, on the live drop, the cold sweep, and the lazy-load sweep alike, since all four call sites share `otherTargetVectors`.

**The fix.**

- `otherTargetVectors` counts the legacy vector (`""`) as a sibling whenever `modelsext.ClassHasLegacyVectorIndex` says the class has one. The shard builds the legacy index on exactly that condition, and the schema keeps a named-only class's legacy fields empty, so this never over-protects.
- For that to protect anything real, the legacy vector's artifact list has to name what the legacy index actually writes. It was keyed on the raw bucket name `vectors`, producing names no index ever creates (`vectors_muvera_vectors`, `vectors.hfresh.d`, `vectors_compressed__centroids`). It is now keyed on the physical ID (`main`), giving `main_muvera_vectors`, `main.hfresh.d`, `main.queue.d`, and `vectors_compressed` for the centroid graph. Named vectors produce byte-identical lists, so nothing changes for them. This also means a named vector merely called `muvera_vectors` or `mv_mappings` is not spuriously protected next to a legacy vector, which would have leaked its raw bucket into a re-created vector of the same name.

- Protection is config-aware, for the legacy vector and named siblings alike. Only an index with a quantizer configured ever writes a compressed bucket, and compression cannot be switched off again, so a sibling whose config has none (hnsw, flat, or dynamic without PQ/BQ/SQ/RQ) does not protect its compressed bucket; hfresh always does through its centroid graph, and a config that cannot be read counts as quantized. Without this, an uncompressed legacy hnsw next to a named vector called `compressed` would have leaked that vector's raw bucket, which a re-created vector of the same name would then open. Raw buckets are protected unconditionally.

**Tests.** Two golden tests on the legacy artifact list, tables for `siblingVectors` and `canOwnCompressedBucket`, a table on which sibling artifacts protection covers, and a sweep journey on a mixed class that drops `compressed` next to a quantized legacy vector (the legacy quantized bucket survives, the named vector's own artifacts go) and next to an uncompressed one (the bucket is the named vector's alone and goes) and `muvera_vectors` (no collision: everything of the dropped vector goes, the legacy `main_muvera_vectors` survives). All four fail without the fix.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

