### PR TITLE
hnsw: derive hnsw compressed bucket names from the physical ID

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/batch_distancer_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/batch_distancer_test.go
@@ -45,7 +45,7 @@ func TestBatchDistancerMatchesDistanceToNode(t *testing.T) {
 					defer store.Shutdown(context.Background())
 
 					compressor, err := compressionhelpers.NewRQCompressor(metric, 1e6, logger, store,
-						memwatch.NewDummyMonitor(), lsmkv.MakeNoopBucketOptions, bits, dim, "", nil)
+						memwatch.NewDummyMonitor(), lsmkv.MakeNoopBucketOptions, bits, dim, "vectors_compressed", nil)
 					require.NoError(t, err)
 					defer compressor.Drop()
 

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
@@ -108,7 +107,7 @@ type quantizedVectorsCompressor[T byte | uint64] struct {
 	storeId           func([]byte, uint64)
 	loadId            func([]byte) uint64
 	logger            logrus.FieldLogger
-	targetVector      string
+	bucketName        string
 	makeBucketOptions lsmkv.MakeBucketOptions
 	vectorForID       common.VectorForID[float32]
 }
@@ -158,7 +157,7 @@ func (compressor *quantizedVectorsCompressor[T]) Len() int32 {
 // before draining, and async compress/prefill goroutines can outlive the
 // shard); callers treat nil as "shard is gone, skip".
 func (compressor *quantizedVectorsCompressor[T]) compressedBucket() *lsmkv.Bucket {
-	return compressor.compressedStore.Bucket(helpers.GetCompressedBucketName(compressor.targetVector))
+	return compressor.compressedStore.Bucket(compressor.bucketName)
 }
 
 func (compressor *quantizedVectorsCompressor[T]) Delete(ctx context.Context, id uint64) {
@@ -314,9 +313,9 @@ func (compressor *quantizedVectorsCompressor[T]) recoverCompressedVector(
 	if err := bucket.Put(idBytes, compressor.quantizer.CompressedBytes(compressed)); err != nil {
 		if stderrors.Is(err, storagestate.ErrStatusReadOnly) {
 			compressor.logger.WithFields(logrus.Fields{
-				"action":        "recover_compressed_vector",
-				"target_vector": compressor.targetVector,
-				"id":            id,
+				"action":            "recover_compressed_vector",
+				"compressed_bucket": compressor.bucketName,
+				"id":                id,
 			}).Debugf("skip write-back to compressed bucket: store is read-only: %v", err)
 			return compressed, nil
 		}
@@ -370,7 +369,7 @@ func (compressor *quantizedVectorsCompressor[T]) NewBag() CompressionDistanceBag
 func (compressor *quantizedVectorsCompressor[T]) initCompressedStore() error {
 	err := compressor.compressedStore.CreateOrLoadBucket(
 		context.Background(),
-		helpers.GetCompressedBucketName(compressor.targetVector),
+		compressor.bucketName,
 		compressor.makeBucketOptions(lsmkv.StrategyReplace)...,
 	)
 	if err != nil {
@@ -529,7 +528,7 @@ func NewHNSWPQCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizer(cfg, distance, dimensions, logger)
@@ -542,7 +541,7 @@ func NewHNSWPQCompressor(
 		storeId:           binary.LittleEndian.PutUint64,
 		loadId:            binary.LittleEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -570,7 +569,7 @@ func RestoreHNSWPQCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizerWithEncoders(cfg, distance, dimensions, encoders, logger)
@@ -583,7 +582,7 @@ func RestoreHNSWPQCompressor(
 		storeId:           binary.LittleEndian.PutUint64,
 		loadId:            binary.LittleEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -606,7 +605,7 @@ func NewHNSWPQMultiCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizer(cfg, distance, dimensions, logger)
@@ -619,7 +618,7 @@ func NewHNSWPQMultiCompressor(
 		storeId:           binary.LittleEndian.PutUint64,
 		loadId:            binary.LittleEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -647,7 +646,7 @@ func RestoreHNSWPQMultiCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizerWithEncoders(cfg, distance, dimensions, encoders, logger)
@@ -660,7 +659,7 @@ func RestoreHNSWPQMultiCompressor(
 		storeId:           binary.LittleEndian.PutUint64,
 		loadId:            binary.LittleEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -680,7 +679,7 @@ func NewBQCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewBinaryQuantizer(distance)
@@ -690,7 +689,7 @@ func NewBQCompressor(
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -710,7 +709,7 @@ func NewBQMultiCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewBinaryQuantizer(distance)
@@ -720,7 +719,7 @@ func NewBQMultiCompressor(
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -741,7 +740,7 @@ func NewHNSWSQCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewScalarQuantizer(data, distance)
@@ -751,7 +750,7 @@ func NewHNSWSQCompressor(
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -774,7 +773,7 @@ func RestoreHNSWSQCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := RestoreScalarQuantizer(a, b, dimensions, distance)
@@ -787,7 +786,7 @@ func RestoreHNSWSQCompressor(
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -808,7 +807,7 @@ func NewHNSWSQMultiCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewScalarQuantizer(data, distance)
@@ -818,7 +817,7 @@ func NewHNSWSQMultiCompressor(
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -841,7 +840,7 @@ func RestoreHNSWSQMultiCompressor(
 	store *lsmkv.Store,
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	allocChecker memwatch.AllocChecker,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := RestoreScalarQuantizer(a, b, dimensions, distance)
@@ -854,7 +853,7 @@ func RestoreHNSWSQMultiCompressor(
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
 		logger:            logger,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
 	}
@@ -876,7 +875,7 @@ func NewRQCompressor(
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	bits int,
 	dim int,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
@@ -891,7 +890,7 @@ func NewRQCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -909,7 +908,7 @@ func NewRQCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -927,7 +926,7 @@ func NewRQCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -975,7 +974,7 @@ func NewCenteredRQ4Compressor(
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	dim int,
 	mean []float32,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewCenteredFourBitRotationalQuantizer(dim, DefaultFastRotationSeed, distance, mean)
@@ -987,7 +986,7 @@ func NewCenteredRQ4Compressor(
 		compressedStore:   store,
 		storeId:           binary.BigEndian.PutUint64,
 		loadId:            binary.BigEndian.Uint64,
-		targetVector:      targetVector,
+		bucketName:        bucketName,
 		logger:            logger,
 		makeBucketOptions: makeBucketOptions,
 		vectorForID:       vectorForID,
@@ -1016,7 +1015,7 @@ func RestoreRQCompressor(
 	store *lsmkv.Store,
 	allocChecker memwatch.AllocChecker,
 	makeBucketOptions lsmkv.MakeBucketOptions,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	if mean != nil && bits != 4 {
@@ -1034,7 +1033,7 @@ func RestoreRQCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1055,7 +1054,7 @@ func RestoreRQCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1076,7 +1075,7 @@ func RestoreRQCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1102,7 +1101,7 @@ func NewRQMultiCompressor(
 	makeBucketOptions lsmkv.MakeBucketOptions,
 	bits int,
 	dim int,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
@@ -1117,7 +1116,7 @@ func NewRQMultiCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1135,7 +1134,7 @@ func NewRQMultiCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1153,7 +1152,7 @@ func NewRQMultiCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1184,7 +1183,7 @@ func RestoreRQMultiCompressor(
 	store *lsmkv.Store,
 	allocChecker memwatch.AllocChecker,
 	makeBucketOptions lsmkv.MakeBucketOptions,
-	targetVector string,
+	bucketName string,
 	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
@@ -1199,7 +1198,7 @@ func RestoreRQMultiCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1220,7 +1219,7 @@ func RestoreRQMultiCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,
@@ -1241,7 +1240,7 @@ func RestoreRQMultiCompressor(
 			compressedStore:   store,
 			storeId:           binary.BigEndian.PutUint64,
 			loadId:            binary.BigEndian.Uint64,
-			targetVector:      targetVector,
+			bucketName:        bucketName,
 			logger:            logger,
 			makeBucketOptions: makeBucketOptions,
 			vectorForID:       vectorForID,

--- a/adapters/repos/db/vector/compressionhelpers/compression_recover_readonly_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_recover_readonly_test.go
@@ -51,11 +51,11 @@ func newTestSQCompressor(t *testing.T, vectorForID func(ctx context.Context, id 
 	sq, err := RestoreScalarQuantizer(1.0, -1.0, 2, distancer.NewCosineDistanceProvider())
 	require.NoError(t, err)
 	return &quantizedVectorsCompressor[byte]{
-		quantizer:    sq,
-		logger:       logrus.New(),
-		targetVector: "test-vector",
-		storeId:      binary.LittleEndian.PutUint64,
-		vectorForID:  vectorForID,
+		quantizer:   sq,
+		logger:      logrus.New(),
+		bucketName:  "vectors_compressed_test-vector",
+		storeId:     binary.LittleEndian.PutUint64,
+		vectorForID: vectorForID,
 	}
 }
 

--- a/adapters/repos/db/vector/compressionhelpers/compression_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_test.go
@@ -198,7 +198,7 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 			testinghelpers.NewDummyStore(t),
 			lsmkv.MakeNoopBucketOptions,
 			memwatch.NewDummyMonitor(),
-			"name",
+			"vectors_compressed_name",
 			nil,
 		)
 		require.Nil(t, err)

--- a/adapters/repos/db/vector/compressionhelpers/rq_wiring_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/rq_wiring_test.go
@@ -158,7 +158,7 @@ func TestRQCompressorFactoryDispatch(t *testing.T) {
 
 	newCompressor := func(store *lsmkv.Store, bits int) (compressionhelpers.VectorCompressor, error) {
 		return compressionhelpers.NewRQCompressor(dist, 1e6, logger, store, memwatch.NewDummyMonitor(),
-			lsmkv.MakeNoopBucketOptions, bits, dim, "", nil)
+			lsmkv.MakeNoopBucketOptions, bits, dim, "vectors_compressed", nil)
 	}
 
 	// statsBits extracts the bit width from the stats type the given
@@ -202,7 +202,7 @@ func TestRQCompressorFactoryDispatch(t *testing.T) {
 			restoredCompressor, err := compressionhelpers.RestoreRQCompressor(dist, 1e6, logger,
 				int(data.InputDim), int(data.Bits), int(data.Rotation.OutputDim), int(data.Rotation.Rounds),
 				data.Rotation.Swaps, data.Rotation.Signs, nil, data.Mean, restoreStore,
-				memwatch.NewDummyMonitor(), lsmkv.MakeNoopBucketOptions, "", nil)
+				memwatch.NewDummyMonitor(), lsmkv.MakeNoopBucketOptions, "vectors_compressed", nil)
 			require.NoError(t, err)
 			defer restoredCompressor.Drop()
 			assert.Equal(t, uint32(bits), statsBits(t, restoredCompressor, bits))
@@ -212,7 +212,7 @@ func TestRQCompressorFactoryDispatch(t *testing.T) {
 			store := testinghelpers.NewDummyStore(t)
 			defer store.Shutdown(context.Background())
 			compressor, err := compressionhelpers.NewRQMultiCompressor(dist, 1e6, logger, store,
-				memwatch.NewDummyMonitor(), lsmkv.MakeNoopBucketOptions, bits, dim, "", nil)
+				memwatch.NewDummyMonitor(), lsmkv.MakeNoopBucketOptions, bits, dim, "vectors_compressed", nil)
 			require.NoError(t, err)
 			defer compressor.Drop()
 			assert.Equal(t, uint32(bits), statsBits(t, compressor, bits))
@@ -227,7 +227,7 @@ func TestRQCompressorFactoryDispatch(t *testing.T) {
 			restoredCompressor, err := compressionhelpers.RestoreRQMultiCompressor(dist, 1e6, logger,
 				int(data.InputDim), int(data.Bits), int(data.Rotation.OutputDim), int(data.Rotation.Rounds),
 				data.Rotation.Swaps, data.Rotation.Signs, nil, restoreStore, memwatch.NewDummyMonitor(),
-				lsmkv.MakeNoopBucketOptions, "", nil)
+				lsmkv.MakeNoopBucketOptions, "vectors_compressed", nil)
 			require.NoError(t, err)
 			defer restoredCompressor.Drop()
 			assert.Equal(t, uint32(bits), statsBits(t, restoredCompressor, bits))

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -85,7 +85,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			var err error
 			h.compressor, err = compressionhelpers.NewCenteredRQ4Compressor(
 				h.distancerProvider, 1e12, h.logger, h.store, h.allocChecker,
-				h.makeBucketOptions, dims, mean, h.getTargetVector(), h.vectorForID)
+				h.makeBucketOptions, dims, mean, h.compressedBucketName(), h.vectorForID)
 			if err != nil {
 				return fmt.Errorf("compressing vectors: %w", err)
 			}
@@ -101,11 +101,11 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			if singleVector {
 				h.compressor, err = compressionhelpers.NewHNSWPQCompressor(
 					cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store,
-					h.makeBucketOptions, h.allocChecker, h.getTargetVector(), h.vectorForID)
+					h.makeBucketOptions, h.allocChecker, h.compressedBucketName(), h.vectorForID)
 			} else {
 				h.compressor, err = compressionhelpers.NewHNSWPQMultiCompressor(
 					cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store,
-					h.makeBucketOptions, h.allocChecker, h.getTargetVector(), h.multiVectorForNodeID)
+					h.makeBucketOptions, h.allocChecker, h.compressedBucketName(), h.multiVectorForNodeID)
 			}
 			if err != nil {
 				h.pqConfig.Enabled = false
@@ -116,11 +116,11 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			if singleVector {
 				h.compressor, err = compressionhelpers.NewHNSWSQCompressor(
 					h.distancerProvider, 1e12, h.logger, cleanData, h.store,
-					h.makeBucketOptions, h.allocChecker, h.getTargetVector(), h.vectorForID)
+					h.makeBucketOptions, h.allocChecker, h.compressedBucketName(), h.vectorForID)
 			} else {
 				h.compressor, err = compressionhelpers.NewHNSWSQMultiCompressor(
 					h.distancerProvider, 1e12, h.logger, cleanData, h.store,
-					h.makeBucketOptions, h.allocChecker, h.getTargetVector(), h.multiVectorForNodeID)
+					h.makeBucketOptions, h.allocChecker, h.compressedBucketName(), h.multiVectorForNodeID)
 			}
 			if err != nil {
 				h.sqConfig.Enabled = false
@@ -132,11 +132,11 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		if singleVector {
 			h.compressor, err = compressionhelpers.NewBQCompressor(
 				h.distancerProvider, 1e12, h.logger, h.store,
-				h.makeBucketOptions, h.allocChecker, h.getTargetVector(), h.vectorForID)
+				h.makeBucketOptions, h.allocChecker, h.compressedBucketName(), h.vectorForID)
 		} else {
 			h.compressor, err = compressionhelpers.NewBQMultiCompressor(
 				h.distancerProvider, 1e12, h.logger, h.store,
-				h.makeBucketOptions, h.allocChecker, h.getTargetVector(), h.multiVectorForNodeID)
+				h.makeBucketOptions, h.allocChecker, h.compressedBucketName(), h.multiVectorForNodeID)
 		}
 		if err != nil {
 			return err

--- a/adapters/repos/db/vector/hnsw/compress_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_test.go
@@ -1148,3 +1148,49 @@ func TestChildLoggersCarryTheIndexID(t *testing.T) {
 	}
 	require.True(t, seen, "the compressor's recovery line was not logged")
 }
+
+// TestCompressedBucketNameDerivesFromID pins the quantized bucket for every
+// ID shape the shard builds: the legacy asymmetry (ID "main", bucket
+// "vectors_compressed"), a named vector, and hfresh's centroid graph.
+func TestCompressedBucketNameDerivesFromID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{"main", "vectors_compressed"},
+		{"vectors_title", "vectors_compressed_title"},
+		{"vectors_title_centroids", "vectors_compressed_title_centroids"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			vectors := [][]float32{{1, 0, 0, 0}}
+			uc := ent.UserConfig{}
+			uc.SetDefaults()
+			uc.BQ = ent.BQConfig{Enabled: true}
+
+			store := testinghelpers.NewDummyStore(t)
+			index, err := New(Config{
+				RootPath:         t.TempDir(),
+				ID:               tt.id,
+				DistanceProvider: distancer.NewCosineDistanceProvider(),
+				AllocChecker:     memwatch.NewDummyMonitor(),
+				MakeCommitLoggerThunk: func(opts ...CommitlogOption) (CommitLogger, error) {
+					return MakeNoopCommitLogger()
+				},
+				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					return vectors[id], nil
+				},
+				GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
+				TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+				MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+			}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+			require.NoError(t, err)
+			defer index.Shutdown(context.Background())
+
+			require.NoError(t, index.Add(context.Background(), 0, vectors[0]))
+
+			assert.Equal(t, tt.want, index.compressedBucketName())
+			assert.NotNil(t, store.Bucket(tt.want), "the compressor must write to %q", tt.want)
+		})
+	}
+}

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -421,11 +421,11 @@ func New(cfg Config, uc ent.UserConfig,
 		if uc.Multivector.Enabled && !uc.Multivector.MuveraEnabled() {
 			index.compressor, err = compressionhelpers.NewBQMultiCompressor(
 				index.distancerProvider, uc.VectorCacheMaxObjects, cfg.Logger, store,
-				cfg.MakeBucketOptions, cfg.AllocChecker, index.getTargetVector(), index.vectorForID)
+				cfg.MakeBucketOptions, cfg.AllocChecker, index.compressedBucketName(), index.vectorForID)
 		} else {
 			index.compressor, err = compressionhelpers.NewBQCompressor(
 				index.distancerProvider, uc.VectorCacheMaxObjects, cfg.Logger, store,
-				cfg.MakeBucketOptions, cfg.AllocChecker, index.getTargetVector(), index.vectorForID)
+				cfg.MakeBucketOptions, cfg.AllocChecker, index.compressedBucketName(), index.vectorForID)
 		}
 		if err != nil {
 			return nil, err
@@ -468,6 +468,12 @@ func New(cfg Config, uc ent.UserConfig,
 	index.insertMetrics = newInsertMetrics(index.metrics)
 
 	return index, nil
+}
+
+// compressedBucketName names the quantized-vectors bucket from the physical
+// ID, the same way flat, dynamic and hfresh name their storage.
+func (h *hnsw) compressedBucketName() string {
+	return helpers.CompressedBucketNameForID(h.id)
 }
 
 func (h *hnsw) getTargetVector() string {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -120,11 +120,11 @@ func (h *hnsw) checkAndCompress() error {
 			if singleVector {
 				h.compressor, err = compressionhelpers.NewRQCompressor(
 					h.distancerProvider, 1e12, h.logger, h.store, h.allocChecker, h.makeBucketOptions,
-					int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector(), h.vectorForID)
+					int(h.rqConfig.Bits), int(h.dims.Load()), h.compressedBucketName(), h.vectorForID)
 			} else {
 				h.compressor, err = compressionhelpers.NewRQMultiCompressor(
 					h.distancerProvider, 1e12, h.logger, h.store, h.allocChecker, h.makeBucketOptions,
-					int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector(), h.multiVectorForNodeID)
+					int(h.rqConfig.Bits), int(h.dims.Load()), h.compressedBucketName(), h.multiVectorForNodeID)
 			}
 
 			if err == nil {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -164,7 +164,7 @@ func (h *hnsw) applyLoadedState(state *ent.DeserializationResult) error {
 						h.store,
 						h.makeBucketOptions,
 						h.allocChecker,
-						h.getTargetVector(),
+						h.compressedBucketName(),
 						h.vectorForID,
 					)
 				} else {
@@ -178,7 +178,7 @@ func (h *hnsw) applyLoadedState(state *ent.DeserializationResult) error {
 						h.store,
 						h.makeBucketOptions,
 						h.allocChecker,
-						h.getTargetVector(),
+						h.compressedBucketName(),
 						h.multiVectorForNodeID,
 					)
 				}
@@ -199,7 +199,7 @@ func (h *hnsw) applyLoadedState(state *ent.DeserializationResult) error {
 					h.store,
 					h.makeBucketOptions,
 					h.allocChecker,
-					h.getTargetVector(),
+					h.compressedBucketName(),
 					h.vectorForID,
 				)
 			} else {
@@ -213,7 +213,7 @@ func (h *hnsw) applyLoadedState(state *ent.DeserializationResult) error {
 					h.store,
 					h.makeBucketOptions,
 					h.allocChecker,
-					h.getTargetVector(),
+					h.compressedBucketName(),
 					h.multiVectorForNodeID,
 				)
 			}
@@ -289,7 +289,7 @@ func (h *hnsw) restoreRotationalQuantization(data *ent.RQData) error {
 				h.store,
 				h.allocChecker,
 				h.makeBucketOptions,
-				h.getTargetVector(),
+				h.compressedBucketName(),
 				h.vectorForID,
 			)
 		})
@@ -311,7 +311,7 @@ func (h *hnsw) restoreRotationalQuantization(data *ent.RQData) error {
 				h.store,
 				h.allocChecker,
 				h.makeBucketOptions,
-				h.getTargetVector(),
+				h.compressedBucketName(),
 				h.multiVectorForNodeID,
 			)
 		})
@@ -339,7 +339,7 @@ func (h *hnsw) restoreBinaryRotationalQuantization(data *ent.BRQData) error {
 				h.store,
 				h.allocChecker,
 				h.makeBucketOptions,
-				h.getTargetVector(),
+				h.compressedBucketName(),
 				h.vectorForID,
 			)
 		})
@@ -359,7 +359,7 @@ func (h *hnsw) restoreBinaryRotationalQuantization(data *ent.BRQData) error {
 				h.store,
 				h.allocChecker,
 				h.makeBucketOptions,
-				h.getTargetVector(),
+				h.compressedBucketName(),
 				h.multiVectorForNodeID,
 			)
 		})


### PR DESCRIPTION
### What's being changed:

Last per-index naming PR of the logical-to-physical vector index mapping RFC (context: #12881, #12919; flat: #12924; dynamic: #12925; hfresh: #12928). hnsw was the one index still naming storage from the target vector: every compressor constructor took `getTargetVector()` and the compressors turned it into their bucket name with `GetCompressedBucketName`.

- **compressionhelpers** constructors take the compressed bucket name (`bucketName`) instead of the target vector. The package no longer derives any storage name; the recovery log line carries `compressed_bucket` instead of `target_vector` (the target vector is already on the identified logger the shard hands every index).
- **hnsw** derives that name once, `compressedBucketName()` = `helpers.CompressedBucketNameForID(h.id)`, and passes it at all nineteen constructor sites (initial compression, RQ on first insert, and every restore path on startup). `getTargetVector()` stays for the object-vector prefill, which the next PR moves to the shard along with the `TargetVector` field.

**No byte on disk changes.** For the IDs the shard builds (`main`, `vectors_<name>`, hfresh's `vectors_<name>_centroids`) the derived name is byte-identical to the old one. Pinned by `TestCompressedBucketNameDerivesFromID` (a BQ index per ID shape, asserting the bucket it writes to), the golden table from #12924, and the layout pin test on real shards.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
