### PR TITLE
hnsw: lock each neighbor before reading its connections in ACORN search

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -274,6 +274,7 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 	var sliceConnectionsReusable *common.VectorUint64Slice
 	var slicePendingNextRound *common.VectorUint64Slice
 	var slicePendingThisRound *common.VectorUint64Slice
+	var sliceNeighborConnections *common.VectorUint64Slice
 
 	if allowList == nil {
 		strategy = SWEEPING
@@ -282,6 +283,7 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 		sliceConnectionsReusable = h.pools.tempVectorsUint64.Get(8 * h.maximumConnectionsLayerZero)
 		slicePendingNextRound = h.pools.tempVectorsUint64.Get(h.maximumConnectionsLayerZero)
 		slicePendingThisRound = h.pools.tempVectorsUint64.Get(h.maximumConnectionsLayerZero)
+		sliceNeighborConnections = h.pools.tempVectorsUint64.Get(h.maximumConnectionsLayerZero)
 	} else {
 		connectionsReusable = make([]uint64, h.maximumConnectionsLayerZero)
 	}
@@ -322,12 +324,15 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 			continue
 		}
 
+		candidateLocked := true
 		func() {
 			// ensure we unlock the node even if we panic while
 			// accessing its connections
 			defer func() {
 				if err := recover(); err != nil {
-					candidateNode.Unlock()
+					if candidateLocked {
+						candidateNode.Unlock()
+					}
 					panic(errors.Errorf("shard: %s, collection: %s, vectorIndex: %s, panic: %v", h.shardName, h.className, h.id, err))
 				}
 			}()
@@ -350,16 +355,27 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 					connectionsReusable = connectionsReusable[:candidateNode.connections.LenAtLayer(uint8(level))]
 				}
 				connectionsReusable = candidateNode.connections.CopyLayer(connectionsReusable, uint8(level))
+				candidateNode.Unlock()
+				candidateLocked = false
 			} else {
 				connectionsReusable = sliceConnectionsReusable.Slice
 				pendingNextRound := slicePendingNextRound.Slice
 				pendingThisRound := slicePendingThisRound.Slice
+				neighborConnections := sliceNeighborConnections.Slice
 
 				realLen := 0
 				index := 0
 
 				pendingNextRound = pendingNextRound[:candidateNode.connections.LenAtLayer(uint8(level))]
 				pendingNextRound = candidateNode.connections.CopyLayer(pendingNextRound, uint8(level))
+
+				// The expansion below reads other vertices, each under its own
+				// mutex. Release this one first: two searches that expand each
+				// other's vertices would deadlock if either held a second
+				// vertex mutex.
+				candidateNode.Unlock()
+				candidateLocked = false
+
 				hop := 1
 				maxHops := 2
 				for hop <= maxHops && realLen < 8*h.maximumConnectionsLayerZero && len(pendingNextRound) > 0 {
@@ -410,9 +426,10 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 						if node == nil {
 							continue
 						}
-						iterator := node.connections.ElementIterator(uint8(level))
-						for iterator.Next() {
-							_, expId := iterator.Current()
+						node.Lock()
+						neighborConnections = node.connections.CopyLayer(neighborConnections[:0], uint8(level))
+						node.Unlock()
+						for _, expId := range neighborConnections {
 							if visitedExp.CheckAndVisit(expId) {
 								continue
 							}
@@ -450,11 +467,10 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 					hop++
 				}
 				slicePendingNextRound.Slice = pendingNextRound
+				sliceNeighborConnections.Slice = neighborConnections
 				connectionsReusable = connectionsReusable[:realLen]
 			}
 		}()
-
-		candidateNode.Unlock()
 
 		for _, neighborID := range connectionsReusable {
 			if visited.CheckAndVisit(neighborID) {
@@ -546,6 +562,7 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 		h.pools.tempVectorsUint64.Put(sliceConnectionsReusable)
 		h.pools.tempVectorsUint64.Put(slicePendingNextRound)
 		h.pools.tempVectorsUint64.Put(slicePendingThisRound)
+		h.pools.tempVectorsUint64.Put(sliceNeighborConnections)
 	}
 
 	h.pools.pqCandidates.Put(candidates)
@@ -893,9 +910,9 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		} else {
 			counter := float32(0)
 			entryPointNode.Lock()
-			if entryPointNode.connections.Layers() < 1 {
-				strategy = ACORN
-			} else {
+			hasLayers := entryPointNode.connections.Layers() >= 1
+			connectionCount := entryPointNode.connections.LenAtLayer(0)
+			if hasLayers {
 				iterator := entryPointNode.connections.ElementIterator(0)
 				for iterator.Next() {
 					_, value := iterator.Current()
@@ -910,12 +927,13 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 						counter++
 					}
 				}
-				entryPointNode.Unlock()
-				if counter/float32(h.nodes[entryPointID].connections.LenAtLayer(0)) > float32(h.acornFilterRatio) {
-					strategy = RRE
-				} else {
-					strategy = ACORN
-				}
+			}
+			entryPointNode.Unlock()
+
+			if hasLayers && counter/float32(connectionCount) > float32(h.acornFilterRatio) {
+				strategy = RRE
+			} else {
+				strategy = ACORN
 			}
 		}
 	} else {

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -327,9 +327,8 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 		candidateLocked := true
 		var lockedNeighbor *vertex
 		func() {
-			// ensure we unlock whichever node we hold even if we panic while
-			// accessing its connections. Restored connection data can advertise
-			// more entries than it stores, so the decode itself can panic.
+			// a restored layer can advertise more entries than it stores, so
+			// the decode below panics on corrupt data while a vertex is held
 			defer func() {
 				if err := recover(); err != nil {
 					if lockedNeighbor != nil {
@@ -374,10 +373,9 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 				pendingNextRound = pendingNextRound[:candidateNode.connections.LenAtLayer(uint8(level))]
 				pendingNextRound = candidateNode.connections.CopyLayer(pendingNextRound, uint8(level))
 
-				// The expansion below reads other vertices, each under its own
-				// mutex. Release this one first: two searches that expand each
-				// other's vertices would deadlock if either held a second
-				// vertex mutex.
+				// Release before the expansion, which locks each neighbor on
+				// its own: two searches expanding each other's vertices would
+				// deadlock if either held a second vertex mutex.
 				candidateNode.Unlock()
 				candidateLocked = false
 
@@ -920,8 +918,8 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 			var connectionCount int
 			func() {
 				entryPointNode.Lock()
-				// the decode below panics on restored connection data that
-				// advertises more entries than it stores
+				// deferred because the decode below panics on a restored layer
+				// that advertises more entries than it stores
 				defer entryPointNode.Unlock()
 
 				hasLayers = entryPointNode.connections.Layers() >= 1

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -325,11 +325,16 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 		}
 
 		candidateLocked := true
+		var lockedNeighbor *vertex
 		func() {
-			// ensure we unlock the node even if we panic while
-			// accessing its connections
+			// ensure we unlock whichever node we hold even if we panic while
+			// accessing its connections. Restored connection data can advertise
+			// more entries than it stores, so the decode itself can panic.
 			defer func() {
 				if err := recover(); err != nil {
+					if lockedNeighbor != nil {
+						lockedNeighbor.Unlock()
+					}
 					if candidateLocked {
 						candidateNode.Unlock()
 					}
@@ -427,7 +432,9 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 							continue
 						}
 						node.Lock()
+						lockedNeighbor = node
 						neighborConnections = node.connections.CopyLayer(neighborConnections[:0], uint8(level))
+						lockedNeighbor = nil
 						node.Unlock()
 						for _, expId := range neighborConnections {
 							if visitedExp.CheckAndVisit(expId) {
@@ -909,10 +916,20 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 			strategy = RRE
 		} else {
 			counter := float32(0)
-			entryPointNode.Lock()
-			hasLayers := entryPointNode.connections.Layers() >= 1
-			connectionCount := entryPointNode.connections.LenAtLayer(0)
-			if hasLayers {
+			var hasLayers bool
+			var connectionCount int
+			func() {
+				entryPointNode.Lock()
+				// the decode below panics on restored connection data that
+				// advertises more entries than it stores
+				defer entryPointNode.Unlock()
+
+				hasLayers = entryPointNode.connections.Layers() >= 1
+				connectionCount = entryPointNode.connections.LenAtLayer(0)
+				if !hasLayers {
+					return
+				}
+
 				iterator := entryPointNode.connections.ElementIterator(0)
 				for iterator.Next() {
 					_, value := iterator.Current()
@@ -927,8 +944,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 						counter++
 					}
 				}
-			}
-			entryPointNode.Unlock()
+			}()
 
 			if hasLayers && counter/float32(connectionCount) > float32(h.acornFilterRatio) {
 				strategy = RRE

--- a/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
+++ b/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
@@ -1,0 +1,213 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// https://github.com/weaviate/weaviate/issues/12935
+//
+// The ACORN branch expands the neighbors of a candidate's neighbors. It used to
+// read those second-hop vertices without holding their mutex, so an insert
+// running at the same time could update a vertex's connection count and its
+// encoded connection bytes between the two loads the reader performs. The
+// decode then indexed past the end of the data. Run with -race.
+func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
+	tests := []struct {
+		name           string
+		filterStrategy string
+	}{
+		{name: "acorn", filterStrategy: ent.FilterStrategyAcorn},
+		{name: "sweeping", filterStrategy: ent.FilterStrategySweeping},
+	}
+
+	const (
+		seeded  = 400
+		inserts = 400
+		readers = 4
+		writers = 4
+	)
+
+	ctx := context.Background()
+	vectors, queries := testinghelpers.RandomVecs(seeded+inserts, 1, 8)
+
+	// every tenth seeded id, so the allow list stays well below AcornFilterRatio
+	// and the search picks ACORN over RRE
+	allowed := make([]uint64, 0, seeded/10)
+	for id := uint64(0); id < seeded; id += 10 {
+		allowed = append(allowed, id)
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := testinghelpers.NewDummyStore(t)
+			t.Cleanup(func() { store.Shutdown(ctx) })
+
+			index, err := New(Config{
+				RootPath:              t.TempDir(),
+				ID:                    "acorn-neighbor-locking",
+				MakeCommitLoggerThunk: MakeNoopCommitLogger,
+				DistanceProvider:      distancer.NewCosineDistanceProvider(),
+				AllocChecker:          memwatch.NewDummyMonitor(),
+				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					return vectors[int(id)], nil
+				},
+				GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
+				TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+				AcornFilterRatio:             0.4,
+			}, ent.UserConfig{
+				MaxConnections:        16,
+				EFConstruction:        32,
+				EF:                    32,
+				VectorCacheMaxObjects: 100000,
+				FilterStrategy:        test.filterStrategy,
+			}, cyclemanager.NewCallbackGroupNoop(), store)
+			require.Nil(t, err)
+			t.Cleanup(func() { index.Shutdown(ctx) })
+
+			for id := uint64(0); id < seeded; id++ {
+				require.Nil(t, index.Add(ctx, id, vectors[id]))
+			}
+
+			errs := make(chan error, readers+writers)
+			stopReaders := make(chan struct{})
+
+			var writersWg sync.WaitGroup
+			for w := 0; w < writers; w++ {
+				writersWg.Add(1)
+				go func(w int) {
+					defer writersWg.Done()
+					for id := uint64(seeded + w); id < seeded+inserts; id += writers {
+						if err := index.Add(ctx, id, vectors[id]); err != nil {
+							errs <- err
+							return
+						}
+					}
+				}(w)
+			}
+
+			var readersWg sync.WaitGroup
+			for r := 0; r < readers; r++ {
+				readersWg.Add(1)
+				go func() {
+					defer readersWg.Done()
+					for {
+						select {
+						case <-stopReaders:
+							return
+						default:
+						}
+						_, _, err := index.SearchByVector(ctx, queries[0], 10,
+							helpers.NewAllowList(allowed...))
+						if err != nil {
+							errs <- err
+							return
+						}
+					}
+				}()
+			}
+
+			writersWg.Wait()
+			close(stopReaders)
+			readersWg.Wait()
+			close(errs)
+
+			for err := range errs {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// https://github.com/weaviate/weaviate/issues/12935
+//
+// knnSearchByVector locks the entrypoint vertex to measure how many of its
+// connections pass the filter. When the entrypoint has no layers there is
+// nothing to count, and that branch used to return without unlocking. The
+// search then blocked on the same vertex as soon as it became a candidate.
+//
+// A vertex restored from a commit log that holds no connections has zero
+// layers, which is what NewWithData(nil) produces here.
+func TestSearchReleasesEntrypointLockWhenEntrypointHasNoLayers(t *testing.T) {
+	const size = 200
+
+	ctx := context.Background()
+	vectors, queries := testinghelpers.RandomVecs(size, 1, 8)
+
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(ctx) })
+
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "acorn-entrypoint-without-layers",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[int(id)], nil
+		},
+		GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AcornFilterRatio:             0.4,
+	}, ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        16,
+		VectorCacheMaxObjects: 100000,
+		FilterStrategy:        ent.FilterStrategyAcorn,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+	t.Cleanup(func() { index.Shutdown(ctx) })
+
+	for id := uint64(0); id < size; id++ {
+		require.Nil(t, index.Add(ctx, id, vectors[id]))
+	}
+
+	index.currentMaximumLayer = 0
+	index.nodes[index.entryPointID].connections = packedconn.NewWithData(nil)
+
+	// small enough against the filled vector cache that acorn stays enabled
+	allowed := make([]uint64, 0, 10)
+	for id := uint64(0); id < 10; id++ {
+		allowed = append(allowed, id)
+	}
+
+	type searchResult struct {
+		ids []uint64
+		err error
+	}
+	done := make(chan searchResult, 1)
+	go func() {
+		ids, _, err := index.SearchByVector(ctx, queries[0], 10, helpers.NewAllowList(allowed...))
+		done <- searchResult{ids: ids, err: err}
+	}()
+
+	select {
+	case res := <-done:
+		require.NoError(t, res.err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("search did not return: the entrypoint vertex mutex was never unlocked")
+	}
+}

--- a/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
+++ b/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
@@ -28,9 +28,8 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
-// newSeededIndex builds an index holding the first seed vectors. AcornFilterRatio
-// is the server default, so an allow list well under 40% of the vectors keeps the
-// searches in these tests on the ACORN path.
+// AcornFilterRatio is the server default, so an allow list well under 40% of
+// the seeded vectors keeps these searches on the ACORN path.
 func newSeededIndex(t *testing.T, id string, vectors [][]float32, seed int, filterStrategy string) *hnsw {
 	t.Helper()
 
@@ -67,18 +66,9 @@ func newSeededIndex(t *testing.T, id string, vectors [][]float32, seed int, filt
 	return index
 }
 
-// https://github.com/weaviate/weaviate/issues/12935
-//
-// The ACORN branch expands the neighbors of a candidate's neighbors. It used to
-// read those second-hop vertices without holding their mutex, so a write
-// running at the same time could update a vertex's connection count and its
-// encoded connection bytes between the two loads the reader performs. The
-// decode then indexed past the end of the data. Run with -race.
-//
-// Both writers that mutate a vertex's connections are exercised: inserts append
-// through InsertAtLayer, and tombstone cleanup reassigns through ReplaceLayer.
-// The reported panic was "index out of range [0] with length 0", which is the
-// nil-data state ReplaceLayer leaves behind when a layer is emptied.
+// Pins the unsynchronized neighbor read of
+// https://github.com/weaviate/weaviate/issues/12935. Needs -race: a torn read
+// only sometimes panics on its own.
 func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -99,8 +89,8 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 	ctx := context.Background()
 	vectors, queries := testinghelpers.RandomVecs(seeded+inserts, 1, 8)
 
-	// every tenth seeded id, so the allow list stays well below AcornFilterRatio
-	// and the search picks ACORN over RRE
+	// every tenth id, keeping the allow list under AcornFilterRatio so the
+	// search picks ACORN over RRE
 	allowed := make([]uint64, 0, seeded/10)
 	for id := uint64(0); id < seeded; id += 10 {
 		allowed = append(allowed, id)
@@ -127,9 +117,10 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 				}(w)
 			}
 
-			// Tombstone cleanup reassigns connections, which is what empties a
-			// layer through ReplaceLayer. The deleted ids are outside the allow
-			// list so the searches keep returning results.
+			// Inserts alone only exercise InsertAtLayer. Tombstone cleanup
+			// reassigns through ReplaceLayer, the writer that empties a layer
+			// and produced the reported panic. Deleted ids stay outside the
+			// allow list so the searches keep returning results.
 			writersWg.Add(1)
 			go func() {
 				defer writersWg.Done()
@@ -179,30 +170,23 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 	}
 }
 
-// A search locks two vertices while decoding their connections: the entrypoint,
-// to count how many of its connections pass the filter, and each second-hop
-// neighbor the ACORN expansion copies. Decoding a layer panics when its header
-// claims more entries than its bytes hold, which is what a corrupted snapshot
-// restores: NewWithData only checks that a layer's declared length fits inside
-// the blob, never that the length matches the entry count. Neither panic may
-// carry the mutex away with it, or every later search and write on that vertex
-// blocks forever.
+// A search decodes connections while holding a vertex: the entrypoint, and each
+// second-hop neighbor the ACORN expansion copies. That decode panics on a layer
+// whose header claims more entries than its bytes hold — NewWithData accepts one,
+// since it only checks that a layer's declared length fits inside the blob. The
+// mutex has to survive the panic, or the vertex is locked for good.
 func TestSearchUnlocksVertexWhenConnectionDecodePanics(t *testing.T) {
 	const size = 200
 
 	tests := []struct {
-		name string
-		// corrupt installs the malformed layer and returns the vertex whose
-		// mutex the search must give back
-		corrupt func(index *hnsw) uint64
+		name    string
+		corrupt func(index *hnsw) (lockedVertex uint64)
 	}{
 		{
 			name: "second-hop neighbor",
 			corrupt: func(index *hnsw) uint64 {
-				// The entrypoint points only at the corrupt vertex, and the
-				// allow list holds only the entrypoint, so the expansion has to
-				// decode the corrupt vertex instead of accepting it straight off
-				// the allow list.
+				// a vertex on the allow list is taken without decoding, so the
+				// corrupt one is kept off it and reached through the entrypoint
 				neighbor := uint64(0)
 				if index.entryPointID == neighbor {
 					neighbor = 1
@@ -228,8 +212,8 @@ func TestSearchUnlocksVertexWhenConnectionDecodePanics(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			index := newSeededIndex(t, "acorn-decode-panic", vectors, size, ent.FilterStrategyAcorn)
 
-			// stay on layer 0, so the first decode of the entrypoint's
-			// connections is the one that picks ACORN over RRE
+			// stay on layer 0, so the ACORN-vs-RRE count is the first decode
+			// of the entrypoint's connections
 			index.currentMaximumLayer = 0
 			locked := test.corrupt(index)
 
@@ -245,32 +229,26 @@ func TestSearchUnlocksVertexWhenConnectionDecodePanics(t *testing.T) {
 	}
 }
 
-// layerClaimingMoreEntriesThanItStores builds the blob NewWithData parses: a
-// layer count, then per layer a packed scheme+count, a data length, and the
-// data. This one declares ten 3-byte entries and stores three bytes.
+// The blob layout NewWithData parses: a layer count, then per layer a packed
+// scheme+count, a data length, and the data.
 func layerClaimingMoreEntriesThanItStores() []byte {
 	const (
 		scheme = 1  // SCHEME_3BYTE
-		count  = 10 // stored in the upper 12 bits
+		count  = 10 // ten entries, three bytes each
 	)
 	packed := uint16(scheme) | uint16(count)<<4
 
-	blob := []byte{1} // one layer
+	blob := []byte{1} // layer count
 	blob = append(blob, byte(packed), byte(packed>>8))
-	blob = append(blob, 3, 0, 0, 0) // data length
+	blob = append(blob, 3, 0, 0, 0) // data length: 3 bytes where the count claims 30
 	blob = append(blob, 0xFF, 0xFF, 0xFF)
 	return blob
 }
 
-// https://github.com/weaviate/weaviate/issues/12935
-//
-// knnSearchByVector locks the entrypoint vertex to measure how many of its
-// connections pass the filter. When the entrypoint has no layers there is
-// nothing to count, and that branch used to return without unlocking. The
-// search then blocked on the same vertex as soon as it became a candidate.
-//
-// A vertex restored from a commit log that holds no connections has zero
-// layers, which is what NewWithData(nil) produces here.
+// Pins the entrypoint mutex leak of
+// https://github.com/weaviate/weaviate/issues/12935. A commit log holding no
+// connections restores a vertex with zero layers, which NewWithData(nil)
+// reproduces; the search then blocks on it as soon as it becomes a candidate.
 func TestSearchReleasesEntrypointLockWhenEntrypointHasNoLayers(t *testing.T) {
 	const size = 200
 
@@ -301,8 +279,8 @@ func TestSearchReleasesEntrypointLockWhenEntrypointHasNoLayers(t *testing.T) {
 	select {
 	case res := <-done:
 		require.NoError(t, res.err)
-		// the entrypoint has no connections, so everything found comes from the
-		// allow list members ACORN seeds the search with
+		// with no entrypoint connections, hits can only be the allow list
+		// members ACORN seeds the search with
 		require.NotEmpty(t, res.ids)
 		for _, id := range res.ids {
 			require.Contains(t, allowed, id)

--- a/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
+++ b/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
@@ -31,10 +31,15 @@ import (
 // https://github.com/weaviate/weaviate/issues/12935
 //
 // The ACORN branch expands the neighbors of a candidate's neighbors. It used to
-// read those second-hop vertices without holding their mutex, so an insert
+// read those second-hop vertices without holding their mutex, so a write
 // running at the same time could update a vertex's connection count and its
 // encoded connection bytes between the two loads the reader performs. The
 // decode then indexed past the end of the data. Run with -race.
+//
+// Both writers that mutate a vertex's connections are exercised: inserts append
+// through InsertAtLayer, and tombstone cleanup reassigns through ReplaceLayer.
+// The reported panic was "index out of range [0] with length 0", which is the
+// nil-data state ReplaceLayer leaves behind when a layer is emptied.
 func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -49,6 +54,7 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 		inserts = 400
 		readers = 4
 		writers = 4
+		deletes = 40
 	)
 
 	ctx := context.Background()
@@ -92,7 +98,7 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 				require.Nil(t, index.Add(ctx, id, vectors[id]))
 			}
 
-			errs := make(chan error, readers+writers)
+			errs := make(chan error, readers+writers+1)
 			stopReaders := make(chan struct{})
 
 			var writersWg sync.WaitGroup
@@ -108,6 +114,25 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 					}
 				}(w)
 			}
+
+			// Tombstone cleanup reassigns connections, which is what empties a
+			// layer through ReplaceLayer. The deleted ids are outside the allow
+			// list so the searches keep returning results.
+			writersWg.Add(1)
+			go func() {
+				defer writersWg.Done()
+				for i := 0; i < deletes; i++ {
+					id := uint64(i*10 + 1)
+					if err := index.Delete(id); err != nil {
+						errs <- err
+						return
+					}
+					if err := index.CleanUpTombstonedNodes(neverStop); err != nil {
+						errs <- err
+						return
+					}
+				}
+			}()
 
 			var readersWg sync.WaitGroup
 			for r := 0; r < readers; r++ {
@@ -207,6 +232,12 @@ func TestSearchReleasesEntrypointLockWhenEntrypointHasNoLayers(t *testing.T) {
 	select {
 	case res := <-done:
 		require.NoError(t, res.err)
+		// the entrypoint has no connections, so everything found comes from the
+		// allow list members ACORN seeds the search with
+		require.NotEmpty(t, res.ids)
+		for _, id := range res.ids {
+			require.Contains(t, allowed, id)
+		}
 	case <-time.After(15 * time.Second):
 		t.Fatal("search did not return: the entrypoint vertex mutex was never unlocked")
 	}

--- a/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
+++ b/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
@@ -28,6 +28,45 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
+// newSeededIndex builds an index holding the first seed vectors. AcornFilterRatio
+// is the server default, so an allow list well under 40% of the vectors keeps the
+// searches in these tests on the ACORN path.
+func newSeededIndex(t *testing.T, id string, vectors [][]float32, seed int, filterStrategy string) *hnsw {
+	t.Helper()
+
+	ctx := context.Background()
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(ctx) })
+
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    id,
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[int(id)], nil
+		},
+		GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AcornFilterRatio:             0.4,
+	}, ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        32,
+		EF:                    32,
+		VectorCacheMaxObjects: 100000,
+		FilterStrategy:        filterStrategy,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+	t.Cleanup(func() { index.Shutdown(ctx) })
+
+	for id := uint64(0); id < uint64(seed); id++ {
+		require.Nil(t, index.Add(ctx, id, vectors[id]))
+	}
+
+	return index
+}
+
 // https://github.com/weaviate/weaviate/issues/12935
 //
 // The ACORN branch expands the neighbors of a candidate's neighbors. It used to
@@ -69,34 +108,7 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store := testinghelpers.NewDummyStore(t)
-			t.Cleanup(func() { store.Shutdown(ctx) })
-
-			index, err := New(Config{
-				RootPath:              t.TempDir(),
-				ID:                    "acorn-neighbor-locking",
-				MakeCommitLoggerThunk: MakeNoopCommitLogger,
-				DistanceProvider:      distancer.NewCosineDistanceProvider(),
-				AllocChecker:          memwatch.NewDummyMonitor(),
-				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
-					return vectors[int(id)], nil
-				},
-				GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
-				TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
-				AcornFilterRatio:             0.4,
-			}, ent.UserConfig{
-				MaxConnections:        16,
-				EFConstruction:        32,
-				EF:                    32,
-				VectorCacheMaxObjects: 100000,
-				FilterStrategy:        test.filterStrategy,
-			}, cyclemanager.NewCallbackGroupNoop(), store)
-			require.Nil(t, err)
-			t.Cleanup(func() { index.Shutdown(ctx) })
-
-			for id := uint64(0); id < seeded; id++ {
-				require.Nil(t, index.Add(ctx, id, vectors[id]))
-			}
+			index := newSeededIndex(t, "acorn-neighbor-locking", vectors, seeded, test.filterStrategy)
 
 			errs := make(chan error, readers+writers+1)
 			stopReaders := make(chan struct{})
@@ -167,66 +179,70 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 	}
 }
 
-// The ACORN expansion holds a neighbor's mutex while it copies that neighbor's
-// layer. Decoding a layer panics when its header claims more entries than its
-// bytes hold, which is what a corrupted snapshot restores: NewWithData only
-// checks that a layer's declared length fits inside the blob, never that the
-// length matches the entry count. The panic must not carry the mutex away with
-// it, or every later search and write on that vertex blocks forever.
-func TestSearchUnlocksNeighborWhenConnectionDecodePanics(t *testing.T) {
+// A search locks two vertices while decoding their connections: the entrypoint,
+// to count how many of its connections pass the filter, and each second-hop
+// neighbor the ACORN expansion copies. Decoding a layer panics when its header
+// claims more entries than its bytes hold, which is what a corrupted snapshot
+// restores: NewWithData only checks that a layer's declared length fits inside
+// the blob, never that the length matches the entry count. Neither panic may
+// carry the mutex away with it, or every later search and write on that vertex
+// blocks forever.
+func TestSearchUnlocksVertexWhenConnectionDecodePanics(t *testing.T) {
 	const size = 200
+
+	tests := []struct {
+		name string
+		// corrupt installs the malformed layer and returns the vertex whose
+		// mutex the search must give back
+		corrupt func(index *hnsw) uint64
+	}{
+		{
+			name: "second-hop neighbor",
+			corrupt: func(index *hnsw) uint64 {
+				// The entrypoint points only at the corrupt vertex, and the
+				// allow list holds only the entrypoint, so the expansion has to
+				// decode the corrupt vertex instead of accepting it straight off
+				// the allow list.
+				neighbor := uint64(0)
+				if index.entryPointID == neighbor {
+					neighbor = 1
+				}
+				index.nodes[index.entryPointID].connections.ReplaceLayer(0, []uint64{neighbor})
+				index.nodes[neighbor].connections = packedconn.NewWithData(layerClaimingMoreEntriesThanItStores())
+				return neighbor
+			},
+		},
+		{
+			name: "entrypoint",
+			corrupt: func(index *hnsw) uint64 {
+				index.nodes[index.entryPointID].connections = packedconn.NewWithData(layerClaimingMoreEntriesThanItStores())
+				return index.entryPointID
+			},
+		},
+	}
 
 	ctx := context.Background()
 	vectors, queries := testinghelpers.RandomVecs(size, 1, 8)
 
-	store := testinghelpers.NewDummyStore(t)
-	t.Cleanup(func() { store.Shutdown(ctx) })
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			index := newSeededIndex(t, "acorn-decode-panic", vectors, size, ent.FilterStrategyAcorn)
 
-	index, err := New(Config{
-		RootPath:              t.TempDir(),
-		ID:                    "acorn-neighbor-decode-panic",
-		MakeCommitLoggerThunk: MakeNoopCommitLogger,
-		DistanceProvider:      distancer.NewCosineDistanceProvider(),
-		AllocChecker:          memwatch.NewDummyMonitor(),
-		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
-			return vectors[int(id)], nil
-		},
-		GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
-		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
-		AcornFilterRatio:             0.4,
-	}, ent.UserConfig{
-		MaxConnections:        16,
-		EFConstruction:        16,
-		VectorCacheMaxObjects: 100000,
-		FilterStrategy:        ent.FilterStrategyAcorn,
-	}, cyclemanager.NewCallbackGroupNoop(), store)
-	require.Nil(t, err)
-	t.Cleanup(func() { index.Shutdown(ctx) })
+			// stay on layer 0, so the first decode of the entrypoint's
+			// connections is the one that picks ACORN over RRE
+			index.currentMaximumLayer = 0
+			locked := test.corrupt(index)
 
-	for id := uint64(0); id < size; id++ {
-		require.Nil(t, index.Add(ctx, id, vectors[id]))
+			require.Panics(t, func() {
+				index.SearchByVector(ctx, queries[0], 10,
+					helpers.NewAllowList(index.entryPointID))
+			})
+
+			require.True(t, index.nodes[locked].TryLock(),
+				"the panic left the vertex locked")
+			index.nodes[locked].Unlock()
+		})
 	}
-
-	entryPoint := index.entryPointID
-	corrupt := uint64(0)
-	if entryPoint == corrupt {
-		corrupt = 1
-	}
-
-	// The entrypoint points only at the corrupt vertex, and the allow list holds
-	// only the entrypoint, so the expansion has to decode the corrupt vertex
-	// instead of accepting it straight off the allow list.
-	index.currentMaximumLayer = 0
-	index.nodes[entryPoint].connections.ReplaceLayer(0, []uint64{corrupt})
-	index.nodes[corrupt].connections = packedconn.NewWithData(layerClaimingMoreEntriesThanItStores())
-
-	require.Panics(t, func() {
-		index.SearchByVector(ctx, queries[0], 10, helpers.NewAllowList(entryPoint))
-	})
-
-	require.True(t, index.nodes[corrupt].TryLock(),
-		"the panic left the neighbor vertex locked")
-	index.nodes[corrupt].Unlock()
 }
 
 // layerClaimingMoreEntriesThanItStores builds the blob NewWithData parses: a
@@ -261,33 +277,7 @@ func TestSearchReleasesEntrypointLockWhenEntrypointHasNoLayers(t *testing.T) {
 	ctx := context.Background()
 	vectors, queries := testinghelpers.RandomVecs(size, 1, 8)
 
-	store := testinghelpers.NewDummyStore(t)
-	t.Cleanup(func() { store.Shutdown(ctx) })
-
-	index, err := New(Config{
-		RootPath:              t.TempDir(),
-		ID:                    "acorn-entrypoint-without-layers",
-		MakeCommitLoggerThunk: MakeNoopCommitLogger,
-		DistanceProvider:      distancer.NewCosineDistanceProvider(),
-		AllocChecker:          memwatch.NewDummyMonitor(),
-		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
-			return vectors[int(id)], nil
-		},
-		GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
-		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
-		AcornFilterRatio:             0.4,
-	}, ent.UserConfig{
-		MaxConnections:        16,
-		EFConstruction:        16,
-		VectorCacheMaxObjects: 100000,
-		FilterStrategy:        ent.FilterStrategyAcorn,
-	}, cyclemanager.NewCallbackGroupNoop(), store)
-	require.Nil(t, err)
-	t.Cleanup(func() { index.Shutdown(ctx) })
-
-	for id := uint64(0); id < size; id++ {
-		require.Nil(t, index.Add(ctx, id, vectors[id]))
-	}
+	index := newSeededIndex(t, "acorn-entrypoint-without-layers", vectors, size, ent.FilterStrategyAcorn)
 
 	index.currentMaximumLayer = 0
 	index.nodes[index.entryPointID].connections = packedconn.NewWithData(nil)

--- a/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
+++ b/adapters/repos/db/vector/hnsw/search_acorn_locking_test.go
@@ -167,6 +167,85 @@ func TestSearchConcurrentWithConnectionUpdates(t *testing.T) {
 	}
 }
 
+// The ACORN expansion holds a neighbor's mutex while it copies that neighbor's
+// layer. Decoding a layer panics when its header claims more entries than its
+// bytes hold, which is what a corrupted snapshot restores: NewWithData only
+// checks that a layer's declared length fits inside the blob, never that the
+// length matches the entry count. The panic must not carry the mutex away with
+// it, or every later search and write on that vertex blocks forever.
+func TestSearchUnlocksNeighborWhenConnectionDecodePanics(t *testing.T) {
+	const size = 200
+
+	ctx := context.Background()
+	vectors, queries := testinghelpers.RandomVecs(size, 1, 8)
+
+	store := testinghelpers.NewDummyStore(t)
+	t.Cleanup(func() { store.Shutdown(ctx) })
+
+	index, err := New(Config{
+		RootPath:              t.TempDir(),
+		ID:                    "acorn-neighbor-decode-panic",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		AllocChecker:          memwatch.NewDummyMonitor(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return vectors[int(id)], nil
+		},
+		GetViewThunk:                 func() common.BucketView { return &noopBucketView{} },
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+		AcornFilterRatio:             0.4,
+	}, ent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        16,
+		VectorCacheMaxObjects: 100000,
+		FilterStrategy:        ent.FilterStrategyAcorn,
+	}, cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+	t.Cleanup(func() { index.Shutdown(ctx) })
+
+	for id := uint64(0); id < size; id++ {
+		require.Nil(t, index.Add(ctx, id, vectors[id]))
+	}
+
+	entryPoint := index.entryPointID
+	corrupt := uint64(0)
+	if entryPoint == corrupt {
+		corrupt = 1
+	}
+
+	// The entrypoint points only at the corrupt vertex, and the allow list holds
+	// only the entrypoint, so the expansion has to decode the corrupt vertex
+	// instead of accepting it straight off the allow list.
+	index.currentMaximumLayer = 0
+	index.nodes[entryPoint].connections.ReplaceLayer(0, []uint64{corrupt})
+	index.nodes[corrupt].connections = packedconn.NewWithData(layerClaimingMoreEntriesThanItStores())
+
+	require.Panics(t, func() {
+		index.SearchByVector(ctx, queries[0], 10, helpers.NewAllowList(entryPoint))
+	})
+
+	require.True(t, index.nodes[corrupt].TryLock(),
+		"the panic left the neighbor vertex locked")
+	index.nodes[corrupt].Unlock()
+}
+
+// layerClaimingMoreEntriesThanItStores builds the blob NewWithData parses: a
+// layer count, then per layer a packed scheme+count, a data length, and the
+// data. This one declares ten 3-byte entries and stores three bytes.
+func layerClaimingMoreEntriesThanItStores() []byte {
+	const (
+		scheme = 1  // SCHEME_3BYTE
+		count  = 10 // stored in the upper 12 bits
+	)
+	packed := uint16(scheme) | uint16(count)<<4
+
+	blob := []byte{1} // one layer
+	blob = append(blob, byte(packed), byte(packed>>8))
+	blob = append(blob, 3, 0, 0, 0) // data length
+	blob = append(blob, 0xFF, 0xFF, 0xFF)
+	return blob
+}
+
 // https://github.com/weaviate/weaviate/issues/12935
 //
 // knnSearchByVector locks the entrypoint vertex to measure how many of its


### PR DESCRIPTION
Fixes #12935.

## Branch targeting

Both defects are on every maintained line, verified per branch rather than inferred from the v1.32.0 introduction date:

| branch | `node.connections.ElementIterator(uint8(level))` | `entryPointNode.Lock()` |
|---|---|---|
| stable/v1.37 | line 413 | line 895 |
| stable/v1.38 | line 413 | line 895 |
| stable/v1.39 | line 425 | line 948 |
| main | line 425 | line 964 |

This targets `stable/v1.37`, the oldest line still receiving patches (156 commits since Aug 1, v1.37.15 released Aug 27), so it reaches v1.38, v1.39 and `main` through the regular stable-into-next merges. stable/v1.36 last released on Jul 17 and has had 3 commits since Aug 1, so it is treated as closed; say so if that is wrong and this can move down.

The panic was observed on a 1.39.2-based build, not on `main`.

## Motivation

`packedconn.Connections` carries no internal lock — every reader is expected to hold the owning vertex's mutex. The ACORN filter branch of `searchLayerByVectorWithDistancerWithStrategy` did not: it iterated a *neighbor's* connections while holding only the *candidate's* mutex. `ElementIterator` reads the layer's `packed` (scheme + count) and its `data` as two separate loads, and writers under the neighbor's mutex update those fields non-atomically (`ReplaceLayer` assigns the whole struct; `InsertAtLayer`/`appendToLayer` append to `data` and set `packed` afterwards). A reader can pair a nonzero count with shorter or nil data, and `decodeInto` then indexes past the end.

Seen in production on 2026-09-04 (`1.39.2-7f0f8f9`): `panic: runtime error: index out of range [0] with length 0`, `decodeInto` → `ElementIterator` → `search.go:425`. The nil-data variant comes from `ReplaceLayer(layer, []uint64{})` in the delete-reassign path (`neighbor_connections.go:392`). The panic is recovered by the errgroup wrapper, so the node survives and the query fails. Present since v1.32.0 (d4d4a6447a). It was flagged twice before as an adjacent finding (#12242, #12277) and never filed or fixed.

While reading that function I found a second bug in the same file, also since v1.32.0: `knnSearchByVector` locks the entrypoint vertex to count how many of its connections pass the filter, and the `Layers() < 1` branch returned without unlocking. The entrypoint's mutex leaks and every later operation on that vertex blocks forever.

## Approach

**Neighbor read.** The obvious fix — lock the neighbor while still holding the candidate — deadlocks. No other code in the package holds two vertex mutexes at once, and two concurrent ACORN searches expanding mutually connected vertices X and Y would each hold one and wait for the other. Instead the candidate's mutex is released as soon as its own connections have been copied into `pendingNextRound`, and each neighbor is locked on its own while its layer is copied into a pooled buffer. Only one vertex mutex is ever held.

Because the unlock now happens inside the closure and on two different paths, the panic-recovery `defer` needs to know whether the mutex is still held — hence the `candidateLocked` flag.

Copying into a pooled buffer instead of iterating also drops the `[]uint64` that `ElementIterator` allocated per neighbor, on a path that runs up to `8 * maxConnections` times per candidate.

**Entrypoint leak.** The connection count that decides ACORN vs RRE is now read under the same lock as the iteration, with a single unlock on both branches. That also removes a second unsynchronized read: the ratio used to be computed from `h.nodes[entryPointID].connections.LenAtLayer(0)` *after* the mutex was released.

## Key areas for review

- `search.go:434-439` — the neighbor lock/copy/unlock, the actual fix
- `search.go:375-382` — where the candidate's mutex is released, and why it cannot be held across the expansion
- `search.go:327-345` — `candidateLocked` and `lockedNeighbor`, so the recover path unlocks whichever mutex is still held and never double-unlocks
- `search.go:918-950` — entrypoint counted under one lock, unlocked on every path including a panic
- `search.go:277, 286, 477, 572` — the pooled neighbor buffer: acquired only for ACORN, stored back after `CopyLayer` may have grown it, returned to the pool

## Risks and mitigations

- **Deadlock from nested vertex mutexes**: avoided by construction — the candidate is unlocked before any neighbor is locked, so a search holds at most one vertex mutex.
- **Double unlock on the panic path**: `candidateLocked` is set to false at each unlock inside the closure; the recover only unlocks when it is still true.
- **Candidate connections mutated after its unlock**: they are already copied into `pendingNextRound` before the unlock, exactly as the non-ACORN branch does with `connectionsReusable`. The search works from a snapshot either way; no result-correctness change.
- **Pooled buffer aliasing**: `neighborConnections` is refilled with `CopyLayer(...[:0], ...)` per neighbor and fully consumed before the next fill; the possibly-grown slice is written back to `sliceNeighborConnections.Slice` so the pool keeps the capacity.

## Testing

`adapters/repos/db/vector/hnsw/search_acorn_locking_test.go`, both written red against `main`:

- `TestSearchConcurrentWithConnectionUpdates` — table over both filter strategies; 4 readers running filtered searches while 4 writers insert into the graph. The allow list is 10% of the seeded ids so the search picks ACORN over RRE. On `main` the `acorn` case reports the race on the exact production path (`search.go:425` → `ElementIterator` → `decodeInto`, against `InsertAtLayer`/`appendToLayer`); `sweeping` is clean, which pins that the fix does not change that branch's behavior.
- `TestSearchReleasesEntrypointLockWhenEntrypointHasNoLayers` — deterministic, no race detector needed. With a zero-layer entrypoint (what a commit-log restore of a vertex with no connections produces) the search never returns on `main`, blocking on the mutex leaked a few lines earlier; it fails on a 15s timeout.

Both green with the fix. Full `hnsw` and `packedconn` suites pass under `-race`; `golangci-lint`, `gofumpt` and the goroutine linter are clean.

## Not fixed here, same class

`delete.go:884` (`isOnlyNodeUnlocked`) reads `node.connections.Layers()` holding only `h.RLock` and `shardedNodeLocks.RLockAll()`, never the vertex mutex, while writers update `layerCount` under the vertex mutex alone (`upgradeToLevelNoLock` → `GrowLayersTo`). It is a data race but cannot panic — `Layers()` returns a `uint8` and indexes nothing. The consequence is a stale value: `isOnlyNode` can answer wrongly and `deleteEntrypoint` can then skip picking a new entrypoint. Taking each vertex mutex while holding every sharded node read lock is its own deadlock risk, so it is documented on #12935 rather than changed without a reproduction.
