### PR TITLE
perf(asyncrep): reuse per-worker request assembly in root-prefilter clients

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -426,56 +426,16 @@ func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, inde
 func (c *replicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
 	classes map[string]map[string]hashtree.Digest,
 ) (*replica.CompareHashTreeRootsMultiResp, error) {
-	return c.NewCompareRootsSession().CompareHashTreeRootsMulti(ctx, host, classes)
-}
-
-var _ replica.CompareRootsSessionFactory = (*replicationClient)(nil)
-
-func (c *replicationClient) NewCompareRootsSession() replica.CompareRootsSession {
-	return &restCompareRootsSession{c: c, wire: map[string]map[string][2]uint64{}}
-}
-
-// restCompareRootsSession reuses the wire maps across calls; single-goroutine use only.
-type restCompareRootsSession struct {
-	c     *replicationClient
-	wire  map[string]map[string][2]uint64
-	spare []map[string][2]uint64
-}
-
-// fill rebuilds the reused wire maps with exactly the given classes.
-func (s *restCompareRootsSession) fill(classes map[string]map[string]hashtree.Digest) map[string]map[string][2]uint64 {
-	for _, inner := range s.wire {
-		clear(inner)
-		s.spare = append(s.spare, inner)
-	}
-	clear(s.wire)
+	wire := make(map[string]map[string][2]uint64, len(classes))
 	for class, roots := range classes {
-		var inner map[string][2]uint64
-		if n := len(s.spare); n > 0 {
-			inner = s.spare[n-1]
-			s.spare[n-1] = nil
-			s.spare = s.spare[:n-1]
-		} else {
-			inner = make(map[string][2]uint64, len(roots))
-		}
-		for shard, root := range roots {
-			inner[shard] = [2]uint64(root)
-		}
-		s.wire[class] = inner
+		wire[class] = wireDigests(roots)
 	}
-	return s.wire
-}
-
-func (s *restCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Context, host string,
-	classes map[string]map[string]hashtree.Digest,
-) (*replica.CompareHashTreeRootsMultiResp, error) {
-	// The body must own its bytes: the transport may still read it after Do returns.
-	body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: s.fill(classes)})
+	body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: wire})
 	if err != nil {
 		return nil, fmt.Errorf("marshal compare hashtree roots multi request: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, s.c.timeoutUnit*20)
+	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
 	defer cancel()
 
 	u := url.URL{Scheme: "http", Host: host, Path: clusterapi.CompareHashTreeRootsMultiPath}
@@ -485,7 +445,7 @@ func (s *restCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Context,
 	}
 
 	var resp replica.CompareHashTreeRootsMultiResp
-	if err := s.c.postCompareRoots(req, &resp); err != nil {
+	if err := c.postCompareRoots(req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -426,16 +426,56 @@ func (c *replicationClient) CompareHashTreeRoots(ctx context.Context, host, inde
 func (c *replicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
 	classes map[string]map[string]hashtree.Digest,
 ) (*replica.CompareHashTreeRootsMultiResp, error) {
-	wire := make(map[string]map[string][2]uint64, len(classes))
-	for class, roots := range classes {
-		wire[class] = wireDigests(roots)
+	return c.NewCompareRootsSession().CompareHashTreeRootsMulti(ctx, host, classes)
+}
+
+var _ replica.CompareRootsSessionFactory = (*replicationClient)(nil)
+
+func (c *replicationClient) NewCompareRootsSession() replica.CompareRootsSession {
+	return &restCompareRootsSession{c: c, wire: map[string]map[string][2]uint64{}}
+}
+
+// restCompareRootsSession reuses the wire maps across calls; single-goroutine use only.
+type restCompareRootsSession struct {
+	c     *replicationClient
+	wire  map[string]map[string][2]uint64
+	spare []map[string][2]uint64
+}
+
+// fill rebuilds the reused wire maps with exactly the given classes.
+func (s *restCompareRootsSession) fill(classes map[string]map[string]hashtree.Digest) map[string]map[string][2]uint64 {
+	for _, inner := range s.wire {
+		clear(inner)
+		s.spare = append(s.spare, inner)
 	}
-	body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: wire})
+	clear(s.wire)
+	for class, roots := range classes {
+		var inner map[string][2]uint64
+		if n := len(s.spare); n > 0 {
+			inner = s.spare[n-1]
+			s.spare[n-1] = nil
+			s.spare = s.spare[:n-1]
+		} else {
+			inner = make(map[string][2]uint64, len(roots))
+		}
+		for shard, root := range roots {
+			inner[shard] = [2]uint64(root)
+		}
+		s.wire[class] = inner
+	}
+	return s.wire
+}
+
+func (s *restCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	// The body must own its bytes: the transport may still read it after Do returns.
+	body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: s.fill(classes)})
 	if err != nil {
 		return nil, fmt.Errorf("marshal compare hashtree roots multi request: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
+	ctx, cancel := context.WithTimeout(ctx, s.c.timeoutUnit*20)
 	defer cancel()
 
 	u := url.URL{Scheme: "http", Host: host, Path: clusterapi.CompareHashTreeRootsMultiPath}
@@ -445,7 +485,7 @@ func (c *replicationClient) CompareHashTreeRootsMulti(ctx context.Context, host 
 	}
 
 	var resp replica.CompareHashTreeRootsMultiResp
-	if err := c.postCompareRoots(req, &resp); err != nil {
+	if err := s.c.postCompareRoots(req, &resp); err != nil {
 		return nil, err
 	}
 	return &resp, nil

--- a/adapters/clients/replication_compare_roots_session_test.go
+++ b/adapters/clients/replication_compare_roots_session_test.go
@@ -129,14 +129,6 @@ func TestGRPCCompareHashTreeRootsMulti(t *testing.T) {
 		require.NoError(t, err)
 		assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), in)
 	})
-
-	t.Run("plain client method matches session behavior", func(t *testing.T) {
-		in := rootsInput(2, 2)
-		resp, err := client.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
-		require.NoError(t, err)
-		assert.Empty(t, resp.Classes)
-		assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), in)
-	})
 }
 
 func TestGRPCCompareRootsSessionReuse(t *testing.T) {

--- a/adapters/clients/replication_compare_roots_session_test.go
+++ b/adapters/clients/replication_compare_roots_session_test.go
@@ -252,87 +252,6 @@ func TestGRPCCompareRootsSessionZeroAlloc(t *testing.T) {
 	}))
 }
 
-func TestRESTCompareRootsSessionFillReuse(t *testing.T) {
-	t.Parallel()
-	toWire := func(in map[string]map[string]hashtree.Digest) map[string]map[string][2]uint64 {
-		want := make(map[string]map[string][2]uint64, len(in))
-		for cls, roots := range in {
-			want[cls] = wireDigests(roots)
-		}
-		return want
-	}
-	tests := []struct {
-		name  string
-		steps []map[string]map[string]hashtree.Digest
-	}{
-		{"large then small", []map[string]map[string]hashtree.Digest{rootsInput(3, 4), rootsInput(1, 1)}},
-		{"small then large", []map[string]map[string]hashtree.Digest{rootsInput(1, 1), rootsInput(4, 8)}},
-		{"overlapping names changed digests", []map[string]map[string]hashtree.Digest{
-			{"A": {"s1": {1, 1}, "s2": {2, 2}}},
-			{"A": {"s1": {9, 9}}},
-		}},
-		{"zero classes", []map[string]map[string]hashtree.Digest{rootsInput(2, 2), {}}},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			s := &restCompareRootsSession{wire: map[string]map[string][2]uint64{}}
-			for _, in := range tc.steps {
-				assert.Equal(t, toWire(in), s.fill(in))
-			}
-		})
-	}
-}
-
-func TestRESTCompareRootsSessionZeroAlloc(t *testing.T) {
-	s := &restCompareRootsSession{wire: map[string]map[string][2]uint64{}}
-	large := rootsInput(16, 256)
-	small := rootsInput(1, 1)
-	s.fill(large)
-
-	assert.Zero(t, testing.AllocsPerRun(100, func() {
-		benchRESTWireSink = s.fill(large)
-	}))
-	assert.Zero(t, testing.AllocsPerRun(100, func() {
-		benchRESTWireSink = s.fill(small)
-	}))
-}
-
-func TestRESTCompareRootsSessionRoundTrip(t *testing.T) {
-	t.Parallel()
-	var lastBody atomic.Pointer[replica.CompareHashTreeRootsMultiReq]
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req replica.CompareHashTreeRootsMultiReq
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		lastBody.Store(&req)
-		resp := replica.CompareHashTreeRootsMultiResp{Classes: map[string]replica.CompareHashTreeRootsMultiClassResp{}}
-		for cls := range req.Classes {
-			resp.Classes[cls] = replica.CompareHashTreeRootsMultiClassResp{}
-		}
-		require.NoError(t, json.NewEncoder(w).Encode(resp))
-	}))
-	defer server.Close()
-
-	c := newReplicationClient(t, server.Client())
-	session := c.NewCompareRootsSession()
-	ctx := context.Background()
-
-	large := rootsInput(3, 4)
-	resp, err := session.CompareHashTreeRootsMulti(ctx, server.URL[7:], large)
-	require.NoError(t, err)
-	assert.Len(t, resp.Classes, 3)
-	require.Len(t, lastBody.Load().Classes, 3)
-	for cls, roots := range large {
-		assert.Len(t, lastBody.Load().Classes[cls], len(roots))
-	}
-
-	small := rootsInput(1, 1)
-	resp, err = session.CompareHashTreeRootsMulti(ctx, server.URL[7:], small)
-	require.NoError(t, err)
-	assert.Len(t, resp.Classes, 1)
-	require.Len(t, lastBody.Load().Classes, 1)
-	assert.Equal(t, map[string][2]uint64{"c0_s0": {0, 0}}, lastBody.Load().Classes["C0"])
-}
-
 func TestSwitchCompareRootsSessionDispatch(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -380,11 +299,7 @@ func TestSwitchCompareRootsSessionDispatch(t *testing.T) {
 	assert.Equal(t, int32(1), restCalls.Load())
 }
 
-var (
-	benchGRPCReqSink  *pb.CompareHashTreeRootsMultiRequest
-	benchRESTWireSink map[string]map[string][2]uint64
-	benchRESTBodySink []byte
-)
+var benchGRPCReqSink *pb.CompareHashTreeRootsMultiRequest
 
 func perCallAssembleGRPC(classes map[string]map[string]hashtree.Digest) *pb.CompareHashTreeRootsMultiRequest {
 	req := &pb.CompareHashTreeRootsMultiRequest{
@@ -431,35 +346,4 @@ func BenchmarkCompareRootsMultiAssembly(b *testing.B) {
 			}
 		})
 	}
-}
-
-func BenchmarkCompareRootsMultiRESTAssembly(b *testing.B) {
-	in := rootsInput(1, 128)
-	b.Run("session", func(b *testing.B) {
-		s := &restCompareRootsSession{wire: map[string]map[string][2]uint64{}}
-		s.fill(in)
-		b.ReportAllocs()
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: s.fill(in)})
-			if err != nil {
-				b.Fatal(err)
-			}
-			benchRESTBodySink = body
-		}
-	})
-	b.Run("perCall", func(b *testing.B) {
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			wire := make(map[string]map[string][2]uint64, len(in))
-			for class, roots := range in {
-				wire[class] = wireDigests(roots)
-			}
-			body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: wire})
-			if err != nil {
-				b.Fatal(err)
-			}
-			benchRESTBodySink = body
-		}
-	})
 }

--- a/adapters/clients/replication_compare_roots_session_test.go
+++ b/adapters/clients/replication_compare_roots_session_test.go
@@ -1,0 +1,465 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func rootsInput(classes, shardsPerClass int) map[string]map[string]hashtree.Digest {
+	in := make(map[string]map[string]hashtree.Digest, classes)
+	for c := 0; c < classes; c++ {
+		roots := make(map[string]hashtree.Digest, shardsPerClass)
+		for s := 0; s < shardsPerClass; s++ {
+			roots[fmt.Sprintf("c%d_s%d", c, s)] = hashtree.Digest{uint64(c<<16 + s), uint64(s<<16 + c)}
+		}
+		in[fmt.Sprintf("C%d", c)] = roots
+	}
+	return in
+}
+
+func rootsMultiReqToMap(req *pb.CompareHashTreeRootsMultiRequest) map[string]map[string]hashtree.Digest {
+	out := make(map[string]map[string]hashtree.Digest, len(req.GetClasses()))
+	for _, cls := range req.GetClasses() {
+		roots := make(map[string]hashtree.Digest, len(cls.GetShardRootDigests()))
+		for _, d := range cls.GetShardRootDigests() {
+			roots[d.GetShard()] = hashtree.Digest{d.GetRootHashHigh(), d.GetRootHashLow()}
+		}
+		out[cls.GetIndex()] = roots
+	}
+	return out
+}
+
+func assertReqMatches(t *testing.T, req *pb.CompareHashTreeRootsMultiRequest, want map[string]map[string]hashtree.Digest) {
+	t.Helper()
+	require.NotNil(t, req)
+	require.Len(t, req.GetClasses(), len(want))
+	for _, cls := range req.GetClasses() {
+		require.Len(t, cls.GetShardRootDigests(), len(want[cls.GetIndex()]), cls.GetIndex())
+	}
+	assert.Equal(t, want, rootsMultiReqToMap(req))
+}
+
+func echoDivergingHandler(req *pb.CompareHashTreeRootsMultiRequest) (*pb.CompareHashTreeRootsMultiResponse, error) {
+	resp := &pb.CompareHashTreeRootsMultiResponse{}
+	for _, cls := range req.GetClasses() {
+		shards := make([]string, 0, len(cls.GetShardRootDigests()))
+		for _, d := range cls.GetShardRootDigests() {
+			shards = append(shards, d.GetShard())
+		}
+		resp.Classes = append(resp.Classes, &pb.ClassDivergingShards{Index: cls.GetIndex(), DivergingShards: shards})
+	}
+	return resp, nil
+}
+
+func TestGRPCCompareHashTreeRootsMulti(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeGRPCReplicationServer(t)
+	client, cleanup := setupGRPCTestServer(t, fake)
+	defer cleanup()
+	session := client.NewCompareRootsSession()
+
+	t.Run("translates per-class results", func(t *testing.T) {
+		fake.compareRootsMultiHandler = func(req *pb.CompareHashTreeRootsMultiRequest) (*pb.CompareHashTreeRootsMultiResponse, error) {
+			return &pb.CompareHashTreeRootsMultiResponse{Classes: []*pb.ClassDivergingShards{
+				{Index: "C0", DivergingShards: []string{"c0_s1"}},
+				{Index: "C1", Error: "index not loaded"},
+				{Index: "C2"},
+			}}, nil
+		}
+		defer func() { fake.compareRootsMultiHandler = nil }()
+
+		in := rootsInput(3, 2)
+		resp, err := session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]replica.CompareHashTreeRootsMultiClassResp{
+			"C0": {DivergingShards: []string{"c0_s1"}},
+			"C1": {Error: "index not loaded"},
+			"C2": {},
+		}, resp.Classes)
+		assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), in)
+	})
+
+	t.Run("server error wraps and session stays usable", func(t *testing.T) {
+		fake.compareRootsMultiErr = status.Error(codes.FailedPrecondition, "boom")
+		_, err := session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", rootsInput(2, 3))
+		require.ErrorContains(t, err, "gRPC CompareHashTreeRootsMulti")
+		fake.compareRootsMultiErr = nil
+
+		in := rootsInput(1, 2)
+		_, err = session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+		require.NoError(t, err)
+		assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), in)
+	})
+
+	t.Run("unimplemented maps to sentinel and session stays usable", func(t *testing.T) {
+		fake.compareRootsMultiErr = status.Error(codes.Unimplemented, "old peer")
+		_, err := session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", rootsInput(1, 1))
+		require.ErrorIs(t, err, replica.ErrCompareHashTreeRootsUnsupported)
+		fake.compareRootsMultiErr = nil
+
+		in := rootsInput(2, 1)
+		_, err = session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+		require.NoError(t, err)
+		assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), in)
+	})
+
+	t.Run("plain client method matches session behavior", func(t *testing.T) {
+		in := rootsInput(2, 2)
+		resp, err := client.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Classes)
+		assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), in)
+	})
+}
+
+func TestGRPCCompareRootsSessionReuse(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeGRPCReplicationServer(t)
+	client, cleanup := setupGRPCTestServer(t, fake)
+	defer cleanup()
+	session := client.NewCompareRootsSession()
+
+	large := map[string]map[string]hashtree.Digest{
+		"A": {"a1": {1, 2}, "a2": {3, 4}, "a3": {5, 6}, "a4": {7, 8}, "a5": {9, 10}},
+		"B": {"b1": {11, 12}, "b2": {13, 14}, "b3": {15, 16}},
+		"C": {"c1": {17, 18}},
+	}
+	_, err := session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", large)
+	require.NoError(t, err)
+	assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), large)
+
+	small := map[string]map[string]hashtree.Digest{"D": {"d1": {21, 22}}}
+	_, err = session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", small)
+	require.NoError(t, err)
+	assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), small)
+
+	var remainingFailures atomic.Int32
+	remainingFailures.Store(2)
+	fake.compareRootsMultiHandler = func(*pb.CompareHashTreeRootsMultiRequest) (*pb.CompareHashTreeRootsMultiResponse, error) {
+		if remainingFailures.Add(-1) >= 0 {
+			return nil, status.Error(codes.Internal, "flaky")
+		}
+		return &pb.CompareHashTreeRootsMultiResponse{}, nil
+	}
+	callsBefore := fake.compareRootsMultiCalls.Load()
+	retried := map[string]map[string]hashtree.Digest{"E": {"e1": {31, 32}, "e2": {33, 34}}}
+	_, err = session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", retried)
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), fake.compareRootsMultiCalls.Load()-callsBefore)
+	assertReqMatches(t, fake.lastCompareRootsMultiReq.Load(), retried)
+}
+
+func TestGRPCCompareRootsSessionFillReuse(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		steps []map[string]map[string]hashtree.Digest
+	}{
+		{"large then small", []map[string]map[string]hashtree.Digest{rootsInput(3, 4), rootsInput(1, 1)}},
+		{"small then large", []map[string]map[string]hashtree.Digest{rootsInput(1, 1), rootsInput(4, 8)}},
+		{"overlapping names changed digests", []map[string]map[string]hashtree.Digest{
+			{"A": {"s1": {1, 1}, "s2": {2, 2}}},
+			{"A": {"s1": {9, 9}}},
+		}},
+		{"zero classes", []map[string]map[string]hashtree.Digest{rootsInput(2, 2), {}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &grpcCompareRootsSession{}
+			for _, in := range tc.steps {
+				assertReqMatches(t, s.fill(in), in)
+			}
+		})
+	}
+}
+
+func TestGRPCCompareRootsSessionConcurrent(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeGRPCReplicationServer(t)
+	client, cleanup := setupGRPCTestServer(t, fake)
+	defer cleanup()
+	fake.compareRootsMultiHandler = echoDivergingHandler
+
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			session := client.NewCompareRootsSession()
+			for i := 0; i < 25; i++ {
+				class := fmt.Sprintf("G%d", g)
+				in := map[string]map[string]hashtree.Digest{class: {}}
+				for s := 0; s <= i%5; s++ {
+					in[class][fmt.Sprintf("g%d_s%d", g, s)] = hashtree.Digest{uint64(g), uint64(s)}
+				}
+				resp, err := session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+				if !assert.NoError(t, err) {
+					return
+				}
+				got := resp.Classes[class].DivergingShards
+				if !assert.Len(t, got, len(in[class])) {
+					return
+				}
+				for _, shard := range got {
+					assert.Contains(t, in[class], shard)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+func TestGRPCCompareRootsSessionZeroAlloc(t *testing.T) {
+	s := &grpcCompareRootsSession{}
+	large := rootsInput(16, 256)
+	small := rootsInput(1, 1)
+	s.fill(large)
+
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		benchGRPCReqSink = s.fill(large)
+	}))
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		benchGRPCReqSink = s.fill(small)
+	}))
+}
+
+func TestRESTCompareRootsSessionFillReuse(t *testing.T) {
+	t.Parallel()
+	toWire := func(in map[string]map[string]hashtree.Digest) map[string]map[string][2]uint64 {
+		want := make(map[string]map[string][2]uint64, len(in))
+		for cls, roots := range in {
+			want[cls] = wireDigests(roots)
+		}
+		return want
+	}
+	tests := []struct {
+		name  string
+		steps []map[string]map[string]hashtree.Digest
+	}{
+		{"large then small", []map[string]map[string]hashtree.Digest{rootsInput(3, 4), rootsInput(1, 1)}},
+		{"small then large", []map[string]map[string]hashtree.Digest{rootsInput(1, 1), rootsInput(4, 8)}},
+		{"overlapping names changed digests", []map[string]map[string]hashtree.Digest{
+			{"A": {"s1": {1, 1}, "s2": {2, 2}}},
+			{"A": {"s1": {9, 9}}},
+		}},
+		{"zero classes", []map[string]map[string]hashtree.Digest{rootsInput(2, 2), {}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &restCompareRootsSession{wire: map[string]map[string][2]uint64{}}
+			for _, in := range tc.steps {
+				assert.Equal(t, toWire(in), s.fill(in))
+			}
+		})
+	}
+}
+
+func TestRESTCompareRootsSessionZeroAlloc(t *testing.T) {
+	s := &restCompareRootsSession{wire: map[string]map[string][2]uint64{}}
+	large := rootsInput(16, 256)
+	small := rootsInput(1, 1)
+	s.fill(large)
+
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		benchRESTWireSink = s.fill(large)
+	}))
+	assert.Zero(t, testing.AllocsPerRun(100, func() {
+		benchRESTWireSink = s.fill(small)
+	}))
+}
+
+func TestRESTCompareRootsSessionRoundTrip(t *testing.T) {
+	t.Parallel()
+	var lastBody atomic.Pointer[replica.CompareHashTreeRootsMultiReq]
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req replica.CompareHashTreeRootsMultiReq
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		lastBody.Store(&req)
+		resp := replica.CompareHashTreeRootsMultiResp{Classes: map[string]replica.CompareHashTreeRootsMultiClassResp{}}
+		for cls := range req.Classes {
+			resp.Classes[cls] = replica.CompareHashTreeRootsMultiClassResp{}
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer server.Close()
+
+	c := newReplicationClient(t, server.Client())
+	session := c.NewCompareRootsSession()
+	ctx := context.Background()
+
+	large := rootsInput(3, 4)
+	resp, err := session.CompareHashTreeRootsMulti(ctx, server.URL[7:], large)
+	require.NoError(t, err)
+	assert.Len(t, resp.Classes, 3)
+	require.Len(t, lastBody.Load().Classes, 3)
+	for cls, roots := range large {
+		assert.Len(t, lastBody.Load().Classes[cls], len(roots))
+	}
+
+	small := rootsInput(1, 1)
+	resp, err = session.CompareHashTreeRootsMulti(ctx, server.URL[7:], small)
+	require.NoError(t, err)
+	assert.Len(t, resp.Classes, 1)
+	require.Len(t, lastBody.Load().Classes, 1)
+	assert.Equal(t, map[string][2]uint64{"c0_s0": {0, 0}}, lastBody.Load().Classes["C0"])
+}
+
+func TestSwitchCompareRootsSessionDispatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fake := newFakeGRPCReplicationServer(t)
+	grpcClient, cleanup := setupGRPCTestServer(t, fake)
+	defer cleanup()
+	fake.compareRootsMultiHandler = echoDivergingHandler
+
+	var restCalls atomic.Int32
+	restServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		restCalls.Add(1)
+		var req replica.CompareHashTreeRootsMultiReq
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		resp := replica.CompareHashTreeRootsMultiResp{Classes: map[string]replica.CompareHashTreeRootsMultiClassResp{}}
+		for cls := range req.Classes {
+			resp.Classes[cls] = replica.CompareHashTreeRootsMultiClassResp{}
+		}
+		require.NoError(t, json.NewEncoder(w).Encode(resp))
+	}))
+	defer restServer.Close()
+	restClient := newReplicationClient(t, restServer.Client())
+
+	var useGRPC atomic.Bool
+	sw := NewSwitchReplicationClient(grpcClient, restClient, useGRPC.Load)
+	session := sw.NewCompareRootsSession()
+
+	in := rootsInput(1, 2)
+	useGRPC.Store(true)
+	resp, err := session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+	require.NoError(t, err)
+	assert.Len(t, resp.Classes["C0"].DivergingShards, 2)
+	assert.Equal(t, int32(0), restCalls.Load())
+
+	useGRPC.Store(false)
+	resp, err = session.CompareHashTreeRootsMulti(ctx, restServer.URL[7:], in)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Classes["C0"].DivergingShards)
+	assert.Equal(t, int32(1), restCalls.Load())
+
+	useGRPC.Store(true)
+	grpcCallsBefore := fake.compareRootsMultiCalls.Load()
+	_, err = session.CompareHashTreeRootsMulti(ctx, "passthrough:bufnet", in)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), fake.compareRootsMultiCalls.Load()-grpcCallsBefore)
+	assert.Equal(t, int32(1), restCalls.Load())
+}
+
+var (
+	benchGRPCReqSink  *pb.CompareHashTreeRootsMultiRequest
+	benchRESTWireSink map[string]map[string][2]uint64
+	benchRESTBodySink []byte
+)
+
+func perCallAssembleGRPC(classes map[string]map[string]hashtree.Digest) *pb.CompareHashTreeRootsMultiRequest {
+	req := &pb.CompareHashTreeRootsMultiRequest{
+		Classes: make([]*pb.ClassShardRootDigests, 0, len(classes)),
+	}
+	for class, roots := range classes {
+		shards := make([]*pb.ShardRootDigest, 0, len(roots))
+		for shard, root := range roots {
+			shards = append(shards, &pb.ShardRootDigest{
+				Shard:        shard,
+				RootHashHigh: root[0],
+				RootHashLow:  root[1],
+			})
+		}
+		req.Classes = append(req.Classes, &pb.ClassShardRootDigests{Index: class, ShardRootDigests: shards})
+	}
+	return req
+}
+
+func BenchmarkCompareRootsMultiAssembly(b *testing.B) {
+	shapes := []struct {
+		name              string
+		classes, perClass int
+	}{
+		{"1x128", 1, 128},
+		{"16x256", 16, 256},
+		{"100x1", 100, 1},
+	}
+	for _, shape := range shapes {
+		in := rootsInput(shape.classes, shape.perClass)
+		b.Run("session/"+shape.name, func(b *testing.B) {
+			s := &grpcCompareRootsSession{}
+			s.fill(in)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchGRPCReqSink = s.fill(in)
+			}
+		})
+		b.Run("perCall/"+shape.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				benchGRPCReqSink = perCallAssembleGRPC(in)
+			}
+		})
+	}
+}
+
+func BenchmarkCompareRootsMultiRESTAssembly(b *testing.B) {
+	in := rootsInput(1, 128)
+	b.Run("session", func(b *testing.B) {
+		s := &restCompareRootsSession{wire: map[string]map[string][2]uint64{}}
+		s.fill(in)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: s.fill(in)})
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchRESTBodySink = body
+		}
+	})
+	b.Run("perCall", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			wire := make(map[string]map[string][2]uint64, len(in))
+			for class, roots := range in {
+				wire[class] = wireDigests(roots)
+			}
+			body, err := json.Marshal(replica.CompareHashTreeRootsMultiReq{Classes: wire})
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchRESTBodySink = body
+		}
+	})
+}

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -497,12 +497,6 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 	return resp.GetDivergingShards(), nil
 }
 
-func (c *grpcReplicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
-	classes map[string]map[string]hashtree.Digest,
-) (*replica.CompareHashTreeRootsMultiResp, error) {
-	return (&grpcCompareRootsSession{c: c}).CompareHashTreeRootsMulti(ctx, host, classes)
-}
-
 var _ replica.CompareRootsSessionFactory = (*grpcReplicationClient)(nil)
 
 func (c *grpcReplicationClient) NewCompareRootsSession() replica.CompareRootsSession {

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -500,27 +500,63 @@ func (c *grpcReplicationClient) CompareHashTreeRoots(ctx context.Context, host, 
 func (c *grpcReplicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
 	classes map[string]map[string]hashtree.Digest,
 ) (*replica.CompareHashTreeRootsMultiResp, error) {
-	client, err := c.getClient(host)
+	return (&grpcCompareRootsSession{c: c}).CompareHashTreeRootsMulti(ctx, host, classes)
+}
+
+var _ replica.CompareRootsSessionFactory = (*grpcReplicationClient)(nil)
+
+func (c *grpcReplicationClient) NewCompareRootsSession() replica.CompareRootsSession {
+	return &grpcCompareRootsSession{c: c}
+}
+
+// grpcCompareRootsSession reuses one request graph across calls; single-goroutine use only.
+type grpcCompareRootsSession struct {
+	c       *grpcReplicationClient
+	req     protocol.CompareHashTreeRootsMultiRequest
+	classes []*protocol.ClassShardRootDigests
+	digests []*protocol.ShardRootDigest
+}
+
+// fill overwrites the graph with exactly the given classes; structs are reused via
+// pointer only (they embed protoimpl.MessageState, which must never be copied).
+func (s *grpcCompareRootsSession) fill(classes map[string]map[string]hashtree.Digest) *protocol.CompareHashTreeRootsMultiRequest {
+	total := 0
+	for _, roots := range classes {
+		total += len(roots)
+	}
+	for len(s.digests) < total {
+		s.digests = append(s.digests, &protocol.ShardRootDigest{})
+	}
+	for len(s.classes) < len(classes) {
+		s.classes = append(s.classes, &protocol.ClassShardRootDigests{})
+	}
+	di, ci := 0, 0
+	for class, roots := range classes {
+		start := di
+		for shard, root := range roots {
+			d := s.digests[di]
+			d.Shard, d.RootHashHigh, d.RootHashLow = shard, root[0], root[1]
+			di++
+		}
+		cls := s.classes[ci]
+		cls.Index = class
+		cls.ShardRootDigests = s.digests[start:di:di]
+		ci++
+	}
+	s.req.Classes = s.classes[:ci]
+	return &s.req
+}
+
+func (s *grpcCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	client, err := s.c.getClient(host)
 	if err != nil {
 		return nil, err
 	}
 
-	req := &protocol.CompareHashTreeRootsMultiRequest{
-		Classes: make([]*protocol.ClassShardRootDigests, 0, len(classes)),
-	}
-	for class, roots := range classes {
-		shards := make([]*protocol.ShardRootDigest, 0, len(roots))
-		for shard, root := range roots {
-			shards = append(shards, &protocol.ShardRootDigest{
-				Shard:        shard,
-				RootHashHigh: root[0],
-				RootHashLow:  root[1],
-			})
-		}
-		req.Classes = append(req.Classes, &protocol.ClassShardRootDigests{Index: class, ShardRootDigests: shards})
-	}
-
-	grpcResp, err := client.CompareHashTreeRootsMulti(ctx, req)
+	// Graph reuse is safe on the next call: retries re-marshal inside this stub call and nothing retains it after return.
+	grpcResp, err := client.CompareHashTreeRootsMulti(ctx, s.fill(classes))
 	if err != nil {
 		// Older peers don't serve this RPC; sentinel lets the caller fall back.
 		if status.Code(err) == codes.Unimplemented {

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -85,6 +85,11 @@ type fakeGRPCReplicationServer struct {
 	digestsInRangeResp    *pb.DigestObjectsInRangeResponse
 	lastCompareDigestsReq atomic.Pointer[pb.CompareDigestsRequest]
 	lastDigestsInRangeReq atomic.Pointer[pb.DigestObjectsInRangeRequest]
+
+	compareRootsMultiErr     error
+	compareRootsMultiHandler func(*pb.CompareHashTreeRootsMultiRequest) (*pb.CompareHashTreeRootsMultiResponse, error)
+	compareRootsMultiCalls   atomic.Int32
+	lastCompareRootsMultiReq atomic.Pointer[pb.CompareHashTreeRootsMultiRequest]
 }
 
 func newFakeGRPCReplicationServer(t *testing.T) *fakeGRPCReplicationServer {
@@ -145,6 +150,18 @@ func (f *fakeGRPCReplicationServer) CompareDigests(_ context.Context, req *pb.Co
 		return f.compareDigestsResp, nil
 	}
 	return &pb.CompareDigestsResponse{}, nil
+}
+
+func (f *fakeGRPCReplicationServer) CompareHashTreeRootsMulti(_ context.Context, req *pb.CompareHashTreeRootsMultiRequest) (*pb.CompareHashTreeRootsMultiResponse, error) {
+	f.lastCompareRootsMultiReq.Store(req)
+	f.compareRootsMultiCalls.Add(1)
+	if f.compareRootsMultiHandler != nil {
+		return f.compareRootsMultiHandler(req)
+	}
+	if f.compareRootsMultiErr != nil {
+		return nil, f.compareRootsMultiErr
+	}
+	return &pb.CompareHashTreeRootsMultiResponse{}, nil
 }
 
 func (f *fakeGRPCReplicationServer) DigestObjectsInRange(_ context.Context, req *pb.DigestObjectsInRangeRequest) (*pb.DigestObjectsInRangeResponse, error) {

--- a/adapters/clients/replication_mixed.go
+++ b/adapters/clients/replication_mixed.go
@@ -219,6 +219,34 @@ func (s *switchReplicationClient) CompareHashTreeRootsMulti(ctx context.Context,
 	return s.restClient.CompareHashTreeRootsMulti(ctx, host, classes)
 }
 
+var _ replica.CompareRootsSessionFactory = (*switchReplicationClient)(nil)
+
+func (s *switchReplicationClient) NewCompareRootsSession() replica.CompareRootsSession {
+	return &switchCompareRootsSession{client: s}
+}
+
+// switchCompareRootsSession lazily holds one sub-session per transport, dispatching per call like the client.
+type switchCompareRootsSession struct {
+	client *switchReplicationClient
+	grpc   replica.CompareRootsSession
+	rest   replica.CompareRootsSession
+}
+
+func (s *switchCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Context, host string,
+	classes map[string]map[string]hashtree.Digest,
+) (*replica.CompareHashTreeRootsMultiResp, error) {
+	if s.client.useGRPC() {
+		if s.grpc == nil {
+			s.grpc = s.client.grpcClient.NewCompareRootsSession()
+		}
+		return s.grpc.CompareHashTreeRootsMulti(ctx, host, classes)
+	}
+	if s.rest == nil {
+		s.rest = s.client.restClient.NewCompareRootsSession()
+	}
+	return s.rest.CompareHashTreeRootsMulti(ctx, host, classes)
+}
+
 func (s *switchReplicationClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {
 	if s.useGRPC() {
 		return s.grpcClient.CountObjects(ctx, host, index, shard)

--- a/adapters/clients/replication_mixed.go
+++ b/adapters/clients/replication_mixed.go
@@ -210,15 +210,6 @@ func (s *switchReplicationClient) CompareHashTreeRoots(ctx context.Context, host
 	return s.restClient.CompareHashTreeRoots(ctx, host, index, roots)
 }
 
-func (s *switchReplicationClient) CompareHashTreeRootsMulti(ctx context.Context, host string,
-	classes map[string]map[string]hashtree.Digest,
-) (*replica.CompareHashTreeRootsMultiResp, error) {
-	if s.useGRPC() {
-		return s.grpcClient.CompareHashTreeRootsMulti(ctx, host, classes)
-	}
-	return s.restClient.CompareHashTreeRootsMulti(ctx, host, classes)
-}
-
 var _ replica.CompareRootsSessionFactory = (*switchReplicationClient)(nil)
 
 func (s *switchReplicationClient) NewCompareRootsSession() replica.CompareRootsSession {

--- a/adapters/clients/replication_mixed.go
+++ b/adapters/clients/replication_mixed.go
@@ -225,11 +225,10 @@ func (s *switchReplicationClient) NewCompareRootsSession() replica.CompareRootsS
 	return &switchCompareRootsSession{client: s}
 }
 
-// switchCompareRootsSession lazily holds one sub-session per transport, dispatching per call like the client.
+// switchCompareRootsSession lazily holds a gRPC sub-session, dispatching per call like the client.
 type switchCompareRootsSession struct {
 	client *switchReplicationClient
 	grpc   replica.CompareRootsSession
-	rest   replica.CompareRootsSession
 }
 
 func (s *switchCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Context, host string,
@@ -241,10 +240,8 @@ func (s *switchCompareRootsSession) CompareHashTreeRootsMulti(ctx context.Contex
 		}
 		return s.grpc.CompareHashTreeRootsMulti(ctx, host, classes)
 	}
-	if s.rest == nil {
-		s.rest = s.client.restClient.NewCompareRootsSession()
-	}
-	return s.rest.CompareHashTreeRootsMulti(ctx, host, classes)
+	// REST leg stays unpooled: it is being deprecated for async replication.
+	return s.client.restClient.CompareHashTreeRootsMulti(ctx, host, classes)
 }
 
 func (s *switchReplicationClient) CountObjects(ctx context.Context, host string, index string, shard string) (int, error) {

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -86,11 +86,6 @@ var asyncRepTargetHostsSeam func(*Shard) ([]string, error)
 // asyncRepPerClassFallbackSeam replaces the per-class fallback pre-filter in tests; nil outside tests.
 var asyncRepPerClassFallbackSeam func(context.Context, map[string]hashtree.Digest) (map[string]struct{}, replica.PrefilterStats)
 
-// crossClassRootComparer is the narrow client surface for the node-level root compare.
-type crossClassRootComparer interface {
-	NewCompareRootsSession() replica.CompareRootsSession
-}
-
 func init() {
 	asyncRepRebuildBaseBackoff.Store(int64(30 * time.Second))
 }
@@ -607,7 +602,7 @@ type AsyncReplicationScheduler struct {
 	dispatchPending []*asyncSchedulerEntry
 
 	// crossClassComparer is the node-level root-compare client; nil falls back to the per-class pre-filter.
-	crossClassComparer crossClassRootComparer
+	crossClassComparer replica.CompareRootsSessionFactory
 
 	metrics asyncReplicationSchedulerMetrics
 	logger  logrus.FieldLogger
@@ -637,9 +632,9 @@ func NewAsyncReplicationScheduler(
 	replicationCfg replication.GlobalConfig,
 	prom *monitoring.PrometheusMetrics,
 	logger logrus.FieldLogger,
-	crossClassComparer ...crossClassRootComparer,
+	crossClassComparer ...replica.CompareRootsSessionFactory,
 ) (*AsyncReplicationScheduler, error) {
-	var comparer crossClassRootComparer
+	var comparer replica.CompareRootsSessionFactory
 	if len(crossClassComparer) > 0 {
 		comparer = crossClassComparer[0]
 	}

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -88,8 +88,7 @@ var asyncRepPerClassFallbackSeam func(context.Context, map[string]hashtree.Diges
 
 // crossClassRootComparer is the narrow client surface for the node-level root compare.
 type crossClassRootComparer interface {
-	CompareHashTreeRootsMulti(ctx context.Context, host string,
-		classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
+	NewCompareRootsSession() replica.CompareRootsSession
 }
 
 func init() {
@@ -1352,6 +1351,8 @@ type batchScratch struct {
 	// byHost: host → class → shard → root; per-host tuples ≤ batch size (≤4096) so one RPC always fits the receiver's cap.
 	byHost map[string]map[string]map[string]hashtree.Digest
 	skip   map[*asyncSchedulerEntry]bool
+	// session reuses the root-compare request assembly across this worker's batches; survives reset.
+	session replica.CompareRootsSession
 }
 
 func newBatchScratch() *batchScratch {
@@ -1717,7 +1718,10 @@ func (sched *AsyncReplicationScheduler) classifyCrossClass(ctx context.Context, 
 			sched.fallbackPerClass(ctx, classes, scratch, &ok, &errored, &unsupported, fallbackDone)
 			continue
 		}
-		resp, err := sched.crossClassComparer.CompareHashTreeRootsMulti(ctx, host, classes)
+		if scratch.session == nil {
+			scratch.session = sched.crossClassComparer.NewCompareRootsSession()
+		}
+		resp, err := scratch.session.CompareHashTreeRootsMulti(ctx, host, classes)
 		switch {
 		case errors.Is(err, replica.ErrCompareHashTreeRootsUnsupported):
 			unsupported++

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -3376,10 +3377,22 @@ func TestRecordRootPrefilterNoDiffCancelRaceLeavesStatsEmpty(t *testing.T) {
 
 type fakeCrossClassComparer func(ctx context.Context, host string, classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error)
 
+func (f fakeCrossClassComparer) NewCompareRootsSession() replica.CompareRootsSession { return f }
+
 func (f fakeCrossClassComparer) CompareHashTreeRootsMulti(ctx context.Context, host string,
 	classes map[string]map[string]hashtree.Digest,
 ) (*replica.CompareHashTreeRootsMultiResp, error) {
 	return f(ctx, host, classes)
+}
+
+type countingSessionFactory struct {
+	inner    fakeCrossClassComparer
+	sessions atomic.Int32
+}
+
+func (c *countingSessionFactory) NewCompareRootsSession() replica.CompareRootsSession {
+	c.sessions.Add(1)
+	return c.inner
 }
 
 func newPrefilterShard(t *testing.T, class, name string) *asyncSchedulerEntry {
@@ -3389,6 +3402,31 @@ func newPrefilterShard(t *testing.T, class, name string) *asyncSchedulerEntry {
 	s.hashtree = ht
 	s.hashtreeFullyInitialized = true
 	return &asyncSchedulerEntry{shard: s}
+}
+
+func TestClassifyCrossClassSessionPerScratch(t *testing.T) {
+	asyncRepTargetHostsSeam = func(*Shard) ([]string, error) { return []string{"h1"}, nil }
+	t.Cleanup(func() { asyncRepTargetHostsSeam = nil })
+
+	comparer := &countingSessionFactory{inner: func(_ context.Context, _ string, classes map[string]map[string]hashtree.Digest) (*replica.CompareHashTreeRootsMultiResp, error) {
+		resp := &replica.CompareHashTreeRootsMultiResp{Classes: map[string]replica.CompareHashTreeRootsMultiClassResp{}}
+		for cls := range classes {
+			resp.Classes[cls] = replica.CompareHashTreeRootsMultiClassResp{}
+		}
+		return resp, nil
+	}}
+	sched := newBareScheduler(512, 1)
+	sched.ctx = context.Background()
+	sched.crossClassComparer = comparer
+
+	scratch := newBatchScratch()
+	for i := 0; i < 3; i++ {
+		scratch.reset()
+		entry := newPrefilterShard(t, "A", fmt.Sprintf("s%d", i))
+		sched.classifyBatch([]*asyncSchedulerEntry{entry}, scratch)
+		assert.True(t, scratch.skip[entry], i)
+	}
+	assert.Equal(t, int32(1), comparer.sessions.Load())
 }
 
 // TestClassifyCrossClass covers skip/descend outcomes across hosts, classes, and fallback paths.

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -313,7 +313,7 @@ func New(logger logrus.FieldLogger, localNodeName string, config Config,
 	scanAndAsyncDeletePending(config.RootPath, logger)
 
 	// Fakes without the cross-class RPC leave the comparer nil → per-class pre-filter fallback.
-	crossClassComparer, _ := replicaClient.(crossClassRootComparer)
+	crossClassComparer, _ := replicaClient.(replica.CompareRootsSessionFactory)
 	asyncReplicationScheduler, err := NewAsyncReplicationScheduler(
 		context.Background(),
 		config.Replication,

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -109,6 +109,17 @@ type CompareHashTreeRootsMultiClassResp struct {
 	Error           string   `json:"error,omitempty"`
 }
 
+// CompareRootsSession issues cross-class root compares reusing its request assembly; single-goroutine use only.
+type CompareRootsSession interface {
+	CompareHashTreeRootsMulti(ctx context.Context, host string,
+		classes map[string]map[string]hashtree.Digest) (*CompareHashTreeRootsMultiResp, error)
+}
+
+// CompareRootsSessionFactory creates independent CompareRootsSessions, one per calling goroutine.
+type CompareRootsSessionFactory interface {
+	NewCompareRootsSession() CompareRootsSession
+}
+
 // WClient is the client used to write to replicas
 type WClient interface {
 	PutObject(ctx context.Context, host, index, shard, requestID string,


### PR DESCRIPTION
## Motivation

The cross-class root-prefilter RPC (#12765) lets one scheduler batch compare up to 4096 shard roots per call, but `CompareHashTreeRootsMulti` rebuilt its gRPC request from scratch on every call: one `ShardRootDigest` proto message per shard plus per-class messages and slices. On a 50k+ tenant fleet this is steady per-sweep garbage — the same profiling round that produced #12929 attributes ~2% of process allocation volume to this assembly.

## Approach

Each scheduler worker now lazily creates one `CompareRootsSession` and reuses its request assembly across batches. The session lives on `batchScratch` (already per-worker) and survives `reset()`, so the single-goroutine contract falls out of existing ownership rather than new locking.

- **gRPC session**: a high-water pointer arena of proto messages, rewritten in place per call. Messages are reused strictly by pointer — they embed `protoimpl.MessageState`, which must never be copied — and per-class sub-slices are carved from one flat digest arena with full-slice-expression capacity caps. The arena is shape-independent and bounded by the 4096-shard batch cap (~256KB worst case per worker).
- **Switch session**: holds a lazy gRPC sub-session and dispatches per call on the runtime gRPC flag; the REST leg calls the plain client method.

The REST path is deliberately left untouched: a reusable map pool there is shape-sensitive (inner maps never shrink, so heterogeneous batches ratchet retained bucket memory while reallocating), the wins were small since `json.Marshal` internals dominate that path, and the REST transport is being deprecated for async replication.

Serialization is untouched: gRPC re-marshals the current field values inside each stub call (retries included, so graph reuse on the next call is safe). The scheduler was the sole consumer of this RPC and now reaches it only through sessions, so the switch and gRPC clients' plain `CompareHashTreeRootsMulti` methods (dead code) are removed — the REST plain method remains as the switch session's REST leg — and the scheduler consumes `replica.CompareRootsSessionFactory` directly instead of a method-identical local interface, with compile-time assertions on both clients guarding the seam.

## Key areas for review

- `adapters/clients/replication_grpc.go:grpcCompareRootsSession.fill` — the arena: high-water growth, in-place rewrite, and the `s.digests[start:di:di]` sub-slicing; verify no call can observe a stale message from a previous (larger) fill
- `adapters/repos/db/async_replication_scheduler.go:classifyCrossClass` — session lifecycle: created lazily per scratch, reused across batches, never shared across workers
- `adapters/clients/replication_mixed.go:switchCompareRootsSession` — per-call dispatch on the runtime flag

## Risks and mitigations

- **Request aliasing after the call returns**: the gRPC stub marshals synchronously within the call (including its internal retries) and nothing retains the message graph afterwards; tests pin that a session stays usable after a server error and after an `Unimplemented` sentinel.
- **Stale state bleeding between calls**: `fill` overwrites the graph with exactly the given classes each time; reuse tests cover shrink-then-grow sequences and assert the wire contents match a from-scratch build.
- **Cross-goroutine sharing**: sessions are documented single-goroutine and reach workers only through per-worker `batchScratch`; a `-race` test runs separate sessions concurrently, and a scheduler test pins exactly one session per scratch across repeated batches.
- **Behavior drift**: the session round-trip tests capture the server-decoded request and compare it against a from-scratch build; the REST client is unchanged.

## Testing

Unit tests (`adapters/clients/replication_compare_roots_session_test.go`, scheduler test): fill reuse across changing batch shapes, zero-alloc assertions on steady-state assembly, round-trips against a fake gRPC server with the request captured and compared, error/`Unimplemented` handling with continued session usability, switch-client dispatch across flag flips (gRPC and REST legs), concurrent sessions under `-race`, and one-session-per-worker in the scheduler.

Assembly benchmark: 11.5KB / 132 allocs → 0 / 0 per call at the default 128-shard batch; 366KB / 4130 → 0 / 0 at the 4096-shard cap (4–5x faster).

Follow-ups deliberately not in this PR: the per-shard routing-plan resolution under `classifyCrossClass` (`TargetHostAddrsForShard`, the other ~2% in the same profile), the same reuse for the single-class fallback RPC, and the eventual parallel-array wire format that would remove per-shard messages on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
