### PR TITLE
perf(aggregation-pr6): let scan workers claim doc IDs one at a time

### DIFF
--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -14,9 +14,8 @@ package docid
 import (
 	"context"
 	"encoding/binary"
-	"math"
-	"runtime"
 	"sync"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -27,9 +26,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/concurrency"
 )
-
-func scanConcurrency() int { return 2 * runtime.GOMAXPROCS(0) }
 
 // A worker carries its largest object between reads, so this bounds what one
 // outsized object pins. A normal object with its vectors fits under it.
@@ -107,14 +105,10 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 
 	lock := sync.Mutex{}
 	eg, groupCtx := enterrors.NewErrorGroupWithContextWrapper(os.logger, ctx)
-	concurrency := scanConcurrency()
-	stride := int(math.Ceil(max(float64(len(os.pointers))/float64(concurrency), 1)))
-	for i := 0; i < concurrency; i++ {
-		start := i * stride
-		end := min(start+stride, len(os.pointers))
-		if start >= len(os.pointers) {
-			break
-		}
+	// drawn one at a time: sizes vary by orders of magnitude, so an equal count is not equal work
+	var nextIdx atomic.Int64
+	workers := min(concurrency.CurrentGOMAXPROCSx2(), len(os.pointers))
+	for range workers {
 		f := func() error {
 			// each object is scanned one after the other, so we can reuse the same memory allocations for all objects
 			docIDBytes := make([]byte, 8)
@@ -126,10 +120,13 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 			// The typed properties are needed for extraction from json
 			var properties models.PropertySchema
 
-			// checked per doc ID rather than every nth: a worker's range is only
-			// len(pointers)/concurrency long, so an interval skips short ranges
-			// outright. BenchmarkScanObjectsLSM sweeps what the check costs.
-			for _, id := range os.pointers[start:end] {
+			for {
+				idx := int(nextIdx.Add(1) - 1)
+				if idx >= len(os.pointers) {
+					return nil
+				}
+				id := os.pointers[idx]
+				// per doc ID: a worker's remaining share is unknown, so an interval bounds nothing
 				if err := groupCtx.Err(); err != nil {
 					return err
 				}
@@ -170,7 +167,6 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 					objBuf = nil
 				}
 			}
-			return nil
 		}
 
 		eg.Go(f)

--- a/adapters/repos/db/docid/scan_test.go
+++ b/adapters/repos/db/docid/scan_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -103,9 +104,8 @@ func runScanObjectsLSMCase(t *testing.T, objectCount, failOnCall, segments int) 
 func TestScanObjectsLSMCancellation(t *testing.T) {
 	const someObjects = 100
 
-	// ten doc IDs per worker, so the first worker's range holds the whole of what
-	// the two part-way rows observe and no other worker can reach scanFn
-	tenPerWorker := 10 * scanConcurrency()
+	// ten times as many doc IDs as workers, so stopping early does far less work
+	tenPerWorker := 10 * concurrency.CurrentGOMAXPROCSx2()
 
 	tests := []struct {
 		name string
@@ -139,14 +139,14 @@ func TestScanObjectsLSMCancellation(t *testing.T) {
 			maxScanCalls:     0,
 		},
 		{
-			// only the first worker's range resolves, so it alone reaches scanFn and
-			// the count below is its own behaviour rather than a race between workers
+			// each worker past its check can still land one call before seeing the cancel
 			name:          "cancelled part way through, every doc ID resolves",
-			storedObjects: 10,
+			storedObjects: tenPerWorker,
 			pointerCount:  tenPerWorker,
-			maxScanCalls:  1,
+			maxScanCalls:  concurrency.CurrentGOMAXPROCSx2(),
 		},
 		{
+			// one resolvable doc ID means one possible call whatever the workers do
 			name:          "cancelled part way through, only the first doc ID resolves",
 			storedObjects: 1,
 			pointerCount:  tenPerWorker,
@@ -181,7 +181,14 @@ func TestScanObjectsLSMCancellation(t *testing.T) {
 
 			err := ScanObjectsLSM(ctx, store, pointers, scan, []string{"name"}, logger)
 
-			require.ErrorIs(t, err, context.Canceled)
+			if tt.cancelBeforeScan {
+				require.ErrorIs(t, err, context.Canceled,
+					"a scan handed a cancelled context must report it")
+			} else if err != nil {
+				// cancelling mid-scan races the per-doc-ID check, so success is a
+				// valid outcome; an error that does come back is the cancellation
+				require.ErrorIs(t, err, context.Canceled)
+			}
 			require.LessOrEqual(t, calls.Load(), int64(tt.maxScanCalls))
 			if calls.Load() > 0 {
 				require.True(t, sawCancel.Load(), "scanFn was handed a context the caller cannot cancel")
@@ -242,8 +249,8 @@ func TestScanObjectsLSMPropertyValues(t *testing.T) {
 					pointers = append(pointers, id)
 				}
 			}
-			require.Greater(t, len(pointers), scanConcurrency(),
-				"a worker must read more than one object or its buffer is never reused")
+			require.Greater(t, len(pointers), concurrency.CurrentGOMAXPROCSx2(),
+				"some worker must read more than one object or its buffer is never reused")
 
 			var lock sync.Mutex
 			scanned := map[uint64]interface{}{}
@@ -432,4 +439,60 @@ func requireSegmentsOnDisk(tb testing.TB, dir string, want int) {
 		}
 	}
 	require.Equal(tb, want, got, "segment files in %s", dir)
+}
+
+// BenchmarkScanObjectsLSMSizeSkew moves only where the large objects sit in an
+// ascending allow list, the order the filtered path passes. spread is the
+// control: equal counts already hold equal bytes there, so both rows read alike.
+func BenchmarkScanObjectsLSMSizeSkew(b *testing.B) {
+	const (
+		objectCount = 5000
+		largeCount  = 200
+		smallBytes  = 512
+		largeBytes  = 200 * 1024
+		segments    = 4
+	)
+
+	benchmarks := []struct {
+		name string
+		// large objects in one contiguous run of doc IDs rather than at a stride
+		clustered bool
+	}{
+		{name: "large objects clustered", clustered: true},
+		{name: "large objects spread", clustered: false},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			stride := objectCount / largeCount
+			props := make([]map[string]interface{}, objectCount)
+			large := 0
+			for i := range props {
+				padding := smallBytes
+				isLarge := i < largeCount
+				if !bm.clustered {
+					isLarge = i%stride == 0
+				}
+				if isLarge {
+					padding = largeBytes
+					large++
+				}
+				props[i] = objectProperties(i, padding)
+			}
+			require.Equal(b, largeCount, large, "both rows must hold the same bytes")
+
+			logger, _ := test.NewNullLogger()
+			store, pointers := storeWithProperties(b, logger, segments, props)
+			scan := func(_ context.Context, _ *models.PropertySchema, _ uint64) error { return nil }
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := ScanObjectsLSM(context.Background(), store, pointers, scan,
+					[]string{"name"}, logger); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }

--- a/entities/concurrency/gomaxprocs.go
+++ b/entities/concurrency/gomaxprocs.go
@@ -31,6 +31,12 @@ var (
 	SROAR_MERGE = GOMAXPROCS_2
 )
 
+// CurrentGOMAXPROCSx2 returns twice GOMAXPROCS read now, where GOMAXPROCSx2 is
+// fixed at package init and misses a later limitResources or debug-endpoint change.
+func CurrentGOMAXPROCSx2() int {
+	return 2 * runtime.GOMAXPROCS(0)
+}
+
 func NoMoreThanGOMAXPROCS(conc int) int {
 	if conc > GOMAXPROCS || conc <= 0 {
 		return GOMAXPROCS

--- a/entities/concurrency/gomaxprocs_test.go
+++ b/entities/concurrency/gomaxprocs_test.go
@@ -13,6 +13,7 @@ package concurrency
 
 import (
 	"fmt"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -216,4 +217,14 @@ func TestFractionOf(t *testing.T) {
 			assert.Equal(t, tc.expected, n)
 		})
 	}
+}
+
+// limitResources and /debug/config/gomaxprocs both change GOMAXPROCS after init.
+func TestCurrentGOMAXPROCSx2FollowsGOMAXPROCS(t *testing.T) {
+	original := runtime.GOMAXPROCS(0)
+	t.Cleanup(func() { runtime.GOMAXPROCS(original) })
+
+	assert.Equal(t, original, runtime.GOMAXPROCS(original+1))
+	assert.Equal(t, 2*(original+1), CurrentGOMAXPROCSx2())
+	assert.Equal(t, 2*original, GOMAXPROCSx2, "the package-init snapshot must not move")
 }


### PR DESCRIPTION
<!-- title: perf(aggregation-pr6): let scan workers claim doc IDs one at a time -->

Stacked on #12914. Review that one first; this diff is only the top two commits.

## Motivation

`ScanObjectsLSM` gave each worker a contiguous equal-count slice of the allow list. Object sizes span orders of magnitude, so a filter whose matches correlate with large objects loads a few slices with most of the bytes, and the scan returns only when the slowest worker does.

## Approach

Workers take the next doc ID from a shared counter, so the imbalance is bounded by one object rather than by a whole slice. The counter is touched once per doc ID, alongside the mutex the loop already takes once per object.

`scanConcurrency` is replaced by `concurrency.CurrentGOMAXPROCSx2`, which the first commit adds. The package-level `GOMAXPROCSx2` holds what `GOMAXPROCS` was at package init, and both `limitResources` and `POST /debug/config/gomaxprocs` change it after that; a fan-out sized once per request reads it per call, as `usecases/backup` already does for the same reason.

## Key areas for review

- `docid/scan.go` — the exhausted-list return stays `nil`. A scan whose every context check passed has done its work; a caller that needs to distinguish cancellation checks `ctx` after the call.
- `concurrency/gomaxprocs.go` — `TimesGOMAXPROCS` still reads the snapshot, and one of its two callers sizes a per-query budget. Same defect, deliberately not fixed here.

## Risks

Peak buffer memory rises: each worker grows its payload buffer to the largest object it reads, and any worker can now draw a large one. `maxRetainedBufferBytes` (#12899) bounds what one worker keeps between reads.

## Testing

- `BenchmarkScanObjectsLSMSizeSkew` places the same large objects either in one contiguous run of doc IDs or at an even stride across them, the two shapes an ascending allow list can carry. The spread row is the control: an equal-count split already holds equal bytes there, so it must read alike on either side of this change while the clustered row is what moves.
- `TestScanObjectsLSMCancellation`'s part-way rows no longer require an error, since a cancellation landing after every worker passed its check leaves nothing to report. They bound the call count, and assert the cancellation where an error does come back. A context already cancelled on entry is still always reported.
- `TestCurrentGOMAXPROCSx2FollowsGOMAXPROCS` fails if the helper returns the package-level snapshot.
