### PR TITLE
perf(aggregation-pr7): reuse one property map for all objects a scan worker reads

### DIFF
--- a/adapters/repos/db/docid/scan.go
+++ b/adapters/repos/db/docid/scan.go
@@ -42,6 +42,10 @@ type ObjectScanFn func(ctx context.Context, prop *models.PropertySchema, docID u
 // specified pointer. If a pointer does not resolve to an object-id, the item
 // will be skipped. The number of times scanFn is called can therefore be
 // smaller than the input length of pointers.
+//
+// prop is refilled for the next object the same worker reads: read the values
+// out rather than keeping the map. *prop is nil when properties is empty;
+// prop itself never is.
 func ScanObjectsLSM(ctx context.Context, store *lsmkv.Store, pointers []uint64, scan ObjectScanFn, properties []string, logger logrus.FieldLogger) error {
 	return newObjectScannerLSM(store, pointers, scan, properties, logger).Do(ctx)
 }
@@ -120,6 +124,13 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 			// The typed properties are needed for extraction from json
 			var properties models.PropertySchema
 
+			// One map per worker: UnmarshalPropertiesFromObject clears it before it writes.
+			var propertiesTyped map[string]any
+			if len(os.properties) > 0 {
+				propertiesTyped = make(map[string]any, len(os.properties))
+				properties = propertiesTyped
+			}
+
 			for {
 				idx := int(nextIdx.Add(1) - 1)
 				if idx >= len(os.pointers) {
@@ -141,13 +152,10 @@ func (os *objectScannerLSM) scan(ctx context.Context) error {
 					continue
 				}
 
-				propertiesTyped := map[string]interface{}{}
-				if len(os.properties) > 0 {
-					err = storobj.UnmarshalPropertiesFromObject(res, propertiesTyped, propertyPaths)
-					if err != nil {
+				if propertiesTyped != nil {
+					if err := storobj.UnmarshalPropertiesFromObject(res, propertiesTyped, propertyPaths); err != nil {
 						return errors.Wrapf(err, "unmarshal data object")
 					}
-					properties = propertiesTyped
 				}
 
 				// majority of time is spend reading the objects => do the analyses sequentially to not cause races

--- a/adapters/repos/db/docid/scan_test.go
+++ b/adapters/repos/db/docid/scan_test.go
@@ -16,8 +16,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -197,14 +199,16 @@ func TestScanObjectsLSMCancellation(t *testing.T) {
 	}
 }
 
-// A worker's payload buffer is grown to the largest object it has read, so a
-// smaller object is parsed out of a buffer whose spare capacity still holds a
-// larger one. These rows pin the values scanFn is handed under that reuse.
+// A worker reuses its payload buffer and its property map across objects, so
+// each is parsed into a buffer and a map the previous object left behind.
+// These rows pin the values scanFn is handed under that reuse.
 func TestScanObjectsLSMPropertyValues(t *testing.T) {
 	const (
-		objectCount = 200
-		sizeStep    = 64
+		sizeStep = 64
+		// a mean, not a floor: workers draw doc IDs from one shared counter
+		objectsPerWorker = 8
 	)
+	objectCount := max(200, concurrency.CurrentGOMAXPROCSx2()*objectsPerWorker)
 	propertyNames := []string{"name", "count", "flag", "tags", "scores", "meta"}
 
 	tests := []struct {
@@ -215,11 +219,18 @@ func TestScanObjectsLSMPropertyValues(t *testing.T) {
 		missingEvery int
 		// every nth object is padded past maxRetainedBufferBytes; 0 pads none
 		oversizedEvery int
+		// objects carry different property sets, so a stale value shows up
+		varyProperties bool
+		// no property is requested at all, so scanFn is handed a nil schema
+		noProperties bool
 	}{
 		{name: "sizes descending", descending: true},
 		{name: "sizes ascending", descending: false},
 		{name: "sizes descending, doc IDs missing mid-scan", descending: true, missingEvery: 7},
 		{name: "objects past the retained buffer cap", oversizedEvery: 13},
+		{name: "property sets differ", varyProperties: true},
+		{name: "property sets differ, doc IDs missing mid-scan", varyProperties: true, missingEvery: 7},
+		{name: "no property requested", noProperties: true},
 	}
 
 	for _, tt := range tests {
@@ -234,6 +245,15 @@ func TestScanObjectsLSMPropertyValues(t *testing.T) {
 					padding = maxRetainedBufferBytes + sizeStep
 				}
 				props[i] = objectProperties(i, padding)
+				if tt.varyProperties {
+					// bit j of i keeps property j, so objects fewer than
+					// 1<<len(propertyNames) apart carry different sets
+					for j, name := range propertyNames {
+						if i&(1<<j) == 0 {
+							delete(props[i], name)
+						}
+					}
+				}
 			}
 
 			logger, _ := test.NewNullLogger()
@@ -249,23 +269,41 @@ func TestScanObjectsLSMPropertyValues(t *testing.T) {
 					pointers = append(pointers, id)
 				}
 			}
-			require.Greater(t, len(pointers), concurrency.CurrentGOMAXPROCSx2(),
-				"some worker must read more than one object or its buffer is never reused")
-
 			var lock sync.Mutex
-			scanned := map[uint64]interface{}{}
+			scanned := map[uint64]map[string]interface{}{}
+			// map addresses, so the count below pins one map per worker not per object
+			handedOut := map[uintptr]bool{}
 			scan := func(_ context.Context, prop *models.PropertySchema, docID uint64) error {
 				lock.Lock()
 				defer lock.Unlock()
-				scanned[docID] = *prop
+				if *prop == nil {
+					scanned[docID] = nil
+					return nil
+				}
+				typed := (*prop).(map[string]interface{})
+				handedOut[reflect.ValueOf(typed).Pointer()] = true
+				// the worker refills this map for its next object
+				scanned[docID] = maps.Clone(typed)
 				return nil
 			}
 
+			requested := propertyNames
+			if tt.noProperties {
+				requested = nil
+			}
+
 			require.NoError(t, ScanObjectsLSM(context.Background(), store, pointers, scan,
-				propertyNames, logger))
+				requested, logger))
 
 			require.Len(t, scanned, objectCount)
+			if !tt.noProperties {
+				require.LessOrEqual(t, len(handedOut), min(concurrency.CurrentGOMAXPROCSx2(), len(pointers)),
+					"a worker hands the same map to every object it reads")
+			}
 			for i, want := range props {
+				if tt.noProperties {
+					want = nil
+				}
 				require.Equal(t, want, scanned[uint64(i)], "properties of object %d", i)
 			}
 		})
@@ -303,10 +341,13 @@ func BenchmarkScanObjectsLSM(b *testing.B) {
 		name          string
 		storedObjects int
 		segments      int
+		// no property requested, as an IncludeMetaCount-only aggregation does
+		noProperties bool
 	}{
 		{name: "every doc ID resolves, one segment", storedObjects: docIDCount, segments: 1},
 		{name: "every doc ID resolves, several segments", storedObjects: docIDCount, segments: manySegments},
 		{name: "no doc ID resolves", storedObjects: 0, segments: 0},
+		{name: "every doc ID resolves, no property requested", storedObjects: docIDCount, segments: 1, noProperties: true},
 	}
 
 	for _, bm := range benchmarks {
@@ -317,12 +358,16 @@ func BenchmarkScanObjectsLSM(b *testing.B) {
 				pointers = append(pointers, uint64(i))
 			}
 			scan := func(_ context.Context, _ *models.PropertySchema, _ uint64) error { return nil }
+			requested := []string{"name"}
+			if bm.noProperties {
+				requested = nil
+			}
 
 			b.ReportAllocs()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
 				if err := ScanObjectsLSM(context.Background(), store, pointers, scan,
-					[]string{"name"}, logger); err != nil {
+					requested, logger); err != nil {
 					b.Fatal(err)
 				}
 			}


### PR DESCRIPTION
Stacked on #12940. Review that one first; this diff is only the top commit.

## Motivation

The property map was the last per-object allocation in `ScanObjectsLSM`'s worker loop, and the contract for reusing it already existed: `UnmarshalPropertiesFromObject` clears the map it is handed before writing, documented for a caller that reuses one.

It was also allocated outside the guard checking whether any property was requested. `filteredAggregator.properties` runs unconditionally, so an `IncludeMetaCount`-only aggregation allocated and discarded one map per object.

## Key areas for review

- The map stays inside the worker closure. Workers fill it outside the mutex, which guards only `scanFn`, so sharing one across workers would be a data race.
- Safety rests on that `clear()`. Without it a property present on one object and absent on the next leaks into the next object's callback — a wrong aggregate, silently.
- The fixture now scales its object count with `GOMAXPROCS`, making #12940's worker-count guard true by construction. The map-identity assertion replacing it fails unless the reuse happens.

## Testing

`TestScanObjectsLSMPropertyValues` gains rows whose consecutive objects carry different property sets — they fail if that `clear()` goes — and one pinning the nil schema a no-property scan hands back. `BenchmarkScanObjectsLSM` gains a row for that shape.
