### PR TITLE
perf(inverted): call ctx.Err() directly instead of the ctxExpired helper

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -66,7 +66,7 @@ func newPropValuePair(class *models.Class) (*propValuePair, error) {
 }
 
 func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
 

--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -91,18 +91,6 @@ func (rr *RowReaderRoaringSet) bareKey(k []byte) []byte {
 	return k[len(rr.keyPrefix):]
 }
 
-// ctxExpired reports whether ctx has been cancelled or timed out. It uses a
-// non-blocking channel receive, which avoids the mutex acquisition that
-// ctx.Err() performs on every call — important for tight cursor loops.
-func ctxExpired(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	default:
-		return nil
-	}
-}
-
 // ReadFn will be called 1..n times per match. This means it will also
 // be called on a non-match, in this case v == empty bitmap.
 // It is up to the caller to decide if that is an error case or not.
@@ -147,7 +135,7 @@ func (rr *RowReaderRoaringSet) Read(ctx context.Context, readFn ReadFn) error {
 func (rr *RowReaderRoaringSet) equal(ctx context.Context,
 	readFn ReadFn,
 ) error {
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 
@@ -177,7 +165,7 @@ func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 
 	fk := rr.fullKey()
 	for k, v := c.Seek(fk); k != nil && rr.inPrefix(k); k, v = c.Next() {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
@@ -223,7 +211,7 @@ func (rr *RowReaderRoaringSet) lessThan(ctx context.Context,
 	// keys appear, and bytes.Compare(k, fk) >= cmpLimit stops the loop before
 	// any higher-prefix key, since those sort after fk = keyPrefix+value.
 	for k, v := initialK, initialV; k != nil && bytes.Compare(k, fk) < cmpLimit; k, v = c.Next() {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
@@ -269,7 +257,7 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 	}
 
 	for k, v := initialK, initialV; k != nil && rr.inPrefix(k); k, v = c.Next() {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -74,7 +74,7 @@ func (e *recExecutor) withProps(props []*models.NestedProperty) *recExecutor {
 // responsible for stripping to docIDs via bitmapOps.MaskRootLeaf when needed
 // and must invoke the returned release.
 func (e *recExecutor) execute(ctx context.Context, plan recPlanNode) (*sroar.Bitmap, func(), error) {
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
 	if plan == nil {
@@ -231,7 +231,7 @@ func (e *recExecutor) collectFlatSubtree(g *recGroupNode) (*flatSubtree, bool) {
 // condition lands on a leaf shared with all the others, which by the
 // analyzer's DFS encoding means they belong to the same physical element.
 func (e *recExecutor) evalFlatRawAndAll(ctx context.Context, flat *flatSubtree, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
 	bitmaps := make([]*sroar.Bitmap, 0, len(flat.leaves)+1)
@@ -383,7 +383,7 @@ func (e *recExecutor) runIdxLoopRecursive(ctx context.Context, g *recGroupNode, 
 	if e.metaBucket == nil {
 		return nil, nil, fmt.Errorf("runIdxLoopRecursive: meta bucket is nil for %q", g.lca)
 	}
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
 
@@ -410,7 +410,7 @@ func (e *recExecutor) runIdxLoopRecursive(ctx context.Context, g *recGroupNode, 
 	defer c.Close()
 
 	for k, elemBitmap := c.Seek(invnested.IdxKey(g.lca, 0)); k != nil; k, elemBitmap = c.Next() {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
 		if !bytes.HasPrefix(k, idxPrefix) {
@@ -532,7 +532,7 @@ func (e *recExecutor) evalSplit(ctx context.Context, n *recSplitNode, parentScop
 	}()
 
 	for _, br := range n.branches {
-		if err := ctxExpired(ctx); err != nil {
+		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
 		bm, rel, err := e.evalSplitBranch(ctx, n.lca, br, parentScope)
@@ -632,7 +632,7 @@ func (e *recExecutor) intersectScope(scope, parentScope *sroar.Bitmap) (*sroar.B
 // parentScope is passed through to each child's evalNode unchanged. Children's
 // own evaluation logic applies the scope; the OR doesn't need to re-apply.
 func (e *recExecutor) evalOr(ctx context.Context, n *recOrNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
 	if len(n.children) == 0 {
@@ -680,7 +680,7 @@ func (e *recExecutor) evalOr(ctx context.Context, n *recOrNode, parentScope *sro
 // the MaskLeaf step in evalNot can be dropped then, and the universe stays
 // raw end-to-end).
 func (e *recExecutor) evalNot(ctx context.Context, n *recNotNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
-	if err := ctxExpired(ctx); err != nil {
+	if err := ctx.Err(); err != nil {
 		return nil, nil, err
 	}
 	if e.metaBucket == nil {

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -837,7 +837,7 @@ func TestRecExecutorFilterExamples(t *testing.T) {
 //
 // Two layers are exercised:
 //
-//   - Top-level: execute() checks ctxExpired at the very top, so any cancelled
+//   - Top-level: execute() checks ctx.Err() at the very top, so any cancelled
 //     context short-circuits regardless of plan shape. The
 //     `cancelled_via_*` sub-tests cover the three execute() dispatches with
 //     a non-nil plan: canUseRawAndAll (raw AndAll, no idx loop),
@@ -924,7 +924,7 @@ func TestRecExecutorContextCancellation(t *testing.T) {
 	t.Run("inner_check_runIdxLoopRecursive_returns_ctx_err", func(t *testing.T) {
 		// Bypass execute() and invoke evalNode directly so the top-level
 		// check is skipped. runIdxLoopRecursive's own start-of-function
-		// ctxExpired guard must still fire — this protects long-running idx
+		// ctx.Err() guard must still fire — this protects long-running idx
 		// iterations after a previous ctx check passed.
 		mb := newIdxBucket(t)
 		writeIdx(t, mb, "garages", 0, []uint64{enc(1, 1, 100)})
@@ -946,7 +946,7 @@ func TestRecExecutorContextCancellation(t *testing.T) {
 
 	t.Run("inner_check_evalSplit_returns_ctx_err", func(t *testing.T) {
 		// Bypass execute() and invoke evalNode directly. evalSplit's
-		// per-branch ctxExpired guard must fire — this protects multi-branch
+		// per-branch ctx.Err() guard must fire — this protects multi-branch
 		// dispatch when each branch incurs a metaBucket read.
 		mb := newIdxBucket(t)
 		writeIdx(t, mb, "garages", 0, []uint64{enc(1, 1, 100)})


### PR DESCRIPTION
`adapters/repos/db/inverted/` had two spellings of one context check: a `ctxExpired` helper at 12 sites, and plain `ctx.Err()` everywhere else. This drops the helper.

## Motivation

Its godoc said the non-blocking receive on `ctx.Done()` avoids a mutex `ctx.Err()` takes on every call. On go1.26 that is backwards: `cancelCtx.Err()` returns after a single atomic load and takes no lock on the uncancelled path, while `cancelCtx.Done()` is the side that locks, allocating the done channel under `c.mu` on first use.

## Key areas for review

Equivalence at the 12 sites: the stdlib contract binds `Err() != nil` exactly when `Done()` is closed, including where `Done()` is nil (`context.Background()`).

## Risks

The equivalence holds for any stdlib context; the only custom `context.Context` in the repo is a test type in `db` that delegates both methods to an embedded context and never reaches this package.

## Testing

The package's unit and `integrationTest` suites pass under `-race`, and deleting the guard in `recExecutor.execute` fails `TestRecExecutorContextCancellation` in well under a second. What green does not prove: the four row-reader guards and the one in `resolveDocIDs` are pinned by no test, before this change as after it.
