### PR TITLE
perf: cache node host:port resolution behind membership events

### DIFF
--- a/cluster/replication/consumer_test.go
+++ b/cluster/replication/consumer_test.go
@@ -1151,13 +1151,13 @@ func TestConsumerOpDuplication(t *testing.T) {
 	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 	status := replication.NewShardReplicationStatus(api.FINALIZING)
 
-	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	completionWg.Add(1)
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 
 	// Send the same operation again to make sure it isn't reprocessed after a state change
 	// as mocked in the above expectations
-	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	completionWg.Add(1)
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 
 	waitChan := make(chan struct{})
 	go func() {
@@ -1282,12 +1282,12 @@ func TestConsumerOpSkip(t *testing.T) {
 	op := replication.NewShardReplicationOp(1, "node1", "node2", "TestCollection", "shard1", api.COPY)
 	status := replication.NewShardReplicationStatus(api.FINALIZING)
 
-	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	completionWg.Add(1)
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 
 	// Send the same operation again twice to make sure it is skipped
-	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	completionWg.Add(1)
+	opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 
 	waitChan := make(chan struct{})
 	go func() {
@@ -1393,8 +1393,8 @@ func TestConsumerShutdown(t *testing.T) {
 			Return(api.HYDRATING, nil)
 		op := replication.NewShardReplicationOp(uint64(i), "node1", "node2", "TestCollection", "test-shard", api.COPY)
 		status := replication.NewShardReplicationStatus(api.HYDRATING)
-		opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 		completionWg.Add(1)
+		opsChan <- replication.NewShardReplicationOpAndStatus(op, status)
 	}
 	// Wait for a second for the ops to start processing
 	time.Sleep(1 * time.Second)

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -93,6 +94,7 @@ type memberInfo struct {
 	gossipPort uint16
 	meta       NodeMetadata
 	metaOK     bool
+	hostAddr   string // host:dataPort, precomputed so resolver reads stay allocation-free
 }
 
 // memberView mirrors the live member set: Members() Node fields race in-place alive updates.
@@ -106,6 +108,7 @@ func (v *memberView) record(node *memberlist.Node) (metaOK bool) {
 	if len(node.Meta) > 0 && json.Unmarshal(node.Meta, &info.meta) == nil {
 		info.metaOK = true
 	}
+	info.hostAddr = net.JoinHostPort(info.addr, strconv.Itoa(info.dataPort()))
 	v.Lock()
 	defer v.Unlock()
 	if v.byName == nil {
@@ -337,7 +340,7 @@ func (s *State) Hostnames() []string {
 		if name == s.LocalName() {
 			continue
 		}
-		out = append(out, net.JoinHostPort(info.addr, fmt.Sprintf("%d", info.dataPort())))
+		out = append(out, info.hostAddr)
 	}
 	return out
 }
@@ -351,7 +354,7 @@ func (s *State) AllHostnames() []string {
 	view := s.members.snapshot()
 	out := make([]string, 0, len(view))
 	for _, info := range view {
-		out = append(out, net.JoinHostPort(info.addr, fmt.Sprintf("%d", info.dataPort())))
+		out = append(out, info.hostAddr)
 	}
 	return out
 }
@@ -451,7 +454,7 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	return net.JoinHostPort(info.addr, fmt.Sprintf("%d", info.dataPort())), true
+	return info.hostAddr, true
 }
 
 // extractHost extracts the host portion from an address string,

--- a/usecases/cluster/state_hostname_test.go
+++ b/usecases/cluster/state_hostname_test.go
@@ -1,0 +1,159 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newHostnameTestState(tb testing.TB, hostname, join string, dataPort int) (*State, int) {
+	tb.Helper()
+
+	logger, _ := logrustest.NewNullLogger()
+	gossipPort := freeGossipPort(tb)
+	state, err := Init(Config{
+		Hostname:       hostname,
+		Localhost:      true,
+		BindAddr:       "127.0.0.1",
+		AdvertiseAddr:  "127.0.0.1",
+		Join:           join,
+		GossipBindPort: gossipPort,
+		DataBindPort:   dataPort,
+	}, 1, tb.TempDir(), nil, logger)
+	require.NoError(tb, err)
+	tb.Cleanup(func() {
+		require.NoError(tb, state.Shutdown())
+	})
+
+	return state, gossipPort
+}
+
+func TestNodeHostnameCached(t *testing.T) {
+	state, _ := newHostnameTestState(t, "hn-cached-node1", "", 8080)
+
+	cold, ok := state.NodeHostname("hn-cached-node1")
+	require.True(t, ok)
+	require.Equal(t, "127.0.0.1:8080", cold)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		warm, ok := state.NodeHostname("hn-cached-node1")
+		if !ok || warm != cold {
+			t.Errorf("warm lookup diverged: %q %v", warm, ok)
+		}
+	})
+	assert.Zero(t, allocs)
+
+	_, ok = state.NodeHostname("hn-cached-unknown")
+	assert.False(t, ok)
+}
+
+func TestNodeHostnameSeesJoinedNode(t *testing.T) {
+	state1, gossipPort1 := newHostnameTestState(t, "hn-join-node1", "", 8080)
+
+	_, ok := state1.NodeHostname("hn-join-node1")
+	require.True(t, ok)
+	_, ok = state1.NodeHostname("hn-join-node2")
+	require.False(t, ok)
+
+	newHostnameTestState(t, "hn-join-node2", "127.0.0.1:"+strconv.Itoa(gossipPort1), 8081)
+
+	require.Eventually(t, func() bool {
+		addr, ok := state1.NodeHostname("hn-join-node2")
+		return ok && addr == "127.0.0.1:8081"
+	}, 10*time.Second, 50*time.Millisecond)
+}
+
+func TestNodeHostnameConcurrentChurn(t *testing.T) {
+	state1, gossipPort1 := newHostnameTestState(t, "hn-churn-node1", "", 8080)
+
+	expected, ok := state1.NodeHostname("hn-churn-node1")
+	require.True(t, ok)
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if addr, ok := state1.NodeHostname("hn-churn-node1"); !ok || addr != expected {
+					t.Errorf("stable node resolution broke: %q %v", addr, ok)
+					return
+				}
+				if _, ok := state1.NodeHostname("hn-churn-never"); ok {
+					t.Error("unknown node resolved")
+					return
+				}
+			}
+		}()
+	}
+
+	for cycle := 0; cycle < 3; cycle++ {
+		name := fmt.Sprintf("hn-churn-extra%d", cycle)
+		logger, _ := logrustest.NewNullLogger()
+		extra, err := Init(Config{
+			Hostname:       name,
+			Localhost:      true,
+			BindAddr:       "127.0.0.1",
+			AdvertiseAddr:  "127.0.0.1",
+			Join:           "127.0.0.1:" + strconv.Itoa(gossipPort1),
+			GossipBindPort: freeGossipPort(t),
+			DataBindPort:   8081,
+		}, 1, t.TempDir(), nil, logger)
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			_, ok := state1.NodeHostname(name)
+			return ok
+		}, 10*time.Second, 50*time.Millisecond)
+
+		require.NoError(t, extra.Leave())
+		require.NoError(t, extra.Shutdown())
+
+		require.Eventually(t, func() bool {
+			_, ok := state1.NodeHostname(name)
+			return !ok
+		}, 10*time.Second, 50*time.Millisecond)
+	}
+
+	close(stop)
+	wg.Wait()
+}
+
+func BenchmarkNodeHostname(b *testing.B) {
+	state, _ := newHostnameTestState(b, "hn-bench-node1", "", 8080)
+
+	if _, ok := state.NodeHostname("hn-bench-node1"); !ok {
+		b.Fatal("local node not resolved")
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, ok := state.NodeHostname("hn-bench-node1"); !ok {
+			b.Fatal("node not resolved")
+		}
+	}
+}

--- a/usecases/cluster/state_join_test.go
+++ b/usecases/cluster/state_join_test.go
@@ -29,7 +29,7 @@ const deadJoinAddr = "127.0.0.1:1"
 
 // freeGossipPort returns a port nothing is listening on, so the test does not
 // collide with memberlist's default 7946
-func freeGossipPort(t *testing.T) int {
+func freeGossipPort(t testing.TB) int {
 	t.Helper()
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -549,8 +549,9 @@ func (f *Finder) CompareDigests(ctx context.Context,
 }
 
 // targetHostAddrsForShard resolves a shard's remote replica host addresses
-// (excluding the local node), mirroring CollectShardDifferences.
-func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
+// (excluding the local node) into buf, mirroring CollectShardDifferences.
+// Host addrs come from the plan's replicas, resolved at plan-build time.
+func (f *Finder) targetHostAddrsForShard(shardName string, buf []string) ([]string, error) {
 	routingPlan, err := f.localReadRoutingPlan(shardName)
 	if err != nil {
 		return nil, fmt.Errorf("%w : class %q shard %q", err, f.class, shardName)
@@ -562,24 +563,19 @@ func (f *Finder) targetHostAddrsForShard(shardName string) ([]string, error) {
 		return nil, fmt.Errorf("could not resolve hostname for local node %q: class %q shard %q", localNodeName, f.class, shardName)
 	}
 
-	replicas := routingPlan.Replicas()
-	hosts := make([]string, 0, len(replicas))
-	for _, replica := range replicas {
-		if replica.NodeName == localNodeName {
+	hosts := buf[:0]
+	for _, replica := range routingPlan.Replicas() {
+		if replica.NodeName == localNodeName || replica.HostAddr == localHostAddr {
 			continue
 		}
-		addr, ok := f.nodeResolver.NodeHostname(replica.NodeName)
-		if !ok || addr == localHostAddr {
-			continue
-		}
-		hosts = append(hosts, addr)
+		hosts = append(hosts, replica.HostAddr)
 	}
 	return hosts, nil
 }
 
 // TargetHostAddrsForShard exposes per-shard replica host resolution for the scheduler's cross-class pre-filter.
 func (f *Finder) TargetHostAddrsForShard(shardName string) ([]string, error) {
-	return f.targetHostAddrsForShard(shardName)
+	return f.targetHostAddrsForShard(shardName, nil)
 }
 
 // prefilterMaxShardsPerRPC caps shards per CompareHashTreeRoots request to bound
@@ -604,12 +600,14 @@ func (f *Finder) PrefilterShardRoots(ctx context.Context,
 	needFull := make(map[string]struct{})
 	byHost := make(map[string]map[string]hashtree.Digest)
 
+	var hostsBuf []string
 	for shard, root := range roots {
-		hosts, err := f.targetHostAddrsForShard(shard)
+		hosts, err := f.targetHostAddrsForShard(shard, hostsBuf)
 		if err != nil {
 			needFull[shard] = struct{}{}
 			continue
 		}
+		hostsBuf = hosts
 		for _, h := range hosts {
 			sub := byHost[h]
 			if sub == nil {

--- a/usecases/replica/finder_target_hosts_internal_test.go
+++ b/usecases/replica/finder_target_hosts_internal_test.go
@@ -1,0 +1,74 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+func TestTargetHostAddrsForShardBufferReuse(t *testing.T) {
+	const (
+		class = "C"
+		local = "A"
+	)
+	plans := map[string]types.ReadRoutingPlan{
+		"s1": {Shard: "s1", ReplicaSet: types.ReadReplicaSet{Replicas: []types.Replica{
+			{NodeName: "A", ShardName: "s1", HostAddr: "10.0.0.1:8080"},
+			{NodeName: "B", ShardName: "s1", HostAddr: "10.0.0.2:8080"},
+			{NodeName: "D", ShardName: "s1", HostAddr: "10.0.0.3:8080"},
+		}}},
+		"s2": {Shard: "s2", ReplicaSet: types.ReadReplicaSet{Replicas: []types.Replica{
+			{NodeName: "A", ShardName: "s2", HostAddr: "10.0.0.1:8080"},
+			{NodeName: "E", ShardName: "s2", HostAddr: "10.0.0.4:8080"},
+		}}},
+	}
+
+	logger, _ := test.NewNullLogger()
+	metrics, err := NewMetrics(monitoring.GetMetrics())
+	require.NoError(t, err)
+
+	mr := types.NewMockRouter(t)
+	mr.EXPECT().BuildRoutingPlanOptions(mock.Anything, mock.Anything, types.ConsistencyLevelOne, "").
+		RunAndReturn(func(shard, tenant string, cl types.ConsistencyLevel, _ string) types.RoutingPlanBuildOptions {
+			return types.RoutingPlanBuildOptions{Shard: shard, Tenant: tenant, ConsistencyLevel: cl}
+		})
+	mr.EXPECT().BuildReadRoutingPlan(mock.Anything).
+		RunAndReturn(func(o types.RoutingPlanBuildOptions) (types.ReadRoutingPlan, error) {
+			return plans[o.Shard], nil
+		})
+
+	nodeResolver := cluster.NewMockNodeResolver(t)
+	nodeResolver.EXPECT().NodeHostname(local).Return("10.0.0.1:8080", true)
+
+	finder := NewFinder(class, mr, nodeResolver, local,
+		NewMockRClient(t), metrics, logger, func() string { return "" })
+
+	first, err := finder.targetHostAddrsForShard("s1", nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.2:8080", "10.0.0.3:8080"}, first)
+
+	retained := first[0]
+	second, err := finder.targetHostAddrsForShard("s2", first)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"10.0.0.4:8080"}, second)
+	assert.Same(t, &first[0], &second[0])
+	assert.Equal(t, "10.0.0.2:8080", retained)
+}

--- a/usecases/replica/finder_target_hosts_test.go
+++ b/usecases/replica/finder_target_hosts_test.go
@@ -1,0 +1,138 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/replica"
+)
+
+func TestTargetHostAddrsForShard(t *testing.T) {
+	const (
+		class = "C"
+		local = "A"
+		shard = "s1"
+	)
+
+	replicas := func(rs ...types.Replica) types.ReadRoutingPlan {
+		return types.ReadRoutingPlan{Shard: shard, ReplicaSet: types.ReadReplicaSet{Replicas: rs}}
+	}
+
+	tests := []struct {
+		name          string
+		plan          types.ReadRoutingPlan
+		planErr       error
+		localAddr     string
+		localResolves bool
+		want          []string
+		wantErr       bool
+	}{
+		{
+			name: "excludes the local node by name",
+			plan: replicas(
+				types.Replica{NodeName: "A", ShardName: shard, HostAddr: "10.0.0.1:8080"},
+				types.Replica{NodeName: "B", ShardName: shard, HostAddr: "10.0.0.2:8080"},
+				types.Replica{NodeName: "D", ShardName: shard, HostAddr: "10.0.0.3:8080"},
+			),
+			localAddr:     "10.0.0.1:8080",
+			localResolves: true,
+			want:          []string{"10.0.0.2:8080", "10.0.0.3:8080"},
+		},
+		{
+			name: "excludes a replica resolving to the local addr",
+			plan: replicas(
+				types.Replica{NodeName: "A", ShardName: shard, HostAddr: "10.0.0.1:8080"},
+				types.Replica{NodeName: "B", ShardName: shard, HostAddr: "10.0.0.1:8080"},
+				types.Replica{NodeName: "D", ShardName: shard, HostAddr: "10.0.0.3:8080"},
+			),
+			localAddr:     "10.0.0.1:8080",
+			localResolves: true,
+			want:          []string{"10.0.0.3:8080"},
+		},
+		{
+			name: "local-only replica set yields no targets",
+			plan: replicas(
+				types.Replica{NodeName: "A", ShardName: shard, HostAddr: "10.0.0.1:8080"},
+			),
+			localAddr:     "10.0.0.1:8080",
+			localResolves: true,
+			want:          []string{},
+		},
+		{
+			name:          "routing plan error propagates",
+			planErr:       errors.New("shard not found"),
+			localResolves: true,
+			wantErr:       true,
+		},
+		{
+			name:    "unresolvable local node errors",
+			plan:    replicas(types.Replica{NodeName: "B", ShardName: shard, HostAddr: "10.0.0.2:8080"}),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			metrics, err := replica.NewMetrics(monitoring.GetMetrics())
+			require.NoError(t, err)
+
+			mr := types.NewMockRouter(t)
+			mr.EXPECT().BuildRoutingPlanOptions(shard, shard, types.ConsistencyLevelOne, "").
+				Return(types.RoutingPlanBuildOptions{Shard: shard, Tenant: shard, ConsistencyLevel: types.ConsistencyLevelOne})
+			mr.EXPECT().
+				BuildReadRoutingPlan(mock.MatchedBy(func(o types.RoutingPlanBuildOptions) bool { return o.LocalOnly })).
+				Return(tt.plan, tt.planErr)
+
+			nodeResolver := cluster.NewMockNodeResolver(t)
+			nodeResolver.EXPECT().NodeHostname(local).Return(tt.localAddr, tt.localResolves).Maybe()
+
+			finder := replica.NewFinder(class, mr, nodeResolver, local,
+				replica.NewMockRClient(t), metrics, logger, func() string { return "" })
+
+			hosts, err := finder.TargetHostAddrsForShard(shard)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if len(tt.want) == 0 {
+				assert.Empty(t, hosts)
+			} else {
+				assert.Equal(t, tt.want, hosts)
+			}
+		})
+	}
+}
+
+func BenchmarkTargetHostAddrsForShard(b *testing.B) {
+	f := newFakeFactory(b, "C", "s1", []string{"A", "B", "D"}, true)
+	finder := f.newFinder("A")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := finder.TargetHostAddrsForShard("s1"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -859,7 +859,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 }
 
 type fakeFactory struct {
-	t              *testing.T
+	t              testing.TB
 	CLS            string
 	Nodes          []string
 	Shard2replicas map[string][]string
@@ -870,7 +870,7 @@ type fakeFactory struct {
 	isMultiTenant  bool
 }
 
-func newFakeFactory(t *testing.T, class, shard string, nodes []string, isMultiTenant bool) *fakeFactory {
+func newFakeFactory(t testing.TB, class, shard string, nodes []string, isMultiTenant bool) *fakeFactory {
 	logger, hook := test.NewNullLogger()
 
 	return &fakeFactory{


### PR DESCRIPTION
> [!NOTE]
> Stacked on #12947 (backport of #12861); the base retargets to the release branch once that merges. The diff shown here is only this PR's two commits.

## Motivation

`State.NodeHostname` is the cluster-wide node→`host:port` resolver: it sits under every read/write routing plan (`buildReplicas` resolves every replica of every replicated query through it), all remote shard operations in `usecases/sharding`, replica movement, backup coordination, schema operations, and more — 43 call sites across 21 files, plus `NodeAddress` which routes through it. It surfaced at ~2% of process allocations on a large-cluster profile, with async replication's per-shard replica resolution as the heaviest consumer.

#12861 already replaced the racy per-call `Members()` scan with the event-callback-maintained member view, which also removed the per-call metadata `json.Unmarshal`. What remains on the hot path is string construction: every `NodeHostname`, `Hostnames`, and `AllHostnames` call still rebuilds the same `host:port` string (`fmt.Sprintf` + `net.JoinHostPort`, 3 allocs/op). This PR finishes the job in the resolver itself, so every caller benefits.

## Approach

Two independent cuts, one per commit:

1. **Precompute the joined `host:port` in the member view** (`usecases/cluster`). `record()` already parses the metadata once per membership event inside the callback; it now also joins the address string there, and the resolver reads serve the stored string. Reads stay an `RLock` + map lookup — zero allocations, no new synchronization, no staleness semantics beyond what the view already has.

2. **Use the routing plan's already-resolved addresses in the finder** (`usecases/replica`). `buildReplicas` resolves `NodeHostname` for every replica at plan-build time and filters out unresolvable nodes, so `targetHostAddrsForShard`'s per-replica re-resolution was duplicate work producing identical values. It now reads `Replica.HostAddr` directly and appends into a caller-supplied buffer that `PrefilterShardRoots` reuses across its per-shard loop.

## Key areas for review

- `usecases/cluster/state.go:record` — the precomputed `hostAddr` must be recomputed on every event that can change address or metadata; join/update both go through `record()`, so the stored string can never outlive the fields it was built from
- `usecases/replica/finder.go:targetHostAddrsForShard` — the dropped per-replica `NodeHostname` call: equivalence holds because `buildReplicas` already filtered unresolvable nodes at plan-build time; the local-node/local-addr skips are retained

## Risks and mitigations

- **Stale string after an address/metadata change**: impossible to serve — the string lives inside the `memberInfo` that the event callback replaces wholesale, under the view's write lock. Staleness bounds are exactly those of the member view introduced by #12861.
- **Finder behavior shift**: a node leaving memberlist between plan build and address use is no longer re-checked per replica. The plan is built at the top of the same call, so the window is microseconds, and the resulting RPC failure is handled the same way as for every other consumer of plan-resolved `HostAddr`s (e.g. `CollectShardDifferences`).

## Drive-by fix

CI on this PR hit a `panic: sync: negative WaitGroup counter` flake in `cluster/replication`'s `TestConsumerOpSkip`: three consumer tests incremented `completionWg` *after* sending the op, so a fast consumer could fire the callback's `Done` before the `Add` executed. The third commit moves `Add` before the send at all five affected sites (`TestConsumerOpDuplication`, `TestConsumerOpSkip`, `TestConsumerShutdown`) — test-only, no production code involved.

## Testing

- State-level tests against real memberlist instances: cached lookup correctness (zero warm-path allocs pinned via `AllocsPerRun`), a joined node becoming visible, and concurrent membership churn under `-race`; the race regression test from #12861 (`UpdateNode` in-place updates vs concurrent readers) keeps passing on top.
- Finder tests: table-driven target-host resolution (local-node and local-addr exclusion) plus an internal buffer-reuse test.
- Benchmarks: `BenchmarkNodeHostname` 77ns/32B/3 allocs (view without this PR) → 9ns/0B/0 allocs; before the view it was 495ns/280B/10 allocs. `BenchmarkTargetHostAddrsForShard` (mock-router harness, constant mock overhead on both sides) 258 → 177 allocs/op.
