### PR TITLE
backport: stop reading memberlist node fields outside the event callbacks

### DIFF
--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -301,10 +301,20 @@ func (d *delegate) updater(period, minPeriod time.Duration, du func(path string)
 // notifications about members joining and leaving. The methods in this
 // delegate may be called by multiple goroutines, but never concurrently.
 // This allows you to reason about ordering.
-// Callbacks run under memberlist's node lock — the one place Node fields are safe to copy into view.
+// Callbacks run synchronously under memberlist's node lock — the one safe place to copy Node fields; async delivery (ChannelEventDelegate) would break this.
 type events struct {
 	d    *delegate
 	view *memberView
+}
+
+func (e events) record(node *memberlist.Node) {
+	if e.view.record(node) {
+		return
+	}
+	e.d.log.WithFields(logrus.Fields{
+		"action": "data_port_fallback",
+		"node":   node.Name,
+	}).Debug("no parseable node metadata, falling back to default data port")
 }
 
 // NotifyJoin is invoked when a node is detected to have joined.
@@ -313,7 +323,7 @@ func (e events) NotifyJoin(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
-	e.view.record(node)
+	e.record(node)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "join",
@@ -345,7 +355,7 @@ func (e events) NotifyUpdate(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
-	e.view.record(node)
+	e.record(node)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "update",

--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -301,8 +301,10 @@ func (d *delegate) updater(period, minPeriod time.Duration, du func(path string)
 // notifications about members joining and leaving. The methods in this
 // delegate may be called by multiple goroutines, but never concurrently.
 // This allows you to reason about ordering.
+// Callbacks run under memberlist's node lock — the one place Node fields are safe to copy into view.
 type events struct {
-	d *delegate
+	d    *delegate
+	view *memberView
 }
 
 // NotifyJoin is invoked when a node is detected to have joined.
@@ -311,6 +313,7 @@ func (e events) NotifyJoin(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
+	e.view.record(node)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "join",
@@ -325,6 +328,7 @@ func (e events) NotifyLeave(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
+	e.view.remove(node.Name)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "leave",
@@ -341,6 +345,7 @@ func (e events) NotifyUpdate(node *memberlist.Node) {
 	if node == nil {
 		return
 	}
+	e.view.record(node)
 	e.d.log.WithFields(logrus.Fields{
 		"action":    "memberlist_event",
 		"event":     "update",

--- a/usecases/cluster/delegate_test.go
+++ b/usecases/cluster/delegate_test.go
@@ -228,7 +228,7 @@ func TestDelegateCleanUp(t *testing.T) {
 	assert.True(t, ok, "N0 must exist")
 	st.delegate.set("N1", NodeInfo{LastTimeMilli: 1})
 	st.delegate.set("N2", NodeInfo{LastTimeMilli: 2})
-	handler := events{&st.delegate}
+	handler := events{d: &st.delegate, view: &st.members}
 	handler.NotifyJoin(nil)
 	handler.NotifyUpdate(nil)
 	handler.NotifyLeave(&memberlist.Node{Name: "N0"})

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -101,7 +101,7 @@ type memberView struct {
 	byName map[string]memberInfo
 }
 
-func (v *memberView) record(node *memberlist.Node) {
+func (v *memberView) record(node *memberlist.Node) (metaOK bool) {
 	info := memberInfo{addr: node.Addr.String(), gossipPort: node.Port}
 	if len(node.Meta) > 0 && json.Unmarshal(node.Meta, &info.meta) == nil {
 		info.metaOK = true
@@ -112,6 +112,7 @@ func (v *memberView) record(node *memberlist.Node) {
 		v.byName = make(map[string]memberInfo)
 	}
 	v.byName[node.Name] = info
+	return info.metaOK
 }
 
 func (v *memberView) remove(name string) {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -83,7 +83,66 @@ type State struct {
 	list                 *memberlist.Memberlist
 	nonStorageNodes      map[string]struct{}
 	delegate             delegate
+	members              memberView
 	maintenanceNodesLock sync.RWMutex
+}
+
+// memberInfo is one member's connection fields, copied inside an event callback.
+type memberInfo struct {
+	addr       string
+	gossipPort uint16
+	meta       NodeMetadata
+	metaOK     bool
+}
+
+// memberView mirrors the live member set: Members() Node fields race in-place alive updates.
+type memberView struct {
+	sync.RWMutex
+	byName map[string]memberInfo
+}
+
+func (v *memberView) record(node *memberlist.Node) {
+	info := memberInfo{addr: node.Addr.String(), gossipPort: node.Port}
+	if len(node.Meta) > 0 && json.Unmarshal(node.Meta, &info.meta) == nil {
+		info.metaOK = true
+	}
+	v.Lock()
+	defer v.Unlock()
+	if v.byName == nil {
+		v.byName = make(map[string]memberInfo)
+	}
+	v.byName[node.Name] = info
+}
+
+func (v *memberView) remove(name string) {
+	v.Lock()
+	defer v.Unlock()
+	delete(v.byName, name)
+}
+
+func (v *memberView) get(name string) (memberInfo, bool) {
+	v.RLock()
+	defer v.RUnlock()
+	info, ok := v.byName[name]
+	return info, ok
+}
+
+func (v *memberView) snapshot() map[string]memberInfo {
+	v.RLock()
+	defer v.RUnlock()
+	out := make(map[string]memberInfo, len(v.byName))
+	for name, info := range v.byName {
+		out[name] = info
+	}
+	return out
+}
+
+// dataPort falls back to gossip+1 when a member published no parseable metadata.
+func (info memberInfo) dataPort() int {
+	if info.metaOK {
+		return info.meta.RestPort
+	}
+	return int(info.gossipPort) + 1
 }
 
 type Config struct {
@@ -178,7 +237,7 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 
 	// Set delegate and events
 	cfg.Delegate = &state.delegate
-	cfg.Events = events{&state.delegate}
+	cfg.Events = events{d: &state.delegate, view: &state.members}
 
 	// Log configuration details
 	logger.WithFields(logrus.Fields{
@@ -271,47 +330,15 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 // Hostnames for all live members, except self. Use AllHostnames to include
 // self, prefixes the data port.
 func (s *State) Hostnames() []string {
-	mem := s.list.Members()
-	out := make([]string, len(mem))
-
-	i := 0
-	for _, m := range mem {
-		if m.Name == s.list.LocalNode().Name {
+	view := s.members.snapshot()
+	out := make([]string, 0, len(view))
+	for name, info := range view {
+		if name == s.LocalName() {
 			continue
 		}
-
-		out[i] = net.JoinHostPort(m.Addr.String(), fmt.Sprintf("%d", s.dataPort(m)))
-		i++
+		out = append(out, net.JoinHostPort(info.addr, fmt.Sprintf("%d", info.dataPort())))
 	}
-
-	return out[:i]
-}
-
-func nodeMetadata(m *memberlist.Node) (NodeMetadata, error) {
-	if len(m.Meta) == 0 {
-		return NodeMetadata{}, errors.New("no metadata available")
-	}
-
-	var meta NodeMetadata
-	if err := json.Unmarshal(m.Meta, &meta); err != nil {
-		return NodeMetadata{}, errors.Wrap(err, "unmarshal node metadata")
-	}
-
-	return meta, nil
-}
-
-func (s *State) dataPort(m *memberlist.Node) int {
-	meta, err := nodeMetadata(m)
-	if err != nil {
-		s.delegate.log.WithFields(logrus.Fields{
-			"action": "data_port_fallback",
-			"node":   m.Name,
-		}).WithError(err).Debug("unable to get node metadata, falling back to default data port")
-
-		return int(m.Port) + 1 // the convention that it's 1 higher than the gossip port
-	}
-
-	return meta.RestPort
+	return out
 }
 
 // AllHostnames for live members, including self.
@@ -320,13 +347,11 @@ func (s *State) AllHostnames() []string {
 		return []string{}
 	}
 
-	mem := s.list.Members()
-	out := make([]string, len(mem))
-
-	for i, m := range mem {
-		out[i] = net.JoinHostPort(m.Addr.String(), fmt.Sprintf("%d", s.dataPort(m)))
+	view := s.members.snapshot()
+	out := make([]string, 0, len(view))
+	for _, info := range view {
+		out = append(out, net.JoinHostPort(info.addr, fmt.Sprintf("%d", info.dataPort())))
 	}
-
 	return out
 }
 
@@ -400,11 +425,13 @@ func (s *State) LocalName() string {
 
 // LocalAddr() returns local address
 func (s *State) LocalAddr() string {
-	if s.config.AdvertiseAddr == "" {
-		return s.list.LocalNode().Addr.String()
+	if s.config.AdvertiseAddr != "" {
+		return s.config.AdvertiseAddr
 	}
-
-	return s.config.AdvertiseAddr
+	if info, ok := s.members.get(s.LocalName()); ok {
+		return info.addr
+	}
+	return s.list.LocalNode().Addr.String()
 }
 
 func (s *State) LocalBindAddr() string {
@@ -419,13 +446,11 @@ func (s *State) ClusterHealthScore() int {
 }
 
 func (s *State) NodeHostname(nodeName string) (string, bool) {
-	for _, mem := range s.list.Members() {
-		if mem.Name == nodeName {
-			return net.JoinHostPort(mem.Addr.String(), fmt.Sprintf("%d", s.dataPort(mem))), true
-		}
+	info, ok := s.members.get(nodeName)
+	if !ok {
+		return "", false
 	}
-
-	return "", false
+	return net.JoinHostPort(info.addr, fmt.Sprintf("%d", info.dataPort())), true
 }
 
 // extractHost extracts the host portion from an address string,
@@ -456,17 +481,14 @@ func (s *State) AllOtherClusterMembers(port int) map[string]string {
 		return map[string]string{}
 	}
 
-	members := s.list.Members()
-	result := make(map[string]string, len(members))
-
-	for _, m := range members {
-		if m.Name == s.list.LocalNode().Name {
-			// skip self
+	view := s.members.snapshot()
+	result := make(map[string]string, len(view))
+	for name, info := range view {
+		if name == s.LocalName() {
 			continue
 		}
-		result[m.Name] = net.JoinHostPort(m.Addr.String(), fmt.Sprintf("%d", port))
+		result[name] = net.JoinHostPort(info.addr, fmt.Sprintf("%d", port))
 	}
-
 	return result
 }
 
@@ -496,12 +518,11 @@ func (s *State) Shutdown() error {
 }
 
 func (s *State) NodeGRPCPort(nodeID string) (int, error) {
-	for _, mem := range s.list.Members() {
-		if mem.Name == nodeID {
-			return s.dataPort(mem), nil
-		}
+	info, ok := s.members.get(nodeID)
+	if !ok {
+		return 0, fmt.Errorf("node not found: %s", nodeID)
 	}
-	return 0, fmt.Errorf("node not found: %s", nodeID)
+	return info.dataPort(), nil
 }
 
 func (s *State) SchemaSyncIgnored() bool {

--- a/usecases/cluster/state_race_test.go
+++ b/usecases/cluster/state_race_test.go
@@ -74,7 +74,7 @@ func TestNodeReadersDoNotRaceAliveUpdates(t *testing.T) {
 			s1.Hostnames()
 			s1.AllOtherClusterMembers(1234)
 			_, _ = s1.NodeGRPCPort("race-n2")
-			s1.LocalAddr()
+			s2.LocalAddr()
 		}
 	}()
 

--- a/usecases/cluster/state_race_test.go
+++ b/usecases/cluster/state_race_test.go
@@ -13,6 +13,7 @@ package cluster
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -56,6 +57,7 @@ func TestNodeReadersDoNotRaceAliveUpdates(t *testing.T) {
 
 	done := make(chan struct{})
 	readerDone := make(chan struct{})
+	var readerErr error
 	go func() {
 		defer close(readerDone)
 		for {
@@ -64,8 +66,9 @@ func TestNodeReadersDoNotRaceAliveUpdates(t *testing.T) {
 				return
 			default:
 			}
-			if hostname, ok := s1.NodeHostname("race-n2"); ok {
-				require.Contains(t, hostname, fmt.Sprintf("%d", port2+1))
+			if hostname, ok := s1.NodeHostname("race-n2"); ok && !strings.Contains(hostname, fmt.Sprintf(":%d", port2+1)) {
+				readerErr = fmt.Errorf("unexpected data port in %q", hostname)
+				return
 			}
 			s1.AllHostnames()
 			s1.Hostnames()
@@ -81,4 +84,5 @@ func TestNodeReadersDoNotRaceAliveUpdates(t *testing.T) {
 	}
 	close(done)
 	<-readerDone
+	require.NoError(t, readerErr)
 }

--- a/usecases/cluster/state_race_test.go
+++ b/usecases/cluster/state_race_test.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNodeReadersDoNotRaceAliveUpdates pins resolver reads racing memberlist's in-place alive updates.
+func TestNodeReadersDoNotRaceAliveUpdates(t *testing.T) {
+	logger, _ := logrustest.NewNullLogger()
+
+	port1 := freeGossipPort(t)
+	s1, err := Init(Config{
+		Hostname:             "race-n1",
+		Localhost:            true,
+		GossipBindPort:       port1,
+		DataBindPort:         port1 + 1,
+		RaftBootstrapExpect:  1,
+		RaftBootstrapTimeout: time.Second,
+	}, 1, t.TempDir(), nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s1.list.Shutdown() })
+
+	port2 := freeGossipPort(t)
+	s2, err := Init(Config{
+		Hostname:             "race-n2",
+		Localhost:            true,
+		GossipBindPort:       port2,
+		DataBindPort:         port2 + 1,
+		Join:                 fmt.Sprintf("127.0.0.1:%d", port1),
+		RaftBootstrapExpect:  2,
+		RaftBootstrapTimeout: 5 * time.Second,
+	}, 1, t.TempDir(), nil, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s2.list.Shutdown() })
+
+	require.Eventually(t, func() bool {
+		_, ok := s1.NodeHostname("race-n2")
+		return ok
+	}, 10*time.Second, 50*time.Millisecond, "nodes never saw each other")
+
+	done := make(chan struct{})
+	readerDone := make(chan struct{})
+	go func() {
+		defer close(readerDone)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+			}
+			if hostname, ok := s1.NodeHostname("race-n2"); ok {
+				require.Contains(t, hostname, fmt.Sprintf("%d", port2+1))
+			}
+			s1.AllHostnames()
+			s1.Hostnames()
+			s1.AllOtherClusterMembers(1234)
+			_, _ = s1.NodeGRPCPort("race-n2")
+			s1.LocalAddr()
+		}
+	}()
+
+	for i := 0; i < 30; i++ {
+		require.NoError(t, s2.list.UpdateNode(2*time.Second))
+		time.Sleep(20 * time.Millisecond)
+	}
+	close(done)
+	<-readerDone
+}


### PR DESCRIPTION
Backport of #12861.

`memberlist.Members()` returns pointers into node structs that `aliveNode` rewrites in place (`Addr`, `Port`, `Meta`), so every field read after `Members()` returns races with alive updates — the race detector caught it live on the raft-transport resolver path. The event callbacks run while memberlist holds its node lock, the one place those fields are safe to read, so the events delegate copies each member's connection fields into a mutex-guarded view and every resolver read (`NodeHostname`, `Hostnames`, `AllHostnames`, `AllOtherClusterMembers`, `NodeGRPCPort`, `LocalAddr`) consults the copy. Includes the regression test driving in-place alive updates against concurrent readers.

Both commits cherry-picked verbatim (clean pick, no conflicts). Also unblocks #12946, which touches the same resolver and will be rebased on top of this.
