### PR TITLE
fix(schema): reject property names that collide with a replaced-bucket dir

### DIFF
--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/schema"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	wsync "github.com/weaviate/weaviate/entities/sync"
@@ -543,7 +544,9 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 // ReplacedBucketDirSuffix names the dir the displaced bucket sits at between
 // [Store.ReplaceBuckets]' two renames. A crash in that window leaves it on
 // disk, where only the per-property cleanup sweep in package db picks it up.
-const ReplacedBucketDirSuffix = "___del"
+// Aliases [schema.InternalReplacedBucketSuffix], which the property-name check
+// reserves so no property can own a bucket dir of this shape.
+const ReplacedBucketDirSuffix = schema.InternalReplacedBucketSuffix
 
 // replaceBucket drains the displaced bucket and swaps the two directories on
 // disk. Caller must hold replacementBucket.flushLock (flushLock OUTER →

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -29,6 +29,11 @@ const (
 	InternalRangeableSuffix      = "_rangeable"
 	InternalTempSuffix           = "_temp"
 	InternalMetaCountSuffix      = "__meta_count"
+	// InternalReplacedBucketSuffix names the dir a displaced bucket sits at
+	// between a crashed and a completed replacement. Re-exported as
+	// lsmkv.ReplacedBucketDirSuffix, which builds those dirs; kept here so the
+	// property-name check and the cleanup sweep read one value.
+	InternalReplacedBucketSuffix = "___del"
 )
 
 var (
@@ -48,6 +53,7 @@ var (
 		InternalMetaCountSuffix,
 		InternalPropertyLengthSuffix,
 		InternalNullStateSuffix,
+		InternalReplacedBucketSuffix,
 	}
 
 	// NamespaceNameRegexCore is the single source of truth for the namespace

--- a/entities/schema/validation_test.go
+++ b/entities/schema/validation_test.go
@@ -169,6 +169,11 @@ func TestValidateReservedPropertyNameSuffix(t *testing.T) {
 		{name: "ok double underscore without a role word", input: "a__foo", wantErr: false},
 		{name: "ok role word not in trailing position", input: "a__reindex_foo", wantErr: false},
 		{name: "ok non-numeric tail after the role word", input: "a__reindex_v2", wantErr: false},
+
+		// A crashed bucket replacement parks property "a"'s displaced bucket at
+		// "property_a___del", and the reindex cleanup sweep deletes that dir on
+		// sight. Property "a___del" owns the same dir, so sweeping "a" wipes it.
+		{name: "reject replaced-bucket dir shape", input: "a___del", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Partly addresses #12621, and narrows what that issue still covers.

`lsmkv.ReplacedBucketDirSuffix` is `"___del"`, the dir a displaced bucket parks at during `Store.ReplaceBuckets`, and `isSidecarDirOf` deletes any dir equal to `<mainBucket>___del` on sight. But `___del` is not in `reservedPropertyNameSuffixes`, so a property may be named `a___del`, whose own filterable bucket dir is `property_a___del` - byte-identical to property `a`'s replaced-bucket dir. Sweeping `a` does `os.RemoveAll` on it. `PropertyNameIsSidecarShaped` does not catch it, because it splits at the first `__` and for `a___del` the remainder is `_del`, whose role word `del` is not in `SidecarRoleWords`.

The reachable path is the plain property delete, `index.go:1186` into `shard.updatePropertyBuckets`, which calls `cleanStaleSidecarDirs` with `preserveSidecars` nil. That is not behind the reindex flag.

The fix adds the suffix to the reserved list and has `lsmkv.ReplacedBucketDirSuffix` alias the same constant, so the code that builds those dirs and the code that refuses those names read one value. That is the pattern the file already uses for `SidecarRoleWords`.

Worth flagging, since it changes the issue: the `property_a__ingest` case in #12621's title no longer reproduces on `main`. `PropertyNameIsSidecarShaped` rejects `a__ingest`, `a__reindex`, `a__backup` and `a__map` at creation today. The variant still getting through is the one the godoc mentions parenthetically, `a___del`.

I would not call this a fix for #12621. It closes the one name family still reachable through creation-time validation; item 2, making the sweep refuse to delete a live property's main bucket, also covers schemas restored from a backup and is untouched.

### Review checklist

- [ ] Documentation updated
- [ ] Chaos pipeline run
- [x] All new code covered by tests
- [ ] Performance tests run

Test is a new row in the existing `TestValidateReservedPropertyNameSuffix` table. It fails on `main` with `An error is expected but got nil`; the package goes from 22 to 23 subtests, all green. `go build ./...`, `go vet ./entities/schema/... ./adapters/repos/db/lsmkv/` and `go test ./usecases/schema/...` are clean.

`adapters/repos/db`'s test package does not build on Windows, `syscall.Stat_t` is undefined there, so I verified the final `isSidecarDirOf("property_a___del", "property_a")` link by reading rather than running. It is a literal comparison against `mainBucketName + "___del"`, and that function's own test table already pins the `main + lsmkv.ReplacedBucketDirSuffix` row as true.