### PR TITLE
fix(reindex): rename a rebuilt index into place only once the schema lists it

### DIFF
--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -19,6 +19,9 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
 )
 
 // migrationTrackerDirAbsent reports whether a migration's tracker dir is
@@ -168,13 +171,18 @@ func fileExistsInDir(dirPath, fileName string) bool {
 //   - Generations with `gen > effective` are in-flight (next migration)
 //     and left alone — recovery picks them up via their `payload.mig`.
 //
+// Promotion follows the schema. A generation whose target index the applied
+// class turns off keeps its staged name and its tracker, and is promoted at
+// the first load after the flag lands. Renaming first would put data at a name
+// the next load's sweep deletes — see [schemaAuthorizesPromotion].
+//
 // CRITICAL: This MUST be called BEFORE bucket loading, NEVER on live
 // buckets. Renaming directories while buckets are open would corrupt
 // the store. The deferred-finalize design relies on the in-memory swap
 // (via DTM) marking tidied while the directory renames are deferred to
 // the next startup when no buckets are loaded. See
 // `docs/runtime-reindex.md` for the rationale.
-func FinalizeCompletedMigrations(lsmPath string, logger logrus.FieldLogger) {
+func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger logrus.FieldLogger) {
 	migrationsDir := filepath.Join(lsmPath, ".migrations")
 	entries, err := os.ReadDir(migrationsDir)
 	if err != nil {
@@ -276,6 +284,19 @@ func FinalizeCompletedMigrations(lsmPath string, logger logrus.FieldLogger) {
 			}
 		}
 
+		effectiveDir := ""
+		for _, g := range gens {
+			if g.gen == effective {
+				effectiveDir = g.dirName
+				break
+			}
+		}
+		if !schemaAuthorizesPromotion(class, lsmPath, effectiveDir) {
+			logger.WithField("migration", effectiveDir).
+				Debug("reindex finalize: deferring promotion until the schema lists the migrated index")
+			continue
+		}
+
 		// Finalize the effective promotion gen, then remove every gen <
 		// effective (their data was superseded by this gen's complete
 		// or recovered ingest dir).
@@ -311,6 +332,56 @@ func FinalizeCompletedMigrations(lsmPath string, logger logrus.FieldLogger) {
 			}
 		}
 	}
+}
+
+// schemaAuthorizesPromotion reports whether the applied class still lists every
+// index this migration would rename onto a canonical property directory.
+//
+// The schema flag is the only authority over a canonical name:
+// [propertyDeleteIndexHelper.ensureBucketsAreRemovedForNonExistentPropertyIndexes]
+// deletes a canonical directory it finds under an index the class turns off, and
+// runs before this on every load. The three migrations that turn an index on run
+// with that flag off for their whole duration, so promoting before the flip puts
+// the migrated data exactly where the next load's sweep will delete it.
+//
+// The refusal mirrors the sweep's own predicate, including which properties it
+// can see: a property the class does not hold is a property the sweep never
+// reaches, so nothing about it needs authorizing.
+func schemaAuthorizesPromotion(class *models.Class, lsmPath, migName string) bool {
+	suffixes := migrationSuffixes(migName)
+	if suffixes == nil {
+		return true
+	}
+	props, err := readMigrationProps(filepath.Join(lsmPath, migrationsDir, migName))
+	if err != nil || len(props) == 0 {
+		// finalizeMigrationDir renames nothing without them.
+		return true
+	}
+
+	byName := make(map[string]*models.Property, len(class.Properties))
+	for _, prop := range class.Properties {
+		byName[prop.Name] = prop
+	}
+	sweep := newPropertyDeleteIndexHelper()
+	for _, propName := range props {
+		prop, listed := byName[propName]
+		if !listed {
+			continue
+		}
+		var index *bool
+		switch suffixes.sourceBucketName(propName) {
+		case helpers.BucketFromPropNameLSM(propName):
+			index = prop.IndexFilterable
+		case helpers.BucketSearchableFromPropNameLSM(propName):
+			index = prop.IndexSearchable
+		case helpers.BucketRangeableFromPropNameLSM(propName):
+			index = prop.IndexRangeFilters
+		}
+		if sweep.isPropertyIndexRemoved(index) {
+			return false
+		}
+	}
+	return true
 }
 
 // writeRecoveryTidiedSentinels is the recovery-path equivalent of the

--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -171,9 +171,9 @@ func fileExistsInDir(dirPath, fileName string) bool {
 //   - Generations with `gen > effective` are in-flight (next migration)
 //     and left alone — recovery picks them up via their `payload.mig`.
 //
-// Promotion is deferred while the class has the target index off: renaming
+// Finalizing is deferred while the class has the target index off: renaming
 // now would put data where the next load's schema sweep deletes it. See
-// [schemaAuthorizesPromotion].
+// [schemaAuthorizesFinalization].
 //
 // CRITICAL: This MUST be called BEFORE bucket loading, NEVER on live
 // buckets. Renaming directories while buckets are open would corrupt
@@ -254,7 +254,7 @@ func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger log
 
 		// Missing tidied.mig means the runtime swap crashed after markMerged
 		// but before markTidied. Backfill the sentinels; the schema check
-		// below still gates promotion.
+		// below still gates finalizing.
 		if effective > highestTidied {
 			for _, g := range gens {
 				if g.gen != effective {
@@ -285,9 +285,9 @@ func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger log
 				break
 			}
 		}
-		if !schemaAuthorizesPromotion(class, lsmPath, effectiveDir) {
+		if !schemaAuthorizesFinalization(class, lsmPath, effectiveDir) {
 			logger.WithField("migration", effectiveDir).
-				Debug("reindex finalize: deferring promotion until the schema lists the migrated index")
+				Debug("reindex finalize: deferring until the schema lists the migrated index")
 			continue
 		}
 
@@ -328,16 +328,16 @@ func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger log
 	}
 }
 
-// schemaAuthorizesPromotion reports whether the applied class still lists
-// every index this migration would promote to its canonical name.
+// schemaAuthorizesFinalization reports whether the applied class still lists
+// every index this migration would rename to its canonical name.
 //
 // The schema flag alone authorizes a canonical name: on every load,
 // [propertyDeleteIndexHelper.ensureBucketsAreRemovedForNonExistentPropertyIndexes]
 // deletes a canonical dir under a disabled index, and each index-enabling
-// migration runs with the flag off throughout. Promoting early would hand
+// migration runs with the flag off throughout. Renaming early would hand
 // that sweep exactly the data it deletes. Properties absent from the class
 // are equally unreached by the sweep, so they need no authorization.
-func schemaAuthorizesPromotion(class *models.Class, lsmPath, migName string) bool {
+func schemaAuthorizesFinalization(class *models.Class, lsmPath, migName string) bool {
 	suffixes := migrationSuffixes(migName)
 	if suffixes == nil {
 		return true

--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -256,11 +256,9 @@ func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger log
 		// If the effective promotion gen lacks tidied.mig, this is the
 		// recovery path: the in-process runtime swap on this node died
 		// after markMerged but before markTidied. Write the missing
-		// sentinels so the rest of the finalize logic sees a consistent
-		// tracker and the same ingest→canonical rename runs. The schema
-		// flip has likely already committed cluster-wide via the DTM
-		// task's FINISHED state; promoting gen-effective here is what
-		// makes this node's bucket data consistent with that schema.
+		// sentinels so the tracker is consistent; the rename that follows
+		// is still subject to the schema check below, which defers it to a
+		// later load while the class turns the index off.
 		if effective > highestTidied {
 			for _, g := range gens {
 				if g.gen != effective {

--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -171,10 +171,9 @@ func fileExistsInDir(dirPath, fileName string) bool {
 //   - Generations with `gen > effective` are in-flight (next migration)
 //     and left alone — recovery picks them up via their `payload.mig`.
 //
-// Promotion follows the schema. A generation whose target index the applied
-// class turns off keeps its staged name and its tracker, and is promoted at
-// the first load after the flag lands. Renaming first would put data at a name
-// the next load's sweep deletes — see [schemaAuthorizesPromotion].
+// Promotion is deferred while the class has the target index off: renaming
+// now would put data where the next load's schema sweep deletes it. See
+// [schemaAuthorizesPromotion].
 //
 // CRITICAL: This MUST be called BEFORE bucket loading, NEVER on live
 // buckets. Renaming directories while buckets are open would corrupt
@@ -253,12 +252,9 @@ func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger log
 			continue
 		}
 
-		// If the effective promotion gen lacks tidied.mig, this is the
-		// recovery path: the in-process runtime swap on this node died
-		// after markMerged but before markTidied. Write the missing
-		// sentinels so the tracker is consistent; the rename that follows
-		// is still subject to the schema check below, which defers it to a
-		// later load while the class turns the index off.
+		// Missing tidied.mig means the runtime swap crashed after markMerged
+		// but before markTidied. Backfill the sentinels; the schema check
+		// below still gates promotion.
 		if effective > highestTidied {
 			for _, g := range gens {
 				if g.gen != effective {
@@ -332,19 +328,15 @@ func FinalizeCompletedMigrations(lsmPath string, class *models.Class, logger log
 	}
 }
 
-// schemaAuthorizesPromotion reports whether the applied class still lists every
-// index this migration would rename onto a canonical property directory.
+// schemaAuthorizesPromotion reports whether the applied class still lists
+// every index this migration would promote to its canonical name.
 //
-// The schema flag is the only authority over a canonical name:
+// The schema flag alone authorizes a canonical name: on every load,
 // [propertyDeleteIndexHelper.ensureBucketsAreRemovedForNonExistentPropertyIndexes]
-// deletes a canonical directory it finds under an index the class turns off, and
-// runs before this on every load. The three migrations that turn an index on run
-// with that flag off for their whole duration, so promoting before the flip puts
-// the migrated data exactly where the next load's sweep will delete it.
-//
-// The refusal mirrors the sweep's own predicate, including which properties it
-// can see: a property the class does not hold is a property the sweep never
-// reaches, so nothing about it needs authorizing.
+// deletes a canonical dir under a disabled index, and each index-enabling
+// migration runs with the flag off throughout. Promoting early would hand
+// that sweep exactly the data it deletes. Properties absent from the class
+// are equally unreached by the sweep, so they need no authorization.
 func schemaAuthorizesPromotion(class *models.Class, lsmPath, migName string) bool {
 	suffixes := migrationSuffixes(migName)
 	if suffixes == nil {

--- a/adapters/repos/db/inverted_reindex_finalize_awaits_flip_test.go
+++ b/adapters/repos/db/inverted_reindex_finalize_awaits_flip_test.go
@@ -28,16 +28,16 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// Promotion must wait for the cluster-wide schema flip: every shard load in
+// Finalizing must wait for the cluster-wide schema flip: every shard load in
 // between must leave the migrated data staged, since the load-time sweep
-// deletes a promoted canonical directory it finds under a disabled index.
-func TestEnableFilterablePromotionWaitsForTheSchemaFlip(t *testing.T) {
+// deletes a canonical directory it finds under a disabled index.
+func TestEnableFilterableFinalizeWaitsForTheSchemaFlip(t *testing.T) {
 	const propName = "title"
 	const numObjects = 25
 	const token = "alpha"
 
 	ctx := testCtx()
-	className := "PromotionAwaitsFlip_" + uuid.NewString()[:8]
+	className := "FinalizeAwaitsFlip_" + uuid.NewString()[:8]
 	class := newEnableFilterableTestClass(className, propName)
 
 	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
@@ -74,7 +74,7 @@ func TestEnableFilterablePromotionWaitsForTheSchemaFlip(t *testing.T) {
 		assert.DirExistsf(t, stagedDir,
 			"load %d: the migrated data must stay under its staged name until the flag lands", load)
 		assert.DirExistsf(t, trackerDir,
-			"load %d: the tracker outlives every load in the window, or nothing knows to promote later", load)
+			"load %d: the tracker outlives every load in the window, or nothing knows to finalize later", load)
 	}
 
 	// Simulates the cluster-wide flip landing.
@@ -83,15 +83,15 @@ func TestEnableFilterablePromotionWaitsForTheSchemaFlip(t *testing.T) {
 	defer current.Shutdown(ctx)
 
 	assert.DirExists(t, canonicalDir,
-		"the first load after the flip must promote the migrated data to the canonical name")
-	assert.NoDirExists(t, stagedDir, "a promoted migration leaves no staged directory")
-	assert.NoDirExists(t, trackerDir, "a promoted migration leaves no tracker")
+		"the first load after the flip must rename the migrated data to its canonical name")
+	assert.NoDirExists(t, stagedDir, "a finalized migration leaves no staged directory")
+	assert.NoDirExists(t, trackerDir, "a finalized migration leaves no tracker")
 
 	found, _, err := current.ObjectSearch(ctx, numObjects,
 		propEqualsFilter(className, propName, token), nil, nil, nil, additional.Properties{}, nil)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, objectIDsHoldingToken(objects, propName, token), objectIDs(found),
-		"the promoted index must answer the filter with every object that holds the token")
+		"the finalized index must answer the filter with every object that holds the token")
 }
 
 func propEqualsFilter(className, propName, value string) *filters.LocalFilter {

--- a/adapters/repos/db/inverted_reindex_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_finalize_test.go
@@ -18,6 +18,8 @@ import (
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
 )
 
 // Tests for the per-migration generation helpers added for
@@ -83,11 +85,144 @@ func TestMigrationTrackerDirAbsentDoesNotReadAStatFailureAsAbsence(t *testing.T)
 		"a tracker dir whose stat fails must not read as one that is not there")
 }
 
+// classWithIndexedProps is the schema state these cases run finalize under: the
+// migrated indexes are listed, so promotion is authorized and what each case
+// exercises is the generation and recovery logic.
+func classWithIndexedProps(names ...string) *models.Class {
+	on := true
+	class := &models.Class{Class: "Finalize"}
+	for _, name := range names {
+		class.Properties = append(class.Properties, &models.Property{
+			Name:              name,
+			IndexFilterable:   &on,
+			IndexSearchable:   &on,
+			IndexRangeFilters: &on,
+		})
+	}
+	return class
+}
+
 // touchSentinel creates an empty file at the given path. Used to
 // simulate sentinel files (started.mig, tidied.mig, etc.) in tests.
 func touchSentinel(t *testing.T, path string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, nil, 0o644))
+}
+
+// Promotion is refused for exactly what the load-time sweep would delete: a
+// canonical directory whose index the class turns off explicitly. A flag that is
+// on, a flag the class leaves unset, a property the class does not hold, and the
+// migrations that flip no flag all promote — refusing any of those would strand
+// the rebuilt data under its staged name with nothing left to free it.
+func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T) {
+	const propName = "text"
+	off, on := false, true
+
+	tests := []struct {
+		name         string
+		tracker      string
+		canonical    string
+		ingestSuffix string
+		props        []*models.Property
+		wantPromoted bool
+	}{
+		{
+			name:         "enable-filterable while the flag is still off",
+			tracker:      "enable_filterable_text_1",
+			canonical:    "property_text",
+			ingestSuffix: "__enable_filterable_ingest_1",
+			props:        []*models.Property{{Name: propName, IndexFilterable: &off}},
+		},
+		{
+			name:         "enable-filterable once the flag has landed",
+			tracker:      "enable_filterable_text_1",
+			canonical:    "property_text",
+			ingestSuffix: "__enable_filterable_ingest_1",
+			props:        []*models.Property{{Name: propName, IndexFilterable: &on}},
+			wantPromoted: true,
+		},
+		{
+			name:         "a flag the class leaves unset",
+			tracker:      "enable_filterable_text_1",
+			canonical:    "property_text",
+			ingestSuffix: "__enable_filterable_ingest_1",
+			props:        []*models.Property{{Name: propName}},
+			wantPromoted: true,
+		},
+		{
+			name:         "a property the class does not hold",
+			tracker:      "enable_filterable_text_1",
+			canonical:    "property_text",
+			ingestSuffix: "__enable_filterable_ingest_1",
+			wantPromoted: true,
+		},
+		{
+			name:         "enable-searchable while the flag is still off",
+			tracker:      "enable_searchable_text_1",
+			canonical:    "property_text_searchable",
+			ingestSuffix: "__enable_searchable_ingest_1",
+			props:        []*models.Property{{Name: propName, IndexSearchable: &off}},
+		},
+		{
+			name:         "filterable-to-rangeable while the flag is still off",
+			tracker:      "filterable_to_rangeable_text_1",
+			canonical:    "property_text_rangeable",
+			ingestSuffix: "__rangeable_ingest_1",
+			props:        []*models.Property{{Name: propName, IndexRangeFilters: &off}},
+		},
+		{
+			name:         "a retokenize onto a searchable index the class turns off",
+			tracker:      "searchable_retokenize_text_1",
+			canonical:    "property_text_searchable",
+			ingestSuffix: "__retokenize_ingest_1",
+			props:        []*models.Property{{Name: propName, IndexSearchable: &off}},
+		},
+		{
+			name:         "rebuild-searchable, which flips no flag of its own",
+			tracker:      "rebuild_searchable_text_1",
+			canonical:    "property_text_searchable",
+			ingestSuffix: "__rebuild_searchable_ingest_1",
+			props:        []*models.Property{{Name: propName, IndexSearchable: &on}},
+			wantPromoted: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			lsmPath := t.TempDir()
+			trackerDir := filepath.Join(lsmPath, migrationsDir, tc.tracker)
+			require.NoError(t, os.MkdirAll(trackerDir, 0o755))
+			touchSentinel(t, filepath.Join(trackerDir, "swapped.mig"))
+			touchSentinel(t, filepath.Join(trackerDir, "tidied.mig"))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(trackerDir, "properties.mig"), []byte(propName), 0o644))
+
+			stagedDir := filepath.Join(lsmPath, tc.canonical+tc.ingestSuffix)
+			require.NoError(t, os.MkdirAll(stagedDir, 0o755))
+			require.NoError(t, os.WriteFile(
+				filepath.Join(stagedDir, "segment.db"), []byte("rebuilt"), 0o644))
+
+			logger, _ := test.NewNullLogger()
+			FinalizeCompletedMigrations(lsmPath,
+				&models.Class{Class: "Finalize", Properties: tc.props}, logger)
+
+			canonicalDir := filepath.Join(lsmPath, tc.canonical)
+			if tc.wantPromoted {
+				data, err := os.ReadFile(filepath.Join(canonicalDir, "segment.db"))
+				require.NoError(t, err, "the rebuilt data must reach the canonical name")
+				require.Equal(t, "rebuilt", string(data))
+				require.NoDirExists(t, stagedDir)
+				require.NoDirExists(t, trackerDir)
+				return
+			}
+			require.NoDirExists(t, canonicalDir,
+				"the next load's sweep deletes a canonical directory under a disabled index")
+			require.FileExists(t, filepath.Join(stagedDir, "segment.db"),
+				"the rebuilt data must keep its staged name until the flag lands")
+			require.DirExists(t, trackerDir,
+				"the tracker must survive, or nothing knows to promote later")
+		})
+	}
 }
 
 // TestFinalizeCompletedMigrations_MultiGen_PickHighestTidied verifies
@@ -125,7 +260,7 @@ func TestFinalizeCompletedMigrations_MultiGen_PickHighestTidied(t *testing.T) {
 		winnerMarker, 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Canonical main dir should exist and contain gen-3's marker.
 	canonical := filepath.Join(lsmPath, "property_text_searchable")
@@ -174,7 +309,7 @@ func TestFinalizeCompletedMigrations_TidiedPlusInFlight(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(lsmPath, "property_text_searchable__retokenize_reindex_2"), 0o755))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Gen 1 finalized → canonical dir exists.
 	_, err := os.Stat(filepath.Join(lsmPath, "property_text_searchable"))
@@ -210,7 +345,7 @@ func TestFinalizeCompletedMigrations_OnlyUntidiedIsNoOp(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(lsmPath, "property_text_searchable__retokenize_reindex_1"), 0o755))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Tracker dir still there.
 	_, err := os.Stat(gen1)
@@ -295,7 +430,7 @@ func TestFinalizeCompletedMigrations_MergedButNotTidied_Recovers(t *testing.T) {
 		gen2Marker, 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Canonical dir must contain gen-2's marker, NOT gen-1's stale data.
 	canonical := filepath.Join(lsmPath, "property_text_searchable")
@@ -340,7 +475,7 @@ func TestFinalizeCompletedMigrations_MergedOnly_NoPriorTidied_Recovers(t *testin
 		marker, 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	canonical := filepath.Join(lsmPath, "property_text_searchable")
 	got, err := os.ReadFile(filepath.Join(canonical, "segment.db"))
@@ -384,7 +519,7 @@ func TestFinalizeCompletedMigrations_TidiedHigherThanMerged_PicksTidied(t *testi
 		winner, 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	got, err := os.ReadFile(filepath.Join(lsmPath, "property_text_searchable", "segment.db"))
 	require.NoError(t, err)
@@ -417,7 +552,7 @@ func TestFinalizeCompletedMigrations_RecoveryWritesMissingSentinels(t *testing.T
 		[]byte("data"), 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// If sentinels weren't written before finalizeMigrationDir ran, the
 	// canonical dir would not be created (finalizeMigrationDir returns
@@ -451,7 +586,7 @@ func TestFinalizeCompletedMigrations_StartedOnlyNotPromoted(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Join(lsmPath, "property_text_searchable__retokenize_reindex_1"), 0o755))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Tracker untouched.
 	_, err := os.Stat(gen1)
@@ -501,7 +636,7 @@ func TestFinalizeCompletedMigrations_RecoveryAcrossNamespaces(t *testing.T) {
 		[]byte("filterable-data"), 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Both canonical dirs should now exist with their respective data.
 	sBytes, err := os.ReadFile(filepath.Join(lsmPath, "property_text_searchable", "s.db"))
@@ -533,10 +668,10 @@ func TestFinalizeCompletedMigrations_IdempotentAfterRecovery(t *testing.T) {
 		[]byte("data"), 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	// Second call should be a complete no-op now that nothing remains in .migrations.
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("text"), logger)
 
 	got, err := os.ReadFile(filepath.Join(lsmPath, "property_text_searchable", "seg.db"))
 	require.NoError(t, err)
@@ -625,7 +760,7 @@ func TestFinalizeCompletedMigrations_ConcurrentMultiPropMigrations_Converge(t *t
 		[]byte("gamma-range-NEW"), 0o644))
 
 	logger, _ := test.NewNullLogger()
-	FinalizeCompletedMigrations(lsmPath, logger)
+	FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("alpha", "beta", "gamma"), logger)
 
 	// All three property migrations must promote to their canonical
 	// names with the correct data. A bug that processed only the first
@@ -724,7 +859,7 @@ func TestFinalizeCompletedMigrations_PerShardDivergentStates_Converge(t *testing
 		case "no_migrations":
 			// Intentionally empty — finalize must be a no-op here.
 		}
-		FinalizeCompletedMigrations(lsmPath, logger)
+		FinalizeCompletedMigrations(lsmPath, classWithIndexedProps("path"), logger)
 	}
 
 	for _, sh := range shards {

--- a/adapters/repos/db/inverted_reindex_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_finalize_test.go
@@ -85,7 +85,7 @@ func TestMigrationTrackerDirAbsentDoesNotReadAStatFailureAsAbsence(t *testing.T)
 		"a tracker dir whose stat fails must not read as one that is not there")
 }
 
-// classWithIndexedProps authorizes promotion for every migrated index, so
+// classWithIndexedProps authorizes finalization for every migrated index, so
 // callers can exercise generation/recovery logic without schema gating.
 func classWithIndexedProps(names ...string) *models.Class {
 	on := true
@@ -108,19 +108,19 @@ func touchSentinel(t *testing.T, path string) {
 	require.NoError(t, os.WriteFile(path, nil, 0o644))
 }
 
-// Promotion is refused only for a canonical dir the load-time sweep would
-// delete (an index explicitly turned off); every other schema state promotes.
-func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T) {
+// Finalizing is refused only for a canonical dir the load-time sweep would
+// delete (an index explicitly turned off); every other schema state finalizes.
+func TestFinalizeCompletedMigrations_FollowsTheSchemaFlag(t *testing.T) {
 	const propName = "text"
 	off, on := false, true
 
 	tests := []struct {
-		name         string
-		tracker      string
-		canonical    string
-		ingestSuffix string
-		props        []*models.Property
-		wantPromoted bool
+		name          string
+		tracker       string
+		canonical     string
+		ingestSuffix  string
+		props         []*models.Property
+		wantFinalized bool
 	}{
 		{
 			name:         "enable-filterable while the flag is still off",
@@ -130,27 +130,27 @@ func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T)
 			props:        []*models.Property{{Name: propName, IndexFilterable: &off}},
 		},
 		{
-			name:         "enable-filterable once the flag has landed",
-			tracker:      "enable_filterable_text_1",
-			canonical:    "property_text",
-			ingestSuffix: "__enable_filterable_ingest_1",
-			props:        []*models.Property{{Name: propName, IndexFilterable: &on}},
-			wantPromoted: true,
+			name:          "enable-filterable once the flag has landed",
+			tracker:       "enable_filterable_text_1",
+			canonical:     "property_text",
+			ingestSuffix:  "__enable_filterable_ingest_1",
+			props:         []*models.Property{{Name: propName, IndexFilterable: &on}},
+			wantFinalized: true,
 		},
 		{
-			name:         "a flag the class leaves unset",
-			tracker:      "enable_filterable_text_1",
-			canonical:    "property_text",
-			ingestSuffix: "__enable_filterable_ingest_1",
-			props:        []*models.Property{{Name: propName}},
-			wantPromoted: true,
+			name:          "a flag the class leaves unset",
+			tracker:       "enable_filterable_text_1",
+			canonical:     "property_text",
+			ingestSuffix:  "__enable_filterable_ingest_1",
+			props:         []*models.Property{{Name: propName}},
+			wantFinalized: true,
 		},
 		{
-			name:         "a property the class does not hold",
-			tracker:      "enable_filterable_text_1",
-			canonical:    "property_text",
-			ingestSuffix: "__enable_filterable_ingest_1",
-			wantPromoted: true,
+			name:          "a property the class does not hold",
+			tracker:       "enable_filterable_text_1",
+			canonical:     "property_text",
+			ingestSuffix:  "__enable_filterable_ingest_1",
+			wantFinalized: true,
 		},
 		{
 			name:         "enable-searchable while the flag is still off",
@@ -174,12 +174,12 @@ func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T)
 			props:        []*models.Property{{Name: propName, IndexSearchable: &off}},
 		},
 		{
-			name:         "rebuild-searchable, which flips no flag of its own",
-			tracker:      "rebuild_searchable_text_1",
-			canonical:    "property_text_searchable",
-			ingestSuffix: "__rebuild_searchable_ingest_1",
-			props:        []*models.Property{{Name: propName, IndexSearchable: &on}},
-			wantPromoted: true,
+			name:          "rebuild-searchable, which flips no flag of its own",
+			tracker:       "rebuild_searchable_text_1",
+			canonical:     "property_text_searchable",
+			ingestSuffix:  "__rebuild_searchable_ingest_1",
+			props:         []*models.Property{{Name: propName, IndexSearchable: &on}},
+			wantFinalized: true,
 		},
 	}
 
@@ -203,7 +203,7 @@ func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T)
 				&models.Class{Class: "Finalize", Properties: tc.props}, logger)
 
 			canonicalDir := filepath.Join(lsmPath, tc.canonical)
-			if tc.wantPromoted {
+			if tc.wantFinalized {
 				data, err := os.ReadFile(filepath.Join(canonicalDir, "segment.db"))
 				require.NoError(t, err, "the rebuilt data must reach the canonical name")
 				require.Equal(t, "rebuilt", string(data))
@@ -216,7 +216,7 @@ func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T)
 			require.FileExists(t, filepath.Join(stagedDir, "segment.db"),
 				"the rebuilt data must keep its staged name until the flag lands")
 			require.DirExists(t, trackerDir,
-				"the tracker must survive, or nothing knows to promote later")
+				"the tracker must survive, or nothing knows to finalize later")
 		})
 	}
 }

--- a/adapters/repos/db/inverted_reindex_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_finalize_test.go
@@ -85,9 +85,8 @@ func TestMigrationTrackerDirAbsentDoesNotReadAStatFailureAsAbsence(t *testing.T)
 		"a tracker dir whose stat fails must not read as one that is not there")
 }
 
-// classWithIndexedProps is the schema state these cases run finalize under: the
-// migrated indexes are listed, so promotion is authorized and what each case
-// exercises is the generation and recovery logic.
+// classWithIndexedProps authorizes promotion for every migrated index, so
+// callers can exercise generation/recovery logic without schema gating.
 func classWithIndexedProps(names ...string) *models.Class {
 	on := true
 	class := &models.Class{Class: "Finalize"}
@@ -109,11 +108,8 @@ func touchSentinel(t *testing.T, path string) {
 	require.NoError(t, os.WriteFile(path, nil, 0o644))
 }
 
-// Promotion is refused for exactly what the load-time sweep would delete: a
-// canonical directory whose index the class turns off explicitly. A flag that is
-// on, a flag the class leaves unset, a property the class does not hold, and the
-// migrations that flip no flag all promote — refusing any of those would strand
-// the rebuilt data under its staged name with nothing left to free it.
+// Promotion is refused only for a canonical dir the load-time sweep would
+// delete (an index explicitly turned off); every other schema state promotes.
 func TestFinalizeCompletedMigrations_PromotionFollowsTheSchemaFlag(t *testing.T) {
 	const propName = "text"
 	off, on := false, true

--- a/adapters/repos/db/inverted_reindex_promotion_awaits_flip_test.go
+++ b/adapters/repos/db/inverted_reindex_promotion_awaits_flip_test.go
@@ -1,0 +1,134 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// enable-filterable runs with IndexFilterable false for its whole duration, and
+// the cluster-wide flip lands one scheduler tick plus one RAFT round after the
+// last shard finishes. Every shard load inside that window must leave the
+// migrated data exactly where the previous one left it: the load-time sweep
+// deletes a canonical directory it finds under a disabled index, so a load that
+// promotes hands the next one the migrated data to delete.
+func TestEnableFilterablePromotionWaitsForTheSchemaFlip(t *testing.T) {
+	const propName = "title"
+	const numObjects = 25
+	const token = "alpha"
+
+	ctx := testCtx()
+	className := "PromotionAwaitsFlip_" + uuid.NewString()[:8]
+	class := newEnableFilterableTestClass(className, propName)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		true, false, false)
+	shard := shd.(*Shard)
+
+	objects := makeConvergenceTestObjects(t, numObjects, className)
+	for _, obj := range objects {
+		require.NoError(t, shard.PutObject(ctx, obj))
+	}
+
+	task, wrapped := newEnableFilterableTask(t, idx, className, propName)
+	require.NoError(t, task.RunReindexOnlyOnShard(ctx, shard))
+	require.NoError(t, task.RunPrepareOnShard(ctx, shard))
+	require.NoError(t, task.RunSwapOnShard(ctx, shard))
+	require.True(t, wrapped.migrationCompleted, "fixture: the migration reaches its swap")
+
+	lsmPath := shard.pathLSM()
+	canonicalDir := filepath.Join(lsmPath, helpers.BucketFromPropNameLSM(propName))
+	stagedDir := filepath.Join(lsmPath,
+		helpers.BucketFromPropNameLSM(propName)+"__enable_filterable_ingest_1")
+	trackerDir := filepath.Join(lsmPath, migrationsDir,
+		MigrationDirPrefixEnableFilterable+"_"+propName+"_1")
+	require.DirExists(t, stagedDir,
+		"fixture: the migration leaves its data under the staged name")
+
+	current := shard
+	for load := 1; load <= 2; load++ {
+		current = reloadShardFromDisk(t, ctx, idx, current, class)
+
+		assert.NoDirExistsf(t, canonicalDir,
+			"load %d: the canonical directory must stay absent while IndexFilterable is false — "+
+				"the next load's sweep deletes what is there", load)
+		assert.DirExistsf(t, stagedDir,
+			"load %d: the migrated data must stay under its staged name until the flag lands", load)
+		assert.DirExistsf(t, trackerDir,
+			"load %d: the tracker outlives every load in the window, or nothing knows to promote later", load)
+	}
+
+	// The cluster-wide flip: the applied class the next load reads now lists the
+	// index, which is the only thing that authorizes the canonical name.
+	class.Properties[0].IndexFilterable = boolPtr(true)
+	current = reloadShardFromDisk(t, ctx, idx, current, class)
+	defer current.Shutdown(ctx)
+
+	assert.DirExists(t, canonicalDir,
+		"the first load after the flip must promote the migrated data to the canonical name")
+	assert.NoDirExists(t, stagedDir, "a promoted migration leaves no staged directory")
+	assert.NoDirExists(t, trackerDir, "a promoted migration leaves no tracker")
+
+	found, _, err := current.ObjectSearch(ctx, numObjects,
+		propEqualsFilter(className, propName, token), nil, nil, nil, additional.Properties{}, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, objectIDsHoldingToken(objects, propName, token), objectIDs(found),
+		"the promoted index must answer the filter with every object that holds the token")
+}
+
+func propEqualsFilter(className, propName, value string) *filters.LocalFilter {
+	return &filters.LocalFilter{
+		Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			On: &filters.Path{
+				Class:    schema.ClassName(className),
+				Property: schema.PropertyName(propName),
+			},
+			Value: &filters.Value{Value: value, Type: schema.DataTypeText},
+		},
+	}
+}
+
+func objectIDsHoldingToken(objects []*storobj.Object, propName, token string) []string {
+	var ids []string
+	for _, obj := range objects {
+		text, _ := obj.Object.Properties.(map[string]interface{})[propName].(string)
+		for _, word := range strings.Fields(text) {
+			if word == token {
+				ids = append(ids, obj.ID().String())
+				break
+			}
+		}
+	}
+	return ids
+}
+
+func objectIDs(objects []*storobj.Object) []string {
+	ids := make([]string, len(objects))
+	for i, obj := range objects {
+		ids[i] = obj.ID().String()
+	}
+	return ids
+}

--- a/adapters/repos/db/inverted_reindex_promotion_awaits_flip_test.go
+++ b/adapters/repos/db/inverted_reindex_promotion_awaits_flip_test.go
@@ -28,12 +28,9 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// enable-filterable runs with IndexFilterable false for its whole duration, and
-// the cluster-wide flip lands one scheduler tick plus one RAFT round after the
-// last shard finishes. Every shard load inside that window must leave the
-// migrated data exactly where the previous one left it: the load-time sweep
-// deletes a canonical directory it finds under a disabled index, so a load that
-// promotes hands the next one the migrated data to delete.
+// Promotion must wait for the cluster-wide schema flip: every shard load in
+// between must leave the migrated data staged, since the load-time sweep
+// deletes a promoted canonical directory it finds under a disabled index.
 func TestEnableFilterablePromotionWaitsForTheSchemaFlip(t *testing.T) {
 	const propName = "title"
 	const numObjects = 25
@@ -80,8 +77,7 @@ func TestEnableFilterablePromotionWaitsForTheSchemaFlip(t *testing.T) {
 			"load %d: the tracker outlives every load in the window, or nothing knows to promote later", load)
 	}
 
-	// The cluster-wide flip: the applied class the next load reads now lists the
-	// index, which is the only thing that authorizes the canonical name.
+	// Simulates the cluster-wide flip landing.
 	class.Properties[0].IndexFilterable = boolPtr(true)
 	current = reloadShardFromDisk(t, ctx, idx, current, class)
 	defer current.Shutdown(ctx)

--- a/adapters/repos/db/inverted_reindex_shard_wiring.go
+++ b/adapters/repos/db/inverted_reindex_shard_wiring.go
@@ -24,7 +24,7 @@ import (
 // in the order they run: both must stay ahead of bucket loading, or a bucket
 // opens at a name one of them is about to move.
 func (s *Shard) settleMigrationDirectories(ctx context.Context, class *models.Class) {
-	FinalizeCompletedMigrations(s.pathLSM(), s.index.logger)
+	FinalizeCompletedMigrations(s.pathLSM(), class, s.index.logger)
 	s.reconcileMigrationRecords(ctx, class)
 }
 

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -167,8 +167,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	// PreReindexHook'd bucket as soon as the cluster-wide schema flag
 	// flips on another node. See [Shard.rangeableLocalReady] for the
 	// full rationale. Props not found in this scan default to "ready"
-	// (no migration ever ran, or every prior migration already tidied —
-	// FinalizeCompletedMigrations above promoted them to canonical).
+	// (no migration ever ran, or every prior migration already tidied).
 	markInFlightRangeableMigrationsNotReady(s)
 
 	if err := s.initNonVector(ctx, class); err != nil {
@@ -263,9 +262,9 @@ func (s *Shard) NotifyReady() {
 // PreReindexHook hasn't fired yet on this replica.
 //
 // Properties that don't have a tracker dir, or whose dir has
-// `tidied.mig` (FinalizeCompletedMigrations promoted them to canonical
-// in this same startup), are left untouched — the default-true policy
-// in [Shard.IsRangeableLocallyReady] applies to them.
+// `tidied.mig` (a completed migration, whose promotion
+// FinalizeCompletedMigrations owns), are left untouched — the
+// default-true policy in [Shard.IsRangeableLocallyReady] applies to them.
 func markInFlightRangeableMigrationsNotReady(s *Shard) {
 	migrationsDir := filepath.Join(s.pathLSM(), ".migrations")
 	entries, err := os.ReadDir(migrationsDir)

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -262,7 +262,7 @@ func (s *Shard) NotifyReady() {
 // PreReindexHook hasn't fired yet on this replica.
 //
 // Properties that don't have a tracker dir, or whose dir has
-// `tidied.mig` (a completed migration, whose promotion
+// `tidied.mig` (a completed migration, whose finalization
 // FinalizeCompletedMigrations owns), are left untouched — the
 // default-true policy in [Shard.IsRangeableLocallyReady] applies to them.
 func markInFlightRangeableMigrationsNotReady(s *Shard) {

--- a/test/acceptance/reindex_singlenode/rebuilt_index_survives_loads_while_off_test.go
+++ b/test/acceptance/reindex_singlenode/rebuilt_index_survives_loads_while_off_test.go
@@ -1,0 +1,183 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_singlenode
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+const (
+	indexOffClass     = "IndexOffShardLoadTest"
+	indexOffTenant    = "tenantone"
+	indexOffProp      = "score"
+	indexOffCanonical = "property_score"
+	indexOffStaged    = "property_score__enable_filterable_ingest"
+	indexOffObjects   = 25
+)
+
+// A finished enable-filterable leaves its rebuilt index under a staged
+// directory name and defers the rename onto the canonical name to the next
+// shard load. Deleting the index while the tenant is inactive turns the schema
+// flag off without reaching that data, which is the same position every shard
+// load inside the migration's own pre-flip window is in: the load-time sweep
+// deletes a canonical directory it finds under an index the class turns off,
+// so a load that renames first hands the next load the rebuilt index to
+// delete.
+func TestRebuiltIndexSurvivesShardLoadsWhileTheIndexIsOff(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := reindexhelpers.StartSingleNode(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	restURI := compose.GetWeaviate().URI()
+	container := compose.GetWeaviate().Container()
+
+	falseVal := false
+	helper.CreateClass(t, &models.Class{
+		Class: indexOffClass,
+		Properties: []*models.Property{
+			{Name: "name", DataType: []string{"text"}, Tokenization: "field"},
+			{
+				Name:              indexOffProp,
+				DataType:          []string{"int"},
+				IndexFilterable:   &falseVal,
+				IndexRangeFilters: &falseVal,
+			},
+		},
+		Vectorizer:         "none",
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	})
+	helper.CreateTenants(t, indexOffClass, []*models.Tenant{{Name: indexOffTenant}})
+
+	objects := make([]*models.Object, indexOffObjects)
+	for i := range objects {
+		objects[i] = &models.Object{
+			Class:  indexOffClass,
+			Tenant: indexOffTenant,
+			Properties: map[string]interface{}{
+				"name":       fmt.Sprintf("item_%d", i),
+				indexOffProp: int64(i % 5),
+			},
+		}
+	}
+	helper.CreateObjectsBatch(t, objects)
+
+	taskID := reindexhelpers.SubmitIndexUpsert(t, restURI, indexOffClass, indexOffProp, "filterable", `{}`)
+	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
+	requireIndexOffFilterableFlag(t, true)
+
+	dirs := listLSMDirs(ctx, t, container, indexOffClass, indexOffTenant)
+	require.NotEmpty(t, indexOffStagedDir(dirs),
+		"fixture: the finished migration leaves its data under a staged name, got %v", dirs)
+
+	// The delete only reaches the buckets of a loaded shard, so an inactive
+	// tenant keeps the rebuilt index on disk under an index the class now
+	// turns off.
+	setIndexOffTenantStatus(t, models.TenantActivityStatusINACTIVE)
+	deleteIndex(t, restURI, indexOffClass, indexOffProp, "filterable")
+	requireIndexOffFilterableFlag(t, false)
+
+	for load := 1; load <= 2; load++ {
+		setIndexOffTenantStatus(t, models.TenantActivityStatusACTIVE)
+		require.Eventually(t, func() bool {
+			ids, err := indexOffTenantObjects(t)
+			return err == nil && len(ids) == indexOffObjects
+		}, 60*time.Second, 200*time.Millisecond,
+			"load %d: activating the tenant must load its shard and serve its objects", load)
+
+		dirs := listLSMDirs(ctx, t, container, indexOffClass, indexOffTenant)
+		assert.NotContainsf(t, dirs, indexOffCanonical,
+			"load %d: the canonical directory must stay absent while the class turns the index off — "+
+				"the next load's sweep deletes what is there", load)
+		assert.NotEmptyf(t, indexOffStagedDir(dirs),
+			"load %d: the rebuilt index must keep its staged name until the flag lands, got %v", load, dirs)
+
+		setIndexOffTenantStatus(t, models.TenantActivityStatusINACTIVE)
+	}
+}
+
+func indexOffStagedDir(dirs []string) string {
+	for _, dir := range dirs {
+		if strings.HasPrefix(dir, indexOffStaged) {
+			return dir
+		}
+	}
+	return ""
+}
+
+func indexOffTenantObjects(t *testing.T) ([]string, error) {
+	t.Helper()
+	return runGraphQLQuery(t, indexOffClass, fmt.Sprintf(`{
+		Get {
+			%s(tenant: %q) {
+				name
+				_additional { id }
+			}
+		}
+	}`, indexOffClass, indexOffTenant))
+}
+
+func requireIndexOffFilterableFlag(t *testing.T, want bool) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		cls := helper.GetClass(t, indexOffClass)
+		if cls == nil {
+			return false
+		}
+		for _, prop := range cls.Properties {
+			if prop.Name == indexOffProp {
+				return prop.IndexFilterable != nil && *prop.IndexFilterable == want
+			}
+		}
+		return false
+	}, 60*time.Second, 50*time.Millisecond, "%s.IndexFilterable must settle on %v", indexOffProp, want)
+}
+
+// Waits for the status to land: the delete and the shard load that follow both
+// read whether the shard is loaded, not what was asked for.
+func setIndexOffTenantStatus(t *testing.T, status string) {
+	t.Helper()
+	switch status {
+	case models.TenantActivityStatusACTIVE:
+		helper.ActivateTenants(t, indexOffClass, []string{indexOffTenant})
+	default:
+		helper.DeactivateTenants(t, indexOffClass, []string{indexOffTenant})
+	}
+	settled := map[string]string{
+		models.TenantActivityStatusACTIVE:   models.TenantActivityStatusHOT,
+		models.TenantActivityStatusINACTIVE: models.TenantActivityStatusCOLD,
+	}[status]
+	require.Eventuallyf(t, func() bool {
+		resp, err := helper.GetOneTenant(t, indexOffClass, indexOffTenant)
+		if err != nil || resp == nil || resp.Payload == nil {
+			return false
+		}
+		return resp.Payload.ActivityStatus == status || resp.Payload.ActivityStatus == settled
+	}, 60*time.Second, 100*time.Millisecond, "tenant must reach %s", status)
+}

--- a/test/acceptance/reindex_singlenode/rebuilt_index_survives_loads_while_off_test.go
+++ b/test/acceptance/reindex_singlenode/rebuilt_index_survives_loads_while_off_test.go
@@ -35,14 +35,9 @@ const (
 	indexOffObjects   = 25
 )
 
-// A finished enable-filterable leaves its rebuilt index under a staged
-// directory name and defers the rename onto the canonical name to the next
-// shard load. Deleting the index while the tenant is inactive turns the schema
-// flag off without reaching that data, which is the same position every shard
-// load inside the migration's own pre-flip window is in: the load-time sweep
-// deletes a canonical directory it finds under an index the class turns off,
-// so a load that renames first hands the next load the rebuilt index to
-// delete.
+// Deleting an index while its tenant is inactive leaves the shard in the same
+// state as the promotion-deferral window: the rebuilt data must survive
+// repeated shard loads under its staged name until the index is on again.
 func TestRebuiltIndexSurvivesShardLoadsWhileTheIndexIsOff(t *testing.T) {
 	ctx := context.Background()
 
@@ -96,9 +91,8 @@ func TestRebuiltIndexSurvivesShardLoadsWhileTheIndexIsOff(t *testing.T) {
 	require.NotEmpty(t, indexOffStagedDir(dirs),
 		"fixture: the finished migration leaves its data under a staged name, got %v", dirs)
 
-	// The delete only reaches the buckets of a loaded shard, so an inactive
-	// tenant keeps the rebuilt index on disk under an index the class now
-	// turns off.
+	// The delete only reaches loaded shards, so an inactive tenant keeps the
+	// rebuilt index on disk after the flag turns off.
 	setIndexOffTenantStatus(t, models.TenantActivityStatusINACTIVE)
 	deleteIndex(t, restURI, indexOffClass, indexOffProp, "filterable")
 	requireIndexOffFilterableFlag(t, false)

--- a/test/acceptance/reindex_singlenode/rebuilt_index_survives_loads_while_off_test.go
+++ b/test/acceptance/reindex_singlenode/rebuilt_index_survives_loads_while_off_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 // Deleting an index while its tenant is inactive leaves the shard in the same
-// state as the promotion-deferral window: the rebuilt data must survive
+// state as the finalize-deferral window: the rebuilt data must survive
 // repeated shard loads under its staged name until the index is on again.
 func TestRebuiltIndexSurvivesShardLoadsWhileTheIndexIsOff(t *testing.T) {
 	ctx := context.Background()

--- a/test/run.sh
+++ b/test/run.sh
@@ -1009,10 +1009,12 @@ function run_acceptance_reindex_singlenode_a() {
   # Profiled locally on M4 (race detector on): TestSingleNode_ReindexSuite
   # totals 265s, dominated by /PropertyStateMigrationMatrix at 128s
   # (~half the suite). Isolating PSMM to -singlenode-b gives this
-  # sub-shard ~137s of suite work + the 4 standalone Test* funcs
+  # sub-shard ~137s of suite work + the 5 standalone Test* funcs
   # (TestCancelThenRetry, TestRestartDuringSwap,
   # TestSingleNode_FinishedStatusRaceWithSchemaFlag,
-  # TestTornResume_StandaloneSmoke), totalling ~3 min local → ~7-8 min CI.
+  # TestTornResume_StandaloneSmoke,
+  # TestRebuiltIndexSurvivesShardLoadsWhileTheIndexIsOff), totalling
+  # ~3 min local → ~7-8 min CI.
   #
   # The -skip filter operates at the level of the subtest path: only
   # TestSingleNode_ReindexSuite/PropertyStateMigrationMatrix is skipped;


### PR DESCRIPTION
A rebuilt index could be deleted moments after it was built, leaving filters on that property returning nothing — no error, no log line. Every 1.39 release has this, behind `RUNTIME_REINDEX_ENABLED`.

Turning an index on rebuilds it, then flips the schema flag once for the whole cluster, only after every shard finishes. A shard that finishes early waits — and in that wait, one shard load moved the rebuilt data onto the property's real directory while the schema still said that index was off, so the next load's cleanup deleted it as data nobody had asked for. Objects were never affected.

**The fix:** look at the schema before that rename. If the index is still off, leave the data where it is and try again on the next load. Three files, one new parameter, one new branch.

**Proof:** `rebuilt_index_survives_loads_while_off_test.go` fails on `stable/v1.39` and passes here, three runs each side, driving a real node.

### Out of scope

Deferring the rename introduces four smaller problems. **#12848 replaces this whole code path and deletes the functions each fix would touch**, so fixing them here means two more files, four more function signatures and three new branches — all discarded the moment that PR merges. What is accepted instead:

- A second copy of the property's index stays on disk until a later rebuild supersedes it. Disk only; a resubmit frees it.
- The first load of an affected tenant after a restart happens even when there is nothing to rename. Bounded per process, not per sweep.
- A failure log tells operators to read the tenant to finish the swap; for these two migration types it no longer helps. The repair command beside it still works.
- A rename that meets missing data reports success quietly. Byte-identical to `stable/v1.39` — pre-existing, not introduced here.

Two more are filed rather than fixed: the crash-recovery path renames without checking too, but needs a different fix and is pre-existing; and #12848's own replacement renames with no schema check, so the same rule has to be written into it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DG7dxF28tQCKrawnhV5xWb
