### PR TITLE
Fix object_count metric Help text (copy-pasted from async_operations_running)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -48,7 +48,7 @@ This document is the single source of truth for Prometheus metrics exposed by We
 #### Object Operations
 | Name | Description | Type | Labels | High Cardinality |
 |---|---|---|---|---|
-| `object_count` | Number of currently ongoing async operations | `Gauge` | `class_name, shard_name` | ❌ High 
+| `object_count` | Number of objects in the shard | `Gauge` | `class_name, shard_name` | ❌ High 
 
 #### Query Operations
 | Name | Description | Type | Labels | High Cardinality |

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -501,7 +501,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		}, []string{"operation", "step", "class_name", "shard_name"}),
 		ObjectCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Name: "object_count",
-			Help: "Number of currently ongoing async operations",
+			Help: "Number of objects in the shard",
 		}, []string{"class_name", "shard_name"}),
 
 		QueriesCount: promauto.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
Fixes #12944

The `object_count` gauge was registered with the Help text of `async_operations_running` ("Number of currently ongoing async operations") — a copy-paste leftover visible on every Prometheus scrape and `GET /v1/metrics`. `object_count` is the live shard object-count gauge, set from shard/bucket counts in `adapters/repos/db/node_wide_metrics.go` and `adapters/repos/db/lsmkv/metrics.go`.

This fixes the Help string in `usecases/monitoring/prometheus.go` and the same wrong description repeated in the `docs/metrics.md` object-operations table. `gofmt` clean, `go build ./usecases/monitoring/` passes.