### PR TITLE
fix(graphql): fix filter array variables for ContainsAny and ContainsAll (gh-5051)

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/filters_types.go
+++ b/adapters/handlers/graphql/local/common_filters/filters_types.go
@@ -20,6 +20,26 @@ import (
 	"github.com/tailor-platform/graphql/language/ast"
 )
 
+func parseScalarOrArray[T any](value interface{}, parseScalar func(interface{}) interface{}) interface{} {
+	switch v := value.(type) {
+	case []T:
+		return v
+	case []interface{}:
+		res := make([]T, len(v))
+		for i := range v {
+			parsed := parseScalar(v[i])
+			if val, ok := parsed.(T); ok {
+				res[i] = val
+			} else {
+				return nil
+			}
+		}
+		return res
+	default:
+		return parseScalar(value)
+	}
+}
+
 func newValueTextType(path string) graphql.Input {
 	return graphql.NewScalar(graphql.ScalarConfig{
 		Name:        fmt.Sprintf("Text%v", path),
@@ -28,7 +48,7 @@ func newValueTextType(path string) graphql.Input {
 			return graphql.String.Serialize(value)
 		},
 		ParseValue: func(value interface{}) interface{} {
-			return graphql.String.ParseValue(value)
+			return parseScalarOrArray[string](value, graphql.String.ParseValue)
 		},
 		ParseLiteral: func(valueAST ast.Value) interface{} {
 			switch valueAST := valueAST.(type) {
@@ -62,7 +82,7 @@ func newValueIntType(path string) graphql.Input {
 			return graphql.Int.Serialize(value)
 		},
 		ParseValue: func(value interface{}) interface{} {
-			return graphql.Int.ParseValue(value)
+			return parseScalarOrArray[int](value, graphql.Int.ParseValue)
 		},
 		ParseLiteral: func(valueAST ast.Value) interface{} {
 			switch valueAST := valueAST.(type) {
@@ -92,7 +112,7 @@ func newValueNumberType(path string) graphql.Input {
 			return graphql.Float.Serialize(value)
 		},
 		ParseValue: func(value interface{}) interface{} {
-			return graphql.Float.ParseValue(value)
+			return parseScalarOrArray[float64](value, graphql.Float.ParseValue)
 		},
 		ParseLiteral: func(valueAST ast.Value) interface{} {
 			switch valueAST := valueAST.(type) {
@@ -126,7 +146,7 @@ func newValueBooleanType(path string) graphql.Input {
 			return graphql.Boolean.Serialize(value)
 		},
 		ParseValue: func(value interface{}) interface{} {
-			return graphql.Boolean.ParseValue(value)
+			return parseScalarOrArray[bool](value, graphql.Boolean.ParseValue)
 		},
 		ParseLiteral: func(valueAST ast.Value) interface{} {
 			switch valueAST := valueAST.(type) {

--- a/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
@@ -72,10 +72,32 @@ func (c *converter) do(in *WhereFilter) (*models.WhereFilter, error) {
 		case float64:
 			val := int64(v)
 			whereFilter.ValueInt = &val
+		case int:
+			val := int64(v)
+			whereFilter.ValueInt = &val
+		case int64:
+			whereFilter.ValueInt = &v
+		case []int:
+			ints := make([]int64, len(v))
+			for i, n := range v {
+				ints[i] = int64(n)
+			}
+			whereFilter.ValueIntArray = ints
+		case []int64:
+			whereFilter.ValueIntArray = v
 		case []interface{}:
 			ints := make([]int64, len(v))
 			for i := range v {
-				ints[i] = int64(v[i].(float64))
+				switch elem := v[i].(type) {
+				case float64:
+					ints[i] = int64(elem)
+				case int:
+					ints[i] = int64(elem)
+				case int64:
+					ints[i] = elem
+				default:
+					return nil, fmt.Errorf("unsupported type in ValueInt array: '%T'", v[i])
+				}
 			}
 			whereFilter.ValueIntArray = ints
 		default:
@@ -86,10 +108,19 @@ func (c *converter) do(in *WhereFilter) (*models.WhereFilter, error) {
 		switch v := in.ValueNumber.(type) {
 		case float64:
 			whereFilter.ValueNumber = &v
+		case []float64:
+			whereFilter.ValueNumberArray = v
 		case []interface{}:
 			numbers := make([]float64, len(v))
 			for i := range v {
-				numbers[i] = v[i].(float64)
+				switch elem := v[i].(type) {
+				case float64:
+					numbers[i] = elem
+				case int:
+					numbers[i] = float64(elem)
+				default:
+					return nil, fmt.Errorf("unsupported type in ValueNumber array: '%T'", v[i])
+				}
 			}
 			whereFilter.ValueNumberArray = numbers
 		default:
@@ -100,10 +131,16 @@ func (c *converter) do(in *WhereFilter) (*models.WhereFilter, error) {
 		switch v := in.ValueBoolean.(type) {
 		case bool:
 			whereFilter.ValueBoolean = &v
+		case []bool:
+			whereFilter.ValueBooleanArray = v
 		case []interface{}:
 			bools := make([]bool, len(v))
 			for i := range v {
-				bools[i] = v[i].(bool)
+				b, ok := v[i].(bool)
+				if !ok {
+					return nil, fmt.Errorf("unsupported type in ValueBoolean array: '%T'", v[i])
+				}
+				bools[i] = b
 			}
 			whereFilter.ValueBooleanArray = bools
 		default:
@@ -154,10 +191,16 @@ func (c *converter) parseString(in interface{}) (value *string, valueArray []str
 	switch v := in.(type) {
 	case string:
 		value = &v
+	case []string:
+		valueArray = v
 	case []interface{}:
 		valueArray = make([]string, len(v))
 		for i := range v {
-			valueArray[i] = v[i].(string)
+			if s, ok := v[i].(string); ok {
+				valueArray[i] = s
+			} else {
+				return nil, nil, fmt.Errorf("unsupported element type in string array: '%T'", v[i])
+			}
 		}
 	default:
 		err = fmt.Errorf("unsupported type: '%T'", in)

--- a/adapters/handlers/graphql/local/common_filters/parse_test.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_test.go
@@ -423,3 +423,112 @@ func TestExtractNearObject(t *testing.T) {
 func ptFloat32(in float32) *float32 {
 	return &in
 }
+
+func TestExtractFilterContainsAny(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		operator  filters.Operator
+		property  string
+		valueType schema.DataType
+		expected  interface{}
+		query     string
+		variables map[string]interface{}
+	}{
+		{
+			name:      "extracts valueText array from variables",
+			operator:  filters.ContainsAny,
+			property:  "name",
+			valueType: schema.DataTypeText,
+			expected:  []string{"english", "german"},
+			query:     `query ($where: GetWhereInpObj) { SomeAction(where: $where) }`,
+			variables: map[string]interface{}{
+				"where": map[string]interface{}{
+					"path":      []interface{}{"name"},
+					"operator":  "ContainsAny",
+					"valueText": []interface{}{"english", "german"},
+				},
+			},
+		},
+		{
+			name:      "extracts valueInt array from variables",
+			operator:  filters.ContainsAny,
+			property:  "intField",
+			valueType: schema.DataTypeInt,
+			expected:  []int{1, 2},
+			query:     `query ($where: GetWhereInpObj) { SomeAction(where: $where) }`,
+			variables: map[string]interface{}{
+				"where": map[string]interface{}{
+					"path":     []interface{}{"intField"},
+					"operator": "ContainsAny",
+					"valueInt": []interface{}{1, 2},
+				},
+			},
+		},
+		{
+			name:      "extracts valueNumber array from variables",
+			operator:  filters.ContainsAny,
+			property:  "weight",
+			valueType: schema.DataTypeNumber,
+			expected:  []float64{1.5, 2.5},
+			query:     `query ($where: GetWhereInpObj) { SomeAction(where: $where) }`,
+			variables: map[string]interface{}{
+				"where": map[string]interface{}{
+					"path":        []interface{}{"weight"},
+					"operator":    "ContainsAny",
+					"valueNumber": []interface{}{1.5, 2.5},
+				},
+			},
+		},
+		{
+			name:      "extracts valueBoolean array from variables",
+			operator:  filters.ContainsAll,
+			property:  "isAvailable",
+			valueType: schema.DataTypeBoolean,
+			expected:  []bool{true, false},
+			query:     `query ($where: GetWhereInpObj) { SomeAction(where: $where) }`,
+			variables: map[string]interface{}{
+				"where": map[string]interface{}{
+					"path":         []interface{}{"isAvailable"},
+					"operator":     "ContainsAll",
+					"valueBoolean": []interface{}{true, false},
+				},
+			},
+		},
+		{
+			name:      "extracts inline literal array without variables",
+			operator:  filters.ContainsAny,
+			property:  "name",
+			valueType: schema.DataTypeText,
+			expected:  []string{"english", "german"},
+			query:     `{ SomeAction(where: { path: ["name"], operator: ContainsAny, valueText: ["english", "german"]}) }`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := newMockResolver(t, mockParams{reportFilter: true})
+			expectedParams := &filters.LocalFilter{Root: &filters.Clause{
+				Operator: tt.operator,
+				On: &filters.Path{
+					Class:    schema.AssertValidClassName("SomeAction"),
+					Property: schema.AssertValidPropertyName(tt.property),
+				},
+				Value: &filters.Value{
+					Value: tt.expected,
+					Type:  tt.valueType,
+				},
+			}}
+
+			resolver.On("ReportFilters", expectedParams).
+				Return(test_helper.EmptyList(), nil).Once()
+
+			if tt.variables != nil {
+				resolver.AssertResolveWithVariables(t, tt.query, tt.variables)
+			} else {
+				resolver.AssertResolve(t, tt.query)
+			}
+		})
+	}
+}

--- a/adapters/handlers/graphql/test/helper/mock_resolver.go
+++ b/adapters/handlers/graphql/test/helper/mock_resolver.go
@@ -38,6 +38,10 @@ type MockResolver struct {
 var schemaBuildLock sync.Mutex
 
 func (mr *MockResolver) Resolve(query string) *graphql.Result {
+	return mr.ResolveWithVariables(query, nil)
+}
+
+func (mr *MockResolver) ResolveWithVariables(query string, variables map[string]interface{}) *graphql.Result {
 	fields := graphql.Fields{}
 	fields[mr.RootFieldName] = mr.RootField
 	schemaObject := graphql.ObjectConfig{
@@ -56,20 +60,29 @@ func (mr *MockResolver) Resolve(query string) *graphql.Result {
 		panic(err)
 	}
 
-	result := graphql.Do(graphql.Params{
-		Schema:        schema,
-		RequestString: query,
-		RootObject:    mr.RootObject,
-		Context:       context.Background(),
+	return graphql.Do(graphql.Params{
+		Schema:         schema,
+		RequestString:  query,
+		RootObject:     mr.RootObject,
+		VariableValues: variables,
+		Context:        context.Background(),
 	})
-
-	return result
 }
 
 func (mr *MockResolver) AssertResolve(t *testing.T, query string) *GraphQLResult {
 	result := mr.Resolve(query)
 	if len(result.Errors) > 0 {
 		t.Fatalf("Failed to resolve; %s", spew.Sdump(result.Errors))
+	}
+
+	mr.AssertExpectations(t)
+	return &GraphQLResult{Result: result.Data}
+}
+
+func (mr *MockResolver) AssertResolveWithVariables(t *testing.T, query string, variables map[string]interface{}) *GraphQLResult {
+	result := mr.ResolveWithVariables(query, variables)
+	if len(result.Errors) > 0 {
+		t.Fatalf("Failed to resolve with variables; %s", spew.Sdump(result.Errors))
 	}
 
 	mr.AssertExpectations(t)


### PR DESCRIPTION
### What's being changed:

fixes #5051

when passing filter arguments through graphql variables (like with `ContainsAny` or `ContainsAll`), the scalar parsers (`valueText`, `valueInt`, `valueNumber`, `valueBoolean`) were passing the whole array directly to the single-value parser.

this caused two issues:
1. for text filters, the array was turned into a single string like `"[item1 item2]"`, which caused weaviate to fail with:
   `value type should be []string but is string`
2. for int, float, and boolean filters, the parser failed and returned `nil`.

what this PR changes:
- `filters_types.go`: added a helper to handle both single values and array values from variables, converting them into typed slices (`[]string`, `[]int`, `[]float64`, `[]bool`).
- `parse_filters_into_ast.go`: updated string parsing and ast conversion to properly handle typed slice values.
- `mock_resolver.go` & `parse_test.go`: added variable support to the test mock resolver and added unit tests covering array variables across text, int, number, and boolean filters.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.