### PR TITLE
fix(grpc): activate cold tenants in batch delete under autoTenantActivation (gh-12953)

### DIFF
--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -73,6 +73,18 @@ func (b *BatchManager) DeleteObjectsFromGRPCAfterAuth(ctx context.Context, princ
 	}
 	schemaVersion := fetchedClasses[className].Version
 
+	if tenant != "" {
+		tenantSchemaVersion, err := b.schemaManager.EnsureTenantActiveForWrite(ctx, className, tenant)
+		if err != nil {
+			return BatchDeleteResult{}, fmt.Errorf("error ensuring tenant active for write: %w", err)
+		}
+		schemaVersion = max(schemaVersion, tenantSchemaVersion)
+	}
+
+	if err := b.schemaManager.WaitForUpdate(ctx, schemaVersion); err != nil {
+		return BatchDeleteResult{}, fmt.Errorf("error waiting for local schema to catch up to version %d: %w", schemaVersion, err)
+	}
+
 	deletionTime := time.UnixMilli(b.timeSource.Now())
 	return b.vectorRepo.BatchDeleteObjects(ctx, params, deletionTime, repl, tenant, schemaVersion)
 }

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -388,17 +388,47 @@ func Test_BatchDelete_FromGRPC_Uses_SchemaVersion(t *testing.T) {
 	const classVersion uint64 = 9
 
 	tests := []struct {
-		name      string
-		lookupErr error
-		wantErr   string
+		name              string
+		tenant            string
+		lookupErr         error
+		activationVersion uint64
+		activationErr     error
+		waitForUpdateErr  error
+		wantVersion       uint64
+		wantErr           string
 	}{
 		{
-			name: "deleted",
+			name:        "deleted",
+			wantVersion: classVersion,
 		},
 		{
 			name:      "collection lookup fails",
 			lookupErr: errors.New("leader unreachable"),
 			wantErr:   "could not get class Foo",
+		},
+		{
+			name:              "deleted with tenant activates tenant and waits for schema update",
+			tenant:            "tenant1",
+			activationVersion: 15,
+			wantVersion:       15,
+		},
+		{
+			name:              "deleted with tenant uses classVersion if higher than activationVersion",
+			tenant:            "tenant1",
+			activationVersion: 5,
+			wantVersion:       classVersion,
+		},
+		{
+			name:          "tenant activation fails",
+			tenant:        "tenant1",
+			activationErr: errors.New("cannot activate tenant"),
+			wantErr:       "error ensuring tenant active for write: cannot activate tenant",
+		},
+		{
+			name:             "wait for update fails with tenant",
+			tenant:           "tenant1",
+			waitForUpdateErr: errors.New("schema timeout"),
+			wantErr:          "error waiting for local schema to catch up to version",
 		},
 	}
 
@@ -410,9 +440,12 @@ func Test_BatchDelete_FromGRPC_Uses_SchemaVersion(t *testing.T) {
 			vectorRepo := &fakeVectorRepo{}
 			vectorRepo.On("BatchDeleteObjects", mock.Anything).Return(BatchDeleteResult{}, nil).Once()
 			schemaManager := &fakeSchemaManager{
-				GetSchemaResponse: sch,
-				ClassVersion:      classVersion,
-				GetschemaErr:      tt.lookupErr,
+				GetSchemaResponse:               sch,
+				ClassVersion:                    classVersion,
+				GetschemaErr:                    tt.lookupErr,
+				EnsureTenantActiveSchemaVersion: tt.activationVersion,
+				EnsureTenantActiveErr:           tt.activationErr,
+				WaitForUpdateErr:                tt.waitForUpdateErr,
 			}
 			cfg := &config.WeaviateConfig{}
 			logger, _ := test.NewNullLogger()
@@ -421,7 +454,7 @@ func Test_BatchDelete_FromGRPC_Uses_SchemaVersion(t *testing.T) {
 				NewAutoSchemaManager(schemaManager, vectorRepo, cfg, logger, prometheus.NewPedanticRegistry()))
 
 			_, err := manager.DeleteObjectsFromGRPCAfterAuth(context.Background(), &models.Principal{},
-				BatchDeleteParams{ClassName: "Foo"}, nil, "")
+				BatchDeleteParams{ClassName: "Foo"}, nil, tt.tenant)
 
 			if tt.wantErr != "" {
 				require.ErrorContains(t, err, tt.wantErr)
@@ -429,8 +462,14 @@ func Test_BatchDelete_FromGRPC_Uses_SchemaVersion(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, classVersion, vectorRepo.CapturedSchemaVersion,
-				"the delete must be made with the collection's schema version")
+			assert.Equal(t, tt.wantVersion, vectorRepo.CapturedSchemaVersion,
+				"the delete must be made with the resolved schema version")
+			if tt.tenant != "" {
+				require.Len(t, schemaManager.EnsureTenantActiveCalls, 1)
+				assert.Equal(t, "Foo", schemaManager.EnsureTenantActiveCalls[0].Class)
+				assert.Equal(t, []string{tt.tenant}, schemaManager.EnsureTenantActiveCalls[0].Tenants)
+				assert.Equal(t, tt.wantVersion, schemaManager.WaitedSchemaVersion)
+			}
 		})
 	}
 }

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -52,16 +52,22 @@ type fakeSchemaManager struct {
 	tenantsEnabled    bool
 	resolveAliasTo    string
 	// test controls
-	AddTenantsSchemaVersion uint64
-	AutoSchemaVersion       uint64
-	ClassVersion            uint64
-	AddClassPropertyErr     error
-	WaitForUpdateErr        error
+	AddTenantsSchemaVersion         uint64
+	AutoSchemaVersion               uint64
+	ClassVersion                    uint64
+	AddClassPropertyErr             error
+	WaitForUpdateErr                error
+	EnsureTenantActiveErr           error
+	EnsureTenantActiveSchemaVersion uint64
 	// observed
-	WaitedSchemaVersion    uint64
-	MaxWaitedSchemaVersion uint64
-	WaitedVersions         []uint64
-	GetClassCalls          []string
+	WaitedSchemaVersion     uint64
+	MaxWaitedSchemaVersion  uint64
+	WaitedVersions          []uint64
+	GetClassCalls           []string
+	EnsureTenantActiveCalls []struct {
+		Class   string
+		Tenants []string
+	}
 }
 
 func (f *fakeSchemaManager) UpdatePropertyAddDataType(ctx context.Context, principal *models.Principal,
@@ -240,7 +246,11 @@ func (f *fakeSchemaManager) ResolveAlias(alias string) string {
 }
 
 func (f *fakeSchemaManager) EnsureTenantActiveForWrite(ctx context.Context, class string, tenants ...string) (uint64, error) {
-	return 0, nil
+	f.EnsureTenantActiveCalls = append(f.EnsureTenantActiveCalls, struct {
+		Class   string
+		Tenants []string
+	}{Class: class, Tenants: tenants})
+	return f.EnsureTenantActiveSchemaVersion, f.EnsureTenantActiveErr
 }
 
 type fakeVectorRepo struct {


### PR DESCRIPTION
### What's being changed:

when `autoTenantActivation: true` is on, batch deleting from a cold/inactive tenant via grpc (`DeleteObjectsFromGRPCAfterAuth`) was skipping tenant activation and not waiting for schema updates, unlike the rest endpoint (`deleteObjects`).

this brings grpc batch delete in line with rest:
1. calls `b.schemaManager.EnsureTenantActiveForWrite` in `DeleteObjectsFromGRPCAfterAuth` when `tenant != ""` to wake up cold tenants before deleting.
2. waits for local schema to catch up via `b.schemaManager.WaitForUpdate(ctx, schemaVersion)` before calling `vectorRepo.BatchDeleteObjects`.
3. adds multi-tenant tests to `Test_BatchDelete_FromGRPC_Uses_SchemaVersion` covering tenant activation, schema version resolution, activation errors, and wait timeouts.

closes #12953

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.