### PR TITLE
security: restrict Google module apiEndpoint, region and location to Google API hosts

### DIFF
--- a/modules/generative-google/clients/google.go
+++ b/modules/generative-google/clients/google.go
@@ -174,6 +174,9 @@ func (v *google) GenerateAllResults(ctx context.Context, properties []*modulecap
 
 func (v *google) generate(ctx context.Context, cfg moduletools.ClassConfig, prompt string, imageProperties []map[string]*string, options interface{}, debug bool) (*modulecapabilities.GenerateResponse, error) {
 	params := v.getParameters(cfg, options, imageProperties)
+	if err := validateEndpoint(params); err != nil {
+		return nil, err
+	}
 	debugInformation := v.getDebugInformation(debug, prompt)
 
 	useGenerativeAIEndpoint := v.useGenerativeAIEndpoint(params.ApiEndpoint)
@@ -248,6 +251,20 @@ func (v *google) parseGenerateMessageResponse(statusCode int, bodyBytes []byte, 
 		Result: nil,
 		Debug:  debug,
 	}, nil
+}
+
+// validateEndpoint rejects endpoint overrides that would send the operator's
+// Google credential off Google's domain. apiEndpoint, region and location all
+// end up in the request host, and a GraphQL or gRPC request can set all three
+// without any schema permission, so the class config check alone is not enough.
+func validateEndpoint(params googleparams.Params) error {
+	if err := modulecomponents.ValidateGoogleApiEndpoint(params.ApiEndpoint); err != nil {
+		return err
+	}
+	if err := modulecomponents.ValidateGoogleLocation("region", params.Region); err != nil {
+		return err
+	}
+	return modulecomponents.ValidateGoogleLocation("location", params.Location)
 }
 
 func (v *google) getParameters(cfg moduletools.ClassConfig, options interface{}, imagePropertiesArray []map[string]*string) googleparams.Params {

--- a/modules/generative-google/clients/google_test.go
+++ b/modules/generative-google/clients/google_test.go
@@ -35,6 +35,45 @@ func nullLogger() logrus.FieldLogger {
 	return l
 }
 
+func TestGenerateRejectsForeignEndpoint(t *testing.T) {
+	tests := []struct {
+		name   string
+		params googleparams.Params
+	}{
+		{
+			name:   "apiEndpoint outside the Google API domain",
+			params: googleparams.Params{ApiEndpoint: "attacker.example.com"},
+		},
+		{
+			name:   "region carrying a host",
+			params: googleparams.Params{ApiEndpoint: "us-central1-aiplatform.googleapis.com", Region: "attacker.example.com/"},
+		},
+		{
+			name:   "location carrying a host",
+			params: googleparams.Params{ApiEndpoint: "us-central1-aiplatform.googleapis.com", Location: "attacker.example.com/"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &google{
+				apiKey:       "apiKey",
+				httpClient:   &http.Client{},
+				googleApiKey: apikey.NewGoogleApiKey(),
+				buildUrlFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID, region, location string) string {
+					t.Fatal("must not build a request URL for a rejected endpoint")
+					return ""
+				},
+				logger: nullLogger(),
+			}
+			props := []*modulecapabilities.GenerateProperties{{Text: map[string]string{"prop": "My name is john"}}}
+
+			_, err := c.GenerateAllResults(context.Background(), props, "What is my name?", tt.params, false, nil)
+
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestGetAnswer(t *testing.T) {
 	t.Run("when the server has a successful answer ", func(t *testing.T) {
 		prompt := "John"
@@ -66,7 +105,7 @@ func TestGetAnswer(t *testing.T) {
 			logger: nullLogger(),
 		}
 
-		params := googleparams.Params{ApiEndpoint: server.URL}
+		params := googleparams.Params{ApiEndpoint: "us-central1-aiplatform.googleapis.com"}
 		props := []*modulecapabilities.GenerateProperties{{Text: map[string]string{"prop": "My name is john"}}}
 		expected := modulecapabilities.GenerateResponse{
 			Result: ptString("John"),

--- a/modules/generative-google/config/class_settings.go
+++ b/modules/generative-google/config/class_settings.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
 )
 
@@ -92,6 +93,15 @@ func (ic *classSettings) Validate(class *models.Class) error {
 
 	apiEndpoint := ic.ApiEndpoint()
 	projectID := ic.ProjectID()
+	if err := modulecomponents.ValidateGoogleApiEndpoint(apiEndpoint); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
+	if err := modulecomponents.ValidateGoogleLocation(regionProperty, ic.Region()); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
+	if err := modulecomponents.ValidateGoogleLocation(locationProperty, ic.Location()); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
 	if apiEndpoint != DefaulGenerativeAIApiEndpoint && projectID == "" {
 		errorMessages = append(errorMessages, fmt.Sprintf("%s cannot be empty", projectIDProperty))
 	}

--- a/modules/generative-google/config/class_settings_test.go
+++ b/modules/generative-google/config/class_settings_test.go
@@ -67,7 +67,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "custom values",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"apiEndpoint": "google.com",
+					"apiEndpoint": "europe-west4-aiplatform.googleapis.com",
 					"projectId":   "cloud-project",
 					"modelId":     "model-id",
 					"temperature": 0.25,
@@ -76,7 +76,7 @@ func Test_classSettings_Validate(t *testing.T) {
 					"topP":        0.97,
 				},
 			},
-			wantApiEndpoint: "google.com",
+			wantApiEndpoint: "europe-west4-aiplatform.googleapis.com",
 			wantProjectID:   "cloud-project",
 			wantModelID:     "model-id",
 			wantTemperature: ptr(0.25),
@@ -84,6 +84,26 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantTopK:        ptr(30),
 			wantTopP:        ptr(0.97),
 			wantErr:         nil,
+		},
+		{
+			name: "apiEndpoint outside the Google API domain",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"apiEndpoint": "attacker.example.com",
+					"projectId":   "cloud-project",
+				},
+			},
+			wantErr: errors.Errorf("apiEndpoint must be a Google API host ending in .googleapis.com, got \"attacker.example.com\""),
+		},
+		{
+			name: "region carrying a host",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"projectId": "cloud-project",
+					"region":    "attacker.example.com/",
+				},
+			},
+			wantErr: errors.Errorf("region must be a Google region name, got \"attacker.example.com/\""),
 		},
 		{
 			name: "wrong temperature",

--- a/modules/multi2vec-google/clients/google.go
+++ b/modules/multi2vec-google/clients/google.go
@@ -72,6 +72,13 @@ func (v *google) VectorizeQuery(ctx context.Context, input []string,
 func (v *google) vectorize(ctx context.Context,
 	texts, images, videos, audios []string, config ent.VectorizationConfig,
 ) (*ent.VectorizationResult, error) {
+	if err := modulecomponents.ValidateGoogleApiEndpoint(config.ApiEndpoint); err != nil {
+		return nil, err
+	}
+	if err := modulecomponents.ValidateGoogleLocation("location", config.Location); err != nil {
+		return nil, err
+	}
+
 	var textEmbeddings [][]float32
 	var imageEmbeddings [][]float32
 	var videoEmbeddings [][]float32

--- a/modules/multi2vec-google/clients/google_test.go
+++ b/modules/multi2vec-google/clients/google_test.go
@@ -29,6 +29,40 @@ import (
 	"github.com/weaviate/weaviate/usecases/modulecomponents/apikey"
 )
 
+func TestVectorizeRejectsForeignEndpoint(t *testing.T) {
+	tests := []struct {
+		name   string
+		config ent.VectorizationConfig
+	}{
+		{
+			name:   "apiEndpoint outside the Google API domain",
+			config: ent.VectorizationConfig{ApiEndpoint: "attacker.example.com", Location: "us-central1", ProjectID: "project", Model: "model"},
+		},
+		{
+			name:   "location carrying a host",
+			config: ent.VectorizationConfig{ApiEndpoint: "us-central1-aiplatform.googleapis.com", Location: "attacker.example.com/", ProjectID: "project", Model: "model"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &google{
+				apiKey:       "apiKey",
+				httpClient:   &http.Client{},
+				googleApiKey: apikey.NewGoogleApiKey(),
+				urlBuilderFn: func(apiEndpoint, location, projectID, model string) string {
+					t.Fatal("must not build a request URL for a rejected endpoint")
+					return ""
+				},
+				logger: nullLogger(),
+			}
+
+			_, err := c.Vectorize(context.Background(), []string{"This is my text"}, nil, nil, nil, tt.config)
+
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestClient(t *testing.T) {
 	t.Run("when all is fine we vectorize text", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})

--- a/modules/multi2vec-google/vectorizer/class_settings.go
+++ b/modules/multi2vec-google/vectorizer/class_settings.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
 )
 
@@ -138,6 +139,13 @@ func (ic *classSettings) Validate() error {
 	}
 
 	var errorMessages []string
+
+	if err := modulecomponents.ValidateGoogleApiEndpoint(ic.ApiEndpoint()); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
+	if err := modulecomponents.ValidateGoogleLocation(locationProperty, ic.Location()); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
 
 	model := ic.Model()
 	if ic.ApiEndpoint() == "" {

--- a/modules/multi2vec-google/vectorizer/class_settings_test.go
+++ b/modules/multi2vec-google/vectorizer/class_settings_test.go
@@ -226,6 +226,29 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "should not pass with an apiEndpoint outside the Google API domain",
+			fields: fields{
+				cfg: newConfigBuilder().
+					addSetting("apiEndpoint", "attacker.example.com").
+					addSetting("location", "us-central1").
+					addSetting("projectId", "projectId").
+					addSetting("imageFields", []any{"image1"}).
+					build(),
+			},
+			wantErr: true,
+		},
+		{
+			name: "should not pass with a location carrying a host",
+			fields: fields{
+				cfg: newConfigBuilder().
+					addSetting("location", "attacker.example.com/").
+					addSetting("projectId", "projectId").
+					addSetting("imageFields", []any{"image1"}).
+					build(),
+			},
+			wantErr: true,
+		},
+		{
 			name: "should not pass with wrong videoIntervalSeconds setting in videoFields together with image fields",
 			fields: fields{
 				cfg: newConfigBuilder().

--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -153,6 +153,13 @@ func (v *google) GetApiKeyHash(ctx context.Context, config moduletools.ClassConf
 func (v *google) vectorize(ctx context.Context, input []string, taskType taskType,
 	titlePropertyValue string, config settings,
 ) (*modulecomponents.VectorizationResult[[]float32], error) {
+	if err := modulecomponents.ValidateGoogleApiEndpoint(config.ApiEndpoint); err != nil {
+		return nil, err
+	}
+	if err := modulecomponents.ValidateGoogleLocation("location", config.Location); err != nil {
+		return nil, err
+	}
+
 	useGenerativeAIEndpoint := v.useGenerativeAIEndpoint(config)
 
 	payload := v.getPayload(useGenerativeAIEndpoint, input, taskType, titlePropertyValue, config)

--- a/modules/text2vec-google/clients/google_test.go
+++ b/modules/text2vec-google/clients/google_test.go
@@ -76,6 +76,40 @@ func TestBuildURL(t *testing.T) {
 	}
 }
 
+func TestVectorizeRejectsForeignEndpoint(t *testing.T) {
+	tests := []struct {
+		name   string
+		config settings
+	}{
+		{
+			name:   "apiEndpoint outside the Google API domain",
+			config: settings{ApiEndpoint: "attacker.example.com", ProjectID: "project", Model: "model", Location: "us-central1"},
+		},
+		{
+			name:   "location carrying a host",
+			config: settings{ApiEndpoint: "us-central1-aiplatform.googleapis.com", ProjectID: "project", Model: "model", Location: "attacker.example.com/"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &google{
+				apiKey:       "apiKey",
+				httpClient:   &http.Client{},
+				googleApiKey: apikey.NewGoogleApiKey(),
+				urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID, location string) string {
+					t.Fatal("must not build a request URL for a rejected endpoint")
+					return ""
+				},
+				logger: nullLogger(),
+			}
+
+			_, err := c.vectorize(context.Background(), []string{"This is my text"}, retrievalDocument, "", tt.config)
+
+			require.Error(t, err)
+		})
+	}
+}
+
 func TestClient(t *testing.T) {
 	t.Run("when all is fine", func(t *testing.T) {
 		server := httptest.NewServer(&fakeHandler{t: t})
@@ -85,7 +119,7 @@ func TestClient(t *testing.T) {
 			httpClient:   &http.Client{},
 			googleApiKey: apikey.NewGoogleApiKey(),
 			urlBuilderFn: func(useGenerativeAI bool, apiEndpoint, projectID, modelID, location string) string {
-				assert.Equal(t, "endpoint", apiEndpoint)
+				assert.Equal(t, "us-central1-aiplatform.googleapis.com", apiEndpoint)
 				assert.Equal(t, "project", projectID)
 				assert.Equal(t, "model", modelID)
 				assert.Equal(t, "us-central1", location)
@@ -96,7 +130,7 @@ func TestClient(t *testing.T) {
 		expected := expectedTextVectorization("This is my text")
 		res, err := c.vectorize(context.Background(), []string{"This is my text"}, retrievalDocument, "",
 			settings{
-				ApiEndpoint: "endpoint",
+				ApiEndpoint: "us-central1-aiplatform.googleapis.com",
 				ProjectID:   "project",
 				Model:       "model",
 				Location:    "us-central1",

--- a/modules/text2vec-google/vectorizer/class_settings.go
+++ b/modules/text2vec-google/vectorizer/class_settings.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
 )
 
@@ -82,6 +83,12 @@ func (ic *classSettings) Validate(class *models.Class) error {
 	}
 
 	apiEndpoint := ic.ApiEndpoint()
+	if err := modulecomponents.ValidateGoogleApiEndpoint(apiEndpoint); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
+	if err := modulecomponents.ValidateGoogleLocation(locationProperty, ic.Location()); err != nil {
+		errorMessages = append(errorMessages, err.Error())
+	}
 	if apiEndpoint != DefaultAIStudioEndpoint {
 		projectID := ic.ProjectID()
 		if projectID == "" {

--- a/modules/text2vec-google/vectorizer/class_settings_test.go
+++ b/modules/text2vec-google/vectorizer/class_settings_test.go
@@ -52,13 +52,13 @@ func Test_classSettings_Validate(t *testing.T) {
 			name: "custom values",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
-					"apiEndpoint":   "google.com",
+					"apiEndpoint":   "europe-west4-aiplatform.googleapis.com",
 					"projectId":     "projectId",
 					"titleProperty": "title",
 					"taskType":      "CODE_RETRIEVAL_QUERY",
 				},
 			},
-			wantApiEndpoint: "google.com",
+			wantApiEndpoint: "europe-west4-aiplatform.googleapis.com",
 			wantProjectID:   "projectId",
 			wantModelID:     "gemini-embedding-001",
 			wantTitle:       "title",
@@ -141,6 +141,26 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantTaskType:    DefaultTaskType,
 			wantDimensions:  nil,
 			wantErr:         errors.New("properties field needs to be of array type, got: string"),
+		},
+		{
+			name: "apiEndpoint outside the Google API domain",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"apiEndpoint": "attacker.example.com",
+					"projectId":   "projectId",
+				},
+			},
+			wantErr: errors.Errorf("apiEndpoint must be a Google API host ending in .googleapis.com, got \"attacker.example.com\""),
+		},
+		{
+			name: "location carrying a host",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"projectId": "projectId",
+					"location":  "attacker.example.com/",
+				},
+			},
+			wantErr: errors.Errorf("location must be a Google region name, got \"attacker.example.com/\""),
 		},
 		{
 			name: "wrong taskType",

--- a/usecases/modulecomponents/validate_google_endpoint.go
+++ b/usecases/modulecomponents/validate_google_endpoint.go
@@ -1,0 +1,60 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const googleAPIHostSuffix = ".googleapis.com"
+
+var (
+	// A DNS name below googleapis.com, e.g. us-central1-aiplatform.googleapis.com
+	// or generativelanguage.googleapis.com.
+	googleAPIHostPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*\.googleapis\.com$`)
+	// A single DNS label, e.g. us-central1 or global.
+	googleLocationPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
+)
+
+// ValidateGoogleApiEndpoint rejects an apiEndpoint outside Google's API domain.
+// The Google modules attach the operator's Google credential to every request
+// they send - with USE_GOOGLE_AUTH that is a broadly scoped OAuth token - so an
+// endpoint pointing elsewhere hands that credential to a foreign host. Unlike
+// ValidateBaseURL this is enforced unconditionally: these modules speak only to
+// Google. An empty value means "use the module default".
+func ValidateGoogleApiEndpoint(apiEndpoint string) error {
+	if apiEndpoint == "" {
+		return nil
+	}
+	if !googleAPIHostPattern.MatchString(strings.ToLower(apiEndpoint)) {
+		return fmt.Errorf("apiEndpoint must be a Google API host ending in %s, got %q", googleAPIHostSuffix, apiEndpoint)
+	}
+	return nil
+}
+
+// ValidateGoogleLocation rejects a location or region that is not a plain
+// Google region name. The Google modules interpolate it into the request host
+// (<region>-aiplatform.googleapis.com), so a value carrying a "/" or an "@" can
+// move the request off Google's domain the same way an apiEndpoint can. The
+// property name is passed in because the modules call it for both "location"
+// and "region". An empty value means "use the module default".
+func ValidateGoogleLocation(property, location string) error {
+	if location == "" {
+		return nil
+	}
+	if !googleLocationPattern.MatchString(strings.ToLower(location)) {
+		return fmt.Errorf("%s must be a Google region name, got %q", property, location)
+	}
+	return nil
+}

--- a/usecases/modulecomponents/validate_google_endpoint_test.go
+++ b/usecases/modulecomponents/validate_google_endpoint_test.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modulecomponents
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateGoogleApiEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiEndpoint string
+		wantErr     bool
+	}{
+		{name: "empty means module default", apiEndpoint: ""},
+		{name: "regional Vertex host", apiEndpoint: "us-central1-aiplatform.googleapis.com"},
+		{name: "global Vertex host", apiEndpoint: "aiplatform.googleapis.com"},
+		{name: "AI Studio host", apiEndpoint: "generativelanguage.googleapis.com"},
+		{name: "private service connect host", apiEndpoint: "abc123.us-central1.p.googleapis.com"},
+		{name: "upper case host", apiEndpoint: "US-CENTRAL1-AIPLATFORM.GOOGLEAPIS.COM"},
+		{name: "foreign host", apiEndpoint: "attacker.example.com", wantErr: true},
+		{name: "google host outside the API domain", apiEndpoint: "google.com", wantErr: true},
+		{name: "suffix as a prefix of a foreign host", apiEndpoint: "aiplatform.googleapis.com.attacker.example.com", wantErr: true},
+		{name: "suffix embedded in a longer label", apiEndpoint: "notgoogleapis.com", wantErr: true},
+		{name: "credentials in the host", apiEndpoint: "aiplatform.googleapis.com@attacker.example.com", wantErr: true},
+		{name: "path appended to the host", apiEndpoint: "attacker.example.com/aiplatform.googleapis.com", wantErr: true},
+		{name: "scheme included", apiEndpoint: "https://aiplatform.googleapis.com", wantErr: true},
+		{name: "port included", apiEndpoint: "aiplatform.googleapis.com:8080", wantErr: true},
+		{name: "trailing dot", apiEndpoint: "aiplatform.googleapis.com.", wantErr: true},
+		{name: "empty label", apiEndpoint: "..googleapis.com", wantErr: true},
+		{name: "bare suffix", apiEndpoint: ".googleapis.com", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGoogleApiEndpoint(tt.apiEndpoint)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "apiEndpoint must be a Google API host")
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateGoogleLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		wantErr  bool
+	}{
+		{name: "empty means module default", location: ""},
+		{name: "region", location: "us-central1"},
+		{name: "global", location: "global"},
+		{name: "path injection", location: "attacker.example.com/", wantErr: true},
+		{name: "credentials injection", location: "attacker.example.com@x", wantErr: true},
+		{name: "dotted host", location: "attacker.example.com", wantErr: true},
+		{name: "port", location: "us-central1:8080", wantErr: true},
+		{name: "leading hyphen", location: "-us-central1", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGoogleLocation("location", tt.location)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "location must be a Google region name")
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

This PR restricts Google module apiEndpoint, region and location to Google API hosts

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
