### PR TITLE
shard: vector indexes and queues live in one slots type

### DIFF
--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -85,6 +85,140 @@ func (_m *MockShardLike) EXPECT() *MockShardLike_Expecter {
 	return &MockShardLike_Expecter{mock: &_m.Mock}
 }
 
+// AcquireVectorIndex provides a mock function with given fields: targetVector
+func (_m *MockShardLike) AcquireVectorIndex(targetVector string) (VectorIndex, func(), bool) {
+	ret := _m.Called(targetVector)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcquireVectorIndex")
+	}
+
+	var r0 VectorIndex
+	var r1 func()
+	var r2 bool
+	if rf, ok := ret.Get(0).(func(string) (VectorIndex, func(), bool)); ok {
+		return rf(targetVector)
+	}
+	if rf, ok := ret.Get(0).(func(string) VectorIndex); ok {
+		r0 = rf(targetVector)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(VectorIndex)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) func()); ok {
+		r1 = rf(targetVector)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(func())
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(string) bool); ok {
+		r2 = rf(targetVector)
+	} else {
+		r2 = ret.Get(2).(bool)
+	}
+
+	return r0, r1, r2
+}
+
+// MockShardLike_AcquireVectorIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcquireVectorIndex'
+type MockShardLike_AcquireVectorIndex_Call struct {
+	*mock.Call
+}
+
+// AcquireVectorIndex is a helper method to define mock.On call
+//   - targetVector string
+func (_e *MockShardLike_Expecter) AcquireVectorIndex(targetVector interface{}) *MockShardLike_AcquireVectorIndex_Call {
+	return &MockShardLike_AcquireVectorIndex_Call{Call: _e.mock.On("AcquireVectorIndex", targetVector)}
+}
+
+func (_c *MockShardLike_AcquireVectorIndex_Call) Run(run func(targetVector string)) *MockShardLike_AcquireVectorIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_AcquireVectorIndex_Call) Return(index VectorIndex, release func(), ok bool) *MockShardLike_AcquireVectorIndex_Call {
+	_c.Call.Return(index, release, ok)
+	return _c
+}
+
+func (_c *MockShardLike_AcquireVectorIndex_Call) RunAndReturn(run func(string) (VectorIndex, func(), bool)) *MockShardLike_AcquireVectorIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AcquireVectorIndexQueue provides a mock function with given fields: targetVector
+func (_m *MockShardLike) AcquireVectorIndexQueue(targetVector string) (*VectorIndexQueue, func(), bool) {
+	ret := _m.Called(targetVector)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcquireVectorIndexQueue")
+	}
+
+	var r0 *VectorIndexQueue
+	var r1 func()
+	var r2 bool
+	if rf, ok := ret.Get(0).(func(string) (*VectorIndexQueue, func(), bool)); ok {
+		return rf(targetVector)
+	}
+	if rf, ok := ret.Get(0).(func(string) *VectorIndexQueue); ok {
+		r0 = rf(targetVector)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*VectorIndexQueue)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) func()); ok {
+		r1 = rf(targetVector)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(func())
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(string) bool); ok {
+		r2 = rf(targetVector)
+	} else {
+		r2 = ret.Get(2).(bool)
+	}
+
+	return r0, r1, r2
+}
+
+// MockShardLike_AcquireVectorIndexQueue_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcquireVectorIndexQueue'
+type MockShardLike_AcquireVectorIndexQueue_Call struct {
+	*mock.Call
+}
+
+// AcquireVectorIndexQueue is a helper method to define mock.On call
+//   - targetVector string
+func (_e *MockShardLike_Expecter) AcquireVectorIndexQueue(targetVector interface{}) *MockShardLike_AcquireVectorIndexQueue_Call {
+	return &MockShardLike_AcquireVectorIndexQueue_Call{Call: _e.mock.On("AcquireVectorIndexQueue", targetVector)}
+}
+
+func (_c *MockShardLike_AcquireVectorIndexQueue_Call) Run(run func(targetVector string)) *MockShardLike_AcquireVectorIndexQueue_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_AcquireVectorIndexQueue_Call) Return(queue *VectorIndexQueue, release func(), ok bool) *MockShardLike_AcquireVectorIndexQueue_Call {
+	_c.Call.Return(queue, release, ok)
+	return _c
+}
+
+func (_c *MockShardLike_AcquireVectorIndexQueue_Call) RunAndReturn(run func(string) (*VectorIndexQueue, func(), bool)) *MockShardLike_AcquireVectorIndexQueue_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Activity provides a mock function with no fields
 func (_m *MockShardLike) Activity() (int32, int32) {
 	ret := _m.Called()
@@ -3797,6 +3931,120 @@ func (_c *MockShardLike_WasDeleted_Call) Return(_a0 bool, _a1 time.Time, _a2 err
 }
 
 func (_c *MockShardLike_WasDeleted_Call) RunAndReturn(run func(context.Context, strfmt.UUID) (bool, time.Time, error)) *MockShardLike_WasDeleted_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithVectorIndex provides a mock function with given fields: targetVector, f
+func (_m *MockShardLike) WithVectorIndex(targetVector string, f func(VectorIndex) error) (bool, error) {
+	ret := _m.Called(targetVector, f)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithVectorIndex")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, func(VectorIndex) error) (bool, error)); ok {
+		return rf(targetVector, f)
+	}
+	if rf, ok := ret.Get(0).(func(string, func(VectorIndex) error) bool); ok {
+		r0 = rf(targetVector, f)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string, func(VectorIndex) error) error); ok {
+		r1 = rf(targetVector, f)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_WithVectorIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithVectorIndex'
+type MockShardLike_WithVectorIndex_Call struct {
+	*mock.Call
+}
+
+// WithVectorIndex is a helper method to define mock.On call
+//   - targetVector string
+//   - f func(VectorIndex) error
+func (_e *MockShardLike_Expecter) WithVectorIndex(targetVector interface{}, f interface{}) *MockShardLike_WithVectorIndex_Call {
+	return &MockShardLike_WithVectorIndex_Call{Call: _e.mock.On("WithVectorIndex", targetVector, f)}
+}
+
+func (_c *MockShardLike_WithVectorIndex_Call) Run(run func(targetVector string, f func(VectorIndex) error)) *MockShardLike_WithVectorIndex_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(func(VectorIndex) error))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_WithVectorIndex_Call) Return(found bool, err error) *MockShardLike_WithVectorIndex_Call {
+	_c.Call.Return(found, err)
+	return _c
+}
+
+func (_c *MockShardLike_WithVectorIndex_Call) RunAndReturn(run func(string, func(VectorIndex) error) (bool, error)) *MockShardLike_WithVectorIndex_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// WithVectorIndexQueue provides a mock function with given fields: targetVector, f
+func (_m *MockShardLike) WithVectorIndexQueue(targetVector string, f func(*VectorIndexQueue) error) (bool, error) {
+	ret := _m.Called(targetVector, f)
+
+	if len(ret) == 0 {
+		panic("no return value specified for WithVectorIndexQueue")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, func(*VectorIndexQueue) error) (bool, error)); ok {
+		return rf(targetVector, f)
+	}
+	if rf, ok := ret.Get(0).(func(string, func(*VectorIndexQueue) error) bool); ok {
+		r0 = rf(targetVector, f)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string, func(*VectorIndexQueue) error) error); ok {
+		r1 = rf(targetVector, f)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_WithVectorIndexQueue_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'WithVectorIndexQueue'
+type MockShardLike_WithVectorIndexQueue_Call struct {
+	*mock.Call
+}
+
+// WithVectorIndexQueue is a helper method to define mock.On call
+//   - targetVector string
+//   - f func(*VectorIndexQueue) error
+func (_e *MockShardLike_Expecter) WithVectorIndexQueue(targetVector interface{}, f interface{}) *MockShardLike_WithVectorIndexQueue_Call {
+	return &MockShardLike_WithVectorIndexQueue_Call{Call: _e.mock.On("WithVectorIndexQueue", targetVector, f)}
+}
+
+func (_c *MockShardLike_WithVectorIndexQueue_Call) Run(run func(targetVector string, f func(*VectorIndexQueue) error)) *MockShardLike_WithVectorIndexQueue_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(func(*VectorIndexQueue) error))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_WithVectorIndexQueue_Call) Return(found bool, err error) *MockShardLike_WithVectorIndexQueue_Call {
+	_c.Call.Return(found, err)
+	return _c
+}
+
+func (_c *MockShardLike_WithVectorIndexQueue_Call) RunAndReturn(run func(string, func(*VectorIndexQueue) error) (bool, error)) *MockShardLike_WithVectorIndexQueue_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -149,6 +149,10 @@ type ShardLike interface {
 	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) // Check if an object was deleted
 	GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool)
 	GetVectorIndex(targetVector string) (VectorIndex, bool)
+	WithVectorIndex(targetVector string, f func(index VectorIndex) error) (found bool, err error)
+	WithVectorIndexQueue(targetVector string, f func(queue *VectorIndexQueue) error) (found bool, err error)
+	AcquireVectorIndex(targetVector string) (index VectorIndex, release func(), ok bool)
+	AcquireVectorIndexQueue(targetVector string) (queue *VectorIndexQueue, release func(), ok bool)
 	ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error
 	ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error
 	ForEachGeoQueue(f func(propName string, queue *VectorIndexQueue) error) error

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -256,11 +256,9 @@ type Shard struct {
 	propLenTracker    *inverted.JsonShardMetaData
 	versioner         *shardVersioner
 
-	vectorIndexMu sync.RWMutex
-	vectorIndex   VectorIndex
-	queue         *VectorIndexQueue
-	vectorIndexes map[string]VectorIndex
-	queues        map[string]*VectorIndexQueue
+	// vectors owns the vector indexes and their queues, one slot per logical
+	// vector; see shard_vector_slots.go
+	vectors vectorIndexSlots
 
 	geoQueues map[string]*VectorIndexQueue
 

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -21,108 +21,52 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/geo"
-	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
 // ForEachVectorIndex iterates through each vector index initialized in the shard (named and legacy).
-// Iteration stops at the first return of non-nil error.
+// Iteration stops at the first return of non-nil error. The callback runs under the read lock.
 func (s *Shard) ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error {
-	// As we expect the mutex to be write-locked very rarely, we allow the callback
-	// to be invoked under the lock. If we find contention here, we should make a copy of the indexes
-	// before iterating over them.
-	s.vectorIndexMu.RLock()
-	defer s.vectorIndexMu.RUnlock()
-
-	for targetVector, idx := range s.vectorIndexes {
-		if idx == nil {
-			continue
-		}
-
-		if err := f(targetVector, idx); err != nil {
-			return err
-		}
-	}
-	if s.vectorIndex != nil {
-		if err := f("", s.vectorIndex); err != nil {
-			return err
-		}
-	}
-	return nil
+	return s.vectors.ForEach(func(targetVector string, index VectorIndex, _ *VectorIndexQueue) error {
+		return f(targetVector, index)
+	})
 }
 
 // ForEachVectorQueue iterates through each vector index queue initialized in the shard (named and legacy).
-// Iteration stops at the first return of non-nil error.
+// Iteration stops at the first return of non-nil error. The callback runs under the read lock.
 func (s *Shard) ForEachVectorQueue(f func(targetVector string, queue *VectorIndexQueue) error) error {
-	// As we expect the mutex to be write-locked very rarely, we allow the callback
-	// to be invoked under the lock. If we find contention here, we should make a copy of the queues
-	// before iterating over them.
-	s.vectorIndexMu.RLock()
-	defer s.vectorIndexMu.RUnlock()
-
-	for targetVector, q := range s.queues {
-		if q == nil {
-			continue
-		}
-
-		if err := f(targetVector, q); err != nil {
-			return err
-		}
-	}
-	if s.queue != nil {
-		if err := f("", s.queue); err != nil {
-			return err
-		}
-	}
-	return nil
+	return s.vectors.ForEach(func(targetVector string, _ VectorIndex, queue *VectorIndexQueue) error {
+		return f(targetVector, queue)
+	})
 }
 
 // GetVectorIndexQueue retrieves a vector index queue associated with the targetVector.
 // Empty targetVector is treated as a request to access a queue for the legacy vector index.
 func (s *Shard) GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool) {
-	s.vectorIndexMu.RLock()
-	defer s.vectorIndexMu.RUnlock()
-
-	if s.isTargetVectorLegacyWithLock(targetVector) {
-		return s.queue, s.queue != nil
+	slot, ok := s.vectors.get(targetVector)
+	if !ok {
+		return nil, false
 	}
-
-	queue, ok := s.queues[targetVector]
-	return queue, ok
+	return slot.queue, true
 }
 
-// GetVectorIndex retrieves a vector index queue associated with the targetVector.
-// Empty targetVector is treated as a request to access a queue for the legacy vector index.
+// GetVectorIndex retrieves a vector index associated with the targetVector.
+// Empty targetVector is treated as a request to access the legacy vector index.
 func (s *Shard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
-	s.vectorIndexMu.RLock()
-	defer s.vectorIndexMu.RUnlock()
-
-	if s.isTargetVectorLegacyWithLock(targetVector) {
-		return s.vectorIndex, s.vectorIndex != nil
+	slot, ok := s.vectors.get(targetVector)
+	if !ok {
+		return nil, false
 	}
-
-	index, ok := s.vectorIndexes[targetVector]
-	return index, ok
-}
-
-func (s *Shard) isTargetVectorLegacyWithLock(targetVector string) bool {
-	if targetVector == "" {
-		return true
-	}
-
-	return s.vectorIndex != nil && targetVector == modelsext.DefaultNamedVectorName
+	return slot.index, true
 }
 
 func (s *Shard) hasLegacyVectorIndex() bool {
-	_, ok := s.GetVectorIndex("")
+	_, ok := s.vectors.get("")
 	return ok
 }
 
 func (s *Shard) hasAnyVectorIndex() bool {
-	s.vectorIndexMu.RLock()
-	defer s.vectorIndexMu.RUnlock()
-
-	return len(s.vectorIndexes) > 0 || s.vectorIndex != nil
+	return s.vectors.Len() > 0
 }
 
 func (s *Shard) Versioner() *shardVersioner {

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -60,6 +60,50 @@ func (s *Shard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
 	return slot.index, true
 }
 
+// WithVectorIndex runs f on the targetVector's index under a lease: a drop
+// of that vector waits until f returns. found is false, and f is not
+// called, when the shard has no such index. Empty targetVector is the
+// legacy vector index.
+func (s *Shard) WithVectorIndex(targetVector string, f func(index VectorIndex) error) (found bool, err error) {
+	slot, release, ok := s.vectors.Acquire(targetVector)
+	if !ok {
+		return false, nil
+	}
+	defer release()
+	return true, f(slot.index)
+}
+
+// WithVectorIndexQueue is WithVectorIndex for the vector's queue.
+func (s *Shard) WithVectorIndexQueue(targetVector string, f func(queue *VectorIndexQueue) error) (found bool, err error) {
+	slot, release, ok := s.vectors.Acquire(targetVector)
+	if !ok {
+		return false, nil
+	}
+	defer release()
+	return true, f(slot.queue)
+}
+
+// AcquireVectorIndex hands out the targetVector's index under a lease the
+// caller owns: it must call release when done, on every path, or a drop of
+// that vector waits for the drain timeout. For a hold that spans a loop;
+// a single call uses WithVectorIndex.
+func (s *Shard) AcquireVectorIndex(targetVector string) (index VectorIndex, release func(), ok bool) {
+	slot, release, ok := s.vectors.Acquire(targetVector)
+	if !ok {
+		return nil, nil, false
+	}
+	return slot.index, release, true
+}
+
+// AcquireVectorIndexQueue is AcquireVectorIndex for the vector's queue.
+func (s *Shard) AcquireVectorIndexQueue(targetVector string) (queue *VectorIndexQueue, release func(), ok bool) {
+	slot, release, ok := s.vectors.Acquire(targetVector)
+	if !ok {
+		return nil, nil, false
+	}
+	return slot.queue, release, true
+}
+
 func (s *Shard) hasLegacyVectorIndex() bool {
 	_, ok := s.vectors.get("")
 	return ok

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -65,21 +65,21 @@ func (s *Shard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
 // called, when the shard has no such index. Empty targetVector is the
 // legacy vector index.
 func (s *Shard) WithVectorIndex(targetVector string, f func(index VectorIndex) error) (found bool, err error) {
-	slot, release, ok := s.vectors.Acquire(targetVector)
+	slot, ok := s.vectors.Acquire(targetVector)
 	if !ok {
 		return false, nil
 	}
-	defer release()
+	defer slot.release()
 	return true, f(slot.index)
 }
 
 // WithVectorIndexQueue is WithVectorIndex for the vector's queue.
 func (s *Shard) WithVectorIndexQueue(targetVector string, f func(queue *VectorIndexQueue) error) (found bool, err error) {
-	slot, release, ok := s.vectors.Acquire(targetVector)
+	slot, ok := s.vectors.Acquire(targetVector)
 	if !ok {
 		return false, nil
 	}
-	defer release()
+	defer slot.release()
 	return true, f(slot.queue)
 }
 
@@ -88,20 +88,20 @@ func (s *Shard) WithVectorIndexQueue(targetVector string, f func(queue *VectorIn
 // that vector waits for the drain timeout. For a hold that spans a loop;
 // a single call uses WithVectorIndex.
 func (s *Shard) AcquireVectorIndex(targetVector string) (index VectorIndex, release func(), ok bool) {
-	slot, release, ok := s.vectors.Acquire(targetVector)
+	slot, ok := s.vectors.Acquire(targetVector)
 	if !ok {
 		return nil, nil, false
 	}
-	return slot.index, release, true
+	return slot.index, slot.release, true
 }
 
 // AcquireVectorIndexQueue is AcquireVectorIndex for the vector's queue.
 func (s *Shard) AcquireVectorIndexQueue(targetVector string) (queue *VectorIndexQueue, release func(), ok bool) {
-	slot, release, ok := s.vectors.Acquire(targetVector)
+	slot, ok := s.vectors.Acquire(targetVector)
 	if !ok {
 		return nil, nil, false
 	}
-	return slot.queue, release, true
+	return slot.queue, slot.release, true
 }
 
 func (s *Shard) hasLegacyVectorIndex() bool {

--- a/adapters/repos/db/shard_accessors_test.go
+++ b/adapters/repos/db/shard_accessors_test.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
 	"github.com/weaviate/weaviate/entities/models"
@@ -26,7 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-func TestShared_GetVectorIndexAndQueue(t *testing.T) {
+func TestShard_LeasedVectorIndexAccessors(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		setup func(idx *Index)
@@ -70,37 +71,64 @@ func TestShared_GetVectorIndexAndQueue(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "test"}, hnsw.UserConfig{}, false, true, false, tt.setup)
 
-			namedQueue, ok := s.GetVectorIndexQueue("named")
-			require.Equal(t, tt.wantNamedExists, ok)
+			for _, target := range []struct {
+				name string
+				want bool
+			}{
+				{"named", tt.wantNamedExists},
+				{"", tt.wantLegacyExists},
+				{modelsext.DefaultNamedVectorName, tt.wantLegacyExists},
+			} {
+				var called bool
+				found, err := s.WithVectorIndex(target.name, func(index VectorIndex) error {
+					called = true
+					require.NotNil(t, index)
+					return nil
+				})
+				require.NoError(t, err)
+				require.Equal(t, target.want, found, "WithVectorIndex(%q)", target.name)
+				require.Equal(t, target.want, called)
 
-			namedIndex, ok := s.GetVectorIndex("named")
-			require.Equal(t, tt.wantNamedExists, ok)
+				called = false
+				found, err = s.WithVectorIndexQueue(target.name, func(queue *VectorIndexQueue) error {
+					called = true
+					require.NotNil(t, queue)
+					return nil
+				})
+				require.NoError(t, err)
+				require.Equal(t, target.want, found, "WithVectorIndexQueue(%q)", target.name)
+				require.Equal(t, target.want, called)
 
-			if tt.wantNamedExists {
-				require.NotNil(t, namedQueue)
-				require.NotNil(t, namedIndex)
-			}
+				index, release, ok := s.AcquireVectorIndex(target.name)
+				require.Equal(t, target.want, ok, "AcquireVectorIndex(%q)", target.name)
+				if ok {
+					require.NotNil(t, index)
+					release()
+				}
 
-			legacyQueue, ok := s.GetVectorIndexQueue("")
-			require.Equal(t, tt.wantLegacyExists, ok)
-
-			legacyIndex, ok := s.GetVectorIndex("")
-			require.Equal(t, tt.wantLegacyExists, ok)
-
-			defaultQueue, ok := s.GetVectorIndex(modelsext.DefaultNamedVectorName)
-			require.Equal(t, tt.wantLegacyExists, ok)
-
-			defaultIndex, ok := s.GetVectorIndex(modelsext.DefaultNamedVectorName)
-			require.Equal(t, tt.wantLegacyExists, ok)
-
-			if tt.wantLegacyExists {
-				require.NotNil(t, legacyQueue)
-				require.NotNil(t, legacyIndex)
-				require.NotNil(t, defaultQueue)
-				require.NotNil(t, defaultIndex)
+				queue, release, ok := s.AcquireVectorIndexQueue(target.name)
+				require.Equal(t, target.want, ok, "AcquireVectorIndexQueue(%q)", target.name)
+				if ok {
+					require.NotNil(t, queue)
+					release()
+				}
 			}
 		})
 	}
+}
+
+func TestShard_WithVectorIndexReturnsTheCallbackError(t *testing.T) {
+	s, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "test"}, hnsw.UserConfig{}, false, true, false, func(idx *Index) {
+		idx.vectorIndexUserConfig = hnsw.NewDefaultUserConfig()
+	})
+
+	found, err := s.WithVectorIndex("", func(VectorIndex) error { return assert.AnError })
+	require.True(t, found)
+	require.ErrorIs(t, err, assert.AnError)
+
+	found, err = s.WithVectorIndexQueue("", func(*VectorIndexQueue) error { return assert.AnError })
+	require.True(t, found)
+	require.ErrorIs(t, err, assert.AnError)
 }
 
 func TestShard_ForEachVectorIndexAndQueue(t *testing.T) {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -352,9 +352,6 @@ func (s *Shard) getOrInitMetadataDB() (*shardmeta.DB, error) {
 func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
 	configs map[string]schemaConfig.VectorIndexConfig, lazyLoadSegments bool,
 ) error {
-	s.vectorIndexMu.Lock()
-	defer s.vectorIndexMu.Unlock()
-
 	if err := newCompressedVectorsMigrator(s.index.logger).do(s, legacy, configs); err != nil {
 		s.index.logger.WithFields(logrus.Fields{
 			"action":   "init_target_vectors",
@@ -362,11 +359,8 @@ func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.Vecto
 		}).Errorf("failed to migrate vectors compressed folder: %v", err)
 	}
 
-	s.vectorIndexes = make(map[string]VectorIndex, len(configs))
-	s.queues = make(map[string]*VectorIndexQueue, len(configs))
-
 	for targetVector, vectorIndexConfig := range configs {
-		if err := s.initTargetVectorWithLock(ctx, targetVector, vectorIndexConfig, lazyLoadSegments); err != nil {
+		if err := s.initTargetVector(ctx, targetVector, vectorIndexConfig, lazyLoadSegments); err != nil {
 			return err
 		}
 	}
@@ -374,16 +368,11 @@ func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.Vecto
 }
 
 func (s *Shard) initTargetVector(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
-	s.vectorIndexMu.Lock()
-	defer s.vectorIndexMu.Unlock()
-	return s.initTargetVectorWithLock(ctx, targetVector, cfg, lazyLoadSegments)
-}
-
-func (s *Shard) initTargetVectorWithLock(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
 	// Recreating an existing target would orphan the current index+queue (never
 	// Dropped). Returning early also makes concurrent UpdateVectorIndexConfigs
-	// calls that both saw the target absent safe.
-	if _, exists := s.vectorIndexes[targetVector]; exists {
+	// calls that both saw the target absent safe: Publish below refuses the
+	// second one.
+	if _, exists := s.vectors.get(targetVector); exists {
 		return nil
 	}
 
@@ -400,14 +389,40 @@ func (s *Shard) initTargetVectorWithLock(ctx context.Context, targetVector strin
 		return fmt.Errorf("cannot create index queue for %q: %w", targetVector, err)
 	}
 
-	s.vectorIndexes[targetVector] = vectorIndex
-	s.queues[targetVector] = queue
+	err = s.vectors.Publish(targetVector, vectorIndex, queue)
+	if err != nil {
+		// another create of the same vector won the race: tear ours down
+		// rather than leak it, and treat it as the early return above
+		s.discardUnpublished(targetVector, vectorIndex, queue)
+		return nil
+	}
 	return nil
 }
 
+// discardUnpublished shuts down an index and queue that lost the publish
+// race to a concurrent create of the same vector. Their files belong to the
+// winner, so nothing is deleted.
+func (s *Shard) discardUnpublished(targetVector string, index VectorIndex, queue *VectorIndexQueue) {
+	if err := queue.Close(s.shutCtx); err != nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action":        "init_target_vector",
+			"target_vector": targetVector,
+		}).Warnf("close queue that lost the publish race: %v", err)
+	}
+	if err := index.Shutdown(s.shutCtx); err != nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action":        "init_target_vector",
+			"target_vector": targetVector,
+		}).Warnf("shut down index that lost the publish race: %v", err)
+	}
+}
+
 func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
-	s.vectorIndexMu.Lock()
-	defer s.vectorIndexMu.Unlock()
+	// A second init used to replace the legacy index with a fresh instance
+	// and orphan the running one; keep the first, as initTargetVector does.
+	if _, exists := s.vectors.get(""); exists {
+		return nil
+	}
 
 	vectorIndex, err := s.initVectorIndex(ctx, "", cfg, lazyLoadSegments)
 	if err != nil {
@@ -421,20 +436,16 @@ func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorInd
 		}
 		return err
 	}
-	s.vectorIndex = vectorIndex
-	s.queue = queue
+	err = s.vectors.Publish("", vectorIndex, queue)
+	if err != nil {
+		s.discardUnpublished("", vectorIndex, queue)
+		return fmt.Errorf("publish legacy vector index: %w", err)
+	}
 	return nil
 }
 
 func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {
-	s.vectorIndexMu.Lock()
-	defer s.vectorIndexMu.Unlock()
-
-	if targetVector == "" {
-		s.vectorIndex = index
-	} else {
-		s.vectorIndexes[targetVector] = index
-	}
+	s.vectors.Replace(targetVector, index)
 }
 
 // perVectorDropper is implemented by index types whose Drop() would reach
@@ -461,21 +472,18 @@ func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
 // from this shard, deleting associated files from disk. It also removes the
 // LSM buckets that store the raw and compressed vector data.
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
-	s.vectorIndexMu.Lock()
-	defer s.vectorIndexMu.Unlock()
-
-	if queue, ok := s.queues[targetVector]; ok && queue != nil {
-		if err := queue.Drop(ctx); err != nil {
-			return fmt.Errorf("drop queue for vector %q: %w", targetVector, err)
+	index, queue, ok := s.vectors.remove(targetVector)
+	if ok {
+		if queue != nil {
+			if err := queue.Drop(ctx); err != nil {
+				return fmt.Errorf("drop queue for vector %q: %w", targetVector, err)
+			}
 		}
-		delete(s.queues, targetVector)
-	}
-
-	if index, ok := s.vectorIndexes[targetVector]; ok && index != nil {
-		if err := dropOneVectorIndex(ctx, index); err != nil {
-			return fmt.Errorf("drop vector index %q: %w", targetVector, err)
+		if index != nil {
+			if err := dropOneVectorIndex(ctx, index); err != nil {
+				return fmt.Errorf("drop vector index %q: %w", targetVector, err)
+			}
 		}
-		delete(s.vectorIndexes, targetVector)
 	}
 
 	// Remove every on-disk artifact this vector owns — the raw and compressed

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -472,7 +472,7 @@ func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
 // from this shard, deleting associated files from disk. It also removes the
 // LSM buckets that store the raw and compressed vector data.
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
-	index, queue, ok := s.vectors.remove(targetVector)
+	index, queue, ok := s.vectors.Remove(ctx, targetVector, s.index.logger)
 	if ok {
 		if queue != nil {
 			if err := queue.Drop(ctx); err != nil {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -435,8 +435,7 @@ func dropOneVectorIndex(ctx context.Context, index VectorIndex) error {
 // from this shard, deleting associated files from disk. It also removes the
 // LSM buckets that store the raw and compressed vector data.
 func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error {
-	index, queue, ok := s.vectors.Remove(ctx, targetVector, s.index.logger)
-	if ok {
+	err := s.vectors.Remove(ctx, targetVector, s.index.logger, func(index VectorIndex, queue *VectorIndexQueue) error {
 		if queue != nil {
 			if err := queue.Drop(ctx); err != nil {
 				return fmt.Errorf("drop queue for vector %q: %w", targetVector, err)
@@ -447,6 +446,10 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 				return fmt.Errorf("drop vector index %q: %w", targetVector, err)
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Remove every on-disk artifact this vector owns — the raw and compressed

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -367,81 +367,44 @@ func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.Vecto
 	return nil
 }
 
+// initTargetVector creates the named vector's index and queue unless the
+// shard has them already. Creates are serialized by the slots, so two
+// concurrent UpdateVectorIndexConfigs calls that both saw the target absent
+// build it once; the second finds it in place and returns.
 func (s *Shard) initTargetVector(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
-	// Recreating an existing target would orphan the current index+queue (never
-	// Dropped). Returning early also makes concurrent UpdateVectorIndexConfigs
-	// calls that both saw the target absent safe: Publish below refuses the
-	// second one.
-	if _, exists := s.vectors.get(targetVector); exists {
-		return nil
-	}
+	_, err := s.vectors.Create(targetVector, func() (VectorIndex, *VectorIndexQueue, error) {
+		return s.buildVectorIndexAndQueue(ctx, targetVector, cfg, lazyLoadSegments)
+	})
+	return err
+}
 
+// buildVectorIndexAndQueue constructs a vector's index and its queue. A queue
+// that fails to build takes the index down with it, so nothing is left
+// running unpublished.
+func (s *Shard) buildVectorIndexAndQueue(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) (VectorIndex, *VectorIndexQueue, error) {
 	vectorIndex, err := s.initVectorIndex(ctx, targetVector, cfg, lazyLoadSegments)
 	if err != nil {
-		return fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)
+		return nil, nil, fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)
 	}
 	queue, err := NewVectorIndexQueue(s, targetVector, vectorIndex)
 	if err != nil {
 		if shutdownErr := vectorIndex.Shutdown(s.shutCtx); shutdownErr != nil {
-			return fmt.Errorf("cannot create index queue for %q: %w (shutting down the orphaned vector index also failed: %w)",
+			return nil, nil, fmt.Errorf("cannot create index queue for %q: %w (shutting down the orphaned vector index also failed: %w)",
 				targetVector, err, shutdownErr)
 		}
-		return fmt.Errorf("cannot create index queue for %q: %w", targetVector, err)
+		return nil, nil, fmt.Errorf("cannot create index queue for %q: %w", targetVector, err)
 	}
-
-	err = s.vectors.Publish(targetVector, vectorIndex, queue)
-	if err != nil {
-		// another create of the same vector won the race: tear ours down
-		// rather than leak it, and treat it as the early return above
-		s.discardUnpublished(targetVector, vectorIndex, queue)
-		return nil
-	}
-	return nil
+	return vectorIndex, queue, nil
 }
 
-// discardUnpublished shuts down an index and queue that lost the publish
-// race to a concurrent create of the same vector. Their files belong to the
-// winner, so nothing is deleted.
-func (s *Shard) discardUnpublished(targetVector string, index VectorIndex, queue *VectorIndexQueue) {
-	if err := queue.Close(s.shutCtx); err != nil {
-		s.index.logger.WithFields(logrus.Fields{
-			"action":        "init_target_vector",
-			"target_vector": targetVector,
-		}).Warnf("close queue that lost the publish race: %v", err)
-	}
-	if err := index.Shutdown(s.shutCtx); err != nil {
-		s.index.logger.WithFields(logrus.Fields{
-			"action":        "init_target_vector",
-			"target_vector": targetVector,
-		}).Warnf("shut down index that lost the publish race: %v", err)
-	}
-}
-
+// initLegacyVector creates the legacy vector's index and queue unless the
+// shard has them already. A second init used to replace the running index
+// with a fresh instance and orphan it; now it finds the first in place.
 func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
-	// A second init used to replace the legacy index with a fresh instance
-	// and orphan the running one; keep the first, as initTargetVector does.
-	if _, exists := s.vectors.get(""); exists {
-		return nil
-	}
-
-	vectorIndex, err := s.initVectorIndex(ctx, "", cfg, lazyLoadSegments)
-	if err != nil {
-		return err
-	}
-
-	queue, err := NewVectorIndexQueue(s, "", vectorIndex)
-	if err != nil {
-		if shutdownErr := vectorIndex.Shutdown(s.shutCtx); shutdownErr != nil {
-			return fmt.Errorf("%w (shutting down the orphaned vector index also failed: %w)", err, shutdownErr)
-		}
-		return err
-	}
-	err = s.vectors.Publish("", vectorIndex, queue)
-	if err != nil {
-		s.discardUnpublished("", vectorIndex, queue)
-		return fmt.Errorf("publish legacy vector index: %w", err)
-	}
-	return nil
+	_, err := s.vectors.Create("", func() (VectorIndex, *VectorIndexQueue, error) {
+		return s.buildVectorIndexAndQueue(ctx, "", cfg, lazyLoadSegments)
+	})
+	return err
 }
 
 func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -42,16 +42,12 @@ func TestInitTargetVector_Idempotent_DoesNotOrphanQueue(t *testing.T) {
 	cfg := enthnsw.UserConfig{Skip: true}
 
 	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
-	shard.vectorIndexMu.RLock()
-	q1 := shard.queues["v1"]
-	shard.vectorIndexMu.RUnlock()
+	q1, _ := shard.GetVectorIndexQueue("v1")
 	require.NotNil(t, q1)
 
 	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
 
-	shard.vectorIndexMu.RLock()
-	q2 := shard.queues["v1"]
-	shard.vectorIndexMu.RUnlock()
+	q2, _ := shard.GetVectorIndexQueue("v1")
 
 	assert.Same(t, q1, q2,
 		"re-initialising an existing target vector must not silently replace and "+
@@ -108,9 +104,7 @@ func TestInitTargetVector_ShutsDownIndexWhenQueueCreationFails(t *testing.T) {
 			require.Error(t, err)
 			require.ErrorContains(t, err, "cannot create index queue")
 
-			s.vectorIndexMu.RLock()
-			_, stored := s.vectorIndexes[target]
-			s.vectorIndexMu.RUnlock()
+			_, stored := s.vectors.get(target)
 			require.False(t, stored, "orphaned index must not be stored")
 
 			require.Eventually(t, func() bool { return watchers() <= baseline }, 5*time.Second, 20*time.Millisecond,

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -169,7 +169,11 @@ func TestInitShardVectors_ConcurrentConfigUpdate(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < 200; i++ {
+	// initShardVectors finds its slots in place after the first call and
+	// returns at once, so a fixed number of iterations can finish before the
+	// writer lands a single update; keep reading until one has.
+	deadline := time.Now().Add(5 * time.Second)
+	for i := 0; i < 200 || (applied.Load() == 0 && time.Now().Before(deadline)); i++ {
 		require.NoError(t, shard.initShardVectors(ctx))
 	}
 

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -23,8 +23,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/entities/models"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -191,4 +193,51 @@ func underlyingShard(t *testing.T, sl ShardLike) *Shard {
 		t.Fatalf("unexpected ShardLike type %T", sl)
 		return nil
 	}
+}
+
+// TestDropVectorIndex_FailedTeardownKeepsTheIndexForCleanup pins that a drop
+// whose index teardown fails leaves the shard owning the index: a retried
+// drop and the shard's own shutdown still reach it through the slots. With
+// the old maps each entry stayed until its own teardown succeeded.
+func TestDropVectorIndex_FailedTeardownKeepsTheIndexForCleanup(t *testing.T) {
+	ctx := context.Background()
+	shardLike, _ := testShardWithSettings(t, ctx, &models.Class{Class: "test"}, enthnsw.UserConfig{}, false, true, false, func(idx *Index) {
+		idx.vectorIndexUserConfig = nil
+		idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+			"named": enthnsw.NewDefaultUserConfig(),
+		}
+	})
+	shard := underlyingShard(t, shardLike)
+
+	// swap a mock in for the real index, which the test shuts down itself
+	real, release, ok := shard.AcquireVectorIndex("named")
+	require.True(t, ok)
+	release()
+	t.Cleanup(func() { real.Shutdown(ctx) })
+
+	failing := NewMockVectorIndex(t)
+	failing.On("Drop", mock.Anything, false).Return(assert.AnError).Once()
+	failing.On("Drop", mock.Anything, false).Return(nil).Once()
+	require.True(t, shard.vectors.Replace("named", failing))
+
+	err := shard.DropVectorIndex(ctx, "named")
+	require.ErrorIs(t, err, assert.AnError)
+
+	var owned []VectorIndex
+	require.NoError(t, shard.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
+		if targetVector == "named" {
+			owned = append(owned, index)
+		}
+		return nil
+	}))
+	require.Len(t, owned, 1, "the index whose teardown failed must stay reachable for cleanup")
+	assert.Same(t, failing, owned[0])
+
+	require.NoError(t, shard.DropVectorIndex(ctx, "named"), "a retried drop tears the same index down")
+	owned = nil
+	require.NoError(t, shard.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
+		owned = append(owned, index)
+		return nil
+	}))
+	assert.Empty(t, owned)
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -790,6 +790,26 @@ func (l *LazyLoadShard) GetVectorIndex(targetVector string) (VectorIndex, bool) 
 	return l.shard.GetVectorIndex(targetVector)
 }
 
+func (l *LazyLoadShard) WithVectorIndex(targetVector string, f func(index VectorIndex) error) (bool, error) {
+	l.mustLoad()
+	return l.shard.WithVectorIndex(targetVector, f)
+}
+
+func (l *LazyLoadShard) WithVectorIndexQueue(targetVector string, f func(queue *VectorIndexQueue) error) (bool, error) {
+	l.mustLoad()
+	return l.shard.WithVectorIndexQueue(targetVector, f)
+}
+
+func (l *LazyLoadShard) AcquireVectorIndex(targetVector string) (VectorIndex, func(), bool) {
+	l.mustLoad()
+	return l.shard.AcquireVectorIndex(targetVector)
+}
+
+func (l *LazyLoadShard) AcquireVectorIndexQueue(targetVector string) (*VectorIndexQueue, func(), bool) {
+	l.mustLoad()
+	return l.shard.AcquireVectorIndexQueue(targetVector)
+}
+
 func (l *LazyLoadShard) ForEachVectorIndex(f func(targetVector string, index VectorIndex) error) error {
 	l.mustLoad()
 	return l.shard.ForEachVectorIndex(f)

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -80,18 +80,26 @@ func (v *vectorIndexSlots) Publish(name string, index VectorIndex, queue *Vector
 }
 
 // Acquire hands out a lease on a slot: the caller may use the index and
-// queue until it calls release, and a removal waits for it. ok is false
-// when no slot has that name or its removal has already started.
-func (v *vectorIndexSlots) Acquire(name string) (slot *vectorIndexSlot, release func(), ok bool) {
+// queue until it calls the slot's release, and a removal waits for it. ok
+// is false when no slot has that name or its removal has already started.
+// No closure is built here, so the hot paths that take a lease per object
+// do not allocate for it.
+func (v *vectorIndexSlots) Acquire(name string) (slot *vectorIndexSlot, ok bool) {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
 	slot, ok = v.slots[v.resolve(name)]
 	if !ok || slot.closing {
-		return nil, nil, false
+		return nil, false
 	}
 	slot.users.Incr()
-	return slot, func() { slot.users.Decr() }, true
+	return slot, true
+}
+
+// release gives a lease back. Calling it twice panics, since a double
+// release would let a removal proceed under a live user.
+func (s *vectorIndexSlot) release() {
+	s.users.Decr()
 }
 
 // get looks a slot up without a lease. Only the shard's own accessors use

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -97,6 +97,21 @@ func (v *vectorIndexSlots) ForEach(f func(name string, index VectorIndex, queue 
 	return nil
 }
 
+// Replace swaps the index of a published slot, for the debug reindex
+// endpoint. The queue stays; the caller re-points it. Reports whether the
+// slot existed.
+func (v *vectorIndexSlots) Replace(name string, index VectorIndex) bool {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	slot, ok := v.slots[v.resolve(name)]
+	if !ok {
+		return false
+	}
+	slot.index = index
+	return true
+}
+
 // Len is the number of published slots.
 func (v *vectorIndexSlots) Len() int {
 	v.mu.RLock()

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"sync"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/modelsext"
 )
 
@@ -29,11 +30,14 @@ type vectorIndexSlots struct {
 }
 
 // vectorIndexSlot is one logical vector's index and queue. They are
-// published and removed together.
+// published and removed together. users counts the leases held on the
+// pair; closing stops new leases once a removal has started.
 type vectorIndexSlot struct {
-	name  string
-	index VectorIndex
-	queue *VectorIndexQueue
+	name    string
+	index   VectorIndex
+	queue   *VectorIndexQueue
+	users   *common.SharedGauge
+	closing bool // guarded by vectorIndexSlots.mu
 }
 
 // resolve maps the legacy vector's two names onto its slot key: "" always,
@@ -61,8 +65,23 @@ func (v *vectorIndexSlots) Publish(name string, index VectorIndex, queue *Vector
 	if _, exists := v.slots[name]; exists {
 		return errVectorIndexSlotExists
 	}
-	v.slots[name] = &vectorIndexSlot{name: name, index: index, queue: queue}
+	v.slots[name] = &vectorIndexSlot{name: name, index: index, queue: queue, users: common.NewSharedGauge()}
 	return nil
+}
+
+// Acquire hands out a lease on a slot: the caller may use the index and
+// queue until it calls release, and a removal waits for it. ok is false
+// when no slot has that name or its removal has already started.
+func (v *vectorIndexSlots) Acquire(name string) (slot *vectorIndexSlot, release func(), ok bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	slot, ok = v.slots[v.resolve(name)]
+	if !ok || slot.closing {
+		return nil, nil, false
+	}
+	slot.users.Incr()
+	return slot, func() { slot.users.Decr() }, true
 }
 
 // get looks a slot up without a lease. Only the shard's own accessors use

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -1,0 +1,105 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/weaviate/weaviate/entities/modelsext"
+)
+
+var errVectorIndexSlotExists = errors.New("vector index slot already exists")
+
+// vectorIndexSlots owns a shard's vector indexes and their queues, one slot
+// per logical vector. The legacy vector is the slot named "". The zero value
+// is ready to use, like the maps it replaces.
+type vectorIndexSlots struct {
+	mu    sync.RWMutex
+	slots map[string]*vectorIndexSlot
+}
+
+// vectorIndexSlot is one logical vector's index and queue. They are
+// published and removed together.
+type vectorIndexSlot struct {
+	name  string
+	index VectorIndex
+	queue *VectorIndexQueue
+}
+
+// resolve maps the legacy vector's two names onto its slot key: "" always,
+// and modelsext.DefaultNamedVectorName only while a legacy slot exists.
+// Callers hold mu.
+func (v *vectorIndexSlots) resolve(name string) string {
+	if name == modelsext.DefaultNamedVectorName {
+		if _, ok := v.slots[""]; ok {
+			return ""
+		}
+	}
+	return name
+}
+
+// Publish installs a slot under name. A taken name is an error, which is
+// what keeps two concurrent creates of the same vector from orphaning an
+// index and queue.
+func (v *vectorIndexSlots) Publish(name string, index VectorIndex, queue *VectorIndexQueue) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	if v.slots == nil {
+		v.slots = map[string]*vectorIndexSlot{}
+	}
+	if _, exists := v.slots[name]; exists {
+		return errVectorIndexSlotExists
+	}
+	v.slots[name] = &vectorIndexSlot{name: name, index: index, queue: queue}
+	return nil
+}
+
+// get looks a slot up without a lease. Only the shard's own accessors use
+// it, for the callers that still hold no lease.
+func (v *vectorIndexSlots) get(name string) (*vectorIndexSlot, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	slot, ok := v.slots[v.resolve(name)]
+	return slot, ok
+}
+
+// ForEach calls f on every slot under the read lock, named slots first and
+// the legacy slot last, stopping at the first error. Creation and removal
+// wait for the walk, as they did with the maps.
+func (v *vectorIndexSlots) ForEach(f func(name string, index VectorIndex, queue *VectorIndexQueue) error) error {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+
+	for name, slot := range v.slots {
+		if name == "" {
+			continue
+		}
+		err := f(name, slot.index, slot.queue)
+		if err != nil {
+			return err
+		}
+	}
+	if slot, ok := v.slots[""]; ok {
+		return f("", slot.index, slot.queue)
+	}
+	return nil
+}
+
+// Len is the number of published slots.
+func (v *vectorIndexSlots) Len() int {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return len(v.slots)
+}

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -112,6 +112,21 @@ func (v *vectorIndexSlots) Replace(name string, index VectorIndex) bool {
 	return true
 }
 
+// remove takes a slot out of the map and hands its index and queue to the
+// caller for teardown. No alias: a drop names the vector exactly. The
+// draining Remove replaces this once leases exist.
+func (v *vectorIndexSlots) remove(name string) (VectorIndex, *VectorIndexQueue, bool) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	slot, ok := v.slots[name]
+	if !ok {
+		return nil, nil, false
+	}
+	delete(v.slots, name)
+	return slot.index, slot.queue, true
+}
+
 // Len is the number of published slots.
 func (v *vectorIndexSlots) Len() int {
 	v.mu.RLock()

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -12,8 +12,12 @@
 package db
 
 import (
+	"context"
 	"errors"
 	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/modelsext"
@@ -21,12 +25,18 @@ import (
 
 var errVectorIndexSlotExists = errors.New("vector index slot already exists")
 
+// slotDrainTimeout bounds how long a removal waits for leases, the bound
+// the shard's own drop drain (drainRefsForDrop) uses.
+const slotDrainTimeout = 30 * time.Second
+
 // vectorIndexSlots owns a shard's vector indexes and their queues, one slot
 // per logical vector. The legacy vector is the slot named "". The zero value
 // is ready to use, like the maps it replaces.
 type vectorIndexSlots struct {
 	mu    sync.RWMutex
 	slots map[string]*vectorIndexSlot
+	// drainTimeout overrides slotDrainTimeout when set; tests shorten it
+	drainTimeout time.Duration
 }
 
 // vectorIndexSlot is one logical vector's index and queue. They are
@@ -131,18 +141,40 @@ func (v *vectorIndexSlots) Replace(name string, index VectorIndex) bool {
 	return true
 }
 
-// remove takes a slot out of the map and hands its index and queue to the
-// caller for teardown. No alias: a drop names the vector exactly. The
-// draining Remove replaces this once leases exist.
-func (v *vectorIndexSlots) remove(name string) (VectorIndex, *VectorIndexQueue, bool) {
+// Remove takes a slot out of service: no new lease is handed out, the ones
+// in flight get up to the drain timeout to finish, and then the index and
+// queue go to the caller for teardown. Past the deadline the removal
+// proceeds and logs the leases it left behind, as the shard-level drop
+// does; a user still running then sees a torn index, which is what it saw
+// with no wait at all. No alias: a drop names the vector exactly.
+func (v *vectorIndexSlots) Remove(ctx context.Context, name string, logger logrus.FieldLogger) (VectorIndex, *VectorIndexQueue, bool) {
 	v.mu.Lock()
-	defer v.mu.Unlock()
-
 	slot, ok := v.slots[name]
 	if !ok {
+		v.mu.Unlock()
 		return nil, nil, false
 	}
+	slot.closing = true
+	v.mu.Unlock()
+
+	timeout := v.drainTimeout
+	if timeout == 0 {
+		timeout = slotDrainTimeout
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	err := slot.users.Wait(waitCtx)
+	if err != nil {
+		logger.WithFields(logrus.Fields{
+			"action":        "drop_vector_index",
+			"target_vector": name,
+			"in_use":        slot.users.Count(),
+		}).Warnf("removing the vector index with leases still held: %v", err)
+	}
+
+	v.mu.Lock()
 	delete(v.slots, name)
+	v.mu.Unlock()
 	return slot.index, slot.queue, true
 }
 

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -35,6 +35,10 @@ const slotDrainTimeout = 30 * time.Second
 type vectorIndexSlots struct {
 	mu    sync.RWMutex
 	slots map[string]*vectorIndexSlot
+	// createMu serializes Create: a build runs outside mu so lookups and
+	// leases go on meanwhile, and this is what keeps two creates of the
+	// same vector from both building it
+	createMu sync.Mutex
 	// drainTimeout overrides slotDrainTimeout when set; tests shorten it
 	drainTimeout time.Duration
 }
@@ -62,9 +66,34 @@ func (v *vectorIndexSlots) resolve(name string) string {
 	return name
 }
 
-// Publish installs a slot under name. A taken name is an error, which is
-// what keeps two concurrent creates of the same vector from orphaning an
-// index and queue.
+// Create builds and publishes the slot for name unless one exists. Creates
+// are serialized, so a concurrent create of the same vector waits and then
+// finds the slot in place; build is never called for a name that is taken.
+// created reports whether this call published the slot.
+func (v *vectorIndexSlots) Create(name string, build func() (VectorIndex, *VectorIndexQueue, error)) (created bool, err error) {
+	v.createMu.Lock()
+	defer v.createMu.Unlock()
+
+	v.mu.RLock()
+	_, exists := v.slots[name]
+	v.mu.RUnlock()
+	if exists {
+		return false, nil
+	}
+
+	index, queue, err := build()
+	if err != nil {
+		return false, err
+	}
+	err = v.Publish(name, index, queue)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Publish installs a slot under name. A taken name is an error; Create is
+// what keeps that from happening for concurrent creates.
 func (v *vectorIndexSlots) Publish(name string, index VectorIndex, queue *VectorIndexQueue) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()

--- a/adapters/repos/db/shard_vector_slots.go
+++ b/adapters/repos/db/shard_vector_slots.go
@@ -143,13 +143,15 @@ func (v *vectorIndexSlots) get(name string) (*vectorIndexSlot, bool) {
 
 // ForEach calls f on every slot under the read lock, named slots first and
 // the legacy slot last, stopping at the first error. Creation and removal
-// wait for the walk, as they did with the maps.
+// wait for the walk, as they did with the maps. A slot whose removal is in
+// progress is skipped, as the old drop held the write lock for its whole
+// teardown; it is visited again if that teardown fails.
 func (v *vectorIndexSlots) ForEach(f func(name string, index VectorIndex, queue *VectorIndexQueue) error) error {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 
 	for name, slot := range v.slots {
-		if name == "" {
+		if name == "" || slot.closing {
 			continue
 		}
 		err := f(name, slot.index, slot.queue)
@@ -157,7 +159,7 @@ func (v *vectorIndexSlots) ForEach(f func(name string, index VectorIndex, queue 
 			return err
 		}
 	}
-	if slot, ok := v.slots[""]; ok {
+	if slot, ok := v.slots[""]; ok && !slot.closing {
 		return f("", slot.index, slot.queue)
 	}
 	return nil
@@ -179,17 +181,22 @@ func (v *vectorIndexSlots) Replace(name string, index VectorIndex) bool {
 }
 
 // Remove takes a slot out of service: no new lease is handed out, the ones
-// in flight get up to the drain timeout to finish, and then the index and
-// queue go to the caller for teardown. Past the deadline the removal
-// proceeds and logs the leases it left behind, as the shard-level drop
-// does; a user still running then sees a torn index, which is what it saw
-// with no wait at all. No alias: a drop names the vector exactly.
-func (v *vectorIndexSlots) Remove(ctx context.Context, name string, logger logrus.FieldLogger) (VectorIndex, *VectorIndexQueue, bool) {
+// in flight get up to the drain timeout to finish, and then teardown runs
+// on the index and queue. The slot leaves the map only once teardown
+// succeeds; a failed teardown reopens it, so the shard keeps the handles
+// for a retried drop or its own shutdown. A missing slot is not an error
+// and teardown is not called. Past the drain deadline the removal proceeds
+// and logs the leases it left behind, as the shard-level drop does; a user
+// still running then sees a torn index, which is what it saw with no wait
+// at all. No alias: a drop names the vector exactly.
+func (v *vectorIndexSlots) Remove(ctx context.Context, name string, logger logrus.FieldLogger,
+	teardown func(index VectorIndex, queue *VectorIndexQueue) error,
+) error {
 	v.mu.Lock()
 	slot, ok := v.slots[name]
 	if !ok {
 		v.mu.Unlock()
-		return nil, nil, false
+		return nil
 	}
 	slot.closing = true
 	v.mu.Unlock()
@@ -209,10 +216,15 @@ func (v *vectorIndexSlots) Remove(ctx context.Context, name string, logger logru
 		}).Warnf("removing the vector index with leases still held: %v", err)
 	}
 
+	err = teardown(slot.index, slot.queue)
 	v.mu.Lock()
+	defer v.mu.Unlock()
+	if err != nil {
+		slot.closing = false
+		return err
+	}
 	delete(v.slots, name)
-	v.mu.Unlock()
-	return slot.index, slot.queue, true
+	return nil
 }
 
 // Len is the number of published slots.

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -132,3 +132,44 @@ func TestVectorIndexSlots_RemoveTakesTheSlotOut(t *testing.T) {
 	_, _, ok = v.remove("title")
 	assert.False(t, ok, "removing twice reports the slot as already gone")
 }
+
+func TestVectorIndexSlots_AcquireCountsLeases(t *testing.T) {
+	var v vectorIndexSlots
+	index := &MockVectorIndex{}
+	require.NoError(t, v.Publish("title", index, nil))
+
+	slot, release, ok := v.Acquire("title")
+	require.True(t, ok)
+	assert.Same(t, index, slot.index)
+	assert.Equal(t, int64(1), slot.users.Count())
+
+	_, release2, ok := v.Acquire("title")
+	require.True(t, ok)
+	assert.Equal(t, int64(2), slot.users.Count())
+
+	release()
+	release2()
+	assert.Equal(t, int64(0), slot.users.Count())
+
+	_, _, ok = v.Acquire("missing")
+	assert.False(t, ok)
+}
+
+func TestVectorIndexSlots_AcquireResolvesTheLegacyAlias(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("", &MockVectorIndex{}, nil))
+
+	slot, release, ok := v.Acquire(modelsext.DefaultNamedVectorName)
+	require.True(t, ok)
+	defer release()
+	assert.Equal(t, "", slot.name)
+}
+
+func TestVectorIndexSlots_ReleaseTwicePanics(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("title", &MockVectorIndex{}, nil))
+	_, release, ok := v.Acquire("title")
+	require.True(t, ok)
+	release()
+	assert.Panics(t, release, "a double release would let a drop proceed under a live user")
+}

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/modelsext"
+)
+
+func TestVectorIndexSlots_Publish(t *testing.T) {
+	var v vectorIndexSlots
+	named := &MockVectorIndex{}
+	legacy := &MockVectorIndex{}
+
+	require.NoError(t, v.Publish("title", named, nil))
+	require.NoError(t, v.Publish("", legacy, nil))
+	assert.Equal(t, 2, v.Len())
+
+	err := v.Publish("title", &MockVectorIndex{}, nil)
+	require.ErrorIs(t, err, errVectorIndexSlotExists,
+		"publishing a taken name must fail, or a concurrent double-create would orphan an index and queue")
+	assert.Equal(t, 2, v.Len())
+}
+
+func TestVectorIndexSlots_LookupResolvesTheLegacyAlias(t *testing.T) {
+	tests := []struct {
+		name       string
+		published  []string
+		lookup     string
+		wantFound  bool
+		wantSlotAs string
+	}{
+		{name: "empty name is the legacy slot", published: []string{""}, lookup: "", wantFound: true, wantSlotAs: ""},
+		{name: "default alias reaches the legacy slot", published: []string{""}, lookup: modelsext.DefaultNamedVectorName, wantFound: true, wantSlotAs: ""},
+		{name: "default alias without a legacy slot is a named lookup", published: []string{"title"}, lookup: modelsext.DefaultNamedVectorName, wantFound: false},
+		{name: "named lookup", published: []string{"", "title"}, lookup: "title", wantFound: true, wantSlotAs: "title"},
+		{name: "unknown name", published: []string{"", "title"}, lookup: "other", wantFound: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v vectorIndexSlots
+			for _, name := range tt.published {
+				require.NoError(t, v.Publish(name, &MockVectorIndex{}, nil))
+			}
+			slot, ok := v.get(tt.lookup)
+			require.Equal(t, tt.wantFound, ok)
+			if ok {
+				assert.Equal(t, tt.wantSlotAs, slot.name)
+			}
+		})
+	}
+}
+
+func TestVectorIndexSlots_ForEachVisitsNamedThenLegacy(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("", &MockVectorIndex{}, nil))
+	require.NoError(t, v.Publish("a", &MockVectorIndex{}, nil))
+	require.NoError(t, v.Publish("b", &MockVectorIndex{}, nil))
+
+	var seen []string
+	err := v.ForEach(func(name string, _ VectorIndex, _ *VectorIndexQueue) error {
+		seen = append(seen, name)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, seen, 3)
+	assert.Equal(t, "", seen[2], "the legacy slot is visited last, as the old accessors did")
+	assert.ElementsMatch(t, []string{"a", "b"}, seen[:2])
+}
+
+func TestVectorIndexSlots_ForEachStopsAtTheFirstError(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("a", &MockVectorIndex{}, nil))
+	require.NoError(t, v.Publish("b", &MockVectorIndex{}, nil))
+
+	calls := 0
+	err := v.ForEach(func(string, VectorIndex, *VectorIndexQueue) error {
+		calls++
+		return assert.AnError
+	})
+	require.ErrorIs(t, err, assert.AnError)
+	assert.Equal(t, 1, calls)
+}
+
+func TestVectorIndexSlots_ZeroValueIsUsable(t *testing.T) {
+	var v vectorIndexSlots
+	_, ok := v.get("")
+	assert.False(t, ok)
+	assert.Equal(t, 0, v.Len())
+	require.NoError(t, v.ForEach(func(string, VectorIndex, *VectorIndexQueue) error { return nil }))
+}

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -117,3 +117,18 @@ func TestVectorIndexSlots_Replace(t *testing.T) {
 	assert.False(t, v.Replace("missing", replacement), "replacing an absent slot installs nothing")
 	assert.Equal(t, 1, v.Len())
 }
+
+func TestVectorIndexSlots_RemoveTakesTheSlotOut(t *testing.T) {
+	var v vectorIndexSlots
+	index := &MockVectorIndex{}
+	require.NoError(t, v.Publish("title", index, nil))
+
+	gotIndex, _, ok := v.remove("title")
+	require.True(t, ok)
+	assert.Same(t, index, gotIndex)
+	_, ok = v.get("title")
+	assert.False(t, ok)
+
+	_, _, ok = v.remove("title")
+	assert.False(t, ok, "removing twice reports the slot as already gone")
+}

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -102,3 +102,18 @@ func TestVectorIndexSlots_ZeroValueIsUsable(t *testing.T) {
 	assert.Equal(t, 0, v.Len())
 	require.NoError(t, v.ForEach(func(string, VectorIndex, *VectorIndexQueue) error { return nil }))
 }
+
+func TestVectorIndexSlots_Replace(t *testing.T) {
+	var v vectorIndexSlots
+	old := &MockVectorIndex{}
+	replacement := &MockVectorIndex{}
+	require.NoError(t, v.Publish("title", old, nil))
+
+	assert.True(t, v.Replace("title", replacement))
+	slot, ok := v.get("title")
+	require.True(t, ok)
+	assert.Same(t, replacement, slot.index)
+
+	assert.False(t, v.Replace("missing", replacement), "replacing an absent slot installs nothing")
+	assert.Equal(t, 1, v.Len())
+}

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -142,7 +142,7 @@ func TestVectorIndexSlots_RemoveWaitsForLeases(t *testing.T) {
 	require.NoError(t, v.Publish("title", &MockVectorIndex{}, nil))
 	logger, _ := test.NewNullLogger()
 
-	_, release, ok := v.Acquire("title")
+	slot, ok := v.Acquire("title")
 	require.True(t, ok)
 
 	removed := make(chan bool, 1)
@@ -157,10 +157,10 @@ func TestVectorIndexSlots_RemoveWaitsForLeases(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 	}
 
-	_, _, ok = v.Acquire("title")
+	_, ok = v.Acquire("title")
 	assert.False(t, ok, "no new lease once a removal has started")
 
-	release()
+	slot.release()
 	select {
 	case ok := <-removed:
 		assert.True(t, ok)
@@ -174,9 +174,9 @@ func TestVectorIndexSlots_RemoveProceedsPastTheDeadline(t *testing.T) {
 	require.NoError(t, v.Publish("title", &MockVectorIndex{}, nil))
 	logger, hook := test.NewNullLogger()
 
-	_, release, ok := v.Acquire("title")
+	slot, ok := v.Acquire("title")
 	require.True(t, ok)
-	t.Cleanup(release)
+	t.Cleanup(slot.release)
 
 	start := time.Now()
 	_, _, ok = v.Remove(context.Background(), "title", logger)
@@ -200,9 +200,9 @@ func TestVectorIndexSlots_RemoveOfOneSlotDoesNotWaitForAnother(t *testing.T) {
 	require.NoError(t, v.Publish("b", &MockVectorIndex{}, nil))
 	logger, _ := test.NewNullLogger()
 
-	_, release, ok := v.Acquire("a")
+	slot, ok := v.Acquire("a")
 	require.True(t, ok)
-	defer release()
+	defer slot.release()
 
 	done := make(chan struct{})
 	go func() {
@@ -216,25 +216,60 @@ func TestVectorIndexSlots_RemoveOfOneSlotDoesNotWaitForAnother(t *testing.T) {
 	}
 }
 
+// BenchmarkVectorIndexSlots_Acquire is the cost a write or a search pays per
+// use on top of the old map lookup: the lease's increment and decrement.
+func BenchmarkVectorIndexSlots_Acquire(b *testing.B) {
+	var v vectorIndexSlots
+	if err := v.Publish("title", &MockVectorIndex{}, nil); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			slot, ok := v.Acquire("title")
+			if !ok {
+				b.Fatal("slot missing")
+			}
+			slot.release()
+		}
+	})
+}
+
+// BenchmarkVectorIndexSlots_Get is the old lookup alone, for the comparison.
+func BenchmarkVectorIndexSlots_Get(b *testing.B) {
+	var v vectorIndexSlots
+	if err := v.Publish("title", &MockVectorIndex{}, nil); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if _, ok := v.get("title"); !ok {
+				b.Fatal("slot missing")
+			}
+		}
+	})
+}
+
 func TestVectorIndexSlots_AcquireCountsLeases(t *testing.T) {
 	var v vectorIndexSlots
 	index := &MockVectorIndex{}
 	require.NoError(t, v.Publish("title", index, nil))
 
-	slot, release, ok := v.Acquire("title")
+	slot, ok := v.Acquire("title")
 	require.True(t, ok)
 	assert.Same(t, index, slot.index)
 	assert.Equal(t, int64(1), slot.users.Count())
 
-	_, release2, ok := v.Acquire("title")
+	_, ok = v.Acquire("title")
 	require.True(t, ok)
 	assert.Equal(t, int64(2), slot.users.Count())
 
-	release()
-	release2()
+	slot.release()
+	slot.release()
 	assert.Equal(t, int64(0), slot.users.Count())
 
-	_, _, ok = v.Acquire("missing")
+	_, ok = v.Acquire("missing")
 	assert.False(t, ok)
 }
 
@@ -242,17 +277,17 @@ func TestVectorIndexSlots_AcquireResolvesTheLegacyAlias(t *testing.T) {
 	var v vectorIndexSlots
 	require.NoError(t, v.Publish("", &MockVectorIndex{}, nil))
 
-	slot, release, ok := v.Acquire(modelsext.DefaultNamedVectorName)
+	slot, ok := v.Acquire(modelsext.DefaultNamedVectorName)
 	require.True(t, ok)
-	defer release()
+	defer slot.release()
 	assert.Equal(t, "", slot.name)
 }
 
 func TestVectorIndexSlots_ReleaseTwicePanics(t *testing.T) {
 	var v vectorIndexSlots
 	require.NoError(t, v.Publish("title", &MockVectorIndex{}, nil))
-	_, release, ok := v.Acquire("title")
+	slot, ok := v.Acquire("title")
 	require.True(t, ok)
-	release()
-	assert.Panics(t, release, "a double release would let a drop proceed under a live user")
+	slot.release()
+	assert.Panics(t, slot.release, "a double release would let a drop proceed under a live user")
 }

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -12,8 +12,11 @@
 package db
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -118,19 +121,99 @@ func TestVectorIndexSlots_Replace(t *testing.T) {
 	assert.Equal(t, 1, v.Len())
 }
 
-func TestVectorIndexSlots_RemoveTakesTheSlotOut(t *testing.T) {
+func TestVectorIndexSlots_RemoveWithoutLeasesReturnsAtOnce(t *testing.T) {
 	var v vectorIndexSlots
 	index := &MockVectorIndex{}
 	require.NoError(t, v.Publish("title", index, nil))
+	logger, _ := test.NewNullLogger()
 
-	gotIndex, _, ok := v.remove("title")
+	gotIndex, _, ok := v.Remove(context.Background(), "title", logger)
 	require.True(t, ok)
 	assert.Same(t, index, gotIndex)
 	_, ok = v.get("title")
 	assert.False(t, ok)
 
-	_, _, ok = v.remove("title")
+	_, _, ok = v.Remove(context.Background(), "title", logger)
 	assert.False(t, ok, "removing twice reports the slot as already gone")
+}
+
+func TestVectorIndexSlots_RemoveWaitsForLeases(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("title", &MockVectorIndex{}, nil))
+	logger, _ := test.NewNullLogger()
+
+	_, release, ok := v.Acquire("title")
+	require.True(t, ok)
+
+	removed := make(chan bool, 1)
+	go func() {
+		_, _, ok := v.Remove(context.Background(), "title", logger)
+		removed <- ok
+	}()
+
+	select {
+	case <-removed:
+		t.Fatal("remove completed while a lease was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	_, _, ok = v.Acquire("title")
+	assert.False(t, ok, "no new lease once a removal has started")
+
+	release()
+	select {
+	case ok := <-removed:
+		assert.True(t, ok)
+	case <-time.After(5 * time.Second):
+		t.Fatal("remove did not complete after the lease was released")
+	}
+}
+
+func TestVectorIndexSlots_RemoveProceedsPastTheDeadline(t *testing.T) {
+	v := vectorIndexSlots{drainTimeout: 50 * time.Millisecond}
+	require.NoError(t, v.Publish("title", &MockVectorIndex{}, nil))
+	logger, hook := test.NewNullLogger()
+
+	_, release, ok := v.Acquire("title")
+	require.True(t, ok)
+	t.Cleanup(release)
+
+	start := time.Now()
+	_, _, ok = v.Remove(context.Background(), "title", logger)
+	require.True(t, ok, "past the deadline the slot is removed anyway, as the shard-level drop does")
+	assert.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond)
+	_, ok = v.get("title")
+	assert.False(t, ok)
+
+	var logged bool
+	for _, entry := range hook.AllEntries() {
+		if entry.Data["action"] == "drop_vector_index" && entry.Data["in_use"] == int64(1) {
+			logged = true
+		}
+	}
+	assert.True(t, logged, "the leftover lease count is logged")
+}
+
+func TestVectorIndexSlots_RemoveOfOneSlotDoesNotWaitForAnother(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("a", &MockVectorIndex{}, nil))
+	require.NoError(t, v.Publish("b", &MockVectorIndex{}, nil))
+	logger, _ := test.NewNullLogger()
+
+	_, release, ok := v.Acquire("a")
+	require.True(t, ok)
+	defer release()
+
+	done := make(chan struct{})
+	go func() {
+		v.Remove(context.Background(), "b", logger)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("removing b waited for a lease on a")
+	}
 }
 
 func TestVectorIndexSlots_AcquireCountsLeases(t *testing.T) {

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -38,6 +38,84 @@ func TestVectorIndexSlots_Publish(t *testing.T) {
 	assert.Equal(t, 2, v.Len())
 }
 
+func TestVectorIndexSlots_CreateBuildsOnce(t *testing.T) {
+	t.Run("an existing name is not built again", func(t *testing.T) {
+		var v vectorIndexSlots
+		first := &MockVectorIndex{}
+		require.NoError(t, v.Publish("title", first, nil))
+
+		built := false
+		created, err := v.Create("title", func() (VectorIndex, *VectorIndexQueue, error) {
+			built = true
+			return &MockVectorIndex{}, nil, nil
+		})
+		require.NoError(t, err)
+		assert.False(t, created)
+		assert.False(t, built, "build must not run for a name that is taken")
+		slot, ok := v.get("title")
+		require.True(t, ok)
+		assert.Same(t, first, slot.index)
+	})
+
+	t.Run("a failed build publishes nothing", func(t *testing.T) {
+		var v vectorIndexSlots
+		created, err := v.Create("title", func() (VectorIndex, *VectorIndexQueue, error) {
+			return nil, nil, assert.AnError
+		})
+		require.ErrorIs(t, err, assert.AnError)
+		assert.False(t, created)
+		assert.Equal(t, 0, v.Len())
+	})
+
+	t.Run("two concurrent creates of the same name build it once", func(t *testing.T) {
+		var v vectorIndexSlots
+		building := make(chan struct{})
+		finish := make(chan struct{})
+		builds := 0
+
+		firstDone := make(chan struct{})
+		go func() {
+			defer close(firstDone)
+			created, err := v.Create("title", func() (VectorIndex, *VectorIndexQueue, error) {
+				builds++
+				close(building)
+				<-finish
+				return &MockVectorIndex{}, nil, nil
+			})
+			assert.NoError(t, err)
+			assert.True(t, created)
+		}()
+		<-building
+
+		// the second create must wait for the first build, then find the slot
+		secondDone := make(chan bool, 1)
+		go func() {
+			created, err := v.Create("title", func() (VectorIndex, *VectorIndexQueue, error) {
+				builds++
+				return &MockVectorIndex{}, nil, nil
+			})
+			assert.NoError(t, err)
+			secondDone <- created
+		}()
+		select {
+		case <-secondDone:
+			t.Fatal("the second create returned while the first was still building")
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		close(finish)
+		<-firstDone
+		select {
+		case created := <-secondDone:
+			assert.False(t, created)
+		case <-time.After(5 * time.Second):
+			t.Fatal("the second create did not return after the first published")
+		}
+		assert.Equal(t, 1, builds)
+		assert.Equal(t, 1, v.Len())
+	})
+}
+
 func TestVectorIndexSlots_LookupResolvesTheLegacyAlias(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/adapters/repos/db/shard_vector_slots_test.go
+++ b/adapters/repos/db/shard_vector_slots_test.go
@@ -199,20 +199,93 @@ func TestVectorIndexSlots_Replace(t *testing.T) {
 	assert.Equal(t, 1, v.Len())
 }
 
+// tornDown is a teardown that records what it was handed.
+func tornDown(got *VectorIndex) func(VectorIndex, *VectorIndexQueue) error {
+	return func(index VectorIndex, _ *VectorIndexQueue) error {
+		*got = index
+		return nil
+	}
+}
+
 func TestVectorIndexSlots_RemoveWithoutLeasesReturnsAtOnce(t *testing.T) {
 	var v vectorIndexSlots
 	index := &MockVectorIndex{}
 	require.NoError(t, v.Publish("title", index, nil))
 	logger, _ := test.NewNullLogger()
 
-	gotIndex, _, ok := v.Remove(context.Background(), "title", logger)
-	require.True(t, ok)
-	assert.Same(t, index, gotIndex)
-	_, ok = v.get("title")
+	var got VectorIndex
+	require.NoError(t, v.Remove(context.Background(), "title", logger, tornDown(&got)))
+	assert.Same(t, index, got)
+	_, ok := v.get("title")
 	assert.False(t, ok)
 
-	_, _, ok = v.Remove(context.Background(), "title", logger)
-	assert.False(t, ok, "removing twice reports the slot as already gone")
+	calls := 0
+	require.NoError(t, v.Remove(context.Background(), "title", logger, func(VectorIndex, *VectorIndexQueue) error {
+		calls++
+		return nil
+	}))
+	assert.Equal(t, 0, calls, "a slot that is already gone is not torn down again")
+}
+
+func TestVectorIndexSlots_RemoveKeepsTheSlotWhenTeardownFails(t *testing.T) {
+	var v vectorIndexSlots
+	index := &MockVectorIndex{}
+	require.NoError(t, v.Publish("title", index, nil))
+	logger, _ := test.NewNullLogger()
+
+	err := v.Remove(context.Background(), "title", logger, func(VectorIndex, *VectorIndexQueue) error {
+		return assert.AnError
+	})
+	require.ErrorIs(t, err, assert.AnError)
+
+	// the shard still owns the pair: a retried drop and shutdown can reach it
+	slot, ok := v.get("title")
+	require.True(t, ok)
+	assert.Same(t, index, slot.index)
+	var seen []string
+	require.NoError(t, v.ForEach(func(name string, _ VectorIndex, _ *VectorIndexQueue) error {
+		seen = append(seen, name)
+		return nil
+	}))
+	assert.Equal(t, []string{"title"}, seen)
+	lease, ok := v.Acquire("title")
+	require.True(t, ok, "leases resume once the failed removal is abandoned")
+	lease.release()
+
+	var got VectorIndex
+	require.NoError(t, v.Remove(context.Background(), "title", logger, tornDown(&got)))
+	assert.Same(t, index, got)
+	assert.Equal(t, 0, v.Len())
+}
+
+func TestVectorIndexSlots_ForEachSkipsASlotBeingRemoved(t *testing.T) {
+	var v vectorIndexSlots
+	require.NoError(t, v.Publish("a", &MockVectorIndex{}, nil))
+	require.NoError(t, v.Publish("b", &MockVectorIndex{}, nil))
+	logger, _ := test.NewNullLogger()
+
+	inTeardown := make(chan struct{})
+	finish := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- v.Remove(context.Background(), "a", logger, func(VectorIndex, *VectorIndexQueue) error {
+			close(inTeardown)
+			<-finish
+			return nil
+		})
+	}()
+	<-inTeardown
+
+	var seen []string
+	require.NoError(t, v.ForEach(func(name string, _ VectorIndex, _ *VectorIndexQueue) error {
+		seen = append(seen, name)
+		return nil
+	}))
+	assert.Equal(t, []string{"b"}, seen, "a slot mid-teardown is not handed to a walk")
+
+	close(finish)
+	require.NoError(t, <-done)
+	assert.Equal(t, 1, v.Len())
 }
 
 func TestVectorIndexSlots_RemoveWaitsForLeases(t *testing.T) {
@@ -223,10 +296,9 @@ func TestVectorIndexSlots_RemoveWaitsForLeases(t *testing.T) {
 	slot, ok := v.Acquire("title")
 	require.True(t, ok)
 
-	removed := make(chan bool, 1)
+	removed := make(chan error, 1)
 	go func() {
-		_, _, ok := v.Remove(context.Background(), "title", logger)
-		removed <- ok
+		removed <- v.Remove(context.Background(), "title", logger, func(VectorIndex, *VectorIndexQueue) error { return nil })
 	}()
 
 	select {
@@ -240,11 +312,12 @@ func TestVectorIndexSlots_RemoveWaitsForLeases(t *testing.T) {
 
 	slot.release()
 	select {
-	case ok := <-removed:
-		assert.True(t, ok)
+	case err := <-removed:
+		assert.NoError(t, err)
 	case <-time.After(5 * time.Second):
 		t.Fatal("remove did not complete after the lease was released")
 	}
+	assert.Equal(t, 0, v.Len())
 }
 
 func TestVectorIndexSlots_RemoveProceedsPastTheDeadline(t *testing.T) {
@@ -257,8 +330,8 @@ func TestVectorIndexSlots_RemoveProceedsPastTheDeadline(t *testing.T) {
 	t.Cleanup(slot.release)
 
 	start := time.Now()
-	_, _, ok = v.Remove(context.Background(), "title", logger)
-	require.True(t, ok, "past the deadline the slot is removed anyway, as the shard-level drop does")
+	err := v.Remove(context.Background(), "title", logger, func(VectorIndex, *VectorIndexQueue) error { return nil })
+	require.NoError(t, err, "past the deadline the slot is removed anyway, as the shard-level drop does")
 	assert.GreaterOrEqual(t, time.Since(start), 50*time.Millisecond)
 	_, ok = v.get("title")
 	assert.False(t, ok)
@@ -284,7 +357,7 @@ func TestVectorIndexSlots_RemoveOfOneSlotDoesNotWaitForAnother(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		v.Remove(context.Background(), "b", logger)
+		v.Remove(context.Background(), "b", logger, func(VectorIndex, *VectorIndexQueue) error { return nil })
 		close(done)
 	}()
 	select {


### PR DESCRIPTION
### What's being changed:

A shard's vector indexes and their queues move out of four loose fields under one mutex into one type, `vectorIndexSlots`, with one slot per logical vector. This is the first of four PRs for the "Logical Slots" section of the vector index mapping RFC; the next three move the callers onto it and remove the old accessors.

The type also introduces leases: a caller that uses an index or queue takes a lease on its slot, and dropping the vector waits for those leases (bounded at 30 seconds, like the shard's own drop drain) before tearing the pair down. Today the drop only excludes the map lookup, not the use, so a search that fetched its index a moment earlier keeps running against an index being torn down. Nothing takes a lease yet in this PR: the leased accessors (`WithVectorIndex`, `AcquireVectorIndex`, and their queue variants) are added but unused, the old `Get` accessors stay, and behavior is unchanged.

Two things a reviewer should look at:

- Creation is serialized inside the type, so two concurrent creates of the same vector build it once, and lookups are no longer blocked for the duration of a build.
- A drop whose teardown fails keeps the slot, so a retried drop and shard shutdown still reach the index.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
