### PR TITLE
shard: request paths hold a lease on the vector index

### DIFF
--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -25,10 +25,11 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params, module
 
 	// we only need the index queue for vector search
 	if params.NearObject != nil || params.NearVector != nil || params.Hybrid != nil || params.SearchVector != nil {
-		idx, ok := s.GetVectorIndex(params.TargetVector)
+		idx, release, ok := s.AcquireVectorIndex(params.TargetVector)
 		if !ok {
 			return nil, fmt.Errorf("no vector index for target vector %q", params.TargetVector)
 		}
+		defer release()
 		vectorIndex = idx
 	}
 

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -657,24 +657,29 @@ func (s *Shard) VectorDistanceForQuery(ctx context.Context, docId uint64, search
 
 	distances := make([]float32, len(targetVectors))
 	for j, target := range targetVectors {
-		index, ok := s.GetVectorIndex(target)
-		if !ok {
+		found, err := s.WithVectorIndex(target, func(index VectorIndex) error {
+			var distancer common.QueryVectorDistancer
+			switch v := searchVectors[j].(type) {
+			case []float32:
+				distancer = index.QueryVectorDistancer(v)
+			case [][]float32:
+				distancer = index.(VectorIndexMulti).QueryMultiVectorDistancer(v)
+			default:
+				return fmt.Errorf("unsupported vector type: %T", v)
+			}
+			dist, err := distancer.DistanceToNode(docId)
+			if err != nil {
+				return err
+			}
+			distances[j] = dist
+			return nil
+		})
+		if !found {
 			return nil, fmt.Errorf("index %s not found", target)
 		}
-		var distancer common.QueryVectorDistancer
-		switch v := searchVectors[j].(type) {
-		case []float32:
-			distancer = index.QueryVectorDistancer(v)
-		case [][]float32:
-			distancer = index.(VectorIndexMulti).QueryMultiVectorDistancer(v)
-		default:
-			return nil, fmt.Errorf("unsupported vector type: %T", v)
-		}
-		dist, err := distancer.DistanceToNode(docId)
 		if err != nil {
 			return nil, err
 		}
-		distances[j] = dist
 	}
 	return distances, nil
 }
@@ -736,10 +741,11 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors []models.V
 				err   error
 			)
 
-			vidx, ok := s.GetVectorIndex(targetVector)
+			vidx, release, ok := s.AcquireVectorIndex(targetVector)
 			if !ok {
 				return fmt.Errorf("index for target vector %q not found", targetVector)
 			}
+			defer release()
 
 			if limit < 0 {
 				switch searchVector := searchVectors[i].(type) {

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -349,14 +349,13 @@ func (ob *objectsBatcher) storeAdditionalStorageWithAsyncQueue(ctx context.Conte
 	}
 
 	for targetVector, vectors := range targetVectors {
-		queue, ok := ob.shard.GetVectorIndexQueue(targetVector)
-		if !ok {
+		found, err := ob.shard.WithVectorIndexQueue(targetVector, func(queue *VectorIndexQueue) error {
+			return queue.Insert(ctx, vectors...)
+		})
+		if !found {
 			ob.setErrorAtIndex(fmt.Errorf("queue not found for target vector %s", targetVector), 0)
-		} else {
-			err := queue.Insert(ctx, vectors...)
-			if err != nil {
-				ob.setErrorAtIndex(err, 0)
-			}
+		} else if err != nil {
+			ob.setErrorAtIndex(err, 0)
 		}
 	}
 }

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -33,34 +33,39 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 
 	for targetVector, vector := range merge.Vectors {
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-		vectorIndex, ok := s.GetVectorIndex(targetVector)
-		if !ok {
+		found, err := s.WithVectorIndex(targetVector, func(vectorIndex VectorIndex) error {
+			switch v := vector.(type) {
+			case []float32:
+				err := vectorIndex.ValidateBeforeInsert(v)
+				if err != nil {
+					return errors.Wrapf(err, "validate vector index for update of %v for target vector %s", merge.ID, targetVector)
+				}
+			case [][]float32:
+				err := vectorIndex.(VectorIndexMulti).ValidateMultiBeforeInsert(v)
+				if err != nil {
+					return errors.Wrapf(err, "validate multi vector index for update of %v for target vector %s", merge.ID, targetVector)
+				}
+			default:
+				return errors.Errorf("validate vector index for update of %v for target vector %s: unrecongnized vector type: %T", merge.ID, targetVector, vector)
+			}
+			return nil
+		})
+		if !found {
 			return errors.Errorf("validate vector index for update of %v for target vector %s: vector index not found", merge.ID, targetVector)
 		}
-		switch v := vector.(type) {
-		case []float32:
-			err := vectorIndex.ValidateBeforeInsert(v)
-			if err != nil {
-				return errors.Wrapf(err, "validate vector index for update of %v for target vector %s", merge.ID, targetVector)
-			}
-		case [][]float32:
-			err := vectorIndex.(VectorIndexMulti).ValidateMultiBeforeInsert(v)
-			if err != nil {
-				return errors.Wrapf(err, "validate multi vector index for update of %v for target vector %s", merge.ID, targetVector)
-			}
-		default:
-			return errors.Errorf("validate vector index for update of %v for target vector %s: unrecongnized vector type: %T", merge.ID, targetVector, vector)
+		if err != nil {
+			return err
 		}
 	}
 
 	if len(merge.Vector) > 0 {
-		vectorIndex, ok := s.GetVectorIndex("")
-		if !ok {
+		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
+		found, err := s.WithVectorIndex("", func(vectorIndex VectorIndex) error {
+			return vectorIndex.ValidateBeforeInsert(merge.Vector)
+		})
+		if !found {
 			return errors.Errorf("validate vector index for update of %v for vector: vector index not found", merge.ID)
 		}
-
-		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-		err := vectorIndex.ValidateBeforeInsert(merge.Vector)
 		if err != nil {
 			return errors.Wrapf(err, "validate vector index for update of %v", merge.ID)
 		}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -115,10 +115,11 @@ func (s *Shard) updateVectorIndexIgnoreDelete(ctx context.Context, vector []floa
 		return nil
 	}
 
-	if queue, ok := s.GetVectorIndexQueue(""); ok {
-		if err := queue.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector}); err != nil {
-			return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
-		}
+	_, err := s.WithVectorIndexQueue("", func(queue *VectorIndexQueue) error {
+		return queue.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector})
+	})
+	if err != nil {
+		return errors.Wrapf(err, "insert doc id %d to vector index", status.docID)
 	}
 
 	return nil
@@ -144,10 +145,11 @@ func (s *Shard) updateVectorIndexesIgnoreDelete(ctx context.Context,
 	}
 
 	for targetVector, vector := range vectors {
-		if q, ok := s.GetVectorIndexQueue(targetVector); ok {
-			if err := q.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector}); err != nil {
-				return errors.Wrapf(err, "insert doc id %d to vector index for target vector %s", status.docID, targetVector)
-			}
+		_, err := s.WithVectorIndexQueue(targetVector, func(q *VectorIndexQueue) error {
+			return q.Insert(ctx, &common.Vector[[]float32]{ID: status.docID, Vector: vector})
+		})
+		if err != nil {
+			return errors.Wrapf(err, "insert doc id %d to vector index for target vector %s", status.docID, targetVector)
 		}
 	}
 
@@ -173,10 +175,11 @@ func (s *Shard) updateMultiVectorIndexesIgnoreDelete(ctx context.Context,
 	}
 
 	for targetVector, vector := range multiVectors {
-		if q, ok := s.GetVectorIndexQueue(targetVector); ok {
-			if err := q.Insert(ctx, &common.Vector[[][]float32]{ID: status.docID, Vector: vector}); err != nil {
-				return errors.Wrapf(err, "insert doc id %d to multi vector index for target vector %s", status.docID, targetVector)
-			}
+		_, err := s.WithVectorIndexQueue(targetVector, func(q *VectorIndexQueue) error {
+			return q.Insert(ctx, &common.Vector[[][]float32]{ID: status.docID, Vector: vector})
+		})
+		if err != nil {
+			return errors.Wrapf(err, "insert doc id %d to multi vector index for target vector %s", status.docID, targetVector)
 		}
 	}
 
@@ -240,27 +243,30 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 	defer s.metrics.PutObject(before)
 
 	for targetVector, vector := range obj.Vectors {
-		if vectorIndex, ok := s.GetVectorIndex(targetVector); ok {
-			if err := vectorIndex.ValidateBeforeInsert(vector); err != nil {
-				return status, errors.Wrapf(err, "Validate vector index %s for target vector %s", targetVector, obj.ID())
-			}
+		_, err := s.WithVectorIndex(targetVector, func(vectorIndex VectorIndex) error {
+			return vectorIndex.ValidateBeforeInsert(vector)
+		})
+		if err != nil {
+			return status, errors.Wrapf(err, "Validate vector index %s for target vector %s", targetVector, obj.ID())
 		}
 	}
 
 	for targetVector, vector := range obj.MultiVectors {
-		if vectorIndex, ok := s.GetVectorIndex(targetVector); ok {
-			if err := vectorIndex.(VectorIndexMulti).ValidateMultiBeforeInsert(vector); err != nil {
-				return status, errors.Wrapf(err, "Validate vector index %s for target multi vector %s", targetVector, obj.ID())
-			}
+		_, err := s.WithVectorIndex(targetVector, func(vectorIndex VectorIndex) error {
+			return vectorIndex.(VectorIndexMulti).ValidateMultiBeforeInsert(vector)
+		})
+		if err != nil {
+			return status, errors.Wrapf(err, "Validate vector index %s for target multi vector %s", targetVector, obj.ID())
 		}
 	}
 
 	if len(obj.Vector) > 0 && s.hasLegacyVectorIndex() {
 		// validation needs to happen before any changes are done. Otherwise, insertion is aborted somewhere in-between.
-		if index, ok := s.GetVectorIndex(""); ok {
-			if err = index.ValidateBeforeInsert(obj.Vector); err != nil {
-				return status, errors.Wrapf(err, "Validate vector index for %s", obj.ID())
-			}
+		_, err = s.WithVectorIndex("", func(index VectorIndex) error {
+			return index.ValidateBeforeInsert(obj.Vector)
+		})
+		if err != nil {
+			return status, errors.Wrapf(err, "Validate vector index for %s", obj.ID())
 		}
 	}
 
@@ -858,10 +864,11 @@ func propsEqual(prevProps, nextProps map[string]interface{}) bool {
 func updateVectorInVectorIndex[T dto.Embedding](ctx context.Context, shard *Shard, targetVector string, vector T,
 	status objectInsertStatus,
 ) error {
-	queue, ok := shard.GetVectorIndexQueue(targetVector)
+	queue, release, ok := shard.AcquireVectorIndexQueue(targetVector)
 	if !ok {
 		return fmt.Errorf("vector index not found for %s", targetVector)
 	}
+	defer release()
 
 	// even if no vector is provided in an update, we still need
 	// to delete the previous vector from the index, if it


### PR DESCRIPTION
### What's being changed:

Second of the four slots PRs, stacked on #12965. The request paths now hold a lease on the vector index while they use it: the object write path (put, merge, batch), the read path (single and multi-target search), and the aggregator. Thirteen call sites move from `GetVectorIndex` / `GetVectorIndexQueue` to the leased accessors, so dropping a vector index waits for the searches and inserts that are on it, instead of tearing it down underneath them.

Single-call uses take the callback form; the multi-target search and the aggregator, which hold the index across their whole operation, take an explicit lease with a deferred release. The maintenance and debug paths keep the old accessors until the next PR, and the accessors themselves are removed in the last one.

No behavior change beyond the wait: a drop of a vector with no request on it returns as before.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
