### PR TITLE
shard: maintenance and debug paths hold a lease on the vector index

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -259,13 +259,14 @@ func setupDebugHandlers(appState *state.State) {
 			return
 		}
 
-		vidx, ok := shard.GetVectorIndex(targetVector)
+		vidx, releaseIndex, ok := shard.AcquireVectorIndex(targetVector)
 		if !ok {
 			release()
 			logger.WithField("shard", shardName).Error("vector index not found")
 			http.Error(w, "vector index not found", http.StatusNotFound)
 			return
 		}
+		defer releaseIndex()
 
 		h, ok := vidx.(hfreshReassignAller)
 		if !ok {
@@ -338,12 +339,13 @@ func setupDebugHandlers(appState *state.State) {
 			return
 		}
 
-		vidx, ok := shard.GetVectorIndex(targetVector)
+		vidx, releaseIndex, ok := shard.AcquireVectorIndex(targetVector)
 		if !ok {
 			logger.WithField("shard", shardName).Error("vector index not found")
 			http.Error(w, "vector index not found", http.StatusNotFound)
 			return
 		}
+		defer releaseIndex()
 
 		h, ok := vidx.(hnswStats)
 		if !ok {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4622,13 +4622,17 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 	}
 
 	// Get the vector index
-	vidx, ok := shard.GetVectorIndex(targetVector)
-	if !ok {
+	found, err := shard.WithVectorIndex(targetVector, func(vidx VectorIndex) error {
+		if !hnsw.IsHNSWIndex(vidx) {
+			return errors.New("vector index is not hnsw")
+		}
+		return nil
+	})
+	if !found {
 		return errors.New("vector index not found")
 	}
-
-	if !hnsw.IsHNSWIndex(vidx) {
-		return errors.New("vector index is not hnsw")
+	if err != nil {
+		return err
 	}
 
 	// Reset the vector index

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -586,12 +586,10 @@ func (s *Shard) UpdateVectorIndexConfig(ctx context.Context, updated schemaConfi
 	// collection that dropped its last vector carries an inert legacy config in
 	// the schema, but its shards were built without a legacy index and there is
 	// nothing to reconfigure.
-	index, ok := s.GetVectorIndex("")
-	if !ok {
-		return nil
-	}
-
-	return index.UpdateUserConfig(updated, noopCallback)
+	_, err := s.WithVectorIndex("", func(index VectorIndex) error {
+		return index.UpdateUserConfig(updated, noopCallback)
+	})
+	return err
 }
 
 func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string]schemaConfig.VectorIndexConfig) error {
@@ -611,8 +609,12 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 
 	var err error
 	for targetVector, targetCfg := range updated {
-		if index, ok := s.GetVectorIndex(targetVector); ok {
-			if err = index.UpdateUserConfig(targetCfg, noopCallback); err != nil {
+		var found bool
+		found, err = s.WithVectorIndex(targetVector, func(index VectorIndex) error {
+			return index.UpdateUserConfig(targetCfg, noopCallback)
+		})
+		if found {
+			if err != nil {
 				break
 			}
 		} else {

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -76,21 +76,23 @@ func (s *Shard) FillQueue(targetVector string, from uint64) error {
 
 	var counter int
 
-	vectorIndex, ok := s.GetVectorIndex(targetVector)
+	vectorIndex, releaseIndex, ok := s.AcquireVectorIndex(targetVector)
 	if !ok {
 		s.index.logger.WithField("targetVector", targetVector).Warn("preload queue: vector index not found")
 		// shard was never initialized, possibly because of a failed shard
 		// initialization. No op.
 		return nil
 	}
+	defer releaseIndex()
 
-	q, ok := s.GetVectorIndexQueue(targetVector)
+	q, releaseQueue, ok := s.AcquireVectorIndexQueue(targetVector)
 	if !ok {
 		s.index.logger.WithField("targetVector", targetVector).Warn("preload queue: queue not found")
 		// queue was never initialized, possibly because of a failed shard
 		// initialization. No op.
 		return nil
 	}
+	defer releaseQueue()
 
 	ctx := context.Background()
 
@@ -277,7 +279,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 	className := s.index.Config.ClassName.String()
 	shardName := s.Name()
 
-	vectorIndex, ok := s.GetVectorIndex(targetVector)
+	vectorIndex, releaseIndex, ok := s.AcquireVectorIndex(targetVector)
 	if !ok {
 		s.index.logger.
 			WithField("class", className).
@@ -288,6 +290,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 		// initialization. No op.
 		return nil
 	}
+	defer releaseIndex()
 
 	// if it's HNSW, trigger a tombstone cleanup
 	if hnsw.IsHNSWIndex(vectorIndex) {
@@ -299,7 +302,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 		}
 	}
 
-	q, ok := s.GetVectorIndexQueue(targetVector)
+	q, releaseQueue, ok := s.AcquireVectorIndexQueue(targetVector)
 	if !ok {
 		s.index.logger.
 			WithField("class", className).
@@ -310,6 +313,7 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 		// initialization. No op.
 		return nil
 	}
+	defer releaseQueue()
 
 	maxDocID := s.Counter().Get()
 	visited := visited.NewList(int(maxDocID))
@@ -552,13 +556,14 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 func (s *Shard) RequantizeIndex(ctx context.Context, targetVector string) error {
 	start := time.Now()
 
-	vectorIndex, ok := s.GetVectorIndex(targetVector)
+	vectorIndex, releaseIndex, ok := s.AcquireVectorIndex(targetVector)
 	if !ok {
 		s.index.logger.WithField("targetVector", targetVector).WithField("action", "requantize").Warn("requantize index: vector index not found")
 		// shard was never initialized, possibly because of a failed shard
 		// initialization. No op.
 		return nil
 	}
+	defer releaseIndex()
 
 	if !vectorIndex.Compressed() {
 		s.index.logger.WithField("targetVector", targetVector).WithField("action", "requantize").Info("vector index is not compressed, skipping requantizing")

--- a/adapters/repos/db/shard_debug.go
+++ b/adapters/repos/db/shard_debug.go
@@ -28,12 +28,16 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 		return fmt.Errorf("async indexing is not enabled")
 	}
 
-	vidx, vok := s.GetVectorIndex(targetVector)
-	q, qok := s.GetVectorIndexQueue(targetVector)
-
-	if !(vok && qok) {
+	vidx, releaseIndex, vok := s.AcquireVectorIndex(targetVector)
+	if !vok {
 		return fmt.Errorf("vector index %q not found", targetVector)
 	}
+	defer releaseIndex()
+	q, releaseQueue, qok := s.AcquireVectorIndexQueue(targetVector)
+	if !qok {
+		return fmt.Errorf("vector index %q not found", targetVector)
+	}
+	defer releaseQueue()
 
 	if err := q.Pause(ctx); err != nil {
 		return errors.Wrap(err, "pause vector index")


### PR DESCRIPTION
### What's being changed:

Third of the four slots PRs, off main now that the type and its accessors are in (#12965); independent of #12970, which covers the request paths. The maintenance and debug paths now hold a lease on the vector index while they use it, so dropping a vector index waits for them instead of tearing the index down mid-operation. Twelve call sites in five files.

The async preload, repair, and requantize each iterate every object in the shard while using the index and queue, so they take an explicit lease with a deferred release. The two config-update paths use the callback form. The debug reindex and the two REST debug endpoints hold the index for the duration of their operation.

The unleased `Get` accessors stay until the last PR removes them, once #12970 and this one are in. No behavior change beyond the wait.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
