### PR TITLE
shard: the unleased vector index accessors go

### DIFF
--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -301,7 +301,10 @@ func TestIndex_AddNewVectorIndex(t *testing.T) {
 		shard, index = testShard(t, ctx, initialClass.Class)
 	)
 
-	_, ok := shard.GetVectorIndex("new_index")
+	_, release, ok := shard.AcquireVectorIndex("new_index")
+	if ok {
+		release()
+	}
 	require.False(t, ok)
 
 	require.NoError(t, index.updateVectorIndexConfigs(ctx, map[string]schemaConfig.VectorIndexConfig{
@@ -310,8 +313,9 @@ func TestIndex_AddNewVectorIndex(t *testing.T) {
 		},
 	}))
 
-	vectorIndex, ok := shard.GetVectorIndex("new_index")
+	vectorIndex, release, ok := shard.AcquireVectorIndex("new_index")
 	require.True(t, ok)
+	defer release()
 	require.NotNil(t, vectorIndex)
 }
 

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -1824,122 +1824,6 @@ func (_c *MockShardLike_GetStatusReason_Call) RunAndReturn(run func() string) *M
 	return _c
 }
 
-// GetVectorIndex provides a mock function with given fields: targetVector
-func (_m *MockShardLike) GetVectorIndex(targetVector string) (VectorIndex, bool) {
-	ret := _m.Called(targetVector)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetVectorIndex")
-	}
-
-	var r0 VectorIndex
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (VectorIndex, bool)); ok {
-		return rf(targetVector)
-	}
-	if rf, ok := ret.Get(0).(func(string) VectorIndex); ok {
-		r0 = rf(targetVector)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(VectorIndex)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string) bool); ok {
-		r1 = rf(targetVector)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-
-	return r0, r1
-}
-
-// MockShardLike_GetVectorIndex_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVectorIndex'
-type MockShardLike_GetVectorIndex_Call struct {
-	*mock.Call
-}
-
-// GetVectorIndex is a helper method to define mock.On call
-//   - targetVector string
-func (_e *MockShardLike_Expecter) GetVectorIndex(targetVector interface{}) *MockShardLike_GetVectorIndex_Call {
-	return &MockShardLike_GetVectorIndex_Call{Call: _e.mock.On("GetVectorIndex", targetVector)}
-}
-
-func (_c *MockShardLike_GetVectorIndex_Call) Run(run func(targetVector string)) *MockShardLike_GetVectorIndex_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_GetVectorIndex_Call) Return(_a0 VectorIndex, _a1 bool) *MockShardLike_GetVectorIndex_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockShardLike_GetVectorIndex_Call) RunAndReturn(run func(string) (VectorIndex, bool)) *MockShardLike_GetVectorIndex_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// GetVectorIndexQueue provides a mock function with given fields: targetVector
-func (_m *MockShardLike) GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool) {
-	ret := _m.Called(targetVector)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetVectorIndexQueue")
-	}
-
-	var r0 *VectorIndexQueue
-	var r1 bool
-	if rf, ok := ret.Get(0).(func(string) (*VectorIndexQueue, bool)); ok {
-		return rf(targetVector)
-	}
-	if rf, ok := ret.Get(0).(func(string) *VectorIndexQueue); ok {
-		r0 = rf(targetVector)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*VectorIndexQueue)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string) bool); ok {
-		r1 = rf(targetVector)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-
-	return r0, r1
-}
-
-// MockShardLike_GetVectorIndexQueue_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetVectorIndexQueue'
-type MockShardLike_GetVectorIndexQueue_Call struct {
-	*mock.Call
-}
-
-// GetVectorIndexQueue is a helper method to define mock.On call
-//   - targetVector string
-func (_e *MockShardLike_Expecter) GetVectorIndexQueue(targetVector interface{}) *MockShardLike_GetVectorIndexQueue_Call {
-	return &MockShardLike_GetVectorIndexQueue_Call{Call: _e.mock.On("GetVectorIndexQueue", targetVector)}
-}
-
-func (_c *MockShardLike_GetVectorIndexQueue_Call) Run(run func(targetVector string)) *MockShardLike_GetVectorIndexQueue_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_GetVectorIndexQueue_Call) Return(_a0 *VectorIndexQueue, _a1 bool) *MockShardLike_GetVectorIndexQueue_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockShardLike_GetVectorIndexQueue_Call) RunAndReturn(run func(string) (*VectorIndexQueue, bool)) *MockShardLike_GetVectorIndexQueue_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // HaltForTransfer provides a mock function with given fields: ctx, offloading, inactivityTimeout
 func (_m *MockShardLike) HaltForTransfer(ctx context.Context, offloading bool, inactivityTimeout time.Duration) error {
 	ret := _m.Called(ctx, offloading, inactivityTimeout)
@@ -5520,8 +5404,7 @@ func (_c *MockShardLike_updateVectorIndexesIgnoreDelete_Call) RunAndReturn(run f
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockShardLike {
+}) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/physical_layout_pin_test.go
+++ b/adapters/repos/db/physical_layout_pin_test.go
@@ -257,7 +257,9 @@ func putNamedBatch(t *testing.T, ctx context.Context, shd ShardLike, className, 
 // exist once the index has actually seen the vectors.
 func drainQueue(t *testing.T, shd ShardLike, targetVector string) {
 	t.Helper()
-	q, ok := shd.GetVectorIndexQueue(targetVector)
+	q, release, ok := shd.AcquireVectorIndexQueue(targetVector)
+	require.True(t, ok)
+	defer release()
 	require.True(t, ok, "no queue for target vector %q", targetVector)
 	require.Eventually(t, func() bool { return q.Size() == 0 }, 30*time.Second, 50*time.Millisecond)
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -147,8 +147,6 @@ type ShardLike interface {
 	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor,
 		additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) // Search and return objects
 	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) // Check if an object was deleted
-	GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool)
-	GetVectorIndex(targetVector string) (VectorIndex, bool)
 	WithVectorIndex(targetVector string, f func(index VectorIndex) error) (found bool, err error)
 	WithVectorIndexQueue(targetVector string, f func(queue *VectorIndexQueue) error) (found bool, err error)
 	AcquireVectorIndex(targetVector string) (index VectorIndex, release func(), ok bool)

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -40,26 +40,6 @@ func (s *Shard) ForEachVectorQueue(f func(targetVector string, queue *VectorInde
 	})
 }
 
-// GetVectorIndexQueue retrieves a vector index queue associated with the targetVector.
-// Empty targetVector is treated as a request to access a queue for the legacy vector index.
-func (s *Shard) GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool) {
-	slot, ok := s.vectors.get(targetVector)
-	if !ok {
-		return nil, false
-	}
-	return slot.queue, true
-}
-
-// GetVectorIndex retrieves a vector index associated with the targetVector.
-// Empty targetVector is treated as a request to access the legacy vector index.
-func (s *Shard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
-	slot, ok := s.vectors.get(targetVector)
-	if !ok {
-		return nil, false
-	}
-	return slot.index, true
-}
-
 // WithVectorIndex runs f on the targetVector's index under a lease: a drop
 // of that vector waits until f returns. found is false, and f is not
 // called, when the shard has no such index. Empty targetVector is the

--- a/adapters/repos/db/shard_autoresume_maintenance_test.go
+++ b/adapters/repos/db/shard_autoresume_maintenance_test.go
@@ -511,7 +511,8 @@ func TestShard_BackupPostFlushWritesAreLostWithoutLateFlush(t *testing.T) {
 		for _, obj := range objects {
 			require.NoError(t, shard.PutObject(ctx, obj))
 		}
-		if queue, ok := shard.GetVectorIndexQueue(""); ok && queue != nil {
+		if queue, release, ok := shard.AcquireVectorIndexQueue(""); ok && queue != nil {
+			defer release()
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				assert.EqualValues(collect, 0, queue.Size())
 			}, 30*time.Second, 100*time.Millisecond, "queue should drain")

--- a/adapters/repos/db/shard_bmw_update_test.go
+++ b/adapters/repos/db/shard_bmw_update_test.go
@@ -52,7 +52,9 @@ func TestUpdateDocBMWIndex(t *testing.T) {
 	createShard := func(t *testing.T) (ShardLike, *VectorIndexQueue) {
 		vectorIndexConfig := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
 		shard, _ := testShardWithSettings(t, ctx, class, vectorIndexConfig, true, true, false)
-		queue, ok := shard.GetVectorIndexQueue("")
+		queue, release, ok := shard.AcquireVectorIndexQueue("")
+		require.True(t, ok)
+		defer release()
 		require.True(t, ok)
 		return shard, queue
 	}

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -32,7 +32,9 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/multi"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storobj"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
@@ -372,4 +374,54 @@ func TestInFlightObjectReadHoldsOffBucketTeardown(t *testing.T) {
 	case <-time.After(time.Minute):
 		t.Fatal("teardown never completed after the read released its pin")
 	}
+}
+
+// TestDropVectorIndexWaitsForALease pins the RFC's deletion step 3 at the
+// shard level: a drop of one named vector waits for a caller that holds
+// its index, and a drop of another vector does not.
+func TestDropVectorIndexWaitsForALease(t *testing.T) {
+	shd, _ := testShardWithSettings(t, testCtx(), &models.Class{Class: "test"}, hnswent.UserConfig{}, false, true, false, func(idx *Index) {
+		idx.vectorIndexUserConfig = nil
+		idx.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+			"held":  hnswent.NewDefaultUserConfig(),
+			"other": hnswent.NewDefaultUserConfig(),
+		}
+	})
+	s := shd.(*Shard)
+
+	_, release, ok := s.AcquireVectorIndex("held")
+	require.True(t, ok)
+
+	otherDropped := make(chan error, 1)
+	go func() { otherDropped <- s.DropVectorIndex(context.Background(), "other") }()
+	select {
+	case err := <-otherDropped:
+		require.NoError(t, err, "a drop of an unrelated vector must not wait for this lease")
+	case <-time.After(10 * time.Second):
+		t.Fatal("dropping the other vector waited for a lease on the held one")
+	}
+
+	heldDropped := make(chan error, 1)
+	go func() { heldDropped <- s.DropVectorIndex(context.Background(), "held") }()
+	select {
+	case <-heldDropped:
+		t.Fatal("the drop completed while the index was leased")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	_, _, ok = s.AcquireVectorIndex("held")
+	require.False(t, ok, "no new lease once the drop has started")
+
+	release()
+	select {
+	case err := <-heldDropped:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the drop did not complete after the lease was released")
+	}
+
+	_, _, ok = s.AcquireVectorIndex("held")
+	require.False(t, ok)
+	_, _, ok = s.AcquireVectorIndex("other")
+	require.False(t, ok)
 }

--- a/adapters/repos/db/shard_geo_props_test.go
+++ b/adapters/repos/db/shard_geo_props_test.go
@@ -566,7 +566,9 @@ func TestVectorIndexLoggerCarriesIdentity(t *testing.T) {
 			for _, err := range shd.PutObjectBatch(ctx, objs) {
 				require.NoError(t, err)
 			}
-			q, ok := shd.GetVectorIndexQueue("title")
+			q, release, ok := shd.AcquireVectorIndexQueue("title")
+			require.True(t, ok)
+			defer release()
 			require.True(t, ok)
 			require.Eventually(t, func() bool { return q.Size() == 0 }, 30*time.Second, 50*time.Millisecond)
 

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -44,12 +44,14 @@ func TestInitTargetVector_Idempotent_DoesNotOrphanQueue(t *testing.T) {
 	cfg := enthnsw.UserConfig{Skip: true}
 
 	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
-	q1, _ := shard.GetVectorIndexQueue("v1")
+	q1, releaseQ1, _ := shard.AcquireVectorIndexQueue("v1")
+	defer releaseQ1()
 	require.NotNil(t, q1)
 
 	require.NoError(t, shard.initTargetVector(ctx, "v1", cfg, false))
 
-	q2, _ := shard.GetVectorIndexQueue("v1")
+	q2, releaseQ2, _ := shard.AcquireVectorIndexQueue("v1")
+	defer releaseQ2()
 
 	assert.Same(t, q1, q2,
 		"re-initialising an existing target vector must not silently replace and "+

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -780,16 +780,6 @@ func (l *LazyLoadShard) MergeObject(ctx context.Context, object objects.MergeDoc
 	return l.shard.MergeObject(ctx, object)
 }
 
-func (l *LazyLoadShard) GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool) {
-	l.mustLoad()
-	return l.shard.GetVectorIndexQueue(targetVector)
-}
-
-func (l *LazyLoadShard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
-	l.mustLoad()
-	return l.shard.GetVectorIndex(targetVector)
-}
-
 func (l *LazyLoadShard) WithVectorIndex(targetVector string, f func(index VectorIndex) error) (bool, error) {
 	l.mustLoad()
 	return l.shard.WithVectorIndex(targetVector, f)

--- a/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
+++ b/adapters/repos/db/shard_skip_vector_reindex_integration_test.go
@@ -539,7 +539,9 @@ func TestShard_SkipVectorReindex(t *testing.T) {
 	createShard := func(t *testing.T, asyncIndexingEnabled bool) (ShardLike, *VectorIndexQueue) {
 		vectorIndexConfig := hnsw.UserConfig{Distance: common.DefaultDistanceMetric}
 		shard, _ := testShardWithSettings(t, ctx, class, vectorIndexConfig, true, true, asyncIndexingEnabled)
-		queue, ok := shard.GetVectorIndexQueue("")
+		queue, release, ok := shard.AcquireVectorIndexQueue("")
+		require.True(t, ok)
+		defer release()
 		require.True(t, ok)
 		return shard, queue
 	}

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -913,7 +913,9 @@ func TestShard_UpgradeIndex(t *testing.T) {
 		}
 	}
 
-	q, ok := shd.GetVectorIndexQueue("")
+	q, release, ok := shd.AcquireVectorIndexQueue("")
+	require.True(t, ok)
+	defer release()
 	require.True(t, ok)
 
 	// wait for the queue to be empty
@@ -1121,8 +1123,14 @@ func TestShard_RequantizeIndex(t *testing.T) {
 }
 
 func getVectorIndexAndQueue(t *testing.T, shard ShardLike, targetVector string) (VectorIndex, *VectorIndexQueue) {
-	idx, vok := shard.GetVectorIndex(targetVector)
-	q, qok := shard.GetVectorIndexQueue(targetVector)
+	idx, releaseIdx, vok := shard.AcquireVectorIndex(targetVector)
+	if vok {
+		defer releaseIdx()
+	}
+	q, releaseQ, qok := shard.AcquireVectorIndexQueue(targetVector)
+	if qok {
+		defer releaseQ()
+	}
 	require.True(t, vok && qok)
 	return idx, q
 }

--- a/adapters/repos/db/vector_index_queue_test.go
+++ b/adapters/repos/db/vector_index_queue_test.go
@@ -53,7 +53,9 @@ func TestVectorIndexQueueBatchSize(t *testing.T) {
 		})
 	}
 
-	q, ok := shd.GetVectorIndexQueue("")
+	q, release, ok := shd.AcquireVectorIndexQueue("")
+	require.True(t, ok)
+	defer release()
 	require.True(t, ok)
 
 	// ensure the queue doesn't get scheduled


### PR DESCRIPTION
### What's being changed:

Last of the four slots PRs, stacked on #12975. With every caller moved onto the leased accessors, the unleased `GetVectorIndex` and `GetVectorIndexQueue` go away: from the shard, the `ShardLike` interface, the lazy loader, and the mock. A pointer handed out with no release was the one remaining way to use an index without a lease; now there is none, and a vector index drop always waits for the users of that vector.

The ten tests that looked an index or queue up through the old accessors take a lease instead. One new shard-level test pins the whole mechanism end to end: a drop of one named vector waits for a caller holding its index and completes once the caller releases, while a drop of another vector on the same shard goes through at once.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
