### PR TITLE
test(db): install a test's log hook before the index starts its goroutines

### DIFF
--- a/adapters/repos/db/inverted_reindex_rangeable_inmemory_finalize_test.go
+++ b/adapters/repos/db/inverted_reindex_rangeable_inmemory_finalize_test.go
@@ -65,15 +65,18 @@ func firstErrorEntry(hook *test.Hook) *logrus.Entry {
 
 // newRangeableFinalizeTestShard builds a shard+index with the rangeable
 // in-memory knob enabled.
-func newRangeableFinalizeTestShard(t *testing.T, classNamePrefix string) (context.Context, *Shard, *Index, string) {
+// newRangeableFinalizeTestShard builds the shard; indexOpts run on the index
+// before the shard starts, which is where a test installs a log hook: the
+// shard's goroutines read index.logger, so a swap afterwards is a data race.
+func newRangeableFinalizeTestShard(t *testing.T, classNamePrefix string, indexOpts ...func(*Index)) (context.Context, *Shard, *Index, string) {
 	t.Helper()
 	ctx := testCtx()
 	className := classNamePrefix + uuid.NewString()[:8]
 	class := newFilterableToRangeableTestClass(className)
 
+	opts := append([]func(*Index){func(idx *Index) { idx.Config.IndexRangeableInMemory = true }}, indexOpts...)
 	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
-		false, false, false,
-		func(idx *Index) { idx.Config.IndexRangeableInMemory = true })
+		false, false, false, opts...)
 	shard := shd.(*Shard)
 	t.Cleanup(func() { shard.Shutdown(ctx) })
 	return ctx, shard, idx, className
@@ -106,12 +109,11 @@ func setupRangeableFinalizeDegradeFixture(t *testing.T, classNamePrefix string) 
 	const numObjects = 25
 	propName := filterableToRangeablePropName
 
-	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, classNamePrefix)
-
-	// The task captures idx.logger by value at construction, so swap in a
-	// hook-capturing logger first to assert on the ERROR log this fixture drives.
+	// the task captures idx.logger at construction, so the hook logger has to
+	// be the index's from the start to see the ERROR log this fixture drives
 	hookLogger, hook := test.NewNullLogger()
-	idx.logger = hookLogger
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, classNamePrefix,
+		func(idx *Index) { idx.logger = hookLogger })
 
 	putRangeableTestObjects(t, ctx, shard, className, numObjects)
 
@@ -324,10 +326,9 @@ func TestRebuildRangeableInMemoryReps_NilBucketRoutesContextCancellation(t *test
 // migration.
 func TestRebuildRangeableInMemoryReps_NilBucketDegradesWithoutCancellation(t *testing.T) {
 	propName := filterableToRangeablePropName
-	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, "RangeableNilBucketDegrade_")
-
 	hookLogger, hook := test.NewNullLogger()
-	idx.logger = hookLogger
+	ctx, shard, idx, className := newRangeableFinalizeTestShard(t, "RangeableNilBucketDegrade_",
+		func(idx *Index) { idx.logger = hookLogger })
 
 	putRangeableTestObjects(t, ctx, shard, className, 5)
 

--- a/adapters/repos/db/reindex_cleanup_budget_bucket_shutdown_test.go
+++ b/adapters/repos/db/reindex_cleanup_budget_bucket_shutdown_test.go
@@ -50,7 +50,6 @@ func sweepStoppedInABucketShutdown(t *testing.T,
 		func(i *Index) { i.logger = logger })
 	shard := shd.(*Shard)
 	t.Cleanup(func() { shard.Shutdown(testCtx()) })
-	idx.logger = logger
 
 	// A cancelled attempt at gen 2: started but never completed, so the sweep
 	// has to shut its ingest bucket down rather than preserve it.

--- a/adapters/repos/db/shard_drop_refcount_test.go
+++ b/adapters/repos/db/shard_drop_refcount_test.go
@@ -145,11 +145,9 @@ func TestShardDropDrainsRealBatchWrite(t *testing.T) {
 // bounded on purpose, so a reference held past the window must not wedge the
 // delete, and must be logged. Runs for the full drain window (~30s).
 func TestShardDropProceedsWhenDrainTimesOut(t *testing.T) {
-	index, cleanup := initIndexAndPopulate(t, t.TempDir())
-	defer cleanup()
-
 	logger, hook := test.NewNullLogger()
-	index.logger = logger
+	index, cleanup := initIndexAndPopulateWithLogger(t, t.TempDir(), logger)
+	defer cleanup()
 
 	start := time.Now()
 	_, release, dropped := dropTestShard(t, index) // pin is never released
@@ -269,11 +267,9 @@ func TestObjectReadsAfterStoreTeardownReturnErrors(t *testing.T) {
 // outliving the drain must fail on the deregistered bucket rather than
 // dereference nil, and must be reported once.
 func TestObjectWritesAfterStoreTeardownReturnErrors(t *testing.T) {
-	index, cleanup := initIndexAndPopulate(t, t.TempDir())
-	defer cleanup()
-
 	logger, hook := test.NewNullLogger()
-	index.logger = logger
+	index, cleanup := initIndexAndPopulateWithLogger(t, t.TempDir(), logger)
+	defer cleanup()
 
 	_, shard := loadTestShard(t, index)
 	// the state a teardown that outran its drain leaves behind

--- a/adapters/repos/db/shard_shutdown_test.go
+++ b/adapters/repos/db/shard_shutdown_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -135,6 +136,15 @@ func TestShardShutdownWhenIdleEventually(t *testing.T) {
 
 func initIndexAndPopulate(t *testing.T, dirName string) (index *Index, cleanup func()) {
 	logger, _ := test.NewNullLogger()
+	return initIndexAndPopulateWithLogger(t, dirName, logger)
+}
+
+// initIndexAndPopulateWithLogger is initIndexAndPopulate with the caller's
+// logger installed from construction. A test that wants a log hook passes
+// its logger here rather than swapping index.logger afterwards: the index
+// starts its lazy-shard warmup goroutine as soon as it exists, and that
+// goroutine reads the logger, so a later swap is a data race.
+func initIndexAndPopulateWithLogger(t *testing.T, dirName string, logger *logrus.Logger) (index *Index, cleanup func()) {
 	className := "Test"
 
 	// create db


### PR DESCRIPTION
### What's being changed:

Four tests in the shard package captured log entries by overwriting `index.logger` after the index existed. By then the index's lazy-shard warmup goroutine and the shard's own goroutines are already reading that field, so the swap is a data race, and the race detector reported it in `TestShardDropProceedsWhenDrainTimesOut` under load.

The helpers now take the test's logger at construction instead: a logger-taking variant of `initIndexAndPopulate` for the two drop tests, index options on the rangeable finalize helper for its two tests, and the cleanup budget test, which already passed its logger through an option, loses its redundant swap. Test behavior is unchanged; the hooks see the same entries they did, from the start rather than from the swap.

The remaining after-the-fact swaps in this package are on bare `Index` literals that start no goroutines, so they are left alone.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
