### PR TITLE
perf(db): skip the startup shard-size sweep when lazy loading is set explicitly

### DIFF
--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ import (
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/cluster/router"
 	"github.com/weaviate/weaviate/entities/diskio"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/tenantactivity"
@@ -295,7 +297,9 @@ func shouldComputeShardSizes(explicitLazyLoad *bool, localShardCount, countThres
 }
 
 // totalShardSizeBytes returns the cumulative on-disk size (in bytes) of all local
-// shards for a given collection.
+// shards for a given collection. Each shard is a directory walk, so they run
+// concurrently. Once the total is past sizeThresholdBytes the rest are skipped,
+// making the result a lower bound rather than an exact sum.
 func (db *DB) totalShardSizeBytes(className schema.ClassName, shardNames []string, sizeThresholdBytes uint64) uint64 {
 	if len(shardNames) == 0 {
 		return 0
@@ -303,53 +307,58 @@ func (db *DB) totalShardSizeBytes(className schema.ClassName, shardNames []strin
 
 	indexPath := path.Join(db.config.RootPath, indexID(className))
 
-	var total uint64
+	var total atomic.Uint64
+	eg := enterrors.NewErrorGroupWrapper(db.logger)
+	eg.SetLimit(min(len(shardNames), _NUMCPU*2))
+
 	for _, shardName := range shardNames {
-		// Prefer precomputed usage data if available; it is cheap to read
-		// and already contains the full shard storage size.
-		if shardusage.ComputedUsageDataExists(indexPath, shardName) {
-			// the fingerprint of the vector configs is not compared here. The full
-			// shard size on disk does not depend on them.
-			saved, err := shardusage.LoadComputedUsageData(indexPath, shardName)
-			if errors.Is(err, shardusage.ErrUsageVersionMismatch) {
-				// a version bump leaves this behind on every shard that stayed
-				// cold across it; the on-disk size below is exact anyway
-				db.logger.WithField("action", "lazy_shard_auto_detection").
-					WithField("class", className).
-					WithField("shard", shardName).
-					Debugf("pre-calculated shard usage unusable; falling back to on-disk size: %v", err)
-			} else if err != nil {
-				db.logger.WithField("action", "lazy_shard_auto_detection").
-					WithField("class", className).
-					WithField("shard", shardName).
-					Warnf("failed to load pre-calculated shard usage; falling back to on-disk size: %v", err)
-			} else {
-				total += saved.ShardUsage.FullShardStorageBytes
-				if sizeThresholdBytes > 0 && total > sizeThresholdBytes {
-					return total
-				}
-				continue
+		eg.Go(func() error {
+			// total only grows, so a skip here means it is already over the
+			// threshold and stays over: the caller's verdict is unchanged.
+			if sizeThresholdBytes > 0 && total.Load() > sizeThresholdBytes {
+				return nil
 			}
-		}
 
-		shardPath := path.Join(indexPath, shardName)
+			// Prefer precomputed usage data if available; it is cheap to read
+			// and already contains the full shard storage size.
+			if shardusage.ComputedUsageDataExists(indexPath, shardName) {
+				// the fingerprint of the vector configs is not compared here. The full
+				// shard size on disk does not depend on them.
+				saved, err := shardusage.LoadComputedUsageData(indexPath, shardName)
+				if errors.Is(err, shardusage.ErrUsageVersionMismatch) {
+					// a version bump leaves this behind on every shard that stayed
+					// cold across it; the on-disk size below is exact anyway
+					db.logger.WithField("action", "lazy_shard_auto_detection").
+						WithField("class", className).
+						WithField("shard", shardName).
+						Debugf("pre-calculated shard usage unusable; falling back to on-disk size: %v", err)
+				} else if err != nil {
+					db.logger.WithField("action", "lazy_shard_auto_detection").
+						WithField("class", className).
+						WithField("shard", shardName).
+						Warnf("failed to load pre-calculated shard usage; falling back to on-disk size: %v", err)
+				} else {
+					total.Add(saved.ShardUsage.FullShardStorageBytes)
+					return nil
+				}
+			}
 
-		size, err := diskio.GetDirSize(shardPath)
-		if err != nil {
-			db.logger.WithField("action", "lazy_shard_auto_detection").
-				WithField("class", className).
-				WithField("shard", shardName).
-				Warnf("failed to determine shard size; ignoring shard in lazy load auto-detection: %v", err)
-			continue
-		}
+			size, err := diskio.GetDirSize(path.Join(indexPath, shardName))
+			if err != nil {
+				db.logger.WithField("action", "lazy_shard_auto_detection").
+					WithField("class", className).
+					WithField("shard", shardName).
+					Warnf("failed to determine shard size; ignoring shard in lazy load auto-detection: %v", err)
+				return nil
+			}
 
-		total += size
-		if sizeThresholdBytes > 0 && total > sizeThresholdBytes {
-			return total
-		}
+			total.Add(size)
+			return nil
+		})
 	}
+	_ = eg.Wait() // no job returns an error; the wrapper logs a recovered panic
 
-	return total
+	return total.Load()
 }
 
 func (db *DB) LocalTenantActivity(filter tenantactivity.UsageFilter) tenantactivity.ByCollection {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -291,10 +291,7 @@ func shouldComputeShardSizes(explicitLazyLoad *bool, localShardCount, countThres
 	if explicitLazyLoad != nil {
 		return false
 	}
-	if sizeThresholdGB <= 0 {
-		return false
-	}
-	return localShardCount <= countThreshold
+	return sizeThresholdGB > 0 && localShardCount <= countThreshold
 }
 
 // totalShardSizeBytes returns the cumulative on-disk size (in bytes) of all local

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -96,11 +96,8 @@ func (db *DB) init(ctx context.Context) error {
 				if err != nil {
 					return fmt.Errorf("get local shards count for class %q: %w", class.Class, err)
 				}
-				// Only calculate shard sizes if the shard-count condition alone wouldn't
-				// already trigger lazy-loading. This avoids walking all shard directories
-				// on large MT setups where the count exceeds the threshold.
-				if localActiveShardsCount <= db.config.LazyLoadShardCountThreshold &&
-					db.config.LazyLoadShardSizeThresholdGB > 0 {
+				if shouldComputeShardSizes(db.config.EnableLazyLoadShards, localActiveShardsCount,
+					db.config.LazyLoadShardCountThreshold, db.config.LazyLoadShardSizeThresholdGB) {
 					// we do need to calculate shard size if it's MT to be able to decide
 					// to enable lazy load shards based on total size
 					localShards, err := db.schemaReader.LocalShards(class.Class)
@@ -286,6 +283,18 @@ func shouldAutoLazyLoadShards(mtEnabled bool, localShardCount int, totalShardSiz
 	// Check shard size threshold (convert GB to bytes: GB * 1024^3)
 	sizeThresholdBytes := uint64(sizeThresholdGB * 1024 * 1024 * 1024)
 	return totalShardSizeBytes > sizeThresholdBytes
+}
+
+// shouldComputeShardSizes reports whether the local shard directories of a
+// collection have to be measured to decide on lazy loading.
+func shouldComputeShardSizes(explicitLazyLoad *bool, localShardCount, countThreshold int, sizeThresholdGB float64) bool {
+	if explicitLazyLoad != nil {
+		return false
+	}
+	if sizeThresholdGB <= 0 {
+		return false
+	}
+	return localShardCount <= countThreshold
 }
 
 // totalShardSizeBytes returns the cumulative on-disk size (in bytes) of all local

--- a/adapters/repos/db/init_test.go
+++ b/adapters/repos/db/init_test.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"math"
 	"os"
 	"path"
 	"testing"
@@ -131,6 +132,16 @@ func TestShouldComputeShardSizes(t *testing.T) {
 			localShardCount: 10,
 			countThreshold:  1000,
 			sizeThresholdGB: 0,
+			want:            false,
+		},
+		{
+			// LAZY_LOAD_SHARD_SIZE_THRESHOLD_GB=NaN parses and passes validation,
+			// and uint64(NaN*1<<30) is not even the same on every arch, so the
+			// threshold it yields can never be meaningfully met
+			name:            "a NaN size threshold skips",
+			localShardCount: 10,
+			countThreshold:  1000,
+			sizeThresholdGB: math.NaN(),
 			want:            false,
 		},
 		{

--- a/adapters/repos/db/init_test.go
+++ b/adapters/repos/db/init_test.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"path"
@@ -135,9 +136,6 @@ func TestShouldComputeShardSizes(t *testing.T) {
 			want:            false,
 		},
 		{
-			// LAZY_LOAD_SHARD_SIZE_THRESHOLD_GB=NaN parses and passes validation,
-			// and uint64(NaN*1<<30) is not even the same on every arch, so the
-			// threshold it yields can never be meaningfully met
 			name:            "a NaN size threshold skips",
 			localShardCount: 10,
 			countThreshold:  1000,
@@ -230,6 +228,44 @@ func TestTotalShardSizeBytes_FallsBackToDirSizeWhenNoMeta(t *testing.T) {
 
 	got := db.totalShardSizeBytes(className, []string{shardName}, 0)
 	require.Equal(t, uint64(len(data)), got)
+}
+
+func TestTotalShardSizeBytes_Concurrent(t *testing.T) {
+	const shardCount, perShard = 64, 1024
+	const exact = uint64(shardCount * perShard)
+
+	// the caller only reads total > threshold; skipped shards must not change it
+	tests := []struct {
+		name        string
+		threshold   uint64
+		wantVerdict bool
+	}{
+		{"no threshold", 0, true},
+		{"threshold above total", exact * 2, false},
+		{"threshold below total", perShard, true},
+		{"threshold one byte under total", exact - 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			db := &DB{logger: logrus.New(), config: Config{RootPath: tmpDir}}
+			className := schema.ClassName("MyClass")
+			indexPath := path.Join(tmpDir, indexID(className))
+
+			shardNames := make([]string, shardCount)
+			for i := range shardNames {
+				shardNames[i] = fmt.Sprintf("shard%d", i)
+				shardPath := path.Join(indexPath, shardNames[i])
+				require.NoError(t, os.MkdirAll(shardPath, 0o777))
+				require.NoError(t, os.WriteFile(path.Join(shardPath, "data.bin"), make([]byte, perShard), 0o644))
+			}
+
+			got := db.totalShardSizeBytes(className, shardNames, tt.threshold)
+			require.Equal(t, tt.wantVerdict, got > tt.threshold)
+			require.LessOrEqual(t, got, exact)
+		})
+	}
 }
 
 func TestTotalShardSizeBytes_PrefersMetaFileWhenPresent(t *testing.T) {

--- a/adapters/repos/db/init_test.go
+++ b/adapters/repos/db/init_test.go
@@ -89,6 +89,80 @@ func TestApplyLazyShardAutoDetection(t *testing.T) {
 	}
 }
 
+// TestShouldComputeShardSizes pins that the startup shard-size sweep is skipped
+// whenever its result cannot change the lazy-loading decision. The guard used to
+// check only the count and size thresholds, so an explicit EnableLazyLoadShards
+// setting still paid a walk over every shard directory before the decision
+// short-circuited on it.
+func TestShouldComputeShardSizes(t *testing.T) {
+	enabled, disabled := true, false
+
+	tests := []struct {
+		name             string
+		explicitLazyLoad *bool
+		localShardCount  int
+		countThreshold   int
+		sizeThresholdGB  float64
+		want             bool
+	}{
+		{
+			name:            "auto-detection below the count threshold measures",
+			localShardCount: 10,
+			countThreshold:  1000,
+			sizeThresholdGB: 100,
+			want:            true,
+		},
+		{
+			name:            "auto-detection at the count threshold measures",
+			localShardCount: 1000,
+			countThreshold:  1000,
+			sizeThresholdGB: 100,
+			want:            true,
+		},
+		{
+			name:            "auto-detection above the count threshold skips",
+			localShardCount: 1001,
+			countThreshold:  1000,
+			sizeThresholdGB: 100,
+			want:            false,
+		},
+		{
+			name:            "a zero size threshold skips",
+			localShardCount: 10,
+			countThreshold:  1000,
+			sizeThresholdGB: 0,
+			want:            false,
+		},
+		{
+			name:             "an explicit enable skips",
+			explicitLazyLoad: &enabled,
+			localShardCount:  10,
+			countThreshold:   1000,
+			sizeThresholdGB:  100,
+			want:             false,
+		},
+		{
+			name:             "an explicit disable skips",
+			explicitLazyLoad: &disabled,
+			localShardCount:  10,
+			countThreshold:   1000,
+			sizeThresholdGB:  100,
+			want:             false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldComputeShardSizes(
+				tt.explicitLazyLoad,
+				tt.localShardCount,
+				tt.countThreshold,
+				tt.sizeThresholdGB,
+			))
+		})
+	}
+}
+
 // TestNewShard_AbortsWhenUsageFileRemovalFails pins that NewShard propagates a
 // failure to remove the stale precomputed usage file, rather than silently
 // ignoring it. Otherwise the outdated usage.json.tmp survives and later gets

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -134,11 +134,8 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		if err != nil {
 			return fmt.Errorf("get local shards count for class %q: %w", class.Class, err)
 		}
-		// Only calculate shard sizes if the shard-count condition alone wouldn't
-		// already trigger lazy-loading. This avoids walking all shard directories
-		// on large MT setups where the count exceeds the threshold.
-		if localActiveShardsCount <= m.db.config.LazyLoadShardCountThreshold &&
-			m.db.config.LazyLoadShardSizeThresholdGB > 0 {
+		if shouldComputeShardSizes(m.db.config.EnableLazyLoadShards, localActiveShardsCount,
+			m.db.config.LazyLoadShardCountThreshold, m.db.config.LazyLoadShardSizeThresholdGB) {
 			// we do need to calculate shard size if it's MT to be able to decide
 			// to enable lazy load shards based on total size
 			localShards, err := m.db.schemaReader.LocalShards(class.Class)


### PR DESCRIPTION
### What's being changed:
Auto detection for lazy shard loading measures the on-disk size of every local shard of an MT collection on `filepath.Walk` per shard, on the startup critical path. The guard around it checked the count and size thresholds, but not whether auto-detection would run at all.
so this PR skipping it if not needed to avoid extra irrelevant calculation.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
