### PR TITLE
fix(nodes): authz logic on `v1/nodes?output=minimal` when caller has `verbose` perms

### DIFF
--- a/test/acceptance/authz/nodes_test.go
+++ b/test/acceptance/authz/nodes_test.go
@@ -125,6 +125,16 @@ func TestAuthzNodes(t *testing.T) {
 		require.Len(t, resp.Payload.Nodes, 1)
 	})
 
+	t.Run("minimal by class does not reveal whether the class exists", func(t *testing.T) {
+		for _, class := range []string{clsA.Class, "DoesNotExist"} {
+			resp, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithClassName(class).WithOutput(String("minimal")), helper.CreateAuth(customKey))
+			require.Nil(t, err, "class %q", class)
+			require.Len(t, resp.Payload.Nodes, 1)
+			require.Empty(t, resp.Payload.Nodes[0].Shards)
+			require.Nil(t, resp.Payload.Nodes[0].Stats)
+		}
+	})
+
 	t.Run("add read_cluster to custom role", func(t *testing.T) {
 		helper.AddPermissions(t, adminKey, customRole, &models.Permission{Action: &authorization.ReadCluster})
 	})
@@ -161,5 +171,80 @@ func TestAuthzNodes(t *testing.T) {
 		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(String("verbose")), helper.CreateAuth(customKey))
 		require.Nil(t, err)
 		require.Len(t, resp.Payload.Nodes, 1)
+	})
+}
+
+// A verbose read_nodes grant on one collection also allows minimal output,
+// because minimal output carries no data about any class. A minimal request for
+// a named class answers 200 whether or not the class exists, so it cannot be
+// used to learn whether a class exists. A verbose request is still checked
+// against the granted collection and still answers 404 for an unknown class.
+func TestAuthzNodesVerboseImpliesMinimal(t *testing.T) {
+	adminKey := "admin-key"
+	customUser := "custom-user"
+	customKey := "custom-key"
+	roleName := "verbose-only"
+
+	_, down := composeUpShared(t)
+	defer down()
+
+	clsA := articles.ArticlesClass()
+	clsP := articles.ParagraphsClass()
+
+	helper.DeleteClassWithAuthz(t, clsP.Class, helper.CreateAuth(adminKey))
+	helper.DeleteClassWithAuthz(t, clsA.Class, helper.CreateAuth(adminKey))
+	helper.CreateClassAuth(t, clsP, adminKey)
+	helper.CreateClassAuth(t, clsA, adminKey)
+
+	helper.DeleteRole(t, adminKey, roleName)
+	defer helper.DeleteRole(t, adminKey, roleName)
+	helper.CreateRole(t, adminKey, &models.Role{Name: &roleName, Permissions: []*models.Permission{
+		helper.NewNodesPermission().WithAction(authorization.ReadNodes).WithVerbosity(verbosity.OutputVerbose).WithCollection(clsA.Class).Permission(),
+	}})
+	helper.AssignRoleToUser(t, adminKey, roleName, customUser)
+
+	minimal := String(verbosity.OutputMinimal)
+	verbose := String(verbosity.OutputVerbose)
+
+	requireMinimal := func(t *testing.T, payload *models.NodesStatusResponse) {
+		require.Len(t, payload.Nodes, 1)
+		require.Empty(t, payload.Nodes[0].Shards)
+		require.Nil(t, payload.Nodes[0].Stats)
+	}
+
+	t.Run("minimal for all nodes", func(t *testing.T) {
+		resp, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams().WithOutput(minimal), helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		requireMinimal(t, resp.Payload)
+	})
+
+	t.Run("minimal by class for granted, other, and unknown collections", func(t *testing.T) {
+		for _, class := range []string{clsA.Class, clsP.Class, "DoesNotExist"} {
+			resp, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithClassName(class).WithOutput(minimal), helper.CreateAuth(customKey))
+			require.Nil(t, err, "class %q", class)
+			requireMinimal(t, resp.Payload)
+		}
+	})
+
+	t.Run("minimal by unknown class answers 200 for admin too", func(t *testing.T) {
+		resp, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithClassName("DoesNotExist").WithOutput(minimal), helper.CreateAuth(adminKey))
+		require.Nil(t, err)
+		requireMinimal(t, resp.Payload)
+	})
+
+	t.Run("verbose stays denied on other and unknown collections", func(t *testing.T) {
+		for _, class := range []string{clsP.Class, "DoesNotExist"} {
+			_, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithClassName(class).WithOutput(verbose), helper.CreateAuth(customKey))
+			require.NotNil(t, err, "class %q", class)
+			var parsed *nodes.NodesGetClassForbidden
+			require.True(t, errors.As(err, &parsed), "class %q: %v", class, err)
+		}
+	})
+
+	t.Run("verbose by unknown class answers 404 for admin", func(t *testing.T) {
+		_, err := helper.Client(t).Nodes.NodesGetClass(nodes.NewNodesGetClassParams().WithClassName("DoesNotExist").WithOutput(verbose), helper.CreateAuth(adminKey))
+		require.NotNil(t, err)
+		var parsed *nodes.NodesGetClassNotFound
+		require.True(t, errors.As(err, &parsed), "%v", err)
 	})
 }

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -1049,3 +1049,101 @@ func TestNarrowedViewerVsReadOnly_ClusterReadDenied(t *testing.T) {
 		})
 	}
 }
+
+// Minimal nodes output is a subset of verbose output, so any verbose grant also
+// satisfies a minimal request. This does not help a namespaced caller, who is
+// denied every nodes request.
+func TestAuthorize_NodesVerboseImpliesMinimal(t *testing.T) {
+	global := &models.Principal{Username: "alice", UserType: models.UserTypeInputDb}
+	namespaced := &models.Principal{Username: "customer1:alice", Namespace: "customer1", UserType: models.UserTypeInputDb}
+
+	nodesGrant := func(verbosity, collection string) *models.PermissionNodes {
+		return &models.PermissionNodes{Verbosity: &verbosity, Collection: &collection}
+	}
+
+	tests := []struct {
+		name      string
+		nsEnabled bool
+		principal *models.Principal
+		grant     *models.PermissionNodes
+		request   []string
+		wantErr   bool
+	}{
+		{
+			name:      "verbose on all collections grants minimal",
+			principal: global,
+			grant:     nodesGrant("verbose", "*"),
+			request:   authorization.Nodes("minimal"),
+		},
+		{
+			name:      "verbose on one collection grants minimal",
+			principal: global,
+			grant:     nodesGrant("verbose", "Articles"),
+			request:   authorization.Nodes("minimal"),
+		},
+		{
+			name:      "verbose grants minimal on a namespace-enabled cluster",
+			nsEnabled: true,
+			principal: global,
+			grant:     nodesGrant("verbose", "Articles"),
+			request:   authorization.Nodes("minimal"),
+		},
+		{
+			name:      "verbose does not grant minimal to a namespaced caller",
+			nsEnabled: true,
+			principal: namespaced,
+			grant:     nodesGrant("verbose", "*"),
+			request:   authorization.Nodes("minimal"),
+			wantErr:   true,
+		},
+		{
+			name:      "minimal does not grant verbose on one collection",
+			principal: global,
+			grant:     nodesGrant("minimal", ""),
+			request:   authorization.Nodes("verbose", "Articles"),
+			wantErr:   true,
+		},
+		{
+			name:      "minimal does not grant verbose on all collections",
+			principal: global,
+			grant:     nodesGrant("minimal", ""),
+			request:   authorization.Nodes("verbose"),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			var m *Manager
+			var err error
+			if tt.nsEnabled {
+				m, err = setupNSEnabledTestManager(t, logger, "customer1")
+			} else {
+				m, err = setupTestManager(t, logger)
+			}
+			require.NoError(t, err)
+
+			policies, err := conv.PermissionToPolicies(&models.Permission{
+				Action: authorization.String(authorization.ReadNodes),
+				Nodes:  tt.grant,
+			})
+			require.NoError(t, err)
+			role := conv.PrefixRoleName("nodes-role")
+			for _, p := range policies {
+				_, err := m.casbin.AddNamedPolicy("p", role, p.Resource, p.Verb, p.Domain)
+				require.NoError(t, err)
+			}
+			_, err = m.casbin.AddRoleForUser(conv.UserNameWithTypeFromId(tt.principal.Username, authentication.AuthTypeDb), role)
+			require.NoError(t, err)
+
+			err = m.Authorize(context.Background(), tt.principal, authorization.READ, tt.request...)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorAs(t, err, new(authzErrors.Forbidden))
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -297,6 +297,12 @@ var (
 	groupsPrefix     = authorization.GroupsDomain + "/"
 )
 
+// Nodes resource path and prefix; see weaviateKeyMatch.
+var (
+	nodesMinimalResource = authorization.NodesDomain + "/verbosity/minimal"
+	nodesVerbosePrefix   = authorization.NodesDomain + "/verbosity/verbose/"
+)
+
 // rejectNamespacedRootSubjects fails startup when a namespace-qualified subject
 // is configured for the root role: a namespaced principal must never inherit
 // cluster-wide root. read-only has no static user list (groups only, deferred
@@ -354,9 +360,14 @@ func operatorOnlyResource(path string) bool {
 
 // weaviateKeyMatch runs the `/shards/#` vs `/shards/.*` carve-out then
 // KeyMatch5: a collection-level request must not match a per-tenant policy.
+//
+// A verbose nodes policy on any collection also satisfies the minimal nodes request.
 func weaviateKeyMatch(reqObj, polObj string) bool {
 	if strings.HasSuffix(reqObj, "/shards/#") && strings.HasSuffix(polObj, "/shards/.*") {
 		return false
+	}
+	if reqObj == nodesMinimalResource && strings.HasPrefix(polObj, nodesVerbosePrefix) {
+		return true
 	}
 	return casbinutil.KeyMatch5(reqObj, polObj)
 }

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -63,6 +63,10 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 		}
 	}
 
+	if verbosityString != verbosity.OutputVerbose {
+		className, shardName = "", ""
+	}
+
 	status, err := m.db.GetNodeStatus(ctxWithTimeout, className, shardName, verbosityString)
 	if err != nil {
 		return nil, err

--- a/usecases/nodes/handler_test.go
+++ b/usecases/nodes/handler_test.go
@@ -72,9 +72,13 @@ func (*forbiddenError) Error() string { return "forbidden" }
 // plus cluster-wide Stats and BatchStats, mirroring what LocalNodeStatus builds.
 type fakeDB struct {
 	status []*models.NodeStatus
+
+	// gotClass and gotShard record the filters of the last GetNodeStatus call.
+	gotClass, gotShard string
 }
 
 func (f *fakeDB) GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error) {
+	f.gotClass, f.gotShard = className, shardName
 	return f.status, nil
 }
 
@@ -173,6 +177,51 @@ func TestGetNodeStatus_VerboseFiltersCrossClassStats(t *testing.T) {
 
 			require.NotNil(t, status[0].BatchStats,
 				"node-wide batch stats leak no per-class data and must always be preserved")
+		})
+	}
+}
+
+// A minimal request must reach the DB without a class or shard filter. A
+// filtered lookup answers 404 for an unknown class and 200 otherwise. That
+// would let a caller authorized only on the minimal resource, which names no
+// class, learn whether a class exists.
+func TestGetNodeStatus_MinimalDropsClassFilter(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	tests := []struct {
+		name      string
+		output    string
+		allowed   []string
+		wantClass string
+		wantShard string
+	}{
+		{
+			name:      "minimal drops class and shard",
+			output:    verbosity.OutputMinimal,
+			allowed:   authorization.Nodes(verbosity.OutputMinimal),
+			wantClass: "",
+			wantShard: "",
+		},
+		{
+			name:      "verbose keeps class and shard",
+			output:    verbosity.OutputVerbose,
+			allowed:   []string{nodeResource("Foo")},
+			wantClass: "Foo",
+			wantShard: "s1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &fakeDB{status: []*models.NodeStatus{{Name: "node1"}}}
+			m := NewManager(logger, &allowlistAuthorizer{allowed: tt.allowed}, db, nil,
+				rbacconf.Config{Enabled: true}, time.Second)
+
+			status, err := m.GetNodeStatus(context.Background(), &models.Principal{}, "Foo", "s1", tt.output)
+			require.NoError(t, err)
+			require.Len(t, status, 1)
+			require.Equal(t, tt.wantClass, db.gotClass)
+			require.Equal(t, tt.wantShard, db.gotShard)
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:

- Ensure that users with verbose permissions on `v1/nodes` can also call on `output=minimal` without error
- Fix user with output=minimal being able to sniff collection existences

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
