### PR TITLE
graphql: add fusionType to Aggregate hybrid search

### DIFF
--- a/adapters/handlers/graphql/local/aggregate/aggregate.go
+++ b/adapters/handlers/graphql/local/aggregate/aggregate.go
@@ -63,8 +63,24 @@ func classFields(databaseSchema *schema.SchemaWithAliases,
 ) (*graphql.Object, error) {
 	fields := graphql.Fields{}
 
+	// needs to be defined outside the individual class as there can only be one definition of an enum.
+	// Named distinctly from Get's "FusionEnum" because both end up registered in the same overall
+	// GraphQL schema (see adapters/handlers/graphql/local/local.go), and the schema builder requires
+	// unique type names.
+	fusionAlgoEnum := graphql.NewEnum(graphql.EnumConfig{
+		Name: "AggregateFusionEnum",
+		Values: graphql.EnumValueConfigMap{
+			"rankedFusion": &graphql.EnumValueConfig{
+				Value: common_filters.HybridRankedFusion,
+			},
+			"relativeScoreFusion": &graphql.EnumValueConfig{
+				Value: common_filters.HybridRelativeScoreFusion,
+			},
+		},
+	})
+
 	for _, class := range databaseSchema.Objects.Classes {
-		field, err := classField(class, class.Description, config, modulesProvider, authorizer)
+		field, err := classField(class, class.Description, config, modulesProvider, authorizer, fusionAlgoEnum)
 		if err != nil {
 			return nil, err
 		}
@@ -89,6 +105,7 @@ func classFields(databaseSchema *schema.SchemaWithAliases,
 
 func classField(class *models.Class, description string,
 	config config.Config, modulesProvider ModulesProvider, authorizer authorization.Authorizer,
+	fusionEnum *graphql.Enum,
 ) (*graphql.Field, error) {
 	metaClassName := fmt.Sprintf("Aggregate%s", class.Class)
 
@@ -135,7 +152,7 @@ func classField(class *models.Class, description string,
 				Description: descriptions.First,
 				Type:        graphql.Int,
 			},
-			"hybrid": hybridArgument(fieldsObject, class, modulesProvider),
+			"hybrid": hybridArgument(fieldsObject, class, modulesProvider, fusionEnum),
 		},
 		Resolve: makeResolveClass(authorizer, modulesProvider, class),
 	}

--- a/adapters/handlers/graphql/local/aggregate/aggregate.go
+++ b/adapters/handlers/graphql/local/aggregate/aggregate.go
@@ -31,9 +31,13 @@ type ModulesProvider interface {
 	ExtractSearchParams(arguments map[string]interface{}, className string) (map[string]interface{}, map[string]*dto.TargetCombination)
 }
 
-// Build the Aggregate Kinds schema
+// Build the Aggregate Kinds schema. fusionEnum is the shared hybrid-search
+// fusion-algorithm enum constructed once by the caller (see
+// common_filters.NewFusionEnum) and also passed to get.Build, so Get and
+// Aggregate register the same GraphQL type rather than two separately named
+// ones.
 func Build(dbSchema *schema.SchemaWithAliases, config config.Config,
-	modulesProvider ModulesProvider, authorizer authorization.Authorizer,
+	modulesProvider ModulesProvider, authorizer authorization.Authorizer, fusionEnum *graphql.Enum,
 ) (*graphql.Field, error) {
 	if len(dbSchema.Objects.Classes) == 0 {
 		return nil, utils.ErrEmptySchema
@@ -42,7 +46,7 @@ func Build(dbSchema *schema.SchemaWithAliases, config config.Config,
 	var err error
 	var localAggregateObjects *graphql.Object
 	if len(dbSchema.Objects.Classes) > 0 {
-		localAggregateObjects, err = classFields(dbSchema, config, modulesProvider, authorizer)
+		localAggregateObjects, err = classFields(dbSchema, config, modulesProvider, authorizer, fusionEnum)
 		if err != nil {
 			return nil, err
 		}
@@ -60,24 +64,9 @@ func Build(dbSchema *schema.SchemaWithAliases, config config.Config,
 
 func classFields(databaseSchema *schema.SchemaWithAliases,
 	config config.Config, modulesProvider ModulesProvider, authorizer authorization.Authorizer,
+	fusionAlgoEnum *graphql.Enum,
 ) (*graphql.Object, error) {
 	fields := graphql.Fields{}
-
-	// needs to be defined outside the individual class as there can only be one definition of an enum.
-	// Named distinctly from Get's "FusionEnum" because both end up registered in the same overall
-	// GraphQL schema (see adapters/handlers/graphql/local/local.go), and the schema builder requires
-	// unique type names.
-	fusionAlgoEnum := graphql.NewEnum(graphql.EnumConfig{
-		Name: "AggregateFusionEnum",
-		Values: graphql.EnumValueConfigMap{
-			"rankedFusion": &graphql.EnumValueConfig{
-				Value: common_filters.HybridRankedFusion,
-			},
-			"relativeScoreFusion": &graphql.EnumValueConfig{
-				Value: common_filters.HybridRelativeScoreFusion,
-			},
-		},
-	})
 
 	for _, class := range databaseSchema.Objects.Classes {
 		field, err := classField(class, class.Description, config, modulesProvider, authorizer, fusionAlgoEnum)

--- a/adapters/handlers/graphql/local/aggregate/helpers_for_test.go
+++ b/adapters/handlers/graphql/local/aggregate/helpers_for_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	testhelper "github.com/weaviate/weaviate/adapters/handlers/graphql/test/helper"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/models"
@@ -45,7 +46,7 @@ func (m *mockAuthorizer) FilterAuthorizedResources(ctx context.Context, principa
 }
 
 func newMockResolver(cfg config.Config) *mockResolver {
-	field, err := Build(&testhelper.CarSchema, cfg, nil, &mockAuthorizer{})
+	field, err := Build(&testhelper.CarSchema, cfg, nil, &mockAuthorizer{}, common_filters.NewFusionEnum())
 	if err != nil {
 		panic(fmt.Sprintf("could not build graphql test schema: %s", err))
 	}

--- a/adapters/handlers/graphql/local/aggregate/hybrid_search.go
+++ b/adapters/handlers/graphql/local/aggregate/hybrid_search.go
@@ -23,14 +23,14 @@ import (
 )
 
 func hybridArgument(classObject *graphql.Object,
-	class *models.Class, modulesProvider ModulesProvider,
+	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) *graphql.ArgumentConfig {
 	prefix := fmt.Sprintf("AggregateObjects%s", class.Class)
 	return &graphql.ArgumentConfig{
 		Type: graphql.NewInputObject(
 			graphql.InputObjectConfig{
 				Name:        fmt.Sprintf("%sHybridInpObj", prefix),
-				Fields:      hybridOperands(classObject, class, modulesProvider),
+				Fields:      hybridOperands(classObject, class, modulesProvider, fusionEnum),
 				Description: "Hybrid search",
 			},
 		),
@@ -38,7 +38,7 @@ func hybridArgument(classObject *graphql.Object,
 }
 
 func hybridOperands(classObject *graphql.Object,
-	class *models.Class, modulesProvider ModulesProvider,
+	class *models.Class, modulesProvider ModulesProvider, fusionEnum *graphql.Enum,
 ) graphql.InputObjectConfigFieldMap {
 	ss := graphql.NewInputObject(graphql.InputObjectConfig{
 		Name:   class.Class + "HybridSubSearch",
@@ -70,6 +70,10 @@ func hybridOperands(classObject *graphql.Object,
 		"properties": &graphql.InputObjectFieldConfig{
 			Description: "Properties to search",
 			Type:        graphql.NewList(graphql.String),
+		},
+		"fusionType": &graphql.InputObjectFieldConfig{
+			Description: "Algorithm used for fusing results from vector and keyword search",
+			Type:        fusionEnum,
 		},
 		"bm25SearchOperator": common_filters.GenerateBM25SearchOperatorFields(prefixName),
 		"searches": &graphql.InputObjectFieldConfig{

--- a/adapters/handlers/graphql/local/aggregate/resolver_test.go
+++ b/adapters/handlers/graphql/local/aggregate/resolver_test.go
@@ -12,6 +12,7 @@
 package aggregate
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,71 @@ func groupCarByMadeByManufacturerName() *filters.Path {
 			Class:    schema.ClassName("Manufacturer"),
 			Property: schema.PropertyName("name"),
 		},
+	}
+}
+
+// hybridFusionTestCase builds a testCase asserting that an explicit
+// `fusionType` argument on an Aggregate hybrid search is propagated to the
+// resolver params with the corresponding FusionAlgorithm value. It is shared
+// by the "hybrid explicit rankedFusion" and "hybrid explicit
+// relativeScoreFusion" cases below, which are otherwise identical apart from
+// the fusionType literal and the resulting algorithm value.
+func hybridFusionTestCase(name, fusionTypeLiteral string, fusionAlgorithm int) testCase {
+	return testCase{
+		name: name,
+		query: fmt.Sprintf(`{
+			Aggregate {
+				Car(
+					hybrid: {query:"apple", maxVectorDistance: 0.5, fusionType: %s}
+				) {
+					horsepower {
+						mean
+					}
+				}
+			}
+		}`, fusionTypeLiteral),
+		expectedProps: []aggregation.ParamProperty{
+			{
+				Name:        "horsepower",
+				Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
+			},
+		},
+		expectedNearHybrid: &searchparams.HybridSearch{
+			Distance:        0.5,
+			WithDistance:    true,
+			Alpha:           0.75,
+			Query:           "apple",
+			FusionAlgorithm: fusionAlgorithm,
+			Type:            "hybrid",
+			// SubSearches is declared as `interface{}` in HybridSearch, so
+			// this must be an explicitly-typed nil slice (matching what the
+			// resolver produces for an empty sub-search list) rather than a
+			// bare `nil`, which would instead produce an untyped-nil
+			// interface and fail to compare equal.
+			SubSearches: []searchparams.WeightedSearchResult(nil),
+		},
+		resolverReturn: []aggregation.Group{
+			{
+				Properties: map[string]aggregation.Property{
+					"horsepower": {
+						Type: aggregation.PropertyTypeNumerical,
+						NumericalAggregations: map[string]interface{}{
+							"mean": 275.7773,
+						},
+					},
+				},
+			},
+		},
+		expectedResults: []result{{
+			pathToField: []string{"Aggregate", "Car"},
+			expectedValue: []interface{}{
+				map[string]interface{}{
+					"horsepower": map[string]interface{}{
+						"mean": 275.7773,
+					},
+				},
+			},
+		}},
 	}
 }
 
@@ -516,108 +582,8 @@ func Test_Resolve(t *testing.T) {
 				},
 			}},
 		},
-		testCase{
-			name: "hybrid explicit rankedFusion",
-			query: `{
-				Aggregate {
-					Car(
-						hybrid: {query:"apple", maxVectorDistance: 0.5, fusionType: rankedFusion}
-					) {
-						horsepower {
-							mean
-						}
-					}
-				}
-			}`,
-			expectedProps: []aggregation.ParamProperty{
-				{
-					Name:        "horsepower",
-					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
-				},
-			},
-			expectedNearHybrid: &searchparams.HybridSearch{
-				Distance:        0.5,
-				WithDistance:    true,
-				Alpha:           0.75,
-				Query:           "apple",
-				FusionAlgorithm: 0,
-				Type:            "hybrid",
-				SubSearches:     emptySubsearch,
-			},
-			resolverReturn: []aggregation.Group{
-				{
-					Properties: map[string]aggregation.Property{
-						"horsepower": {
-							Type: aggregation.PropertyTypeNumerical,
-							NumericalAggregations: map[string]interface{}{
-								"mean": 275.7773,
-							},
-						},
-					},
-				},
-			},
-			expectedResults: []result{{
-				pathToField: []string{"Aggregate", "Car"},
-				expectedValue: []interface{}{
-					map[string]interface{}{
-						"horsepower": map[string]interface{}{
-							"mean": 275.7773,
-						},
-					},
-				},
-			}},
-		},
-		testCase{
-			name: "hybrid explicit relativeScoreFusion",
-			query: `{
-				Aggregate {
-					Car(
-						hybrid: {query:"apple", maxVectorDistance: 0.5, fusionType: relativeScoreFusion}
-					) {
-						horsepower {
-							mean
-						}
-					}
-				}
-			}`,
-			expectedProps: []aggregation.ParamProperty{
-				{
-					Name:        "horsepower",
-					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
-				},
-			},
-			expectedNearHybrid: &searchparams.HybridSearch{
-				Distance:        0.5,
-				WithDistance:    true,
-				Alpha:           0.75,
-				Query:           "apple",
-				FusionAlgorithm: 1,
-				Type:            "hybrid",
-				SubSearches:     emptySubsearch,
-			},
-			resolverReturn: []aggregation.Group{
-				{
-					Properties: map[string]aggregation.Property{
-						"horsepower": {
-							Type: aggregation.PropertyTypeNumerical,
-							NumericalAggregations: map[string]interface{}{
-								"mean": 275.7773,
-							},
-						},
-					},
-				},
-			},
-			expectedResults: []result{{
-				pathToField: []string{"Aggregate", "Car"},
-				expectedValue: []interface{}{
-					map[string]interface{}{
-						"horsepower": map[string]interface{}{
-							"mean": 275.7773,
-						},
-					},
-				},
-			}},
-		},
+		hybridFusionTestCase("hybrid explicit rankedFusion", "rankedFusion", 0),
+		hybridFusionTestCase("hybrid explicit relativeScoreFusion", "relativeScoreFusion", 1),
 		testCase{
 			name: "single prop: mean with a where filter",
 			query: `{

--- a/adapters/handlers/graphql/local/aggregate/resolver_test.go
+++ b/adapters/handlers/graphql/local/aggregate/resolver_test.go
@@ -517,6 +517,108 @@ func Test_Resolve(t *testing.T) {
 			}},
 		},
 		testCase{
+			name: "hybrid explicit rankedFusion",
+			query: `{
+				Aggregate {
+					Car(
+						hybrid: {query:"apple", maxVectorDistance: 0.5, fusionType: rankedFusion}
+					) {
+						horsepower {
+							mean
+						}
+					}
+				}
+			}`,
+			expectedProps: []aggregation.ParamProperty{
+				{
+					Name:        "horsepower",
+					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
+				},
+			},
+			expectedNearHybrid: &searchparams.HybridSearch{
+				Distance:        0.5,
+				WithDistance:    true,
+				Alpha:           0.75,
+				Query:           "apple",
+				FusionAlgorithm: 0,
+				Type:            "hybrid",
+				SubSearches:     emptySubsearch,
+			},
+			resolverReturn: []aggregation.Group{
+				{
+					Properties: map[string]aggregation.Property{
+						"horsepower": {
+							Type: aggregation.PropertyTypeNumerical,
+							NumericalAggregations: map[string]interface{}{
+								"mean": 275.7773,
+							},
+						},
+					},
+				},
+			},
+			expectedResults: []result{{
+				pathToField: []string{"Aggregate", "Car"},
+				expectedValue: []interface{}{
+					map[string]interface{}{
+						"horsepower": map[string]interface{}{
+							"mean": 275.7773,
+						},
+					},
+				},
+			}},
+		},
+		testCase{
+			name: "hybrid explicit relativeScoreFusion",
+			query: `{
+				Aggregate {
+					Car(
+						hybrid: {query:"apple", maxVectorDistance: 0.5, fusionType: relativeScoreFusion}
+					) {
+						horsepower {
+							mean
+						}
+					}
+				}
+			}`,
+			expectedProps: []aggregation.ParamProperty{
+				{
+					Name:        "horsepower",
+					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
+				},
+			},
+			expectedNearHybrid: &searchparams.HybridSearch{
+				Distance:        0.5,
+				WithDistance:    true,
+				Alpha:           0.75,
+				Query:           "apple",
+				FusionAlgorithm: 1,
+				Type:            "hybrid",
+				SubSearches:     emptySubsearch,
+			},
+			resolverReturn: []aggregation.Group{
+				{
+					Properties: map[string]aggregation.Property{
+						"horsepower": {
+							Type: aggregation.PropertyTypeNumerical,
+							NumericalAggregations: map[string]interface{}{
+								"mean": 275.7773,
+							},
+						},
+					},
+				},
+			},
+			expectedResults: []result{{
+				pathToField: []string{"Aggregate", "Car"},
+				expectedValue: []interface{}{
+					map[string]interface{}{
+						"horsepower": map[string]interface{}{
+							"mean": 275.7773,
+						},
+					},
+				},
+			}},
+		},
+		testCase{
 			name: "single prop: mean with a where filter",
 			query: `{
 				Aggregate {

--- a/adapters/handlers/graphql/local/aggregate/resolver_test.go
+++ b/adapters/handlers/graphql/local/aggregate/resolver_test.go
@@ -58,6 +58,45 @@ func groupCarByMadeByManufacturerName() *filters.Path {
 	}
 }
 
+// hybridAggregateProps, hybridAggregateResolverReturn, and
+// hybridAggregateExpectedResults are the property/response/assertion shape
+// shared by every "Car" hybrid-aggregate test case that only aggregates
+// horsepower.mean over an unmodified result set (the "hybrid vector
+// distance" case above and every hybridFusionTestCase case below) - the
+// resolver's request/response contract doesn't change based on the
+// fusionType or distance arguments, so there's nothing case-specific left to
+// assert here beyond what's already covered by expectedNearHybrid.
+var (
+	hybridAggregateProps = []aggregation.ParamProperty{
+		{
+			Name:        "horsepower",
+			Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
+		},
+	}
+	hybridAggregateResolverReturn = []aggregation.Group{
+		{
+			Properties: map[string]aggregation.Property{
+				"horsepower": {
+					Type: aggregation.PropertyTypeNumerical,
+					NumericalAggregations: map[string]interface{}{
+						"mean": 275.7773,
+					},
+				},
+			},
+		},
+	}
+	hybridAggregateExpectedResults = []result{{
+		pathToField: []string{"Aggregate", "Car"},
+		expectedValue: []interface{}{
+			map[string]interface{}{
+				"horsepower": map[string]interface{}{
+					"mean": 275.7773,
+				},
+			},
+		},
+	}}
+)
+
 // hybridFusionTestCase builds a testCase asserting that an explicit
 // `fusionType` argument on an Aggregate hybrid search is propagated to the
 // resolver params with the corresponding FusionAlgorithm value. It is shared
@@ -78,12 +117,7 @@ func hybridFusionTestCase(name, fusionTypeLiteral string, fusionAlgorithm int) t
 				}
 			}
 		}`, fusionTypeLiteral),
-		expectedProps: []aggregation.ParamProperty{
-			{
-				Name:        "horsepower",
-				Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
-			},
-		},
+		expectedProps: hybridAggregateProps,
 		expectedNearHybrid: &searchparams.HybridSearch{
 			Distance:        0.5,
 			WithDistance:    true,
@@ -98,28 +132,8 @@ func hybridFusionTestCase(name, fusionTypeLiteral string, fusionAlgorithm int) t
 			// interface and fail to compare equal.
 			SubSearches: []searchparams.WeightedSearchResult(nil),
 		},
-		resolverReturn: []aggregation.Group{
-			{
-				Properties: map[string]aggregation.Property{
-					"horsepower": {
-						Type: aggregation.PropertyTypeNumerical,
-						NumericalAggregations: map[string]interface{}{
-							"mean": 275.7773,
-						},
-					},
-				},
-			},
-		},
-		expectedResults: []result{{
-			pathToField: []string{"Aggregate", "Car"},
-			expectedValue: []interface{}{
-				map[string]interface{}{
-					"horsepower": map[string]interface{}{
-						"mean": 275.7773,
-					},
-				},
-			},
-		}},
+		resolverReturn:  hybridAggregateResolverReturn,
+		expectedResults: hybridAggregateExpectedResults,
 	}
 }
 
@@ -544,12 +558,7 @@ func Test_Resolve(t *testing.T) {
 					}
 				}
 			}`,
-			expectedProps: []aggregation.ParamProperty{
-				{
-					Name:        "horsepower",
-					Aggregators: []aggregation.Aggregator{aggregation.MeanAggregator},
-				},
-			},
+			expectedProps: hybridAggregateProps,
 			expectedNearHybrid: &searchparams.HybridSearch{
 				Distance:        0.5,
 				WithDistance:    true,
@@ -559,28 +568,8 @@ func Test_Resolve(t *testing.T) {
 				Type:            "hybrid",
 				SubSearches:     emptySubsearch,
 			},
-			resolverReturn: []aggregation.Group{
-				{
-					Properties: map[string]aggregation.Property{
-						"horsepower": {
-							Type: aggregation.PropertyTypeNumerical,
-							NumericalAggregations: map[string]interface{}{
-								"mean": 275.7773,
-							},
-						},
-					},
-				},
-			},
-			expectedResults: []result{{
-				pathToField: []string{"Aggregate", "Car"},
-				expectedValue: []interface{}{
-					map[string]interface{}{
-						"horsepower": map[string]interface{}{
-							"mean": 275.7773,
-						},
-					},
-				},
-			}},
+			resolverReturn:  hybridAggregateResolverReturn,
+			expectedResults: hybridAggregateExpectedResults,
 		},
 		hybridFusionTestCase("hybrid explicit rankedFusion", "rankedFusion", 0),
 		hybridFusionTestCase("hybrid explicit relativeScoreFusion", "relativeScoreFusion", 1),

--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -14,6 +14,7 @@ package common_filters
 import (
 	"fmt"
 
+	"github.com/tailor-platform/graphql"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
 
@@ -26,6 +27,28 @@ const (
 	HybridRelativeScoreFusion
 )
 const HybridFusionDefault = HybridRelativeScoreFusion
+
+// NewFusionEnum returns the GraphQL enum type used to select a hybrid
+// search's fusion algorithm. Callers must construct this exactly once and
+// pass the same *graphql.Enum instance into every builder that uses it
+// (currently Get and Aggregate) - a GraphQL schema can only have one type
+// definition per name, and constructing two separate instances (even with
+// identical Values) forces them to be registered under different names,
+// which then stops a client from reusing one GraphQL variable across both
+// operations.
+func NewFusionEnum() *graphql.Enum {
+	return graphql.NewEnum(graphql.EnumConfig{
+		Name: "FusionEnum",
+		Values: graphql.EnumValueConfigMap{
+			"rankedFusion": &graphql.EnumValueConfig{
+				Value: HybridRankedFusion,
+			},
+			"relativeScoreFusion": &graphql.EnumValueConfig{
+				Value: HybridRelativeScoreFusion,
+			},
+		},
+	})
+}
 
 func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*searchparams.HybridSearch, *dto.TargetCombination, error) {
 	var subsearches []interface{}

--- a/adapters/handlers/graphql/local/common_filters/hybrid_test.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid_test.go
@@ -40,6 +40,18 @@ func TestHybrid(t *testing.T) {
 			outputCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: nilweights},
 		},
 		{
+			// omitting fusionType must keep the default (relativeScoreFusion) for backward compatibility
+			input:             map[string]interface{}{"vector": []float32{1.0, 2.0, 3.0}},
+			output:            &searchparams.HybridSearch{Vector: []float32{1.0, 2.0, 3.0}, SubSearches: ss, Type: "hybrid", Alpha: 0.75, FusionAlgorithm: HybridFusionDefault},
+			outputCombination: nil,
+		},
+		{
+			// explicitly setting fusionType must override the default
+			input:             map[string]interface{}{"vector": []float32{1.0, 2.0, 3.0}, "fusionType": HybridRankedFusion},
+			output:            &searchparams.HybridSearch{Vector: []float32{1.0, 2.0, 3.0}, SubSearches: ss, Type: "hybrid", Alpha: 0.75, FusionAlgorithm: HybridRankedFusion},
+			outputCombination: nil,
+		},
+		{
 			input:             map[string]interface{}{"targetVectors": []interface{}{"target1", "target2"}, "searches": []interface{}{map[string]interface{}{"nearVector": map[string]interface{}{"vector": []float32{float32(1.0), float32(2.0), float32(3.0)}}}}},
 			output:            &searchparams.HybridSearch{NearVectorParams: &searchparams.NearVector{Vectors: []models.Vector{[]float32{1, 2, 3}, []float32{1, 2, 3}}}, TargetVectors: []string{"target1", "target2"}, SubSearches: ss, Type: "hybrid", Alpha: 0.75, FusionAlgorithm: 1},
 			outputCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: nilweights},

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -31,10 +31,11 @@ type classBuilder struct {
 	beaconClass     *graphql.Object
 	logger          logrus.FieldLogger
 	modulesProvider ModulesProvider
+	fusionEnum      *graphql.Enum
 }
 
 func newClassBuilder(schema *schema.SchemaWithAliases, logger logrus.FieldLogger,
-	modulesProvider ModulesProvider, authorizer authorization.Authorizer,
+	modulesProvider ModulesProvider, authorizer authorization.Authorizer, fusionEnum *graphql.Enum,
 ) *classBuilder {
 	b := &classBuilder{}
 
@@ -42,6 +43,7 @@ func newClassBuilder(schema *schema.SchemaWithAliases, logger logrus.FieldLogger
 	b.schema = schema
 	b.modulesProvider = modulesProvider
 	b.authorizer = authorizer
+	b.fusionEnum = fusionEnum
 
 	b.initKnownClasses()
 	b.initBeaconClass()
@@ -69,22 +71,9 @@ func (b *classBuilder) objects() (*graphql.Object, error) {
 }
 
 func (b *classBuilder) kinds(kindSchema *models.Schema) (*graphql.Object, error) {
-	// needs to be defined outside the individual class as there can only be one definition of an enum
-	fusionAlgoEnum := graphql.NewEnum(graphql.EnumConfig{
-		Name: "FusionEnum",
-		Values: graphql.EnumValueConfigMap{
-			"rankedFusion": &graphql.EnumValueConfig{
-				Value: common_filters.HybridRankedFusion,
-			},
-			"relativeScoreFusion": &graphql.EnumValueConfig{
-				Value: common_filters.HybridRelativeScoreFusion,
-			},
-		},
-	})
-
 	classFields := graphql.Fields{}
 	for _, class := range kindSchema.Classes {
-		classField, err := b.classField(class, fusionAlgoEnum)
+		classField, err := b.classField(class, b.fusionEnum)
 		if err != nil {
 			return nil, fmt.Errorf("could not build class for %s", class.Class)
 		}

--- a/adapters/handlers/graphql/local/get/get.go
+++ b/adapters/handlers/graphql/local/get/get.go
@@ -33,15 +33,19 @@ type ModulesProvider interface {
 	GetAll() []modulecapabilities.Module
 }
 
-// Build the Local.Get part of the graphql tree
+// Build the Local.Get part of the graphql tree. fusionEnum is the shared
+// hybrid-search fusion-algorithm enum constructed once by the caller (see
+// common_filters.NewFusionEnum) and also passed to aggregate.Build, so Get
+// and Aggregate register the same GraphQL type rather than two separately
+// named ones.
 func Build(schema *schema.SchemaWithAliases, logger logrus.FieldLogger,
-	modulesProvider ModulesProvider, authorizer authorization.Authorizer,
+	modulesProvider ModulesProvider, authorizer authorization.Authorizer, fusionEnum *graphql.Enum,
 ) (*graphql.Field, error) {
 	if len(schema.Objects.Classes) == 0 {
 		return nil, utils.ErrEmptySchema
 	}
 
-	cb := newClassBuilder(schema, logger, modulesProvider, authorizer)
+	cb := newClassBuilder(schema, logger, modulesProvider, authorizer, fusionEnum)
 
 	var err error
 	var objects *graphql.Object

--- a/adapters/handlers/graphql/local/get/helper_test.go
+++ b/adapters/handlers/graphql/local/get/helper_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tailor-platform/graphql/language/ast"
 
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/descriptions"
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	test_helper "github.com/weaviate/weaviate/adapters/handlers/graphql/test/helper"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
@@ -649,7 +650,7 @@ func newMockResolver() *mockResolver {
 func newMockResolverWithVectorizer(vectorizer string) *mockResolver {
 	logger, _ := test.NewNullLogger()
 	simpleSchema := test_helper.CreateSimpleSchema(vectorizer)
-	field, err := Build(&simpleSchema, logger, getFakeModulesProvider(), getFakeAuthorizer())
+	field, err := Build(&simpleSchema, logger, getFakeModulesProvider(), getFakeAuthorizer(), common_filters.NewFusionEnum())
 	if err != nil {
 		panic(fmt.Sprintf("could not build graphql test schema: %s", err))
 	}
@@ -663,7 +664,7 @@ func newMockResolverWithVectorizer(vectorizer string) *mockResolver {
 
 func newMockResolverWithNoModules() *mockResolver {
 	logger, _ := test.NewNullLogger()
-	field, err := Build(&test_helper.SimpleSchema, logger, nil, getFakeAuthorizer())
+	field, err := Build(&test_helper.SimpleSchema, logger, nil, getFakeAuthorizer(), common_filters.NewFusionEnum())
 	if err != nil {
 		panic(fmt.Sprintf("could not build graphql test schema: %s", err))
 	}

--- a/adapters/handlers/graphql/local/local.go
+++ b/adapters/handlers/graphql/local/local.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tailor-platform/graphql"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/aggregate"
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/explore"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/get"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -27,12 +28,17 @@ import (
 func Build(dbSchema *schema.SchemaWithAliases, logger logrus.FieldLogger,
 	config config.Config, modulesProvider *modules.Provider, authorizer authorization.Authorizer,
 ) (graphql.Fields, error) {
-	getField, err := get.Build(dbSchema, logger, modulesProvider, authorizer)
+	// Constructed once and shared between Get and Aggregate: a GraphQL schema
+	// can only have one type definition per name, so both builders must use
+	// this exact instance rather than each building their own "FusionEnum".
+	fusionEnum := common_filters.NewFusionEnum()
+
+	getField, err := get.Build(dbSchema, logger, modulesProvider, authorizer, fusionEnum)
 	if err != nil {
 		return nil, err
 	}
 
-	aggregateField, err := aggregate.Build(dbSchema, config, modulesProvider, authorizer)
+	aggregateField, err := aggregate.Build(dbSchema, config, modulesProvider, authorizer, fusionEnum)
 	if err != nil {
 		return nil, err
 	}

--- a/modules/text2vec-contextionary/helpers_test.go
+++ b/modules/text2vec-contextionary/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tailor-platform/graphql"
 	"github.com/tailor-platform/graphql/language/ast"
 
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/explore"
 	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/get"
 	test_helper "github.com/weaviate/weaviate/adapters/handlers/graphql/test/helper"
@@ -338,7 +339,7 @@ func getFakeAuthorizer() *fakeAuthorizer {
 
 func newMockResolver() *mockResolver {
 	logger, _ := test.NewNullLogger()
-	field, err := get.Build(&test_helper.SimpleSchema, logger, getFakeModulesProvider(), getFakeAuthorizer())
+	field, err := get.Build(&test_helper.SimpleSchema, logger, getFakeModulesProvider(), getFakeAuthorizer(), common_filters.NewFusionEnum())
 	if err != nil {
 		panic(fmt.Sprintf("could not build graphql test schema: %s", err))
 	}


### PR DESCRIPTION
Fixes #12983 

### What's being changed:

`Get{ClassName}(hybrid: {...})` already exposes `fusionType` to choose between
`rankedFusion` (legacy) and `relativeScoreFusion`; `Aggregate{ClassName}(hybrid: {...})`
was missing the same field, silently locking Aggregate hybrid queries to the default
fusion algorithm even though the shared extraction path (`ExtractHybridSearch`) already
supports selecting it.

This adds `fusionType` to Aggregate's hybrid GraphQL schema and threads it through to
`aggregation.Params`, mirroring Get's existing wiring.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Not necessary — schema/resolver-level change, no storage/execution-path risk.
- [x] All new code is covered by tests where it is reasonable. Added `hybrid_explicit_rankedFusion` and `hybrid_explicit_relativeScoreFusion` cases to `aggregate/resolver_test.go`, confirming both fusion algorithms now correctly propagate into `aggregation.Params`.
- [x] Performance tests have been run or not necessary. Not necessary — additive schema field, no change to existing query paths when omitted.