### PR TITLE
shard: add the vectorIndexMapping type

### DIFF
--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -181,3 +181,30 @@ func putVectorIndexRecord(b *shardmeta.Batch, name string, rec vectorIndexRecord
 	}
 	return b.Put([]byte(vectorIndexMappingKey(name)), value)
 }
+
+// Put writes or overwrites name's record. The mapping must be initialized:
+// a record with no format version is what Load refuses.
+func (m *vectorIndexMapping) Put(name string, rec vectorIndexRecord) error {
+	err := m.ns.Update(func(b *shardmeta.Batch) error {
+		err := requireVectorIndexMappingInitialized(b)
+		if err != nil {
+			return err
+		}
+		return putVectorIndexRecord(b, name, rec)
+	})
+	if err != nil {
+		return fmt.Errorf("put vector index mapping record %q: %w", name, err)
+	}
+	return nil
+}
+
+func requireVectorIndexMappingInitialized(b *shardmeta.Batch) error {
+	v, err := b.Get([]byte(vectorIndexMappingFormatVersionKey))
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return errVectorIndexMappingUninitialized
+	}
+	return nil
+}

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -148,14 +148,14 @@ func (m *vectorIndexMapping) Initialize(records map[string]vectorIndexRecord) er
 	err := m.ns.Update(func(b *shardmeta.Batch) error {
 		existing, err := b.Get([]byte(vectorIndexMappingFormatVersionKey))
 		if err != nil {
-			return err
+			return fmt.Errorf("read format version: %w", err)
 		}
 		if existing != nil {
 			return errVectorIndexMappingInitialized
 		}
 		err = b.Put([]byte(vectorIndexMappingFormatVersionKey), []byte(vectorIndexMappingFormatVersion))
 		if err != nil {
-			return err
+			return fmt.Errorf("write format version: %w", err)
 		}
 		for name, rec := range records {
 			err = putVectorIndexRecord(b, name, rec)
@@ -203,7 +203,7 @@ func (m *vectorIndexMapping) Put(name string, rec vectorIndexRecord) error {
 func requireVectorIndexMappingInitialized(b *shardmeta.Batch) error {
 	v, err := b.Get([]byte(vectorIndexMappingFormatVersionKey))
 	if err != nil {
-		return err
+		return fmt.Errorf("read format version: %w", err)
 	}
 	if v == nil {
 		return errVectorIndexMappingUninitialized

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -208,3 +208,19 @@ func requireVectorIndexMappingInitialized(b *shardmeta.Batch) error {
 	}
 	return nil
 }
+
+// Delete removes name's record. A record that is not there is already
+// deleted, so a retried drop succeeds.
+func (m *vectorIndexMapping) Delete(name string) error {
+	err := m.ns.Update(func(b *shardmeta.Batch) error {
+		err := requireVectorIndexMappingInitialized(b)
+		if err != nil {
+			return err
+		}
+		return b.Delete([]byte(vectorIndexMappingKey(name)))
+	})
+	if err != nil {
+		return fmt.Errorf("delete vector index mapping record %q: %w", name, err)
+	}
+	return nil
+}

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -1,0 +1,81 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
+)
+
+// The mapping's on-disk layout inside index.db. Every key and field name
+// below is read by later versions; changing one is a format change.
+const (
+	vectorIndexMappingNamespace        = "vector_index_mapping"
+	vectorIndexMappingFormatVersionKey = "format_version"
+	vectorIndexMappingFormatVersion    = "1"
+	vectorIndexMappingLegacyKey        = "legacy"
+	vectorIndexMappingNamedPrefix      = "named/"
+)
+
+// Record states. There is no dropped state: the schema carries deletion
+// intent, and a record outlives it until cleanup completes.
+const (
+	vectorIndexStateCreating = "creating"
+	vectorIndexStateReady    = "ready"
+)
+
+var (
+	errVectorIndexMappingUninitialized = errors.New("vector index mapping is not initialized")
+	errVectorIndexMappingInitialized   = errors.New("vector index mapping is already initialized")
+)
+
+// vectorIndexRecord is what the shard persists about one logical vector:
+// where its index lives on disk, which implementation opens it, and whether
+// creation completed.
+type vectorIndexRecord struct {
+	PhysicalID string `json:"physical_id"`
+	IndexType  string `json:"index_type"`
+	State      string `json:"state"`
+}
+
+// vectorIndexMapping is a shard's persisted view of which physical vector
+// indexes it has: one record per logical vector, in index.db. The legacy
+// vector is the empty name.
+type vectorIndexMapping struct {
+	ns *shardmeta.Namespace
+}
+
+func newVectorIndexMapping(db *shardmeta.DB) *vectorIndexMapping {
+	return &vectorIndexMapping{ns: db.Namespace(vectorIndexMappingNamespace)}
+}
+
+// vectorIndexMappingKey is the on-disk key of a logical vector name.
+func vectorIndexMappingKey(name string) string {
+	if name == "" {
+		return vectorIndexMappingLegacyKey
+	}
+	return vectorIndexMappingNamedPrefix + name
+}
+
+// vectorIndexMappingName is the inverse of vectorIndexMappingKey. ok is
+// false for a key that does not name a vector.
+func vectorIndexMappingName(key string) (name string, ok bool) {
+	if key == vectorIndexMappingLegacyKey {
+		return "", true
+	}
+	if strings.HasPrefix(key, vectorIndexMappingNamedPrefix) {
+		return strings.TrimPrefix(key, vectorIndexMappingNamedPrefix), true
+	}
+	return "", false
+}

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -137,3 +137,47 @@ func (m *vectorIndexMapping) Load() (records map[string]vectorIndexRecord, initi
 	}
 	return records, initialized, nil
 }
+
+// Initialize writes the format version and every record in one
+// transaction, or nothing. It is the first-load step for a shard whose
+// Load reported initialized=false, and it refuses to run on a mapping
+// that already has a format version.
+func (m *vectorIndexMapping) Initialize(records map[string]vectorIndexRecord) error {
+	err := m.ns.Update(func(b *shardmeta.Batch) error {
+		existing, err := b.Get([]byte(vectorIndexMappingFormatVersionKey))
+		if err != nil {
+			return err
+		}
+		if existing != nil {
+			return errVectorIndexMappingInitialized
+		}
+		err = b.Put([]byte(vectorIndexMappingFormatVersionKey), []byte(vectorIndexMappingFormatVersion))
+		if err != nil {
+			return err
+		}
+		for name, rec := range records {
+			err = putVectorIndexRecord(b, name, rec)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("initialize vector index mapping: %w", err)
+	}
+	return nil
+}
+
+// putVectorIndexRecord validates and writes one record inside a batch.
+func putVectorIndexRecord(b *shardmeta.Batch, name string, rec vectorIndexRecord) error {
+	err := rec.validate()
+	if err != nil {
+		return fmt.Errorf("record %q: %w", name, err)
+	}
+	value, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("record %q: %w", name, err)
+	}
+	return b.Put([]byte(vectorIndexMappingKey(name)), value)
+}

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -12,7 +12,9 @@
 package db
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
@@ -78,4 +80,60 @@ func vectorIndexMappingName(key string) (name string, ok bool) {
 		return strings.TrimPrefix(key, vectorIndexMappingNamedPrefix), true
 	}
 	return "", false
+}
+
+// validate rejects a record that no version of this code writes.
+func (r vectorIndexRecord) validate() error {
+	if r.PhysicalID == "" {
+		return errors.New("empty physical id")
+	}
+	if r.IndexType == "" {
+		return errors.New("empty index type")
+	}
+	if r.State != vectorIndexStateCreating && r.State != vectorIndexStateReady {
+		return fmt.Errorf("unknown state %q", r.State)
+	}
+	return nil
+}
+
+// Load reads every record, keyed by logical name. initialized is false when
+// the namespace has no format version, which is a shard from before the
+// mapping existed and the signal for first-load initialization. Anything
+// the mapping cannot account for fails the load: an unknown format version,
+// a key that names no vector, a record that does not parse or validate.
+func (m *vectorIndexMapping) Load() (records map[string]vectorIndexRecord, initialized bool, err error) {
+	records = map[string]vectorIndexRecord{}
+	err = m.ns.ForEach(func(key, value []byte) error {
+		k := string(key)
+		if k == vectorIndexMappingFormatVersionKey {
+			if string(value) != vectorIndexMappingFormatVersion {
+				return fmt.Errorf("unsupported format version %q, this binary reads %q",
+					value, vectorIndexMappingFormatVersion)
+			}
+			initialized = true
+			return nil
+		}
+		name, ok := vectorIndexMappingName(k)
+		if !ok {
+			return fmt.Errorf("unknown key %q", k)
+		}
+		var rec vectorIndexRecord
+		err := json.Unmarshal(value, &rec)
+		if err != nil {
+			return fmt.Errorf("record %q: %w", name, err)
+		}
+		err = rec.validate()
+		if err != nil {
+			return fmt.Errorf("record %q: %w", name, err)
+		}
+		records[name] = rec
+		return nil
+	})
+	if err != nil {
+		return nil, false, fmt.Errorf("load vector index mapping: %w", err)
+	}
+	if !initialized && len(records) > 0 {
+		return nil, false, errors.New("load vector index mapping: records without a format version")
+	}
+	return records, initialized, nil
 }

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -71,13 +71,15 @@ func vectorIndexMappingKey(name string) string {
 }
 
 // vectorIndexMappingName is the inverse of vectorIndexMappingKey. ok is
-// false for a key that does not name a vector.
+// false for a key that does not name a vector, including a bare "named/":
+// the empty name is the legacy vector, and only the legacy key may say so.
 func vectorIndexMappingName(key string) (name string, ok bool) {
 	if key == vectorIndexMappingLegacyKey {
 		return "", true
 	}
-	if strings.HasPrefix(key, vectorIndexMappingNamedPrefix) {
-		return strings.TrimPrefix(key, vectorIndexMappingNamedPrefix), true
+	name, found := strings.CutPrefix(key, vectorIndexMappingNamedPrefix)
+	if found && name != "" {
+		return name, true
 	}
 	return "", false
 }

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -188,3 +188,60 @@ func TestVectorIndexMapping_Initialize(t *testing.T) {
 		assert.Empty(t, records)
 	})
 }
+
+func TestVectorIndexMapping_Put(t *testing.T) {
+	t.Run("writes and overwrites one record", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		require.NoError(t, m.Initialize(nil))
+
+		creating := vectorIndexRecord{PhysicalID: "vectors_title", IndexType: "hnsw", State: "creating"}
+		require.NoError(t, m.Put("title", creating))
+		records, _, err := m.Load()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]vectorIndexRecord{"title": creating}, records)
+
+		ready := creating
+		ready.State = "ready"
+		require.NoError(t, m.Put("title", ready))
+		records, _, err = m.Load()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]vectorIndexRecord{"title": ready}, records)
+
+		// the legacy vector is the empty name
+		legacy := vectorIndexRecord{PhysicalID: "main", IndexType: "hnsw", State: "ready"}
+		require.NoError(t, m.Put("", legacy))
+		records, _, err = m.Load()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]vectorIndexRecord{"title": ready, "": legacy}, records)
+	})
+
+	t.Run("refuses an uninitialized mapping", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		err := m.Put("title", vectorIndexRecord{PhysicalID: "vectors_title", IndexType: "hnsw", State: "ready"})
+		require.ErrorIs(t, err, errVectorIndexMappingUninitialized)
+		_, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.False(t, initialized)
+	})
+
+	tests := []struct {
+		name    string
+		rec     vectorIndexRecord
+		wantErr string
+	}{
+		{name: "unknown state", rec: vectorIndexRecord{PhysicalID: "vectors_title", IndexType: "hnsw", State: "done"}, wantErr: `state "done"`},
+		{name: "empty physical id", rec: vectorIndexRecord{IndexType: "hnsw", State: "ready"}, wantErr: "physical id"},
+		{name: "empty index type", rec: vectorIndexRecord{PhysicalID: "vectors_title", State: "ready"}, wantErr: "index type"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, _ := newTestVectorIndexMapping(t)
+			require.NoError(t, m.Initialize(nil))
+			err := m.Put("title", tt.rec)
+			require.ErrorContains(t, err, tt.wantErr)
+			records, _, err := m.Load()
+			require.NoError(t, err)
+			assert.Empty(t, records)
+		})
+	}
+}

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -54,10 +54,11 @@ func TestVectorIndexMapping_KeyLayout(t *testing.T) {
 		})
 	}
 
-	_, ok := vectorIndexMappingName("format_version")
-	assert.False(t, ok)
-	_, ok = vectorIndexMappingName("unknown")
-	assert.False(t, ok)
+	// keys that name no vector; a bare "named/" would alias the legacy vector
+	for _, key := range []string{"format_version", "unknown", "named/", "named"} {
+		_, ok := vectorIndexMappingName(key)
+		assert.False(t, ok, key)
+	}
 }
 
 func TestVectorIndexMapping_Load(t *testing.T) {
@@ -109,6 +110,7 @@ func TestVectorIndexMapping_Load(t *testing.T) {
 	}{
 		{name: "unknown format version", noVersion: true, key: "format_version", value: "2", wantErr: "format version"},
 		{name: "unknown key", key: "something", value: "x", wantErr: `unknown key "something"`},
+		{name: "bare named prefix", key: "named/", value: `{"physical_id":"main","index_type":"hnsw","state":"ready"}`, wantErr: `unknown key "named/"`},
 		{name: "unparsable value", key: "named/title", value: "{", wantErr: `record "title"`},
 		{name: "unknown state", key: "named/title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"gone"}`, wantErr: `state "gone"`},
 		{name: "empty physical id", key: "named/title", value: `{"physical_id":"","index_type":"hnsw","state":"ready"}`, wantErr: "physical id"},

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -1,0 +1,61 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+func newTestVectorIndexMapping(t *testing.T) (*vectorIndexMapping, *shardmeta.DB) {
+	t.Helper()
+	db, err := shardmeta.Open(t.TempDir(), entlsmkv.BoltFlockTimeout)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return newVectorIndexMapping(db), db
+}
+
+// TestVectorIndexMapping_KeyLayout pins the on-disk keys. They are read by
+// every later version, so a change here is a format change, not a rename.
+func TestVectorIndexMapping_KeyLayout(t *testing.T) {
+	assert.Equal(t, "vector_index_mapping", vectorIndexMappingNamespace)
+	assert.Equal(t, "format_version", vectorIndexMappingFormatVersionKey)
+	assert.Equal(t, "1", vectorIndexMappingFormatVersion)
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "", key: "legacy"},
+		{name: "title", key: "named/title"},
+		{name: "default", key: "named/default"},
+		{name: "with/slash", key: "named/with/slash"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			assert.Equal(t, tt.key, vectorIndexMappingKey(tt.name))
+			name, ok := vectorIndexMappingName(tt.key)
+			require.True(t, ok)
+			assert.Equal(t, tt.name, name)
+		})
+	}
+
+	_, ok := vectorIndexMappingName("format_version")
+	assert.False(t, ok)
+	_, ok = vectorIndexMappingName("unknown")
+	assert.False(t, ok)
+}

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -245,3 +245,36 @@ func TestVectorIndexMapping_Put(t *testing.T) {
 		})
 	}
 }
+
+func TestVectorIndexMapping_Delete(t *testing.T) {
+	t.Run("removes one record and leaves the rest", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		legacy := vectorIndexRecord{PhysicalID: "main", IndexType: "hnsw", State: "ready"}
+		title := vectorIndexRecord{PhysicalID: "vectors_title", IndexType: "flat", State: "ready"}
+		require.NoError(t, m.Initialize(map[string]vectorIndexRecord{"": legacy, "title": title}))
+
+		require.NoError(t, m.Delete("title"))
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Equal(t, map[string]vectorIndexRecord{"": legacy}, records)
+
+		require.NoError(t, m.Delete(""))
+		records, initialized, err = m.Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Empty(t, records)
+	})
+
+	t.Run("a missing record is already deleted", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		require.NoError(t, m.Initialize(nil))
+		require.NoError(t, m.Delete("title"))
+	})
+
+	t.Run("refuses an uninitialized mapping", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		err := m.Delete("title")
+		require.ErrorIs(t, err, errVectorIndexMappingUninitialized)
+	})
+}

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -59,3 +59,71 @@ func TestVectorIndexMapping_KeyLayout(t *testing.T) {
 	_, ok = vectorIndexMappingName("unknown")
 	assert.False(t, ok)
 }
+
+func TestVectorIndexMapping_Load(t *testing.T) {
+	put := func(t *testing.T, db *shardmeta.DB, key, value string) {
+		t.Helper()
+		require.NoError(t, db.Namespace(vectorIndexMappingNamespace).Put([]byte(key), []byte(value)))
+	}
+
+	t.Run("empty db is uninitialized", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.False(t, initialized)
+		assert.Empty(t, records)
+	})
+
+	t.Run("reads every record under its logical name", func(t *testing.T) {
+		m, db := newTestVectorIndexMapping(t)
+		put(t, db, "format_version", "1")
+		put(t, db, "legacy", `{"physical_id":"main","index_type":"hnsw","state":"ready"}`)
+		put(t, db, "named/title", `{"physical_id":"vectors_title","index_type":"dynamic","state":"ready"}`)
+		put(t, db, "named/summary", `{"physical_id":"vectors_summary","index_type":"flat","state":"creating"}`)
+
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Equal(t, map[string]vectorIndexRecord{
+			"":        {PhysicalID: "main", IndexType: "hnsw", State: "ready"},
+			"title":   {PhysicalID: "vectors_title", IndexType: "dynamic", State: "ready"},
+			"summary": {PhysicalID: "vectors_summary", IndexType: "flat", State: "creating"},
+		}, records)
+	})
+
+	t.Run("initialized with no records", func(t *testing.T) {
+		m, db := newTestVectorIndexMapping(t)
+		put(t, db, "format_version", "1")
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Empty(t, records)
+	})
+
+	tests := []struct {
+		name      string
+		noVersion bool // do not write format_version "1" first
+		key       string
+		value     string
+		wantErr   string
+	}{
+		{name: "unknown format version", noVersion: true, key: "format_version", value: "2", wantErr: "format version"},
+		{name: "unknown key", key: "something", value: "x", wantErr: `unknown key "something"`},
+		{name: "unparsable value", key: "named/title", value: "{", wantErr: `record "title"`},
+		{name: "unknown state", key: "named/title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"gone"}`, wantErr: `state "gone"`},
+		{name: "empty physical id", key: "named/title", value: `{"physical_id":"","index_type":"hnsw","state":"ready"}`, wantErr: "physical id"},
+		{name: "empty index type", key: "named/title", value: `{"physical_id":"vectors_title","index_type":"","state":"ready"}`, wantErr: "index type"},
+		{name: "record without format version", noVersion: true, key: "named/title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"ready"}`, wantErr: "format version"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, db := newTestVectorIndexMapping(t)
+			if !tt.noVersion {
+				put(t, db, "format_version", "1")
+			}
+			put(t, db, tt.key, tt.value)
+			_, _, err := m.Load()
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -127,3 +127,64 @@ func TestVectorIndexMapping_Load(t *testing.T) {
 		})
 	}
 }
+
+func TestVectorIndexMapping_Initialize(t *testing.T) {
+	t.Run("writes the format version and every record at once", func(t *testing.T) {
+		m, db := newTestVectorIndexMapping(t)
+		err := m.Initialize(map[string]vectorIndexRecord{
+			"":      {PhysicalID: "main", IndexType: "hnsw", State: "ready"},
+			"title": {PhysicalID: "vectors_title", IndexType: "flat", State: "ready"},
+		})
+		require.NoError(t, err)
+
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Len(t, records, 2)
+		assert.Equal(t, vectorIndexRecord{PhysicalID: "main", IndexType: "hnsw", State: "ready"}, records[""])
+		assert.Equal(t, vectorIndexRecord{PhysicalID: "vectors_title", IndexType: "flat", State: "ready"}, records["title"])
+
+		// the bytes on disk are the pinned layout
+		ns := db.Namespace(vectorIndexMappingNamespace)
+		v, err := ns.Get([]byte("format_version"))
+		require.NoError(t, err)
+		assert.Equal(t, "1", string(v))
+		v, err = ns.Get([]byte("named/title"))
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"physical_id":"vectors_title","index_type":"flat","state":"ready"}`, string(v))
+	})
+
+	t.Run("no records is a valid initialization", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		require.NoError(t, m.Initialize(nil))
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Empty(t, records)
+	})
+
+	t.Run("refuses to initialize twice", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		require.NoError(t, m.Initialize(nil))
+		err := m.Initialize(map[string]vectorIndexRecord{
+			"title": {PhysicalID: "vectors_title", IndexType: "flat", State: "ready"},
+		})
+		require.ErrorIs(t, err, errVectorIndexMappingInitialized)
+		records, _, err := m.Load()
+		require.NoError(t, err)
+		assert.Empty(t, records)
+	})
+
+	t.Run("an invalid record writes nothing", func(t *testing.T) {
+		m, _ := newTestVectorIndexMapping(t)
+		err := m.Initialize(map[string]vectorIndexRecord{
+			"":      {PhysicalID: "main", IndexType: "hnsw", State: "ready"},
+			"title": {PhysicalID: "vectors_title", IndexType: "flat", State: "bogus"},
+		})
+		require.ErrorContains(t, err, `record "title"`)
+		records, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.False(t, initialized)
+		assert.Empty(t, records)
+	})
+}


### PR DESCRIPTION
### What's being changed:

The `vectorIndexMapping` type, in its own file `shard_vector_mapping.go`: a shard's persisted view of which physical vector indexes it has, one record per logical vector in the shard's `index.db`. This is the "Mapping" section of the logical-to-physical vector index mapping RFC (design in `.claude/plans/PR4-vector-index-mapping.md`). Stacked on #12993, which adds the two shardmeta primitives it uses.

A record holds the physical ID, the index type, and a state, `creating` or `ready`, as JSON under the namespace `vector_index_mapping`. The legacy vector is the key `legacy`, a named vector is `named/<name>`, and a `format_version` key marks the mapping as initialized. For a shard with a legacy hnsw vector, a named dynamic vector `title`, and a flat vector `summary` whose creation is in progress, the namespace holds:

```
format_version   1
legacy           {"physical_id":"main","index_type":"hnsw","state":"ready"}
named/title      {"physical_id":"vectors_title","index_type":"dynamic","state":"ready"}
named/summary    {"physical_id":"vectors_summary","index_type":"flat","state":"creating"}
```

Those bytes are the compatibility surface and a test pins them. `Load` reads everything once and fails on anything it cannot account for: an unknown format version, a key that names no vector, a record that does not parse or validate. `Initialize` writes the format version and every record in one transaction and refuses to run twice. `Put` and `Delete` change one record and refuse an uninitialized mapping.

Nothing calls the type yet, the same shape as the slots type PR: the surface lands, the callers follow. Next in the series: `index.db` opened for every shard, then startup, then live creation.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
