### PR TITLE
shard: open index.db for every shard, add the vector index storage probe and sync

### DIFF
--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -96,6 +96,14 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	if idx == nil {
 		return fmt.Errorf("index for collection %q not found", collection)
 	}
+	// A loaded shard has already been swept: by the marker apply's drop if it
+	// was loaded then, or by its own load, which removes a dropped vector's
+	// files before it opens anything. Sweeping it here by path would delete
+	// storage under a live shard, and wait out the lock on its index.db for
+	// every target. The offline route below is for cold shards only.
+	if loadedShard(idx.shards.Load(shardName)) != nil {
+		return nil
+	}
 	helper := newVectorDropIndexHelper()
 	class := idx.getClass()
 	for _, target := range targets {
@@ -206,4 +214,18 @@ func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Cont
 		return nil
 	}
 	return fmt.Errorf("drop-vector finalize: bounded retry exhausted: %w", lastErr)
+}
+
+// loadedShard returns the *Shard behind a ShardLike when it is loaded, and
+// nil for a missing or cold shard. It never loads one.
+func loadedShard(shard ShardLike) *Shard {
+	switch s := shard.(type) {
+	case *Shard:
+		return s
+	case *LazyLoadShard:
+		if s.isLoaded() {
+			return s.shard
+		}
+	}
+	return nil
 }

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -98,7 +98,7 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	}
 	// A loaded shard retries its own drop: idempotent, it finishes a drop that
 	// failed part-way, and it never opens index.db against its own lock.
-	if loaded := loadedShard(idx.shards.Load(shardName)); loaded != nil {
+	if loaded := idx.shards.loaded(shardName); loaded != nil {
 		done, err := loaded.retryDroppedVectorIndexes(targets)
 		if done || err != nil {
 			return err
@@ -231,17 +231,4 @@ func (s *Shard) retryDroppedVectorIndexes(targets []string) (done bool, err erro
 		}
 	}
 	return true, nil
-}
-
-// loadedShard returns the loaded *Shard behind shard, or nil. It never loads.
-func loadedShard(shard ShardLike) *Shard {
-	switch s := shard.(type) {
-	case *Shard:
-		return s
-	case *LazyLoadShard:
-		if s.isLoaded() {
-			return s.shard
-		}
-	}
-	return nil
 }

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -96,13 +96,17 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	if idx == nil {
 		return fmt.Errorf("index for collection %q not found", collection)
 	}
-	// A loaded shard has already been swept: by the marker apply's drop if it
-	// was loaded then, or by its own load, which removes a dropped vector's
-	// files before it opens anything. Sweeping it here by path would delete
-	// storage under a live shard, and wait out the lock on its index.db for
-	// every target. The offline route below is for cold shards only.
-	if loadedShard(idx.shards.Load(shardName)) != nil {
-		return nil
+	// A loaded shard owns its files, so its drop is retried through the shard
+	// rather than swept by path: the retry is idempotent (a slot, bucket or
+	// directory already gone costs a lookup), it finishes a drop that failed
+	// part-way, and it never opens index.db offline against the shard's own
+	// lock. The offline route below is for cold shards, and for a shard
+	// caught shutting down, whose handle is going away.
+	if loaded := loadedShard(idx.shards.Load(shardName)); loaded != nil {
+		done, err := loaded.retryDroppedVectorIndexes(targets)
+		if done || err != nil {
+			return err
+		}
 	}
 	helper := newVectorDropIndexHelper()
 	class := idx.getClass()
@@ -214,6 +218,24 @@ func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Cont
 		return nil
 	}
 	return fmt.Errorf("drop-vector finalize: bounded retry exhausted: %w", lastErr)
+}
+
+// retryDroppedVectorIndexes re-runs the shard's own drop for each target, held
+// against shutdown for the duration. done is false when the shard is already
+// shutting down, and the caller takes the offline route instead.
+func (s *Shard) retryDroppedVectorIndexes(targets []string) (done bool, err error) {
+	release, err := s.preventShutdown()
+	if err != nil {
+		return false, nil
+	}
+	defer release()
+	for _, target := range targets {
+		err := s.DropVectorIndex(context.Background(), target)
+		if err != nil {
+			return true, fmt.Errorf("retry drop of vector %q on loaded shard: %w", target, err)
+		}
+	}
+	return true, nil
 }
 
 // loadedShard returns the *Shard behind a ShardLike when it is loaded, and

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -96,12 +96,8 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	if idx == nil {
 		return fmt.Errorf("index for collection %q not found", collection)
 	}
-	// A loaded shard owns its files, so its drop is retried through the shard
-	// rather than swept by path: the retry is idempotent (a slot, bucket or
-	// directory already gone costs a lookup), it finishes a drop that failed
-	// part-way, and it never opens index.db offline against the shard's own
-	// lock. The offline route below is for cold shards, and for a shard
-	// caught shutting down, whose handle is going away.
+	// A loaded shard retries its own drop: idempotent, it finishes a drop that
+	// failed part-way, and it never opens index.db against its own lock.
 	if loaded := loadedShard(idx.shards.Load(shardName)); loaded != nil {
 		done, err := loaded.retryDroppedVectorIndexes(targets)
 		if done || err != nil {
@@ -220,9 +216,8 @@ func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Cont
 	return fmt.Errorf("drop-vector finalize: bounded retry exhausted: %w", lastErr)
 }
 
-// retryDroppedVectorIndexes re-runs the shard's own drop for each target, held
-// against shutdown for the duration. done is false when the shard is already
-// shutting down, and the caller takes the offline route instead.
+// retryDroppedVectorIndexes re-runs the shard's drop for each target, pinned
+// against shutdown. done is false when the shard is already shutting down.
 func (s *Shard) retryDroppedVectorIndexes(targets []string) (done bool, err error) {
 	release, err := s.preventShutdown()
 	if err != nil {
@@ -238,8 +233,7 @@ func (s *Shard) retryDroppedVectorIndexes(targets []string) (done bool, err erro
 	return true, nil
 }
 
-// loadedShard returns the *Shard behind a ShardLike when it is loaded, and
-// nil for a missing or cold shard. It never loads one.
+// loadedShard returns the loaded *Shard behind shard, or nil. It never loads.
 func loadedShard(shard ShardLike) *Shard {
 	switch s := shard.(type) {
 	case *Shard:

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -87,6 +87,13 @@ func FlatMetadataFileNameForID(physicalID string) string {
 	return FlatMetadataFileName(PhysicalIDSuffix(physicalID))
 }
 
+// HNSWCommitLogDirNameForID names the hnsw commit log directory of a
+// physical index ID, under the shard directory. The ID-based twin of
+// GetHNSWCommitLogDirName.
+func HNSWCommitLogDirNameForID(physicalID string) string {
+	return physicalID + ".hnsw.commitlog.d"
+}
+
 // A multivector index keeps one bucket of its own, named off the index ID:
 // muvera encodings when muvera is on, node-to-doc mappings when it is off. The
 // two are mutually exclusive.

--- a/adapters/repos/db/helpers/helpers.go
+++ b/adapters/repos/db/helpers/helpers.go
@@ -87,9 +87,7 @@ func FlatMetadataFileNameForID(physicalID string) string {
 	return FlatMetadataFileName(PhysicalIDSuffix(physicalID))
 }
 
-// HNSWCommitLogDirNameForID names the hnsw commit log directory of a
-// physical index ID, under the shard directory. The ID-based twin of
-// GetHNSWCommitLogDirName.
+// HNSWCommitLogDirNameForID is GetHNSWCommitLogDirName by physical ID.
 func HNSWCommitLogDirNameForID(physicalID string) string {
 	return physicalID + ".hnsw.commitlog.d"
 }

--- a/adapters/repos/db/helpers/helpers_test.go
+++ b/adapters/repos/db/helpers/helpers_test.go
@@ -146,19 +146,20 @@ func TestPhysicalNamesForID(t *testing.T) {
 		raw        string
 		compressed string
 		flatMeta   string
+		hnswDir    string
 	}{
 		// legacy unnamed vector: ID "main", but raw bucket "vectors" —
 		// the historical asymmetry that must never change
-		{"main", "", "vectors", "vectors_compressed", "meta.db"},
-		{"vectors_title", "title", "vectors_title", "vectors_compressed_title", "meta_title.db"},
-		{"vectors_de_DE", "de_DE", "vectors_de_DE", "vectors_compressed_de_DE", "meta_de_DE.db"},
+		{"main", "", "vectors", "vectors_compressed", "meta.db", "main.hnsw.commitlog.d"},
+		{"vectors_title", "title", "vectors_title", "vectors_compressed_title", "meta_title.db", "vectors_title.hnsw.commitlog.d"},
+		{"vectors_de_DE", "de_DE", "vectors_de_DE", "vectors_compressed_de_DE", "meta_de_DE.db", "vectors_de_DE.hnsw.commitlog.d"},
 		// hfresh centroid hnsw for a named vector: suffix keeps the
 		// "_centroids" tail, exactly what the old strip-based derivation gave
-		{"vectors_title_centroids", "title_centroids", "vectors_title_centroids", "vectors_compressed_title_centroids", "meta_title_centroids.db"},
+		{"vectors_title_centroids", "title_centroids", "vectors_title_centroids", "vectors_compressed_title_centroids", "meta_title_centroids.db", "vectors_title_centroids.hnsw.commitlog.d"},
 		// IDs outside the vectors_/main scheme (geo."prop",
 		// "main_centroids"): suffix "" — mirrors the old CutPrefix fallback
-		{"geo.location", "", "vectors", "vectors_compressed", "meta.db"},
-		{"main_centroids", "", "vectors", "vectors_compressed", "meta.db"},
+		{"geo.location", "", "vectors", "vectors_compressed", "meta.db", "geo.location.hnsw.commitlog.d"},
+		{"main_centroids", "", "vectors", "vectors_compressed", "meta.db", "main_centroids.hnsw.commitlog.d"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.id, func(t *testing.T) {
@@ -166,8 +167,13 @@ func TestPhysicalNamesForID(t *testing.T) {
 			assert.Equal(t, tc.raw, VectorsBucketNameForID(tc.id))
 			assert.Equal(t, tc.compressed, CompressedBucketNameForID(tc.id))
 			assert.Equal(t, tc.flatMeta, FlatMetadataFileNameForID(tc.id))
+			assert.Equal(t, tc.hnswDir, HNSWCommitLogDirNameForID(tc.id))
 		})
 	}
+
+	// the ID-based name agrees with the logical-name helper
+	assert.Equal(t, GetHNSWCommitLogDirName(""), HNSWCommitLogDirNameForID("main"))
+	assert.Equal(t, GetHNSWCommitLogDirName("title"), HNSWCommitLogDirNameForID("vectors_title"))
 }
 
 // TestCentroidsID pins the hfresh centroid graph's ID for both shipped

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -218,6 +218,19 @@ func (m *shardMap) CompareAndSwap(name string, old, new ShardLike) bool {
 	return (*sync.Map)(m).CompareAndSwap(name, old, new)
 }
 
+// loaded returns the loaded *Shard named name, or nil. It never loads.
+func (m *shardMap) loaded(name string) *Shard {
+	switch s := m.Load(name).(type) {
+	case *Shard:
+		return s
+	case *LazyLoadShard:
+		if s.isLoaded() {
+			return s.shard
+		}
+	}
+	return nil
+}
+
 // LoadAndDelete deletes the value for a key, returning the previous value if any.
 // The loaded result reports whether the key was present.
 func (m *shardMap) LoadAndDelete(name string) (ShardLike, bool) {

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -65,7 +65,8 @@ func TestIndex_DropIndex(t *testing.T) {
 	indexFilesAfterDelete, err := getIndexFilenames(dirName, class.Class)
 	require.Nil(t, err)
 
-	assert.Equal(t, 5, len(indexFilesBeforeDelete))
+	// index.db, indexcount, lsm, the hnsw commit log dir, proplengths, version
+	assert.Equal(t, 6, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
 }
 
@@ -90,9 +91,9 @@ func TestIndex_DropEmptyAndRecreateEmptyIndex(t *testing.T) {
 	indexFilesAfterRecreate, err := getIndexFilenames(dirName, class.Class)
 	require.Nil(t, err)
 
-	assert.Equal(t, 5, len(indexFilesBeforeDelete))
+	assert.Equal(t, 6, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
-	assert.Equal(t, 5, len(indexFilesAfterRecreate))
+	assert.Equal(t, 6, len(indexFilesAfterRecreate))
 
 	err = index.drop()
 	require.Nil(t, err)
@@ -280,9 +281,9 @@ func TestIndex_DropWithDataAndRecreateWithDataIndex(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, 99, afterVectorConfig.EF)
 
-	assert.Equal(t, 5, len(indexFilesBeforeDelete))
+	assert.Equal(t, 6, len(indexFilesBeforeDelete))
 	assert.Equal(t, 0, len(indexFilesAfterDelete))
-	assert.Equal(t, 5, len(indexFilesAfterRecreate))
+	assert.Equal(t, 6, len(indexFilesAfterRecreate))
 	assert.Equal(t, indexFilesBeforeDelete, indexFilesAfterRecreate)
 	assert.NotNil(t, beforeDeleteObj1)
 	assert.NotNil(t, beforeDeleteObj2)

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -82,9 +82,7 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 	//
 	// Unconditional because nothing here can tell a dynamic vector from any
 	// other — the drop rewrote this entry's VectorIndexType to "none" and
-	// discarded the original type along with its config. Every shard has an
-	// index.db since the shard opens it at load; one from before that has
-	// none, which costs a failed open.
+	// discarded the original type along with its config.
 	if err := dynamic.RemoveStateKey(shardDir, targetVector); err != nil {
 		return fmt.Errorf("remove dynamic state for %q: %w", targetVector, err)
 	}

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -82,8 +82,9 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 	//
 	// Unconditional because nothing here can tell a dynamic vector from any
 	// other — the drop rewrote this entry's VectorIndexType to "none" and
-	// discarded the original type along with its config. A shard that never ran
-	// a dynamic index has no index.db, so this costs it one failed open.
+	// discarded the original type along with its config. Every shard has an
+	// index.db since the shard opens it at load; one from before that has
+	// none, which costs a failed open.
 	if err := dynamic.RemoveStateKey(shardDir, targetVector); err != nil {
 		return fmt.Errorf("remove dynamic state for %q: %w", targetVector, err)
 	}

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -148,12 +148,9 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, err
 	}
 
-	// The shard's metadata DB stays open for the shard's whole life: the
-	// vector index mapping is read from it at load, a dynamic index writes
-	// its upgrade verdict to it, and bolt's file lock is what makes an
-	// offline operation that raced this load fail cleanly. Shutdown and the
-	// drop close it. The timeout bounds the wait on a lock a leaked handle
-	// still holds; without it bolt retries forever.
+	// Open for the shard's life: read at load, written by dynamic, and its
+	// file lock makes an offline operation that raced this load fail cleanly.
+	// The timeout bounds the wait on a leaked handle's lock.
 	s.metadataDB, err = shardmeta.Open(s.path(), entlsmkv.BoltFlockTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("open metadata db for shard %q: %w", s.ID(), err)

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -28,7 +28,9 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/entities/storagestate"
@@ -144,6 +146,17 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 
 	if err := os.MkdirAll(s.path(), os.ModePerm); err != nil {
 		return nil, err
+	}
+
+	// The shard's metadata DB stays open for the shard's whole life: the
+	// vector index mapping is read from it at load, a dynamic index writes
+	// its upgrade verdict to it, and bolt's file lock is what makes an
+	// offline operation that raced this load fail cleanly. Shutdown and the
+	// drop close it. The timeout bounds the wait on a lock a leaked handle
+	// still holds; without it bolt retries forever.
+	s.metadataDB, err = shardmeta.Open(s.path(), entlsmkv.BoltFlockTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("open metadata db for shard %q: %w", s.ID(), err)
 	}
 
 	if err := s.sweepChangelogDir(); err != nil {

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -586,10 +586,8 @@ func (s *Shard) removeBucket(ctx context.Context, bucketName string) error {
 			return fmt.Errorf("failed to shutdown bucket %s: %w", bucketName, err)
 		}
 	}
-	// Remove the bucket's directory from disk. A bucket the store no longer
-	// knows can still have one: a removal that failed right here left the
-	// files behind after the shutdown, and the retry must not stop at the
-	// registry lookup.
+	// Remove the directory even if the store forgot the bucket: a removal
+	// that failed here after the shutdown left it behind.
 	if err := s.removeDirIfExists(s.pathLSM(), bucketName); err != nil {
 		return fmt.Errorf("bucket %s shut down successfully but directory removal failed: %w", bucketName, err)
 	}

--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -580,17 +580,16 @@ func sidecarRoleWord(suffix string) string {
 }
 
 func (s *Shard) removeBucket(ctx context.Context, bucketName string) error {
-	bucket := s.store.Bucket(bucketName)
-	if bucket == nil {
-		return nil // bucket doesn't exist, nothing to remove
-	}
 	// Shutdown the bucket first - after this point, the bucket cannot be used
-	if err := s.store.ShutdownBucket(ctx, bucketName); err != nil {
-		return fmt.Errorf("failed to shutdown bucket %s: %w", bucketName, err)
+	if s.store.Bucket(bucketName) != nil {
+		if err := s.store.ShutdownBucket(ctx, bucketName); err != nil {
+			return fmt.Errorf("failed to shutdown bucket %s: %w", bucketName, err)
+		}
 	}
-	// Remove the bucket's directory from disk
-	// If this fails after successful shutdown, we're in an inconsistent state:
-	// the bucket is removed from the store but its data remains on disk
+	// Remove the bucket's directory from disk. A bucket the store no longer
+	// knows can still have one: a removal that failed right here left the
+	// files behind after the shutdown, and the retry must not stop at the
+	// registry lookup.
 	if err := s.removeDirIfExists(s.pathLSM(), bucketName); err != nil {
 		return fmt.Errorf("bucket %s shut down successfully but directory removal failed: %w", bucketName, err)
 	}

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 	vcommon "github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/flat"
@@ -30,7 +29,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/noop"
-	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex"
@@ -216,11 +214,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
-		metaDB, err := s.getOrInitMetadataDB()
-		if err != nil {
-			return nil, errors.Wrapf(err, "init shard %q: dynamic index", s.ID())
-		}
-
 		vi, err := dynamic.New(dynamic.Config{
 			ID:                           vecIdxID,
 			Logger:                       logger,
@@ -245,7 +238,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 				)
 			},
 			TombstoneCallbacks:   s.cycleCallbacks.vectorTombstoneCleanupCallbacks,
-			State:                metaDB.Namespace(dynamic.StateNamespace),
+			State:                s.metadataDB.Namespace(dynamic.StateNamespace),
 			AllocChecker:         s.index.allocChecker,
 			MakeBucketOptions:    makeBucketOptions,
 			AsyncIndexingEnabled: s.index.AsyncIndexingEnabled,
@@ -330,20 +323,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 	}
 	defer vectorIndex.PostStartup(s.shutCtx)
 	return vectorIndex, nil
-}
-
-func (s *Shard) getOrInitMetadataDB() (*shardmeta.DB, error) {
-	if s.metadataDB == nil {
-		// Timeout: a leaked handle from a failed shard teardown holds the
-		// flock; without it this open retries forever and wedges the loading
-		// goroutine.
-		db, err := shardmeta.Open(s.path(), entlsmkv.BoltFlockTimeout)
-		if err != nil {
-			return nil, err
-		}
-		s.metadataDB = db
-	}
-	return s.metadataDB, nil
 }
 
 // initTargetVectors builds the named target-vector indexes. legacy and configs

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -1154,3 +1154,27 @@ func TestShard_OpensMetadataDBForEveryShard(t *testing.T) {
 	_, _, err = shardmeta.GetOffline(s.path(), dynamicindex.StateNamespace, []byte("upgraded"))
 	require.Error(t, err)
 }
+
+// TestEnsureDroppedVectorFilesRemoved_SkipsLoadedShard pins that the drop
+// task's completion sweep leaves a loaded shard alone: the shard was swept
+// by the drop itself or by its own load, and an offline open of its index.db
+// would only wait out the lock timeout per target.
+func TestEnsureDroppedVectorFilesRemoved_SkipsLoadedShard(t *testing.T) {
+	ctx := testCtx()
+	className := "SweepLoadedShard"
+	shd, idx := testShard(t, ctx, className)
+	s := shd.(*Shard)
+
+	state := s.metadataDB.Namespace(dynamicindex.StateNamespace)
+	require.NoError(t, state.Put([]byte("upgraded_gone"), []byte{1}))
+
+	db := &DB{logger: idx.logger, indices: map[string]*Index{idx.ID(): idx}}
+	start := time.Now()
+	require.NoError(t, db.EnsureDroppedVectorFilesRemoved(className, s.name, []string{"gone", "gone2"}))
+	// the offline route waits a second per target on the lock this shard holds
+	assert.Less(t, time.Since(start), time.Second)
+
+	v, err := state.Get([]byte("upgraded_gone"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte{1}, v, "a loaded shard's state is the shard's to manage")
+}

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -1136,10 +1136,7 @@ func getVectorIndexAndQueue(t *testing.T, shard ShardLike, targetVector string) 
 	return idx, q
 }
 
-// TestShard_OpensMetadataDBForEveryShard pins that index.db is opened at
-// load for every shard, not only for one with a dynamic index: the vector
-// index mapping is read from it, and its file lock is what makes an offline
-// operation that raced the load fail instead of writing next to us.
+// Every shard opens index.db at load, and its lock makes an offline read fail.
 func TestShard_OpensMetadataDBForEveryShard(t *testing.T) {
 	ctx := testCtx()
 	shd, _ := testShard(t, ctx, "MetaDBEveryShard")
@@ -1149,8 +1146,7 @@ func TestShard_OpensMetadataDBForEveryShard(t *testing.T) {
 	_, err := os.Stat(path.Join(s.path(), shardmeta.FileName))
 	require.NoError(t, err)
 
-	// the loaded shard holds the lock: the offline read reports an error,
-	// not "no state"
+	// the loaded shard holds the lock
 	_, _, err = shardmeta.GetOffline(s.path(), dynamicindex.StateNamespace, []byte("upgraded"))
 	require.Error(t, err)
 }

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -32,6 +32,8 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
+	dynamicindex "github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	hnswindex "github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -1132,4 +1134,23 @@ func getVectorIndexAndQueue(t *testing.T, shard ShardLike, targetVector string) 
 	}
 	require.True(t, vok && qok)
 	return idx, q
+}
+
+// TestShard_OpensMetadataDBForEveryShard pins that index.db is opened at
+// load for every shard, not only for one with a dynamic index: the vector
+// index mapping is read from it, and its file lock is what makes an offline
+// operation that raced the load fail instead of writing next to us.
+func TestShard_OpensMetadataDBForEveryShard(t *testing.T) {
+	ctx := testCtx()
+	shd, _ := testShard(t, ctx, "MetaDBEveryShard")
+	s := shd.(*Shard)
+
+	require.NotNil(t, s.metadataDB)
+	_, err := os.Stat(path.Join(s.path(), shardmeta.FileName))
+	require.NoError(t, err)
+
+	// the loaded shard holds the lock: the offline read reports an error,
+	// not "no state"
+	_, _, err = shardmeta.GetOffline(s.path(), dynamicindex.StateNamespace, []byte("upgraded"))
+	require.Error(t, err)
 }

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -1154,27 +1154,3 @@ func TestShard_OpensMetadataDBForEveryShard(t *testing.T) {
 	_, _, err = shardmeta.GetOffline(s.path(), dynamicindex.StateNamespace, []byte("upgraded"))
 	require.Error(t, err)
 }
-
-// TestEnsureDroppedVectorFilesRemoved_SkipsLoadedShard pins that the drop
-// task's completion sweep leaves a loaded shard alone: the shard was swept
-// by the drop itself or by its own load, and an offline open of its index.db
-// would only wait out the lock timeout per target.
-func TestEnsureDroppedVectorFilesRemoved_SkipsLoadedShard(t *testing.T) {
-	ctx := testCtx()
-	className := "SweepLoadedShard"
-	shd, idx := testShard(t, ctx, className)
-	s := shd.(*Shard)
-
-	state := s.metadataDB.Namespace(dynamicindex.StateNamespace)
-	require.NoError(t, state.Put([]byte("upgraded_gone"), []byte{1}))
-
-	db := &DB{logger: idx.logger, indices: map[string]*Index{idx.ID(): idx}}
-	start := time.Now()
-	require.NoError(t, db.EnsureDroppedVectorFilesRemoved(className, s.name, []string{"gone", "gone2"}))
-	// the offline route waits a second per target on the lock this shard holds
-	assert.Less(t, time.Since(start), time.Second)
-
-	v, err := state.Get([]byte("upgraded_gone"))
-	require.NoError(t, err)
-	assert.Equal(t, []byte{1}, v, "a loaded shard's state is the shard's to manage")
-}

--- a/adapters/repos/db/shard_vector_storage.go
+++ b/adapters/repos/db/shard_vector_storage.go
@@ -23,16 +23,10 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex"
 )
 
-// vectorIndexStorageDirs lists the directories a vector index of indexType
-// occupies at physicalID under shardDir. The startup probe checks that they
-// exist and the durability step syncs them, both from this one list, so the
-// two cannot drift apart. It is a presence list, not a validity check: a
-// directory that exists but is corrupt fails inside the constructor.
-//
-// A dynamic index lives in its flat bucket until it upgrades, then in its
-// hnsw commit log directory; state is the shard's dynamic namespace, read
-// through the open handle. PR5 moves this into the implementations along
-// with cleanup.
+// vectorIndexStorageDirs lists the directories an index of indexType at
+// physicalID occupies under shardDir. The startup probe and the durability
+// sync both use it, so they cannot drift. A dynamic index is in its flat
+// bucket until its verdict says it upgraded.
 func vectorIndexStorageDirs(shardDir string, state dynamic.StateOps, indexType, physicalID string) ([]string, error) {
 	hnswDir := filepath.Join(shardDir, helpers.HNSWCommitLogDirNameForID(physicalID))
 	flatDir := filepath.Join(shardDir, "lsm", helpers.VectorsBucketNameForID(physicalID))
@@ -58,8 +52,8 @@ func vectorIndexStorageDirs(shardDir string, state dynamic.StateOps, indexType, 
 	}
 }
 
-// vectorIndexStorageExists reports whether every directory in dirs exists.
-// A path that exists but is not a directory is an error, not an absence.
+// vectorIndexStorageExists reports whether every dir exists; a file in a
+// dir's place is an error.
 func vectorIndexStorageExists(dirs []string) (bool, error) {
 	for _, dir := range dirs {
 		info, err := os.Stat(dir)
@@ -76,11 +70,9 @@ func vectorIndexStorageExists(dirs []string) (bool, error) {
 	return true, nil
 }
 
-// syncVectorIndexStorage fsyncs every directory in dirs and its parent, so
-// their directory entries are durable before a record that points at them
-// is. The constructors create these directories without a sync (hnsw's
-// commit logger and lsmkv's bucket both MkdirAll and move on), and after a
-// power loss a synced record could otherwise outlive an unsynced entry.
+// syncVectorIndexStorage fsyncs every dir and its parent: the constructors
+// MkdirAll without a sync, and a record must not outlive the entries it
+// points at.
 func syncVectorIndexStorage(dirs []string) error {
 	synced := map[string]struct{}{}
 	for _, dir := range dirs {

--- a/adapters/repos/db/shard_vector_storage.go
+++ b/adapters/repos/db/shard_vector_storage.go
@@ -75,3 +75,25 @@ func vectorIndexStorageExists(dirs []string) (bool, error) {
 	}
 	return true, nil
 }
+
+// syncVectorIndexStorage fsyncs every directory in dirs and its parent, so
+// their directory entries are durable before a record that points at them
+// is. The constructors create these directories without a sync (hnsw's
+// commit logger and lsmkv's bucket both MkdirAll and move on), and after a
+// power loss a synced record could otherwise outlive an unsynced entry.
+func syncVectorIndexStorage(dirs []string) error {
+	synced := map[string]struct{}{}
+	for _, dir := range dirs {
+		for _, path := range []string{dir, filepath.Dir(dir)} {
+			if _, done := synced[path]; done {
+				continue
+			}
+			err := fsyncDir(path)
+			if err != nil {
+				return fmt.Errorf("sync directory %s: %w", path, err)
+			}
+			synced[path] = struct{}{}
+		}
+	}
+	return nil
+}

--- a/adapters/repos/db/shard_vector_storage.go
+++ b/adapters/repos/db/shard_vector_storage.go
@@ -1,0 +1,77 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
+	"github.com/weaviate/weaviate/entities/vectorindex"
+)
+
+// vectorIndexStorageDirs lists the directories a vector index of indexType
+// occupies at physicalID under shardDir. The startup probe checks that they
+// exist and the durability step syncs them, both from this one list, so the
+// two cannot drift apart. It is a presence list, not a validity check: a
+// directory that exists but is corrupt fails inside the constructor.
+//
+// A dynamic index lives in its flat bucket until it upgrades, then in its
+// hnsw commit log directory; state is the shard's dynamic namespace, read
+// through the open handle. PR5 moves this into the implementations along
+// with cleanup.
+func vectorIndexStorageDirs(shardDir string, state dynamic.StateOps, indexType, physicalID string) ([]string, error) {
+	hnswDir := filepath.Join(shardDir, helpers.HNSWCommitLogDirNameForID(physicalID))
+	flatDir := filepath.Join(shardDir, "lsm", helpers.VectorsBucketNameForID(physicalID))
+
+	switch indexType {
+	case vectorindex.VectorIndexTypeHNSW:
+		return []string{hnswDir}, nil
+	case vectorindex.VectorIndexTypeFLAT:
+		return []string{flatDir}, nil
+	case vectorindex.VectorIndexTypeHFresh:
+		return []string{filepath.Join(shardDir, helpers.HFreshDirName(physicalID))}, nil
+	case vectorindex.VectorIndexTypeDYNAMIC:
+		upgraded, err := dynamic.UpgradedInState(state, shardDir, physicalID)
+		if err != nil {
+			return nil, fmt.Errorf("dynamic index %q: %w", physicalID, err)
+		}
+		if upgraded {
+			return []string{hnswDir}, nil
+		}
+		return []string{flatDir}, nil
+	default:
+		return nil, fmt.Errorf("unknown vector index type %q", indexType)
+	}
+}
+
+// vectorIndexStorageExists reports whether every directory in dirs exists.
+// A path that exists but is not a directory is an error, not an absence.
+func vectorIndexStorageExists(dirs []string) (bool, error) {
+	for _, dir := range dirs {
+		info, err := os.Stat(dir)
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, nil
+		}
+		if err != nil {
+			return false, err
+		}
+		if !info.IsDir() {
+			return false, fmt.Errorf("%s is not a directory", dir)
+		}
+	}
+	return true, nil
+}

--- a/adapters/repos/db/shard_vector_storage_test.go
+++ b/adapters/repos/db/shard_vector_storage_test.go
@@ -24,8 +24,7 @@ import (
 	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 )
 
-// newTestDynamicState opens a metadata DB in shardDir and returns dynamic's
-// state namespace, the way the shard hands it to the index.
+// newTestDynamicState returns dynamic's state namespace on a fresh index.db.
 func newTestDynamicState(t *testing.T, shardDir string) dynamic.StateOps {
 	t.Helper()
 	db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
@@ -34,9 +33,7 @@ func newTestDynamicState(t *testing.T, shardDir string) dynamic.StateOps {
 	return db.Namespace(dynamic.StateNamespace)
 }
 
-// TestVectorIndexStorageDirs pins which directories each index type
-// occupies for a physical ID; the probe checks them and the durability
-// step syncs them.
+// TestVectorIndexStorageDirs pins the directories each index type occupies.
 func TestVectorIndexStorageDirs(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -90,7 +87,6 @@ func TestVectorIndexStorageExists(t *testing.T) {
 		filepath.Join(shardDir, "lsm", "vectors"),
 	}
 
-	// nothing there yet
 	exists, err := vectorIndexStorageExists(dirs)
 	require.NoError(t, err)
 	assert.False(t, exists)
@@ -106,13 +102,12 @@ func TestVectorIndexStorageExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	// a file where a directory belongs is an error, not "absent"
+	// a file in a dir's place is an error, not "absent"
 	require.NoError(t, os.RemoveAll(dirs[0]))
 	require.NoError(t, os.WriteFile(dirs[0], []byte("x"), 0o644))
 	_, err = vectorIndexStorageExists(dirs)
 	require.ErrorContains(t, err, "not a directory")
 
-	// no directories means nothing can be missing
 	exists, err = vectorIndexStorageExists(nil)
 	require.NoError(t, err)
 	assert.True(t, exists)
@@ -132,7 +127,6 @@ func TestSyncVectorIndexStorage(t *testing.T) {
 	require.NoError(t, syncVectorIndexStorage(dirs))
 	require.NoError(t, syncVectorIndexStorage(nil))
 
-	// a directory that is not there cannot be made durable
 	missing := filepath.Join(shardDir, "vectors_gone.hnsw.commitlog.d")
 	err := syncVectorIndexStorage([]string{missing})
 	require.ErrorContains(t, err, missing)

--- a/adapters/repos/db/shard_vector_storage_test.go
+++ b/adapters/repos/db/shard_vector_storage_test.go
@@ -117,3 +117,23 @@ func TestVectorIndexStorageExists(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, exists)
 }
+
+func TestSyncVectorIndexStorage(t *testing.T) {
+	shardDir := t.TempDir()
+	dirs := []string{
+		filepath.Join(shardDir, "main.hnsw.commitlog.d"),
+		filepath.Join(shardDir, "lsm", "vectors"),
+		filepath.Join(shardDir, "lsm", "vectors_title"),
+	}
+	for _, dir := range dirs {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
+
+	require.NoError(t, syncVectorIndexStorage(dirs))
+	require.NoError(t, syncVectorIndexStorage(nil))
+
+	// a directory that is not there cannot be made durable
+	missing := filepath.Join(shardDir, "vectors_gone.hnsw.commitlog.d")
+	err := syncVectorIndexStorage([]string{missing})
+	require.ErrorContains(t, err, missing)
+}

--- a/adapters/repos/db/shard_vector_storage_test.go
+++ b/adapters/repos/db/shard_vector_storage_test.go
@@ -1,0 +1,119 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
+)
+
+// newTestDynamicState opens a metadata DB in shardDir and returns dynamic's
+// state namespace, the way the shard hands it to the index.
+func newTestDynamicState(t *testing.T, shardDir string) dynamic.StateOps {
+	t.Helper()
+	db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+	return db.Namespace(dynamic.StateNamespace)
+}
+
+// TestVectorIndexStorageDirs pins which directories each index type
+// occupies for a physical ID; the probe checks them and the durability
+// step syncs them.
+func TestVectorIndexStorageDirs(t *testing.T) {
+	tests := []struct {
+		name      string
+		indexType string
+		id        string
+		verdict   []byte // dynamic only: stored under its state key, nil for none
+		want      []string
+		wantErr   string
+	}{
+		{name: "hnsw legacy", indexType: "hnsw", id: "main", want: []string{"main.hnsw.commitlog.d"}},
+		{name: "hnsw named", indexType: "hnsw", id: "vectors_title", want: []string{"vectors_title.hnsw.commitlog.d"}},
+		{name: "flat legacy", indexType: "flat", id: "main", want: []string{"lsm/vectors"}},
+		{name: "flat named", indexType: "flat", id: "vectors_title", want: []string{"lsm/vectors_title"}},
+		{name: "hfresh", indexType: "hfresh", id: "vectors_title", want: []string{"vectors_title.hfresh.d"}},
+		{name: "dynamic not upgraded", indexType: "dynamic", id: "vectors_title", verdict: []byte{0}, want: []string{"lsm/vectors_title"}},
+		{name: "dynamic upgraded", indexType: "dynamic", id: "vectors_title", verdict: []byte{1}, want: []string{"vectors_title.hnsw.commitlog.d"}},
+		{name: "dynamic legacy without a verdict is flat", indexType: "dynamic", id: "main", want: []string{"lsm/vectors"}},
+		{name: "unknown type", indexType: "bogus", id: "main", wantErr: `unknown vector index type "bogus"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shardDir := t.TempDir()
+			state := newTestDynamicState(t, shardDir)
+			if tt.verdict != nil {
+				key := "upgraded"
+				if tt.id != "main" {
+					key = "upgraded_" + tt.id[len("vectors_"):]
+				}
+				require.NoError(t, state.Put([]byte(key), tt.verdict))
+			}
+
+			dirs, err := vectorIndexStorageDirs(shardDir, state, tt.indexType, tt.id)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			var want []string
+			for _, rel := range tt.want {
+				want = append(want, filepath.Join(shardDir, rel))
+			}
+			assert.Equal(t, want, dirs)
+		})
+	}
+}
+
+func TestVectorIndexStorageExists(t *testing.T) {
+	shardDir := t.TempDir()
+	dirs := []string{
+		filepath.Join(shardDir, "main.hnsw.commitlog.d"),
+		filepath.Join(shardDir, "lsm", "vectors"),
+	}
+
+	// nothing there yet
+	exists, err := vectorIndexStorageExists(dirs)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// one of two is not all
+	require.NoError(t, os.MkdirAll(dirs[0], 0o755))
+	exists, err = vectorIndexStorageExists(dirs)
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	require.NoError(t, os.MkdirAll(dirs[1], 0o755))
+	exists, err = vectorIndexStorageExists(dirs)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// a file where a directory belongs is an error, not "absent"
+	require.NoError(t, os.RemoveAll(dirs[0]))
+	require.NoError(t, os.WriteFile(dirs[0], []byte("x"), 0o644))
+	_, err = vectorIndexStorageExists(dirs)
+	require.ErrorContains(t, err, "not a directory")
+
+	// no directories means nothing can be missing
+	exists, err = vectorIndexStorageExists(nil)
+	require.NoError(t, err)
+	assert.True(t, exists)
+}

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -252,18 +252,15 @@ func TestDropVectorIndex_BatchRejected(t *testing.T) {
 	require.NoError(t, errs[1])
 }
 
-// TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard pins the drop
-// task's completion sweep on a loaded shard: it re-runs the shard's own drop,
-// which finishes a drop that failed part-way and never opens index.db offline
-// against the lock the shard holds.
+// The completion sweep on a loaded shard re-runs the shard's drop: it finishes
+// a drop that failed part-way and never opens index.db against the shard's lock.
 func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
 	markDropped(class, "foo")
 	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
 
-	// a removal that failed part-way leaves directories behind: the hnsw
-	// commit log, and a bucket the store already shut down and forgot
+	// leftovers of a removal that failed part-way
 	leftovers := []string{
 		filepath.Join(shard.path(), helpers.GetHNSWCommitLogDirName("foo")),
 		filepath.Join(shard.pathLSM(), helpers.GetVectorsBucketName("foo")),
@@ -275,7 +272,7 @@ func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) 
 	db := &DB{logger: shard.index.logger, indices: map[string]*Index{shard.index.ID(): shard.index}}
 	start := time.Now()
 	require.NoError(t, db.EnsureDroppedVectorFilesRemoved(class.Class, shard.name, []string{"foo"}))
-	// the offline route would wait a second on the lock this shard holds
+	// the offline route waits a second per target on this shard's lock
 	assert.Less(t, time.Since(start), time.Second)
 
 	for _, dir := range leftovers {

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -15,11 +15,17 @@ package db
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
@@ -244,4 +250,33 @@ func TestDropVectorIndex_BatchRejected(t *testing.T) {
 	require.Contains(t, errs[0].Error(), "vector index not found")
 	require.Contains(t, errs[0].Error(), "foo")
 	require.NoError(t, errs[1])
+}
+
+// TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard pins the drop
+// task's completion sweep on a loaded shard: it re-runs the shard's own drop,
+// which finishes a drop that failed part-way and never opens index.db offline
+// against the lock the shard holds.
+func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+	markDropped(class, "foo")
+	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
+
+	// a removal that failed part-way leaves a directory behind
+	leftover := filepath.Join(shard.path(), helpers.GetHNSWCommitLogDirName("foo"))
+	require.NoError(t, os.MkdirAll(leftover, 0o755))
+
+	db := &DB{logger: shard.index.logger, indices: map[string]*Index{shard.index.ID(): shard.index}}
+	start := time.Now()
+	require.NoError(t, db.EnsureDroppedVectorFilesRemoved(class.Class, shard.name, []string{"foo"}))
+	// the offline route would wait a second on the lock this shard holds
+	assert.Less(t, time.Since(start), time.Second)
+
+	_, err := os.Stat(leftover)
+	assert.True(t, os.IsNotExist(err), "the sweep finished the drop")
+
+	// the sibling vector is untouched
+	found, err := shard.WithVectorIndex("mv", func(VectorIndex) error { return nil })
+	require.NoError(t, err)
+	assert.True(t, found)
 }

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -262,9 +262,15 @@ func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) 
 	markDropped(class, "foo")
 	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
 
-	// a removal that failed part-way leaves a directory behind
-	leftover := filepath.Join(shard.path(), helpers.GetHNSWCommitLogDirName("foo"))
-	require.NoError(t, os.MkdirAll(leftover, 0o755))
+	// a removal that failed part-way leaves directories behind: the hnsw
+	// commit log, and a bucket the store already shut down and forgot
+	leftovers := []string{
+		filepath.Join(shard.path(), helpers.GetHNSWCommitLogDirName("foo")),
+		filepath.Join(shard.pathLSM(), helpers.GetVectorsBucketName("foo")),
+	}
+	for _, dir := range leftovers {
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+	}
 
 	db := &DB{logger: shard.index.logger, indices: map[string]*Index{shard.index.ID(): shard.index}}
 	start := time.Now()
@@ -272,8 +278,10 @@ func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) 
 	// the offline route would wait a second on the lock this shard holds
 	assert.Less(t, time.Since(start), time.Second)
 
-	_, err := os.Stat(leftover)
-	assert.True(t, os.IsNotExist(err), "the sweep finished the drop")
+	for _, dir := range leftovers {
+		_, err := os.Stat(dir)
+		assert.True(t, os.IsNotExist(err), "the sweep finished the drop: %s", dir)
+	}
 
 	// the sibling vector is untouched
 	found, err := shard.WithVectorIndex("mv", func(VectorIndex) error { return nil })

--- a/adapters/repos/db/vector/dynamic/drop_target_vector_test.go
+++ b/adapters/repos/db/vector/dynamic/drop_target_vector_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // newDynamicForDrop builds one dynamic index over a SHARED metadata DB,
-// mirroring the shard: getOrInitMetadataDB opens index.db once and every
+// mirroring the shard: NewShard opens index.db once and every
 // dynamic vector on that shard is a key inside it.
 func newDynamicForDrop(t *testing.T, meta *shardmeta.DB, rootPath, targetVector string) *dynamic {
 	t.Helper()

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -325,24 +325,39 @@ func RemoveStateKey(rootPath, targetVector string) error {
 // State that could not be read returns false along with the error, so a
 // caller can tell that answer apart from a shard positively known to be flat.
 func UpgradedOnDisk(rootPath, id string) (bool, error) {
-	upgradedWithoutStateKey := false
-	if helpers.PhysicalIDSuffix(id) != "" {
-		_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
-		upgradedWithoutStateKey = err == nil
-	}
-
-	v, ok, err := shardmeta.GetOffline(rootPath, StateNamespace, dbKeyForID(id))
+	v, _, err := shardmeta.GetOffline(rootPath, StateNamespace, dbKeyForID(id))
 	if err != nil {
 		return false, fmt.Errorf("read dynamic state: %w", err)
 	}
-	if !ok {
-		// only a shard that never wrote state may fall back to the directory
-		return upgradedWithoutStateKey, nil
+	return upgradedFromVerdict(v, rootPath, id), nil
+}
+
+// UpgradedInState is UpgradedOnDisk for a LOADED shard: the same verdict,
+// read through the shard's own metadata handle instead of opening the
+// file, which the loaded shard holds locked. It reads only; the index's
+// own load is what migrates a missing named-vector key.
+func UpgradedInState(state StateOps, rootPath, id string) (bool, error) {
+	v, err := state.Get(dbKeyForID(id))
+	if err != nil {
+		return false, fmt.Errorf("read dynamic state: %w", err)
 	}
+	return upgradedFromVerdict(v, rootPath, id), nil
+}
+
+// upgradedFromVerdict decodes a stored verdict the way the index's own
+// load does: a recorded value wins; no value (a missing file, namespace,
+// key, or an empty value) falls back to the hnsw commit log directory for
+// a named vector only. An unnamed vector's load reads a missing key as not
+// upgraded and then deletes that directory, so nothing may infer from it.
+func upgradedFromVerdict(v []byte, rootPath, id string) bool {
 	if len(v) > 0 {
-		return v[0] != 0, nil
+		return v[0] != 0
 	}
-	return upgradedWithoutStateKey, nil
+	if helpers.PhysicalIDSuffix(id) == "" {
+		return false
+	}
+	_, err := os.Stat(hnswCommitLogDirectory(rootPath, id))
+	return err == nil
 }
 
 func (dynamic *dynamic) getBucketName() string {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -332,10 +332,8 @@ func UpgradedOnDisk(rootPath, id string) (bool, error) {
 	return upgradedFromVerdict(v, rootPath, id), nil
 }
 
-// UpgradedInState is UpgradedOnDisk for a LOADED shard: the same verdict,
-// read through the shard's own metadata handle instead of opening the
-// file, which the loaded shard holds locked. It reads only; the index's
-// own load is what migrates a missing named-vector key.
+// UpgradedInState is UpgradedOnDisk through a loaded shard's own handle. It
+// only reads; the index's load is what migrates a missing named key.
 func UpgradedInState(state StateOps, rootPath, id string) (bool, error) {
 	v, err := state.Get(dbKeyForID(id))
 	if err != nil {
@@ -344,11 +342,9 @@ func UpgradedInState(state StateOps, rootPath, id string) (bool, error) {
 	return upgradedFromVerdict(v, rootPath, id), nil
 }
 
-// upgradedFromVerdict decodes a stored verdict the way the index's own
-// load does: a recorded value wins; no value (a missing file, namespace,
-// key, or an empty value) falls back to the hnsw commit log directory for
-// a named vector only. An unnamed vector's load reads a missing key as not
-// upgraded and then deletes that directory, so nothing may infer from it.
+// upgradedFromVerdict decodes a verdict as the index's load does: a value
+// wins; none falls back to the commit log directory for a named vector only,
+// since an unnamed vector's load deletes that directory.
 func upgradedFromVerdict(v []byte, rootPath, id string) bool {
 	if len(v) > 0 {
 		return v[0] != 0

--- a/adapters/repos/db/vector/dynamic/upgrade_state_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_state_test.go
@@ -214,8 +214,7 @@ func setUpStateDB(t *testing.T, rootPath string, state stateDB, key string, valu
 	require.NoError(t, db.Close())
 }
 
-// TestUpgradedInState pins the loaded-shard twin of UpgradedOnDisk: the
-// same verdict, read through the shard's open metadata handle.
+// TestUpgradedInState pins UpgradedOnDisk's verdicts read through an open handle.
 func TestUpgradedInState(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/adapters/repos/db/vector/dynamic/upgrade_state_test.go
+++ b/adapters/repos/db/vector/dynamic/upgrade_state_test.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -211,4 +212,53 @@ func setUpStateDB(t *testing.T, rootPath string, state stateDB, key string, valu
 		return
 	}
 	require.NoError(t, db.Close())
+}
+
+// TestUpgradedInState pins the loaded-shard twin of UpgradedOnDisk: the
+// same verdict, read through the shard's open metadata handle.
+func TestUpgradedInState(t *testing.T) {
+	tests := []struct {
+		name          string
+		targetVector  string
+		storedKey     string
+		storedValue   []byte
+		hnswDirExists bool
+		want          bool
+	}{
+		{name: "no state and no hnsw dir"},
+		{name: "unnamed vector never infers an upgrade from its hnsw dir", hnswDirExists: true},
+		{name: "state says upgraded", storedKey: "upgraded", storedValue: []byte{1}, want: true},
+		{name: "state outranks an hnsw dir", storedKey: "upgraded", storedValue: []byte{0}, hnswDirExists: true},
+		{name: "empty value falls back like no value", storedKey: "upgraded", storedValue: []byte{}, hnswDirExists: true},
+		{name: "named vector with no state and no hnsw dir", targetVector: "custom"},
+		{name: "named vector infers an upgrade from its hnsw dir", targetVector: "custom", hnswDirExists: true, want: true},
+		{name: "named state says upgraded", targetVector: "custom", storedKey: "upgraded_custom", storedValue: []byte{1}, want: true},
+		{name: "named state outranks its hnsw dir", targetVector: "custom", storedKey: "upgraded_custom", storedValue: []byte{0}, hnswDirExists: true},
+		{name: "another vector's state does not count", targetVector: "custom", storedKey: "upgraded_other", storedValue: []byte{1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rootPath := t.TempDir()
+			id := "main"
+			if tt.targetVector != "" {
+				id = "vectors_" + tt.targetVector
+			}
+			if tt.hnswDirExists {
+				require.NoError(t, os.MkdirAll(hnswCommitLogDirectory(rootPath, id), 0o777))
+			}
+
+			db, err := shardmeta.Open(rootPath, time.Second)
+			require.NoError(t, err)
+			defer db.Close()
+			state := db.Namespace(StateNamespace)
+			if tt.storedKey != "" {
+				require.NoError(t, state.Put([]byte(tt.storedKey), tt.storedValue))
+			}
+
+			upgraded, err := UpgradedInState(state, rootPath, id)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, upgraded)
+		})
+	}
 }


### PR DESCRIPTION
### What's being changed:

Third slice of the persisted vector index mapping, stacked on #12994. One live change and two helpers the startup slice will call.

**Every shard opens `index.db` at load.** Until now the shard opened its metadata DB lazily and only when a dynamic index asked for its state namespace. The mapping is read from that file at load, so `NewShard` now opens it right after the shard directory exists and keeps it open for the shard's life; shutdown and drop already close it. What changes on disk: every shard has an `index.db`, and every backup includes it, through the same snapshot code that already handled the dynamic case. The handle also stays open for its file lock: the offline helpers that touch `index.db` of a cold shard rely on a loaded shard holding that lock so an operation that raced the load fails instead of writing next to it. A test pins the file, the handle, and the lock.

**The storage probe and the directory sync**, in `shard_vector_storage.go`, uncalled for now. One function lists the directories a vector index of a given type and physical ID occupies (hnsw commit log directory, flat bucket under `lsm/`, hfresh directory, dynamic whichever of the two its upgrade verdict says). The probe checks that they all exist; the sync fsyncs each one and its parent, so a directory entry is durable before a record that points at it. Both take their paths from the one list, so they cannot drift apart. The dynamic branch needs the verdict of a loaded shard, so the dynamic package gains `UpgradedInState`, the in-process twin of `UpgradedOnDisk`, with both decoding through one function; `helpers` gains the ID-based twin of the hnsw commit log directory name.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
