### PR TITLE
Reconcile orphaned class directories against the schema on DB reload

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -280,6 +280,14 @@ func (m *Migrator) DropClass(ctx context.Context, className string, hasFrozen bo
 	return nil
 }
 
+// DropOrphanedIndexDirectories removes class directories on disk that the
+// reloaded schema no longer names. See DB.dropOrphanedIndexDirectories for why
+// the reload path needs this. ctx is part of the Migrator contract; the removal
+// itself is asynchronous and outlives the call.
+func (m *Migrator) DropOrphanedIndexDirectories(ctx context.Context, keepClasses []string) error {
+	return m.db.dropOrphanedIndexDirectories(keepClasses)
+}
+
 func (m *Migrator) UpdateClass(ctx context.Context, className string, newClassName *string) error {
 	if newClassName != nil {
 		return errors.New("weaviate does not support renaming of classes")

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -99,6 +99,12 @@ func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 				_, err := os.Stat(orphanDir)
 				return os.IsNotExist(err)
 			}, 10*time.Second, 20*time.Millisecond, "reload left the orphan class directory on disk")
+			// A cycle manager of a still-running index would recreate the path on
+			// its next write; DeleteIndex must have stopped them before the rename.
+			require.Never(t, func() bool {
+				_, err := os.Stat(orphanDir)
+				return err == nil
+			}, 2*time.Second, 50*time.Millisecond, "orphan class directory reappeared after the reload")
 
 			db.indexLock.RLock()
 			_, stillLoaded := db.indices[indexID(orphanClass)]

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	ubak "github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -112,8 +113,8 @@ func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 
 // TestDropOrphanedIndexDirectoriesPreservesReservedEntries pins what the
 // reconcile must never touch: a class still in the schema, the raft directory,
-// the backup framework's marked and staging directories, a directory already
-// pending async delete, and files at the data root.
+// the backup framework's marked, staging and restore-temp directories, a
+// directory already pending async delete, and files at the data root.
 func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 	root := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -125,6 +126,7 @@ func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 		filepath.Join(root, config.DefaultRaftDir),
 		filepath.Join(root, backup.DeleteMarker+indexID("BackedUpClass")),
 		filepath.Join(root, backup.BackupStagingPrefix+"backup-1-"+indexID("StagedClass")),
+		filepath.Join(root, ubak.TempDirectory, indexID("RestoringClass")),
 		filepath.Join(root, "gone.123.abcd"+asyncDeleteSuffix),
 	}
 	for _, d := range append(preserved, orphanDir) {

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -120,8 +120,11 @@ func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 // TestDropOrphanedIndexDirectoriesPreservesReservedEntries pins what the
 // reconcile must never touch: a class still in the schema, the raft directory,
 // the backup framework's marked, staging and restore-temp directories, a
-// directory already pending async delete, a mount point's lost+found, and
-// files at the data root.
+// directory already pending async delete, a mount point's lost+found, files at
+// the data root, and two directories whose name alone passes as a class: a
+// filesystem backup root colocated under the data root
+// (BACKUP_FILESYSTEM_PATH=<RootPath>/backups) and an index directory with no
+// shard store on this node.
 func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 	root := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -136,8 +139,10 @@ func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 		filepath.Join(root, ubak.TempDirectory, indexID("RestoringClass")),
 		filepath.Join(root, "gone.123.abcd"+asyncDeleteSuffix),
 		filepath.Join(root, "lost+found"),
+		filepath.Join(root, "backups", "backup-1", "node1", indexID("BackedUpClass")),
+		filepath.Join(root, indexID("ShardlessClass")),
 	}
-	for _, d := range append(preserved, orphanDir) {
+	for _, d := range append(preserved, filepath.Join(orphanDir, "shard1", "lsm")) {
 		require.NoError(t, os.MkdirAll(d, 0o755))
 	}
 	schemaFile := filepath.Join(root, "schema.db")

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -18,96 +18,121 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/backup"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 // TestReloadLocalDBReconcilesOrphanClassDirectories reproduces the two RAFT
-// paths that leave a deleted collection's directory on disk forever:
+// paths that leave a deleted collection's directory on disk forever, through
+// the reload both of them run: executor.ReloadLocalDB with a schema that no
+// longer names the class.
 //
 //   - 0-weaviate-issues#652: a node restarted mid-DELETE_CLASS replays the entry
 //     schema-only, so DeleteIndex never runs; the reload after catch-up
 //     (Store.Apply -> reloadDBFromSchema) only re-opens classes still in the
-//     schema.
+//     schema. The orphan was never opened by this process.
 //   - 0-weaviate-issues#651: a node that rejoins via an InstallSnapshot gets a
 //     schema without the deleted class; the reload after restore
 //     (Store.Restore -> reloadDBFromSchema) again only re-opens present classes.
+//     After a restart the orphan is unopened like #652; a snapshot installed on
+//     a running node instead keeps the deleted class's *Index loaded.
 //
-// Both funnel through executor.ReloadLocalDB with a schema that no longer names
-// the class, so one reconcile step in that reload closes both. The two subtests
-// differ only in which RAFT entry point produced the schema-without-the-class;
-// the on-disk symptom and the fix are identical.
+// The two cases cover the two states an orphan can be in when the reload runs.
 func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 	cases := []struct {
-		name  string
-		issue string
+		name   string
+		loaded bool
 	}{
-		{name: "restart_replays_delete_schema_only", issue: "0-weaviate-issues#652"},
-		{name: "rejoin_installs_snapshot", issue: "0-weaviate-issues#651"},
+		{name: "unopened_orphan_652_and_651_after_restart", loaded: false},
+		{name: "loaded_orphan_651_snapshot_on_running_node", loaded: true},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			root := t.TempDir()
 			logger, _ := test.NewNullLogger()
+			db := &DB{config: Config{RootPath: root}, logger: logger, indices: map[string]*Index{}}
 
-			// The orphan: a class directory the schema no longer names, as either
-			// RAFT path leaves it. The raft directory is the one reserved
-			// non-class entry at the data root (usecases/schema/parser.go rejects
-			// a class named "raft"), so the reconcile must leave it untouched.
-			orphanDir := filepath.Join(root, "orphanclass")
-			require.NoError(t, os.MkdirAll(filepath.Join(orphanDir, "shard1", "lsm"), 0o755))
+			const orphanClass = "OrphanClass"
+			orphanDir := filepath.Join(root, indexID(orphanClass))
+			if tc.loaded {
+				idx := newTestIndexOnDisk(t, db, orphanClass, logger)
+				db.indices[idx.ID()] = idx
+			} else {
+				require.NoError(t, os.MkdirAll(filepath.Join(orphanDir, "shard1", "lsm"), 0o755))
+			}
+			_, err := os.Stat(orphanDir)
+			require.NoError(t, err, "precondition: orphan directory exists before the reload")
 			raftDir := filepath.Join(root, config.DefaultRaftDir)
 			require.NoError(t, os.MkdirAll(raftDir, 0o755))
 
 			executor := schemaUC.NewExecutor(
-				&Migrator{db: &DB{config: Config{RootPath: root}, logger: logger}, nodeId: "node1"},
+				&Migrator{db: db, nodeId: "node1"},
 				schemaUC.NewMockSchemaReader(t),
 				logger,
 				func(string) error { return nil },
 			)
 
 			// The reloaded schema names no class: the deleted collection is gone
-			// from it on every node, which is exactly the client-visible state
-			// both issues describe.
+			// from it on every node, the client-visible state both issues describe.
 			require.NoError(t, executor.ReloadLocalDB(context.Background(), []command.UpdateClassRequest{}))
 
 			require.Eventually(t, func() bool {
 				_, err := os.Stat(orphanDir)
 				return os.IsNotExist(err)
-			}, 10*time.Second, 20*time.Millisecond,
-				"%s: reload left the orphan class directory on disk", tc.issue)
+			}, 10*time.Second, 20*time.Millisecond, "reload left the orphan class directory on disk")
 
-			_, err := os.Stat(raftDir)
+			db.indexLock.RLock()
+			_, stillLoaded := db.indices[indexID(orphanClass)]
+			db.indexLock.RUnlock()
+			require.False(t, stillLoaded, "reload left the orphan index loaded")
+
+			_, err = os.Stat(raftDir)
 			require.NoError(t, err, "reconcile must not remove the raft directory")
 		})
 	}
 }
 
-// TestDropOrphanedIndexDirectoriesPreservesLiveState pins what the reconcile
-// must never touch: a class still in the schema, the raft directory, a
-// directory already pending async delete, and non-directory bookkeeping at the
-// data root.
-func TestDropOrphanedIndexDirectoriesPreservesLiveState(t *testing.T) {
+// TestDropOrphanedIndexDirectoriesPreservesReservedEntries pins what the
+// reconcile must never touch: a class still in the schema, the raft directory,
+// the backup framework's marked and staging directories, a directory already
+// pending async delete, and files at the data root.
+func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 	root := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
-	// Index directories are the lowercased class name; the keep set below names
-	// "KeptClass", so its directory is "keptclass".
-	keptDir := filepath.Join(root, "keptclass")
-	orphanDir := filepath.Join(root, "orphanclass")
-	raftDir := filepath.Join(root, config.DefaultRaftDir)
-	pendingDir := filepath.Join(root, "gone.123.abcd.deleteme")
-	for _, d := range []string{keptDir, orphanDir, raftDir, pendingDir} {
+	keptDir := filepath.Join(root, indexID("KeptClass"))
+	orphanDir := filepath.Join(root, indexID("OrphanClass"))
+	preserved := []string{
+		keptDir,
+		filepath.Join(root, config.DefaultRaftDir),
+		filepath.Join(root, backup.DeleteMarker+indexID("BackedUpClass")),
+		filepath.Join(root, backup.BackupStagingPrefix+"backup-1-"+indexID("StagedClass")),
+		filepath.Join(root, "gone.123.abcd"+asyncDeleteSuffix),
+	}
+	for _, d := range append(preserved, orphanDir) {
 		require.NoError(t, os.MkdirAll(d, 0o755))
 	}
-	// schema.db and friends are files at the data root, never class directories.
 	schemaFile := filepath.Join(root, "schema.db")
 	require.NoError(t, os.WriteFile(schemaFile, []byte("x"), 0o644))
+	preserved = append(preserved, schemaFile)
 
 	db := &DB{config: Config{RootPath: root}, logger: logger}
 	require.NoError(t, db.dropOrphanedIndexDirectories([]string{"KeptClass"}))
@@ -117,8 +142,53 @@ func TestDropOrphanedIndexDirectoriesPreservesLiveState(t *testing.T) {
 		return os.IsNotExist(err)
 	}, 10*time.Second, 20*time.Millisecond, "orphan class directory must be removed")
 
-	for _, keep := range []string{keptDir, raftDir, pendingDir, schemaFile} {
+	for _, keep := range preserved {
 		_, err := os.Stat(keep)
 		require.NoError(t, err, "reconcile removed %s, which it must preserve", keep)
 	}
+}
+
+// newTestIndexOnDisk builds a real single-shard index under db's root, the
+// way TestUpdateIndexTenants does, so a test can exercise the loaded-index
+// path of the reconcile.
+func newTestIndexOnDisk(t *testing.T, db *DB, className string, logger *logrus.Logger) *Index {
+	t.Helper()
+
+	class := &models.Class{
+		Class:               className,
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+	}
+	state := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"shard1": {Name: "shard1", BelongsToNodes: []string{"node1"}},
+		},
+	}
+	schemaGetter := schemaUC.NewMockSchemaGetter(t)
+	schemaGetter.On("NodeName").Return("node1").Maybe()
+	schemaGetter.On("ReadOnlyClass", className).Return(class).Maybe()
+	schemaReader := schemaUC.NewMockSchemaReader(t)
+	schemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(_ string, _ bool, readFunc func(*models.Class, *sharding.State) error) error {
+			return readFunc(class, state)
+		}).Maybe()
+	db.schemaGetter = schemaGetter
+
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+	shardResolver := resolver.NewShardResolver(className, false, schemaGetter)
+	idx, err := NewIndex(context.Background(), IndexConfig{
+		ClassName:         schema.ClassName(className),
+		RootPath:          db.config.RootPath,
+		ReplicationFactor: 1,
+		ShardLoadLimiter:  loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		hnsw.NewDefaultUserConfig(), nil, nil, shardResolver, schemaGetter, schemaReader, nil, logger,
+		nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil,
+		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+	require.NoError(t, err)
+
+	shard, err := NewShard(context.Background(), nil, "shard1", idx, class, nil, scheduler, nil,
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+	require.NoError(t, err)
+	idx.shards.Store("shard1", shard)
+	return idx
 }

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -77,7 +77,7 @@ func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 				idx := newTestIndexOnDisk(t, db, orphanClass, logger)
 				db.indices[idx.ID()] = idx
 			} else {
-				require.NoError(t, os.MkdirAll(filepath.Join(orphanDir, "shard1", "lsm"), 0o755))
+				writeShardSignature(t, orphanDir, "shard1")
 			}
 			_, err := os.Stat(orphanDir)
 			require.NoError(t, err, "precondition: orphan directory exists before the reload")
@@ -123,8 +123,9 @@ func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 // directory already pending async delete, a mount point's lost+found, files at
 // the data root, and two directories whose name alone passes as a class: a
 // filesystem backup root colocated under the data root
-// (BACKUP_FILESYSTEM_PATH=<RootPath>/backups) and an index directory with no
-// shard store on this node.
+// (BACKUP_FILESYSTEM_PATH=<RootPath>/backups, laid out as
+// <backupID>/<node>/<class>/chunk-N, once with a node named lsm) and an index
+// directory with no shard store on this node.
 func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 	root := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -140,11 +141,13 @@ func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 		filepath.Join(root, "gone.123.abcd"+asyncDeleteSuffix),
 		filepath.Join(root, "lost+found"),
 		filepath.Join(root, "backups", "backup-1", "node1", indexID("BackedUpClass")),
+		filepath.Join(root, "backups", "backup-2", "lsm", indexID("BackedUpClass")),
 		filepath.Join(root, indexID("ShardlessClass")),
 	}
-	for _, d := range append(preserved, filepath.Join(orphanDir, "shard1", "lsm")) {
+	for _, d := range preserved {
 		require.NoError(t, os.MkdirAll(d, 0o755))
 	}
+	writeShardSignature(t, orphanDir, "shard1")
 	schemaFile := filepath.Join(root, "schema.db")
 	require.NoError(t, os.WriteFile(schemaFile, []byte("x"), 0o644))
 	preserved = append(preserved, schemaFile)
@@ -161,6 +164,15 @@ func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 		_, err := os.Stat(keep)
 		require.NoError(t, err, "reconcile removed %s, which it must preserve", keep)
 	}
+}
+
+// writeShardSignature creates what hasShardStore looks for in a shard
+// directory that no index has opened: the lsm store directory and the version
+// file.
+func writeShardSignature(t *testing.T, indexDir, shard string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(indexDir, shard, "lsm"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(indexDir, shard, "version"), []byte{1, 0}, 0o644))
 }
 
 // newTestIndexOnDisk builds a real single-shard index under db's root, the

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -120,7 +120,8 @@ func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
 // TestDropOrphanedIndexDirectoriesPreservesReservedEntries pins what the
 // reconcile must never touch: a class still in the schema, the raft directory,
 // the backup framework's marked, staging and restore-temp directories, a
-// directory already pending async delete, and files at the data root.
+// directory already pending async delete, a mount point's lost+found, and
+// files at the data root.
 func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 	root := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -134,6 +135,7 @@ func TestDropOrphanedIndexDirectoriesPreservesReservedEntries(t *testing.T) {
 		filepath.Join(root, backup.BackupStagingPrefix+"backup-1-"+indexID("StagedClass")),
 		filepath.Join(root, ubak.TempDirectory, indexID("RestoringClass")),
 		filepath.Join(root, "gone.123.abcd"+asyncDeleteSuffix),
+		filepath.Join(root, "lost+found"),
 	}
 	for _, d := range append(preserved, orphanDir) {
 		require.NoError(t, os.MkdirAll(d, 0o755))

--- a/adapters/repos/db/reload_orphan_dir_test.go
+++ b/adapters/repos/db/reload_orphan_dir_test.go
@@ -1,0 +1,124 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/usecases/config"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+)
+
+// TestReloadLocalDBReconcilesOrphanClassDirectories reproduces the two RAFT
+// paths that leave a deleted collection's directory on disk forever:
+//
+//   - 0-weaviate-issues#652: a node restarted mid-DELETE_CLASS replays the entry
+//     schema-only, so DeleteIndex never runs; the reload after catch-up
+//     (Store.Apply -> reloadDBFromSchema) only re-opens classes still in the
+//     schema.
+//   - 0-weaviate-issues#651: a node that rejoins via an InstallSnapshot gets a
+//     schema without the deleted class; the reload after restore
+//     (Store.Restore -> reloadDBFromSchema) again only re-opens present classes.
+//
+// Both funnel through executor.ReloadLocalDB with a schema that no longer names
+// the class, so one reconcile step in that reload closes both. The two subtests
+// differ only in which RAFT entry point produced the schema-without-the-class;
+// the on-disk symptom and the fix are identical.
+func TestReloadLocalDBReconcilesOrphanClassDirectories(t *testing.T) {
+	cases := []struct {
+		name  string
+		issue string
+	}{
+		{name: "restart_replays_delete_schema_only", issue: "0-weaviate-issues#652"},
+		{name: "rejoin_installs_snapshot", issue: "0-weaviate-issues#651"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			logger, _ := test.NewNullLogger()
+
+			// The orphan: a class directory the schema no longer names, as either
+			// RAFT path leaves it. The raft directory is the one reserved
+			// non-class entry at the data root (usecases/schema/parser.go rejects
+			// a class named "raft"), so the reconcile must leave it untouched.
+			orphanDir := filepath.Join(root, "orphanclass")
+			require.NoError(t, os.MkdirAll(filepath.Join(orphanDir, "shard1", "lsm"), 0o755))
+			raftDir := filepath.Join(root, config.DefaultRaftDir)
+			require.NoError(t, os.MkdirAll(raftDir, 0o755))
+
+			executor := schemaUC.NewExecutor(
+				&Migrator{db: &DB{config: Config{RootPath: root}, logger: logger}, nodeId: "node1"},
+				schemaUC.NewMockSchemaReader(t),
+				logger,
+				func(string) error { return nil },
+			)
+
+			// The reloaded schema names no class: the deleted collection is gone
+			// from it on every node, which is exactly the client-visible state
+			// both issues describe.
+			require.NoError(t, executor.ReloadLocalDB(context.Background(), []command.UpdateClassRequest{}))
+
+			require.Eventually(t, func() bool {
+				_, err := os.Stat(orphanDir)
+				return os.IsNotExist(err)
+			}, 10*time.Second, 20*time.Millisecond,
+				"%s: reload left the orphan class directory on disk", tc.issue)
+
+			_, err := os.Stat(raftDir)
+			require.NoError(t, err, "reconcile must not remove the raft directory")
+		})
+	}
+}
+
+// TestDropOrphanedIndexDirectoriesPreservesLiveState pins what the reconcile
+// must never touch: a class still in the schema, the raft directory, a
+// directory already pending async delete, and non-directory bookkeeping at the
+// data root.
+func TestDropOrphanedIndexDirectoriesPreservesLiveState(t *testing.T) {
+	root := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	// Index directories are the lowercased class name; the keep set below names
+	// "KeptClass", so its directory is "keptclass".
+	keptDir := filepath.Join(root, "keptclass")
+	orphanDir := filepath.Join(root, "orphanclass")
+	raftDir := filepath.Join(root, config.DefaultRaftDir)
+	pendingDir := filepath.Join(root, "gone.123.abcd.deleteme")
+	for _, d := range []string{keptDir, orphanDir, raftDir, pendingDir} {
+		require.NoError(t, os.MkdirAll(d, 0o755))
+	}
+	// schema.db and friends are files at the data root, never class directories.
+	schemaFile := filepath.Join(root, "schema.db")
+	require.NoError(t, os.WriteFile(schemaFile, []byte("x"), 0o644))
+
+	db := &DB{config: Config{RootPath: root}, logger: logger}
+	require.NoError(t, db.dropOrphanedIndexDirectories([]string{"KeptClass"}))
+
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(orphanDir)
+		return os.IsNotExist(err)
+	}, 10*time.Second, 20*time.Millisecond, "orphan class directory must be removed")
+
+	for _, keep := range []string{keptDir, raftDir, pendingDir, schemaFile} {
+		_, err := os.Stat(keep)
+		require.NoError(t, err, "reconcile removed %s, which it must preserve", keep)
+	}
+}

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -39,13 +39,16 @@ func isIndexDirName(name string) bool {
 	return indexDirNameRegex.MatchString(name) && name != config.DefaultRaftDir
 }
 
-// hasShardStore reports whether indexPath holds at least one shard store, the
-// <shard>/lsm directory every shard creates when it initializes. The name
-// pattern alone also admits directories Weaviate does not own at the data
-// root: BACKUP_FILESYSTEM_PATH accepts any absolute path, so
-// <RootPath>/backups is a valid setup. A filesystem backup stores each class
-// as compressed chunk files under the backup id, never as an lsm directory,
-// so it does not match here.
+// hasShardStore reports whether indexPath holds at least one shard directory:
+// a child with the lsm store directory and the version file every shard
+// creates when it initializes (shard_init_lsm.go). The name pattern alone also
+// admits directories Weaviate does not own at the data root:
+// BACKUP_FILESYSTEM_PATH accepts any absolute path, so <RootPath>/backups is
+// a valid setup. A filesystem backup is laid out as
+// <backupID>/<node>/<class>/chunk-N, with one file name per level
+// (backup_config.json, backup.json, chunk-N) and node and class names as
+// directories, so a regular file named version two levels down cannot come
+// from a backup, whatever the node or class is called.
 func hasShardStore(indexPath string) (bool, error) {
 	entries, err := os.ReadDir(indexPath)
 	if err != nil {
@@ -55,8 +58,21 @@ func hasShardStore(indexPath string) (bool, error) {
 		if !entry.IsDir() {
 			continue
 		}
-		info, err := os.Stat(shardPathLSM(indexPath, entry.Name()))
-		if err == nil && info.IsDir() {
+		lsm, err := os.Stat(shardPathLSM(indexPath, entry.Name()))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, err
+		}
+		version, err := os.Stat(filepath.Join(shardPath(indexPath, entry.Name()), "version"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, err
+		}
+		if lsm.IsDir() && version.Mode().IsRegular() {
 			return true, nil
 		}
 	}
@@ -159,8 +175,14 @@ func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 			// DeleteIndex logs a failed Index.drop and still returns nil (the
 			// schema removal must not fail on a partial drop), so a surviving
 			// directory is the only signal that the drop did not rename it.
-			if _, statErr := os.Stat(path); statErr == nil {
+			_, statErr := os.Stat(path)
+			switch {
+			case statErr == nil:
 				err := fmt.Errorf("drop loaded orphan index %q left its directory in place", name)
+				log.Error(err)
+				ec.Add(err)
+			case !os.IsNotExist(statErr):
+				err := fmt.Errorf("confirm drop of loaded orphan index %q: %w", name, statErr)
 				log.Error(err)
 				ec.Add(err)
 			}

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -26,16 +26,18 @@ import (
 )
 
 // isReservedDataRootDir reports whether a directory at the data root is not a
-// class index directory. Every other directory there is one: Index.path() is
-// RootPath/<lowercased class>, and a class named "raft" is rejected at parse
-// time (usecases/schema/parser.go). The list must agree with the startup sweep
-// in New(): backup-marked and staging directories belong to the backup
-// framework, and .deleteme directories are already pending async removal.
+// class index directory. Index.path() is RootPath/<lowercased class>, a class
+// name starts with a letter, and a class named "raft" is rejected at parse
+// time (usecases/schema/parser.go). So a class directory never starts with a
+// dot and is never "raft". Dot-prefixed directories are the backup framework's
+// staging (.backup-staging-*) and restore temp (.backup.tmp) directories; the
+// __DELETE_ME_AFTER_BACKUP__ prefix marks an index kept for a running backup;
+// .deleteme directories are already pending async removal.
 func isReservedDataRootDir(name string) bool {
 	return name == config.DefaultRaftDir ||
+		strings.HasPrefix(name, ".") ||
 		strings.HasSuffix(name, asyncDeleteSuffix) ||
-		strings.HasPrefix(name, backup.DeleteMarker) ||
-		strings.HasPrefix(name, backup.BackupStagingPrefix)
+		strings.HasPrefix(name, backup.DeleteMarker)
 }
 
 // dropOrphanedIndexDirectories removes class directories under the data root

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -12,15 +12,31 @@
 package db
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
 )
+
+// isReservedDataRootDir reports whether a directory at the data root is not a
+// class index directory. Every other directory there is one: Index.path() is
+// RootPath/<lowercased class>, and a class named "raft" is rejected at parse
+// time (usecases/schema/parser.go). The list must agree with the startup sweep
+// in New(): backup-marked and staging directories belong to the backup
+// framework, and .deleteme directories are already pending async removal.
+func isReservedDataRootDir(name string) bool {
+	return name == config.DefaultRaftDir ||
+		strings.HasSuffix(name, asyncDeleteSuffix) ||
+		strings.HasPrefix(name, backup.DeleteMarker) ||
+		strings.HasPrefix(name, backup.BackupStagingPrefix)
+}
 
 // dropOrphanedIndexDirectories removes class directories under the data root
 // that the reloaded schema no longer names. Two RAFT paths delete a class from
@@ -32,12 +48,7 @@ import (
 //   - a rejoin via InstallSnapshot restores a schema without the class
 //     (0-weaviate-issues#651).
 //
-// keepClasses is the set of classes in the reloaded schema. Index directories
-// are the lowercased class name (Index.path()). The raft directory is the only
-// reserved non-class entry at the data root — a class named "raft" is rejected
-// at parse time (usecases/schema/parser.go) — so any other directory absent
-// from keepClasses is an orphan. Files are left alone; other bookkeeping at the
-// data root (schema.db, modules.db, migration flags) is files, not directories.
+// keepClasses is the set of classes in the reloaded schema.
 //
 // A snapshot install on an already-running node (Store.reloadDBFromSchema with
 // st.raft != nil) leaves the deleted class's *Index loaded in memory, so an
@@ -48,10 +59,14 @@ import (
 // running cycles, so its directory is renamed and removed directly. Both use
 // the rename-then-async-delete path Index.drop uses, so a large leftover does
 // not stall the RAFT goroutine this runs on.
+//
+// Failures are logged here as well as returned: the reload caller
+// (SchemaManager.ReloadDBFromSchema) discards the error, and a silently
+// surviving orphan is the symptom this function exists to remove.
 func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 	keep := make(map[string]struct{}, len(keepClasses))
 	for _, class := range keepClasses {
-		keep[strings.ToLower(class)] = struct{}{}
+		keep[indexID(schema.ClassName(class))] = struct{}{}
 	}
 
 	entries, err := os.ReadDir(db.config.RootPath)
@@ -68,33 +83,39 @@ func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 			continue
 		}
 		name := entry.Name()
-		if name == config.DefaultRaftDir || strings.HasSuffix(name, asyncDeleteSuffix) {
+		if isReservedDataRootDir(name) {
 			continue
 		}
 		if _, ok := keep[name]; ok {
 			continue
 		}
 
-		db.logger.WithFields(logrus.Fields{
+		path := filepath.Join(db.config.RootPath, name)
+		log := db.logger.WithFields(logrus.Fields{
 			"action": "reconcile_orphan_index_dir",
 			"class":  name,
-		}).Info("dropping class directory absent from the schema after reload")
+			"path":   path,
+		})
+		log.Info("dropping class directory absent from the schema after reload")
 
-		// db.indices is keyed by the lowercased class name, which is the on-disk
-		// directory name (Index.path()).
+		// db.indices is keyed by indexID, which is also the directory name.
 		db.indexLock.RLock()
 		liveIndex, loaded := db.indices[name]
 		db.indexLock.RUnlock()
 
 		if loaded {
 			if err := db.DeleteIndex(liveIndex.Config.ClassName); err != nil {
+				err = fmt.Errorf("drop loaded orphan index: %w", err)
+				log.Error(err)
 				ec.Add(err)
 			}
 			continue
 		}
 
-		renamed, err := renameForAsyncDelete(filepath.Join(db.config.RootPath, name), db.logger)
+		renamed, err := renameForAsyncDelete(path, db.logger)
 		if err != nil {
+			err = fmt.Errorf("rename orphan class directory for async delete: %w", err)
+			log.Error(err)
 			ec.Add(err)
 			continue
 		}

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -76,6 +76,8 @@ func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 		if os.IsNotExist(err) {
 			return nil
 		}
+		err = fmt.Errorf("list data root %q for orphan class directories: %w", db.config.RootPath, err)
+		db.logger.WithField("action", "reconcile_orphan_index_dir").Error(err)
 		return err
 	}
 

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// dropOrphanedIndexDirectories removes class directories under the data root
+// that the reloaded schema no longer names. Two RAFT paths delete a class from
+// the schema without dropping its index directory, and nothing else in the
+// reload path enumerates the data directory against the schema:
+//
+//   - a restart mid-DELETE_CLASS replays the entry schema-only, so DeleteIndex
+//     never runs (0-weaviate-issues#652);
+//   - a rejoin via InstallSnapshot restores a schema without the class
+//     (0-weaviate-issues#651).
+//
+// keepClasses is the set of classes in the reloaded schema. Index directories
+// are the lowercased class name (Index.path()). The raft directory is the only
+// reserved non-class entry at the data root — a class named "raft" is rejected
+// at parse time (usecases/schema/parser.go) — so any other directory absent
+// from keepClasses is an orphan. Files are left alone; other bookkeeping at the
+// data root (schema.db, modules.db, migration flags) is files, not directories.
+//
+// A snapshot install on an already-running node (Store.reloadDBFromSchema with
+// st.raft != nil) leaves the deleted class's *Index loaded in memory, so an
+// orphan may still be live. A live index is dropped through DeleteIndex, which
+// stops its cycle managers before renaming: renaming the directory out from
+// under a running index would let its next commitlog or compaction write
+// recreate it. An index that was never opened (both reproduced paths) has no
+// running cycles, so its directory is renamed and removed directly. Both use
+// the rename-then-async-delete path Index.drop uses, so a large leftover does
+// not stall the RAFT goroutine this runs on.
+func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
+	keep := make(map[string]struct{}, len(keepClasses))
+	for _, class := range keepClasses {
+		keep[strings.ToLower(class)] = struct{}{}
+	}
+
+	entries, err := os.ReadDir(db.config.RootPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	ec := errorcompounder.New()
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if name == config.DefaultRaftDir || strings.HasSuffix(name, asyncDeleteSuffix) {
+			continue
+		}
+		if _, ok := keep[name]; ok {
+			continue
+		}
+
+		db.logger.WithFields(logrus.Fields{
+			"action": "reconcile_orphan_index_dir",
+			"class":  name,
+		}).Info("dropping class directory absent from the schema after reload")
+
+		// db.indices is keyed by the lowercased class name, which is the on-disk
+		// directory name (Index.path()).
+		db.indexLock.RLock()
+		liveIndex, loaded := db.indices[name]
+		db.indexLock.RUnlock()
+
+		if loaded {
+			if err := db.DeleteIndex(liveIndex.Config.ClassName); err != nil {
+				ec.Add(err)
+			}
+			continue
+		}
+
+		renamed, err := renameForAsyncDelete(filepath.Join(db.config.RootPath, name), db.logger)
+		if err != nil {
+			ec.Add(err)
+			continue
+		}
+		if renamed == "" {
+			// already gone
+			continue
+		}
+		spawnAsyncDelete(renamed, db.logger)
+	}
+	return ec.ToError()
+}

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -39,6 +39,30 @@ func isIndexDirName(name string) bool {
 	return indexDirNameRegex.MatchString(name) && name != config.DefaultRaftDir
 }
 
+// hasShardStore reports whether indexPath holds at least one shard store, the
+// <shard>/lsm directory every shard creates when it initializes. The name
+// pattern alone also admits directories Weaviate does not own at the data
+// root: BACKUP_FILESYSTEM_PATH accepts any absolute path, so
+// <RootPath>/backups is a valid setup. A filesystem backup stores each class
+// as compressed chunk files under the backup id, never as an lsm directory,
+// so it does not match here.
+func hasShardStore(indexPath string) (bool, error) {
+	entries, err := os.ReadDir(indexPath)
+	if err != nil {
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := os.Stat(shardPathLSM(indexPath, entry.Name()))
+		if err == nil && info.IsDir() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // dropOrphanedIndexDirectories removes class directories under the data root
 // that the reloaded schema no longer names. Two RAFT paths delete a class from
 // the schema without dropping its index directory, and nothing else in the
@@ -50,6 +74,12 @@ func isIndexDirName(name string) bool {
 //     (0-weaviate-issues#651).
 //
 // keepClasses is the set of classes in the reloaded schema.
+//
+// A directory is only dropped once it is positively an index: either its
+// *Index is loaded in db.indices, or it holds a shard store (hasShardStore).
+// A name-shaped directory with neither is left alone, which also leaves an
+// index directory whose shards all live on other nodes; that leftover is
+// empty.
 //
 // A snapshot install on an already-running node (Store.reloadDBFromSchema with
 // st.raft != nil) leaves the deleted class's *Index loaded in memory, so an
@@ -99,12 +129,25 @@ func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 			"class":  name,
 			"path":   path,
 		})
-		log.Info("dropping class directory absent from the schema after reload")
 
 		// db.indices is keyed by indexID, which is also the directory name.
 		db.indexLock.RLock()
 		liveIndex, loaded := db.indices[name]
 		db.indexLock.RUnlock()
+
+		if !loaded {
+			isIndex, err := hasShardStore(path)
+			if err != nil {
+				err = fmt.Errorf("inspect directory absent from the schema: %w", err)
+				log.Error(err)
+				ec.Add(err)
+				continue
+			}
+			if !isIndex {
+				continue
+			}
+		}
+		log.Info("dropping class directory absent from the schema after reload")
 
 		if loaded {
 			if err := db.DeleteIndex(liveIndex.Config.ClassName); err != nil {

--- a/adapters/repos/db/reload_reconcile.go
+++ b/adapters/repos/db/reload_reconcile.go
@@ -15,29 +15,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+	"regexp"
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
-// isReservedDataRootDir reports whether a directory at the data root is not a
-// class index directory. Index.path() is RootPath/<lowercased class>, a class
-// name starts with a letter, and a class named "raft" is rejected at parse
-// time (usecases/schema/parser.go). So a class directory never starts with a
-// dot and is never "raft". Dot-prefixed directories are the backup framework's
-// staging (.backup-staging-*) and restore temp (.backup.tmp) directories; the
-// __DELETE_ME_AFTER_BACKUP__ prefix marks an index kept for a running backup;
-// .deleteme directories are already pending async removal.
-func isReservedDataRootDir(name string) bool {
-	return name == config.DefaultRaftDir ||
-		strings.HasPrefix(name, ".") ||
-		strings.HasSuffix(name, asyncDeleteSuffix) ||
-		strings.HasPrefix(name, backup.DeleteMarker)
+// indexDirNameRegex is schema.ClassNameRegexCore lowercased: Index.path() is
+// RootPath/<indexID>, and indexID lowercases the validated class name.
+var indexDirNameRegex = regexp.MustCompile(`^[a-z][_0-9a-z]{0,254}$`)
+
+// isIndexDirName reports whether a data-root directory name can be a class
+// index directory, so that anything else there is left alone: the backup
+// framework's .backup-staging-* and .backup.tmp directories, an index renamed
+// to __DELETE_ME_AFTER_BACKUP__* while a backup still reads it, .deleteme
+// directories pending async removal, and operator-owned entries such as a
+// mount point's lost+found. The raft directory matches the class pattern, but
+// a class named "raft" is rejected at parse time (usecases/schema/parser.go).
+func isIndexDirName(name string) bool {
+	return indexDirNameRegex.MatchString(name) && name != config.DefaultRaftDir
 }
 
 // dropOrphanedIndexDirectories removes class directories under the data root
@@ -87,7 +86,7 @@ func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 			continue
 		}
 		name := entry.Name()
-		if isReservedDataRootDir(name) {
+		if !isIndexDirName(name) {
 			continue
 		}
 		if _, ok := keep[name]; ok {
@@ -110,6 +109,15 @@ func (db *DB) dropOrphanedIndexDirectories(keepClasses []string) error {
 		if loaded {
 			if err := db.DeleteIndex(liveIndex.Config.ClassName); err != nil {
 				err = fmt.Errorf("drop loaded orphan index: %w", err)
+				log.Error(err)
+				ec.Add(err)
+				continue
+			}
+			// DeleteIndex logs a failed Index.drop and still returns nil (the
+			// schema removal must not fail on a partial drop), so a surviving
+			// directory is the only signal that the drop did not rename it.
+			if _, statErr := os.Stat(path); statErr == nil {
+				err := fmt.Errorf("drop loaded orphan index %q left its directory in place", name)
 				log.Error(err)
 				ec.Add(err)
 			}

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -90,7 +90,21 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 	if err := g.Wait(); err != nil {
 		return err
 	}
-	return errList
+	if errList != nil {
+		return errList
+	}
+
+	// Every class the schema still names has been loaded above; drop the index
+	// directories of classes it no longer names. A class delete can reach the
+	// schema without dropping its index directory — a schema-only DELETE_CLASS
+	// replay on restart (0-weaviate-issues#652) or a snapshot install on rejoin
+	// (0-weaviate-issues#651) — and this reload is the only place the data
+	// directory is reconciled against the schema.
+	keepClasses := make([]string, len(all))
+	for i, u := range all {
+		keepClasses[i] = u.Class.Class
+	}
+	return e.migrator.DropOrphanedIndexDirectories(ctx, keepClasses)
 }
 
 func (e *executor) Close(ctx context.Context) error {

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -99,10 +99,10 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 
 	// Every class the schema still names has been loaded above; drop the index
 	// directories of classes it no longer names. A class delete can reach the
-	// schema without dropping its index directory — a schema-only DELETE_CLASS
+	// schema without dropping its index directory: a schema-only DELETE_CLASS
 	// replay on restart (0-weaviate-issues#652) or a snapshot install on rejoin
-	// (0-weaviate-issues#651) — and this reload is the only place the data
-	// directory is reconciled against the schema.
+	// (0-weaviate-issues#651). This reload is the only place the data directory
+	// is reconciled against the schema.
 	keepClasses := make([]string, len(all))
 	for i, u := range all {
 		keepClasses[i] = u.Class.Class

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -62,6 +62,9 @@ func (e *executor) Open(ctx context.Context) error {
 func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassRequest) error {
 	cs := make([]*models.Class, len(all))
 
+	// The error group cancels the context it returns as soon as Wait returns,
+	// so the reconcile after the group needs the caller's context.
+	reconcileCtx := ctx
 	g, ctx := enterrors.NewErrorGroupWithContextWrapper(e.logger, ctx)
 	g.SetLimit(_NUMCPU * 2)
 
@@ -104,7 +107,7 @@ func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassReque
 	for i, u := range all {
 		keepClasses[i] = u.Class.Class
 	}
-	return e.migrator.DropOrphanedIndexDirectories(ctx, keepClasses)
+	return e.migrator.DropOrphanedIndexDirectories(reconcileCtx, keepClasses)
 }
 
 func (e *executor) Close(ctx context.Context) error {

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -362,6 +362,10 @@ func (*fakeMigrator) ValidateVectorIndexConfigsUpdate(old, updated map[string]sc
 	return nil
 }
 
+func (f *fakeMigrator) DropOrphanedIndexDirectories(ctx context.Context, keepClasses []string) error {
+	return nil
+}
+
 func (*fakeMigrator) UpdateVectorIndexConfigs(ctx context.Context, className string,
 	updated map[string]schemaConfig.VectorIndexConfig,
 ) error {

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -48,6 +48,13 @@ type Migrator interface {
 		property *models.Property) error
 	UpdateIndex(ctx context.Context, class *models.Class, shardingState *sharding.State) error
 
+	// DropOrphanedIndexDirectories removes index directories on disk for classes
+	// absent from keepClasses (the reloaded schema). It reconciles the data
+	// directory against the schema after a reload, closing the paths that delete
+	// a class from the schema without dropping its index directory
+	// (0-weaviate-issues#651, #652).
+	DropOrphanedIndexDirectories(ctx context.Context, keepClasses []string) error
+
 	NewTenants(ctx context.Context, class *models.Class, creates []*CreateTenantPayload) error
 	UpdateTenants(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload, implicitUpdate bool) error
 	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error


### PR DESCRIPTION
## Motivation

A deleted collection can leave `/var/lib/weaviate/<class>` on disk forever while the class is gone from the schema on every node. The leftover is invisible to every API and only shows up as disk usage (210 GB per node on the customer cluster that led here). Two RAFT paths produce it, and nothing in the reload path enumerates the data directory against the schema afterwards:

- **weaviate/0-weaviate-issues#652**: a node restarted while its FSM applies `DELETE_CLASS` replays the entry schema-only on restart (`index <= lastAppliedIndexToDB`), so `DeleteIndex` never runs; the reload after catch-up only re-opens classes still in the schema.
- **weaviate/0-weaviate-issues#651**: a node that rejoins through `InstallSnapshot` restores a schema without the class; `Store.Restore -> reloadDBFromSchema` again only re-opens present classes.

Startup cleanup only rescans marked directories (`.deleteme`, backup marker and staging), so a plain-named class directory absent from the schema is never touched.

## Fix

Both paths funnel through `executor.ReloadLocalDB`. After it loads every class the reloaded schema still names, it now drops the index directories of classes the schema no longer names (`DB.dropOrphanedIndexDirectories`, exposed as `Migrator.DropOrphanedIndexDirectories`). One reconcile step closes both issues, which is what both issues predicted.

- A data-root directory is a candidate only if its name is a lowercased class name (`isIndexDirName`: the class-name pattern, minus `raft`, which the parser rejects as a class name). That excludes everything else Weaviate or the operator keeps there: `.backup-staging-*`, `.backup.tmp`, `__DELETE_ME_AFTER_BACKUP__*`, `.deleteme` directories pending removal, `lost+found`, files.
- A candidate is dropped only once it is positively an index: its `*Index` is loaded in `db.indices`, or it holds a shard directory (`hasShardStore`: a child with the `lsm` store directory and the `version` file, both created by every shard on init). A name-shaped directory with neither is left alone. `BACKUP_FILESYSTEM_PATH` accepts any absolute path, so `<RootPath>/backups` is a valid setup; a filesystem backup is laid out as `<backupID>/<node>/<class>/chunk-N` with one file name per level (`backup_config.json`, `backup.json`, `chunk-N`) and node and class names as directories, so a regular file named `version` two levels down cannot come from a backup, whatever the node or class is called.
- A live index (a snapshot install on an already-running node keeps the deleted class's `*Index` loaded) is dropped through `DeleteIndex`, so its cycle managers stop before the rename. Renaming the directory out from under a running index would let its next commitlog or compaction write recreate it.
- An index that was never opened (both reproduced paths) has no running cycles; its directory is renamed and removed directly.
- Both use the existing rename-then-async-delete path `Index.drop` uses, so a large leftover does not stall the RAFT goroutine the reload runs on.
- Failures are logged at the DB layer as well as returned, because `SchemaManager.ReloadDBFromSchema` discards the reload's error and a silently surviving orphan is the symptom this removes.
- The reconcile receives the caller's context, not the error group's, which is cancelled the moment `Wait` returns.

## Tests

`adapters/repos/db/reload_orphan_dir_test.go`:

- `TestReloadLocalDBReconcilesOrphanClassDirectories` drives the real reload path with a real DB, an orphan class directory on disk, and a schema that no longer names it. Two cases cover the two states an orphan can be in when the reload runs: never opened by this process (weaviate/0-weaviate-issues#652, and weaviate/0-weaviate-issues#651 after a restart) and still loaded in `db.indices` (weaviate/0-weaviate-issues#651 on a running node), the latter exercising the `DeleteIndex` branch. Without the reconcile both fail (the directory survives the reload); with it both pass.
- `TestDropOrphanedIndexDirectoriesPreservesReservedEntries` pins what the reconcile must never touch: a class still in the schema, the `raft` directory, a backup-marked directory, a backup staging directory, a restore temp directory, a directory already pending async delete, `lost+found`, files at the data root, a filesystem backup tree colocated under the data root, and an index directory with no shard store on this node. The last two fail without `hasShardStore`.

`usecases/schema`, `cluster`, `cluster/schema` suites pass; gofumpt, golangci-lint and the goroutine linter are clean on the changed files.

The same two scenarios are also reproduced end-to-end on a 3-node kind cluster in weaviate/weaviate-e2e-tests#524 (recovery tests, currently xfail on the exact bug signature; they turn green once this ships).

## Review focus

- `isIndexDirName` + `hasShardStore`: whether any directory Weaviate does not own can pass both.
- `executor.ReloadLocalDB`: the reconcile runs only after every present class loaded without error, and only at reload time (restore and catch-up), never during normal schema operations.

Fixes weaviate/0-weaviate-issues#651
Fixes weaviate/0-weaviate-issues#652
