### PR TITLE
test(batch_ref_test.go): Use Go client v6 in acceptance tests

### DIFF
--- a/test/acceptance_with_go_client/batch_ref_test.go
+++ b/test/acceptance_with_go_client/batch_ref_test.go
@@ -19,15 +19,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
 	"github.com/weaviate/weaviate-go-client/v6/collections"
 	"github.com/weaviate/weaviate-go-client/v6/data"
-	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate-go-client/v6/tenant"
 )
 
 const (
 	UUID1 = "10523cdd-15a2-42f4-81fa-267fe92f7cd6"
-	UUID2 = ("5b6a08ba-1d46-43aa-89cc-8b070790c6f2")
+	UUID2 = "5b6a08ba-1d46-43aa-89cc-8b070790c6f2"
 )
 
 func TestBatchReferenceCreateNoObjects(t *testing.T) {
@@ -44,9 +43,8 @@ func TestBatchReferenceCreateNoObjects(t *testing.T) {
 	c.Collections.Delete(ctx, collectionTo)
 	t.Cleanup(func() { c.Collections.Delete(context.Background(), collectionTo) })
 
-	to, err := c.Collections.Create(ctx, collections.Collection{Name: collectionTo})
+	_, err := c.Collections.Create(ctx, collections.Collection{Name: collectionTo})
 	require.NoError(t, err)
-	require.NotNilf(t, to, "%q collection handle", collectionTo)
 
 	from, err := c.Collections.Create(ctx, collections.Collection{
 		Name: collectionFrom,
@@ -75,60 +73,56 @@ func TestBatchReferenceCreateNoObjects(t *testing.T) {
 }
 
 func TestBatchReferenceTargetIsMT(t *testing.T) {
-	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: wvhost.REST()})
-	require.Nil(t, err)
+	ctx := t.Context()
+	c := wvhost.NewClient(t)
 
-	classNameFrom := "RedTeddyFlowerFrom"
-	classNameTo := "RedTeddyFlowerTo"
+	collectionFrom := "RedTeddyFlowerFrom"
+	collectionTo := "RedTeddyFlowerTo"
+	uuid1, uuid2 := uuid.MustParse(UUID1), uuid.MustParse(UUID2)
 
 	// delete class if exists and cleanup after test
-	client.Schema().ClassDeleter().WithClassName(classNameFrom).Do(ctx)
-	defer client.Schema().ClassDeleter().WithClassName(classNameFrom).Do(ctx)
-	client.Schema().ClassDeleter().WithClassName(classNameTo).Do(ctx)
-	defer client.Schema().ClassDeleter().WithClassName(classNameTo).Do(ctx)
+	c.Collections.Delete(ctx, collectionFrom)
+	t.Cleanup(func() { c.Collections.Delete(context.Background(), collectionFrom) })
+	c.Collections.Delete(ctx, collectionTo)
+	t.Cleanup(func() { c.Collections.Delete(context.Background(), collectionTo) })
 
-	classTo := &models.Class{Class: classNameTo, Vectorizer: "none", MultiTenancyConfig: &models.MultiTenancyConfig{
-		Enabled: true,
-	}}
-	require.Nil(t, client.Schema().ClassCreator().WithClass(classTo).Do(ctx))
-	require.Nil(t, client.Schema().TenantsCreator().
-		WithClassName(classNameTo).
-		WithTenants(models.Tenant{Name: "Tenant"}).
-		Do(context.Background()))
+	to, err := c.Collections.Create(ctx, collections.Collection{
+		Name:         collectionTo,
+		MultiTenancy: &collections.MultiTenancyConfig{Enabled: true},
+	})
+	require.NoError(t, err)
+	require.NotNilf(t, to, "%q collection handle", collectionTo)
+	require.NoError(t, to.Tenants.Create(ctx, tenant.Tenant{Name: "john_doe"}))
 
-	require.Nil(t, err)
-	classFrom := &models.Class{
-		Class: classNameFrom,
-		Properties: []*models.Property{
-			{Name: "ref", DataType: []string{classNameTo}},
+	from, err := c.Collections.Create(ctx, collections.Collection{
+		Name: collectionFrom,
+		References: []collections.Reference{
+			{Name: "ref", Collections: []string{collectionTo}},
 		},
-		Vectorizer: "none",
-	}
-	require.Nil(t, client.Schema().ClassCreator().WithClass(classFrom).Do(ctx))
+	})
+	require.NoError(t, err)
+	require.NotNilf(t, from, "%q collection handle", collectionFrom)
 
 	// add object to target and source class
-	_, err = client.Data().Creator().WithClassName(classNameTo).WithID(UUID1).WithTenant("Tenant").WithProperties(map[string]interface{}{}).Do(ctx)
-	require.Nil(t, err)
-	_, err = client.Data().Creator().WithClassName(classNameFrom).WithID(UUID2).WithProperties(map[string]interface{}{}).Do(ctx)
-	require.Nil(t, err)
+	to = to.WithOptions(collections.WithTenant("john_doe"))
+	_, err = to.Data.Insert(ctx, &data.Object{UUID: &uuid1})
+	require.NoError(t, err)
 
-	rpb := client.Batch().ReferencePayloadBuilder().
-		WithFromClassName(classNameFrom).
-		WithFromRefProp("ref").
-		WithFromID(UUID2).
-		WithToID(UUID1) // no to class supplied, will be auto-detected
-	references := []*models.BatchReference{rpb.Payload()}
+	_, err = from.Data.Insert(ctx, &data.Object{UUID: &uuid2})
+	require.NoError(t, err)
 
-	resp, err := client.Batch().ReferencesBatcher().
-		WithReferences(references...).
-		Do(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, resp)
-	assert.Len(t, resp, len(references))
-	for i := range resp {
-		require.NotNil(t, resp[i].Result)
-		require.NotNil(t, resp[i].Result.Status)
-		assert.Equal(t, "FAILED", *resp[i].Result.Status)
-		assert.NotNil(t, resp[i].Result.Errors)
+	ref := data.Reference{
+		Origin: data.ObjectPath{
+			Property: "ref",
+			UUID:     uuid2,
+		},
+		UUID: uuid1,
+	}
+	_, err = from.Data.AddReferences(ctx, ref)
+
+	var partial data.AddReferencesError
+	if assert.ErrorAs(t, err, &partial) {
+		require.Len(t, partial.Errors, 1, "number of failed inserts")
+		require.Contains(t, partial.Errors, ref, "add-reference from %+v must fail", ref)
 	}
 }

--- a/test/acceptance_with_go_client/batch_ref_test.go
+++ b/test/acceptance_with_go_client/batch_ref_test.go
@@ -16,62 +16,61 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate-go-client/v6/collections"
+	"github.com/weaviate/weaviate-go-client/v6/data"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
 const (
 	UUID1 = "10523cdd-15a2-42f4-81fa-267fe92f7cd6"
-	UUID2 = "5b6a08ba-1d46-43aa-89cc-8b070790c6f2"
+	UUID2 = ("5b6a08ba-1d46-43aa-89cc-8b070790c6f2")
 )
 
 func TestBatchReferenceCreateNoObjects(t *testing.T) {
-	client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: wvhost.REST()})
-	require.Nil(t, err)
+	ctx := t.Context()
+	c := wvhost.NewClient(t)
 
-	classNameFrom := "GreenTeddyFlowerFrom"
-	classNameTo := "GreenTeddyFlowerTo"
+	collectionFrom := "GreenTeddyFlowerFrom"
+	collectionTo := "GreenTeddyFlowerTo"
+	uuid1, uuid2 := uuid.MustParse(UUID1), uuid.MustParse(UUID2)
 
 	// delete class if exists and cleanup after test
-	client.Schema().ClassDeleter().WithClassName(classNameFrom).Do(ctx)
-	defer client.Schema().ClassDeleter().WithClassName(classNameFrom).Do(ctx)
-	client.Schema().ClassDeleter().WithClassName(classNameTo).Do(ctx)
-	defer client.Schema().ClassDeleter().WithClassName(classNameTo).Do(ctx)
+	c.Collections.Delete(ctx, collectionFrom)
+	t.Cleanup(func() { c.Collections.Delete(context.Background(), collectionFrom) })
+	c.Collections.Delete(ctx, collectionTo)
+	t.Cleanup(func() { c.Collections.Delete(context.Background(), collectionTo) })
 
-	classTo := &models.Class{Class: classNameTo, Vectorizer: "none"}
-	require.Nil(t, client.Schema().ClassCreator().WithClass(classTo).Do(ctx))
+	to, err := c.Collections.Create(ctx, collections.Collection{Name: collectionTo})
+	require.NoError(t, err)
+	require.NotNilf(t, to, "%q collection handle", collectionTo)
 
-	classFrom := &models.Class{
-		Class: classNameFrom,
-		Properties: []*models.Property{
-			{Name: "ref", DataType: []string{classNameTo}},
+	from, err := c.Collections.Create(ctx, collections.Collection{
+		Name: collectionFrom,
+		References: []collections.Reference{
+			{Name: "ref", Collections: []string{collectionTo}},
 		},
-		Vectorizer: "none",
-	}
-	require.Nil(t, client.Schema().ClassCreator().WithClass(classFrom).Do(ctx))
+	})
+	require.NoError(t, err)
+	require.NotNilf(t, from, "%q collection handle", collectionTo)
 
 	// no objects exist, ref must fail - note that we tolerate if the target does not exist, however the source must exist
-	rpb := client.Batch().ReferencePayloadBuilder().
-		WithFromClassName(classNameFrom).
-		WithFromRefProp("ref").
-		WithFromID(UUID1). // uuids dont matter as we havent added any objects
-		WithToClassName(classNameTo).
-		WithToID(UUID2)
-	references := []*models.BatchReference{rpb.Payload()}
+	ref := data.Reference{
+		Origin: data.ObjectPath{
+			Property: "ref",
+			UUID:     uuid1,
+		},
+		UUID: uuid2,
+	}
+	_, err = from.Data.AddReferences(ctx, ref)
 
-	resp, err := client.Batch().ReferencesBatcher().
-		WithReferences(references...).
-		Do(context.Background())
-	require.Nil(t, err)
-	require.NotNil(t, resp)
-	assert.Len(t, resp, len(references))
-	for i := range resp {
-		require.NotNil(t, resp[i].Result)
-		require.NotNil(t, resp[i].Result.Status)
-		assert.Equal(t, "FAILED", *resp[i].Result.Status)
-		assert.NotNil(t, resp[i].Result.Errors)
+	var partial data.AddReferencesError
+	if assert.ErrorAs(t, err, &partial) {
+		require.Len(t, partial.Errors, 1, "number of failed inserts")
+		require.Contains(t, partial.Errors, ref, "add-reference from %+v must fail", ref)
 	}
 }
 

--- a/test/acceptance_with_go_client/batch_ref_test.go
+++ b/test/acceptance_with_go_client/batch_ref_test.go
@@ -58,8 +58,9 @@ func TestBatchReferenceCreateNoObjects(t *testing.T) {
 	// no objects exist, ref must fail - note that we tolerate if the target does not exist, however the source must exist
 	ref := data.Reference{
 		Origin: data.ObjectPath{
-			Property: "ref",
-			UUID:     uuid1,
+			Collection: collectionFrom,
+			Property:   "ref",
+			UUID:       uuid1,
 		},
 		UUID: uuid2,
 	}
@@ -113,8 +114,9 @@ func TestBatchReferenceTargetIsMT(t *testing.T) {
 
 	ref := data.Reference{
 		Origin: data.ObjectPath{
-			Property: "ref",
-			UUID:     uuid2,
+			Collection: collectionFrom,
+			Property:   "ref",
+			UUID:       uuid2,
 		},
 		UUID: uuid1,
 	}

--- a/test/acceptance_with_go_client/go.mod
+++ b/test/acceptance_with_go_client/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/tailor-platform/graphql v0.6.0
 	github.com/weaviate/weaviate v1.36.0
 	github.com/weaviate/weaviate-go-client/v5 v5.7.3-0.20260413120914-0d665cebe735
-	github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908090540-70bd5f780ba2
+	github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908143328-6dc6f0db0b42
 	golang.org/x/sync v0.22.0
 	google.golang.org/grpc v1.83.2
 )

--- a/test/acceptance_with_go_client/go.sum
+++ b/test/acceptance_with_go_client/go.sum
@@ -626,6 +626,10 @@ github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908083840-a501664
 github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908083840-a501664e4f12/go.mod h1:8ZJeez2D0ePagj+gN6Djfg25rnu3yeOZ0pwIfTH7PfI=
 github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908090540-70bd5f780ba2 h1:ehdJMgXWw1/MS7hAyGA0xYET+9QkCm5ibt0ccSQNNCw=
 github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908090540-70bd5f780ba2/go.mod h1:8ZJeez2D0ePagj+gN6Djfg25rnu3yeOZ0pwIfTH7PfI=
+github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908142903-51a887f715a1 h1:Bg+m94gNzHf/+Q54ENOtP1aAm86UUQTQ/KtQT6ldh6U=
+github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908142903-51a887f715a1/go.mod h1:8ZJeez2D0ePagj+gN6Djfg25rnu3yeOZ0pwIfTH7PfI=
+github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908143328-6dc6f0db0b42 h1:/4reOdfggFlnaZDcLeaZvmUwtmxENLC1+vVfVB3rlvU=
+github.com/weaviate/weaviate-go-client/v6 v6.0.0-beta.2.0.20260908143328-6dc6f0db0b42/go.mod h1:8ZJeez2D0ePagj+gN6Djfg25rnu3yeOZ0pwIfTH7PfI=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=


### PR DESCRIPTION
### What's being changed:

Rewrite acceptance tests in `test/acceptance_with_go_client/batch_ref_test.go` to use Go client v6. 

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
