### PR TITLE
Pre-compile regexp for role validation

### DIFF
--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -88,6 +88,20 @@ var resourcePatterns = []string{
 	fmt.Sprintf(`^%s/[^/]+$`, authorization.NamespacesDomain),
 }
 
+// resourcePatterns and VALID_VERBS are fixed at init, so compile them once.
+// validResource runs per policy on every role read and permission conversion;
+// recompiling there dominated those paths.
+var (
+	compiledResourcePatterns = func() []*regexp.Regexp {
+		out := make([]*regexp.Regexp, len(resourcePatterns))
+		for i, pattern := range resourcePatterns {
+			out[i] = regexp.MustCompile(pattern)
+		}
+		return out
+	}()
+	compiledValidVerbs = regexp.MustCompile(VALID_VERBS)
+)
+
 func newPolicy(policy []string) *authorization.Policy {
 	return &authorization.Policy{
 		Resource: fromCasbinResource(policy[1]),
@@ -607,12 +621,8 @@ func permission(policy []string, validatePath bool) (*models.Permission, error) 
 }
 
 func validResource(input string) bool {
-	for _, pattern := range resourcePatterns {
-		matched, err := regexp.MatchString(pattern, input)
-		if err != nil {
-			return false
-		}
-		if matched {
+	for _, re := range compiledResourcePatterns {
+		if re.MatchString(input) {
 			return true
 		}
 	}
@@ -620,7 +630,7 @@ func validResource(input string) bool {
 }
 
 func validVerb(input string) bool {
-	return regexp.MustCompile(VALID_VERBS).MatchString(input)
+	return compiledValidVerbs.MatchString(input)
 }
 
 func PrefixRoleName(name string) string {

--- a/usecases/auth/authorization/conv/casbin_types_bench_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_bench_test.go
@@ -1,0 +1,44 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package conv
+
+import "testing"
+
+// validResource runs once per policy on every role read, and validVerb runs on
+// every authorization audit line. Both matched against freshly compiled
+// patterns before, which dominated listing users. These benchmarks pin the
+// compiled-once behaviour: a regression back to compiling per call shows up as
+// a jump from nanoseconds to tens of microseconds and an allocation count in
+// the hundreds.
+
+func BenchmarkValidResource_Schema(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		validResource("schema/collections/Movies")
+	}
+}
+
+// The data domain sits late in resourcePatterns, so it walks nearly the whole
+// pattern list before matching — the worst case for per-call compilation.
+func BenchmarkValidResource_Data(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		validResource("data/collections/Movies/shards/s1/objects/o1")
+	}
+}
+
+func BenchmarkValidVerb(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		validVerb("R")
+	}
+}


### PR DESCRIPTION
### What's being changed:

Before, the regexp was recompiled for each user for each call when listing all users.

  - validResource: 48–142x faster (32.8µs → 230ns for a schema resource)
  - per-user role read: 823µs → 35µs
  - 5000 local role reads: 3.88s → 0.19s

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
