### PR TITLE
refactor(schema): read shard status from the indexer, not the RAFT schema

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -753,6 +753,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	schemaManager, err := schema.NewManager(migrator,
 		appState.ClusterService.Raft,
 		appState.ClusterService.SchemaReader(),
+		executor,
 		schemaRepo,
 		appState.Logger, appState.Authorizer, &appState.ServerConfig.Config.SchemaHandlerConfig, appState.ServerConfig.Config,
 		vectorIndex.ParseAndValidateConfig, appState.Modules, inverted.ValidateConfig,

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -435,7 +435,7 @@ func (s *schemaHandlers) getSchema(params schema.SchemaDumpParams, principal *mo
 	return schema.NewSchemaDumpOK().WithPayload(payload)
 }
 
-func (s *schemaHandlers) getShardsStatus(params schema.SchemaObjectsShardsGetParams,
+func (s *schemaHandlers) getShardsStorageStatus(params schema.SchemaObjectsShardsGetParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
@@ -685,7 +685,7 @@ func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager,
 		SchemaDumpHandlerFunc(h.getSchema)
 
 	api.SchemaSchemaObjectsShardsGetHandler = schema.
-		SchemaObjectsShardsGetHandlerFunc(h.getShardsStatus)
+		SchemaObjectsShardsGetHandlerFunc(h.getShardsStorageStatus)
 	api.SchemaSchemaObjectsShardsUpdateHandler = schema.
 		SchemaObjectsShardsUpdateHandlerFunc(h.updateShardStatus)
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4213,7 +4213,7 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	return size, nil
 }
 
-// getShardsStatus returns the status of the collection's shards on each of its
+// getShardsStorageStatus returns the status of the collection's shards on each of its
 // replica nodes. Example:
 //
 //	map[string]map[string]string{
@@ -4224,7 +4224,7 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 // The second return value are shard statuses mirroring the legacy implementation,
 // where the status is returned based on the first replica to contain the shard,
 // preferably local.
-func (i *Index) getShardsStatus(ctx context.Context, tenant string) (map[string]map[string]string, map[string]string, error) {
+func (i *Index) getShardsStorageStatus(ctx context.Context, tenant string) (map[string]map[string]string, map[string]string, error) {
 	thisNode := i.getSchema.NodeName()
 	className := i.Config.ClassName.String()
 	shardNames, err := i.schemaReader.Shards(className)

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -343,7 +343,7 @@ func (f *fakeRouter) NodeHostname(nodeName string) (string, bool) {
 	return host, ok
 }
 
-func TestIndex_getShardsStatus(t *testing.T) {
+func TestIndex_getShardsStorageStatus(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	clusterNodes := []string{"node-0", "node-1", "node-2"}
 	targetNode := clusterNodes[0]
@@ -459,7 +459,7 @@ func TestIndex_getShardsStatus(t *testing.T) {
 	}
 
 	// Act
-	got, gotLegacy, err := index.getShardsStatus(t.Context(), "")
+	got, gotLegacy, err := index.getShardsStorageStatus(t.Context(), "")
 
 	// Assert
 	assert.NoError(t, err)

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -598,14 +598,14 @@ func (m *Migrator) GetShardsQueueSize(ctx context.Context, className, tenant str
 	return idx.getShardsQueueSize(ctx, tenant)
 }
 
-func (m *Migrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error) {
+func (m *Migrator) GetShardsStorageStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error) {
 	idx := m.db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		// index not yet local (RAFT schema not applied on this node) or class does not exist
 		return nil, nil, fmt.Errorf("cannot get shards status for a non-existing index for %s: %w", className, schemaUC.ErrNotFound)
 	}
 
-	return idx.getShardsStatus(ctx, tenant)
+	return idx.getShardsStorageStatus(ctx, tenant)
 }
 
 func (m *Migrator) UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error {

--- a/adapters/repos/db/migrator_tenant_locks_test.go
+++ b/adapters/repos/db/migrator_tenant_locks_test.go
@@ -105,8 +105,8 @@ func migratorOpsWithoutClassLock(reachIndex bool) map[string]func(*Migrator) err
 		"DeleteTenants": func(m *Migrator) error {
 			return m.DeleteTenants(ctx, lockTestClass, nil)
 		},
-		"GetShardsStatus": func(m *Migrator) error {
-			_, _, err := m.GetShardsStatus(ctx, lockTestClass, "")
+		"GetShardsStorageStatus": func(m *Migrator) error {
+			_, _, err := m.GetShardsStorageStatus(ctx, lockTestClass, "")
 			return err
 		},
 		"GetShardsQueueSize": func(m *Migrator) error {

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -987,9 +987,9 @@ func TestShardsStatusNonExistingIndexWrapsNotFound(t *testing.T) {
 		call func() error
 	}{
 		{
-			name: "GetShardsStatus",
+			name: "GetShardsStorageStatus",
 			call: func() error {
-				_, _, err := migrator.GetShardsStatus(context.Background(), "DoesNotExist", "")
+				_, _, err := migrator.GetShardsStorageStatus(context.Background(), "DoesNotExist", "")
 				return err
 			},
 		},

--- a/adapters/repos/db/reindex_blockmax_repair_test.go
+++ b/adapters/repos/db/reindex_blockmax_repair_test.go
@@ -130,7 +130,7 @@ func TestReconcileClassSearchableBlockmax_BackfillsResidualStamp(t *testing.T) {
 	// Real schema.Manager wired to fakes: the stamp write routes through
 	// Handler's unexported schemaManager/schemaReader, so NewHandler is the
 	// only way to inject the capture; mgr.ReadOnlyClass resolves via the embedded SchemaReader.
-	h, err := schemauc.NewHandler(reader, capMgr, nil, logger, nil, nil, config.Config{},
+	h, err := schemauc.NewHandler(reader, capMgr, nil, nil, logger, nil, nil, config.Config{},
 		nil, nil, nil, nil, nil, nil, schemauc.Parser{}, nil, nil, nil)
 	require.NoError(t, err)
 	mgr := &schemauc.Manager{Handler: h, SchemaReader: reader}
@@ -195,7 +195,7 @@ func TestReconcileClassSearchableBlockmax_SeedsFromFinishedTaskWhileShardless(t 
 	logger, _ := test.NewNullLogger()
 	capMgr := &capturingSchemaManager{}
 	reader := repairResidualReader{class: residualClass}
-	h, err := schemauc.NewHandler(reader, capMgr, nil, logger, nil, nil, config.Config{},
+	h, err := schemauc.NewHandler(reader, capMgr, nil, nil, logger, nil, nil, config.Config{},
 		nil, nil, nil, nil, nil, nil, schemauc.Parser{}, nil, nil, nil)
 	require.NoError(t, err)
 	mgr := &schemauc.Manager{Handler: h, SchemaReader: reader}

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -108,7 +108,7 @@ type SchemaManager struct {
 
 func NewSchemaManager(nodeId string, db Indexer, parser Parser, reg prometheus.Registerer, log *logrus.Logger) *SchemaManager {
 	return &SchemaManager{
-		schema: NewSchema(nodeId, db, reg),
+		schema: NewSchema(nodeId, reg),
 		db:     db,
 		parser: parser,
 		log:    log,
@@ -229,7 +229,6 @@ func (s *SchemaManager) NewSchemaReaderWithWaitFunc(f func(context.Context, uint
 
 func (s *SchemaManager) SetIndexer(idx Indexer) {
 	s.db = idx
-	s.schema.shardReader = idx
 }
 
 func (s *SchemaManager) SetReplicationFSM(fsm replicationFSM) {

--- a/cluster/schema/manager_query_test.go
+++ b/cluster/schema/manager_query_test.go
@@ -31,7 +31,7 @@ import (
 func TestQueryCollectionsCount(t *testing.T) {
 	newManager := func(t *testing.T) *SchemaManager {
 		sm := &SchemaManager{
-			schema: NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry()),
+			schema: NewSchema(t.Name(), prometheus.NewPedanticRegistry()),
 		}
 		ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
 		require.NoError(t, sm.schema.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))

--- a/cluster/schema/manager_test.go
+++ b/cluster/schema/manager_test.go
@@ -57,7 +57,7 @@ func TestResolveAlais(t *testing.T) {
 func TestVersionedSchemaReaderShardReplicas(t *testing.T) {
 	var (
 		ctx = context.Background()
-		sc  = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc  = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		vsc = VersionedSchemaReader{
 			schema:        sc,
 			WaitForUpdate: func(ctx context.Context, version uint64) error { return nil },
@@ -89,7 +89,7 @@ func TestVersionedSchemaReaderClass(t *testing.T) {
 		retErr error
 		f      = func(ctx context.Context, version uint64) error { return retErr }
 		nodes  = []string{"N1", "N2"}
-		s      = NewSchema(t.Name(), &MockShardReader{}, prometheus.NewPedanticRegistry())
+		s      = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		sc     = VersionedSchemaReader{s, f}
 	)
 
@@ -185,8 +185,8 @@ func TestVersionedSchemaReaderClass(t *testing.T) {
 }
 
 func TestSchemaReaderShardReplicas(t *testing.T) {
-	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
-	rsc := SchemaReader{sc, VersionedSchemaReader{}}
+	sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
+	rsc := SchemaReader{schema: sc}
 	// class not found
 	_, _, err := sc.ShardReplicas("C", "S")
 	assert.ErrorIs(t, err, ErrClassNotFound)
@@ -210,8 +210,8 @@ func TestSchemaReaderShardReplicas(t *testing.T) {
 func TestSchemaReaderClass(t *testing.T) {
 	var (
 		nodes = []string{"N1", "N2"}
-		s     = NewSchema(t.Name(), &MockShardReader{}, prometheus.NewPedanticRegistry())
-		sc    = SchemaReader{s, VersionedSchemaReader{}}
+		s     = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
+		sc    = SchemaReader{schema: s}
 	)
 
 	// class not found
@@ -266,9 +266,6 @@ func TestSchemaReaderClass(t *testing.T) {
 	shard, _ := sc.TenantsShards("C", "S2")
 	assert.Empty(t, shard)
 	assert.Empty(t, sc.ShardFromUUID("Cx", nil))
-
-	_, err = sc.GetShardsStatus("C", "")
-	assert.Nil(t, err)
 
 	// Add Multi Tenant Class (PartitioningEnabled: true)
 	cls2 := &models.Class{Class: "D", MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true}}
@@ -465,15 +462,6 @@ func TestApplyPartialSchemaErr(t *testing.T) {
 			}
 		})
 	}
-}
-
-type MockShardReader struct {
-	lst models.ShardStatusList
-	err error
-}
-
-func (m *MockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	return m.lst, m.err
 }
 
 // fakeReplicationFSM stands in for the real FSM here because importing

--- a/cluster/schema/reader.go
+++ b/cluster/schema/reader.go
@@ -263,13 +263,6 @@ func (rs SchemaReader) TenantsShards(class string, tenants ...string) (map[strin
 	return rs.TenantsShardsWithVersion(context.TODO(), 0, class, tenants...)
 }
 
-func (rs SchemaReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	t := prometheus.NewTimer(monitoring.GetMetrics().SchemaReadsLocal.WithLabelValues("GetShardsStatus"))
-	defer t.ObserveDuration()
-
-	return rs.schema.GetShardsStatus(class, tenant)
-}
-
 func (rs SchemaReader) Len() int { return rs.schema.len() }
 
 func (rs SchemaReader) retry(f func(*schema) error) error {

--- a/cluster/schema/reader_test.go
+++ b/cluster/schema/reader_test.go
@@ -181,7 +181,7 @@ func TestSchemaReader_WithShardingStateCheck(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// GIVEN
-			s := NewSchema("test-node", nil, prometheus.NewPedanticRegistry())
+			s := NewSchema("test-node", prometheus.NewPedanticRegistry())
 			className := tt.setupSchema(s)
 
 			reader := SchemaReader{schema: s}

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -83,8 +83,7 @@ func (ci *ClassInfo) Version() uint64 {
 }
 
 type schema struct {
-	nodeID      string
-	shardReader shardReader
+	nodeID string
 
 	// mu protects `classes`, `aliases` and `classCountByNamespace`
 	mu      sync.RWMutex
@@ -107,7 +106,7 @@ type schema struct {
 	shardsCount *prometheus.GaugeVec
 }
 
-func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer) *schema {
+func NewSchema(nodeID string, reg prometheus.Registerer) *schema {
 	// this also registers the prometheus metrics with given `reg` in addition to just creating it.
 	r := promauto.With(reg)
 
@@ -116,7 +115,6 @@ func NewSchema(nodeID string, shardReader shardReader, reg prometheus.Registerer
 		classes:               make(map[string]*metaClass, 128),
 		aliases:               make(map[string]string, 128),
 		classCountByNamespace: make(map[string]int),
-		shardReader:           shardReader,
 		collectionsCount: r.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace:   "weaviate",
 			Name:        "schema_collections",
@@ -342,14 +340,6 @@ func (s *schema) CopyShardingState(class string) (*sharding.State, uint64) {
 	})
 
 	return &shardingState, version
-}
-
-func (s *schema) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	return s.shardReader.GetShardsStatus(class, tenant)
-}
-
-type shardReader interface {
-	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 }
 
 func (s *schema) len() int {

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -37,7 +37,7 @@ import (
 
 func TestCollectionNameConflictWithAlias(t *testing.T) {
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -55,7 +55,7 @@ func TestCollectionNameConflictWithAlias(t *testing.T) {
 func Test_schemaCollectionMetrics(t *testing.T) {
 	r := prometheus.NewPedanticRegistry()
 
-	s := NewSchema("testNode", nil, r)
+	s := NewSchema("testNode", r)
 	ss := &sharding.State{}
 
 	c1 := &models.Class{
@@ -102,7 +102,7 @@ func Test_schemaCollectionMetrics(t *testing.T) {
 func Test_schemaShardMetrics(t *testing.T) {
 	r := prometheus.NewPedanticRegistry()
 
-	s := NewSchema("testNode", nil, r)
+	s := NewSchema("testNode", r)
 	ss := &sharding.State{}
 
 	c1 := &models.Class{
@@ -230,7 +230,7 @@ func Test_UpdateTenants_TransitionalStateRejection(t *testing.T) {
 		className  = "TestClass"
 	)
 	newSchema := func() *schema {
-		return NewSchema(nodeID, nil, prometheus.NewPedanticRegistry())
+		return NewSchema(nodeID, prometheus.NewPedanticRegistry())
 	}
 	newClass := func() *models.Class {
 		return &models.Class{
@@ -342,7 +342,7 @@ func Test_UpdateTenants_MovementRejection(t *testing.T) {
 	}
 	setup := func(t *testing.T, node, startStatus string) *schema {
 		t.Helper()
-		s := NewSchema(node, nil, prometheus.NewPedanticRegistry())
+		s := NewSchema(node, prometheus.NewPedanticRegistry())
 		require.NoError(t, s.addClass(newClass(), &sharding.State{}, 0))
 		require.NoError(t, s.addTenants(className, 0, &api.AddTenantsRequest{
 			ClusterNodes: []string{node},
@@ -401,7 +401,7 @@ func Test_UpdateTenants_MovementRejection(t *testing.T) {
 	})
 
 	t.Run("partial: only the moving tenant is blocked, sibling still applies", func(t *testing.T) {
-		s := NewSchema(nodeID, nil, prometheus.NewPedanticRegistry())
+		s := NewSchema(nodeID, prometheus.NewPedanticRegistry())
 		require.NoError(t, s.addClass(newClass(), &sharding.State{}, 0))
 		require.NoError(t, s.addTenants(className, 0, &api.AddTenantsRequest{
 			ClusterNodes: []string{nodeID},
@@ -441,7 +441,7 @@ func Test_UpdateTenants_RecordsPreFreezeStatus(t *testing.T) {
 	)
 	setup := func(t *testing.T, existing []*api.Tenant) *schema {
 		t.Helper()
-		s := NewSchema(nodeID, nil, prometheus.NewPedanticRegistry())
+		s := NewSchema(nodeID, prometheus.NewPedanticRegistry())
 		require.NoError(t, s.addClass(&models.Class{
 			Class:              className,
 			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
@@ -841,7 +841,7 @@ func Test_UpdateProperty_MovementRejection(t *testing.T) {
 
 func Test_schemaDeepCopy(t *testing.T) {
 	r := prometheus.NewPedanticRegistry()
-	s := NewSchema("testNode", nil, r)
+	s := NewSchema("testNode", r)
 
 	class := &models.Class{
 		Class: "test",
@@ -899,7 +899,7 @@ func Test_schemaDeepCopy(t *testing.T) {
 func TestSchemaRestoreLegacyWithEmptyClasses(t *testing.T) {
 	// Test the scenario where snapshot contains "classes":{} which should unmarshal to empty map
 	t.Run("empty classes object", func(t *testing.T) {
-		s := NewSchema("test-node", &MockShardReader{}, nil)
+		s := NewSchema("test-node", nil)
 
 		// Create snapshot JSON with empty classes object
 		snapData := `{"node_id":"test-node","snapshot_id":"test-snapshot","classes":{}}`
@@ -919,7 +919,7 @@ func TestSchemaRestoreLegacyWithEmptyClasses(t *testing.T) {
 func TestSchemaRestoreLegacyWithNilClasses(t *testing.T) {
 	// Test the scenario where snapshot JSON unmarshaling results in nil Classes
 	t.Run("nil classes after unmarshal", func(t *testing.T) {
-		s := NewSchema("test-node", &MockShardReader{}, nil)
+		s := NewSchema("test-node", nil)
 
 		// Create a snapshot struct with nil Classes to simulate unmarshal failure
 		snap := snapshot{
@@ -946,7 +946,7 @@ func TestSchemaRestoreLegacyWithNilClasses(t *testing.T) {
 func TestSchemaAddClassAfterRestoreWithEmptyClasses(t *testing.T) {
 	// Test the scenario where addClass is called after restoring empty classes
 	t.Run("add class after empty restore", func(t *testing.T) {
-		s := NewSchema("test-node", &MockShardReader{}, nil)
+		s := NewSchema("test-node", nil)
 
 		// First restore with empty classes
 		snapData := `{"node_id":"test-node","snapshot_id":"test-snapshot","classes":{}}`
@@ -973,7 +973,7 @@ func TestSchemaAddClassAfterRestoreWithEmptyClasses(t *testing.T) {
 func TestSchemaAddClassAfterRestoreWithNilClasses(t *testing.T) {
 	// Test the scenario where addClass is called after restoring with nil classes
 	t.Run("add class after nil restore", func(t *testing.T) {
-		s := NewSchema("test-node", &MockShardReader{}, nil)
+		s := NewSchema("test-node", nil)
 
 		// First restore with nil classes (simulating unmarshal failure)
 		snap := snapshot{
@@ -1006,7 +1006,7 @@ func TestSchemaAddClassAfterRestoreWithNilClasses(t *testing.T) {
 
 func TestCreateAlias(t *testing.T) {
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -1046,7 +1046,7 @@ func TestSchemaAliasCasing(t *testing.T) {
 	// Meaning, MyCar, MYCar, myCar all same.
 
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -1074,7 +1074,7 @@ func TestSchemaAliasCasing(t *testing.T) {
 
 func TestReplaceAlias(t *testing.T) {
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -1100,7 +1100,7 @@ func TestReplaceAlias(t *testing.T) {
 
 func TestDeleteAlias(t *testing.T) {
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -1120,7 +1120,7 @@ func TestDeleteAlias(t *testing.T) {
 
 func TestResolveAlias(t *testing.T) {
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -1140,7 +1140,7 @@ func TestResolveAlias(t *testing.T) {
 
 func TestGetAlias(t *testing.T) {
 	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		sc = NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
 	)
 
@@ -1196,7 +1196,7 @@ func TestGetAlias(t *testing.T) {
 // kept lowercase, and that ResolveAlias still finds it under that key. Only
 // the class portion of the name is normalized.
 func TestAliasNamespacePrefixPreserved(t *testing.T) {
-	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
 	require.NoError(t, sc.addClass(&models.Class{Class: "delhappy:Movies"}, ss, 1))
 	require.NoError(t, sc.createAlias("delhappy:Movies", "delhappy:Films"))
@@ -1311,7 +1311,7 @@ func TestCollectionsCount_Namespaced(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+			sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 			tt.setup(t, sc)
 
 			for namespace, want := range tt.want {
@@ -1324,7 +1324,7 @@ func TestCollectionsCount_Namespaced(t *testing.T) {
 // A namespace that loses its last class must leave no entry behind: a cluster
 // that churns namespaces would otherwise grow the map for the life of the node.
 func TestClassCountByNamespace_DropsEmptyNamespace(t *testing.T) {
-	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
 
 	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
@@ -1339,7 +1339,7 @@ func TestClassCountByNamespace_DropsEmptyNamespace(t *testing.T) {
 // A snapshot the parser rejects must leave the previous classes and their gauge
 // series untouched: replaceClasses runs only after every class has parsed.
 func TestRestore_RejectedSnapshotLeavesStateIntact(t *testing.T) {
-	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
 	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
 
@@ -1443,7 +1443,7 @@ func TestCollectionsGauge_ByNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+			sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 			tt.setup(t, sc)
 
 			// Counted before any read below: WithLabelValues creates the series
@@ -1463,7 +1463,7 @@ func TestCollectionsGauge_ByNamespace(t *testing.T) {
 // The count is read under a read lock, so all three writers of the map must
 // write it under the lock that guards s.classes. Run with -race.
 func TestCollectionsCount_ConcurrentAccess(t *testing.T) {
-	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	sc := NewSchema(t.Name(), prometheus.NewPedanticRegistry())
 	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
 
 	snapshot, err := json.Marshal(map[string]*metaClass{

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -781,7 +781,7 @@ func testConcurrentAliasSnapshot(t *testing.T, s *schema) {
 // the schema-map lock before returning the pointer — so reading Sharding and
 // ClassVersion afterwards is unsynchronised, while updateClass mutates exactly
 // those fields under the class lock. The sibling test above only drives
-// GetShardsStatus, which goes through a different reader, so it never covered
+// GetShardsStorageStatus, which goes through a different reader, so it never covered
 // this path.
 //
 // Only meaningful under -race: without the class lock the detector reports the

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -75,10 +75,6 @@ func TestConcurrentSchemaAccess(t *testing.T) {
 			test: testConcurrentTenantManagementOperations,
 		},
 		{
-			name: "concurrent sharding state operations",
-			test: testConcurrentShardingStateOperations,
-		},
-		{
 			name: "concurrent alias snapshot and alias writes",
 			test: testConcurrentAliasSnapshot,
 		},
@@ -90,7 +86,7 @@ func TestConcurrentSchemaAccess(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := NewSchema("testNode", &mockShardReader{}, prometheus.NewPedanticRegistry())
+			s := NewSchema("testNode", prometheus.NewPedanticRegistry())
 			tt.test(t, s)
 		})
 	}
@@ -717,47 +713,6 @@ func testConcurrentTenantManagementOperations(t *testing.T, s *schema) {
 	wg.Wait()
 }
 
-func testConcurrentShardingStateOperations(t *testing.T, s *schema) {
-	// Setup initial class
-	class := &models.Class{
-		Class: "TestClass",
-		Properties: []*models.Property{
-			{Name: "prop1", DataType: []string{"string"}},
-		},
-	}
-	shardState := &sharding.State{
-		Physical: map[string]sharding.Physical{
-			"shard1": {
-				Name:   "shard1",
-				Status: "HOT",
-			},
-		},
-	}
-	require.NoError(t, s.addClass(class, shardState, 1))
-
-	const numGoroutines = 10
-	const iterations = 100
-
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines) // For GetShardsStatus operations
-
-	// Test concurrent GetShardsStatus operations
-	for i := 0; i < numGoroutines; i++ {
-		go func() {
-			defer wg.Done()
-			for j := 0; j < iterations; j++ {
-				status, _ := s.GetShardsStatus("TestClass", "")
-				if status != nil {
-					assert.NotEmpty(t, status)
-				}
-				time.Sleep(time.Microsecond)
-			}
-		}()
-	}
-
-	wg.Wait()
-}
-
 // AliasSnapshot runs while raft applies alias commands. Reading the alias map
 // without the lock is a concurrent map iteration and write, which crashes the
 // process. RestoreAlias is covered too: it replaces the map rather than
@@ -816,15 +771,6 @@ func testConcurrentAliasSnapshot(t *testing.T, s *schema) {
 	}
 
 	wg.Wait()
-}
-
-// Additional mock for shard reader
-type mockShardReader struct{}
-
-func (m *mockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	return models.ShardStatusList{
-		{Status: "HOT", Name: "shard1"},
-	}, nil
 }
 
 // testConcurrentCopyShardingStateAndUpdate reproduces the production pair that

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -51,7 +51,7 @@ type Indexer interface {
 	ReconcileAsyncReplicationForShard(class, shard string) error
 	LoadShard(class, shard string)     // is a no-op
 	ShutdownShard(class, shard string) // is a no-op
-	GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error)
+	GetShardsStorageStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error)
 
 	TriggerSchemaUpdateCallbacks()
 

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -51,7 +51,7 @@ type Indexer interface {
 	ReconcileAsyncReplicationForShard(class, shard string) error
 	LoadShard(class, shard string)     // is a no-op
 	ShutdownShard(class, shard string) // is a no-op
-	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
+	GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error)
 
 	TriggerSchemaUpdateCallbacks()
 

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -863,12 +863,3 @@ func putObjectAndFlush(t *testing.T, repo *db.DB, className, tenant string, vect
 		return nil
 	})
 }
-
-type MockShardReader struct {
-	lst models.ShardStatusList
-	err error
-}
-
-func (m MockShardReader) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	return m.lst, m.err
-}

--- a/test/acceptance/multi_tenancy/get_shards_status_with_tenant_test.go
+++ b/test/acceptance/multi_tenancy/get_shards_status_with_tenant_test.go
@@ -19,9 +19,9 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-func TestGetShardsStatusWithTenant(t *testing.T) {
+func TestGetShardsStorageStatusWithTenant(t *testing.T) {
 	testClass := models.Class{
-		Class: "ClassGetShardsStatusWithTenant",
+		Class: "ClassGetShardsStorageStatusWithTenant",
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled: true,
 		},

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -120,7 +120,7 @@ func (m *MockSchemaExecutor) UpdateShardStatus(req *cmd.UpdateShardStatusRequest
 	return args.Error(0)
 }
 
-func (m *MockSchemaExecutor) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
+func (m *MockSchemaExecutor) GetShardsStorageStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	args := m.Called(ctx, class, tenant)
 	return models.ShardStatusList{}, args.Error(1)
 }

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -120,8 +120,8 @@ func (m *MockSchemaExecutor) UpdateShardStatus(req *cmd.UpdateShardStatusRequest
 	return args.Error(0)
 }
 
-func (m *MockSchemaExecutor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	args := m.Called(class, tenant)
+func (m *MockSchemaExecutor) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
+	args := m.Called(ctx, class, tenant)
 	return models.ShardStatusList{}, args.Error(1)
 }
 

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -203,7 +203,8 @@ func Test_Schema_Authorization(t *testing.T) {
 			t.Run(test.methodName, func(t *testing.T) {
 				authorizer := mocks.NewMockAuthorizer()
 				authorizer.SetErr(errors.New("just a test fake"))
-				handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+				db := &fakeDB{}
+				handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, db, authorizer)
 				fakeSchemaManager.On("ReadOnlySchema").Return(models.Schema{})
 				fakeSchemaManager.On("ReadOnlyClass", mock.Anything).Return(models.Class{})
 				fakeSchemaManager.On("GetAliases", mock.Anything, mock.Anything, mock.Anything).Return([]*models.Alias{{}}, nil)
@@ -269,7 +270,8 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 
 	t.Run("GetConsistentClass - authorization uses resolved class name, not alias", func(t *testing.T) {
 		authorizer := mocks.NewMockAuthorizer()
-		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+		db := &fakeDB{}
+		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, db, authorizer)
 
 		// Mock class retrieval
 		fakeSchemaManager.On("ReadOnlyClassWithVersion", mock.Anything, resolvedClassName, mock.Anything).Return(&models.Class{Class: resolvedClassName}, nil)
@@ -297,7 +299,8 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 
 	t.Run("ShardsStatus - authorization uses resolved class name, not alias", func(t *testing.T) {
 		authorizer := mocks.NewMockAuthorizer()
-		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+		db := &fakeDB{}
+		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, db, authorizer)
 
 		// Mock shard status retrieval
 		expectedStatus := models.ShardStatusList{
@@ -306,7 +309,7 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 				Status: "READY",
 			},
 		}
-		fakeSchemaManager.On("GetShardsStatus", resolvedClassName, shardName).Return(expectedStatus, nil)
+		db.On("GetShardsStatus", mock.Anything, resolvedClassName, shardName).Return(expectedStatus, nil)
 
 		// Create custom schema manager with alias resolution
 		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{
@@ -331,7 +334,8 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 
 	t.Run("ShardsStatus - NS-enabled authorization uses namespace-qualified resolved class name", func(t *testing.T) {
 		authorizer := mocks.NewMockAuthorizer()
-		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+		db := &fakeDB{}
+		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, db, authorizer)
 		handler.config.Namespaces.Enabled = true
 
 		nsPrincipal := &models.Principal{Username: "u1", Namespace: "customer1"}
@@ -342,7 +346,7 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 		expectedStatus := models.ShardStatusList{
 			&models.ShardStatusGetResponse{Name: shardName, Status: "READY"},
 		}
-		fakeSchemaManager.On("GetShardsStatus", qualifiedClass, shardName).Return(expectedStatus, nil)
+		db.On("GetShardsStatus", mock.Anything, qualifiedClass, shardName).Return(expectedStatus, nil)
 
 		handler.schemaReader = &fakeSchemaManagerWithAlias{
 			fakeSchemaManager: fakeSchemaManager,
@@ -364,7 +368,8 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 
 	t.Run("GetConsistentClass - authorization uses original class name when no alias resolution", func(t *testing.T) {
 		authorizer := mocks.NewMockAuthorizer()
-		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+		db := &fakeDB{}
+		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, db, authorizer)
 
 		className := "DirectClassName"
 
@@ -394,7 +399,8 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 
 	t.Run("ShardsStatus - authorization uses original class name when no alias resolution", func(t *testing.T) {
 		authorizer := mocks.NewMockAuthorizer()
-		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+		db := &fakeDB{}
+		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, db, authorizer)
 
 		className := "DirectClassName"
 
@@ -405,7 +411,7 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 				Status: "READY",
 			},
 		}
-		fakeSchemaManager.On("GetShardsStatus", className, shardName).Return(expectedStatus, nil)
+		db.On("GetShardsStatus", mock.Anything, className, shardName).Return(expectedStatus, nil)
 
 		// Create custom schema manager without alias resolution
 		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -411,7 +411,7 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 				Status: "READY",
 			},
 		}
-		db.On("GetShardsStatus", mock.Anything, className, shardName).Return(expectedStatus, nil)
+		db.On("GetShardsStorageStatus", mock.Anything, className, shardName).Return(expectedStatus, nil)
 
 		// Create custom schema manager without alias resolution
 		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -309,7 +309,7 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 				Status: "READY",
 			},
 		}
-		db.On("GetShardsStatus", mock.Anything, resolvedClassName, shardName).Return(expectedStatus, nil)
+		db.On("GetShardsStorageStatus", mock.Anything, resolvedClassName, shardName).Return(expectedStatus, nil)
 
 		// Create custom schema manager with alias resolution
 		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{
@@ -346,7 +346,7 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 		expectedStatus := models.ShardStatusList{
 			&models.ShardStatusGetResponse{Name: shardName, Status: "READY"},
 		}
-		db.On("GetShardsStatus", mock.Anything, qualifiedClass, shardName).Return(expectedStatus, nil)
+		db.On("GetShardsStorageStatus", mock.Anything, qualifiedClass, shardName).Return(expectedStatus, nil)
 
 		handler.schemaReader = &fakeSchemaManagerWithAlias{
 			fakeSchemaManager: fakeSchemaManager,

--- a/usecases/schema/class_muvera_bounds_test.go
+++ b/usecases/schema/class_muvera_bounds_test.go
@@ -43,7 +43,7 @@ func newTestHandlerWithRealVectorConfigParser(t *testing.T) *Handler {
 	fakeValidator := &fakeValidator{}
 	schemaParser := NewParser(fakeClusterState, vectorindex.ParseAndValidateConfig, fakeValidator, fakeModulesProvider{}, nil, nil)
 	handler, err := NewHandler(
-		schemaManager, schemaManager, fakeValidator, logger, mocks.NewMockAuthorizer(),
+		schemaManager, schemaManager, &fakeDB{}, fakeValidator, logger, mocks.NewMockAuthorizer(),
 		&cfg.SchemaHandlerConfig, cfg, vectorindex.ParseAndValidateConfig, vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, fakeClusterState, nil, *schemaParser, nil, nil, nil)
 	require.NoError(t, err)

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -384,8 +384,7 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 	return e.migrator.UpdateShardStatus(ctx, req.Class, req.Shard, req.Status, req.SchemaVersion)
 }
 
-func (e *executor) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	ctx := context.Background()
+func (e *executor) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	shardsStatus, legacyStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant)
 	if err != nil {
 		return nil, err

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -384,8 +384,8 @@ func (e *executor) UpdateShardStatus(req *api.UpdateShardStatusRequest) error {
 	return e.migrator.UpdateShardStatus(ctx, req.Class, req.Shard, req.Status, req.SchemaVersion)
 }
 
-func (e *executor) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
-	shardsStatus, legacyStatus, err := e.migrator.GetShardsStatus(ctx, class, tenant)
+func (e *executor) GetShardsStorageStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
+	shardsStatus, legacyStatus, err := e.migrator.GetShardsStorageStatus(ctx, class, tenant)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -355,7 +355,7 @@ func TestExecutor(t *testing.T) {
 		legacy := map[string]string{"A": "C"}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, legacy, nil)
 		x := newMockExecutor(migrator, store)
-		statusList, err := x.GetShardsStatus("A", "")
+		statusList, err := x.GetShardsStatus(ctx, "A", "")
 		assert.NoError(t, err)
 		assert.Len(t, statusList, 1, "number of shards in the status list")
 		statusList0 := statusList[0]
@@ -369,7 +369,7 @@ func TestExecutor(t *testing.T) {
 		legacy := map[string]string{"A": "C"}
 		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, legacy, ErrAny)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus("A", "")
+		_, err := x.GetShardsStatus(ctx, "A", "")
 		assert.ErrorIs(t, err, ErrAny)
 	})
 	t.Run("UpdateShardStatus", func(t *testing.T) {

--- a/usecases/schema/executor_test.go
+++ b/usecases/schema/executor_test.go
@@ -349,13 +349,13 @@ func TestExecutor(t *testing.T) {
 		assert.ErrorIs(t, x.AddTenants("A", req), ErrNotFound)
 	})
 
-	t.Run("GetShardsStatus", func(t *testing.T) {
+	t.Run("GetShardsStorageStatus", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		status := map[string]map[string]string{"A": {"B": "C"}}
 		legacy := map[string]string{"A": "C"}
-		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, legacy, nil)
+		migrator.On("GetShardsStorageStatus", Anything, "A", "").Return(status, legacy, nil)
 		x := newMockExecutor(migrator, store)
-		statusList, err := x.GetShardsStatus(ctx, "A", "")
+		statusList, err := x.GetShardsStorageStatus(ctx, "A", "")
 		assert.NoError(t, err)
 		assert.Len(t, statusList, 1, "number of shards in the status list")
 		statusList0 := statusList[0]
@@ -363,13 +363,13 @@ func TestExecutor(t *testing.T) {
 		assert.Equal(t, statusList0.Status, "C", "shard legacy status")
 		assert.Equal(t, statusList0.PerNodeStatus, map[string]string{"B": "C"})
 	})
-	t.Run("GetShardsStatusError", func(t *testing.T) {
+	t.Run("GetShardsStorageStatusError", func(t *testing.T) {
 		migrator := &fakeMigrator{}
 		status := map[string]map[string]string{"A": {"B": "C"}}
 		legacy := map[string]string{"A": "C"}
-		migrator.On("GetShardsStatus", Anything, "A", "").Return(status, legacy, ErrAny)
+		migrator.On("GetShardsStorageStatus", Anything, "A", "").Return(status, legacy, ErrAny)
 		x := newMockExecutor(migrator, store)
-		_, err := x.GetShardsStatus(ctx, "A", "")
+		_, err := x.GetShardsStorageStatus(ctx, "A", "")
 		assert.ErrorIs(t, err, ErrAny)
 	})
 	t.Run("UpdateShardStatus", func(t *testing.T) {

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -299,7 +299,7 @@ func (f *fakeSchemaManager) LocalActiveShardsCount(class string) (int, error) {
 	return args.Get(0).(int), args.Error(1)
 }
 
-func (f *fakeSchemaManager) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
+func (f *fakeSchemaManager) GetShardsStorageStatus(class, tenant string) (models.ShardStatusList, error) {
 	args := f.Called(class, tenant)
 	return args.Get(0).(models.ShardStatusList), args.Error(1)
 }

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -131,7 +131,6 @@ type SchemaReader interface {
 	Shards(class string) ([]string, error)
 	LocalShards(class string) ([]string, error)
 	LocalActiveShardsCount(class string) (int, error)
-	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 	ResolveAlias(alias string) string
 	GetAliasesForClass(class string) []*models.Alias
 
@@ -161,6 +160,9 @@ type validator interface {
 type Handler struct {
 	schemaManager SchemaManager
 	schemaReader  SchemaReader
+	// indexer answers ShardsStatus, which reports each local index's
+	// READY/READONLY/INDEXING state.
+	indexer clusterSchema.Indexer
 
 	// dropVectorEnqueuer submits the background cleanup task when a named vector is
 	// dropped. nil when the distributed-task machinery is not wired.
@@ -260,6 +262,7 @@ func normalizeAllowList(in []string, isValid func(string) bool) []string {
 func NewHandler(
 	schemaReader SchemaReader,
 	schemaManager SchemaManager,
+	indexer clusterSchema.Indexer,
 	validator validator,
 	logger logrus.FieldLogger, authorizer authorization.Authorizer, schemaConfig *config.SchemaHandlerConfig,
 	config config.Config,
@@ -276,6 +279,7 @@ func NewHandler(
 		schemaConfig:            schemaConfig,
 		schemaReader:            schemaReader,
 		schemaManager:           schemaManager,
+		indexer:                 indexer,
 		parser:                  parser,
 		validator:               validator,
 		logger:                  logger,
@@ -379,7 +383,7 @@ func (h *Handler) ShardsStatus(ctx context.Context,
 		return nil, err
 	}
 
-	return h.schemaReader.GetShardsStatus(class, shard)
+	return h.indexer.GetShardsStatus(ctx, class, shard)
 }
 
 // JoinNode adds the given node to the cluster.

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -383,7 +383,7 @@ func (h *Handler) ShardsStatus(ctx context.Context,
 		return nil, err
 	}
 
-	return h.indexer.GetShardsStatus(ctx, class, shard)
+	return h.indexer.GetShardsStorageStatus(ctx, class, shard)
 }
 
 // JoinNode adds the given node to the cluster.

--- a/usecases/schema/handler_test.go
+++ b/usecases/schema/handler_test.go
@@ -454,7 +454,9 @@ func TestShardsStatus(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			handler, fakeSchemaManager := newTestHandlerWithNamespaces(t, tc.namespacesEnabled)
-			fakeSchemaManager.On("GetShardsStatus", tc.resolvedClass, shardName).Return(expectedStatus, nil)
+			db := &fakeDB{}
+			db.On("GetShardsStatus", mock.Anything, tc.resolvedClass, shardName).Return(expectedStatus, nil)
+			handler.indexer = db
 			handler.schemaReader = &fakeSchemaManagerWithAlias{
 				fakeSchemaManager: fakeSchemaManager,
 				aliasMap:          tc.aliasMap,

--- a/usecases/schema/handler_test.go
+++ b/usecases/schema/handler_test.go
@@ -455,7 +455,7 @@ func TestShardsStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			handler, fakeSchemaManager := newTestHandlerWithNamespaces(t, tc.namespacesEnabled)
 			db := &fakeDB{}
-			db.On("GetShardsStatus", mock.Anything, tc.resolvedClass, shardName).Return(expectedStatus, nil)
+			db.On("GetShardsStorageStatus", mock.Anything, tc.resolvedClass, shardName).Return(expectedStatus, nil)
 			handler.indexer = db
 			handler.schemaReader = &fakeSchemaManagerWithAlias{
 				fakeSchemaManager: fakeSchemaManager,

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -163,7 +163,7 @@ func (f *fakeDB) UpdateShardStatus(cmd *command.UpdateShardStatusRequest) error 
 	return nil
 }
 
-func (f *fakeDB) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
+func (f *fakeDB) GetShardsStorageStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
 	args := f.Called(ctx, class, tenant)
 	return args.Get(0).(models.ShardStatusList), nil
 }
@@ -365,7 +365,7 @@ func (f *fakeMigrator) DeleteTenants(ctx context.Context, class string, tenants 
 	return args.Error(0)
 }
 
-func (f *fakeMigrator) GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error) {
+func (f *fakeMigrator) GetShardsStorageStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error) {
 	args := f.Called(ctx, className, tenant)
 	return args.Get(0).(map[string]map[string]string), args.Get(1).(map[string]string), args.Error(2)
 }

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -49,7 +49,7 @@ func newTestHandler(t *testing.T, db clusterSchema.Indexer) (*Handler, *fakeSche
 	fakeValidator := &fakeValidator{}
 	schemaParser := NewParser(fakeClusterState, dummyParseVectorConfig, fakeValidator, fakeModulesProvider{}, nil, nil)
 	handler, err := NewHandler(
-		schemaManager, schemaManager, fakeValidator, logger, mocks.NewMockAuthorizer(),
+		schemaManager, schemaManager, db, fakeValidator, logger, mocks.NewMockAuthorizer(),
 		&cfg.SchemaHandlerConfig, cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, fakeClusterState, nil, *schemaParser, nil, nil, nil)
 	require.NoError(t, err)
@@ -70,7 +70,7 @@ func newTestHandlerWithCustomAuthorizer(t *testing.T, db clusterSchema.Indexer, 
 	fakeValidator := &fakeValidator{}
 	schemaParser := NewParser(fakeClusterState, dummyParseVectorConfig, fakeValidator, nil, nil, nil)
 	handler, err := NewHandler(
-		metaHandler, metaHandler, fakeValidator, logger, authorizer,
+		metaHandler, metaHandler, db, fakeValidator, logger, authorizer,
 		&cfg.SchemaHandlerConfig, cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, fakeClusterState, nil, *schemaParser, nil, nil, nil)
 	require.Nil(t, err)
@@ -163,8 +163,8 @@ func (f *fakeDB) UpdateShardStatus(cmd *command.UpdateShardStatusRequest) error 
 	return nil
 }
 
-func (f *fakeDB) GetShardsStatus(class, tenant string) (models.ShardStatusList, error) {
-	args := f.Called(class, tenant)
+func (f *fakeDB) GetShardsStatus(ctx context.Context, class, tenant string) (models.ShardStatusList, error) {
+	args := f.Called(ctx, class, tenant)
 	return args.Get(0).(models.ShardStatusList), nil
 }
 

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
+	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -204,6 +205,7 @@ type clusterState interface {
 func NewManager(validator validator,
 	schemaManager SchemaManager,
 	schemaReader SchemaReader,
+	indexer clusterSchema.Indexer,
 	repo SchemaStore,
 	logger logrus.FieldLogger, authorizer authorization.Authorizer,
 	schemaConfig *config.SchemaHandlerConfig,
@@ -220,6 +222,7 @@ func NewManager(validator validator,
 	handler, err := NewHandler(
 		schemaReader,
 		schemaManager,
+		indexer,
 		validator,
 		logger, authorizer,
 		schemaConfig,

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -58,7 +58,7 @@ type Migrator interface {
 	UpdateTenantsForProcess(ctx context.Context, class *models.Class, updates []*UpdateTenantPayload) error
 	DeleteTenants(ctx context.Context, class string, tenants []*models.Tenant) error
 
-	GetShardsStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error)
+	GetShardsStorageStatus(ctx context.Context, className, tenant string) (map[string]map[string]string, map[string]string, error)
 	UpdateShardStatus(ctx context.Context, className, shardName, targetStatus string, schemaVersion uint64) error
 
 	UpdateVectorIndexConfig(ctx context.Context, className string, updated schemaConfig.VectorIndexConfig) error

--- a/usecases/schema/mock_schema_reader.go
+++ b/usecases/schema/mock_schema_reader.go
@@ -285,65 +285,6 @@ func (_c *MockSchemaReader_GetAliasesForClass_Call) RunAndReturn(run func(string
 	return _c
 }
 
-// GetShardsStatus provides a mock function with given fields: class, tenant
-func (_m *MockSchemaReader) GetShardsStatus(class string, tenant string) (models.ShardStatusList, error) {
-	ret := _m.Called(class, tenant)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetShardsStatus")
-	}
-
-	var r0 models.ShardStatusList
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (models.ShardStatusList, error)); ok {
-		return rf(class, tenant)
-	}
-	if rf, ok := ret.Get(0).(func(string, string) models.ShardStatusList); ok {
-		r0 = rf(class, tenant)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(models.ShardStatusList)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(string, string) error); ok {
-		r1 = rf(class, tenant)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockSchemaReader_GetShardsStatus_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetShardsStatus'
-type MockSchemaReader_GetShardsStatus_Call struct {
-	*mock.Call
-}
-
-// GetShardsStatus is a helper method to define mock.On call
-//   - class string
-//   - tenant string
-func (_e *MockSchemaReader_Expecter) GetShardsStatus(class interface{}, tenant interface{}) *MockSchemaReader_GetShardsStatus_Call {
-	return &MockSchemaReader_GetShardsStatus_Call{Call: _e.mock.On("GetShardsStatus", class, tenant)}
-}
-
-func (_c *MockSchemaReader_GetShardsStatus_Call) Run(run func(class string, tenant string)) *MockSchemaReader_GetShardsStatus_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string))
-	})
-	return _c
-}
-
-func (_c *MockSchemaReader_GetShardsStatus_Call) Return(_a0 models.ShardStatusList, _a1 error) *MockSchemaReader_GetShardsStatus_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockSchemaReader_GetShardsStatus_Call) RunAndReturn(run func(string, string) (models.ShardStatusList, error)) *MockSchemaReader_GetShardsStatus_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // LocalActiveShardsCount provides a mock function with given fields: class
 func (_m *MockSchemaReader) LocalActiveShardsCount(class string) (int, error) {
 	ret := _m.Called(class)
@@ -1428,7 +1369,8 @@ func (_c *MockSchemaReader_WaitForUpdate_Call) RunAndReturn(run func(context.Con
 func NewMockSchemaReader(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockSchemaReader {
+},
+) *MockSchemaReader {
 	mock := &MockSchemaReader{}
 	mock.Mock.Test(t)
 

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -75,7 +75,7 @@ func newTestHandlerWithNamespaces(t *testing.T, enabled bool) (*Handler, *fakeSc
 	// Tests that exercise placement should set handler.namespacesExister
 	// directly to override this default.
 	handler, err := NewHandler(
-		schemaManager, schemaManager, fakeValidator, logger, mocks.NewMockAuthorizer(),
+		schemaManager, schemaManager, &fakeDB{}, fakeValidator, logger, mocks.NewMockAuthorizer(),
 		&cfg.SchemaHandlerConfig, cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
 		&fakeModuleConfig{}, fakeClusterState, nil, *schemaParser, nil,
 		fakeNamespacesExister{defaultHomeNode: "node-1"}, nil)


### PR DESCRIPTION
### What's being changed:
- remove duplicated interface and untangle GetShardStatus() func from schema as it's intended to get storage status 
- rename getShardsStatus to getShardsStorageStatus

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
