### PR TITLE
refactor(schema): drop the mirror schemaReader interfaces

### DIFF
--- a/adapters/handlers/mcp/search/hybrid_test.go
+++ b/adapters/handlers/mcp/search/hybrid_test.go
@@ -21,16 +21,22 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/handlers/mcp/auth"
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/fakes"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 // stubSchemaManager satisfies namespacing.SchemaManager. ResolveAlias returns
@@ -43,12 +49,28 @@ func (s stubSchemaManager) ResolveAlias(alias string) string {
 	return s.aliases[alias]
 }
 
-type stubSchemaReader struct {
-	classes map[string]*models.Class
-}
+// schemaReaderWith builds a real SchemaReader over classes. The searcher takes
+// the concrete reader, so a test that wants the schema to hold something has to
+// seed one. Classes are added in the order given: a reference property whose
+// target is not in the schema yet is rejected.
+func schemaReaderWith(t *testing.T, classes ...*models.Class) clusterSchema.SchemaReader {
+	t.Helper()
+	parser := fakes.NewMockParser()
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	logger, _ := test.NewNullLogger()
+	sm := clusterSchema.NewSchemaManager("node1", nil, parser, prometheus.NewPedanticRegistry(), logger)
 
-func (s stubSchemaReader) ReadOnlyClass(name string) *models.Class {
-	return s.classes[name]
+	for _, cls := range classes {
+		sub, err := json.Marshal(api.AddClassRequest{
+			Class: cls,
+			State: &sharding.State{PartitioningEnabled: true},
+		})
+		require.NoError(t, err)
+		require.NoError(t, sm.AddClass(&api.ApplyRequest{
+			Type: api.ApplyRequest_TYPE_ADD_CLASS, Class: cls.Class, SubCommand: sub,
+		}, "node1", true, false))
+	}
+	return sm.NewSchemaReader()
 }
 
 // recordingTraverser captures the GetParams it last received so tests can
@@ -73,7 +95,7 @@ func newSearcher(t *testing.T, principal *models.Principal, namespacesEnabled bo
 	return NewWeaviateSearcher(
 		authHandler,
 		trav,
-		stubSchemaReader{},
+		schemaReaderWith(t),
 		stubSchemaManager{aliases: aliases},
 		namespacesEnabled,
 		logger,
@@ -200,7 +222,7 @@ func newSearcherWithResults(t *testing.T, principal *models.Principal, results [
 	authHandler := auth.NewAuth(false, composer, &authorization.DummyAuthorizer{}, nil)
 	logger, _ := test.NewNullLogger()
 	return NewWeaviateSearcher(authHandler, &stubTraverser{results: results},
-		stubSchemaReader{}, stubSchemaManager{}, true, logger)
+		schemaReaderWith(t), stubSchemaManager{}, true, logger)
 }
 
 // TestHybrid_NestedRefClassStripped pins the NS strip on nested
@@ -300,10 +322,13 @@ func TestHybrid_DefaultSelectProperties(t *testing.T) {
 			{Name: "body", DataType: []string{"text"}},
 		},
 	}
-	reader := stubSchemaReader{classes: map[string]*models.Class{"Things": class}}
+	// Owner is seeded too: the real schema rejects a reference property whose
+	// target class it does not hold.
+	owner := &models.Class{Class: "Owner"}
 
 	newSearcherWithSchema := func(t *testing.T) (*WeaviateSearcher, *recordingTraverser) {
 		t.Helper()
+		reader := schemaReaderWith(t, owner, class)
 		composer := func(token string, _ []string) (*models.Principal, error) { return &models.Principal{}, nil }
 		authHandler := auth.NewAuth(false, composer, &authorization.DummyAuthorizer{}, nil)
 		trav := &recordingTraverser{}

--- a/adapters/handlers/mcp/search/search.go
+++ b/adapters/handlers/mcp/search/search.go
@@ -15,7 +15,9 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/adapters/handlers/mcp/auth"
+	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
@@ -25,7 +27,7 @@ type WeaviateSearcher struct {
 	auth.Auth
 
 	traverser         traverser
-	schemaReader      schemaReader
+	schemaReader      clusterSchema.SchemaReader
 	schemaManager     namespacing.SchemaManager
 	namespacesEnabled bool
 	logger            logrus.FieldLogger
@@ -35,11 +37,7 @@ type traverser interface {
 	GetClass(ctx context.Context, principal *models.Principal, params dto.GetParams) ([]any, error)
 }
 
-type schemaReader interface {
-	ReadOnlyClass(name string) *models.Class
-}
-
-func NewWeaviateSearcher(auth *auth.Auth, traverser traverser, schemaReader schemaReader, schemaManager namespacing.SchemaManager, namespacesEnabled bool, logger logrus.FieldLogger) *WeaviateSearcher {
+func NewWeaviateSearcher(auth *auth.Auth, traverser traverser, schemaReader clusterSchema.SchemaReader, schemaManager namespacing.SchemaManager, namespacesEnabled bool, logger logrus.FieldLogger) *WeaviateSearcher {
 	return &WeaviateSearcher{
 		traverser:         traverser,
 		schemaReader:      schemaReader,

--- a/adapters/handlers/mcp/server.go
+++ b/adapters/handlers/mcp/server.go
@@ -74,7 +74,7 @@ func NewMCPServer(state *state.State, objectsManager *objects.Manager, reg prome
 			server.WithRecovery(),
 		),
 		creator:        create.NewWeaviateCreator(authHandler, state.BatchManager, logger, writeAccessEnabled),
-		searcher:       search.NewWeaviateSearcher(authHandler, state.Traverser, state.SchemaManager, state.SchemaManager, state.ServerConfig.Config.Namespaces.Enabled, logger),
+		searcher:       search.NewWeaviateSearcher(authHandler, state.Traverser, state.ClusterService.SchemaReader(), state.SchemaManager, state.ServerConfig.Config.Namespaces.Enabled, logger),
 		reader:         read.NewWeaviateReader(authHandler, state.SchemaManager, state.SchemaManager, state.ServerConfig.Config.Namespaces.Enabled, objectsManager, logger),
 		state:          state,
 		logger:         logger,

--- a/adapters/handlers/rest/handlers_search.go
+++ b/adapters/handlers/rest/handlers_search.go
@@ -36,7 +36,7 @@ import (
 func setupSearchHandlers(api *operations.WeaviateAPI, appState *state.State) {
 	h := restsearch.NewHandler(restsearch.HandlerConfig{
 		Traverser:          appState.Traverser,
-		SchemaReader:       appState.SchemaManager,
+		SchemaReader:       appState.ClusterService.SchemaReader(),
 		Authorizer:         appState.Authorizer,
 		NamespacesEnabled:  appState.ServerConfig.Config.Namespaces.Enabled,
 		DefaultLimit:       appState.ServerConfig.Config.QueryDefaults.Limit,

--- a/adapters/handlers/rest/search/aggregate_test.go
+++ b/adapters/handlers/rest/search/aggregate_test.go
@@ -385,8 +385,7 @@ func TestAggregateHandlerTenantAuthorization(t *testing.T) {
 }
 
 func TestAggregateHandlerResolvesAliases(t *testing.T) {
-	deps := newTestHandler(t)
-	deps.schemaReader.aliases = map[string]string{"Films": "Movie"}
+	deps := newTestHandlerWithAliases(t, map[string]string{"Films": "Movie"})
 	deps.searcher.aggregateRes = ungroupedCount(1)
 
 	_, apiErr := doAggregate(t, deps, nil, "Films", `{}`)
@@ -637,11 +636,12 @@ func TestGroupValueBeaconStrip(t *testing.T) {
 // the reply builder strips beacon namespaces; a non-ref groupBy is not
 // flagged. Exercised through the full handler with a namespaced principal.
 func TestAggregateGroupByRefDetection(t *testing.T) {
-	deps := newTestHandler(t)
+	// the namespaced schema stores the qualified class name
+	qualified := movieClass()
+	qualified.Class = "ns1:Movie"
+	deps := newTestHandlerWithClass(t, qualified)
 	deps.handler.namespacesEnabled = true
 	principal := &models.Principal{Username: "someone", Namespace: "ns1"}
-	// the namespaced schema stores the qualified class name
-	deps.schemaReader.classes["ns1:Movie"] = movieClass()
 	deps.searcher.aggregateRes = &aggregation.Result{Groups: []aggregation.Group{
 		{
 			GroupedBy: &aggregation.GroupedBy{

--- a/adapters/handlers/rest/search/handler.go
+++ b/adapters/handlers/rest/search/handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	restCtx "github.com/weaviate/weaviate/adapters/handlers/rest/context"
+	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -57,16 +58,10 @@ type classSearcher interface {
 		params *aggregation.Params) (any, error)
 }
 
-// schemaReader is the subset of schema.Manager used by the handler.
-type schemaReader interface {
-	ReadOnlyClass(name string) *models.Class
-	ResolveAlias(alias string) string
-}
-
 // HandlerConfig wires the handler's dependencies.
 type HandlerConfig struct {
 	Traverser         classSearcher
-	SchemaReader      schemaReader
+	SchemaReader      schema.SchemaReader
 	Authorizer        authorization.Authorizer
 	NamespacesEnabled bool
 	DefaultLimit      int64
@@ -82,7 +77,7 @@ type HandlerConfig struct {
 // the swagger security layer; the handler receives the resulting principal.
 type Handler struct {
 	traverser          classSearcher
-	schemaReader       schemaReader
+	schemaReader       schema.SchemaReader
 	authorizer         authorization.Authorizer
 	namespacesEnabled  bool
 	defaultLimit       int64

--- a/adapters/handlers/rest/search/handler_test.go
+++ b/adapters/handlers/rest/search/handler_test.go
@@ -15,16 +15,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
 	pkgerrors "github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	gproto "google.golang.org/protobuf/proto"
 
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
@@ -38,7 +44,9 @@ import (
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
 type fakeSearcher struct {
@@ -69,19 +77,6 @@ func (f *fakeSearcher) Aggregate(ctx context.Context, principal *models.Principa
 		return nil, f.aggregateErr
 	}
 	return f.aggregateRes, nil
-}
-
-type fakeSchemaReader struct {
-	classes map[string]*models.Class
-	aliases map[string]string
-}
-
-func (f *fakeSchemaReader) ReadOnlyClass(name string) *models.Class {
-	return f.classes[name]
-}
-
-func (f *fakeSchemaReader) ResolveAlias(alias string) string {
-	return f.aliases[alias]
 }
 
 func movieClass() *models.Class {
@@ -150,31 +145,112 @@ func comicClass() *models.Class {
 	}
 }
 
+// seedSchema builds a real SchemaReader over classes and aliases. The handler
+// takes the concrete reader, so a test that wants the schema to hold something
+// has to seed one.
+func seedSchema(t *testing.T, classes []*models.Class, aliases map[string]string) clusterSchema.SchemaReader {
+	t.Helper()
+	parser := fakes.NewMockParser()
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	sm := clusterSchema.NewSchemaManager("node1", nil, parser, prometheus.NewPedanticRegistry(), logger)
+
+	// A reference property whose target class is not in the schema yet is
+	// rejected, and the fixtures cross-link, so retry the rejects until a pass
+	// adds nothing — a reference cycle or a genuinely bad class.
+	remaining := classes
+	for len(remaining) > 0 {
+		var deferred []*models.Class
+		var firstErr error
+		for _, cls := range remaining {
+			sub, err := json.Marshal(api.AddClassRequest{
+				Class: cls,
+				State: &sharding.State{PartitioningEnabled: true},
+			})
+			require.NoError(t, err)
+			if err := sm.AddClass(&api.ApplyRequest{
+				Type: api.ApplyRequest_TYPE_ADD_CLASS, Class: cls.Class, SubCommand: sub,
+			}, "node1", true, false); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				deferred = append(deferred, cls)
+			}
+		}
+		if len(deferred) == len(remaining) {
+			require.NoError(t, firstErr, "seeding made no progress; check for a reference cycle")
+		}
+		remaining = deferred
+	}
+
+	for alias, collection := range aliases {
+		sub, err := gproto.Marshal(&api.CreateAliasRequest{Alias: alias, Collection: collection})
+		require.NoError(t, err)
+		require.NoError(t, sm.CreateAlias(&api.ApplyRequest{
+			Type: api.ApplyRequest_TYPE_CREATE_ALIAS, Class: collection, SubCommand: sub,
+		}))
+	}
+
+	return sm.NewSchemaReader()
+}
+
 type testDeps struct {
-	searcher     *fakeSearcher
-	schemaReader *fakeSchemaReader
-	authorizer   *mocks.FakeAuthorizer
-	handler      *Handler
+	searcher   *fakeSearcher
+	authorizer *mocks.FakeAuthorizer
+	handler    *Handler
+	// classes mirrors what the schema was seeded with, for the few tests that
+	// resolve collections themselves instead of going through the handler.
+	classes map[string]*models.Class
 }
 
 func newTestHandler(t *testing.T) *testDeps {
 	t.Helper()
+	return newTestHandlerSeeded(t, nil, nil)
+}
+
+// newTestHandlerWithAliases seeds aliases at construction.
+func newTestHandlerWithAliases(t *testing.T, aliases map[string]string) *testDeps {
+	t.Helper()
+	return newTestHandlerSeeded(t, nil, aliases)
+}
+
+// newTestHandlerWithClass seeds one extra collection beyond the fixture set.
+func newTestHandlerWithClass(t *testing.T, extra *models.Class) *testDeps {
+	t.Helper()
+	return newTestHandlerSeeded(t, []*models.Class{extra}, nil)
+}
+
+// newTestHandlerSeeded builds the handler over a real schema. Everything is
+// seeded at construction because the handler takes a concrete schema reader,
+// which, unlike a stub, cannot be re-pointed once built.
+func newTestHandlerSeeded(t *testing.T, extra []*models.Class, aliases map[string]string) *testDeps {
+	t.Helper()
 	deps := &testDeps{
-		searcher: &fakeSearcher{},
-		schemaReader: &fakeSchemaReader{
-			classes: map[string]*models.Class{
-				"Movie":  movieClass(),
-				"Author": authorClass(),
-				"Studio": studioClass(),
-				"Book":   bookClass(),
-				"Comic":  comicClass(),
-			},
-		},
+		searcher:   &fakeSearcher{},
 		authorizer: mocks.NewMockAuthorizer(),
+		classes:    map[string]*models.Class{},
 	}
+
+	// extra overrides a fixture class of the same name, the way assigning into
+	// the old stub's map did.
+	for _, c := range []*models.Class{
+		movieClass(), authorClass(), studioClass(), bookClass(), comicClass(),
+	} {
+		deps.classes[c.Class] = c
+	}
+	for _, c := range extra {
+		deps.classes[c.Class] = c
+	}
+
+	classes := make([]*models.Class, 0, len(deps.classes))
+	for _, c := range deps.classes {
+		classes = append(classes, c)
+	}
+
 	deps.handler = NewHandler(HandlerConfig{
 		Traverser:    deps.searcher,
-		SchemaReader: deps.schemaReader,
+		SchemaReader: seedSchema(t, classes, aliases),
 		Authorizer:   deps.authorizer,
 		DefaultLimit: 10,
 		// matches DefaultQueryCrossReferenceDepthLimit
@@ -500,8 +576,7 @@ func TestHandlerTenantAuthorization(t *testing.T) {
 }
 
 func TestHandlerResolvesAliases(t *testing.T) {
-	deps := newTestHandler(t)
-	deps.schemaReader.aliases = map[string]string{"Films": "Movie"}
+	deps := newTestHandlerWithAliases(t, map[string]string{"Films": "Movie"})
 
 	_, apiErr := doNearText(t, deps, nil, "Films", `{"query":["space"]}`)
 	require.Nil(t, apiErr)
@@ -533,9 +608,8 @@ func (a rbacLikeAuthorizer) FilterAuthorizedResources(ctx context.Context, princ
 // TestHandlerAliasForbiddenDoesNotLeakTarget: a denied request against an
 // alias must not disclose the alias's target collection in the 403.
 func TestHandlerAliasForbiddenDoesNotLeakTarget(t *testing.T) {
-	deps := newTestHandler(t)
+	deps := newTestHandlerWithAliases(t, map[string]string{"Films": "Movie"})
 	deps.handler.authorizer = rbacLikeAuthorizer{}
-	deps.schemaReader.aliases = map[string]string{"Films": "Movie"}
 
 	_, apiErr := doNearText(t, deps, nil, "Films", `{"query":["space"]}`)
 	require.NotNil(t, apiErr)
@@ -549,9 +623,8 @@ func TestHandlerAliasForbiddenDoesNotLeakTarget(t *testing.T) {
 // collection — else the difference reveals the alias to a denied caller.
 func TestHandlerAliasForbiddenNoExistenceOracle(t *testing.T) {
 	// registered alias Films -> Movie, caller denied everything
-	aliased := newTestHandler(t)
+	aliased := newTestHandlerWithAliases(t, map[string]string{"Films": "Movie"})
 	aliased.handler.authorizer = rbacLikeAuthorizer{}
-	aliased.schemaReader.aliases = map[string]string{"Films": "Movie"}
 	_, aliasErr := doNearText(t, aliased, nil, "Films", `{"query":["space"]}`)
 	require.NotNil(t, aliasErr)
 

--- a/adapters/handlers/rest/search/request_test.go
+++ b/adapters/handlers/rest/search/request_test.go
@@ -63,7 +63,7 @@ func decodeModel(body string) (*models.SearchNearTextRequest, *APIError) {
 // not-found sentinel the real classGetterWithAuthz produces.
 func fixtureGetClass(deps *testDeps) classGetterFunc {
 	return func(name string) (*models.Class, error) {
-		if c, ok := deps.schemaReader.classes[name]; ok {
+		if c, ok := deps.classes[name]; ok {
 			return c, nil
 		}
 		return nil, fmt.Errorf("%w %s in schema", errCollectionNotFound, name)
@@ -75,8 +75,7 @@ func fixtureGetClass(deps *testDeps) classGetterFunc {
 // the handler runs before buildNearTextParams.
 func buildParams(t *testing.T, class *models.Class, body string) (*fakeSearcher, *APIError) {
 	t.Helper()
-	deps := newTestHandler(t)
-	deps.schemaReader.classes[class.Class] = class
+	deps := newTestHandlerWithClass(t, class)
 
 	parsed, apiErr := decodeModel(body)
 	if apiErr != nil {
@@ -111,8 +110,7 @@ func decodeBm25Model(body string) (*models.SearchBm25Request, *APIError) {
 // runs before buildBm25Params.
 func buildBm25(t *testing.T, class *models.Class, body string) (*fakeSearcher, *APIError) {
 	t.Helper()
-	deps := newTestHandler(t)
-	deps.schemaReader.classes[class.Class] = class
+	deps := newTestHandlerWithClass(t, class)
 
 	parsed, apiErr := decodeBm25Model(body)
 	if apiErr != nil {
@@ -1012,8 +1010,7 @@ func decodeNearObjectModel(body string) (*models.SearchNearObjectRequest, *APIEr
 // the handler runs before buildNearObjectParams.
 func buildNearObject(t *testing.T, class *models.Class, body string) (*fakeSearcher, *APIError) {
 	t.Helper()
-	deps := newTestHandler(t)
-	deps.schemaReader.classes[class.Class] = class
+	deps := newTestHandlerWithClass(t, class)
 
 	parsed, apiErr := decodeNearObjectModel(body)
 	if apiErr != nil {
@@ -1200,8 +1197,7 @@ func decodeHybridModel(body string) (*models.SearchHybridRequest, *APIError) {
 // runs before buildHybridParams.
 func buildHybrid(t *testing.T, class *models.Class, body string) (*fakeSearcher, *APIError) {
 	t.Helper()
-	deps := newTestHandler(t)
-	deps.schemaReader.classes[class.Class] = class
+	deps := newTestHandlerWithClass(t, class)
 
 	parsed, apiErr := decodeHybridModel(body)
 	if apiErr != nil {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -377,7 +377,7 @@ func (db *DB) migrateToHierarchicalFS() error {
 	for _, class := range schema.Classes {
 		shards, err := db.schemaReader.Shards(class.Class)
 		if err != nil {
-			return fmt.Errorf("unable to retrieve shards for class %s", class.Class)
+			return fmt.Errorf("unable to retrieve shards for class %q: %w", class.Class, err)
 		}
 		collections = append(collections, migratefs.ClassShards{Class: class, Shards: shards})
 	}

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -372,7 +372,17 @@ func (db *DB) migrateFileStructureIfNecessary() error {
 func (db *DB) migrateToHierarchicalFS() error {
 	before := time.Now()
 
-	if err := migratefs.MigrateToHierarchicalFS(db.config.RootPath, db.schemaReader); err != nil {
+	schema := db.schemaReader.ReadOnlySchema()
+	collections := make([]migratefs.ClassShards, 0, len(schema.Classes))
+	for _, class := range schema.Classes {
+		shards, err := db.schemaReader.Shards(class.Class)
+		if err != nil {
+			return fmt.Errorf("unable to retrieve shards for class %s", class.Class)
+		}
+		collections = append(collections, migratefs.ClassShards{Class: class, Shards: shards})
+	}
+
+	if err := migratefs.MigrateToHierarchicalFS(db.config.RootPath, collections); err != nil {
 		return err
 	}
 	db.logger.WithField("action", "hierarchical_fs_migration").

--- a/adapters/repos/db/multitenancy/validator.go
+++ b/adapters/repos/db/multitenancy/validator.go
@@ -21,20 +21,8 @@ import (
 	"github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/schema"
 )
-
-// schemaReader abstracts schema operations required for tenant validation.
-// It provides access to tenant status information and class metadata
-// needed to validate tenant requests against the current schema state.
-type schemaReader interface {
-	// TenantsShards returns a map of tenant names to their activity status
-	// for the specified class. Used for bulk tenant validation.
-	TenantsShards(ctx context.Context, className string, tenants ...string) (map[string]string, error)
-
-	// ReadOnlyClass returns the class definition for the given class name.
-	// Returns nil if the class does not exist in the schema.
-	ReadOnlyClass(className string) *models.Class
-}
 
 // singleTenantValidator validates requests for collections with multi-tenancy disabled.
 // It ensures that no tenant parameters are provided in requests to single-tenant
@@ -83,8 +71,8 @@ func (v *singleTenantValidator) ValidateTenants(ctx context.Context, tenants ...
 // schema and are in active (HOT) status. Inactive tenants are rejected to prevent
 // operations on cold or frozen tenant data.
 type multiTenantValidator struct {
-	className    string
-	schemaReader schemaReader
+	className string
+	schema    schema.SchemaGetter
 }
 
 // newMultiTenantValidator creates a validator for multi-tenant collections.
@@ -95,10 +83,10 @@ type multiTenantValidator struct {
 //   - schemaReader: provides access to schema and tenant status information
 //
 // Returns a configured multiTenantValidator.
-func newMultiTenantValidator(className string, schemaReader schemaReader) *multiTenantValidator {
+func newMultiTenantValidator(className string, schemaGetter schema.SchemaGetter) *multiTenantValidator {
 	return &multiTenantValidator{
-		className:    className,
-		schemaReader: schemaReader,
+		className: className,
+		schema:    schemaGetter,
 	}
 }
 
@@ -133,7 +121,7 @@ func (v *multiTenantValidator) ValidateTenants(ctx context.Context, tenants ...s
 
 	tenants = deduplicateTenants(tenants)
 
-	statusMap, err := v.schemaReader.TenantsShards(ctx, v.className, tenants...)
+	statusMap, err := v.schema.TenantsShards(ctx, v.className, tenants...)
 	if err != nil {
 		return fmt.Errorf("fetch tenant status for class %q: %w", v.className, err)
 	}
@@ -167,7 +155,7 @@ func (v *multiTenantValidator) ValidateTenants(ctx context.Context, tenants ...s
 // Returns a multi-tenancy error for invalid tenants, nil for valid tenants.
 func (v *multiTenantValidator) validateTenantStatus(tenant, status string) error {
 	if status == "" {
-		class := v.schemaReader.ReadOnlyClass(v.className)
+		class := v.schema.ReadOnlyClass(v.className)
 		if class == nil {
 			return fmt.Errorf("class %q not found in schema", v.className)
 		}
@@ -230,9 +218,9 @@ func (v *TenantValidator) ValidateTenants(ctx context.Context, tenants ...string
 //   - schemaReader: provides access to schema operations for tenant validation
 //
 // Returns a configured TenantValidator that uses the appropriate validation strategy.
-func NewTenantValidator(className string, multiTenancyEnabled bool, schemaReader schemaReader) *TenantValidator {
+func NewTenantValidator(className string, multiTenancyEnabled bool, schemaGetter schema.SchemaGetter) *TenantValidator {
 	if multiTenancyEnabled {
-		validator := newMultiTenantValidator(className, schemaReader)
+		validator := newMultiTenantValidator(className, schemaGetter)
 		return &TenantValidator{
 			validateTenants: validator.ValidateTenants,
 		}

--- a/adapters/repos/db/multitenancy/validator_test.go
+++ b/adapters/repos/db/multitenancy/validator_test.go
@@ -17,25 +17,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/multitenancy"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/objects"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
-// fakeSchemaReader is a single test fake that satisfies multitenancy.schemaReader
-// (and resolver.schemaReader). It can behave as:
-//   - A tenant status mapper: set tenantShards = map[string]string{"tenantA": models.TenantActivityStatusHOT} to simulate active tenants.
-//   - A tenant error simulator: set tenantsShardErr to simulate schema connection failures.
-//   - A class existence controller: set classExists = true/false to control whether ReadOnlyClass returns a class or nil.
-//
-// Example configs:
-//
-//	&fakeSchemaReader{tenantShards: map[string]string{"tenantA": models.TenantActivityStatusHOT}, classExists: true} // Valid active tenant
-//	&fakeSchemaReader{tenantShards: map[string]string{"tenantA": models.TenantActivityStatusCOLD}, classExists: true} // Inactive tenant
-//	&fakeSchemaReader{tenantShards: map[string]string{}, classExists: true} // No tenants exist
-//	&fakeSchemaReader{tenantsShardErr: fmt.Errorf("connection failed"), classExists: true} // Schema error simulation
-//	&fakeSchemaReader{tenantShards: map[string]string{}, classExists: false} // Class doesn't exist
 type fakeSchemaReader struct {
+	schemaUC.SchemaGetter
+
 	tenantShards    map[string]string
 	tenantsShardErr error
 	classExists     bool

--- a/adapters/repos/db/sharding/resolver.go
+++ b/adapters/repos/db/sharding/resolver.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/multitenancy"
-	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/schema"
 )
 
 // ShardTarget represents the computed shard destination for a single object.
@@ -87,32 +88,13 @@ func (t ShardTargets) Shards() []string {
 // Returns the number of target shards.
 func (t ShardTargets) Len() int { return len(t) }
 
-// schemaReader provides access to schema operations required by shard resolvers.
-// It abstracts the underlying schema storage to enable testing and provides a
-// minimal interface focused on shard resolution needs.
-type schemaReader interface {
-	// ShardFromUUID returns the target shard name for a class and UUID bytes
-	// using consistent hashing. This enables deterministic shard assignment
-	// based on object UUIDs.
-	ShardFromUUID(className string, uuidBytes []byte) string
-
-	// TenantsShards returns tenant status information keyed by the tenant name.
-	// The tenant names match shard names in multi-tenant configurations.
-	// This method supports bulk tenant lookups for performance optimization.
-	TenantsShards(ctx context.Context, className string, tenantNames ...string) (map[string]string, error)
-
-	// ReadOnlyClass returns the class metadata for the specified class name.
-	// Returns nil if the class does not exist in the schema.
-	ReadOnlyClass(className string) *models.Class
-}
-
 // byUUIDShardResolver implements shard resolution using consistent hashing of object UUIDs.
 // This strategy is used for single-tenant collections where objects are distributed
 // across shards based on their UUID to achieve balanced data distribution and
 // consistent routing for the same object across requests.
 type byUUIDShardResolver struct {
 	className       string
-	schemaReader    schemaReader
+	schemaReader    schema.SchemaGetter
 	tenantValidator *multitenancy.TenantValidator
 }
 
@@ -157,7 +139,7 @@ func (r *byUUIDShardResolver) ResolveShardByObjectID(ctx context.Context, object
 //   - schemaReader: provides access to schema operations for UUID-to-shard mapping
 //
 // Returns a configured byUUIDShardResolver.
-func newByUUIDShardResolver(className string, schemaReader schemaReader) *byUUIDShardResolver {
+func newByUUIDShardResolver(className string, schemaReader schema.SchemaGetter) *byUUIDShardResolver {
 	return &byUUIDShardResolver{
 		className:       className,
 		schemaReader:    schemaReader,
@@ -231,7 +213,7 @@ func (r *byUUIDShardResolver) ResolveShards(ctx context.Context, objects []*stor
 // isolated in its own shard, with the tenant name directly mapping to the shard name.
 type byTenantShardResolver struct {
 	className       string
-	schemaReader    schemaReader
+	schemaReader    schema.SchemaGetter
 	tenantValidator *multitenancy.TenantValidator
 }
 
@@ -268,7 +250,7 @@ func (r *byTenantShardResolver) ResolveShardByObjectID(ctx context.Context, _ st
 //   - schemaReader: provides access to schema operations for tenant validation
 //
 // Returns a configured byTenantShardResolver.
-func newByTenantShardResolver(className string, schemaReader schemaReader) *byTenantShardResolver {
+func newByTenantShardResolver(className string, schemaReader schema.SchemaGetter) *byTenantShardResolver {
 	return &byTenantShardResolver{
 		className:       className,
 		schemaReader:    schemaReader,
@@ -438,7 +420,7 @@ func (r *ShardResolver) ResolveShards(ctx context.Context, objects []*storobj.Ob
 //   - schemaReader: provides access to schema operations
 //
 // Returns a configured ShardResolver that uses the appropriate strategy.
-func NewShardResolver(className string, multiTenancyEnabled bool, schemaReader schemaReader) *ShardResolver {
+func NewShardResolver(className string, multiTenancyEnabled bool, schemaReader schema.SchemaGetter) *ShardResolver {
 	if multiTenancyEnabled {
 		resolver := newByTenantShardResolver(className, schemaReader)
 		return &ShardResolver{

--- a/adapters/repos/db/sharding/resolver_test.go
+++ b/adapters/repos/db/sharding/resolver_test.go
@@ -22,24 +22,16 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
 	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
-// fakeSchemaReader is a single test fake that satisfies sharding.schemaReader
-// (and multitenancy.schemaReader). It can behave as:
-//   - A fixed-shard mapper: set shards = []string{"shard1"} to always return "shard1" for all UUIDs.
-//   - A hashing mapper: set shards = []string{...} to distribute UUIDs across shard using a simple hash on the first byte of the UUID.
-//   - A tenant mapper: set tenantShards = map[string]string{"tenantA": models.TenantActivityStatusHOT} to
-//     distribute UUIDs across tenants based on the tenant name.
-//
-// Example configs:
-//
-//	&fakeSchemaReader{shards: []string{"shard1"}} // UUID-hashing distribution with fixed shard (always "shard1")
-//	&fakeSchemaReader{shards: []string{"shard1","shard2","shard3"}} // UUID-hashing distribution
-//	&fakeSchemaReader{tenantShards: map[string]string{"tenantA": models.TenantActivityStatusHOT}} // tenant sharding distribution
 type fakeSchemaReader struct {
+	schemaUC.SchemaGetter
+
 	shards          []string
 	tenantShards    map[string]string
 	tenantsShardErr error

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -285,31 +285,6 @@ func (r *restorer) validate(ctx context.Context, store *nodeStore, req *Request)
 	return meta, cs, nil
 }
 
-// oneClassSchema allows for creating schema with one class
-// This is required when migrating to hierarchical file structure from pre-v1.23
-type oneClassSchema struct {
-	cls *models.Class
-	ss  *sharding.State
-}
-
-func (s oneClassSchema) Read(_ string, reader func(*models.Class, *sharding.State) error) error {
-	return reader(s.cls, s.ss)
-}
-
-func (s oneClassSchema) Shards(_ string) ([]string, error) {
-	return s.ss.AllPhysicalShards(), nil
-}
-
-func (s oneClassSchema) LocalShards() ([]string, error) {
-	return s.ss.AllLocalPhysicalShards(), nil
-}
-
-func (s oneClassSchema) ReadOnlySchema() models.Schema {
-	return models.Schema{
-		Classes: []*models.Class{s.cls},
-	}
-}
-
 // hfsMigrator builds and return a class migrator ready for use
 func hfsMigrator(desc *backup.ClassDescriptor, nodeName string, serverVersion string) (func(classDir string) error, error) {
 	if serverVersion >= "1.23" {
@@ -331,6 +306,8 @@ func hfsMigrator(desc *backup.ClassDescriptor, nodeName string, serverVersion st
 	}
 
 	return func(classDir string) error {
-		return migratefs.MigrateToHierarchicalFS(classDir, oneClassSchema{class, &ss})
+		return migratefs.MigrateToHierarchicalFS(classDir, []migratefs.ClassShards{
+			{Class: class, Shards: ss.AllPhysicalShards()},
+		})
 	}, nil
 }

--- a/usecases/schema/migrate/fs/file_structure_migration.go
+++ b/usecases/schema/migrate/fs/file_structure_migration.go
@@ -18,23 +18,26 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/weaviate/weaviate/entities/models"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 )
 
 const vectorIndexCommitLog = `hnsw.commitlog.d`
 
-func MigrateToHierarchicalFS(rootPath string, s schemaReader) error {
+// ClassShards is one collection and the shards it owns, as the migration needs
+// to see it.
+type ClassShards struct {
+	Class  *models.Class
+	Shards []string
+}
+
+func MigrateToHierarchicalFS(rootPath string, classes []ClassShards) error {
 	root, err := os.ReadDir(rootPath)
 	if err != nil {
 		return fmt.Errorf("read source path %q: %w", rootPath, err)
 	}
-	fm, err := newFileMatcher(s, rootPath)
-	if err != nil {
-		return fmt.Errorf("error while migrating to hierarchical fs: %w", err)
-	}
+	fm := newFileMatcher(classes, rootPath)
 	plan, err := assembleFSMigrationPlan(root, rootPath, fm)
 	if err != nil {
 		return err
@@ -155,24 +158,14 @@ type fileMatcher struct {
 	classes             map[string][]*classShard
 }
 
-type schemaReader interface {
-	Shards(class string) ([]string, error)
-	ReadOnlySchema() models.Schema
-}
-
-func newFileMatcher(schemaReader schemaReader, rootPath string) (*fileMatcher, error) {
+func newFileMatcher(collections []ClassShards, rootPath string) *fileMatcher {
 	shardLsmDirs := make(map[string]*classShard)
 	shardFilePrefixes := make(map[string]*classShard)
 	shardGeoDirPrefixes := make(map[string]*classShardGeoProp)
 	classes := make(map[string][]*classShard)
 
-	schema := schemaReader.ReadOnlySchema()
-	for _, class := range schema.Classes {
-		className := class.Class
-		shards, err := schemaReader.Shards(className)
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve shards for class %s", className)
-		}
+	for _, col := range collections {
+		class, shards := col.Class, col.Shards
 		lowercasedClass := strings.ToLower(class.Class)
 
 		var geoProps []string
@@ -202,7 +195,7 @@ func newFileMatcher(schemaReader schemaReader, rootPath string) (*fileMatcher, e
 		shardFilePrefixes:   shardFilePrefixes,
 		shardGeoDirPrefixes: shardGeoDirPrefixes,
 		classes:             classes,
-	}, nil
+	}
 }
 
 // Checks if entry is directory with name (class is lowercased):


### PR DESCRIPTION
### What's being changed:
fix the repo schema pkg structure and remove duplicates of schemaReader interface

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
