### PR TITLE
shard: drops delete the vector index mapping record

### DIFF
--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -96,6 +96,13 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	if idx == nil {
 		return fmt.Errorf("index for collection %q not found", collection)
 	}
+	// Every load and unload holds the shard's create lock through the map
+	// update and the shutdown, so under it a shard absent from the map has
+	// released index.db. Index.Shutdown bypasses it; the retry's shutdown
+	// error covers that.
+	idx.shardCreateLocks.RLock(shardName)
+	defer idx.shardCreateLocks.RUnlock(shardName)
+
 	// A loaded shard retries its own drop: idempotent, it finishes a drop that
 	// failed part-way, and it never opens index.db against its own lock.
 	if loaded := idx.shards.loaded(shardName); loaded != nil {

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -99,10 +99,7 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	// A loaded shard retries its own drop: idempotent, it finishes a drop that
 	// failed part-way, and it never opens index.db against its own lock.
 	if loaded := idx.shards.loaded(shardName); loaded != nil {
-		done, err := loaded.retryDroppedVectorIndexes(targets)
-		if done || err != nil {
-			return err
-		}
+		return loaded.retryDroppedVectorIndexes(targets)
 	}
 	helper := newVectorDropIndexHelper()
 	class := idx.getClass()
@@ -217,18 +214,19 @@ func (f *schemaVectorConfigFinalizer) RemoveDroppedVectorConfig(ctx context.Cont
 }
 
 // retryDroppedVectorIndexes re-runs the shard's drop for each target, pinned
-// against shutdown. done is false when the shard is already shutting down.
-func (s *Shard) retryDroppedVectorIndexes(targets []string) (done bool, err error) {
+// against shutdown. A shard shutting down is an error: the ack fails, and the
+// next load or the replayed callback sweeps files and record together.
+func (s *Shard) retryDroppedVectorIndexes(targets []string) error {
 	release, err := s.preventShutdown()
 	if err != nil {
-		return false, nil
+		return fmt.Errorf("sweep dropped vectors of shard %q: %w", s.ID(), err)
 	}
 	defer release()
 	for _, target := range targets {
 		err := s.DropVectorIndex(context.Background(), target)
 		if err != nil {
-			return true, fmt.Errorf("retry drop of vector %q on loaded shard: %w", target, err)
+			return fmt.Errorf("retry drop of vector %q on loaded shard: %w", target, err)
 		}
 	}
-	return true, nil
+	return nil
 }

--- a/adapters/repos/db/drop_vector_index_wiring.go
+++ b/adapters/repos/db/drop_vector_index_wiring.go
@@ -96,10 +96,9 @@ func (db *DB) EnsureDroppedVectorFilesRemoved(collection, shardName string, targ
 	if idx == nil {
 		return fmt.Errorf("index for collection %q not found", collection)
 	}
-	// Every load and unload holds the shard's create lock through the map
-	// update and the shutdown, so under it a shard absent from the map has
-	// released index.db. Index.Shutdown bypasses it; the retry's shutdown
-	// error covers that.
+	// Loads and unloads hold this lock while they update the map and shut the
+	// shard down. Under it, a shard in the map stays loaded, and one missing
+	// from the map has already closed index.db, so the offline path is safe.
 	idx.shardCreateLocks.RLock(shardName)
 	defer idx.shardCreateLocks.RUnlock(shardName)
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -463,13 +463,10 @@ type Shard struct {
 	activityTrackerRead  atomic.Int32
 	activityTrackerWrite atomic.Int32
 
-	// metadataDB is the shard-owned metadata database (<shard>/index.db),
-	// opened for the shard's whole life by NewShard, closed by shutdown and
-	// by drop, snapshotted by backup. The vector index mapping and dynamic's
-	// upgrade verdicts live in it.
+	// metadataDB is <shard>/index.db, open for the shard's life: the vector
+	// index mapping and dynamic's upgrade verdicts live in it.
 	metadataDB *shardmeta.DB
-	// mapping is the shard's persisted view of its vector indexes, one record
-	// per logical vector in metadataDB.
+	// mapping is the shard's persisted view of its vector indexes.
 	mapping *vectorIndexMapping
 
 	// indicates whether shard is shut down or dropped (or ongoing)

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -463,10 +463,14 @@ type Shard struct {
 	activityTrackerRead  atomic.Int32
 	activityTrackerWrite atomic.Int32
 
-	// metadataDB is the shard-owned metadata database (<shard>/index.db).
-	// Lazily opened (today only dynamic vector indexes store state in it),
-	// closed by shutdown and by drop, snapshotted by backup.
+	// metadataDB is the shard-owned metadata database (<shard>/index.db),
+	// opened for the shard's whole life by NewShard, closed by shutdown and
+	// by drop, snapshotted by backup. The vector index mapping and dynamic's
+	// upgrade verdicts live in it.
 	metadataDB *shardmeta.DB
+	// mapping is the shard's persisted view of its vector indexes, one record
+	// per logical vector in metadataDB.
+	mapping *vectorIndexMapping
 
 	// indicates whether shard is shut down or dropped (or ongoing)
 	shut atomic.Bool

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -87,6 +87,13 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 		return fmt.Errorf("remove dynamic state for %q: %w", targetVector, err)
 	}
 
+	// The vector's mapping record lives in the same file and goes the same
+	// way, last, so a sweep that failed above leaves it for the retry.
+	err := deleteVectorIndexRecordOffline(shardDir, targetVector)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
@@ -88,7 +89,8 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 	}
 
 	// the record goes last, so a failed sweep keeps it for the retry
-	if err := deleteVectorIndexRecordOffline(shardDir, targetVector); err != nil {
+	key := []byte(vectorIndexMappingKey(targetVector))
+	if err := shardmeta.DeleteOffline(shardDir, vectorIndexMappingNamespace, key); err != nil {
 		return fmt.Errorf("remove mapping record for %q: %w", targetVector, err)
 	}
 

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -87,8 +87,7 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 		return fmt.Errorf("remove dynamic state for %q: %w", targetVector, err)
 	}
 
-	// The vector's mapping record lives in the same file and goes the same
-	// way, last, so a sweep that failed above leaves it for the retry.
+	// the record goes last, so a failed sweep keeps it for the retry
 	err := deleteVectorIndexRecordOffline(shardDir, targetVector)
 	if err != nil {
 		return err

--- a/adapters/repos/db/shard_drop_vector_index_helper.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper.go
@@ -88,9 +88,8 @@ func (h *vectorDropIndexHelper) removeVectorIndexFiles(
 	}
 
 	// the record goes last, so a failed sweep keeps it for the retry
-	err := deleteVectorIndexRecordOffline(shardDir, targetVector)
-	if err != nil {
-		return err
+	if err := deleteVectorIndexRecordOffline(shardDir, targetVector); err != nil {
+		return fmt.Errorf("remove mapping record for %q: %w", targetVector, err)
 	}
 
 	return nil

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -206,7 +206,7 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 		shardDir := filepath.Join(indexPath, shardName)
 		require.NoError(t, os.MkdirAll(shardDir, 0o755))
 
-		// an open read-write handle is what a loaded shard holds
+		// what a loaded shard holds
 		db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
 		require.NoError(t, err)
 		defer db.Close()

--- a/adapters/repos/db/shard_drop_vector_index_helper_test.go
+++ b/adapters/repos/db/shard_drop_vector_index_helper_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/vectorindex"
 )
@@ -175,6 +177,48 @@ func TestVectorDropIndexHelper_RemoveVectorIndexFiles(t *testing.T) {
 
 		err := h.removeVectorIndexFiles(indexPath, shardName, "nonexistent", nil)
 		require.NoError(t, err)
+	})
+	t.Run("deletes the vector's mapping record offline", func(t *testing.T) {
+		indexPath, shardName := setup(t)
+		shardDir := filepath.Join(indexPath, shardName)
+		require.NoError(t, os.MkdirAll(shardDir, 0o755))
+
+		db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
+		require.NoError(t, err)
+		foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+		bar := vectorIndexRecord{PhysicalID: "vectors_bar", IndexType: "flat", State: "ready"}
+		require.NoError(t, newVectorIndexMapping(db).Initialize(map[string]vectorIndexRecord{"foo": foo, "bar": bar}))
+		require.NoError(t, db.Close())
+
+		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, "foo", nil))
+
+		db, err = shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
+		require.NoError(t, err)
+		defer db.Close()
+		records, initialized, err := newVectorIndexMapping(db).Load()
+		require.NoError(t, err)
+		assert.True(t, initialized)
+		assert.Equal(t, map[string]vectorIndexRecord{"bar": bar}, records)
+	})
+
+	t.Run("leaves the record to a shard that holds the file locked", func(t *testing.T) {
+		indexPath, shardName := setup(t)
+		shardDir := filepath.Join(indexPath, shardName)
+		require.NoError(t, os.MkdirAll(shardDir, 0o755))
+
+		// an open read-write handle is what a loaded shard holds
+		db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
+		require.NoError(t, err)
+		defer db.Close()
+		foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+		require.NoError(t, newVectorIndexMapping(db).Initialize(map[string]vectorIndexRecord{"foo": foo}))
+
+		require.NoError(t, h.removeVectorIndexFiles(indexPath, shardName, "foo", nil))
+
+		records, _, err := newVectorIndexMapping(db).Load()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]vectorIndexRecord{"foo": foo}, records,
+			"the loaded owner deletes through its own handle")
 	})
 }
 

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -155,6 +155,7 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	if err != nil {
 		return nil, fmt.Errorf("open metadata db for shard %q: %w", s.ID(), err)
 	}
+	s.mapping = newVectorIndexMapping(s.metadataDB)
 
 	if err := s.sweepChangelogDir(); err != nil {
 		return nil, fmt.Errorf("sweep changelog dir for shard %q: %w", s.ID(), err)

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -450,8 +450,7 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 		}
 	}
 
-	// The record goes last: a drop that failed above keeps it, so the retry
-	// and the next load still know the physical ID and type of what is left.
+	// the record goes last, so a failed drop keeps it for the retry
 	err = s.mapping.Delete(targetVector)
 	if err != nil {
 		return fmt.Errorf("drop mapping record for vector %q: %w", targetVector, err)

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -450,5 +450,11 @@ func (s *Shard) DropVectorIndex(ctx context.Context, targetVector string) error 
 		}
 	}
 
+	// The record goes last: a drop that failed above keeps it, so the retry
+	// and the next load still know the physical ID and type of what is left.
+	err = s.mapping.Delete(targetVector)
+	if err != nil {
+		return fmt.Errorf("drop mapping record for vector %q: %w", targetVector, err)
+	}
 	return nil
 }

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -225,6 +225,8 @@ func TestDropVectorIndex_FailedTeardownKeepsTheIndexForCleanup(t *testing.T) {
 	failing.On("Drop", mock.Anything, false).Return(assert.AnError).Once()
 	failing.On("Drop", mock.Anything, false).Return(nil).Once()
 	require.True(t, shard.vectors.Replace("named", failing))
+	named := vectorIndexRecord{PhysicalID: "vectors_named", IndexType: "hnsw", State: "ready"}
+	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"named": named}))
 
 	err := shard.DropVectorIndex(ctx, "named")
 	require.ErrorIs(t, err, assert.AnError)
@@ -238,6 +240,10 @@ func TestDropVectorIndex_FailedTeardownKeepsTheIndexForCleanup(t *testing.T) {
 	}))
 	require.Len(t, owned, 1, "the index whose teardown failed must stay reachable for cleanup")
 	assert.Same(t, failing, owned[0])
+	records, _, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]vectorIndexRecord{"named": named}, records,
+		"the record outlives a failed teardown: the retry needs it")
 
 	require.NoError(t, shard.DropVectorIndex(ctx, "named"), "a retried drop tears the same index down")
 	owned = nil
@@ -246,4 +252,7 @@ func TestDropVectorIndex_FailedTeardownKeepsTheIndexForCleanup(t *testing.T) {
 		return nil
 	}))
 	assert.Empty(t, owned)
+	records, _, err = shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Empty(t, records, "the retried drop deleted the record")
 }

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -226,9 +226,5 @@ func (m *vectorIndexMapping) Delete(name string) error {
 // deleteVectorIndexRecordOffline removes name's record from a cold shard's
 // mapping. A missing or locked file is success: see shardmeta.DeleteOffline.
 func deleteVectorIndexRecordOffline(shardDir, name string) error {
-	err := shardmeta.DeleteOffline(shardDir, vectorIndexMappingNamespace, []byte(vectorIndexMappingKey(name)))
-	if err != nil {
-		return fmt.Errorf("delete vector index mapping record %q: %w", name, err)
-	}
-	return nil
+	return shardmeta.DeleteOffline(shardDir, vectorIndexMappingNamespace, []byte(vectorIndexMappingKey(name)))
 }

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -222,9 +222,3 @@ func (m *vectorIndexMapping) Delete(name string) error {
 	}
 	return nil
 }
-
-// deleteVectorIndexRecordOffline removes name's record from a cold shard's
-// mapping. A missing or locked file is success: see shardmeta.DeleteOffline.
-func deleteVectorIndexRecordOffline(shardDir, name string) error {
-	return shardmeta.DeleteOffline(shardDir, vectorIndexMappingNamespace, []byte(vectorIndexMappingKey(name)))
-}

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -211,11 +211,8 @@ func requireVectorIndexMappingInitialized(b *shardmeta.Batch) error {
 	return nil
 }
 
-// Delete removes name's record. A record that is not there is already
-// deleted, so a retried drop succeeds, and so does a drop on a shard whose
-// mapping was never initialized: it has no records. The write transaction
-// creates the namespace but no format version, so Load still reports the
-// mapping uninitialized afterwards.
+// Delete removes name's record. A missing record, or a mapping that was
+// never initialized, is already deleted.
 func (m *vectorIndexMapping) Delete(name string) error {
 	err := m.ns.Update(func(b *shardmeta.Batch) error {
 		return b.Delete([]byte(vectorIndexMappingKey(name)))
@@ -226,10 +223,8 @@ func (m *vectorIndexMapping) Delete(name string) error {
 	return nil
 }
 
-// deleteVectorIndexRecordOffline removes name's record from an UNLOADED
-// shard's mapping, opening the file briefly. A missing file, a missing
-// namespace, or a file locked by a loaded shard is success: nothing was
-// recorded, or the loaded owner deletes through its own handle.
+// deleteVectorIndexRecordOffline removes name's record from a cold shard's
+// mapping. A missing or locked file is success: see shardmeta.DeleteOffline.
 func deleteVectorIndexRecordOffline(shardDir, name string) error {
 	err := shardmeta.DeleteOffline(shardDir, vectorIndexMappingNamespace, []byte(vectorIndexMappingKey(name)))
 	if err != nil {

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -212,13 +212,12 @@ func requireVectorIndexMappingInitialized(b *shardmeta.Batch) error {
 }
 
 // Delete removes name's record. A record that is not there is already
-// deleted, so a retried drop succeeds.
+// deleted, so a retried drop succeeds, and so does a drop on a shard whose
+// mapping was never initialized: it has no records. The write transaction
+// creates the namespace but no format version, so Load still reports the
+// mapping uninitialized afterwards.
 func (m *vectorIndexMapping) Delete(name string) error {
 	err := m.ns.Update(func(b *shardmeta.Batch) error {
-		err := requireVectorIndexMappingInitialized(b)
-		if err != nil {
-			return err
-		}
 		return b.Delete([]byte(vectorIndexMappingKey(name)))
 	})
 	if err != nil {

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -225,3 +225,15 @@ func (m *vectorIndexMapping) Delete(name string) error {
 	}
 	return nil
 }
+
+// deleteVectorIndexRecordOffline removes name's record from an UNLOADED
+// shard's mapping, opening the file briefly. A missing file, a missing
+// namespace, or a file locked by a loaded shard is success: nothing was
+// recorded, or the loaded owner deletes through its own handle.
+func deleteVectorIndexRecordOffline(shardDir, name string) error {
+	err := shardmeta.DeleteOffline(shardDir, vectorIndexMappingNamespace, []byte(vectorIndexMappingKey(name)))
+	if err != nil {
+		return fmt.Errorf("delete vector index mapping record %q: %w", name, err)
+	}
+	return nil
+}

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -274,9 +274,11 @@ func TestVectorIndexMapping_Delete(t *testing.T) {
 		require.NoError(t, m.Delete("title"))
 	})
 
-	t.Run("refuses an uninitialized mapping", func(t *testing.T) {
+	t.Run("an uninitialized mapping has nothing to delete", func(t *testing.T) {
 		m, _ := newTestVectorIndexMapping(t)
-		err := m.Delete("title")
-		require.ErrorIs(t, err, errVectorIndexMappingUninitialized)
+		require.NoError(t, m.Delete("title"))
+		_, initialized, err := m.Load()
+		require.NoError(t, err)
+		assert.False(t, initialized, "a delete does not initialize the mapping")
 	})
 }

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -323,3 +323,27 @@ func TestDropVectorIndex_UninitializedMapping(t *testing.T) {
 	assert.False(t, initialized)
 	assert.Empty(t, records)
 }
+
+// TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown pins that a
+// loaded shard caught shutting down is an error for the completion sweep,
+// not a fallback to the offline route: the shard still holds index.db
+// locked while its references drain, so an offline delete would report
+// success and leave the record behind after the marker is gone.
+func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"foo": foo}))
+	markDropped(class, "foo")
+
+	shard.shutdownRequested.Store(true)
+	defer shard.shutdownRequested.Store(false)
+
+	db := &DB{logger: shard.index.logger, indices: map[string]*Index{shard.index.ID(): shard.index}}
+	err := db.EnsureDroppedVectorFilesRemoved(class.Class, shard.name, []string{"foo"})
+	require.ErrorIs(t, err, errShutdownInProgress)
+
+	records, _, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Equal(t, map[string]vectorIndexRecord{"foo": foo}, records, "nothing was swept, so the record stays for the retry")
+}

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -26,7 +26,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 	"github.com/weaviate/weaviate/entities/additional"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -346,4 +348,65 @@ func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) 
 	records, _, err := shard.mapping.Load()
 	require.NoError(t, err)
 	assert.Equal(t, map[string]vectorIndexRecord{"foo": foo}, records, "nothing was swept, so the record stays for the retry")
+}
+
+// TestDropVectorIndex_CompletionSweepWaitsForAnUnload pins the lifecycle
+// path where an unload has removed the shard from the map but not yet shut
+// it down: the sweep waits on the shard's create lock, which every unload
+// holds through its shutdown, instead of deleting offline against a file
+// the shard still holds locked. The shard is kept alive past both offline
+// lock timeouts (dynamic's key, then the record, a second each), because
+// that is how long the unsynchronized sweep takes to report a false success.
+func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"foo": foo}))
+	markDropped(class, "foo")
+	idx := shard.index
+
+	// what an unload does first: take the create lock, leave the map
+	idx.shardCreateLocks.Lock(shard.name)
+	_, ok := idx.shards.LoadAndDelete(shard.name)
+	require.True(t, ok)
+
+	db := &DB{logger: idx.logger, indices: map[string]*Index{idx.ID(): idx}}
+	done := make(chan error, 1)
+	go func() {
+		done <- db.EnsureDroppedVectorFilesRemoved(class.Class, shard.name, []string{"foo"})
+	}()
+
+	// the shard is still alive and holds index.db; a sweep that went offline
+	// would have reported success by now
+	select {
+	case err := <-done:
+		t.Fatalf("the sweep did not wait for the unload: %v", err)
+	case <-time.After(2500 * time.Millisecond):
+	}
+
+	// the unload finishes: shutdown releases the file, then the lock
+	require.NoError(t, shard.Shutdown(ctx))
+	idx.shardCreateLocks.Unlock(shard.name)
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("the sweep did not run after the unload")
+	}
+
+	// the shard is cold now: the record was deleted offline
+	records, initialized, err := reopenMapping(t, shard.path())
+	require.NoError(t, err)
+	assert.True(t, initialized)
+	assert.Empty(t, records)
+}
+
+// reopenMapping reads a shut-down shard's mapping through a fresh handle.
+func reopenMapping(t *testing.T, shardDir string) (map[string]vectorIndexRecord, bool, error) {
+	t.Helper()
+	db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
+	require.NoError(t, err)
+	defer db.Close()
+	return newVectorIndexMapping(db).Load()
 }

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -285,3 +285,41 @@ func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) 
 	require.NoError(t, err)
 	assert.True(t, found)
 }
+
+// TestDropVectorIndex_DeletesTheMappingRecord pins that a loaded drop
+// removes the vector's record after its files, and leaves the siblings'.
+func TestDropVectorIndex_DeletesTheMappingRecord(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+
+	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+	mv := vectorIndexRecord{PhysicalID: "vectors_mv", IndexType: "hnsw", State: "ready"}
+	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"foo": foo, "mv": mv}))
+
+	markDropped(class, "foo")
+	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
+
+	records, initialized, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.True(t, initialized)
+	assert.Equal(t, map[string]vectorIndexRecord{"mv": mv}, records)
+
+	// a retried drop has nothing left to delete and still succeeds
+	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
+}
+
+// TestDropVectorIndex_UninitializedMapping pins that a drop on a shard
+// whose mapping was never written (every shard before slice 4b, and a
+// shard restored from an older backup) succeeds and writes no record.
+func TestDropVectorIndex_UninitializedMapping(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+
+	markDropped(class, "foo")
+	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
+
+	records, initialized, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.False(t, initialized)
+	assert.Empty(t, records)
+}

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -288,8 +288,7 @@ func TestDropVectorIndex_CompletionSweepRetriesThroughLoadedShard(t *testing.T) 
 	assert.True(t, found)
 }
 
-// TestDropVectorIndex_DeletesTheMappingRecord pins that a loaded drop
-// removes the vector's record after its files, and leaves the siblings'.
+// A loaded drop removes the vector's record and leaves the siblings'.
 func TestDropVectorIndex_DeletesTheMappingRecord(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
@@ -306,13 +305,12 @@ func TestDropVectorIndex_DeletesTheMappingRecord(t *testing.T) {
 	assert.True(t, initialized)
 	assert.Equal(t, map[string]vectorIndexRecord{"mv": mv}, records)
 
-	// a retried drop has nothing left to delete and still succeeds
+	// a retried drop still succeeds
 	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
 }
 
-// TestDropVectorIndex_UninitializedMapping pins that a drop on a shard
-// whose mapping was never written (every shard before slice 4b, and a
-// shard restored from an older backup) succeeds and writes no record.
+// A drop on a shard without a mapping (an older backup) succeeds and writes
+// no record.
 func TestDropVectorIndex_UninitializedMapping(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
@@ -326,11 +324,8 @@ func TestDropVectorIndex_UninitializedMapping(t *testing.T) {
 	assert.Empty(t, records)
 }
 
-// TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown pins that a
-// loaded shard caught shutting down is an error for the completion sweep,
-// not a fallback to the offline route: the shard still holds index.db
-// locked while its references drain, so an offline delete would report
-// success and leave the record behind after the marker is gone.
+// The completion sweep errors on a shard shutting down instead of going
+// offline: the shard still holds index.db locked while its references drain.
 func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
@@ -350,13 +345,10 @@ func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) 
 	assert.Equal(t, map[string]vectorIndexRecord{"foo": foo}, records, "nothing was swept, so the record stays for the retry")
 }
 
-// TestDropVectorIndex_CompletionSweepWaitsForAnUnload pins the lifecycle
-// path where an unload has removed the shard from the map but not yet shut
-// it down: the sweep waits on the shard's create lock, which every unload
-// holds through its shutdown, instead of deleting offline against a file
-// the shard still holds locked. The shard is kept alive past both offline
-// lock timeouts (dynamic's key, then the record, a second each), because
-// that is how long the unsynchronized sweep takes to report a false success.
+// An unload has left the map but not yet shut down: the sweep waits on the
+// create lock instead of deleting offline against the lock the shard holds.
+// The shard stays alive past both offline timeouts (two seconds), which is
+// when an unsynchronized sweep reports a false success.
 func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
@@ -365,7 +357,7 @@ func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
 	markDropped(class, "foo")
 	idx := shard.index
 
-	// what an unload does first: take the create lock, leave the map
+	// what an unload does first
 	idx.shardCreateLocks.Lock(shard.name)
 	_, ok := idx.shards.LoadAndDelete(shard.name)
 	require.True(t, ok)
@@ -376,15 +368,14 @@ func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
 		done <- db.EnsureDroppedVectorFilesRemoved(class.Class, shard.name, []string{"foo"})
 	}()
 
-	// the shard is still alive and holds index.db; a sweep that went offline
-	// would have reported success by now
+	// an offline sweep would have reported success by now
 	select {
 	case err := <-done:
 		t.Fatalf("the sweep did not wait for the unload: %v", err)
 	case <-time.After(2500 * time.Millisecond):
 	}
 
-	// the unload finishes: shutdown releases the file, then the lock
+	// the unload finishes
 	require.NoError(t, shard.Shutdown(ctx))
 	idx.shardCreateLocks.Unlock(shard.name)
 
@@ -395,7 +386,7 @@ func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
 		t.Fatal("the sweep did not run after the unload")
 	}
 
-	// the shard is cold now: the record was deleted offline
+	// the record was deleted offline
 	records, initialized, err := reopenMapping(t, shard.path())
 	require.NoError(t, err)
 	assert.True(t, initialized)


### PR DESCRIPTION
### What's being changed:

Fourth slice of the persisted vector index mapping, stacked on #12998. Every path that removes a dropped vector index's files now also deletes the vector's mapping record, so that once startup begins writing records in the next slice, no drop can leave a stale one behind for the fail-closed load check to trip on.

**Two routes, one record each.** A loaded shard's `DropVectorIndex` deletes the record through the shard's open `index.db` handle, last, after teardown and every file removal succeeded; a drop that failed part-way keeps the record, so the retry and the next load still know the physical ID and type of what is left, and the completion sweep's retry through the same method deletes it then. The cold sweep, shared by the cold drop, the load-time sweep, and the finalizer's cleanup, deletes the record offline after the files, with the semantics dynamic's state key already has there: a file locked by a loaded shard means the owner deletes through its own handle.

**Behavior today: none.** Nothing writes records yet, so every drop meets an uninitialized mapping. Deleting from one is now a no-op rather than an error, since such a mapping has no records; that also covers a shard restored from a backup taken before the mapping existed. `Put` stays strict. The shard gains a `mapping` field built from its handle in `NewShard`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
