### PR TITLE
docs: add Lintspace score verification badge (88/100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Build Status](https://github.com/weaviate/weaviate/actions/workflows/.github/workflows/pull_requests.yaml/badge.svg?branch=main)](https://github.com/weaviate/weaviate/actions/workflows/.github/workflows/pull_requests.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/weaviate/weaviate)](https://goreportcard.com/report/github.com/weaviate/weaviate)
 [![Coverage Status](https://codecov.io/gh/weaviate/weaviate/branch/main/graph/badge.svg)](https://codecov.io/gh/weaviate/weaviate)
+[![Lintspace Score](https://lintspace.com/api/badge/93137679-4729-427b-b09d-360010cecaa0.svg)](https://lintspace.com/verdict/93137679-4729-427b-b09d-360010cecaa0)
 
 **Weaviate** is an open-source, cloud-native vector database that stores both objects and vectors, enabling semantic search at scale. It combines vector similarity search with keyword filtering, retrieval-augmented generation (RAG), and reranking in a single query interface. Common use cases include RAG systems, semantic and image search, recommendation engines, chatbots, and content classification.
 


### PR DESCRIPTION
Hi @bobvanluijt and the Weaviate team! 👋

Lintspace recently evaluated `weaviate` across architectural maturity, documentation quality, release cadence, and production readiness, scoring it **88/100 (Production Ready)**.

Proposing to add the live Lintspace verification badge to the header badge row in the README:

```markdown
[![Lintspace Score](https://lintspace.com/api/badge/93137679-4729-427b-b09d-360010cecaa0.svg)](https://lintspace.com/verdict/93137679-4729-427b-b09d-360010cecaa0)
```

Full evaluation breakdown and metrics: https://lintspace.com/verdict/93137679-4729-427b-b09d-360010cecaa0