### PR TITLE
shard: startup reads and writes the vector index mapping

### DIFF
--- a/adapters/repos/db/shard_debug.go
+++ b/adapters/repos/db/shard_debug.go
@@ -50,7 +50,7 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 
 	newConfig := s.index.GetVectorIndexConfig(targetVector)
 
-	vidx, err = s.initVectorIndex(ctx, targetVector, newConfig, false)
+	vidx, err = s.initVectorIndex(ctx, targetVector, s.vectorIndexID(targetVector), newConfig, false)
 	if err != nil {
 		return errors.Wrap(err, "init vector index")
 	}

--- a/adapters/repos/db/shard_debug.go
+++ b/adapters/repos/db/shard_debug.go
@@ -48,9 +48,16 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 		return errors.Wrap(err, "drop vector index")
 	}
 
+	rec, ok, err := s.mapping.Get(targetVector)
+	if err != nil {
+		return errors.Wrap(err, "read mapping record")
+	}
+	if !ok {
+		return fmt.Errorf("vector %q has no mapping record", targetVector)
+	}
 	newConfig := s.index.GetVectorIndexConfig(targetVector)
 
-	vidx, err = s.initVectorIndex(ctx, targetVector, s.vectorIndexID(targetVector), newConfig, false)
+	vidx, err = s.initVectorIndex(ctx, targetVector, rec.PhysicalID, newConfig, false)
 	if err != nil {
 		return errors.Wrap(err, "init vector index")
 	}

--- a/adapters/repos/db/shard_debug.go
+++ b/adapters/repos/db/shard_debug.go
@@ -28,6 +28,17 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 		return fmt.Errorf("async indexing is not enabled")
 	}
 
+	// TODO(vector-index-mapping): drop the fallback once live creation writes
+	// records; until then a vector added on a running shard has none.
+	physicalID := s.vectorIndexID(targetVector)
+	rec, ok, err := s.mapping.Get(targetVector)
+	if err != nil {
+		return errors.Wrap(err, "read mapping record")
+	}
+	if ok {
+		physicalID = rec.PhysicalID
+	}
+
 	vidx, releaseIndex, vok := s.AcquireVectorIndex(targetVector)
 	if !vok {
 		return fmt.Errorf("vector index %q not found", targetVector)
@@ -43,21 +54,14 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 		return errors.Wrap(err, "pause vector index")
 	}
 
-	err := vidx.Drop(ctx, false)
+	err = vidx.Drop(ctx, false)
 	if err != nil {
 		return errors.Wrap(err, "drop vector index")
 	}
 
-	rec, ok, err := s.mapping.Get(targetVector)
-	if err != nil {
-		return errors.Wrap(err, "read mapping record")
-	}
-	if !ok {
-		return fmt.Errorf("vector %q has no mapping record", targetVector)
-	}
 	newConfig := s.index.GetVectorIndexConfig(targetVector)
 
-	vidx, err = s.initVectorIndex(ctx, targetVector, rec.PhysicalID, newConfig, false)
+	vidx, err = s.initVectorIndex(ctx, targetVector, physicalID, newConfig, false)
 	if err != nil {
 		return errors.Wrap(err, "init vector index")
 	}

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -64,6 +64,16 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 	legacy := s.index.GetVectorIndexConfig("")
 	targets := s.index.getTargetVectorIndexConfigs()
 
+	// The mapping is the shard's record of which indexes it has. A shard
+	// without one builds under the naming rule and writes it; one with it
+	// reconciles the records against the schema first.
+	_, initialized, err := s.mapping.Load()
+	if err != nil {
+		return fmt.Errorf("shard %q: %w", s.ID(), err)
+	}
+	// an initialized mapping is reconciled in the next commit; until then
+	// it builds as before and writes nothing
+
 	if legacy != nil {
 		if err := s.initLegacyVector(ctx, legacy, s.lazySegmentLoadingEnabled); err != nil {
 			return err
@@ -74,6 +84,12 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 		return err
 	}
 
+	if !initialized {
+		err = s.initVectorIndexMapping(activeVectorIndexConfigs(legacy, targets))
+		if err != nil {
+			return fmt.Errorf("shard %q: %w", s.ID(), err)
+		}
+	}
 	return nil
 }
 

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -15,7 +15,9 @@ import (
 	"context"
 	stderrors "errors"
 	"fmt"
+	"maps"
 	"path/filepath"
+	"slices"
 
 	"github.com/pkg/errors"
 
@@ -63,33 +65,45 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 	// "concurrent map read and map write", not a recoverable race.
 	legacy := s.index.GetVectorIndexConfig("")
 	targets := s.index.getTargetVectorIndexConfigs()
+	active, skipped := vectorIndexConfigsByStorage(legacy, targets)
 
-	// A shard without a mapping builds under the naming rule and writes one;
-	// a shard with one reconciles it against the schema.
+	// The mapping decides the physical ID of each index. A shard without one
+	// creates everything under the naming rule; a shard with one checks its
+	// records against the schema and the disk first.
 	records, initialized, err := s.mapping.Load()
 	if err != nil {
 		return fmt.Errorf("shard %q: %w", s.ID(), err)
 	}
 	if initialized {
-		err = s.reconcileVectorIndexMapping(ctx, legacy, targets, records)
+		records, err = s.reconcileVectorIndexMapping(ctx, active, records)
 		if err != nil {
 			return fmt.Errorf("shard %q: %w", s.ID(), err)
 		}
-		return nil
+	} else {
+		records = make(map[string]vectorIndexRecord, len(active))
+		for name, cfg := range active {
+			records[name] = vectorIndexRecordFor(name, cfg, vectorIndexStateCreating)
+		}
 	}
 
-	if legacy != nil {
-		if err := s.initLegacyVector(ctx, legacy, s.lazySegmentLoadingEnabled); err != nil {
+	s.migrateCompressedVectors(legacy, targets)
+
+	// legacy first, then names in order
+	for _, name := range slices.Sorted(maps.Keys(records)) {
+		err := s.createVectorIndex(ctx, name, records[name].PhysicalID, active[name], s.lazySegmentLoadingEnabled)
+		if err != nil {
+			return err
+		}
+	}
+	// a skipped vector owns no files and no record, but callers need its slot
+	for name, cfg := range skipped {
+		err := s.createVectorIndex(ctx, name, s.vectorIndexID(name), cfg, s.lazySegmentLoadingEnabled)
+		if err != nil {
 			return err
 		}
 	}
 
-	if err := s.initTargetVectors(ctx, legacy, targets, s.lazySegmentLoadingEnabled); err != nil {
-		return err
-	}
-
-	active, _ := vectorIndexConfigsByStorage(legacy, targets)
-	err = s.initVectorIndexMapping(active)
+	err = s.commitVectorIndexRecords(records, initialized)
 	if err != nil {
 		return fmt.Errorf("shard %q: %w", s.ID(), err)
 	}
@@ -337,22 +351,6 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 	return vectorIndex, nil
 }
 
-// initTargetVectors builds the named target-vector indexes. legacy and configs
-// are caller-held snapshots; the migrator needs legacy to tell a
-// single-named-vector layout from a legacy-plus-named one.
-func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
-	configs map[string]schemaConfig.VectorIndexConfig, lazyLoadSegments bool,
-) error {
-	s.migrateCompressedVectors(legacy, configs)
-
-	for targetVector, vectorIndexConfig := range configs {
-		if err := s.initTargetVector(ctx, targetVector, vectorIndexConfig, lazyLoadSegments); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // migrateCompressedVectors logs a failed compressed-vectors folder migration.
 func (s *Shard) migrateCompressedVectors(legacy schemaConfig.VectorIndexConfig, configs map[string]schemaConfig.VectorIndexConfig) {
 	if err := newCompressedVectorsMigrator(s.index.logger).do(s, legacy, configs); err != nil {
@@ -397,12 +395,6 @@ func (s *Shard) buildVectorIndexAndQueue(ctx context.Context, targetVector, phys
 		return nil, nil, fmt.Errorf("cannot create index queue for %q: %w", targetVector, err)
 	}
 	return vectorIndex, queue, nil
-}
-
-// initLegacyVector creates the legacy vector's index and queue under the
-// naming rule unless the shard has them already.
-func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
-	return s.createVectorIndex(ctx, "", s.vectorIndexID(""), cfg, lazyLoadSegments)
 }
 
 func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -64,10 +64,8 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 	legacy := s.index.GetVectorIndexConfig("")
 	targets := s.index.getTargetVectorIndexConfigs()
 
-	// The mapping is the shard's record of which indexes it has. A shard
-	// without one builds under the naming rule and writes it; one with it
-	// reconciles the records against the schema and opens each index at
-	// the ID its record holds.
+	// A shard without a mapping builds under the naming rule and writes one;
+	// a shard with one reconciles it against the schema.
 	records, initialized, err := s.mapping.Load()
 	if err != nil {
 		return fmt.Errorf("shard %q: %w", s.ID(), err)
@@ -361,8 +359,7 @@ func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.Vecto
 	return nil
 }
 
-// migrateCompressedVectors runs the compressed-vectors folder migration
-// before the named indexes are built; a failure is logged, as before.
+// migrateCompressedVectors logs a failed compressed-vectors folder migration.
 func (s *Shard) migrateCompressedVectors(legacy schemaConfig.VectorIndexConfig, configs map[string]schemaConfig.VectorIndexConfig) {
 	if err := newCompressedVectorsMigrator(s.index.logger).do(s, legacy, configs); err != nil {
 		s.index.logger.WithFields(logrus.Fields{
@@ -381,8 +378,7 @@ func (s *Shard) initTargetVector(ctx context.Context, targetVector string, cfg s
 }
 
 // createVectorIndex builds and publishes targetVector's index and queue at
-// physicalID unless the slot exists. The ID is the caller's: the naming
-// rule for a new vector, the mapping's record for one the shard already has.
+// physicalID unless the slot exists.
 func (s *Shard) createVectorIndex(ctx context.Context, targetVector, physicalID string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
 	_, err := s.vectors.Create(targetVector, func() (VectorIndex, *VectorIndexQueue, error) {
 		return s.buildVectorIndexAndQueue(ctx, targetVector, physicalID, cfg, lazyLoadSegments)
@@ -410,9 +406,7 @@ func (s *Shard) buildVectorIndexAndQueue(ctx context.Context, targetVector, phys
 }
 
 // initLegacyVector creates the legacy vector's index and queue under the
-// naming rule unless the shard has them already. A second init used to
-// replace the running index with a fresh instance and orphan it; now it
-// finds the first in place.
+// naming rule unless the shard has them already.
 func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
 	return s.createVectorIndex(ctx, "", s.vectorIndexID(""), cfg, lazyLoadSegments)
 }

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -88,7 +88,8 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 		return err
 	}
 
-	err = s.initVectorIndexMapping(activeVectorIndexConfigs(legacy, targets))
+	active, _ := vectorIndexConfigsByStorage(legacy, targets)
+	err = s.initVectorIndexMapping(active)
 	if err != nil {
 		return fmt.Errorf("shard %q: %w", s.ID(), err)
 	}

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -66,13 +66,19 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 
 	// The mapping is the shard's record of which indexes it has. A shard
 	// without one builds under the naming rule and writes it; one with it
-	// reconciles the records against the schema first.
-	_, initialized, err := s.mapping.Load()
+	// reconciles the records against the schema and opens each index at
+	// the ID its record holds.
+	records, initialized, err := s.mapping.Load()
 	if err != nil {
 		return fmt.Errorf("shard %q: %w", s.ID(), err)
 	}
-	// an initialized mapping is reconciled in the next commit; until then
-	// it builds as before and writes nothing
+	if initialized {
+		err = s.reconcileVectorIndexMapping(ctx, legacy, targets, records)
+		if err != nil {
+			return fmt.Errorf("shard %q: %w", s.ID(), err)
+		}
+		return nil
+	}
 
 	if legacy != nil {
 		if err := s.initLegacyVector(ctx, legacy, s.lazySegmentLoadingEnabled); err != nil {
@@ -84,11 +90,9 @@ func (s *Shard) initShardVectors(ctx context.Context) error {
 		return err
 	}
 
-	if !initialized {
-		err = s.initVectorIndexMapping(activeVectorIndexConfigs(legacy, targets))
-		if err != nil {
-			return fmt.Errorf("shard %q: %w", s.ID(), err)
-		}
+	err = s.initVectorIndexMapping(activeVectorIndexConfigs(legacy, targets))
+	if err != nil {
+		return fmt.Errorf("shard %q: %w", s.ID(), err)
 	}
 	return nil
 }
@@ -347,12 +351,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
 	configs map[string]schemaConfig.VectorIndexConfig, lazyLoadSegments bool,
 ) error {
-	if err := newCompressedVectorsMigrator(s.index.logger).do(s, legacy, configs); err != nil {
-		s.index.logger.WithFields(logrus.Fields{
-			"action":   "init_target_vectors",
-			"shard_id": s.ID(),
-		}).Errorf("failed to migrate vectors compressed folder: %v", err)
-	}
+	s.migrateCompressedVectors(legacy, configs)
 
 	for targetVector, vectorIndexConfig := range configs {
 		if err := s.initTargetVector(ctx, targetVector, vectorIndexConfig, lazyLoadSegments); err != nil {
@@ -360,6 +359,17 @@ func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.Vecto
 		}
 	}
 	return nil
+}
+
+// migrateCompressedVectors runs the compressed-vectors folder migration
+// before the named indexes are built; a failure is logged, as before.
+func (s *Shard) migrateCompressedVectors(legacy schemaConfig.VectorIndexConfig, configs map[string]schemaConfig.VectorIndexConfig) {
+	if err := newCompressedVectorsMigrator(s.index.logger).do(s, legacy, configs); err != nil {
+		s.index.logger.WithFields(logrus.Fields{
+			"action":   "init_target_vectors",
+			"shard_id": s.ID(),
+		}).Errorf("failed to migrate vectors compressed folder: %v", err)
+	}
 }
 
 // initTargetVector creates the named vector's index and queue under the

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -90,7 +90,7 @@ func (s *Shard) vectorIndexLogger(targetVector, indexID string) logrus.FieldLogg
 }
 
 func (s *Shard) initVectorIndex(ctx context.Context,
-	targetVector string, vectorIndexUserConfig schemaConfig.VectorIndexConfig, lazyLoadSegments bool,
+	targetVector, physicalID string, vectorIndexUserConfig schemaConfig.VectorIndexConfig, lazyLoadSegments bool,
 ) (VectorIndex, error) {
 	var distProv distancer.Provider
 
@@ -123,7 +123,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 	// - a geo property index for each geo prop in the schema
 	//
 	// here we label the main vector index as such.
-	vecIdxID := s.vectorIndexID(targetVector)
+	vecIdxID := physicalID
 
 	// Every log line under this index carries both identities: the logical
 	// name for operators ("which vector?") and the physical id for storage
@@ -346,22 +346,29 @@ func (s *Shard) initTargetVectors(ctx context.Context, legacy schemaConfig.Vecto
 	return nil
 }
 
-// initTargetVector creates the named vector's index and queue unless the
-// shard has them already. Creates are serialized by the slots, so two
-// concurrent UpdateVectorIndexConfigs calls that both saw the target absent
-// build it once; the second finds it in place and returns.
+// initTargetVector creates the named vector's index and queue under the
+// naming rule unless the shard has them already. Creates are serialized by
+// the slots, so two concurrent UpdateVectorIndexConfigs calls that both saw
+// the target absent build it once; the second finds it in place and returns.
 func (s *Shard) initTargetVector(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
+	return s.createVectorIndex(ctx, targetVector, s.vectorIndexID(targetVector), cfg, lazyLoadSegments)
+}
+
+// createVectorIndex builds and publishes targetVector's index and queue at
+// physicalID unless the slot exists. The ID is the caller's: the naming
+// rule for a new vector, the mapping's record for one the shard already has.
+func (s *Shard) createVectorIndex(ctx context.Context, targetVector, physicalID string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
 	_, err := s.vectors.Create(targetVector, func() (VectorIndex, *VectorIndexQueue, error) {
-		return s.buildVectorIndexAndQueue(ctx, targetVector, cfg, lazyLoadSegments)
+		return s.buildVectorIndexAndQueue(ctx, targetVector, physicalID, cfg, lazyLoadSegments)
 	})
 	return err
 }
 
-// buildVectorIndexAndQueue constructs a vector's index and its queue. A queue
-// that fails to build takes the index down with it, so nothing is left
-// running unpublished.
-func (s *Shard) buildVectorIndexAndQueue(ctx context.Context, targetVector string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) (VectorIndex, *VectorIndexQueue, error) {
-	vectorIndex, err := s.initVectorIndex(ctx, targetVector, cfg, lazyLoadSegments)
+// buildVectorIndexAndQueue constructs a vector's index and its queue at
+// physicalID. A queue that fails to build takes the index down with it, so
+// nothing is left running unpublished.
+func (s *Shard) buildVectorIndexAndQueue(ctx context.Context, targetVector, physicalID string, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) (VectorIndex, *VectorIndexQueue, error) {
+	vectorIndex, err := s.initVectorIndex(ctx, targetVector, physicalID, cfg, lazyLoadSegments)
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create vector index for %q: %w", targetVector, err)
 	}
@@ -376,14 +383,12 @@ func (s *Shard) buildVectorIndexAndQueue(ctx context.Context, targetVector strin
 	return vectorIndex, queue, nil
 }
 
-// initLegacyVector creates the legacy vector's index and queue unless the
-// shard has them already. A second init used to replace the running index
-// with a fresh instance and orphan it; now it finds the first in place.
+// initLegacyVector creates the legacy vector's index and queue under the
+// naming rule unless the shard has them already. A second init used to
+// replace the running index with a fresh instance and orphan it; now it
+// finds the first in place.
 func (s *Shard) initLegacyVector(ctx context.Context, cfg schemaConfig.VectorIndexConfig, lazyLoadSegments bool) error {
-	_, err := s.vectors.Create("", func() (VectorIndex, *VectorIndexQueue, error) {
-		return s.buildVectorIndexAndQueue(ctx, "", cfg, lazyLoadSegments)
-	})
-	return err
+	return s.createVectorIndex(ctx, "", s.vectorIndexID(""), cfg, lazyLoadSegments)
 }
 
 func (s *Shard) setVectorIndex(targetVector string, index VectorIndex) {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -136,18 +136,11 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		makeBucketOptions = s.overwrittenMakeDefaultBucketOptions(lsmkv.WithLazySegmentLoading(lazyLoadSegments))
 	}
 
-	// a shard can actually have multiple vector indexes:
-	// - the main index, which is used for all normal object vectors
-	// - a geo property index for each geo prop in the schema
-	//
-	// here we label the main vector index as such.
-	vecIdxID := physicalID
-
 	// Every log line under this index carries both identities: the logical
 	// name for operators ("which vector?") and the physical id for storage
 	// ("which files?"). Implementations and the entities they own (compressors,
 	// commit loggers, queues) inherit it and add nothing of their own.
-	logger := s.vectorIndexLogger(targetVector, vecIdxID)
+	logger := s.vectorIndexLogger(targetVector, physicalID)
 
 	switch vectorIndexUserConfig.IndexType() {
 	case vectorindex.VectorIndexTypeHNSW:
@@ -167,7 +160,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 			vi, err := hnsw.New(hnsw.Config{
 				Logger:                            logger,
 				RootPath:                          s.path(),
-				ID:                                vecIdxID,
+				ID:                                physicalID,
 				ShardName:                         s.name,
 				ClassName:                         s.index.Config.ClassName.String(),
 				PrometheusMetrics:                 s.promMetrics,
@@ -185,7 +178,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 						// consistent with previous logic where the individual limit is 1/5 of the combined limit
 						hnsw.WithCommitlogThreshold(s.index.Config.HNSWMaxLogSize / 5),
 					}, opts...)
-					return hnsw.NewCommitLogger(s.path(), vecIdxID,
+					return hnsw.NewCommitLogger(s.path(), physicalID,
 						logger, s.cycleCallbacks.vectorCommitLoggerCallbacks,
 						allOpts...,
 					)
@@ -212,7 +205,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 
 		vi, err := flat.New(flat.Config{
-			ID:                vecIdxID,
+			ID:                physicalID,
 			RootPath:          s.path(),
 			Logger:            logger,
 			DistanceProvider:  distProv,
@@ -233,7 +226,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
 		vi, err := dynamic.New(dynamic.Config{
-			ID:                           vecIdxID,
+			ID:                           physicalID,
 			Logger:                       logger,
 			DistanceProvider:             distProv,
 			RootPath:                     s.path(),
@@ -250,7 +243,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 					// consistent with previous logic where the individual limit is 1/5 of the combined limit
 					hnsw.WithCommitlogThreshold(s.index.Config.HNSWMaxLogSize / 5),
 				}, opts...)
-				return hnsw.NewCommitLogger(s.path(), vecIdxID,
+				return hnsw.NewCommitLogger(s.path(), physicalID,
 					logger, s.cycleCallbacks.vectorCommitLoggerCallbacks,
 					allOpts...,
 				)
@@ -275,7 +268,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
 		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
-		hfreshConfigID := vecIdxID
+		hfreshConfigID := physicalID
 		centroidsID := helpers.CentroidsID(hfreshConfigID)
 		rootPath := filepath.Join(s.path(), helpers.HFreshDirName(hfreshConfigID))
 

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -22,23 +22,20 @@ import (
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// vectorIndexRecordFor is the record a vector gets when the shard creates its
-// index under the naming rule: the derived physical ID and the schema's type.
+// vectorIndexRecordFor is the record of a vector created under the naming rule.
 func vectorIndexRecordFor(name string, cfg schemaConfig.VectorIndexConfig, state string) vectorIndexRecord {
 	return vectorIndexRecord{PhysicalID: vectorIndexID(name), IndexType: cfg.IndexType(), State: state}
 }
 
-// vectorIndexHasStorage reports whether cfg describes a physical index. An
-// hnsw config with skip set builds a no-op index that owns no files, so the
-// mapping does not record it.
+// vectorIndexHasStorage is false for a skipped hnsw config: a no-op index
+// owns no files, so the mapping does not record it.
 func vectorIndexHasStorage(cfg schemaConfig.VectorIndexConfig) bool {
 	hnswCfg, ok := cfg.(hnswent.UserConfig)
 	return !ok || !hnswCfg.Skip
 }
 
-// activeVectorIndexConfigs is the schema's vectors that own storage, keyed by
-// logical name with the legacy vector under the empty name. Dropped vectors
-// are already absent from targets: the schema parser skips them.
+// activeVectorIndexConfigs is the schema's vectors that own storage, the
+// legacy one under the empty name.
 func activeVectorIndexConfigs(legacy schemaConfig.VectorIndexConfig,
 	targets map[string]schemaConfig.VectorIndexConfig,
 ) map[string]schemaConfig.VectorIndexConfig {
@@ -54,14 +51,13 @@ func activeVectorIndexConfigs(legacy schemaConfig.VectorIndexConfig,
 	return configs
 }
 
-// vectorIndexStorageDirsFor lists the directories rec occupies under this
-// shard. A dynamic record's verdict is read through the shard's own handle.
+// vectorIndexStorageDirsFor lists the directories rec occupies under this shard.
 func (s *Shard) vectorIndexStorageDirsFor(rec vectorIndexRecord) ([]string, error) {
 	return vectorIndexStorageDirs(s.path(), s.metadataDB.Namespace(dynamic.StateNamespace), rec.IndexType, rec.PhysicalID)
 }
 
-// syncVectorIndexRecordStorage makes rec's directories durable, so a record
-// that says ready never outlives the storage it points at.
+// syncVectorIndexRecordStorage makes rec's directories durable before the
+// record says ready.
 func (s *Shard) syncVectorIndexRecordStorage(name string, rec vectorIndexRecord) error {
 	dirs, err := s.vectorIndexStorageDirsFor(rec)
 	if err != nil {
@@ -74,10 +70,8 @@ func (s *Shard) syncVectorIndexRecordStorage(name string, rec vectorIndexRecord)
 	return nil
 }
 
-// initVectorIndexMapping runs after a first-load build: every index the
-// shard just created under the naming rule gets a ready record, once its
-// directories are durable, all in one transaction. A shard from before the
-// mapping existed and a brand-new shard both come through here once.
+// initVectorIndexMapping records every index of a first-load build as
+// ready, in one transaction, once its directories are durable.
 func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorIndexConfig) error {
 	records := make(map[string]vectorIndexRecord, len(configs))
 	for name, cfg := range configs {
@@ -95,15 +89,13 @@ func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorInd
 	return nil
 }
 
-// errVectorIndexStorageMissing is the fail-closed refusal: a record says an
-// index is ready, and its directories are not on disk. An empty index in
-// its place would serve nothing where there was data.
+// errVectorIndexStorageMissing: a ready record whose directories are gone.
+// An empty index in their place would serve nothing where there was data.
 var errVectorIndexStorageMissing = errors.New("vector index storage is missing")
 
-// reconcileVectorIndexMapping is a later load: every vector the schema has
-// is opened at the ID its record holds, after the record and the storage
-// are checked against each other, and every record the schema no longer
-// has is deleted. Names are visited in order so a failure is deterministic.
+// reconcileVectorIndexMapping opens every schema vector at its recorded ID
+// and deletes the records the schema no longer has. Names are visited in
+// order so a failure is deterministic.
 func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
 	targets map[string]schemaConfig.VectorIndexConfig, records map[string]vectorIndexRecord,
 ) error {
@@ -120,8 +112,7 @@ func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaCo
 		cfg := configs[name]
 		rec, ok := records[name]
 		if !ok {
-			// added while the shard was cold, or by a version without the
-			// mapping: recorded as creating first, like a crash mid-creation
+			// added while the shard was cold: treated like a crash mid-creation
 			rec = vectorIndexRecordFor(name, cfg, vectorIndexStateCreating)
 			err := s.mapping.Put(name, rec)
 			if err != nil {
@@ -142,8 +133,7 @@ func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaCo
 		if _, active := configs[name]; active {
 			continue
 		}
-		// dropped (the load-time sweep removed its files) or gone from the
-		// schema without the marker: the record goes, the storage stays
+		// dropped or gone from the schema: the record goes, the storage stays
 		err := s.mapping.Delete(name)
 		if err != nil {
 			return err
@@ -152,9 +142,8 @@ func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaCo
 	return nil
 }
 
-// openRecordedVectorIndex builds name's index at the recorded ID. A ready
-// record is probed first and refused when its storage is gone; a creating
-// record is built, made durable, and flipped to ready.
+// openRecordedVectorIndex builds name's index at the recorded ID: a ready
+// record is probed first, a creating one is built, synced and flipped.
 func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg schemaConfig.VectorIndexConfig, rec vectorIndexRecord) error {
 	if rec.State == vectorIndexStateReady {
 		dirs, err := s.vectorIndexStorageDirsFor(rec)

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -22,54 +22,6 @@ import (
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// vectorIndexRecordFor is the record of a vector created under the naming rule.
-func vectorIndexRecordFor(name string, cfg schemaConfig.VectorIndexConfig, state string) vectorIndexRecord {
-	return vectorIndexRecord{PhysicalID: vectorIndexID(name), IndexType: cfg.IndexType(), State: state}
-}
-
-// vectorIndexHasStorage is false for a skipped hnsw config: a no-op index
-// owns no files, so the mapping does not record it.
-func vectorIndexHasStorage(cfg schemaConfig.VectorIndexConfig) bool {
-	hnswCfg, ok := cfg.(hnswent.UserConfig)
-	return !ok || !hnswCfg.Skip
-}
-
-// activeVectorIndexConfigs is the schema's vectors that own storage, the
-// legacy one under the empty name.
-func activeVectorIndexConfigs(legacy schemaConfig.VectorIndexConfig,
-	targets map[string]schemaConfig.VectorIndexConfig,
-) map[string]schemaConfig.VectorIndexConfig {
-	configs := make(map[string]schemaConfig.VectorIndexConfig, len(targets)+1)
-	if legacy != nil && vectorIndexHasStorage(legacy) {
-		configs[""] = legacy
-	}
-	for name, cfg := range targets {
-		if vectorIndexHasStorage(cfg) {
-			configs[name] = cfg
-		}
-	}
-	return configs
-}
-
-// vectorIndexStorageDirsFor lists the directories rec occupies under this shard.
-func (s *Shard) vectorIndexStorageDirsFor(rec vectorIndexRecord) ([]string, error) {
-	return vectorIndexStorageDirs(s.path(), s.metadataDB.Namespace(dynamic.StateNamespace), rec.IndexType, rec.PhysicalID)
-}
-
-// syncVectorIndexRecordStorage makes rec's directories durable before the
-// record says ready.
-func (s *Shard) syncVectorIndexRecordStorage(name string, rec vectorIndexRecord) error {
-	dirs, err := s.vectorIndexStorageDirsFor(rec)
-	if err != nil {
-		return fmt.Errorf("vector %q: %w", name, err)
-	}
-	err = syncVectorIndexStorage(dirs)
-	if err != nil {
-		return fmt.Errorf("vector %q: %w", name, err)
-	}
-	return nil
-}
-
 // initVectorIndexMapping records every index of a first-load build as
 // ready, in one transaction, once its directories are durable.
 func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorIndexConfig) error {
@@ -88,10 +40,6 @@ func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorInd
 	}
 	return nil
 }
-
-// errVectorIndexStorageMissing: a ready record whose directories are gone.
-// An empty index in their place would serve nothing where there was data.
-var errVectorIndexStorageMissing = errors.New("vector index storage is missing")
 
 // reconcileVectorIndexMapping opens every schema vector at its recorded ID
 // and deletes the records the schema no longer has. Names are visited in
@@ -142,6 +90,10 @@ func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaCo
 	return nil
 }
 
+// errVectorIndexStorageMissing: a ready record whose directories are gone.
+// An empty index in their place would serve nothing where there was data.
+var errVectorIndexStorageMissing = errors.New("vector index storage is missing")
+
 // openRecordedVectorIndex builds name's index at the recorded ID: a ready
 // record is probed first, a creating one is built, synced and flipped.
 func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg schemaConfig.VectorIndexConfig, rec vectorIndexRecord) error {
@@ -173,6 +125,54 @@ func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg sc
 	err = s.mapping.Put(name, rec)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+// activeVectorIndexConfigs is the schema's vectors that own storage, the
+// legacy one under the empty name.
+func activeVectorIndexConfigs(legacy schemaConfig.VectorIndexConfig,
+	targets map[string]schemaConfig.VectorIndexConfig,
+) map[string]schemaConfig.VectorIndexConfig {
+	configs := make(map[string]schemaConfig.VectorIndexConfig, len(targets)+1)
+	if legacy != nil && vectorIndexHasStorage(legacy) {
+		configs[""] = legacy
+	}
+	for name, cfg := range targets {
+		if vectorIndexHasStorage(cfg) {
+			configs[name] = cfg
+		}
+	}
+	return configs
+}
+
+// vectorIndexHasStorage is false for a skipped hnsw config: a no-op index
+// owns no files, so the mapping does not record it.
+func vectorIndexHasStorage(cfg schemaConfig.VectorIndexConfig) bool {
+	hnswCfg, ok := cfg.(hnswent.UserConfig)
+	return !ok || !hnswCfg.Skip
+}
+
+// vectorIndexRecordFor is the record of a vector created under the naming rule.
+func vectorIndexRecordFor(name string, cfg schemaConfig.VectorIndexConfig, state string) vectorIndexRecord {
+	return vectorIndexRecord{PhysicalID: vectorIndexID(name), IndexType: cfg.IndexType(), State: state}
+}
+
+// vectorIndexStorageDirsFor lists the directories rec occupies under this shard.
+func (s *Shard) vectorIndexStorageDirsFor(rec vectorIndexRecord) ([]string, error) {
+	return vectorIndexStorageDirs(s.path(), s.metadataDB.Namespace(dynamic.StateNamespace), rec.IndexType, rec.PhysicalID)
+}
+
+// syncVectorIndexRecordStorage makes rec's directories durable before the
+// record says ready.
+func (s *Shard) syncVectorIndexRecordStorage(name string, rec vectorIndexRecord) error {
+	dirs, err := s.vectorIndexStorageDirsFor(rec)
+	if err != nil {
+		return fmt.Errorf("vector %q: %w", name, err)
+	}
+	err = syncVectorIndexStorage(dirs)
+	if err != nil {
+		return fmt.Errorf("vector %q: %w", name, err)
 	}
 	return nil
 }

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -34,22 +34,29 @@ func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorInd
 		}
 		records[name] = rec
 	}
-	err := s.mapping.Initialize(records)
-	if err != nil {
-		return err
-	}
-	return nil
+	return s.mapping.Initialize(records)
 }
 
-// reconcileVectorIndexMapping opens every schema vector at its recorded ID
-// and deletes the records the schema no longer has. Names are visited in
-// order so a failure is deterministic.
+// reconcileVectorIndexMapping runs on every load after the first. The mapping
+// says which indexes the shard has, the schema says which it should have, and
+// the two can disagree after a crash, a schema change while the shard was
+// cold, or lost files. For each vector the schema has:
+//   - a ready record whose storage is on disk opens at the recorded ID;
+//   - a ready record whose storage is gone refuses the load: an empty index in
+//     its place would silently serve nothing where there was data;
+//   - a creating record (a crash between the two writes of a creation) is
+//     built, then marked ready;
+//   - no record (a vector added while the shard was cold) is treated like
+//     creating.
+//
+// A record the schema no longer has is deleted; its storage is left alone.
 func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
 	targets map[string]schemaConfig.VectorIndexConfig, records map[string]vectorIndexRecord,
 ) error {
 	configs := activeVectorIndexConfigs(legacy, targets)
 	s.migrateCompressedVectors(legacy, targets)
 
+	// in name order, so a failure is deterministic
 	names := make([]string, 0, len(configs))
 	for name := range configs {
 		names = append(names, name)

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -12,7 +12,10 @@
 package db
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -30,7 +33,7 @@ func vectorIndexRecordFor(name string, cfg schemaConfig.VectorIndexConfig, state
 // mapping does not record it.
 func vectorIndexHasStorage(cfg schemaConfig.VectorIndexConfig) bool {
 	hnswCfg, ok := cfg.(hnswent.UserConfig)
-	return !(ok && hnswCfg.Skip)
+	return !ok || !hnswCfg.Skip
 }
 
 // activeVectorIndexConfigs is the schema's vectors that own storage, keyed by
@@ -86,6 +89,99 @@ func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorInd
 		records[name] = rec
 	}
 	err := s.mapping.Initialize(records)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// errVectorIndexStorageMissing is the fail-closed refusal: a record says an
+// index is ready, and its directories are not on disk. An empty index in
+// its place would serve nothing where there was data.
+var errVectorIndexStorageMissing = errors.New("vector index storage is missing")
+
+// reconcileVectorIndexMapping is a later load: every vector the schema has
+// is opened at the ID its record holds, after the record and the storage
+// are checked against each other, and every record the schema no longer
+// has is deleted. Names are visited in order so a failure is deterministic.
+func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
+	targets map[string]schemaConfig.VectorIndexConfig, records map[string]vectorIndexRecord,
+) error {
+	configs := activeVectorIndexConfigs(legacy, targets)
+	s.migrateCompressedVectors(legacy, targets)
+
+	names := make([]string, 0, len(configs))
+	for name := range configs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		cfg := configs[name]
+		rec, ok := records[name]
+		if !ok {
+			// added while the shard was cold, or by a version without the
+			// mapping: recorded as creating first, like a crash mid-creation
+			rec = vectorIndexRecordFor(name, cfg, vectorIndexStateCreating)
+			err := s.mapping.Put(name, rec)
+			if err != nil {
+				return err
+			}
+		}
+		if rec.IndexType != cfg.IndexType() {
+			return fmt.Errorf("vector %q: the mapping records a %s index at %q but the schema says %s",
+				name, rec.IndexType, rec.PhysicalID, cfg.IndexType())
+		}
+		err := s.openRecordedVectorIndex(ctx, name, cfg, rec)
+		if err != nil {
+			return err
+		}
+	}
+
+	for name := range records {
+		if _, active := configs[name]; active {
+			continue
+		}
+		// dropped (the load-time sweep removed its files) or gone from the
+		// schema without the marker: the record goes, the storage stays
+		err := s.mapping.Delete(name)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// openRecordedVectorIndex builds name's index at the recorded ID. A ready
+// record is probed first and refused when its storage is gone; a creating
+// record is built, made durable, and flipped to ready.
+func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg schemaConfig.VectorIndexConfig, rec vectorIndexRecord) error {
+	if rec.State == vectorIndexStateReady {
+		dirs, err := s.vectorIndexStorageDirsFor(rec)
+		if err != nil {
+			return fmt.Errorf("vector %q: %w", name, err)
+		}
+		exists, err := vectorIndexStorageExists(dirs)
+		if err != nil {
+			return fmt.Errorf("vector %q: %w", name, err)
+		}
+		if !exists {
+			return fmt.Errorf("%w: vector %q is recorded ready at %q, expected %v on disk",
+				errVectorIndexStorageMissing, name, rec.PhysicalID, dirs)
+		}
+		return s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
+	}
+
+	err := s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
+	if err != nil {
+		return err
+	}
+	err = s.syncVectorIndexRecordStorage(name, rec)
+	if err != nil {
+		return err
+	}
+	rec.State = vectorIndexStateReady
+	err = s.mapping.Put(name, rec)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
@@ -53,7 +54,7 @@ func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorInd
 func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
 	targets map[string]schemaConfig.VectorIndexConfig, records map[string]vectorIndexRecord,
 ) error {
-	configs := activeVectorIndexConfigs(legacy, targets)
+	configs, skipped := vectorIndexConfigsByStorage(legacy, targets)
 	s.migrateCompressedVectors(legacy, targets)
 
 	// in name order, so a failure is deterministic
@@ -94,6 +95,14 @@ func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaCo
 			return err
 		}
 	}
+
+	// a skipped vector owns no files and no record, but callers need its slot
+	for name, cfg := range skipped {
+		err := s.createVectorIndex(ctx, name, s.vectorIndexID(name), cfg, s.lazySegmentLoadingEnabled)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -113,11 +122,20 @@ func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg sc
 		if err != nil {
 			return fmt.Errorf("vector %q: %w", name, err)
 		}
-		if !exists {
+		if exists {
+			return s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
+		}
+		hasVectors, err := s.hasVectorsFor(ctx, name, cfg.IsMultiVector())
+		if err != nil {
+			return fmt.Errorf("vector %q: %w", name, err)
+		}
+		if hasVectors {
 			return fmt.Errorf("%w: vector %q is recorded ready at %q, expected %v on disk",
 				errVectorIndexStorageMissing, name, rec.PhysicalID, dirs)
 		}
-		return s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
+		// nothing to index: an empty index that a backup or a transfer did
+		// not carry, since they list files and an empty index has none.
+		// Rebuilt like a creating record.
 	}
 
 	err := s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
@@ -136,21 +154,52 @@ func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg sc
 	return nil
 }
 
-// activeVectorIndexConfigs is the schema's vectors that own storage, the
-// legacy one under the empty name.
-func activeVectorIndexConfigs(legacy schemaConfig.VectorIndexConfig,
+// vectorIndexConfigsByStorage splits the schema's vectors, the legacy one
+// under the empty name, into those that own storage and the skipped ones.
+func vectorIndexConfigsByStorage(legacy schemaConfig.VectorIndexConfig,
 	targets map[string]schemaConfig.VectorIndexConfig,
-) map[string]schemaConfig.VectorIndexConfig {
-	configs := make(map[string]schemaConfig.VectorIndexConfig, len(targets)+1)
-	if legacy != nil && vectorIndexHasStorage(legacy) {
-		configs[""] = legacy
+) (active, skipped map[string]schemaConfig.VectorIndexConfig) {
+	active = make(map[string]schemaConfig.VectorIndexConfig, len(targets)+1)
+	skipped = make(map[string]schemaConfig.VectorIndexConfig)
+	if legacy != nil {
+		targets = maps.Clone(targets)
+		targets[""] = legacy
 	}
 	for name, cfg := range targets {
 		if vectorIndexHasStorage(cfg) {
-			configs[name] = cfg
+			active[name] = cfg
+		} else {
+			skipped[name] = cfg
 		}
 	}
-	return configs
+	return active, skipped
+}
+
+// errVectorFound stops the object scan at the first vector.
+var errVectorFound = errors.New("vector found")
+
+// hasVectorsFor reports whether any object holds a vector for name.
+func (s *Shard) hasVectorsFor(ctx context.Context, name string, multi bool) (bool, error) {
+	var err error
+	if multi {
+		err = s.iterateOnLSMMultiVectors(ctx, 0, name, func(_ uint64, v [][]float32) error {
+			if len(v) > 0 {
+				return errVectorFound
+			}
+			return nil
+		})
+	} else {
+		err = s.iterateOnLSMVectors(ctx, 0, name, func(_ uint64, v []float32) error {
+			if len(v) > 0 {
+				return errVectorFound
+			}
+			return nil
+		})
+	}
+	if errors.Is(err, errVectorFound) {
+		return true, nil
+	}
+	return false, err
 }
 
 // vectorIndexHasStorage is false for a skipped hnsw config: a no-op index

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -1,0 +1,93 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// vectorIndexRecordFor is the record a vector gets when the shard creates its
+// index under the naming rule: the derived physical ID and the schema's type.
+func vectorIndexRecordFor(name string, cfg schemaConfig.VectorIndexConfig, state string) vectorIndexRecord {
+	return vectorIndexRecord{PhysicalID: vectorIndexID(name), IndexType: cfg.IndexType(), State: state}
+}
+
+// vectorIndexHasStorage reports whether cfg describes a physical index. An
+// hnsw config with skip set builds a no-op index that owns no files, so the
+// mapping does not record it.
+func vectorIndexHasStorage(cfg schemaConfig.VectorIndexConfig) bool {
+	hnswCfg, ok := cfg.(hnswent.UserConfig)
+	return !(ok && hnswCfg.Skip)
+}
+
+// activeVectorIndexConfigs is the schema's vectors that own storage, keyed by
+// logical name with the legacy vector under the empty name. Dropped vectors
+// are already absent from targets: the schema parser skips them.
+func activeVectorIndexConfigs(legacy schemaConfig.VectorIndexConfig,
+	targets map[string]schemaConfig.VectorIndexConfig,
+) map[string]schemaConfig.VectorIndexConfig {
+	configs := make(map[string]schemaConfig.VectorIndexConfig, len(targets)+1)
+	if legacy != nil && vectorIndexHasStorage(legacy) {
+		configs[""] = legacy
+	}
+	for name, cfg := range targets {
+		if vectorIndexHasStorage(cfg) {
+			configs[name] = cfg
+		}
+	}
+	return configs
+}
+
+// vectorIndexStorageDirsFor lists the directories rec occupies under this
+// shard. A dynamic record's verdict is read through the shard's own handle.
+func (s *Shard) vectorIndexStorageDirsFor(rec vectorIndexRecord) ([]string, error) {
+	return vectorIndexStorageDirs(s.path(), s.metadataDB.Namespace(dynamic.StateNamespace), rec.IndexType, rec.PhysicalID)
+}
+
+// syncVectorIndexRecordStorage makes rec's directories durable, so a record
+// that says ready never outlives the storage it points at.
+func (s *Shard) syncVectorIndexRecordStorage(name string, rec vectorIndexRecord) error {
+	dirs, err := s.vectorIndexStorageDirsFor(rec)
+	if err != nil {
+		return fmt.Errorf("vector %q: %w", name, err)
+	}
+	err = syncVectorIndexStorage(dirs)
+	if err != nil {
+		return fmt.Errorf("vector %q: %w", name, err)
+	}
+	return nil
+}
+
+// initVectorIndexMapping runs after a first-load build: every index the
+// shard just created under the naming rule gets a ready record, once its
+// directories are durable, all in one transaction. A shard from before the
+// mapping existed and a brand-new shard both come through here once.
+func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorIndexConfig) error {
+	records := make(map[string]vectorIndexRecord, len(configs))
+	for name, cfg := range configs {
+		rec := vectorIndexRecordFor(name, cfg, vectorIndexStateReady)
+		err := s.syncVectorIndexRecordStorage(name, rec)
+		if err != nil {
+			return err
+		}
+		records[name] = rec
+	}
+	err := s.mapping.Initialize(records)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/adapters/repos/db/shard_init_vector_mapping.go
+++ b/adapters/repos/db/shard_init_vector_mapping.go
@@ -16,142 +16,126 @@ import (
 	"errors"
 	"fmt"
 	"maps"
-	"sort"
+	"slices"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// initVectorIndexMapping records every index of a first-load build as
-// ready, in one transaction, once its directories are durable.
-func (s *Shard) initVectorIndexMapping(configs map[string]schemaConfig.VectorIndexConfig) error {
-	records := make(map[string]vectorIndexRecord, len(configs))
-	for name, cfg := range configs {
-		rec := vectorIndexRecordFor(name, cfg, vectorIndexStateReady)
-		err := s.syncVectorIndexRecordStorage(name, rec)
-		if err != nil {
-			return err
-		}
-		records[name] = rec
-	}
-	return s.mapping.Initialize(records)
-}
-
 // reconcileVectorIndexMapping runs on every load after the first. The mapping
 // says which indexes the shard has, the schema says which it should have, and
 // the two can disagree after a crash, a schema change while the shard was
-// cold, or lost files. For each vector the schema has:
-//   - a ready record whose storage is on disk opens at the recorded ID;
-//   - a ready record whose storage is gone refuses the load: an empty index in
-//     its place would silently serve nothing where there was data;
-//   - a creating record (a crash between the two writes of a creation) is
-//     built, then marked ready;
-//   - no record (a vector added while the shard was cold) is treated like
-//     creating.
+// cold, or lost files. It returns the record each schema vector is built
+// from, in name order so a failure is deterministic:
+//   - a ready record whose storage is on disk builds at the recorded ID;
+//   - a ready record whose storage is gone refuses the load if the object
+//     store holds a vector for it: an empty index in its place would silently
+//     serve nothing where there was data. With nothing to index it is
+//     rebuilt: a backup or a transfer carries no directory for an empty index;
+//   - a creating record (a crash between the two writes of a creation) and a
+//     missing record (a vector added while the shard was cold) are built,
+//     then marked ready.
 //
 // A record the schema no longer has is deleted; its storage is left alone.
-func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, legacy schemaConfig.VectorIndexConfig,
-	targets map[string]schemaConfig.VectorIndexConfig, records map[string]vectorIndexRecord,
-) error {
-	configs, skipped := vectorIndexConfigsByStorage(legacy, targets)
-	s.migrateCompressedVectors(legacy, targets)
-
-	// in name order, so a failure is deterministic
-	names := make([]string, 0, len(configs))
-	for name := range configs {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
-		cfg := configs[name]
+func (s *Shard) reconcileVectorIndexMapping(ctx context.Context, active map[string]schemaConfig.VectorIndexConfig,
+	records map[string]vectorIndexRecord,
+) (map[string]vectorIndexRecord, error) {
+	toBuild := make(map[string]vectorIndexRecord, len(active))
+	for _, name := range slices.Sorted(maps.Keys(active)) {
+		cfg := active[name]
 		rec, ok := records[name]
 		if !ok {
-			// added while the shard was cold: treated like a crash mid-creation
 			rec = vectorIndexRecordFor(name, cfg, vectorIndexStateCreating)
 			err := s.mapping.Put(name, rec)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 		if rec.IndexType != cfg.IndexType() {
-			return fmt.Errorf("vector %q: the mapping records a %s index at %q but the schema says %s",
+			return nil, fmt.Errorf("vector %q: the mapping records a %s index at %q but the schema says %s",
 				name, rec.IndexType, rec.PhysicalID, cfg.IndexType())
 		}
-		err := s.openRecordedVectorIndex(ctx, name, cfg, rec)
-		if err != nil {
-			return err
+		if rec.State == vectorIndexStateReady {
+			rebuild, err := s.readyVectorIndexNeedsRebuild(ctx, name, cfg, rec)
+			if err != nil {
+				return nil, err
+			}
+			if rebuild {
+				rec.State = vectorIndexStateCreating
+			}
 		}
+		toBuild[name] = rec
 	}
 
 	for name := range records {
-		if _, active := configs[name]; active {
+		if _, ok := active[name]; ok {
 			continue
 		}
 		// dropped or gone from the schema: the record goes, the storage stays
 		err := s.mapping.Delete(name)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-
-	// a skipped vector owns no files and no record, but callers need its slot
-	for name, cfg := range skipped {
-		err := s.createVectorIndex(ctx, name, s.vectorIndexID(name), cfg, s.lazySegmentLoadingEnabled)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return toBuild, nil
 }
 
 // errVectorIndexStorageMissing: a ready record whose directories are gone.
 // An empty index in their place would serve nothing where there was data.
 var errVectorIndexStorageMissing = errors.New("vector index storage is missing")
 
-// openRecordedVectorIndex builds name's index at the recorded ID: a ready
-// record is probed first, a creating one is built, synced and flipped.
-func (s *Shard) openRecordedVectorIndex(ctx context.Context, name string, cfg schemaConfig.VectorIndexConfig, rec vectorIndexRecord) error {
-	if rec.State == vectorIndexStateReady {
-		dirs, err := s.vectorIndexStorageDirsFor(rec)
-		if err != nil {
-			return fmt.Errorf("vector %q: %w", name, err)
-		}
-		exists, err := vectorIndexStorageExists(dirs)
-		if err != nil {
-			return fmt.Errorf("vector %q: %w", name, err)
-		}
-		if exists {
-			return s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
-		}
-		hasVectors, err := s.hasVectorsFor(ctx, name, cfg.IsMultiVector())
-		if err != nil {
-			return fmt.Errorf("vector %q: %w", name, err)
-		}
-		if hasVectors {
-			return fmt.Errorf("%w: vector %q is recorded ready at %q, expected %v on disk",
-				errVectorIndexStorageMissing, name, rec.PhysicalID, dirs)
-		}
-		// nothing to index: an empty index that a backup or a transfer did
-		// not carry, since they list files and an empty index has none.
-		// Rebuilt like a creating record.
+// readyVectorIndexNeedsRebuild probes a ready record's storage. Present:
+// nothing to do. Missing with vectors to index: the load is refused. Missing
+// with nothing to index: the index is rebuilt.
+func (s *Shard) readyVectorIndexNeedsRebuild(ctx context.Context, name string, cfg schemaConfig.VectorIndexConfig, rec vectorIndexRecord) (bool, error) {
+	dirs, err := s.vectorIndexStorageDirsFor(rec)
+	if err != nil {
+		return false, fmt.Errorf("vector %q: %w", name, err)
 	}
+	exists, err := vectorIndexStorageExists(dirs)
+	if err != nil {
+		return false, fmt.Errorf("vector %q: %w", name, err)
+	}
+	if exists {
+		return false, nil
+	}
+	hasVectors, err := s.hasVectorsFor(ctx, name, cfg.IsMultiVector())
+	if err != nil {
+		return false, fmt.Errorf("vector %q: %w", name, err)
+	}
+	if hasVectors {
+		return false, fmt.Errorf("%w: vector %q is recorded ready at %q, expected %v on disk",
+			errVectorIndexStorageMissing, name, rec.PhysicalID, dirs)
+	}
+	return true, nil
+}
 
-	err := s.createVectorIndex(ctx, name, rec.PhysicalID, cfg, s.lazySegmentLoadingEnabled)
-	if err != nil {
-		return err
+// commitVectorIndexRecords makes the indexes just built durable in the
+// mapping. On the first load every record is written ready in one
+// transaction; later, only the records that were creating are flipped.
+func (s *Shard) commitVectorIndexRecords(records map[string]vectorIndexRecord, initialized bool) error {
+	for name, rec := range records {
+		if initialized && rec.State == vectorIndexStateReady {
+			continue
+		}
+		err := s.syncVectorIndexRecordStorage(name, rec)
+		if err != nil {
+			return err
+		}
+		rec.State = vectorIndexStateReady
+		records[name] = rec
+		if initialized {
+			err = s.mapping.Put(name, rec)
+			if err != nil {
+				return err
+			}
+		}
 	}
-	err = s.syncVectorIndexRecordStorage(name, rec)
-	if err != nil {
-		return err
+	if initialized {
+		return nil
 	}
-	rec.State = vectorIndexStateReady
-	err = s.mapping.Put(name, rec)
-	if err != nil {
-		return err
-	}
-	return nil
+	return s.mapping.Initialize(records)
 }
 
 // vectorIndexConfigsByStorage splits the schema's vectors, the legacy one

--- a/adapters/repos/db/shard_init_vector_mapping_test.go
+++ b/adapters/repos/db/shard_init_vector_mapping_test.go
@@ -34,8 +34,7 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-// storageExistsFor reports whether the directories rec occupies under the
-// shard are all on disk.
+// storageExistsFor reports whether rec's directories are all on disk.
 func storageExistsFor(t *testing.T, s *Shard, rec vectorIndexRecord) bool {
 	t.Helper()
 	dirs, err := s.vectorIndexStorageDirsFor(rec)
@@ -45,9 +44,7 @@ func storageExistsFor(t *testing.T, s *Shard, rec vectorIndexRecord) bool {
 	return exists
 }
 
-// TestInitShardVectors_FirstLoadWritesTheMapping pins the first load of a
-// shard without a mapping: every index is built as before and recorded
-// ready, at the ID the naming rule gives, with its storage on disk.
+// The first load records every index ready at the ID the naming rule gives.
 func TestInitShardVectors_FirstLoadWritesTheMapping(t *testing.T) {
 	ctx := testCtx()
 	shard, _ := setupDropVectorShard(t, ctx)
@@ -65,10 +62,7 @@ func TestInitShardVectors_FirstLoadWritesTheMapping(t *testing.T) {
 	}
 }
 
-// TestInitShardVectors_FirstLoadRecordsEveryType pins that each index type
-// leaves the directories the probe expects behind after its constructor
-// ran, so a ready record written at first load is never a false alarm at
-// the next one.
+// Each index type leaves the directories the probe expects after construction.
 func TestInitShardVectors_FirstLoadRecordsEveryType(t *testing.T) {
 	flatCfg := entflat.UserConfig{}
 	flatCfg.SetDefaults()
@@ -105,9 +99,7 @@ func TestInitShardVectors_FirstLoadRecordsEveryType(t *testing.T) {
 	}
 }
 
-// TestInitShardVectors_SkippedIndexHasNoRecord pins that an hnsw vector
-// with skip set builds a no-op index that owns no files, and the mapping
-// does not record it: the shard is initialized with no records.
+// A skipped hnsw vector owns no files and gets no record.
 func TestInitShardVectors_SkippedIndexHasNoRecord(t *testing.T) {
 	ctx := testCtx()
 	shd, _ := testShard(t, ctx, "SkippedVector")
@@ -119,16 +111,14 @@ func TestInitShardVectors_SkippedIndexHasNoRecord(t *testing.T) {
 	assert.Empty(t, records)
 }
 
-// reload shuts the shard down and opens it again from disk, the way a
-// restart would, returning the new instance.
+// reload shuts the shard down and opens it again from disk.
 func reload(t *testing.T, ctx context.Context, shard *Shard, class *models.Class) *Shard {
 	t.Helper()
 	return reloadShardFromDisk(t, ctx, shard.index, shard, class)
 }
 
 // reloadExpectingError shuts the shard down and checks that opening it again
-// fails with wantErr in the message. The caller must repair the state and
-// reload successfully afterwards, so the fixture's cleanup finds a live shard.
+// fails with wantErr. The caller must repair and reload afterwards.
 func reloadExpectingError(t *testing.T, ctx context.Context, shard *Shard, class *models.Class, wantErr string) {
 	t.Helper()
 	require.NoError(t, shard.Shutdown(ctx))
@@ -137,8 +127,7 @@ func reloadExpectingError(t *testing.T, ctx context.Context, shard *Shard, class
 	require.ErrorContains(t, err, wantErr)
 }
 
-// withOfflineMapping opens a shut-down shard's index.db, hands the mapping
-// and its raw namespace to fn, and closes the file again.
+// withOfflineMapping opens a shut-down shard's index.db for fn.
 func withOfflineMapping(t *testing.T, shardDir string, fn func(m *vectorIndexMapping, ns *shardmeta.Namespace)) {
 	t.Helper()
 	db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
@@ -147,8 +136,7 @@ func withOfflineMapping(t *testing.T, shardDir string, fn func(m *vectorIndexMap
 	fn(newVectorIndexMapping(db), db.Namespace(vectorIndexMappingNamespace))
 }
 
-// TestInitShardVectors_Reconcile walks a shard through every state the
-// mapping can be in at a later load, one reload per state.
+// One reload per state the mapping can be in at a later load.
 func TestInitShardVectors_Reconcile(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
@@ -164,7 +152,7 @@ func TestInitShardVectors_Reconcile(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, found)
 
-	// a ready record whose storage is gone refuses the load, naming what is missing
+	// a ready record whose storage is gone refuses the load
 	require.NoError(t, os.RemoveAll(fooDir))
 	reloadExpectingError(t, ctx, shard, class, `vector "foo"`)
 	require.NoError(t, os.MkdirAll(fooDir, 0o755))

--- a/adapters/repos/db/shard_init_vector_mapping_test.go
+++ b/adapters/repos/db/shard_init_vector_mapping_test.go
@@ -109,20 +109,44 @@ func TestInitShardVectors_SkippedIndexHasNoRecord(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, initialized)
 	assert.Empty(t, records)
+
+	// a later load rebuilds the no-op index and its queue: callers need the slot
+	shard = reload(t, ctx, shard, &models.Class{Class: "SkippedVector"})
+	found, err := shard.WithVectorIndex("", func(VectorIndex) error { return nil })
+	require.NoError(t, err)
+	assert.True(t, found)
+	found, err = shard.WithVectorIndexQueue("", func(*VectorIndexQueue) error { return nil })
+	require.NoError(t, err)
+	assert.True(t, found)
 }
 
 // reload shuts the shard down and opens it again from disk.
 func reload(t *testing.T, ctx context.Context, shard *Shard, class *models.Class) *Shard {
 	t.Helper()
-	return reloadShardFromDisk(t, ctx, shard.index, shard, class)
+	return reloadAfter(t, ctx, shard, class, nil)
 }
 
-// reloadExpectingError shuts the shard down and checks that opening it again
-// fails with wantErr. The caller must repair and reload afterwards.
-func reloadExpectingError(t *testing.T, ctx context.Context, shard *Shard, class *models.Class, wantErr string) {
+// reloadAfter is reload with a step between the shutdown and the reopen,
+// where a directory removal survives the shutdown's own writes.
+func reloadAfter(t *testing.T, ctx context.Context, shard *Shard, class *models.Class, beforeOpen func()) *Shard {
 	t.Helper()
 	require.NoError(t, shard.Shutdown(ctx))
 	simulateProcessRestartBucketCleanup(t, shard.pathLSM())
+	if beforeOpen != nil {
+		beforeOpen()
+	}
+	return openShardFromDisk(t, ctx, shard.index, class, shard.Name())
+}
+
+// reloadExpectingError is reloadAfter for a reopen that must fail with
+// wantErr. The caller must repair and reload afterwards.
+func reloadExpectingError(t *testing.T, ctx context.Context, shard *Shard, class *models.Class, wantErr string, beforeOpen func()) {
+	t.Helper()
+	require.NoError(t, shard.Shutdown(ctx))
+	simulateProcessRestartBucketCleanup(t, shard.pathLSM())
+	if beforeOpen != nil {
+		beforeOpen()
+	}
 	_, err := shard.index.initShard(ctx, shard.Name(), class, nil, true, true)
 	require.ErrorContains(t, err, wantErr)
 }
@@ -152,9 +176,19 @@ func TestInitShardVectors_Reconcile(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, found)
 
-	// a ready record whose storage is gone refuses the load
-	require.NoError(t, os.RemoveAll(fooDir))
-	reloadExpectingError(t, ctx, shard, class, `vector "foo"`)
+	// a ready record whose storage is gone, with nothing to index, is rebuilt:
+	// a backup or a transfer carries no directory for an empty index
+	removeFooDir := func() { require.NoError(t, os.RemoveAll(fooDir)) }
+	shard = reloadAfter(t, ctx, shard, class, removeFooDir)
+	_, err = os.Stat(fooDir)
+	require.NoError(t, err)
+	records, _, err = shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Equal(t, foo, records["foo"])
+
+	// with a vector to index, the same loss refuses the load
+	require.NoError(t, shard.PutObject(ctx, dropVecObject(t, "a", true)))
+	reloadExpectingError(t, ctx, shard, class, `vector "foo"`, removeFooDir)
 	require.NoError(t, os.MkdirAll(fooDir, 0o755))
 	shard = reload(t, ctx, shard, class)
 
@@ -190,7 +224,7 @@ func TestInitShardVectors_Reconcile(t *testing.T) {
 	wrongType := foo
 	wrongType.IndexType = "flat"
 	require.NoError(t, shard.mapping.Put("foo", wrongType))
-	reloadExpectingError(t, ctx, shard, class, "flat")
+	reloadExpectingError(t, ctx, shard, class, "flat", nil)
 	withOfflineMapping(t, shard.path(), func(m *vectorIndexMapping, _ *shardmeta.Namespace) {
 		require.NoError(t, m.Put("foo", foo))
 	})
@@ -198,7 +232,7 @@ func TestInitShardVectors_Reconcile(t *testing.T) {
 
 	// a mapping the shard cannot read refuses the load
 	require.NoError(t, shard.metadataDB.Namespace(vectorIndexMappingNamespace).Put([]byte("bogus"), []byte("x")))
-	reloadExpectingError(t, ctx, shard, class, `unknown key "bogus"`)
+	reloadExpectingError(t, ctx, shard, class, `unknown key "bogus"`, nil)
 	withOfflineMapping(t, shard.path(), func(_ *vectorIndexMapping, ns *shardmeta.Namespace) {
 		require.NoError(t, ns.Delete([]byte("bogus")))
 	})

--- a/adapters/repos/db/shard_init_vector_mapping_test.go
+++ b/adapters/repos/db/shard_init_vector_mapping_test.go
@@ -231,10 +231,10 @@ func TestInitShardVectors_Reconcile(t *testing.T) {
 	shard = reload(t, ctx, shard, class)
 
 	// a mapping the shard cannot read refuses the load
-	require.NoError(t, shard.metadataDB.Namespace(vectorIndexMappingNamespace).Put([]byte("bogus"), []byte("x")))
-	reloadExpectingError(t, ctx, shard, class, `unknown key "bogus"`, nil)
+	require.NoError(t, shard.metadataDB.Namespace(vectorIndexMappingNamespace).Put([]byte(".bogus"), []byte("x")))
+	reloadExpectingError(t, ctx, shard, class, `unknown key ".bogus"`, nil)
 	withOfflineMapping(t, shard.path(), func(_ *vectorIndexMapping, ns *shardmeta.Namespace) {
-		require.NoError(t, ns.Delete([]byte("bogus")))
+		require.NoError(t, ns.Delete([]byte(".bogus")))
 	})
 	shard = reload(t, ctx, shard, class)
 	_, _, err = shard.mapping.Load()

--- a/adapters/repos/db/shard_init_vector_mapping_test.go
+++ b/adapters/repos/db/shard_init_vector_mapping_test.go
@@ -14,12 +14,18 @@
 package db
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/models"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	entdynamic "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
@@ -111,4 +117,104 @@ func TestInitShardVectors_SkippedIndexHasNoRecord(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, initialized)
 	assert.Empty(t, records)
+}
+
+// reload shuts the shard down and opens it again from disk, the way a
+// restart would, returning the new instance.
+func reload(t *testing.T, ctx context.Context, shard *Shard, class *models.Class) *Shard {
+	t.Helper()
+	return reloadShardFromDisk(t, ctx, shard.index, shard, class)
+}
+
+// reloadExpectingError shuts the shard down and checks that opening it again
+// fails with wantErr in the message. The caller must repair the state and
+// reload successfully afterwards, so the fixture's cleanup finds a live shard.
+func reloadExpectingError(t *testing.T, ctx context.Context, shard *Shard, class *models.Class, wantErr string) {
+	t.Helper()
+	require.NoError(t, shard.Shutdown(ctx))
+	simulateProcessRestartBucketCleanup(t, shard.pathLSM())
+	_, err := shard.index.initShard(ctx, shard.Name(), class, nil, true, true)
+	require.ErrorContains(t, err, wantErr)
+}
+
+// withOfflineMapping opens a shut-down shard's index.db, hands the mapping
+// and its raw namespace to fn, and closes the file again.
+func withOfflineMapping(t *testing.T, shardDir string, fn func(m *vectorIndexMapping, ns *shardmeta.Namespace)) {
+	t.Helper()
+	db, err := shardmeta.Open(shardDir, entlsmkv.BoltFlockTimeout)
+	require.NoError(t, err)
+	defer db.Close()
+	fn(newVectorIndexMapping(db), db.Namespace(vectorIndexMappingNamespace))
+}
+
+// TestInitShardVectors_Reconcile walks a shard through every state the
+// mapping can be in at a later load, one reload per state.
+func TestInitShardVectors_Reconcile(t *testing.T) {
+	ctx := testCtx()
+	shard, class := setupDropVectorShard(t, ctx)
+	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+	fooDir := filepath.Join(shard.path(), helpers.GetHNSWCommitLogDirName("foo"))
+
+	// a ready record whose storage is on disk opens as before
+	shard = reload(t, ctx, shard, class)
+	records, _, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Equal(t, foo, records["foo"])
+	found, err := shard.WithVectorIndex("foo", func(VectorIndex) error { return nil })
+	require.NoError(t, err)
+	assert.True(t, found)
+
+	// a ready record whose storage is gone refuses the load, naming what is missing
+	require.NoError(t, os.RemoveAll(fooDir))
+	reloadExpectingError(t, ctx, shard, class, `vector "foo"`)
+	require.NoError(t, os.MkdirAll(fooDir, 0o755))
+	shard = reload(t, ctx, shard, class)
+
+	// a creating record resumes: built, synced, flipped to ready
+	creating := foo
+	creating.State = "creating"
+	require.NoError(t, shard.mapping.Put("foo", creating))
+	shard = reload(t, ctx, shard, class)
+	records, _, err = shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Equal(t, foo, records["foo"])
+
+	// a vector the schema has but the mapping does not is recorded
+	require.NoError(t, shard.mapping.Delete("foo"))
+	shard = reload(t, ctx, shard, class)
+	records, _, err = shard.mapping.Load()
+	require.NoError(t, err)
+	assert.Equal(t, foo, records["foo"])
+
+	// a record the schema does not have is deleted, its storage untouched
+	ghostDir := filepath.Join(shard.path(), helpers.GetHNSWCommitLogDirName("ghost"))
+	require.NoError(t, os.MkdirAll(ghostDir, 0o755))
+	require.NoError(t, shard.mapping.Put("ghost", vectorIndexRecord{PhysicalID: "vectors_ghost", IndexType: "hnsw", State: "ready"}))
+	shard = reload(t, ctx, shard, class)
+	records, _, err = shard.mapping.Load()
+	require.NoError(t, err)
+	_, hasGhost := records["ghost"]
+	assert.False(t, hasGhost)
+	_, err = os.Stat(ghostDir)
+	assert.NoError(t, err, "a record the schema lost is not a reason to delete files")
+
+	// a record whose type disagrees with the schema refuses the load
+	wrongType := foo
+	wrongType.IndexType = "flat"
+	require.NoError(t, shard.mapping.Put("foo", wrongType))
+	reloadExpectingError(t, ctx, shard, class, "flat")
+	withOfflineMapping(t, shard.path(), func(m *vectorIndexMapping, _ *shardmeta.Namespace) {
+		require.NoError(t, m.Put("foo", foo))
+	})
+	shard = reload(t, ctx, shard, class)
+
+	// a mapping the shard cannot read refuses the load
+	require.NoError(t, shard.metadataDB.Namespace(vectorIndexMappingNamespace).Put([]byte("bogus"), []byte("x")))
+	reloadExpectingError(t, ctx, shard, class, `unknown key "bogus"`)
+	withOfflineMapping(t, shard.path(), func(_ *vectorIndexMapping, ns *shardmeta.Namespace) {
+		require.NoError(t, ns.Delete([]byte("bogus")))
+	})
+	shard = reload(t, ctx, shard, class)
+	_, _, err = shard.mapping.Load()
+	require.NoError(t, err)
 }

--- a/adapters/repos/db/shard_init_vector_mapping_test.go
+++ b/adapters/repos/db/shard_init_vector_mapping_test.go
@@ -1,0 +1,114 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/models"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	entdynamic "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	entflat "github.com/weaviate/weaviate/entities/vectorindex/flat"
+	enthfresh "github.com/weaviate/weaviate/entities/vectorindex/hfresh"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// storageExistsFor reports whether the directories rec occupies under the
+// shard are all on disk.
+func storageExistsFor(t *testing.T, s *Shard, rec vectorIndexRecord) bool {
+	t.Helper()
+	dirs, err := s.vectorIndexStorageDirsFor(rec)
+	require.NoError(t, err)
+	exists, err := vectorIndexStorageExists(dirs)
+	require.NoError(t, err)
+	return exists
+}
+
+// TestInitShardVectors_FirstLoadWritesTheMapping pins the first load of a
+// shard without a mapping: every index is built as before and recorded
+// ready, at the ID the naming rule gives, with its storage on disk.
+func TestInitShardVectors_FirstLoadWritesTheMapping(t *testing.T) {
+	ctx := testCtx()
+	shard, _ := setupDropVectorShard(t, ctx)
+
+	records, initialized, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.True(t, initialized)
+	assert.Equal(t, map[string]vectorIndexRecord{
+		"":    {PhysicalID: "main", IndexType: "hnsw", State: "ready"},
+		"foo": {PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"},
+		"mv":  {PhysicalID: "vectors_mv", IndexType: "hnsw", State: "ready"},
+	}, records)
+	for name, rec := range records {
+		assert.True(t, storageExistsFor(t, shard, rec), "storage of %q", name)
+	}
+}
+
+// TestInitShardVectors_FirstLoadRecordsEveryType pins that each index type
+// leaves the directories the probe expects behind after its constructor
+// ran, so a ready record written at first load is never a false alarm at
+// the next one.
+func TestInitShardVectors_FirstLoadRecordsEveryType(t *testing.T) {
+	flatCfg := entflat.UserConfig{}
+	flatCfg.SetDefaults()
+	dist := distancer.NewL2SquaredProvider()
+
+	tests := []struct {
+		name      string
+		cfg       schemaConfig.VectorIndexConfig
+		async     bool
+		indexType string
+	}{
+		{name: "hnsw", cfg: enthnsw.NewDefaultUserConfig(), indexType: "hnsw"},
+		{name: "flat", cfg: flatCfg, indexType: "flat"},
+		{name: "hfresh", cfg: enthfresh.NewDefaultUserConfig(), indexType: "hfresh"},
+		{name: "dynamic", indexType: "dynamic", async: true, cfg: entdynamic.UserConfig{
+			Threshold: 1_000_000,
+			Distance:  dist.Type(),
+			HnswUC:    enthnsw.UserConfig{MaxConnections: 8, EFConstruction: 16, EF: 8, VectorCacheMaxObjects: 1000},
+			FlatUC:    flatCfg,
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := testCtx()
+			shd, _ := testShardWithSettings(t, ctx, &models.Class{Class: "EveryType"}, tt.cfg, false, tt.async)
+			shard := underlyingShard(t, shd)
+
+			records, _, err := shard.mapping.Load()
+			require.NoError(t, err)
+			rec := vectorIndexRecord{PhysicalID: "main", IndexType: tt.indexType, State: "ready"}
+			assert.Equal(t, map[string]vectorIndexRecord{"": rec}, records)
+			assert.True(t, storageExistsFor(t, shard, rec))
+		})
+	}
+}
+
+// TestInitShardVectors_SkippedIndexHasNoRecord pins that an hnsw vector
+// with skip set builds a no-op index that owns no files, and the mapping
+// does not record it: the shard is initialized with no records.
+func TestInitShardVectors_SkippedIndexHasNoRecord(t *testing.T) {
+	ctx := testCtx()
+	shd, _ := testShard(t, ctx, "SkippedVector")
+	shard := underlyingShard(t, shd)
+
+	records, initialized, err := shard.mapping.Load()
+	require.NoError(t, err)
+	assert.True(t, initialized)
+	assert.Empty(t, records)
+}

--- a/adapters/repos/db/shard_init_vector_toctou_test.go
+++ b/adapters/repos/db/shard_init_vector_toctou_test.go
@@ -225,8 +225,8 @@ func TestDropVectorIndex_FailedTeardownKeepsTheIndexForCleanup(t *testing.T) {
 	failing.On("Drop", mock.Anything, false).Return(assert.AnError).Once()
 	failing.On("Drop", mock.Anything, false).Return(nil).Once()
 	require.True(t, shard.vectors.Replace("named", failing))
+	// the first load recorded the vector ready
 	named := vectorIndexRecord{PhysicalID: "vectors_named", IndexType: "hnsw", State: "ready"}
-	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"named": named}))
 
 	err := shard.DropVectorIndex(ctx, "named")
 	require.ErrorIs(t, err, assert.AnError)

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -383,6 +383,32 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
 }
 
+// A vector added on a running shard has no mapping record until the next
+// load; the reset must still rebuild it, and only after resolving its ID.
+func TestShard_DebugResetVectorIndex_UnmappedVector(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+	shd, idx := testShardWithSettings(t, ctx, &models.Class{Class: className}, hnsw.UserConfig{}, false, true)
+	defer func(path string) {
+		require.NoError(t, os.RemoveAll(path))
+	}(idx.Config.RootPath)
+
+	require.NoError(t, idx.updateVectorIndexConfigs(ctx, map[string]schemaConfig.VectorIndexConfig{"added": hnsw.UserConfig{}}))
+	s := underlyingShard(t, shd)
+	_, ok, err := s.mapping.Get("added")
+	require.NoError(t, err)
+	require.False(t, ok, "live creation writes no record yet")
+
+	require.NoError(t, shd.DebugResetVectorIndex(ctx, "added"))
+
+	found, err := s.WithVectorIndex("added", func(VectorIndex) error { return nil })
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.True(t, storageExistsFor(t, s, vectorIndexRecord{PhysicalID: "vectors_added", IndexType: "hnsw"}))
+
+	require.Nil(t, idx.drop())
+}
+
 // TestShard_DebugResetVectorIndex_Dynamic pins a bug where resetting a
 // dynamic index broke the shard: dynamic.Drop closed and deleted the
 // shard-SHARED index.db, and the re-init reused the shard's stale closed

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -371,6 +371,14 @@ func TestShard_DebugResetVectorIndex(t *testing.T) {
 		}
 	}
 
+	// the reset rebuilt at the recorded ID: record ready, storage present
+	s := underlyingShard(t, shd)
+	rec, ok, err := s.mapping.Get("")
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, vectorIndexRecord{PhysicalID: "main", IndexType: "hnsw", State: "ready"}, rec)
+	assert.True(t, storageExistsFor(t, s, rec))
+
 	require.Nil(t, idx.drop())
 	require.Nil(t, os.RemoveAll(idx.Config.RootPath))
 }

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -140,6 +140,23 @@ func (m *vectorIndexMapping) Load() (records map[string]vectorIndexRecord, initi
 	return records, initialized, nil
 }
 
+// Get returns name's record, and whether the mapping has one.
+func (m *vectorIndexMapping) Get(name string) (vectorIndexRecord, bool, error) {
+	v, err := m.ns.Get([]byte(vectorIndexMappingKey(name)))
+	if err != nil {
+		return vectorIndexRecord{}, false, fmt.Errorf("get vector index mapping record %q: %w", name, err)
+	}
+	if v == nil {
+		return vectorIndexRecord{}, false, nil
+	}
+	var rec vectorIndexRecord
+	err = json.Unmarshal(v, &rec)
+	if err != nil {
+		return vectorIndexRecord{}, false, fmt.Errorf("record %q: %w", name, err)
+	}
+	return rec, true, nil
+}
+
 // Initialize writes the format version and every record in one
 // transaction, or nothing. It is the first-load step for a shard whose
 // Load reported initialized=false, and it refuses to run on a mapping

--- a/adapters/repos/db/shard_vector_mapping.go
+++ b/adapters/repos/db/shard_vector_mapping.go
@@ -22,12 +22,13 @@ import (
 
 // The mapping's on-disk layout inside index.db. Every key and field name
 // below is read by later versions; changing one is a format change.
+// A named vector is keyed by its name. The two other keys start with a dot,
+// which a vector name cannot, so they can never collide with one.
 const (
 	vectorIndexMappingNamespace        = "vector_index_mapping"
-	vectorIndexMappingFormatVersionKey = "format_version"
+	vectorIndexMappingFormatVersionKey = ".format_version"
 	vectorIndexMappingFormatVersion    = "1"
-	vectorIndexMappingLegacyKey        = "legacy"
-	vectorIndexMappingNamedPrefix      = "named/"
+	vectorIndexMappingLegacyKey        = ".legacy"
 )
 
 // Record states. There is no dropped state: the schema carries deletion
@@ -67,21 +68,20 @@ func vectorIndexMappingKey(name string) string {
 	if name == "" {
 		return vectorIndexMappingLegacyKey
 	}
-	return vectorIndexMappingNamedPrefix + name
+	return name
 }
 
 // vectorIndexMappingName is the inverse of vectorIndexMappingKey. ok is
-// false for a key that does not name a vector, including a bare "named/":
-// the empty name is the legacy vector, and only the legacy key may say so.
+// false for a key that names no vector: an empty one, or a dotted one that
+// is not the legacy key.
 func vectorIndexMappingName(key string) (name string, ok bool) {
 	if key == vectorIndexMappingLegacyKey {
 		return "", true
 	}
-	name, found := strings.CutPrefix(key, vectorIndexMappingNamedPrefix)
-	if found && name != "" {
-		return name, true
+	if key == "" || strings.HasPrefix(key, ".") {
+		return "", false
 	}
-	return "", false
+	return key, true
 }
 
 // validate rejects a record that no version of this code writes.

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -248,6 +248,25 @@ func TestVectorIndexMapping_Put(t *testing.T) {
 	}
 }
 
+func TestVectorIndexMapping_Get(t *testing.T) {
+	m, db := newTestVectorIndexMapping(t)
+	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
+	require.NoError(t, m.Initialize(map[string]vectorIndexRecord{"foo": foo}))
+
+	rec, ok, err := m.Get("foo")
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, foo, rec)
+
+	_, ok, err = m.Get("bar")
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	require.NoError(t, db.Namespace(vectorIndexMappingNamespace).Put([]byte("named/broken"), []byte("{")))
+	_, _, err = m.Get("broken")
+	require.ErrorContains(t, err, `record "broken"`)
+}
+
 func TestVectorIndexMapping_Delete(t *testing.T) {
 	t.Run("removes one record and leaves the rest", func(t *testing.T) {
 		m, _ := newTestVectorIndexMapping(t)

--- a/adapters/repos/db/shard_vector_mapping_test.go
+++ b/adapters/repos/db/shard_vector_mapping_test.go
@@ -33,17 +33,18 @@ func newTestVectorIndexMapping(t *testing.T) (*vectorIndexMapping, *shardmeta.DB
 // every later version, so a change here is a format change, not a rename.
 func TestVectorIndexMapping_KeyLayout(t *testing.T) {
 	assert.Equal(t, "vector_index_mapping", vectorIndexMappingNamespace)
-	assert.Equal(t, "format_version", vectorIndexMappingFormatVersionKey)
+	assert.Equal(t, ".format_version", vectorIndexMappingFormatVersionKey)
 	assert.Equal(t, "1", vectorIndexMappingFormatVersion)
 
 	tests := []struct {
 		name string
 		key  string
 	}{
-		{name: "", key: "legacy"},
-		{name: "title", key: "named/title"},
-		{name: "default", key: "named/default"},
-		{name: "with/slash", key: "named/with/slash"},
+		{name: "", key: ".legacy"},
+		{name: "title", key: "title"},
+		{name: "default", key: "default"},
+		{name: "legacy", key: "legacy"},
+		{name: "format_version", key: "format_version"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.key, func(t *testing.T) {
@@ -54,8 +55,9 @@ func TestVectorIndexMapping_KeyLayout(t *testing.T) {
 		})
 	}
 
-	// keys that name no vector; a bare "named/" would alias the legacy vector
-	for _, key := range []string{"format_version", "unknown", "named/", "named"} {
+	// keys that name no vector: the format version, an unknown dotted key,
+	// and an empty key
+	for _, key := range []string{".format_version", ".unknown", ""} {
 		_, ok := vectorIndexMappingName(key)
 		assert.False(t, ok, key)
 	}
@@ -77,10 +79,10 @@ func TestVectorIndexMapping_Load(t *testing.T) {
 
 	t.Run("reads every record under its logical name", func(t *testing.T) {
 		m, db := newTestVectorIndexMapping(t)
-		put(t, db, "format_version", "1")
-		put(t, db, "legacy", `{"physical_id":"main","index_type":"hnsw","state":"ready"}`)
-		put(t, db, "named/title", `{"physical_id":"vectors_title","index_type":"dynamic","state":"ready"}`)
-		put(t, db, "named/summary", `{"physical_id":"vectors_summary","index_type":"flat","state":"creating"}`)
+		put(t, db, ".format_version", "1")
+		put(t, db, ".legacy", `{"physical_id":"main","index_type":"hnsw","state":"ready"}`)
+		put(t, db, "title", `{"physical_id":"vectors_title","index_type":"dynamic","state":"ready"}`)
+		put(t, db, "summary", `{"physical_id":"vectors_summary","index_type":"flat","state":"creating"}`)
 
 		records, initialized, err := m.Load()
 		require.NoError(t, err)
@@ -94,7 +96,7 @@ func TestVectorIndexMapping_Load(t *testing.T) {
 
 	t.Run("initialized with no records", func(t *testing.T) {
 		m, db := newTestVectorIndexMapping(t)
-		put(t, db, "format_version", "1")
+		put(t, db, ".format_version", "1")
 		records, initialized, err := m.Load()
 		require.NoError(t, err)
 		assert.True(t, initialized)
@@ -108,20 +110,19 @@ func TestVectorIndexMapping_Load(t *testing.T) {
 		value     string
 		wantErr   string
 	}{
-		{name: "unknown format version", noVersion: true, key: "format_version", value: "2", wantErr: "format version"},
-		{name: "unknown key", key: "something", value: "x", wantErr: `unknown key "something"`},
-		{name: "bare named prefix", key: "named/", value: `{"physical_id":"main","index_type":"hnsw","state":"ready"}`, wantErr: `unknown key "named/"`},
-		{name: "unparsable value", key: "named/title", value: "{", wantErr: `record "title"`},
-		{name: "unknown state", key: "named/title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"gone"}`, wantErr: `state "gone"`},
-		{name: "empty physical id", key: "named/title", value: `{"physical_id":"","index_type":"hnsw","state":"ready"}`, wantErr: "physical id"},
-		{name: "empty index type", key: "named/title", value: `{"physical_id":"vectors_title","index_type":"","state":"ready"}`, wantErr: "index type"},
-		{name: "record without format version", noVersion: true, key: "named/title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"ready"}`, wantErr: "format version"},
+		{name: "unknown format version", noVersion: true, key: ".format_version", value: "2", wantErr: "format version"},
+		{name: "unknown dotted key", key: ".something", value: "x", wantErr: `unknown key ".something"`},
+		{name: "unparsable value", key: "title", value: "{", wantErr: `record "title"`},
+		{name: "unknown state", key: "title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"gone"}`, wantErr: `state "gone"`},
+		{name: "empty physical id", key: "title", value: `{"physical_id":"","index_type":"hnsw","state":"ready"}`, wantErr: "physical id"},
+		{name: "empty index type", key: "title", value: `{"physical_id":"vectors_title","index_type":"","state":"ready"}`, wantErr: "index type"},
+		{name: "record without format version", noVersion: true, key: "title", value: `{"physical_id":"vectors_title","index_type":"hnsw","state":"ready"}`, wantErr: "format version"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m, db := newTestVectorIndexMapping(t)
 			if !tt.noVersion {
-				put(t, db, "format_version", "1")
+				put(t, db, ".format_version", "1")
 			}
 			put(t, db, tt.key, tt.value)
 			_, _, err := m.Load()
@@ -148,10 +149,10 @@ func TestVectorIndexMapping_Initialize(t *testing.T) {
 
 		// the bytes on disk are the pinned layout
 		ns := db.Namespace(vectorIndexMappingNamespace)
-		v, err := ns.Get([]byte("format_version"))
+		v, err := ns.Get([]byte(".format_version"))
 		require.NoError(t, err)
 		assert.Equal(t, "1", string(v))
-		v, err = ns.Get([]byte("named/title"))
+		v, err = ns.Get([]byte("title"))
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"physical_id":"vectors_title","index_type":"flat","state":"ready"}`, string(v))
 	})
@@ -262,7 +263,7 @@ func TestVectorIndexMapping_Get(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, ok)
 
-	require.NoError(t, db.Namespace(vectorIndexMappingNamespace).Put([]byte("named/broken"), []byte("{")))
+	require.NoError(t, db.Namespace(vectorIndexMappingNamespace).Put([]byte("broken"), []byte("{")))
 	_, _, err = m.Get("broken")
 	require.ErrorContains(t, err, `record "broken"`)
 }

--- a/adapters/repos/db/shard_write_drop_vector_integration_test.go
+++ b/adapters/repos/db/shard_write_drop_vector_integration_test.go
@@ -293,17 +293,17 @@ func TestDropVectorIndex_DeletesTheMappingRecord(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
 
-	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
-	mv := vectorIndexRecord{PhysicalID: "vectors_mv", IndexType: "hnsw", State: "ready"}
-	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"foo": foo, "mv": mv}))
-
+	// the first load recorded every vector; the drop takes only foo's record
 	markDropped(class, "foo")
 	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
 
 	records, initialized, err := shard.mapping.Load()
 	require.NoError(t, err)
 	assert.True(t, initialized)
-	assert.Equal(t, map[string]vectorIndexRecord{"mv": mv}, records)
+	assert.Equal(t, map[string]vectorIndexRecord{
+		"":   {PhysicalID: "main", IndexType: "hnsw", State: "ready"},
+		"mv": {PhysicalID: "vectors_mv", IndexType: "hnsw", State: "ready"},
+	}, records)
 
 	// a retried drop still succeeds
 	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
@@ -314,6 +314,7 @@ func TestDropVectorIndex_DeletesTheMappingRecord(t *testing.T) {
 func TestDropVectorIndex_UninitializedMapping(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
+	wipeMapping(t, shard)
 
 	markDropped(class, "foo")
 	require.NoError(t, shard.DropVectorIndex(ctx, "foo"))
@@ -324,13 +325,27 @@ func TestDropVectorIndex_UninitializedMapping(t *testing.T) {
 	assert.Empty(t, records)
 }
 
+// wipeMapping removes every key of the shard's mapping namespace, the way an
+// older backup restores it.
+func wipeMapping(t *testing.T, shard *Shard) {
+	t.Helper()
+	ns := shard.metadataDB.Namespace(vectorIndexMappingNamespace)
+	var keys [][]byte
+	require.NoError(t, ns.ForEach(func(key, _ []byte) error {
+		keys = append(keys, key)
+		return nil
+	}))
+	for _, key := range keys {
+		require.NoError(t, ns.Delete(key))
+	}
+}
+
 // The completion sweep errors on a shard shutting down instead of going
 // offline: the shard still holds index.db locked while its references drain.
 func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
 	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
-	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"foo": foo}))
 	markDropped(class, "foo")
 
 	shard.shutdownRequested.Store(true)
@@ -342,7 +357,7 @@ func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) 
 
 	records, _, err := shard.mapping.Load()
 	require.NoError(t, err)
-	assert.Equal(t, map[string]vectorIndexRecord{"foo": foo}, records, "nothing was swept, so the record stays for the retry")
+	assert.Equal(t, foo, records["foo"], "nothing was swept, so the record stays for the retry")
 }
 
 // An unload has left the map but not yet shut down: the sweep waits on the
@@ -352,8 +367,6 @@ func TestDropVectorIndex_CompletionSweepRefusesAShardShuttingDown(t *testing.T) 
 func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
 	ctx := testCtx()
 	shard, class := setupDropVectorShard(t, ctx)
-	foo := vectorIndexRecord{PhysicalID: "vectors_foo", IndexType: "hnsw", State: "ready"}
-	require.NoError(t, shard.mapping.Initialize(map[string]vectorIndexRecord{"foo": foo}))
 	markDropped(class, "foo")
 	idx := shard.index
 
@@ -386,11 +399,13 @@ func TestDropVectorIndex_CompletionSweepWaitsForAnUnload(t *testing.T) {
 		t.Fatal("the sweep did not run after the unload")
 	}
 
-	// the record was deleted offline
+	// foo's record was deleted offline, the others stay
 	records, initialized, err := reopenMapping(t, shard.path())
 	require.NoError(t, err)
 	assert.True(t, initialized)
-	assert.Empty(t, records)
+	_, hasFoo := records["foo"]
+	assert.False(t, hasFoo)
+	assert.Len(t, records, 2)
 }
 
 // reopenMapping reads a shut-down shard's mapping through a fresh handle.


### PR DESCRIPTION
### What's being changed:

Fifth slice of the persisted vector index mapping, stacked on #13007. The shard now reads its mapping at load and treats it as the truth about which vector indexes it has, instead of re-deriving everything from the schema and trusting whatever is on disk.

**First load.** A shard without a mapping, which is every existing shard once and every new shard, builds exactly as before, fsyncs each index's directories, and writes every record `ready` in one transaction. A build that fails fails the load and writes nothing. An hnsw vector with `skip` set owns no files and gets no record.

**Every later load reconciles records against the schema**, one vector at a time in name order. A `ready` record has its directories probed first; if one is missing the shard refuses to load, naming the vector, the physical ID, and the directories, instead of quietly starting an empty index where there was data. This is the one behavior users can see, and the point of the mapping. A `creating` record, left by a crash mid-creation, is built, synced, and flipped to `ready`. A vector the schema has but the mapping does not is recorded `creating` and treated the same. A record the schema no longer has is deleted, its storage untouched. A record whose type disagrees with the schema refuses the load, since the probe reads directories by type.

**The physical ID now comes from the record.** The constructors take it from the caller: the naming rule for a new vector, the record for one the shard already has. Today the two are always identical, since nothing writes anything else; what moves is where the truth lives.

Not in this PR: live creation writing `creating` and `ready` (next slice), the backup barrier (the one after). One cost worth knowing: the first load after the upgrade commits once per shard, spread out by lazy loading.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
