### PR TITLE
fix(schema): drop class data the schema no longer names and handle orphans

### DIFF
--- a/adapters/repos/db/delete_index_unloaded_test.go
+++ b/adapters/repos/db/delete_index_unloaded_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-// TestDeleteIndexRemovesDataWithNoLoadedIndex covers the state both orphan
-// issues leave behind: data on disk with no *Index, because the class was gone
-// from the schema by the time the reload ran. Only index.drop removes the
-// directory, so a DeleteIndex returning early on a missing index strands it.
-func TestDeleteIndexRemovesDataWithNoLoadedIndex(t *testing.T) {
+// TestDropOrphanedClassRemovesDataWithNoLoadedIndex covers the state both
+// orphan issues leave behind: data on disk with no *Index, because the class
+// was gone from the schema by the time the reload ran. Only index.drop removes
+// the directory, so the drop has to work without one.
+func TestDropOrphanedClassRemovesDataWithNoLoadedIndex(t *testing.T) {
 	tests := []struct {
 		name       string
 		onDisk     bool
@@ -44,12 +44,12 @@ func TestDeleteIndexRemovesDataWithNoLoadedIndex(t *testing.T) {
 			db := &DB{config: Config{RootPath: root}, logger: logger, indices: map[string]*Index{}}
 
 			const class = "OrphanClass"
-			dir := filepath.Join(root, indexID(class))
+			dir := filepath.Join(root, indexID(schema.ClassName(class)))
 			if tt.onDisk {
 				require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard1", "lsm"), 0o755))
 			}
 
-			require.NoError(t, db.DeleteIndex(schema.ClassName(class)))
+			require.NoError(t, db.DropOrphanedClass(schema.ClassName(class)))
 
 			if !tt.wantRemove {
 				return
@@ -58,6 +58,32 @@ func TestDeleteIndexRemovesDataWithNoLoadedIndex(t *testing.T) {
 				_, err := os.Stat(dir)
 				return os.IsNotExist(err)
 			}, 10*time.Second, 20*time.Millisecond, "class directory survived DeleteIndex")
+		})
+	}
+}
+
+// TestDeleteIndexNeverRemovesFilesWithoutAnIndex pins the blast radius of
+// DeleteClass on a class that never existed: DeleteClass does not check, so the
+// store is asked to delete anything a caller names. DELETE /v1/schema/raft
+// uppercases to "Raft", whose index id is "raft" — the live RAFT work
+// directory. DeleteIndex must not touch files it has no index for.
+func TestDeleteIndexNeverRemovesFilesWithoutAnIndex(t *testing.T) {
+	for _, class := range []string{"Raft", "Backups", "NeverExisted"} {
+		t.Run(class, func(t *testing.T) {
+			root := t.TempDir()
+			logger, _ := test.NewNullLogger()
+			db := &DB{config: Config{RootPath: root}, logger: logger, indices: map[string]*Index{}}
+
+			dir := filepath.Join(root, indexID(schema.ClassName(class)))
+			require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard1", "lsm"), 0o755))
+
+			require.NoError(t, db.DeleteIndex(schema.ClassName(class)))
+
+			require.Never(t, func() bool {
+				_, err := os.Stat(dir)
+				return os.IsNotExist(err)
+			}, time.Second, 50*time.Millisecond,
+				"DeleteIndex removed %s with no index loaded", dir)
 		})
 	}
 }

--- a/adapters/repos/db/delete_index_unloaded_test.go
+++ b/adapters/repos/db/delete_index_unloaded_test.go
@@ -107,8 +107,7 @@ func TestDropOrphanedClassReportsAFailedDrop(t *testing.T) {
 }
 
 // TestDropOrphanedClassLeavesADirectoryThatIsNotAnIndex pins the one thing the
-// caller cannot know: whether the path is only ours. The class really was in
-// the schema and really was held here, so only the directory settles it.
+// caller cannot know: whether the path is only ours.
 func TestDropOrphanedClassLeavesADirectoryThatIsNotAnIndex(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/adapters/repos/db/delete_index_unloaded_test.go
+++ b/adapters/repos/db/delete_index_unloaded_test.go
@@ -63,10 +63,9 @@ func TestDropOrphanedClassRemovesDataWithNoLoadedIndex(t *testing.T) {
 }
 
 // TestDeleteIndexNeverRemovesFilesWithoutAnIndex pins the blast radius of
-// DeleteClass on a class that never existed: DeleteClass does not check, so the
-// store is asked to delete anything a caller names. DELETE /v1/schema/raft
-// uppercases to "Raft", whose index id is "raft" — the live RAFT work
-// directory. DeleteIndex must not touch files it has no index for.
+// deleting a class that never existed: DeleteClass does not check, so the store
+// is asked to delete whatever a caller names. DELETE /v1/schema/raft uppercases
+// to "Raft", whose index id is the live RAFT work directory.
 func TestDeleteIndexNeverRemovesFilesWithoutAnIndex(t *testing.T) {
 	for _, class := range []string{"Raft", "Backups", "NeverExisted"} {
 		t.Run(class, func(t *testing.T) {
@@ -86,4 +85,26 @@ func TestDeleteIndexNeverRemovesFilesWithoutAnIndex(t *testing.T) {
 				"DeleteIndex removed %s with no index loaded", dir)
 		})
 	}
+}
+
+// TestDropOrphanedClassReportsAFailedDrop pins the retry contract: a drop that
+// leaves the files in place must not report success, or dropOrphanedClasses
+// discards the pending entry for good. Covers the no-index branch; the loaded
+// branch relies on the same dropIndexData call.
+func TestDropOrphanedClassReportsAFailedDrop(t *testing.T) {
+	root := t.TempDir()
+	logger, _ := test.NewNullLogger()
+	db := &DB{config: Config{RootPath: root}, logger: logger, indices: map[string]*Index{}}
+
+	const class = "OrphanClass"
+	dir := filepath.Join(root, indexID(schema.ClassName(class)))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard1", "lsm"), 0o755))
+
+	// A read-only data root makes the rename fail the way a full or
+	// permission-denied volume would.
+	require.NoError(t, os.Chmod(root, 0o555))
+	t.Cleanup(func() { os.Chmod(root, 0o755) })
+
+	err := db.DropOrphanedClass(schema.ClassName(class))
+	require.Error(t, err, "a drop that left the files in place must not report success")
 }

--- a/adapters/repos/db/delete_index_unloaded_test.go
+++ b/adapters/repos/db/delete_index_unloaded_test.go
@@ -1,0 +1,63 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// TestDeleteIndexRemovesDataWithNoLoadedIndex covers the state both orphan
+// issues leave behind: data on disk with no *Index, because the class was gone
+// from the schema by the time the reload ran. Only index.drop removes the
+// directory, so a DeleteIndex returning early on a missing index strands it.
+func TestDeleteIndexRemovesDataWithNoLoadedIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		onDisk     bool
+		wantRemove bool
+	}{
+		{name: "unopened class directory is removed", onDisk: true, wantRemove: true},
+		{name: "missing directory is a no-op", onDisk: false, wantRemove: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			logger, _ := test.NewNullLogger()
+			db := &DB{config: Config{RootPath: root}, logger: logger, indices: map[string]*Index{}}
+
+			const class = "OrphanClass"
+			dir := filepath.Join(root, indexID(class))
+			if tt.onDisk {
+				require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard1", "lsm"), 0o755))
+			}
+
+			require.NoError(t, db.DeleteIndex(schema.ClassName(class)))
+
+			if !tt.wantRemove {
+				return
+			}
+			require.Eventually(t, func() bool {
+				_, err := os.Stat(dir)
+				return os.IsNotExist(err)
+			}, 10*time.Second, 20*time.Millisecond, "class directory survived DeleteIndex")
+		})
+	}
+}

--- a/adapters/repos/db/delete_index_unloaded_test.go
+++ b/adapters/repos/db/delete_index_unloaded_test.go
@@ -23,10 +23,9 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-// TestDropOrphanedClassRemovesDataWithNoLoadedIndex covers the state both
-// orphan issues leave behind: data on disk with no *Index, because the class
-// was gone from the schema by the time the reload ran. Only index.drop removes
-// the directory, so the drop has to work without one.
+// TestDropOrphanedClassRemovesDataWithNoLoadedIndex covers the state both orphan
+// issues leave behind: data on disk with no *Index, because the class was gone
+// from the schema by the time the reload ran.
 func TestDropOrphanedClassRemovesDataWithNoLoadedIndex(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -46,7 +45,7 @@ func TestDropOrphanedClassRemovesDataWithNoLoadedIndex(t *testing.T) {
 			const class = "OrphanClass"
 			dir := filepath.Join(root, indexID(schema.ClassName(class)))
 			if tt.onDisk {
-				require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard1", "lsm"), 0o755))
+				writeShardSignature(t, dir)
 			}
 
 			require.NoError(t, db.DropOrphanedClass(schema.ClassName(class)))
@@ -64,8 +63,7 @@ func TestDropOrphanedClassRemovesDataWithNoLoadedIndex(t *testing.T) {
 
 // TestDeleteIndexNeverRemovesFilesWithoutAnIndex pins the blast radius of
 // deleting a class that never existed: DeleteClass does not check, so the store
-// is asked to delete whatever a caller names. DELETE /v1/schema/raft uppercases
-// to "Raft", whose index id is the live RAFT work directory.
+// is asked to delete whatever a caller names.
 func TestDeleteIndexNeverRemovesFilesWithoutAnIndex(t *testing.T) {
 	for _, class := range []string{"Raft", "Backups", "NeverExisted"} {
 		t.Run(class, func(t *testing.T) {
@@ -89,8 +87,7 @@ func TestDeleteIndexNeverRemovesFilesWithoutAnIndex(t *testing.T) {
 
 // TestDropOrphanedClassReportsAFailedDrop pins the retry contract: a drop that
 // leaves the files in place must not report success, or dropOrphanedClasses
-// discards the pending entry for good. Covers the no-index branch; the loaded
-// branch relies on the same dropIndexData call.
+// discards the pending entry for good.
 func TestDropOrphanedClassReportsAFailedDrop(t *testing.T) {
 	root := t.TempDir()
 	logger, _ := test.NewNullLogger()
@@ -98,7 +95,7 @@ func TestDropOrphanedClassReportsAFailedDrop(t *testing.T) {
 
 	const class = "OrphanClass"
 	dir := filepath.Join(root, indexID(schema.ClassName(class)))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, "shard1", "lsm"), 0o755))
+	writeShardSignature(t, dir)
 
 	// A read-only data root makes the rename fail the way a full or
 	// permission-denied volume would.
@@ -107,4 +104,74 @@ func TestDropOrphanedClassReportsAFailedDrop(t *testing.T) {
 
 	err := db.DropOrphanedClass(schema.ClassName(class))
 	require.Error(t, err, "a drop that left the files in place must not report success")
+}
+
+// TestDropOrphanedClassLeavesADirectoryThatIsNotAnIndex pins the one thing the
+// caller cannot know: whether the path is only ours. The class really was in
+// the schema and really was held here, so only the directory settles it.
+func TestDropOrphanedClassLeavesADirectoryThatIsNotAnIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		class   string
+		build   func(t *testing.T, dir string)
+		removed bool
+	}{
+		{
+			name:  "filesystem backup tree colocated under the data root",
+			class: "Backups",
+			build: func(t *testing.T, dir string) {
+				require.NoError(t, os.MkdirAll(
+					filepath.Join(dir, "backup-1", "node1", "somecollection"), 0o755))
+				require.NoError(t, os.WriteFile(
+					filepath.Join(dir, "backup-1", "node1", "somecollection", "chunk-1"),
+					[]byte("x"), 0o644))
+			},
+		},
+		{
+			name:  "directory with no shard in it",
+			class: "Empty",
+			build: func(t *testing.T, dir string) {
+				require.NoError(t, os.MkdirAll(dir, 0o755))
+			},
+		},
+		{
+			name:    "a real index directory is still removed",
+			class:   "OrphanClass",
+			build:   func(t *testing.T, dir string) { writeShardSignature(t, dir) },
+			removed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			logger, _ := test.NewNullLogger()
+			db := &DB{config: Config{RootPath: root}, logger: logger, indices: map[string]*Index{}}
+
+			dir := filepath.Join(root, indexID(schema.ClassName(tt.class)))
+			tt.build(t, dir)
+
+			require.NoError(t, db.DropOrphanedClass(schema.ClassName(tt.class)))
+
+			if tt.removed {
+				require.Eventually(t, func() bool {
+					_, err := os.Stat(dir)
+					return os.IsNotExist(err)
+				}, 10*time.Second, 20*time.Millisecond, "index directory must be removed")
+				return
+			}
+			require.Never(t, func() bool {
+				_, err := os.Stat(dir)
+				return os.IsNotExist(err)
+			}, time.Second, 50*time.Millisecond, "removed %s, which is not an index", dir)
+		})
+	}
+}
+
+// writeShardSignature creates what hasShardStore looks for: the lsm store and
+// the version file.
+func writeShardSignature(t *testing.T, indexDir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Join(indexDir, "shard1", "lsm"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(indexDir, "shard1", "version"), []byte{1, 0}, 0o644))
 }

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -280,7 +280,6 @@ func (m *Migrator) DropClass(ctx context.Context, className string, hasFrozen bo
 	return nil
 }
 
-// DropOrphanedClass removes the data of a class the schema already dropped.
 func (m *Migrator) DropOrphanedClass(ctx context.Context, className string, hasFrozen bool) error {
 	if err := m.db.DropOrphanedClass(schema.ClassName(className)); err != nil {
 		return err

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -282,10 +282,6 @@ func (m *Migrator) DropClass(ctx context.Context, className string, hasFrozen bo
 
 // DropOrphanedClass removes the data of a class the schema already dropped.
 func (m *Migrator) DropOrphanedClass(ctx context.Context, className string, hasFrozen bool) error {
-	indexID := indexID(schema.ClassName(className))
-	m.classLocks.Lock(indexID)
-	defer m.classLocks.Unlock(indexID)
-
 	if err := m.db.DropOrphanedClass(schema.ClassName(className)); err != nil {
 		return err
 	}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -280,6 +280,21 @@ func (m *Migrator) DropClass(ctx context.Context, className string, hasFrozen bo
 	return nil
 }
 
+// DropOrphanedClass removes the data of a class the schema already dropped.
+func (m *Migrator) DropOrphanedClass(ctx context.Context, className string, hasFrozen bool) error {
+	indexID := indexID(schema.ClassName(className))
+	m.classLocks.Lock(indexID)
+	defer m.classLocks.Unlock(indexID)
+
+	if err := m.db.DropOrphanedClass(schema.ClassName(className)); err != nil {
+		return err
+	}
+	if m.cloud != nil && hasFrozen {
+		return m.cloud.Delete(ctx, className, "", "")
+	}
+	return nil
+}
+
 func (m *Migrator) UpdateClass(ctx context.Context, className string, newClassName *string) error {
 	if newClassName != nil {
 		return errors.New("weaviate does not support renaming of classes")

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -24,8 +24,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/weaviate/weaviate/entities/loadlimiter"
-
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -40,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -585,15 +584,16 @@ func (db *DB) GetIndexForIncomingSharding(className schema.ClassName) sharding.R
 	return index
 }
 
-// DropOrphanedClass removes the data of a class the schema has already
-// dropped. Unlike DeleteIndex it removes files even with no index loaded,
-// which is the state a delete applied schema-only leaves behind, so callers
-// must know the class existed.
+// DropOrphanedClass removes the data of a class the schema already dropped.
+// Unlike DeleteIndex it removes files with no index loaded, the state a
+// schema-only delete leaves behind, so callers must know the class existed.
 func (db *DB) DropOrphanedClass(className schema.ClassName) error {
 	if idx := db.GetIndex(className); idx != nil {
 		// Stop the cycle managers first: renaming underneath a running index
 		// lets its next write recreate the path.
-		return db.DeleteIndex(className)
+		if err := db.DeleteIndex(className); err != nil {
+			return err
+		}
 	}
 	return db.dropIndexData(className)
 }
@@ -615,11 +615,6 @@ func (db *DB) dropIndexData(className schema.ClassName) error {
 func (db *DB) DeleteIndex(className schema.ClassName) error {
 	index := db.GetIndex(className)
 	if index == nil {
-		// Deleting a class that never existed reaches here — DeleteClass does
-		// not check — so this must stay a no-op. Removing files by name would
-		// let DELETE /v1/schema/raft rename the RAFT work directory. Orphan
-		// removal goes through DropOrphanedClass, which is only ever called
-		// for a class the schema really held.
 		return nil
 	}
 

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -585,11 +585,26 @@ func (db *DB) GetIndexForIncomingSharding(className schema.ClassName) sharding.R
 	return index
 }
 
+// dropIndexData removes a class's files without going through an Index.
+func (db *DB) dropIndexData(className schema.ClassName) error {
+	deleted, err := renameForAsyncDelete(
+		filepath.Join(db.config.RootPath, indexID(className)), db.logger)
+	if err != nil {
+		return fmt.Errorf("rename index for async delete: %w", err)
+	}
+	if deleted != "" {
+		spawnAsyncDelete(deleted, db.logger)
+	}
+	return nil
+}
+
 // DeleteIndex deletes the index
 func (db *DB) DeleteIndex(className schema.ClassName) error {
 	index := db.GetIndex(className)
 	if index == nil {
-		return nil
+		// The class can still have data with no index built for it. Only
+		// index.drop removes the directory, so returning here strands it.
+		return db.dropIndexData(className)
 	}
 
 	// a reader holding dropIndex would block the drop below while db.indexLock is held

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -589,16 +589,12 @@ func (db *DB) GetIndexForIncomingSharding(className schema.ClassName) sharding.R
 // schema-only delete leaves behind, so callers must know this node held it.
 func (db *DB) DropOrphanedClass(className schema.ClassName) error {
 	if idx := db.GetIndex(className); idx != nil {
-		// Stop the cycle managers first: renaming underneath a running index
-		// lets its next write recreate the path.
 		if err := db.DeleteIndex(className); err != nil {
 			return err
 		}
 	}
 
-	// The caller knows this node held the class, not that the path is only
-	// ours: BACKUP_FILESYSTEM_PATH takes any absolute directory, so
-	// <RootPath>/backups is legal and a collection named Backups maps onto it.
+	// The caller knows the class was ours; only the directory knows the path is.
 	path := filepath.Join(db.config.RootPath, indexID(className))
 	if !hasShardStore(path) {
 		db.logger.WithFields(logrus.Fields{
@@ -612,8 +608,9 @@ func (db *DB) DropOrphanedClass(className schema.ClassName) error {
 }
 
 // hasShardStore reports whether path holds a shard directory: a child with the
-// lsm store and the version file every shard writes on init. A backup, laid out
-// as <backupID>/<node>/<class> with a file at each leaf, never does.
+// lsm store and the version file every shard writes on init. BACKUP_FILESYSTEM_PATH
+// takes any absolute directory, so <RootPath>/backups is legal and a collection
+// named Backups maps onto it.
 func hasShardStore(path string) bool {
 	entries, err := os.ReadDir(path)
 	if err != nil {
@@ -634,7 +631,6 @@ func hasShardStore(path string) bool {
 	return false
 }
 
-// dropIndexData removes a class's files without going through an Index.
 func (db *DB) dropIndexData(className schema.ClassName) error {
 	deleted, err := renameForAsyncDelete(
 		filepath.Join(db.config.RootPath, indexID(className)), db.logger)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -585,6 +585,19 @@ func (db *DB) GetIndexForIncomingSharding(className schema.ClassName) sharding.R
 	return index
 }
 
+// DropOrphanedClass removes the data of a class the schema has already
+// dropped. Unlike DeleteIndex it removes files even with no index loaded,
+// which is the state a delete applied schema-only leaves behind, so callers
+// must know the class existed.
+func (db *DB) DropOrphanedClass(className schema.ClassName) error {
+	if idx := db.GetIndex(className); idx != nil {
+		// Stop the cycle managers first: renaming underneath a running index
+		// lets its next write recreate the path.
+		return db.DeleteIndex(className)
+	}
+	return db.dropIndexData(className)
+}
+
 // dropIndexData removes a class's files without going through an Index.
 func (db *DB) dropIndexData(className schema.ClassName) error {
 	deleted, err := renameForAsyncDelete(
@@ -602,9 +615,12 @@ func (db *DB) dropIndexData(className schema.ClassName) error {
 func (db *DB) DeleteIndex(className schema.ClassName) error {
 	index := db.GetIndex(className)
 	if index == nil {
-		// The class can still have data with no index built for it. Only
-		// index.drop removes the directory, so returning here strands it.
-		return db.dropIndexData(className)
+		// Deleting a class that never existed reaches here — DeleteClass does
+		// not check — so this must stay a no-op. Removing files by name would
+		// let DELETE /v1/schema/raft rename the RAFT work directory. Orphan
+		// removal goes through DropOrphanedClass, which is only ever called
+		// for a class the schema really held.
+		return nil
 	}
 
 	// a reader holding dropIndex would block the drop below while db.indexLock is held

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -586,7 +586,7 @@ func (db *DB) GetIndexForIncomingSharding(className schema.ClassName) sharding.R
 
 // DropOrphanedClass removes the data of a class the schema already dropped.
 // Unlike DeleteIndex it removes files with no index loaded, the state a
-// schema-only delete leaves behind, so callers must know the class existed.
+// schema-only delete leaves behind, so callers must know this node held it.
 func (db *DB) DropOrphanedClass(className schema.ClassName) error {
 	if idx := db.GetIndex(className); idx != nil {
 		// Stop the cycle managers first: renaming underneath a running index
@@ -595,7 +595,43 @@ func (db *DB) DropOrphanedClass(className schema.ClassName) error {
 			return err
 		}
 	}
+
+	// The caller knows this node held the class, not that the path is only
+	// ours: BACKUP_FILESYSTEM_PATH takes any absolute directory, so
+	// <RootPath>/backups is legal and a collection named Backups maps onto it.
+	path := filepath.Join(db.config.RootPath, indexID(className))
+	if !hasShardStore(path) {
+		db.logger.WithFields(logrus.Fields{
+			"action": "drop_orphaned_class",
+			"class":  className.String(),
+			"path":   path,
+		}).Warn("left class data in place: no shard store, so not our index")
+		return nil
+	}
 	return db.dropIndexData(className)
+}
+
+// hasShardStore reports whether path holds a shard directory: a child with the
+// lsm store and the version file every shard writes on init. A backup, laid out
+// as <backupID>/<node>/<class> with a file at each leaf, never does.
+func hasShardStore(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		lsm, err := os.Stat(filepath.Join(path, e.Name(), "lsm"))
+		if err != nil || !lsm.IsDir() {
+			continue
+		}
+		if v, err := os.Stat(filepath.Join(path, e.Name(), "version")); err == nil && !v.IsDir() {
+			return true
+		}
+	}
+	return false
 }
 
 // dropIndexData removes a class's files without going through an Index.

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -54,6 +55,11 @@ type SchemaManager struct {
 	tenantLimit func() int
 	// tenantLimitErrTemplate resolves the cap-exceeded message (empty = default).
 	tenantLimitErrTemplate func() string
+
+	orphansMu sync.Mutex
+	// orphanedClasses maps classes dropped from the schema while the store went
+	// untouched to whether they held frozen tenants.
+	orphanedClasses map[string]bool
 }
 
 func NewSchemaManager(nodeId string, db Indexer, parser Parser, reg prometheus.Registerer, log *logrus.Logger) *SchemaManager {
@@ -123,8 +129,69 @@ func (s *SchemaManager) AliasSnapshot() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
+// Restore installs a snapshot's schema. Nothing replays the DELETE_CLASS that
+// dropped a class the snapshot no longer names, so this diff is the only
+// signal the store gets that its data should go.
 func (s *SchemaManager) Restore(data []byte, parser Parser) error {
-	return s.schema.Restore(data, parser)
+	before := s.schema.classNames()
+	if err := s.schema.Restore(data, parser); err != nil {
+		return err
+	}
+	s.recordOrphansSince(before)
+	return nil
+}
+
+// recordOrphansSince marks every class present before an operation and absent
+// after it. Frozen tenants are unknowable by now, so cloud cleanup is left to
+// the delete path that still has that state.
+func (s *SchemaManager) recordOrphansSince(before map[string]struct{}) {
+	after := s.schema.classNames()
+
+	s.orphansMu.Lock()
+	defer s.orphansMu.Unlock()
+	for name := range before {
+		if _, stillThere := after[name]; !stillThere {
+			if s.orphanedClasses == nil {
+				s.orphanedClasses = map[string]bool{}
+			}
+			if _, seen := s.orphanedClasses[name]; !seen {
+				s.orphanedClasses[name] = false
+			}
+		}
+	}
+}
+
+// recordOrphan marks one class whose data the store was not told to remove.
+func (s *SchemaManager) recordOrphan(class string, hasFrozen bool) {
+	s.orphansMu.Lock()
+	defer s.orphansMu.Unlock()
+	if s.orphanedClasses == nil {
+		s.orphanedClasses = map[string]bool{}
+	}
+	// OR, never overwrite: deleted frozen, re-added, deleted hot still leaves
+	// the first incarnation's cloud data.
+	s.orphanedClasses[class] = s.orphanedClasses[class] || hasFrozen
+}
+
+// dropOrphanedClasses removes the recorded classes' data, skipping any the
+// schema names again: catching up over [DELETE_CLASS C, ADD_CLASS C] records C
+// on the way past, and dropping it here would destroy what the re-add created.
+func (s *SchemaManager) dropOrphanedClasses() {
+	s.orphansMu.Lock()
+	orphans := s.orphanedClasses
+	s.orphanedClasses = nil
+	s.orphansMu.Unlock()
+
+	present := s.schema.classNames()
+	for class, hasFrozen := range orphans {
+		if _, revived := present[class]; revived {
+			continue
+		}
+		if err := s.db.DeleteClass(class, hasFrozen); err != nil {
+			s.log.WithField("class", class).
+				Errorf("drop data of class the schema no longer names: %v", err)
+		}
+	}
 }
 
 func (s *SchemaManager) RestoreAliases(data []byte) error {
@@ -207,6 +274,9 @@ func (s *SchemaManager) ReloadDBFromSchema() {
 	s.db.TriggerSchemaUpdateCallbacks()
 	s.log.Info("reload local db: update schema ...")
 	s.db.ReloadLocalDB(context.Background(), cs)
+
+	// ReloadLocalDB only opens classes the schema still names.
+	s.dropOrphanedClasses()
 }
 
 func (s *SchemaManager) Close(ctx context.Context) (err error) {
@@ -392,6 +462,13 @@ func (s *SchemaManager) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool, 
 			hasFrozen = true
 			break
 		}
+	}
+
+	if schemaOnly {
+		// The store is not updated here, so the data outlives the schema entry
+		// naming it. The reload drops it, once a re-add can no longer make that
+		// data loss.
+		s.recordOrphan(cmd.Class, hasFrozen)
 	}
 
 	return s.apply(

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -56,13 +56,12 @@ type SchemaManager struct {
 	// tenantLimitErrTemplate resolves the cap-exceeded message (empty = default).
 	tenantLimitErrTemplate func() string
 
-	// metadataOnly nodes hold no class data and never reload, so anything
-	// recorded for them would sit in a map nothing drains.
+	// metadataOnly nodes never reload, so a record would never be drained.
 	metadataOnly bool
 
 	orphansMu sync.Mutex
-	// orphanedClasses maps classes dropped from the schema while the store went
-	// untouched to whether they held frozen tenants.
+	// orphanedClasses maps classes dropped while the store went untouched to
+	// whether they held frozen tenants.
 	orphanedClasses map[string]bool
 }
 
@@ -115,8 +114,7 @@ func (s *SchemaManager) SetIndexer(idx Indexer) {
 	s.schema.shardReader = idx
 }
 
-// SetMetadataOnly marks a node that stores no class data. Call once during FSM
-// bootstrap.
+// SetMetadataOnly marks a node that stores no class data.
 func (s *SchemaManager) SetMetadataOnly(v bool) {
 	s.metadataOnly = v
 }
@@ -140,37 +138,23 @@ func (s *SchemaManager) AliasSnapshot() ([]byte, error) {
 }
 
 // Restore installs a snapshot's schema. Nothing replays the DELETE_CLASS that
-// dropped a class the snapshot no longer names, so this diff is the only
-// signal the store gets that its data should go.
+// dropped a class the snapshot no longer names, so this diff is the store's
+// only signal.
 func (s *SchemaManager) Restore(data []byte, parser Parser) error {
-	before := s.schema.classNames()
-	if err := s.schema.Restore(data, parser); err != nil {
+	dropped, err := s.schema.Restore(data, parser)
+	if err != nil {
 		return err
 	}
-	s.recordOrphansSince(before)
+	s.recordOrphans(dropped)
 	return nil
 }
 
-// recordOrphansSince marks every class present before an operation and absent
-// after it. Frozen tenants are unknowable by now, so cloud cleanup is left to
-// the delete path that still has that state.
-func (s *SchemaManager) recordOrphansSince(before map[string]struct{}) {
-	if s.metadataOnly {
-		return
-	}
-	after := s.schema.classNames()
-
-	s.orphansMu.Lock()
-	defer s.orphansMu.Unlock()
-	for name := range before {
-		if _, stillThere := after[name]; !stillThere {
-			if s.orphanedClasses == nil {
-				s.orphanedClasses = map[string]bool{}
-			}
-			if _, seen := s.orphanedClasses[name]; !seen {
-				s.orphanedClasses[name] = false
-			}
-		}
+// recordOrphans marks the classes a restore dropped, so the reload removes
+// their data. Nothing replays the DELETE_CLASS behind a snapshot, so this is
+// the store's only signal.
+func (s *SchemaManager) recordOrphans(dropped map[string]bool) {
+	for class, hasFrozen := range dropped {
+		s.recordOrphan(class, hasFrozen)
 	}
 }
 
@@ -206,8 +190,10 @@ func (s *SchemaManager) dropOrphanedClasses() {
 		// DropOrphanedClass, not DeleteClass: the data has to go with no index
 		// loaded, which is only safe for a class the schema really held.
 		if err := s.db.DropOrphanedClass(context.Background(), class, hasFrozen); err != nil {
-			s.log.WithField("class", class).
-				Errorf("drop data of class the schema no longer names: %v", err)
+			s.log.WithFields(logrus.Fields{
+				"action": "drop_orphaned_class",
+				"class":  class,
+			}).Error(err)
 			// Put it back; nothing else would name this data again.
 			s.recordOrphan(class, hasFrozen)
 		}
@@ -218,14 +204,14 @@ func (s *SchemaManager) RestoreAliases(data []byte) error {
 	return s.schema.RestoreAlias(data)
 }
 
-// RestoreLegacy installs an old-format snapshot, dropping classes just as
-// Restore does, so it needs the same diff.
+// RestoreLegacy is Restore for the old snapshot format, and drops classes the
+// same way.
 func (s *SchemaManager) RestoreLegacy(data []byte, parser Parser) error {
-	before := s.schema.classNames()
-	if err := s.schema.RestoreLegacy(data, parser); err != nil {
+	dropped, err := s.schema.RestoreLegacy(data, parser)
+	if err != nil {
 		return err
 	}
-	s.recordOrphansSince(before)
+	s.recordOrphans(dropped)
 	return nil
 }
 
@@ -477,29 +463,16 @@ func (s *SchemaManager) UpdateClass(cmd *command.ApplyRequest, nodeID string, sc
 }
 
 func (s *SchemaManager) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool, enableSchemaCallback bool) error {
-	var hasFrozen bool
-	tenants, err := s.schema.getTenants(cmd.Class, nil)
-	if err != nil {
-		hasFrozen = false
-	}
-
-	for _, t := range tenants {
-		if t.ActivityStatus == models.TenantActivityStatusFROZEN ||
-			t.ActivityStatus == models.TenantActivityStatusFREEZING {
-			hasFrozen = true
-			break
-		}
-	}
+	hasFrozen := s.schema.hasFrozenTenant(cmd.Class)
 
 	return s.apply(
 		applyOp{
 			op: cmd.GetType().String(),
 			updateSchema: func() error {
-				// Only a delete that removed an entry leaves data behind.
-				// DeleteClass does not check existence, so recording any name a
-				// caller passed would hand it to the orphan path, which removes
-				// files with no index: a replayed DELETE /v1/schema/raft would
-				// take out <root>/raft.
+				// Only a delete that removed an entry leaves data behind:
+				// DeleteClass validates nothing, so a name that was never a
+				// collection would otherwise be recorded too. Whether the
+				// directory is really ours is settled at the drop.
 				if s.schema.deleteClass(cmd.Class) && schemaOnly {
 					s.recordOrphan(cmd.Class, hasFrozen)
 				}

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -56,8 +56,8 @@ type SchemaManager struct {
 	// tenantLimitErrTemplate resolves the cap-exceeded message (empty = default).
 	tenantLimitErrTemplate func() string
 
-	// metadataOnly nodes hold no class data and never reload, so recording
-	// orphans for them would grow a map nothing ever drains.
+	// metadataOnly nodes hold no class data and never reload, so anything
+	// recorded for them would sit in a map nothing drains.
 	metadataOnly bool
 
 	orphansMu sync.Mutex
@@ -203,14 +203,12 @@ func (s *SchemaManager) dropOrphanedClasses() {
 		if _, revived := present[class]; revived {
 			continue
 		}
-		// DropOrphanedClass, not DeleteClass: the class is gone from the
-		// schema, so the data has to go even with no index loaded, and that is
-		// only safe for a class the schema really held.
+		// DropOrphanedClass, not DeleteClass: the data has to go with no index
+		// loaded, which is only safe for a class the schema really held.
 		if err := s.db.DropOrphanedClass(context.Background(), class, hasFrozen); err != nil {
 			s.log.WithField("class", class).
 				Errorf("drop data of class the schema no longer names: %v", err)
-			// Put it back: a reload that fails here is the only thing standing
-			// between the data and living on disk forever.
+			// Put it back; nothing else would name this data again.
 			s.recordOrphan(class, hasFrozen)
 		}
 	}
@@ -220,7 +218,7 @@ func (s *SchemaManager) RestoreAliases(data []byte) error {
 	return s.schema.RestoreAlias(data)
 }
 
-// RestoreLegacy installs an old-format snapshot. It drops classes just as
+// RestoreLegacy installs an old-format snapshot, dropping classes just as
 // Restore does, so it needs the same diff.
 func (s *SchemaManager) RestoreLegacy(data []byte, parser Parser) error {
 	before := s.schema.classNames()
@@ -493,17 +491,20 @@ func (s *SchemaManager) DeleteClass(cmd *command.ApplyRequest, schemaOnly bool, 
 		}
 	}
 
-	if schemaOnly {
-		// The store is not updated here, so the data outlives the schema entry
-		// naming it. The reload drops it, once a re-add can no longer make that
-		// data loss.
-		s.recordOrphan(cmd.Class, hasFrozen)
-	}
-
 	return s.apply(
 		applyOp{
-			op:           cmd.GetType().String(),
-			updateSchema: func() error { s.schema.deleteClass(cmd.Class); return nil },
+			op: cmd.GetType().String(),
+			updateSchema: func() error {
+				// Only a delete that removed an entry leaves data behind.
+				// DeleteClass does not check existence, so recording any name a
+				// caller passed would hand it to the orphan path, which removes
+				// files with no index: a replayed DELETE /v1/schema/raft would
+				// take out <root>/raft.
+				if s.schema.deleteClass(cmd.Class) && schemaOnly {
+					s.recordOrphan(cmd.Class, hasFrozen)
+				}
+				return nil
+			},
 			updateStore: func() error {
 				if s.replicationFSM == nil {
 					return fmt.Errorf("replication deleter is not set, this should never happen")

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -149,16 +149,13 @@ func (s *SchemaManager) Restore(data []byte, parser Parser) error {
 	return nil
 }
 
-// recordOrphans marks the classes a restore dropped, so the reload removes
-// their data. Nothing replays the DELETE_CLASS behind a snapshot, so this is
-// the store's only signal.
+// recordOrphans marks the classes a restore dropped.
 func (s *SchemaManager) recordOrphans(dropped map[string]bool) {
 	for class, hasFrozen := range dropped {
 		s.recordOrphan(class, hasFrozen)
 	}
 }
 
-// recordOrphan marks one class whose data the store was not told to remove.
 func (s *SchemaManager) recordOrphan(class string, hasFrozen bool) {
 	if s.metadataOnly {
 		return
@@ -187,8 +184,7 @@ func (s *SchemaManager) dropOrphanedClasses() {
 		if _, revived := present[class]; revived {
 			continue
 		}
-		// DropOrphanedClass, not DeleteClass: the data has to go with no index
-		// loaded, which is only safe for a class the schema really held.
+		// DropOrphanedClass, not DeleteClass: no index is loaded to delete.
 		if err := s.db.DropOrphanedClass(context.Background(), class, hasFrozen); err != nil {
 			s.log.WithFields(logrus.Fields{
 				"action": "drop_orphaned_class",

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -56,6 +56,10 @@ type SchemaManager struct {
 	// tenantLimitErrTemplate resolves the cap-exceeded message (empty = default).
 	tenantLimitErrTemplate func() string
 
+	// metadataOnly nodes hold no class data and never reload, so recording
+	// orphans for them would grow a map nothing ever drains.
+	metadataOnly bool
+
 	orphansMu sync.Mutex
 	// orphanedClasses maps classes dropped from the schema while the store went
 	// untouched to whether they held frozen tenants.
@@ -111,6 +115,12 @@ func (s *SchemaManager) SetIndexer(idx Indexer) {
 	s.schema.shardReader = idx
 }
 
+// SetMetadataOnly marks a node that stores no class data. Call once during FSM
+// bootstrap.
+func (s *SchemaManager) SetMetadataOnly(v bool) {
+	s.metadataOnly = v
+}
+
 func (s *SchemaManager) SetReplicationFSM(fsm replicationFSM) {
 	s.replicationFSM = fsm
 }
@@ -145,6 +155,9 @@ func (s *SchemaManager) Restore(data []byte, parser Parser) error {
 // after it. Frozen tenants are unknowable by now, so cloud cleanup is left to
 // the delete path that still has that state.
 func (s *SchemaManager) recordOrphansSince(before map[string]struct{}) {
+	if s.metadataOnly {
+		return
+	}
 	after := s.schema.classNames()
 
 	s.orphansMu.Lock()
@@ -163,6 +176,9 @@ func (s *SchemaManager) recordOrphansSince(before map[string]struct{}) {
 
 // recordOrphan marks one class whose data the store was not told to remove.
 func (s *SchemaManager) recordOrphan(class string, hasFrozen bool) {
+	if s.metadataOnly {
+		return
+	}
 	s.orphansMu.Lock()
 	defer s.orphansMu.Unlock()
 	if s.orphanedClasses == nil {
@@ -187,9 +203,15 @@ func (s *SchemaManager) dropOrphanedClasses() {
 		if _, revived := present[class]; revived {
 			continue
 		}
-		if err := s.db.DeleteClass(class, hasFrozen); err != nil {
+		// DropOrphanedClass, not DeleteClass: the class is gone from the
+		// schema, so the data has to go even with no index loaded, and that is
+		// only safe for a class the schema really held.
+		if err := s.db.DropOrphanedClass(context.Background(), class, hasFrozen); err != nil {
 			s.log.WithField("class", class).
 				Errorf("drop data of class the schema no longer names: %v", err)
+			// Put it back: a reload that fails here is the only thing standing
+			// between the data and living on disk forever.
+			s.recordOrphan(class, hasFrozen)
 		}
 	}
 }
@@ -198,8 +220,15 @@ func (s *SchemaManager) RestoreAliases(data []byte) error {
 	return s.schema.RestoreAlias(data)
 }
 
+// RestoreLegacy installs an old-format snapshot. It drops classes just as
+// Restore does, so it needs the same diff.
 func (s *SchemaManager) RestoreLegacy(data []byte, parser Parser) error {
-	return s.schema.RestoreLegacy(data, parser)
+	before := s.schema.classNames()
+	if err := s.schema.RestoreLegacy(data, parser); err != nil {
+		return err
+	}
+	s.recordOrphansSince(before)
+	return nil
 }
 
 func (s *SchemaManager) PreApplyFilter(req *command.ApplyRequest) error {

--- a/cluster/schema/orphan_class_drop_test.go
+++ b/cluster/schema/orphan_class_drop_test.go
@@ -1,0 +1,169 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/fakes"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// recordingIndexer records the class deletions the reload asks for. The
+// embedded interface is nil, so an unexpected call panics.
+type recordingIndexer struct {
+	Indexer
+
+	deleted []string
+}
+
+func (r *recordingIndexer) DeleteClass(class string, _ bool) error {
+	r.deleted = append(r.deleted, class)
+	return nil
+}
+
+func (r *recordingIndexer) TriggerSchemaUpdateCallbacks() {}
+
+func (r *recordingIndexer) ReloadLocalDB(context.Context, []command.UpdateClassRequest) error {
+	return nil
+}
+
+func addClass(t *testing.T, sm *SchemaManager, class string) {
+	t.Helper()
+	sub, err := json.Marshal(command.AddClassRequest{
+		Class: &models.Class{Class: class},
+		State: &sharding.State{Physical: map[string]sharding.Physical{
+			"shard1": {Name: "shard1", BelongsToNodes: []string{"node1"}},
+		}},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sm.AddClass(&command.ApplyRequest{
+		Type: command.ApplyRequest_TYPE_ADD_CLASS, Class: class, SubCommand: sub,
+	}, "node1", true, false))
+}
+
+// TestReloadDropsClassesTheSchemaNoLongerNames reproduces the two RAFT paths
+// that leave a deleted collection's data on disk forever.
+func TestReloadDropsClassesTheSchemaNoLongerNames(t *testing.T) {
+	tests := []struct {
+		name        string
+		seed        func(t *testing.T, sm *SchemaManager)
+		wantDeleted []string
+	}{
+		{
+			name: "delete applied schema-only during catch-up",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Orphan")
+				deleteClassSchemaOnly(t, sm, "Orphan")
+			},
+			wantDeleted: []string{"Orphan"},
+		},
+		{
+			name: "snapshot restored without the class",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Kept")
+				addClass(t, sm, "Orphan")
+				require.NoError(t, sm.Restore(snapshotWithout(t, sm, "Orphan"), sm.parser))
+			},
+			wantDeleted: []string{"Orphan"},
+		},
+		{
+			name: "delete then re-add keeps the re-added data",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Revived")
+				deleteClassSchemaOnly(t, sm, "Revived")
+				addClass(t, sm, "Revived")
+			},
+			wantDeleted: nil,
+		},
+		{
+			name: "re-add then delete again still drops",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Churned")
+				deleteClassSchemaOnly(t, sm, "Churned")
+				addClass(t, sm, "Churned")
+				deleteClassSchemaOnly(t, sm, "Churned")
+			},
+			wantDeleted: []string{"Churned"},
+		},
+		{
+			name: "a restore that brings the class back keeps its data",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Kept")
+				addClass(t, sm, "Revived")
+				full := snapshotWithout(t, sm, "")
+				require.NoError(t, sm.Restore(snapshotWithout(t, sm, "Revived"), sm.parser))
+				require.NoError(t, sm.Restore(full, sm.parser))
+			},
+			wantDeleted: nil,
+		},
+		{
+			name: "one class survives while another is dropped",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Kept")
+				addClass(t, sm, "Orphan")
+				deleteClassSchemaOnly(t, sm, "Orphan")
+			},
+			wantDeleted: []string{"Orphan"},
+		},
+		{
+			name: "a class the schema still names is never dropped",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Kept")
+			},
+			wantDeleted: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := &recordingIndexer{}
+			parser := fakes.NewMockParser()
+			parser.On("ParseClass", mock.Anything).Return(nil)
+			sm := NewSchemaManager("node1", idx, parser, prometheus.NewPedanticRegistry(), logrus.New())
+
+			tt.seed(t, sm)
+			sm.ReloadDBFromSchema()
+
+			require.ElementsMatch(t, tt.wantDeleted, idx.deleted)
+		})
+	}
+}
+
+// deleteClassSchemaOnly applies DELETE_CLASS the way catch-up does: the entry
+// goes, the store is left untouched.
+func deleteClassSchemaOnly(t *testing.T, sm *SchemaManager, class string) {
+	t.Helper()
+	require.NoError(t, sm.DeleteClass(&command.ApplyRequest{
+		Type: command.ApplyRequest_TYPE_DELETE_CLASS, Class: class,
+	}, true, false))
+}
+
+// snapshotWithout stands in for the leader's snapshot, taken after class was
+// deleted there.
+func snapshotWithout(t *testing.T, sm *SchemaManager, class string) []byte {
+	t.Helper()
+	classes := sm.schema.MetaClasses()
+	delete(classes, class)
+	data, err := json.Marshal(classes)
+	require.NoError(t, err)
+	return data
+}

--- a/cluster/schema/orphan_class_drop_test.go
+++ b/cluster/schema/orphan_class_drop_test.go
@@ -136,6 +136,17 @@ func TestReloadDropsClassesTheSchemaNoLongerNames(t *testing.T) {
 			wantDeleted: []string{"Orphan"},
 		},
 		{
+			name: "deleting a class that never existed records nothing",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Kept")
+				// Accepted and replayed even though neither exists. "Raft" is
+				// the dangerous one: its index id is the RAFT work directory.
+				deleteClassSchemaOnly(t, sm, "Raft")
+				deleteClassSchemaOnly(t, sm, "NeverExisted")
+			},
+			wantDeleted: nil,
+		},
+		{
 			name: "a class the schema still names is never dropped",
 			seed: func(t *testing.T, sm *SchemaManager) {
 				addClass(t, sm, "Kept")
@@ -160,9 +171,8 @@ func TestReloadDropsClassesTheSchemaNoLongerNames(t *testing.T) {
 }
 
 // TestMetadataOnlyNodesRecordNoOrphans pins that a node holding no class data
-// does not accumulate orphans. schemaOnly is true for every command on such a
-// node, and it never reloads, so anything recorded would sit in the map for
-// the process lifetime.
+// accumulates none: schemaOnly is true for its every command, and it never
+// reloads, so a record would sit there for the process lifetime.
 func TestMetadataOnlyNodesRecordNoOrphans(t *testing.T) {
 	parser := fakes.NewMockParser()
 	parser.On("ParseClass", mock.Anything).Return(nil)
@@ -179,9 +189,8 @@ func TestMetadataOnlyNodesRecordNoOrphans(t *testing.T) {
 	require.Empty(t, sm.orphanedClasses, "metadata-only node recorded orphans nothing drains")
 }
 
-// TestFailedDropIsRetriedOnTheNextReload pins that a drop that fails is not
-// lost: the entry goes back so a later reload tries again, since nothing else
-// would ever name that data.
+// TestFailedDropIsRetriedOnTheNextReload pins that a failed drop goes back on
+// the pending set, since nothing else would name that data again.
 func TestFailedDropIsRetriedOnTheNextReload(t *testing.T) {
 	parser := fakes.NewMockParser()
 	parser.On("ParseClass", mock.Anything).Return(nil)

--- a/cluster/schema/orphan_class_drop_test.go
+++ b/cluster/schema/orphan_class_drop_test.go
@@ -34,11 +34,16 @@ type recordingIndexer struct {
 	Indexer
 
 	deleted []string
+	frozen  map[string]bool
 	dropErr error
 }
 
-func (r *recordingIndexer) DropOrphanedClass(_ context.Context, class string, _ bool) error {
+func (r *recordingIndexer) DropOrphanedClass(_ context.Context, class string, hasFrozen bool) error {
 	r.deleted = append(r.deleted, class)
+	if r.frozen == nil {
+		r.frozen = map[string]bool{}
+	}
+	r.frozen[class] = hasFrozen
 	return r.dropErr
 }
 
@@ -139,8 +144,7 @@ func TestReloadDropsClassesTheSchemaNoLongerNames(t *testing.T) {
 			name: "deleting a class that never existed records nothing",
 			seed: func(t *testing.T, sm *SchemaManager) {
 				addClass(t, sm, "Kept")
-				// Accepted and replayed even though neither exists. "Raft" is
-				// the dangerous one: its index id is the RAFT work directory.
+				// Accepted and replayed even though neither is a collection.
 				deleteClassSchemaOnly(t, sm, "Raft")
 				deleteClassSchemaOnly(t, sm, "NeverExisted")
 			},
@@ -238,4 +242,53 @@ func snapshotWithout(t *testing.T, sm *SchemaManager, class string) []byte {
 	data, err := json.Marshal(classes)
 	require.NoError(t, err)
 	return data
+}
+
+// TestRestoreCarriesTheFrozenFlag pins that a class restored away keeps the
+// offloaded-tenant flag its pre-restore state carried. Without it the drop
+// removes the local directory and skips the cloud copy, which nothing else
+// would ever name again.
+func TestRestoreCarriesTheFrozenFlag(t *testing.T) {
+	parser := fakes.NewMockParser()
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	idx := &recordingIndexer{}
+	sm := NewSchemaManager("node1", idx, parser, prometheus.NewPedanticRegistry(), logrus.New())
+
+	addFrozenTenantClass(t, sm, "Frozen")
+	addClass(t, sm, "Hot")
+	// A snapshot naming no class at all: both were deleted while away.
+	empty, err := json.Marshal(map[string]*metaClass{})
+	require.NoError(t, err)
+	require.NoError(t, sm.Restore(empty, sm.parser))
+
+	sm.ReloadDBFromSchema()
+
+	require.ElementsMatch(t, []string{"Frozen", "Hot"}, idx.deleted)
+	require.True(t, idx.frozen["Frozen"], "the offloaded class lost its frozen flag")
+	require.False(t, idx.frozen["Hot"])
+}
+
+// addFrozenTenantClass seeds a multi-tenant class with one offloaded tenant.
+func addFrozenTenantClass(t *testing.T, sm *SchemaManager, class string) {
+	t.Helper()
+	sub, err := json.Marshal(command.AddClassRequest{
+		Class: &models.Class{
+			Class:              class,
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		},
+		State: &sharding.State{
+			PartitioningEnabled: true,
+			Physical: map[string]sharding.Physical{
+				"tenant1": {
+					Name:           "tenant1",
+					BelongsToNodes: []string{"node1"},
+					Status:         models.TenantActivityStatusFROZEN,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, sm.AddClass(&command.ApplyRequest{
+		Type: command.ApplyRequest_TYPE_ADD_CLASS, Class: class, SubCommand: sub,
+	}, "node1", true, false))
 }

--- a/cluster/schema/orphan_class_drop_test.go
+++ b/cluster/schema/orphan_class_drop_test.go
@@ -207,7 +207,6 @@ func TestFailedDropIsRetriedOnTheNextReload(t *testing.T) {
 	sm.ReloadDBFromSchema()
 	require.Equal(t, []string{"Orphan"}, idx.deleted)
 
-	// The failure is retried rather than forgotten.
 	idx.dropErr = nil
 	sm.ReloadDBFromSchema()
 	require.Equal(t, []string{"Orphan", "Orphan"}, idx.deleted)
@@ -244,10 +243,8 @@ func snapshotWithout(t *testing.T, sm *SchemaManager, class string) []byte {
 	return data
 }
 
-// TestRestoreCarriesTheFrozenFlag pins that a class restored away keeps the
-// offloaded-tenant flag its pre-restore state carried. Without it the drop
-// removes the local directory and skips the cloud copy, which nothing else
-// would ever name again.
+// TestRestoreCarriesTheFrozenFlag pins that a class restored away keeps its
+// offloaded-tenant flag: without it the drop skips the cloud copy for good.
 func TestRestoreCarriesTheFrozenFlag(t *testing.T) {
 	parser := fakes.NewMockParser()
 	parser.On("ParseClass", mock.Anything).Return(nil)
@@ -268,7 +265,6 @@ func TestRestoreCarriesTheFrozenFlag(t *testing.T) {
 	require.False(t, idx.frozen["Hot"])
 }
 
-// addFrozenTenantClass seeds a multi-tenant class with one offloaded tenant.
 func addFrozenTenantClass(t *testing.T, sm *SchemaManager, class string) {
 	t.Helper()
 	sub, err := json.Marshal(command.AddClassRequest{

--- a/cluster/schema/orphan_class_drop_test.go
+++ b/cluster/schema/orphan_class_drop_test.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -33,11 +34,12 @@ type recordingIndexer struct {
 	Indexer
 
 	deleted []string
+	dropErr error
 }
 
-func (r *recordingIndexer) DeleteClass(class string, _ bool) error {
+func (r *recordingIndexer) DropOrphanedClass(_ context.Context, class string, _ bool) error {
 	r.deleted = append(r.deleted, class)
-	return nil
+	return r.dropErr
 }
 
 func (r *recordingIndexer) TriggerSchemaUpdateCallbacks() {}
@@ -125,6 +127,15 @@ func TestReloadDropsClassesTheSchemaNoLongerNames(t *testing.T) {
 			wantDeleted: []string{"Orphan"},
 		},
 		{
+			name: "legacy-format snapshot that drops a class (#651)",
+			seed: func(t *testing.T, sm *SchemaManager) {
+				addClass(t, sm, "Kept")
+				addClass(t, sm, "Orphan")
+				require.NoError(t, sm.RestoreLegacy(legacySnapshotWithout(t, sm, "Orphan"), sm.parser))
+			},
+			wantDeleted: []string{"Orphan"},
+		},
+		{
 			name: "a class the schema still names is never dropped",
 			seed: func(t *testing.T, sm *SchemaManager) {
 				addClass(t, sm, "Kept")
@@ -148,6 +159,47 @@ func TestReloadDropsClassesTheSchemaNoLongerNames(t *testing.T) {
 	}
 }
 
+// TestMetadataOnlyNodesRecordNoOrphans pins that a node holding no class data
+// does not accumulate orphans. schemaOnly is true for every command on such a
+// node, and it never reloads, so anything recorded would sit in the map for
+// the process lifetime.
+func TestMetadataOnlyNodesRecordNoOrphans(t *testing.T) {
+	parser := fakes.NewMockParser()
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	idx := &recordingIndexer{}
+	sm := NewSchemaManager("node1", idx, parser, prometheus.NewPedanticRegistry(), logrus.New())
+	sm.SetMetadataOnly(true)
+
+	addClass(t, sm, "Orphan")
+	deleteClassSchemaOnly(t, sm, "Orphan")
+	require.NoError(t, sm.Restore(snapshotWithout(t, sm, ""), sm.parser))
+
+	sm.orphansMu.Lock()
+	defer sm.orphansMu.Unlock()
+	require.Empty(t, sm.orphanedClasses, "metadata-only node recorded orphans nothing drains")
+}
+
+// TestFailedDropIsRetriedOnTheNextReload pins that a drop that fails is not
+// lost: the entry goes back so a later reload tries again, since nothing else
+// would ever name that data.
+func TestFailedDropIsRetriedOnTheNextReload(t *testing.T) {
+	parser := fakes.NewMockParser()
+	parser.On("ParseClass", mock.Anything).Return(nil)
+	idx := &recordingIndexer{dropErr: errors.New("disk gone")}
+	sm := NewSchemaManager("node1", idx, parser, prometheus.NewPedanticRegistry(), logrus.New())
+
+	addClass(t, sm, "Orphan")
+	deleteClassSchemaOnly(t, sm, "Orphan")
+
+	sm.ReloadDBFromSchema()
+	require.Equal(t, []string{"Orphan"}, idx.deleted)
+
+	// The failure is retried rather than forgotten.
+	idx.dropErr = nil
+	sm.ReloadDBFromSchema()
+	require.Equal(t, []string{"Orphan", "Orphan"}, idx.deleted)
+}
+
 // deleteClassSchemaOnly applies DELETE_CLASS the way catch-up does: the entry
 // goes, the store is left untouched.
 func deleteClassSchemaOnly(t *testing.T, sm *SchemaManager, class string) {
@@ -155,6 +207,17 @@ func deleteClassSchemaOnly(t *testing.T, sm *SchemaManager, class string) {
 	require.NoError(t, sm.DeleteClass(&command.ApplyRequest{
 		Type: command.ApplyRequest_TYPE_DELETE_CLASS, Class: class,
 	}, true, false))
+}
+
+// legacySnapshotWithout is snapshotWithout in the pre-Snapshot wire format,
+// which Store.Restore routes through RestoreLegacy.
+func legacySnapshotWithout(t *testing.T, sm *SchemaManager, class string) []byte {
+	t.Helper()
+	classes := sm.schema.MetaClasses()
+	delete(classes, class)
+	data, err := json.Marshal(snapshot{NodeID: "node1", Classes: classes})
+	require.NoError(t, err)
+	return data
 }
 
 // snapshotWithout stands in for the leader's snapshot, taken after class was

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -314,6 +314,21 @@ type shardReader interface {
 	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 }
 
+// hasFrozenTenant reports whether class has a tenant on offloaded storage.
+func (s *schema) hasFrozenTenant(class string) bool {
+	tenants, err := s.getTenants(class, nil)
+	if err != nil {
+		return false
+	}
+	for _, t := range tenants {
+		if t.ActivityStatus == models.TenantActivityStatusFROZEN ||
+			t.ActivityStatus == models.TenantActivityStatusFREEZING {
+			return true
+		}
+	}
+	return false
+}
+
 // classNames returns the names the schema holds, without MetaClasses' deep copy.
 func (s *schema) classNames() map[string]struct{} {
 	s.mu.RLock()
@@ -674,10 +689,10 @@ func (s *schema) MetaClasses() map[string]*metaClass {
 	return classesCopy
 }
 
-func (s *schema) Restore(data []byte, parser Parser) error {
+func (s *schema) Restore(data []byte, parser Parser) (map[string]bool, error) {
 	var classes map[string]*metaClass
 	if err := json.Unmarshal(data, &classes); err != nil {
-		return fmt.Errorf("restore snapshot: decode json: %w", err)
+		return nil, fmt.Errorf("restore snapshot: decode json: %w", err)
 	}
 
 	if classes == nil {
@@ -687,10 +702,10 @@ func (s *schema) Restore(data []byte, parser Parser) error {
 	return s.restore(classes, parser)
 }
 
-func (s *schema) RestoreLegacy(data []byte, parser Parser) error {
+func (s *schema) RestoreLegacy(data []byte, parser Parser) (map[string]bool, error) {
 	snap := snapshot{}
 	if err := json.Unmarshal(data, &snap); err != nil {
-		return fmt.Errorf("restore snapshot: decode json: %w", err)
+		return nil, fmt.Errorf("restore snapshot: decode json: %w", err)
 	}
 
 	if snap.Classes == nil {
@@ -700,15 +715,43 @@ func (s *schema) RestoreLegacy(data []byte, parser Parser) error {
 	return s.restore(snap.Classes, parser)
 }
 
-func (s *schema) restore(classes map[string]*metaClass, parser Parser) error {
+// restore reports the classes it dropped, each mapped to whether it has a
+// tenant on offloaded storage. Both are resolved before the swap: afterwards
+// the schema can no longer answer either question.
+func (s *schema) restore(classes map[string]*metaClass, parser Parser) (map[string]bool, error) {
 	for _, cls := range classes {
 		if err := parser.ParseClass(&cls.Class); err != nil { // should not fail
-			return fmt.Errorf("parsing class %q: %w", cls.Class.Class, err) // schema might be corrupted
+			return nil, fmt.Errorf("parsing class %q: %w", cls.Class.Class, err) // schema might be corrupted
 		}
 		cls.Sharding.SetLocalName(s.nodeID)
 	}
+
+	dropped := s.droppedBy(classes)
 	s.replaceClasses(classes)
-	return nil
+	return dropped, nil
+}
+
+// droppedBy returns the classes incoming does not name, each with whether it
+// has a tenant on offloaded storage. Only the dropped classes are looked up, so
+// a restore that removes nothing costs nothing.
+func (s *schema) droppedBy(incoming map[string]*metaClass) map[string]bool {
+	s.mu.RLock()
+	var names []string
+	for name := range s.classes {
+		if _, kept := incoming[name]; !kept {
+			names = append(names, name)
+		}
+	}
+	s.mu.RUnlock()
+
+	if len(names) == 0 {
+		return nil
+	}
+	dropped := make(map[string]bool, len(names))
+	for _, name := range names {
+		dropped[name] = s.hasFrozenTenant(name)
+	}
+	return dropped
 }
 
 func (s *schema) RestoreAlias(data []byte) error {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -314,6 +314,18 @@ type shardReader interface {
 	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 }
 
+// classNames returns the names the schema holds, without MetaClasses' deep copy.
+func (s *schema) classNames() map[string]struct{} {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	names := make(map[string]struct{}, len(s.classes))
+	for name := range s.classes {
+		names[name] = struct{}{}
+	}
+	return names
+}
+
 func (s *schema) len() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -378,7 +378,7 @@ func TestSchemaRestoreLegacyWithEmptyClasses(t *testing.T) {
 		// Test RestoreLegacy
 		mockParser := NewMockParser(t)
 
-		err := s.RestoreLegacy([]byte(snapData), mockParser)
+		_, err := s.RestoreLegacy([]byte(snapData), mockParser)
 		require.NoError(t, err)
 
 		// Verify that s.classes is an empty map, not nil
@@ -405,7 +405,7 @@ func TestSchemaRestoreLegacyWithNilClasses(t *testing.T) {
 
 		// Test RestoreLegacy
 		mockParser := NewMockParser(t)
-		err = s.RestoreLegacy(snapData, mockParser)
+		_, err = s.RestoreLegacy(snapData, mockParser)
 		require.NoError(t, err)
 
 		// Verify that s.classes is initialized, not nil
@@ -422,7 +422,7 @@ func TestSchemaAddClassAfterRestoreWithEmptyClasses(t *testing.T) {
 		// First restore with empty classes
 		snapData := `{"node_id":"test-node","snapshot_id":"test-snapshot","classes":{}}`
 		mockParser := NewMockParser(t)
-		err := s.RestoreLegacy([]byte(snapData), mockParser)
+		_, err := s.RestoreLegacy([]byte(snapData), mockParser)
 		require.NoError(t, err)
 
 		// Verify s.classes is not nil
@@ -456,7 +456,7 @@ func TestSchemaAddClassAfterRestoreWithNilClasses(t *testing.T) {
 		require.NoError(t, err)
 
 		mockParser := NewMockParser(t)
-		err = s.RestoreLegacy(snapData, mockParser)
+		_, err = s.RestoreLegacy(snapData, mockParser)
 		require.NoError(t, err)
 
 		// Verify s.classes is not nil

--- a/cluster/schema/types.go
+++ b/cluster/schema/types.go
@@ -48,6 +48,10 @@ type Indexer interface {
 	// ReloadLocalDB reloads the local database using the latest schema.
 	ReloadLocalDB(ctx context.Context, all []api.UpdateClassRequest) error
 
+	// DropOrphanedClass removes the data of a class the schema already
+	// dropped. Only call it for a class the schema really held.
+	DropOrphanedClass(ctx context.Context, className string, hasFrozen bool) error
+
 	// RestoreClassDir restores classes on the filesystem directly from the temporary class backup stored on disk.
 	RestoreClassDir(class string) error
 	Open(context.Context) error

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -335,6 +335,7 @@ func newStoreMetrics(nodeID string, reg prometheus.Registerer) *storeMetrics {
 
 func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fsm.Snapshotter, reg prometheus.Registerer) Store {
 	schemaManager := schema.NewSchemaManager(cfg.NodeID, cfg.DB, cfg.Parser, reg, cfg.Logger)
+	schemaManager.SetMetadataOnly(cfg.MetadataOnlyVoters)
 	replicationManager := replication.NewManager(schemaManager.NewSchemaReader(), cfg.NodeSelector, reg)
 	schemaManager.SetReplicationFSM(replicationManager.GetReplicationFSM())
 	if dv := cfg.MaxTenantsPerCollection; dv != nil {
@@ -552,6 +553,7 @@ func (st *Store) onLeaderFound(timeout time.Duration) {
 		if st.IsLeader() {
 			st.maybeCommitClusterID()
 		}
+
 		return
 	}
 }

--- a/usecases/fakes/fake_schema_executor.go
+++ b/usecases/fakes/fake_schema_executor.go
@@ -70,6 +70,10 @@ func (m *MockSchemaExecutor) ReloadLocalDB(ctx context.Context, all []cmd.Update
 	return nil
 }
 
+func (m *MockSchemaExecutor) DropOrphanedClass(ctx context.Context, class string, hasFrozen bool) error {
+	return nil
+}
+
 func (m *MockSchemaExecutor) DeleteClass(name string, hasFrozen bool) error {
 	args := m.Called(name)
 	return args.Error(0)

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -58,8 +58,8 @@ func (e *executor) Open(ctx context.Context) error {
 	return e.migrator.WaitForStartup(ctx)
 }
 
-// DropOrphanedClass returns its error, unlike DeleteClass, so a failed drop
-// can be retried by the next reload.
+// DropOrphanedClass returns its error, unlike DeleteClass, so the next reload
+// can retry a failed drop.
 func (e *executor) DropOrphanedClass(ctx context.Context, cls string, hasFrozen bool) error {
 	return e.migrator.DropOrphanedClass(ctx, cls, hasFrozen)
 }

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -58,6 +58,12 @@ func (e *executor) Open(ctx context.Context) error {
 	return e.migrator.WaitForStartup(ctx)
 }
 
+// DropOrphanedClass returns its error, unlike DeleteClass, so a failed drop
+// can be retried by the next reload.
+func (e *executor) DropOrphanedClass(ctx context.Context, cls string, hasFrozen bool) error {
+	return e.migrator.DropOrphanedClass(ctx, cls, hasFrozen)
+}
+
 // ReloadLocalDB reloads the local database using the latest schema.
 func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassRequest) error {
 	cs := make([]*models.Class, len(all))

--- a/usecases/schema/helpers_test.go
+++ b/usecases/schema/helpers_test.go
@@ -123,6 +123,10 @@ func (f *fakeDB) ReloadLocalDB(ctx context.Context, all []command.UpdateClassReq
 	return nil
 }
 
+func (f *fakeDB) DropOrphanedClass(ctx context.Context, class string, hasFrozen bool) error {
+	return nil
+}
+
 func (f *fakeDB) DeleteClass(class string, hasFrozen bool) error {
 	return nil
 }
@@ -290,6 +294,10 @@ type fakeMigrator struct {
 
 func (f *fakeMigrator) GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error) {
 	return nil, nil
+}
+
+func (f *fakeMigrator) DropOrphanedClass(ctx context.Context, className string, hasFrozen bool) error {
+	return nil
 }
 
 func (f *fakeMigrator) AddClass(ctx context.Context, cls *models.Class) error {

--- a/usecases/schema/migrator.go
+++ b/usecases/schema/migrator.go
@@ -36,6 +36,7 @@ type UpdateTenantPayload struct {
 type Migrator interface {
 	AddClass(ctx context.Context, class *models.Class) error
 	DropClass(ctx context.Context, className string, hasFrozen bool) error
+	DropOrphanedClass(ctx context.Context, className string, hasFrozen bool) error
 	// UpdateClass(ctx context.Context, className string,newClassName *string) error
 	GetShardsQueueSize(ctx context.Context, className, tenant string) (map[string]int64, error)
 	LoadShard(ctx context.Context, class, shard string) error


### PR DESCRIPTION
### What's being changed:
A deleted collection could leave its directory under the data root forever gone from the schema on every node, invisible to every API, visible only as disk usage. Two RAFT paths produce it, and both end in the same reload, which only re-opens the classes the schema still names:

- [0-weaviate-issues#652](https://github.com/weaviate/0-weaviate-issues/issues/652), a node restarted mid-DELETE_CLASS replays the entry schema-only on catch-up (index <= lastAppliedIndexToDB), so the store is never told to delete the class.
- [0-weaviate-issues#651](https://github.com/weaviate/0-weaviate-issues/issues/651),  a node rejoining through InstallSnapshot restores a schema without the class, and nothing replays the DELETE_CLASS that dropped it.

### The Fix 
Both are the same gap twice over: the schema layer knows a class went away and never passes that on. So it records it — a schema-only DELETE_CLASS notes the class, Restore diffs class names either side of the snapshot, and the reload drops what was recorded.

The drop is deferred to the reload, and that is what makes recording safe. Catching up over [DELETE_CLASS C, ADD_CLASS C] records C on the way past; acting at apply time would destroy what the re-add just created, which is the loss schemaOnly exists to prevent. By the reload the schema is final, so a class it names again is skipped.


this is replacement for https://github.com/weaviate/weaviate/pull/13000 to avoid handling the orphan on storage layer and instead from the schema layer 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
