### PR TITLE
refact(modules): use SchemaGetter and remove interface duplicate

### DIFF
--- a/usecases/modules/fakes_for_test.go
+++ b/usecases/modules/fakes_for_test.go
@@ -13,6 +13,7 @@ package modules
 
 import (
 	"context"
+	"testing"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/mock"
@@ -23,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 func newDummyModule(name string, t modulecapabilities.ModuleType) modulecapabilities.Module {
@@ -179,10 +181,13 @@ func (m dummyNonVectorizerModule) Type() modulecapabilities.ModuleType {
 	return non
 }
 
-type fakeSchemaGetter struct{ schema schema.Schema }
-
-func (f *fakeSchemaGetter) ReadOnlyClass(name string) *models.Class {
-	return f.schema.GetClass(name)
+// newMockSchemaGetter returns a generated SchemaGetter mock that serves
+// ReadOnlyClass from sch. The expectation is optional so setups that never
+// look up a class don't fail the mock's cleanup assertion.
+func newMockSchemaGetter(t *testing.T, sch schema.Schema) *schemaUC.MockSchemaGetter {
+	sg := schemaUC.NewMockSchemaGetter(t)
+	sg.EXPECT().ReadOnlyClass(mock.Anything).RunAndReturn(sch.GetClass).Maybe()
+	return sg
 }
 
 type fakeObjectsRepo struct {

--- a/usecases/modules/modules.go
+++ b/usecases/modules/modules.go
@@ -34,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 var (
@@ -49,15 +50,11 @@ type Provider struct {
 	vectorsLock               sync.RWMutex
 	registered                map[string]modulecapabilities.Module
 	altNames                  map[string]string
-	schemaGetter              schemaGetter
+	schemaGetter              schemaUC.SchemaGetter
 	hasMultipleVectorizers    bool
 	targetVectorNameValidator *regexp.Regexp
 	logger                    logrus.FieldLogger
 	cfg                       config.Config
-}
-
-type schemaGetter interface {
-	ReadOnlyClass(name string) *models.Class
 }
 
 func NewProvider(logger logrus.FieldLogger, cfg config.Config) *Provider {
@@ -141,7 +138,7 @@ func (p *Provider) Close() error {
 	return nil
 }
 
-func (p *Provider) SetSchemaGetter(sg schemaGetter) {
+func (p *Provider) SetSchemaGetter(sg schemaUC.SchemaGetter) {
 	p.schemaGetter = sg
 }
 

--- a/usecases/modules/modules_test.go
+++ b/usecases/modules/modules_test.go
@@ -32,6 +32,7 @@ import (
 	enitiesSchema "github.com/weaviate/weaviate/entities/schema"
 	ubackup "github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/config"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
 
 func TestModulesProvider(t *testing.T) {
@@ -46,7 +47,7 @@ func TestModulesProvider(t *testing.T) {
 		schema := &models.Schema{
 			Classes: []*models.Class{class},
 		}
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		params := map[string]interface{}{}
@@ -75,7 +76,7 @@ func TestModulesProvider(t *testing.T) {
 		// given
 		logger, _ := test.NewNullLogger()
 		modulesProvider := NewProvider(logger, config.Config{})
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		// when
@@ -91,7 +92,7 @@ func TestModulesProvider(t *testing.T) {
 		// given
 		logger, _ := test.NewNullLogger()
 		modulesProvider := NewProvider(logger, config.Config{})
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		// when
@@ -118,7 +119,7 @@ func TestModulesProvider(t *testing.T) {
 		// given
 		logger, _ := test.NewNullLogger()
 		modulesProvider := NewProvider(logger, config.Config{})
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		// when
@@ -153,7 +154,7 @@ func TestModulesProvider(t *testing.T) {
 		schema := &models.Schema{
 			Classes: []*models.Class{class},
 		}
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		params := map[string]interface{}{}
@@ -195,7 +196,7 @@ func TestModulesProvider(t *testing.T) {
 		// given
 		logger, _ := test.NewNullLogger()
 		modulesProvider := NewProvider(logger, config.Config{})
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		// when
@@ -219,7 +220,7 @@ func TestModulesProvider(t *testing.T) {
 		// given
 		logger, _ := test.NewNullLogger()
 		modulesProvider := NewProvider(logger, config.Config{})
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		// when
@@ -274,7 +275,7 @@ func TestModulesProvider(t *testing.T) {
 		// given
 		logger, _ := test.NewNullLogger()
 		modulesProvider := NewProvider(logger, config.Config{})
-		schemaGetter := getFakeSchemaGetter()
+		schemaGetter := getMockSchemaGetter(t)
 		modulesProvider.SetSchemaGetter(schemaGetter)
 
 		// when
@@ -453,7 +454,7 @@ func (m *dummyAdditionalModule) AdditionalProperties() map[string]modulecapabili
 	return m.additionalProperties
 }
 
-func getFakeSchemaGetter() schemaGetter {
+func getMockSchemaGetter(t *testing.T) *schemaUC.MockSchemaGetter {
 	sch := enitiesSchema.Schema{
 		Objects: &models.Schema{
 			Classes: []*models.Class{
@@ -487,7 +488,7 @@ func getFakeSchemaGetter() schemaGetter {
 			},
 		},
 	}
-	return &fakeSchemaGetter{schema: sch}
+	return newMockSchemaGetter(t, sch)
 }
 
 type dummyBackupModuleWithAltNames struct{}
@@ -553,7 +554,7 @@ func (m *dummyBackupModuleWithAltNames) Initialize(ctx context.Context, backupID
 func TestVectorFromSearchParamNoVectorizerTypedError(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	p := NewProvider(logger, config.Config{})
-	p.SetSchemaGetter(getFakeSchemaGetter())
+	p.SetSchemaGetter(getMockSchemaGetter(t))
 
 	_, err := p.VectorFromSearchParam(context.Background(),
 		"ClassOne", "", "", "nearText", nil, nil)

--- a/usecases/modules/searchers_test.go
+++ b/usecases/modules/searchers_test.go
@@ -47,9 +47,7 @@ func TestModulesWithSearchers(t *testing.T) {
 
 	t.Run("get a vector for a class", func(t *testing.T) {
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{
-			schema: sch,
-		})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(newSearcherModule[[]float32]("mod").
 			withArg("nearGrape").
 			withSearcher("nearGrape", func(ctx context.Context, params interface{},
@@ -79,9 +77,7 @@ func TestModulesWithSearchers(t *testing.T) {
 
 	t.Run("no module configured for a class", func(t *testing.T) {
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{
-			schema: sch,
-		})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(newSearcherModule[[]float32]("mod").
 			withArg("nearGrape").
 			withSearcher("nearGrape", func(ctx context.Context, params interface{},
@@ -111,9 +107,7 @@ func TestModulesWithSearchers(t *testing.T) {
 
 	t.Run("get a vector across classes", func(t *testing.T) {
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{
-			schema: sch,
-		})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(newSearcherModule[[]float32]("mod").
 			withArg("nearGrape").
 			withSearcher("nearGrape", func(ctx context.Context, params interface{},
@@ -148,9 +142,7 @@ func TestModulesWithSearchers(t *testing.T) {
 
 	t.Run("explore no vectorizer", func(t *testing.T) {
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{
-			schema: sch,
-		})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(newSearcherModule[[]float32]("mod").
 			withArg("nearGrape").
 			withSearcher("nearGrape", func(ctx context.Context, params interface{},
@@ -183,9 +175,7 @@ func TestModulesWithSearchers(t *testing.T) {
 
 	t.Run("get a multi vector for a class", func(t *testing.T) {
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{
-			schema: sch,
-		})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(newSearcherModule[[][]float32]("mod").
 			withArg("nearGrape").
 			withSearcher("nearGrape", func(ctx context.Context, params interface{},
@@ -215,9 +205,7 @@ func TestModulesWithSearchers(t *testing.T) {
 
 	t.Run("get a multi vector across classes", func(t *testing.T) {
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{
-			schema: sch,
-		})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(newSearcherModule[[][]float32]("mod").
 			withArg("nearGrape").
 			withSearcher("nearGrape", func(ctx context.Context, params interface{},

--- a/usecases/modules/vectorizer_test.go
+++ b/usecases/modules/vectorizer_test.go
@@ -92,7 +92,7 @@ func TestProvider_UsingRef2Vec(t *testing.T) {
 			}},
 		}}
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(mod)
 		assert.True(t, p.UsingRef2Vec(className))
 	})
@@ -110,7 +110,7 @@ func TestProvider_UsingRef2Vec(t *testing.T) {
 			}},
 		}}
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(mod)
 		assert.False(t, p.UsingRef2Vec(className))
 	})
@@ -120,7 +120,7 @@ func TestProvider_UsingRef2Vec(t *testing.T) {
 		mod := newDummyModule("", "")
 
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{schema.Schema{}})
+		p.SetSchemaGetter(newMockSchemaGetter(t, schema.Schema{}))
 		p.Register(mod)
 		assert.False(t, p.UsingRef2Vec(className))
 	})
@@ -135,7 +135,7 @@ func TestProvider_UsingRef2Vec(t *testing.T) {
 			}},
 		}}
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		p.Register(mod)
 		assert.False(t, p.UsingRef2Vec(className))
 	})
@@ -152,7 +152,7 @@ func TestProvider_UsingRef2Vec(t *testing.T) {
 			}},
 		}}
 		p := NewProvider(logger, config.Config{})
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 		assert.False(t, p.UsingRef2Vec(className))
 	})
 }
@@ -186,12 +186,12 @@ func droppedAndLiveVectorClass(className, modName string) *models.Class {
 
 // dropVectorTestProvider serves class through the schema getter with a dummy
 // text2vec module registered under modName.
-func dropVectorTestProvider(class *models.Class, modName string) (*Provider, *logrus.Logger) {
+func dropVectorTestProvider(t *testing.T, class *models.Class, modName string) (*Provider, *logrus.Logger) {
 	logger, _ := test.NewNullLogger()
 	p := NewProvider(logger, config.Config{})
 	p.Register(newDummyModule(modName, modulecapabilities.Text2Vec))
 	sch := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
-	p.SetSchemaGetter(&fakeSchemaGetter{sch})
+	p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 	return p, logger
 }
 
@@ -203,7 +203,7 @@ func TestProvider_BatchUpdateVector(t *testing.T) {
 		// Computing it here would therefore fail every write to the collection
 		// until the drop finalizes. Single-object twin in TestProvider_UpdateVector.
 		class := droppedAndLiveVectorClass("SomeClass", "some-vzr")
-		p, logger := dropVectorTestProvider(class, "some-vzr")
+		p, logger := dropVectorTestProvider(t, class, "some-vzr")
 
 		objs := []*models.Object{
 			{Class: class.Class, ID: newUUID()},
@@ -229,7 +229,7 @@ func TestProvider_BatchUpdateVector(t *testing.T) {
 				"dropped": moduleVectorEntry("some-vzr", true),
 			},
 		}
-		p, logger := dropVectorTestProvider(class, "some-vzr")
+		p, logger := dropVectorTestProvider(t, class, "some-vzr")
 
 		objs := []*models.Object{{Class: class.Class, ID: newUUID()}}
 		vecErrs, err := p.BatchUpdateVector(context.Background(), class, objs, (&fakeObjectsRepo{}).Object, logger)
@@ -267,7 +267,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 
 		p := NewProvider(logger, config.Config{})
 		p.Register(mod)
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 
 		obj := &models.Object{Class: className, ID: newUUID()}
 		err := p.UpdateVector(ctx, obj, &class, repo.Object, logger)
@@ -286,7 +286,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 
 		p := NewProvider(logger, config.Config{})
 		p.Register(mod)
-		p.SetSchemaGetter(&fakeSchemaGetter{schema.Schema{}})
+		p.SetSchemaGetter(newMockSchemaGetter(t, schema.Schema{}))
 
 		obj := &models.Object{Class: class.Class, ID: newUUID()}
 		err := p.UpdateVector(ctx, obj, class, (&fakeObjectsRepo{}).Object, logger)
@@ -355,7 +355,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 				logger, _ := test.NewNullLogger()
 
 				p := NewProvider(logger, config.Config{})
-				p.SetSchemaGetter(&fakeSchemaGetter{sch})
+				p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 
 				tt.object.ID = newUUID()
 				err := p.UpdateVector(ctx, tt.object, class, (&fakeObjectsRepo{}).Object, logger)
@@ -368,7 +368,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 		// Regression for weaviate/0-weaviate-issues#481 — see
 		// TestProvider_BatchUpdateVector for the batch twin.
 		class := droppedAndLiveVectorClass("SomeClass", "some-vzr")
-		p, logger := dropVectorTestProvider(class, "some-vzr")
+		p, logger := dropVectorTestProvider(t, class, "some-vzr")
 
 		obj := &models.Object{Class: class.Class, ID: newUUID()}
 		err := p.UpdateVector(context.Background(), obj, class, (&fakeObjectsRepo{}).Object, logger)
@@ -400,7 +400,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 
 		p := NewProvider(logger, config.Config{})
 		p.Register(mod)
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 
 		obj := &models.Object{Class: className, ID: newUUID()}
 		err := p.UpdateVector(ctx, obj, class, repo.Object, logger)
@@ -428,7 +428,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 
 		p := NewProvider(logger, config.Config{})
 		p.Register(mod)
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 
 		obj := &models.Object{Class: className, ID: newUUID()}
 
@@ -463,7 +463,7 @@ func TestProvider_UpdateVector(t *testing.T) {
 
 		p := NewProvider(logger, config.Config{})
 		p.Register(mod)
-		p.SetSchemaGetter(&fakeSchemaGetter{sch})
+		p.SetSchemaGetter(newMockSchemaGetter(t, sch))
 
 		obj := &models.Object{Class: className, ID: newUUID()}
 		err := p.UpdateVector(ctx, obj, &class, repo.Object, logger)


### PR DESCRIPTION
### What's being changed:
remove interface duplicate

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
