### PR TITLE
fix(usage): report every dimensions row for multi-vector targets

### DIFF
--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -362,9 +362,9 @@ func (i *Index) calculateLoadedShardUsage(ctx context.Context, shard *Shard, exa
 }
 
 // vectorUsages builds the usage entry of every vector index of a loaded shard.
-// dimensionalities holds the raw dimensions [Shard.VectorStorageUsage] already read
-// from the dimensions bucket; whatever it cannot answer is read on demand.
-func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities map[string]types.Dimensionality) (types.VectorsUsage, error) {
+// scans holds the dimensions rows [Shard.VectorStorageUsage] already read from the
+// dimensions bucket; whatever it cannot answer is read on demand.
+func (i *Index) vectorUsages(ctx context.Context, shard *Shard, scans map[string]shardusage.DimensionsScan) (types.VectorsUsage, error) {
 	vectorConfigs := i.GetVectorIndexConfigs()
 	var usages types.VectorsUsage
 	if err := shard.ForEachVectorIndex(func(targetVector string, vectorIndex VectorIndex) error {
@@ -392,16 +392,28 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 		}
 		dimInfo := GetDimensionCategory(vectorIndexConfig, isDynamicUpgraded)
 
-		// a target vector added since VectorStorageUsage ran is missing from the map, and
-		// MUVERA reports encoded dimensions that the raw scan does not carry
 		encodedDimensions := i.muveraEncodedDimensions(shard.Name(), targetVector, vectorIndexConfig)
-		dimensionality, cached := dimensionalities[targetVector]
-		if !cached || encodedDimensions > 0 {
-			scan, err := shard.DimensionsUsage(ctx, targetVector, encodedDimensions)
+		scan, cached := scans[targetVector]
+		if !cached {
+			// a target vector added since VectorStorageUsage ran is missing from the map
+			var err error
+			scan, err = shard.DimensionsUsage(ctx, targetVector, shardusage.ScanOpts{
+				MultiVector:       vectorIndexConfig.IsMultiVector(),
+				EncodedDimensions: encodedDimensions,
+			})
 			if err != nil {
 				return err
 			}
-			dimensionality = scan.Reported
+		}
+		reported := scan.Reported
+		if encodedDimensions > 0 && len(scan.Rows) > 0 {
+			// the sweep's scan does not carry the MUVERA encoding, so derive the encoded
+			// entry from its rows instead of scanning the bucket again
+			reported = []types.Dimensionality{{Dimensions: encodedDimensions, Count: scan.TotalCount()}}
+		}
+		reportedDims := 0
+		if len(reported) > 0 {
+			reportedDims = reported[0].Dimensions
 		}
 
 		usages = append(usages, &types.VectorUsage{
@@ -409,10 +421,10 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 			Compression:            dimInfo.category.String(),
 			VectorIndexType:        indexType,
 			IsDynamic:              isDynamic,
-			VectorCompressionRatio: vectorCompressionRatio(vectorIndex.CompressionStats(), dimensionality.Dimensions),
+			VectorCompressionRatio: vectorCompressionRatio(vectorIndex.CompressionStats(), reportedDims),
 			Bits:                   dimInfo.bits,
 			MultiVectorConfig:      multiVectorConfigFromConfig(vectorIndexConfig),
-			Dimensionalities:       trackedDimensionalities(dimensionality),
+			Dimensionalities:       trackedDimensionalities(reported),
 		})
 		return nil
 	}); err != nil {
@@ -422,14 +434,23 @@ func (i *Index) vectorUsages(ctx context.Context, shard *Shard, dimensionalities
 	return usages, nil
 }
 
-// trackedDimensionalities wraps one target vector's dimensionality for the report,
-// and returns nothing when nothing was tracked. A configured vector holding no data
-// has no dimensionality to bill, rather than one of zero.
-func trackedDimensionalities(dimensionality types.Dimensionality) []*types.Dimensionality {
-	if dimensionality.Count <= 0 && dimensionality.Dimensions <= 0 {
+// trackedDimensionalities wraps a target vector's reported rows for the report, and
+// returns nothing when nothing was tracked. A configured vector holding no data has
+// no dimensionality to bill, rather than one of zero. Multi-vector targets without
+// MUVERA carry one row per distinct per-object total token dims, so consumers must
+// sum the entries instead of reading only the first.
+func trackedDimensionalities(reported []types.Dimensionality) []*types.Dimensionality {
+	tracked := make([]*types.Dimensionality, 0, len(reported))
+	for _, row := range reported {
+		if row.Count <= 0 && row.Dimensions <= 0 {
+			continue
+		}
+		tracked = append(tracked, &row)
+	}
+	if len(tracked) == 0 {
 		return nil
 	}
-	return []*types.Dimensionality{&dimensionality}
+	return tracked
 }
 
 // unloadedVectorState is what a shard's files say about one target vector that
@@ -468,22 +489,26 @@ func (i *Index) unloadedVectorState(shardName, targetVector string,
 // shard from its schema config, the dimensions read off disk, and what the shard's
 // files say about the index the config asks for.
 func unloadedVectorUsage(targetVector string, vectorConfig models.VectorConfig,
-	dimensionality types.Dimensionality, state unloadedVectorState,
+	reported []types.Dimensionality, state unloadedVectorState,
 ) (*types.VectorUsage, error) {
 	vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
 	if !ok {
 		return nil, fmt.Errorf("vector index config for %q is not of expected type", targetVector)
 	}
 
+	reportedDims := 0
+	if len(reported) > 0 {
+		reportedDims = reported[0].Dimensions
+	}
 	dimInfo := GetDimensionCategory(vectorIndexConfig, state.dynamicUpgraded)
 	vectorUsage := &types.VectorUsage{
 		Name:                   targetVector,
 		Compression:            dimInfo.category.String(),
 		Bits:                   dimInfo.bits,
-		VectorCompressionRatio: dimInfo.compressionRatio(dimensionality.Dimensions, state.quantizedVectorsExist),
+		VectorCompressionRatio: dimInfo.compressionRatio(reportedDims, state.quantizedVectorsExist),
 		VectorIndexType:        vectorIndexConfig.IndexType(),
 		IsDynamic:              vectorConfig.VectorIndexType == common.IndexTypeDynamic,
-		Dimensionalities:       trackedDimensionalities(dimensionality),
+		Dimensionalities:       trackedDimensionalities(reported),
 		MultiVectorConfig:      multiVectorConfigFromConfig(vectorIndexConfig),
 	}
 	if vectorUsage.IsDynamic {
@@ -546,17 +571,20 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	}
 
 	// Get named vector data for cold shards from schema configuration
-	encodedDimensions := make(map[string]int, len(vectorConfigs))
+	scanOpts := make(map[string]shardusage.ScanOpts, len(vectorConfigs))
 	for targetVector, vectorConfig := range vectorConfigs {
 		cfg, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
 		if !ok {
 			return nil, fmt.Errorf("class %s, shard %s: vector index config for target vector %q has unexpected type %T",
 				i.Config.ClassName, shardName, targetVector, vectorConfig.VectorIndexConfig)
 		}
-		encodedDimensions[targetVector] = i.muveraEncodedDimensions(shardName, targetVector, cfg)
+		scanOpts[targetVector] = shardusage.ScanOpts{
+			MultiVector:       cfg.IsMultiVector(),
+			EncodedDimensions: i.muveraEncodedDimensions(shardName, targetVector, cfg),
+		}
 	}
 	// open the dimensions bucket once for all target vectors
-	scansAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, encodedDimensions)
+	scansAll, err := shardusage.CalculateUnloadedDimensionsUsageAll(ctx, i.logger, i.path(), shardName, scanOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -565,9 +593,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 	uncompressedVectorSize := uint64(0) // calculate total uncompressed vector size for all vectors
 	for targetVector, vectorConfig := range vectorConfigs {
 		scan := scansAll[targetVector]
-		// disk accounting keeps modelling raw dimensions, which is a single row and so
-		// under-counts multi-vectors with varying token counts
-		uncompressedVectorSize += uint64(scan.Raw.Count) * uint64(scan.Raw.Dimensions) * 4
+		uncompressedVectorSize += uint64(scan.TotalDimensions()) * 4
 
 		state := i.unloadedVectorState(shardName, targetVector, vectorConfig, vectorMetrics)
 		vectorUsage, err := unloadedVectorUsage(targetVector, vectorConfig, scan.Reported, state)

--- a/adapters/repos/db/index_usage_compression_ratio_test.go
+++ b/adapters/repos/db/index_usage_compression_ratio_test.go
@@ -308,7 +308,7 @@ func TestUnloadedVectorUsage(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			usage, err := unloadedVectorUsage("vec", tt.vectorConfig, dimensionality, tt.state)
+			usage, err := unloadedVectorUsage("vec", tt.vectorConfig, []types.Dimensionality{dimensionality}, tt.state)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/adapters/repos/db/index_vector_storage_test.go
+++ b/adapters/repos/db/index_vector_storage_test.go
@@ -322,13 +322,12 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 
 				// the caller looks these up by target vector name
 				require.Contains(t, dimensionalities, targetVector)
-				assert.Equal(t, tt.objectCount, dimensionalities[targetVector].Count)
-				assert.Equal(t, tt.vectorDimensions, dimensionalities[targetVector].Dimensions)
+				assert.Equal(t, tt.objectCount, dimensionalities[targetVector].TotalCount())
+				assert.Equal(t, tt.vectorDimensions, dimensionalities[targetVector].FirstDims())
 				if targetVector != "" {
 					// the legacy index is iterated too and keeps its own entry
 					require.Contains(t, dimensionalities, "")
-					assert.Equal(t, 0, dimensionalities[""].Count)
-					assert.Equal(t, 0, dimensionalities[""].Dimensions)
+					assert.Empty(t, dimensionalities[""].Rows)
 				}
 
 				// For PQ compression, we need to account for the actual compression ratio
@@ -393,8 +392,7 @@ func TestIndex_CalculateUnloadedVectorsMetrics(t *testing.T) {
 
 				// an index with no vectors written yet still gets an entry
 				require.Contains(t, dimensionalities, "")
-				assert.Equal(t, 0, dimensionalities[""].Count)
-				assert.Equal(t, 0, dimensionalities[""].Dimensions)
+				assert.Empty(t, dimensionalities[""].Rows)
 
 				// Release the shard (this will flush all data to disk)
 				release()
@@ -619,11 +617,11 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 
-				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, 0)
+				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, shardusage.ScanOpts{})
 				require.NoError(t, err)
 
-				assert.Equal(t, tt.expectedCount, dimensionality.Raw.Count)
-				assert.Equal(t, tt.expectedDims, dimensionality.Raw.Dimensions)
+				assert.Equal(t, tt.expectedCount, dimensionality.TotalCount())
+				assert.Equal(t, tt.expectedDims, dimensionality.FirstDims())
 
 				// Release the shard (this will flush all data to disk)
 				release()
@@ -650,11 +648,11 @@ func TestIndex_CalculateUnloadedDimensionsUsage(t *testing.T) {
 				require.True(t, ok)
 				require.NoError(t, lazyShard.Load(ctx))
 
-				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, 0)
+				dimensionality, err := lazyShard.shard.DimensionsUsage(ctx, tt.targetVector, shardusage.ScanOpts{})
 				require.NoError(t, err)
 
-				assert.Equal(t, tt.expectedCount, dimensionality.Raw.Count)
-				assert.Equal(t, tt.expectedDims, dimensionality.Raw.Dimensions)
+				assert.Equal(t, tt.expectedCount, dimensionality.TotalCount())
+				assert.Equal(t, tt.expectedDims, dimensionality.FirstDims())
 
 				// Release the shard (this will flush all data to disk)
 				release()
@@ -841,8 +839,8 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	// Test that active calculations are correct
 	expectedSize := int64(objectCount*vectorDimensions*4) + int64(commitLogSize)
 	assert.Equal(t, expectedSize, activeVectorStorageSize, "Active vector storage size should be close to expected")
-	assert.Equal(t, objectCount, dimensionality.Count, "Active shard object count should match")
-	assert.Equal(t, vectorDimensions, dimensionality.Dimensions, "Active shard dimensions should match")
+	assert.Equal(t, objectCount, dimensionality.TotalCount(), "Active shard object count should match")
+	assert.Equal(t, vectorDimensions, dimensionality.FirstDims(), "Active shard dimensions should match")
 	assert.Equal(t, objectCount, activeObjectCount, "Active object count should match")
 
 	// the dimensionalities read once per sweep reach the usage report unchanged
@@ -865,10 +863,10 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 	// from the captured map, and has to be read on demand instead
 	dimensionalitySources := []struct {
 		name             string
-		dimensionalities map[string]usagetypes.Dimensionality
+		dimensionalities map[string]shardusage.DimensionsScan
 	}{
 		{name: "captured by the sweep", dimensionalities: dimensionalities},
-		{name: "read on demand", dimensionalities: map[string]usagetypes.Dimensionality{}},
+		{name: "read on demand", dimensionalities: map[string]shardusage.DimensionsScan{}},
 	}
 	for _, tt := range dimensionalitySources {
 		t.Run(tt.name, func(t *testing.T) {
@@ -958,4 +956,213 @@ func TestIndex_VectorStorageSize_ActiveVsUnloaded(t *testing.T) {
 
 	// Verify all mock expectations were met
 	mockSchema.AssertExpectations(t)
+}
+
+// TestIndex_MultiVectorUsage_VaryingTokenCounts pins the usage accounting of a multi-vector
+// target without MUVERA whose objects differ in token count: the objects spread over one
+// dimensions-bucket row per distinct total token dims, and both the hot and the cold path
+// must report every row and model the vector bytes from their sum instead of reading only
+// the first row (weaviate/0-weaviate-issues#659).
+func TestIndex_MultiVectorUsage_VaryingTokenCounts(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	const (
+		className    = "TestClass"
+		shardName    = "test-shard"
+		targetVector = "colbert"
+		objectCount  = 30
+		tokenDim     = 8
+	)
+	// object i holds 1 + i%3 token vectors, spreading the objects over three rows
+	tokensOf := func(i int) int { return 1 + i%3 }
+	totalFloats := 0
+	for i := range objectCount {
+		totalFloats += tokensOf(i) * tokenDim
+	}
+	expectedRows := []usagetypes.Dimensionality{
+		{Dimensions: 1 * tokenDim, Count: objectCount / 3},
+		{Dimensions: 2 * tokenDim, Count: objectCount / 3},
+		{Dimensions: 3 * tokenDim, Count: objectCount / 3},
+	}
+	// the report enumerates the same rows; a consumer sums them
+	assertReportedDimensionalities := func(t *testing.T, reported []*usagetypes.Dimensionality) {
+		t.Helper()
+		require.Len(t, reported, len(expectedRows))
+		countSum, floatSum := 0, 0
+		for i, row := range reported {
+			assert.Equal(t, expectedRows[i], *row)
+			countSum += row.Count
+			floatSum += row.Count * row.Dimensions
+		}
+		assert.Equal(t, objectCount, countSum, "summed counts must be the object count")
+		assert.Equal(t, totalFloats, floatSum, "summed dims must be the stored float count")
+	}
+
+	dirName := t.TempDir()
+
+	shardState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			shardName: {
+				Name:           shardName,
+				BelongsToNodes: []string{"test-node"},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+	}
+	shardState.SetLocalName("test-node")
+
+	multiCfg := enthnsw.NewDefaultMultiVectorUserConfig()
+	multiCfg.VectorCacheMaxObjects = 1000
+
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
+		},
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+		MultiTenancyConfig:  &models.MultiTenancyConfig{Enabled: shardState.PartitioningEnabled},
+		VectorConfig: map[string]models.VectorConfig{
+			targetVector: {VectorIndexType: "hnsw", VectorIndexConfig: multiCfg},
+		},
+	}
+	fakeSchema := schema.Schema{Objects: &models.Schema{Classes: []*models.Class{class}}}
+
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{Logger: logger, Workers: 1})
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(func(className string, retryIfClassNotFound bool, readerFunc func(*models.Class, *sharding.State) error) error {
+		return readerFunc(class, shardState)
+	}).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{"test-node"}, nil).Maybe()
+	mockSchemaReader.EXPECT().WaitForUpdate(mock.Anything, mock.Anything).Return(nil).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: []*models.Class{class}}).Maybe()
+
+	mockSchema := schemaUC.NewMockSchemaGetter(t)
+	mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+	mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
+	mockSchema.EXPECT().NodeName().Maybe().Return("test-node")
+	mockSchema.EXPECT().ShardFromUUID(className, mock.Anything).Return(shardName).Maybe()
+	mockSchema.EXPECT().ShardOwner(className, shardName).Maybe().Return("test-node", nil)
+
+	mockRouter := types.NewMockRouter(t)
+	mockRouter.EXPECT().GetWriteReplicasLocation(className, mock.Anything, shardName).
+		Return(types.WriteReplicaSet{
+			Replicas: []types.Replica{{NodeName: "test-node", ShardName: shardName, HostAddr: "10.14.57.56"}},
+		}, nil).Maybe()
+	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, mockSchema)
+
+	index, err := NewIndex(ctx, nil, IndexConfig{
+		RootPath:              dirName,
+		ClassName:             schema.ClassName(className),
+		ReplicationFactor:     1,
+		ShardLoadLimiter:      loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+		TrackVectorDimensions: true,
+		EnableLazyLoadShards:  true,
+	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		enthnsw.UserConfig{VectorCacheMaxObjects: 1000},
+		map[string]schemaConfig.VectorIndexConfig{targetVector: multiCfg},
+		mockRouter, shardResolver, mockSchema, mockSchemaReader, nil, logger, nil, nil, nil,
+		&replication.GlobalConfig{}, nil, class, nil, scheduler, memwatch.NewDummyMonitor(),
+		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+
+	err = index.addProperty(ctx, &models.Property{
+		Name:         "name",
+		DataType:     schema.DataTypeText.PropString(),
+		Tokenization: models.PropertyTokenizationWhitespace,
+	})
+	require.NoError(t, err)
+
+	for i := range objectCount {
+		obj := &models.Object{
+			Class: className,
+			ID:    strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+			Properties: map[string]interface{}{
+				"name": fmt.Sprintf("test-object-%d", i),
+			},
+		}
+		tokens := make([][]float32, tokensOf(i))
+		for tk := range tokens {
+			tokens[tk] = make([]float32, tokenDim)
+			for d := range tokens[tk] {
+				tokens[tk][d] = float32(i+tk+d) / 1000.0
+			}
+		}
+		storageObj := storobj.FromObject(obj, nil, nil, map[string][][]float32{targetVector: tokens})
+		require.NoError(t, index.putObject(ctx, storageObj, nil, obj.Tenant, 0))
+	}
+
+	shard, release, err := index.GetShard(ctx, shardName)
+	require.NoError(t, err)
+	require.NotNil(t, shard)
+	lazyShard, ok := shard.(*LazyLoadShard)
+	require.True(t, ok)
+	require.NoError(t, lazyShard.Load(ctx))
+
+	lsmPath := filepath.Join(index.path(), shard.Name(), "lsm")
+	directories, err := diskio.GetSubdirNames(lsmPath)
+	require.NoError(t, err)
+
+	t.Run("hot path models the bytes from all rows", func(t *testing.T) {
+		_, uncompressed, scans, err := lazyShard.shard.VectorStorageUsage(ctx, lsmPath, directories)
+		require.NoError(t, err)
+		require.Contains(t, scans, targetVector)
+		assert.Equal(t, expectedRows, scans[targetVector].Rows)
+		assert.Equal(t, int64(totalFloats*4), uncompressed)
+
+		dimensions, err := shard.Dimensions(ctx, targetVector)
+		require.NoError(t, err)
+		assert.Equal(t, totalFloats, dimensions)
+
+		for name, cached := range map[string]map[string]shardusage.DimensionsScan{
+			"captured by the sweep": scans,
+			"read on demand":        {},
+		} {
+			t.Run(name, func(t *testing.T) {
+				usages, err := index.vectorUsages(ctx, lazyShard.shard, cached)
+				require.NoError(t, err)
+				var found *usagetypes.VectorUsage
+				for _, usage := range usages {
+					if usage.Name == targetVector {
+						found = usage
+					}
+				}
+				require.NotNil(t, found, "multi-vector target missing from the usage entries")
+				assertReportedDimensionalities(t, found.Dimensionalities)
+			})
+		}
+	})
+
+	release()
+	require.NoError(t, index.ForEachShard(func(name string, shard ShardLike) error {
+		return shard.Shutdown(ctx)
+	}))
+	index.shards.LoadAndDelete(shardName)
+
+	t.Run("cold path reports the same rows and bytes", func(t *testing.T) {
+		collectionUsage, err := index.usageForCollection(ctx, semaphore.NewWeighted(4), true, class.VectorConfig)
+		require.NoError(t, err)
+		require.Len(t, collectionUsage.Shards, 1)
+		tenant := collectionUsage.Shards[0]
+
+		var found *usagetypes.VectorUsage
+		for _, usage := range tenant.NamedVectors {
+			if usage.Name == targetVector {
+				found = usage
+			}
+		}
+		require.NotNil(t, found, "multi-vector target missing from the cold usage entries")
+		assertReportedDimensionalities(t, found.Dimensionalities)
+
+		assert.GreaterOrEqual(t, tenant.VectorStorageBytes, uint64(totalFloats*4),
+			"vector storage must cover the modelled float payload of every row")
+		assert.Greater(t, tenant.ObjectsStorageBytes, uint64(0),
+			"the objects bucket holds more than the modelled vector bytes")
+	})
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -36,7 +36,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/shardmeta"
 	"github.com/weaviate/weaviate/cluster/replication/changelog"
 	"github.com/weaviate/weaviate/cluster/router/types"
-	usagetypes "github.com/weaviate/weaviate/cluster/usage/types"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/backup"
@@ -682,33 +681,29 @@ func (s *Shard) ObjectStorageSize(ctx context.Context) (int64, error) {
 }
 
 // VectorStorageUsage calculates the total storage size of all vector indexes in the shard. It also
-// returns every target vector's dimensionality, so callers need not re-read the dimensions bucket.
-func (s *Shard) VectorStorageUsage(ctx context.Context, lsmPath string, directories []string) (int64, int64, map[string]usagetypes.Dimensionality, error) {
+// returns every target vector's dimensions scan, so callers need not re-read the dimensions bucket.
+func (s *Shard) VectorStorageUsage(ctx context.Context, lsmPath string, directories []string) (int64, int64, map[string]shardusage.DimensionsScan, error) {
 	vectorMetrics, err := shardusage.CalculateUnloadedVectorsMetrics(lsmPath, directories)
 	if err != nil {
 		return 0, 0, nil, err
 	}
 
 	uncompressedSize := int64(0)
-	dimensionalities := map[string]usagetypes.Dimensionality{}
+	scans := map[string]shardusage.DimensionsScan{}
 	if err := s.ForEachVectorIndex(func(targetVector string, index VectorIndex) error {
-		// Get dimensions and object count from the dimensions bucket for this specific target vector
-		dimensionality, err := s.calcTargetVectorDimensions(ctx, targetVector)
+		// Get dimensions and object counts from the dimensions bucket for this specific target vector
+		scan, err := s.calcTargetVectorDimensions(ctx, targetVector)
 		if err != nil {
 			return err
 		}
-		dimensionalities[targetVector] = dimensionality
-		if dimensionality.Count == 0 || dimensionality.Dimensions == 0 {
-			return nil
-		}
-
-		uncompressedSize += int64(dimensionality.Count) * int64(dimensionality.Dimensions) * 4
+		scans[targetVector] = scan
+		uncompressedSize += int64(scan.TotalDimensions()) * 4
 		return nil
 	}); err != nil {
 		return 0, 0, nil, err
 	}
 
-	return vectorMetrics.StorageBytes, uncompressedSize, dimensionalities, nil
+	return vectorMetrics.StorageBytes, uncompressedSize, scans, nil
 }
 
 func (s *Shard) isFallbackToSearchable() bool {

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -22,7 +22,6 @@ import (
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
-	"github.com/weaviate/weaviate/cluster/usage/types"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	flatent "github.com/weaviate/weaviate/entities/vectorindex/flat"
@@ -66,47 +65,58 @@ func (c DimensionCategory) String() string {
 }
 
 // DimensionsUsage scans the dimensions bucket for a given vector, see shardusage.ScanTargetVectorDimensions
-func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string, encodedDimensions int) (shardusage.DimensionsScan, error) {
+func (s *Shard) DimensionsUsage(ctx context.Context, targetVector string, opts shardusage.ScanOpts) (shardusage.DimensionsScan, error) {
 	b := s.store.Bucket(helpers.DimensionsBucketLSM)
 	if b == nil {
 		return shardusage.DimensionsScan{}, errors.Errorf("dimensionsUsage: no bucket dimensions")
 	}
-	return shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, encodedDimensions)
+	return shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, opts)
 }
 
-// Dimensions returns the total number of dimensions for a given vector
+// targetVectorScanOpts resolves how the dimensions bucket has to be scanned for a target vector:
+// a multi-vector target spreads its objects over one row per distinct total token dims, so every
+// row has to be read. A vector without a config scans like a single vector, which matches the
+// single row it writes.
+func (s *Shard) targetVectorScanOpts(targetVector string) shardusage.ScanOpts {
+	cfg, ok := s.index.GetVectorIndexConfigs()[targetVector]
+	return shardusage.ScanOpts{MultiVector: ok && cfg.IsMultiVector()}
+}
+
+// Dimensions returns the total number of dimensions stored for a given vector, summed across all
+// of its dimensions-bucket rows: the raw float count, also for multi-vector targets with varying
+// token counts and regardless of any MUVERA encoding, which changes the index but not the stored
+// vectors.
 func (s *Shard) Dimensions(ctx context.Context, targetVector string) (int, error) {
-	dimensionality, err := s.calcTargetVectorDimensions(ctx, targetVector)
+	scan, err := s.calcTargetVectorDimensions(ctx, targetVector)
 	if err != nil {
 		return 0, err
 	}
-	return dimensionality.Count * dimensionality.Dimensions, nil
+	return scan.TotalDimensions(), nil
 }
 
 func (s *Shard) QuantizedDimensions(ctx context.Context, targetVector string, segments int) (int, error) {
-	dimensionality, err := s.calcTargetVectorDimensions(ctx, targetVector)
+	scan, err := s.calcTargetVectorDimensions(ctx, targetVector)
 	if err != nil {
 		return 0, err
 	}
-	return dimensionality.Count * correctEmptySegments(segments, dimensionality.Dimensions), nil
+	// for multi-vector targets the smallest row stands in for the per-object dimensionality, so
+	// quantized segments stay an approximation there
+	return scan.TotalCount() * correctEmptySegments(segments, scan.FirstDims()), nil
 }
 
 func (s *Shard) calcTargetVectorDimensions(ctx context.Context, targetVector string,
-) (types.Dimensionality, error) {
+) (shardusage.DimensionsScan, error) {
+	opts := s.targetVectorScanOpts(targetVector)
 	if b := s.store.Bucket(helpers.DimensionsBucketLSM); b != nil {
-		scan, err := shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, 0)
-		if err != nil {
-			return types.Dimensionality{}, err
-		}
-		return scan.Raw, nil
+		return shardusage.ScanTargetVectorDimensions(ctx, b, targetVector, opts)
 	}
 	if s.index.Config.TrackVectorDimensions {
-		return types.Dimensionality{}, errors.Errorf("calcTargetVectorDimensions: no bucket dimensions")
+		return shardusage.DimensionsScan{}, errors.Errorf("calcTargetVectorDimensions: no bucket dimensions")
 	}
 	// A shard that does not track dimensions never opened the bucket, so read what
 	// an earlier tracking run left on disk — the same source an unloaded shard
 	// reads, so one shard reports the same either way.
-	return shardusage.CalculateUnloadedDimensionsUsage(ctx, s.index.logger, s.index.path(), s.name, targetVector)
+	return shardusage.CalculateUnloadedDimensionsUsage(ctx, s.index.logger, s.index.path(), s.name, targetVector, opts)
 }
 
 // DimensionMetrics represents the dimension tracking metrics for a vector.

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -581,6 +581,8 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 		vectorConfig      func() enthnsw.UserConfig
 		namedVectorConfig func() enthnsw.UserConfig
 		multiVectorConfig func() enthnsw.UserConfig
+		// multiVecCardFn gives object i's token count; nil keeps the fixed multiVecCard
+		multiVecCardFn func(i int) int
 
 		expectDimensions float64
 		expectSegments   float64
@@ -602,6 +604,31 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 			multiVectorConfig: func() enthnsw.UserConfig { return enthnsw.NewDefaultUserConfig() },
 
 			expectDimensions: multiVecCard * dimensionsPerVector * objectCount,
+		},
+		{
+			// varying token counts spread the objects over several dimensions-bucket rows;
+			// the metric must sum every row instead of reading only the first
+			name:              "multi_varying_tokens",
+			multiVectorConfig: func() enthnsw.UserConfig { return enthnsw.NewDefaultUserConfig() },
+			multiVecCardFn:    func(i int) int { return 1 + i%4 },
+
+			// Σ (1 + i%4) over 100 objects = 100 + 25*(0+1+2+3) = 250 tokens
+			expectDimensions: 250 * dimensionsPerVector,
+		},
+		{
+			// MUVERA changes the index, not the stored vectors, so the metric still
+			// reports the raw token dimensions summed across all rows
+			name: "multi_muvera_varying_tokens",
+			multiVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.Multivector.MuveraConfig = enthnsw.MuveraConfig{
+					Enabled: true, KSim: 1, Repetitions: 2, DProjections: 5,
+				}
+				return cfg
+			},
+			multiVecCardFn: func(i int) int { return 1 + i%4 },
+
+			expectDimensions: 250 * dimensionsPerVector,
 		},
 		{
 			name:              "mixed",
@@ -715,7 +742,7 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 
 			if tt.multiVectorConfig != nil {
 				config := tt.multiVectorConfig()
-				config.Multivector = enthnsw.MultivectorConfig{Enabled: true}
+				config.Multivector.Enabled = true
 				class.VectorConfig[multiVectorName] = models.VectorConfig{
 					VectorIndexConfig: config,
 				}
@@ -736,7 +763,15 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 							Class: tt.name,
 							ID:    intToUUID(i),
 						}
-						err := db.PutObject(context.Background(), obj, legacyVec, namedVecs, multiVecs, nil, 0)
+						objMultiVecs := multiVecs
+						if tt.multiVecCardFn != nil {
+							objMultiVecs = map[string][][]float32{}
+							for range tt.multiVecCardFn(i) {
+								objMultiVecs[multiVectorName] = append(objMultiVecs[multiVectorName],
+									randVector(dimensionsPerVector))
+							}
+						}
+						err := db.PutObject(context.Background(), obj, legacyVec, namedVecs, objMultiVecs, nil, 0)
 						require.Nil(t, err)
 					}
 					publishVectorMetricsFromDB(t, db)

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -732,11 +732,13 @@ func (l *LazyLoadShard) Dimensions(ctx context.Context, targetVector string) (in
 
 	// For unloaded shards, get dimensions from unloaded shard/tenant calculation
 	idx := l.shardOpts.index
-	dimensionality, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, idx.logger, idx.path(), l.shardOpts.name, targetVector)
+	cfg, ok := idx.GetVectorIndexConfigs()[targetVector]
+	opts := shardusage.ScanOpts{MultiVector: ok && cfg.IsMultiVector()}
+	scan, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, idx.logger, idx.path(), l.shardOpts.name, targetVector, opts)
 	if err != nil {
 		return 0, err
 	}
-	return dimensionality.Count * dimensionality.Dimensions, nil
+	return scan.TotalDimensions(), nil
 }
 
 func (l *LazyLoadShard) QuantizedDimensions(ctx context.Context, targetVector string, segments int) (int, error) {

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -165,33 +165,32 @@ func openUnloadedDimensionsBucket(ctx context.Context, logger logrus.FieldLogger
 	)
 }
 
-// CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
-func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
+// CalculateUnloadedDimensionsUsage calculates dimensions and object counts for an unloaded shard
+// without loading it into memory.
+func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger,
+	path, tenantName, targetVector string, opts ScanOpts,
+) (DimensionsScan, error) {
 	bucketPath := shardPathDimensionsLSM(path, tenantName)
 	if err := unloadedDimensionsBucketLocks.LockWithContext(bucketPath, ctx); err != nil {
-		return types.Dimensionality{}, fmt.Errorf("lock dimensions bucket: %w", err)
+		return DimensionsScan{}, fmt.Errorf("lock dimensions bucket: %w", err)
 	}
 	defer unloadedDimensionsBucketLocks.Unlock(bucketPath)
 
 	bucket, err := openUnloadedDimensionsBucket(ctx, logger, path, bucketPath)
 	if err != nil {
-		return types.Dimensionality{}, err
+		return DimensionsScan{}, err
 	}
 	defer bucket.Shutdown(ctx)
 
-	scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, 0)
-	if err != nil {
-		return types.Dimensionality{}, err
-	}
-	return scan.Raw, nil
+	return ScanTargetVectorDimensions(ctx, bucket, targetVector, opts)
 }
 
-// CalculateUnloadedDimensionsUsageAll calculates dimensions and object count for all target
+// CalculateUnloadedDimensionsUsageAll calculates dimensions and object counts for all target
 // vectors of an unloaded shard without loading it into memory. The dimensions bucket is opened
 // once and shared by all target vector calculations, instead of once per target vector.
-// targetVectors maps each vector name to its MUVERA-encoded dimensionality, or 0 if not MUVERA.
+// targetVectors maps each vector name to its scan options.
 func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
-	logger logrus.FieldLogger, path, tenantName string, targetVectors map[string]int,
+	logger logrus.FieldLogger, path, tenantName string, targetVectors map[string]ScanOpts,
 ) (map[string]DimensionsScan, error) {
 	if len(targetVectors) == 0 {
 		return nil, nil
@@ -210,8 +209,8 @@ func CalculateUnloadedDimensionsUsageAll(ctx context.Context,
 	defer bucket.Shutdown(ctx)
 
 	scans := make(map[string]DimensionsScan, len(targetVectors))
-	for targetVector, encodedDimensions := range targetVectors {
-		scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, encodedDimensions)
+	for targetVector, opts := range targetVectors {
+		scan, err := ScanTargetVectorDimensions(ctx, bucket, targetVector, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -446,19 +445,62 @@ func nonLSMStorage(shardPath string, files map[string]int64, dirs []string) (uin
 	return vectorCommitLogsStorageSize, otherNonLSMFoldersStorageSize, nil
 }
 
+// ScanOpts controls how ScanTargetVectorDimensions reads a target vector's rows.
+type ScanOpts struct {
+	// MultiVector scans every row of the name instead of stopping at the first complete one. A
+	// multi-vector object's row is keyed by its total token dimensions, so objects with different
+	// token counts land in different rows and no single row can describe the target.
+	MultiVector bool
+	// EncodedDimensions, when positive, is the target's MUVERA-encoded dimensionality. Reported
+	// then collapses to a single {EncodedDimensions, total object count} entry. Implies a scan of
+	// every row.
+	EncodedDimensions int
+}
+
+// DimensionsScan is the result of scanning a target vector's rows in the dimensions bucket.
 type DimensionsScan struct {
-	Raw      types.Dimensionality
-	Reported types.Dimensionality
+	// Rows holds every complete row of the target, sorted ascending by Dimensions. Single-vector
+	// targets carry at most one entry: their first complete row, where the scan stops.
+	Rows []types.Dimensionality
+	// Reported is what the usage report shows: Rows, except for MUVERA targets, which report a
+	// single {encoded dimensionality, total object count} entry.
+	Reported []types.Dimensionality
+}
+
+// TotalCount is the object count summed across all rows.
+func (s DimensionsScan) TotalCount() int {
+	total := 0
+	for _, row := range s.Rows {
+		total += row.Count
+	}
+	return total
+}
+
+// TotalDimensions is the stored float count: Σ row object count × row dimensionality. For
+// multi-vector targets this is the true total over all token vectors, which no single row holds.
+func (s DimensionsScan) TotalDimensions() int {
+	total := 0
+	for _, row := range s.Rows {
+		total += row.Count * row.Dimensions
+	}
+	return total
+}
+
+// FirstDims is the smallest row's dimensionality, or 0 for a target without rows.
+func (s DimensionsScan) FirstDims() int {
+	if len(s.Rows) == 0 {
+		return 0
+	}
+	return s.Rows[0].Dimensions
 }
 
 const contextCheckInterval = 1024
 
-// ScanTargetVectorDimensions calculates dimensions and object count for a target vector from an
-// LSMKV bucket. A non-zero encodedDimensions reports that fixed dimensionality against the object
-// count summed across all rows, which costs a scan of the whole prefix instead of stopping at the
-// first complete row.
+// ScanTargetVectorDimensions calculates dimensions and object counts for a target vector from an
+// LSMKV bucket. Single-vector targets stop at the first complete row; multi-vector or MUVERA
+// targets pay a scan of the whole prefix to collect every row, see ScanOpts.
 func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVector string,
-	encodedDimensions int,
+	opts ScanOpts,
 ) (DimensionsScan, error) {
 	scan := DimensionsScan{}
 
@@ -469,7 +511,7 @@ func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVect
 	prefix := []byte(targetVector)
 	nameLen := len(targetVector)
 	expectedKeyLen := nameLen + 4 // vector name + uint32
-	totalCount := 0
+	scanAllRows := opts.MultiVector || opts.EncodedDimensions > 0
 	rows := 0
 	addRow := func(k []byte, count int) (done bool) {
 		// a full-prefix scan is long enough to need cancelling; the error is picked up after the loop
@@ -481,20 +523,13 @@ func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVect
 			return false
 		}
 		dimLength := binary.LittleEndian.Uint32(k[nameLen:])
-		if dimLength == 0 {
+		if dimLength == 0 || count == 0 {
 			return false
 		}
-		if scan.Raw.Dimensions == 0 || scan.Raw.Count == 0 {
-			scan.Raw.Dimensions = int(dimLength)
-			scan.Raw.Count = count
-		}
-		if encodedDimensions > 0 {
-			totalCount += count
-			return false
-		}
-		// remaining keys cannot change a complete result, and an empty name
+		scan.Rows = append(scan.Rows, types.Dimensionality{Dimensions: int(dimLength), Count: count})
+		// remaining keys cannot change a complete single-vector result, and an empty name
 		// matches every key so the prefix break above never fires
-		return scan.Raw.Dimensions != 0 && scan.Raw.Count != 0
+		return !scanAllRows
 	}
 	var k []byte
 
@@ -538,12 +573,17 @@ func ScanTargetVectorDimensions(ctx context.Context, b *lsmkv.Bucket, targetVect
 	}
 
 	if err := ctx.Err(); err != nil {
-		return scan, err
+		return DimensionsScan{}, err
 	}
 
-	scan.Reported = scan.Raw
-	if encodedDimensions > 0 && totalCount > 0 {
-		scan.Reported = types.Dimensionality{Dimensions: encodedDimensions, Count: totalCount}
+	// the cursor yields keys in byte order of the little-endian dimension bytes, which is not
+	// numeric order once dimensionalities differ in their low bytes
+	slices.SortFunc(scan.Rows, func(a, b types.Dimensionality) int {
+		return a.Dimensions - b.Dimensions
+	})
+	scan.Reported = scan.Rows
+	if opts.EncodedDimensions > 0 && len(scan.Rows) > 0 {
+		scan.Reported = []types.Dimensionality{{Dimensions: opts.EncodedDimensions, Count: scan.TotalCount()}}
 	}
 	return scan, nil
 }

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -557,7 +557,7 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for range 10 {
-				if _, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, "text"); err != nil {
+				if _, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, "text", ScanOpts{}); err != nil {
 					errs <- err
 				}
 			}
@@ -566,7 +566,7 @@ func TestCalculateUnloadedDimensionsUsage_Concurrent(t *testing.T) {
 			defer wg.Done()
 			<-start
 			for range 10 {
-				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, map[string]int{"text": 0}); err != nil {
+				if _, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, map[string]ScanOpts{"text": {}}); err != nil {
 					errs <- err
 				}
 			}
@@ -616,30 +616,35 @@ func TestCalculateUnloadedDimensionsUsageAll(t *testing.T) {
 
 	writeDims(t, b, "text", 128, []uint64{1, 2, 3, 4, 5})
 	writeDims(t, b, "image", 512, []uint64{1, 2, 3})
+	// a multi-vector target with varying per-object token counts spans several rows
+	writeDims(t, b, "colbert", 64, []uint64{1, 2})
+	writeDims(t, b, "colbert", 128, []uint64{3})
 	require.NoError(t, b.FlushMemtable())
 	require.NoError(t, b.Shutdown(ctx))
 
-	targetVectors := map[string]int{"text": 0, "image": 0, "missing": 0}
+	targetVectors := map[string]ScanOpts{"text": {}, "image": {}, "missing": {}, "colbert": {MultiVector: true}}
 	all, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, targetVectors)
 	require.NoError(t, err)
 	require.Len(t, all, len(targetVectors))
-	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, all["text"].Reported)
-	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, all["image"].Reported)
+	assert.Equal(t, []types.Dimensionality{{Dimensions: 128, Count: 5}}, all["text"].Reported)
+	assert.Equal(t, []types.Dimensionality{{Dimensions: 512, Count: 3}}, all["image"].Reported)
+	assert.Equal(t, []types.Dimensionality{{Dimensions: 64, Count: 2}, {Dimensions: 128, Count: 1}},
+		all["colbert"].Reported)
 	assert.Equal(t, DimensionsScan{}, all["missing"])
 
 	// parity with the single-vector variant
-	for targetVector := range targetVectors {
-		single, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, targetVector)
+	for targetVector, opts := range targetVectors {
+		single, err := CalculateUnloadedDimensionsUsage(ctx, logger, dirName, tenantName, targetVector, opts)
 		require.NoError(t, err)
-		assert.Equal(t, all[targetVector].Raw, single, targetVector)
+		assert.Equal(t, all[targetVector], single, targetVector)
 	}
 
 	withEncoded, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName,
-		map[string]int{"text": 2560, "image": 0})
+		map[string]ScanOpts{"text": {MultiVector: true, EncodedDimensions: 2560}, "image": {}})
 	require.NoError(t, err)
-	assert.Equal(t, types.Dimensionality{Dimensions: 2560, Count: 5}, withEncoded["text"].Reported)
-	assert.Equal(t, types.Dimensionality{Dimensions: 128, Count: 5}, withEncoded["text"].Raw)
-	assert.Equal(t, types.Dimensionality{Dimensions: 512, Count: 3}, withEncoded["image"].Reported)
+	assert.Equal(t, []types.Dimensionality{{Dimensions: 2560, Count: 5}}, withEncoded["text"].Reported)
+	assert.Equal(t, []types.Dimensionality{{Dimensions: 128, Count: 5}}, withEncoded["text"].Rows)
+	assert.Equal(t, []types.Dimensionality{{Dimensions: 512, Count: 3}}, withEncoded["image"].Reported)
 
 	// no target vectors → nothing to calculate, no bucket open
 	none, err := CalculateUnloadedDimensionsUsageAll(ctx, logger, dirName, tenantName, nil)
@@ -674,84 +679,119 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 		{targetVector: "colbert", dims: 2560, docIDs: []uint64{3, 4, 5}},
 		{targetVector: "colbert", dims: 12800, docIDs: []uint64{6}},
 		{targetVector: "novectors", dims: 0, docIDs: []uint64{1, 2, 3}},
+		// all objects share one token count, so the rows collapse into one
+		{targetVector: "uniform", dims: 96, docIDs: []uint64{1, 2, 3}},
+		// 260 sorts before 8 in little-endian byte order but after it numerically
+		{targetVector: "mixed", dims: 8, docIDs: []uint64{1}},
+		{targetVector: "mixed", dims: 260, docIDs: []uint64{2, 3}},
 	}
 
 	tests := []struct {
-		name              string
-		targetVector      string
-		encodedDimensions int
-		expectedRaw       types.Dimensionality
-		expectedReported  types.Dimensionality
+		name             string
+		targetVector     string
+		opts             ScanOpts
+		expectedRows     []types.Dimensionality
+		expectedReported []types.Dimensionality
 	}{
 		{
 			name:             "no other name shares the prefix",
 			targetVector:     "image",
-			expectedRaw:      types.Dimensionality{Dimensions: 512, Count: 4},
-			expectedReported: types.Dimensionality{Dimensions: 512, Count: 4},
+			expectedRows:     []types.Dimensionality{{Dimensions: 512, Count: 4}},
+			expectedReported: []types.Dimensionality{{Dimensions: 512, Count: 4}},
 		},
 		{
 			name:             "name is a prefix of two longer names",
 			targetVector:     "text",
-			expectedRaw:      types.Dimensionality{Dimensions: 384, Count: 3},
-			expectedReported: types.Dimensionality{Dimensions: 384, Count: 3},
+			expectedRows:     []types.Dimensionality{{Dimensions: 384, Count: 3}},
+			expectedReported: []types.Dimensionality{{Dimensions: 384, Count: 3}},
 		},
 		{
 			name:             "name extends a shorter name",
 			targetVector:     "texts",
-			expectedRaw:      types.Dimensionality{Dimensions: 256, Count: 2},
-			expectedReported: types.Dimensionality{Dimensions: 256, Count: 2},
+			expectedRows:     []types.Dimensionality{{Dimensions: 256, Count: 2}},
+			expectedReported: []types.Dimensionality{{Dimensions: 256, Count: 2}},
 		},
 		{
 			name:             "name extends a shorter name and precedes a sibling",
 			targetVector:     "textbook",
-			expectedRaw:      types.Dimensionality{Dimensions: 192, Count: 5},
-			expectedReported: types.Dimensionality{Dimensions: 192, Count: 5},
+			expectedRows:     []types.Dimensionality{{Dimensions: 192, Count: 5}},
+			expectedReported: []types.Dimensionality{{Dimensions: 192, Count: 5}},
 		},
 		{
 			name:             "unnamed vector alongside named ones",
 			targetVector:     "",
-			expectedRaw:      types.Dimensionality{Dimensions: 128, Count: 6},
-			expectedReported: types.Dimensionality{Dimensions: 128, Count: 6},
+			expectedRows:     []types.Dimensionality{{Dimensions: 128, Count: 6}},
+			expectedReported: []types.Dimensionality{{Dimensions: 128, Count: 6}},
 		},
 		{
-			name:             "vector without entries",
-			targetVector:     "missing",
-			expectedRaw:      types.Dimensionality{},
-			expectedReported: types.Dimensionality{},
+			name:         "vector without entries",
+			targetVector: "missing",
 		},
 		{
-			name:              "muvera vector sums the count across all its rows",
-			targetVector:      "colbert",
-			encodedDimensions: encodedDims,
-			expectedRaw:       types.Dimensionality{Dimensions: 1280, Count: 2},
-			expectedReported:  types.Dimensionality{Dimensions: encodedDims, Count: 6},
+			name:         "multi-vector reports every row, not just the first",
+			targetVector: "colbert",
+			opts:         ScanOpts{MultiVector: true},
+			expectedRows: []types.Dimensionality{
+				{Dimensions: 1280, Count: 2}, {Dimensions: 2560, Count: 3}, {Dimensions: 12800, Count: 1},
+			},
+			expectedReported: []types.Dimensionality{
+				{Dimensions: 1280, Count: 2}, {Dimensions: 2560, Count: 3}, {Dimensions: 12800, Count: 1},
+			},
 		},
 		{
-			name:             "muvera vector without muvera reporting keeps the raw reading",
+			name:         "multi-vector rows sort numerically, not by little-endian bytes",
+			targetVector: "mixed",
+			opts:         ScanOpts{MultiVector: true},
+			expectedRows: []types.Dimensionality{
+				{Dimensions: 8, Count: 1}, {Dimensions: 260, Count: 2},
+			},
+			expectedReported: []types.Dimensionality{
+				{Dimensions: 8, Count: 1}, {Dimensions: 260, Count: 2},
+			},
+		},
+		{
+			name:             "multi-vector with a uniform token count keeps a single row",
+			targetVector:     "uniform",
+			opts:             ScanOpts{MultiVector: true},
+			expectedRows:     []types.Dimensionality{{Dimensions: 96, Count: 3}},
+			expectedReported: []types.Dimensionality{{Dimensions: 96, Count: 3}},
+		},
+		{
+			name:             "single-vector scan still stops at the first complete row",
 			targetVector:     "colbert",
-			expectedRaw:      types.Dimensionality{Dimensions: 1280, Count: 2},
-			expectedReported: types.Dimensionality{Dimensions: 1280, Count: 2},
+			expectedRows:     []types.Dimensionality{{Dimensions: 1280, Count: 2}},
+			expectedReported: []types.Dimensionality{{Dimensions: 1280, Count: 2}},
 		},
 		{
-			name:              "muvera single-vector name is unaffected by the summing",
-			targetVector:      "image",
-			encodedDimensions: encodedDims,
-			expectedRaw:       types.Dimensionality{Dimensions: 512, Count: 4},
-			expectedReported:  types.Dimensionality{Dimensions: encodedDims, Count: 4},
+			name:         "muvera vector sums the count across all its rows",
+			targetVector: "colbert",
+			opts:         ScanOpts{MultiVector: true, EncodedDimensions: encodedDims},
+			expectedRows: []types.Dimensionality{
+				{Dimensions: 1280, Count: 2}, {Dimensions: 2560, Count: 3}, {Dimensions: 12800, Count: 1},
+			},
+			expectedReported: []types.Dimensionality{{Dimensions: encodedDims, Count: 6}},
 		},
 		{
-			name:              "muvera vector with only objects without a vector",
-			targetVector:      "novectors",
-			encodedDimensions: encodedDims,
-			expectedRaw:       types.Dimensionality{},
-			expectedReported:  types.Dimensionality{},
+			name:             "muvera single-vector name is unaffected by the summing",
+			targetVector:     "image",
+			opts:             ScanOpts{EncodedDimensions: encodedDims},
+			expectedRows:     []types.Dimensionality{{Dimensions: 512, Count: 4}},
+			expectedReported: []types.Dimensionality{{Dimensions: encodedDims, Count: 4}},
 		},
 		{
-			name:              "muvera vector without entries",
-			targetVector:      "missing",
-			encodedDimensions: encodedDims,
-			expectedRaw:       types.Dimensionality{},
-			expectedReported:  types.Dimensionality{},
+			name:         "multi-vector with only objects without a vector",
+			targetVector: "novectors",
+			opts:         ScanOpts{MultiVector: true},
+		},
+		{
+			name:         "muvera vector with only objects without a vector",
+			targetVector: "novectors",
+			opts:         ScanOpts{MultiVector: true, EncodedDimensions: encodedDims},
+		},
+		{
+			name:         "muvera vector without entries",
+			targetVector: "missing",
+			opts:         ScanOpts{MultiVector: true, EncodedDimensions: encodedDims},
 		},
 	}
 
@@ -775,9 +815,9 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 
 				for _, tt := range tests {
 					t.Run(tt.name, func(t *testing.T) {
-						scan, err := ScanTargetVectorDimensions(ctx, b, tt.targetVector, tt.encodedDimensions)
+						scan, err := ScanTargetVectorDimensions(ctx, b, tt.targetVector, tt.opts)
 						require.NoError(t, err)
-						assert.Equal(t, tt.expectedRaw, scan.Raw, "raw reading")
+						assert.Equal(t, tt.expectedRows, scan.Rows, "rows")
 						assert.Equal(t, tt.expectedReported, scan.Reported, "reported reading")
 					})
 				}
@@ -792,7 +832,7 @@ func TestScanTargetVectorDimensions(t *testing.T) {
 		require.NoError(t, err)
 		defer b.Shutdown(ctx)
 
-		_, err = ScanTargetVectorDimensions(ctx, b, "text", 0)
+		_, err = ScanTargetVectorDimensions(ctx, b, "text", ScanOpts{})
 		require.Error(t, err)
 	})
 }

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -15,7 +15,9 @@ package types
 // sizes change meaning, or shards that stay cold keep serving the old numbers.
 // VectorConfigsFingerprint invalidates the same file on its own, for the numbers
 // that depend on the collection's vector configs rather than on this format.
-const UsageDiskVersion int = 2
+// Version 3: multi-vector targets without MUVERA report every dimensions row and
+// model their vector bytes from the summed rows, instead of the first row only.
+const UsageDiskVersion int = 3
 
 // UsageDisk defines format of saved pre-computed shard usage data
 type UsageDisk struct {

--- a/test/acceptance_with_go_client/usage/usage_test.go
+++ b/test/acceptance_with_go_client/usage/usage_test.go
@@ -12,7 +12,6 @@
 package usage
 
 import (
-	"acceptance_tests_with_client/internal/wvhost"
 	"context"
 	"fmt"
 	"math/rand"
@@ -22,6 +21,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"acceptance_tests_with_client/internal/wvhost"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -388,10 +389,10 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 
 	// every vector gets its own dimensions and object count, so a report that attributes one
 	// vector's numbers to another cannot pass
-	expected := map[string]usagetypes.Dimensionality{
-		vectorPrefix: {Dimensions: 384, Count: 100},
-		vector1:      {Dimensions: 128, Count: 60},
-		vector2:      {Dimensions: 256, Count: 30},
+	expected := map[string][]usagetypes.Dimensionality{
+		vectorPrefix: {{Dimensions: 384, Count: 100}},
+		vector1:      {{Dimensions: 128, Count: 60}},
+		vector2:      {{Dimensions: 256, Count: 30}},
 	}
 
 	c.Schema().ClassDeleter().WithClassName(className).Do(ctx)
@@ -442,8 +443,8 @@ func TestAlterSchemaDropVectorIndex(t *testing.T) {
 	for i := range numObjects {
 		vectors := models.Vectors{}
 		for name, dimensionality := range expected {
-			if i < dimensionality.Count {
-				vectors[name] = generateRandomVector(dimensionality.Dimensions)
+			if i < dimensionality[0].Count {
+				vectors[name] = generateRandomVector(dimensionality[0].Dimensions)
 			}
 		}
 		objs[i] = &models.Object{
@@ -855,13 +856,18 @@ func settledShardUsage(t *testing.T, c *client.Client, className, tenantName str
 	return settled
 }
 
-// namedVectorDimensionalities maps every named vector of a shard usage report to the
-// dimensionality it reports.
-func namedVectorDimensionalities(t require.TestingT, shard *usagetypes.ShardUsage) map[string]usagetypes.Dimensionality {
-	dimensionalities := make(map[string]usagetypes.Dimensionality, len(shard.NamedVectors))
+// namedVectorDimensionalities maps every named vector of a shard usage report to all the
+// dimensionality rows it reports. Multi-vector targets without MUVERA report one row per
+// distinct per-object total token dims, so callers must compare or sum the whole slice.
+func namedVectorDimensionalities(t require.TestingT, shard *usagetypes.ShardUsage) map[string][]usagetypes.Dimensionality {
+	dimensionalities := make(map[string][]usagetypes.Dimensionality, len(shard.NamedVectors))
 	for name, v := range namedVectors(t, shard) {
 		require.NotEmpty(t, v.Dimensionalities, "no dimensionality reported for vector %q", name)
-		dimensionalities[name] = *v.Dimensionalities[0]
+		rows := make([]usagetypes.Dimensionality, 0, len(v.Dimensionalities))
+		for _, row := range v.Dimensionalities {
+			rows = append(rows, *row)
+		}
+		dimensionalities[name] = rows
 	}
 	return dimensionalities
 }
@@ -1782,9 +1788,8 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 	regularVec := "regular"
 
 	const (
-		numObjects  = 20
-		tokenDim    = 32
-		fixedTokens = 3
+		numObjects = 20
+		tokenDim   = 32
 
 		ksim         = 4
 		dprojections = 16
@@ -1792,10 +1797,17 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 		encodedDims  = repetitions * (1 << ksim) * dprojections
 	)
 
-	expected := map[string]usagetypes.Dimensionality{
-		muveraVec:  {Dimensions: encodedDims, Count: numObjects},
-		colbertVec: {Dimensions: fixedTokens * tokenDim, Count: numObjects},
-		regularVec: {Dimensions: tokenDim, Count: numObjects},
+	// both multi-vector targets hold 2 + i%3 tokens, so objects spread over one dimensions
+	// row per token count: 7 objects at 2 tokens, 7 at 3, 6 at 4. MUVERA collapses them into
+	// a single encoded row; without MUVERA the report enumerates every row.
+	expected := map[string][]usagetypes.Dimensionality{
+		muveraVec: {{Dimensions: encodedDims, Count: numObjects}},
+		colbertVec: {
+			{Dimensions: 2 * tokenDim, Count: 7},
+			{Dimensions: 3 * tokenDim, Count: 7},
+			{Dimensions: 4 * tokenDim, Count: 6},
+		},
+		regularVec: {{Dimensions: tokenDim, Count: numObjects}},
 	}
 
 	multivectorIndexConfig := func(muvera bool) map[string]any {
@@ -1851,10 +1863,10 @@ func testUsageMuvera(t *testing.T, c *client.Client, debug string) {
 				"name": fmt.Sprintf("name %d", i),
 			},
 			Vectors: models.Vectors{
-				// varying token counts spread the raw dims over several rows, so a
-				// single-row report cannot reach the full count
+				// varying token counts spread the raw dims over several rows; the muvera
+				// report must sum them and the colbert report must enumerate them
 				muveraVec:  generateRandomMultiVector(2+i%3, tokenDim),
-				colbertVec: generateRandomMultiVector(fixedTokens, tokenDim),
+				colbertVec: generateRandomMultiVector(2+i%3, tokenDim),
 				regularVec: generateRandomVector(tokenDim),
 			},
 		}


### PR DESCRIPTION
## Motivation

Fixes [weaviate/0-weaviate-issues#659](https://github.com/weaviate/0-weaviate-issues/issues/659). A multi-vector object's dimensions-bucket row is keyed by its *total* token dims, so objects with different token counts land in different rows. The usage scan stopped at the first complete row and treated it as the whole target, which under-counted multi-vector targets without MUVERA in two ways: the reported dimensionality/object count covered only one row, and the uncompressed vector byte model (billing input) was derived from that single row.

## Approach

`DimensionsScan` now carries a slice of rows instead of a single `Raw`/`Reported` pair, and `ScanOpts` tells the scanner when to keep going: single-vector targets still stop at the first complete row (unchanged cost), while multi-vector or MUVERA targets scan the whole prefix. Whether a target is multi-vector is resolved from the vector index config at every call site (hot shard, lazy/unloaded shard, cold-shard sweep), so all paths scan the same way.

Consequences of the row model:

- **Report shape**: `Dimensionalities` was already a slice on the wire; multi-vector targets without MUVERA now fill it with one entry per distinct total token dims instead of a single first-row entry. MUVERA targets still collapse to one `{encodedDims, totalCount}` entry — but the totalCount is now the sum over all rows.
- **Byte model**: uncompressed vector size is now `Σ rowCount × rowDims × 4` (`TotalDimensions`), on both the hot path (`Shard.VectorStorageUsage`) and the cold path (`calculateUnloadedShardUsage`). This also corrects the `vector_dimensions_sum` metric, which reported first-row-only for any multi-vector.
- **Cache invalidation**: `UsageDiskVersion` bumped 2 → 3 so pre-computed per-shard usage files from older versions are discarded rather than serving the old single-row numbers for cold shards.
- Rows are sorted numerically after the scan because the LSM cursor yields little-endian dimension keys in byte order, not numeric order.

An alternative — one synthetic "average dims" row — was not taken: enumerating real rows loses no information and lets consumers sum or inspect the distribution.

## Key areas for review

- `adapters/repos/db/shard_usage/usage.go` — `ScanTargetVectorDimensions` early-stop vs full-prefix logic and the `ScanOpts` contract; verify single-vector targets still stop at the first complete row
- `adapters/repos/db/index_usage.go` (`vectorUsages`) — the cached-scan path derives the MUVERA entry from the sweep's rows instead of re-scanning the bucket; check the `cached`/`encodedDimensions` interplay
- `adapters/repos/db/shard_dimension_tracking.go` (`QuantizedDimensions`) — for multi-vector targets the smallest row's dims stands in for per-object dimensionality (see Risks)
- `cluster/usage/types/types.go` — the disk-version bump; confirm every consumer of the cached file is covered by it

## Risks and mitigations

- **Consumers reading only `Dimensionalities[0]`**: the wire type was always a slice, but multi-vector targets now populate more than one entry. Downstream consumers must sum entries; documented on `trackedDimensionalities` and pinned in the acceptance test. Reading `[0]` was already wrong for these targets today.
- **Stale cold-shard numbers**: mitigated by the `UsageDiskVersion` bump — old cache files are recomputed instead of replayed.
- **Full-prefix scan cost**: only paid by multi-vector/MUVERA targets, which already paid it for MUVERA; single-vector targets keep the first-row early exit. The scan checks `ctx` every 1024 keys.
- **`QuantizedDimensions` approximation**: with varying token counts there is no single per-object dimensionality; the smallest row is used, keeping prior behavior in the uniform case. Flagged in a code comment rather than silently averaged.

## Testing

- `shard_usage/usage_test.go` — scanner-level: multi-row multi-vector targets, single-row collapse when token counts are uniform, little-endian vs numeric row ordering (dims 8 vs 260), MUVERA collapse with summed counts, parity between the single-target and all-targets unloaded variants, concurrency over the shared bucket lock.
- `index_vector_storage_test.go` (`TestIndex_MultiVectorUsage_VaryingTokenCounts`) — pins the bug end-to-end for both hot and cold paths: every row reported and bytes modeled from the row sum; fails on main.
- `shard_dimension_tracking_test.go` — Prometheus dimension metrics sum all rows, with and without MUVERA (MUVERA changes the index, not the stored vectors).
- `test/acceptance_with_go_client/usage` — the colbert target now uses varying token counts (2 + i%3 tokens) and must enumerate three rows `[{64,7},{96,7},{128,6}]`, while MUVERA collapses them into one encoded row with the full count. Whole package passes locally against the fix image.
- E2E: new `test_usage_metrics_colbert_multi_vector_varying_tokens` in weaviate/weaviate-e2e-tests#529 asserts the usage-s3 report end-to-end; both raw and MUVERA variants pass against a kind cluster running this branch.