### PR TITLE
fix(hnsw): tolerate a tombstoned entrypoint whose node slot is nil

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -78,22 +78,19 @@ func (h *hnsw) Delete(ids ...uint64) error {
 		// connect it to (the entrypoint). With that one being tombstoned, the new
 		// node would be guaranteed to have zero edges
 
-		node := h.nodeByID(id)
-		if node == nil {
-			// node was already deleted/cleaned up
-			continue
-		}
-
 		if h.getEntrypoint() == id {
+			// the entrypoint must be moved even when its node slot is already
+			// nil, e.g. a torn crash-recovery state where the DeleteNode
+			// commit survived but the matching RemoveTombstone commit did not
 			if err := func() error {
 				beforeDeleteEP := time.Now()
 				defer h.metrics.TrackDelete(beforeDeleteEP, "delete_entrypoint")
 
 				denyList := h.tombstonesAsDenyList()
-				if onlyNode, err := h.resetIfOnlyNode(node, denyList); err != nil {
+				if onlyNode, err := h.resetIfOnlyNode(id, denyList); err != nil {
 					return errors.Wrap(err, "reset index")
 				} else if !onlyNode {
-					if err := h.deleteEntrypoint(node, denyList); err != nil {
+					if err := h.deleteEntrypoint(id, denyList); err != nil {
 						return errors.Wrap(err, "delete entrypoint")
 					}
 				}
@@ -169,7 +166,7 @@ func (h *hnsw) resetIfEmpty() (empty bool, err error) {
 	return false, nil
 }
 
-func (h *hnsw) resetIfOnlyNode(needle *vertex, denyList helpers.AllowList) (onlyNode bool, err error) {
+func (h *hnsw) resetIfOnlyNode(needleID uint64, denyList helpers.AllowList) (onlyNode bool, err error) {
 	h.resetLock.Lock()
 	defer h.resetLock.Unlock()
 	h.Lock()
@@ -181,7 +178,7 @@ func (h *hnsw) resetIfOnlyNode(needle *vertex, denyList helpers.AllowList) (only
 		h.shardedNodeLocks.RLockAll()
 		defer h.shardedNodeLocks.RUnlockAll()
 
-		return h.isOnlyNodeUnlocked(needle, denyList)
+		return h.isOnlyNodeUnlocked(needleID, denyList)
 	}()
 	// It can happen that between calls of isOnlyNodeUnlocked and resetUnlocked
 	// values of h.nodes will change (due to locks being RUnlocked and Locked again)
@@ -470,11 +467,7 @@ func (h *hnsw) replaceDeletedEntrypoint(deleteList helpers.AllowList, breakClean
 			// level, we need to find an entrypoint on a lower level
 			// 2. there is a risk that this is the only node in the entire graph. In
 			// this case we must reset the graph
-			h.shardedNodeLocks.RLock(id)
-			node := h.nodes[id]
-			h.shardedNodeLocks.RUnlock(id)
-
-			if err := h.deleteEntrypoint(node, deleteList); err != nil {
+			if err := h.deleteEntrypoint(id, deleteList); err != nil {
 				return false, errors.Wrap(err, "delete entrypoint")
 			}
 		}
@@ -692,15 +685,11 @@ func connectionsPointTo(connections *packedconn.Connections, needles helpers.All
 // one. It respects the attached denyList, so that it doesn't assign another
 // node which also has a tombstone and is also in the process of being cleaned
 // up
-func (h *hnsw) deleteEntrypoint(node *vertex, denyList helpers.AllowList) error {
-	if h.isOnlyNode(node, denyList) {
+func (h *hnsw) deleteEntrypoint(id uint64, denyList helpers.AllowList) error {
+	if h.isOnlyNode(id, denyList) {
 		// no point in finding another entrypoint if this is the only node
 		return nil
 	}
-
-	node.Lock()
-	id := node.id
-	node.Unlock()
 
 	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, id)
 	if !ok {
@@ -863,25 +852,25 @@ func (h *hnsw) findNewLocalEntrypoint(denyList helpers.AllowList, oldEntrypoint 
 		return 0, nil
 	}
 
-	if h.isOnlyNode(&vertex{id: oldEntrypoint}, denyList) {
+	if h.isOnlyNode(oldEntrypoint, denyList) {
 		return 0, nil
 	}
 
 	return 0, fmt.Errorf("class %s: shard %s: findNewLocalEntrypoint called on an empty hnsw graph", h.className, h.shardName)
 }
 
-func (h *hnsw) isOnlyNode(needle *vertex, denyList helpers.AllowList) bool {
+func (h *hnsw) isOnlyNode(needleID uint64, denyList helpers.AllowList) bool {
 	h.RLock()
 	h.shardedNodeLocks.RLockAll()
 	defer h.RUnlock()
 	defer h.shardedNodeLocks.RUnlockAll()
 
-	return h.isOnlyNodeUnlocked(needle, denyList)
+	return h.isOnlyNodeUnlocked(needleID, denyList)
 }
 
-func (h *hnsw) isOnlyNodeUnlocked(needle *vertex, denyList helpers.AllowList) bool {
+func (h *hnsw) isOnlyNodeUnlocked(needleID uint64, denyList helpers.AllowList) bool {
 	for _, node := range h.nodes {
-		if node == nil || node.id == needle.id || denyList.Contains(node.id) || node.connections.Layers() == 0 {
+		if node == nil || node.id == needleID || denyList.Contains(node.id) || node.connections.Layers() == 0 {
 			continue
 		}
 		return false

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -301,7 +301,7 @@ func (h *hnsw) CleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 	return err
 }
 
-func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (bool, error) {
+func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallback) (executed bool, err error) {
 	if !h.tombstoneCleanupRunning.CompareAndSwap(false, true) {
 		return false, errors.New("tombstone cleanup already running")
 	}
@@ -310,11 +310,13 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 	h.compressActionLock.RLock()
 	defer h.compressActionLock.RUnlock()
 	defer func() {
-		err := recover()
-		if err != nil {
-			entsentry.Recover(err)
-			h.logger.WithField("panic", err).Errorf("class %s: tombstone cleanup panicked", h.className)
+		if r := recover(); r != nil {
+			entsentry.Recover(r)
+			h.logger.WithField("panic", r).Errorf("class %s: tombstone cleanup panicked", h.className)
 			enterrors.PrintStack(h.logger)
+			// surface the panic as an error: a swallowed panic makes the
+			// cycle report success while no cleanup progress was made
+			err = fmt.Errorf("tombstone cleanup panicked: %v", r)
 		}
 	}()
 
@@ -328,7 +330,6 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 		return resetCtx.Err() != nil || shouldAbort()
 	}
 
-	executed := false
 	ok, deleteList := h.copyTombstonesToAllowList(breakCleanUpTombstonedNodes)
 	if !ok {
 		return executed, nil
@@ -691,16 +692,17 @@ func (h *hnsw) deleteEntrypoint(id uint64, denyList helpers.AllowList) error {
 		return nil
 	}
 
-	newEntrypoint, level, ok := h.findNewGlobalEntrypoint(denyList, id)
-	if !ok {
-		return nil
-	}
-
-	h.Lock()
-	h.entryPointID = newEntrypoint
-	h.currentMaximumLayer = level
-	h.Unlock()
-	if err := h.commitLog.SetEntryPointWithMaxLayer(newEntrypoint, level); err != nil {
+	// repairGlobalEntrypoint re-checks under h.Lock that the entrypoint is
+	// still the one being replaced — the callers of deleteEntrypoint do not
+	// exclude concurrent inserts, and an insert's promotion of a
+	// higher-level entrypoint must not be clobbered by an unconditional
+	// write here. It also persists within the same critical section, so
+	// memory and commit log cannot record different entrypoints.
+	// errNoUsableEntrypoint maps back to a no-op: every remaining candidate
+	// is deny-listed or under maintenance, which callers treat as "nothing
+	// to do" (the tombstone stays, a later cycle retries).
+	if _, err := h.repairGlobalEntrypoint(id, denyList); err != nil &&
+		!errors.Is(err, errNoUsableEntrypoint) {
 		return err
 	}
 
@@ -922,6 +924,14 @@ func (h *hnsw) removeTombstonesAndNodes(deleteList helpers.AllowList, breakClean
 	for id, ok := it.Next(); ok; id, ok = it.Next() {
 		if breakCleanUpTombstonedNodes() {
 			return false, nil
+		}
+		if h.getEntrypoint() == id && !h.isOnlyNode(id, deleteList) {
+			// the entrypoint could not be replaced earlier in this cycle
+			// (e.g. every candidate was under maintenance by a concurrent
+			// insert): keep the node and its tombstone so a later cycle
+			// retries, instead of leaving a dangling entrypoint with no
+			// tombstone that no cycle would ever revisit
+			continue
 		}
 		h.metrics.RemoveTombstone()
 		h.tombstoneLock.Lock()

--- a/adapters/repos/db/vector/hnsw/delete_entrypoint_persist_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_entrypoint_persist_test.go
@@ -1,0 +1,175 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	ent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+)
+
+// entrypointPersistCall captures the state observed at the moment an
+// entrypoint change was persisted to the commit log.
+type entrypointPersistCall struct {
+	id       uint64
+	level    int
+	memID    uint64
+	memLevel int
+	lockHeld bool
+}
+
+// entrypointPersistSpy wraps a CommitLogger and records, for every
+// SetEntryPointWithMaxLayer call while armed, whether the caller held the
+// hnsw main lock and whether the in-memory entrypoint state matched the
+// persisted values at that moment. Both must hold: an entrypoint change
+// persisted outside the critical section that performed the memory write can
+// interleave with a concurrent entrypoint change, appending commit-log
+// entries in the opposite order of the memory writes — after a restart the
+// replayed entrypoint would diverge from what memory had.
+type entrypointPersistSpy struct {
+	CommitLogger
+	h     *hnsw
+	armed atomic.Bool
+
+	mu    sync.Mutex
+	calls []entrypointPersistCall
+}
+
+func (s *entrypointPersistSpy) SetEntryPointWithMaxLayer(id uint64, level int) error {
+	if s.armed.Load() {
+		// If the caller performs the persist inside its h.Lock() critical
+		// section, TryLock must fail. The tests using this spy are
+		// single-threaded, so a failing TryLock cannot be a false positive
+		// from an unrelated concurrent lock holder.
+		lockHeld := !s.h.TryLock()
+		call := entrypointPersistCall{
+			id:       id,
+			level:    level,
+			memID:    s.h.entryPointID,
+			memLevel: s.h.currentMaximumLayer,
+			lockHeld: lockHeld,
+		}
+		if !lockHeld {
+			s.h.Unlock()
+		}
+
+		s.mu.Lock()
+		s.calls = append(s.calls, call)
+		s.mu.Unlock()
+	}
+
+	return s.CommitLogger.SetEntryPointWithMaxLayer(id, level)
+}
+
+func (s *entrypointPersistSpy) recorded() []entrypointPersistCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]entrypointPersistCall(nil), s.calls...)
+}
+
+// TestDeleteEntrypoint_PersistsUnderLock pins that every path replacing the
+// global entrypoint after a delete persists the change to the commit log
+// within the same h.Lock() critical section as the in-memory write, matching
+// the pattern of repairGlobalEntrypoint. Delete() (holding deleteLock) and
+// the tombstone-cleanup path replaceDeletedEntrypoint (holding resetLock) are
+// not mutually exclusive, so a persist outside the lock lets the two
+// interleave: memory updated in one order, commit log appended in the other.
+func TestDeleteEntrypoint_PersistsUnderLock(t *testing.T) {
+	tests := []struct {
+		name    string
+		replace func(t *testing.T, h *hnsw, entrypoint uint64)
+	}{
+		{
+			// user-facing Delete of the current entrypoint
+			name: "via Delete",
+			replace: func(t *testing.T, h *hnsw, entrypoint uint64) {
+				require.Nil(t, h.Delete(entrypoint))
+			},
+		},
+		{
+			// tombstone-cleanup cycle discovering a tombstoned entrypoint
+			name: "via replaceDeletedEntrypoint",
+			replace: func(t *testing.T, h *hnsw, entrypoint uint64) {
+				require.Nil(t, h.addTombstone(entrypoint))
+				ok, err := h.replaceDeletedEntrypoint(
+					h.tombstonesAsDenyList(), func() bool { return false })
+				require.Nil(t, err)
+				require.True(t, ok)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			vectors := vectorsForDeleteTest()
+
+			store := testinghelpers.NewDummyStore(t)
+			defer store.Shutdown(ctx)
+
+			spy := &entrypointPersistSpy{CommitLogger: &NoopCommitLogger{}}
+			index, err := New(Config{
+				RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+				ID:                    "delete-entrypoint-persist-test",
+				MakeCommitLoggerThunk: func(opts ...CommitlogOption) (CommitLogger, error) { return spy, nil },
+				DistanceProvider:      distancer.NewCosineDistanceProvider(),
+				VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+					return vectors[int(id)], nil
+				},
+				GetViewThunk:                 GetViewThunk,
+				TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+				AllocChecker:                 memwatch.NewDummyMonitor(),
+			}, ent.UserConfig{
+				MaxConnections:        30,
+				EFConstruction:        128,
+				VectorCacheMaxObjects: 100000,
+			}, cyclemanager.NewCallbackGroupNoop(), store)
+			require.Nil(t, err)
+			spy.h = index
+
+			for i, vec := range vectors {
+				require.Nil(t, index.Add(ctx, uint64(i), vec))
+			}
+
+			oldEntrypoint := index.getEntrypoint()
+			spy.armed.Store(true)
+			tt.replace(t, index, oldEntrypoint)
+			spy.armed.Store(false)
+
+			calls := spy.recorded()
+			require.NotEmpty(t, calls,
+				"replacing the entrypoint must persist the change")
+			for _, call := range calls {
+				assert.NotEqual(t, oldEntrypoint, call.id,
+					"new entrypoint must differ from the deleted one")
+				assert.True(t, call.lockHeld,
+					"entrypoint persist must happen under the hnsw main lock")
+				assert.Equal(t, call.memID, call.id,
+					"persisted entrypoint must match in-memory entrypoint")
+				assert.Equal(t, call.memLevel, call.level,
+					"persisted max layer must match in-memory max layer")
+			}
+
+			require.Nil(t, index.Drop(ctx, false))
+		})
+	}
+}

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -2239,71 +2239,70 @@ func TestDelete_EntrypointWithLowerLevelThanOtherNodes(t *testing.T) {
 	})
 }
 
-// TestDelete_TombstonedEntrypointWithNilNode reproduces a crash-recovery state
-// where the entrypoint id still carries a tombstone but its node slot is nil.
-//
+// newTombstonedNilEntrypointIndex manufactures a torn crash-recovery state:
 // removeTombstonesAndNodes persists DeleteNode and RemoveTombstone as two
-// separate commit-log entries. If the process dies between the two (and the
-// entrypoint had not been replaced first, e.g. because findNewGlobalEntrypoint
-// found no candidate), replay yields: entryPointID = X, tombstones = {X},
-// nodes[X] = nil. The multivector startup repair (restoreDocMappings) can
-// produce the same shape by nilling a node with a missing doc mapping.
-//
-// The cleanup cycle then handed the nil node to deleteEntrypoint/isOnlyNode,
-// which dereferenced it and panicked. The recover in cleanUpTombstonedNodes
-// swallowed the panic and returned a nil error, so every subsequent cycle
-// panicked at the same point and tombstone cleanup never made progress again.
+// separate commit-log entries, and a crash between the two replays into
+// entryPointID = 0, tombstones = {0}, nodes[0] = nil.
+func newTombstonedNilEntrypointIndex(t *testing.T, withLiveNodes bool) *hnsw {
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "tombstoned-nil-entrypoint-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:      testVectorForID,
+		GetViewThunk:          GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk([][]float32{
+			{0.1, 0.2},
+			{0.3, 0.4},
+			{0.5, 0.6},
+		}),
+		AllocChecker: memwatch.NewDummyMonitor(),
+	}, ent.UserConfig{
+		MaxConnections:         30,
+		EFConstruction:         128,
+		EF:                     36,
+		CleanupIntervalSeconds: 0,
+		VectorCacheMaxObjects:  100000,
+	}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+	t.Cleanup(func() { index.Drop(context.Background(), false) })
+
+	index.Lock()
+	index.entryPointID = 0
+	index.currentMaximumLayer = 0
+	index.nodes = make([]*vertex, 10)
+	// slot 0 deliberately stays nil: the DeleteNode commit for the old
+	// entrypoint was persisted, the matching RemoveTombstone was not
+	if withLiveNodes {
+		conns1, _ := packedconn.NewWithElements([][]uint64{{2}})
+		index.nodes[1] = &vertex{id: 1, level: 0, connections: conns1}
+		conns2, _ := packedconn.NewWithElements([][]uint64{{1}})
+		index.nodes[2] = &vertex{id: 2, level: 0, connections: conns2}
+	}
+	index.Unlock()
+
+	index.tombstoneLock.Lock()
+	index.tombstones = map[uint64]struct{}{0: {}}
+	index.tombstoneLock.Unlock()
+
+	return index
+}
+
+func tombstoneCountOf(index *hnsw) int {
+	index.tombstoneLock.Lock()
+	defer index.tombstoneLock.Unlock()
+	return len(index.tombstones)
+}
+
+// TestDelete_TombstonedEntrypointWithNilNode: on the torn state (see
+// newTombstonedNilEntrypointIndex) the cleanup cycle dereferenced the nil
+// entrypoint node and panicked; the cycle's recover swallowed the panic, so
+// no cycle ever made progress again. The first and third subtests are
+// regression tests for that; the second pins the adjacent journey where no
+// live node remains (which also worked before the fix).
 func TestDelete_TombstonedEntrypointWithNilNode(t *testing.T) {
-	newCorruptIndex := func(t *testing.T, withLiveNodes bool) *hnsw {
-		index, err := New(Config{
-			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
-			ID:                    "tombstoned-nil-entrypoint-test",
-			MakeCommitLoggerThunk: MakeNoopCommitLogger,
-			DistanceProvider:      distancer.NewCosineDistanceProvider(),
-			VectorForIDThunk:      testVectorForID,
-			GetViewThunk:          GetViewThunk,
-			TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk([][]float32{
-				{0.1, 0.2},
-				{0.3, 0.4},
-				{0.5, 0.6},
-			}),
-			AllocChecker: memwatch.NewDummyMonitor(),
-		}, ent.UserConfig{
-			MaxConnections:         30,
-			EFConstruction:         128,
-			EF:                     36,
-			CleanupIntervalSeconds: 0,
-			VectorCacheMaxObjects:  100000,
-		}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
-		require.Nil(t, err)
-		t.Cleanup(func() { index.Drop(context.Background(), false) })
-
-		index.Lock()
-		index.entryPointID = 0
-		index.currentMaximumLayer = 0
-		index.nodes = make([]*vertex, 10)
-		// slot 0 deliberately stays nil: the DeleteNode commit for the old
-		// entrypoint was persisted, the matching RemoveTombstone was not
-		if withLiveNodes {
-			conns1, _ := packedconn.NewWithElements([][]uint64{{2}})
-			index.nodes[1] = &vertex{id: 1, level: 0, connections: conns1}
-			conns2, _ := packedconn.NewWithElements([][]uint64{{1}})
-			index.nodes[2] = &vertex{id: 2, level: 0, connections: conns2}
-		}
-		index.Unlock()
-
-		index.tombstoneLock.Lock()
-		index.tombstones = map[uint64]struct{}{0: {}}
-		index.tombstoneLock.Unlock()
-
-		return index
-	}
-
-	tombstoneCount := func(index *hnsw) int {
-		index.tombstoneLock.Lock()
-		defer index.tombstoneLock.Unlock()
-		return len(index.tombstones)
-	}
+	newCorruptIndex := newTombstonedNilEntrypointIndex
+	tombstoneCount := tombstoneCountOf
 
 	t.Run("cleanup replaces the entrypoint and removes the tombstone", func(t *testing.T) {
 		index := newCorruptIndex(t, true)

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -2238,3 +2238,100 @@ func TestDelete_EntrypointWithLowerLevelThanOtherNodes(t *testing.T) {
 		require.Equal(t, 3, index.currentMaximumLayer)
 	})
 }
+
+// TestDelete_TombstonedEntrypointWithNilNode reproduces a crash-recovery state
+// where the entrypoint id still carries a tombstone but its node slot is nil.
+//
+// removeTombstonesAndNodes persists DeleteNode and RemoveTombstone as two
+// separate commit-log entries. If the process dies between the two (and the
+// entrypoint had not been replaced first, e.g. because findNewGlobalEntrypoint
+// found no candidate), replay yields: entryPointID = X, tombstones = {X},
+// nodes[X] = nil. The multivector startup repair (restoreDocMappings) can
+// produce the same shape by nilling a node with a missing doc mapping.
+//
+// The cleanup cycle then handed the nil node to deleteEntrypoint/isOnlyNode,
+// which dereferenced it and panicked. The recover in cleanUpTombstonedNodes
+// swallowed the panic and returned a nil error, so every subsequent cycle
+// panicked at the same point and tombstone cleanup never made progress again.
+func TestDelete_TombstonedEntrypointWithNilNode(t *testing.T) {
+	newCorruptIndex := func(t *testing.T, withLiveNodes bool) *hnsw {
+		index, err := New(Config{
+			RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+			ID:                    "tombstoned-nil-entrypoint-test",
+			MakeCommitLoggerThunk: MakeNoopCommitLogger,
+			DistanceProvider:      distancer.NewCosineDistanceProvider(),
+			VectorForIDThunk:      testVectorForID,
+			GetViewThunk:          GetViewThunk,
+			TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk([][]float32{
+				{0.1, 0.2},
+				{0.3, 0.4},
+				{0.5, 0.6},
+			}),
+			AllocChecker: memwatch.NewDummyMonitor(),
+		}, ent.UserConfig{
+			MaxConnections:         30,
+			EFConstruction:         128,
+			EF:                     36,
+			CleanupIntervalSeconds: 0,
+			VectorCacheMaxObjects:  100000,
+		}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+		require.Nil(t, err)
+		t.Cleanup(func() { index.Drop(context.Background(), false) })
+
+		index.Lock()
+		index.entryPointID = 0
+		index.currentMaximumLayer = 0
+		index.nodes = make([]*vertex, 10)
+		// slot 0 deliberately stays nil: the DeleteNode commit for the old
+		// entrypoint was persisted, the matching RemoveTombstone was not
+		if withLiveNodes {
+			conns1, _ := packedconn.NewWithElements([][]uint64{{2}})
+			index.nodes[1] = &vertex{id: 1, level: 0, connections: conns1}
+			conns2, _ := packedconn.NewWithElements([][]uint64{{1}})
+			index.nodes[2] = &vertex{id: 2, level: 0, connections: conns2}
+		}
+		index.Unlock()
+
+		index.tombstoneLock.Lock()
+		index.tombstones = map[uint64]struct{}{0: {}}
+		index.tombstoneLock.Unlock()
+
+		return index
+	}
+
+	tombstoneCount := func(index *hnsw) int {
+		index.tombstoneLock.Lock()
+		defer index.tombstoneLock.Unlock()
+		return len(index.tombstones)
+	}
+
+	t.Run("cleanup replaces the entrypoint and removes the tombstone", func(t *testing.T) {
+		index := newCorruptIndex(t, true)
+
+		require.Nil(t, index.CleanUpTombstonedNodes(neverStop))
+
+		assert.Equal(t, uint64(1), index.getEntrypoint(),
+			"entrypoint must move to a live node")
+		assert.Equal(t, 0, tombstoneCount(index),
+			"the stale tombstone must be cleaned up")
+	})
+
+	t.Run("cleanup resets the graph when no live node remains", func(t *testing.T) {
+		index := newCorruptIndex(t, false)
+
+		require.Nil(t, index.CleanUpTombstonedNodes(neverStop))
+
+		assert.Equal(t, 0, tombstoneCount(index),
+			"the stale tombstone must be cleaned up")
+		assert.True(t, index.isEmpty(), "graph must be reset to empty")
+	})
+
+	t.Run("Delete on the corrupt entrypoint id replaces the entrypoint", func(t *testing.T) {
+		index := newCorruptIndex(t, true)
+
+		require.Nil(t, index.Delete(0))
+
+		assert.Equal(t, uint64(1), index.getEntrypoint(),
+			"entrypoint must move to a live node even though its slot is nil")
+	})
+}

--- a/adapters/repos/db/vector/hnsw/entrypoint_stranded_test.go
+++ b/adapters/repos/db/vector/hnsw/entrypoint_stranded_test.go
@@ -27,8 +27,9 @@ import (
 
 // TestDeleteEntrypoint_CandidatesUnderMaintenance deletes the entrypoint while
 // every other node is under maintenance, stranding the entrypoint on the
-// tombstoned node: cleanup must not wipe the live nodes and the next search
-// must repair the entrypoint.
+// tombstoned node: cleanup must not wipe the live nodes, must keep the
+// stranded entrypoint's tombstone for a retry, and the next cycle (once the
+// candidates left maintenance) must repair the entrypoint.
 func TestDeleteEntrypoint_CandidatesUnderMaintenance(t *testing.T) {
 	ctx := context.Background()
 	vectors := vectorsForEntrypointRepairTest()
@@ -117,7 +118,19 @@ func TestDeleteEntrypoint_CandidatesUnderMaintenance(t *testing.T) {
 	assert.NotEmpty(t, ids, "search must still find the live nodes")
 	assert.NotContains(t, ids, oldEP, "results must not contain the deleted node")
 
+	// the stranded entrypoint keeps its tombstone (removing it would leave
+	// a dangling entrypoint no cycle revisits), so with the candidates out
+	// of maintenance the next cleanup cycle repairs the entrypoint
+	index.tombstoneLock.Lock()
+	_, tombstoned := index.tombstones[oldEP]
+	index.tombstoneLock.Unlock()
+	assert.True(t, tombstoned, "stranded entrypoint must keep its tombstone for a retry")
+
+	_, err = index.cleanUpTombstonedNodes(neverStop)
+	require.NoError(t, err)
+
 	newEP := index.getEntrypoint()
-	assert.NotEqual(t, oldEP, newEP, "search must have repaired the entrypoint")
+	assert.NotEqual(t, oldEP, newEP, "next cleanup cycle must have repaired the entrypoint")
 	assert.NotNil(t, index.nodeByID(newEP), "repaired entrypoint must be a live node")
+	assert.Equal(t, 0, tombstoneCountOf(index), "tombstone must drain once the entrypoint moved")
 }

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -857,11 +857,18 @@ func (h *hnsw) Iterate(fn func(docID uint64) bool) {
 func (h *hnsw) iterate(fn func(docID uint64) bool) {
 	var id uint64
 
+	// snapshot under resetLock: resetUnlocked swaps h.resetCtx and an
+	// unsynchronized read races that write. The snapshot still observes a
+	// reset, because the old context is cancelled before being replaced.
+	h.resetLock.RLock()
+	resetCtx := h.resetCtx
+	h.resetLock.RUnlock()
+
 	for {
 		if h.shutdownCtx.Err() != nil {
 			return
 		}
-		if h.resetCtx.Err() != nil {
+		if resetCtx.Err() != nil {
 			return
 		}
 
@@ -894,8 +901,13 @@ func (h *hnsw) iterateMulti(fn func(docID uint64) bool) {
 	}
 	h.RUnlock()
 
+	// snapshot under resetLock — see iterate for why
+	h.resetLock.RLock()
+	resetCtx := h.resetCtx
+	h.resetLock.RUnlock()
+
 	for _, docID := range indexedDocIDs {
-		if h.shutdownCtx.Err() != nil || h.resetCtx.Err() != nil {
+		if h.shutdownCtx.Err() != nil || resetCtx.Err() != nil {
 			return
 		}
 

--- a/adapters/repos/db/vector/hnsw/restore_doc_mappings_test.go
+++ b/adapters/repos/db/vector/hnsw/restore_doc_mappings_test.go
@@ -30,15 +30,16 @@ type restoreDocNoopBucketView struct{}
 
 func (n *restoreDocNoopBucketView) ReleaseView() {}
 
-func TestRestoreDocMappingsWithMissingBucket(t *testing.T) {
-	rootPath := t.TempDir()
-	store := testinghelpers.NewDummyStore(t)
+// newRestoreDocMappingsIndex builds the multivector index shared by the
+// TestRestoreDocMappings* tests.
+func newRestoreDocMappingsIndex(t *testing.T) *hnsw {
+	t.Helper()
 
 	uc := ent.UserConfig{}
 	uc.Multivector.Enabled = true
 
 	index, err := New(Config{
-		RootPath:              rootPath,
+		RootPath:              t.TempDir(),
 		ID:                    "doc-mappings",
 		MakeCommitLoggerThunk: MakeNoopCommitLogger,
 		DistanceProvider:      distancer.NewL2SquaredProvider(),
@@ -50,11 +51,16 @@ func TestRestoreDocMappingsWithMissingBucket(t *testing.T) {
 			return nil, nil
 		},
 		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
-	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	}, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
 
-	assert.Nil(t, err)
+	return index
+}
 
-	err = index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
+func TestRestoreDocMappingsWithMissingBucket(t *testing.T) {
+	index := newRestoreDocMappingsIndex(t)
+
+	err := index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
 	assert.Nil(t, err)
 
 	newStore := testinghelpers.NewDummyStore(t)
@@ -65,30 +71,9 @@ func TestRestoreDocMappingsWithMissingBucket(t *testing.T) {
 }
 
 func TestRestoreDocMappingsWithNilData(t *testing.T) {
-	rootPath := t.TempDir()
-	store := testinghelpers.NewDummyStore(t)
+	index := newRestoreDocMappingsIndex(t)
 
-	uc := ent.UserConfig{}
-	uc.Multivector.Enabled = true
-
-	index, err := New(Config{
-		RootPath:              rootPath,
-		ID:                    "doc-mappings",
-		MakeCommitLoggerThunk: MakeNoopCommitLogger,
-		DistanceProvider:      distancer.NewL2SquaredProvider(),
-		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
-			return nil, nil
-		},
-		GetViewThunk: func() common.BucketView { return &restoreDocNoopBucketView{} },
-		TempVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
-			return nil, nil
-		},
-		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
-	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
-
-	assert.Nil(t, err)
-
-	err = index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
+	err := index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
 	assert.Nil(t, err)
 	err = index.AddMulti(context.Background(), 2, [][]float32{{4, 5, 6}, {7, 8, 9}})
 	assert.Nil(t, err)
@@ -120,29 +105,9 @@ func TestRestoreDocMappingsWithNilData(t *testing.T) {
 // it the entrypoint dangles forever: nodes[ep] is nil but no tombstone means
 // no cleanup path ever looks at it.
 func TestRestoreDocMappingsTombstonesRemovedEntrypoint(t *testing.T) {
-	rootPath := t.TempDir()
-	store := testinghelpers.NewDummyStore(t)
+	index := newRestoreDocMappingsIndex(t)
 
-	uc := ent.UserConfig{}
-	uc.Multivector.Enabled = true
-
-	index, err := New(Config{
-		RootPath:              rootPath,
-		ID:                    "doc-mappings",
-		MakeCommitLoggerThunk: MakeNoopCommitLogger,
-		DistanceProvider:      distancer.NewL2SquaredProvider(),
-		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
-			return nil, nil
-		},
-		GetViewThunk: func() common.BucketView { return &restoreDocNoopBucketView{} },
-		TempVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
-			return nil, nil
-		},
-		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
-	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
-	require.Nil(t, err)
-
-	err = index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
+	err := index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
 	require.Nil(t, err)
 	err = index.AddMulti(context.Background(), 2, [][]float32{{4, 5, 6}})
 	require.Nil(t, err)

--- a/adapters/repos/db/vector/hnsw/restore_doc_mappings_test.go
+++ b/adapters/repos/db/vector/hnsw/restore_doc_mappings_test.go
@@ -101,4 +101,65 @@ func TestRestoreDocMappingsWithNilData(t *testing.T) {
 	err = index.restoreDocMappings()
 	require.Nil(t, err)
 	assert.Nil(t, index.nodes[2])
+
+	// a node removed by the startup repair must be tombstoned (in memory —
+	// the commit logger is not wired up yet at this point of startup) so
+	// that the next cleanup cycle reassigns the edges still pointing at it
+	// and, if it was the entrypoint, moves the entrypoint off the dangling
+	// id. Without the tombstone nothing ever revisits the removed node.
+	index.tombstoneLock.Lock()
+	_, tombstoned := index.tombstones[2]
+	index.tombstoneLock.Unlock()
+	assert.True(t, tombstoned, "node removed by startup repair must carry a tombstone")
+}
+
+// TestRestoreDocMappingsTombstonesRemovedEntrypoint: when the node removed by
+// the startup repair is the entrypoint, the tombstone is what makes the next
+// cleanup cycle move the entrypoint off the dangling id (the cycle's handling
+// of a tombstoned nil-slot entrypoint is pinned in delete_test.go). Without
+// it the entrypoint dangles forever: nodes[ep] is nil but no tombstone means
+// no cleanup path ever looks at it.
+func TestRestoreDocMappingsTombstonesRemovedEntrypoint(t *testing.T) {
+	rootPath := t.TempDir()
+	store := testinghelpers.NewDummyStore(t)
+
+	uc := ent.UserConfig{}
+	uc.Multivector.Enabled = true
+
+	index, err := New(Config{
+		RootPath:              rootPath,
+		ID:                    "doc-mappings",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewL2SquaredProvider(),
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			return nil, nil
+		},
+		GetViewThunk: func() common.BucketView { return &restoreDocNoopBucketView{} },
+		TempVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([]float32, error) {
+			return nil, nil
+		},
+		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+	}, uc, cyclemanager.NewCallbackGroupNoop(), store)
+	require.Nil(t, err)
+
+	err = index.AddMulti(context.Background(), 1, [][]float32{{1, 2, 3}})
+	require.Nil(t, err)
+	err = index.AddMulti(context.Background(), 2, [][]float32{{4, 5, 6}})
+	require.Nil(t, err)
+
+	ep := index.getEntrypoint()
+	nodeIDBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(nodeIDBytes, ep)
+	err = index.store.Bucket(index.id + "_mv_mappings").Delete(nodeIDBytes)
+	require.Nil(t, err)
+
+	err = index.restoreDocMappings()
+	require.Nil(t, err)
+
+	require.Nil(t, index.nodes[ep], "entrypoint node must be removed")
+	index.tombstoneLock.Lock()
+	_, tombstoned := index.tombstones[ep]
+	index.tombstoneLock.Unlock()
+	assert.True(t, tombstoned,
+		"removed entrypoint must carry a tombstone so cleanup can move the entrypoint")
 }

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -262,9 +262,25 @@ func (h *hnsw) applyLoadedState(state *ent.DeserializationResult) error {
 }
 
 func (h *hnsw) setDimensionsFromEntrypoint() {
-	if len(h.nodes) > 0 {
-		if vec, err := h.VectorForIDThunk(context.Background(), h.entryPointID); err == nil {
+	if len(h.nodes) == 0 {
+		return
+	}
+	if vec, err := h.VectorForIDThunk(context.Background(), h.entryPointID); err == nil && len(vec) > 0 {
+		h.dims.Store(int32(len(vec)))
+		return
+	}
+	// the entrypoint's object may already be gone (e.g. a torn crash
+	// recovery where the entrypoint id is tombstoned but still set): fall
+	// back to any live node rather than leaving dims at 0, which would
+	// disable dimension validation for every subsequent insert and let a
+	// single wrong-length insert poison the recorded dimensionality
+	for _, node := range h.nodes {
+		if node == nil || node.id == h.entryPointID {
+			continue
+		}
+		if vec, err := h.VectorForIDThunk(context.Background(), node.id); err == nil && len(vec) > 0 {
 			h.dims.Store(int32(len(vec)))
+			return
 		}
 	}
 }
@@ -384,6 +400,7 @@ func (h *hnsw) restoreDocMappings() error {
 	}
 	defer release()
 
+	var removed []uint64
 	for _, node := range h.nodes {
 		if node == nil {
 			continue
@@ -399,6 +416,7 @@ func (h *hnsw) restoreDocMappings() error {
 				"error":   err.Error(),
 			}).Error("skipping node with missing doc mapping")
 			h.nodes[node.id] = nil
+			removed = append(removed, node.id)
 			continue
 		}
 
@@ -410,6 +428,7 @@ func (h *hnsw) restoreDocMappings() error {
 				"bytes_length": len(docIDBytes),
 			}).Error("skipping node with invalid doc mapping data")
 			h.nodes[node.id] = nil
+			removed = append(removed, node.id)
 			continue
 		}
 
@@ -433,6 +452,24 @@ func (h *hnsw) restoreDocMappings() error {
 	h.vecIDcounter = maxNodeID + 1
 	h.maxDocID = maxDocID
 	h.Unlock()
+
+	if len(removed) > 0 {
+		// tombstone the removed nodes in memory only — the commit logger is
+		// wired up after restoreFromDisk returns, so persisting here would
+		// nil-panic; that is fine, since a crash before the next cleanup
+		// cycle re-detects the missing mappings on the next restore. The
+		// tombstones make the next cleanup cycle reassign the edges still
+		// pointing at the removed nodes and, when one of them is the
+		// entrypoint, move the entrypoint off the dangling id.
+		h.tombstoneLock.Lock()
+		if h.tombstones == nil {
+			h.tombstones = make(map[uint64]struct{}, len(removed))
+		}
+		for _, id := range removed {
+			h.tombstones[id] = struct{}{}
+		}
+		h.tombstoneLock.Unlock()
+	}
 	return nil
 }
 

--- a/adapters/repos/db/vector/hnsw/tombstone_cleanup_regression_test.go
+++ b/adapters/repos/db/vector/hnsw/tombstone_cleanup_regression_test.go
@@ -1,0 +1,194 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw/packedconn"
+)
+
+// TestCleanupTombstones_PanicSurfacesAsError pins the error contract of the
+// cleanup cycle's recover: a panic anywhere in the cycle must surface as an
+// error, not as a successful run. A swallowed panic is how the original
+// nil-entrypoint crash stayed invisible while tombstones accumulated.
+func TestCleanupTombstones_PanicSurfacesAsError(t *testing.T) {
+	index := newTombstonedNilEntrypointIndex(t, true)
+
+	err := index.CleanUpTombstonedNodes(func() bool { panic("injected panic") })
+	require.ErrorContains(t, err, "tombstone cleanup panicked")
+}
+
+// TestCleanupTombstones_KeepsTombstoneWhenEntrypointNotReplaceable: when the
+// entrypoint is tombstoned but every replacement candidate is under
+// maintenance by a concurrent insert, the cycle must keep the entrypoint's
+// tombstone for a later retry. Removing it would leave a dangling,
+// untombstoned entrypoint that no later cycle revisits.
+func TestCleanupTombstones_KeepsTombstoneWhenEntrypointNotReplaceable(t *testing.T) {
+	index := newTombstonedNilEntrypointIndex(t, false)
+
+	conns, err := packedconn.NewWithElements([][]uint64{{}})
+	require.Nil(t, err)
+	index.Lock()
+	index.nodes[1] = &vertex{id: 1, level: 0, connections: conns}
+	index.Unlock()
+	index.nodes[1].markAsMaintenance()
+
+	// cleanup's reassignment unmarks maintenance, so re-mark on every
+	// shouldAbort invocation to keep simulating an in-flight insert
+	keepInMaintenance := func() bool {
+		if node := index.nodeByID(1); node != nil {
+			node.markAsMaintenance()
+		}
+		return false
+	}
+
+	require.Nil(t, index.CleanUpTombstonedNodes(keepInMaintenance))
+	assert.Equal(t, uint64(0), index.getEntrypoint(),
+		"entrypoint cannot move while the only candidate is under maintenance")
+	assert.Equal(t, 1, tombstoneCountOf(index),
+		"tombstone must be kept so a later cycle retries")
+
+	index.nodes[1].unmarkAsMaintenance()
+
+	require.Nil(t, index.CleanUpTombstonedNodes(neverStop))
+	assert.Equal(t, uint64(1), index.getEntrypoint(),
+		"entrypoint must move once the candidate leaves maintenance")
+	assert.Equal(t, 0, tombstoneCountOf(index),
+		"tombstone must drain once the entrypoint has been replaced")
+}
+
+// promotingDenyList simulates a concurrent insert promoting a new, higher
+// entrypoint while findNewGlobalEntrypoint is scanning for a replacement:
+// the promotion fires during the deny-list check of the scan's final
+// candidate, i.e. after the scan's last look at the current entrypoint.
+type promotingDenyList struct {
+	helpers.AllowList
+	index        *hnsw
+	triggerID    uint64
+	promoteTo    uint64
+	promoteLevel int
+	once         sync.Once
+}
+
+func (p *promotingDenyList) Contains(id uint64) bool {
+	if id == p.triggerID {
+		p.once.Do(func() {
+			p.index.Lock()
+			p.index.entryPointID = p.promoteTo
+			p.index.currentMaximumLayer = p.promoteLevel
+			p.index.Unlock()
+		})
+	}
+	return p.AllowList.Contains(id)
+}
+
+// TestDeleteEntrypoint_DoesNotClobberConcurrentPromotion: deleteEntrypoint's
+// callers do not exclude concurrent inserts, so a promotion that lands
+// between the candidate scan and the entrypoint write must win — an
+// unconditional write would demote the entrypoint and lower
+// currentMaximumLayer, cutting off the promoted node's upper layers.
+func TestDeleteEntrypoint_DoesNotClobberConcurrentPromotion(t *testing.T) {
+	index := newTombstonedNilEntrypointIndex(t, false)
+
+	conns3, err := packedconn.NewWithElements([][]uint64{{}, {}, {}, {}, {}, {}})
+	require.Nil(t, err)
+	conns9, err := packedconn.NewWithElements([][]uint64{{}})
+	require.Nil(t, err)
+	index.Lock()
+	index.nodes[3] = &vertex{id: 3, level: 5, connections: conns3}
+	index.nodes[9] = &vertex{id: 9, level: 0, connections: conns9}
+	index.Unlock()
+	// node 3 is mid-insert: under maintenance, so the scan must not pick
+	// it — but the insert promotes it to entrypoint mid-scan
+	index.nodes[3].markAsMaintenance()
+
+	deny := &promotingDenyList{
+		AllowList:    helpers.NewAllowList(0),
+		index:        index,
+		triggerID:    9,
+		promoteTo:    3,
+		promoteLevel: 5,
+	}
+
+	require.Nil(t, index.deleteEntrypoint(0, deny))
+
+	assert.Equal(t, uint64(3), index.getEntrypoint(),
+		"the concurrent promotion must not be clobbered")
+	index.RLock()
+	maxLayer := index.currentMaximumLayer
+	index.RUnlock()
+	assert.Equal(t, 5, maxLayer,
+		"currentMaximumLayer must keep the promoted node's level")
+}
+
+// TestSetDimensions_FallsBackWhenEntrypointObjectGone: after a torn crash
+// recovery the entrypoint's object may be gone from the object store. dims
+// must then come from another live node — leaving it at 0 disables dimension
+// validation for every insert, and the first wrong-length insert would
+// poison the recorded dimensionality.
+func TestSetDimensions_FallsBackWhenEntrypointObjectGone(t *testing.T) {
+	index := newTombstonedNilEntrypointIndex(t, true)
+	index.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+		if id == 0 {
+			return nil, fmt.Errorf("object %d deleted", id)
+		}
+		return []float32{0.1, 0.2, 0.3}, nil
+	}
+
+	index.setDimensionsFromEntrypoint()
+
+	assert.Equal(t, int32(3), index.dims.Load(),
+		"dims must fall back to a live node when the entrypoint's object is gone")
+}
+
+// TestIterate_ConcurrentResetIsRaceFree: resetUnlocked swaps h.resetCtx while
+// iterate reads it per iteration; run under -race this pins that the read is
+// synchronized. The iterator must still terminate after the reset.
+func TestIterate_ConcurrentResetIsRaceFree(t *testing.T) {
+	index := newTombstonedNilEntrypointIndex(t, false)
+	conns, err := packedconn.NewWithElements([][]uint64{{}})
+	require.Nil(t, err)
+	index.Lock()
+	// a wide, almost-empty nodes slice keeps the iterator busy reading the
+	// reset context long enough to overlap the concurrent reset below
+	index.nodes = make([]*vertex, 1_000_000)
+	index.nodes[0] = &vertex{id: 0, connections: conns}
+	index.Unlock()
+	index.tombstoneLock.Lock()
+	index.tombstones = map[uint64]struct{}{}
+	index.tombstoneLock.Unlock()
+
+	entered := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		index.iterate(func(docID uint64) bool {
+			close(entered) // only node 0 is live, so this fires exactly once
+			return true
+		})
+	}()
+
+	<-entered
+	// deleting the only node resets the graph, which swaps h.resetCtx
+	// while the iterator is still scanning
+	require.Nil(t, index.Delete(0))
+	<-done
+}


### PR DESCRIPTION
## Motivation

Production nodes hit a recurring panic in the tombstone cleanup cycle:

```
runtime error: invalid memory address or nil pointer dereference
  hnsw.(*hnsw).isOnlyNodeUnlocked   delete.go:884
  hnsw.(*hnsw).deleteEntrypoint     delete.go:696
  hnsw.(*hnsw).replaceDeletedEntrypoint
  hnsw.(*hnsw).cleanUpTombstonedNodes
```

The state behind it: the entrypoint id still carries a tombstone, but its slot in `h.nodes` is nil. `replaceDeletedEntrypoint` read that nil slot and passed it into `deleteEntrypoint` → `isOnlyNode`, which dereferenced it.

Because `cleanUpTombstonedNodes` wraps the cycle in a `recover()`, the panic is swallowed and reported as a successful (nil-error) run — so on an affected shard **every cleanup cycle fails at the same point and tombstones accumulate indefinitely**, with only a log line and a Sentry event as evidence.

## How the corrupt state arises

- **Torn crash recovery**: `removeTombstonesAndNodes` persists each removal as two separate commit-log entries — `DeleteNode(id)` then `RemoveTombstone(id)`. A crash between the two (after the entrypoint could not be replaced, e.g. every other node was also tombstoned) replays into `nodes[id] = nil` with the tombstone and entrypoint pointer intact.
- **Multivector startup repair**: `restoreDocMappings` previously nil'd out nodes with missing/corrupt doc mappings *without* a tombstone — a related but distinct shape (dangling entrypoint, nothing to ever revisit it). As of the review-hardening commit it now tombstones the removed nodes, converging on the same shape this PR's cleanup handles.

## Approach

`deleteEntrypoint`, `isOnlyNode`, `isOnlyNodeUnlocked` and `resetIfOnlyNode` only ever used the vertex's id, so they now take a `uint64` instead of a `*vertex`. This removes the nil dereference structurally rather than guarding one call site, and `replaceDeletedEntrypoint` no longer reads the node at all.

The `Delete()` API path had the mirror-image bug: on the same corrupt state it skipped entrypoint repair entirely (`node == nil → continue`), leaving a dangling entrypoint. It now repairs the entrypoint regardless of whether the slot is nil.

## Review hardening (second commit)

An adversarial review of the first commit surfaced eight adjacent defects; all are fixed here, each pinned by a regression test verified to fail without its fix:

- **Entrypoint clobbering**: `deleteEntrypoint` wrote the new entrypoint unconditionally after an unlocked candidate scan. Its callers do not exclude concurrent inserts, so an insert's promotion of a higher-level entrypoint could be overwritten (demoting `currentMaximumLayer` and persisting the demotion). It now delegates to `repairGlobalEntrypoint`, which compare-and-sets under `h.Lock` and persists in the same critical section — this also closes a window where memory and commit log could record different entrypoints.
- **Swallowed panics**: the cycle's `recover()` returned a nil error on panic — exactly why the incident was invisible. It now surfaces the panic as an error via named returns.
- **Tombstone dropped on failed replacement**: when every replacement candidate was under maintenance, the cycle removed the entrypoint's node *and* tombstone anyway, manufacturing an untombstoned dangling entrypoint no cycle revisits. `removeTombstonesAndNodes` now keeps the tombstone of an id that is still the entrypoint (unless it is the only node) so the next cycle retries. **Behavior change**: `TestDeleteEntrypoint_CandidatesUnderMaintenance` is updated accordingly — the stranded entrypoint is repaired by the next cleanup cycle rather than reactively by the next search (the reactive search repair remains as defense-in-depth).
- **`restoreDocMappings` gap**: see above. Tombstones are added in memory only — the commit logger is wired up after `restoreFromDisk`, so persisting there would nil-panic; a crash before the next cycle simply re-detects the missing mappings on the next restore.
- **Dimension validation disabled after torn restart**: with the entrypoint's object gone, `dims` stayed 0, inserts skipped length validation, and a single wrong-length insert could poison the recorded dimensionality. `setDimensionsFromEntrypoint` now falls back to any live node.
- **Data race on `resetCtx`**: `iterate`/`iterateMulti` read `h.resetCtx` unsynchronized against `resetUnlocked` swapping it. They now snapshot it under `resetLock` (correct because the old context is cancelled before replacement).

No behavior change for healthy graphs beyond the maintenance-stranded journey called out above.

## Key areas for review

- `deleteEntrypoint` delegating to `repairGlobalEntrypoint` — `errNoUsableEntrypoint` maps back to a no-op to preserve "no candidate → nothing to do" semantics for callers
- The `removeTombstonesAndNodes` skip condition (`getEntrypoint() == id && !isOnlyNode(id, deleteList)`) — the only-node exception is what lets the graph-reset journey still drain its tombstone
- The restructured entrypoint block in `Delete()` — entrypoint repair now runs even for ids whose slot is nil

## Testing

- `TestDelete_TombstonedEntrypointWithNilNode` manufactures the post-crash state directly and asserts on outcomes (tombstone removed, entrypoint moved) so the cycle's `recover()` cannot mask a regression; covers cleanup with live nodes remaining, cleanup with none remaining (reset path), and a user `Delete` on the corrupt id.
- `tombstone_cleanup_regression_test.go`: panic-surfacing contract, maintenance-stranded retry, concurrent-promotion no-clobber (deterministic via a deny-list hook), dims fallback, and an iterate-vs-reset race test that trips the race detector on the old code.
- `delete_entrypoint_persist_test.go`: a commit-logger spy asserting the entrypoint persist happens under the main lock and matches in-memory state, for both non-mutually-exclusive callers.
- `restore_doc_mappings_test.go`: removed nodes (including the entrypoint) now carry tombstones.

Every regression test was verified red against the unfixed code and green with the fixes. Full `./adapters/repos/db/vector/hnsw/...` suite passes with `-race`; `golangci-lint` and the goroutine linter are clean.

Operational note: shards that have been hitting this panic have been accumulating tombstones since the first occurrence; the first cleanup cycle after upgrade will drain the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
