### PR TITLE
fix(lsmkv): remove symlink tracing when listing backup files

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_backup.go
+++ b/adapters/repos/db/lsmkv/bucket_backup.go
@@ -17,10 +17,8 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 )
 
 // FlushMemtable flushes any active memtable and returns only once the memtable
@@ -42,25 +40,7 @@ func (b *Bucket) FlushMemtable() error {
 // in a stable state if the memtable is empty, and if compactions are paused. If one
 // of those conditions is not given, it errors
 func (b *Bucket) ListFiles(ctx context.Context, basePath string) ([]string, error) {
-	bucketRoot := b.disk.dir
-
-	files, err := b.listFiles(bucketRoot, basePath)
-	if err != nil {
-		return nil, err
-	}
-
-	// This is temporary check for the vectors_compressed folder, should be removed in v1.36
-	// We need to be able to downgrade to a version that doesn't contain the named vectors with quantization fix
-	// in order to be able to do that we need to also look for vectors_compressed folder and include it during backup
-	if strings.Contains(basePath, fmt.Sprintf("%s_", helpers.VectorsCompressedBucketLSM)) {
-		vectorCompressedFiles, err := b.tryTolistLegacyVectorCompressed(basePath)
-		if err != nil {
-			return nil, errors.Errorf("failed to list files in legacy vectors_compressed folder for bucket: %s", err)
-		}
-		files = append(files, vectorCompressedFiles...)
-	}
-
-	return files, nil
+	return b.listFiles(b.disk.dir, basePath)
 }
 
 func (b *Bucket) listFiles(bucketRoot, basePath string) ([]string, error) {
@@ -90,13 +70,4 @@ func (b *Bucket) listFiles(bucketRoot, basePath string) ([]string, error) {
 	}
 
 	return files, nil
-}
-
-func (b *Bucket) tryTolistLegacyVectorCompressed(basePath string) ([]string, error) {
-	vectorsCompressedBucketRoot := filepath.Join(b.GetRootDir(), "lsm", helpers.VectorsCompressedBucketLSM)
-	vectorsCompressedBasePath := filepath.Join(basePath[:strings.LastIndex(basePath, "/")], helpers.VectorsCompressedBucketLSM)
-	if _, err := os.Stat(vectorsCompressedBucketRoot); !os.IsNotExist(err) {
-		return b.listFiles(vectorsCompressedBucketRoot, vectorsCompressedBasePath)
-	}
-	return nil, nil
 }


### PR DESCRIPTION
### What's being changed:

Backwards compatibility code around the `vector_compressed_` directories in the `lsmkv` that was added in v1.34 to handle downgrades was not removed in v1.36. Since v1.37, backups use `os.Link` to create snapshots to unblock compactions. In collections where this BC migration code fired, the `os.Link` attempts to hardlink the real `vector_compressed_` directory and the symlink into the same location throwing an error.

With this code removed, the symlink will no longer be listed by `ListFiles` and therefore will not be hard-linked.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
