### PR TITLE
fix(hnsw): preserve isolated nodes during compaction

### DIFF
--- a/adapters/repos/db/vector/hfresh/index_metadata_test.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata_test.go
@@ -13,10 +13,14 @@ package hfresh
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/compact"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 )
 
@@ -51,6 +55,43 @@ func TestQuantizationDataSurvivesRestart(t *testing.T) {
 	require.Equal(t, dataBefore.Rotation.Rounds, dataAfter.Rotation.Rounds)
 	require.Equal(t, dataBefore.Rotation.Swaps, dataAfter.Rotation.Swaps)
 	require.Equal(t, dataBefore.Rotation.Signs, dataAfter.Rotation.Signs)
+}
+
+func TestSingleCentroidSurvivesCompactionAndRestart(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+	vectors, _ := testinghelpers.RandomVecsFixedSeed(3, 1, 64)
+	cfg.VectorForIDThunk = func(_ context.Context, id uint64) ([]float32, error) {
+		return vectors[id], nil
+	}
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	for id, vector := range vectors {
+		require.NoError(t, index.Add(t.Context(), uint64(id), vector))
+	}
+	require.Eventually(t, func() bool { return index.taskQueue.Size() == 0 }, 10*time.Second, 10*time.Millisecond)
+
+	for round := 0; round < 3; round++ {
+		for _, vector := range vectors {
+			ids, _, err := index.SearchByVector(t.Context(), vector, len(vectors), nil)
+			require.NoError(t, err)
+			require.ElementsMatch(t, []uint64{0, 1, 2}, ids, "restart %d", round)
+		}
+		if round == 2 {
+			break
+		}
+		require.NoError(t, index.Shutdown(t.Context()))
+		dir := filepath.Join(cfg.RootPath, "centroids.hnsw.commitlog.d")
+		// A newer active WAL makes the closed log eligible for compaction,
+		// as happens on restart, regardless of the size of the closed log.
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "999999999999999999"), nil, 0o600))
+		compactor := compact.NewCompactor(compact.DefaultCompactorConfig(dir), cfg.Logger)
+		action, err := compactor.RunCycle(nil)
+		require.NoError(t, err)
+		if round == 0 {
+			require.Equal(t, compact.ActionCreateSnapshot, action)
+		}
+		index = makeHFreshWithConfig(t, store, cfg, uc)
+	}
 }
 
 func TestRestoreMetadataMigratesPostingMapV1ToV2(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/compact/compactor_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/compactor_test.go
@@ -12,6 +12,7 @@
 package compact
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,6 +21,64 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestCompactor_IsolatedNode(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		id    uint64
+		level uint16
+	}{
+		{name: "first HNSW object", id: 0},
+		{name: "first HFresh centroid", id: 1},
+		{name: "higher level node", id: 7, level: 3},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			logger := logrus.New()
+			compactor := NewCompactor(DefaultCompactorConfig(dir), logger)
+			for round := 0; round < 3; round++ {
+				name := fmt.Sprint(1000 + round)
+				f, err := os.Create(filepath.Join(dir, name))
+				require.NoError(t, err)
+				writer := NewWALWriter(f)
+				switch round {
+				case 0:
+					require.NoError(t, writer.WriteSetEntryPointMaxLevel(tc.id, tc.level))
+					require.NoError(t, writer.WriteAddNode(tc.id, tc.level))
+				case 1:
+					// A later log has no AddNode. It must not lower the stored level.
+					require.NoError(t, writer.WriteAddLinksAtLevel(tc.id, 0, nil))
+				case 2:
+					// Deletion must still win over the isolated node in the snapshot.
+					require.NoError(t, writer.WriteDeleteNode(tc.id))
+				}
+				require.NoError(t, f.Close())
+				createEmptyFile(t, dir, fmt.Sprint(1001+round))
+				// Force another snapshot even when the delta is smaller than 20%.
+				compactor.config.SnapshotThreshold = 0.000001
+				action, err := compactor.RunCycle(nil)
+				require.NoError(t, err)
+				require.Equal(t, ActionCreateSnapshot, action)
+				state, err := NewFileDiscovery(dir).Scan()
+				require.NoError(t, err)
+				require.NotNil(t, state.Snapshot)
+				res, err := NewSnapshotReader(logger).ReadFromFile(state.Snapshot.Path)
+				require.NoError(t, err)
+				if round == 2 {
+					if int(tc.id) < len(res.Graph.Nodes) {
+						require.Nil(t, res.Graph.Nodes[tc.id])
+					}
+					continue
+				}
+				require.Greater(t, len(res.Graph.Nodes), int(tc.id))
+				node := res.Graph.Nodes[tc.id]
+				require.NotNil(t, node, "isolated node must survive compaction round %d", round)
+				require.Equal(t, int(tc.level), node.Level)
+				require.Equal(t, tc.id, res.Graph.Entrypoint)
+			}
+		})
+	}
+}
 
 func TestCompactor_EmptyDirectory(t *testing.T) {
 	dir := t.TempDir()

--- a/adapters/repos/db/vector/hnsw/compact/nway_merger.go
+++ b/adapters/repos/db/vector/hnsw/compact/nway_merger.go
@@ -437,9 +437,9 @@ func (m *commitMerger) result() *NodeCommits {
 
 	for _, level := range levels {
 		links := m.linksPerLevel[level]
-		if len(links) == 0 {
-			continue
-		}
+		// Empty link records still carry state: they can be the only record
+		// of an isolated level-0 node, or replace links from an older file.
+		// Dropping them can erase the node or resurrect its old links.
 
 		if m.linksReplaced[level] {
 			commits = append(commits, &ReplaceLinksAtLevelCommit{

--- a/adapters/repos/db/vector/hnsw/compact/nway_merger_test.go
+++ b/adapters/repos/db/vector/hnsw/compact/nway_merger_test.go
@@ -12,6 +12,7 @@
 package compact
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -56,6 +57,59 @@ func TestNWayMerger_SingleIterator(t *testing.T) {
 	nodeCommits, err = merger.Next()
 	require.NoError(t, err)
 	assert.Nil(t, nodeCommits)
+}
+
+func TestNWayMerger_EmptyLinksSurviveRepeatedMerges(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		delta     Commit
+		wantLinks []uint64
+	}{
+		{
+			name:      "empty add preserves older links",
+			delta:     &AddLinksAtLevelCommit{Source: 5, Level: 0},
+			wantLinks: []uint64{2},
+		},
+		{
+			name:  "empty replace removes older links",
+			delta: &ReplaceLinksAtLevelCommit{Source: 5, Level: 0},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := logrus.New()
+			it, err := NewIterator(newFakeCommitReader([]Commit{tc.delta}), 1, logger)
+			require.NoError(t, err)
+			merger, err := NewNWayMerger([]IteratorLike{it}, logger)
+			require.NoError(t, err)
+			merged, err := merger.Next()
+			require.NoError(t, err)
+			require.NotNil(t, merged)
+			require.Len(t, merged.Commits, 1, "the empty link operation must survive a sorted-file merge")
+
+			// Merge that result with an older file. An empty replacement must
+			// still clear old links, while an empty addition must preserve them.
+			older, err := NewIterator(newFakeCommitReader([]Commit{
+				&AddNodeCommit{ID: 5, Level: 3},
+				&AddLinksAtLevelCommit{Source: 5, Level: 0, Targets: []uint64{2}},
+			}), 0, logger)
+			require.NoError(t, err)
+			newer, err := NewIterator(newFakeCommitReader(merged.Commits), 1, logger)
+			require.NoError(t, err)
+			merger, err = NewNWayMerger([]IteratorLike{older, newer}, logger)
+			require.NoError(t, err)
+			merged, err = merger.Next()
+			require.NoError(t, err)
+			require.NotNil(t, merged)
+			var buf bytes.Buffer
+			compactor := NewCompactor(DefaultCompactorConfig(t.TempDir()), logger)
+			require.NoError(t, compactor.writeNodeCommits(NewWALWriter(&buf), merged))
+			res, err := NewInMemoryReader(NewWALCommitReader(&buf, logger), logger).Do(nil, false)
+			require.NoError(t, err)
+			require.NotNil(t, res.Graph.Nodes[5])
+			require.Equal(t, 3, res.Graph.Nodes[5].Level)
+			require.ElementsMatch(t, tc.wantLinks, res.Graph.Nodes[5].Connections.GetLayer(0))
+		})
+	}
 }
 
 func TestNWayMerger_TwoIteratorsNoOverlap(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/persistence_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/persistence_integration_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/compact"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -36,6 +37,64 @@ import (
 type persistenceIntegrationNoopBucketView struct{}
 
 func (n *persistenceIntegrationNoopBucketView) ReleaseView() {}
+
+func TestHnswPersistence_IsolatedNodeSurvivesCompactionAndRestart(t *testing.T) {
+	for _, id := range []uint64{0, 1} {
+		t.Run(fmt.Sprintf("id_%d", id), func(t *testing.T) {
+			dir := t.TempDir()
+			const indexID = "isolated"
+			logger, _ := test.NewNullLogger()
+			store := testinghelpers.NewDummyStore(t)
+			cfg := Config{
+				AllocChecker: memwatch.NewDummyMonitor(),
+				RootPath:     dir,
+				ID:           indexID,
+				MakeCommitLoggerThunk: func(opts ...CommitlogOption) (CommitLogger, error) {
+					return NewCommitLogger(dir, indexID, logger, cyclemanager.NewCallbackGroupNoop(), opts...)
+				},
+				DistanceProvider: distancer.NewCosineDistanceProvider(),
+				VectorForIDThunk: testVectorForID,
+				GetViewThunk:     func() common.BucketView { return &persistenceIntegrationNoopBucketView{} },
+			}
+			uc := ent.UserConfig{MaxConnections: 30, EFConstruction: 60}
+			index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), store)
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				if index != nil {
+					require.NoError(t, index.Shutdown(context.Background()))
+				}
+			})
+			require.NoError(t, index.Add(t.Context(), id, testVectors[id]))
+
+			for round := 0; round < 3; round++ {
+				ids, _, err := index.SearchByVector(t.Context(), testVectors[id], 1, nil)
+				require.NoError(t, err)
+				require.Equal(t, []uint64{id}, ids, "search after %d compaction/restart rounds", round)
+				if round == 2 {
+					break
+				}
+
+				require.NoError(t, index.Flush())
+				require.NoError(t, index.Shutdown(t.Context()))
+				index = nil
+				logDir := filepath.Join(dir, indexID+".hnsw.commitlog.d")
+				// A newer active WAL makes the closed log eligible for compaction,
+				// as happens on restart, regardless of the closed log's size.
+				activeWAL := filepath.Join(logDir, "999999999999999999")
+				require.NoError(t, os.WriteFile(activeWAL, nil, 0o600))
+				compactor := compact.NewCompactor(compact.DefaultCompactorConfig(logDir), logger)
+				action, err := compactor.RunCycle(nil)
+				require.NoError(t, err)
+				if round == 0 {
+					require.Equal(t, compact.ActionCreateSnapshot, action)
+				}
+				require.NoError(t, os.Remove(activeWAL))
+				index, err = New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), store)
+				require.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestHnswPersistence(t *testing.T) {
 	dirName := t.TempDir()


### PR DESCRIPTION
### What's being changed:

Prevent HNSW compaction from dropping isolated level-0 nodes. A collection with one HFresh centroid (or one HNSW object) can return no search results after compaction and restart because the merger discards the empty link record that represents the node.

Preserve empty link records during merging. This also keeps empty replacements from resurrecting older links. Regression tests cover repeated merges and snapshots, node levels and deletion, and three-object HFresh searches after compaction and restart. Recovery of already damaged indexes is deferred to a separate change.

Refs weaviate/0-weaviate-issues#660.

Validation:
- Full `hnsw/compact` and `hfresh` package tests passed.
- Relocated regression tests passed again in the existing test files.
- `golangci-lint run ./...` reported 0 issues; the goroutine linter and `git diff --check` passed.

### Review checklist

- [x] Documentation has been updated, if necessary. No public API or configuration changes.
- [x] Chaos pipeline run or not necessary. Covered by deterministic compaction and restart tests.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. This preserves existing empty link records in the compaction path.
