### PR TITLE
fix(hfresh): recover orphaned postings through reassign-all

### DIFF
--- a/adapters/repos/db/vector/hfresh/reassign.go
+++ b/adapters/repos/db/vector/hfresh/reassign.go
@@ -58,6 +58,11 @@ func (h *HFresh) doReassign(ctx context.Context, op reassignOperation) error {
 	if !needsReassign {
 		return nil
 	}
+	if replicas.Len() == 0 {
+		// Preserve the surviving copies if the centroid graph has no usable
+		// destination. EnqueueReassignAll can bootstrap one before retrying.
+		return errors.Errorf("no destination postings for vector %d", op.VectorID)
+	}
 
 	// increment the vector version. this will invalidate all the existing copies
 	// of the vector in other postings.

--- a/adapters/repos/db/vector/hfresh/reassign_all.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all.go
@@ -37,6 +37,8 @@ type ReassignAllStats struct {
 // operation is proportional to how many vectors are actually misplaced, not
 // to the corpus size. Stale entries (version mismatch) and deleted vectors
 // are skipped so each reassignment is anchored to the vector's live copy.
+// Before enqueueing the first live vector, ensure a destination exists so an
+// index whose centroid graph was lost can recover its surviving postings.
 //
 // This exists to repair placement damage persisted by indexes built before
 // the reassignment-gate fixes: an idle index runs no maintenance that could
@@ -54,6 +56,7 @@ func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, erro
 	if quantizer == nil {
 		return stats, errors.New("index is not initialized")
 	}
+	var destinationChecked bool
 
 	// The posting map enumerates the allocated posting IDs; the posting is
 	// still read from the store because only its entries carry the per-copy
@@ -88,6 +91,28 @@ func (h *HFresh) EnqueueReassignAll(ctx context.Context) (ReassignAllStats, erro
 			if version != v.Version() {
 				stats.SkippedStale++
 				continue
+			}
+
+			if !destinationChecked {
+				vector, err := h.config.VectorForIDThunk(ctx, v.ID())
+				if err != nil {
+					return stats, errors.Wrapf(err, "failed to read vector %d for initial posting", v.ID())
+				}
+				if err := h.ValidateBeforeInsert(vector); err != nil {
+					return stats, errors.Wrapf(err, "invalid vector %d for initial posting", v.ID())
+				}
+				if err := ctx.Err(); err != nil {
+					return stats, err
+				}
+				if err := h.ctx.Err(); err != nil {
+					return stats, err
+				}
+				vector = h.normalizeVec(vector)
+				compressed := quantizer.CompressedBytes(quantizer.Encode(vector))
+				if _, err := h.ensureInitialPosting(vector, compressed); err != nil {
+					return stats, errors.Wrap(err, "failed to ensure initial posting for reassignment")
+				}
+				destinationChecked = true
 			}
 
 			err = h.taskQueue.EnqueueReassign(postingID, v.ID())

--- a/adapters/repos/db/vector/hfresh/reassign_all_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_all_test.go
@@ -13,10 +13,143 @@ package hfresh
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 )
+
+func TestEnqueueReassignAllRecoversEmptyCentroidGraph(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+	vectors := &testVectorStore{m: make(map[uint64][]float32)}
+	cfg.VectorForIDThunk = vectors.get
+	t.Cleanup(func() { cfg.Scheduler.Close(context.Background()) })
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+	tf := TestHFresh{Index: index, Vectors: vectors}
+	vecs := make([][]float32, 3)
+	for i := range vecs {
+		vecs[i] = make([]float32, 64)
+		vecs[i][i] = 1
+	}
+	require.NoError(t, index.initDimensions(vecs[0]))
+	// Model the compacted graph losing its sole centroid while the posting,
+	// its membership, and the source vectors survive.
+	postingID, posting := createPostingWithVectors(t, &tf, vecs, 100)
+	require.NoError(t, index.PostingStore.Put(t.Context(), postingID, posting))
+	require.NoError(t, index.setPostingVectorIDs(t.Context(), postingID, posting))
+	ids, _, err := index.SearchByVector(t.Context(), vecs[0], 3, nil)
+	require.NoError(t, err)
+	require.Empty(t, ids)
+
+	for round := 0; round < 2; round++ {
+		stats, err := index.EnqueueReassignAll(t.Context())
+		require.NoError(t, err)
+		require.Positive(t, stats.Enqueued)
+		destinations, err := index.Centroids.Search(vecs[0], 10, nil)
+		require.NoError(t, err)
+		require.Len(t, destinations.data, 1, "a retry must reuse the recovered centroid")
+		require.NotEqual(t, postingID, destinations.data[0].ID)
+		_, err = index.taskQueue.reassignQueue.ForceSwitch(t.Context(), cfg.RootPath)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool { return index.taskQueue.reassignQueue.Size() == 0 }, 10*time.Second, 10*time.Millisecond)
+		for id := uint64(100); id < 103; id++ {
+			version, err := index.VersionMap.Get(t.Context(), id)
+			require.NoError(t, err)
+			require.Equal(t, VectorVersion(2), version, "retry must not reassign an already healthy vector")
+		}
+		for _, result := range destinations.data {
+			p, err := index.PostingStore.Get(t.Context(), result.ID)
+			require.NoError(t, err)
+			p, err = p.GarbageCollect(index.VersionMap)
+			require.NoError(t, err)
+			require.Len(t, p, 3)
+			require.NoError(t, index.PostingStore.Put(t.Context(), result.ID, p))
+			require.NoError(t, index.setPostingVectorIDs(t.Context(), result.ID, p))
+		}
+		ids, _, err = index.SearchByVector(t.Context(), vecs[0], 3, nil)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []uint64{100, 101, 102}, ids)
+	}
+
+	require.NoError(t, index.Shutdown(t.Context()))
+	index = makeHFreshWithConfig(t, store, cfg, uc)
+	ids, _, err = index.SearchByVector(t.Context(), vecs[0], 3, nil)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []uint64{100, 101, 102}, ids, "recovery must survive restart")
+}
+
+func TestEnqueueReassignAllBootstrapFailureIsRetryable(t *testing.T) {
+	for _, failure := range []string{"read error", "invalid dimensions", "canceled read"} {
+		t.Run(failure, func(t *testing.T) {
+			tf := createHFreshIndex(t)
+			postingID, posting := createPostingWithVectors(t, &tf, [][]float32{{1, 0, 0, 0}}, 100)
+			require.NoError(t, tf.Index.PostingStore.Put(t.Context(), postingID, posting))
+			require.NoError(t, tf.Index.setPostingVectorIDs(t.Context(), postingID, posting))
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			tf.Index.config.VectorForIDThunk = func(context.Context, uint64) ([]float32, error) {
+				switch failure {
+				case "read error":
+					return nil, errors.New("source unavailable")
+				case "invalid dimensions":
+					return []float32{1}, nil
+				default:
+					cancel()
+					return []float32{1, 0, 0, 0}, nil
+				}
+			}
+			stats, err := tf.Index.EnqueueReassignAll(ctx)
+			require.Error(t, err)
+			require.Zero(t, stats.Enqueued)
+			require.Zero(t, tf.Index.taskQueue.reassignQueue.Size())
+			version, err := tf.Index.VersionMap.Get(t.Context(), 100)
+			require.NoError(t, err)
+			require.Equal(t, VectorVersion(1), version)
+			destinations, err := tf.Index.Centroids.Search([]float32{1, 0, 0, 0}, 10, nil)
+			require.NoError(t, err)
+			require.Empty(t, destinations.data)
+
+			tf.Index.config.VectorForIDThunk = tf.Vectors.get
+			stats, err = tf.Index.EnqueueReassignAll(t.Context())
+			require.NoError(t, err)
+			require.Equal(t, 1, stats.Enqueued)
+		})
+	}
+}
+
+func TestEnqueueReassignAllConcurrentBootstrap(t *testing.T) {
+	tf := createHFreshIndex(t)
+	postingID, posting := createPostingWithVectors(t, &tf, [][]float32{{1, 0, 0, 0}}, 100)
+	require.NoError(t, tf.Index.PostingStore.Put(t.Context(), postingID, posting))
+	require.NoError(t, tf.Index.setPostingVectorIDs(t.Context(), postingID, posting))
+	// Hold the queued work so this test isolates concurrent bootstrap calls.
+	require.NoError(t, tf.Index.taskQueue.reassignQueue.Pause(t.Context()))
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for range 2 {
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			_, err := tf.Index.EnqueueReassignAll(t.Context())
+			errs <- err
+		}, tf.Index.logger)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	destinations, err := tf.Index.Centroids.Search([]float32{1, 0, 0, 0}, 10, nil)
+	require.NoError(t, err)
+	require.Len(t, destinations.data, 1)
+	require.NotEqual(t, postingID, destinations.data[0].ID)
+	require.Equal(t, int64(1), tf.Index.taskQueue.reassignQueue.Size())
+}
 
 func TestEnqueueReassignAllUninitialized(t *testing.T) {
 	tf := createHFreshIndex(t)

--- a/adapters/repos/db/vector/hfresh/reassign_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_test.go
@@ -20,6 +20,21 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 )
 
+func TestReassignWithoutDestinationsPreservesVector(t *testing.T) {
+	tf := createHFreshIndex(t)
+	postingID, posting := createPostingWithVectors(t, &tf, [][]float32{{1, 0, 0, 0}}, 100)
+
+	err := tf.Index.doReassign(t.Context(), reassignOperation{PostingID: postingID, VectorID: 100})
+	require.ErrorContains(t, err, "no destination postings")
+
+	version, err := tf.Index.VersionMap.Get(t.Context(), 100)
+	require.NoError(t, err)
+	require.Equal(t, VectorVersion(1), version)
+	retained, err := posting.GarbageCollect(tf.Index.VersionMap)
+	require.NoError(t, err)
+	require.Len(t, retained, 1, "failed reassignment must not invalidate the surviving copy")
+}
+
 // Reassign a vector that has been deleted
 func TestReassignDeletedVector(t *testing.T) {
 	tf := createHFreshIndex(t)


### PR DESCRIPTION
### What's being changed:

When HFresh loses its centroid graph during compaction, posting contents can survive while searches return no results. The existing `POST /debug/index/reassign/vector` operation currently finds those vectors but cannot recover them without a destination; its workers can advance their versions without writing replacement copies.

Before enqueueing the first live vector, `EnqueueReassignAll` now uses the existing initial-posting helper to ensure a destination exists. Reassignment workers also reject an empty destination list before advancing the version, preserving surviving copies for a retry. The operation keeps the index open and adds no pause to searches or writes.

Deploy the compaction fix in #13033 before running recovery, so later compaction does not remove the recovered centroid again. This change recovers surviving current-version copies discoverable through the posting map; it does not reconstruct vectors missing from that map.

### Validation

- Full HFresh test suite passed; reassignment tests passed with the race detector.
- Added regressions for empty-destination safety, recovery through the task queue, garbage collection, restart, repeated scans, bootstrap failures and concurrent bootstrap calls.
- Additional local validation used the actual buggy compactor: three objects became unsearchable after compaction/restart and were recovered by reassign-all. The same experiment passed for version-4 vectors and for data added after corruption. All three scenarios passed with race detection, garbage collection, repeated recovery and restart. This experiment used a temporary test overlay; disabling the bootstrap made the recovery test fail.
- Repository-wide lint, the goroutine linter and `git diff --check` passed.

### Review checklist

- [x] Documentation has been updated, if necessary. Existing debug endpoint; behavior documented in code and above.
- [x] Chaos pipeline run or not necessary. Targeted compaction/recovery/restart tests used; no chaos pipeline run.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. No load benchmark; the bootstrap runs once per explicit scan.
