### PR TITLE
feat(debug): make shard optional for HFresh reassignment

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/adapters/repos/db"
@@ -216,90 +217,19 @@ func setupDebugHandlers(appState *state.State) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
-	// Enqueues a reassignment for every live vector of one shard's hfresh
-	// index, re-routing vectors that earlier maintenance left in the wrong
-	// postings. The reassignment tasks only write for vectors whose current
+	// Enqueues a reassignment for every live vector of a shard's hfresh
+	// index (or all local shards when shard is omitted), re-routing vectors
+	// that earlier maintenance left in the wrong postings. The reassignment tasks only write for vectors whose current
 	// posting is no longer among their RNG-selected targets, so this is safe
 	// to run on a healthy index. Call via something like:
 	// curl -X POST "localhost:6060/debug/index/reassign/vector?collection=Foo&shard=abc123&vector=default"
-	http.HandleFunc("/debug/index/reassign/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// unlike its read-only siblings, this endpoint starts a corpus-wide
-		// mutating job — do not let a probing GET trigger it
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed, use POST", http.StatusMethodNotAllowed)
-			return
-		}
-
-		colName := r.URL.Query().Get("collection")
-		shardName := r.URL.Query().Get("shard")
-		targetVector := r.URL.Query().Get("vector")
-
-		if colName == "" || shardName == "" {
-			http.Error(w, "collection and shard are required", http.StatusBadRequest)
-			return
-		}
-
-		idx := appState.DB.GetIndex(schema.ClassName(colName))
+	// Omit shard to enqueue all local shards of the collection.
+	http.HandleFunc("/debug/index/reassign/vector", newHFreshReassignHandler(logger, func(name schema.ClassName) hfreshReassignIndex {
+		idx := appState.DB.GetIndex(name)
 		if idx == nil {
-			logger.WithField("collection", colName).Error("collection not found")
-			http.Error(w, "collection not found", http.StatusNotFound)
-			return
+			return nil
 		}
-
-		shard, release, err := idx.GetShard(context.Background(), shardName)
-		if err != nil {
-			logger.WithField("shard", shardName).Error(err)
-			http.Error(w, err.Error(), http.StatusNotFound)
-			return
-		}
-		if shard == nil {
-			release()
-			logger.WithField("shard", shardName).Error("shard not found")
-			http.Error(w, "shard not found", http.StatusNotFound)
-			return
-		}
-
-		vidx, ok := shard.GetVectorIndex(targetVector)
-		if !ok {
-			release()
-			logger.WithField("shard", shardName).Error("vector index not found")
-			http.Error(w, "vector index not found", http.StatusNotFound)
-			return
-		}
-
-		h, ok := vidx.(hfreshReassignAller)
-		if !ok {
-			release()
-			http.Error(w, "not an hfresh index", http.StatusBadRequest)
-			return
-		}
-
-		// The scan needs no shard reference: EnqueueReassignAll also watches
-		// the index's own lifecycle context and stops when the shard shuts
-		// down or is dropped, like the version map warmup does.
-		release()
-
-		reassignLogger := logger.
-			WithField("collection", colName).
-			WithField("shard", shardName).
-			WithField("targetVector", targetVector)
-
-		enterrors.GoWrapper(func() {
-			stats, err := h.EnqueueReassignAll(context.Background())
-			statsLogger := reassignLogger.
-				WithField("postings", stats.Postings).
-				WithField("enqueued", stats.Enqueued).
-				WithField("skippedDeleted", stats.SkippedDeleted).
-				WithField("skippedStale", stats.SkippedStale)
-			if err != nil {
-				statsLogger.Error(err)
-				return
-			}
-			statsLogger.Info("reassign-all enqueue completed")
-		}, reassignLogger)
-
-		reassignLogger.Info("reassign-all enqueue started")
-		w.WriteHeader(http.StatusAccepted)
+		return idx
 	}))
 
 	http.HandleFunc("/debug/stats/collection/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -982,6 +912,101 @@ type MaintenanceMode struct {
 
 type hnswStats interface {
 	Stats() (*hnsw.HnswStats, error)
+}
+
+type hfreshReassignIndex interface {
+	GetShard(context.Context, string) (db.ShardLike, func(), error)
+	ForEachShard(func(string, db.ShardLike) error) error
+}
+
+func newHFreshReassignHandler(logger logrus.FieldLogger, getIndex func(schema.ClassName) hfreshReassignIndex) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// This starts a mutating job; a probing GET must not trigger it.
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed, use POST", http.StatusMethodNotAllowed)
+			return
+		}
+
+		colName := r.URL.Query().Get("collection")
+		shardName := r.URL.Query().Get("shard")
+		targetVector := r.URL.Query().Get("vector")
+		if colName == "" {
+			http.Error(w, "collection is required", http.StatusBadRequest)
+			return
+		}
+		idx := getIndex(schema.ClassName(colName))
+		if idx == nil {
+			http.Error(w, "collection not found", http.StatusNotFound)
+			return
+		}
+
+		reassignLogger := logger.WithField("collection", colName).WithField("targetVector", targetVector)
+		if shardName == "" {
+			// Walk local shards in the background, scanning one at a time so
+			// a large collection does not launch a scan goroutine per shard.
+			enterrors.GoWrapper(func() {
+				err := idx.ForEachShard(func(name string, _ db.ShardLike) error {
+					shardLogger := reassignLogger.WithField("shard", name)
+					h, _, err := getHFreshReassigner(idx, name, targetVector)
+					if err != nil {
+						shardLogger.Errorf("failed to start reassign-all: %v", err)
+						return nil
+					}
+					enqueueHFreshReassign(h, shardLogger)
+					return nil
+				})
+				if err != nil {
+					reassignLogger.Errorf("failed to iterate local shards for reassign-all: %v", err)
+				}
+			}, reassignLogger)
+			reassignLogger.Info("reassign-all started for all local shards")
+		} else {
+			h, status, err := getHFreshReassigner(idx, shardName, targetVector)
+			if err != nil {
+				http.Error(w, err.Error(), status)
+				return
+			}
+			shardLogger := reassignLogger.WithField("shard", shardName)
+			enterrors.GoWrapper(func() { enqueueHFreshReassign(h, shardLogger) }, shardLogger)
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}
+}
+
+func getHFreshReassigner(idx hfreshReassignIndex, shardName, targetVector string) (hfreshReassignAller, int, error) {
+	shard, release, err := idx.GetShard(context.Background(), shardName)
+	if err != nil {
+		return nil, http.StatusNotFound, err
+	}
+	// The scan watches HFresh's lifecycle context itself; retain the shard
+	// reference only while resolving its vector index, as for a single shard.
+	defer release()
+	if shard == nil {
+		return nil, http.StatusNotFound, fmt.Errorf("shard not found")
+	}
+	vidx, ok := shard.GetVectorIndex(targetVector)
+	if !ok {
+		return nil, http.StatusNotFound, fmt.Errorf("vector index not found")
+	}
+	h, ok := vidx.(hfreshReassignAller)
+	if !ok {
+		return nil, http.StatusBadRequest, fmt.Errorf("not an hfresh index")
+	}
+	return h, http.StatusAccepted, nil
+}
+
+func enqueueHFreshReassign(h hfreshReassignAller, logger logrus.FieldLogger) {
+	logger.Info("reassign-all enqueue started")
+	stats, err := h.EnqueueReassignAll(context.Background())
+	statsLogger := logger.WithField("postings", stats.Postings).
+		WithField("enqueued", stats.Enqueued).
+		WithField("skippedDeleted", stats.SkippedDeleted).
+		WithField("skippedStale", stats.SkippedStale)
+	if err != nil {
+		statsLogger.Errorf("reassign-all enqueue failed: %v", err)
+		return
+	}
+	statsLogger.Info("reassign-all enqueue completed")
 }
 
 type hfreshReassignAller interface {

--- a/adapters/handlers/rest/handlers_debug_test.go
+++ b/adapters/handlers/rest/handlers_debug_test.go
@@ -12,12 +12,23 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hfresh"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/schema"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	ucfg "github.com/weaviate/weaviate/usecases/config"
@@ -173,4 +184,171 @@ func TestRedactDebugConfigSecrets_RealConfigPipeline(t *testing.T) {
 
 	sentryM, _ := cleaned["sentry"].(map[string]any)
 	assert.Equal(t, "<redacted>", sentryM["dsn"])
+}
+
+type debugReassignTestIndex struct {
+	names       []string
+	shards      map[string]*debugReassignTestShard
+	lookupError string
+	walkDone    chan struct{}
+}
+
+func (i *debugReassignTestIndex) GetShard(_ context.Context, name string) (db.ShardLike, func(), error) {
+	if name == i.lookupError {
+		return nil, func() {}, errors.New("shard unavailable")
+	}
+	shard := i.shards[name]
+	if shard == nil {
+		return nil, func() {}, nil
+	}
+	shard.released.Store(false)
+	return shard, func() { shard.released.Store(true) }, nil
+}
+
+func (i *debugReassignTestIndex) ForEachShard(fn func(string, db.ShardLike) error) error {
+	defer close(i.walkDone)
+	for _, name := range i.names {
+		if err := fn(name, i.shards[name]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type debugReassignTestShard struct {
+	db.ShardLike
+	index    db.VectorIndex
+	target   string
+	released atomic.Bool
+}
+
+func (s *debugReassignTestShard) GetVectorIndex(target string) (db.VectorIndex, bool) {
+	s.target = target
+	return s.index, s.index != nil
+}
+
+type debugReassignTestVector struct {
+	db.VectorIndex
+	run func() (hfresh.ReassignAllStats, error)
+}
+
+func (v *debugReassignTestVector) EnqueueReassignAll(context.Context) (hfresh.ReassignAllStats, error) {
+	return v.run()
+}
+
+func TestHFreshReassignHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, query string
+		missingCollection   bool
+		status              int
+		want                []string
+		all                 bool
+	}{
+		{name: "single shard", method: http.MethodPost, query: "collection=Movies&shard=a&vector=description", status: 202, want: []string{"a"}},
+		{name: "all shards", method: http.MethodPost, query: "collection=Movies&vector=description", status: 202, want: []string{"a", "b"}, all: true},
+		{name: "explicit empty shard", method: http.MethodPost, query: "collection=Movies&shard=&vector=description", status: 202, want: []string{"a", "b"}, all: true},
+		{name: "missing collection argument", method: http.MethodPost, query: "shard=a", status: 400},
+		{name: "unknown collection", method: http.MethodPost, query: "collection=Missing", missingCollection: true, status: 404},
+		{name: "shard lookup failure", method: http.MethodPost, query: "collection=Movies&shard=unavailable", status: 404},
+		{name: "unknown shard", method: http.MethodPost, query: "collection=Movies&shard=missing", status: 404},
+		{name: "missing vector", method: http.MethodPost, query: "collection=Movies&shard=no-vector", status: 404},
+		{name: "non hfresh", method: http.MethodPost, query: "collection=Movies&shard=non-hfresh", status: 400},
+		{name: "get cannot enqueue", method: http.MethodGet, query: "collection=Movies", status: 405},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			calls := make(chan string, 4)
+			idx := &debugReassignTestIndex{names: []string{"a", "missing", "unavailable", "no-vector", "non-hfresh", "b"}, lookupError: "unavailable", shards: map[string]*debugReassignTestShard{}, walkDone: make(chan struct{})}
+			for _, name := range []string{"a", "b"} {
+				shard := &debugReassignTestShard{}
+				shard.index = &debugReassignTestVector{run: func() (hfresh.ReassignAllStats, error) {
+					assert.True(t, shard.released.Load(), "release shard reference before the scan")
+					assert.Equal(t, "description", shard.target)
+					calls <- name
+					if name == "a" {
+						return hfresh.ReassignAllStats{}, errors.New("scan failed")
+					}
+					return hfresh.ReassignAllStats{}, nil
+				}}
+				idx.shards[name] = shard
+			}
+			idx.shards["no-vector"] = &debugReassignTestShard{}
+			idx.shards["non-hfresh"] = &debugReassignTestShard{index: &dbVectorIndexWithoutReassign{}}
+			handler := newHFreshReassignHandler(logger, func(name schema.ClassName) hfreshReassignIndex {
+				if tc.missingCollection {
+					return nil
+				}
+				assert.Equal(t, schema.ClassName("Movies"), name)
+				return idx
+			})
+			rec := httptest.NewRecorder()
+			handler(rec, httptest.NewRequest(tc.method, "/debug/index/reassign/vector?"+tc.query, nil))
+			require.Equal(t, tc.status, rec.Code)
+			var got []string
+			for range tc.want {
+				select {
+				case name := <-calls:
+					got = append(got, name)
+				case <-time.After(5 * time.Second):
+					t.Fatal("reassignment did not start")
+				}
+			}
+			if tc.all {
+				select {
+				case <-idx.walkDone:
+				case <-time.After(5 * time.Second):
+					t.Fatal("shard walk did not finish")
+				}
+			}
+			require.ElementsMatch(t, tc.want, got)
+			require.Empty(t, calls)
+		})
+	}
+}
+
+type dbVectorIndexWithoutReassign struct{ db.VectorIndex }
+
+func TestHFreshReassignAllShardsRunsInBackground(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	unblock := make(chan struct{})
+	defer close(unblock)
+	started := make(chan string, 2)
+	idx := &debugReassignTestIndex{names: []string{"a", "b"}, shards: map[string]*debugReassignTestShard{}, walkDone: make(chan struct{})}
+	for _, name := range idx.names {
+		idx.shards[name] = &debugReassignTestShard{index: &debugReassignTestVector{run: func() (hfresh.ReassignAllStats, error) {
+			started <- name
+			if name == "a" {
+				<-unblock
+			}
+			return hfresh.ReassignAllStats{}, nil
+		}}}
+	}
+	handler := newHFreshReassignHandler(logger, func(schema.ClassName) hfreshReassignIndex { return idx })
+	rec := httptest.NewRecorder()
+	returned := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		handler(rec, httptest.NewRequest(http.MethodPost, "/debug/index/reassign/vector?collection=Movies", nil))
+		close(returned)
+	}, logger)
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("HTTP response waited for shard scan to complete")
+	}
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	select {
+	case name := <-started:
+		require.Equal(t, "a", name)
+	case <-time.After(5 * time.Second):
+		t.Fatal("first shard did not start")
+	}
+	require.Empty(t, started, "second shard must wait until the first scan finishes")
+	// Unblock the first scan, then wait for the worker to exit before the test ends.
+	unblock <- struct{}{}
+	select {
+	case <-idx.walkDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("all-shard scan did not finish")
+	}
+	require.Equal(t, "b", <-started)
 }


### PR DESCRIPTION
### What's being changed:

`POST /debug/index/reassign/vector` currently requires a shard name. Omitting `shard` (or passing `shard=`) now starts reassignment for all local shards of the selected collection, using the same vector name for each shard:

```sh
curl -X POST "http://localhost:6060/debug/index/reassign/vector?collection=Movies&vector=default"
```

One background worker scans shards sequentially, releasing each shard reference before starting its HFresh scan. A missing/unavailable shard, missing vector index, unsupported index type, or failed scan is logged without stopping the remaining shards. The response is `202 Accepted`; per-shard logs report enqueue results.

Supplying `shard` preserves the existing single-shard behavior and validation. This debug endpoint operates on the receiving node; it does not forward to other nodes. Collections still require `collection`, and named vectors still require the appropriate `vector` parameter.

### Validation

- Full REST package tests passed with the race detector.
- Handler regressions cover omitted/empty shard, explicit shard, named-vector forwarding, invalid requests, lookup/type/scan failures, and continuing to subsequent shards.
- A blocked scan test verifies that the HTTP response returns immediately and shard scans run sequentially.
- Repository-wide lint, goroutine lint and `git diff --check` passed. Code review found no blockers.

### Review checklist

- [x] Documentation has been updated, if necessary. Endpoint comment and usage example above describe the optional shard and node-local scope.
- [x] Chaos pipeline run or not necessary. Request dispatch change covered by handler tests; no chaos pipeline run.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. No benchmark; the all-shards path uses one sequential background worker.
