### PR TITLE
feat(debug): make shard optional for vector index repair

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
+	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/adapters/repos/db"
@@ -131,49 +132,13 @@ func setupDebugHandlers(appState *state.State) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
-	http.HandleFunc("/debug/index/repair/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !appState.DB.AsyncIndexingEnabled {
-			http.Error(w, "async indexing is not enabled", http.StatusNotImplemented)
-			return
-		}
-
-		colName := r.URL.Query().Get("collection")
-		shardName := r.URL.Query().Get("shard")
-		targetVector := r.URL.Query().Get("vector")
-
-		if colName == "" || shardName == "" {
-			http.Error(w, "collection and shard are required", http.StatusBadRequest)
-			return
-		}
-
-		idx := appState.DB.GetIndex(schema.ClassName(colName))
+	// Omit shard to repair all local shards of the collection in the background.
+	http.HandleFunc("/debug/index/repair/vector", newVectorRepairHandler(logger, appState.DB.AsyncIndexingEnabled, func(name schema.ClassName) vectorRepairIndex {
+		idx := appState.DB.GetIndex(name)
 		if idx == nil {
-			logger.WithField("collection", colName).Error("collection not found")
-			http.Error(w, "collection not found", http.StatusNotFound)
-			return
+			return nil
 		}
-
-		err := idx.DebugRepairIndex(context.Background(), shardName, targetVector)
-		if err != nil {
-			logger.
-				WithField("shard", shardName).
-				WithField("targetVector", targetVector).
-				WithError(err).
-				Error("failed to repair vector index")
-			if errTxt := err.Error(); strings.Contains(errTxt, "not found") {
-				http.Error(w, "shard not found", http.StatusNotFound)
-			}
-
-			http.Error(w, "failed to repair vector index", http.StatusInternalServerError)
-			return
-		}
-
-		logger.
-			WithField("shard", shardName).
-			WithField("targetVector", targetVector).
-			Info("repair started")
-
-		w.WriteHeader(http.StatusAccepted)
+		return idx
 	}))
 
 	http.HandleFunc("/debug/index/requantize/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -982,6 +947,64 @@ type MaintenanceMode struct {
 
 type hnswStats interface {
 	Stats() (*hnsw.HnswStats, error)
+}
+
+type vectorRepairIndex interface {
+	DebugRepairIndex(context.Context, string, string) error
+}
+
+func newVectorRepairHandler(logger logrus.FieldLogger, asyncEnabled bool, getIndex func(schema.ClassName) vectorRepairIndex) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if !asyncEnabled {
+			http.Error(w, "async indexing is not enabled", http.StatusNotImplemented)
+			return
+		}
+
+		colName := r.URL.Query().Get("collection")
+		shardName := r.URL.Query().Get("shard")
+		targetVector := r.URL.Query().Get("vector")
+
+		if colName == "" {
+			http.Error(w, "collection is required", http.StatusBadRequest)
+			return
+		}
+
+		idx := getIndex(schema.ClassName(colName))
+		if idx == nil {
+			logger.WithField("collection", colName).Error("collection not found")
+			http.Error(w, "collection not found", http.StatusNotFound)
+			return
+		}
+
+		err := idx.DebugRepairIndex(context.Background(), shardName, targetVector)
+		if err != nil {
+			logger.
+				WithField("collection", colName).
+				WithField("shard", shardName).
+				WithField("targetVector", targetVector).
+				Errorf("failed to repair vector index: %v", err)
+			if errTxt := err.Error(); strings.Contains(errTxt, "not found") {
+				http.Error(w, "shard not found", http.StatusNotFound)
+				return
+			}
+
+			http.Error(w, "failed to repair vector index", http.StatusInternalServerError)
+			return
+		}
+
+		logger.
+			WithField("collection", colName).
+			WithField("shard", shardName).
+			WithField("targetVector", targetVector).
+			Info("vector index repair accepted (empty shard selects all local shards)")
+
+		w.WriteHeader(http.StatusAccepted)
+	}
 }
 
 type hfreshReassignAller interface {

--- a/adapters/handlers/rest/handlers_debug_test.go
+++ b/adapters/handlers/rest/handlers_debug_test.go
@@ -12,12 +12,17 @@
 package rest
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/entities/schema"
 	entsentry "github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	ucfg "github.com/weaviate/weaviate/usecases/config"
@@ -173,4 +178,55 @@ func TestRedactDebugConfigSecrets_RealConfigPipeline(t *testing.T) {
 
 	sentryM, _ := cleaned["sentry"].(map[string]any)
 	assert.Equal(t, "<redacted>", sentryM["dsn"])
+}
+
+type debugRepairTestIndex struct{ repair func(string, string) error }
+
+func (i *debugRepairTestIndex) DebugRepairIndex(_ context.Context, shard, vector string) error {
+	return i.repair(shard, vector)
+}
+
+func TestVectorRepairHandler(t *testing.T) {
+	for _, tc := range []struct {
+		name, method, query, shard, vector string
+		disabled, missing                  bool
+		repairErr                          error
+		status                             int
+		called                             bool
+	}{
+		{name: "single shard", method: "POST", query: "collection=Movies&shard=a&vector=description", shard: "a", vector: "description", status: 202, called: true},
+		{name: "all shards", method: "POST", query: "collection=Movies", status: 202, called: true},
+		{name: "all shards named vector", method: "POST", query: "collection=Movies&shard=&vector=description", vector: "description", status: 202, called: true},
+		{name: "missing collection", method: "POST", query: "shard=a", status: 400},
+		{name: "unknown collection", method: "POST", query: "collection=Movies", missing: true, status: 404},
+		{name: "missing shard", method: "POST", query: "collection=Movies&shard=missing", shard: "missing", repairErr: errors.New("shard not found"), status: 404, called: true},
+		{name: "repair start failure", method: "POST", query: "collection=Movies&shard=a", shard: "a", repairErr: errors.New("shard closing"), status: 500, called: true},
+		{name: "async disabled", method: "POST", query: "collection=Movies", disabled: true, status: 501},
+		{name: "get cannot repair", method: "GET", query: "collection=Movies", status: 405},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			called := false
+			idx := &debugRepairTestIndex{repair: func(shard, vector string) error {
+				called = true
+				require.Equal(t, tc.shard, shard)
+				require.Equal(t, tc.vector, vector)
+				return tc.repairErr
+			}}
+			handler := newVectorRepairHandler(logger, !tc.disabled, func(name schema.ClassName) vectorRepairIndex {
+				require.Equal(t, schema.ClassName("Movies"), name)
+				if tc.missing {
+					return nil
+				}
+				return idx
+			})
+			rec := httptest.NewRecorder()
+			handler(rec, httptest.NewRequest(tc.method, "/debug/index/repair/vector?"+tc.query, nil))
+			require.Equal(t, tc.status, rec.Code)
+			require.Equal(t, tc.called, called)
+			if tc.status == 404 {
+				require.NotContains(t, rec.Body.String(), "failed to repair vector index")
+			}
+		})
+	}
 }

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -4537,23 +4537,52 @@ func (i *Index) DebugResetVectorIndex(ctx context.Context, shardName, targetVect
 	return nil
 }
 
+// DebugRepairIndex repairs the selected shard, or all local shards when shardName
+// is empty. Repairs run in the background, sequentially for an all-shards request.
 func (i *Index) DebugRepairIndex(ctx context.Context, shardName, targetVector string) error {
+	repair := func(name string, shard ShardLike, release func()) {
+		defer release()
+		if err := shard.RepairIndex(context.Background(), targetVector); err != nil {
+			i.logger.WithField("shard", name).WithField("targetVector", targetVector).
+				Errorf("failed to repair vector index: %v", err)
+		}
+	}
+
+	if shardName == "" {
+		enterrors.GoWrapper(func() {
+			err := i.ForEachShard(func(name string, _ ShardLike) error {
+				shard, release, err := i.GetShard(context.Background(), name)
+				if err != nil || shard == nil {
+					release()
+					if err == nil {
+						err = errors.New("shard not found")
+					}
+					i.logger.WithField("shard", name).WithField("targetVector", targetVector).
+						Errorf("failed to get shard for vector index repair: %v", err)
+					return nil
+				}
+				repair(name, shard, release)
+				return nil
+			})
+			if err != nil {
+				i.logger.Errorf("failed to iterate shards for vector index repair: %v", err)
+			}
+		}, i.logger)
+		return nil
+	}
+
 	shard, release, err := i.GetShard(ctx, shardName)
 	if err != nil {
+		release()
 		return err
 	}
-	defer release()
 	if shard == nil {
+		release()
 		return errors.New("shard not found")
 	}
 
-	// Repair in the background
 	enterrors.GoWrapper(func() {
-		err := shard.RepairIndex(context.Background(), targetVector)
-		if err != nil {
-			i.logger.WithField("shard", shardName).WithError(err).Error("failed to repair vector index")
-			return
-		}
+		repair(shardName, shard, release)
 	}, i.logger)
 
 	return nil

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -25,6 +25,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/clients"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/aggregation"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/schema"
 	esync "github.com/weaviate/weaviate/entities/sync"
 	"github.com/weaviate/weaviate/usecases/cluster"
@@ -492,4 +494,130 @@ func TestIndexDropLocalShard(t *testing.T) {
 		}
 		require.True(t, sawNamedDropLog, "expected a drop_shard error log naming the shard")
 	})
+}
+
+type debugRepairTestShard struct {
+	ShardLike
+	pinErr error
+	held   atomic.Bool
+	run    func(string) error
+}
+
+func (s *debugRepairTestShard) preventShutdown() (func(), error) {
+	if s.pinErr != nil {
+		return func() {}, s.pinErr
+	}
+	s.held.Store(true)
+	return func() { s.held.Store(false) }, nil
+}
+
+func (s *debugRepairTestShard) RepairIndex(_ context.Context, vector string) error {
+	return s.run(vector)
+}
+
+func TestIndexDebugRepairShardSelection(t *testing.T) {
+	for _, tc := range []struct {
+		name, shard string
+		want        []string
+		wantError   bool
+	}{
+		{name: "explicit shard", shard: "a", want: []string{"a"}},
+		{name: "all local shards", want: []string{"a", "b"}},
+		{name: "missing shard", shard: "missing", wantError: true},
+		{name: "unavailable shard", shard: "unavailable", wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, _ := test.NewNullLogger()
+			idx := &Index{logger: logger, shardCreateLocks: esync.NewKeyRWLocker()}
+			calls := make(chan string, 2)
+			shards := map[string]*debugRepairTestShard{}
+			for _, name := range []string{"a", "b"} {
+				shard := &debugRepairTestShard{}
+				shard.run = func(vector string) error {
+					if vector != "description" {
+						t.Errorf("unexpected target vector %q", vector)
+					}
+					if !shard.held.Load() {
+						t.Error("shard reference released before repair finished")
+					}
+					calls <- name
+					if name == "a" {
+						return errors.New("repair failed")
+					}
+					return nil
+				}
+				idx.shards.Store(name, shard)
+				shards[name] = shard
+			}
+			idx.shards.Store("unavailable", &debugRepairTestShard{pinErr: errors.New("shard closing")})
+			err := idx.DebugRepairIndex(t.Context(), tc.shard, "description")
+			if tc.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			var got []string
+			for range tc.want {
+				select {
+				case name := <-calls:
+					got = append(got, name)
+				case <-time.After(5 * time.Second):
+					t.Fatal("repair did not run")
+				}
+			}
+			require.ElementsMatch(t, tc.want, got)
+			require.Eventually(t, func() bool { return !shards["a"].held.Load() && !shards["b"].held.Load() }, time.Second, time.Millisecond)
+		})
+	}
+}
+
+func TestIndexDebugRepairAllShardsRunsSequentiallyInBackground(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	idx := &Index{logger: logger, shardCreateLocks: esync.NewKeyRWLocker()}
+	started := make(chan string, 2)
+	unblock := make(chan struct{})
+	defer close(unblock)
+	shards := make([]*debugRepairTestShard, 0, 2)
+	for _, name := range []string{"a", "b"} {
+		shard := &debugRepairTestShard{run: func(string) error {
+			started <- name
+			<-unblock
+			return nil
+		}}
+		shards = append(shards, shard)
+		idx.shards.Store(name, shard)
+	}
+
+	accepted := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		accepted <- idx.DebugRepairIndex(t.Context(), "", "")
+	}, logger)
+	select {
+	case err := <-accepted:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair blocked the caller")
+	}
+	var first string
+	select {
+	case first = <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("repair did not start")
+	}
+	select {
+	case <-started:
+		t.Fatal("started another repair before the first finished")
+	case <-time.After(100 * time.Millisecond):
+	}
+	unblock <- struct{}{}
+	select {
+	case second := <-started:
+		require.NotEqual(t, first, second)
+	case <-time.After(5 * time.Second):
+		t.Fatal("second shard was not repaired")
+	}
+	unblock <- struct{}{}
+	require.Eventually(t, func() bool {
+		return !shards[0].held.Load() && !shards[1].held.Load()
+	}, time.Second, time.Millisecond)
 }


### PR DESCRIPTION
### What's being changed:

Allow `POST /debug/index/repair/vector?collection=Movies` to repair all local shards when `shard` is omitted or empty, matching the collection-wide behavior of #13043. One background worker repairs shards sequentially and logs individual failures while continuing to the remaining shards. An explicit `shard` retains synchronous shard validation.

Keep each shard referenced until its repair finishes, require POST, and avoid writing a second error response after a missing-shard 404. Async indexing is still required; `vector` selects the target vector as before. HTTP 202 means accepted, not completed.

This uses the existing repair algorithm. It can load active lazy shards through the normal shard lookup, but does not activate inactive tenants or forward work to other nodes.

### Validation

- Full REST package tests with the race detector.
- New DB dispatch tests with the race detector: shard selection, sequential background work, failure handling, and shard reference lifetime.
- Existing `TestShard_RepairIndex` integration test.
- Full golangci-lint (zero issues), goroutine linter, and `git diff --check`.

### Review checklist

- [x] Documentation has been updated, if necessary: internal debug endpoint behavior documented above and in code.
- [x] Chaos pipeline run or not necessary: scoped to existing repair dispatch.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary: one worker per request; repair algorithm unchanged.
