### PR TITLE
refactor(backups): allow backups and restores that carry users and roles but no collection

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8199,21 +8199,21 @@ func init() {
           "type": "string"
         },
         "include": {
-          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection is rejected.",
+          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection is rejected unless ` + "`" + `includeUsers` + "`" + ` or ` + "`" + `includeRoles` + "`" + ` selects at least one user or role, in which case the backup carries users and roles only; the same applies to a cluster without collections. A backup must select at least one collection, user or role.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeRoles": {
-          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
+          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied. Setting this permits a backup with zero collections, provided at least one user or role is selected.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeUsers": {
-          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.",
+          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users. Setting this permits a backup with zero collections, provided at least one user or role is selected.",
           "type": "array",
           "items": {
             "type": "string"
@@ -20853,21 +20853,21 @@ func init() {
           "type": "string"
         },
         "include": {
-          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection is rejected.",
+          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection is rejected unless ` + "`" + `includeUsers` + "`" + ` or ` + "`" + `includeRoles` + "`" + ` selects at least one user or role, in which case the backup carries users and roles only; the same applies to a cluster without collections. A backup must select at least one collection, user or role.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeRoles": {
-          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
+          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied. Setting this permits a backup with zero collections, provided at least one user or role is selected.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeUsers": {
-          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.",
+          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users. Setting this permits a backup with zero collections, provided at least one user or role is selected.",
           "type": "array",
           "items": {
             "type": "string"

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8199,21 +8199,21 @@ func init() {
           "type": "string"
         },
         "include": {
-          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `.",
+          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection is rejected.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeRoles": {
-          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
+          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeUsers": {
-          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured and each is authorized individually.",
+          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.",
           "type": "array",
           "items": {
             "type": "string"
@@ -8397,7 +8397,7 @@ func init() {
           }
         },
         "include": {
-          "description": "List of collections (classes) to include in the backup restoration process.",
+          "description": "List of collections (classes) to include in the backup restoration process. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection in the backup is rejected.",
           "type": "array",
           "items": {
             "type": "string"
@@ -20853,21 +20853,21 @@ func init() {
           "type": "string"
         },
         "include": {
-          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `.",
+          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with ` + "`" + `exclude` + "`" + `. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection is rejected.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeRoles": {
-          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
+          "description": "List of RBAC roles to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeUsers": {
-          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured and each is authorized individually.",
+          "description": "List of dynamic DB users to include in the backup. Permits ` + "`" + `*` + "`" + ` and ` + "`" + `?` + "`" + ` wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.",
           "type": "array",
           "items": {
             "type": "string"
@@ -21054,7 +21054,7 @@ func init() {
           }
         },
         "include": {
-          "description": "List of collections (classes) to include in the backup restoration process.",
+          "description": "List of collections (classes) to include in the backup restoration process. Permits wildcards, e.g. ` + "`" + `*` + "`" + ` or ` + "`" + `prefix*` + "`" + `. A list made only of wildcards that match no collection in the backup is rejected.",
           "type": "array",
           "items": {
             "type": "string"

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -57,6 +57,11 @@ type DistributedBackupDescriptor struct {
 	BaseBackupID            string                     `json:"baseBackupId"`
 	Users                   []string                   `json:"users,omitempty"`
 	Roles                   []string                   `json:"roles,omitempty"`
+	// SkipUsers/SkipRoles record that includeUsers/includeRoles was given but
+	// matched nothing. Restore discards any user or RBAC blob a node uploaded
+	// anyway, which a participant predating the request-level skip flag does.
+	SkipUsers bool `json:"skipUsers,omitempty"`
+	SkipRoles bool `json:"skipRoles,omitempty"`
 }
 
 // Len returns how many nodes exist in d

--- a/entities/models/backup_create_request.go
+++ b/entities/models/backup_create_request.go
@@ -38,13 +38,13 @@ type BackupCreateRequest struct {
 	// The ID of the backup (required). Must be URL-safe and work as a filesystem path, only lowercase, numbers, underscore, minus characters allowed.
 	ID string `json:"id,omitempty"`
 
-	// List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`.
+	// List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection is rejected.
 	Include []string `json:"include"`
 
-	// List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.
+	// List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.
 	IncludeRoles []string `json:"includeRoles"`
 
-	// List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured and each is authorized individually.
+	// List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.
 	IncludeUsers []string `json:"includeUsers"`
 
 	// The ID of an existing backup to use as the base for a file-based incremental backup. If set, only files that have changed since the base backup will be included in the new backup.

--- a/entities/models/backup_create_request.go
+++ b/entities/models/backup_create_request.go
@@ -38,13 +38,13 @@ type BackupCreateRequest struct {
 	// The ID of the backup (required). Must be URL-safe and work as a filesystem path, only lowercase, numbers, underscore, minus characters allowed.
 	ID string `json:"id,omitempty"`
 
-	// List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection is rejected.
+	// List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection is rejected unless `includeUsers` or `includeRoles` selects at least one user or role, in which case the backup carries users and roles only; the same applies to a cluster without collections. A backup must select at least one collection, user or role.
 	Include []string `json:"include"`
 
-	// List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.
+	// List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied. Setting this permits a backup with zero collections, provided at least one user or role is selected.
 	IncludeRoles []string `json:"includeRoles"`
 
-	// List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.
+	// List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users. Setting this permits a backup with zero collections, provided at least one user or role is selected.
 	IncludeUsers []string `json:"includeUsers"`
 
 	// The ID of an existing backup to use as the base for a file-based incremental backup. If set, only files that have changed since the base backup will be included in the new backup.

--- a/entities/models/backup_restore_request.go
+++ b/entities/models/backup_restore_request.go
@@ -35,7 +35,7 @@ type BackupRestoreRequest struct {
 	// List of collections (classes) to exclude from the backup restoration process.
 	Exclude []string `json:"exclude"`
 
-	// List of collections (classes) to include in the backup restoration process.
+	// List of collections (classes) to include in the backup restoration process. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection in the backup is rejected.
 	Include []string `json:"include"`
 
 	// Allows overriding the node names stored in the backup with different ones. Useful when restoring backups to a different environment.

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -2342,7 +2342,7 @@
           "$ref": "#/definitions/BackupConfig"
         },
         "include": {
-          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection is rejected.",
+          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection is rejected unless `includeUsers` or `includeRoles` selects at least one user or role, in which case the backup carries users and roles only; the same applies to a cluster without collections. A backup must select at least one collection, user or role.",
           "type": "array",
           "items": {
             "type": "string"
@@ -2356,14 +2356,14 @@
           }
         },
         "includeUsers": {
-          "description": "List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.",
+          "description": "List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users. Setting this permits a backup with zero collections, provided at least one user or role is selected.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeRoles": {
-          "description": "List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
+          "description": "List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied. Setting this permits a backup with zero collections, provided at least one user or role is selected.",
           "type": "array",
           "items": {
             "type": "string"

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -2342,7 +2342,7 @@
           "$ref": "#/definitions/BackupConfig"
         },
         "include": {
-          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`.",
+          "description": "List of collections to include in the backup creation process. If not set, all collections are included. Cannot be used together with `exclude`. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection is rejected.",
           "type": "array",
           "items": {
             "type": "string"
@@ -2356,14 +2356,14 @@
           }
         },
         "includeUsers": {
-          "description": "List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured and each is authorized individually.",
+          "description": "List of dynamic DB users to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole dynamic-user store is captured as part of the cluster snapshot and no per-user permission check is applied; when set, only matching users are captured. An exact user name that does not exist is rejected; wildcards that match nothing back up no users.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "includeRoles": {
-          "description": "List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
+          "description": "List of RBAC roles to include in the backup. Permits `*` and `?` wildcards, e.g. `*` or `prefix*`. When omitted, the whole RBAC state is captured as part of the cluster snapshot; when set, the RBAC blob is filtered to the matching roles. An exact role name that does not exist is rejected; wildcards that match nothing back up no roles. Built-in roles are rejected and are never selected by wildcards (they are re-applied automatically on restore). No per-role permission check is applied.",
           "type": "array",
           "items": {
             "type": "string"
@@ -2486,7 +2486,7 @@
           "$ref": "#/definitions/RestoreConfig"
         },
         "include": {
-          "description": "List of collections (classes) to include in the backup restoration process.",
+          "description": "List of collections (classes) to include in the backup restoration process. Permits wildcards, e.g. `*` or `prefix*`. A list made only of wildcards that match no collection in the backup is rejected.",
           "type": "array",
           "items": {
             "type": "string"

--- a/test/acceptance/backups/selective_rbac_backup_test.go
+++ b/test/acceptance/backups/selective_rbac_backup_test.go
@@ -59,7 +59,8 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 	helper.SetupClient(compose.GetWeaviate().URI())
 	defer helper.ResetClient()
 
-	// A backup needs at least one class, so every subtest carries this one.
+	// Subtests that need a collection create this one. The class-less subtests
+	// rely on its absence.
 	par := articles.ParagraphsClass()
 
 	t.Run("RestoreReplacesTheStore", func(t *testing.T) {
@@ -70,14 +71,14 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 		helper.CreateClassAuth(t, par, adminKey)
 		defer helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
 
-		createSelectiveBackup(t, par.Class, backupID,
+		createSelectiveBackup(t, []string{par.Class}, backupID,
 			[]string{roleName(1), roleName(2)},
 			[]string{userName(1), userName(2)})
 
 		// Nothing is deleted here. The restore itself is what removes roles 3 to 5 and
 		// users 3 to 5, because it clears the store and reloads it from the blob.
 		helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
-		restoreAll(t, par.Class, backupID)
+		restoreAll(t, []string{par.Class}, backupID)
 
 		gotRoles := customRoleNames(t)
 		assert.ElementsMatch(t, []string{roleName(1), roleName(2)}, gotRoles)
@@ -94,7 +95,7 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 		helper.CreateClassAuth(t, par, adminKey)
 		defer helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
 
-		createSelectiveBackup(t, par.Class, backupID,
+		createSelectiveBackup(t, []string{par.Class}, backupID,
 			[]string{roleName(1), roleName(2)},
 			[]string{userName(1), userName(2)})
 
@@ -106,7 +107,7 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 		require.Empty(t, dynamicUserNames(t))
 
 		helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
-		restoreAll(t, par.Class, backupID)
+		restoreAll(t, []string{par.Class}, backupID)
 
 		assert.ElementsMatch(t, []string{roleName(1), roleName(2)}, customRoleNames(t))
 		assert.ElementsMatch(t, []string{userName(1), userName(2)}, dynamicUserNames(t))
@@ -129,11 +130,11 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 
 		// No selection at all. This is the branch that must stay byte-compatible with
 		// the behaviour that shipped before includeRoles existed.
-		createSelectiveBackup(t, par.Class, backupID, nil, nil)
+		createSelectiveBackup(t, []string{par.Class}, backupID, nil, nil)
 
 		deleteAllSeeded(t)
 		helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
-		restoreAll(t, par.Class, backupID)
+		restoreAll(t, []string{par.Class}, backupID)
 
 		assert.ElementsMatch(t, allRoleNames(), customRoleNames(t))
 		assert.ElementsMatch(t, allUserNames(), dynamicUserNames(t))
@@ -149,7 +150,7 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 
 		// Nothing is named "no-such-*". The backup must still succeed and carry no
 		// RBAC or user blob, so a restore with both options set changes nothing.
-		createSelectiveBackup(t, par.Class, backupID, []string{"no-such-*"}, []string{"no-such-*"})
+		createSelectiveBackup(t, []string{par.Class}, backupID, []string{"no-such-*"}, []string{"no-such-*"})
 
 		// Deleting one pair before the restore separates the three outcomes: a
 		// whole-cluster blob would bring role 5 and user 5 back, an empty blob
@@ -161,7 +162,7 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 		}
 
 		helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
-		restoreAll(t, par.Class, backupID)
+		restoreAll(t, []string{par.Class}, backupID)
 
 		assert.ElementsMatch(t, survivors(roleName), customRoleNames(t))
 		assert.ElementsMatch(t, survivors(userName), dynamicUserNames(t))
@@ -208,6 +209,74 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("ClassLessBackupWithNoCollections", func(t *testing.T) {
+		backupID := "no-collections"
+		_, err := helper.GetClassAuthWithReturn(t, par.Class, adminKey)
+		require.Error(t, err, "this subtest needs a cluster without collections")
+
+		seedRBAC(t)
+		defer cleanupRBAC(t)
+
+		resp := createSelectiveBackup(t, nil, backupID,
+			[]string{roleName(1), roleName(2)},
+			[]string{userName(1), userName(2)})
+		assert.Empty(t, resp.Classes)
+		assertBackupListed(t, backupID)
+
+		deleteAllSeeded(t)
+		require.Empty(t, customRoleNames(t))
+		require.Empty(t, dynamicUserNames(t))
+
+		restoreAll(t, nil, backupID)
+
+		assert.ElementsMatch(t, []string{roleName(1), roleName(2)}, customRoleNames(t))
+		assert.ElementsMatch(t, []string{userName(1), userName(2)}, dynamicUserNames(t))
+		_, err = helper.GetClassAuthWithReturn(t, par.Class, adminKey)
+		assert.Error(t, err, "a class-less restore must not create a collection")
+	})
+
+	t.Run("ClassLessBackupWithIncludeMiss", func(t *testing.T) {
+		backupID := "include-miss"
+		_, err := helper.GetClassAuthWithReturn(t, par.Class, adminKey)
+		require.Error(t, err, "the previous subtest must have left no collection behind")
+
+		seedRBAC(t)
+		defer cleanupRBAC(t)
+
+		helper.CreateClassAuth(t, par, adminKey)
+		defer helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
+
+		resp := createSelectiveBackup(t, []string{"NoSuch*"}, backupID,
+			[]string{roleName(1), roleName(2)},
+			[]string{userName(1), userName(2)})
+		assert.Empty(t, resp.Classes)
+		assertBackupListed(t, backupID)
+
+		deleteAllSeeded(t)
+		require.Empty(t, customRoleNames(t))
+		require.Empty(t, dynamicUserNames(t))
+
+		restoreAll(t, nil, backupID)
+
+		assert.ElementsMatch(t, []string{roleName(1), roleName(2)}, customRoleNames(t))
+		assert.ElementsMatch(t, []string{userName(1), userName(2)}, dynamicUserNames(t))
+		_, err = helper.GetClassAuthWithReturn(t, par.Class, adminKey)
+		assert.NoError(t, err, "a class-less restore must leave the existing collection alone")
+	})
+}
+
+// assertBackupListed fails unless the list endpoint reports backupID. That
+// endpoint resolves a zero-class backup to the backups/collections/* resource.
+func assertBackupListed(t *testing.T, backupID string) {
+	t.Helper()
+	resp, err := helper.ListBackupsWithAuthz(t, backend, auth())
+	require.Nil(t, err)
+	var ids []string
+	for _, b := range resp.Payload {
+		ids = append(ids, b.ID)
+	}
+	assert.Contains(t, ids, backupID)
 }
 
 func roleName(i int) string { return fmt.Sprintf("backup-role-%d", i) }
@@ -327,14 +396,15 @@ func roleNamesForUser(t *testing.T, user string) []string {
 }
 
 // createSelectiveBackup posts a backup carrying includeRoles and includeUsers, which the
-// shared helper does not expose, then waits for it to finish.
-func createSelectiveBackup(t *testing.T, className, backupID string, roles, users []string) {
+// shared helper does not expose, then waits for it to finish. A nil include selects
+// every collection the cluster has, which is none for the class-less subtests.
+func createSelectiveBackup(t *testing.T, include []string, backupID string, roles, users []string) *models.BackupCreateResponse {
 	t.Helper()
 	params := backups.NewBackupsCreateParams().
 		WithBackend(backend).
 		WithBody(&models.BackupCreateRequest{
 			ID:           backupID,
-			Include:      []string{className},
+			Include:      include,
 			IncludeRoles: roles,
 			IncludeUsers: users,
 			Config:       helper.DefaultBackupConfig(),
@@ -346,18 +416,29 @@ func createSelectiveBackup(t *testing.T, className, backupID string, roles, user
 
 	helper.ExpectBackupEventuallyCreated(t, backupID, backend, auth(),
 		helper.WithPollInterval(helper.MinPollInterval), helper.WithDeadline(helper.MaxDeadline))
+	return resp.Payload
 }
 
 // restoreAll restores with both RBAC options set, since the API defaults both to
-// noRestore and would otherwise leave roles and users untouched.
-func restoreAll(t *testing.T, className, backupID string) {
+// noRestore and would otherwise leave roles and users untouched. The request is built
+// here rather than through helper.RestoreBackupWithAuthz. That helper always sets a
+// one-entry include, so it cannot express a class-less restore.
+func restoreAll(t *testing.T, include []string, backupID string) {
 	t.Helper()
 	all := "all"
 	cfg := helper.DefaultRestoreConfig()
 	cfg.RolesOptions = &all
 	cfg.UsersOptions = &all
 
-	resp, err := helper.RestoreBackupWithAuthz(t, cfg, className, backend, backupID, map[string]string{}, auth())
+	params := backups.NewBackupsRestoreParams().
+		WithBackend(backend).
+		WithID(backupID).
+		WithBody(&models.BackupRestoreRequest{
+			Include:     include,
+			NodeMapping: map[string]string{},
+			Config:      cfg,
+		})
+	resp, err := helper.Client(t).Backups.BackupsRestore(params, auth())
 	require.Nil(t, err)
 	require.NotNil(t, resp.Payload)
 	require.Equal(t, "", resp.Payload.Error)

--- a/test/acceptance/backups/selective_rbac_backup_test.go
+++ b/test/acceptance/backups/selective_rbac_backup_test.go
@@ -138,6 +138,76 @@ func TestSelectiveRBACBackupRestore(t *testing.T) {
 		assert.ElementsMatch(t, allRoleNames(), customRoleNames(t))
 		assert.ElementsMatch(t, allUserNames(), dynamicUserNames(t))
 	})
+
+	t.Run("WildcardMissBacksUpNothing", func(t *testing.T) {
+		backupID := "wildcard-miss"
+		seedRBAC(t)
+		defer cleanupRBAC(t)
+
+		helper.CreateClassAuth(t, par, adminKey)
+		defer helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
+
+		// Nothing is named "no-such-*". The backup must still succeed and carry no
+		// RBAC or user blob, so a restore with both options set changes nothing.
+		createSelectiveBackup(t, par.Class, backupID, []string{"no-such-*"}, []string{"no-such-*"})
+
+		// Deleting one pair before the restore separates the three outcomes: a
+		// whole-cluster blob would bring role 5 and user 5 back, an empty blob
+		// would wipe roles and users 1 to 4, and no blob leaves 1 to 4 alone.
+		helper.DeleteRole(t, adminKey, roleName(5))
+		helper.DeleteUser(t, userName(5), adminKey)
+		survivors := func(name func(int) string) []string {
+			return []string{name(1), name(2), name(3), name(4)}
+		}
+
+		helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
+		restoreAll(t, par.Class, backupID)
+
+		assert.ElementsMatch(t, survivors(roleName), customRoleNames(t))
+		assert.ElementsMatch(t, survivors(userName), dynamicUserNames(t))
+	})
+
+	t.Run("ExactMissIsRejected", func(t *testing.T) {
+		seedRBAC(t)
+		defer cleanupRBAC(t)
+
+		helper.CreateClassAuth(t, par, adminKey)
+		defer helper.DeleteClassWithAuthz(t, par.Class, helper.CreateAuth(adminKey))
+
+		tests := []struct {
+			name    string
+			include []string
+			roles   []string
+			users   []string
+			want    string
+		}{
+			{name: "user", users: []string{"no-such-user"}, want: `user "no-such-user" in 'includeUsers' does not exist`},
+			{name: "role", roles: []string{"no-such-role"}, want: `role "no-such-role" in 'includeRoles' does not exist`},
+			{name: "class-wildcard", include: []string{"NoSuch*"}, want: "matches no class"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				include := []string{par.Class}
+				if tt.include != nil {
+					include = tt.include
+				}
+				params := backups.NewBackupsCreateParams().
+					WithBackend(backend).
+					WithBody(&models.BackupCreateRequest{
+						ID:           "exact-miss-" + tt.name,
+						Include:      include,
+						IncludeRoles: tt.roles,
+						IncludeUsers: tt.users,
+						Config:       helper.DefaultBackupConfig(),
+					})
+				_, err := helper.Client(t).Backups.BackupsCreate(params, auth())
+				var unproc *backups.BackupsCreateUnprocessableEntity
+				require.ErrorAs(t, err, &unproc)
+				require.NotEmpty(t, unproc.Payload.Error)
+				assert.Contains(t, unproc.Payload.Error[0].Message, tt.want)
+			})
+		}
+	})
 }
 
 func roleName(i int) string { return fmt.Sprintf("backup-role-%d", i) }

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -208,12 +208,9 @@ type uploader struct {
 	sourcer        Sourcer
 	rbacSourcer    RBACSnapshotter
 	dynUserSourcer dynUserSnapshotter
-	// Resolved includeUsers ids; empty → whole-cluster snapshot.
-	users []string
-	// Resolved includeRoles names; empty → whole-cluster RBAC snapshot.
-	roles    []string
-	backend  nodeStore
-	backupID string
+	selection      snapshotSelection
+	backend        nodeStore
+	backupID       string
 	zipConfig
 	// slot is the node's own operation slot, which is what a status poll reads
 	// until the descriptor is written to the backend.
@@ -229,7 +226,15 @@ type statusPublisher interface {
 	setFailed(reason string)
 }
 
-func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer RBACSnapshotter, dynUserSourcer dynUserSnapshotter, users, roles []string, backend nodeStore,
+// snapshotSelection is what the scheduler resolved from includeUsers and
+// includeRoles. Empty users/roles mean the whole-cluster snapshot; the skip
+// flags mean the selector matched nothing and no snapshot is uploaded.
+type snapshotSelection struct {
+	users, roles         []string
+	skipUsers, skipRoles bool
+}
+
+func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer RBACSnapshotter, dynUserSourcer dynUserSnapshotter, selection snapshotSelection, backend nodeStore,
 	backupID string, slot statusPublisher, l logrus.FieldLogger,
 ) *uploader {
 	return &uploader{
@@ -237,8 +242,7 @@ func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer RBACSnapshotter
 		sourcer:        sourcer,
 		rbacSourcer:    rbacSourcer,
 		dynUserSourcer: dynUserSourcer,
-		users:          users,
-		roles:          roles,
+		selection:      selection,
 		backend:        backend,
 		backupID:       backupID,
 		zipConfig: newZipConfig(Compression{
@@ -434,27 +438,31 @@ Loop:
 
 	if err := ctx.Err(); err != nil {
 		return contextChecker(ctx)
+	} else if u.selection.skipRoles {
+		u.log.Info("includeRoles matched no role, skipping RBAC backup")
 	} else if u.rbacSourcer != nil {
 		u.log.Info("start uploading RBAC backups")
-		descrp, err := u.rbacSourcer.Snapshot(u.roles...)
+		descrp, err := u.rbacSourcer.Snapshot(u.selection.roles...)
 		if err != nil {
 			return err
 		}
 		desc.RbacBackups = descrp
-	} else if len(u.roles) > 0 {
+	} else if len(u.selection.roles) > 0 {
 		return fmt.Errorf("includeRoles requested but RBAC is not enabled")
 	}
 
 	if err := ctx.Err(); err != nil {
 		return contextChecker(ctx)
+	} else if u.selection.skipUsers {
+		u.log.Info("includeUsers matched no user, skipping dynamic user backup")
 	} else if u.dynUserSourcer != nil {
 		u.log.Info("start uploading dynamic user backups")
-		descrp, err := u.dynUserSourcer.Snapshot(u.users...)
+		descrp, err := u.dynUserSourcer.Snapshot(u.selection.users...)
 		if err != nil {
 			return err
 		}
 		desc.UserBackups = descrp
-	} else if len(u.users) > 0 {
+	} else if len(u.selection.users) > 0 {
 		return fmt.Errorf("includeUsers requested but DB Users are not enabled")
 	}
 

--- a/usecases/backup/backend_pool_test.go
+++ b/usecases/backup/backend_pool_test.go
@@ -257,7 +257,7 @@ func newProbeUploader(t *testing.T, p *uploadProbe, poolSize int) (*uploader, *b
 	logger, _ := test.NewNullLogger()
 	store := nodeStore{objectStore{backend: p, backupId: "backup-1"}}
 	stat := &backupStat{}
-	u := newUploader(config.Backup{}, p, nil, nil, nil, nil, store, "backup-1", stat, logger).
+	u := newUploader(config.Backup{}, p, nil, nil, snapshotSelection{}, store, "backup-1", stat, logger).
 		withCompression(zipConfig{Level: int(NoCompression), GoPoolSize: poolSize})
 
 	desc := &backup.BackupDescriptor{ID: "backup-1", Classes: make([]backup.ClassDescriptor, 0, len(names))}

--- a/usecases/backup/backend_test.go
+++ b/usecases/backup/backend_test.go
@@ -1783,3 +1783,65 @@ func TestLabelErr(t *testing.T) {
 		})
 	}
 }
+
+// A skip flag means the coordinator's selector matched nothing. The uploader
+// must call neither snapshotter and leave both blobs absent, since restore
+// treats an absent blob as a no-op and a present one as a replacement.
+func TestUploaderSnapshotSkip(t *testing.T) {
+	const class = "Article"
+
+	tests := []struct {
+		name                string
+		sel                 snapshotSelection
+		wantUsers, wantRBAC bool
+	}{
+		{name: "whole-cluster default", sel: snapshotSelection{}, wantUsers: true, wantRBAC: true},
+		{name: "explicit selection", sel: snapshotSelection{users: []string{"u"}, roles: []string{"r"}}, wantUsers: true, wantRBAC: true},
+		{name: "users missed", sel: snapshotSelection{skipUsers: true, roles: []string{"r"}}, wantUsers: false, wantRBAC: true},
+		{name: "roles missed", sel: snapshotSelection{users: []string{"u"}, skipRoles: true}, wantUsers: true, wantRBAC: false},
+		{name: "both missed", sel: snapshotSelection{skipUsers: true, skipRoles: true}, wantUsers: false, wantRBAC: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backupID := "skip-" + tt.name
+			descriptors := make(chan backup.ClassDescriptor, 1)
+			descriptors <- backup.ClassDescriptor{Name: class}
+			close(descriptors)
+
+			sourcer := &fakeSourcer{}
+			sourcer.On("BackupDescriptors", mock.Anything, backupID, []string{class}, mock.Anything).
+				Return((<-chan backup.ClassDescriptor)(descriptors))
+			sourcer.On("ReleaseBackup", mock.Anything, backupID, class).Return(nil)
+
+			backend := newFakeBackend()
+			backend.On("SourceDataPath").Return(t.TempDir())
+			backend.On("PutObject", mock.Anything, backupID, BackupFile, mock.Anything).Return(nil)
+
+			logger := logrus.New()
+			logger.Out = io.Discard
+			bp := &backupper{logger: logger}
+			require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/"+backupID, "", ""))
+
+			rbac, users := &countingSnapshotter{}, &countingSnapshotter{}
+			store := nodeStore{objectStore{backend: backend, backupId: backupID}}
+			u := newUploader(config.Backup{}, sourcer, rbac, users, tt.sel, store, backupID, &bp.lastOp, logger)
+			desc := backup.BackupDescriptor{ID: backupID}
+			require.NoError(t, u.all(context.Background(), []string{class}, &desc, nil, "", ""))
+
+			assert.Equal(t, tt.wantRBAC, rbac.calls == 1, "rbac snapshotter calls: %d", rbac.calls)
+			assert.Equal(t, tt.wantRBAC, len(desc.RbacBackups) > 0)
+			assert.Equal(t, tt.wantUsers, users.calls == 1, "user snapshotter calls: %d", users.calls)
+			assert.Equal(t, tt.wantUsers, len(desc.UserBackups) > 0)
+		})
+	}
+}
+
+type countingSnapshotter struct{ calls int }
+
+func (s *countingSnapshotter) Snapshot(...string) ([]byte, error) {
+	s.calls++
+	return []byte(`{"v":1}`), nil
+}
+
+func (s *countingSnapshotter) Restore([]byte, bool) error { return nil }

--- a/usecases/backup/backupper.go
+++ b/usecases/backup/backupper.go
@@ -129,7 +129,8 @@ func (b *backupper) backup(store nodeStore, req *Request) (CanCommitResponse, er
 			return
 		}
 
-		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, req.Users, req.Roles, store, req.ID, &b.lastOp, b.logger).
+		selection := snapshotSelection{users: req.Users, roles: req.Roles, skipUsers: req.SkipUsers, skipRoles: req.SkipRoles}
+		provider := newUploader(b.cfg, b.sourcer, b.rbacSourcer, b.dynUserSourcer, selection, store, req.ID, &b.lastOp, b.logger).
 			withCompression(newZipConfig(req.Compression))
 
 		compressionType, err := CompressionTypeFromLevel(req.Level)

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -851,6 +851,10 @@ func (c *coordinator) queryAll(ctx context.Context, req *StatusRequest, nodes ma
 // commitAll tells all participants to proceed with their backup operations
 // It returns the number of failures
 func (c *coordinator) commitAll(ctx context.Context, req *StatusRequest, nodes map[string]string) int {
+	// With no worker nothing closes errChan, so the range below would block forever.
+	if len(nodes) == 0 {
+		return 0
+	}
 	type pair struct {
 		node string
 		err  error

--- a/usecases/backup/coordinator.go
+++ b/usecases/backup/coordinator.go
@@ -209,6 +209,8 @@ func (c *coordinator) Backup(ctx context.Context, cstore coordStore, req *Reques
 		BaseBackupID:    req.BaseBackupID,
 		Users:           req.Users,
 		Roles:           req.Roles,
+		SkipUsers:       req.SkipUsers,
+		SkipRoles:       req.SkipRoles,
 	}
 
 	for key := range c.Participants {
@@ -591,6 +593,8 @@ func (c *coordinator) canCommit(ctx context.Context, req *Request) (map[string]s
 				Classes:           gr.Classes,
 				Users:             req.Users,
 				Roles:             req.Roles,
+				SkipUsers:         req.SkipUsers,
+				SkipRoles:         req.SkipRoles,
 				Duration:          _BookingPeriod,
 				NodeMapping:       c.descriptor.NodeMapping,
 				Compression:       req.Compression,
@@ -736,6 +740,15 @@ func (c *coordinator) commit(ctx context.Context,
 					}
 
 					if meta, err := nodeStore.Meta(ctx, req.ID, req.Bucket, req.Path); err == nil {
+						// A node predating Request.SkipUsers/SkipRoles ignores the flag
+						// and uploads a whole-cluster snapshot. Fail rather than leave a
+						// backup that older restore code would apply in full.
+						if (c.descriptor.SkipUsers && len(meta.UserBackups) > 0) ||
+							(c.descriptor.SkipRoles && len(meta.RbacBackups) > 0) {
+							status = backup.Failed
+							st.Status = backup.Failed
+							reason = fmt.Sprintf("node %q uploaded a user or RBAC snapshot the request excluded; it predates the includeUsers/includeRoles skip, retry after the upgrade", node)
+						}
 						st.PreCompressionSizeBytes = meta.PreCompressionSizeBytes
 						totalPreCompressionSize += meta.PreCompressionSizeBytes
 						c.log.WithFields(logrus.Fields{

--- a/usecases/backup/coordinator_test.go
+++ b/usecases/backup/coordinator_test.go
@@ -1357,3 +1357,30 @@ func TestRestoreRolesAndUsersGatedOnStagingNotClasses(t *testing.T) {
 		assert.Contains(t, f.coord.descriptor.Error, authErr.Error())
 	})
 }
+
+// commitAll starts one worker per node. The last worker to finish closes the
+// result channel. With no node, nothing closes it and the consumer blocks
+// forever.
+func TestCommitAllEmptyNodes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns zero failures without blocking", func(t *testing.T) {
+		ctx := context.Background()
+		fc := newFakeCoordinator(newFakeNodeResolver(nil))
+		c := fc.coordinator()
+		req := &StatusRequest{Method: OpRestore, ID: "empty-nodes", Backend: "s3"}
+
+		done := make(chan int, 1)
+		enterrors.GoWrapper(func() {
+			done <- c.commitAll(ctx, req, map[string]string{})
+		}, c.log)
+
+		select {
+		case nFailures := <-done:
+			assert.Equal(t, 0, nFailures)
+		case <-time.After(5 * time.Second):
+			t.Fatal("commitAll blocked on an empty node map")
+		}
+		fc.client.AssertNotCalled(t, "Commit", mock.Anything, mock.Anything, mock.Anything)
+	})
+}

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -250,10 +250,12 @@ type BackupRequest struct {
 
 	// Non-empty switches the backup to a filtered dynamic-user snapshot.
 	// Empty keeps the whole-cluster snapshot. Same '*'/'?' wildcards as Include.
+	// An exact name must exist; wildcards matching nothing back up no users.
 	IncludeUsers []string
 
 	// Non-empty filters the RBAC snapshot to the matching roles. Empty keeps the
 	// whole-cluster snapshot. Same '*'/'?' wildcards as Include; built-ins rejected.
+	// An exact name must exist; wildcards matching nothing back up no roles.
 	IncludeRoles []string
 
 	// NodeMapping is a map of node name replacement where key is the old name and value is the new name

--- a/usecases/backup/handler_status_err_test.go
+++ b/usecases/backup/handler_status_err_test.go
@@ -207,7 +207,7 @@ func TestHandlerOnStatusServesTheReasonAFailedUploadPublished(t *testing.T) {
 			require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
 
 			store := nodeStore{objectStore{backend: backend, backupId: backupID}}
-			uploader := newUploader(config.Backup{}, sourcer, nil, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+			uploader := newUploader(config.Backup{}, sourcer, nil, nil, snapshotSelection{}, store, backupID, &bp.lastOp, logger)
 			desc := backup.BackupDescriptor{ID: backupID}
 			require.ErrorIs(t, uploader.all(context.Background(), []string{class}, &desc, nil, "", ""), tc.uploadErr)
 
@@ -274,7 +274,7 @@ func TestUploaderPublishesSuccessOnlyOnceTheDescriptorIsWritten(t *testing.T) {
 			require.Empty(t, bp.lastOp.renew(backupID, "bucket/backups/1", "", ""))
 
 			store := nodeStore{objectStore{backend: backend, backupId: backupID}}
-			uploader := newUploader(config.Backup{}, sourcer, nil, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+			uploader := newUploader(config.Backup{}, sourcer, nil, nil, snapshotSelection{}, store, backupID, &bp.lastOp, logger)
 			desc := backup.BackupDescriptor{ID: backupID}
 			err := uploader.all(context.Background(), []string{class}, &desc, nil, "", "")
 
@@ -326,7 +326,7 @@ func TestUploaderPublishesAnAbortAsCancelled(t *testing.T) {
 	rbac := &abortingSnapshotter{cancel: cancel, err: errors.New("roles snapshot interrupted")}
 
 	store := nodeStore{objectStore{backend: backend, backupId: backupID}}
-	uploader := newUploader(config.Backup{}, sourcer, rbac, nil, nil, nil, store, backupID, &bp.lastOp, logger)
+	uploader := newUploader(config.Backup{}, sourcer, rbac, nil, snapshotSelection{}, store, backupID, &bp.lastOp, logger)
 	desc := backup.BackupDescriptor{ID: backupID}
 	require.Error(t, uploader.all(ctx, []string{class}, &desc, nil, "", ""))
 

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -174,13 +174,13 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	sel, err := s.validateBackupRequest(ctx, store, req)
+	selection, err := s.validateBackupRequest(ctx, store, req)
 	if err != nil {
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
 	if !explicitInclude {
-		sel.classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, sel.classes)
+		selection.classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, selection.classes)
 		if err != nil {
 			return nil, err
 		}
@@ -193,9 +193,11 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		Method:       OpCreate,
 		ID:           req.ID,
 		Backend:      req.Backend,
-		Classes:      sel.classes,
-		Users:        sel.users,
-		Roles:        sel.roles,
+		Classes:      selection.classes,
+		Users:        selection.users,
+		Roles:        selection.roles,
+		SkipUsers:    selection.skipUsers,
+		SkipRoles:    selection.skipRoles,
 		Compression:  req.Compression,
 		Bucket:       req.Bucket,
 		Path:         req.Path,
@@ -207,7 +209,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		st := s.backupper.lastOp.get()
 		status := string(st.Status)
 		return &models.BackupCreateResponse{
-			Classes: sel.classes,
+			Classes: selection.classes,
 			ID:      req.ID,
 			Backend: req.Backend,
 			Status:  &status,
@@ -260,6 +262,23 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	schema, userBlob, rbacBlob, err := s.fetchSchema(ctx, req.Backend, req.Bucket, req.Path, meta)
 	if err != nil {
 		return nil, err
+	}
+	// The selector matched nothing at backup time. A node that ignored the
+	// request-level skip flag uploaded a whole-cluster blob; applying it would
+	// replace every user or role on this cluster.
+	if meta.SkipUsers && len(userBlob) > 0 {
+		s.logger.WithField("action", "try_restore").WithField("backup_id", req.ID).
+			Warn("discarding the user snapshot: 'includeUsers' matched no user at backup time, a participant uploaded one anyway")
+	}
+	if meta.SkipRoles && len(rbacBlob) > 0 {
+		s.logger.WithField("action", "try_restore").WithField("backup_id", req.ID).
+			Warn("discarding the RBAC snapshot: 'includeRoles' matched no role at backup time, a participant uploaded one anyway")
+	}
+	if meta.SkipUsers {
+		userBlob = nil
+	}
+	if meta.SkipRoles {
+		rbacBlob = nil
 	}
 
 	if err := s.validateNamespaceStripping(ctx, schema, userBlob, rbacBlob, meta.Classes(), req.UserRestoreOption, req.RbacRestoreOption); err != nil {
@@ -679,9 +698,12 @@ func coordBackend(provider BackupBackendProvider, backend, id, overrideBucket, o
 }
 
 // backupSelections is what a backup request resolves to. Nil users and roles
-// mean an ordinary class-only backup.
+// keep the whole-cluster user and RBAC snapshots.
 type backupSelections struct {
 	classes, users, roles []string
+	// skipUsers/skipRoles: the selector list was given but matched nothing,
+	// so the participant must upload no snapshot rather than the default one.
+	skipUsers, skipRoles bool
 }
 
 // validateBackupRequest resolves the request into concrete classes, users, and
@@ -718,6 +740,10 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 
 	// Expand wildcards in Include list
 	include := expandWildcards(req.Include, allClasses)
+	// An include list that expands to nothing must not fall through to every class.
+	if len(req.Include) > 0 && len(include) == 0 {
+		return selections, fmt.Errorf("class list 'include' %v matches no class", req.Include)
+	}
 
 	// Expand wildcards in Exclude list
 	exclude := expandWildcards(req.Exclude, allClasses)
@@ -738,11 +764,13 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 	if err != nil {
 		return selections, err
 	}
+	selections.skipUsers = len(req.IncludeUsers) > 0 && len(users) == 0
 
 	roles, err := s.resolveRoles(req.IncludeRoles)
 	if err != nil {
 		return selections, err
 	}
+	selections.skipRoles = len(req.IncludeRoles) > 0 && len(roles) == 0
 
 	if err = s.checkIfBackupExists(ctx, store, req); err != nil {
 		return selections, err
@@ -755,6 +783,17 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 	}
 	if _, err = resolveBaseBackupChain(ctx, req.BaseBackupID, time.Now().UTC(), req.Bucket, req.Path, compressionType, store.MetaForBackupID); err != nil {
 		return selections, fmt.Errorf("resolve base backup chain: %w", err)
+	}
+
+	// The response does not report users or roles, so a selector that matched
+	// nothing is only visible here.
+	if selections.skipUsers {
+		s.logger.WithField("action", "try_backup").WithField("backup_id", req.ID).
+			Warnf("'includeUsers' %v matches no dynamic user, backing up none", req.IncludeUsers)
+	}
+	if selections.skipRoles {
+		s.logger.WithField("action", "try_backup").WithField("backup_id", req.ID).
+			Warnf("'includeRoles' %v matches no role, backing up none", req.IncludeRoles)
 	}
 
 	selections.classes = classes
@@ -777,8 +816,9 @@ func (s *Scheduler) resolveUsers(includeUsers []string) ([]string, error) {
 }
 
 // resolveUserSelectors mirrors class-selector semantics: '*'/'?' wildcards,
-// dedup, exact selectors must exist, and a non-empty list matching nothing
-// errors. Absent includeUsers is the caller's job — not equivalent to "all".
+// dedup, exact selectors must exist. Wildcards matching nothing yield an empty
+// result, which the caller turns into "back up no users". Absent includeUsers
+// is the caller's job and is not equivalent to "all".
 func resolveUserSelectors(includeUsers, allUsers []string) ([]string, error) {
 	if dup := findDuplicate(includeUsers); dup != "" {
 		return nil, fmt.Errorf("user list 'includeUsers' contains duplicate: %s", dup)
@@ -794,9 +834,6 @@ func resolveUserSelectors(includeUsers, allUsers []string) ([]string, error) {
 		if _, ok := known[u]; !ok {
 			return nil, fmt.Errorf("user %q in 'includeUsers' does not exist", u)
 		}
-	}
-	if len(users) == 0 {
-		return nil, fmt.Errorf("no dynamic users match 'includeUsers' %v", includeUsers)
 	}
 	return users, nil
 }
@@ -818,7 +855,7 @@ func (s *Scheduler) resolveRoles(includeRoles []string) ([]string, error) {
 }
 
 // resolveRoleSelectors follows resolveUserSelectors: '*'/'?' wildcards, dedup,
-// exact selectors must exist, and a non-empty list matching nothing is an error.
+// exact selectors must exist, and wildcards matching nothing yield an empty result.
 //
 // Built-in roles are the exception. Naming one explicitly is rejected, and
 // wildcards expand over custom roles only, so '*' never picks up a built-in.
@@ -852,9 +889,6 @@ func resolveRoleSelectors(includeRoles, allRoles []string) ([]string, error) {
 		if _, ok := known[r]; !ok {
 			return nil, fmt.Errorf("role %q in 'includeRoles' does not exist", r)
 		}
-	}
-	if len(roles) == 0 {
-		return nil, fmt.Errorf("no roles match 'includeRoles' %v", includeRoles)
 	}
 	return roles, nil
 }
@@ -921,6 +955,10 @@ func (s *Scheduler) validateRestoreRequest(ctx context.Context, store coordStore
 
 	// Expand wildcards in Include list against backup's classes
 	include := expandWildcards(req.Include, cs)
+	// An include list that expands to nothing must not fall through to every class.
+	if len(req.Include) > 0 && len(include) == 0 {
+		return nil, fmt.Errorf("class list 'include' %v matches no class in the backup", req.Include)
+	}
 
 	// Expand wildcards in Exclude list against backup's classes
 	exclude := expandWildcards(req.Exclude, cs)

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -340,9 +340,15 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 }
 
 // filterBackupableClasses returns the subset of classes the caller may act on
-// with verb, narrowing the empty-Include operation instead of failing it whole.
-// An empty result is Forbidden; any other authorizer error is Unprocessable.
+// with verb. Callers use it only when the request omits 'include', so a caller
+// allowed some of the classes acts on those instead of being refused outright.
+// An empty input list is a class-less backup and passes through. A non-empty
+// input that leaves nothing allowed is Forbidden. Any other authorizer error is
+// Unprocessable.
 func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Principal, verb string, classes []string) ([]string, error) {
+	if len(classes) == 0 {
+		return classes, nil
+	}
 	allowed := make([]string, 0, len(classes))
 	for _, c := range classes {
 		if err := s.authorizer.Authorize(ctx, pr, verb, authorization.Backups(c)...); err != nil {
@@ -734,30 +740,26 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 
 	// Get all available classes first for wildcard expansion
 	allClasses := s.backupper.selector.ListClasses(ctx)
-	if len(allClasses) == 0 {
-		return selections, fmt.Errorf("no available classes to backup, there's nothing to do here")
-	}
 
 	// Expand wildcards in Include list
 	include := expandWildcards(req.Include, allClasses)
-	// An include list that expands to nothing must not fall through to every class.
-	if len(req.Include) > 0 && len(include) == 0 {
-		return selections, fmt.Errorf("class list 'include' %v matches no class", req.Include)
-	}
 
 	// Expand wildcards in Exclude list
 	exclude := expandWildcards(req.Exclude, allClasses)
 
+	// Only an omitted 'include' list means every class. Testing len(classes)
+	// here instead of len(req.Include) would back up the whole cluster when an
+	// include pattern matched nothing.
 	classes := include
-	if len(classes) == 0 {
+	if len(req.Include) == 0 {
 		classes = allClasses
 	}
-	if classes = filterClasses(classes, exclude); len(classes) == 0 {
-		return selections, fmt.Errorf("empty class list: please choose from : %v", allClasses)
-	}
+	classes = filterClasses(classes, exclude)
 
-	if err := s.backupper.selector.Backupable(ctx, classes); err != nil {
-		return selections, err
+	if len(classes) > 0 {
+		if err := s.backupper.selector.Backupable(ctx, classes); err != nil {
+			return selections, err
+		}
 	}
 
 	users, err := s.resolveUsers(req.IncludeUsers)
@@ -771,6 +773,24 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 		return selections, err
 	}
 	selections.skipRoles = len(req.IncludeRoles) > 0 && len(roles) == 0
+
+	// Zero collections is legitimate as long as a user or a role was selected.
+	// Selecting none of the three would produce an empty backup.
+	if len(classes) == 0 && len(users) == 0 && len(roles) == 0 {
+		classReason := "no collection selected"
+		if len(req.Include) > 0 {
+			classReason = fmt.Sprintf("class list 'include' %v matches no class", req.Include)
+		}
+		userReason := "'includeUsers' not set"
+		if selections.skipUsers {
+			userReason = fmt.Sprintf("'includeUsers' %v matches no user", req.IncludeUsers)
+		}
+		roleReason := "'includeRoles' not set"
+		if selections.skipRoles {
+			roleReason = fmt.Sprintf("'includeRoles' %v matches no role", req.IncludeRoles)
+		}
+		return selections, fmt.Errorf("nothing to back up: %s, %s, %s", classReason, userReason, roleReason)
+	}
 
 	if err = s.checkIfBackupExists(ctx, store, req); err != nil {
 		return selections, err
@@ -953,27 +973,45 @@ func (s *Scheduler) validateRestoreRequest(ctx context.Context, store coordStore
 
 	cs := meta.Classes()
 
-	// Expand wildcards in Include list against backup's classes
-	include := expandWildcards(req.Include, cs)
-	// An include list that expands to nothing must not fall through to every class.
-	if len(req.Include) > 0 && len(include) == 0 {
-		return nil, fmt.Errorf("class list 'include' %v matches no class in the backup", req.Include)
-	}
-
-	// Expand wildcards in Exclude list against backup's classes
-	exclude := expandWildcards(req.Exclude, cs)
-
-	if len(include) > 0 {
-		if first := meta.AllExist(include); first != "" {
-			err = fmt.Errorf("class %s doesn't exist in the backup, but does have %v: ", first, cs)
-			return nil, err
+	if len(cs) == 0 {
+		// AllExist returns "" when every class is present. It also returns ""
+		// for a missing class named "", so it cannot report an empty-string
+		// entry. Both lists are rejected here instead of going through it.
+		if len(req.Include) > 0 || len(req.Exclude) > 0 {
+			return nil, fmt.Errorf("backup %q contains no collection: 'include' %v and 'exclude' %v must be omitted",
+				req.ID, req.Include, req.Exclude)
 		}
-		meta.Include(include)
+		if req.UserRestoreOption == models.RestoreConfigUsersOptionsNoRestore &&
+			req.RbacRestoreOption == models.RestoreConfigRolesOptionsNoRestore {
+			return nil, fmt.Errorf("backup %q contains no collection and both 'usersOptions' and 'rolesOptions' are %q: nothing to restore",
+				req.ID, models.RestoreConfigUsersOptionsNoRestore)
+		}
+		// RemoveEmpty is not called here. It would drop the leader's class-less
+		// entry, and the coordinator fans out only to the nodes the descriptor
+		// lists. The restore would then run with no participant, so the leader's
+		// per-node descriptor check, its status entry and the cancel target would
+		// all be skipped.
 	} else {
-		meta.Exclude(exclude)
-	}
-	if meta.RemoveEmpty().Count() == 0 {
-		return nil, fmt.Errorf("nothing left to restore: please choose from : %v", cs)
+		include := expandWildcards(req.Include, cs)
+		// An include list that expands to nothing must not fall through to every class.
+		if len(req.Include) > 0 && len(include) == 0 {
+			return nil, fmt.Errorf("class list 'include' %v matches no class in the backup", req.Include)
+		}
+
+		exclude := expandWildcards(req.Exclude, cs)
+
+		if len(include) > 0 {
+			if first := meta.AllExist(include); first != "" {
+				err = fmt.Errorf("class %s doesn't exist in the backup, but does have %v: ", first, cs)
+				return nil, err
+			}
+			meta.Include(include)
+		} else {
+			meta.Exclude(exclude)
+		}
+		if meta.RemoveEmpty().Count() == 0 {
+			return nil, fmt.Errorf("nothing left to restore: please choose from : %v", cs)
+		}
 	}
 	if len(req.NodeMapping) > 0 {
 		meta.NodeMapping = req.NodeMapping

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
@@ -1276,7 +1277,7 @@ type fakeScheduler struct {
 	schema       fakeSchemaManger
 	backend      *fakeBackend
 	backendErr   error
-	auth         authorization.Authorizer
+	auth         *mocks.FakeAuthorizer
 	nodeResolver NodeResolver
 	log          logrus.FieldLogger
 	// staticAPIKeyUsers is what the cluster configures in
@@ -1414,7 +1415,7 @@ func TestCancellingBackup(t *testing.T) {
 		err = fakeScheduler.scheduler().Cancel(ctx, nil, backendName, backupID, "", "")
 		assert.NoError(t, err)
 
-		calls := fakeScheduler.auth.(*mocks.FakeAuthorizer).Calls()
+		calls := fakeScheduler.auth.Calls()
 		assert.Len(t, calls, 1)
 		assert.Equal(t, authorization.DELETE, calls[0].Verb)
 		assert.Equal(t, authorization.Backups("Class1"), calls[0].Resources)
@@ -1670,7 +1671,7 @@ func TestCancellingRestore(t *testing.T) {
 		err = fakeScheduler.scheduler().CancelRestore(ctx, nil, backendName, backupID, "", "")
 		assert.NoError(t, err)
 
-		calls := fakeScheduler.auth.(*mocks.FakeAuthorizer).Calls()
+		calls := fakeScheduler.auth.Calls()
 		assert.Len(t, calls, 1)
 		assert.Equal(t, authorization.DELETE, calls[0].Verb)
 		assert.Equal(t, authorization.Backups("Class1"), calls[0].Resources)
@@ -3210,5 +3211,388 @@ func TestIncludeWildcardMiss(t *testing.T) {
 		}
 		require.Error(t, err, "resolved classes: %v", classes)
 		assert.Contains(t, err.Error(), "Zzz*")
+	})
+}
+
+func TestValidateBackupRequestNoCollections(t *testing.T) {
+	t.Parallel()
+	var (
+		ctx  = context.Background()
+		id   = "no-collections"
+		path = "bucket/backups/" + id
+	)
+
+	tests := []struct {
+		name       string
+		allClasses []string
+		// users and roles are what the cluster holds, not what is selected.
+		users, roles []string
+		req          BackupRequest
+		// backupableWith is the class list Backupable must be called with. Nil
+		// means Backupable must not be called at all.
+		backupableWith []string
+		backupableErr  error
+		wantErr        []string
+		wantUsers      []string
+		wantRoles      []string
+	}{
+		{
+			name:       "no collections with a selected user proceeds",
+			allClasses: []string{},
+			users:      []string{"ns1:alice", "ns2:bob"},
+			req:        BackupRequest{IncludeUsers: []string{"ns1:*"}},
+			wantUsers:  []string{"ns1:alice"},
+		},
+		{
+			name:       "include pattern matching nothing with a selected user yields zero classes",
+			allClasses: []string{"C1", "C2"},
+			users:      []string{"ns1:alice"},
+			req:        BackupRequest{Include: []string{"ns1:*"}, IncludeUsers: []string{"ns1:*"}},
+			wantUsers:  []string{"ns1:alice"},
+		},
+		{
+			name:       "exclude removing every class with a selected role yields zero classes",
+			allClasses: []string{"C1"},
+			roles:      []string{"backup-role"},
+			req:        BackupRequest{Exclude: []string{"C1"}, IncludeRoles: []string{"backup-*"}},
+			wantRoles:  []string{"backup-role"},
+		},
+		{
+			name:           "exact include name on an empty cluster is rejected by Backupable",
+			allClasses:     []string{},
+			users:          []string{"ns1:alice"},
+			req:            BackupRequest{Include: []string{"Movies"}, IncludeUsers: []string{"ns1:*"}},
+			backupableWith: []string{"Movies"},
+			backupableErr:  errors.New("class Movies doesn't exist"),
+			wantErr:        []string{"class Movies doesn't exist"},
+		},
+		{
+			name:       "no collections with neither list set is rejected",
+			allClasses: []string{},
+			req:        BackupRequest{},
+			wantErr: []string{
+				"nothing to back up", "no collection selected",
+				"'includeUsers' not set", "'includeRoles' not set",
+			},
+		},
+		{
+			name:       "no collections with both lists matching nothing is rejected",
+			allClasses: []string{},
+			users:      []string{"ns1:alice"},
+			roles:      []string{"backup-role"},
+			req:        BackupRequest{IncludeUsers: []string{"zz*"}, IncludeRoles: []string{"zz*"}},
+			wantErr: []string{
+				"nothing to back up", "no collection selected",
+				"'includeUsers' [zz*] matches no user", "'includeRoles' [zz*] matches no role",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fs := newFakeScheduler(nil)
+			fs.userLister.users = tt.users
+			fs.roleLister.roles = tt.roles
+			fs.selector.On("ListClasses", ctx).Return(tt.allClasses)
+			if tt.backupableWith != nil {
+				fs.selector.On("Backupable", ctx, tt.backupableWith).Return(tt.backupableErr)
+			}
+			fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+			fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+			fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
+			store := coordStore{objectStore{fs.backend, id, "", "", ""}}
+
+			req := tt.req
+			req.ID = id
+			req.Backend = "s3"
+			got, err := fs.scheduler().validateBackupRequest(ctx, store, &req)
+
+			if tt.backupableWith == nil {
+				fs.selector.AssertNotCalled(t, "Backupable", mock.Anything, mock.Anything)
+			} else {
+				fs.selector.AssertNumberOfCalls(t, "Backupable", 1)
+			}
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err, "resolved classes: %v", got.classes)
+				for _, want := range tt.wantErr {
+					assert.Contains(t, err.Error(), want)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Empty(t, got.classes)
+			assert.Equal(t, tt.wantUsers, got.users)
+			assert.Equal(t, tt.wantRoles, got.roles)
+			assert.False(t, got.skipUsers)
+			assert.False(t, got.skipRoles)
+		})
+	}
+}
+
+func TestSchedulerCreateBackupNoCollections(t *testing.T) {
+	t.Parallel()
+	var (
+		node        = "Node-A"
+		backendName = "gcs"
+		backupID    = "create-no-collections"
+		any         = mock.Anything
+		ctx         = context.Background()
+		path        = "dst/path"
+		cresp       = &CanCommitResponse{Method: OpCreate, ID: backupID, Timeout: 1}
+		sReq        = &StatusRequest{OpCreate, backupID, backendName, "", "", ""}
+		sresp       = &StatusResponse{Status: backup.Success, ID: backupID, Method: OpCreate}
+	)
+
+	// setup returns the request fanned out to the node. Neither Backupable nor
+	// Shards is stubbed: a class-less create must call neither.
+	setup := func(fs *fakeScheduler) *Request {
+		nodeReq := new(Request)
+		fs.userLister.users = []string{"ns1:alice", "ns2:bob"}
+		fs.selector.On("ListClasses", ctx).Return([]string{})
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("HomeDir", any, any, any).Return(path)
+		fs.backend.On("Initialize", ctx, any).Return(nil)
+		fs.client.On("CanCommit", any, node, any).Return(cresp, nil).Run(func(a mock.Arguments) {
+			*nodeReq = *a.Get(2).(*Request)
+		})
+		fs.client.On("Commit", any, node, sReq).Return(nil)
+		fs.client.On("Status", any, node, sReq).Return(sresp, nil)
+		fs.backend.On("PutObject", any, backupID, GlobalBackupFile, any).Return(nil).Twice()
+		fs.backend.On("GetObject", any, any, any, any, any).
+			Return(marshalMeta(backup.BackupDescriptor{Status: backup.Success}), nil)
+		return nodeReq
+	}
+
+	// awaitGlobalMeta blocks until the coordinator goroutine writes the terminal
+	// global descriptor. That write happens after Backup returns.
+	awaitGlobalMeta := func(t *testing.T, fs *fakeScheduler) {
+		t.Helper()
+		select {
+		case <-fs.backend.doneChan:
+		case <-time.After(10 * time.Second):
+			t.Fatal("backup did not reach a terminal global descriptor")
+		}
+	}
+
+	t.Run("leader is the only participant and receives no classes", func(t *testing.T) {
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		nodeReq := setup(fs)
+		req := BackupRequest{ID: backupID, Backend: backendName, IncludeUsers: []string{"ns1:*"}}
+
+		resp, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Empty(t, resp.Classes)
+
+		awaitGlobalMeta(t, fs)
+		assert.Empty(t, nodeReq.Classes)
+		assert.Equal(t, []string{"ns1:alice"}, nodeReq.Users)
+		assert.False(t, nodeReq.SkipUsers)
+		assert.False(t, nodeReq.SkipRoles)
+		assert.ElementsMatch(t, []string{"ns1:alice"}, fs.backend.glMeta.UserList())
+		require.Len(t, fs.backend.glMeta.Nodes, 1)
+		require.Contains(t, fs.backend.glMeta.Nodes, node)
+		assert.Empty(t, fs.backend.glMeta.Nodes[node].Classes)
+	})
+
+	// Known limitation: the explicit-include check is skipped and
+	// filterBackupableClasses has no class to check, so nothing authorizes this
+	// request.
+	t.Run("implicit-include class-less create performs no authorization call", func(t *testing.T) {
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		setup(fs)
+		fs.auth.SetErr(authzerrors.NewForbidden(&models.Principal{}, authorization.CREATE,
+			authorization.Backups("*")...))
+		req := BackupRequest{ID: backupID, Backend: backendName, IncludeUsers: []string{"ns1:*"}}
+
+		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
+		require.NoError(t, err)
+		assert.Empty(t, fs.auth.Calls())
+		awaitGlobalMeta(t, fs)
+	})
+}
+
+// An empty input is a class-less backup, not a denial. A non-empty input that
+// leaves nothing allowed must stay Forbidden, or a caller allowed no class
+// would act on every class.
+func TestFilterBackupableClasses(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	pr := &models.Principal{}
+
+	t.Run("empty input returns empty without error", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		got, err := fs.scheduler().filterBackupableClasses(ctx, pr, authorization.CREATE, nil)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("non-empty input with nothing allowed is Forbidden", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		fs.auth.SetErr(authzerrors.NewForbidden(pr, authorization.CREATE, authorization.Backups("C1")...))
+		got, err := fs.scheduler().filterBackupableClasses(ctx, pr, authorization.CREATE, []string{"C1"})
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.ErrorAs(t, err, &authzerrors.Forbidden{})
+	})
+}
+
+// A descriptor with zero classes is a valid restore source. The leader's node
+// entry has to survive validation: the coordinator fans out only to the nodes
+// the descriptor lists, and the users and roles blobs are read from the
+// leader's descriptor.
+func TestValidateRestoreRequestNoCollections(t *testing.T) {
+	t.Parallel()
+	var (
+		ctx  = context.Background()
+		id   = "restore-no-collections"
+		node = "Node-1"
+		path = "bucket/backups/" + id
+	)
+
+	tests := []struct {
+		name    string
+		req     BackupRequest
+		wantErr []string
+	}{
+		{
+			name: "usersOptions all keeps the leader node",
+			req: BackupRequest{
+				UserRestoreOption: models.RestoreConfigUsersOptionsAll,
+				RbacRestoreOption: models.RestoreConfigRolesOptionsNoRestore,
+			},
+		},
+		{
+			name: "both options noRestore is rejected",
+			req: BackupRequest{
+				UserRestoreOption: models.RestoreConfigUsersOptionsNoRestore,
+				RbacRestoreOption: models.RestoreConfigRolesOptionsNoRestore,
+			},
+			wantErr: []string{"contains no collection", "'usersOptions'", "'rolesOptions'", "nothing to restore"},
+		},
+		{
+			// AllExist cannot report a missing class named "": its "" return
+			// means "all present".
+			name: "explicit include entry is rejected",
+			req: BackupRequest{
+				Include:           []string{""},
+				UserRestoreOption: models.RestoreConfigUsersOptionsAll,
+				RbacRestoreOption: models.RestoreConfigRolesOptionsAll,
+			},
+			wantErr: []string{"contains no collection", "'include'", "must be omitted"},
+		},
+		{
+			name: "explicit exclude entry is rejected",
+			req: BackupRequest{
+				Exclude:           []string{"Movies"},
+				UserRestoreOption: models.RestoreConfigUsersOptionsAll,
+				RbacRestoreOption: models.RestoreConfigRolesOptionsAll,
+			},
+			wantErr: []string{"contains no collection", "'exclude'", "must be omitted"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := backup.DistributedBackupDescriptor{
+				ID: id, StartedAt: time.Now().UTC(), Version: Version,
+				ServerVersion: "1.23", Status: backup.Success, Leader: node,
+				Nodes: map[string]*backup.NodeDescriptor{node: {Classes: nil}},
+			}
+			fs := newFakeScheduler(nil)
+			fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(marshalCoordinatorMeta(meta), nil)
+			fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+			store := coordStore{objectStore{fs.backend, id, "", "", ""}}
+
+			req := tt.req
+			req.ID = id
+			req.Backend = "s3"
+			got, err := fs.scheduler().validateRestoreRequest(ctx, store, &req)
+
+			if len(tt.wantErr) > 0 {
+				require.Error(t, err)
+				for _, want := range tt.wantErr {
+					assert.Contains(t, err.Error(), want)
+				}
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, got.Nodes, 1)
+			assert.Contains(t, got.Nodes, node)
+		})
+	}
+}
+
+func TestSchedulerRestoreNoCollections(t *testing.T) {
+	t.Parallel()
+	var (
+		ctx       = context.Background()
+		backupID  = "restore-no-collections"
+		node      = "Node-1"
+		rolesBlob = []byte(`{"roles_policies":[],"version":1}`)
+	)
+
+	drive := func(t *testing.T, forbidEverything bool) (*fakeScheduler, []rolesAndUsersCall) {
+		t.Helper()
+		userBlob := makeUserSnapshot(t, "ns1:alice")
+		meta := backup.DistributedBackupDescriptor{
+			ID: backupID, StartedAt: time.Now().UTC(), Version: Version,
+			ServerVersion: "1.23", Status: backup.Success, Leader: node,
+			Nodes: map[string]*backup.NodeDescriptor{node: {Classes: nil}},
+			Users: []string{"ns1:alice"},
+		}
+		nodeMeta, err := json.Marshal(backup.BackupDescriptor{
+			ID: backupID, Status: backup.Success, Classes: nil,
+			UserBackups: userBlob, RbacBackups: rolesBlob,
+		})
+		require.NoError(t, err)
+
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		rec := &recordingRolesAndUsersRestorer{}
+		fs.rolesAndUsers = rec
+		if forbidEverything {
+			fs.auth.SetErr(authzerrors.NewForbidden(&models.Principal{}, authorization.CREATE,
+				authorization.Backups("*")...))
+		}
+		fs.backend.On("Initialize", mock.Anything, mock.Anything).Return(nil)
+		fs.backend.On("GetObject", ctx, backupID, GlobalBackupFile).Return(marshalCoordinatorMeta(meta), nil)
+		fs.backend.On("GetObject", ctx, backupID, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", ctx, backupID+"/"+node, BackupFile).Return(nodeMeta, nil)
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return("bucket/" + backupID)
+		fs.backend.On("PutObject", mock.Anything, mock.Anything, GlobalRestoreFile, mock.Anything).Return(nil)
+		fs.client.On("CanCommit", mock.Anything, node, mock.Anything).
+			Return(&CanCommitResponse{Method: OpRestore, ID: backupID, Timeout: 1}, nil)
+		fs.client.On("Commit", mock.Anything, node, mock.Anything).Return(nil)
+		fs.client.On("Status", mock.Anything, node, mock.Anything).
+			Return(&StatusResponse{Status: backup.Success, ID: backupID, Method: OpRestore}, nil)
+
+		s := fs.scheduler()
+		_, err = s.Restore(ctx, &models.Principal{}, &BackupRequest{
+			ID: backupID, Backend: "gcs",
+			UserRestoreOption: models.RestoreConfigUsersOptionsAll,
+			RbacRestoreOption: models.RestoreConfigRolesOptionsAll,
+		}, false)
+		require.NoError(t, err)
+		require.Eventually(t, func() bool { return s.restorer.lastOp.get().Status == "" },
+			10*time.Second, 10*time.Millisecond, "restore did not finish")
+		return fs, rec.recorded()
+	}
+
+	t.Run("class-less restore applies the leader's blobs and succeeds", func(t *testing.T) {
+		fs, calls := drive(t, false)
+		require.Len(t, calls, 1)
+		assert.Equal(t, rolesBlob, calls[0].roles)
+		assert.NotEmpty(t, calls[0].users)
+		assert.Equal(t, backup.Success, fs.backend.glMeta.Status)
+		assert.False(t, fs.schema.lastStripNamespaces, "no class was restored, so RestoreClass never ran")
+	})
+
+	// Known limitation, as on the create side: nothing authorizes a class-less
+	// restore.
+	t.Run("implicit-include class-less restore performs no authorization call", func(t *testing.T) {
+		fs, calls := drive(t, true)
+		require.Len(t, calls, 1)
+		assert.Empty(t, fs.auth.Calls())
 	})
 }

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -1679,8 +1679,8 @@ func TestCancellingRestore(t *testing.T) {
 }
 
 // resolveUserSelectors is the pure core of includeUsers resolution: it must
-// behave like the class include-list (dedup + wildcard expansion) while
-// rejecting selectors that name nothing.
+// behave like the class include-list (dedup + wildcard expansion), reject an
+// exact selector that names nothing, and let a missed wildcard through empty.
 func TestResolveUserSelectors(t *testing.T) {
 	t.Parallel()
 
@@ -1730,9 +1730,19 @@ func TestResolveUserSelectors(t *testing.T) {
 			wantErrPart: `user "ns1:zoe" in 'includeUsers' does not exist`,
 		},
 		{
-			name:        "wildcard matches nothing",
-			include:     []string{"ns9:*"},
-			wantErrPart: "no dynamic users match",
+			name:    "wildcard matches nothing",
+			include: []string{"ns9:*"},
+			want:    []string{},
+		},
+		{
+			name:    "missed wildcard beside a live user",
+			include: []string{"ns9:*", "dave"},
+			want:    []string{"dave"},
+		},
+		{
+			name:        "missed wildcard beside a missing user",
+			include:     []string{"ns9:*", "ns1:zoe"},
+			wantErrPart: `user "ns1:zoe" in 'includeUsers' does not exist`,
 		},
 	}
 
@@ -1832,9 +1842,19 @@ func TestResolveRoleSelectors(t *testing.T) {
 			wantErrPart: `role "ns1:ghost" in 'includeRoles' does not exist`,
 		},
 		{
-			name:        "wildcard matches nothing",
-			include:     []string{"ns9:*"},
-			wantErrPart: "no roles match",
+			name:    "wildcard matches nothing",
+			include: []string{"ns9:*"},
+			want:    []string{},
+		},
+		{
+			name:    "missed wildcard beside a live role",
+			include: []string{"ns9:*", "dave"},
+			want:    []string{"dave"},
+		},
+		{
+			name:        "missed wildcard beside a missing role",
+			include:     []string{"ns9:*", "ns1:ghost"},
+			wantErrPart: `role "ns1:ghost" in 'includeRoles' does not exist`,
 		},
 		{
 			name:        "explicit built-in role rejected",
@@ -1947,24 +1967,6 @@ func TestSchedulerCreateBackupIncludeUsers(t *testing.T) {
 		assert.Contains(t, err.Error(), "does not exist")
 		assert.IsType(t, backup.ErrUnprocessable{}, err)
 	})
-
-	t.Run("includeUsers matching no users is rejected", func(t *testing.T) {
-		fs := newFakeScheduler(nil)
-		// userLister.users left empty: nothing for the selector to match.
-		fs.selector.On("ListClasses", ctx).Return([]string{cls})
-		fs.selector.On("Backupable", ctx, mock.Anything).Return(nil)
-
-		resp, err := fs.scheduler().Backup(ctx, &models.Principal{}, &BackupRequest{
-			ID:           backupID,
-			Backend:      backendName,
-			Include:      []string{cls},
-			IncludeUsers: []string{"ns1:*"},
-		})
-		assert.Nil(t, resp)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no dynamic users match")
-		assert.IsType(t, backup.ErrUnprocessable{}, err)
-	})
 }
 
 // Scheduler.Backup must record the resolved dynamic-user IDs on the global
@@ -1986,7 +1988,10 @@ func TestSchedulerCreateBackupRecordsUsers(t *testing.T) {
 		sresp       = &StatusResponse{Status: backup.Success, ID: backupID, Method: OpCreate}
 	)
 
-	setup := func(fs *fakeScheduler, req *BackupRequest) {
+	// setup returns the request fanned out to the node, so the users and the
+	// skip flag the participant actually sees are pinned, not just the descriptor.
+	setup := func(fs *fakeScheduler, req *BackupRequest) *Request {
+		nodeReq := new(Request)
 		fs.selector.On("ListClasses", ctx).Return([]string{cls})
 		fs.selector.On("Backupable", ctx, req.Include).Return(nil)
 		fs.selector.On("Shards", ctx, cls).Return([]string{node}, nil)
@@ -1994,12 +1999,15 @@ func TestSchedulerCreateBackupRecordsUsers(t *testing.T) {
 		fs.backend.On("GetObject", ctx, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
 		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
-		fs.client.On("CanCommit", any, node, any).Return(cresp, nil)
+		fs.client.On("CanCommit", any, node, any).Return(cresp, nil).Run(func(a mock.Arguments) {
+			*nodeReq = *a.Get(2).(*Request)
+		})
 		fs.client.On("Commit", any, node, sReq).Return(nil)
 		fs.client.On("Status", any, node, sReq).Return(sresp, nil)
 		fs.backend.On("PutObject", any, backupID, GlobalBackupFile, any).Return(nil).Twice()
 		fs.backend.On("GetObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(marshalMeta(backup.BackupDescriptor{Status: backup.Success}), nil)
+		return nodeReq
 	}
 
 	t.Run("includeUsers are recorded on the global descriptor", func(t *testing.T) {
@@ -2011,11 +2019,13 @@ func TestSchedulerCreateBackupRecordsUsers(t *testing.T) {
 		}
 		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
 		fs.userLister.users = []string{"ns1:alice", "ns1:bob", "ns2:carol"}
-		setup(fs, &req)
+		nodeReq := setup(fs, &req)
 
 		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
 		require.Nil(t, err)
 		assert.ElementsMatch(t, []string{"ns1:alice", "ns1:bob"}, fs.backend.glMeta.UserList())
+		assert.ElementsMatch(t, []string{"ns1:alice", "ns1:bob"}, nodeReq.Users)
+		assert.False(t, nodeReq.SkipUsers)
 	})
 
 	t.Run("ordinary backup records no users", func(t *testing.T) {
@@ -2025,11 +2035,35 @@ func TestSchedulerCreateBackupRecordsUsers(t *testing.T) {
 			Backend: backendName,
 		}
 		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
-		setup(fs, &req)
+		nodeReq := setup(fs, &req)
 
 		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
 		require.Nil(t, err)
 		assert.Nil(t, fs.backend.glMeta.Users)
+		assert.False(t, fs.backend.glMeta.SkipUsers)
+		assert.Empty(t, nodeReq.Users)
+		assert.False(t, nodeReq.SkipUsers)
+	})
+
+	t.Run("includeUsers matching no user skips the user snapshot", func(t *testing.T) {
+		req := BackupRequest{
+			ID:           backupID,
+			Include:      []string{cls},
+			Backend:      backendName,
+			IncludeUsers: []string{"ns9:*"},
+		}
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		fs.userLister.users = []string{"ns1:alice"}
+		nodeReq := setup(fs, &req)
+
+		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
+		require.NoError(t, err)
+		assert.Empty(t, fs.backend.glMeta.Users)
+		assert.True(t, fs.backend.glMeta.SkipUsers)
+		assert.False(t, fs.backend.glMeta.SkipRoles)
+		assert.Empty(t, nodeReq.Users)
+		assert.True(t, nodeReq.SkipUsers)
+		assert.False(t, nodeReq.SkipRoles)
 	})
 }
 
@@ -2055,12 +2089,12 @@ func TestSchedulerCreateBackupRecordsRoles(t *testing.T) {
 		sresp       = &StatusResponse{Status: backup.Success, ID: backupID, Method: OpCreate}
 	)
 
-	// setup returns the roles carried on the per-node request. The global descriptor is
+	// setup returns the per-node request, so the roles and the skip flag are pinned. The global descriptor is
 	// written by a different line than the one that fans out to the nodes, so asserting
 	// the descriptor alone leaves that fan-out unpinned: a node would take a full RBAC
 	// snapshot while the descriptor still advertised the caller's subset.
-	setup := func(fs *fakeScheduler, req *BackupRequest) *[]string {
-		nodeRoles := new([]string)
+	setup := func(fs *fakeScheduler, req *BackupRequest) *Request {
+		nodeReq := new(Request)
 		fs.selector.On("ListClasses", ctx).Return([]string{cls})
 		fs.selector.On("Backupable", ctx, req.Include).Return(nil)
 		fs.selector.On("Shards", ctx, cls).Return([]string{node}, nil)
@@ -2069,14 +2103,14 @@ func TestSchedulerCreateBackupRecordsRoles(t *testing.T) {
 		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
 		fs.backend.On("Initialize", ctx, mock.Anything).Return(nil)
 		fs.client.On("CanCommit", any, node, any).Return(cresp, nil).Run(func(a mock.Arguments) {
-			*nodeRoles = a.Get(2).(*Request).Roles
+			*nodeReq = *a.Get(2).(*Request)
 		})
 		fs.client.On("Commit", any, node, sReq).Return(nil)
 		fs.client.On("Status", any, node, sReq).Return(sresp, nil)
 		fs.backend.On("PutObject", any, backupID, GlobalBackupFile, any).Return(nil).Twice()
 		fs.backend.On("GetObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(marshalMeta(backup.BackupDescriptor{Status: backup.Success}), nil)
-		return nodeRoles
+		return nodeReq
 	}
 
 	t.Run("includeRoles are resolved and recorded on the global descriptor", func(t *testing.T) {
@@ -2088,12 +2122,13 @@ func TestSchedulerCreateBackupRecordsRoles(t *testing.T) {
 		}
 		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
 		fs.roleLister.roles = []string{"ns1:reader", "ns1:writer", "ns2:auditor", authorization.Admin}
-		nodeRoles := setup(fs, &req)
+		nodeReq := setup(fs, &req)
 
 		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{"ns1:reader", "ns1:writer"}, fs.backend.glMeta.Roles)
-		assert.ElementsMatch(t, []string{"ns1:reader", "ns1:writer"}, *nodeRoles)
+		assert.ElementsMatch(t, []string{"ns1:reader", "ns1:writer"}, nodeReq.Roles)
+		assert.False(t, nodeReq.SkipRoles)
 	})
 
 	t.Run("ordinary backup records no roles", func(t *testing.T) {
@@ -2104,12 +2139,34 @@ func TestSchedulerCreateBackupRecordsRoles(t *testing.T) {
 		}
 		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
 		fs.roleLister.roles = []string{"ns1:reader"}
-		nodeRoles := setup(fs, &req)
+		nodeReq := setup(fs, &req)
 
 		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
 		require.NoError(t, err)
 		assert.Nil(t, fs.backend.glMeta.Roles)
-		assert.Empty(t, *nodeRoles)
+		assert.Empty(t, nodeReq.Roles)
+		assert.False(t, nodeReq.SkipRoles)
+	})
+
+	t.Run("includeRoles matching no role skips the RBAC snapshot", func(t *testing.T) {
+		req := BackupRequest{
+			ID:           backupID,
+			Include:      []string{cls},
+			Backend:      backendName,
+			IncludeRoles: []string{"ns9:*"},
+		}
+		fs := newFakeScheduler(newFakeNodeResolver([]string{node}))
+		fs.roleLister.roles = []string{"ns1:reader"}
+		nodeReq := setup(fs, &req)
+
+		_, err := fs.scheduler().Backup(ctx, &models.Principal{}, &req)
+		require.NoError(t, err)
+		assert.Empty(t, fs.backend.glMeta.Roles)
+		assert.True(t, fs.backend.glMeta.SkipRoles)
+		assert.False(t, fs.backend.glMeta.SkipUsers)
+		assert.Empty(t, nodeReq.Roles)
+		assert.True(t, nodeReq.SkipRoles)
+		assert.False(t, nodeReq.SkipUsers)
 	})
 }
 
@@ -2942,7 +2999,8 @@ func TestRestoreRejectsInactiveNamespaceRefs(t *testing.T) {
 }
 
 // TestRestoreSelectsLeaderBlob pins which snapshots the cluster-wide entry
-// carries: the leader's, and none at all when the subsystem is disabled here.
+// carries: the leader's, none at all when the subsystem is disabled here, and
+// none for a subsystem whose descriptor says the selector matched nothing.
 func TestRestoreSelectsLeaderBlob(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -2951,7 +3009,8 @@ func TestRestoreSelectsLeaderBlob(t *testing.T) {
 	userBlob := []byte(`{"Version":0,"Data":{"Users":{"alice":{"Id":"alice"}}}}`)
 
 	// nodeBlobs maps a node name to the RBAC blob its own descriptor carries.
-	drive := func(t *testing.T, leader string, nodeBlobs map[string][]byte, nilListers bool) []rolesAndUsersCall {
+	type skip struct{ users, roles bool }
+	drive := func(t *testing.T, leader string, nodeBlobs map[string][]byte, nilListers bool, sk skip) []rolesAndUsersCall {
 		t.Helper()
 		backupID := "pick-blob"
 		nodes := make([]string, 0, len(nodeBlobs))
@@ -2967,6 +3026,7 @@ func TestRestoreSelectsLeaderBlob(t *testing.T) {
 		meta := backup.DistributedBackupDescriptor{
 			ID: backupID, StartedAt: time.Now().UTC(), Version: Version,
 			ServerVersion: "1.23", Status: backup.Success, Leader: leader, Nodes: descNodes,
+			SkipUsers: sk.users, SkipRoles: sk.roles,
 		}
 
 		fs := newFakeScheduler(newFakeNodeResolver(nodes))
@@ -3005,15 +3065,36 @@ func TestRestoreSelectsLeaderBlob(t *testing.T) {
 	}
 
 	t.Run("the leader's snapshots are the ones applied", func(t *testing.T) {
-		calls := drive(t, "Node-B", map[string][]byte{"Node-A": blobA, "Node-B": blobB}, false)
+		calls := drive(t, "Node-B", map[string][]byte{"Node-A": blobA, "Node-B": blobB}, false, skip{})
 		require.Len(t, calls, 1)
 		assert.Equal(t, blobB, calls[0].roles)
 		assert.Equal(t, userBlob, calls[0].users)
 	})
 
 	t.Run("subsystems disabled: no blob and no entry", func(t *testing.T) {
-		calls := drive(t, "Node-A", map[string][]byte{"Node-A": blobA}, true)
+		calls := drive(t, "Node-A", map[string][]byte{"Node-A": blobA}, true, skip{})
 		assert.Empty(t, calls, "a nil lister means the subsystem is off on this cluster")
+	})
+
+	// The node uploaded blobs the descriptor says were never selected, as a
+	// participant without the request-level skip flag does.
+	t.Run("descriptor skip discards the users blob", func(t *testing.T) {
+		calls := drive(t, "Node-A", map[string][]byte{"Node-A": blobA}, false, skip{users: true})
+		require.Len(t, calls, 1)
+		assert.Equal(t, blobA, calls[0].roles)
+		assert.Empty(t, calls[0].users)
+	})
+
+	t.Run("descriptor skip discards the roles blob", func(t *testing.T) {
+		calls := drive(t, "Node-A", map[string][]byte{"Node-A": blobA}, false, skip{roles: true})
+		require.Len(t, calls, 1)
+		assert.Empty(t, calls[0].roles)
+		assert.Equal(t, userBlob, calls[0].users)
+	})
+
+	t.Run("descriptor skip on both: no entry", func(t *testing.T) {
+		calls := drive(t, "Node-A", map[string][]byte{"Node-A": blobA}, false, skip{users: true, roles: true})
+		assert.Empty(t, calls)
 	})
 }
 
@@ -3077,4 +3158,57 @@ func TestRestoreIgnoresNodeMappingForUnknownNode(t *testing.T) {
 			fs.client.AssertNotCalled(t, "CanCommit", mock.Anything, newNode, mock.Anything)
 		})
 	}
+}
+
+// A class include list made only of wildcards that match nothing must not fall
+// through to every class: the authorization check saw only the pattern, and a
+// backup or restore of every class is not what was asked for.
+func TestIncludeWildcardMiss(t *testing.T) {
+	t.Parallel()
+	var (
+		ctx  = context.Background()
+		id   = "wildcard-miss"
+		path = "bucket/backups/" + id
+	)
+
+	t.Run("backup", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		fs.selector.On("ListClasses", ctx).Return([]string{"C1", "C2"})
+		fs.selector.On("Backupable", ctx, mock.Anything).Return(nil)
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
+		store := coordStore{objectStore{fs.backend, id, "", "", ""}}
+
+		selection, err := fs.scheduler().validateBackupRequest(ctx, store, &BackupRequest{
+			ID: id, Backend: "s3", Include: []string{"Zzz*"},
+		})
+		require.Error(t, err, "resolved classes: %v", selection.classes)
+		assert.Contains(t, err.Error(), "Zzz*")
+	})
+
+	t.Run("restore", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		meta := backup.DistributedBackupDescriptor{
+			ID:            id,
+			StartedAt:     time.Now().UTC(),
+			Version:       Version,
+			ServerVersion: "1.23",
+			Status:        backup.Success,
+			Nodes:         map[string]*backup.NodeDescriptor{"Node-1": {Classes: []string{"C1", "C2"}}},
+		}
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(marshalCoordinatorMeta(meta), nil)
+		fs.backend.On("HomeDir", mock.Anything, mock.Anything, mock.Anything).Return(path)
+		store := coordStore{objectStore{fs.backend, id, "", "", ""}}
+
+		got, err := fs.scheduler().validateRestoreRequest(ctx, store, &BackupRequest{
+			ID: id, Backend: "s3", Include: []string{"Zzz*"},
+		})
+		var classes []string
+		if got != nil {
+			classes = got.Classes()
+		}
+		require.Error(t, err, "resolved classes: %v", classes)
+		assert.Contains(t, err.Error(), "Zzz*")
+	})
 }

--- a/usecases/backup/transport.go
+++ b/usecases/backup/transport.go
@@ -44,12 +44,21 @@ type Request struct {
 	Classes []string
 
 	// Resolved from BackupRequest.IncludeUsers by the scheduler. Empty
-	// means the participant keeps its whole-cluster user-snapshot default.
+	// means the participant keeps its whole-cluster user-snapshot default
+	// unless SkipUsers is set.
 	Users []string
 
 	// Resolved from BackupRequest.IncludeRoles by the scheduler. Empty
-	// means the participant keeps its whole-cluster RBAC-snapshot default.
+	// means the participant keeps its whole-cluster RBAC-snapshot default
+	// unless SkipRoles is set.
 	Roles []string
+
+	// SkipUsers is set when IncludeUsers was given but matched no user. The
+	// participant then uploads no user snapshot.
+	SkipUsers bool
+
+	// SkipRoles is the IncludeRoles counterpart of SkipUsers.
+	SkipRoles bool
 
 	// Duration
 	Duration time.Duration


### PR DESCRIPTION
A backup can now select zero collections, as long as it selects at least one user or role through `includeUsers` or `includeRoles`. Such a backup restores its users and roles without touching any collection. A request that selects nothing at all is still rejected.

### What's being changed

- A create request that resolves to no collection succeeds when at least one user or role is selected. This covers a cluster without collections and an `include` pattern that matches none, such as a namespace with users and roles but no collection yet.
- A create request that selects no collection, no user and no role is rejected. The message says which of the three was unset or matched nothing.
- An `include` pattern that matches nothing no longer falls through to every collection. Only an omitted `include` means all collections.
- A restore of a backup with zero classes is accepted. It applies users and roles according to `usersOptions` and `rolesOptions` and touches no collection.
- Such a restore is rejected when it names any `include` or `exclude` entry, or when both restore options are `noRestore`.
- The coordinator's commit step returns at once on an empty node set instead of blocking forever. The restore validator keeps the leader's node entry, so this path stays unreachable.
- The API descriptions of `include`, `includeUsers` and `includeRoles` state the new rule.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
