### PR TITLE
Fix shifted weaviate_module_error_total labels and qna-openai nil-response panic

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -366,7 +366,7 @@ This document is the single source of truth for Prometheus metrics exposed by We
 | `weaviate_vectorizer_request_tokens` | Number of tokens in the request sent to an external vectorizer | `Histogram` | `api, inout` | ❌ High 
 | `weaviate_module_request_single_count` | Number of single-item external API requests | `Counter` | `api, op` | ❌ High 
 | `weaviate_module_request_batch_count` | Number of batched module requests | `Counter` | `api, op` | ❌ High 
-| `weaviate_module_error_total` | Number of OpenAI errors | `Counter` | `endpoint, module, op, status_code` | ❌ High 
+| `weaviate_module_error_total` | Number of module errors from external APIs | `Counter` | `endpoint, module, op, status_code` | - Low (bounded values; pre-fix series carried error text in `endpoint` and drain on process restart) 
 | `weaviate_module_call_error_total` | Number of module errors (related to external calls) | `Counter` | `endpoint, module, status_code` | ❌ High 
 | `weaviate_module_response_status_total` | Number of API response statuses | `Counter` | `endpoint, op, status` | ❌ High 
 | `weaviate_module_batch_error_total` | Number of batch errors | `Counter` | `class_name, operation` | ❌ High 

--- a/modules/qna-openai/clients/qna.go
+++ b/modules/qna-openai/clients/qna.go
@@ -121,9 +121,11 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 		vrst.WithLabelValues("qna", oaiUrl, fmt.Sprintf("%v", res.StatusCode)).Inc()
 	}
 	if err != nil {
-		vrst := metrics.ModuleExternalResponseStatus
-		vrst.WithLabelValues("qna", oaiUrl, fmt.Sprintf("%v", res.StatusCode)).Inc()
-		monitoring.GetMetrics().ModuleExternalError.WithLabelValues("qna", "openai", "OpenAI API", fmt.Sprintf("%v", res.StatusCode)).Inc()
+		code := -1
+		if res != nil {
+			code = res.StatusCode
+		}
+		monitoring.GetMetrics().ModuleExternalError.WithLabelValues("qna", "openai", "OpenAI API", fmt.Sprintf("%v", code)).Inc()
 		return nil, errors.Wrap(err, "send POST request")
 	}
 	defer res.Body.Close()
@@ -140,8 +142,6 @@ func (v *qna) Answer(ctx context.Context, text, question string, cfg moduletools
 	}
 
 	monitoring.GetMetrics().ModuleExternalResponseSize.WithLabelValues("generate", oaiUrl).Observe(float64(len(bodyBytes)))
-	vrst := monitoring.GetMetrics().ModuleExternalResponseStatus
-	vrst.WithLabelValues("qna", oaiUrl, fmt.Sprintf("%v", res.StatusCode)).Inc()
 
 	if res.StatusCode != 200 || resBody.Error != nil {
 		return nil, v.getError(res.StatusCode, requestID, resBody.Error, settings.IsAzure())

--- a/modules/qna-openai/clients/qna_test.go
+++ b/modules/qna-openai/clients/qna_test.go
@@ -19,11 +19,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/modules/qna-openai/ent"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 func nullLogger() logrus.FieldLogger {
@@ -137,6 +139,48 @@ func TestGetAnswer(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "https://headerResourceName.openai.azure.com/openai/deployments/headerDeploymentId/completions?api-version=2022-12-01", buildURL)
 	})
+}
+
+func TestAnswerTransportError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
+	c := New("openAIApiKey", "", "", 0, nullLogger())
+	c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
+		return buildUrl(server.URL, resourceName, deploymentID, isAzure)
+	}
+
+	vec := monitoring.GetMetrics().ModuleExternalError
+	series := vec.WithLabelValues("qna", "openai", "OpenAI API", "-1")
+	before := testutil.ToFloat64(series)
+
+	_, err := c.Answer(context.Background(), "My name is John", "What is my name?", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "send POST request")
+	assert.Equal(t, before+1, testutil.ToFloat64(series))
+}
+
+func TestAnswerResponseStatusCountedOnce(t *testing.T) {
+	server := httptest.NewServer(&testAnswerHandler{
+		t:      t,
+		answer: answersResponse{Choices: []choice{{Text: "John"}}},
+	})
+	defer server.Close()
+
+	c := New("openAIApiKey", "", "", 0, nullLogger())
+	c.buildUrlFn = func(baseURL, resourceName, deploymentID string, isAzure bool) (string, error) {
+		return buildUrl(server.URL, resourceName, deploymentID, isAzure)
+	}
+
+	vec := monitoring.GetMetrics().ModuleExternalResponseStatus
+	series := vec.WithLabelValues("qna", server.URL+"/v1/completions", "200")
+	before := testutil.ToFloat64(series)
+
+	_, err := c.Answer(context.Background(), "My name is John", "What is my name?", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, before+1, testutil.ToFloat64(series))
 }
 
 type testAnswerHandler struct {

--- a/modules/text2vec-digitalocean/clients/digitalocean.go
+++ b/modules/text2vec-digitalocean/clients/digitalocean.go
@@ -143,7 +143,7 @@ func (c *Client) vectorize(ctx context.Context, input []string, cfg moduletools.
 		metrics.ModuleExternalResponseStatus.WithLabelValues("text2vec", endpoint, strconv.Itoa(res.StatusCode)).Inc()
 	}
 	if err != nil {
-		metrics.ModuleCallError.WithLabelValues(moduleLabel, endpoint, err.Error()).Inc()
+		metrics.ModuleCallError.WithLabelValues(moduleLabel, endpoint, "transport_error").Inc()
 		return nil, nil, 0, errors.Wrap(err, "send POST request")
 	}
 	defer res.Body.Close()
@@ -226,7 +226,7 @@ func formatError(statusCode int, requestID string, body *digitalOceanError) erro
 	if body != nil && body.Message != "" {
 		msg = fmt.Sprintf("%s error: %s", msg, body.Message)
 	}
-	monitoring.GetMetrics().ModuleExternalError.WithLabelValues("text2vec", endpoint, msg, strconv.Itoa(statusCode)).Inc()
+	monitoring.GetMetrics().ModuleExternalError.WithLabelValues("text2vec", moduleLabel, endpoint, strconv.Itoa(statusCode)).Inc()
 	return errors.New(msg)
 }
 

--- a/modules/text2vec-digitalocean/clients/digitalocean_test.go
+++ b/modules/text2vec-digitalocean/clients/digitalocean_test.go
@@ -19,15 +19,18 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
 type fakeClassConfig struct {
@@ -111,6 +114,57 @@ func TestClient_Vectorize_ErrorBody(t *testing.T) {
 	assert.Contains(t, err.Error(), "status: 400")
 	assert.Contains(t, err.Error(), "req-123")
 	assert.Contains(t, err.Error(), "model not found")
+}
+
+func TestClient_Vectorize_ErrorMetricLabels(t *testing.T) {
+	var reqNum atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-request-id", fmt.Sprintf("req-%d", reqNum.Add(1)))
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error": {"message": "model not found", "type": "not_found"}}`)
+	}))
+	t.Cleanup(server.Close)
+
+	c := New("test-key", 5*time.Second, logrus.New())
+	cfg := fakeClassConfig{cfg: map[string]any{
+		"model":   "bogus",
+		"baseURL": server.URL,
+	}}
+
+	vec := monitoring.GetMetrics().ModuleExternalError
+	series := vec.WithLabelValues("text2vec", moduleLabel, "DigitalOcean Serverless Inference API", "400")
+	before := testutil.ToFloat64(series)
+	seriesCount := testutil.CollectAndCount(vec)
+
+	for range 2 {
+		_, _, _, err := c.Vectorize(context.Background(), []string{"hello"}, cfg)
+		require.Error(t, err)
+	}
+
+	assert.Equal(t, before+2, testutil.ToFloat64(series))
+	assert.Equal(t, seriesCount, testutil.CollectAndCount(vec))
+}
+
+func TestClient_Vectorize_TransportErrorMetric(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
+	c := New("test-key", 5*time.Second, logrus.New())
+	cfg := fakeClassConfig{cfg: map[string]any{
+		"model":   "bogus",
+		"baseURL": server.URL,
+	}}
+
+	vec := monitoring.GetMetrics().ModuleCallError
+	series := vec.WithLabelValues(moduleLabel, server.URL+"/v1/embeddings", "transport_error")
+	before := testutil.ToFloat64(series)
+	seriesCount := testutil.CollectAndCount(vec)
+
+	_, _, _, err := c.Vectorize(context.Background(), []string{"hello"}, cfg)
+	require.Error(t, err)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(series))
+	assert.Equal(t, seriesCount, testutil.CollectAndCount(vec))
 }
 
 func TestClient_Vectorize_MissingApiKey(t *testing.T) {

--- a/modules/text2vec-digitalocean/module.go
+++ b/modules/text2vec-digitalocean/module.go
@@ -123,14 +123,14 @@ func (m *DigitalOceanModule) initAdditionalPropertiesProvider() error {
 func (m *DigitalOceanModule) VectorizeObject(ctx context.Context,
 	obj *models.Object, cfg moduletools.ClassConfig,
 ) ([]float32, models.AdditionalProperties, error) {
-	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues(m.Name(), "vectorizeObject").Inc()
+	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues("vectorizeObject", m.Name()).Inc()
 	icheck := ent.NewClassSettings(cfg)
 	return m.vectorizer.Object(ctx, obj, cfg, icheck)
 }
 
 func (m *DigitalOceanModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	monitoring.GetMetrics().ModuleExternalBatchLength.WithLabelValues("vectorizeBatch", m.Name()).Observe(float64(len(objs)))
-	monitoring.GetMetrics().ModuleExternalRequestBatchCount.WithLabelValues(m.Name(), "vectorizeBatch").Inc()
+	monitoring.GetMetrics().ModuleExternalRequestBatchCount.WithLabelValues("vectorizeBatch", m.Name()).Inc()
 	vecs, errs := m.vectorizer.ObjectBatch(ctx, objs, skipObject, cfg)
 	return vecs, nil, errs
 }
@@ -146,8 +146,8 @@ func (m *DigitalOceanModule) AdditionalProperties() map[string]modulecapabilitie
 func (m *DigitalOceanModule) VectorizeInput(ctx context.Context,
 	input string, cfg moduletools.ClassConfig,
 ) ([]float32, error) {
-	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues(m.Name(), "vectorizeTexts").Inc()
-	monitoring.GetMetrics().ModuleExternalRequestSize.WithLabelValues(m.Name(), "vectorizeTexts").Observe(float64(len(input)))
+	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues("vectorizeTexts", m.Name()).Inc()
+	monitoring.GetMetrics().ModuleExternalRequestSize.WithLabelValues("vectorizeTexts", m.Name()).Observe(float64(len(input)))
 	return m.vectorizer.Texts(ctx, []string{input}, cfg)
 }
 

--- a/modules/text2vec-digitalocean/module_metrics_test.go
+++ b/modules/text2vec-digitalocean/module_metrics_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package moddigitalocean
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	objectsvectorizer "github.com/weaviate/weaviate/usecases/modulecomponents/vectorizer"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+type fakeVectorizer struct{}
+
+func (fakeVectorizer) Texts(context.Context, []string, moduletools.ClassConfig) ([]float32, error) {
+	return nil, nil
+}
+
+func (fakeVectorizer) Object(context.Context, *models.Object, moduletools.ClassConfig, objectsvectorizer.ClassSettings) ([]float32, models.AdditionalProperties, error) {
+	return nil, nil, nil
+}
+
+func (fakeVectorizer) ObjectBatch(context.Context, []*models.Object, []bool, moduletools.ClassConfig) ([][]float32, map[int]error) {
+	return nil, nil
+}
+
+func TestModuleRequestMetricLabels(t *testing.T) {
+	m := &DigitalOceanModule{vectorizer: fakeVectorizer{}}
+	metrics := monitoring.GetMetrics()
+	ctx := context.Background()
+
+	sizeVec := metrics.ModuleExternalRequestSize
+	sizeVec.WithLabelValues("vectorizeTexts", Name)
+	sizeSeries := testutil.CollectAndCount(sizeVec)
+
+	tests := []struct {
+		op   string
+		vec  *prometheus.CounterVec
+		call func(t *testing.T)
+	}{
+		{"vectorizeObject", metrics.ModuleExternalRequestSingleCount, func(t *testing.T) {
+			_, _, err := m.VectorizeObject(ctx, &models.Object{}, nil)
+			require.NoError(t, err)
+		}},
+		{"vectorizeBatch", metrics.ModuleExternalRequestBatchCount, func(t *testing.T) {
+			_, _, errs := m.VectorizeBatch(ctx, []*models.Object{{}}, []bool{false}, nil)
+			require.Empty(t, errs)
+		}},
+		{"vectorizeTexts", metrics.ModuleExternalRequestSingleCount, func(t *testing.T) {
+			_, err := m.VectorizeInput(ctx, "hello", nil)
+			require.NoError(t, err)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.op, func(t *testing.T) {
+			series := tt.vec.WithLabelValues(tt.op, Name)
+			before := testutil.ToFloat64(series)
+			tt.call(t)
+			assert.Equal(t, before+1, testutil.ToFloat64(series))
+		})
+	}
+
+	assert.Equal(t, sizeSeries, testutil.CollectAndCount(sizeVec))
+}

--- a/modules/text2vec-morph/module.go
+++ b/modules/text2vec-morph/module.go
@@ -124,14 +124,14 @@ func (m *MorphModule) initAdditionalPropertiesProvider() error {
 func (m *MorphModule) VectorizeObject(ctx context.Context,
 	obj *models.Object, cfg moduletools.ClassConfig,
 ) ([]float32, models.AdditionalProperties, error) {
-	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues(m.Name(), "vectorizeObject").Inc()
+	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues("vectorizeObject", m.Name()).Inc()
 	icheck := ent.NewClassSettings(cfg)
 	return m.vectorizer.Object(ctx, obj, cfg, icheck)
 }
 
 func (m *MorphModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	monitoring.GetMetrics().ModuleExternalBatchLength.WithLabelValues("vectorizeBatch", m.Name()).Observe(float64(len(objs)))
-	monitoring.GetMetrics().ModuleExternalRequestBatchCount.WithLabelValues(m.Name(), "vectorizeBatch").Inc()
+	monitoring.GetMetrics().ModuleExternalRequestBatchCount.WithLabelValues("vectorizeBatch", m.Name()).Inc()
 	vecs, errs := m.vectorizer.ObjectBatch(ctx, objs, skipObject, cfg)
 	return vecs, nil, errs
 }
@@ -147,8 +147,8 @@ func (m *MorphModule) AdditionalProperties() map[string]modulecapabilities.Addit
 func (m *MorphModule) VectorizeInput(ctx context.Context,
 	input string, cfg moduletools.ClassConfig,
 ) ([]float32, error) {
-	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues(m.Name(), "vectorizeTexts").Inc()
-	monitoring.GetMetrics().ModuleExternalRequestSize.WithLabelValues(m.Name(), "vectorizeTexts").Observe(float64(len(input)))
+	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues("vectorizeTexts", m.Name()).Inc()
+	monitoring.GetMetrics().ModuleExternalRequestSize.WithLabelValues("vectorizeTexts", m.Name()).Observe(float64(len(input)))
 	return m.vectorizer.Texts(ctx, []string{input}, cfg)
 }
 

--- a/modules/text2vec-morph/module_metrics_test.go
+++ b/modules/text2vec-morph/module_metrics_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modmorph
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	objectsvectorizer "github.com/weaviate/weaviate/usecases/modulecomponents/vectorizer"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+type fakeVectorizer struct{}
+
+func (fakeVectorizer) Texts(context.Context, []string, moduletools.ClassConfig) ([]float32, error) {
+	return nil, nil
+}
+
+func (fakeVectorizer) Object(context.Context, *models.Object, moduletools.ClassConfig, objectsvectorizer.ClassSettings) ([]float32, models.AdditionalProperties, error) {
+	return nil, nil, nil
+}
+
+func (fakeVectorizer) ObjectBatch(context.Context, []*models.Object, []bool, moduletools.ClassConfig) ([][]float32, map[int]error) {
+	return nil, nil
+}
+
+func TestModuleRequestMetricLabels(t *testing.T) {
+	m := &MorphModule{vectorizer: fakeVectorizer{}}
+	metrics := monitoring.GetMetrics()
+	ctx := context.Background()
+
+	sizeVec := metrics.ModuleExternalRequestSize
+	sizeVec.WithLabelValues("vectorizeTexts", Name)
+	sizeSeries := testutil.CollectAndCount(sizeVec)
+
+	tests := []struct {
+		op   string
+		vec  *prometheus.CounterVec
+		call func(t *testing.T)
+	}{
+		{"vectorizeObject", metrics.ModuleExternalRequestSingleCount, func(t *testing.T) {
+			_, _, err := m.VectorizeObject(ctx, &models.Object{}, nil)
+			require.NoError(t, err)
+		}},
+		{"vectorizeBatch", metrics.ModuleExternalRequestBatchCount, func(t *testing.T) {
+			_, _, errs := m.VectorizeBatch(ctx, []*models.Object{{}}, []bool{false}, nil)
+			require.Empty(t, errs)
+		}},
+		{"vectorizeTexts", metrics.ModuleExternalRequestSingleCount, func(t *testing.T) {
+			_, err := m.VectorizeInput(ctx, "hello", nil)
+			require.NoError(t, err)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.op, func(t *testing.T) {
+			series := tt.vec.WithLabelValues(tt.op, Name)
+			before := testutil.ToFloat64(series)
+			tt.call(t)
+			assert.Equal(t, before+1, testutil.ToFloat64(series))
+		})
+	}
+
+	assert.Equal(t, sizeSeries, testutil.CollectAndCount(sizeVec))
+}

--- a/modules/text2vec-openai/module.go
+++ b/modules/text2vec-openai/module.go
@@ -128,14 +128,14 @@ func (m *OpenAIModule) initAdditionalPropertiesProvider() error {
 func (m *OpenAIModule) VectorizeObject(ctx context.Context,
 	obj *models.Object, cfg moduletools.ClassConfig,
 ) ([]float32, models.AdditionalProperties, error) {
-	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues(m.Name(), "vectorizeObject").Inc()
+	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues("vectorizeObject", m.Name()).Inc()
 	icheck := ent.NewClassSettings(cfg)
 	return m.vectorizer.Object(ctx, obj, cfg, icheck)
 }
 
 func (m *OpenAIModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	monitoring.GetMetrics().ModuleExternalBatchLength.WithLabelValues("vectorizeBatch", m.Name()).Observe(float64(len(objs)))
-	monitoring.GetMetrics().ModuleExternalRequestBatchCount.WithLabelValues(m.Name(), "vectorizeBatch").Inc()
+	monitoring.GetMetrics().ModuleExternalRequestBatchCount.WithLabelValues("vectorizeBatch", m.Name()).Inc()
 	vecs, errs := m.vectorizer.ObjectBatch(ctx, objs, skipObject, cfg)
 	return vecs, nil, errs
 }
@@ -151,8 +151,8 @@ func (m *OpenAIModule) AdditionalProperties() map[string]modulecapabilities.Addi
 func (m *OpenAIModule) VectorizeInput(ctx context.Context,
 	input string, cfg moduletools.ClassConfig,
 ) ([]float32, error) {
-	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues(m.Name(), "vectorizeTexts").Inc()
-	monitoring.GetMetrics().ModuleExternalRequestSize.WithLabelValues(m.Name(), "vectorizeTexts").Observe(float64(len(input)))
+	monitoring.GetMetrics().ModuleExternalRequestSingleCount.WithLabelValues("vectorizeTexts", m.Name()).Inc()
+	monitoring.GetMetrics().ModuleExternalRequestSize.WithLabelValues("vectorizeTexts", m.Name()).Observe(float64(len(input)))
 	return m.vectorizer.Texts(ctx, []string{input}, cfg)
 }
 

--- a/modules/text2vec-openai/module_metrics_test.go
+++ b/modules/text2vec-openai/module_metrics_test.go
@@ -1,0 +1,80 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modopenai
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	objectsvectorizer "github.com/weaviate/weaviate/usecases/modulecomponents/vectorizer"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+type fakeVectorizer struct{}
+
+func (fakeVectorizer) Texts(context.Context, []string, moduletools.ClassConfig) ([]float32, error) {
+	return nil, nil
+}
+
+func (fakeVectorizer) Object(context.Context, *models.Object, moduletools.ClassConfig, objectsvectorizer.ClassSettings) ([]float32, models.AdditionalProperties, error) {
+	return nil, nil, nil
+}
+
+func (fakeVectorizer) ObjectBatch(context.Context, []*models.Object, []bool, moduletools.ClassConfig) ([][]float32, map[int]error) {
+	return nil, nil
+}
+
+func TestModuleRequestMetricLabels(t *testing.T) {
+	m := &OpenAIModule{vectorizer: fakeVectorizer{}}
+	metrics := monitoring.GetMetrics()
+	ctx := context.Background()
+
+	sizeVec := metrics.ModuleExternalRequestSize
+	sizeVec.WithLabelValues("vectorizeTexts", Name)
+	sizeSeries := testutil.CollectAndCount(sizeVec)
+
+	tests := []struct {
+		op   string
+		vec  *prometheus.CounterVec
+		call func(t *testing.T)
+	}{
+		{"vectorizeObject", metrics.ModuleExternalRequestSingleCount, func(t *testing.T) {
+			_, _, err := m.VectorizeObject(ctx, &models.Object{}, nil)
+			require.NoError(t, err)
+		}},
+		{"vectorizeBatch", metrics.ModuleExternalRequestBatchCount, func(t *testing.T) {
+			_, _, errs := m.VectorizeBatch(ctx, []*models.Object{{}}, []bool{false}, nil)
+			require.Empty(t, errs)
+		}},
+		{"vectorizeTexts", metrics.ModuleExternalRequestSingleCount, func(t *testing.T) {
+			_, err := m.VectorizeInput(ctx, "hello", nil)
+			require.NoError(t, err)
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.op, func(t *testing.T) {
+			series := tt.vec.WithLabelValues(tt.op, Name)
+			before := testutil.ToFloat64(series)
+			tt.call(t)
+			assert.Equal(t, before+1, testutil.ToFloat64(series))
+		})
+	}
+
+	assert.Equal(t, sizeSeries, testutil.CollectAndCount(sizeVec))
+}

--- a/usecases/modulecomponents/clients/openai/openai.go
+++ b/usecases/modulecomponents/clients/openai/openai.go
@@ -204,7 +204,7 @@ func (v *Client) vectorize(ctx context.Context, input []string, model string, se
 		vrst.WithLabelValues("text2vec", endpoint, fmt.Sprintf("%v", res.StatusCode)).Inc()
 	}
 	if err != nil {
-		metrics.ModuleCallError.WithLabelValues("openai", endpoint, fmt.Sprintf("%v", err)).Inc()
+		metrics.ModuleCallError.WithLabelValues("openai", endpoint, "transport_error").Inc()
 		return nil, nil, 0, errors.Wrap(err, "send POST request")
 	}
 	defer res.Body.Close()
@@ -287,7 +287,7 @@ func (v *Client) getError(statusCode int, requestID string, resBodyError *openAI
 	if resBodyError != nil {
 		errorMsg = fmt.Sprintf("%s error: %v", errorMsg, resBodyError.Message)
 	}
-	monitoring.GetMetrics().ModuleExternalError.WithLabelValues("text2vec", endpoint, errorMsg, fmt.Sprintf("%v", statusCode)).Inc()
+	monitoring.GetMetrics().ModuleExternalError.WithLabelValues("text2vec", "openai", endpoint, fmt.Sprintf("%v", statusCode)).Inc()
 	return errors.New(errorMsg)
 }
 

--- a/usecases/modulecomponents/clients/openai/openai_test.go
+++ b/usecases/modulecomponents/clients/openai/openai_test.go
@@ -21,8 +21,10 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/usecases/modulecomponents"
+	"github.com/weaviate/weaviate/usecases/monitoring"
 
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -582,6 +584,53 @@ func TestGetErrorFormat(t *testing.T) {
 	assert.Contains(t, err.Error(), "403")
 	assert.Contains(t, err.Error(), "abc-123")
 	assert.Contains(t, err.Error(), "denied")
+}
+
+func TestGetErrorMetricLabels(t *testing.T) {
+	c := New("", "", "", 0, nullLogger())
+	vec := monitoring.GetMetrics().ModuleExternalError
+
+	tests := []struct {
+		name     string
+		isAzure  bool
+		endpoint string
+	}{
+		{"openai", false, "OpenAI API"},
+		{"azure", true, "Azure OpenAI API"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			series := vec.WithLabelValues("text2vec", "openai", tt.endpoint, "429")
+			before := testutil.ToFloat64(series)
+
+			err := c.getError(429, "req-1", &openAIApiError{Message: "rate limited org-abc"}, tt.isAzure)
+			require.ErrorContains(t, err, "req-1")
+			seriesCount := testutil.CollectAndCount(vec)
+
+			err = c.getError(429, "req-2", &openAIApiError{Message: "rate limited org-xyz"}, tt.isAzure)
+			require.ErrorContains(t, err, "req-2")
+
+			assert.Equal(t, seriesCount, testutil.CollectAndCount(vec))
+			assert.Equal(t, before+2, testutil.ToFloat64(series))
+		})
+	}
+}
+
+func TestVectorizeTransportErrorMetric(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server.Close()
+
+	c := New("apiKey", "", "", 0, nullLogger())
+	vec := monitoring.GetMetrics().ModuleCallError
+	series := vec.WithLabelValues("openai", server.URL+"/v1/embeddings", "transport_error")
+	before := testutil.ToFloat64(series)
+	seriesCount := testutil.CollectAndCount(vec)
+
+	_, _, _, err := c.vectorize(context.Background(), []string{"x"}, "ada", Settings{BaseURL: server.URL})
+	require.Error(t, err)
+
+	assert.Equal(t, before+1, testutil.ToFloat64(series))
+	assert.Equal(t, seriesCount, testutil.CollectAndCount(vec))
 }
 
 func TestOpenAIApiErrorDecode(t *testing.T) {


### PR DESCRIPTION
## Motivation

`weaviate_module_error_total` is declared with labels `{op, module, endpoint, status_code}`, but the shared OpenAI vectorizer client and the text2vec-digitalocean client passed `(op, endpoint, errorMessage, statusCode)` — one slot short, everything shifted. The `endpoint` label ended up carrying the full provider error message, including the per-request `x-request-id`, so every failed provider request minted a brand-new time series. Beyond the cardinality explosion, the flood of single-sample series meant `rate()`-based alerts on this metric could never fire — exactly when the provider was failing — and provider error text leaked into label values. The sibling `weaviate_module_call_error_total` had the same unboundedness: transport `err.Error()` in its `status_code` label.

Fixing those paths surfaced a worse bug next door: qna-openai's `err != nil` branch after `httpClient.Do` dereferences `res.StatusCode`, and `res` is nil on any transport error — every connection failure in the qna path panicked instead of returning an error.

## Approach

Call-site fixes only — no metric is renamed and no declared label set changes; the declarations were always right, the values passed were wrong. Shifted callers now fill `module` and `endpoint` in their declared positions with the numeric code in `status_code`; transport errors count under bounded sentinels (`transport_error` for the call-error metric, `-1` when no response exists, matching the existing generative-openai convention). qna-openai additionally stops multi-counting `ModuleExternalResponseStatus` — previously each failed response was counted twice and each success twice (a post-parse re-increment); each response is now counted exactly once. Error messages returned to callers are byte-identical to before.

Every other `ModuleExternalError`/`ModuleCallError` call site in the tree was audited: the four fixed here were the only ones passing unbounded or misordered values.

A follow-up audit of all labeled metric call sites found the same order-swap pattern in the module layer: twelve sites across text2vec-openai, text2vec-digitalocean, and text2vec-morph passed `(module name, operation)` to counters declared `{op, api}` (`weaviate_module_request_single_count`, `_batch_count`, `_size_bytes`). Both values are bounded, so no cardinality impact — but any `op`/`api` aggregation silently dropped the module-layer counts. The `ModuleExternalBatchLength` call in the same functions already used the declared order. Fixed in the third commit with per-module regression tests.

## Key areas for review

- `usecases/modulecomponents/clients/openai/openai.go:getError` and `modules/text2vec-digitalocean/clients/digitalocean.go:formatError` — verify the four values now line up with the declared `{op, module, endpoint, status_code}` order
- `modules/qna-openai/clients/qna.go:Answer` — nil-response guard and the exactly-once response-status accounting
- `docs/metrics.md` — cardinality note downgraded to Low for `weaviate_module_error_total`; sanity-check the wording

## Risks and mitigations

- **Dashboards/alerts keyed on the old label values**: any query on this metric was already broken by the shift (`module` carried the endpoint, `endpoint` carried error text), so nothing functional can regress; the fixed values match what `docs/metrics.md` documents. Pre-fix high-cardinality series persist in the process until restart (counter series are never dropped) — noted in the docs.
- **New sentinel values**: `-1` and `transport_error` are new but bounded; `-1` mirrors what generative-openai already emits, so consumers filtering on numeric codes see nothing novel cluster-wide.

## Testing

Unit tests using prometheus `testutil`, each pinning behavior the unfixed code violates:

- exact label-set pins for the shared OpenAI client (both OpenAI and Azure endpoints) and digitalocean: two failures carrying distinct request-ids increment one series and `CollectAndCount` stays flat — against the unfixed code every request-id mints a new series
- qna transport-error regression: a closed `httptest` server forces a connection failure, which panics on nil `res` without the fix; asserts the `status_code="-1"` series increments and the wrapped error is returned
- exactly-once `ModuleExternalResponseStatus` count on a successful qna answer
